### PR TITLE
perf: optimize prefer-as-const hot paths

### DIFF
--- a/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const.go
+++ b/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const.go
@@ -5,165 +5,131 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func buildPreferConstAssertionMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "preferConstAssertion",
-		Description: "Expected a `const` instead of a literal type assertion.",
-	}
+var preferConstAssertionMessage = rule.RuleMessage{
+	Id:          "preferConstAssertion",
+	Description: "Expected a `const` instead of a literal type assertion.",
 }
 
-func buildVariableConstAssertionMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "variableConstAssertion",
-		Description: "Expected a `const` assertion instead of a literal type annotation.",
-	}
+var variableConstAssertionMessage = rule.RuleMessage{
+	Id:          "variableConstAssertion",
+	Description: "Expected a `const` assertion instead of a literal type annotation.",
 }
 
-func buildVariableSuggestMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "variableSuggest",
-		Description: "You should use `as const` instead of type annotation.",
+var variableSuggestMessage = rule.RuleMessage{
+	Id:          "variableSuggest",
+	Description: "You should use `as const` instead of type annotation.",
+}
+
+const (
+	constAssertionText = "const"
+	asConstSuffixText  = " as const"
+)
+
+func trimmedLiteralRange(sourceText string, node *ast.Node) (core.TextRange, bool) {
+	start := scanner.SkipTrivia(sourceText, node.Pos())
+	end := node.End()
+	if start < 0 || start > end || end > len(sourceText) {
+		return core.TextRange{}, false
 	}
+	return core.NewTextRange(start, end), true
+}
+
+func isComparableLiteral(node *ast.Node) bool {
+	kind := node.Kind
+	// ESTree represents booleans as Literal nodes, while ts-go's literal-token
+	// range excludes keyword literals. Null remains excluded because ESTree
+	// represents a null type annotation as TSNullKeyword, not TSLiteralType.
+	return kind >= ast.KindFirstLiteralToken && kind <= ast.KindLastLiteralToken ||
+		kind == ast.KindTrueKeyword || kind == ast.KindFalseKeyword
+}
+
+func matchingLiteralRange(sourceText string, valueNode *ast.Node, typeNode *ast.Node) (core.TextRange, bool) {
+	literalNode := typeNode.AsLiteralTypeNode().Literal
+	if literalNode == nil || !isComparableLiteral(literalNode) ||
+		literalNode.Kind == ast.KindNoSubstitutionTemplateLiteral {
+		return core.TextRange{}, false
+	}
+
+	valueRange, ok := trimmedLiteralRange(sourceText, valueNode)
+	if !ok {
+		return core.TextRange{}, false
+	}
+	literalRange, ok := trimmedLiteralRange(sourceText, literalNode)
+	if !ok || valueRange.End()-valueRange.Pos() != literalRange.End()-literalRange.Pos() ||
+		sourceText[valueRange.Pos():valueRange.End()] != sourceText[literalRange.Pos():literalRange.End()] {
+		return core.TextRange{}, false
+	}
+	return literalRange, true
+}
+
+// TypeScript starts a parsed type node immediately after its annotation colon;
+// trivia between the colon and the first type token belongs to the type node.
+func typeAnnotationRange(sourceText string, typeNode *ast.Node) (core.TextRange, bool) {
+	colonStart := typeNode.Pos() - 1
+	if colonStart < 0 || typeNode.End() > len(sourceText) || sourceText[colonStart] != ':' {
+		return core.TextRange{}, false
+	}
+	return core.NewTextRange(colonStart, typeNode.End()), true
+}
+
+func compareLiteralTypes(ctx *rule.RuleContext, sourceText string, valueNode *ast.Node, typeNode *ast.Node, canFix bool) {
+	literalRange, matches := matchingLiteralRange(sourceText, valueNode, typeNode)
+	if !matches {
+		return
+	}
+
+	if canFix {
+		ctx.ReportRangeWithDeferredFixes(literalRange, preferConstAssertionMessage, func() []rule.RuleFix {
+			return []rule.RuleFix{rule.RuleFixReplaceRange(literalRange, constAssertionText)}
+		})
+		return
+	}
+
+	ctx.ReportRangeWithDeferredSuggestions(literalRange, variableConstAssertionMessage, func() []rule.RuleSuggestion {
+		annotationRange, ok := typeAnnotationRange(sourceText, typeNode)
+		if !ok {
+			return nil
+		}
+		return []rule.RuleSuggestion{
+			{
+				Message: variableSuggestMessage,
+				FixesArr: []rule.RuleFix{
+					rule.RuleFixReplaceRange(annotationRange, ""),
+					rule.RuleFixInsertAfter(valueNode, asConstSuffixText),
+				},
+			},
+		}
+	})
 }
 
 var PreferAsConstRule = rule.CreateRule(rule.Rule{
 	Name: "prefer-as-const",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-
 		compareTypes := func(valueNode *ast.Node, typeNode *ast.Node, canFix bool) {
-			if valueNode == nil || typeNode == nil {
+			if valueNode == nil || typeNode == nil ||
+				!isComparableLiteral(valueNode) || typeNode.Kind != ast.KindLiteralType {
 				return
 			}
-
-			// Check if valueNode is a literal and typeNode is a literal type
-			if !ast.IsLiteralExpression(valueNode) {
-				return
-			}
-
-			var isLiteralType bool
-			var literalNode *ast.Node
-
-			if ast.IsLiteralTypeNode(typeNode) {
-				literalTypeNode := typeNode.AsLiteralTypeNode()
-				if literalTypeNode == nil {
-					return
-				}
-				literalNode = literalTypeNode.Literal
-				isLiteralType = true
-			} else {
-				return
-			}
-
-			if !isLiteralType || literalNode == nil {
-				return
-			}
-
-			// Check if both are literals and have the same raw value
-			if !ast.IsLiteralExpression(literalNode) {
-				return
-			}
-
-			// Skip template literal types - they are different from regular literal types
-			if literalNode.Kind == ast.KindNoSubstitutionTemplateLiteral {
-				return
-			}
-
-			valueRange := utils.TrimNodeTextRange(ctx.SourceFile, valueNode)
-			valueText := ctx.SourceFile.Text()[valueRange.Pos():valueRange.End()]
-			typeRange := utils.TrimNodeTextRange(ctx.SourceFile, literalNode)
-			typeText := ctx.SourceFile.Text()[typeRange.Pos():typeRange.End()]
-
-			if valueText == typeText {
-				if canFix {
-					// For type assertions, we can directly fix to 'const'
-					ctx.ReportNodeWithFixes(literalNode, buildPreferConstAssertionMessage(),
-						rule.RuleFixReplace(ctx.SourceFile, typeNode, "const"))
-				} else {
-					// For variable declarations, suggest replacing with 'as const'
-					// We need to find the colon token before the type annotation
-					// and remove from there to the end of the type annotation
-					parent := typeNode.Parent
-					if parent != nil {
-						// Find the colon token between the variable name and type
-						s := scanner.GetScannerForSourceFile(ctx.SourceFile, parent.Pos())
-						colonStart := -1
-						for s.TokenStart() < typeNode.Pos() {
-							if s.Token() == ast.KindColonToken {
-								colonStart = s.TokenStart()
-							}
-							s.Scan()
-						}
-
-						if colonStart != -1 {
-							ctx.ReportNodeWithSuggestions(literalNode, buildVariableConstAssertionMessage(),
-								rule.RuleSuggestion{
-									Message: buildVariableSuggestMessage(),
-									FixesArr: []rule.RuleFix{
-										rule.RuleFixReplaceRange(
-											core.NewTextRange(colonStart, typeNode.End()),
-											"",
-										),
-										rule.RuleFixInsertAfter(valueNode, " as const"),
-									},
-								})
-						}
-					}
-				}
-			}
+			compareLiteralTypes(&ctx, ctx.SourceFile.Text(), valueNode, typeNode, canFix)
 		}
-
 		return rule.RuleListeners{
-			// PropertyDefinition in TypeScript corresponds to PropertyDeclaration in Go AST
 			ast.KindPropertyDeclaration: func(node *ast.Node) {
-				if node.Kind != ast.KindPropertyDeclaration {
-					return
-				}
-				propDecl := node.AsPropertyDeclaration()
-				if propDecl == nil {
-					return
-				}
-				if propDecl.Initializer != nil && propDecl.Type != nil {
-					compareTypes(propDecl.Initializer, propDecl.Type, false)
-				}
+				declaration := node.AsPropertyDeclaration()
+				compareTypes(declaration.Initializer, declaration.Type, false)
 			},
-
 			ast.KindAsExpression: func(node *ast.Node) {
-				if node.Kind != ast.KindAsExpression {
-					return
-				}
-				asExpr := node.AsAsExpression()
-				if asExpr == nil {
-					return
-				}
-				compareTypes(asExpr.Expression, asExpr.Type, true)
+				expression := node.AsAsExpression()
+				compareTypes(expression.Expression, expression.Type, true)
 			},
-
 			ast.KindTypeAssertionExpression: func(node *ast.Node) {
-				if node.Kind != ast.KindTypeAssertionExpression {
-					return
-				}
-				typeAssertion := node.AsTypeAssertion()
-				if typeAssertion == nil {
-					return
-				}
-				compareTypes(typeAssertion.Expression, typeAssertion.Type, true)
+				expression := node.AsTypeAssertion()
+				compareTypes(expression.Expression, expression.Type, true)
 			},
-
-			// VariableDeclarator in TypeScript corresponds to VariableDeclaration in Go AST
 			ast.KindVariableDeclaration: func(node *ast.Node) {
-				if node.Kind != ast.KindVariableDeclaration {
-					return
-				}
-				varDecl := node.AsVariableDeclaration()
-				if varDecl == nil {
-					return
-				}
-				if varDecl.Initializer != nil && varDecl.Type != nil {
-					compareTypes(varDecl.Initializer, varDecl.Type, false)
-				}
+				declaration := node.AsVariableDeclaration()
+				compareTypes(declaration.Initializer, declaration.Type, false)
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const_test.go
+++ b/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const_test.go
@@ -3,7 +3,11 @@ package prefer_as_const
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -21,8 +25,13 @@ func TestPreferAsConstRule(t *testing.T) {
 		{Code: "let foo = `bar` as `bar`;"},
 		{Code: "let foo = `bar` as `foo`;"},
 		{Code: "let foo = `bar` as 'bar';"},
+		{Code: `let foo = "bar" as 'bar';`},
+		{Code: `let foo = '\x62ar' as 'bar';`},
+		{Code: `let foo = 1.0 as 1;`},
+		{Code: `let foo = -1 as -1;`},
 		{Code: "let foo: string = 'bar';"},
 		{Code: "let foo: number = 1;"},
+		{Code: "let foo: null = null;"},
 		{Code: "let foo: 'bar' = baz;"},
 		{Code: "let foo = 'bar';"},
 		{Code: "let foo: 'bar';"},
@@ -321,5 +330,155 @@ class foo {
 }
 			`},
 		},
+		{
+			Code: `let truth: true = true;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "variableConstAssertion",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "variableSuggest",
+							Output:    `let truth = true as const;`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `let falsity = false as false;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferConstAssertion"},
+			},
+			Output: []string{`let falsity = false as const;`},
+		},
+		{
+			Code: `let value /* before colon */ : /* after: colon */ '值' = /* before value */ '值';`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "variableConstAssertion",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "variableSuggest",
+							Output:    `let value /* before colon */  = /* before value */ '值' as const;`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `class C { readonly ['x:y'] /* before colon */ : /* after: colon */ '值' = /* before value */ '值'; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "variableConstAssertion",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "variableSuggest",
+							Output:    `class C { readonly ['x:y'] /* before colon */  = /* before value */ '值' as const; }`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const value = /* before value */ '值' as /* before type */ '值';`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferConstAssertion"},
+			},
+			Output: []string{`const value = /* before value */ '值' as /* before type */ const;`},
+		},
+		{
+			Code: `const value = < /* before type */ '值'>/* before value */ '值';`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferConstAssertion"},
+			},
+			Output: []string{`const value = < /* before type */ const>/* before value */ '值';`},
+		},
 	})
+}
+
+func TestPreferAsConstDefersEdits(t *testing.T) {
+	const source = `let annotation /* before colon */ : /* after: colon */ '值' = /* before value */ '值';
+const assertion = /* before value */ 'x' as /* before type */ 'x';`
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/prefer-as-const.ts",
+			Path:     "/prefer-as-const.ts",
+		}, source, core.ScriptKindTS)
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(
+			PreferAsConstRule.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		)
+
+		listeners := PreferAsConstRule.Run(ctx, nil)
+		var visit func(*ast.Node) bool
+		visit = func(node *ast.Node) bool {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+			node.ForEachChild(visit)
+			return false
+		}
+		visit(sourceFile.AsNode())
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	if len(diagnosticsOnly) != 2 {
+		t.Fatalf("diagnostics-only run produced %d diagnostics, want 2", len(diagnosticsOnly))
+	}
+	for _, diagnostic := range diagnosticsOnly {
+		if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+			t.Fatalf("diagnostics-only %s report materialized edits", diagnostic.Message.Id)
+		}
+	}
+
+	withEdits := run(rule.EditDemandAll)
+	if len(withEdits) != 2 {
+		t.Fatalf("edit-demand run produced %d diagnostics, want 2", len(withEdits))
+	}
+	for _, diagnostic := range withEdits {
+		switch diagnostic.Message.Id {
+		case "preferConstAssertion":
+			fixes := diagnostic.Fixes()
+			if len(fixes) != 1 {
+				t.Fatalf("assertion report produced %d fixes, want 1", len(fixes))
+			}
+			fix := fixes[0]
+			if got := source[fix.Range.Pos():fix.Range.End()]; got != "'x'" {
+				t.Fatalf("assertion fix replaces %q, want 'x'", got)
+			}
+			if fix.Text != constAssertionText {
+				t.Fatalf("assertion replacement = %q, want %q", fix.Text, constAssertionText)
+			}
+		case "variableConstAssertion":
+			if diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != 1 {
+				t.Fatal("annotation report did not produce exactly one suggestion")
+			}
+			fixes := (*diagnostic.Suggestions)[0].Fixes()
+			if len(fixes) != 2 {
+				t.Fatalf("annotation suggestion produced %d fixes, want 2", len(fixes))
+			}
+			if got := source[fixes[0].Range.Pos():fixes[0].Range.End()]; got != ": /* after: colon */ '值'" {
+				t.Fatalf("annotation removal covers %q", got)
+			}
+			if fixes[1].Range.Pos() != fixes[1].Range.End() || fixes[1].Text != asConstSuffixText {
+				t.Fatalf("annotation insertion = %#v", fixes[1])
+			}
+		default:
+			t.Fatalf("unexpected diagnostic %q", diagnostic.Message.Id)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Replace repeated token scanners used for literal text/range lookup with ranges derived from parsed nodes plus source trivia, and derive type-annotation removal ranges directly from parser positions.
- Defer autofix and suggestion materialization until the diagnostic consumer requests the corresponding edits.
- Preserve raw-literal spelling semantics, comments, Unicode ranges, assertion fixes, and annotation suggestions; align boolean literals with the upstream ESTree rule while keeping null, template, signed, and raw-mismatch cases excluded.
- Keep the optimization entirely within the rule. `ctx.Refs` was evaluated but is not applicable because the rule performs no identifier or symbol-reference analysis.

### Benchmark

Temporary rule-local Go benchmark and embedded main-branch reference implementation, both removed before commit. Parsing and candidate collection are outside the timed region; every operation runs `Rule.Run` and 256 candidate listener events. Values are medians of 8 runs with 1,000 fixed iterations on Go 1.26.1, darwin/arm64, Apple M1 Max, `GOMAXPROCS=1`.

| Scenario | Before | After | Time |
| --- | ---: | ---: | ---: |
| No match | 3,264 ns/op; 416 B/op; 8 allocs/op | 3,013 ns/op; 416 B/op; 8 allocs/op | -7.7% |
| Literal mismatch | 87,768 ns/op; 125,344 B/op; 776 allocs/op | 7,970 ns/op; 416 B/op; 8 allocs/op | -90.9% |
| Assertion, diagnostics only | 242,994 ns/op; 348,576 B/op; 2,568 allocs/op | 11,132 ns/op; 416 B/op; 8 allocs/op | -95.4% |
| Assertion, autofix | 263,001 ns/op; 348,576 B/op; 2,568 allocs/op | 27,162 ns/op; 12,704 B/op; 520 allocs/op | -89.7% |
| Annotation, diagnostics only | 254,998 ns/op; 371,104 B/op; 2,824 allocs/op | 11,510 ns/op; 416 B/op; 8 allocs/op | -95.5% |
| Annotation, suggestions | 255,058 ns/op; 371,104 B/op; 2,824 allocs/op | 44,419 ns/op; 35,232 B/op; 776 allocs/op | -82.6% |

Benchmark command:

`GOMAXPROCS=1 go test -buildvcs=false ./internal/plugins/typescript/rules/prefer_as_const -run '^$' -bench '^BenchmarkPreferAsConstRule(Baseline)?$' -benchmem -benchtime=1000x -count=8 -cpu=1`

### Validation

- `go test -buildvcs=false ./internal/plugins/typescript/rules/prefer_as_const -count=1`
- Temporary differential attack against the scanner-based reference across raw mismatches, comments, Unicode, booleans, null, bigint, optional/definite/computed properties, and both assertion syntaxes
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run internal/plugins/typescript/rules/prefer_as_const/prefer_as_const.go internal/plugins/typescript/rules/prefer_as_const/prefer_as_const_test.go`

## Related Links

- https://typescript-eslint.io/rules/prefer-as-const/

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required; rule configuration and architecture are unchanged).
