### PR TITLE
docs: init typescript-go submodule shallow and non-recursive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This document summarizes how to work on rslint effectively and consistently.
 
 ## Build, Test, and Development Commands
 
-- Setup submodule: `git submodule update --init --depth 1 typescript-go`
+- Setup submodule: `git submodule update --init --depth 1`
 - Install Deps: `pnpm install`
 - Build JS/TS: `pnpm build`
 - Run Go tests: `pnpm run test:go`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This document summarizes how to work on rslint effectively and consistently.
 
 ## Build, Test, and Development Commands
 
-- Setup submodule: `git submodule update --init --recursive`
+- Setup submodule: `git submodule update --init --depth 1 typescript-go`
 - Install Deps: `pnpm install`
 - Build JS/TS: `pnpm build`
 - Run Go tests: `pnpm run test:go`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Build the project:
 
 ```bash
 # init typescript-go submodule
-git submodule update --init --recursive
+git submodule update --init --depth 1 typescript-go
 pnpm install
 pnpm build
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Build the project:
 
 ```bash
 # init typescript-go submodule
-git submodule update --init --depth 1 typescript-go
+git submodule update --init --depth 1
 pnpm install
 pnpm build
 ```


### PR DESCRIPTION
`--recursive` pulls the nested `_submodules/TypeScript` (~3 GB) that nothing in the build or test path reads.