### PR TITLE
perf: optimize prefer-namespace-keyword

### DIFF
--- a/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword.go
+++ b/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword.go
@@ -2,15 +2,38 @@ package prefer_namespace_keyword
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-func buildUseNamespaceMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useNamespace",
-		Description: "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
+var useNamespaceMessage = rule.RuleMessage{
+	Id:          "useNamespace",
+	Description: "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
+}
+
+const (
+	moduleKeywordText    = "module"
+	namespaceKeywordText = "namespace"
+)
+
+func moduleDeclarationRanges(sourceFile *ast.SourceFile, node *ast.Node) (core.TextRange, core.TextRange, bool) {
+	text := sourceFile.Text()
+	declarationStart := scanner.SkipTrivia(text, node.Pos())
+	keywordStart := declarationStart
+	if modifiers := node.Modifiers(); modifiers != nil && len(modifiers.Nodes) != 0 {
+		keywordStart = scanner.SkipTrivia(text, modifiers.End())
 	}
+	if keywordStart < 0 || keywordStart > len(text)-len(moduleKeywordText) {
+		return core.TextRange{}, core.TextRange{}, false
+	}
+	keywordEnd := keywordStart + len(moduleKeywordText)
+	// Nested nodes in `module foo.bar {}` inherit ModuleKeyword from the
+	// outer declaration but do not have their own keyword in the source.
+	if text[keywordStart:keywordEnd] != moduleKeywordText {
+		return core.TextRange{}, core.TextRange{}, false
+	}
+	return node.Loc.WithPos(declarationStart), core.NewTextRange(keywordStart, keywordEnd), true
 }
 
 var PreferNamespaceKeywordRule = rule.CreateRule(rule.Rule{
@@ -37,22 +60,18 @@ var PreferNamespaceKeywordRule = rule.CreateRule(rule.Rule{
 					return
 				}
 
-				// Find the "module" token to replace it with "namespace"
-				s := scanner.GetScannerForSourceFile(ctx.SourceFile, node.Pos())
-				for s.TokenStart() < name.Pos() {
-					if s.Token() == ast.KindModuleKeyword && s.TokenText() == "module" {
-						moduleTokenStart := s.TokenStart()
-						moduleTokenEnd := s.TokenEnd()
-						ctx.ReportNodeWithFixes(node, buildUseNamespaceMessage(),
-							rule.RuleFixReplaceRange(
-								node.Loc.WithPos(moduleTokenStart).WithEnd(moduleTokenEnd),
-								"namespace",
-							),
-						)
-						return
-					}
-					s.Scan()
+				declarationRange, keywordRange, ok := moduleDeclarationRanges(ctx.SourceFile, node)
+				if !ok {
+					return
 				}
+
+				ctx.ReportRangeWithDeferredFixes(
+					declarationRange,
+					useNamespaceMessage,
+					func() []rule.RuleFix {
+						return []rule.RuleFix{rule.RuleFixReplaceRange(keywordRange, namespaceKeywordText)}
+					},
+				)
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword_test.go
+++ b/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword_test.go
@@ -3,7 +3,11 @@ package prefer_namespace_keyword
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -11,6 +15,7 @@ func TestPreferNamespaceKeywordRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferNamespaceKeywordRule, []rule_tester.ValidTestCase{
 		{Code: `declare module 'foo';`},
 		{Code: `declare module 'foo' {}`},
+		{Code: `declare /* before keyword */ module /* before name */ 'foo' {}`},
 		{Code: `namespace foo {}`},
 		{Code: `declare namespace foo {}`},
 		{Code: `declare global {}`},
@@ -55,5 +60,102 @@ declare namespace foo {
   declare namespace bar {}
 }`},
 		},
+		{
+			Code: `export declare /* before keyword */ module /* before name */ foo {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "useNamespace",
+					Line:      1,
+					Column:    1,
+				},
+			},
+			Output: []string{`export declare /* before keyword */ namespace /* before name */ foo {}`},
+		},
+		{
+			Code: `module foo.bar {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "useNamespace",
+					Line:      1,
+					Column:    1,
+				},
+			},
+			Output: []string{`namespace foo.bar {}`},
+		},
+		{
+			Code: `/* before declaration */
+module foo {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "useNamespace",
+					Line:      2,
+					Column:    1,
+				},
+			},
+			Output: []string{`/* before declaration */
+namespace foo {}`},
+		},
 	})
+}
+
+func TestPreferNamespaceKeywordDefersAutofix(t *testing.T) {
+	const source = `export declare /* before keyword */ module foo {}`
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/test.ts",
+			Path:     "/test.ts",
+		}, source, core.ScriptKindTS)
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(
+			PreferNamespaceKeywordRule.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		)
+		listener := PreferNamespaceKeywordRule.Run(ctx, nil)[ast.KindModuleDeclaration]
+		var visit func(*ast.Node) bool
+		visit = func(node *ast.Node) bool {
+			if node.Kind == ast.KindModuleDeclaration {
+				listener(node)
+			}
+			node.ForEachChild(visit)
+			return false
+		}
+		visit(sourceFile.AsNode())
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	if len(diagnosticsOnly) != 1 {
+		t.Fatalf("diagnostics-only run produced %d diagnostics, want 1", len(diagnosticsOnly))
+	}
+	if diagnosticsOnly[0].FixesPtr != nil {
+		t.Fatal("diagnostics-only run materialized an autofix")
+	}
+
+	withAutofix := run(rule.EditDemandAutofix)
+	if len(withAutofix) != 1 {
+		t.Fatalf("autofix run produced %d diagnostics, want 1", len(withAutofix))
+	}
+	fixes := withAutofix[0].Fixes()
+	if len(fixes) != 1 {
+		t.Fatalf("autofix run produced %d fixes, want 1", len(fixes))
+	}
+	fix := fixes[0]
+	if got := source[fix.Range.Pos():fix.Range.End()]; got != "module" {
+		t.Fatalf("autofix replaces %q, want module", got)
+	}
+	if fix.Text != "namespace" {
+		t.Fatalf("autofix replacement = %q, want namespace", fix.Text)
+	}
 }


### PR DESCRIPTION
## Summary

- Replace the per-diagnostic scanner allocation and token walk with ranges derived from the parsed module declaration, its modifiers, and source trivia.
- Defer autofix materialization until the diagnostic consumer requests fixes.
- Preserve external-module handling, dotted namespace behavior, comments, diagnostic ranges, and exact keyword replacement with focused regression coverage.

### Benchmark

Temporary rule-local Go benchmark (removed before commit), run on Apple M1 Max / darwin-arm64 with GOMAXPROCS=1. Each iteration reports 256 offending declarations; values are medians of 8 runs with a 1-second benchtime.

| Demand | Before | After | Result |
| --- | ---: | ---: | ---: |
| Diagnostics only | 85,643 ns/op; 94,208 B/op; 1,024 allocs/op | 11,278 ns/op; 0 B/op; 0 allocs/op | 7.59x faster |
| Autofix | 86,303 ns/op; 94,208 B/op; 1,024 allocs/op | 24,326 ns/op; 12,288 B/op; 512 allocs/op | 3.55x faster |

Benchmark command: `GOMAXPROCS=1 go test ./internal/plugins/typescript/rules/prefer_namespace_keyword -run '^$' -bench '^BenchmarkPreferNamespaceKeywordRule$' -benchmem -benchtime=1s -count=8`

### Validation

- `go test ./internal/plugins/typescript/rules/prefer_namespace_keyword -count=1`
- `pnpm check-spell`
- `pnpm format:check`
- Changed-file-only `golangci-lint` run for the implementation and test files

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; no behavior or configuration change).
