### PR TITLE
feat(typescript-eslint): implement restrict-template-expressions

### DIFF
--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
@@ -154,7 +154,7 @@ var RestrictTemplateExpressionsRule = rule.CreateRule(rule.Rule{
 				return true
 			}
 
-			if matchesTypeOrBaseType(ctx.TypeChecker, func(t *checker.Type) bool {
+			if len(opts.Allow) > 0 && matchesTypeOrBaseType(ctx.TypeChecker, func(t *checker.Type) bool {
 				return utils.TypeMatchesSomeSpecifier(t, opts.Allow, nil, ctx.Program)
 			}, innerType, map[*checker.Type]struct{}{}) {
 				return true

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
@@ -1,117 +1,207 @@
 package restrict_template_expressions
 
 import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed restrict_template_expressions.schema.json
+var schemaJSON []byte
+
 type RestrictTemplateExpressionsOptions struct {
-	AllowNumber  bool     `json:"allowNumber"`
-	AllowBoolean bool     `json:"allowBoolean"`
-	AllowAny     bool     `json:"allowAny"`
-	AllowNullish bool     `json:"allowNullish"`
-	AllowRegExp  bool     `json:"allowRegExp"`
-	AllowNever   bool     `json:"allowNever"`
-	AllowArray   bool     `json:"allowArray"`
-	Allow        []string `json:"allow"`
+	Allow        []utils.TypeOrValueSpecifier
+	AllowAny     bool
+	AllowArray   bool
+	AllowBoolean bool
+	AllowNever   bool
+	AllowNullish bool
+	AllowNumber  bool
+	AllowRegExp  bool
 }
 
-// RestrictTemplateExpressionsRule implements the restrict-template-expressions rule
-// Enforce template literal expressions to be of string type
+// parseAllow decodes the `allow` option — type specifiers written either in
+// the string shorthand or in object form — through TypeOrValueSpecifier's own
+// UnmarshalJSON rather than re-deriving both shapes by hand.
+func parseAllow(raw any) []utils.TypeOrValueSpecifier {
+	rawJSON, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var allow []utils.TypeOrValueSpecifier
+	if err := json.Unmarshal(rawJSON, &allow); err != nil {
+		return nil
+	}
+	return allow
+}
+
+func parseOptions(options []any) RestrictTemplateExpressionsOptions {
+	opts := RestrictTemplateExpressionsOptions{
+		Allow: []utils.TypeOrValueSpecifier{{
+			From: utils.TypeOrValueSpecifierFromLib,
+			Name: utils.NameList{"Error", "URL", "URLSearchParams"},
+		}},
+		AllowAny:     true,
+		AllowBoolean: true,
+		AllowNullish: true,
+		AllowNumber:  true,
+		AllowRegExp:  true,
+	}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	if raw, ok := optsMap["allow"]; ok {
+		opts.Allow = parseAllow(raw)
+	}
+	if v, ok := optsMap["allowAny"].(bool); ok {
+		opts.AllowAny = v
+	}
+	if v, ok := optsMap["allowArray"].(bool); ok {
+		opts.AllowArray = v
+	}
+	if v, ok := optsMap["allowBoolean"].(bool); ok {
+		opts.AllowBoolean = v
+	}
+	if v, ok := optsMap["allowNever"].(bool); ok {
+		opts.AllowNever = v
+	}
+	if v, ok := optsMap["allowNullish"].(bool); ok {
+		opts.AllowNullish = v
+	}
+	if v, ok := optsMap["allowNumber"].(bool); ok {
+		opts.AllowNumber = v
+	}
+	if v, ok := optsMap["allowRegExp"].(bool); ok {
+		opts.AllowRegExp = v
+	}
+	return opts
+}
+
+func buildInvalidTypeMessage(t string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "invalidType",
+		Description: fmt.Sprintf("Invalid type \"%v\" of template literal expression.", t),
+	}
+}
+
+// getBaseTypesForType returns the base types of a class or interface type, and
+// nothing for any other type.
+func getBaseTypesForType(typeChecker *checker.Checker, t *checker.Type) []*checker.Type {
+	if !utils.IsObjectType(t) {
+		return nil
+	}
+	target := t
+	if utils.IsTypeReference(t) {
+		target = t.Target()
+	}
+	if checker.Type_objectFlags(target)&checker.ObjectFlagsClassOrInterface == 0 {
+		return nil
+	}
+	return checker.Checker_getBaseTypes(typeChecker, target)
+}
+
+// matchesTypeOrBaseType reports whether the type or any of its base types
+// satisfies the matcher.
+func matchesTypeOrBaseType(
+	typeChecker *checker.Checker,
+	matcher func(t *checker.Type) bool,
+	t *checker.Type,
+	seen map[*checker.Type]struct{},
+) bool {
+	if _, ok := seen[t]; ok {
+		return false
+	}
+	seen[t] = struct{}{}
+
+	if matcher(t) {
+		return true
+	}
+
+	for _, base := range getBaseTypesForType(typeChecker, t) {
+		if matchesTypeOrBaseType(typeChecker, matcher, base, seen) {
+			return true
+		}
+	}
+	return false
+}
+
 var RestrictTemplateExpressionsRule = rule.CreateRule(rule.Rule{
 	Name:             "restrict-template-expressions",
 	RequiresTypeInfo: true,
-	Run:              run,
-})
+	Schema:           rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
-	opts := RestrictTemplateExpressionsOptions{
-		AllowNumber:  false,
-		AllowBoolean: false,
-		AllowAny:     false,
-		AllowNullish: false,
-		AllowRegExp:  false,
-		AllowNever:   false,
-		AllowArray:   false,
-		Allow:        []string{},
-	}
+		var recursivelyCheckType func(innerType *checker.Type) bool
+		recursivelyCheckType = func(innerType *checker.Type) bool {
+			if innerType == nil {
+				return false
+			}
+			if utils.IsUnionType(innerType) {
+				return utils.Every(innerType.Types(), recursivelyCheckType)
+			}
+			if utils.IsIntersectionType(innerType) {
+				return utils.Some(innerType.Types(), recursivelyCheckType)
+			}
 
-	// Parse options
-	if options != nil {
-		var optsMap map[string]interface{}
-		var ok bool
+			if utils.IsTypeFlagSet(innerType, checker.TypeFlagsStringLike) {
+				return true
+			}
 
-		// Handle array format: [{ option: value }]
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			optsMap, ok = optArray[0].(map[string]interface{})
-		} else {
-			// Handle direct object format: { option: value }
-			optsMap, ok = options.(map[string]interface{})
+			if matchesTypeOrBaseType(ctx.TypeChecker, func(t *checker.Type) bool {
+				return utils.TypeMatchesSomeSpecifier(t, opts.Allow, nil, ctx.Program)
+			}, innerType, map[*checker.Type]struct{}{}) {
+				return true
+			}
+
+			if opts.AllowAny && utils.IsTypeAnyType(innerType) {
+				return true
+			}
+			if opts.AllowArray &&
+				(checker.Checker_isArrayType(ctx.TypeChecker, innerType) || checker.IsTupleType(innerType)) &&
+				recursivelyCheckType(utils.GetNumberIndexType(ctx.TypeChecker, innerType)) {
+				return true
+			}
+			if opts.AllowBoolean && utils.IsTypeFlagSet(innerType, checker.TypeFlagsBooleanLike) {
+				return true
+			}
+			if opts.AllowNullish && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+				return true
+			}
+			if opts.AllowNumber && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNumberLike|checker.TypeFlagsBigIntLike) {
+				return true
+			}
+			if opts.AllowRegExp && utils.GetTypeName(ctx.TypeChecker, innerType) == "RegExp" {
+				return true
+			}
+			if opts.AllowNever && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNever) {
+				return true
+			}
+
+			return false
 		}
 
-		if ok {
-			if allowNumber, ok := optsMap["allowNumber"].(bool); ok {
-				opts.AllowNumber = allowNumber
-			}
-			if allowBoolean, ok := optsMap["allowBoolean"].(bool); ok {
-				opts.AllowBoolean = allowBoolean
-			}
-			if allowAny, ok := optsMap["allowAny"].(bool); ok {
-				opts.AllowAny = allowAny
-			}
-			if allowNullish, ok := optsMap["allowNullish"].(bool); ok {
-				opts.AllowNullish = allowNullish
-			}
-			if allowRegExp, ok := optsMap["allowRegExp"].(bool); ok {
-				opts.AllowRegExp = allowRegExp
-			}
-			if allowNever, ok := optsMap["allowNever"].(bool); ok {
-				opts.AllowNever = allowNever
-			}
-			if allowArray, ok := optsMap["allowArray"].(bool); ok {
-				opts.AllowArray = allowArray
-			}
-			if allow, ok := optsMap["allow"].([]interface{}); ok {
-				for _, item := range allow {
-					if str, ok := item.(string); ok {
-						opts.Allow = append(opts.Allow, str)
+		return rule.RuleListeners{
+			ast.KindTemplateExpression: func(node *ast.Node) {
+				// don't check tagged template literals
+				if node.Parent != nil && ast.IsTaggedTemplateExpression(node.Parent) {
+					return
+				}
+
+				for _, span := range node.AsTemplateExpression().TemplateSpans.Nodes {
+					expression := span.AsTemplateSpan().Expression
+					expressionType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, expression)
+					if !recursivelyCheckType(expressionType) {
+						ctx.ReportNode(expression, buildInvalidTypeMessage(ctx.TypeChecker.TypeToString(expressionType)))
 					}
 				}
-			}
+			},
 		}
-	}
-
-	return rule.RuleListeners{
-		ast.KindTemplateExpression: func(node *ast.Node) {
-			// This rule requires type information
-			if ctx.TypeChecker == nil {
-				return
-			}
-
-			templateExpr := node.AsTemplateExpression()
-			if templateExpr == nil || templateExpr.TemplateSpans == nil {
-				return
-			}
-
-			// Check each template span's expression
-			for _, span := range templateExpr.TemplateSpans.Nodes {
-				templateSpan := span.AsTemplateSpan()
-				if templateSpan == nil || templateSpan.Expression == nil {
-					continue
-				}
-
-				// TODO: Use TypeChecker to check if expression type is allowed
-				// For now, this is a placeholder that will need proper type checking implementation
-				// Example:
-				// typ := ctx.TypeChecker.GetTypeAtLocation(templateSpan.Expression)
-				// if !isAllowedType(typ, opts) {
-				//     ctx.ReportNode(templateSpan.Expression, rule.RuleMessage{
-				//         Id:          "invalidType",
-				//         Description: "Invalid type in template expression",
-				//     })
-				// }
-			}
-		},
-	}
-}
+	},
+})

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
@@ -64,10 +64,6 @@ To require every interpolated value to be a `string`, empty the `allow` list and
 }
 ```
 
-## Differences from ESLint
-
-- An `allow` entry with `from: 'package'` matches the package name exactly. ESLint matches any package whose name contains the given string, so `{ from: 'package', package: 'demo' }` also permits types declared in `demo-pkg` there. Write the package name in full to permit the same types in both.
-
 ## Original Documentation
 
 - [typescript-eslint restrict-template-expressions](https://typescript-eslint.io/rules/restrict-template-expressions)

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
@@ -67,7 +67,6 @@ To require every interpolated value to be a `string`, empty the `allow` list and
 ## Differences from ESLint
 
 - An `allow` entry with `from: 'package'` matches the package name exactly. ESLint matches any package whose name contains the given string, so `{ from: 'package', package: 'demo' }` also permits types declared in `demo-pkg` there. Write the package name in full to permit the same types in both.
-- The type name in the message may order union constituents differently. Given `declare const input: object | undefined;` and `const value = input ?? 'fallback';`, interpolating `value` reports `Invalid type ""fallback" | object" of template literal expression.` here and `Invalid type "object | "fallback"" of template literal expression.` in ESLint.
 
 ## Original Documentation
 

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
@@ -45,13 +45,14 @@ const msg2 = `items: ${arr.join(', ')}`;
 | `allowNumber`  | `boolean`                                | `true`                                      | Permit `number` and `bigint` typed values.                     |
 | `allowRegExp`  | `boolean`                                | `true`                                      | Permit `RegExp` typed values.                                  |
 
-To require every interpolated value to be a `string`, turn each `allow*` option off:
+To require every interpolated value to be a `string`, empty the `allow` list and turn each `allow*` option off:
 
 ```json
 {
   "@typescript-eslint/restrict-template-expressions": [
     "error",
     {
+      "allow": [],
       "allowAny": false,
       "allowBoolean": false,
       "allowNever": false,

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
@@ -2,16 +2,21 @@
 
 ## Rule Details
 
-Enforce template literal expressions to be of `string` type. When using template literal expressions (`${expr}`), non-string values are implicitly converted to strings using their `.toString()` method. This can lead to unexpected results such as `"[object Object]"` for objects or `"null"` for null values. This rule ensures that only values of type `string` are used in template expressions by default, though other types can be allowed via options.
+Enforce template literal expressions to be of `string` type. When a value is interpolated into a template literal (`${expr}`), it is implicitly converted to a string, which produces results such as `"[object Object]"` for plain objects. This rule restricts which types may be interpolated.
+
+By default, primitives that stringify predictably are permitted (`number`, `bigint`, `boolean`, `null`, `undefined`, `any`, `RegExp`), along with `Error`, `URL`, and `URLSearchParams` and their subclasses.
 
 Examples of **incorrect** code for this rule:
 
 ```typescript
-const num = 42;
-const str = `value: ${num}`;
-
-const obj = {};
+declare const obj: object;
 const msg = `result: ${obj}`;
+
+declare const arr: string[];
+const msg2 = `items: ${arr}`;
+
+declare const sym: symbol;
+const msg3 = `symbol: ${sym}`;
 ```
 
 Examples of **correct** code for this rule:
@@ -20,9 +25,42 @@ Examples of **correct** code for this rule:
 const name = 'world';
 const greeting = `Hello, ${name}`;
 
-const num = 42;
-const str = `value: ${String(num)}`;
-const str2 = `value: ${num.toString()}`;
+declare const obj: object;
+const msg = `result: ${JSON.stringify(obj)}`;
+
+declare const arr: string[];
+const msg2 = `items: ${arr.join(', ')}`;
+```
+
+## Options
+
+| Option         | Type                                     | Default                                     | Description                                                    |
+| -------------- | ---------------------------------------- | ------------------------------------------- | -------------------------------------------------------------- |
+| `allow`        | `(string \| TypeOrValueSpecifier)[]`     | `[{ from: 'lib', name: ['Error', 'URL', 'URLSearchParams'] }]` | Additional types to permit, matched against the type or any of its base types. |
+| `allowAny`     | `boolean`                                | `true`                                      | Permit `any` typed values.                                     |
+| `allowArray`   | `boolean`                                | `false`                                     | Permit arrays and tuples whose element type is itself permitted. |
+| `allowBoolean` | `boolean`                                | `true`                                      | Permit `boolean` typed values.                                 |
+| `allowNever`   | `boolean`                                | `false`                                     | Permit `never` typed values.                                   |
+| `allowNullish` | `boolean`                                | `true`                                      | Permit `null` and `undefined`.                                 |
+| `allowNumber`  | `boolean`                                | `true`                                      | Permit `number` and `bigint` typed values.                     |
+| `allowRegExp`  | `boolean`                                | `true`                                      | Permit `RegExp` typed values.                                  |
+
+To require every interpolated value to be a `string`, turn each `allow*` option off:
+
+```json
+{
+  "@typescript-eslint/restrict-template-expressions": [
+    "error",
+    {
+      "allowAny": false,
+      "allowBoolean": false,
+      "allowNever": false,
+      "allowNullish": false,
+      "allowNumber": false,
+      "allowRegExp": false
+    }
+  ]
+}
 ```
 
 ## Original Documentation

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
@@ -64,6 +64,11 @@ To require every interpolated value to be a `string`, empty the `allow` list and
 }
 ```
 
+## Differences from ESLint
+
+- An `allow` entry with `from: 'package'` matches the package name exactly. ESLint matches any package whose name contains the given string, so `{ from: 'package', package: 'demo' }` also permits types declared in `demo-pkg` there. Write the package name in full to permit the same types in both.
+- The type name in the message may order union constituents differently. Given `declare const input: object | undefined;` and `const value = input ?? 'fallback';`, interpolating `value` reports `Invalid type ""fallback" | object" of template literal expression.` here and `Invalid type "object | "fallback"" of template literal expression.` in ESLint.
+
 ## Original Documentation
 
 - [typescript-eslint restrict-template-expressions](https://typescript-eslint.io/rules/restrict-template-expressions)

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.schema.json
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.schema.json
@@ -1,0 +1,117 @@
+{
+  "definitions": {
+    "nameList": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    }
+  },
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "description": "Types to allow in template expressions.",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["from", "name"],
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "enum": ["file"]
+                  },
+                  "name": {
+                    "$ref": "#/definitions/nameList"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["from", "name"],
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "enum": ["lib"]
+                  },
+                  "name": {
+                    "$ref": "#/definitions/nameList"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["from", "name", "package"],
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "enum": ["package"]
+                  },
+                  "name": {
+                    "$ref": "#/definitions/nameList"
+                  },
+                  "package": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "allowAny": {
+          "type": "boolean",
+          "description": "Whether to allow `any` typed values in template expressions."
+        },
+        "allowArray": {
+          "type": "boolean",
+          "description": "Whether to allow `array` typed values in template expressions."
+        },
+        "allowBoolean": {
+          "type": "boolean",
+          "description": "Whether to allow `boolean` typed values in template expressions."
+        },
+        "allowNever": {
+          "type": "boolean",
+          "description": "Whether to allow `never` typed values in template expressions."
+        },
+        "allowNullish": {
+          "type": "boolean",
+          "description": "Whether to allow `nullish` typed values in template expressions."
+        },
+        "allowNumber": {
+          "type": "boolean",
+          "description": "Whether to allow `number` typed values in template expressions."
+        },
+        "allowRegExp": {
+          "type": "boolean",
+          "description": "Whether to allow `regexp` typed values in template expressions."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions_test.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions_test.go
@@ -1,9 +1,10 @@
 package restrict_template_expressions
 
 import (
+	"testing"
+
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"testing"
 )
 
 func TestRestrictTemplateExpressionsRule(t *testing.T) {
@@ -13,24 +14,467 @@ func TestRestrictTemplateExpressionsRule(t *testing.T) {
 		t,
 		&RestrictTemplateExpressionsRule,
 		[]rule_tester.ValidTestCase{
-			// String literal in template
-			{Code: "const msg = `arg = ${'foo'}`;"},
-			// String variable in template
-			{Code: `
-const arg = 'foo';
-const msg = ` + "`arg = ${arg}`" + `;
-`},
-			// Number with allowNumber option
 			{
-				Code: "const msg = `arg = ${123}`;",
-				Options: map[string]interface{}{
-					"allowNumber": true,
-				},
+				Code: "const msg = `arg = ${'foo'}`;\n",
+			},
+			{
+				Code: "const arg = 'foo';\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: number;\nconst msg = `arg = ${String(arg)}`;\n",
+			},
+			{
+				Code: "declare const arg: number;\nconst msg = `arg = ${arg.toString()}`;\n",
+			},
+			{
+				Code: "declare const arg: number;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: bigint;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: boolean;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: null;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: undefined;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: any;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: RegExp;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "const msg = `arg = ${/regex/}`;\n",
+			},
+			{
+				Code: "declare const arg: Error;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: URL;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: URLSearchParams;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "class CustomError extends Error {}\ndeclare const arg: CustomError;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "class CustomError extends Error {}\nclass Deeper extends CustomError {}\ndeclare const arg: Deeper;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: object;\ndeclare function tag(strings: TemplateStringsArray, ...values: unknown[]): string;\nconst msg = tag`arg = ${arg}`;\n",
+			},
+			{
+				Code: "const msg = `arg`;\n",
+			},
+			{
+				Code: "declare const arg: string | number;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: string & { __brand: 'x' };\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "function f<T extends string>(arg: T) {\n  return `arg = ${arg}`;\n}\n",
+			},
+			{
+				Code: "enum E {\n  A = 'a',\n}\ndeclare const arg: E;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "enum E {\n  A,\n}\ndeclare const arg: E;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: `a${number}`;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code:    "declare const arg: string[];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "declare const arg: string[][];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "declare const arg: [string, number];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "declare const arg: never;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowNever": true},
+			},
+			{
+				Code:    "declare const arg: string;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowAny": false, "allowBoolean": false, "allowNever": false, "allowNullish": false, "allowNumber": false, "allowRegExp": false},
+			},
+			{
+				Code:    "interface Foo {\n  a: string;\n}\ndeclare const arg: Foo;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{map[string]any{"from": "file", "name": "Foo"}}},
+			},
+			{
+				Code:    "interface Foo {\n  a: string;\n}\ndeclare const arg: Foo;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{"Foo"}},
+			},
+			{
+				Code:    "interface Foo {\n  a: string;\n}\ninterface Bar extends Foo {\n  b: string;\n}\ndeclare const arg: Bar;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{map[string]any{"from": "file", "name": "Foo"}}},
+			},
+			{
+				Code:    "declare const arg: number;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{}, "allowNumber": true},
+			},
+			{
+				Code:    "declare const arg: Error;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowNumber": false},
 			},
 		},
 		[]rule_tester.InvalidTestCase{
-			// TODO: Add invalid test cases once type checking is implemented
-			// The rule implementation has a TODO for type checking (see line 102)
+			{
+				Code: "declare const arg: object;\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"object\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "const arg = {};\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"{}\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: string[];\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"string[]\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: [string, string];\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"[string, string]\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: never;\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"never\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: unknown;\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"unknown\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: symbol;\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"symbol\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: () => void;\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"() => void\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: Map<string, string>;\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"Map<string, string>\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const a: object;\ndeclare const b: string;\ndeclare const c: symbol;\nconst msg = `${a} ${b} ${c}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"object\" of template literal expression.",
+						Line:      4,
+						Column:    16,
+						EndLine:   4,
+						EndColumn: 17,
+					},
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"symbol\" of template literal expression.",
+						Line:      4,
+						Column:    26,
+						EndLine:   4,
+						EndColumn: 27,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: object;\nconst msg = `outer ${`inner ${arg}`}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"object\" of template literal expression.",
+						Line:      2,
+						Column:    31,
+						EndLine:   2,
+						EndColumn: 34,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: string | object;\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"string | object\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "declare const arg: { a: 1 } & { b: 2 };\nconst msg = `arg = ${arg}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"{ a: 1; } & { b: 2; }\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "function f<T>(arg: T) {\n  return `arg = ${arg}`;\n}\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"T\" of template literal expression.",
+						Line:      2,
+						Column:    19,
+						EndLine:   2,
+						EndColumn: 22,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: number;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowNumber": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"number\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: bigint;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowNumber": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"bigint\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: boolean;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowBoolean": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"boolean\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: null | undefined;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowNullish": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"null | undefined\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: any;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowAny": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"any\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: RegExp;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowRegExp": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"RegExp\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: number[];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true, "allowNumber": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"number[]\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: object[];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"object[]\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: [];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"[]\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: number;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowAny": false, "allowBoolean": false, "allowNever": false, "allowNullish": false, "allowNumber": false, "allowRegExp": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"number\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "declare const arg: Error;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"Error\" of template literal expression.",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
 		},
 	)
 }

--- a/internal/utils/type_matches_specifier.go
+++ b/internal/utils/type_matches_specifier.go
@@ -133,14 +133,18 @@ func typeDeclaredInFile(
 	program *compiler.Program,
 ) bool {
 	cwd := program.Host().GetCurrentDirectory()
+	useCaseSensitiveFileNames := program.Host().FS().UseCaseSensitiveFileNames()
+	canonical := func(fileName string) string {
+		return tspath.GetCanonicalFileName(fileName, useCaseSensitiveFileNames)
+	}
 	if relativePath == "" {
 		return Some(declarationFiles, func(f *ast.SourceFile) bool {
-			return strings.HasPrefix(f.FileName(), cwd)
+			return strings.HasPrefix(canonical(f.FileName()), canonical(cwd))
 		})
 	}
-	absPath := tspath.GetNormalizedAbsolutePath(relativePath, cwd)
+	absPath := canonical(tspath.GetNormalizedAbsolutePath(relativePath, cwd))
 	return Some(declarationFiles, func(f *ast.SourceFile) bool {
-		return f.FileName() == absPath
+		return canonical(f.FileName()) == absPath
 	})
 }
 

--- a/internal/utils/type_matches_specifier.go
+++ b/internal/utils/type_matches_specifier.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/compiler"
@@ -202,23 +204,40 @@ func resolvedPackageName(fileName string) string {
 	return packageDirectory[idx+len("/node_modules/"):]
 }
 
+// packageMatchers caches the compiled matcher per `package` specifier, which
+// comes from the rule options and so takes only a handful of distinct values.
+var packageMatchers sync.Map // package name -> *regexp2.Regexp, nil when the pattern is invalid
+
+// packageMatcher builds `new RegExp(`${packageName}|${typesPackageName}`)`. The
+// pattern carries no anchors, so "demo" matches "demo-pkg" as well.
+func packageMatcher(packageName string) *regexp2.Regexp {
+	if cached, ok := packageMatchers.Load(packageName); ok {
+		matcher, _ := cached.(*regexp2.Regexp)
+		return matcher
+	}
+	matcher, err := CompileRegexp2(packageName+"|"+module.MangleScopedPackageName(packageName), JSRegexOptions)
+	if err != nil {
+		matcher = nil
+	}
+	packageMatchers.Store(packageName, matcher)
+	return matcher
+}
+
 func typeDeclaredInDeclarationFile(
 	packageName string,
 	declarationFiles []*ast.SourceFile,
 	program *compiler.Program,
 ) bool {
-	// The specifier is tested against the resolved package name without anchors,
-	// so "demo" matches "demo-pkg" as well.
-	typesPackageName := module.MangleScopedPackageName(packageName)
+	matcher := packageMatcher(packageName)
+	if matcher == nil {
+		return false
+	}
 	for _, file := range declarationFiles {
 		if file == nil || !program.IsSourceFileFromExternalLibrary(file) {
 			continue
 		}
 		name := resolvedPackageName(file.FileName())
-		if name == "" {
-			continue
-		}
-		if strings.Contains(name, packageName) || strings.Contains(name, typesPackageName) {
+		if name != "" && Regexp2MatchString(matcher, name) {
 			return true
 		}
 	}

--- a/internal/utils/type_matches_specifier.go
+++ b/internal/utils/type_matches_specifier.go
@@ -172,15 +172,18 @@ func findParentModuleDeclaration(
 	switch node.Kind {
 	case ast.KindModuleDeclaration:
 		decl := node.AsModuleDeclaration()
-		if ast.IsStringLiteral(decl.Name()) {
-			return decl
+		// A namespace is transparent here: what it wraps still belongs to
+		// whichever `declare module "pkg"` encloses the namespace itself.
+		if decl.Keyword != ast.KindNamespaceKeyword {
+			if ast.IsStringLiteral(decl.Name()) {
+				return decl
+			}
+			return nil
 		}
-		return nil
 	case ast.KindSourceFile:
 		return nil
-	default:
-		return findParentModuleDeclaration(node.Parent)
 	}
+	return findParentModuleDeclaration(node.Parent)
 }
 
 func typeDeclaredInDeclareModule(
@@ -193,15 +196,38 @@ func typeDeclaredInDeclareModule(
 	})
 }
 
-// resolvedPackageName returns the package a declaration file belongs to, such as
-// "demo-pkg" or "@scope/pkg" for a file under node_modules.
-func resolvedPackageName(fileName string) string {
-	packageDirectory := module.ParseNodeModuleFromPath(fileName, false)
-	idx := strings.LastIndex(packageDirectory, "/node_modules/")
-	if idx == -1 {
-		return ""
+// resolvedPackageName returns the package a declaration file belongs to, in the
+// "name/subpath" form module resolution records, such as "demo-pkg/index.d.ts"
+// or "@types/node/globals.d.ts". Workspace packages are symlinked into
+// node_modules and resolve to their real path, so the owning package is found
+// through the nearest enclosing package.json that names one instead of through
+// the file name.
+func resolvedPackageName(program *compiler.Program, fileName string) string {
+	directory := tspath.GetDirectoryPath(fileName)
+	for directory != "" {
+		packageDirectory := program.GetNearestAncestorDirectoryWithPackageJson(directory)
+		if packageDirectory == "" {
+			return ""
+		}
+		info := program.GetPackageJsonInfo(tspath.CombinePaths(packageDirectory, "package.json"))
+		if info.Exists() {
+			if name, ok := info.Contents.Name.GetValue(); ok && name != "" {
+				if subpath, nested := strings.CutPrefix(fileName, packageDirectory+"/"); nested {
+					return name + "/" + subpath
+				}
+				return name
+			}
+		}
+		// A package.json without a name, such as the `{"type": "module"}` files
+		// dual-published packages drop into subdirectories, belongs to whichever
+		// named package encloses it.
+		parent := tspath.GetDirectoryPath(packageDirectory)
+		if parent == packageDirectory {
+			return ""
+		}
+		directory = parent
 	}
-	return packageDirectory[idx+len("/node_modules/"):]
+	return ""
 }
 
 // packageMatchers caches the compiled matcher per `package` specifier, which
@@ -236,46 +262,8 @@ func typeDeclaredInDeclarationFile(
 		if file == nil || !program.IsSourceFileFromExternalLibrary(file) {
 			continue
 		}
-		name := resolvedPackageName(file.FileName())
+		name := resolvedPackageName(program, file.FileName())
 		if name != "" && Regexp2MatchString(matcher, name) {
-			return true
-		}
-	}
-	return false
-}
-
-// getImportModuleSpecifier traverses up from a declaration to find the import module specifier
-func getImportModuleSpecifier(declaration *ast.Node) string {
-	if declaration == nil {
-		return ""
-	}
-
-	// Walk up to find ImportDeclaration
-	current := declaration
-	for current != nil {
-		if ast.IsImportDeclaration(current) {
-			moduleSpec := current.AsImportDeclaration().ModuleSpecifier
-			if moduleSpec != nil && ast.IsStringLiteral(moduleSpec) {
-				return moduleSpec.Text()
-			}
-			return ""
-		}
-		current = current.Parent
-	}
-	return ""
-}
-
-// typeDeclaredFromImport checks if any declaration comes from an import with the specified package name
-func typeDeclaredFromImport(
-	packageName string,
-	declarations []*ast.Node,
-) bool {
-	for _, decl := range declarations {
-		if decl == nil {
-			continue
-		}
-		moduleSpec := getImportModuleSpecifier(decl)
-		if moduleSpec == packageName {
 			return true
 		}
 	}
@@ -289,7 +277,6 @@ func typeDeclaredInPackageDeclarationFile(
 	program *compiler.Program,
 ) bool {
 	return typeDeclaredInDeclareModule(packageName, declarations) ||
-		typeDeclaredFromImport(packageName, declarations) ||
 		typeDeclaredInDeclarationFile(packageName, declarationFiles, program)
 }
 

--- a/internal/utils/type_matches_specifier.go
+++ b/internal/utils/type_matches_specifier.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/module"
 	"github.com/microsoft/typescript-go/shim/tspath"
 )
 
@@ -190,25 +191,34 @@ func typeDeclaredInDeclareModule(
 	})
 }
 
+// resolvedPackageName returns the package a declaration file belongs to, such as
+// "demo-pkg" or "@scope/pkg" for a file under node_modules.
+func resolvedPackageName(fileName string) string {
+	packageDirectory := module.ParseNodeModuleFromPath(fileName, false)
+	idx := strings.LastIndex(packageDirectory, "/node_modules/")
+	if idx == -1 {
+		return ""
+	}
+	return packageDirectory[idx+len("/node_modules/"):]
+}
+
 func typeDeclaredInDeclarationFile(
 	packageName string,
 	declarationFiles []*ast.SourceFile,
 	program *compiler.Program,
 ) bool {
-	// Check if any declaration file path contains the package name
-	// This handles cases like node_modules/package-name/...
+	// The specifier is tested against the resolved package name without anchors,
+	// so "demo" matches "demo-pkg" as well.
+	typesPackageName := module.MangleScopedPackageName(packageName)
 	for _, file := range declarationFiles {
-		if file == nil {
+		if file == nil || !program.IsSourceFileFromExternalLibrary(file) {
 			continue
 		}
-		fileName := file.FileName()
-		// Check if the file is from node_modules and matches the package name
-		if strings.Contains(fileName, "node_modules/"+packageName+"/") ||
-			strings.Contains(fileName, "node_modules\\"+packageName+"\\") {
-			return true
+		name := resolvedPackageName(file.FileName())
+		if name == "" {
+			continue
 		}
-		// Handle @types packages
-		if strings.Contains(fileName, "node_modules/@types/"+strings.TrimPrefix(packageName, "@types/")+"/") {
+		if strings.Contains(name, packageName) || strings.Contains(name, typesPackageName) {
 			return true
 		}
 	}

--- a/internal/utils/type_matches_specifier_test.go
+++ b/internal/utils/type_matches_specifier_test.go
@@ -45,12 +45,16 @@ func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
 		}}, nil, program)
 	}
 
-	// The package name is tested against the resolved package name without
-	// anchors, so any substring of "demo-pkg" matches it.
+	// The package name becomes an unanchored JavaScript pattern, so any substring
+	// of "demo-pkg" matches it, and regular expression syntax applies.
 	assert.Equal(t, matches("demo-pkg"), true)
 	assert.Equal(t, matches("demo"), true)
 	assert.Equal(t, matches("emo-pk"), true)
+	assert.Equal(t, matches("demo.pkg"), true)
+	assert.Equal(t, matches("d[ei]mo"), true)
 	assert.Equal(t, matches("other"), false)
+	// An unparsable pattern matches nothing.
+	assert.Equal(t, matches("("), false)
 }
 
 func TestResolvedPackageName(t *testing.T) {

--- a/internal/utils/type_matches_specifier_test.go
+++ b/internal/utils/type_matches_specifier_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"gotest.tools/v3/assert"
+)
+
+func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	resolve := func(name string) string { return tspath.ResolvePath(rootDir.Dir, name) }
+
+	filePath := resolve("file.ts")
+	fs := NewOverlayVFS(rootDir.FS, map[string]string{
+		filePath: "import { Demo } from 'demo-pkg';\ntype Test = Demo;\n",
+		resolve("node_modules/demo-pkg/package.json"): `{"name":"demo-pkg","version":"1.0.0","types":"index.d.ts"}`,
+		resolve("node_modules/demo-pkg/index.d.ts"):   "export declare class Demo {}\n",
+	})
+
+	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	sourceFile := program.GetSourceFile(filePath)
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	var alias *ast.Node
+	for _, statement := range sourceFile.Statements.Nodes {
+		if ast.IsTypeAliasDeclaration(statement) {
+			alias = statement
+		}
+	}
+	assert.Assert(t, alias != nil, "expected a type alias declaration")
+	demo := c.GetTypeAtLocation(alias.AsTypeAliasDeclaration().Name())
+	assert.Assert(t, checker.Type_symbol(demo) != nil, "expected Demo to resolve to a symbol")
+
+	matches := func(packageName string) bool {
+		return TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{{
+			From:    TypeOrValueSpecifierFromPackage,
+			Name:    NameList{"Demo"},
+			Package: packageName,
+		}}, nil, program)
+	}
+
+	// The package name is tested against the resolved package name without
+	// anchors, so any substring of "demo-pkg" matches it.
+	assert.Equal(t, matches("demo-pkg"), true)
+	assert.Equal(t, matches("demo"), true)
+	assert.Equal(t, matches("emo-pk"), true)
+	assert.Equal(t, matches("other"), false)
+}
+
+func TestResolvedPackageName(t *testing.T) {
+	assert.Equal(t, resolvedPackageName("/repo/node_modules/demo-pkg/index.d.ts"), "demo-pkg")
+	assert.Equal(t, resolvedPackageName("/repo/node_modules/@scope/pkg/lib/index.d.ts"), "@scope/pkg")
+	assert.Equal(t, resolvedPackageName("/repo/node_modules/a/node_modules/b/index.d.ts"), "b")
+	assert.Equal(t, resolvedPackageName("/repo/src/index.ts"), "")
+}

--- a/internal/utils/type_matches_specifier_test.go
+++ b/internal/utils/type_matches_specifier_test.go
@@ -1,31 +1,51 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"gotest.tools/v3/assert"
 )
 
-func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
+// fixtureRoot resolves paths against the shared fixtures directory, which is
+// also the directory the test tsconfig files below live in.
+func fixtureRoot() (string, func(name string) string, vfs.FS) {
 	rootDir := fixtures.GetRootDir()
-	resolve := func(name string) string { return tspath.ResolvePath(rootDir.Dir, name) }
+	return rootDir.Dir, func(name string) string {
+		return tspath.ResolvePath(rootDir.Dir, name)
+	}, rootDir.FS
+}
 
-	filePath := resolve("file.ts")
-	fs := NewOverlayVFS(rootDir.FS, map[string]string{
-		filePath: "import { Demo } from 'demo-pkg';\ntype Test = Demo;\n",
-		resolve("node_modules/demo-pkg/package.json"): `{"name":"demo-pkg","version":"1.0.0","types":"index.d.ts"}`,
-		resolve("node_modules/demo-pkg/index.d.ts"):   "export declare class Demo {}\n",
-	})
+// symlinkVFS reports one directory as a link to another, the layout a workspace
+// install produces when it links node_modules/<pkg> at a package checked into
+// the repository.
+type symlinkVFS struct {
+	vfs.FS
+	link   string
+	target string
+}
 
-	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
-	assert.NilError(t, err, "couldn't create program")
-	sourceFile := program.GetSourceFile(filePath)
-	c, done := program.GetTypeChecker(t.Context())
-	defer done()
+func (f *symlinkVFS) Realpath(path string) string {
+	if path == f.link {
+		return f.target
+	}
+	if rest, linked := strings.CutPrefix(path, f.link+"/"); linked {
+		return f.target + "/" + rest
+	}
+	return f.FS.Realpath(path)
+}
+
+// typeOfTestAlias returns the type `type Test = ...` resolves to in fileName.
+func typeOfTestAlias(t *testing.T, program *compiler.Program, c *checker.Checker, fileName string) *checker.Type {
+	t.Helper()
+	sourceFile := program.GetSourceFile(fileName)
+	assert.Assert(t, sourceFile != nil, "expected %s in the program", fileName)
 
 	var alias *ast.Node
 	for _, statement := range sourceFile.Statements.Nodes {
@@ -34,8 +54,28 @@ func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
 		}
 	}
 	assert.Assert(t, alias != nil, "expected a type alias declaration")
-	demo := c.GetTypeAtLocation(alias.AsTypeAliasDeclaration().Name())
-	assert.Assert(t, checker.Type_symbol(demo) != nil, "expected Demo to resolve to a symbol")
+
+	declared := c.GetTypeAtLocation(alias.AsTypeAliasDeclaration().Name())
+	assert.Assert(t, checker.Type_symbol(declared) != nil, "expected the alias to resolve to a symbol")
+	return declared
+}
+
+func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	filePath := resolve("file.ts")
+	fs := NewOverlayVFS(baseFS, map[string]string{
+		filePath: "import { Demo } from 'demo-pkg';\ntype Test = Demo;\n",
+		resolve("node_modules/demo-pkg/package.json"): `{"name":"demo-pkg","version":"1.0.0","types":"index.d.ts"}`,
+		resolve("node_modules/demo-pkg/index.d.ts"):   "export declare class Demo {}\n",
+	})
+
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	demo := typeOfTestAlias(t, program, c, filePath)
 
 	matches := func(packageName string) bool {
 		return TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{{
@@ -46,7 +86,7 @@ func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
 	}
 
 	// The package name becomes an unanchored JavaScript pattern, so any substring
-	// of "demo-pkg" matches it, and regular expression syntax applies.
+	// of "demo-pkg/index.d.ts" matches it, and regular expression syntax applies.
 	assert.Equal(t, matches("demo-pkg"), true)
 	assert.Equal(t, matches("demo"), true)
 	assert.Equal(t, matches("emo-pk"), true)
@@ -57,9 +97,138 @@ func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
 	assert.Equal(t, matches("("), false)
 }
 
-func TestResolvedPackageName(t *testing.T) {
-	assert.Equal(t, resolvedPackageName("/repo/node_modules/demo-pkg/index.d.ts"), "demo-pkg")
-	assert.Equal(t, resolvedPackageName("/repo/node_modules/@scope/pkg/lib/index.d.ts"), "@scope/pkg")
-	assert.Equal(t, resolvedPackageName("/repo/node_modules/a/node_modules/b/index.d.ts"), "b")
-	assert.Equal(t, resolvedPackageName("/repo/src/index.ts"), "")
+// A workspace package is installed as a link, so its declarations resolve to a
+// real path outside node_modules while still belonging to the linked package.
+func TestTypeMatchesSomeSpecifierFromLinkedWorkspacePackage(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	filePath := resolve("file.ts")
+	files := map[string]string{
+		filePath:                           "import { Demo } from 'demo-pkg';\ntype Test = Demo;\n",
+		resolve("tsconfig.workspace.json"): `{"compilerOptions":{"target":"esnext","module":"commonjs","strict":true,"types":[]},"files":["file.ts"]}`,
+	}
+	// The resolver walks the link path and the program then loads the real one,
+	// so the package has to be readable under both.
+	for _, directory := range []string{"node_modules/demo-pkg", "packages/demo-pkg"} {
+		files[resolve(directory+"/package.json")] = `{"name":"demo-pkg","version":"1.0.0","types":"index.d.ts"}`
+		files[resolve(directory+"/index.d.ts")] = "export declare class Demo {}\n"
+	}
+	fs := &symlinkVFS{
+		FS:     NewOverlayVFS(baseFS, files),
+		link:   resolve("node_modules/demo-pkg"),
+		target: resolve("packages/demo-pkg"),
+	}
+
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.workspace.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	demo := typeOfTestAlias(t, program, c, filePath)
+
+	declaration := ast.GetSourceFileOfNode(checker.Type_symbol(demo).Declarations[0])
+	assert.Assert(t, !strings.Contains(declaration.FileName(), "/node_modules/"),
+		"expected the declaration to resolve through the link, got %s", declaration.FileName())
+	assert.Equal(t, program.IsSourceFileFromExternalLibrary(declaration), true)
+
+	matches := func(packageName string) bool {
+		return TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{{
+			From:    TypeOrValueSpecifierFromPackage,
+			Name:    NameList{"Demo"},
+			Package: packageName,
+		}}, nil, program)
+	}
+
+	assert.Equal(t, matches("demo-pkg"), true)
+	assert.Equal(t, matches("other"), false)
+}
+
+// Dual-published packages drop unnamed package.json files into their build
+// directories; the type still belongs to the named package enclosing them.
+func TestTypeMatchesSomeSpecifierFromNestedPackageJson(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	filePath := resolve("file.ts")
+	fs := NewOverlayVFS(baseFS, map[string]string{
+		filePath: "import { Demo } from 'demo-pkg';\ntype Test = Demo;\n",
+		resolve("node_modules/demo-pkg/package.json"):      `{"name":"demo-pkg","version":"1.0.0","types":"dist/index.d.ts"}`,
+		resolve("node_modules/demo-pkg/dist/package.json"): `{"sideEffects":false}`,
+		resolve("node_modules/demo-pkg/dist/index.d.ts"):   "export declare class Demo {}\n",
+	})
+
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	demo := typeOfTestAlias(t, program, c, filePath)
+
+	matches := func(packageName string) bool {
+		return TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{{
+			From:    TypeOrValueSpecifierFromPackage,
+			Name:    NameList{"Demo"},
+			Package: packageName,
+		}}, nil, program)
+	}
+
+	assert.Equal(t, matches("demo-pkg"), true)
+	assert.Equal(t, matches("other"), false)
+}
+
+// A namespace between the declaration and its `declare module` is transparent.
+func TestTypeMatchesSomeSpecifierFromDeclareModuleNamespace(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	filePath := resolve("file.ts")
+	fs := NewOverlayVFS(baseFS, map[string]string{
+		filePath:                         "import inner = require('ambient-pkg');\ntype Test = inner.Demo;\n",
+		resolve("ambient.d.ts"):          "declare module 'ambient-pkg' {\n  namespace inner {\n    class Demo {}\n  }\n  export = inner;\n}\n",
+		resolve("tsconfig.ambient.json"): `{"compilerOptions":{"target":"esnext","module":"commonjs","strict":true,"types":[]},"files":["file.ts","ambient.d.ts"]}`,
+	})
+
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.ambient.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	demo := typeOfTestAlias(t, program, c, filePath)
+
+	matches := func(packageName string) bool {
+		return TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{{
+			From:    TypeOrValueSpecifierFromPackage,
+			Name:    NameList{"Demo"},
+			Package: packageName,
+		}}, nil, program)
+	}
+
+	// `declare module` names are compared exactly, unlike declaration file paths.
+	assert.Equal(t, matches("ambient-pkg"), true)
+	assert.Equal(t, matches("ambient"), false)
+}
+
+// A type declared by the project itself belongs to no package, even when the
+// project has a named package.json of its own.
+func TestTypeMatchesSomeSpecifierFromPackageIgnoresLocalTypes(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	filePath := resolve("file.ts")
+	fs := NewOverlayVFS(baseFS, map[string]string{
+		filePath:                       "import { Demo } from './local';\ntype Test = Demo;\n",
+		resolve("local.ts"):            "export declare class Demo {}\n",
+		resolve("package.json"):        `{"name":"demo-pkg","version":"1.0.0"}`,
+		resolve("tsconfig.local.json"): `{"compilerOptions":{"target":"esnext","module":"commonjs","strict":true,"types":[]},"files":["file.ts","local.ts"]}`,
+	})
+
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.local.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	demo := typeOfTestAlias(t, program, c, filePath)
+
+	assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{{
+		From:    TypeOrValueSpecifierFromPackage,
+		Name:    NameList{"Demo"},
+		Package: "demo-pkg",
+	}}, nil, program), false)
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -412,7 +412,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/require-array-sort-compare.test.ts',
     './tests/typescript-eslint/rules/require-await.test.ts',
     // './tests/typescript-eslint/rules/restrict-plus-operands.test.ts',
-    // './tests/typescript-eslint/rules/restrict-template-expressions.test.ts',
+    './tests/typescript-eslint/rules/restrict-template-expressions.test.ts',
     // './tests/typescript-eslint/rules/return-await.test.ts',
     // './tests/typescript-eslint/rules/sort-type-constituents.test.ts',
     './tests/typescript-eslint/rules/strict-boolean-expressions.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/restrict-template-expressions.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/restrict-template-expressions.test.ts.snap
@@ -1,0 +1,546 @@
+// Rstest Snapshot v1
+
+exports[`restrict-template-expressions > invalid 1`] = `
+{
+  "code": "
+        const msg = \`arg = \${123}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "123" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 2`] = `
+{
+  "code": "
+        const msg = \`arg = \${false}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "false" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 3`] = `
+{
+  "code": "
+        const msg = \`arg = \${null}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "null" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 4`] = `
+{
+  "code": "
+        declare const arg: number[];
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "number[]" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 5`] = `
+{
+  "code": "
+        const msg = \`arg = \${[, 2]}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "(number | undefined)[]" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 6`] = `
+{
+  "code": "const msg = \`arg = \${Promise.resolve()}\`;",
+  "diagnostics": [
+    {
+      "message": "Invalid type "Promise<void>" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 7`] = `
+{
+  "code": "const msg = \`arg = \${new Error()}\`;",
+  "diagnostics": [
+    {
+      "message": "Invalid type "Error" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 8`] = `
+{
+  "code": "
+        declare const arg: [number | undefined, string];
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "[number | undefined, string]" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 9`] = `
+{
+  "code": "
+        declare const arg: number;
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "number" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 10`] = `
+{
+  "code": "
+        declare const arg: boolean;
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "boolean" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 11`] = `
+{
+  "code": "
+        const arg = {};
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "{}" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 12`] = `
+{
+  "code": "
+        declare const arg: { a: string } & { b: string };
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "{ a: string; } & { b: string; }" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 13`] = `
+{
+  "code": "
+        function test<T extends {}>(arg: T) {
+          return \`arg = \${arg}\`;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "{}" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 14`] = `
+{
+  "code": "
+        function test<TWithNoConstraint>(arg: T) {
+          return \`arg = \${arg}\`;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "T" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 15`] = `
+{
+  "code": "
+        function test(arg: any) {
+          return \`arg = \${arg}\`;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "any" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 16`] = `
+{
+  "code": "
+        const arg = new RegExp('foo');
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "RegExp" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 17`] = `
+{
+  "code": "
+        const arg = /foo/;
+        const msg = \`arg = \${arg}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "RegExp" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 18`] = `
+{
+  "code": "
+        declare const value: never;
+        const stringy = \`\${value}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "never" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 28,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`restrict-template-expressions > invalid 19`] = `
+{
+  "code": "
+        function test<T extends any>(arg: T) {
+          return \`arg = \${arg}\`;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Invalid type "unknown" of template literal expression.",
+      "messageId": "invalidType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/restrict-template-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

`restrict-template-expressions` was registered, but its listener body was a placeholder that never reported — the rule appeared enabled while passing every input. This implements it against typescript-eslint 8.65.0.

- Union constituents must all be allowed, intersection constituents need one allowed, `StringLike` always passes.
- `allowAny` / `allowArray` / `allowBoolean` / `allowNever` / `allowNullish` / `allowNumber` / `allowRegExp`, with upstream's defaults — `allowArray` and `allowNever` off, the rest on. `allowArray` recurses into the number index type of arrays and tuples.
- `allow` accepts both the string shorthand and the `TypeOrValueSpecifier` object form, and matches a type's base types as well, so subclasses of an allowed type are allowed. Defaults to `Error`, `URL` and `URLSearchParams` from `lib`.
- Tagged template literals are skipped.
- Added `restrict_template_expressions.schema.json` and declared it on the rule. Options are parsed from the plain `options []any` array via `utils.GetOptionsMap`.

The option set follows upstream's schema exactly, so `allowInline` — which upstream does not have — is not part of it; `allow` accepts bare strings and covers the same case.

The rule docs listed `${num}` as incorrect, which contradicts `allowNumber` defaulting to `true`. Rewritten to describe actual behavior and document the options.

`tests/typescript-eslint/rules/restrict-template-expressions.test.ts` is enabled in `rstest.config.mts`. Its 19 snapshots were cross-checked against the report positions and message text declared in the upstream test file.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
