### PR TITLE
feat(rstest): add no-conditional-expect rule

### DIFF
--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
@@ -77,6 +77,9 @@ func resolvePendingTestCallbackNames(
 			if !names[name] {
 				break
 			}
+			if vd.Initializer == nil {
+				break
+			}
 			init := ast.SkipParentheses(vd.Initializer)
 			if ast.IsFunctionExpressionOrArrowFunction(init) {
 				callbacks[init] = true

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
@@ -1,42 +1,11 @@
 package no_conditional_expect
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_conditional_expect"
 )
-
-func buildConditionalExpectMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "conditionalExpect",
-		Description: "Avoid calling `expect` conditionally",
-	}
-}
-
-func isPromiseCatchCall(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindCallExpression {
-		return false
-	}
-
-	name := jestUtils.CalleeChainName(node.AsCallExpression().Expression)
-	return name == "catch" || strings.HasSuffix(name, ".catch")
-}
-
-func isConditionalNode(node *ast.Node) bool {
-	switch node.Kind {
-	case ast.KindCatchClause,
-		ast.KindIfStatement,
-		ast.KindSwitchStatement,
-		ast.KindConditionalExpression:
-		return true
-	case ast.KindBinaryExpression:
-		return ast.IsLogicalExpression(node)
-	default:
-		return false
-	}
-}
 
 func collectTestFunctionCallbacks(ctx rule.RuleContext) map[*ast.Node]bool {
 	callbacks := map[*ast.Node]bool{}
@@ -126,131 +95,16 @@ func resolvePendingTestCallbackNames(
 	}
 }
 
-type callExpressionFrame struct {
-	jestFnCall *jestUtils.ParsedJestFnCall
-	isCatch    bool
-}
-
-var NoConditionalExpectRule = rule.Rule{
-	Name:   "jest/no-conditional-expect",
-	Schema: rule.EmptyArraySchema,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		testCallbackFunctions := collectTestFunctionCallbacks(ctx)
-		testCaseDepth := 0
-		conditionalDepth := 0
-		inPromiseCatch := false
-		callExpressionFrames := map[*ast.Node]callExpressionFrame{}
-
-		inTestCase := func() bool {
-			return testCaseDepth > 0
-		}
-
-		enterTestCase := func() {
-			testCaseDepth++
-		}
-
-		exitTestCase := func() {
-			if testCaseDepth > 0 {
-				testCaseDepth--
-			}
-		}
-
-		enterConditional := func(node *ast.Node) {
-			if !inTestCase() {
-				return
-			}
-			if node.Kind == ast.KindBinaryExpression && !ast.IsLogicalExpression(node) {
-				return
-			}
-			if isConditionalNode(node) {
-				conditionalDepth++
-			}
-		}
-
-		exitConditional := func(node *ast.Node) {
-			if !inTestCase() || conditionalDepth == 0 {
-				return
-			}
-			if node.Kind == ast.KindBinaryExpression && !ast.IsLogicalExpression(node) {
-				return
-			}
-			if isConditionalNode(node) {
-				conditionalDepth--
-			}
-		}
-
-		enterTestCallbackFunction := func(node *ast.Node) {
-			if testCallbackFunctions[node] {
-				enterTestCase()
-			}
-		}
-
-		exitTestCallbackFunction := func(node *ast.Node) {
-			if testCallbackFunctions[node] {
-				exitTestCase()
-			}
-		}
-
-		return rule.RuleListeners{
-			ast.KindFunctionDeclaration:                      enterTestCallbackFunction,
-			rule.ListenerOnExit(ast.KindFunctionDeclaration): exitTestCallbackFunction,
-			ast.KindFunctionExpression:                       enterTestCallbackFunction,
-			rule.ListenerOnExit(ast.KindFunctionExpression):  exitTestCallbackFunction,
-			ast.KindArrowFunction:                            enterTestCallbackFunction,
-			rule.ListenerOnExit(ast.KindArrowFunction):       exitTestCallbackFunction,
-
-			ast.KindCatchClause:                                enterConditional,
-			rule.ListenerOnExit(ast.KindCatchClause):           exitConditional,
-			ast.KindIfStatement:                                enterConditional,
-			rule.ListenerOnExit(ast.KindIfStatement):           exitConditional,
-			ast.KindSwitchStatement:                            enterConditional,
-			rule.ListenerOnExit(ast.KindSwitchStatement):       exitConditional,
-			ast.KindConditionalExpression:                      enterConditional,
-			rule.ListenerOnExit(ast.KindConditionalExpression): exitConditional,
-			ast.KindBinaryExpression:                           enterConditional,
-			rule.ListenerOnExit(ast.KindBinaryExpression):      exitConditional,
-
-			ast.KindCallExpression: func(node *ast.Node) {
-				jestFnCall := jestUtils.ParseJestFnCall(node, ctx)
-				isCatch := isPromiseCatchCall(node)
-				callExpressionFrames[node] = callExpressionFrame{
-					jestFnCall: jestFnCall,
-					isCatch:    isCatch,
-				}
-
-				if jestFnCall != nil && jestFnCall.Kind == jestUtils.JestFnTypeTest {
-					enterTestCase()
-				}
-
-				if isCatch {
-					inPromiseCatch = true
-				}
-
-				if jestFnCall == nil || jestFnCall.Kind != jestUtils.JestFnTypeExpect {
-					return
-				}
-
-				if inTestCase() && conditionalDepth > 0 {
-					ctx.ReportNode(node, buildConditionalExpectMessage())
-				}
-				if inPromiseCatch {
-					ctx.ReportNode(node, buildConditionalExpectMessage())
-				}
-			},
-			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
-				frame, ok := callExpressionFrames[node]
-				if ok {
-					delete(callExpressionFrames, node)
-				}
-
-				if frame.jestFnCall != nil && frame.jestFnCall.Kind == jestUtils.JestFnTypeTest {
-					exitTestCase()
-				}
-
-				if frame.isCatch {
-					inPromiseCatch = false
-				}
+var NoConditionalExpectRule = shared.NewRule(shared.Config{
+	Name: "jest/no-conditional-expect",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		return shared.Runtime{
+			TestCallbackFunctions: collectTestFunctionCallbacks(ctx),
+			ClassifyCall: func(node *ast.Node) (bool, bool) {
+				parsed := jestUtils.ParseJestFnCall(node, ctx)
+				return parsed != nil && parsed.Kind == jestUtils.JestFnTypeTest,
+					parsed != nil && parsed.Kind == jestUtils.JestFnTypeExpect
 			},
 		}
 	},
-}
+})

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -653,6 +653,18 @@ func TestNoConditionalExpectRule(t *testing.T) {
 				},
 			},
 			{
+				// The receiver of `.catch` need not resolve to a name: upstream
+				// `isCatchCall` only inspects the immediate property.
+				Code: `
+        it('works', async () => {
+          await promises[key].catch(error => expect(error).toBeInstanceOf(Error));
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
 				Code: `
         it('works', async () => {
           await Promise.resolve()

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -665,6 +665,27 @@ func TestNoConditionalExpectRule(t *testing.T) {
 				},
 			},
 			{
+				// Nested catches: leaving the inner one must not clear the outer.
+				// Upstream misses the second assertion; we track catch depth.
+				Code: `
+        it('works', async () => {
+          await a().catch(() => {
+            b().catch(() => { expect(1).toBe(1); });
+            expect(2).toBe(2);
+          });
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				// Chained catches nest in the AST, so upstream's bool is cleared
+				// by every inner exit and it reports only one of the three. Each
+				// callback is its own conditional assertion, so we report all
+				// three. Deliberate divergence: see the package doc comment on
+				// internal/utils/test_framework/rules/no_conditional_expect.
 				Code: `
         it('works', async () => {
           await Promise.resolve()
@@ -678,9 +699,12 @@ func TestNoConditionalExpectRule(t *testing.T) {
       `,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
 				},
 			},
 			{
+				// Same divergence as above.
 				Code: `
         it('works', async () => {
           await Promise.resolve()
@@ -690,6 +714,8 @@ func TestNoConditionalExpectRule(t *testing.T) {
         });
       `,
 				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
 					{MessageId: "conditionalExpect"},
 				},
 			},

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -15,6 +15,12 @@ func TestNoConditionalExpectRule(t *testing.T) {
 		t,
 		&no_conditional_expect.NoConditionalExpectRule,
 		[]rule_tester.ValidTestCase{
+			// A callback name that resolves to an uninitialized declaration must
+			// not reach SkipParentheses in the pending-name walk.
+			{Code: `it("case", cb);
+let cb;`},
+			{Code: `let cb;
+it("case", cb);`},
 			{Code: `
       it('foo', () => {
         expect(1).toBe(2);

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -2,6 +2,7 @@ package rstest
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_commented_out_tests"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
@@ -11,6 +12,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		no_commented_out_tests.NoCommentedOutTestsRule,
+		no_conditional_expect.NoConditionalExpectRule,
 		no_disabled_tests.NoDisabledTestsRule,
 		no_identical_title.NoIdenticalTitleRule,
 		no_mocks_import.NoMocksImportRule,

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
@@ -14,7 +14,7 @@ var NoConditionalExpectRule = shared.NewRule(shared.Config{
 		return shared.Runtime{
 			TestCallbackFunctions: callbacks.Functions,
 			ClassifyCall: func(node *ast.Node) (bool, bool) {
-				parsed := rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx)
+				parsed := callbacks.ParseFnCall(node)
 				return parsed != nil && parsed.Kind == rstestUtils.RstestFnTypeTest,
 					rstestUtils.IsRstestExpectCall(node, ctx, callbacks)
 			},

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
@@ -1,0 +1,23 @@
+package no_conditional_expect
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_conditional_expect"
+)
+
+var NoConditionalExpectRule = shared.NewRule(shared.Config{
+	Name: "rstest/no-conditional-expect",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		return shared.Runtime{
+			TestCallbackFunctions: callbacks.Functions,
+			ClassifyCall: func(node *ast.Node) (bool, bool) {
+				parsed := rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx)
+				return parsed != nil && parsed.Kind == rstestUtils.RstestFnTypeTest,
+					rstestUtils.IsRstestExpectCall(node, ctx, callbacks)
+			},
+		}
+	},
+})

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.md
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.md
@@ -1,0 +1,55 @@
+# no-conditional-expect
+
+## Rule Details
+
+Disallow calling Rstest `expect` APIs conditionally. When an assertion only
+runs on one branch, the test can pass without executing that assertion.
+
+Examples of incorrect code:
+
+```ts
+test("loads user", () => {
+  if (user) {
+    expect(user.name).toBe("Alice");
+  }
+});
+
+test("rejects", async () => {
+  await request().catch((error) => {
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+test("uses local expect", ({ expect }) => {
+  ready && expect(value).toBeDefined();
+});
+```
+
+The rule recognizes Rstest APIs from globals, `@rstest/core`,
+`import.meta.rstest`, test context `expect`, Browser Mode `expect.element`,
+and `@rstest/playwright`.
+
+Examples of correct code:
+
+```ts
+test("loads user", () => {
+  expect(user).toBeDefined();
+  expect(user?.name).toBe("Alice");
+});
+
+test("rejects", async () => {
+  await expect(request()).rejects.toThrow();
+});
+
+test("prepares conditionally", () => {
+  if (mode === "a") {
+    setupA();
+  } else {
+    setupB();
+  }
+
+  expect(result).toBeDefined();
+});
+```
+
+The rule has no options and does not provide an automatic fix.

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -59,9 +59,6 @@ test.describe("suite", () => {
 test.beforeEach(() => {
   if (condition) expect(value).toBe(1);
 });`},
-			{Code: `import.meta.rstest?.test("case", () => {
-  if (condition) import.meta.rstest?.expect(value).toBe(1);
-});`},
 			// A declaration without an initializer must not reach SkipParentheses
 			// while the expect root is being resolved.
 			{Code: `let logger;
@@ -75,6 +72,25 @@ export function run() { logger(); }`},
 let state;`},
 		},
 		[]rule_tester.InvalidTestCase{
+			// `import.meta.rstest` is typed optional, so `?.` is the idiomatic
+			// access and must not disable recognition of either the test call or
+			// the expect call.
+			{
+				Code: `import.meta.rstest.test("case", () => {
+  if (condition) import.meta.rstest?.expect(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import.meta.rstest?.test("case", () => {
+  if (condition) import.meta.rstest?.expect(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
 			{
 				Code: `test("case", () => {
   if (condition) expect(value).toBe(1);

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -62,6 +62,10 @@ test.beforeEach(() => {
 			{Code: `import.meta.rstest?.test("case", () => {
   if (condition) import.meta.rstest?.expect(value).toBe(1);
 });`},
+			// A declaration without an initializer must not reach SkipParentheses
+			// while the expect root is being resolved.
+			{Code: `let logger;
+export function run() { logger(); }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -121,6 +121,30 @@ let state;`},
 				},
 			},
 			{
+				// An unresolvable timeout in the third position must not stop the
+				// second argument from being treated as the callback.
+				Code: `test("case", ({ expect }) => { if (condition) expect(value).toBe(1); }, TIMEOUT);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `const TIMEOUT = 5000;
+test("case", ({ expect }) => { if (condition) expect(value).toBe(1); }, TIMEOUT);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				// The `(name, options, fn)` shape still resolves the third argument
+				// through the pending walk.
+				Code: `test("case", { timeout: 1 }, handler);
+function handler({ expect }) { if (condition) expect(value).toBe(1); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
 				Code: `import { expect as check, test } from "@rstest/core";
 test("case", () => { if (condition) check(value).toBe(1); });`,
 				Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -271,6 +271,31 @@ forCase("case", (row, context) => {
 				},
 			},
 			{
+				Code: `test("case", () => {
+  if (condition) log(expect(value).toBe(1));
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", () => {
+  if (condition) expect(value).toBe(expect.stringContaining("x"));
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", () => {
+  if (condition) results[expect(value).toBe(1)] = 1;
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
 				Code: `function callback() {
   if (condition) expect(value).toBe(1);
 }

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -66,6 +66,9 @@ test.beforeEach(() => {
 			// while the expect root is being resolved.
 			{Code: `let logger;
 export function run() { logger(); }`},
+			// Same, for a callback argument that resolves to an uninitialized
+			// declaration.
+			{Code: `let cb; cb = () => {}; test("case", cb);`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -69,6 +69,10 @@ export function run() { logger(); }`},
 			// Same, for a callback argument that resolves to an uninitialized
 			// declaration.
 			{Code: `let cb; cb = () => {}; test("case", cb);`},
+			// An unresolvable callback name starts the pending walk, which visits
+			// every declaration in the file including uninitialized ones.
+			{Code: `test("case", callback);
+let state;`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -271,6 +271,19 @@ forCase("case", (row, context) => {
 				},
 			},
 			{
+				// Leaving the inner catch must not clear the outer one.
+				Code: `test("case", async () => {
+  await a().catch(() => {
+    b().catch(() => { expect(1).toBe(1); });
+    expect(2).toBe(2);
+  });
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
 				Code: `test("case", () => {
   if (condition) log(expect(value).toBe(1));
 });`,

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -1,0 +1,293 @@
+package no_conditional_expect_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_expect"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConditionalExpectRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_conditional_expect.NoConditionalExpectRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `test("case", () => { expect(value).toBe(1); });`},
+			{Code: `test("case", () => {
+  if (condition) setup();
+  expect(value).toBe(1);
+});`},
+			{Code: `test("case", () => {
+  const expected = condition ? 1 : 2;
+  expect(value).toBe(expected);
+});`},
+			{Code: `test("case", () => {
+  try { run(); } catch { recover(); } finally {
+    expect(value).toBe(1);
+  }
+});`},
+			{Code: `describe("suite", () => {
+  if (condition) expect(value).toBe(1);
+});`},
+			{Code: `beforeEach(() => {
+  if (condition) expect(value).toBe(1);
+});`},
+			{Code: `import { expect } from "vitest";
+test("case", () => { if (condition) expect(value).toBe(1); });`},
+			{Code: `import { expect } from "@jest/globals";
+test("case", () => { if (condition) expect(value).toBe(1); });`},
+			{Code: `import { test, expect } from "@playwright/test";
+test("case", () => { if (condition) expect(value).toBe(1); });`},
+			{Code: `const expect = createAssertionLibrary();
+test("case", () => { if (condition) expect(value); });`},
+			{Code: `const custom = { expect };
+test("case", () => { if (condition) custom.expect(value).toBe(1); });`},
+			{Code: `test.each([[1]])("case", value => {
+  if (value) custom.expect(value);
+});`},
+			{Code: `test.each([{ expect: customExpect }])("case", ({ expect }) => {
+  if (condition) expect(value);
+});`},
+			{Code: `import { expect, test } from "@rstest/playwright";
+test.describe("suite", () => {
+  if (condition) expect(value).toBe(1);
+});`},
+			{Code: `import { expect, test } from "@rstest/playwright";
+test.beforeEach(() => {
+  if (condition) expect(value).toBe(1);
+});`},
+			{Code: `import.meta.rstest?.test("case", () => {
+  if (condition) import.meta.rstest?.expect(value).toBe(1);
+});`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `test("case", () => {
+  if (condition) expect(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect", Line: 2, Column: 18},
+				},
+			},
+			{
+				Code: `it("case", () => {
+  condition && expect(value).toBe(1);
+  condition || expect(other).toBe(2);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect", Line: 2, Column: 16},
+					{MessageId: "conditionalExpect", Line: 3, Column: 16},
+				},
+			},
+			{
+				Code: `test("case", () => {
+  condition ? expect(value).toBe(1) : expect(value).toBe(2);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", async () => {
+  try { await request(); } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+  }
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", async () => {
+  await request().catch(error => expect(error).toBeInstanceOf(Error));
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import { expect as check, test } from "@rstest/core";
+test("case", () => { if (condition) check(value).toBe(1); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `const { expect: check, test } = require("@rstest/core");
+test("case", () => { if (condition) check(value).toBe(1); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import * as rstest from "@rstest/core";
+rstest.test("case", () => {
+  if (condition) rstest.expect(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `const rstest = require("@rstest/core");
+rstest.test("case", () => {
+  if (condition) rstest["expect"](value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `if (import.meta.rstest) {
+  import.meta.rstest.test("case", () => {
+    if (condition) import.meta.rstest.expect(value).toBe(1);
+  });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `if (import.meta.rstest) {
+  const { test, expect: check } = import.meta.rstest;
+  test("case", () => { if (condition) check(value).toBe(1); });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `if (import.meta.rstest) {
+  const api = import.meta.rstest;
+  api.test("case", () => { if (condition) api.expect(value).toBe(1); });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", context => {
+  if (condition) context.expect(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", ({ expect: check }) => {
+  if (condition) check(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test.for([{ enabled: true }])("case", (row, context) => {
+  if (row.enabled) context.expect(row).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", { timeout: 100 }, ({ expect }) => {
+  if (condition) expect(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `const appTest = test.extend({});
+appTest.concurrent("case", ({ expect }) => {
+  if (condition) expect.soft(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", async () => {
+  if (condition) await expect.poll(readValue).toBe(1);
+  if (other) await expect.element(locator).toBeVisible();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `test("case", () => {
+  if (condition) {
+    expect.assertions(1);
+    expect.hasAssertions();
+    expect.unreachable();
+  }
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import { expect, test } from "@rstest/playwright";
+test.fail("case", async ({ page }) => {
+  if (condition) await expect.soft(page).toHaveTitle("Dashboard");
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import { expect as check, test as playwrightTest } from "@rstest/playwright";
+playwrightTest.extend({}).for([{ enabled: true }])("case", (row, context) => {
+  if (row.enabled) check(context).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import * as playwright from "@rstest/playwright";
+playwright.test("case", async ({ page }) => {
+  if (condition) await playwright.expect(page).toHaveTitle("Dashboard");
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `const forCase = test.for([{ enabled: true }]);
+forCase("case", (row, context) => {
+  if (row.enabled) context.expect(row).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `function callback() {
+  if (condition) expect(value).toBe(1);
+}
+test("case", callback);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `const callback = () => {
+  if (condition) expect(value).toBe(1);
+};
+test("case", { retry: 1 }, callback);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
@@ -1,8 +1,6 @@
 package no_disabled_tests
 
 import (
-	"slices"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -15,9 +13,11 @@ func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
 		return nil
 	}
 	return &shared.ParsedCall{
-		Call:    &parsed.ParsedCall,
-		HasSkip: slices.Contains(parsed.Members, "skip"),
-		HasTodo: slices.Contains(parsed.Members, "todo"),
+		Call: &parsed.ParsedCall,
+		// Semantic fields rather than Members, so `const skipped = test.skip`
+		// followed by `skipped('case', fn)` is still recognized.
+		HasSkip: parsed.Skipped,
+		HasTodo: parsed.Todo,
 	}
 }
 

--- a/internal/plugins/rstest/rules/no_identical_title/no_identical_title.go
+++ b/internal/plugins/rstest/rules/no_identical_title/no_identical_title.go
@@ -14,7 +14,7 @@ func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
 	}
 	return &shared.ParsedCall{
 		Call:          &parsed.ParsedCall,
-		Parameterized: parsed.Parameterized,
+		Parameterized: parsed.IsParameterized(),
 	}
 }
 

--- a/internal/plugins/rstest/utils/members_contract_test.go
+++ b/internal/plugins/rstest/utils/members_contract_test.go
@@ -1,0 +1,117 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func probeMessage(id string, description string) rule.RuleMessage {
+	return rule.RuleMessage{Id: id, Description: description}
+}
+
+// misalignedMembersProbe reports whenever a parsed call's Members and
+// MemberEntries disagree, so any such call shows up as an error on a test case
+// declared valid.
+var misalignedMembersProbe = rule.Rule{
+	Name:             "rstest/members-alignment-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestFnCall(node, ctx)
+				if parsed == nil {
+					return
+				}
+				aligned := len(parsed.Members) == len(parsed.MemberEntries)
+				if aligned {
+					for i := range parsed.Members {
+						if parsed.Members[i] != parsed.MemberEntries[i].Name {
+							aligned = false
+							break
+						}
+					}
+				}
+				if !aligned {
+					ctx.ReportNode(node, probeMessage(
+						"misaligned", "Members and MemberEntries disagree"))
+				}
+			},
+		}
+	},
+}
+
+// Members and MemberEntries are the syntactic view of a call: both cover exactly
+// the members written at the call site, so Members[i] == MemberEntries[i].Name
+// holds by construction, and neither carries members consumed while following a
+// const alias. Rules index one by the other, so feeding only Members would
+// misreport or go out of range.
+func TestMembersStayAlignedWithMemberEntries(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &misalignedMembersProbe,
+		[]rule_tester.ValidTestCase{
+			{Code: `test.skip.each([1])("case", cb);`},
+			{Code: `const skipped = test.skip; skipped("case", cb);`},
+			{Code: `const forCase = test.for([1]); forCase("case", cb);`},
+			{Code: `const appTest = test.extend({}); appTest.concurrent("case", cb);`},
+			{Code: `const base = test;
+const skipped = base.skip;
+skipped.each([1])("case", cb);`},
+			{Code: `import * as rstest from "@rstest/core";
+const skippedSuite = rstest.describe.skip;
+skippedSuite("suite", cb);`},
+			{Code: `describe.only("suite", cb);`},
+		},
+		[]rule_tester.InvalidTestCase{},
+	)
+}
+
+// semanticFlagProbe reports whenever a parsed call carries a semantic flag, so a
+// test case listed as invalid asserts that the flag survived alias resolution
+// even though Members is empty there.
+var semanticFlagProbe = rule.Rule{
+	Name:             "rstest/semantic-flag-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestFnCall(node, ctx)
+				if parsed == nil {
+					return
+				}
+				if parsed.Skipped || parsed.Todo || parsed.IsParameterized() {
+					ctx.ReportNode(node, probeMessage("flagged", "call carries a semantic flag"))
+				}
+			},
+		}
+	},
+}
+
+// The semantic fields carry across an alias what Members deliberately drops:
+// every invalid case below has an empty Members yet must still be flagged.
+func TestSemanticFieldsSurviveAliases(t *testing.T) {
+	flagged := []rule_tester.InvalidTestCaseError{{MessageId: "flagged"}}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &semanticFlagProbe,
+		[]rule_tester.ValidTestCase{
+			{Code: `test("case", cb);`},
+			{Code: `describe("suite", cb);`},
+			{Code: `const plain = test; plain("case", cb);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: `const skipped = test.skip; skipped("case", cb);`, Errors: flagged},
+			{Code: `const todoTest = test.todo; todoTest("case");`, Errors: flagged},
+			{Code: `const forCase = test.for([1]); forCase("case", cb);`, Errors: flagged},
+			{Code: `const base = test;
+const skipped = base.skip;
+skipped.each([1])("case", cb);`, Errors: flagged},
+			{Code: `import * as rstest from "@rstest/core";
+const skippedSuite = rstest.describe.skip;
+skippedSuite("suite", cb);`, Errors: flagged},
+		},
+	)
+}

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -31,23 +31,32 @@ func IsRstestExpectCall(
 	return isImportedOrGlobalExpectRoot(root, entries, ctx)
 }
 
+// findTopMostCallExpression walks up the call/member chain that node is the
+// head of. Ascending only continues while node stays on the callee side of its
+// parent: a call in argument or computed-key position heads its own chain.
 func findTopMostCallExpression(node *ast.Node) *ast.Node {
 	top := node
-	for parent := node.Parent; parent != nil; {
-		if parent.Kind == ast.KindParenthesizedExpression {
-			parent = parent.Parent
-			continue
-		}
-		if parent.Kind == ast.KindCallExpression {
+	current := node
+	for parent := current.Parent; parent != nil; {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+		case ast.KindCallExpression:
+			if parent.AsCallExpression().Expression != current {
+				return top
+			}
 			top = parent
-			parent = parent.Parent
-			continue
+		case ast.KindPropertyAccessExpression:
+			if parent.AsPropertyAccessExpression().Expression != current {
+				return top
+			}
+		case ast.KindElementAccessExpression:
+			if parent.AsElementAccessExpression().Expression != current {
+				return top
+			}
+		default:
+			return top
 		}
-		if parent.Kind != ast.KindPropertyAccessExpression &&
-			parent.Kind != ast.KindElementAccessExpression {
-			break
-		}
-		parent = parent.Parent
+		current, parent = parent, parent.Parent
 	}
 	return top
 }

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -1,0 +1,137 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+func IsRstestExpectCall(
+	node *ast.Node,
+	ctx rule.RuleContext,
+	callbacks RstestTestCallbacks,
+) bool {
+	if node == nil || node.Kind != ast.KindCallExpression || findTopMostCallExpression(node) != node {
+		return false
+	}
+
+	if isImportMetaRstestExpectCall(node) {
+		return true
+	}
+
+	entries := testFramework.GetMemberEntries(node)
+	if len(entries) == 0 || entries[0].Node == nil || entries[0].Node.Kind != ast.KindIdentifier {
+		return false
+	}
+
+	root := entries[0].Node
+	if isContextExpectRoot(root, entries, ctx, callbacks) {
+		return true
+	}
+	return isImportedOrGlobalExpectRoot(root, entries, ctx)
+}
+
+func findTopMostCallExpression(node *ast.Node) *ast.Node {
+	top := node
+	for parent := node.Parent; parent != nil; {
+		if parent.Kind == ast.KindParenthesizedExpression {
+			parent = parent.Parent
+			continue
+		}
+		if parent.Kind == ast.KindCallExpression {
+			top = parent
+			parent = parent.Parent
+			continue
+		}
+		if parent.Kind != ast.KindPropertyAccessExpression &&
+			parent.Kind != ast.KindElementAccessExpression {
+			break
+		}
+		parent = parent.Parent
+	}
+	return top
+}
+
+func isContextExpectRoot(
+	root *ast.Node,
+	entries []testFramework.MemberEntry,
+	ctx rule.RuleContext,
+	callbacks RstestTestCallbacks,
+) bool {
+	if ctx.TypeChecker == nil {
+		return false
+	}
+	symbol := ctx.TypeChecker.GetSymbolAtLocation(root)
+	if symbol == nil {
+		return false
+	}
+	if callbacks.ContextExpectNames[symbol] {
+		return true
+	}
+	return callbacks.ContextReceivers[symbol] &&
+		len(entries) > 1 &&
+		entries[1].Name == "expect"
+}
+
+func isImportedOrGlobalExpectRoot(
+	root *ast.Node,
+	entries []testFramework.MemberEntry,
+	ctx rule.RuleContext,
+) bool {
+	localName := root.AsIdentifier().Text
+	var symbol *ast.Symbol
+	if ctx.TypeChecker != nil {
+		symbol = ctx.TypeChecker.GetSymbolAtLocation(root)
+	}
+
+	if name, _, ok := resolveImportMetaRstestBinding(symbol); ok {
+		return name == "expect"
+	}
+	if isImportMetaRstestObjectAlias(symbol) {
+		return len(entries) > 1 && entries[1].Name == "expect"
+	}
+
+	for _, module := range []string{RstestImportModule, RstestPlaywrightImportModule} {
+		name, _, _ := testFramework.ResolveFunctionIdentifierReferenceFromSymbol(
+			localName,
+			root,
+			symbol,
+			ctx.SourceFile,
+			module,
+		)
+		if name == "expect" {
+			return true
+		}
+		if testFramework.IsModuleNamespaceSymbol(symbol, module) &&
+			len(entries) > 1 &&
+			entries[1].Name == "expect" {
+			return true
+		}
+	}
+	return false
+}
+
+func isImportMetaRstestExpectCall(node *ast.Node) bool {
+	call := node.AsCallExpression()
+	if call == nil {
+		return false
+	}
+	_, parts, _, ok := parseImportMetaRstestChain(call.Expression)
+	return ok && len(parts) > 0 && parts[0].name == "expect"
+}
+
+func isImportMetaRstestObjectAlias(symbol *ast.Symbol) bool {
+	if symbol == nil {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil || declaration.Kind != ast.KindVariableDeclaration {
+			continue
+		}
+		initializer := declaration.AsVariableDeclaration().Initializer
+		if isImportMetaRstest(initializer) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
@@ -38,27 +39,79 @@ type rstestResolvedAPI struct {
 	state        rstestAPIState
 	originalNode *ast.Node
 	mode         RstestImportMode
+	profile      rstestAPIProfile
 	// members collects every chain member applied to the resolved API,
 	// including members consumed while following same-file const aliases.
-	members []string
+	members           []string
+	parameterizedKind RstestParameterizedKind
 }
+
+type rstestAPIProfile uint8
+
+const (
+	rstestProfileCore rstestAPIProfile = iota
+	rstestProfilePlaywright
+)
 
 // ParseRstestFnCall parses a final Rstest test/describe registration call.
 // Factory calls such as test.each(cases), test.runIf(condition), and
 // test.extend(fixtures) are intentionally not returned.
 func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall {
+	return parseRstestFnCall(node, ctx, false, false)
+}
+
+func ParseRstestFnCallWithOfficialExtensions(
+	node *ast.Node,
+	ctx rule.RuleContext,
+) *ParsedRstestFnCall {
+	return parseRstestFnCall(node, ctx, true, true)
+}
+
+func parseRstestFnCall(
+	node *ast.Node,
+	ctx rule.RuleContext,
+	includeImportMeta bool,
+	includePlaywright bool,
+) *ParsedRstestFnCall {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return nil
 	}
 
 	call := node.AsCallExpression()
 	root, parts, rootInvoked, ok := parseRstestChain(call.Expression)
-	if !ok || rootInvoked || root == nil {
-		return nil
+	var resolved rstestResolvedAPI
+	consumed := 0
+	if ok && !rootInvoked && root != nil {
+		resolved, consumed, ok = resolveRstestRoot(
+			root,
+			parts,
+			ctx,
+			nil,
+			0,
+			includeImportMeta,
+			includePlaywright,
+		)
+	} else if includeImportMeta {
+		var importMetaRoot *ast.Node
+		importMetaRoot, parts, rootInvoked, ok = parseImportMetaRstestChain(call.Expression)
+		if ok && !rootInvoked && importMetaRoot != nil && len(parts) > 0 {
+			state := directRstestAPIState(rstestProfileCore, parts[0].name)
+			if state != rstestAPIInvalid && parts[0].invocation == rstestNotInvoked {
+				resolved = rstestResolvedAPI{
+					name:         parts[0].name,
+					state:        state,
+					originalNode: parts[0].node,
+					mode:         RSTEST_IMPORT_MODE,
+					profile:      rstestProfileCore,
+				}
+				root = importMetaRoot
+				consumed = 1
+			} else {
+				ok = false
+			}
+		}
 	}
-
-	resolved, consumed, ok := resolveRstestRoot(root, parts, ctx, nil, 0)
-	if !ok {
+	if !ok || root == nil {
 		return nil
 	}
 
@@ -94,7 +147,10 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 		})
 	}
 
-	localName := root.AsIdentifier().Text
+	localName := "import.meta.rstest"
+	if root.Kind == ast.KindIdentifier {
+		localName = root.AsIdentifier().Text
+	}
 	return &ParsedRstestFnCall{
 		ParsedCall: testFramework.ParsedCall{
 			Name:          resolved.name,
@@ -114,7 +170,8 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 				},
 			},
 		},
-		Parameterized: parameterized,
+		Parameterized:     parameterized,
+		ParameterizedKind: resolved.parameterizedKind,
 	}
 }
 
@@ -186,12 +243,83 @@ func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool)
 	}
 }
 
+func parseImportMetaRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return nil, nil, false, false
+	}
+	if ast.IsOptionalChain(node) {
+		return nil, nil, false, false
+	}
+	if isImportMetaRstest(node) {
+		return node, nil, false, true
+	}
+
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		root, parts, rootInvoked, ok := parseImportMetaRstestChain(property.Expression)
+		if !ok {
+			return nil, nil, false, false
+		}
+		nameNode := property.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return nil, nil, false, false
+		}
+		return root, append(parts, rstestChainPart{
+			name: nameNode.AsIdentifier().Text,
+			node: nameNode,
+		}), rootInvoked, true
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		root, parts, rootInvoked, ok := parseImportMetaRstestChain(element.Expression)
+		if !ok {
+			return nil, nil, false, false
+		}
+		nameNode := ast.SkipParentheses(element.ArgumentExpression)
+		name, ok := internalUtils.GetStaticStringLiteralValue(nameNode)
+		if !ok || name == "" {
+			return nil, nil, false, false
+		}
+		return root, append(parts, rstestChainPart{
+			name: name,
+			node: nameNode,
+		}), rootInvoked, true
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		root, parts, rootInvoked, ok := parseImportMetaRstestChain(call.Expression)
+		if !ok {
+			return nil, nil, false, false
+		}
+		if len(parts) == 0 {
+			return nil, nil, false, false
+		}
+		if parts[len(parts)-1].invocation != rstestNotInvoked {
+			return nil, nil, false, false
+		}
+		parts[len(parts)-1].invocation = rstestCallInvoked
+		return root, parts, rootInvoked, true
+	case ast.KindTaggedTemplateExpression:
+		tagged := node.AsTaggedTemplateExpression()
+		root, parts, rootInvoked, ok := parseImportMetaRstestChain(tagged.Tag)
+		if !ok || len(parts) == 0 || parts[len(parts)-1].invocation != rstestNotInvoked {
+			return nil, nil, false, false
+		}
+		parts[len(parts)-1].invocation = rstestTagInvoked
+		return root, parts, rootInvoked, true
+	default:
+		return nil, nil, false, false
+	}
+}
+
 func resolveRstestRoot(
 	root *ast.Node,
 	parts []rstestChainPart,
 	ctx rule.RuleContext,
 	visited map[*ast.Symbol]bool,
 	depth int,
+	includeImportMeta bool,
+	includePlaywright bool,
 ) (rstestResolvedAPI, int, bool) {
 	if root == nil || root.Kind != ast.KindIdentifier || depth > 16 {
 		return rstestResolvedAPI{}, 0, false
@@ -202,36 +330,57 @@ func resolveRstestRoot(
 	if ctx.TypeChecker != nil {
 		symbol = ctx.TypeChecker.GetSymbolAtLocation(root)
 	}
-	name, originalNode, mode := testFramework.ResolveFunctionIdentifierReferenceFromSymbol(
-		localName,
-		root,
-		symbol,
-		ctx.SourceFile,
-		RstestImportModule,
-	)
-	if state := directRstestAPIState(name); state != rstestAPIInvalid {
-		return rstestResolvedAPI{
-			name:         name,
-			state:        state,
-			originalNode: originalNode,
-			mode:         mode,
-		}, 0, true
+	for _, profile := range rstestProfiles(includePlaywright) {
+		module := profileImportModule(profile)
+		name, originalNode, mode := testFramework.ResolveFunctionIdentifierReferenceFromSymbol(
+			localName,
+			root,
+			symbol,
+			ctx.SourceFile,
+			module,
+		)
+		if state := directRstestAPIState(profile, name); state != rstestAPIInvalid {
+			return rstestResolvedAPI{
+				name:         name,
+				state:        state,
+				originalNode: originalNode,
+				mode:         mode,
+				profile:      profile,
+			}, 0, true
+		}
 	}
 
-	if testFramework.IsModuleNamespaceSymbol(symbol, RstestImportModule) {
-		if len(parts) == 0 || parts[0].invocation != rstestNotInvoked {
-			return rstestResolvedAPI{}, 0, false
+	if includeImportMeta {
+		if name, originalNode, ok := resolveImportMetaRstestBinding(symbol); ok {
+			if state := directRstestAPIState(rstestProfileCore, name); state != rstestAPIInvalid {
+				return rstestResolvedAPI{
+					name:         name,
+					state:        state,
+					originalNode: originalNode,
+					mode:         RSTEST_IMPORT_MODE,
+					profile:      rstestProfileCore,
+				}, 0, true
+			}
 		}
-		state := directRstestAPIState(parts[0].name)
-		if state == rstestAPIInvalid {
-			return rstestResolvedAPI{}, 0, false
+	}
+
+	for _, profile := range rstestProfiles(includePlaywright) {
+		if testFramework.IsModuleNamespaceSymbol(symbol, profileImportModule(profile)) {
+			if len(parts) == 0 || parts[0].invocation != rstestNotInvoked {
+				return rstestResolvedAPI{}, 0, false
+			}
+			state := directRstestAPIState(profile, parts[0].name)
+			if state == rstestAPIInvalid {
+				return rstestResolvedAPI{}, 0, false
+			}
+			return rstestResolvedAPI{
+				name:         parts[0].name,
+				state:        state,
+				originalNode: parts[0].node,
+				mode:         RSTEST_IMPORT_MODE,
+				profile:      profile,
+			}, 1, true
 		}
-		return rstestResolvedAPI{
-			name:         parts[0].name,
-			state:        state,
-			originalNode: parts[0].node,
-			mode:         RSTEST_IMPORT_MODE,
-		}, 1, true
 	}
 
 	if symbol == nil || (visited != nil && visited[symbol]) {
@@ -245,6 +394,22 @@ func resolveRstestRoot(
 		}
 		initializer := declaration.AsVariableDeclaration().Initializer
 		aliasRoot, aliasParts, aliasRootInvoked, ok := parseRstestChain(initializer)
+		if includeImportMeta && !ok && isImportMetaRstest(initializer) {
+			if len(parts) == 0 || parts[0].invocation != rstestNotInvoked {
+				continue
+			}
+			state := directRstestAPIState(rstestProfileCore, parts[0].name)
+			if state == rstestAPIInvalid {
+				continue
+			}
+			return rstestResolvedAPI{
+				name:         parts[0].name,
+				state:        state,
+				originalNode: parts[0].node,
+				mode:         RSTEST_IMPORT_MODE,
+				profile:      rstestProfileCore,
+			}, 1, true
+		}
 		if !ok || aliasRootInvoked {
 			continue
 		}
@@ -256,7 +421,15 @@ func resolveRstestRoot(
 			defer delete(visited, symbol)
 			tracking = true
 		}
-		resolved, consumed, ok := resolveRstestRoot(aliasRoot, aliasParts, ctx, visited, depth+1)
+		resolved, consumed, ok := resolveRstestRoot(
+			aliasRoot,
+			aliasParts,
+			ctx,
+			visited,
+			depth+1,
+			includeImportMeta,
+			includePlaywright,
+		)
 		if !ok {
 			continue
 		}
@@ -276,6 +449,36 @@ func resolveRstestRoot(
 	return rstestResolvedAPI{}, 0, false
 }
 
+func resolveImportMetaRstestBinding(symbol *ast.Symbol) (string, *ast.Node, bool) {
+	if symbol == nil {
+		return "", nil, false
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil || declaration.Kind != ast.KindBindingElement {
+			continue
+		}
+		variable := internalUtils.EnclosingVariableDeclarationOfBindingElement(declaration)
+		if variable == nil || !isImportMetaRstest(variable.AsVariableDeclaration().Initializer) {
+			continue
+		}
+		binding := declaration.AsBindingElement()
+		if binding.PropertyName != nil {
+			name, ok := internalUtils.GetStaticStringLiteralValue(binding.PropertyName)
+			if ok {
+				return name, binding.PropertyName, true
+			}
+			if binding.PropertyName.Kind == ast.KindIdentifier {
+				return binding.PropertyName.AsIdentifier().Text, binding.PropertyName, true
+			}
+		}
+		name := binding.Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text, name, true
+		}
+	}
+	return "", nil, false
+}
+
 func isConstRstestVariableDeclaration(declaration *ast.Node) bool {
 	return declaration != nil &&
 		declaration.Kind == ast.KindVariableDeclaration &&
@@ -285,9 +488,12 @@ func isConstRstestVariableDeclaration(declaration *ast.Node) bool {
 		declaration.AsVariableDeclaration().Initializer != nil
 }
 
-func directRstestAPIState(name string) rstestAPIState {
+func directRstestAPIState(profile rstestAPIProfile, name string) rstestAPIState {
 	switch name {
 	case "test", "it":
+		if profile == rstestProfilePlaywright && name == "it" {
+			return rstestAPIInvalid
+		}
 		return rstestAPITestWithExtend
 	case "describe":
 		return rstestAPIDescribe
@@ -296,12 +502,16 @@ func directRstestAPIState(name string) rstestAPIState {
 	}
 }
 
-func applyRstestChainPart(state rstestAPIState, part rstestChainPart) rstestAPIState {
+func applyRstestChainPart(profile rstestAPIProfile, state rstestAPIState, part rstestChainPart) rstestAPIState {
 	switch state {
 	case rstestAPITest, rstestAPITestWithExtend:
 		switch part.name {
 		case "only", "skip", "todo", "fails", "concurrent", "sequential":
 			if part.invocation == rstestNotInvoked {
+				return rstestAPITest
+			}
+		case "fail":
+			if profile == rstestProfilePlaywright && part.invocation == rstestNotInvoked {
 				return rstestAPITest
 			}
 		case "runIf", "skipIf":
@@ -315,6 +525,10 @@ func applyRstestChainPart(state rstestAPIState, part rstestChainPart) rstestAPIS
 		case "extend":
 			if state == rstestAPITestWithExtend && part.invocation == rstestCallInvoked {
 				return rstestAPITestWithExtend
+			}
+		case "describe":
+			if profile == rstestProfilePlaywright && part.invocation == rstestNotInvoked {
+				return rstestAPIDescribe
 			}
 		}
 	case rstestAPIDescribe:
@@ -337,12 +551,63 @@ func applyRstestChainPart(state rstestAPIState, part rstestChainPart) rstestAPIS
 }
 
 func applyResolvedRstestChainPart(resolved *rstestResolvedAPI, part rstestChainPart) bool {
-	state := applyRstestChainPart(resolved.state, part)
+	state := applyRstestChainPart(resolved.profile, resolved.state, part)
 	if state == rstestAPIInvalid {
+		resolved.state = rstestAPIInvalid
 		return false
 	}
-
 	resolved.state = state
 	resolved.members = append(resolved.members, part.name)
+	if part.name == "each" {
+		resolved.parameterizedKind = RstestParameterizedEach
+	} else if part.name == "for" {
+		resolved.parameterizedKind = RstestParameterizedFor
+	}
 	return true
+}
+
+func profileImportModule(profile rstestAPIProfile) string {
+	if profile == rstestProfilePlaywright {
+		return RstestPlaywrightImportModule
+	}
+	return RstestImportModule
+}
+
+func rstestProfiles(includePlaywright bool) []rstestAPIProfile {
+	if includePlaywright {
+		return []rstestAPIProfile{rstestProfileCore, rstestProfilePlaywright}
+	}
+	return []rstestAPIProfile{rstestProfileCore}
+}
+
+func isImportMetaRstest(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		return property.Name() != nil &&
+			property.Name().Text() == "rstest" &&
+			isImportMeta(property.Expression)
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		name, ok := internalUtils.GetStaticStringLiteralValue(ast.SkipParentheses(element.ArgumentExpression))
+		return ok && name == "rstest" && isImportMeta(element.Expression)
+	default:
+		return false
+	}
+}
+
+func isImportMeta(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil || node.Kind != ast.KindMetaProperty {
+		return false
+	}
+	meta := node.AsMetaProperty()
+	return meta != nil &&
+		scanner.TokenToString(meta.KeywordToken) == "import" &&
+		meta.Name() != nil &&
+		meta.Name().Text() == "meta"
 }

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -574,6 +574,11 @@ func rstestProfiles(includePlaywright bool) []rstestAPIProfile {
 }
 
 func isImportMetaRstest(node *ast.Node) bool {
+	// SkipParentheses dereferences its argument, so the nil check has to come
+	// first: callers pass initializers, which are nil for a bare `let x;`.
+	if node == nil {
+		return false
+	}
 	node = ast.SkipParentheses(node)
 	if node == nil {
 		return false

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -121,18 +121,11 @@ func parseRstestFnCall(
 		}
 	}
 
-	parameterized := false
 	switch resolved.state {
-	case rstestAPITest, rstestAPITestWithExtend:
+	case rstestAPITest, rstestAPITestWithExtend, rstestAPIParameterizedTest:
 		resolved.kind = RstestFnTypeTest
-	case rstestAPIDescribe:
+	case rstestAPIDescribe, rstestAPIParameterizedDescribe:
 		resolved.kind = RstestFnTypeDescribe
-	case rstestAPIParameterizedTest:
-		resolved.kind = RstestFnTypeTest
-		parameterized = true
-	case rstestAPIParameterizedDescribe:
-		resolved.kind = RstestFnTypeDescribe
-		parameterized = true
 	default:
 		return nil
 	}
@@ -170,7 +163,6 @@ func parseRstestFnCall(
 				},
 			},
 		},
-		Parameterized:     parameterized,
 		ParameterizedKind: resolved.parameterizedKind,
 	}
 }

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -558,9 +558,10 @@ func applyResolvedRstestChainPart(resolved *rstestResolvedAPI, part rstestChainP
 	}
 	resolved.state = state
 	resolved.members = append(resolved.members, part.name)
-	if part.name == "each" {
+	switch part.name {
+	case "each":
 		resolved.parameterizedKind = RstestParameterizedEach
-	} else if part.name == "for" {
+	case "for":
 		resolved.parameterizedKind = RstestParameterizedFor
 	}
 	return true

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -40,10 +40,13 @@ type rstestResolvedAPI struct {
 	originalNode *ast.Node
 	mode         RstestImportMode
 	profile      rstestAPIProfile
-	// members collects every chain member applied to the resolved API,
-	// including members consumed while following same-file const aliases.
-	members           []string
+	// Semantic conclusions, applied on both the call-site chain and the chain
+	// consumed while following same-file const aliases. Members deliberately
+	// carries no alias-internal information, so anything that has to hold
+	// across an alias belongs here instead.
 	parameterizedKind RstestParameterizedKind
+	skipped           bool
+	todo              bool
 }
 
 type rstestAPIProfile uint8
@@ -130,10 +133,16 @@ func parseRstestFnCall(
 		return nil
 	}
 
-	// MemberEntries only covers members written at the call site, because
-	// members resolved through an alias have no node in this expression.
+	// Members and MemberEntries are the syntactic view: both cover exactly the
+	// members written at the call site, in order, so Members[i] equals
+	// MemberEntries[i].Name. Members resolved through an alias are deliberately
+	// absent from both — they have no node in this expression, and a rule
+	// cannot tell them apart from call-site members. Conclusions that must hold
+	// across an alias are exposed as semantic fields instead.
+	members := make([]string, 0, len(parts)-consumed)
 	memberEntries := make([]ParsedRstestFnMemberEntry, 0, len(parts)-consumed)
 	for _, part := range parts[consumed:] {
+		members = append(members, part.name)
 		memberEntries = append(memberEntries, ParsedRstestFnMemberEntry{
 			Name: part.name,
 			Node: part.node,
@@ -149,7 +158,7 @@ func parseRstestFnCall(
 			Name:          resolved.name,
 			LocalName:     localName,
 			Kind:          resolved.kind,
-			Members:       resolved.members,
+			Members:       members,
 			MemberEntries: memberEntries,
 			Head: ParsedRstestFnCallHead{
 				Type: resolved.mode,
@@ -164,6 +173,8 @@ func parseRstestFnCall(
 			},
 		},
 		ParameterizedKind: resolved.parameterizedKind,
+		Skipped:           resolved.skipped,
+		Todo:              resolved.todo,
 	}
 }
 
@@ -552,12 +563,19 @@ func applyResolvedRstestChainPart(resolved *rstestResolvedAPI, part rstestChainP
 		return false
 	}
 	resolved.state = state
-	resolved.members = append(resolved.members, part.name)
+	// Only semantic conclusions are recorded here. This runs on the alias chain
+	// as well as the call-site chain, so anything accumulated becomes visible
+	// across aliases — which is why the member names themselves are collected
+	// by the caller from parts[consumed:] instead.
 	switch part.name {
 	case "each":
 		resolved.parameterizedKind = RstestParameterizedEach
 	case "for":
 		resolved.parameterizedKind = RstestParameterizedFor
+	case "skip":
+		resolved.skipped = true
+	case "todo":
+		resolved.todo = true
 	}
 	return true
 }

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -246,9 +246,6 @@ func parseImportMetaRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, b
 	if node == nil {
 		return nil, nil, false, false
 	}
-	if ast.IsOptionalChain(node) {
-		return nil, nil, false, false
-	}
 	if isImportMetaRstest(node) {
 		return node, nil, false, true
 	}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -168,6 +168,9 @@ func parseRstestFnCall(
 }
 
 func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool) {
+	if node == nil {
+		return nil, nil, false, false
+	}
 	node = ast.SkipParentheses(node)
 	if node == nil {
 		return nil, nil, false, false
@@ -236,6 +239,9 @@ func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool)
 }
 
 func parseImportMetaRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool) {
+	if node == nil {
+		return nil, nil, false, false
+	}
 	node = ast.SkipParentheses(node)
 	if node == nil {
 		return nil, nil, false, false
@@ -599,6 +605,9 @@ func isImportMetaRstest(node *ast.Node) bool {
 }
 
 func isImportMeta(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
 	node = ast.SkipParentheses(node)
 	if node == nil || node.Kind != ast.KindMetaProperty {
 		return false

--- a/internal/plugins/rstest/utils/parse_rstest_fn_nil_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn_nil_test.go
@@ -1,0 +1,34 @@
+package utils
+
+import "testing"
+
+// ast.SkipParentheses dereferences its argument, so every helper that may be
+// handed a nil node — an initializer, an optional expression — has to nil-check
+// before calling it. These are white-box tests because the call sites that
+// would reach them are currently all guarded; the point is to keep the helpers
+// safe if a future caller is not.
+func TestParseRstestChainAcceptsNil(t *testing.T) {
+	root, parts, rootInvoked, ok := parseRstestChain(nil)
+	if root != nil || parts != nil || rootInvoked || ok {
+		t.Fatalf("expected zero values, got (%v, %v, %v, %v)", root, parts, rootInvoked, ok)
+	}
+}
+
+func TestParseImportMetaRstestChainAcceptsNil(t *testing.T) {
+	root, parts, rootInvoked, ok := parseImportMetaRstestChain(nil)
+	if root != nil || parts != nil || rootInvoked || ok {
+		t.Fatalf("expected zero values, got (%v, %v, %v, %v)", root, parts, rootInvoked, ok)
+	}
+}
+
+func TestIsImportMetaAcceptsNil(t *testing.T) {
+	if isImportMeta(nil) {
+		t.Fatal("expected false")
+	}
+}
+
+func TestIsImportMetaRstestAcceptsNil(t *testing.T) {
+	if isImportMetaRstest(nil) {
+		t.Fatal("expected false")
+	}
+}

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -8,14 +8,24 @@ import (
 )
 
 const RstestImportModule = "@rstest/core"
+const RstestPlaywrightImportModule = "@rstest/playwright"
 
 type RstestFnType = testFramework.FnKind
 
 type RstestImportMode = testFramework.ReferenceMode
 
+type RstestParameterizedKind string
+
+const (
+	RstestParameterizedNone RstestParameterizedKind = ""
+	RstestParameterizedEach RstestParameterizedKind = "each"
+	RstestParameterizedFor  RstestParameterizedKind = "for"
+)
+
 type ParsedRstestFnCall struct {
 	testFramework.ParsedCall
-	Parameterized bool
+	Parameterized     bool
+	ParameterizedKind RstestParameterizedKind
 }
 
 type ParsedRstestFnCallHead = testFramework.ParsedCallHead

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -24,8 +24,13 @@ const (
 
 type ParsedRstestFnCall struct {
 	testFramework.ParsedCall
-	Parameterized     bool
 	ParameterizedKind RstestParameterizedKind
+}
+
+// IsParameterized reports whether the call was registered through `.each` or
+// `.for`. This survives alias resolution, unlike the call site's Members.
+func (parsed *ParsedRstestFnCall) IsParameterized() bool {
+	return parsed.ParameterizedKind != RstestParameterizedNone
 }
 
 type ParsedRstestFnCallHead = testFramework.ParsedCallHead

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -25,6 +25,11 @@ const (
 type ParsedRstestFnCall struct {
 	testFramework.ParsedCall
 	ParameterizedKind RstestParameterizedKind
+	// Skipped and Todo report whether the call carries `.skip` / `.todo`.
+	// Like ParameterizedKind these are semantic conclusions that survive alias
+	// resolution, so prefer them over scanning Members, which is call-site only.
+	Skipped bool
+	Todo    bool
 }
 
 // IsParameterized reports whether the call was registered through `.each` or

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -10,6 +10,35 @@ type RstestTestCallbacks struct {
 	Functions          map[*ast.Node]bool
 	ContextReceivers   map[*ast.Symbol]bool
 	ContextExpectNames map[*ast.Symbol]bool
+	fnCalls            *rstestFnCallCache
+}
+
+// rstestFnCallCache memoizes call parsing so that the collection walk and the
+// rule traversal that follows it do not each parse every call expression.
+type rstestFnCallCache struct {
+	ctx    rule.RuleContext
+	parsed map[*ast.Node]*ParsedRstestFnCall
+}
+
+func (cache *rstestFnCallCache) parse(node *ast.Node) *ParsedRstestFnCall {
+	if cache == nil {
+		return nil
+	}
+	if parsed, ok := cache.parsed[node]; ok {
+		return parsed
+	}
+	parsed := ParseRstestFnCallWithOfficialExtensions(node, cache.ctx)
+	cache.parsed[node] = parsed
+	return parsed
+}
+
+// ParseFnCall parses node the way CollectRstestTestCallbacks did, reusing the
+// cached result when the collection walk already visited node.
+func (callbacks RstestTestCallbacks) ParseFnCall(node *ast.Node) *ParsedRstestFnCall {
+	if callbacks.fnCalls == nil {
+		return nil
+	}
+	return callbacks.fnCalls.parse(node)
 }
 
 type rstestCallbackInfo struct {
@@ -23,6 +52,10 @@ func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
 		Functions:          map[*ast.Node]bool{},
 		ContextReceivers:   map[*ast.Symbol]bool{},
 		ContextExpectNames: map[*ast.Symbol]bool{},
+		fnCalls: &rstestFnCallCache{
+			ctx:    ctx,
+			parsed: map[*ast.Node]*ParsedRstestFnCall{},
+		},
 	}
 	pending := map[string][]*ParsedRstestFnCall{}
 
@@ -32,7 +65,7 @@ func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
 			return
 		}
 		if node.Kind == ast.KindCallExpression {
-			parsed := ParseRstestFnCallWithOfficialExtensions(node, ctx)
+			parsed := result.fnCalls.parse(node)
 			if parsed != nil && parsed.Kind == RstestFnTypeTest {
 				info := resolveRstestTestCallback(ctx, parsed, node.AsCallExpression())
 				if info.functionNode != nil {

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -44,7 +44,6 @@ func (callbacks RstestTestCallbacks) ParseFnCall(node *ast.Node) *ParsedRstestFn
 type rstestCallbackInfo struct {
 	functionNode *ast.Node
 	name         string
-	parsed       *ParsedRstestFnCall
 }
 
 func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
@@ -67,7 +66,7 @@ func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
 		if node.Kind == ast.KindCallExpression {
 			parsed := result.fnCalls.parse(node)
 			if parsed != nil && parsed.Kind == RstestFnTypeTest {
-				info := resolveRstestTestCallback(ctx, parsed, node.AsCallExpression())
+				info := resolveRstestTestCallback(ctx, node.AsCallExpression())
 				if info.functionNode != nil {
 					recordRstestCallback(ctx, &result, info.functionNode, parsed)
 				} else if info.name != "" {
@@ -92,7 +91,6 @@ func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
 
 func resolveRstestTestCallback(
 	ctx rule.RuleContext,
-	parsed *ParsedRstestFnCall,
 	call *ast.CallExpression,
 ) rstestCallbackInfo {
 	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
@@ -105,7 +103,6 @@ func resolveRstestTestCallback(
 	// there must not shadow the real callback in the second position.
 	if len(arguments) >= 3 {
 		if info := resolveRstestCallbackArgument(ctx, arguments[2]); info.functionNode != nil {
-			info.parsed = parsed
 			return info
 		}
 	}
@@ -115,11 +112,9 @@ func resolveRstestTestCallback(
 		// The second argument is not a callback at all, so an unresolved name in
 		// the third position is still worth deferring to the pending walk.
 		if third := resolveRstestCallbackArgument(ctx, arguments[2]); third.name != "" {
-			third.parsed = parsed
 			return third
 		}
 	}
-	info.parsed = parsed
 	return info
 }
 

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -1,0 +1,222 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type RstestTestCallbacks struct {
+	Functions          map[*ast.Node]bool
+	ContextReceivers   map[*ast.Symbol]bool
+	ContextExpectNames map[*ast.Symbol]bool
+}
+
+type rstestCallbackInfo struct {
+	functionNode *ast.Node
+	name         string
+	parsed       *ParsedRstestFnCall
+}
+
+func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
+	result := RstestTestCallbacks{
+		Functions:          map[*ast.Node]bool{},
+		ContextReceivers:   map[*ast.Symbol]bool{},
+		ContextExpectNames: map[*ast.Symbol]bool{},
+	}
+	pending := map[string][]*ParsedRstestFnCall{}
+
+	var visit func(*ast.Node)
+	visit = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindCallExpression {
+			parsed := ParseRstestFnCallWithOfficialExtensions(node, ctx)
+			if parsed != nil && parsed.Kind == RstestFnTypeTest {
+				info := resolveRstestTestCallback(ctx, parsed, node.AsCallExpression())
+				if info.functionNode != nil {
+					recordRstestCallback(ctx, &result, info.functionNode, parsed)
+				} else if info.name != "" {
+					pending[info.name] = append(pending[info.name], parsed)
+				}
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return false
+		})
+	}
+
+	if ctx.SourceFile != nil {
+		visit(ctx.SourceFile.Node.AsNode())
+	}
+	if len(pending) > 0 {
+		resolvePendingRstestCallbacks(ctx, &result, pending)
+	}
+	return result
+}
+
+func resolveRstestTestCallback(
+	ctx rule.RuleContext,
+	parsed *ParsedRstestFnCall,
+	call *ast.CallExpression,
+) rstestCallbackInfo {
+	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+		return rstestCallbackInfo{}
+	}
+
+	arguments := call.Arguments.Nodes
+	if len(arguments) >= 3 {
+		if info := resolveRstestCallbackArgument(ctx, arguments[2]); info.functionNode != nil || info.name != "" {
+			info.parsed = parsed
+			return info
+		}
+	}
+
+	info := resolveRstestCallbackArgument(ctx, arguments[1])
+	info.parsed = parsed
+	return info
+}
+
+func resolveRstestCallbackArgument(ctx rule.RuleContext, argument *ast.Node) rstestCallbackInfo {
+	argument = ast.SkipParentheses(argument)
+	if argument == nil {
+		return rstestCallbackInfo{}
+	}
+	if ast.IsFunctionExpressionOrArrowFunction(argument) {
+		return rstestCallbackInfo{functionNode: argument}
+	}
+	if argument.Kind != ast.KindIdentifier {
+		return rstestCallbackInfo{}
+	}
+
+	name := argument.AsIdentifier().Text
+	declaration := internalUtils.GetDeclaration(ctx.TypeChecker, argument)
+	if declaration == nil {
+		return rstestCallbackInfo{name: name}
+	}
+	switch declaration.Kind {
+	case ast.KindFunctionDeclaration:
+		return rstestCallbackInfo{functionNode: declaration, name: name}
+	case ast.KindVariableDeclaration:
+		initializer := ast.SkipParentheses(declaration.AsVariableDeclaration().Initializer)
+		if ast.IsFunctionExpressionOrArrowFunction(initializer) {
+			return rstestCallbackInfo{functionNode: initializer, name: name}
+		}
+	}
+	return rstestCallbackInfo{}
+}
+
+func resolvePendingRstestCallbacks(
+	ctx rule.RuleContext,
+	result *RstestTestCallbacks,
+	pending map[string][]*ParsedRstestFnCall,
+) {
+	var visit func(*ast.Node)
+	visit = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+
+		name := ""
+		var function *ast.Node
+		switch node.Kind {
+		case ast.KindFunctionDeclaration:
+			declaration := node.AsFunctionDeclaration()
+			if declaration != nil && declaration.Name() != nil {
+				name = declaration.Name().Text()
+				function = node
+			}
+		case ast.KindVariableDeclaration:
+			declaration := node.AsVariableDeclaration()
+			if declaration != nil && declaration.Name() != nil && declaration.Name().Kind == ast.KindIdentifier {
+				name = declaration.Name().AsIdentifier().Text
+				initializer := ast.SkipParentheses(declaration.Initializer)
+				if ast.IsFunctionExpressionOrArrowFunction(initializer) {
+					function = initializer
+				}
+			}
+		}
+
+		if function != nil {
+			for _, parsed := range pending[name] {
+				recordRstestCallback(ctx, result, function, parsed)
+			}
+			delete(pending, name)
+		}
+
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return false
+		})
+	}
+
+	if ctx.SourceFile != nil {
+		visit(ctx.SourceFile.Node.AsNode())
+	}
+}
+
+func recordRstestCallback(
+	ctx rule.RuleContext,
+	result *RstestTestCallbacks,
+	function *ast.Node,
+	parsed *ParsedRstestFnCall,
+) {
+	if function == nil {
+		return
+	}
+	result.Functions[function] = true
+
+	contextIndex := 0
+	switch parsed.ParameterizedKind {
+	case RstestParameterizedEach:
+		return
+	case RstestParameterizedFor:
+		contextIndex = 1
+	}
+
+	parameters := function.Parameters()
+	if contextIndex >= len(parameters) {
+		return
+	}
+	parameter := parameters[contextIndex].AsParameterDeclaration()
+	if parameter == nil || parameter.Name() == nil || ctx.TypeChecker == nil {
+		return
+	}
+	name := parameter.Name()
+	switch name.Kind {
+	case ast.KindIdentifier:
+		if symbol := ctx.TypeChecker.GetSymbolAtLocation(name); symbol != nil {
+			result.ContextReceivers[symbol] = true
+		}
+	case ast.KindObjectBindingPattern:
+		pattern := name.AsBindingPattern()
+		if pattern == nil || pattern.Elements == nil {
+			return
+		}
+		for _, element := range pattern.Elements.Nodes {
+			if element == nil || element.Kind != ast.KindBindingElement {
+				continue
+			}
+			binding := element.AsBindingElement()
+			if binding == nil || binding.Name() == nil || binding.Name().Kind != ast.KindIdentifier {
+				continue
+			}
+			propertyName := binding.Name().AsIdentifier().Text
+			if binding.PropertyName != nil {
+				if value, ok := internalUtils.GetStaticStringLiteralValue(binding.PropertyName); ok {
+					propertyName = value
+				} else if binding.PropertyName.Kind == ast.KindIdentifier {
+					propertyName = binding.PropertyName.AsIdentifier().Text
+				}
+			}
+			if propertyName != "expect" {
+				continue
+			}
+			if symbol := ctx.TypeChecker.GetSymbolAtLocation(binding.Name()); symbol != nil {
+				result.ContextExpectNames[symbol] = true
+			}
+		}
+	}
+}

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -100,14 +100,25 @@ func resolveRstestTestCallback(
 	}
 
 	arguments := call.Arguments.Nodes
+	// The third argument is the callback only in the `(name, options, fn)` shape.
+	// In `(name, fn, timeout)` it is a timeout, and an unresolvable identifier
+	// there must not shadow the real callback in the second position.
 	if len(arguments) >= 3 {
-		if info := resolveRstestCallbackArgument(ctx, arguments[2]); info.functionNode != nil || info.name != "" {
+		if info := resolveRstestCallbackArgument(ctx, arguments[2]); info.functionNode != nil {
 			info.parsed = parsed
 			return info
 		}
 	}
 
 	info := resolveRstestCallbackArgument(ctx, arguments[1])
+	if info.functionNode == nil && info.name == "" && len(arguments) >= 3 {
+		// The second argument is not a callback at all, so an unresolved name in
+		// the third position is still worth deferring to the pending walk.
+		if third := resolveRstestCallbackArgument(ctx, arguments[2]); third.name != "" {
+			third.parsed = parsed
+			return third
+		}
+	}
 	info.parsed = parsed
 	return info
 }

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -172,9 +172,11 @@ func resolvePendingRstestCallbacks(
 			declaration := node.AsVariableDeclaration()
 			if declaration != nil && declaration.Name() != nil && declaration.Name().Kind == ast.KindIdentifier {
 				name = declaration.Name().AsIdentifier().Text
-				initializer := ast.SkipParentheses(declaration.Initializer)
-				if ast.IsFunctionExpressionOrArrowFunction(initializer) {
-					function = initializer
+				if declaration.Initializer != nil {
+					initializer := ast.SkipParentheses(declaration.Initializer)
+					if ast.IsFunctionExpressionOrArrowFunction(initializer) {
+						function = initializer
+					}
 				}
 			}
 		}

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -113,6 +113,9 @@ func resolveRstestTestCallback(
 }
 
 func resolveRstestCallbackArgument(ctx rule.RuleContext, argument *ast.Node) rstestCallbackInfo {
+	if argument == nil {
+		return rstestCallbackInfo{}
+	}
 	argument = ast.SkipParentheses(argument)
 	if argument == nil {
 		return rstestCallbackInfo{}
@@ -133,7 +136,11 @@ func resolveRstestCallbackArgument(ctx rule.RuleContext, argument *ast.Node) rst
 	case ast.KindFunctionDeclaration:
 		return rstestCallbackInfo{functionNode: declaration, name: name}
 	case ast.KindVariableDeclaration:
-		initializer := ast.SkipParentheses(declaration.AsVariableDeclaration().Initializer)
+		initializer := declaration.AsVariableDeclaration().Initializer
+		if initializer == nil {
+			return rstestCallbackInfo{}
+		}
+		initializer = ast.SkipParentheses(initializer)
 		if ast.IsFunctionExpressionOrArrowFunction(initializer) {
 			return rstestCallbackInfo{functionNode: initializer, name: name}
 		}

--- a/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
@@ -1,3 +1,20 @@
+// Package no_conditional_expect holds the framework-neutral traversal shared by
+// jest/no-conditional-expect and rstest/no-conditional-expect.
+//
+// Known deliberate divergences from eslint-plugin-jest's no-conditional-expect.
+// Both fix cases where upstream loses nesting state; do not "restore parity" by
+// turning either back into a bool.
+//
+//  1. Test-case tracking is a depth counter, not a bool. Upstream sets
+//     `inTestCase = true` and clears it on any test call's exit, so a nested
+//     test registration ends the enclosing one early.
+//  2. Promise-catch tracking is a depth counter, not a bool. Upstream clears
+//     `inPromiseCatch` when an inner `.catch` exits, so assertions later in an
+//     outer `.catch` body go unreported.
+//
+// Behavior intentionally kept identical to upstream: an `expect` that is both
+// inside a conditional and inside a `.catch` is reported twice at the same
+// range, because the two checks are independent.
 package no_conditional_expect
 
 import (
@@ -65,11 +82,15 @@ func NewRule(config Config) rule.Rule {
 			runtime := config.Prepare(ctx)
 			testCaseDepth := 0
 			conditionalDepth := 0
-			inPromiseCatch := false
+			promiseCatchDepth := 0
 			callExpressionFrames := map[*ast.Node]callExpressionFrame{}
 
 			inTestCase := func() bool {
 				return testCaseDepth > 0
+			}
+
+			inPromiseCatch := func() bool {
+				return promiseCatchDepth > 0
 			}
 
 			enterTestCase := func() {
@@ -141,7 +162,7 @@ func NewRule(config Config) rule.Rule {
 						enterTestCase()
 					}
 					if isCatch {
-						inPromiseCatch = true
+						promiseCatchDepth++
 					}
 					if !isExpect {
 						return
@@ -149,7 +170,7 @@ func NewRule(config Config) rule.Rule {
 					if inTestCase() && conditionalDepth > 0 {
 						ctx.ReportNode(node, buildConditionalExpectMessage())
 					}
-					if inPromiseCatch {
+					if inPromiseCatch() {
 						ctx.ReportNode(node, buildConditionalExpectMessage())
 					}
 				},
@@ -161,8 +182,8 @@ func NewRule(config Config) rule.Rule {
 					if frame.isTest {
 						exitTestCase()
 					}
-					if frame.isCatch {
-						inPromiseCatch = false
+					if frame.isCatch && promiseCatchDepth > 0 {
+						promiseCatchDepth--
 					}
 				},
 			}

--- a/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
@@ -1,0 +1,171 @@
+package no_conditional_expect
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type Runtime struct {
+	TestCallbackFunctions map[*ast.Node]bool
+	ClassifyCall          func(*ast.Node) (isTest bool, isExpect bool)
+}
+
+type Config struct {
+	Name    string
+	Prepare func(rule.RuleContext) Runtime
+}
+
+func buildConditionalExpectMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "conditionalExpect",
+		Description: "Avoid calling `expect` conditionally",
+	}
+}
+
+func isPromiseCatchCall(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	name := calleeChainName(node.AsCallExpression().Expression)
+	return name == "catch" || strings.HasSuffix(name, ".catch")
+}
+
+func calleeChainName(node *ast.Node) string {
+	entries := testFramework.GetMemberEntries(node)
+	return testFramework.JoinMemberEntries(entries)
+}
+
+func isConditionalNode(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindCatchClause,
+		ast.KindIfStatement,
+		ast.KindSwitchStatement,
+		ast.KindConditionalExpression:
+		return true
+	case ast.KindBinaryExpression:
+		return ast.IsLogicalExpression(node)
+	default:
+		return false
+	}
+}
+
+type callExpressionFrame struct {
+	isTest  bool
+	isCatch bool
+}
+
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+			runtime := config.Prepare(ctx)
+			testCaseDepth := 0
+			conditionalDepth := 0
+			inPromiseCatch := false
+			callExpressionFrames := map[*ast.Node]callExpressionFrame{}
+
+			inTestCase := func() bool {
+				return testCaseDepth > 0
+			}
+
+			enterTestCase := func() {
+				testCaseDepth++
+			}
+
+			exitTestCase := func() {
+				if testCaseDepth > 0 {
+					testCaseDepth--
+				}
+			}
+
+			enterConditional := func(node *ast.Node) {
+				if inTestCase() && isConditionalNode(node) {
+					conditionalDepth++
+				}
+			}
+
+			exitConditional := func(node *ast.Node) {
+				if inTestCase() && conditionalDepth > 0 && isConditionalNode(node) {
+					conditionalDepth--
+				}
+			}
+
+			enterTestCallbackFunction := func(node *ast.Node) {
+				if runtime.TestCallbackFunctions[node] {
+					enterTestCase()
+				}
+			}
+
+			exitTestCallbackFunction := func(node *ast.Node) {
+				if runtime.TestCallbackFunctions[node] {
+					exitTestCase()
+				}
+			}
+
+			return rule.RuleListeners{
+				ast.KindFunctionDeclaration:                      enterTestCallbackFunction,
+				rule.ListenerOnExit(ast.KindFunctionDeclaration): exitTestCallbackFunction,
+				ast.KindFunctionExpression:                       enterTestCallbackFunction,
+				rule.ListenerOnExit(ast.KindFunctionExpression):  exitTestCallbackFunction,
+				ast.KindArrowFunction:                            enterTestCallbackFunction,
+				rule.ListenerOnExit(ast.KindArrowFunction):       exitTestCallbackFunction,
+
+				ast.KindCatchClause:                                enterConditional,
+				rule.ListenerOnExit(ast.KindCatchClause):           exitConditional,
+				ast.KindIfStatement:                                enterConditional,
+				rule.ListenerOnExit(ast.KindIfStatement):           exitConditional,
+				ast.KindSwitchStatement:                            enterConditional,
+				rule.ListenerOnExit(ast.KindSwitchStatement):       exitConditional,
+				ast.KindConditionalExpression:                      enterConditional,
+				rule.ListenerOnExit(ast.KindConditionalExpression): exitConditional,
+				ast.KindBinaryExpression:                           enterConditional,
+				rule.ListenerOnExit(ast.KindBinaryExpression):      exitConditional,
+
+				ast.KindCallExpression: func(node *ast.Node) {
+					isTest := false
+					isExpect := false
+					if runtime.ClassifyCall != nil {
+						isTest, isExpect = runtime.ClassifyCall(node)
+					}
+					isCatch := isPromiseCatchCall(node)
+					callExpressionFrames[node] = callExpressionFrame{
+						isTest:  isTest,
+						isCatch: isCatch,
+					}
+
+					if isTest {
+						enterTestCase()
+					}
+					if isCatch {
+						inPromiseCatch = true
+					}
+					if !isExpect {
+						return
+					}
+					if inTestCase() && conditionalDepth > 0 {
+						ctx.ReportNode(node, buildConditionalExpectMessage())
+					}
+					if inPromiseCatch {
+						ctx.ReportNode(node, buildConditionalExpectMessage())
+					}
+				},
+				rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+					frame, ok := callExpressionFrames[node]
+					if ok {
+						delete(callExpressionFrames, node)
+					}
+					if frame.isTest {
+						exitTestCase()
+					}
+					if frame.isCatch {
+						inPromiseCatch = false
+					}
+				},
+			}
+		},
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -545,6 +545,7 @@ export default defineConfig({
 
     // rstest
     './tests/rstest/rules/no-commented-out-tests.test.ts',
+    './tests/rstest/rules/no-conditional-expect.test.ts',
     './tests/rstest/rules/no-disabled-tests.test.ts',
     './tests/rstest/rules/no-identical-title.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -76,6 +76,7 @@ describe('defineConfig and config presets', () => {
     expect(rec.plugins).toContain('rstest');
     expect(rec.rules).toEqual({
       'rstest/no-commented-out-tests': 'warn',
+      'rstest/no-conditional-expect': 'error',
       'rstest/no-disabled-tests': 'warn',
       'rstest/no-identical-title': 'error',
       'rstest/no-mocks-import': 'error',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-conditional-expect.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-conditional-expect.test.ts
@@ -623,6 +623,11 @@ ruleTester.run('no-conditional-expect', {} as never, {
       errors: [{ messageId: 'conditionalExpect' }],
     },
     {
+      // Chained catches nest in the AST, so upstream's bool is cleared by every
+      // inner exit and it reports only one of the three. Each callback is its
+      // own conditional assertion, so we report all three. Deliberate
+      // divergence: see the package doc comment on
+      // internal/utils/test_framework/rules/no_conditional_expect.
       code: `
         it('works', async () => {
           await Promise.resolve()
@@ -634,9 +639,14 @@ ruleTester.run('no-conditional-expect', {} as never, {
             .catch(error => expect(error).toBeInstanceOf(Error));
         });
       `,
-      errors: [{ messageId: 'conditionalExpect' }],
+      errors: [
+        { messageId: 'conditionalExpect' },
+        { messageId: 'conditionalExpect' },
+        { messageId: 'conditionalExpect' },
+      ],
     },
     {
+      // Same divergence as above.
       code: `
         it('works', async () => {
           await Promise.resolve()
@@ -645,7 +655,11 @@ ruleTester.run('no-conditional-expect', {} as never, {
             .catch(error => expect(error).toBeInstanceOf(Error));
         });
       `,
-      errors: [{ messageId: 'conditionalExpect' }],
+      errors: [
+        { messageId: 'conditionalExpect' },
+        { messageId: 'conditionalExpect' },
+        { messageId: 'conditionalExpect' },
+      ],
     },
     {
       code: `

--- a/packages/rslint-test-tools/tests/rstest/rules/no-conditional-expect.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-conditional-expect.test.ts
@@ -1,0 +1,74 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-conditional-expect', {} as never, {
+  valid: [
+    {
+      code: `
+        test('case', () => {
+          if (condition) setup();
+          expect(value).toBe(1);
+        });
+      `,
+    },
+    {
+      code: `
+        describe('suite', () => {
+          if (condition) expect(value).toBe(1);
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('case', () => {
+          if (condition) expect(value).toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'conditionalExpect', line: 4, column: 26 }],
+    },
+    {
+      code: `
+        test('case', ({ expect }) => {
+          condition && expect(value).toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'conditionalExpect', line: 3, column: 24 }],
+    },
+    {
+      code: `
+        if (import.meta.rstest) {
+          const { test, expect } = import.meta.rstest;
+          test('case', () => {
+            condition && expect(value).toBe(1);
+          });
+        }
+      `,
+      errors: [{ messageId: 'conditionalExpect', line: 5, column: 26 }],
+    },
+    {
+      code: `
+        test('browser case', async () => {
+          if (condition) {
+            await expect.element(locator).toBeVisible();
+          }
+        });
+      `,
+      errors: [{ messageId: 'conditionalExpect', line: 4, column: 19 }],
+    },
+    {
+      code: `
+        import { expect, test } from '@rstest/playwright';
+        test.fail('playwright case', async ({ page }) => {
+          if (condition) {
+            await expect.soft(page).toHaveTitle('Dashboard');
+          }
+        });
+      `,
+      errors: [{ messageId: 'conditionalExpect', line: 5, column: 19 }],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -4,6 +4,7 @@ const recommended: RslintConfigEntry = {
   plugins: ['rstest'],
   rules: {
     'rstest/no-commented-out-tests': 'warn',
+    'rstest/no-conditional-expect': 'error',
     'rstest/no-disabled-tests': 'warn',
     'rstest/no-identical-title': 'error',
     'rstest/no-mocks-import': 'error',


### PR DESCRIPTION
## Summary

- add `rstest/no-conditional-expect` and enable it in the recommended preset
- share conditional-expect traversal between Jest and Rstest; this changes Jest behavior in two ways, detailed below
- support Rstest assertions from globals, `@rstest/core`, `import.meta.rstest`, test context, Browser Mode, and `@rstest/playwright`
- extend Rstest call parsing for parameterized tests, callback overloads, aliases, and official extension APIs
- add Go unit tests, JS integration tests, and rule documentation

## Jest-side impact

Extracting the traversal into `internal/utils/test_framework/rules/no_conditional_expect/` means `jest/no-conditional-expect` now runs the shared code. Two behavior changes follow, both widening what the rule reports. No case that previously reported stops reporting.

**1. `.catch` receivers that do not resolve to a name are now recognized.**

`isPromiseCatchCall` moved from `jestUtils.CalleeChainName` to `GetMemberEntries` + `JoinMemberEntries`. The two differ when the object part yields no name — `CalleeChainName` propagates `""` upward, the member-entry form drops the unresolvable prefix and keeps the `catch` entry:

```js
it('works', async () => {
  await promises[key].catch(error => expect(error).toBeInstanceOf(Error));
});
// before: not treated as a promise catch  →  after: reported
```

This aligns with upstream, whose `isCatchCall` only inspects the immediate property and never looks at the receiver. Covered by a new test.

**2. Promise-catch tracking is now a depth counter, not a bool — a deliberate divergence from `eslint-plugin-jest`.**

Upstream clears `inPromiseCatch` whenever any `.catch` call exits, which loses the enclosing state. Because chained `.catch` calls **nest in the AST** — the outermost call holds the inner ones in its callee subtree — this affects ordinary chains, not just lexically nested ones:

```js
it('works', async () => {
  await Promise.resolve()
    .catch(error => expect(error).toBeInstanceOf(Error))
    .catch(error => expect(error).toBeInstanceOf(Error))
    .catch(error => expect(error).toBeInstanceOf(Error));
});
// upstream and this rule before: 1 error
// after: 3 errors
```

Each callback is an independent assertion that only runs on its own rejection path, so three is the correct answer. `eslint-plugin-jest`'s own fixtures assert one error here, so the previous behavior was a faithful port rather than a bug — the change is intentional. Two existing test expectations were updated from 1 to 3 accordingly, and a nested-catch regression test was added.

Note that the rule already diverged from upstream on the same axis before this PR: test-case tracking has been a depth counter, where upstream uses a bool that a nested test registration ends early. Both divergences are now recorded in a package doc comment on the shared traversal so a later "restore parity" pass cannot silently revert them.

Behavior deliberately left identical to upstream: an `expect` that sits inside both a conditional and a `.catch` is still reported twice at the same range, since the two checks are independent.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
