### PR TITLE
perf: optimize for-direction

### DIFF
--- a/internal/rules/for_direction/for_direction.go
+++ b/internal/rules/for_direction/for_direction.go
@@ -1,316 +1,552 @@
 package for_direction
 
 import (
-	"math/big"
+	"errors"
+	"math"
+	"strconv"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// Message builder
-func buildIncorrectDirection() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "incorrectDirection",
-		Description: "The update clause in this loop moves the variable in the wrong direction.",
+var incorrectDirectionMessage = rule.RuleMessage{
+	Id:          "incorrectDirection",
+	Description: "The update clause in this loop moves the variable in the wrong direction.",
+}
+
+type staticNumericKind uint8
+
+const (
+	staticNumber staticNumericKind = iota
+	staticBigInt
+	staticBoolean
+)
+
+type staticNumeric struct {
+	value float64
+	kind  staticNumericKind
+}
+
+type staticCacheEntry struct {
+	value    staticNumeric
+	resolved bool
+	ok       bool
+}
+
+type forDirectionChecker struct {
+	ctx         rule.RuleContext
+	staticCache map[*ast.Symbol]staticCacheEntry
+}
+
+func (checker *forDirectionChecker) check(node *ast.Node) {
+	forStatement := node.AsForStatement()
+	if forStatement == nil || forStatement.Condition == nil || forStatement.Incrementor == nil {
+		return
+	}
+
+	condition := forStatement.Condition
+	if condition.Kind != ast.KindBinaryExpression {
+		return
+	}
+	binary := condition.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		return
+	}
+
+	operator := binary.OperatorToken.Kind
+	if operator != ast.KindLessThanToken && operator != ast.KindLessThanEqualsToken &&
+		operator != ast.KindGreaterThanToken && operator != ast.KindGreaterThanEqualsToken {
+		return
+	}
+	incrementor := skipParentheses(forStatement.Incrementor)
+	if incrementor == nil ||
+		(incrementor.Kind != ast.KindPostfixUnaryExpression &&
+			incrementor.Kind != ast.KindPrefixUnaryExpression &&
+			incrementor.Kind != ast.KindBinaryExpression) {
+		return
+	}
+
+	left := skipParentheses(binary.Left)
+	if left != nil && left.Kind == ast.KindIdentifier {
+		direction, modifications := checker.modificationDirection(
+			incrementor,
+			left.AsIdentifier().Text,
+		)
+		if modifications == 1 && direction == wrongUpdateDirection(operator, true) {
+			checker.report(node, forStatement)
+			return
+		}
+	}
+
+	right := skipParentheses(binary.Right)
+	if right == nil || right.Kind != ast.KindIdentifier {
+		return
+	}
+	direction, modifications := checker.modificationDirection(
+		incrementor,
+		right.AsIdentifier().Text,
+	)
+	if modifications == 1 && direction == wrongUpdateDirection(operator, false) {
+		checker.report(node, forStatement)
 	}
 }
 
-// getUpdateDirection determines the direction of a unary update expression (++ or --)
-// Returns: 1 for increment, -1 for decrement, 0 for unknown
-func getUpdateDirection(updateExpr *ast.Node) int {
-	if updateExpr == nil {
+func wrongUpdateDirection(operator ast.Kind, counterOnLeft bool) int {
+	switch operator {
+	case ast.KindLessThanToken, ast.KindLessThanEqualsToken:
+		if counterOnLeft {
+			return -1
+		}
+		return 1
+	case ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken:
+		if counterOnLeft {
+			return 1
+		}
+		return -1
+	default:
 		return 0
 	}
-
-	switch updateExpr.Kind {
-	case ast.KindPostfixUnaryExpression:
-		postfix := updateExpr.AsPostfixUnaryExpression()
-		if postfix != nil {
-			switch postfix.Operator {
-			case ast.KindPlusPlusToken:
-				return 1
-			case ast.KindMinusMinusToken:
-				return -1
-			}
-		}
-	case ast.KindPrefixUnaryExpression:
-		prefix := updateExpr.AsPrefixUnaryExpression()
-		if prefix != nil {
-			switch prefix.Operator {
-			case ast.KindPlusPlusToken:
-				return 1
-			case ast.KindMinusMinusToken:
-				return -1
-			}
-		}
-	}
-
-	return 0
 }
 
-// getStaticNumberValue extracts static numeric value from an expression
-// Returns the numeric value and true if it's a static number, 0 and false otherwise
-func getStaticNumberValue(node *ast.Node, ctx *rule.RuleContext) (*big.Float, bool) {
+// modificationDirection returns the direction of the only expression that
+// modifies counter, together with the number of modifying expressions found.
+// A count other than one makes the loop ambiguous and suppresses a report.
+func (checker *forDirectionChecker) modificationDirection(node *ast.Node, counter string) (int, int) {
 	if node == nil {
-		return nil, false
+		return 0, 0
 	}
+	node = skipParentheses(node)
+
+	switch node.Kind {
+	case ast.KindPostfixUnaryExpression:
+		update := node.AsPostfixUnaryExpression()
+		if update == nil || !isIdentifierNamed(update.Operand, counter) {
+			return 0, 0
+		}
+		switch update.Operator {
+		case ast.KindPlusPlusToken:
+			return 1, 1
+		case ast.KindMinusMinusToken:
+			return -1, 1
+		default:
+			return 0, 0
+		}
+
+	case ast.KindPrefixUnaryExpression:
+		update := node.AsPrefixUnaryExpression()
+		if update == nil || !isIdentifierNamed(update.Operand, counter) {
+			return 0, 0
+		}
+		switch update.Operator {
+		case ast.KindPlusPlusToken:
+			return 1, 1
+		case ast.KindMinusMinusToken:
+			return -1, 1
+		default:
+			return 0, 0
+		}
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary == nil || binary.OperatorToken == nil {
+			return 0, 0
+		}
+		operator := binary.OperatorToken.Kind
+		if operator == ast.KindCommaToken {
+			leftDirection, leftCount := checker.modificationDirection(binary.Left, counter)
+			rightDirection, rightCount := checker.modificationDirection(binary.Right, counter)
+			count := leftCount + rightCount
+			if count != 1 {
+				return 0, count
+			}
+			if leftCount == 1 {
+				return leftDirection, 1
+			}
+			return rightDirection, 1
+		}
+
+		if !ast.IsAssignmentOperator(operator) || !isIdentifierNamed(binary.Left, counter) {
+			return 0, 0
+		}
+
+		direction := 0
+		if operator == ast.KindPlusEqualsToken || operator == ast.KindMinusEqualsToken {
+			direction = checker.staticDirection(binary.Right)
+			if operator == ast.KindMinusEqualsToken {
+				direction = -direction
+			}
+		}
+		return direction, 1
+	}
+
+	return 0, 0
+}
+
+func isIdentifierNamed(node *ast.Node, name string) bool {
+	node = skipParentheses(node)
+	return node != nil && node.Kind == ast.KindIdentifier && node.AsIdentifier().Text == name
+}
+
+func skipParentheses(node *ast.Node) *ast.Node {
+	if node != nil && node.Kind == ast.KindParenthesizedExpression {
+		return ast.SkipParentheses(node)
+	}
+	return node
+}
+
+func (checker *forDirectionChecker) staticDirection(node *ast.Node) int {
+	value, ok := checker.staticNumericValue(node)
+	if !ok || value.value == 0 || math.IsNaN(value.value) {
+		return 0
+	}
+	if value.value < 0 {
+		return -1
+	}
+	return 1
+}
+
+func (checker *forDirectionChecker) staticNumericValue(node *ast.Node) (staticNumeric, bool) {
+	if node == nil {
+		return staticNumeric{}, false
+	}
+	node = ast.SkipOuterExpressions(node, ast.OEKAll)
 
 	switch node.Kind {
 	case ast.KindNumericLiteral:
-		// Parse numeric literal
-		text := node.Text()
-		if text != "" {
-			val := new(big.Float)
-			if _, ok := val.SetString(text); ok {
-				return val, true
-			}
-		}
-		return nil, false
+		value, ok := parseNonNegativeNumeric(node.AsNumericLiteral().Text)
+		return staticNumeric{value: value, kind: staticNumber}, ok
 
-	case ast.KindPrefixUnaryExpression:
-		// Handle unary minus/plus
-		prefix := node.AsPrefixUnaryExpression()
-		if prefix != nil && prefix.Operand != nil {
-			if val, ok := getStaticNumberValue(prefix.Operand, ctx); ok {
-				switch prefix.Operator {
-				case ast.KindMinusToken:
-					negVal := new(big.Float).Neg(val)
-					return negVal, true
-				case ast.KindPlusToken:
-					return val, true
-				}
-			}
+	case ast.KindBigIntLiteral:
+		text := node.AsBigIntLiteral().Text
+		if len(text) == 0 || text[len(text)-1] != 'n' {
+			return staticNumeric{}, false
 		}
-		return nil, false
+		value, ok := parseNonNegativeNumeric(text[:len(text)-1])
+		return staticNumeric{value: value, kind: staticBigInt}, ok
 
-	case ast.KindParenthesizedExpression:
-		// Unwrap parentheses
-		expr := node.Expression()
-		return getStaticNumberValue(expr, ctx)
+	case ast.KindTrueKeyword:
+		return staticNumeric{value: 1, kind: staticBoolean}, true
+
+	case ast.KindFalseKeyword:
+		return staticNumeric{kind: staticBoolean}, true
 
 	case ast.KindIdentifier:
-		// Try to resolve constant variable values
-		if ctx != nil && ctx.TypeChecker != nil {
-			constValue := ctx.TypeChecker.GetConstantValue(node)
-			if constValue != nil {
-				// Try to convert the constant value to a float
-				switch v := constValue.(type) {
-				case float64:
-					return big.NewFloat(v), true
-				case int:
-					return big.NewFloat(float64(v)), true
-				case int64:
-					return big.NewFloat(float64(v)), true
-				}
-			}
+		return checker.staticIdentifierValue(node)
+
+	case ast.KindPrefixUnaryExpression:
+		prefix := node.AsPrefixUnaryExpression()
+		if prefix == nil {
+			return staticNumeric{}, false
 		}
-		return nil, false
+		value, ok := checker.staticNumericValue(prefix.Operand)
+		if !ok {
+			return staticNumeric{}, false
+		}
+		switch prefix.Operator {
+		case ast.KindPlusToken:
+			if value.kind == staticBigInt {
+				return staticNumeric{}, false
+			}
+			value.kind = staticNumber
+			return value, true
+		case ast.KindMinusToken:
+			value.value = -value.value
+			if value.kind != staticBigInt {
+				value.kind = staticNumber
+			}
+			return value, true
+		case ast.KindTildeToken:
+			if value.kind == staticBigInt {
+				value.value = -value.value - 1
+				return value, true
+			}
+			return staticNumeric{value: float64(^toInt32(value.value)), kind: staticNumber}, true
+		case ast.KindExclamationToken:
+			if value.value == 0 || math.IsNaN(value.value) {
+				return staticNumeric{value: 1, kind: staticBoolean}, true
+			}
+			return staticNumeric{kind: staticBoolean}, true
+		default:
+			return staticNumeric{}, false
+		}
+
+	case ast.KindBinaryExpression:
+		return checker.staticBinaryValue(node.AsBinaryExpression())
+
+	case ast.KindConditionalExpression:
+		conditional := node.AsConditionalExpression()
+		if conditional == nil {
+			return staticNumeric{}, false
+		}
+		condition, ok := checker.staticNumericValue(conditional.Condition)
+		if !ok {
+			return staticNumeric{}, false
+		}
+		if condition.value != 0 && !math.IsNaN(condition.value) {
+			return checker.staticNumericValue(conditional.WhenTrue)
+		}
+		return checker.staticNumericValue(conditional.WhenFalse)
 	}
 
-	return nil, false
+	return staticNumeric{}, false
 }
 
-// getAssignmentDirection determines the direction of a compound assignment (+=, -=)
-// Returns: 1 for positive direction, -1 for negative direction, 0 for unknown
-func getAssignmentDirection(binaryExpr *ast.Node, ctx *rule.RuleContext) int {
-	if binaryExpr == nil || binaryExpr.Kind != ast.KindBinaryExpression {
-		return 0
-	}
-
-	binary := binaryExpr.AsBinaryExpression()
+func (checker *forDirectionChecker) staticBinaryValue(binary *ast.BinaryExpression) (staticNumeric, bool) {
 	if binary == nil || binary.OperatorToken == nil {
-		return 0
+		return staticNumeric{}, false
+	}
+	operator := binary.OperatorToken.Kind
+	if operator == ast.KindEqualsToken || operator == ast.KindCommaToken {
+		return checker.staticNumericValue(binary.Right)
 	}
 
-	operator := binary.OperatorToken.Kind
+	left, leftOK := checker.staticNumericValue(binary.Left)
+	if !leftOK {
+		return staticNumeric{}, false
+	}
+	if operator == ast.KindAmpersandAmpersandToken {
+		if left.value == 0 || math.IsNaN(left.value) {
+			return left, true
+		}
+		return checker.staticNumericValue(binary.Right)
+	}
+	if operator == ast.KindBarBarToken {
+		if left.value != 0 && !math.IsNaN(left.value) {
+			return left, true
+		}
+		return checker.staticNumericValue(binary.Right)
+	}
+	if operator == ast.KindQuestionQuestionToken {
+		return left, true
+	}
+
+	right, rightOK := checker.staticNumericValue(binary.Right)
+	if !rightOK {
+		return staticNumeric{}, false
+	}
+
+	boolean := func(value bool) (staticNumeric, bool) {
+		if value {
+			return staticNumeric{value: 1, kind: staticBoolean}, true
+		}
+		return staticNumeric{kind: staticBoolean}, true
+	}
+	const maxSafeInteger = 1<<53 - 1
+	leftUnsafeBigInt := left.kind == staticBigInt && math.Abs(left.value) > maxSafeInteger
+	rightUnsafeBigInt := right.kind == staticBigInt && math.Abs(right.value) > maxSafeInteger
+	if leftUnsafeBigInt || rightUnsafeBigInt {
+		switch operator {
+		case ast.KindEqualsEqualsEqualsToken:
+			if left.kind != right.kind {
+				return boolean(false)
+			}
+		case ast.KindExclamationEqualsEqualsToken:
+			if left.kind != right.kind {
+				return boolean(true)
+			}
+		}
+		return staticNumeric{}, false
+	}
+	switch operator {
+	case ast.KindEqualsEqualsEqualsToken:
+		return boolean(left.kind == right.kind && left.value == right.value)
+	case ast.KindExclamationEqualsEqualsToken:
+		return boolean(left.kind != right.kind || left.value != right.value)
+	case ast.KindEqualsEqualsToken:
+		return boolean(left.value == right.value)
+	case ast.KindExclamationEqualsToken:
+		return boolean(left.value != right.value)
+	}
+
+	leftIsBigInt := left.kind == staticBigInt
+	rightIsBigInt := right.kind == staticBigInt
+	if leftIsBigInt != rightIsBigInt {
+		return staticNumeric{}, false
+	}
+	kind := staticNumber
+	if leftIsBigInt {
+		kind = staticBigInt
+	}
 
 	switch operator {
-	case ast.KindPlusEqualsToken:
-		// += direction depends on the right operand
-		if val, ok := getStaticNumberValue(binary.Right, ctx); ok {
-			if val.Sign() > 0 {
-				return 1
-			} else if val.Sign() < 0 {
-				return -1
+	case ast.KindPlusToken:
+		return staticNumeric{value: left.value + right.value, kind: kind}, true
+	case ast.KindMinusToken:
+		return staticNumeric{value: left.value - right.value, kind: kind}, true
+	case ast.KindAsteriskToken:
+		return staticNumeric{value: left.value * right.value, kind: kind}, true
+	case ast.KindSlashToken:
+		if kind == staticBigInt {
+			if right.value == 0 {
+				return staticNumeric{}, false
+			}
+			return staticNumeric{value: math.Trunc(left.value / right.value), kind: kind}, true
+		}
+		return staticNumeric{value: left.value / right.value, kind: kind}, true
+	case ast.KindPercentToken:
+		if kind == staticBigInt && right.value == 0 {
+			return staticNumeric{}, false
+		}
+		return staticNumeric{value: math.Mod(left.value, right.value), kind: kind}, true
+	case ast.KindAsteriskAsteriskToken:
+		if kind == staticBigInt &&
+			(right.value < 0 || right.value != math.Trunc(right.value) || math.IsInf(right.value, 0)) {
+			return staticNumeric{}, false
+		}
+		return staticNumeric{value: math.Pow(left.value, right.value), kind: kind}, true
+	case ast.KindLessThanToken:
+		return boolean(left.value < right.value)
+	case ast.KindLessThanEqualsToken:
+		return boolean(left.value <= right.value)
+	case ast.KindGreaterThanToken:
+		return boolean(left.value > right.value)
+	case ast.KindGreaterThanEqualsToken:
+		return boolean(left.value >= right.value)
+	}
+
+	if kind == staticBigInt || math.IsNaN(left.value) || math.IsNaN(right.value) ||
+		math.IsInf(left.value, 0) || math.IsInf(right.value, 0) {
+		return staticNumeric{}, false
+	}
+
+	switch operator {
+	case ast.KindAmpersandToken:
+		return staticNumeric{value: float64(toInt32(left.value) & toInt32(right.value)), kind: staticNumber}, true
+	case ast.KindBarToken:
+		return staticNumeric{value: float64(toInt32(left.value) | toInt32(right.value)), kind: staticNumber}, true
+	case ast.KindCaretToken:
+		return staticNumeric{value: float64(toInt32(left.value) ^ toInt32(right.value)), kind: staticNumber}, true
+	case ast.KindLessThanLessThanToken:
+		return staticNumeric{value: float64(toInt32(left.value) << (toUint32(right.value) & 31)), kind: staticNumber}, true
+	case ast.KindGreaterThanGreaterThanToken:
+		return staticNumeric{value: float64(toInt32(left.value) >> (toUint32(right.value) & 31)), kind: staticNumber}, true
+	case ast.KindGreaterThanGreaterThanGreaterThanToken:
+		return staticNumeric{value: float64(toUint32(left.value) >> (toUint32(right.value) & 31)), kind: staticNumber}, true
+	default:
+		return staticNumeric{}, false
+	}
+}
+
+func (checker *forDirectionChecker) staticIdentifierValue(node *ast.Node) (staticNumeric, bool) {
+	if checker.ctx.Refs == nil {
+		return staticNumeric{}, false
+	}
+	symbol := checker.ctx.Refs.Resolve(node)
+	if symbol == nil {
+		return staticNumeric{}, false
+	}
+	if cached, ok := checker.staticCache[symbol]; ok {
+		if !cached.resolved {
+			return staticNumeric{}, false
+		}
+		return cached.value, cached.ok
+	}
+	if checker.staticCache == nil {
+		checker.staticCache = make(map[*ast.Symbol]staticCacheEntry)
+	}
+	checker.staticCache[symbol] = staticCacheEntry{}
+
+	var declaration *ast.Node
+	for _, candidate := range symbol.Declarations {
+		if candidate == nil || candidate.Kind != ast.KindVariableDeclaration ||
+			candidate.Name() == nil || candidate.Name().Kind != ast.KindIdentifier {
+			continue
+		}
+		if declaration != nil {
+			checker.staticCache[symbol] = staticCacheEntry{resolved: true}
+			return staticNumeric{}, false
+		}
+		declaration = candidate
+	}
+	if declaration == nil {
+		checker.staticCache[symbol] = staticCacheEntry{resolved: true}
+		return staticNumeric{}, false
+	}
+
+	declarationList := declaration.Parent
+	if declarationList == nil || declarationList.Kind != ast.KindVariableDeclarationList {
+		checker.staticCache[symbol] = staticCacheEntry{resolved: true}
+		return staticNumeric{}, false
+	}
+	if declarationList.Flags&ast.NodeFlagsConst == 0 {
+		for _, reference := range checker.ctx.Refs.References(symbol) {
+			if utils.IsWriteReference(reference) {
+				checker.staticCache[symbol] = staticCacheEntry{resolved: true}
+				return staticNumeric{}, false
 			}
 		}
-		return 0
+	}
 
-	case ast.KindMinusEqualsToken:
-		// -= direction is opposite of the right operand
-		if val, ok := getStaticNumberValue(binary.Right, ctx); ok {
-			if val.Sign() > 0 {
-				return -1
-			} else if val.Sign() < 0 {
-				return 1
+	initializer := declaration.AsVariableDeclaration().Initializer
+	value, ok := checker.staticNumericValue(initializer)
+	checker.staticCache[symbol] = staticCacheEntry{value: value, resolved: true, ok: ok}
+	return value, ok
+}
+
+func parseNonNegativeNumeric(text string) (float64, bool) {
+	if len(text) > 2 && text[0] == '0' {
+		base := 0
+		switch text[1] {
+		case 'b', 'B':
+			base = 2
+		case 'o', 'O':
+			base = 8
+		case 'x', 'X':
+			base = 16
+		}
+		if base != 0 {
+			value, err := strconv.ParseUint(text[2:], base, 64)
+			if err == nil {
+				return float64(value), true
 			}
+			if errors.Is(err, strconv.ErrRange) {
+				return math.Inf(1), true
+			}
+			return 0, false
 		}
-		return 0
 	}
 
-	return 0
+	value, err := strconv.ParseFloat(text, 64)
+	if err == nil || math.IsInf(value, 1) {
+		return value, true
+	}
+	return 0, false
 }
 
-// getVariableName extracts the variable name from an expression
-func getVariableName(node *ast.Node) string {
-	if node == nil {
-		return ""
-	}
-
-	switch node.Kind {
-	case ast.KindIdentifier:
-		return node.Text()
-	case ast.KindPostfixUnaryExpression:
-		postfix := node.AsPostfixUnaryExpression()
-		if postfix != nil {
-			return getVariableName(postfix.Operand)
-		}
-	case ast.KindPrefixUnaryExpression:
-		prefix := node.AsPrefixUnaryExpression()
-		if prefix != nil {
-			return getVariableName(prefix.Operand)
-		}
-	case ast.KindBinaryExpression:
-		binary := node.AsBinaryExpression()
-		if binary != nil {
-			return getVariableName(binary.Left)
-		}
-	}
-
-	return ""
-}
-
-// getExpectedDirection determines the expected direction based on the comparison operator
-// Returns: 1 for increasing, -1 for decreasing, 0 for unknown
-func getExpectedDirection(testExpr *ast.Node, counterOnLeft bool) int {
-	if testExpr == nil || testExpr.Kind != ast.KindBinaryExpression {
+func toUint32(value float64) uint32 {
+	if value == 0 || math.IsNaN(value) || math.IsInf(value, 0) {
 		return 0
 	}
-
-	binary := testExpr.AsBinaryExpression()
-	if binary == nil || binary.OperatorToken == nil {
-		return 0
+	value = math.Mod(math.Trunc(value), 1<<32)
+	if value < 0 {
+		value += 1 << 32
 	}
-
-	operator := binary.OperatorToken.Kind
-
-	// Determine expected direction based on operator and counter position
-	if counterOnLeft {
-		// Counter is on the left side (e.g., i < 10)
-		switch operator {
-		case ast.KindLessThanToken, ast.KindLessThanEqualsToken:
-			// i < 10 or i <= 10 -> should increase
-			return 1
-		case ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken:
-			// i > 10 or i >= 10 -> should decrease
-			return -1
-		}
-	} else {
-		// Counter is on the right side (e.g., 10 > i)
-		// The logic is reversed: 10 > i means i < 10
-		switch operator {
-		case ast.KindLessThanToken, ast.KindLessThanEqualsToken:
-			// 10 < i or 10 <= i is equivalent to i > 10 -> should decrease
-			return -1
-		case ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken:
-			// 10 > i or 10 >= i is equivalent to i < 10 -> should increase
-			return 1
-		}
-	}
-
-	return 0
+	return uint32(value)
 }
 
-// ForDirectionRule enforces that for loop update clauses move the counter in the right direction
+func toInt32(value float64) int32 {
+	return int32(toUint32(value))
+}
+
+func (checker *forDirectionChecker) report(node *ast.Node, forStatement *ast.ForStatement) {
+	text := checker.ctx.SourceFile.Text()
+	start := scanner.SkipTrivia(text, node.Pos())
+	end := forStatement.Incrementor.End()
+	closeParen := scanner.SkipTrivia(text, end)
+	if closeParen < len(text) && text[closeParen] == ')' {
+		end = closeParen + 1
+	}
+	checker.ctx.ReportRange(core.NewTextRange(start, end), incorrectDirectionMessage)
+}
+
+// ForDirectionRule enforces that for loop update clauses move the counter in the right direction.
 var ForDirectionRule = rule.Rule{
 	Name: "for-direction",
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindForStatement: func(node *ast.Node) {
-				forStmt := node.AsForStatement()
-				if forStmt == nil {
-					return
-				}
-
-				// We need all three parts: initializer, condition, and incrementor
-				if forStmt.Condition == nil || forStmt.Incrementor == nil {
-					return
-				}
-
-				condition := forStmt.Condition
-				incrementor := forStmt.Incrementor
-
-				// Condition must be a binary expression with comparison operator
-				if condition.Kind != ast.KindBinaryExpression {
-					return
-				}
-
-				binary := condition.AsBinaryExpression()
-				if binary == nil || binary.OperatorToken == nil {
-					return
-				}
-
-				operator := binary.OperatorToken.Kind
-
-				// Only check comparison operators
-				switch operator {
-				case ast.KindLessThanToken, ast.KindLessThanEqualsToken,
-					ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken:
-					// These are the operators we care about
-				default:
-					// Not a comparison operator we handle
-					return
-				}
-
-				// Try to determine which side has the counter variable
-				// First, try assuming counter is on the left
-				counterOnLeft := true
-				counterName := getVariableName(binary.Left)
-
-				// If left side doesn't give us a variable name, try right side
-				if counterName == "" {
-					counterOnLeft = false
-					counterName = getVariableName(binary.Right)
-				}
-
-				// If we still don't have a counter name, we can't proceed
-				if counterName == "" {
-					return
-				}
-
-				// Get the name of the variable being updated
-				updateVarName := getVariableName(incrementor)
-
-				// If the update variable doesn't match the test variable, we can't determine direction
-				if updateVarName != counterName {
-					return
-				}
-
-				// Get expected direction from the test condition
-				expectedDirection := getExpectedDirection(condition, counterOnLeft)
-				if expectedDirection == 0 {
-					return
-				}
-
-				// Get actual direction from the update expression
-				actualDirection := getUpdateDirection(incrementor)
-
-				// If we couldn't determine direction from unary operators, try compound assignment
-				if actualDirection == 0 {
-					actualDirection = getAssignmentDirection(incrementor, &ctx)
-				}
-
-				// If we still can't determine direction, it's ambiguous (e.g., i += unknown)
-				if actualDirection == 0 {
-					return
-				}
-
-				// Check if directions match
-				if expectedDirection != actualDirection {
-					// Report error on the entire for statement (from 'for' to opening brace)
-					ctx.ReportNode(node, buildIncorrectDirection())
-				}
-			},
-		}
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		checker := &forDirectionChecker{ctx: ctx}
+		return rule.RuleListeners{ast.KindForStatement: checker.check}
 	},
 }

--- a/internal/rules/for_direction/for_direction_test.go
+++ b/internal/rules/for_direction/for_direction_test.go
@@ -56,7 +56,8 @@ func TestForDirectionRule(t *testing.T) {
 			{Code: `for(var i = 10; i > 0; i-=x){}`},
 			{Code: `for(var i = MIN; i <= MAX; i++){}`},
 			{Code: `for(var i = MIN; i <= MAX; i+=true){}`},
-			{Code: `for(var i = MIN; i <= MAX; i-=true){}`},
+			{Code: `for(var i = MIN; i <= MAX; i-=false){}`},
+			{Code: `for(var i = MIN; i <= MAX; i-=0/0){}`},
 
 			// Neutral increment (no effect)
 			{Code: `for(var i = 10; i >= 0; i-=0){}`},
@@ -83,6 +84,35 @@ func TestForDirectionRule(t *testing.T) {
 			// BigInt literals (if supported)
 			{Code: `for(var i = 0n; i < 10n; i++){}`},
 			{Code: `for(var i = 0n; i > l; i-=1n){}`},
+			{Code: `for(var i = 0n; i < l; i-=-1n){}`},
+			{Code: `for(var i = 10n; i >= 0n; i+=0n){}`},
+
+			// Static expressions supported by ESLint's getStaticValue
+			{Code: `for(var i = 0; i < 10; i+=+5e-7){}`},
+			{Code: `for(var i = 0; i < MAX; i -= ~2);`},
+			{Code: `for(var i = 0, n = -1; i < MAX; i += -n);`},
+			{Code: `var n = -2; n = 2; for(var i = 0; i < 10; i += n);`},
+			{Code: `var step = -1; { let step = 1; for(var i = 0; i < 10; i += step){} }`},
+			{Code: `const a = b, b = a; for(var i = 0; i < 10; i += a){}`},
+			{Code: `for(var i = 10; i > 0; i += (1 === true)){}`},
+			{Code: `for(var i = 10n; i > 0n; i += (1n / 2n)){}`},
+			{Code: `for(var i = 10n; i > 0n; i += (2n ** -1n)){}`},
+			{Code: `for(var i = 10n; i > 0n; i += (9007199254740992n === 9007199254740993n)){}`},
+
+			// Only direct condition identifiers are counters.
+			{Code: `for(var i = 0; i + 1 < 10; i--){}`},
+
+			// Sequence expressions with exactly one unambiguous counter update
+			{Code: `for(var i = 0; i < 10; (i++, j++)){}`},
+			{Code: `for(var i = 0; i < 10; (j++, i++)){}`},
+			{Code: `for(var i = 10; i > 0; (j++, i--, k++)){}`},
+			{Code: `for(var i = 0; i < 10; (j++, k++)){}`},
+
+			// Multiple or ambiguous counter modifications are ignored.
+			{Code: `for(var i = 10; i < 20; (i--, i++)){}`},
+			{Code: `for(var i = 10; i < 20; (i--, i += 2)){}`},
+			{Code: `for(var i = 10; i < 20; (i--, i += STEP_SIZE)){}`},
+			{Code: `for(var i = 10; i < 20; (i--, (i = 5, j++))){}`},
 
 			// TypeScript syntax with type annotations
 			{Code: `for(let i: number = 0; i < 10; i++){}`},
@@ -94,7 +124,7 @@ func TestForDirectionRule(t *testing.T) {
 			{
 				Code: `for(var i = 0; i < 10; i--){}`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+					{MessageId: "incorrectDirection", Line: 1, Column: 1, EndLine: 1, EndColumn: 28},
 				},
 			},
 			{
@@ -234,14 +264,78 @@ func TestForDirectionRule(t *testing.T) {
 				},
 			},
 
-			// TODO: With const variable - requires full scope-based constant resolution
-			// which is not yet implemented. This test is skipped for now.
-			// {
-			// 	Code: `const n = -2; for(var i = 0; i < 10; i+=n){}`,
-			// 	Errors: []rule_tester.InvalidTestCaseError{
-			// 		{MessageId: "incorrectDirection", Line: 1, Column: 15},
-			// 	},
-			// },
+			// Static RHS values, including effectively constant variables
+			{
+				Code: `for(var i = MIN; i <= MAX; i-=true){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for(var i = 0n; i > l; i+=1n){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for(var i = 0; i < 10; i-=+5e-7){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for(var i = 0; i < MAX; i += (2 - 3));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `var n = -2; for(var i = 0; i < 10; i += n);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 13, EndLine: 1, EndColumn: 43},
+				},
+			},
+			{
+				Code: `const step = -1; for(var i = 0; i < 10; i += step){} for(var j = 0; j < 10; j += step){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection"},
+					{MessageId: "incorrectDirection"},
+				},
+			},
+			{
+				Code: `for(var i = 10; i > 0; i += (1 !== true)){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for(var i = 0; i < 10; i += (-1 as number)){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
+
+			// The matching counter may be on the right even when both sides are identifiers.
+			{
+				Code: `for(var i = 0, limit = 10; limit > i; i--){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
+
+			// Sequence expressions report only when exactly one counter mutation is wrong.
+			{
+				Code: `for(var i = 0; i < 10; (i--, j++)){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code: `for(var i = 10; i > 0; (j++, (i++, k++))){}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "incorrectDirection", Line: 1, Column: 1},
+				},
+			},
 
 			// TypeScript syntax with wrong direction
 			{


### PR DESCRIPTION
## Summary

- Optimize for-direction hot paths with allocation-free numeric direction checks and direct header-range reporting.
- Align counter/update analysis with ESLint for sequence expressions, both condition operands, booleans, BigInt values, and static RHS expressions.
- Resolve static variables through a lazy per-rule ctx.Refs cache. Deferred report builders do not apply because this rule has no fixes or suggestions.

## Benchmark

Command: go test ./internal/rules/for_direction -run ^$ -bench ^BenchmarkForDirectionRule$ -benchmem -count=5

Environment: Apple M1 Max, darwin/arm64. Each operation processes 256 for loops; values are the median of five runs.

| Case | Before | After | Time | Memory / allocations |
| --- | ---: | ---: | ---: | ---: |
| unary, valid | 4.391 us/op | 3.693 us/op | -15.9% | 0 B / 0 to 0 B / 0 |
| unary, invalid | 28.129 us/op | 9.581 us/op | -65.9% | 40,960 B / 256 to 0 B / 0 |
| compound, valid | 35.852 us/op | 8.851 us/op | -75.3% | 29,696 B / 1,024 to 0 B / 0 |
| compound, invalid | 61.440 us/op | 15.372 us/op | -75.0% | 70,656 B / 1,280 to 0 B / 0 |
| skipped | 0.953 us/op | 0.962 us/op | +1.0% | 0 B / 0 to 0 B / 0 |

The temporary benchmark file is not included in this PR.

## Validation

- pnpm check-spell
- pnpm format:check
- pnpm exec golangci-lint run ./internal/rules/for_direction
- go test ./internal/rules/for_direction -count=10

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).