### PR TITLE
feat: port rule unicode-bom

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -43,6 +43,13 @@ func (fs *canonicalPathVFS) Realpath(filePath string) string {
 	return fs.FS.Realpath(filePath)
 }
 
+// SourceHasBOM forwards to the wrapped VFS. Embedding vfs.FS promotes only
+// that interface's methods, so this layer has to pass [utils.BOMSource]
+// through by hand or every overlay identity below it becomes invisible.
+func (fs *canonicalPathVFS) SourceHasBOM(filePath string) bool {
+	return utils.SourceHasBOM(fs.FS, filePath)
+}
+
 // programCache holds a cached Program instance for AST info requests
 type programCache struct {
 	mu              sync.RWMutex
@@ -749,7 +756,13 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	if req.Fix && len(diagnosticsByFile) > 0 {
 		output = make(map[string]string)
 		for filePath, fileDiags := range diagnosticsByFile {
+			// The parsed text has no byte order mark — reading the file
+			// consumed it — so put it back before fixing. Output is what the
+			// JS side writes to disk, and it has to be the whole file.
 			originalContent := fileDiags[0].SourceFile.Text()
+			if utils.SourceHasBOM(buildContext.FS(), filePath) {
+				originalContent = utils.BOM + originalContent
+			}
 			fixedContent, _, didFix := linter.ApplyRuleFixes(originalContent, fileDiags)
 			if didFix {
 				output[tspath.ConvertToRelativePath(filePath, comparePathOptions)] = fixedContent
@@ -1045,7 +1058,13 @@ func buildTsConfigContent(fileName string, compilerOptions map[string]any) strin
 // which counts UTF-16 units from a line start); fix ranges are flat offsets
 // from the start of the file.
 func byteOffsetToUTF16(text string, byteOffset int) int {
-	if byteOffset <= 0 {
+	if byteOffset < 0 {
+		// A fix reaching back before the text — ESLint's [-1, 0] for removing
+		// a byte order mark. There is nothing to measure, and the position is
+		// meaningful as it stands.
+		return byteOffset
+	}
+	if byteOffset == 0 {
 		return 0
 	}
 	if byteOffset >= len(text) {

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -229,7 +229,7 @@ func preferTypeScriptDiagnostic(candidate rule.RuleDiagnostic, current rule.Rule
 // applyFixPass applies auto-fixes for all files in diagnosticsByFile,
 // writes fixed content to disk, and returns the number of issues fixed. Write
 // failures are returned after all independent files have been attempted.
-func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) (int, error) {
+func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic, fsys vfs.FS) (int, error) {
 	fixed := 0
 	fileNames := make([]string, 0, len(diagnosticsByFile))
 	for fileName := range diagnosticsByFile {
@@ -250,7 +250,13 @@ func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) (int, erro
 			continue
 		}
 
+		// The parsed text has no byte order mark — decoding the file consumed
+		// it — so put it back before fixing. ApplyRuleFixes carries it through
+		// to the bytes written here, and drops it only for a fix that asks.
 		originalContent := diagnosticsWithFixes[0].SourceFile.Text()
+		if utils.SourceHasBOM(fsys, fileName) {
+			originalContent = utils.BOM + originalContent
+		}
 		fixedContent, unapplied, wasFixed := linter.ApplyRuleFixes(originalContent, diagnosticsWithFixes)
 
 		if wasFixed {
@@ -1034,7 +1040,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	const maxFixPasses = 10
 	if fix && len(allDiags) > 0 {
 		diagnosticsByFile := groupDiagsByFile(allDiags)
-		passFixed, fixErr := applyFixPass(diagnosticsByFile)
+		passFixed, fixErr := applyFixPass(diagnosticsByFile, fs)
 		// Replace the entire source generation after every write attempt and
 		// before any Program rebuild. os.WriteFile may truncate or partially
 		// mutate a file even when it ultimately returns an error, and whole-
@@ -1164,7 +1170,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				break
 			}
 
-			passFixed, fixErr := applyFixPass(groupDiagsByFile(passDiags))
+			passFixed, fixErr := applyFixPass(groupDiagsByFile(passDiags), fs)
 			// See the first fix pass above: invalidate before inspecting the
 			// result so a partially successful write can never feed a rebuild.
 			buildContext.InvalidateSourceSnapshots()

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1645,7 +1645,7 @@ func TestApplyFixPassReturnsWriteError(t *testing.T) {
 
 	fixed, err := applyFixPass(map[string][]rule.RuleDiagnostic{
 		directoryPath: {diagnostic},
-	})
+	}, bundled.WrapFS(cachedvfs.From(osvfs.FS())))
 	if err == nil {
 		t.Fatal("expected a write error")
 		return

--- a/internal/linter/eslint_plugin.go
+++ b/internal/linter/eslint_plugin.go
@@ -387,19 +387,11 @@ func applyEslintPluginResults(batch []EslintPluginFileInput, res *EslintPluginLi
 			continue
 		}
 		text := tsf.Text()
-		// The worker computes every offset against the BOM-STRIPPED source (it
-		// slices a leading BOM before parsing). When the rebuild frame KEEPS a
-		// leading BOM — the LSP overlay, whose frame must match the BOM-inclusive
-		// editor document + native diagnostics + the with-BOM content source.fix-
-		// All splices into — shift every worker offset past the BOM into this
-		// frame. The CLI frame (ts-go SourceFile) is already BOM-stripped, so the
-		// shift is 0 there.
-		bomShift := 0
-		if strings.HasPrefix(text, utf8BOM) {
-			bomShift = len(utf8BOM)
-		}
+		// The worker computes every offset against the BOM-stripped source (it
+		// slices a leading BOM before parsing), which is the one coordinate
+		// space rslint uses as well — see eslintPluginSourceFile. So worker
+		// offsets land in this frame as they stand.
 		clamp := func(p int) int {
-			p += bomShift
 			if p < 0 {
 				return 0
 			}
@@ -471,14 +463,12 @@ func applyEslintPluginResults(batch []EslintPluginFileInput, res *EslintPluginLi
 //     divergence can be byte-shifted (the clamp keeps it in-bounds — never a
 //     panic). The LSP path is immune: it ships req.text and rebuilds against
 //     that identical string.
-//   - LSP: f.Text is the overlay string the worker linted, kept VERBATIM
-//     (including any leading BOM). The LSP editor document and the native
-//     diagnostics are BOM-inclusive (ts-go's scanner treats a leading BOM as
-//     whitespace but keeps it in the text with inclusive positions), and
-//     source.fixAll splices into the with-BOM overlay \u2014 so the plugin frame must
-//     keep the BOM too. The worker reports BOM-stripped offsets (it slices the
-//     BOM before parsing); applyEslintPluginResults shifts them back past the
-//     BOM into this frame (see bomShift).
+//   - LSP: f.Text is the overlay string the worker linted, minus a leading
+//     BOM. A byte order mark is never part of the text an offset indexes \u2014 the
+//     worker slices it before parsing, ts-go decodes it away, and rslint strips
+//     it from caller-supplied source for the same reason \u2014 so stripping it here
+//     puts plugin diagnostics, native diagnostics and source.fixAll in one
+//     coordinate space.
 //
 // ok=false only if the caller supplied neither (defensive).
 func eslintPluginSourceFile(f EslintPluginFileInput) (ast.SourceFileLike, bool) {
@@ -486,7 +476,7 @@ func eslintPluginSourceFile(f EslintPluginFileInput) (ast.SourceFileLike, bool) 
 		return f.SourceFile, true
 	}
 	if f.Text != nil {
-		return newTextSourceFile(*f.Text), true
+		return newTextSourceFile(strings.TrimPrefix(*f.Text, utf8BOM)), true
 	}
 	return nil, false
 }

--- a/internal/linter/eslint_plugin_test.go
+++ b/internal/linter/eslint_plugin_test.go
@@ -431,12 +431,11 @@ func TestEslintPluginSourceFile(t *testing.T) {
 	if got, ok := eslintPluginSourceFile(EslintPluginFileInput{SourceFile: sf}); !ok || got != sf {
 		t.Errorf("SourceFile branch must reuse the provided frame verbatim")
 	}
-	// (b) LSP overlay: the frame keeps the BOM VERBATIM (it must match the
-	// BOM-inclusive editor document + native frame; the worker's BOM-stripped
-	// offsets are shifted back past the BOM during rebuild).
+	// (b) LSP overlay: the frame drops a leading BOM, so its offsets are the
+	// worker's and the native frame's.
 	withBOM := "\ufeff" + code
-	if got, ok := eslintPluginSourceFile(EslintPluginFileInput{Text: &withBOM}); !ok || got.Text() != withBOM {
-		t.Errorf("overlay frame must keep the BOM verbatim: text = %q, want %q", got.Text(), withBOM)
+	if got, ok := eslintPluginSourceFile(EslintPluginFileInput{Text: &withBOM}); !ok || got.Text() != code {
+		t.Errorf("overlay frame must drop the BOM: text = %q, want %q", got.Text(), code)
 	}
 	plain := code
 	if got, ok := eslintPluginSourceFile(EslintPluginFileInput{Text: &plain}); !ok || got.Text() != code {
@@ -481,12 +480,10 @@ func TestDispatchEslintPlugin_FrameReuseOverlayAndNoFrame(t *testing.T) {
 		t.Errorf("range over reused frame: want [6,12], got [%d,%d]", diags[0].Range.Pos(), diags[0].Range.End())
 	}
 
-	// (b) LSP overlay with a leading BOM. The frame KEEPS the BOM (matching the
-	// BOM-inclusive editor document + native diagnostics + the with-BOM content
-	// source.fixAll splices into). The worker reports BOM-stripped offsets [6,7]
-	// (the 'x'); Go shifts them +3 past the BOM into this frame \u2192 [9,10], so the
-	// fix splices the 'x' (NOT the BOM). Pre-fix this rebuilt against a BOM-
-	// stripped frame and corrupted source.fixAll on well-formed BOM files.
+	// (b) LSP overlay with a leading BOM. The frame drops the mark, matching the
+	// worker, the native diagnostics and source.fixAll: an offset never counts
+	// a byte order mark. The worker's [6,7] (the 'x') therefore lands as it
+	// stands, and the fix splices the 'x' rather than the mark.
 	const code = "const x = 1;"
 	bomText := "\ufeff" + code
 	files2 := []EslintPluginFileInput{
@@ -508,15 +505,15 @@ func TestDispatchEslintPlugin_FrameReuseOverlayAndNoFrame(t *testing.T) {
 	if len(diags2) != 1 {
 		t.Fatalf("want 1 diagnostic, got %d", len(diags2))
 	}
-	if diags2[0].SourceFile.Text() != bomText {
-		t.Errorf("overlay frame must keep the BOM: got %q, want %q", diags2[0].SourceFile.Text(), bomText)
+	if diags2[0].SourceFile.Text() != code {
+		t.Errorf("overlay frame must drop the BOM: got %q, want %q", diags2[0].SourceFile.Text(), code)
 	}
-	if diags2[0].Range.Pos() != 9 || diags2[0].Range.End() != 10 {
-		t.Errorf("overlay range: worker [6,7] + BOM shift \u2192 want [9,10], got [%d,%d]", diags2[0].Range.Pos(), diags2[0].Range.End())
+	if diags2[0].Range.Pos() != 6 || diags2[0].Range.End() != 7 {
+		t.Errorf("overlay range: worker [6,7] \u2192 want [6,7], got [%d,%d]", diags2[0].Range.Pos(), diags2[0].Range.End())
 	}
 	fx := diags2[0].Fixes()
-	if len(fx) != 1 || fx[0].Range.Pos() != 9 || fx[0].Range.End() != 10 || fx[0].Text != "y" {
-		t.Errorf("overlay fix: worker [6,7] + BOM shift \u2192 want [9,10]='y', got %+v", fx)
+	if len(fx) != 1 || fx[0].Range.Pos() != 6 || fx[0].Range.End() != 7 || fx[0].Text != "y" {
+		t.Errorf("overlay fix: worker [6,7] \u2192 want [6,7]='y', got %+v", fx)
 	}
 	// End-to-end: applying the fix to the with-BOM overlay must replace the 'x'
 	// and PRESERVE the BOM \u2014 no off-by-3 corruption.

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -208,6 +208,15 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 			refs = rule.NewRefStore(file, opts.Program.Options(), fileChecker)
 		}
 
+		// One lazy byte-order-mark answer shared by every rule in this file.
+		// The mark is gone from the text by the time the file is parsed, so
+		// answering means going back to whatever produced that text; a file no
+		// rule asks about never does.
+		var sourceBOM *rule.SourceBOM
+		if opts.Program != nil {
+			sourceBOM = rule.NewSourceBOM(opts.Program.Host().FS(), file.FileName())
+		}
+
 		for ruleIndex, r := range rules {
 			ctx := rule.RuleContext{
 				SourceFile:     file,
@@ -218,6 +227,7 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 				Globals:        rule.MergeGlobals(r.Globals, inlineGlobals),
 				Comments:       comments,
 				Refs:           refs,
+				BOM:            sourceBOM,
 				TypeChecker:    fileChecker,
 				DisableManager: disableManager,
 			}.WithDiagnosticConsumer(

--- a/internal/linter/source_code_fixer.go
+++ b/internal/linter/source_code_fixer.go
@@ -5,13 +5,29 @@ import (
 	"strings"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 type LintMessage interface {
 	Fixes() []rule.RuleFix
 }
 
+// ApplyRuleFixes applies non-conflicting fixes to a file's original text and
+// returns the result, the diagnostics whose fixes were left for a later pass,
+// and whether anything was applied.
+//
+// `code` is the text as it exists in the file, byte order mark included, while
+// fix ranges index the text without one — the mark is never part of what a
+// rule sees. That puts the mark at range position -1, which is how a rule asks
+// for it to be removed, and is ESLint's convention in SourceCodeFixer.
 func ApplyRuleFixes[M LintMessage](code string, diagnostics []M) (string, []M, bool) {
+	bom := ""
+	text := code
+	if strings.HasPrefix(text, utils.BOM) {
+		bom = utils.BOM
+		text = text[len(utils.BOM):]
+	}
+
 	unapplied := []M{}
 	withFixes := []M{}
 
@@ -44,7 +60,9 @@ func ApplyRuleFixes[M LintMessage](code string, diagnostics []M) (string, []M, b
 
 	var builder strings.Builder
 
-	lastFixEnd := 0
+	// Below every legal fix position, including the byte order mark's -1, so
+	// the first fix is never mistaken for an overlap.
+	lastFixEnd := -1
 	lastWasInsertion := false
 	for _, diagnostic := range withFixes {
 		fixes := diagnostic.Fixes()
@@ -65,7 +83,12 @@ func ApplyRuleFixes[M LintMessage](code string, diagnostics []M) (string, []M, b
 			lastFixEnd == firstFix.Range.Pos() &&
 			(isCurrentFixInsertion || lastWasInsertion)
 
-		if isOverlapping || isAdjacentConflict {
+		// An inverted range is not a range this fixer can honor.
+		isInverted := slices.ContainsFunc(fixes, func(fix rule.RuleFix) bool {
+			return fix.Range.Pos() > fix.Range.End()
+		})
+
+		if isOverlapping || isAdjacentConflict || isInverted {
 			unapplied = append(unapplied, diagnostic)
 			continue
 		}
@@ -74,14 +97,22 @@ func ApplyRuleFixes[M LintMessage](code string, diagnostics []M) (string, []M, b
 			fixed = true
 			lastWasInsertion = fix.Range.Pos() == fix.Range.End()
 
-			builder.WriteString(code[lastFixEnd:fix.Range.Pos()])
+			// A fix reaching back before the text either cuts the mark out or
+			// writes over it; either way the mark does not survive. So does a
+			// fix that replaces the start of the text with one of its own.
+			if (fix.Range.Pos() < 0 && fix.Range.End() >= 0) ||
+				(fix.Range.Pos() == 0 && strings.HasPrefix(fix.Text, utils.BOM)) {
+				bom = ""
+			}
+
+			builder.WriteString(text[max(0, lastFixEnd):max(0, fix.Range.Pos())])
 			builder.WriteString(fix.Text)
 
 			lastFixEnd = fix.Range.End()
 		}
 	}
 
-	builder.WriteString(code[lastFixEnd:])
+	builder.WriteString(text[max(0, lastFixEnd):])
 
-	return builder.String(), unapplied, fixed
+	return bom + builder.String(), unapplied, fixed
 }

--- a/internal/linter/source_code_fixer_test.go
+++ b/internal/linter/source_code_fixer_test.go
@@ -260,6 +260,60 @@ func TestApplyRuleFixes(t *testing.T) {
 			expectedUnapplied:   1,
 			expectedFixedStatus: true,
 		},
+		{
+			// ESLint's unicode-bom fix: a range starting one position ahead of
+			// the text, where the mark lives.
+			name: "fix reaching before the text removes the byte order mark",
+			code: "\uFEFFvar a = 123;",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newReplaceFix(-1, 0, "")),
+			},
+			expectedCode:        "var a = 123;",
+			expectedUnapplied:   0,
+			expectedFixedStatus: true,
+		},
+		{
+			name: "a fix elsewhere leaves the byte order mark in place",
+			code: "\uFEFFconst x = 1",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newInsertFix(11, ";")),
+			},
+			expectedCode:        "\uFEFFconst x = 1;",
+			expectedUnapplied:   0,
+			expectedFixedStatus: true,
+		},
+		{
+			name: "the mark is dropped once and the other fixes still land",
+			code: "\uFEFFconst foo = bar",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newReplaceFix(-1, 0, "")),
+				newMockDiagnostic(newReplaceFix(6, 9, "baz")),
+				newMockDiagnostic(newInsertFix(15, ";")),
+			},
+			expectedCode:        "const baz = bar;",
+			expectedUnapplied:   0,
+			expectedFixedStatus: true,
+		},
+		{
+			name: "removing an absent mark changes nothing",
+			code: "var a = 123;",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newReplaceFix(-1, 0, "")),
+			},
+			expectedCode:        "var a = 123;",
+			expectedUnapplied:   0,
+			expectedFixedStatus: true,
+		},
+		{
+			name: "inverted range is left for a later pass",
+			code: "var a = 123;",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newReplaceFix(9, 4, "x")),
+			},
+			expectedCode:        "var a = 123;",
+			expectedUnapplied:   1,
+			expectedFixedStatus: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -41,9 +41,12 @@ type lintPassResult struct {
 }
 
 // ruleFixToTextEdit converts a rule fix into an LSP TextEdit using the
-// source file's line map for position encoding.
+// source file's line map for position encoding. A fix reaching back before the
+// text — ESLint's [-1, 0] for a byte order mark — starts at the document's
+// first position: an editor document holds decoded text, and the mark is part
+// of the file's encoding rather than of that text.
 func ruleFixToTextEdit(sourceFile ast.SourceFileLike, fix rule.RuleFix) *lsproto.TextEdit {
-	startLine, startChar := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, fix.Range.Pos())
+	startLine, startChar := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, max(0, fix.Range.Pos()))
 	endLine, endChar := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, fix.Range.End())
 	return &lsproto.TextEdit{
 		Range: lsproto.Range{

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -1052,6 +1052,10 @@ func lintSingleFile(
 
 	// Create collector function
 	diagnosticCollector := func(d rule.RuleDiagnostic) {
+		// A unicode-bom fix is not expressible as an editor text edit, so skip it.
+		if d.RuleName == "unicode-bom" {
+			d.FixesPtr = nil
+		}
 		diagnosticsLock.Lock()
 		defer diagnosticsLock.Unlock()
 		diagnostics = append(diagnostics, d)

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -41,12 +41,9 @@ type lintPassResult struct {
 }
 
 // ruleFixToTextEdit converts a rule fix into an LSP TextEdit using the
-// source file's line map for position encoding. A fix reaching back before the
-// text — ESLint's [-1, 0] for a byte order mark — starts at the document's
-// first position: an editor document holds decoded text, and the mark is part
-// of the file's encoding rather than of that text.
+// source file's line map for position encoding.
 func ruleFixToTextEdit(sourceFile ast.SourceFileLike, fix rule.RuleFix) *lsproto.TextEdit {
-	startLine, startChar := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, max(0, fix.Range.Pos()))
+	startLine, startChar := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, fix.Range.Pos())
 	endLine, endChar := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, fix.Range.End())
 	return &lsproto.TextEdit{
 		Range: lsproto.Range{
@@ -1017,6 +1014,38 @@ func runLintWithProgramLoader(
 	), nil
 }
 
+// rulesSkippedInEditors names the rules the language server never runs. A rule
+// belongs here when what it checks is a property of the file's bytes rather
+// than of its text: an editor's document holds text that has already been
+// decoded, so such a property is neither visible in the document nor reachable
+// by a text edit.
+var rulesSkippedInEditors = map[string]bool{
+	// unicode-bom checks for a leading byte order mark. An editor decodes the
+	// mark into the document's encoding — VS Code shows it in the status bar as
+	// "UTF-8 with BOM" — so the document text never carries it and no text edit
+	// adds or removes it. The file on disk is the only remaining witness, and an
+	// unsaved buffer may already disagree with it. `rslint --fix`, which rewrites
+	// the file itself, is where the rule applies.
+	"unicode-bom": true,
+}
+
+// rulesServedToEditors drops the rules the language server never runs. The
+// input is a cached slice shared across files, so filtering builds a new one
+// and an unaffected configuration keeps the original.
+func rulesServedToEditors(rules []linter.ConfiguredRule) []linter.ConfiguredRule {
+	skipped := func(r linter.ConfiguredRule) bool { return rulesSkippedInEditors[r.Name] }
+	if !slices.ContainsFunc(rules, skipped) {
+		return rules
+	}
+	served := make([]linter.ConfiguredRule, 0, len(rules))
+	for _, configured := range rules {
+		if !skipped(configured) {
+			served = append(served, configured)
+		}
+	}
+	return served
+}
+
 func lintSingleFile(
 	program *compiler.Program,
 	sourceFile *ast.SourceFile,
@@ -1052,10 +1081,6 @@ func lintSingleFile(
 
 	// Create collector function
 	diagnosticCollector := func(d rule.RuleDiagnostic) {
-		// A unicode-bom fix is not expressible as an editor text edit, so skip it.
-		if d.RuleName == "unicode-bom" {
-			d.FixesPtr = nil
-		}
 		diagnosticsLock.Lock()
 		defer diagnosticsLock.Unlock()
 		diagnostics = append(diagnostics, d)
@@ -1066,7 +1091,7 @@ func lintSingleFile(
 		File:        sourceFile.FileName(),
 		HasTypeInfo: hasTypeInfo,
 		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return fileConfigResolver.ActiveRulesForFileHasTypeInfo(configFilePath, hasTypeInfo)
+			return rulesServedToEditors(fileConfigResolver.ActiveRulesForFileHasTypeInfo(configFilePath, hasTypeInfo))
 		},
 		Consumer: rule.DiagnosticConsumer{
 			Demand: editDemand,

--- a/internal/lsp/unicode_bom_test.go
+++ b/internal/lsp/unicode_bom_test.go
@@ -1,0 +1,162 @@
+package lsp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// markedProgram writes a file whose bytes begin with a byte order mark and
+// returns a Program over it, plus the normalized path. The mark is written as
+// an escape: a literal U+FEFF in a source file is invisible, and Go rejects one
+// in its own source outright.
+func markedProgram(t *testing.T, source string) (string, string, *compiler.Program, vfs.FS) {
+	t.Helper()
+
+	dir := t.TempDir()
+	file := tspath.NormalizePath(filepath.Join(dir, "marked.ts"))
+	if err := os.WriteFile(file, []byte("\uFEFF"+source), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(dir, fs)
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		Target: core.ScriptTargetESNext,
+		Module: core.ModuleKindESNext,
+	}, []string{file}, host)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
+	}
+	return dir, file, program, fs
+}
+
+// The mark is real and the rule finds it, so the editor reports it — a user
+// who has `unicode-bom` on should see it flagged.
+//
+// What the editor cannot do is remove it. The fix is a range over [-1, 0], one
+// position ahead of the text, because the mark is not in the text; an editor's
+// document holds decoded text, with the mark already turned into the
+// document's encoding. So the diagnostic arrives without its fix, and no
+// quick fix or fixAll edit can be built from it.
+func TestUnicodeBomIsReportedWithoutItsFix(t *testing.T) {
+	config.RegisterAllRules()
+
+	dir, file, program, fs := markedProgram(t, "let a = 1;\n")
+	sourceFile := sourceFileForPath(program, file, fs)
+	if sourceFile == nil {
+		t.Fatal("fixture is not in the program")
+	}
+
+	cfg := config.RslintConfig{{Rules: config.Rules{"unicode-bom": "error"}}}
+	resolver := config.NewFileConfigResolver(cfg, dir, false)
+
+	served := lintSingleFile(
+		program, sourceFile, file, true, resolver, rule.EditDemandAll, context.Background(),
+	).Diagnostics
+
+	if len(served) != 1 || served[0].RuleName != "unicode-bom" {
+		t.Fatalf("the editor should report the mark, got %+v", served)
+	}
+	if fixes := served[0].Fixes(); len(fixes) != 0 {
+		t.Errorf("the editor must not carry a fix it cannot apply, got %+v", fixes)
+	}
+	if action := createCodeActionFromRuleDiagnostic(served[0], "file:///marked.ts"); action != nil {
+		t.Errorf("a diagnostic with no fix must yield no quick fix, got %q", action.Title)
+	}
+}
+
+// Off the editor path the same rule on the same file keeps its fix, so the
+// withholding above is the language server's doing and not a broken rule.
+func TestUnicodeBomKeepsItsFixOffTheEditorPath(t *testing.T) {
+	config.RegisterAllRules()
+
+	dir, file, program, _ := markedProgram(t, "let a = 1;\n")
+	cfg := config.RslintConfig{{Rules: config.Rules{"unicode-bom": "error"}}}
+	resolver := config.NewFileConfigResolver(cfg, dir, false)
+
+	var direct []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program: program,
+		File:    file,
+		GetRulesForFile: func(f *ast.SourceFile) []linter.ConfiguredRule {
+			return resolver.ActiveRulesForFileHasTypeInfo(f.FileName(), true)
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandAll,
+			Report: func(d rule.RuleDiagnostic) { direct = append(direct, d) },
+		},
+	})
+
+	if len(direct) != 1 || direct[0].RuleName != "unicode-bom" {
+		t.Fatalf("expected one unicode-bom diagnostic, got %+v", direct)
+	}
+	fixes := direct[0].Fixes()
+	if len(fixes) != 1 {
+		t.Fatalf("expected the removal fix, got %+v", fixes)
+	}
+	// ESLint's [-1, 0]: one position ahead of the text, which is exactly why
+	// an editor cannot express it.
+	if fixes[0].Range.Pos() != -1 || fixes[0].Range.End() != 0 || fixes[0].Text != "" {
+		t.Errorf("expected a removal over [-1, 0], got %+v", fixes[0])
+	}
+}
+
+// Only unicode-bom is affected: another rule reporting on the same file in the
+// same pass keeps its fix.
+func TestOtherRulesKeepTheirFixesInTheEditor(t *testing.T) {
+	config.RegisterAllRules()
+
+	// `export` makes this a module and the function gives the `var` a local
+	// scope: no-var declines to fix a global in script mode, and the point here
+	// is a second rule that really does carry a fix.
+	dir, file, program, fs := markedProgram(t, "export function f() {\n  var a = 1;\n  return a;\n}\n")
+	sourceFile := sourceFileForPath(program, file, fs)
+	if sourceFile == nil {
+		t.Fatal("fixture is not in the program")
+	}
+
+	cfg := config.RslintConfig{{
+		Rules: config.Rules{
+			"unicode-bom": "error",
+			"no-var":      "error",
+		},
+	}}
+	resolver := config.NewFileConfigResolver(cfg, dir, false)
+
+	served := lintSingleFile(
+		program, sourceFile, file, true, resolver, rule.EditDemandAll, context.Background(),
+	).Diagnostics
+
+	byRule := make(map[string][]rule.RuleFix, len(served))
+	for _, d := range served {
+		byRule[d.RuleName] = d.Fixes()
+	}
+	if _, found := byRule["unicode-bom"]; !found {
+		t.Fatalf("expected a unicode-bom diagnostic, got %v", byRule)
+	}
+	if len(byRule["unicode-bom"]) != 0 {
+		t.Errorf("unicode-bom should have lost its fix, got %+v", byRule["unicode-bom"])
+	}
+	fixes, found := byRule["no-var"]
+	if !found {
+		t.Fatalf("expected a no-var diagnostic, got %v", byRule)
+	}
+	if len(fixes) == 0 {
+		t.Error("no-var must keep its fix")
+	}
+}

--- a/internal/lsp/unicode_bom_test.go
+++ b/internal/lsp/unicode_bom_test.go
@@ -20,16 +20,18 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// markedProgram writes a file whose bytes begin with a byte order mark and
-// returns a Program over it, plus the normalized path. The mark is written as
-// an escape: a literal U+FEFF in a source file is invisible, and Go rejects one
-// in its own source outright.
-func markedProgram(t *testing.T, source string) (string, string, *compiler.Program, vfs.FS) {
+// bom is the Unicode byte order mark, U+FEFF, spelled as an escape: a literal
+// one in a source file is invisible.
+const bom = "\uFEFF"
+
+// programOver writes a file with exactly the given bytes and returns a Program
+// over it, plus the normalized path.
+func programOver(t *testing.T, content string) (string, string, *compiler.Program, vfs.FS) {
 	t.Helper()
 
 	dir := t.TempDir()
-	file := tspath.NormalizePath(filepath.Join(dir, "marked.ts"))
-	if err := os.WriteFile(file, []byte("\uFEFF"+source), 0o644); err != nil {
+	file := tspath.NormalizePath(filepath.Join(dir, "subject.ts"))
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
 
@@ -45,51 +47,10 @@ func markedProgram(t *testing.T, source string) (string, string, *compiler.Progr
 	return dir, file, program, fs
 }
 
-// The mark is real and the rule finds it, so the editor reports it — a user
-// who has `unicode-bom` on should see it flagged.
-//
-// What the editor cannot do is remove it. The fix is a range over [-1, 0], one
-// position ahead of the text, because the mark is not in the text; an editor's
-// document holds decoded text, with the mark already turned into the
-// document's encoding. So the diagnostic arrives without its fix, and no
-// quick fix or fixAll edit can be built from it.
-func TestUnicodeBomIsReportedWithoutItsFix(t *testing.T) {
-	config.RegisterAllRules()
-
-	dir, file, program, fs := markedProgram(t, "let a = 1;\n")
-	sourceFile := sourceFileForPath(program, file, fs)
-	if sourceFile == nil {
-		t.Fatal("fixture is not in the program")
-	}
-
-	cfg := config.RslintConfig{{Rules: config.Rules{"unicode-bom": "error"}}}
-	resolver := config.NewFileConfigResolver(cfg, dir, false)
-
-	served := lintSingleFile(
-		program, sourceFile, file, true, resolver, rule.EditDemandAll, context.Background(),
-	).Diagnostics
-
-	if len(served) != 1 || served[0].RuleName != "unicode-bom" {
-		t.Fatalf("the editor should report the mark, got %+v", served)
-	}
-	if fixes := served[0].Fixes(); len(fixes) != 0 {
-		t.Errorf("the editor must not carry a fix it cannot apply, got %+v", fixes)
-	}
-	if action := createCodeActionFromRuleDiagnostic(served[0], "file:///marked.ts"); action != nil {
-		t.Errorf("a diagnostic with no fix must yield no quick fix, got %q", action.Title)
-	}
-}
-
-// Off the editor path the same rule on the same file keeps its fix, so the
-// withholding above is the language server's doing and not a broken rule.
-func TestUnicodeBomKeepsItsFixOffTheEditorPath(t *testing.T) {
-	config.RegisterAllRules()
-
-	dir, file, program, _ := markedProgram(t, "let a = 1;\n")
-	cfg := config.RslintConfig{{Rules: config.Rules{"unicode-bom": "error"}}}
-	resolver := config.NewFileConfigResolver(cfg, dir, false)
-
-	var direct []rule.RuleDiagnostic
+// lintOffTheEditorPath runs the configured rules the way everything that is not
+// the language server does, with no filtering in between.
+func lintOffTheEditorPath(program *compiler.Program, file string, resolver *config.FileConfigResolver) []rule.RuleDiagnostic {
+	var reported []rule.RuleDiagnostic
 	linter.LintSingleFile(linter.LintSingleFileOptions{
 		Program: program,
 		File:    file,
@@ -98,33 +59,90 @@ func TestUnicodeBomKeepsItsFixOffTheEditorPath(t *testing.T) {
 		},
 		Consumer: rule.DiagnosticConsumer{
 			Demand: rule.EditDemandAll,
-			Report: func(d rule.RuleDiagnostic) { direct = append(direct, d) },
+			Report: func(d rule.RuleDiagnostic) { reported = append(reported, d) },
 		},
 	})
+	return reported
+}
 
-	if len(direct) != 1 || direct[0].RuleName != "unicode-bom" {
-		t.Fatalf("expected one unicode-bom diagnostic, got %+v", direct)
-	}
-	fixes := direct[0].Fixes()
-	if len(fixes) != 1 {
-		t.Fatalf("expected the removal fix, got %+v", fixes)
-	}
-	// ESLint's [-1, 0]: one position ahead of the text, which is exactly why
-	// an editor cannot express it.
-	if fixes[0].Range.Pos() != -1 || fixes[0].Range.End() != 0 || fixes[0].Text != "" {
-		t.Errorf("expected a removal over [-1, 0], got %+v", fixes[0])
+// The language server does not run unicode-bom, in either direction: a marked
+// file under `never` and an unmarked one under `always` both come back silent.
+// An editor's document holds decoded text, so the mark it would report on is
+// not in the document, cannot be reached by a text edit, and — for an unsaved
+// buffer — is only answerable from a file on disk the buffer may already
+// disagree with.
+//
+// Each case is run off the editor path too, where it does report: the silence
+// is the language server's doing, and not a rule that never had anything to say.
+func TestUnicodeBomIsNotServedToEditors(t *testing.T) {
+	config.RegisterAllRules()
+
+	for _, test := range []struct {
+		name    string
+		content string
+		option  any
+		// The fix the rule reports off the editor path. Removal is ESLint's
+		// [-1, 0], one position ahead of the text, because the mark is not in
+		// the text; `rslint --fix` rewrites the file and can act on it.
+		fixPos, fixEnd int
+		fixText        string
+	}{
+		{
+			name:    "never on a marked file",
+			content: bom + "let a = 1;\n",
+			option:  "error",
+			fixPos:  -1, fixEnd: 0, fixText: "",
+		},
+		{
+			name:    "always on an unmarked file",
+			content: "let a = 1;\n",
+			option:  []any{"error", "always"},
+			fixPos:  0, fixEnd: 0, fixText: bom,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir, file, program, fs := programOver(t, test.content)
+			sourceFile := sourceFileForPath(program, file, fs)
+			if sourceFile == nil {
+				t.Fatal("fixture is not in the program")
+			}
+
+			cfg := config.RslintConfig{{Rules: config.Rules{"unicode-bom": test.option}}}
+			resolver := config.NewFileConfigResolver(cfg, dir, false)
+
+			served := lintSingleFile(
+				program, sourceFile, file, true, resolver, rule.EditDemandAll, context.Background(),
+			).Diagnostics
+
+			if len(served) != 0 {
+				t.Errorf("the editor should be served nothing, got %+v", served)
+			}
+
+			direct := lintOffTheEditorPath(program, file, resolver)
+			if len(direct) != 1 || direct[0].RuleName != "unicode-bom" {
+				t.Fatalf("expected one unicode-bom diagnostic off the editor path, got %+v", direct)
+			}
+			fixes := direct[0].Fixes()
+			if len(fixes) != 1 {
+				t.Fatalf("expected one fix off the editor path, got %+v", fixes)
+			}
+			if fixes[0].Range.Pos() != test.fixPos || fixes[0].Range.End() != test.fixEnd || fixes[0].Text != test.fixText {
+				t.Errorf("expected a fix over [%d, %d] with %q, got %+v",
+					test.fixPos, test.fixEnd, test.fixText, fixes[0])
+			}
+		})
 	}
 }
 
-// Only unicode-bom is affected: another rule reporting on the same file in the
-// same pass keeps its fix.
-func TestOtherRulesKeepTheirFixesInTheEditor(t *testing.T) {
+// Only unicode-bom is held back: another rule configured for the same file in
+// the same pass reports and keeps its fix.
+func TestOtherRulesStillRunInTheEditor(t *testing.T) {
 	config.RegisterAllRules()
 
 	// `export` makes this a module and the function gives the `var` a local
 	// scope: no-var declines to fix a global in script mode, and the point here
 	// is a second rule that really does carry a fix.
-	dir, file, program, fs := markedProgram(t, "export function f() {\n  var a = 1;\n  return a;\n}\n")
+	dir, file, program, fs := programOver(t, bom+"export function f() {\n  var a = 1;\n  return a;\n}\n")
 	sourceFile := sourceFileForPath(program, file, fs)
 	if sourceFile == nil {
 		t.Fatal("fixture is not in the program")
@@ -146,11 +164,8 @@ func TestOtherRulesKeepTheirFixesInTheEditor(t *testing.T) {
 	for _, d := range served {
 		byRule[d.RuleName] = d.Fixes()
 	}
-	if _, found := byRule["unicode-bom"]; !found {
-		t.Fatalf("expected a unicode-bom diagnostic, got %v", byRule)
-	}
-	if len(byRule["unicode-bom"]) != 0 {
-		t.Errorf("unicode-bom should have lost its fix, got %+v", byRule["unicode-bom"])
+	if fixes, found := byRule["unicode-bom"]; found {
+		t.Errorf("unicode-bom should not have run, got %+v", fixes)
 	}
 	fixes, found := byRule["no-var"]
 	if !found {

--- a/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing_test.go
+++ b/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing_test.go
@@ -2255,19 +2255,17 @@ func TestJsxCurlySpacingRule(t *testing.T) {
 
 		// ===== BOM + Unicode invalid lock-in =====
 
-		// BOM at file start — tsgo's scanner counts the BOM as 1 UTF-16
-		// character on line 1 (not stripped during position calculation),
-		// so columns shift by +1 vs the BOM-less equivalent: `{` at col 11,
-		// `}` at col 17. Locked in as observable rslint behaviour; if
-		// upstream ESLint differs here that is a framework-level position-
-		// calc divergence, not a rule-logic issue.
+		// BOM at file start — the mark is consumed when the source is decoded,
+		// so it occupies no column and positions match the BOM-less equivalent:
+		// `{` at col 10, `}` at col 16. ESLint reports the same. The fix leaves
+		// the mark in place, since nothing asked to remove it.
 		{
 			Code:   "\uFEFF<App foo={ bar } />",
 			Tsx:    true,
 			Output: []string{"\uFEFF<App foo={bar} />"},
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noSpaceAfter", Line: 1, Column: 11},
-				{MessageId: "noSpaceBefore", Line: 1, Column: 17},
+				{MessageId: "noSpaceAfter", Line: 1, Column: 10},
+				{MessageId: "noSpaceBefore", Line: 1, Column: 16},
 			},
 		},
 		// BMP non-ASCII identifier — `中` and `文` each count as 1 UTF-16

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_extras_test.go
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_extras_test.go
@@ -135,9 +135,11 @@ const value = 1;
 				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(4, 1, "foo")},
 			},
 			{
+				// The mark is consumed when the source is decoded, so it occupies
+				// no column: the reference starts at column 1, as ESLint reports it.
 				Code:    "\ufeff/// <reference path=\"bom\" />\n",
 				Options: map[string]interface{}{"path": "never"},
-				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(1, 2, "bom")},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(1, 1, "bom")},
 			},
 			{
 				Code:    "#!/usr/bin/env node\n/// <reference path=\"shebang\" />\n",

--- a/internal/rule/context.go
+++ b/internal/rule/context.go
@@ -64,7 +64,11 @@ type RuleContext struct {
 	// instead of walking the AST and calling TypeChecker.GetSymbolAtLocation
 	// per identifier. Keys are binder symbols (node.Symbol()); see RefStore.
 	// Nil when no program is available.
-	Refs           *RefStore
+	Refs *RefStore
+	// BOM lazily answers whether this file's source text began with a byte
+	// order mark. Rules read it through [RuleContext.HasBOM]; nil answers
+	// false, which is what a context with no program can say.
+	BOM            *SourceBOM
 	Program        *compiler.Program
 	TypeChecker    *checker.Checker
 	DisableManager *DisableManager

--- a/internal/rule/source_bom.go
+++ b/internal/rule/source_bom.go
@@ -1,0 +1,45 @@
+package rule
+
+import (
+	"sync"
+
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// SourceBOM lazily answers whether one file's source text began with a Unicode
+// byte order mark. The text a rule sees never contains the mark — see
+// [utils.BOMSource] — so this is the only witness, and answering costs a read
+// of the file's own bytes whenever the text came off disk. One store per file
+// is shared by every rule on it, and a file no rule asks about pays nothing.
+type SourceBOM struct {
+	fs   vfs.FS
+	path string
+	once sync.Once
+	has  bool
+}
+
+// NewSourceBOM returns the store for one file. A nil file system yields a
+// store that answers false, which is what a context with no program has to
+// say.
+func NewSourceBOM(fileSystem vfs.FS, path string) *SourceBOM {
+	return &SourceBOM{fs: fileSystem, path: path}
+}
+
+// Value reports whether the file's source text began with a byte order mark.
+func (s *SourceBOM) Value() bool {
+	if s == nil || s.fs == nil {
+		return false
+	}
+	s.once.Do(func() {
+		s.has = utils.SourceHasBOM(s.fs, s.path)
+	})
+	return s.has
+}
+
+// HasBOM reports whether this file's source text began with a Unicode byte
+// order mark, U+FEFF. It is ESLint's `SourceCode#hasBOM`: SourceFile.Text()
+// never contains the mark, so a rule that cares about one asks here.
+func (ctx RuleContext) HasBOM() bool {
+	return ctx.BOM.Value()
+}

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -150,6 +150,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/require_yield"
 	"github.com/web-infra-dev/rslint/internal/rules/strict"
 	"github.com/web-infra-dev/rslint/internal/rules/symbol_description"
+	"github.com/web-infra-dev/rslint/internal/rules/unicode_bom"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
 	"github.com/web-infra-dev/rslint/internal/rules/valid_typeof"
 )
@@ -306,5 +307,6 @@ func GetAllRules() []rule.Rule {
 		require_yield.RequireYieldRule,
 		symbol_description.SymbolDescriptionRule,
 		no_unexpected_multiline.NoUnexpectedMultilineRule,
+		unicode_bom.UnicodeBomRule,
 	}
 }

--- a/internal/rules/unicode_bom/unicode_bom.go
+++ b/internal/rules/unicode_bom/unicode_bom.go
@@ -1,0 +1,49 @@
+// Package unicode_bom implements the core ESLint rule `unicode-bom`, narrowed
+// to its `never` option: a file must not begin with a Unicode byte order mark,
+// U+FEFF.
+//
+// `always` is not supported and not planned, so the schema admits `never`
+// alone and rejects anything else.
+//
+// The mark is never part of the text a rule sees — reading a file decodes it
+// away, and caller-supplied source is stripped to match — so the question is
+// answered by ctx.HasBOM, rslint's SourceCode#hasBOM. Removing it is the fix
+// ESLint writes: a range starting at -1, one position ahead of the text.
+package unicode_bom
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+//go:embed unicode_bom.schema.json
+var schemaJSON []byte
+
+// UnicodeBomRule disallows a Unicode BOM.
+// https://eslint.org/docs/latest/rules/unicode-bom
+var UnicodeBomRule = rule.Rule{
+	Name:   "unicode-bom",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		// `never` is the only option the schema admits, and it is also the
+		// default, so there is nothing to read out of options.
+		if !ctx.HasBOM() {
+			return rule.RuleListeners{}
+		}
+
+		// The linter never fires a KindSourceFile listener, so report eagerly.
+		// The whole check is one property of the file; there is no node to
+		// wait for. The zero-width range at offset 0 renders as line 1,
+		// column 1 — where ESLint puts it.
+		ctx.ReportRangeWithDeferredFixes(core.NewTextRange(0, 0), rule.RuleMessage{
+			Id:          "unexpected",
+			Description: "Unexpected Unicode BOM (Byte Order Mark).",
+		}, func() []rule.RuleFix {
+			return []rule.RuleFix{rule.RuleFixRemoveRange(core.NewTextRange(-1, 0))}
+		})
+
+		return rule.RuleListeners{}
+	},
+}

--- a/internal/rules/unicode_bom/unicode_bom.go
+++ b/internal/rules/unicode_bom/unicode_bom.go
@@ -1,14 +1,12 @@
-// Package unicode_bom implements the core ESLint rule `unicode-bom`, narrowed
-// to its `never` option: a file must not begin with a Unicode byte order mark,
-// U+FEFF.
-//
-// `always` is not supported and not planned, so the schema admits `never`
-// alone and rejects anything else.
+// Package unicode_bom implements the core ESLint rule `unicode-bom`: a file
+// must begin with a Unicode byte order mark, U+FEFF, under `always`, and must
+// not under `never`.
 //
 // The mark is never part of the text a rule sees — reading a file decodes it
 // away, and caller-supplied source is stripped to match — so the question is
-// answered by ctx.HasBOM, rslint's SourceCode#hasBOM. Removing it is the fix
-// ESLint writes: a range starting at -1, one position ahead of the text.
+// answered by ctx.HasBOM, rslint's SourceCode#hasBOM. Both fixes are the ones
+// ESLint writes: writing a mark in is an insertion at the front of the text,
+// and cutting one out is a range starting at -1, one position ahead of it.
 package unicode_bom
 
 import (
@@ -16,33 +14,53 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 //go:embed unicode_bom.schema.json
 var schemaJSON []byte
 
-// UnicodeBomRule disallows a Unicode BOM.
+// parseOptions reports whether the file is required to carry a mark. `never`
+// is the default, matching upstream's `defaultOptions`.
+func parseOptions(options []any) bool {
+	if len(options) == 0 {
+		return false
+	}
+	mode, _ := options[0].(string)
+	return mode == "always"
+}
+
+// UnicodeBomRule requires or disallows a Unicode BOM.
 // https://eslint.org/docs/latest/rules/unicode-bom
 var UnicodeBomRule = rule.Rule{
 	Name:   "unicode-bom",
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// `never` is the only option the schema admits, and it is also the
-		// default, so there is nothing to read out of options.
-		if !ctx.HasBOM() {
-			return rule.RuleListeners{}
-		}
+		requireBOM := parseOptions(options)
+		hasBOM := ctx.HasBOM()
 
 		// The linter never fires a KindSourceFile listener, so report eagerly.
 		// The whole check is one property of the file; there is no node to
 		// wait for. The zero-width range at offset 0 renders as line 1,
 		// column 1 — where ESLint puts it.
-		ctx.ReportRangeWithDeferredFixes(core.NewTextRange(0, 0), rule.RuleMessage{
-			Id:          "unexpected",
-			Description: "Unexpected Unicode BOM (Byte Order Mark).",
-		}, func() []rule.RuleFix {
-			return []rule.RuleFix{rule.RuleFixRemoveRange(core.NewTextRange(-1, 0))}
-		})
+		reportRange := core.NewTextRange(0, 0)
+
+		switch {
+		case requireBOM && !hasBOM:
+			ctx.ReportRangeWithDeferredFixes(reportRange, rule.RuleMessage{
+				Id:          "expected",
+				Description: "Expected Unicode BOM (Byte Order Mark).",
+			}, func() []rule.RuleFix {
+				return []rule.RuleFix{rule.RuleFixReplaceRange(core.NewTextRange(0, 0), utils.BOM)}
+			})
+		case !requireBOM && hasBOM:
+			ctx.ReportRangeWithDeferredFixes(reportRange, rule.RuleMessage{
+				Id:          "unexpected",
+				Description: "Unexpected Unicode BOM (Byte Order Mark).",
+			}, func() []rule.RuleFix {
+				return []rule.RuleFix{rule.RuleFixRemoveRange(core.NewTextRange(-1, 0))}
+			})
+		}
 
 		return rule.RuleListeners{}
 	},

--- a/internal/rules/unicode_bom/unicode_bom.md
+++ b/internal/rules/unicode_bom/unicode_bom.md
@@ -6,7 +6,9 @@ The Unicode byte order mark (BOM, U+FEFF) marks whether code units are big endia
 
 This rule controls whether a file begins with a BOM. Only the first position counts: a U+FEFF character anywhere else in the file is ordinary text and is left alone.
 
-`rslint --fix` adds or removes the mark and rewrites the rest of the file unchanged.
+The mark lives in a file's bytes rather than in its text, so this rule reads the file itself. It runs wherever rslint reads files — the CLI and the API — and `rslint --fix` adds or removes the mark, rewriting the rest of the file unchanged.
+
+Editors work from decoded text: VS Code turns a leading mark into the document's encoding, shown in the status bar as "UTF-8 with BOM". The language server therefore leaves this rule to the CLI and the API, where the file's own bytes are in reach.
 
 ## Options
 

--- a/internal/rules/unicode_bom/unicode_bom.md
+++ b/internal/rules/unicode_bom/unicode_bom.md
@@ -4,13 +4,17 @@
 
 The Unicode byte order mark (BOM, U+FEFF) marks whether code units are big endian or little endian. UTF-8 does not need one, because byte ordering does not matter when a character is a single byte, and UTF-8 dominates the web.
 
-This rule disallows a BOM at the very start of a file. Only the first position counts: a U+FEFF character anywhere else in the file is ordinary text and is left alone.
+This rule controls whether a file begins with a BOM. Only the first position counts: a U+FEFF character anywhere else in the file is ordinary text and is left alone.
 
-`rslint --fix` removes the mark and rewrites the rest of the file unchanged.
+`rslint --fix` adds or removes the mark and rewrites the rest of the file unchanged.
 
 ## Options
 
-This rule takes one string option, `"never"`, which is also the default:
+This rule takes one string option.
+
+### `"never"` (default)
+
+A file must not begin with a byte order mark.
 
 ```json
 { "unicode-bom": ["error", "never"] }
@@ -29,11 +33,28 @@ Example of **incorrect** code:
 let abc;
 ```
 
-The mark itself is invisible, so the comment stands in for it: the file's first three bytes are `EF BB BF`. A UTF-16 file, whose mark is `FF FE` or `FE FF`, is incorrect for the same reason.
+### `"always"`
 
-## Differences from ESLint
+A file must begin with a byte order mark.
 
-- ESLint's `"always"` option is not supported in rslint and is not planned. `"never"` is the only allowed option; anything else is rejected as an invalid configuration.
+```json
+{ "unicode-bom": ["error", "always"] }
+```
+
+Example of **correct** code:
+
+```javascript
+// U+FEFF at the beginning
+let abc;
+```
+
+Example of **incorrect** code:
+
+```javascript
+let abc;
+```
+
+The mark itself is invisible, so the comment stands in for it: the file's first three bytes are `EF BB BF`. A UTF-16 file, whose mark is `FF FE` or `FE FF`, counts as carrying one for the same reason.
 
 ## When Not To Use It
 

--- a/internal/rules/unicode_bom/unicode_bom.md
+++ b/internal/rules/unicode_bom/unicode_bom.md
@@ -1,0 +1,44 @@
+# unicode-bom
+
+## Rule Details
+
+The Unicode byte order mark (BOM, U+FEFF) marks whether code units are big endian or little endian. UTF-8 does not need one, because byte ordering does not matter when a character is a single byte, and UTF-8 dominates the web.
+
+This rule disallows a BOM at the very start of a file. Only the first position counts: a U+FEFF character anywhere else in the file is ordinary text and is left alone.
+
+`rslint --fix` removes the mark and rewrites the rest of the file unchanged.
+
+## Options
+
+This rule takes one string option, `"never"`, which is also the default:
+
+```json
+{ "unicode-bom": ["error", "never"] }
+```
+
+Example of **correct** code:
+
+```javascript
+let abc;
+```
+
+Example of **incorrect** code:
+
+```javascript
+// U+FEFF at the beginning
+let abc;
+```
+
+The mark itself is invisible, so the comment stands in for it: the file's first three bytes are `EF BB BF`. A UTF-16 file, whose mark is `FF FE` or `FE FF`, is incorrect for the same reason.
+
+## Differences from ESLint
+
+- ESLint's `"always"` option is not supported in rslint and is not planned. `"never"` is the only allowed option; anything else is rejected as an invalid configuration.
+
+## When Not To Use It
+
+If you do not care about the presence of a byte order mark in your files, you can turn this rule off.
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/unicode-bom

--- a/internal/rules/unicode_bom/unicode_bom.schema.json
+++ b/internal/rules/unicode_bom/unicode_bom.schema.json
@@ -1,0 +1,10 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "enum": ["never"]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/unicode_bom/unicode_bom.schema.json
+++ b/internal/rules/unicode_bom/unicode_bom.schema.json
@@ -2,7 +2,7 @@
   "type": "array",
   "items": [
     {
-      "enum": ["never"]
+      "enum": ["always", "never"]
     }
   ],
   "minItems": 0,

--- a/internal/rules/unicode_bom/unicode_bom_disk_test.go
+++ b/internal/rules/unicode_bom/unicode_bom_disk_test.go
@@ -1,0 +1,161 @@
+package unicode_bom
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"gotest.tools/v3/assert"
+)
+
+// TestUnicodeBomOnDisk lints real files through the real file system. Every
+// other test in this package hands the rule its source as caller-supplied
+// content; a file read off disk reaches the rule by a different route, and the
+// answer has to be the same one.
+func TestUnicodeBomOnDisk(t *testing.T) {
+	t.Parallel()
+
+	const source = "var a = 123;\n"
+
+	for _, tc := range []struct {
+		name       string
+		bytes      string
+		wantText   string
+		wantReport bool
+	}{
+		{name: "utf-8 mark", bytes: "\uFEFF" + source, wantReport: true},
+		// A UTF-16 file is decoded to UTF-8 and loses its mark on the way, so
+		// it counts as marked just like a UTF-8 one.
+		{name: "utf-16 mark", bytes: "\xFF\xFE" + utf16LE(source), wantReport: true},
+		{name: "no mark", bytes: source},
+		// Real-user: eslint#6580 / #4878 — files written by Windows editors
+		// where the mark sits ahead of a shebang.
+		{
+			name:       "mark ahead of a shebang",
+			bytes:      "\uFEFF#!/usr/bin/env node\n" + source,
+			wantText:   "#!/usr/bin/env node\n" + source,
+			wantReport: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			filePath := writeFixture(t, tc.bytes)
+			diagnostics := lintOnDisk(t, filePath)
+
+			if !tc.wantReport {
+				assert.Equal(t, 0, len(diagnostics), "expected no diagnostic")
+				return
+			}
+
+			assert.Equal(t, 1, len(diagnostics))
+			assert.Equal(t, "Unexpected Unicode BOM (Byte Order Mark).", diagnostics[0].Message.Description)
+			wantText := tc.wantText
+			if wantText == "" {
+				wantText = source
+			}
+			assert.Equal(t, wantText, diagnostics[0].SourceFile.Text(),
+				"the mark never reaches the source text")
+		})
+	}
+}
+
+// TestUnicodeBomFixRewritesFile walks a marked file through a full lint, fix
+// and write cycle the way the CLI does — putting the mark back in front of the
+// parsed text before fixing, because that is what the file holds — then lints
+// the written bytes again.
+func TestUnicodeBomFixRewritesFile(t *testing.T) {
+	t.Parallel()
+
+	const source = "var a = 123;\n"
+	filePath := writeFixture(t, utils.BOM+source)
+
+	diagnostics := lintOnDisk(t, filePath)
+	assert.Equal(t, 1, len(diagnostics))
+
+	original := utils.BOM + diagnostics[0].SourceFile.Text()
+	fixed, _, wasFixed := linter.ApplyRuleFixes(original, diagnostics)
+	assert.Assert(t, wasFixed, "the diagnostic must carry an applicable fix")
+	assert.NilError(t, os.WriteFile(filePath, []byte(fixed), 0o644))
+
+	written, err := os.ReadFile(filePath)
+	assert.NilError(t, err)
+	assert.Equal(t, source, string(written), "the written bytes must have lost the mark")
+
+	assert.Equal(t, 0, len(lintOnDisk(t, filePath)),
+		"the file must be clean once its own fix has been written back")
+}
+
+// writeFixture puts bytes on disk verbatim, byte order mark included, and
+// returns the normalized path a Program will know the file by.
+func writeFixture(t *testing.T, bytes string) string {
+	t.Helper()
+
+	filePath := tspath.NormalizePath(filepath.Join(t.TempDir(), "file.ts"))
+	assert.NilError(t, os.WriteFile(filePath, []byte(bytes), 0o644))
+	return filePath
+}
+
+// lintOnDisk runs the rule over a real file with no overlay in the way.
+func lintOnDisk(t *testing.T, filePath string) []rule.RuleDiagnostic {
+	t.Helper()
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(filepath.Dir(filePath), fs)
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		Module:       core.ModuleKindESNext,
+		SkipLibCheck: core.TSTrue,
+		Target:       core.ScriptTargetESNext,
+	}, []string{filePath}, host)
+	assert.NilError(t, err)
+
+	ruleRan := false
+	var diagnostics []rule.RuleDiagnostic
+	linter.RunLinterInProgram(
+		program,
+		nil,
+		nil,
+		utils.ExcludePaths,
+		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+			if sourceFile.FileName() != filePath {
+				return nil
+			}
+			return []linter.ConfiguredRule{{
+				Name:     UnicodeBomRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					ruleRan = true
+					return UnicodeBomRule.Run(ctx, []any{"never"})
+				},
+			}}
+		},
+		false,
+		func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+		nil,
+		nil,
+	)
+	assert.Assert(t, ruleRan, "the rule did not run for %s", filePath)
+
+	return diagnostics
+}
+
+// utf16LE encodes ASCII source as little-endian UTF-16, without a mark — the
+// caller prepends one.
+func utf16LE(source string) string {
+	encoded := make([]byte, 0, len(source)*2)
+	for _, r := range source {
+		encoded = append(encoded, byte(r), byte(r>>8))
+	}
+	return string(encoded)
+}

--- a/internal/rules/unicode_bom/unicode_bom_extras_test.go
+++ b/internal/rules/unicode_bom/unicode_bom_extras_test.go
@@ -67,6 +67,16 @@ func TestUnicodeBomExtras(t *testing.T) {
 			// The CLI hands a single positional option through as `["never"]`;
 			// this asserts the rule survives options that are not an array.
 			{Code: "var a = 123;", Options: "never"},
+
+			// ---- `always`: the mark is present, which is all the mode asks ----
+			{Code: "\uFEFFvar a = 123;", Options: []interface{}{"always"}},
+			// A file that is nothing but the mark still carries one.
+			{Code: "\uFEFF", Options: []interface{}{"always"}},
+			// Doubled: the first is the file's mark, the second is text behind
+			// it, and the mode is satisfied by the first.
+			{Code: "\uFEFF\uFEFFvar a = 123;", Options: []interface{}{"always"}},
+			// A mark ahead of a shebang, the shape Windows editors write.
+			{Code: "\uFEFF#!/usr/bin/env node\nvar a = 123;", Options: []interface{}{"always"}},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: graceful degradation — file is nothing but a mark ----
@@ -167,19 +177,107 @@ func TestUnicodeBomExtras(t *testing.T) {
 					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
 				}},
 			},
+
+			// ---- `always`: graceful degradation \u2014 an empty file ----
+			// There is nothing for the mark to precede, and writing it in is
+			// the whole of the fixed file.
+			{
+				Code:    "",
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFF"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected",
+					Message:   "Expected Unicode BOM (Byte Order Mark).",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- `always`: a U+FEFF present but not in the first position ----
+			// Mid-file it is ordinary text, so the file still has no mark.
+			{
+				Code:    "var a = 123; \uFEFFvar b = 1;",
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFFvar a = 123; \uFEFFvar b = 1;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+			// After a leading newline \u2014 position 0 is the newline, not a mark.
+			{
+				Code:    "\n\uFEFFvar a = 123;",
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFF\n\uFEFFvar a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- `always`: the mark goes ahead of a shebang ----
+			{
+				Code:    "#!/usr/bin/env node\nvar a = 123;",
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFF#!/usr/bin/env node\nvar a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- `always`: CRLF line endings ----
+			{
+				Code:    "var a = 123;\r\nvar b = 1;\r\n",
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFFvar a = 123;\r\nvar b = 1;\r\n"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- `always`: multibyte content, and .tsx source ----
+			{
+				Code:    "var 日本 = '𝟘';",
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFFvar 日本 = '𝟘';"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+			{
+				Code:    "const a = <div />;\n",
+				Tsx:     true,
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFFconst a = <div />;\n"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- `always` via the JSON path: bare string rather than array ----
+			{
+				Code:    "var a = 123;",
+				Options: "always",
+				Output:  []string{"\uFEFFvar a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
 		},
 	)
 }
 
-// TestUnicodeBomRejectsAlways locks in that `always` is refused where every
-// other unusable configuration is refused — schema validation, before the rule
-// runs — rather than accepted and then silently ignored.
-func TestUnicodeBomRejectsAlways(t *testing.T) {
+// TestUnicodeBomSchema locks in the option surface: both modes are accepted,
+// and anything else is refused where every other unusable configuration is
+// refused — schema validation, before the rule runs — rather than accepted and
+// then silently ignored.
+func TestUnicodeBomSchema(t *testing.T) {
 	t.Parallel()
 
-	assert.Assert(t, UnicodeBomRule.Schema.Validate([]any{"always"}) != nil,
-		"the schema must reject the always option")
+	assert.NilError(t, UnicodeBomRule.Schema.Validate([]any{"always"}))
 	assert.NilError(t, UnicodeBomRule.Schema.Validate([]any{"never"}))
+	assert.NilError(t, UnicodeBomRule.Schema.Validate([]any{}))
+	assert.Assert(t, UnicodeBomRule.Schema.Validate([]any{"sometimes"}) != nil,
+		"the schema must reject a mode that is neither always nor never")
+	assert.Assert(t, UnicodeBomRule.Schema.Validate([]any{"never", "never"}) != nil,
+		"the schema must reject a second option")
 }
 
 // TestUnicodeBomTextNeverCarriesTheMark locks in the contract the rule rests

--- a/internal/rules/unicode_bom/unicode_bom_extras_test.go
+++ b/internal/rules/unicode_bom/unicode_bom_extras_test.go
@@ -1,0 +1,286 @@
+package unicode_bom
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"gotest.tools/v3/assert"
+)
+
+// TestUnicodeBomExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row it covers, so future refactors can't
+// silently regress them without breaking a named lock-in.
+//
+// Dimension 4 rows that do not apply to this rule, and why:
+//   - N/A: receiver / expression wrappers (parens, `!`, `as`, `satisfies`,
+//     optional chain) — the rule never reads an expression; it tests one
+//     property of the file.
+//   - N/A: access / key forms (identifier vs string vs numeric vs private vs
+//     computed) — the rule inspects no property names.
+//   - N/A: declaration / container forms (class vs class expression, function
+//     vs arrow vs method, async / generator) — the rule targets no declaration.
+//   - N/A: nesting / traversal boundaries — the rule runs once per file and
+//     registers no listeners, so there is no traversal to bleed past.
+//   - N/A: SpreadAssignment / RestElement graceful degradation — no object or
+//     binding pattern is ever visited.
+//
+// The rows that DO apply are the text-shape analogues of "graceful
+// degradation": files with no content for a mark to precede, and a U+FEFF that
+// is present but not in the first position.
+func TestUnicodeBomExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&UnicodeBomRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream's `defaultOptions: ["never"]`: with no options
+			// at all a mark-free file is silent.
+			{Code: "var a = 123;"},
+			// Same default, reached through an explicitly empty option array.
+			{Code: "var a = 123;", Options: []interface{}{}},
+
+			// ---- Dimension 4: graceful degradation — empty file ----
+			// Nothing to precede, and `never` is satisfied by the absence of a mark.
+			{Code: "", Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: U+FEFF present but not in the first position ----
+			// Mid-file: ordinary text, not a mark.
+			{Code: "var a = 123; \uFEFF var b = 1;", Options: []interface{}{"never"}},
+			// Inside a string literal on line 1.
+			{Code: "var a = '\uFEFF';", Options: []interface{}{"never"}},
+			// After a leading newline — position 0 is the newline, not the mark.
+			{Code: "\n\uFEFFvar a = 123;", Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: a shebang, with no mark in play ----
+			{Code: "#!/usr/bin/env node\nvar a = 123;", Options: []interface{}{"never"}},
+
+			// ---- Options via the JSON path: bare string rather than an array ----
+			// The CLI hands a single positional option through as `["never"]`;
+			// this asserts the rule survives options that are not an array.
+			{Code: "var a = 123;", Options: "never"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: graceful degradation — file is nothing but a mark ----
+			{
+				Code:    "\uFEFF",
+				Options: []interface{}{"never"},
+				Output:  []string{""},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected",
+					Message:   "Unexpected Unicode BOM (Byte Order Mark).",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- Dimension 4: a doubled leading U+FEFF ----
+			// Only the first is the file's mark; the second is ordinary text at
+			// the front of it, and one report covers the file either way.
+			{
+				Code:    "\uFEFF\uFEFFvar a = 123;",
+				Options: []interface{}{"never"},
+				// Two passes: removing the file's mark promotes the second
+				// U+FEFF to first position and makes it the mark in turn.
+				Output: []string{"\uFEFFvar a = 123;", "var a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- Real-user: eslint#6580 / #4878 — a mark ahead of a shebang ----
+			// Files written by Windows editors. The mark is not part of the
+			// text, so `#!` is still the first thing in it and the file parses.
+			{
+				Code:    "\uFEFF#!/usr/bin/env node\nvar a = 123;",
+				Options: []interface{}{"never"},
+				Output:  []string{"#!/usr/bin/env node\nvar a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- Dimension 4: CRLF line endings ----
+			{
+				Code:    "\uFEFFvar a = 123;\r\nvar b = 1;\r\n",
+				Options: []interface{}{"never"},
+				Output:  []string{"var a = 123;\r\nvar b = 1;\r\n"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- Dimension 4: multibyte content after the mark ----
+			// Column math is UTF-16 based; the report must stay at column 1.
+			{
+				Code:    "\uFEFFvar 日本 = '𝟘';",
+				Options: []interface{}{"never"},
+				Output:  []string{"var 日本 = '𝟘';"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- Dimension 4: a mark immediately followed by a line break ----
+			// The report stays on line 1 even though line 1 holds nothing else.
+			{
+				Code:    "\uFEFF\nvar a = 123;",
+				Options: []interface{}{"never"},
+				Output:  []string{"\nvar a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- Dimension 4: .tsx source ----
+			{
+				Code:    "\uFEFFconst a = <div />;\n",
+				Tsx:     true,
+				Options: []interface{}{"never"},
+				Output:  []string{"const a = <div />;\n"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// Locks in the option default reached with no options configured at
+			// all, and again through an explicitly empty option array.
+			{
+				Code:   "\uFEFFvar a = 123;",
+				Output: []string{"var a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+			{
+				Code:    "\uFEFFvar a = 123;",
+				Options: []interface{}{},
+				Output:  []string{"var a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+		},
+	)
+}
+
+// TestUnicodeBomRejectsAlways locks in that `always` is refused where every
+// other unusable configuration is refused — schema validation, before the rule
+// runs — rather than accepted and then silently ignored.
+func TestUnicodeBomRejectsAlways(t *testing.T) {
+	t.Parallel()
+
+	assert.Assert(t, UnicodeBomRule.Schema.Validate([]any{"always"}) != nil,
+		"the schema must reject the always option")
+	assert.NilError(t, UnicodeBomRule.Schema.Validate([]any{"never"}))
+}
+
+// TestUnicodeBomTextNeverCarriesTheMark locks in the contract the rule rests
+// on: whatever the source came from, the text a rule sees starts past the mark,
+// so every offset a rule reports is measured against the same thing.
+func TestUnicodeBomTextNeverCarriesTheMark(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := runUnicodeBom(t, "\uFEFFvar a = 123;", rule.EditDemandAll)
+	assert.Equal(t, 1, len(diagnostics))
+	assert.Equal(t, "var a = 123;", diagnostics[0].SourceFile.Text())
+}
+
+// TestUnicodeBomEditDemand asserts that the diagnostic identity (count,
+// messageId, message, range) is identical under every edit demand, and that
+// the autofix materializes only when EditDemandAutofix is requested. The rule
+// emits no suggestions, so EditDemandSuggestion must behave like
+// EditDemandNone.
+func TestUnicodeBomEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const code = "\uFEFFvar a = 123;"
+	const withoutBOM = "var a = 123;"
+
+	for _, demand := range []struct {
+		name    string
+		demand  rule.EditDemand
+		wantFix bool
+	}{
+		{"none", rule.EditDemandNone, false},
+		{"autofix", rule.EditDemandAutofix, true},
+		{"suggestion", rule.EditDemandSuggestion, false},
+		{"all", rule.EditDemandAll, true},
+	} {
+		t.Run(demand.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostics := runUnicodeBom(t, code, demand.demand)
+
+			assert.Equal(t, 1, len(diagnostics), "diagnostic count must not depend on edit demand")
+			d := diagnostics[0]
+			assert.Equal(t, "Unexpected Unicode BOM (Byte Order Mark).", d.Message.Description)
+			assert.Equal(t, 0, d.Range.Pos(), "report range must not depend on edit demand")
+			assert.Equal(t, 0, d.Range.End(), "report range must not depend on edit demand")
+			assert.Assert(t, d.Suggestions == nil, "the rule emits no suggestions")
+
+			fixes := d.Fixes()
+			if demand.wantFix {
+				assert.Equal(t, 1, len(fixes))
+				assert.Equal(t, -1, fixes[0].Range.Pos(), "the mark sits one position ahead of the text")
+				assert.Equal(t, 0, fixes[0].Range.End())
+			} else {
+				assert.Equal(t, 0, len(fixes))
+			}
+
+			output, _, fixed := linter.ApplyRuleFixes(code, diagnostics)
+			assert.Equal(t, demand.wantFix, fixed)
+			if demand.wantFix {
+				assert.Equal(t, withoutBOM, output, "the fix removes the mark")
+			} else {
+				assert.Equal(t, code, output, "no fix, no change")
+			}
+		})
+	}
+}
+
+// runUnicodeBom lints one snippet with the rule bound to an explicit edit
+// demand, which RunRuleTester cannot express (it always requests every edit
+// category).
+func runUnicodeBom(t *testing.T, code string, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+
+	root := fixtures.GetRootDir()
+	fileName := "file.ts"
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{tspath.ResolvePath(root.Dir, fileName): code})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+
+	program, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", host)
+	assert.NilError(t, err)
+
+	var diagnostics []rule.RuleDiagnostic
+	_, err = linter.RunLinter(linter.RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		Scope:          linter.FileScope{Files: []string{program.GetSourceFile(fileName).FileName()}},
+		ExcludePaths:   []string{},
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     UnicodeBomRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return UnicodeBomRule.Run(ctx, []any{"never"})
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) },
+		},
+	})
+	assert.NilError(t, err)
+
+	return diagnostics
+}

--- a/internal/rules/unicode_bom/unicode_bom_upstream_test.go
+++ b/internal/rules/unicode_bom/unicode_bom_upstream_test.go
@@ -1,0 +1,53 @@
+package unicode_bom
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestUnicodeBomUpstream migrates the `never` half of the valid/invalid suite
+// from upstream eslint/tests/lib/rules/unicode-bom.js. Position assertions
+// cover line/column for every invalid case. The `always` cases have no
+// counterpart here — see the package comment. rslint-specific lock-in cases
+// live in unicode_bom_extras_test.go.
+//
+// Upstream asserts `endLine: void 0, endColumn: void 0` on every error
+// because ESLint reports a `loc` with no `end`. rslint diagnostics always
+// carry a range, so the zero-width range [0, 0) surfaces as end line 1,
+// end column 1 — the same point as the start. Those assertions are made
+// explicitly here.
+func TestUnicodeBomUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&UnicodeBomRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "var a = 123;", Options: []interface{}{"never"}},
+			{Code: "var a = 123; \uFEFF", Options: []interface{}{"never"}},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   "\uFEFF var a = 123;",
+				Output: []string{" var a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected",
+					Message:   "Unexpected Unicode BOM (Byte Order Mark).",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+			{
+				Code:    "\uFEFF var a = 123;",
+				Options: []interface{}{"never"},
+				Output:  []string{" var a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected",
+					Message:   "Unexpected Unicode BOM (Byte Order Mark).",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+		},
+	)
+}

--- a/internal/rules/unicode_bom/unicode_bom_upstream_test.go
+++ b/internal/rules/unicode_bom/unicode_bom_upstream_test.go
@@ -7,11 +7,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-// TestUnicodeBomUpstream migrates the `never` half of the valid/invalid suite
-// from upstream eslint/tests/lib/rules/unicode-bom.js. Position assertions
-// cover line/column for every invalid case. The `always` cases have no
-// counterpart here — see the package comment. rslint-specific lock-in cases
-// live in unicode_bom_extras_test.go.
+// TestUnicodeBomUpstream migrates the valid/invalid suite from upstream
+// eslint/tests/lib/rules/unicode-bom.js. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// unicode_bom_extras_test.go.
 //
 // Upstream asserts `endLine: void 0, endColumn: void 0` on every error
 // because ESLint reports a `loc` with no `end`. rslint diagnostics always
@@ -27,6 +26,7 @@ func TestUnicodeBomUpstream(t *testing.T) {
 		[]rule_tester.ValidTestCase{
 			{Code: "var a = 123;", Options: []interface{}{"never"}},
 			{Code: "var a = 123; \uFEFF", Options: []interface{}{"never"}},
+			{Code: "\uFEFF var a = 123;", Options: []interface{}{"always"}},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -45,6 +45,16 @@ func TestUnicodeBomUpstream(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "unexpected",
 					Message:   "Unexpected Unicode BOM (Byte Order Mark).",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+			{
+				Code:    " var a = 123;",
+				Options: []interface{}{"always"},
+				Output:  []string{"\uFEFF var a = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expected",
+					Message:   "Expected Unicode BOM (Byte Order Mark).",
 					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
 				}},
 			},

--- a/internal/utils/overlay_vfs.go
+++ b/internal/utils/overlay_vfs.go
@@ -34,9 +34,18 @@ func (vfs *OverlayVFS) FileExists(path string) bool {
 
 func (vfs *OverlayVFS) ReadFile(path string) (contents string, ok bool) {
 	if src, ok := vfs.virtualFile(path); ok {
-		return src, ok
+		return strings.TrimPrefix(src, BOM), ok
 	}
 	return vfs.fs.ReadFile(path)
+}
+
+// SourceHasBOM answers for content this overlay supplies; anything else is the
+// underlying file system's to answer. See [BOMSource].
+func (vfs *OverlayVFS) SourceHasBOM(path string) bool {
+	if src, ok := vfs.virtualFile(path); ok {
+		return strings.HasPrefix(src, BOM)
+	}
+	return SourceHasBOM(vfs.fs, path)
 }
 
 func (vfs *OverlayVFS) DirectoryExists(path string) bool {
@@ -124,7 +133,7 @@ func (vfs *OverlayVFS) Stat(path string) vfs.FileInfo {
 	if src, ok := vfs.virtualFile(path); ok {
 		return &overlayVFSFileInfo{
 			name: path,
-			size: int64(len(src)),
+			size: int64(len(strings.TrimPrefix(src, BOM))),
 		}
 	}
 	return vfs.fs.Stat(path)

--- a/internal/utils/parallel_program_fs.go
+++ b/internal/utils/parallel_program_fs.go
@@ -32,6 +32,13 @@ func newParallelProgramFS(fs vfs.FS) *parallelProgramFS {
 	return &parallelProgramFS{FS: fs}
 }
 
+// SourceHasBOM forwards to the wrapped VFS. Embedding vfs.FS promotes only
+// that interface's methods, so this layer has to pass [BOMSource] through by
+// hand or every overlay identity below it becomes invisible.
+func (f *parallelProgramFS) SourceHasBOM(path string) bool {
+	return SourceHasBOM(f.FS, path)
+}
+
 func (f *parallelProgramFS) Realpath(path string) string {
 	for {
 		if cached, ok := f.realpathCache.Load(path); ok {

--- a/internal/utils/program_build_context.go
+++ b/internal/utils/program_build_context.go
@@ -314,6 +314,13 @@ func (f *programMetadataFS) ReadFile(fileName string) (string, bool) {
 	return f.readAndPublish(generation, fileName, candidate)
 }
 
+// SourceHasBOM forwards to the wrapped VFS. Embedding vfs.FS promotes only
+// that interface's methods, so this layer has to pass [BOMSource] through by
+// hand or every overlay identity below it becomes invisible.
+func (f *programMetadataFS) SourceHasBOM(path string) bool {
+	return SourceHasBOM(f.FS, path)
+}
+
 func mustProgramMetadataRead(value any) *programMetadataRead {
 	read, ok := value.(*programMetadataRead)
 	if !ok {

--- a/internal/utils/source_bom.go
+++ b/internal/utils/source_bom.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"io"
+	"os"
+
+	"github.com/microsoft/typescript-go/shim/vfs"
+)
+
+// BOM is the Unicode byte order mark, U+FEFF, in the UTF-8 encoding source
+// text uses by the time rslint sees it.
+const BOM = "\uFEFF"
+
+// BOMSource is implemented by a VFS layer that knows whether the text it hands
+// out for a path began with a byte order mark. Source text always reaches the
+// linter with the mark already removed — ts-go's file reader decodes it away,
+// and [OverlayVFS] strips it from caller-supplied content so both shapes agree
+// — which leaves the layer that removed it as the only one able to answer.
+//
+// A wrapping VFS must forward this explicitly. Wrappers embed the vfs.FS
+// interface, and interface embedding promotes only that interface's own
+// methods.
+type BOMSource interface {
+	SourceHasBOM(path string) bool
+}
+
+// SourceHasBOM reports whether the source text for path began with a byte
+// order mark. A VFS that tracks the mark answers directly; anything else falls
+// back to the file's own bytes, which is the right answer for every path whose
+// text came off disk unchanged.
+func SourceHasBOM(fileSystem vfs.FS, path string) bool {
+	if source, ok := fileSystem.(BOMSource); ok {
+		return source.SourceHasBOM(path)
+	}
+	return fileBytesStartWithBOM(path)
+}
+
+// fileBytesStartWithBOM reports whether the bytes of path begin with a byte
+// order mark. UTF-16 marks count: those files are decoded to UTF-8 and lose
+// their mark exactly as UTF-8 ones do. A path with no bytes to read — a
+// virtual file, a bundled lib — has nothing to speak for it.
+func fileBytesStartWithBOM(path string) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	var head [3]byte
+	n, err := io.ReadFull(file, head[:])
+	if err != nil && n < 2 {
+		return false
+	}
+	if n >= 3 && head[0] == 0xEF && head[1] == 0xBB && head[2] == 0xBF {
+		return true
+	}
+	return (head[0] == 0xFF && head[1] == 0xFE) || (head[0] == 0xFE && head[1] == 0xFF)
+}

--- a/internal/utils/source_bom_test.go
+++ b/internal/utils/source_bom_test.go
@@ -103,7 +103,9 @@ func TestSourceHasBOMThroughWrappers(t *testing.T) {
 	metadata := newProgramMetadataFS(overlay)
 	parallel := newParallelProgramFS(metadata)
 
-	for name, fs := range map[string]interface{ SourceHasBOM(string) bool }{
+	for name, fs := range map[string]interface {
+		SourceHasBOM(path string) bool
+	}{
 		"programMetadataFS": metadata,
 		"parallelProgramFS": parallel,
 	} {

--- a/internal/utils/source_bom_test.go
+++ b/internal/utils/source_bom_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+)
+
+// writeTestFile writes bytes to a file under dir and returns the path in the
+// normalized form the VFS layers key on.
+func writeTestFile(t *testing.T, dir string, name string, contents []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return tspath.NormalizePath(path)
+}
+
+// TestSourceHasBOMFromDisk covers the answer for text that came off disk. The
+// file reader decodes the mark away before anyone sees the text, so the file's
+// own bytes are the only witness left — including for UTF-16, which is decoded
+// to UTF-8 and loses its mark the same way.
+func TestSourceHasBOMFromDisk(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	utf8BOM := writeTestFile(t, dir, "utf8-bom.ts", []byte("\uFEFFlet a = 1;\n"))
+	clean := writeTestFile(t, dir, "clean.ts", []byte("let a = 1;\n"))
+	empty := writeTestFile(t, dir, "empty.ts", nil)
+	utf16LE := writeTestFile(t, dir, "utf16-le.ts", []byte{0xFF, 0xFE, 'a', 0x00})
+	utf16BE := writeTestFile(t, dir, "utf16-be.ts", []byte{0xFE, 0xFF, 0x00, 'a'})
+	missing := tspath.NormalizePath(filepath.Join(dir, "missing.ts"))
+
+	fs := osvfs.FS()
+	for _, tt := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"utf-8 mark", utf8BOM, true},
+		{"no mark", clean, false},
+		{"empty file", empty, false},
+		{"utf-16 little endian mark", utf16LE, true},
+		{"utf-16 big endian mark", utf16BE, true},
+		{"unreadable path", missing, false},
+	} {
+		if got := SourceHasBOM(fs, tt.path); got != tt.want {
+			t.Errorf("SourceHasBOM(%s) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestSourceHasBOMFromOverlay locks in that caller-supplied content answers for
+// itself. Consulting the file behind an overlay would report a mark on a buffer
+// that does not have one, and miss a mark on one that does.
+func TestSourceHasBOMFromOverlay(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	markedOnDisk := writeTestFile(t, dir, "marked.ts", []byte("\uFEFFlet a = 1;\n"))
+	cleanOnDisk := writeTestFile(t, dir, "clean.ts", []byte("let a = 1;\n"))
+
+	fs := NewOverlayVFS(osvfs.FS(), map[string]string{
+		markedOnDisk: "let a = 1;\n",
+		cleanOnDisk:  "\uFEFFlet a = 1;\n",
+	})
+
+	if SourceHasBOM(fs, markedOnDisk) {
+		t.Error("a clean overlay over a marked file reports a mark")
+	}
+	if !SourceHasBOM(fs, cleanOnDisk) {
+		t.Error("a marked overlay over a clean file reports no mark")
+	}
+
+	// The text handed to the parser never carries the mark, whichever side it
+	// came from, so offsets measured against it agree across both shapes.
+	if text, _ := fs.ReadFile(cleanOnDisk); text != "let a = 1;\n" {
+		t.Errorf("overlay ReadFile = %q, want the text without its mark", text)
+	}
+	if size := fs.Stat(cleanOnDisk).Size(); size != int64(len("let a = 1;\n")) {
+		t.Errorf("overlay Stat size = %d, want the size without the mark", size)
+	}
+}
+
+// TestSourceHasBOMThroughWrappers is the guard for the fragile part of
+// [BOMSource]: the wrapping VFS layers embed the vfs.FS interface, which
+// promotes only that interface's own methods. A layer that forgets to forward
+// makes every overlay beneath it invisible, and the answer silently falls back
+// to the file on disk.
+func TestSourceHasBOMThroughWrappers(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	markedOnDisk := writeTestFile(t, dir, "marked.ts", []byte("\uFEFFlet a = 1;\n"))
+
+	overlay := NewOverlayVFS(osvfs.FS(), map[string]string{
+		markedOnDisk: "let a = 1;\n",
+	})
+	metadata := newProgramMetadataFS(overlay)
+	parallel := newParallelProgramFS(metadata)
+
+	for name, fs := range map[string]interface{ SourceHasBOM(string) bool }{
+		"programMetadataFS": metadata,
+		"parallelProgramFS": parallel,
+	} {
+		if fs.SourceHasBOM(markedOnDisk) {
+			t.Errorf("%s does not forward to the overlay beneath it", name)
+		}
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -495,6 +495,7 @@ export default defineConfig({
     './tests/eslint/rules/require-await.test.ts',
     './tests/eslint/rules/require-yield.test.ts',
     './tests/eslint/rules/symbol-description.test.ts',
+    './tests/eslint/rules/unicode-bom.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/expect-expect.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/unicode-bom.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/unicode-bom.test.ts.snap
@@ -51,3 +51,29 @@ exports[`unicode-bom > invalid 2`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`unicode-bom > invalid 3`] = `
+{
+  "code": " var a = 123;",
+  "diagnostics": [
+    {
+      "message": "Expected Unicode BOM (Byte Order Mark).",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "unicode-bom",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/unicode-bom.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/unicode-bom.test.ts.snap
@@ -1,0 +1,53 @@
+// Rstest Snapshot v1
+
+exports[`unicode-bom > invalid 1`] = `
+{
+  "code": "﻿ var a = 123;",
+  "diagnostics": [
+    {
+      "message": "Unexpected Unicode BOM (Byte Order Mark).",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "unicode-bom",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`unicode-bom > invalid 2`] = `
+{
+  "code": "﻿ var a = 123;",
+  "diagnostics": [
+    {
+      "message": "Unexpected Unicode BOM (Byte Order Mark).",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "unicode-bom",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/unicode-bom.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/unicode-bom.test.ts
@@ -1,0 +1,23 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const BOM = '\ufeff';
+
+ruleTester.run('unicode-bom', {
+  valid: [
+    { code: 'var a = 123;', options: ['never'] as any },
+    { code: `var a = 123; ${BOM}`, options: ['never'] as any },
+  ],
+  invalid: [
+    {
+      code: `${BOM} var a = 123;`,
+      errors: [{ messageId: 'unexpected', line: 1, column: 1 }],
+    },
+    {
+      code: `${BOM} var a = 123;`,
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpected', line: 1, column: 1 }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/rules/unicode-bom.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/unicode-bom.test.ts
@@ -8,6 +8,7 @@ ruleTester.run('unicode-bom', {
   valid: [
     { code: 'var a = 123;', options: ['never'] as any },
     { code: `var a = 123; ${BOM}`, options: ['never'] as any },
+    { code: `${BOM} var a = 123;`, options: ['always'] as any },
   ],
   invalid: [
     {
@@ -18,6 +19,11 @@ ruleTester.run('unicode-bom', {
       code: `${BOM} var a = 123;`,
       options: ['never'] as any,
       errors: [{ messageId: 'unexpected', line: 1, column: 1 }],
+    },
+    {
+      code: ' var a = 123;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expected', line: 1, column: 1 }],
     },
   ],
 });

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -325,8 +325,10 @@ export class Rslint {
         },
         discoverySession?.handlers ?? {},
       );
+      // Go strips a leading BOM from caller-supplied source before parsing, so
+      // fix ranges index the code without it; strip it here to match.
       const results = this.#toLintResults(response, this.#cwd, [filePath], {
-        [filePath]: code,
+        [filePath]: stripBOM(code),
       });
       // ESLint's lintText returns exactly one result — for the linted buffer. An
       // in-memory overlay dependency file (pulled into the program and matching
@@ -461,10 +463,7 @@ export class Rslint {
         },
         discoverySession?.handlers ?? {},
       );
-      const { contents, bomFiles } = await this.#readDiagnosticContents(
-        response,
-        this.#cwd,
-      );
+      const contents = await this.#readDiagnosticContents(response, this.#cwd);
       // The multi-config native path returns absolute identities. Relative
       // values remain accepted for low-level/older implementations.
       const linted = response.lintedFiles
@@ -474,13 +473,9 @@ export class Rslint {
               : path.resolve(this.#cwd, file),
           )
         : files;
-      return this.#toLintResults(
-        response,
-        this.#cwd,
-        linted,
-        contents,
-        bomFiles,
-      ).sort((a, b) => nativePathIdentity.compare(a.filePath, b.filePath));
+      return this.#toLintResults(response, this.#cwd, linted, contents).sort(
+        (a, b) => nativePathIdentity.compare(a.filePath, b.filePath),
+      );
     } finally {
       await discoverySession?.shutdown();
     }
@@ -629,40 +624,28 @@ export class Rslint {
   async #readDiagnosticContents(
     response: LintResponse,
     configDirectory: string,
-  ): Promise<{ contents: Record<string, string>; bomFiles: Set<string> }> {
+  ): Promise<Record<string, string>> {
     // Read source for each file that produced a diagnostic so mergeFixes can
     // gap-fill multi-edit fixes (parity with lintText, which has the source
     // in-hand). Only diagnosed files are read; a lint with no findings reads
     // nothing.
     const contents: Record<string, string> = {};
-    // Disk files whose bytes start with a UTF-8 BOM. Go reads them through a
-    // decoder that strips the BOM, so its fix offsets AND Output are
-    // BOM-stripped. We strip the BOM from the source fed to mergeFixes so the
-    // gap-fill slices line up with those offsets — and `fix.range` therefore
-    // stays BOM-stripped, matching ESLint v10 and the message line/column —
-    // then re-prepend the BOM to Output (in toLintResults) so outputFixes writes
-    // back the real file. (lintText is unaffected: its overlay keeps the BOM and
-    // Go's offsets already include it, so no adjustment is needed there.)
-    const bomFiles = new Set<string>();
     for (const d of response.diagnostics ?? []) {
       const abs = path.isAbsolute(d.filePath)
         ? path.normalize(d.filePath)
         : path.resolve(configDirectory, d.filePath);
       if (!(abs in contents)) {
         try {
-          const raw = await readFile(abs, 'utf8');
-          if (raw.charCodeAt(0) === 0xfeff) {
-            bomFiles.add(nativePathIdentity.key(abs));
-            contents[abs] = raw.slice(1); // BOM-stripped, matching Go's offsets
-          } else {
-            contents[abs] = raw;
-          }
+          // A BOM is never part of the text a fix range indexes — Go strips it
+          // and reports it separately, matching ESLint's SourceCode — so strip
+          // it here too and the gap-fill slices line up.
+          contents[abs] = stripBOM(await readFile(abs, 'utf8'));
         } catch {
           // Unreadable (e.g. virtual/deleted) — mergeFixes degrades to first edit.
         }
       }
     }
-    return { contents, bomFiles };
+    return contents;
   }
 
   #toLintResults(
@@ -670,7 +653,6 @@ export class Rslint {
     configDirectory: string,
     files: string[],
     contents?: Record<string, string>,
-    bomFiles?: Set<string>,
   ): LintResult[] {
     const toAbs = (p: string): string =>
       path.isAbsolute(p) ? path.normalize(p) : path.resolve(configDirectory, p);
@@ -734,11 +716,9 @@ export class Rslint {
       };
       const output = outputByPath.get(key);
       if (output !== undefined) {
-        // Go's Output is BOM-stripped (ApplyRuleFixes runs over the decoded
-        // SourceFile text); re-prepend the BOM for a disk file that had one so
-        // outputFixes writes back a file identical to the original but for the
-        // fix.
-        result.output = bomFiles?.has(key) ? '\uFEFF' + output : output;
+        // Go's Output is the whole file, byte order mark included when the
+        // original had one and no fix removed it.
+        result.output = output;
       }
       results.push(result);
     }
@@ -815,8 +795,16 @@ function mergeFixes(
     // rather than emitting corrupt merged text); rslint rules emit
     // non-overlapping edits per diagnostic, so this is a guard, not a path.
     if (f.startPos < lastPos) continue;
-    text += sourceText.slice(lastPos, f.startPos) + f.text;
+    // An edit can start ahead of the text at -1, where the byte order mark
+    // lives; there is nothing to gap-fill from before position 0.
+    text +=
+      sourceText.slice(Math.max(0, lastPos), Math.max(0, f.startPos)) + f.text;
     lastPos = f.endPos;
   }
   return { range: [start, end], text };
+}
+
+/** Drop a leading byte order mark, which is never part of a fix's coordinates. */
+function stripBOM(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
 }

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -278,14 +278,13 @@ export class Rslint {
    * Lint a string of code as if it lived at `filePath` (default a synthetic
    * `.ts` path).
    *
-   * ESLint-alignment note: if `code` begins with a UTF-8 BOM, the reported
-   * offsets (`fix.range`, `column`) are relative to the BOM-included input you
-   * passed — self-consistent within that input (result `output`, line/column,
-   * and re-applying `fix` all line up), but one unit ahead of ESLint v10, which
-   * strips a leading BOM from its in-memory source. (The overlay keeps the BOM
-   * and Go's offsets include it; lintFiles is unaffected because Go reads disk
-   * files BOM-stripped.) Strip a leading `U+FEFF` first for ESLint-identical
-   * offsets.
+   * A leading `U+FEFF` in `code` is a byte order mark, and a byte order mark is
+   * never part of the text an offset indexes — the mark is stripped before
+   * parsing, exactly as reading the same bytes off disk would strip it. So
+   * `column` and `fix.range` are measured from the character after it, the way
+   * ESLint measures them, and `lintText` and `lintFiles` agree on the same
+   * source. Result `output` is the whole file and carries the mark through,
+   * unless a fix asked for its removal.
    */
   async lintText(
     code: string,
@@ -764,10 +763,11 @@ function toLintMessage(d: Diagnostic, sourceText?: string): LintMessage {
  * sourceText (e.g. a diagnosed file whose source could not be read), a
  * multi-edit fix degrades to its first edit rather than guessing across a gap.
  *
- * Offsets are flat UTF-16, in the same BOM-stripped space as Go's fix ranges
- * (matching ESLint v10, whose `fix.range` is relative to BOM-stripped source).
- * The caller passes a BOM-stripped sourceText for disk files so the gap-fill
- * slices line up; the BOM is re-applied only to the per-file Output.
+ * Offsets are flat UTF-16, in the same byte-order-mark-free space as Go's fix
+ * ranges (matching ESLint v10, whose `fix.range` is relative to BOM-stripped
+ * source). The caller passes a BOM-stripped sourceText so the gap-fill slices
+ * line up. An edit can start at -1, where the mark sits, one position ahead of
+ * the text; there is nothing to gap-fill from before position 0.
  */
 function mergeFixes(
   fixes: Fix[] | undefined,

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -1974,13 +1974,10 @@ module.exports = config;`
     }
   });
 
-  test('lintFiles keeps fix.range BOM-stripped and re-prepends the BOM only to output', async () => {
-    // A disk file whose bytes start with a UTF-8 BOM: Go reads it BOM-stripped,
-    // so its fix offsets and Output carry no BOM. fix.range stays BOM-stripped
-    // (matching ESLint v10, whose fix.range is relative to BOM-stripped source,
-    // and the message column); only `output` gets the BOM re-prepended so
-    // outputFixes writes back the real on-disk file. (lintText is unaffected —
-    // its overlay keeps the BOM and Go's offsets already include it.)
+  test('lintFiles keeps fix.range BOM-stripped and keeps the BOM in output', async () => {
+    // A BOM is never part of the text a fix range indexes, so fix.range stays
+    // BOM-stripped — matching ESLint v10 and the message column. `output` is
+    // the whole file, so it keeps the mark a fix did not ask to remove.
     const BOM = String.fromCharCode(0xfeff);
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-bom-'));
     try {
@@ -2016,7 +2013,7 @@ module.exports = config;`
     // no-extra-bind emits a multi-edit fix; on a BOM-prefixed disk file the
     // merged range must stay BOM-stripped (Go's coordinate space) so applying it
     // to the BOM-stripped body reproduces output minus its BOM. Exercises the
-    // multi-edit merge branch together with the strip-then-re-prepend path.
+    // multi-edit merge branch on a file that carries a mark.
     const BOM = String.fromCharCode(0xfeff);
     const body = 'const f = (function () { return 1; }).bind(this);\n';
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-bom-multi-'));
@@ -2049,6 +2046,70 @@ module.exports = config;`
           m.fix.text +
           body.slice(m.fix.range[1]);
         expect(results[0].output).toBe(BOM + applied);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('unicode-bom fix removes the mark from a disk file through lintFiles', async () => {
+    // The mark reaches the rule as ctx.HasBOM rather than as text, and the fix
+    // is ESLint's [-1, 0] — a range one position ahead of the source. Output is
+    // the whole file, so this is where that range takes effect.
+    const BOM = String.fromCharCode(0xfeff);
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-bom-rule-'));
+    try {
+      await writeFile(path.join(tmp, 'tsconfig.json'), '{}');
+      await writeFile(path.join(tmp, 'bom.ts'), BOM + 'let a = 1;\n');
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [
+          { files: ['**/*.ts'], rules: { 'unicode-bom': 'error' } },
+        ],
+        fix: true,
+      });
+      try {
+        const results = await rslint.lintFiles('bom.ts');
+        expect(results[0].messages[0].ruleId).toBe('unicode-bom');
+        expect(results[0].messages[0].fix.range).toEqual([-1, 0]);
+        expect(results[0].messages[0].fix.text).toBe('');
+        expect(results[0].output).toBe('let a = 1;\n');
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('unicode-bom fix removes a mark the caller passed to lintText', async () => {
+    // Caller-supplied source is stripped of its mark before parsing exactly as
+    // a file read off disk is, so both routes reach the rule the same way and
+    // produce the same output.
+    const BOM = String.fromCharCode(0xfeff);
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-bom-text-'));
+    try {
+      await writeFile(path.join(tmp, 'tsconfig.json'), '{}');
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [
+          { files: ['**/*.ts'], rules: { 'unicode-bom': 'error' } },
+        ],
+        fix: true,
+      });
+      try {
+        const results = await rslint.lintText(BOM + 'let a = 1;\n', {
+          filePath: path.join(tmp, 'buffer.ts'),
+        });
+        expect(results[0].messages[0].ruleId).toBe('unicode-bom');
+        // Line 1, column 1 — the mark's own position, as ESLint reports it.
+        expect(results[0].messages[0].line).toBe(1);
+        expect(results[0].messages[0].column).toBe(1);
+        expect(results[0].output).toBe('let a = 1;\n');
       } finally {
         await rslint.close();
       }
@@ -2422,10 +2483,10 @@ module.exports = config;`
     }
   });
 
-  // lintText reports BOM-INCLUSIVE offsets for BOM-prefixed code (known
-  // limitation, one ahead of ESLint v10 which strips the BOM). Pinned without
-  // hardcoding offsets: the same code with a leading BOM shifts every offset +1.
-  test('lintText reports BOM-inclusive offsets for BOM-prefixed code (known limitation)', async () => {
+  // A leading BOM is not part of the text an offset indexes, matching ESLint
+  // v10. Pinned without hardcoding offsets: the same code with and without a
+  // BOM reports identical columns and fix ranges.
+  test('lintText reports BOM-stripped offsets for BOM-prefixed code', async () => {
     const rslint = new Rslint({
       cwd: '/',
       overrideConfigFile: true,
@@ -2455,10 +2516,11 @@ module.exports = config;`
       const pm = plain.messages[0];
       const bm = bom.messages[0];
       expect(pm.ruleId).toBe('@typescript-eslint/array-type');
-      // The BOM shifts every offset by exactly one UTF-16 unit.
-      expect(bm.column).toBe(pm.column + 1);
-      expect(bm.fix.range[0]).toBe(pm.fix.range[0] + 1);
-      expect(bm.fix.range[1]).toBe(pm.fix.range[1] + 1);
+      // The BOM leaves every offset untouched.
+      expect(bm.column).toBe(pm.column);
+      expect(bm.line).toBe(pm.line);
+      expect(bm.fix.range[0]).toBe(pm.fix.range[0]);
+      expect(bm.fix.range[1]).toBe(pm.fix.range[1]);
     } finally {
       await rslint.close();
     }

--- a/packages/vscode-extension/__tests__/fixtures-unicode-bom/rslint.json
+++ b/packages/vscode-extension/__tests__/fixtures-unicode-bom/rslint.json
@@ -1,0 +1,14 @@
+[
+  {
+    "files": ["**/*.ts"],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.json"]
+      }
+    },
+    "rules": {
+      "unicode-bom": "error"
+    }
+  }
+]

--- a/packages/vscode-extension/__tests__/fixtures-unicode-bom/rslint.json
+++ b/packages/vscode-extension/__tests__/fixtures-unicode-bom/rslint.json
@@ -8,7 +8,8 @@
       }
     },
     "rules": {
-      "unicode-bom": "error"
+      "unicode-bom": "error",
+      "no-var": "error"
     }
   }
 ]

--- a/packages/vscode-extension/__tests__/fixtures-unicode-bom/src/unmarked.ts
+++ b/packages/vscode-extension/__tests__/fixtures-unicode-bom/src/unmarked.ts
@@ -1,0 +1,1 @@
+export const unmarked = 1;

--- a/packages/vscode-extension/__tests__/fixtures-unicode-bom/tsconfig.json
+++ b/packages/vscode-extension/__tests__/fixtures-unicode-bom/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "strict": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -218,6 +218,11 @@ async function main(): Promise<void> {
       workspace: path.resolve(testsSourceDir, 'fixtures-eslint-plugins'),
       tests: path.resolve(__dirname, './suite-eslint-plugins'),
     },
+    {
+      name: 'unicode-bom tests',
+      workspace: path.resolve(testsSourceDir, 'fixtures-unicode-bom'),
+      tests: path.resolve(__dirname, './suite-unicode-bom'),
+    },
   ];
 
   const failures: unknown[] = [];

--- a/packages/vscode-extension/__tests__/suite-unicode-bom/index.ts
+++ b/packages/vscode-extension/__tests__/suite-unicode-bom/index.ts
@@ -1,0 +1,1 @@
+export { run } from '../runSuite';

--- a/packages/vscode-extension/__tests__/suite-unicode-bom/unicode-bom.test.ts
+++ b/packages/vscode-extension/__tests__/suite-unicode-bom/unicode-bom.test.ts
@@ -109,26 +109,52 @@ suite('rslint unicode-bom over LSP', function () {
     await waitForCodeActionRegistryQuiescence();
 
     const before = doc.getText();
-    for (const kind of [
-      vscode.CodeActionKind.QuickFix,
-      vscode.CodeActionKind.SourceFixAll.append('rslint'),
+    const actionsOfKind = async (
+      kind: vscode.CodeActionKind,
+    ): Promise<vscode.CodeAction[]> =>
+      (await vscode.commands.executeCommand<vscode.CodeAction[]>(
+        'vscode.executeCodeActionProvider',
+        doc.uri,
+        new vscode.Range(0, 0, doc.lineCount, 0),
+        kind.value,
+      )) ?? [];
+
+    const quickFixes = await actionsOfKind(vscode.CodeActionKind.QuickFix);
+    const titles = quickFixes.map((action) => action.title);
+
+    // rslint titles a rule's own fix "Fix: <message>". That is the one the
+    // server withholds, because no text edit removes a mark the document never
+    // had. Matched on the message too, so a TypeScript quick fix on this file
+    // could neither satisfy nor trip the assertion.
+    assert.ok(
+      !titles.some(
+        (title) => title.startsWith('Fix:') && title.includes('Unicode BOM'),
+      ),
+      `no fix action should be offered, got: ${titles.join(' | ')}`,
+    );
+    // The disable-directive actions still appear. They are what make the
+    // absence above meaningful: quick fixes were computed for this diagnostic,
+    // and only the fix itself is missing.
+    for (const expected of [
+      'Disable unicode-bom for this line',
+      'Disable unicode-bom for entire file',
     ]) {
-      const actions =
-        (await vscode.commands.executeCommand<vscode.CodeAction[]>(
-          'vscode.executeCodeActionProvider',
-          doc.uri,
-          new vscode.Range(0, 0, doc.lineCount, 0),
-          kind.value,
-        )) ?? [];
-      const edits = actions.flatMap(
-        (action) => action.edit?.get(doc.uri) ?? [],
-      );
-      assert.deepStrictEqual(
-        edits.map((edit) => edit.newText),
-        [],
-        `${kind.value} should produce no edits for a marked file`,
+      assert.ok(
+        titles.includes(expected),
+        `expected ${JSON.stringify(expected)}, got: ${titles.join(' | ')}`,
       );
     }
+
+    // fixAll applies fixes only, never disable directives, so it has nothing
+    // to contribute at all.
+    const fixAll = await actionsOfKind(
+      vscode.CodeActionKind.SourceFixAll.append('rslint'),
+    );
+    assert.deepStrictEqual(
+      fixAll.flatMap((action) => action.edit?.get(doc.uri) ?? []),
+      [],
+      'fixAll should produce no edits for a marked file',
+    );
 
     assert.strictEqual(doc.getText(), before, 'the document must be untouched');
     assert.ok(!doc.isDirty, 'nothing should have modified the document');

--- a/packages/vscode-extension/__tests__/suite-unicode-bom/unicode-bom.test.ts
+++ b/packages/vscode-extension/__tests__/suite-unicode-bom/unicode-bom.test.ts
@@ -1,0 +1,154 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import path from 'node:path';
+import fs from 'node:fs';
+import {
+  waitForRslintDiagnostics,
+  waitForRslintDiagnosticsCount,
+} from '../utils/diagnostics';
+import { waitForCodeActionRegistryQuiescence } from '../utils/codeActionRegistry';
+
+/**
+ * A byte order mark is the one thing a linter can see about a file that an
+ * editor's document cannot hold. VS Code decodes the file before handing it to
+ * the model — the mark becomes the document's *encoding*, shown in the status
+ * bar as "UTF-8 with BOM", never a character the text contains.
+ *
+ * So `unicode-bom` is reported over LSP but cannot be fixed there: its fix is a
+ * range over [-1, 0], one position ahead of the text, and no text edit says
+ * that. The server withholds the fix rather than offering an action that runs
+ * and changes nothing. `rslint --fix`, which rewrites the file itself, removes
+ * the mark.
+ *
+ * `src/marked.ts` is written here rather than committed: a file whose first
+ * bytes are EF BB BF is invisible in review and formatters keep wanting to
+ * strip it. The mark is only ever written as the escape `\uFEFF`, never as the
+ * character itself.
+ */
+suite('rslint unicode-bom over LSP', function () {
+  this.timeout(120000);
+
+  const BOM = '\uFEFF';
+  const markedSource = 'export const marked = 1;\n';
+
+  function workspaceRoot(): string {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) throw new Error('VS Code test workspace is unavailable');
+    return folder.uri.fsPath;
+  }
+
+  function fixturePath(filename: string): string {
+    return path.join(workspaceRoot(), 'src', filename);
+  }
+
+  async function openFixture(filename: string): Promise<vscode.TextDocument> {
+    const doc = await vscode.workspace.openTextDocument(fixturePath(filename));
+    await vscode.window.showTextDocument(doc);
+    return doc;
+  }
+
+  suiteSetup(() => {
+    fs.writeFileSync(fixturePath('marked.ts'), BOM + markedSource, 'utf8');
+  });
+
+  suiteTeardown(() => {
+    fs.rmSync(fixturePath('marked.ts'), { force: true });
+  });
+
+  // ======== The constraint the behavior rests on ========
+
+  test('the file carries a mark that its editor document does not', async () => {
+    const bytes = fs.readFileSync(fixturePath('marked.ts'));
+    assert.deepStrictEqual(
+      [...bytes.subarray(0, 3)],
+      [0xef, 0xbb, 0xbf],
+      'the fixture must start with the UTF-8 encoding of U+FEFF',
+    );
+
+    const doc = await openFixture('marked.ts');
+    const text = doc.getText();
+
+    assert.ok(
+      !text.startsWith(BOM),
+      'VS Code decodes the mark into the document encoding, so the model text ' +
+        'must not contain U+FEFF. If this ever fails, a text edit could remove ' +
+        'the mark after all and withholding the fix would be wrong.',
+    );
+    assert.strictEqual(
+      text,
+      markedSource,
+      'the document should hold the source without the mark',
+    );
+  });
+
+  // ======== Reported, but not fixable ========
+
+  test('reports the mark on a marked file', async () => {
+    const doc = await openFixture('marked.ts');
+    const diagnostics = await waitForRslintDiagnostics(doc, (all) =>
+      all.some((d) => d.message.includes('unicode-bom')),
+    );
+    const marks = diagnostics.filter((d) => d.message.includes('unicode-bom'));
+
+    assert.strictEqual(
+      marks.length,
+      1,
+      `expected exactly one unicode-bom diagnostic, got: ${diagnostics
+        .map((d) => d.message)
+        .join(' | ')}`,
+    );
+    assert.strictEqual(marks[0].range.start.line, 0, 'sits on line 1');
+    assert.strictEqual(marks[0].range.start.character, 0, 'sits on column 1');
+  });
+
+  test('offers no code action that claims to remove the mark', async () => {
+    const doc = await openFixture('marked.ts');
+    await waitForRslintDiagnostics(doc, (all) =>
+      all.some((d) => d.message.includes('unicode-bom')),
+    );
+    await waitForCodeActionRegistryQuiescence();
+
+    const before = doc.getText();
+    for (const kind of [
+      vscode.CodeActionKind.QuickFix,
+      vscode.CodeActionKind.SourceFixAll.append('rslint'),
+    ]) {
+      const actions =
+        (await vscode.commands.executeCommand<vscode.CodeAction[]>(
+          'vscode.executeCodeActionProvider',
+          doc.uri,
+          new vscode.Range(0, 0, doc.lineCount, 0),
+          kind.value,
+        )) ?? [];
+      const edits = actions.flatMap(
+        (action) => action.edit?.get(doc.uri) ?? [],
+      );
+      assert.deepStrictEqual(
+        edits.map((edit) => edit.newText),
+        [],
+        `${kind.value} should produce no edits for a marked file`,
+      );
+    }
+
+    assert.strictEqual(doc.getText(), before, 'the document must be untouched');
+    assert.ok(!doc.isDirty, 'nothing should have modified the document');
+  });
+
+  test('reports nothing on a file whose bytes carry no mark', async () => {
+    // Lint the marked file first: zero diagnostics is also what a server that
+    // never answered looks like, so establish the rule is live in this
+    // workspace before reading silence as an answer.
+    const marked = await openFixture('marked.ts');
+    await waitForRslintDiagnostics(marked, (all) =>
+      all.some((d) => d.message.includes('unicode-bom')),
+    );
+
+    const doc = await openFixture('unmarked.ts');
+    const diagnostics = await waitForRslintDiagnosticsCount(doc, 0);
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.message),
+      [],
+      'an unmarked file should report nothing',
+    );
+  });
+});

--- a/packages/vscode-extension/__tests__/suite-unicode-bom/unicode-bom.test.ts
+++ b/packages/vscode-extension/__tests__/suite-unicode-bom/unicode-bom.test.ts
@@ -2,10 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import fs from 'node:fs';
-import {
-  waitForRslintDiagnostics,
-  waitForRslintDiagnosticsCount,
-} from '../utils/diagnostics';
+import { waitForRslintDiagnostics } from '../utils/diagnostics';
 import { waitForCodeActionRegistryQuiescence } from '../utils/codeActionRegistry';
 
 /**
@@ -14,22 +11,27 @@ import { waitForCodeActionRegistryQuiescence } from '../utils/codeActionRegistry
  * the model — the mark becomes the document's *encoding*, shown in the status
  * bar as "UTF-8 with BOM", never a character the text contains.
  *
- * So `unicode-bom` is reported over LSP but cannot be fixed there: its fix is a
- * range over [-1, 0], one position ahead of the text, and no text edit says
- * that. The server withholds the fix rather than offering an action that runs
- * and changes nothing. `rslint --fix`, which rewrites the file itself, removes
- * the mark.
+ * So the language server does not run `unicode-bom` at all. The mark is not in
+ * the document, no text edit reaches it, and for an unsaved buffer the only
+ * remaining witness is the file on disk, which the buffer may already disagree
+ * with. `rslint --fix`, which rewrites the file itself, is where the rule
+ * applies.
  *
  * `src/marked.ts` is written here rather than committed: a file whose first
  * bytes are EF BB BF is invisible in review and formatters keep wanting to
  * strip it. The mark is only ever written as the escape `\uFEFF`, never as the
  * character itself.
+ *
+ * The fixture also enables `no-var` and the source declares one, so every
+ * assertion of silence below runs against a file the server is demonstrably
+ * linting.
  */
 suite('rslint unicode-bom over LSP', function () {
   this.timeout(120000);
 
   const BOM = '\uFEFF';
-  const markedSource = 'export const marked = 1;\n';
+  const markedSource =
+    'export function marked() {\n  var value = 1;\n  return value;\n}\n';
 
   function workspaceRoot(): string {
     const folder = vscode.workspace.workspaceFolders?.[0];
@@ -41,10 +43,21 @@ suite('rslint unicode-bom over LSP', function () {
     return path.join(workspaceRoot(), 'src', filename);
   }
 
-  async function openFixture(filename: string): Promise<vscode.TextDocument> {
-    const doc = await vscode.workspace.openTextDocument(fixturePath(filename));
+  async function openMarked(): Promise<vscode.TextDocument> {
+    const doc = await vscode.workspace.openTextDocument(
+      fixturePath('marked.ts'),
+    );
     await vscode.window.showTextDocument(doc);
     return doc;
+  }
+
+  /** Waits for the pass that reports `no-var`, and returns everything it said. */
+  async function lintedDiagnostics(
+    doc: vscode.TextDocument,
+  ): Promise<vscode.Diagnostic[]> {
+    return waitForRslintDiagnostics(doc, (all) =>
+      all.some((d) => d.message.includes('no-var')),
+    );
   }
 
   suiteSetup(() => {
@@ -65,14 +78,14 @@ suite('rslint unicode-bom over LSP', function () {
       'the fixture must start with the UTF-8 encoding of U+FEFF',
     );
 
-    const doc = await openFixture('marked.ts');
+    const doc = await openMarked();
     const text = doc.getText();
 
     assert.ok(
       !text.startsWith(BOM),
       'VS Code decodes the mark into the document encoding, so the model text ' +
-        'must not contain U+FEFF. If this ever fails, a text edit could remove ' +
-        'the mark after all and withholding the fix would be wrong.',
+        'must not contain U+FEFF. If this ever fails, an editor could see the ' +
+        'mark after all and skipping the rule would be worth revisiting.',
     );
     assert.strictEqual(
       text,
@@ -81,100 +94,53 @@ suite('rslint unicode-bom over LSP', function () {
     );
   });
 
-  // ======== Reported, but not fixable ========
+  // ======== The rule does not run in the editor ========
 
-  test('reports the mark on a marked file', async () => {
-    const doc = await openFixture('marked.ts');
-    const diagnostics = await waitForRslintDiagnostics(doc, (all) =>
-      all.some((d) => d.message.includes('unicode-bom')),
-    );
-    const marks = diagnostics.filter((d) => d.message.includes('unicode-bom'));
+  test('reports nothing about the mark on a marked file', async () => {
+    const doc = await openMarked();
+    const diagnostics = await lintedDiagnostics(doc);
 
-    assert.strictEqual(
-      marks.length,
-      1,
-      `expected exactly one unicode-bom diagnostic, got: ${diagnostics
+    assert.deepStrictEqual(
+      diagnostics
+        .filter((d) => d.message.includes('unicode-bom'))
+        .map((d) => d.message),
+      [],
+      `expected no unicode-bom diagnostic, got: ${diagnostics
         .map((d) => d.message)
         .join(' | ')}`,
     );
-    assert.strictEqual(marks[0].range.start.line, 0, 'sits on line 1');
-    assert.strictEqual(marks[0].range.start.character, 0, 'sits on column 1');
   });
 
-  test('offers no code action that claims to remove the mark', async () => {
-    const doc = await openFixture('marked.ts');
-    await waitForRslintDiagnostics(doc, (all) =>
-      all.some((d) => d.message.includes('unicode-bom')),
-    );
+  test('offers no code action for the mark', async () => {
+    const doc = await openMarked();
+    await lintedDiagnostics(doc);
     await waitForCodeActionRegistryQuiescence();
 
     const before = doc.getText();
-    const actionsOfKind = async (
-      kind: vscode.CodeActionKind,
-    ): Promise<vscode.CodeAction[]> =>
+    const quickFixes =
       (await vscode.commands.executeCommand<vscode.CodeAction[]>(
         'vscode.executeCodeActionProvider',
         doc.uri,
         new vscode.Range(0, 0, doc.lineCount, 0),
-        kind.value,
+        vscode.CodeActionKind.QuickFix.value,
       )) ?? [];
-
-    const quickFixes = await actionsOfKind(vscode.CodeActionKind.QuickFix);
     const titles = quickFixes.map((action) => action.title);
 
-    // rslint titles a rule's own fix "Fix: <message>". That is the one the
-    // server withholds, because no text edit removes a mark the document never
-    // had. Matched on the message too, so a TypeScript quick fix on this file
-    // could neither satisfy nor trip the assertion.
     assert.ok(
       !titles.some(
-        (title) => title.startsWith('Fix:') && title.includes('Unicode BOM'),
+        (title) =>
+          title.includes('unicode-bom') || title.includes('Unicode BOM'),
       ),
-      `no fix action should be offered, got: ${titles.join(' | ')}`,
+      `no unicode-bom action should be offered, got: ${titles.join(' | ')}`,
     );
-    // The disable-directive actions still appear. They are what make the
-    // absence above meaningful: quick fixes were computed for this diagnostic,
-    // and only the fix itself is missing.
-    for (const expected of [
-      'Disable unicode-bom for this line',
-      'Disable unicode-bom for entire file',
-    ]) {
-      assert.ok(
-        titles.includes(expected),
-        `expected ${JSON.stringify(expected)}, got: ${titles.join(' | ')}`,
-      );
-    }
-
-    // fixAll applies fixes only, never disable directives, so it has nothing
-    // to contribute at all.
-    const fixAll = await actionsOfKind(
-      vscode.CodeActionKind.SourceFixAll.append('rslint'),
-    );
-    assert.deepStrictEqual(
-      fixAll.flatMap((action) => action.edit?.get(doc.uri) ?? []),
-      [],
-      'fixAll should produce no edits for a marked file',
+    // no-var's own actions are what make the absence above meaningful: quick
+    // fixes were computed for this file, and only unicode-bom's are missing.
+    assert.ok(
+      titles.includes('Disable no-var for this line'),
+      `expected no-var's actions to be present, got: ${titles.join(' | ')}`,
     );
 
     assert.strictEqual(doc.getText(), before, 'the document must be untouched');
     assert.ok(!doc.isDirty, 'nothing should have modified the document');
-  });
-
-  test('reports nothing on a file whose bytes carry no mark', async () => {
-    // Lint the marked file first: zero diagnostics is also what a server that
-    // never answered looks like, so establish the rule is live in this
-    // workspace before reading silence as an answer.
-    const marked = await openFixture('marked.ts');
-    await waitForRslintDiagnostics(marked, (all) =>
-      all.some((d) => d.message.includes('unicode-bom')),
-    );
-
-    const doc = await openFixture('unmarked.ts');
-    const diagnostics = await waitForRslintDiagnosticsCount(doc, 0);
-    assert.deepStrictEqual(
-      diagnostics.map((d) => d.message),
-      [],
-      'an unmarked file should report nothing',
-    );
   });
 });


### PR DESCRIPTION
## Summary

Port the `unicode-bom` rule from ESLint. `"never"` (the default) disallows a leading Unicode byte order mark, U+FEFF; `"always"` requires one. Only the first position counts — a U+FEFF anywhere else is ordinary text. Diagnostics land on the zero-width range at offset 0, which renders as line 1, column 1, where ESLint reports it.

The mark is consumed while a file's bytes are decoded, so it reaches neither `SourceFile.Text()` nor any offset measured against it. `ctx.HasBOM` answers the question instead, reading it from whichever layer removed it: a VFS that tracks the mark answers directly, and anything else falls back to the file's own bytes. UTF-16 marks count, since those files are decoded to UTF-8 and lose their mark the same way. Source supplied by a caller rather than read from disk — an editor buffer, an API request, a test fixture — is stripped to match, so both shapes agree.

Fixes follow ESLint's own: inserting a mark is an insertion at the front of the text, and removing one is a range over `[-1, 0]`, a position ahead of the text because the mark is not in it. `ApplyRuleFixes` splits a leading mark off before applying fixes and puts it back afterwards, unless a fix asked for its removal.

### Behavior changes beyond the new rule

- **A byte order mark now survives `--fix`.** Fixes were applied to the decoded text and written back, so any file rewritten by any rule silently lost its mark. The CLI and the API now re-attach it before fixing.
- **A byte order mark no longer shifts columns.** Positions were measured against text that still counted the mark, putting every line-1 column one past where ESLint reports it. Two existing tests asserted the shifted values and have been corrected; `jsx_curly_spacing` had already flagged the divergence in a comment.
- **`fix.range` from the API matches ESLint**, including the `[-1, 0]` removal range, which is no longer clamped to 0.

### Editor behavior

The language server does not run this rule. An editor's document holds decoded text — VS Code turns a leading mark into the document's encoding, shown in the status bar as "UTF-8 with BOM" — so the mark is not in the document and no text edit adds or removes it. That leaves the file on disk as the only witness, and an unsaved buffer may already disagree with it. `rslint --fix`, which rewrites the file itself, is where the rule applies. A VS Code end-to-end suite pins this, starting with the fact it rests on: the fixture's bytes begin `EF BB BF` while its document text does not.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/unicode-bom
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/unicode-bom.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

