### PR TITLE
perf: optimize unicorn no-thenable rule

### DIFF
--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
@@ -1,8 +1,6 @@
 package no_thenable
 
 import (
-	"slices"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -35,10 +33,7 @@ var NoThenableRule = rule.Rule{
 	Name:   "unicorn/no-thenable",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		state := &ruleState{
-			ctx:           ctx,
-			staticStrings: utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile),
-		}
+		state := &ruleState{ctx: ctx}
 
 		return rule.RuleListeners{
 			ast.KindObjectLiteralExpression: state.checkObjectExpression,
@@ -57,8 +52,16 @@ var NoThenableRule = rule.Rule{
 }
 
 type ruleState struct {
-	ctx           rule.RuleContext
-	staticStrings *utils.StaticStringEvaluator
+	ctx               rule.RuleContext
+	staticStrings     *utils.StaticStringEvaluator
+	staticStringCache *staticStringCacheEntry
+}
+
+type staticStringCacheEntry struct {
+	name       string
+	identifier *ast.Node
+	symbol     *ast.Symbol
+	value      string
 }
 
 func (state *ruleState) checkObjectExpression(node *ast.Node) {
@@ -107,17 +110,33 @@ func (state *ruleState) checkAssignmentExpression(node *ast.Node) {
 }
 
 func (state *ruleState) checkCallExpression(node *ast.Node) {
-	state.checkDefinePropertyCall(node)
-	state.checkFromEntriesCall(node)
-}
-
-func (state *ruleState) checkDefinePropertyCall(node *ast.Node) {
-	if !isNonOptionalMethodCall(node, []string{"Object", "Reflect"}, "defineProperty", 3, -1) {
+	call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{})
+	if !ok {
 		return
 	}
 
+	methodName := call.Property.AsIdentifier().Text
+	if methodName != "defineProperty" && methodName != "fromEntries" {
+		return
+	}
+
+	object := ast.SkipParentheses(call.Object)
+	if object == nil || object.Kind != ast.KindIdentifier {
+		return
+	}
+	objectName := object.AsIdentifier().Text
 	args := node.Arguments()
-	if ast.IsSpreadElement(args[0]) {
+
+	switch methodName {
+	case "defineProperty":
+		state.checkDefinePropertyCall(objectName, args)
+	case "fromEntries":
+		state.checkFromEntriesCall(objectName, args)
+	}
+}
+
+func (state *ruleState) checkDefinePropertyCall(objectName string, args []*ast.Node) {
+	if (objectName != "Object" && objectName != "Reflect") || len(args) < 3 || ast.IsSpreadElement(args[0]) {
 		return
 	}
 
@@ -129,13 +148,8 @@ func (state *ruleState) checkDefinePropertyCall(node *ast.Node) {
 	state.ctx.ReportNode(reportExpressionNode(secondArgument), messageObject)
 }
 
-func (state *ruleState) checkFromEntriesCall(node *ast.Node) {
-	if !isNonOptionalMethodCall(node, []string{"Object"}, "fromEntries", -1, 1) {
-		return
-	}
-
-	args := node.Arguments()
-	if len(args) != 1 || ast.IsSpreadElement(args[0]) {
+func (state *ruleState) checkFromEntriesCall(objectName string, args []*ast.Node) {
+	if objectName != "Object" || len(args) != 1 || ast.IsSpreadElement(args[0]) {
 		return
 	}
 
@@ -262,7 +276,7 @@ func (state *ruleState) staticPropertyName(name *ast.Node) (string, bool) {
 	}
 
 	if name.Kind == ast.KindComputedPropertyName {
-		return state.staticStrings.Eval(name.AsComputedPropertyName().Expression)
+		return state.staticString(name.AsComputedPropertyName().Expression)
 	}
 
 	return utils.GetStaticPropertyName(name)
@@ -290,8 +304,79 @@ func (state *ruleState) thenAccessReportNode(node *ast.Node) (*ast.Node, bool) {
 }
 
 func (state *ruleState) isStringThen(node *ast.Node) bool {
-	value, ok := state.staticStrings.Eval(node)
+	value, ok := state.staticString(node)
 	return ok && value == "then"
+}
+
+func (state *ruleState) staticString(node *ast.Node) (string, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return "", false
+	}
+
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text, true
+	case ast.KindIdentifier:
+		return state.staticIdentifierString(node)
+	default:
+		return state.staticStringEvaluator().Eval(node)
+	}
+}
+
+func (state *ruleState) staticIdentifierString(identifier *ast.Node) (string, bool) {
+	if value, ok := state.cachedStaticIdentifier(identifier); ok {
+		return value, true
+	}
+
+	value, ok := state.staticStringEvaluator().Eval(identifier)
+	if ok && state.ctx.Refs != nil {
+		state.rememberStaticIdentifier(identifier, value)
+	}
+	return value, ok
+}
+
+func (state *ruleState) cachedStaticIdentifier(identifier *ast.Node) (string, bool) {
+	if state.ctx.Refs == nil || state.staticStringCache == nil {
+		return "", false
+	}
+
+	// Keep the first occurrence on the canonical evaluator path. Only a
+	// same-spelled subsequent candidate pays for RefStore resolution, which
+	// confirms the binding identity before reusing the last result. A single
+	// entry bounds memory on generated files with many one-off static keys.
+	entry := state.staticStringCache
+	if entry.name != identifier.AsIdentifier().Text {
+		return "", false
+	}
+	currentSymbol := state.ctx.Refs.Resolve(identifier)
+	if currentSymbol == nil {
+		return "", false
+	}
+	if entry.symbol == nil {
+		entry.symbol = state.ctx.Refs.Resolve(entry.identifier)
+	}
+	return entry.value, entry.symbol == currentSymbol
+}
+
+func (state *ruleState) rememberStaticIdentifier(identifier *ast.Node, value string) {
+	if state.staticStringCache == nil {
+		state.staticStringCache = &staticStringCacheEntry{}
+	}
+	*state.staticStringCache = staticStringCacheEntry{
+		name:       identifier.AsIdentifier().Text,
+		identifier: identifier,
+		value:      value,
+	}
+}
+
+func (state *ruleState) staticStringEvaluator() *utils.StaticStringEvaluator {
+	if state.staticStrings == nil {
+		state.staticStrings = utils.NewStaticStringEvaluatorWithSourceFile(state.ctx.TypeChecker, state.ctx.SourceFile)
+	}
+	return state.staticStrings
 }
 
 func reportPropertyNameNode(name *ast.Node) *ast.Node {
@@ -307,28 +392,6 @@ func reportExpressionNode(node *ast.Node) *ast.Node {
 		return unwrapped
 	}
 	return node
-}
-
-// isNonOptionalMethodCall mirrors unicorn's isMethodCall with computed:false,
-// optionalCall:false, and optionalMember:false. The wider
-// utils.IsSpecificMemberAccess intentionally accepts bracket access and
-// optional chains, which would diverge from this rule's upstream matcher.
-func isNonOptionalMethodCall(node *ast.Node, objects []string, method string, minimumArguments int, argumentsLength int) bool {
-	options := unicornutil.DotMethodCallOptions{Method: method}
-	if minimumArguments >= 0 {
-		options.MinimumArguments = &minimumArguments
-	}
-	if argumentsLength >= 0 {
-		options.ArgumentsLength = &argumentsLength
-	}
-	call, ok := unicornutil.MatchDotMethodCall(node, options)
-	if !ok {
-		return false
-	}
-
-	object := ast.SkipParentheses(call.Object)
-	return object != nil && object.Kind == ast.KindIdentifier &&
-		slices.Contains(objects, object.AsIdentifier().Text)
 }
 
 func isIdentifierNamed(node *ast.Node, name string) bool {

--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable_extras_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+const repeatedStaticKeyCode = `const key = "then";
+const object = {[key]: 1};
+object[key] = 2;
+Object.defineProperty(object, key, {value: 3});
+Object.fromEntries([[key, 4]]);
+class Box {[key]() {}}`
+
+const shadowedStaticKeyCode = `const key = "then";
+const first = {[key]: 1};
+{
+	const key = "other";
+	const ignored = {[key]: 2};
+}
+const last = {[key]: 3};`
+
 // TestNoThenableExtras locks in branches and edge shapes that the upstream test
 // suite doesn't exercise. Each case carries an inline comment pointing at the
 // specific branch / Dimension 4 row / upstream issue it covers, so future
@@ -49,6 +64,9 @@ func TestNoThenableExtras(t *testing.T) {
 			tsValid("{ const String = { raw: () => \"then\" }; const foo = {[String.raw`then`]: 1} }"),
 			tsValid("let RawString = String; RawString = {raw: () => \"then\"} as any; const foo = {[RawString.raw`then`]: 1}"),
 			tsValid(`let key = "then"; key = "other"; const foo = {[key]: 1}`),
+			tsValid(`let key = "then"; key = "other"; const foo = {[key]: 1}; bar[key] = 2`),
+			tsValid(`var key = "then"; var key = "other"; const foo = {[key]: 1}`),
+			tsValid(`const first = second; const second = first; const foo = {[first]: 1}`),
 
 			// ---- Dimension 4: non-assignment member access is allowed ----
 			tsValid(`const value = foo.then`),
@@ -121,6 +139,28 @@ func TestNoThenableExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					expectedError(`const prefix = "th"; const foo = {[prefix + "en"]: {nested: {[prefix + "en"]: 1}}}`, `prefix + "en"`, messageIDObject, messageObject),
 					expectedError(`const prefix = "th"; const foo = {[prefix + "en"]: {nested: {[prefix + "en"]: 1}}}`, `prefix + "en"`, messageIDObject, messageObject, 2),
+				},
+			},
+			{
+				// Repeated references share one cached static value without
+				// changing diagnostic ranges, messages, or source order.
+				Code:     repeatedStaticKeyCode,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(repeatedStaticKeyCode, `key`, messageIDObject, messageObject, 2),
+					expectedError(repeatedStaticKeyCode, `key`, messageIDObject, messageObject, 3),
+					expectedError(repeatedStaticKeyCode, `key`, messageIDObject, messageObject, 4),
+					expectedError(repeatedStaticKeyCode, `key`, messageIDObject, messageObject, 5),
+					expectedError(repeatedStaticKeyCode, `key`, messageIDClass, messageClass, 6),
+				},
+			},
+			{
+				// Same-spelling bindings must never reuse each other's cached value.
+				Code:     shadowedStaticKeyCode,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(shadowedStaticKeyCode, `key`, messageIDObject, messageObject, 2),
+					expectedError(shadowedStaticKeyCode, `key`, messageIDObject, messageObject, 5),
 				},
 			},
 


### PR DESCRIPTION
## Summary

- Parse dot-method calls once and dispatch only Object/Reflect helpers relevant to unicorn/no-thenable.
- Fast-path literal keys, create the static-string evaluator lazily, and reuse the latest repeated identifier result only after ctx.Refs confirms the same binding.
- Add correctness coverage for repeated references, shadowed same-name bindings, reassigned variables, duplicate declarations, and alias cycles.
- Deferred reporting is not used because this rule has no fixes or suggestions to materialize lazily.

### Benchmark

Temporary rule-level benchmark only; the benchmark source is intentionally not committed.

Command shape: `GOMAXPROCS=1 go test ./internal/plugins/unicorn/rules/no_thenable -run ^$ -bench BenchmarkNoThenable/... -benchmem -benchtime=1s -count=10`

Apple M1 Max, benchstat medians:

| Scenario | sec/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Irrelevant nodes | 1.335 ms -> 1.367 ms, statistically unchanged (p=0.280) | 3.617 KiB -> 3.477 KiB (-3.87%) | 58 -> 53 (-8.62%) |
| Literal candidates | 1.656 ms -> 1.500 ms (-9.47%) | 667.8 KiB -> 628.5 KiB (-5.88%) | 6,558 -> 4,053 (-38.20%) |
| Repeated identifier candidates | 1.735 ms -> 1.313 ms (-24.33%) | 366.1 KiB -> 295.0 KiB (-19.42%) | 8,809 -> 3,210 (-63.56%) |
| Geomean | -11.16% | -10.00% | -40.96% |

Adversarial cache-only benchmarks (10 x 500 ms):

| Scenario | Result |
| --- | --- |
| 900 one-use static identifiers | +1.25% sec/op; +0.05% B/op and allocs/op |
| 700 unresolved dynamic identifiers | Statistically unchanged (p=0.190) |
| Repeated static identifiers | -19.39% sec/op, -19.42% B/op, -63.56% allocs/op |

The one-entry cache keeps memory bounded and leaves unresolved identifiers on the original evaluator path.

### Validation

- `go test ./internal/plugins/unicorn/rules/no_thenable -run ^TestNoThenable -count=1`
- `pnpm run format:check`
- `pnpm run check-spell`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/unicorn/rules/no_thenable/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; no user-visible behavior or architecture change).
