### PR TITLE
perf: optimize no-const-assign hot paths

### DIFF
--- a/internal/rules/no_const_assign/no_const_assign.go
+++ b/internal/rules/no_const_assign/no_const_assign.go
@@ -1,6 +1,8 @@
 package no_const_assign
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -14,49 +16,47 @@ func buildConstMessage(name string) rule.RuleMessage {
 	}
 }
 
-// NoConstAssignRule disallows reassigning const variables
+func isConstantBindingSymbol(symbol *ast.Symbol, sourceFile *ast.SourceFile) bool {
+	if symbol == nil || sourceFile == nil {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if ast.GetSourceFileOfNode(declaration) != sourceFile {
+			continue
+		}
+		declList := utils.GetDeclListForSymbolDecl(declaration)
+		if declList != nil && declList.Flags&ast.NodeFlagsConstant != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// NoConstAssignRule disallows reassigning constant variables.
 var NoConstAssignRule = rule.Rule{
 	Name: "no-const-assign",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// Track const declarations by their symbol
-		constSymbols := make(map[*ast.Symbol]bool)
+		// Every constant variable declaration contains one of these literal
+		// keywords. Avoid an identifier listener when the rule cannot report;
+		// false positives in comments or strings only retain the normal path.
+		if ctx.SourceFile != nil {
+			text := ctx.SourceFile.Text()
+			if !strings.Contains(text, "const") && !strings.Contains(text, "using") {
+				return nil
+			}
+		}
 
 		return rule.RuleListeners{
-			// Track const variable declarations
-			ast.KindVariableDeclarationList: func(node *ast.Node) {
-				if node.Flags&ast.NodeFlagsConst == 0 {
-					return
-				}
-
-				declList := node.AsVariableDeclarationList()
-				if declList == nil || declList.Declarations == nil {
-					return
-				}
-
-				for _, decl := range declList.Declarations.Nodes {
-					if decl.Kind != ast.KindVariableDeclaration {
-						continue
-					}
-					varDecl := decl.AsVariableDeclaration()
-					if varDecl == nil || varDecl.Name() == nil {
-						continue
-					}
-					for _, sym := range utils.BindingSymbols(varDecl.Name()) {
-						constSymbols[sym] = true
-					}
-				}
-			},
-
 			// Check every write reference in the file — including shorthand
 			// destructuring writes like `({x} = {x: 1})`, since ctx.Refs.Resolve
 			// resolves the shorthand name's own binding symbol rather than the
 			// property symbol a TypeChecker lookup would otherwise return.
 			ast.KindIdentifier: func(node *ast.Node) {
-				if len(constSymbols) == 0 || !utils.IsWriteReference(node) {
+				if !utils.IsWriteReference(node) {
 					return
 				}
-				sym := ctx.Refs.Resolve(node)
-				if sym == nil || !constSymbols[sym] {
+				symbol := ctx.Refs.Resolve(node)
+				if !isConstantBindingSymbol(symbol, ctx.SourceFile) {
 					return
 				}
 				ctx.ReportNode(node, buildConstMessage(node.Text()))

--- a/internal/rules/no_const_assign/no_const_assign.md
+++ b/internal/rules/no_const_assign/no_const_assign.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-Disallows reassigning `const` variables. Variables declared with `const` cannot be reassigned after their initial declaration. Attempting to modify them (via assignment, increment, decrement, or destructuring assignment) is always a mistake and would throw a `TypeError` at runtime.
+Disallows reassigning variables declared with `const`, `using`, or `await using`. These constant bindings cannot be reassigned after their initial declaration. Attempting to modify them (via assignment, increment, decrement, or destructuring assignment) is always a mistake and would throw a `TypeError` at runtime.
 
 Examples of **incorrect** code for this rule:
 
@@ -18,6 +18,9 @@ z = 3;
 
 const [a, b] = [1, 2];
 [a, b] = [3, 4];
+
+using resource = acquireResource();
+resource = acquireOtherResource();
 ```
 
 Examples of **correct** code for this rule:
@@ -31,6 +34,9 @@ y = 1;
 
 const obj = {};
 obj.key = 'value'; // mutating properties is fine
+
+using resource = acquireResource();
+resource.use();
 ```
 
 ## Original Documentation

--- a/internal/rules/no_const_assign/no_const_assign_test.go
+++ b/internal/rules/no_const_assign/no_const_assign_test.go
@@ -30,6 +30,10 @@ func TestNoConstAssignRule(t *testing.T) {
 			// For-of loop - x is redeclared on each iteration
 			{Code: `for (const x of [1,2,3]) { foo(x); }`},
 
+			// Explicit resource management bindings are constant but may be read.
+			{Code: `function f() { using x = foo(); bar(x); }`},
+			{Code: `async function f() { await using x = foo(); bar(x); }`},
+
 			// Modifying property, not reassigning the constant
 			{Code: `const x = {key: 0}; x.key = 1;`},
 
@@ -38,6 +42,17 @@ func TestNoConstAssignRule(t *testing.T) {
 
 			// let can be reassigned
 			{Code: `let x = 0; x = 1;`},
+
+			// Keyword filter false positives must not change symbol semantics.
+			{Code: `let constable = 0; constable = 1;`},
+
+			// The DOM global `name` is declared with const in lib.dom.d.ts, but
+			// this rule only owns constant declarations in the linted file.
+			{Code: `const local = 0; name = "value";`},
+
+			// A later mutable declaration shadows the outer constant for the
+			// entire block, including its temporal dead zone.
+			{Code: `const x = 0; { x = 1; let x; }`},
 
 			// Function declaration can be reassigned
 			{Code: `function x() {} x = 1;`},
@@ -59,6 +74,9 @@ func TestNoConstAssignRule(t *testing.T) {
 
 			// Const object with method calls
 			{Code: `const x = {}; x.method();`},
+
+			// A using binding's object may be mutated without reassigning it.
+			{Code: `function f() { using x = foo(); x.value = 1; }`},
 
 			// Reading const in conditional
 			{Code: `const x = 0; if (x === 0) {}`},
@@ -124,11 +142,34 @@ func TestNoConstAssignRule(t *testing.T) {
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
+			// References are resolved against declarations that occur later in
+			// the same scope as well as declarations already visited.
+			{
+				Code: "x = 1;\nconst x = 0;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 1, Column: 1},
+				},
+			},
+
 			// Direct reassignment
 			{
 				Code: `const x = 0; x = 1;`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "const", Line: 1, Column: 14},
+				},
+			},
+
+			// `using` and `await using` declarations are constant bindings too.
+			{
+				Code: "function f() {\n  using x = foo();\n  x = 1;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 3, Column: 3},
+				},
+			},
+			{
+				Code: "async function f() {\n  await using x = foo();\n  x ||= bar();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 3, Column: 3},
 				},
 			},
 
@@ -153,6 +194,38 @@ func TestNoConstAssignRule(t *testing.T) {
 				Code: `const x = 0; x += 1;`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "const", Line: 1, Column: 14},
+				},
+			},
+
+			// A pre-existing constant is written by a for-of initializer.
+			{
+				Code: `const x = 0; for (x of values) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 1, Column: 19},
+				},
+			},
+
+			// TypeScript wrappers do not hide an assignment target.
+			{
+				Code: `const x = 0; (x as any) = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 1, Column: 15},
+				},
+			},
+
+			// Defaults inside an assignment pattern still write the target.
+			{
+				Code: `const x = 0; [x = 1] = values;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 1, Column: 15},
+				},
+			},
+
+			// Resource bindings remain constant inside destructuring writes.
+			{
+				Code: "function f() {\n  using x = foo();\n  [x, y] = bar();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 3, Column: 4},
 				},
 			},
 


### PR DESCRIPTION
## Summary

- Remove the per-file const-symbol map and declaration listener. Write references now use `ctx.Refs.Resolve` and inspect the resolved symbol's constant declaration in the current source file.
- Skip the identifier listener when the source cannot contain a `const`, `using`, or `await using` declaration.
- Preserve shorthand/destructuring and shadowing behavior while covering writes before declarations, `using`/`await using` bindings, and cross-file global isolation.
- Update the rule documentation and add adversarial coverage for declaration order, TDZ shadowing, for-of writes, TypeScript assignment wrappers, destructuring defaults, resource bindings, and DOM globals.

### Benchmarks

Apple M1 Max, darwin/arm64, `GOMAXPROCS=1`. The temporary rule-only benchmark was not committed. Time is the median of 8 alternating baseline/final 1-second samples; allocation figures are medians from 10 `benchmem` samples.

| Workload | Baseline ns/op | Final ns/op | Time | Baseline B/op | Final B/op | Bytes | Baseline allocs/op | Final allocs/op | Allocs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| No constant declarations | 114,342 | 82,943 | -27.73% | 3,142 | 2,821 | -10.2% | 36 | 29 | -19.4% |
| Read-heavy constants | 147,716 | 139,380 | -5.80% | 7,772 | 3,086 | -60.3% | 46 | 33 | -28.3% |
| Write-heavy constants | 332,680 | 319,964 | -3.94% | 149,264 | 144,544 | -3.2% | 1,583 | 1,569 | -0.9% |
| Destructuring writes | 234,390 | 198,585 | -15.42% | 92,915 | 73,803 | -20.6% | 818 | 801 | -2.1% |

### Verification

- `go test ./internal/rules/no_const_assign -run '^TestNoConstAssignRule$' -count=1`
- `pnpm check-spell`
- `pnpm format:check`
- `pnpm exec golangci-lint run ./internal/rules/no_const_assign/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
