### PR TITLE
perf: optimize no-global-assign resolution

### DIFF
--- a/internal/rules/no_global_assign/no_global_assign.go
+++ b/internal/rules/no_global_assign/no_global_assign.go
@@ -1,8 +1,6 @@
 package no_global_assign
 
 import (
-	"fmt"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -13,12 +11,15 @@ type options struct {
 }
 
 func parseOptions(opts any) options {
-	result := options{exceptions: make(map[string]bool)}
+	var result options
 	optsMap := utils.GetOptionsMap(opts)
 	if optsMap != nil {
 		if exceptions, ok := optsMap["exceptions"].([]interface{}); ok {
 			for _, e := range exceptions {
 				if s, ok := e.(string); ok {
+					if result.exceptions == nil {
+						result.exceptions = make(map[string]bool, len(exceptions))
+					}
 					result.exceptions[s] = true
 				}
 			}
@@ -46,12 +47,27 @@ func isWriteThroughTypeAssertion(node *ast.Node) bool {
 	return false
 }
 
+func buildGlobalShouldNotBeModifiedMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "globalShouldNotBeModified",
+		Description: "Read-only global '" + name + "' should not be modified.",
+	}
+}
+
 // NoGlobalAssignRule disallows assignments to native objects or read-only global variables
 var NoGlobalAssignRule = rule.Rule{
 	Name: "no-global-assign",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
+		// A single-entry cache covers the common case of repeated writes to one
+		// global without allocating maps for files that report once.
+		cache := struct {
+			name         string
+			globalSymbol *ast.Symbol
+			message      rule.RuleMessage
+			messageBuilt bool
+		}{}
 
 		return rule.RuleListeners{
 			ast.KindIdentifier: func(node *ast.Node) {
@@ -72,14 +88,38 @@ var NoGlobalAssignRule = rule.Rule{
 					return
 				}
 
-				if utils.IsShadowed(node, name) {
-					return
+				if cache.name != name {
+					cache.name = name
+					cache.messageBuilt = false
+					if ctx.Refs != nil && ctx.TypeChecker != nil {
+						cache.globalSymbol = ctx.TypeChecker.GetGlobalSymbol(name, ast.SymbolFlagsValue, nil)
+					}
 				}
 
-				ctx.ReportNode(node, rule.RuleMessage{
-					Id:          "globalShouldNotBeModified",
-					Description: fmt.Sprintf("Read-only global '%s' should not be modified.", name),
-				})
+				if ctx.Refs == nil || ctx.TypeChecker == nil {
+					if utils.IsShadowed(node, name) {
+						return
+					}
+				} else {
+					if cache.globalSymbol == nil {
+						if utils.IsShadowed(node, name) {
+							return
+						}
+					} else {
+						// Resolve uses the binder's scope walk first, so a local shadow
+						// produces its own symbol; only an unshadowed reference falls back
+						// to the checker global cached above.
+						if ctx.Refs.Resolve(node) != cache.globalSymbol {
+							return
+						}
+					}
+				}
+
+				if !cache.messageBuilt {
+					cache.message = buildGlobalShouldNotBeModifiedMessage(name)
+					cache.messageBuilt = true
+				}
+				ctx.ReportNode(node, cache.message)
 			},
 		}
 	},

--- a/internal/rules/no_global_assign/no_global_assign_test.go
+++ b/internal/rules/no_global_assign/no_global_assign_test.go
@@ -246,6 +246,15 @@ func TestNoGlobalAssignRule(t *testing.T) {
 			// Var with computed property destructuring shadows
 			{Code: `const k = "x"; var {[k]: Object}: any = {}; Object = 1;`},
 
+			// A later parameter already owns the binding used by an earlier default.
+			{Code: `function f(x = (Object = 1), Object: any) {}`},
+
+			// Switch clauses share one lexical scope.
+			{Code: `switch (0) { case 0: Object = 1; break; case 1: let Object: any; }`},
+
+			// Var declarations are hoisted within class static blocks.
+			{Code: `class C { static { Object = 1; var Object: any; } }`},
+
 			// Config `off` un-declares the builtin
 			{Code: `Object = 1;`, Globals: map[string]bool{"Object": false}},
 			{Code: `String = 'test';`, Globals: map[string]bool{"String": false}},
@@ -326,10 +335,11 @@ func TestNoGlobalAssignRule(t *testing.T) {
 
 			// Multiple globals assigned
 			{
-				Code: `String = 1; Array = 2;`,
+				Code: `String = 1; Array = 2; String = 3;`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 1},
-					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 13},
+					{MessageId: "globalShouldNotBeModified", Message: "Read-only global 'String' should not be modified.", Line: 1, Column: 1},
+					{MessageId: "globalShouldNotBeModified", Message: "Read-only global 'Array' should not be modified.", Line: 1, Column: 13},
+					{MessageId: "globalShouldNotBeModified", Message: "Read-only global 'String' should not be modified.", Line: 1, Column: 24},
 				},
 			},
 
@@ -936,6 +946,39 @@ func TestNoGlobalAssignRule(t *testing.T) {
 				Code: `function f() { Object = 1; class Inner { m() { class Object {} } } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 16},
+				},
+			},
+
+			// A body var does not shadow a write in a parameter default.
+			{
+				Code: `function f(x = (Object = 1)) { var Object: any; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 17},
+				},
+			},
+
+			// A switch-local binding does not escape the switch.
+			{
+				Code: `switch (0) { case 0: let Object: any; } Object = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 41},
+				},
+			},
+
+			// Local shadowing suppresses only writes within that scope.
+			{
+				Code: "Object = 1;\n{ let Object: any; Object = 2; }\nObject = 3;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 1},
+					{MessageId: "globalShouldNotBeModified", Line: 3, Column: 1},
+				},
+			},
+
+			// A nested type-only declaration does not shadow the value global.
+			{
+				Code: "function f() {\ninterface Object {}\nObject = 1;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 3, Column: 1},
 				},
 			},
 


### PR DESCRIPTION
## Summary

- Resolve candidate writes with `ctx.Refs` against the checker global symbol, avoiding repeated whole-scope declaration scans while preserving the original fallback when refs or checker globals are unavailable.
- Cache the most recent global symbol and diagnostic message without allocating maps for the common single-name case.
- Add adversarial coverage for parameter-default environments, switch scopes, static-block hoisting, type-only declarations, scope transitions, and message-cache correctness.
- Benchmark on Apple M1 Max (`darwin/arm64`), using the median of six 500 ms paired runs from a temporary benchmark harness:

| Workload | Before | After | Change | Allocs/op |
| --- | ---: | ---: | ---: | ---: |
| One write in a one-statement file | 3.171 µs | 3.282 µs | +3.5% | 36 → 35 |
| 500-line file with ordinary identifiers | 228.585 µs | 230.899 µs | +1.0% | 33 → 33 |
| One write after 500 ordinary lines | 291.250 µs | 245.355 µs | -15.8% | 36 → 35 |
| 500 writes to one global | 21.560 ms | 0.365 ms | -98.3% (59.1× faster) | ~1576 → 534 |
| 500 alternating writes to two globals | 12.806 ms | 0.349 ms | -97.3% (36.7× faster) | 1558 → 1033 |
| 500 writes to a shadowed global name | 408.511 µs | 106.865 µs | -73.8% (3.8× faster) | 33 → 33 |

Validation:

- `go test ./internal/rules/no_global_assign -run '^TestNoGlobalAssignRule$' -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/no_global_assign/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
