### PR TITLE
perf: optimize react no-deprecated rule

### DIFF
--- a/internal/plugins/react/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated.go
@@ -2,7 +2,6 @@ package no_deprecated
 
 import (
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -122,6 +121,12 @@ var jsxPragmaRe = regexp.MustCompile(`@jsx\s+([A-Za-z_$][\w$.]*)`)
 // detectJsxPragma returns the identifier following the first `@jsx` directive
 // in the source, or "" when no directive is present.
 func detectJsxPragma(sourceText string) string {
+	// Most files do not carry a classic-runtime pragma. Avoid putting the
+	// regexp engine on the hot path for every file in that overwhelmingly
+	// common case.
+	if !strings.Contains(sourceText, "@jsx") {
+		return ""
+	}
 	m := jsxPragmaRe.FindStringSubmatch(sourceText)
 	if m == nil {
 		return ""
@@ -135,35 +140,59 @@ func detectJsxPragma(sourceText string) string {
 // eslint-plugin-react's version util for simple `>= X` checks.
 func parseVersion(s string) (int, int, int) {
 	var parts [3]int
-	i := 0
-	for _, seg := range strings.Split(s, ".") {
-		if i >= 3 {
-			break
+	segmentStart := 0
+	for part := 0; part < len(parts) && segmentStart <= len(s); part++ {
+		segmentEnd := len(s)
+		hasNext := false
+		if dot := strings.IndexByte(s[segmentStart:], '.'); dot >= 0 {
+			segmentEnd = segmentStart + dot
+			hasNext = true
 		}
-		// Strip a trailing non-digit tail (e.g. "-rc.1", "+build").
-		cut := len(seg)
-		for j, c := range seg {
-			if c < '0' || c > '9' {
-				cut = j
-				break
+
+		// Strip a trailing non-digit tail (e.g. "-rc" or "+build") and
+		// parse the numeric prefix without allocating a split slice.
+		digitEnd := segmentStart
+		for digitEnd < segmentEnd && s[digitEnd] >= '0' && s[digitEnd] <= '9' {
+			digitEnd++
+		}
+		if digitEnd > segmentStart {
+			value := 0
+			overflow := false
+			maxInt := int(^uint(0) >> 1)
+			for i := segmentStart; i < digitEnd; i++ {
+				digit := int(s[i] - '0')
+				if value > (maxInt-digit)/10 {
+					overflow = true
+					break
+				}
+				value = value*10 + digit
+			}
+			if !overflow {
+				parts[part] = value
 			}
 		}
-		n, err := strconv.Atoi(seg[:cut])
-		if err == nil {
-			parts[i] = n
+
+		if !hasNext {
+			break
 		}
-		i++
+		segmentStart = segmentEnd + 1
 	}
 	return parts[0], parts[1], parts[2]
 }
 
-// versionActive reports whether the configured React version is greater-or-
-// equal to `deprecVersion` — i.e. whether the deprecation is "in effect" for
-// this project. An absent `settings.react.version` defaults to 999.999.999
-// (matching upstream's "latest"), so every deprecation fires by default.
-func versionActive(settings map[string]interface{}, deprecVersion string) bool {
-	major, minor, patch := parseVersion(deprecVersion)
-	return !reactutil.ReactVersionLessThan(settings, major, minor, patch)
+// versionAtLeast compares a React version parsed once per file with one of
+// the fixed deprecation versions. Keeping the settings lookup and regexp-based
+// version parsing out of each diagnostic is especially important for files
+// that import or destructure several deprecated APIs.
+func versionAtLeast(major, minor, patch int, deprecVersion string) bool {
+	wantMajor, wantMinor, wantPatch := parseVersion(deprecVersion)
+	if major != wantMajor {
+		return major > wantMajor
+	}
+	if minor != wantMinor {
+		return minor > wantMinor
+	}
+	return patch >= wantPatch
 }
 
 // buildDottedPath walks down the Expression chain of a PropertyAccessExpression
@@ -179,7 +208,11 @@ func versionActive(settings map[string]interface{}, deprecVersion string) bool {
 // We flag it — a more permissive, rule-catches-more-cases divergence that
 // we lock in via a dedicated test. See the rule's `.md` for details.
 func buildDottedPath(node *ast.Node) string {
-	var segs []string
+	// Deprecation keys are at most three members deep. Back the slice with a
+	// small local array so all matching paths avoid a separate slice allocation;
+	// append still preserves behavior for arbitrarily deep non-matching chains.
+	var segmentBuffer [4]string
+	segs := segmentBuffer[:0]
 	cur := node
 	for {
 		cur = ast.SkipParentheses(cur)
@@ -215,6 +248,42 @@ func buildDottedPath(node *ast.Node) string {
 	return b.String()
 }
 
+// canBeDeprecatedPropertyName is a cheap allocation-free gate for the
+// PropertyAccessExpression listener. Only these terminal names occur in the
+// deprecation table; checking them first keeps dotted-path construction off
+// unrelated property accesses such as response.data or props.children.
+func canBeDeprecatedPropertyName(name string) bool {
+	switch name {
+	case "renderComponent",
+		"renderComponentToString",
+		"renderComponentToStaticMarkup",
+		"isValidComponent",
+		"component",
+		"renderable",
+		"isValidClass",
+		"transferPropsTo",
+		"classSet",
+		"cloneWithProps",
+		"render",
+		"unmountComponentAtNode",
+		"findDOMNode",
+		"renderToString",
+		"renderToStaticMarkup",
+		"LinkedStateMixin",
+		"printDOM",
+		"getMeasurementsSummaryMap",
+		"createClass",
+		"TestUtils",
+		"PropTypes",
+		"DOM",
+		"hydrate",
+		"renderToNodeStream":
+		return true
+	default:
+		return false
+	}
+}
+
 // formatMessage builds the deprecation diagnostic string. Mirrors upstream's
 // message template:
 //
@@ -239,6 +308,20 @@ func formatMessage(methodName string, d deprecationInfo) string {
 	return b.String()
 }
 
+// The default pragma is used by virtually every file. Its lookup table and
+// messages are immutable, so construct them once instead of rebuilding the
+// same map and strings for every Rule.Run invocation. Custom pragmas still
+// get a per-file table because their keys and replacement text are dynamic.
+var defaultDeprecated = buildDeprecated(reactutil.DefaultReactPragma)
+
+var defaultDeprecatedMessages = func() map[string]string {
+	messages := make(map[string]string, len(defaultDeprecated))
+	for methodName, d := range defaultDeprecated {
+		messages[methodName] = formatMessage(methodName, d)
+	}
+	return messages
+}()
+
 var NoDeprecatedRule = rule.Rule{
 	Name:   "react/no-deprecated",
 	Schema: rule.EmptyArraySchema,
@@ -250,12 +333,25 @@ var NoDeprecatedRule = rule.Rule{
 			pragma = reactutil.GetReactPragma(ctx.Settings)
 		}
 		createClass := reactutil.GetReactCreateClass(ctx.Settings)
-		deprecated := buildDeprecated(pragma)
+		usesDefaultPragma := pragma == reactutil.DefaultReactPragma
+		deprecated := defaultDeprecated
+		if !usesDefaultPragma {
+			deprecated = buildDeprecated(pragma)
+		}
+		reactMajor, reactMinor, reactPatch := 0, 0, 0
+		reactVersionParsed := false
 
 		report := func(node *ast.Node, methodName string, d deprecationInfo) {
+			description := ""
+			if usesDefaultPragma {
+				description = defaultDeprecatedMessages[methodName]
+			}
+			if description == "" {
+				description = formatMessage(methodName, d)
+			}
 			ctx.ReportNode(node, rule.RuleMessage{
 				Id:          "deprecated",
-				Description: formatMessage(methodName, d),
+				Description: description,
 			})
 		}
 
@@ -266,7 +362,11 @@ var NoDeprecatedRule = rule.Rule{
 			if !ok {
 				return
 			}
-			if !versionActive(ctx.Settings, d.version) {
+			if !reactVersionParsed {
+				reactMajor, reactMinor, reactPatch = reactutil.ParseReactVersion(ctx.Settings)
+				reactVersionParsed = true
+			}
+			if !versionAtLeast(reactMajor, reactMinor, reactPatch, d.version) {
 				return
 			}
 			report(node, methodName, d)
@@ -299,6 +399,10 @@ var NoDeprecatedRule = rule.Rule{
 			// PropertyAccessExpression level is checked independently;
 			// `React.DOM.div` ⇒ inner `React.DOM` matches, outer doesn't.
 			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				name := node.AsPropertyAccessExpression().Name()
+				if name == nil || name.Kind != ast.KindIdentifier || !canBeDeprecatedPropertyName(name.AsIdentifier().Text) {
+					return
+				}
 				path := buildDottedPath(node)
 				if path == "" {
 					return

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
@@ -1,8 +1,11 @@
 package no_deprecated
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
@@ -21,6 +24,111 @@ func msg(oldMethod, version, newMethod, refs string) string {
 
 const lifecycleRefsTail = ". Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components."
 const lifecycleRefsHead = "https://reactjs.org/docs/react-component.html#"
+
+func TestDetectJsxPragmaFastPathMatchesRegexp(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{
+		"",
+		"const value = 'jsx';",
+		"const value = '@jsx';",
+		"/** @jsx Foo */",
+		"// prefix @jsx\t$Foo_1.Bar trailing",
+		"/* @jsx\nFoo.Bar */",
+		"@jsx Foo-Bar",
+		"@jsx9 Foo",
+		"@@jsx Foo",
+	} {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+
+			want := ""
+			if match := jsxPragmaRe.FindStringSubmatch(source); match != nil {
+				want = match[1]
+			}
+			if got := detectJsxPragma(source); got != want {
+				t.Fatalf("detectJsxPragma(%q) = %q, want regexp result %q", source, got, want)
+			}
+		})
+	}
+}
+
+func TestParseVersionMatchesPreviousImplementation(t *testing.T) {
+	t.Parallel()
+
+	reference := func(version string) (int, int, int) {
+		var parts [3]int
+		for i, segment := range strings.Split(version, ".") {
+			if i >= len(parts) {
+				break
+			}
+			cut := len(segment)
+			for j, char := range segment {
+				if char < '0' || char > '9' {
+					cut = j
+					break
+				}
+			}
+			if value, err := strconv.Atoi(segment[:cut]); err == nil {
+				parts[i] = value
+			}
+		}
+		return parts[0], parts[1], parts[2]
+	}
+
+	for _, version := range []string{
+		"",
+		".",
+		"..",
+		"0.12.0",
+		"15.5.0",
+		"16.9.0-rc.1",
+		"18.0.0+build.7",
+		"1..3",
+		"1.2.3.4",
+		"1.a.3",
+		"v18.2.0",
+		" 18.2.0",
+		"999999999999999999999999.1.2",
+		"1.２.3",
+	} {
+		t.Run(version, func(t *testing.T) {
+			t.Parallel()
+
+			wantMajor, wantMinor, wantPatch := reference(version)
+			gotMajor, gotMinor, gotPatch := parseVersion(version)
+			if gotMajor != wantMajor || gotMinor != wantMinor || gotPatch != wantPatch {
+				t.Fatalf(
+					"parseVersion(%q) = (%d, %d, %d), want (%d, %d, %d)",
+					version,
+					gotMajor,
+					gotMinor,
+					gotPatch,
+					wantMajor,
+					wantMinor,
+					wantPatch,
+				)
+			}
+		})
+	}
+}
+
+func TestDeprecatedPropertyGateCoversLookupTable(t *testing.T) {
+	t.Parallel()
+
+	for _, pragma := range []string{reactutil.DefaultReactPragma, "Foo", "Foo.Bar"} {
+		for methodName := range buildDeprecated(pragma) {
+			dot := strings.LastIndexByte(methodName, '.')
+			if dot < 0 {
+				continue
+			}
+			propertyName := methodName[dot+1:]
+			if !canBeDeprecatedPropertyName(propertyName) {
+				t.Errorf("property gate rejects %q from pragma %q", methodName, pragma)
+			}
+		}
+	}
+}
 
 func TestNoDeprecatedRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDeprecatedRule, []rule_tester.ValidTestCase{


### PR DESCRIPTION
## Summary

- Skip dotted-path construction for property names that cannot match a deprecated React API.
- Reuse the immutable default-pragma deprecation table and formatted messages, parse configured React versions lazily once per file, and keep short dotted paths on a stack-backed buffer.
- Keep the optimization rule-local. `ctx.Refs` would add reference-index work and change this syntax-based rule's matching semantics; deferred report helpers do not apply because the rule has no fixes or suggestions.
- Add equivalence and coverage tests for the pragma fast path, version parsing, and property-name gate.

### Benchmark

Command: `go test ./internal/plugins/react/rules/no_deprecated -run '^$' -bench '^BenchmarkNoDeprecated$' -benchmem -count=10`

Apple M1 Max, darwin/arm64; median of 10 paired runs:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Unrelated code, ns/op | 439,313 | 190,806 | -56.6% |
| Unrelated code, B/op | 128,629 | 632 | -99.5% |
| Unrelated code, allocs/op | 6,845 | 14 | -99.8% |
| Deprecated-heavy code, ns/op | 332,392 | 215,706 | -35.1% |
| Deprecated-heavy code, B/op | 358,276 | 107,832 | -69.9% |
| Deprecated-heavy code, allocs/op | 4,446 | 1,414 | -68.2% |

## Verification

- `go test ./internal/plugins/react/rules/no_deprecated -run '^(TestDetectJsxPragmaFastPathMatchesRegexp|TestParseVersionMatchesPreviousImplementation|TestDeprecatedPropertyGateCoversLookupTable|TestNoDeprecatedRule)$' -count=1`
- Targeted race run for the same rule tests
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/react/rules/no_deprecated`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; no user-facing behavior or configuration changed).
