### PR TITLE
perf: optimize no-eval hot paths

### DIFF
--- a/internal/rules/no_eval/no_eval.go
+++ b/internal/rules/no_eval/no_eval.go
@@ -1,20 +1,42 @@
 package no_eval
 
 import (
-	"slices"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-var globalObjects = []string{"window", "global", "globalThis"}
+var noEvalMessage = rule.RuleMessage{
+	Id:          "unexpected",
+	Description: "`eval` can be harmful.",
+}
+
+func sourceMayUseEval(sourceFile *ast.SourceFile) bool {
+	// Parsed identifier names are normalized, including Unicode escapes. The
+	// text checks retain computed string accesses such as window['eval']; an
+	// escaped computed name necessarily contains both '[' and a backslash.
+	// Stay conservative for direct callers that do not provide parser metadata.
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	if _, ok := sourceFile.Identifiers["eval"]; ok {
+		return true
+	}
+	text := sourceFile.Text()
+	return strings.Contains(text, "eval") ||
+		(strings.Contains(text, "[") && strings.Contains(text, "\\"))
+}
 
 // https://eslint.org/docs/latest/rules/no-eval
 var NoEvalRule = rule.Rule{
 	Name: "no-eval",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
+		if !sourceMayUseEval(ctx.SourceFile) {
+			return nil
+		}
+
 		options := rule.LegacyUnwrapOptions(_options)
 		allowIndirect := false
 		optsMap := utils.GetOptionsMap(options)
@@ -22,11 +44,6 @@ var NoEvalRule = rule.Rule{
 			if v, ok := optsMap["allowIndirect"].(bool); ok {
 				allowIndirect = v
 			}
-		}
-
-		msg := rule.RuleMessage{
-			Id:          "unexpected",
-			Description: "`eval` can be harmful.",
 		}
 
 		if allowIndirect {
@@ -38,175 +55,301 @@ var NoEvalRule = rule.Rule{
 					if call.QuestionDotToken != nil {
 						return
 					}
-					callee := call.Expression
+					callee := ast.SkipParentheses(call.Expression)
 					if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "eval" {
-						ctx.ReportNode(callee, msg)
+						ctx.ReportNode(callee, noEvalMessage)
 					}
 				},
 			}
 		}
 
-		// Default mode: flag all eval usage
-		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				call := node.AsCallExpression()
-				callee := call.Expression
-				if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "eval" {
-					ctx.ReportNode(callee, msg)
-				}
-			},
-			ast.KindPropertyAccessExpression: func(node *ast.Node) {
-				propAccess := node.AsPropertyAccessExpression()
-				name := propAccess.Name()
-				if name == nil || name.Text() != "eval" {
-					return
-				}
-
-				obj := ast.SkipParentheses(propAccess.Expression)
-				if obj == nil {
-					return
-				}
-
-				// Check for this.eval
-				if obj.Kind == ast.KindThisKeyword {
-					if isThisReferringToGlobal(obj, ctx.SourceFile) {
-						ctx.ReportNode(name, msg)
-					}
-					return
-				}
-
-				// Check for window.eval, global.eval, globalThis.eval
-				// and chained forms like window.window.eval
-				if isGlobalObjectChain(obj, ctx.TypeChecker, ctx.Globals) {
-					ctx.ReportNode(name, msg)
-				}
-			},
-			ast.KindElementAccessExpression: func(node *ast.Node) {
-				elemAccess := node.AsElementAccessExpression()
-				argExpr := elemAccess.ArgumentExpression
-				if argExpr == nil {
-					return
-				}
-
-				// Check if accessing ['eval'] or [`eval`]
-				if utils.GetStaticStringValue(argExpr) != "eval" {
-					return
-				}
-
-				obj := ast.SkipParentheses(elemAccess.Expression)
-				if obj == nil {
-					return
-				}
-
-				// Check for this['eval']
-				if obj.Kind == ast.KindThisKeyword {
-					if isThisReferringToGlobal(obj, ctx.SourceFile) {
-						ctx.ReportNode(argExpr, msg)
-					}
-					return
-				}
-
-				if isGlobalObjectChain(obj, ctx.TypeChecker, ctx.Globals) {
-					ctx.ReportNode(argExpr, msg)
-				}
-			},
-			ast.KindIdentifier: func(node *ast.Node) {
-				if node.AsIdentifier().Text != "eval" {
-					return
-				}
-
-				parent := node.Parent
-				if parent == nil {
-					return
-				}
-
-				// Skip if this is a direct call callee (handled by KindCallExpression)
-				if ast.IsCallExpression(parent) && parent.AsCallExpression().Expression == node {
-					return
-				}
-
-				// Skip if this is a property name in property access (handled above)
-				if ast.IsPropertyAccessExpression(parent) && parent.AsPropertyAccessExpression().Name() == node {
-					return
-				}
-
-				// Skip non-reference identifiers.
-				if utils.IsNonReferenceIdentifier(node) {
-					return
-				}
-
-				// Skip if eval is shadowed by a local variable/parameter
-				if utils.IsShadowed(node, "eval") {
-					return
-				}
-
-				// A config `/* global eval: off */` / `languageOptions.globals`
-				// entry un-declares the builtin, so it no longer resolves to a
-				// known global — ESLint's `getVariableByName(globalScope, "eval")`
-				// would be undefined and this non-call-reference check stays
-				// silent (direct `eval(...)` calls are unaffected — see the
-				// CallExpression listener above, which never consults scope).
-				if declared, ok := ctx.Globals["eval"]; ok && !declared {
-					return
-				}
-
-				// Non-call reference to eval (e.g., var x = eval, func(eval))
-				ctx.ReportNode(node, msg)
-			},
-		}
+		return noEvalListeners(ctx)
 	},
 }
 
-// isGlobalObjectChain checks if a node represents a reference to a global object,
-// potentially through chaining (e.g., window.window).
-// When TypeChecker is available, it verifies the root identifier actually resolves
-// to a known global (e.g., window from lib.dom.d.ts) rather than a local variable.
-// globals is ctx.Globals; a config `/* global window: off */` / `languageOptions.globals`
-// entry un-declares the name, so it no longer counts as a global object reference —
-// mirrors ESLint's `getVariableByName(globalScope, name)` returning undefined.
-func isGlobalObjectChain(node *ast.Node, tc *checker.Checker, globals map[string]bool) bool {
-	node = ast.SkipParentheses(node)
-	if node == nil {
+type noEvalState struct {
+	ctx              rule.RuleContext
+	evalBinding      sourceBindingState
+	windowStatus     globalObjectStatus
+	globalStatus     globalObjectStatus
+	globalThisStatus globalObjectStatus
+}
+
+type sourceBindingState uint8
+
+const (
+	sourceBindingUnchecked sourceBindingState = iota
+	sourceBindingAbsent
+	sourceBindingPresent
+)
+
+type bindingPresence struct {
+	checked bool
+	present bool
+}
+
+type globalObjectStatus struct {
+	bindingPresence
+	knownChecked bool
+	known        bool
+}
+
+func noEvalListeners(ctx rule.RuleContext) rule.RuleListeners {
+	state := &noEvalState{ctx: ctx}
+	return rule.RuleListeners{
+		ast.KindIdentifier:              state.checkIdentifier,
+		ast.KindElementAccessExpression: state.checkElementAccess,
+	}
+}
+
+func (state *noEvalState) checkIdentifier(node *ast.Node) {
+	if node.AsIdentifier().Text != "eval" {
+		return
+	}
+
+	parent := node.Parent
+	if parent == nil {
+		return
+	}
+
+	// Property names are already identifier nodes, so handle dot access here
+	// instead of dispatching a listener for every PropertyAccessExpression.
+	if ast.IsPropertyAccessExpression(parent) && parent.AsPropertyAccessExpression().Name() == node {
+		state.checkMemberAccess(parent.AsPropertyAccessExpression().Expression, node)
+		return
+	}
+
+	// Grouping parentheses are absent from ESTree. Walk through them so direct
+	// calls retain ESLint's scope-independent behavior without a call listener.
+	callee := utils.OutermostParenthesizedExpression(node)
+	if callee.Parent != nil && ast.IsCallExpression(callee.Parent) &&
+		callee.Parent.AsCallExpression().Expression == callee {
+		state.ctx.ReportNode(node, noEvalMessage)
+		return
+	}
+
+	if utils.IsNonReferenceIdentifier(node) || !state.isGlobalEvalReference(node) {
+		return
+	}
+	state.ctx.ReportNode(node, noEvalMessage)
+}
+
+func (state *noEvalState) checkElementAccess(node *ast.Node) {
+	elementAccess := node.AsElementAccessExpression()
+	argument := elementAccess.ArgumentExpression
+	if argument == nil || utils.GetStaticStringValue(argument) != "eval" {
+		return
+	}
+	state.checkMemberAccess(elementAccess.Expression, argument)
+}
+
+func (state *noEvalState) checkMemberAccess(object *ast.Node, reportNode *ast.Node) {
+	object = ast.SkipParentheses(object)
+	if object == nil {
+		return
+	}
+	if object.Kind == ast.KindThisKeyword {
+		if isThisReferringToGlobal(object, state.ctx.SourceFile) {
+			state.ctx.ReportNode(reportNode, noEvalMessage)
+		}
+		return
+	}
+	if state.isGlobalObjectChain(object) {
+		state.ctx.ReportNode(reportNode, noEvalMessage)
+	}
+}
+
+func (state *noEvalState) isGlobalEvalReference(node *ast.Node) bool {
+	if declared, ok := state.ctx.Globals["eval"]; ok && !declared {
+		return false
+	}
+	// A full-file miss is cached because IsShadowed's SourceFile check scans
+	// top-level declarations; repeating it for many global eval references can
+	// otherwise become quadratic. Files with any binding retain the exact
+	// per-reference lexical check.
+	if state.evalBinding == sourceBindingAbsent {
+		return true
+	}
+	if state.evalBinding == sourceBindingUnchecked {
+		if sourceHasValueBinding(state.ctx.SourceFile, "eval") {
+			state.evalBinding = sourceBindingPresent
+		} else {
+			state.evalBinding = sourceBindingAbsent
+			return true
+		}
+	}
+	return !utils.IsShadowed(node, "eval")
+}
+
+func isGlobalObjectName(name string) bool {
+	return name == "window" || name == "global" || name == "globalThis"
+}
+
+// isGlobalObjectChain accepts chained forms such as window.window and
+// window['window'], then verifies that the root is a known, unshadowed global.
+func (state *noEvalState) isGlobalObjectChain(node *ast.Node) bool {
+	chainName := ""
+	for {
+		node = ast.SkipParentheses(node)
+		if node == nil {
+			return false
+		}
+		if ast.IsIdentifier(node) {
+			name := node.AsIdentifier().Text
+			return isGlobalObjectName(name) &&
+				(chainName == "" || chainName == name) &&
+				state.isGlobalObjectReference(node, name)
+		}
+		if ast.IsPropertyAccessExpression(node) {
+			propertyAccess := node.AsPropertyAccessExpression()
+			name := propertyAccess.Name()
+			if name == nil || !isGlobalObjectName(name.Text()) {
+				return false
+			}
+			if chainName == "" {
+				chainName = name.Text()
+			} else if chainName != name.Text() {
+				return false
+			}
+			node = propertyAccess.Expression
+			continue
+		}
+		if ast.IsElementAccessExpression(node) {
+			elementAccess := node.AsElementAccessExpression()
+			name := utils.GetStaticStringValue(elementAccess.ArgumentExpression)
+			if !isGlobalObjectName(name) {
+				return false
+			}
+			if chainName == "" {
+				chainName = name
+			} else if chainName != name {
+				return false
+			}
+			node = elementAccess.Expression
+			continue
+		}
+		return false
+	}
+}
+
+func (state *noEvalState) isGlobalObjectReference(identifier *ast.Node, name string) bool {
+	if declared, ok := state.ctx.Globals[name]; ok && !declared {
 		return false
 	}
 
-	if ast.IsIdentifier(node) {
-		name := node.AsIdentifier().Text
-		if !slices.Contains(globalObjects, name) {
-			return false
+	status := state.globalObjectStatus(name)
+	if isInsideNamedExpression(identifier, name) {
+		return false
+	}
+	if !state.hasSourceBinding(name, &status.bindingPresence) {
+		return state.isKnownGlobalObject(name, status)
+	}
+
+	// Resolve only when this file can shadow the global root. The common
+	// no-binding case above avoids a NameResolver/checker round trip entirely.
+	if state.ctx.Refs != nil {
+		if symbol := state.ctx.Refs.Resolve(identifier); symbol != nil {
+			return isGlobalObjectSymbol(symbol, state.ctx.SourceFile)
 		}
-		if declared, ok := globals[name]; ok && !declared {
-			return false
+	}
+	return state.isKnownGlobalObject(name, status) && !utils.IsShadowed(identifier, name)
+}
+
+func isInsideNamedExpression(identifier *ast.Node, name string) bool {
+	for current := identifier.Parent; current != nil; current = current.Parent {
+		if (current.Kind == ast.KindFunctionExpression || current.Kind == ast.KindClassExpression) &&
+			current.Name() != nil && current.Name().Text() == name {
+			return true
 		}
-		// When TypeChecker is available, verify the identifier is actually declared
-		// (from lib.dom.d.ts, @types/node, etc.). If it doesn't resolve, it's an
-		// unknown variable — not a known global object.
-		if tc != nil {
-			if tc.GetSymbolAtLocation(node) == nil {
-				return false
-			}
-		}
+	}
+	return false
+}
+
+func isGlobalObjectSymbol(symbol *ast.Symbol, sourceFile *ast.SourceFile) bool {
+	if !utils.IsValueSymbolDeclaredInFile(symbol, sourceFile) {
 		return true
 	}
-
-	// Handle window.window, global.global, globalThis.globalThis, etc.
-	if ast.IsPropertyAccessExpression(node) {
-		prop := node.AsPropertyAccessExpression()
-		name := prop.Name()
-		if name != nil && slices.Contains(globalObjects, name.Text()) {
-			return isGlobalObjectChain(prop.Expression, tc, globals)
-		}
+	if sourceFile == nil || ast.IsExternalModule(sourceFile) {
+		return false
 	}
 
-	// Handle window['window'], global['global'], etc.
-	if ast.IsElementAccessExpression(node) {
-		elem := node.AsElementAccessExpression()
-		argText := utils.GetStaticStringValue(elem.ArgumentExpression)
-		if slices.Contains(globalObjects, argText) {
-			return isGlobalObjectChain(ast.SkipParentheses(elem.Expression), tc, globals)
+	// ESLint's global-scope variable remains a global-object candidate even
+	// when a script declares it itself. Only a nested binding (or a module's
+	// top-level binding, handled above) shadows that candidate. The binder's
+	// SourceFile.Locals identity also handles a `var` nested syntactically in a
+	// block but hoisted into the script's global scope.
+	topLevel := sourceFile.Locals[symbol.Name]
+	if topLevel == symbol {
+		return true
+	}
+	if topLevel != nil {
+		for _, declaration := range symbol.Declarations {
+			for _, topLevelDeclaration := range topLevel.Declarations {
+				if declaration == topLevelDeclaration {
+					return true
+				}
+			}
 		}
 	}
+	return false
+}
 
+func (state *noEvalState) globalObjectStatus(name string) *globalObjectStatus {
+	switch name {
+	case "window":
+		return &state.windowStatus
+	case "global":
+		return &state.globalStatus
+	default:
+		return &state.globalThisStatus
+	}
+}
+
+func (state *noEvalState) isKnownGlobalObject(name string, status *globalObjectStatus) bool {
+	if status.knownChecked {
+		return status.known
+	}
+	status.knownChecked = true
+	if declared, ok := state.ctx.Globals[name]; ok {
+		status.known = declared
+	} else if state.ctx.TypeChecker != nil {
+		status.known = state.ctx.TypeChecker.GetGlobalSymbol(name, ast.SymbolFlagsValue, nil) != nil
+	} else {
+		status.known = true
+	}
+	return status.known
+}
+
+func (state *noEvalState) hasSourceBinding(name string, presence *bindingPresence) bool {
+	if presence.checked {
+		return presence.present
+	}
+	presence.checked = true
+	presence.present = sourceHasValueBinding(state.ctx.SourceFile, name)
+	return presence.present
+}
+
+func sourceHasValueBinding(sourceFile *ast.SourceFile, name string) bool {
+	if sourceFile == nil || !sourceFile.IsBound() {
+		return true
+	}
+	// Binder links every locals container in source order, so a miss here
+	// disproves shadowing without walking the full AST for every reference.
+	for container := sourceFile.AsNode(); container != nil; {
+		data := container.LocalsContainerData()
+		if data == nil {
+			return true
+		}
+		if len(data.Locals) != 0 &&
+			utils.IsValueSymbolDeclaredInFile(data.Locals[name], sourceFile) {
+			return true
+		}
+		if (container.Kind == ast.KindFunctionExpression || container.Kind == ast.KindClassExpression) &&
+			container.Name() != nil && container.Name().Text() == name {
+			return true
+		}
+		container = data.NextContainer
+	}
 	return false
 }
 

--- a/internal/rules/no_eval/no_eval_test.go
+++ b/internal/rules/no_eval/no_eval_test.go
@@ -147,6 +147,19 @@ func TestNoEvalRule(t *testing.T) {
 			{Code: `var { a: eval } = obj; var x = eval`},
 			// Import creates local eval binding
 			{Code: `import { eval } from 'mod'; var x = eval`},
+			// Global-object names can be shadowed locally.
+			{Code: `function foo(window: any) { window.eval('foo') }`},
+			{Code: `function foo(globalThis: any) { globalThis.globalThis.eval('foo') }`},
+			{Code: `export {}; const window = { eval() {} }; window['eval']()`},
+			{Code: `function foo() { const global = { eval() {} }; global.eval() }`},
+			{Code: `function foo(x = window.eval('foo'), window: any) {}`},
+			{Code: `switch (0) { case 0: window.eval('foo'); break; case 1: let window: any; }`},
+			{Code: `const fn = function window() { window.eval('foo') }`},
+			{Code: `const C = class window { static value = window.eval('foo') }`},
+			{Code: `{ const window = { eval() {} }; window.eval() }`},
+			// ESLint follows only repeated same-name global-object chains.
+			{Code: `window.globalThis.eval('foo')`},
+			{Code: `globalThis['window'].eval('foo')`},
 
 			// ================================================================
 			// Config `off` un-declares the builtin (non-call references only —
@@ -180,6 +193,7 @@ func TestNoEvalRule(t *testing.T) {
 			{Code: `globalThis.globalThis.eval('foo');`, Options: map[string]interface{}{"allowIndirect": true}},
 			// Optional call is not direct eval
 			{Code: `eval?.('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `(eval)?.('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
 			{Code: `window?.eval('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
 			{Code: `(window?.eval)('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
 		},
@@ -294,6 +308,23 @@ func TestNoEvalRule(t *testing.T) {
 					{MessageId: "unexpected", Line: 1, Column: 22},
 				},
 			},
+			// Grouping parentheses are not semantically indirect and ESTree omits
+			// them around a callee.
+			{
+				Code:    `function foo(eval) { (eval)('foo') }`,
+				Options: map[string]interface{}{"allowIndirect": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			// Parser identifier metadata normalizes Unicode escapes, so the
+			// file-level candidate filter must retain this direct call.
+			{
+				Code: `ev\u0061l('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
 
 			// ================================================================
 			// Indirect eval — flagged in default mode
@@ -320,6 +351,34 @@ func TestNoEvalRule(t *testing.T) {
 					{MessageId: "unexpected", Line: 1, Column: 15},
 				},
 			},
+			// Script-level declarations remain global-scope candidates; only
+			// nested or module bindings shadow the global object.
+			{
+				Code: `const window = { eval() {} }; window.eval()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code: `if (true) { var window = { eval() {} }; } window.eval()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected"},
+				},
+			},
+			// A type-only declaration does not shadow the global value.
+			{
+				Code: `interface window {}; window.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+			// A body var does not shadow a reference in the parameter environment.
+			{
+				Code: `function foo(x = window.eval('foo')) { var window: any; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
 			// global.eval — global is not declared in test env (no @types/node)
 			// so these are valid. Tested via window/globalThis which ARE declared.
 			{
@@ -334,6 +393,23 @@ func TestNoEvalRule(t *testing.T) {
 					{MessageId: "unexpected", Line: 1, Column: 23},
 				},
 			},
+			// Configured globals are known even when the TypeScript environment
+			// does not declare them.
+			{
+				Code:    `global.eval('foo')`,
+				Globals: map[string]bool{"global": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			// A local shadow suppresses only references in its own scope.
+			{
+				Code: "window.eval('a');\nfunction f(window: any) { window.eval('b'); }\nwindow.eval('c');",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+					{MessageId: "unexpected", Line: 3, Column: 8},
+				},
+			},
 
 			// ================================================================
 			// Global object property access: bracket notation
@@ -342,6 +418,19 @@ func TestNoEvalRule(t *testing.T) {
 				Code: `window.window['eval']('foo')`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			// Escaped static member names do not appear as an `eval` identifier.
+			{
+				Code: `window['\x65val']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `window.ev\u0061l('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
 				},
 			},
 			{
@@ -408,6 +497,13 @@ func TestNoEvalRule(t *testing.T) {
 				Code: `var EVAL = eval; EVAL('foo')`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			// A type-only declaration does not shadow the global value.
+			{
+				Code: `interface eval {}; var x = eval`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
 				},
 			},
 			// Passed as argument


### PR DESCRIPTION
## Summary

- Skip listener registration when parser metadata and a conservative source-text guard prove that a file cannot use `eval`.
- Reduce the default-mode listener set from four AST kinds to two, cache file-level binding/global lookups, and consult `ctx.Refs` only when a same-name source binding can shadow a global object.
- Preserve and strengthen ESLint-compatible behavior for escaped names, grouped direct calls, configured globals, repeated global-object chains, and script/module/nested binding scopes.

### Benchmark

Temporary benchmark harness (removed before commit):

```console
go test ./tests/bench-go -run '^$' -bench '^BenchmarkNoEval$' -benchtime=1s -benchmem -cpu=1
```

Median on darwin/arm64, Apple M1 Max (8 baseline samples, 10 optimized samples):

| Workload | Before | After | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| No `eval` candidate | 384,253 ns/op | 246,758 ns/op | -35.78% | 31,605 → 31,082 | 319 → 309 |
| Text-only candidate | 379,642 ns/op | 367,817 ns/op | -3.11% | 31,621 → 31,533 | 319 → 316 |
| Shadowed `eval` references | 276,756 ns/op | 277,452 ns/op | +0.25% (flat) | 31,568 → 31,488 | 319 → 316 |
| Dense violations | 911,388 ns/op | 367,428 ns/op | -59.68% | 159,742 → 159,520 | 1,119 → 1,116 |

The workloads cover 400-function candidate-free and shadowed files plus a 200-function file containing direct, indirect, dot-member, and computed-member violations.

### Validation

- `go test ./internal/rules/no_eval -run '^TestNoEvalRule$' -count=3`
- `pnpm check-spell`
- `pnpm format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/rules/no_eval/...`
- Adversarial scope and syntax cases compared against ESLint 10 with `@typescript-eslint/parser`.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
