### PR TITLE
feat: port rule import/no-restricted-paths

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -604,6 +604,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	runOpts := linter.RunLinterOptions{
 		Programs:       programs,
 		SingleThreaded: false, // Don't use single-threaded mode for IPC
+		Cwd:            currentDirectory,
 		Scope:          linter.FileScope{Files: allowedFiles},
 		TargetFiles:    targetsByProgram,
 		// RunLinter repeats the RequiresTypeInfo eligibility check for files

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -962,6 +962,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	runOpts := linter.RunLinterOptions{
 		Programs:              programs,
 		SingleThreaded:        singleThreaded,
+		Cwd:                   cwd,
 		Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
 		TargetFiles:           targetsByProgram,
 		GetRulesForFile:       rulesForFile,
@@ -1109,6 +1110,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			fixRunOpts := linter.RunLinterOptions{
 				Programs:              newPrograms,
 				SingleThreaded:        singleThreaded,
+				Cwd:                   cwd,
 				Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
 				TargetFiles:           fixTargetsByProgram,
 				GetRulesForFile:       fixRulesForFile,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -67,6 +67,7 @@ func isDirAllowed(fileName string, allowDirs []string) bool {
 // runProgramOptions is the internal per-program input to runLintRulesInProgram.
 type runProgramOptions struct {
 	Program          *compiler.Program
+	Cwd              string
 	Scope            FileScope
 	ExcludePaths     []string
 	FileFilter       FileFilter
@@ -211,6 +212,7 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 		for ruleIndex, r := range rules {
 			ctx := rule.RuleContext{
 				SourceFile:     file,
+				Cwd:            opts.Cwd,
 				Program:        opts.Program,
 				Settings:       r.Settings,
 				ConfigGlobals:  r.Globals,
@@ -511,6 +513,7 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 
 			programOpts := runProgramOptions{
 				Program:              program,
+				Cwd:                  opts.Cwd,
 				Scope:                opts.Scope,
 				ExcludePaths:         opts.ExcludePaths,
 				FileFilter:           filter,
@@ -758,6 +761,7 @@ func LintSingleFile(opts LintSingleFileOptions) {
 	}
 	runLintRulesInProgram(runProgramOptions{
 		Program:          opts.Program,
+		Cwd:              opts.Cwd,
 		ExcludePaths:     opts.ExcludePaths,
 		TargetFiles:      []string{opts.File},
 		HasTargetFiles:   true,

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -111,6 +111,9 @@ type LintResult struct {
 type RunLinterOptions struct {
 	Programs       []*compiler.Program
 	SingleThreaded bool
+	// Cwd is the working directory of the linting run, forwarded verbatim to
+	// every RuleContext. See RuleContext.Cwd for what rules may assume of it.
+	Cwd string
 
 	Scope            FileScope
 	ExcludePaths     []string
@@ -147,6 +150,8 @@ type LintSingleFileOptions struct {
 	HasTypeInfo     bool
 	GetRulesForFile RuleHandler
 	ExcludePaths    []string
+	// Cwd has the same meaning as RunLinterOptions.Cwd.
+	Cwd string
 	// Consumer has the same native-only semantics as RunLinterOptions.Consumer.
 	Consumer rule.DiagnosticConsumer
 }

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -964,16 +964,21 @@ type lintProgramLoader func(
 ) (*compiler.Program, *ast.SourceFile, error)
 
 func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx context.Context, rslintConfig config.RslintConfig, cwd string, enforcePlugins bool, tsConfigPaths []string, fs vfs.FS) ([]rule.RuleDiagnostic, error) {
-	result, err := runLintWithProgramLoader(uri, session, ctx, rslintConfig, cwd, enforcePlugins, tsConfigPaths, fs, nil)
+	result, err := runLintWithProgramLoader(uri, session, ctx, rslintConfig, cwd, cwd, enforcePlugins, tsConfigPaths, fs, nil)
 	return result.Diagnostics, err
 }
 
+// runLintWithProgramLoader resolves one document against two distinct
+// directories: configCwd is the config's own path space, which a nested JS
+// config moves to its own directory, while processCwd is the server's working
+// directory that rules see as RuleContext.Cwd.
 func runLintWithProgramLoader(
 	uri lsproto.DocumentUri,
 	session *project.Session,
 	ctx context.Context,
 	rslintConfig config.RslintConfig,
 	cwd string,
+	processCwd string,
 	enforcePlugins bool,
 	tsConfigPaths []string,
 	fs vfs.FS,
@@ -1007,6 +1012,7 @@ func runLintWithProgramLoader(
 		program,
 		sourceFile,
 		configFilePath,
+		processCwd,
 		hasTypeInfo,
 		fileConfigResolver,
 		rule.EditDemandAll,
@@ -1018,6 +1024,7 @@ func lintSingleFile(
 	program *compiler.Program,
 	sourceFile *ast.SourceFile,
 	configFilePath string,
+	processCwd string,
 	hasTypeInfo bool,
 	fileConfigResolver *config.FileConfigResolver,
 	editDemand rule.EditDemand,
@@ -1057,6 +1064,7 @@ func lintSingleFile(
 	linter.LintSingleFile(linter.LintSingleFileOptions{
 		Program:     program,
 		File:        sourceFile.FileName(),
+		Cwd:         processCwd,
 		HasTypeInfo: hasTypeInfo,
 		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
 			return fileConfigResolver.ActiveRulesForFileHasTypeInfo(configFilePath, hasTypeInfo)
@@ -1244,6 +1252,7 @@ func (s *Server) runConfiguredLint(
 		ctx,
 		rslintConfig,
 		cwd,
+		s.cwd,
 		enforcePlugins,
 		tsConfigPaths,
 		s.fs,
@@ -1289,6 +1298,7 @@ func (s *Server) runConfiguredLintForContent(
 				program,
 				sourceFile,
 				configFilePath,
+				s.cwd,
 				true,
 				resolver,
 				rule.EditDemandAutofix,
@@ -1305,6 +1315,7 @@ func (s *Server) runConfiguredLintForContent(
 		program,
 		sourceFileForPath(program, filename, overlayFS),
 		configFilePath,
+		s.cwd,
 		false,
 		resolver,
 		rule.EditDemandAutofix,

--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_default_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_mutable_exports"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_restricted_paths"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_self_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_webpack_loader_syntax"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -24,6 +25,7 @@ func GetAllRules() []rule.Rule {
 		no_default_export.NoDefaultExportRule,
 		no_duplicates.NoDuplicatesRule,
 		no_mutable_exports.NoMutableExportsRule,
+		no_restricted_paths.NoRestrictedPathsRule,
 		no_self_import.NoSelfImportRule,
 		no_webpack_loader_syntax.NoWebpackLoaderSyntax,
 	}

--- a/internal/plugins/import/fixtures/restricted-paths/client/a.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/client/a.ts
@@ -1,0 +1,2 @@
+const clientA = 'client/a';
+export default clientA;

--- a/internal/plugins/import/fixtures/restricted-paths/client/b.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/client/b.ts
@@ -1,0 +1,2 @@
+const clientB = 'client/b';
+export default clientB;

--- a/internal/plugins/import/fixtures/restricted-paths/client/consumer.js
+++ b/internal/plugins/import/fixtures/restricted-paths/client/consumer.js
@@ -1,0 +1,2 @@
+const clientConsumer = 'client/consumer';
+module.exports = clientConsumer;

--- a/internal/plugins/import/fixtures/restricted-paths/other/a.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/other/a.ts
@@ -1,0 +1,2 @@
+const otherA = 'other/a';
+export default otherA;

--- a/internal/plugins/import/fixtures/restricted-paths/server/b.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/server/b.ts
@@ -1,0 +1,2 @@
+const serverB = 'server/b';
+export default serverB;

--- a/internal/plugins/import/fixtures/restricted-paths/server/c.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/server/c.ts
@@ -1,0 +1,2 @@
+const serverC = 'server/c';
+export default serverC;

--- a/internal/plugins/import/fixtures/restricted-paths/server/consumer.js
+++ b/internal/plugins/import/fixtures/restricted-paths/server/consumer.js
@@ -1,0 +1,2 @@
+const serverConsumer = 'server/consumer';
+module.exports = serverConsumer;

--- a/internal/plugins/import/fixtures/restricted-paths/server/one/a.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/server/one/a.ts
@@ -1,0 +1,2 @@
+const serverOneA = 'server/one/a';
+export default serverOneA;

--- a/internal/plugins/import/fixtures/restricted-paths/server/one/b.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/server/one/b.ts
@@ -1,0 +1,2 @@
+const serverOneB = 'server/one/b';
+export default serverOneB;

--- a/internal/plugins/import/fixtures/restricted-paths/server/two-new/a.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/server/two-new/a.ts
@@ -1,0 +1,2 @@
+const serverTwoNewA = 'server/two-new/a';
+export default serverTwoNewA;

--- a/internal/plugins/import/fixtures/restricted-paths/server/two/a.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/server/two/a.ts
@@ -1,0 +1,2 @@
+const serverTwoA = 'server/two/a';
+export default serverTwoA;

--- a/internal/plugins/import/fixtures/restricted-paths/x(server)/a.ts
+++ b/internal/plugins/import/fixtures/restricted-paths/x(server)/a.ts
@@ -1,0 +1,2 @@
+const parenthesizedA = 'x(server)/a';
+export default parenthesizedA;

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
@@ -50,11 +50,12 @@ var NoRestrictedPathsRule = rule.Rule{
 		}
 
 		basePath := resolveBasePath(ctx, opts.basePath)
+		caseSensitive := ctx.Program.Host().FS().UseCaseSensitiveFileNames()
 
 		currentFilename := import_utils.GetPhysicalFilename(ctx)
 		matchingZones := make([]zone, 0, len(opts.zones))
 		for _, z := range opts.zones {
-			if isMatchingZone(z, basePath, currentFilename) {
+			if isMatchingZone(z, basePath, currentFilename, caseSensitive) {
 				matchingZones = append(matchingZones, z)
 			}
 		}
@@ -74,7 +75,7 @@ var NoRestrictedPathsRule = rule.Rule{
 
 			for i := range matchingZones {
 				if !built[i] {
-					validators[i] = makePathValidators(matchingZones[i].fromPaths, matchingZones[i].except, basePath)
+					validators[i] = makePathValidators(matchingZones[i].fromPaths, matchingZones[i].except, basePath, caseSensitive)
 					built[i] = true
 				}
 
@@ -165,23 +166,23 @@ func toStringSlice(raw any) []string {
 	return nil
 }
 
-func isMatchingZone(z zone, basePath string, currentFilename string) bool {
+func isMatchingZone(z zone, basePath string, currentFilename string, caseSensitive bool) bool {
 	for _, target := range z.targets {
-		if isMatchingTargetPath(currentFilename, tspath.ResolvePath(basePath, target)) {
+		if isMatchingTargetPath(currentFilename, tspath.ResolvePath(basePath, target), caseSensitive) {
 			return true
 		}
 	}
 	return false
 }
 
-func isMatchingTargetPath(fileName string, targetPath string) bool {
+func isMatchingTargetPath(fileName string, targetPath string, caseSensitive bool) bool {
 	if isGlob(targetPath) {
 		return utils.MatchGlob(targetPath, fileName)
 	}
-	return containsPath(fileName, targetPath)
+	return containsPath(fileName, targetPath, caseSensitive)
 }
 
-func makePathValidators(fromPaths []string, except []string, basePath string) []pathValidator {
+func makePathValidators(fromPaths []string, except []string, basePath string, caseSensitive bool) []pathValidator {
 	anyGlob := false
 	anyNonGlob := false
 	for _, from := range fromPaths {
@@ -209,7 +210,7 @@ func makePathValidators(fromPaths []string, except []string, basePath string) []
 		if anyGlob {
 			validators = append(validators, computeGlobPatternPathValidator(absoluteFrom, except))
 		} else {
-			validators = append(validators, computeAbsolutePathValidator(absoluteFrom, except))
+			validators = append(validators, computeAbsolutePathValidator(absoluteFrom, except, caseSensitive))
 		}
 	}
 	return validators
@@ -250,10 +251,10 @@ func computeGlobPatternPathValidator(absoluteFrom string, except []string) pathV
 	return validator
 }
 
-func computeAbsolutePathValidator(absoluteFrom string, except []string) pathValidator {
+func computeAbsolutePathValidator(absoluteFrom string, except []string, caseSensitive bool) pathValidator {
 	validator := pathValidator{
 		isPathRestricted: func(absoluteImportPath string) bool {
-			return containsPath(absoluteImportPath, absoluteFrom)
+			return containsPath(absoluteImportPath, absoluteFrom, caseSensitive)
 		},
 		hasValidExceptions: true,
 		invalidException: rule.RuleMessage{
@@ -268,7 +269,7 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string) pathVali
 		// Upstream classifies the `from`-relative exception path with
 		// importType and rejects it when it comes out as "parent", which is
 		// exactly the set of paths that escape `from`.
-		if !containsPath(absoluteException, absoluteFrom) {
+		if !containsPath(absoluteException, absoluteFrom, caseSensitive) {
 			validator.hasValidExceptions = false
 			return validator
 		}
@@ -277,7 +278,7 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string) pathVali
 
 	validator.isPathException = func(absoluteImportPath string) bool {
 		for _, absoluteException := range absoluteExceptions {
-			if containsPath(absoluteImportPath, absoluteException) {
+			if containsPath(absoluteImportPath, absoluteException, caseSensitive) {
 				return true
 			}
 		}
@@ -288,18 +289,35 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string) pathVali
 
 // containsPath reports whether filePath is target itself or one of its
 // descendants, mirroring upstream's `path.relative(target, filePath)` check.
-func containsPath(filePath string, target string) bool {
+// Components are compared the way the host file system resolves names, which
+// is what Node's `path.win32.relative` does on a case-insensitive platform.
+func containsPath(filePath string, target string, caseSensitive bool) bool {
 	fileComponents := pathComponents(filePath)
 	targetComponents := pathComponents(target)
 	if len(targetComponents) > len(fileComponents) {
 		return false
 	}
 	for i, component := range targetComponents {
-		if component != fileComponents[i] {
+		if !equalPathComponent(component, fileComponents[i], caseSensitive) {
 			return false
 		}
 	}
+	// `path.relative` joins the components left over, and upstream reads a
+	// leading `..` in that relative path as "outside target". A first leftover
+	// component such as `..secret.js` therefore keeps the file out of target
+	// even though it names a real child of it.
+	if len(fileComponents) > len(targetComponents) &&
+		strings.HasPrefix(fileComponents[len(targetComponents)], "..") {
+		return false
+	}
 	return true
+}
+
+func equalPathComponent(a string, b string, caseSensitive bool) bool {
+	if caseSensitive {
+		return a == b
+	}
+	return strings.EqualFold(a, b)
 }
 
 // pathComponents splits a path into its root plus segments, dropping the empty

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -50,7 +51,10 @@ var NoRestrictedPathsRule = rule.Rule{
 		}
 
 		basePath := resolveBasePath(ctx, opts.basePath)
-		caseSensitive := ctx.Program.Host().FS().UseCaseSensitiveFileNames()
+		// `path.relative` compares case-insensitively only in its win32 flavor,
+		// so this follows the platform rather than the host file system: a
+		// case-insensitive volume on macOS still gets a case-sensitive compare.
+		caseSensitive := runtime.GOOS != "windows"
 
 		currentFilename := import_utils.GetPhysicalFilename(ctx)
 		matchingZones := make([]zone, 0, len(opts.zones))
@@ -267,9 +271,11 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string, caseSens
 	for _, exception := range except {
 		absoluteException := tspath.ResolvePath(absoluteFrom, exception)
 		// Upstream classifies the `from`-relative exception path with
-		// importType and rejects it when it comes out as "parent", which is
-		// exactly the set of paths that escape `from`.
-		if !containsPath(absoluteException, absoluteFrom, caseSensitive) {
+		// importType and rejects it when it comes out as "parent", whose regex
+		// `^\.\.$|^\.\.[\\/]` matches only a leading `..` component. A name such
+		// as `..secret` therefore stays a valid exception, even though
+		// containsPath reads the same leftover as escaping `from`.
+		if !isPathWithin(absoluteException, absoluteFrom, caseSensitive) {
 			validator.hasValidExceptions = false
 			return validator
 		}
@@ -288,10 +294,27 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string, caseSens
 }
 
 // containsPath reports whether filePath is target itself or one of its
-// descendants, mirroring upstream's `path.relative(target, filePath)` check.
-// Components are compared the way the host file system resolves names, which
-// is what Node's `path.win32.relative` does on a case-insensitive platform.
+// descendants, mirroring upstream's `relative === '' || !relative.startsWith('..')`
+// check on `path.relative(target, filePath)`.
 func containsPath(filePath string, target string, caseSensitive bool) bool {
+	if !isPathWithin(filePath, target, caseSensitive) {
+		return false
+	}
+	// `path.relative` joins the components left over, and upstream's prefix test
+	// reads a leading `..` in that relative path as "outside target". A first
+	// leftover component such as `..secret.js` therefore keeps the file out of
+	// target even though it names a real child of it.
+	fileComponents := pathComponents(filePath)
+	targetComponents := pathComponents(target)
+	return len(fileComponents) == len(targetComponents) ||
+		!strings.HasPrefix(fileComponents[len(targetComponents)], "..")
+}
+
+// isPathWithin reports whether filePath resolves inside target, i.e. whether
+// `path.relative(target, filePath)` walks no `..` component upwards. Components
+// are compared the way the platform's `path.relative` does, so a leftover such
+// as `..secret.js` still counts as inside target.
+func isPathWithin(filePath string, target string, caseSensitive bool) bool {
 	fileComponents := pathComponents(filePath)
 	targetComponents := pathComponents(target)
 	if len(targetComponents) > len(fileComponents) {
@@ -301,14 +324,6 @@ func containsPath(filePath string, target string, caseSensitive bool) bool {
 		if !equalPathComponent(component, fileComponents[i], caseSensitive) {
 			return false
 		}
-	}
-	// `path.relative` joins the components left over, and upstream reads a
-	// leading `..` in that relative path as "outside target". A first leftover
-	// component such as `..secret.js` therefore keeps the file out of target
-	// even though it names a real child of it.
-	if len(fileComponents) > len(targetComponents) &&
-		strings.HasPrefix(fileComponents[len(targetComponents)], "..") {
-		return false
 	}
 	return true
 }

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
@@ -12,7 +12,6 @@ import (
 	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
-	"github.com/web-infra-dev/rslint/internal/utils/minimatch"
 )
 
 //go:embed no_restricted_paths.schema.json
@@ -182,7 +181,7 @@ func isMatchingZone(z zone, basePath string, currentFilename string, windows boo
 
 func isMatchingTargetPath(fileName string, targetPath string, windows bool) bool {
 	if isGlob(targetPath) {
-		return minimatch.Match(fileName, targetPath, minimatch.Options{})
+		return utils.MatchGlob(escapeExtglob(targetPath), fileName)
 	}
 	return containsPath(fileName, targetPath, windows)
 }
@@ -213,7 +212,7 @@ func makePathValidators(fromPaths []string, except []string, basePath string, wi
 	for _, from := range fromPaths {
 		absoluteFrom := tspath.ResolvePath(basePath, from)
 		if anyGlob {
-			validators = append(validators, computeGlobPatternPathValidator(absoluteFrom, except))
+			validators = append(validators, computeGlobPatternPathValidator(absoluteFrom, except, windows))
 		} else {
 			validators = append(validators, computeAbsolutePathValidator(absoluteFrom, except, windows))
 		}
@@ -225,11 +224,11 @@ func makePathValidators(fromPaths []string, except []string, basePath string, wi
 // patterns. Note that upstream matches `except` patterns verbatim rather than
 // resolving them against `basePath` first, so only absolute exception patterns
 // can ever match a resolved import path.
-func computeGlobPatternPathValidator(absoluteFrom string, except []string) pathValidator {
-	fromMatcher := minimatch.New(absoluteFrom, minimatch.Options{})
+func computeGlobPatternPathValidator(absoluteFrom string, except []string, windows bool) pathValidator {
+	fromPattern := escapeExtglob(absoluteFrom)
 	validator := pathValidator{
 		isPathRestricted: func(absoluteImportPath string) bool {
-			return fromMatcher.Match(absoluteImportPath)
+			return utils.MatchGlob(fromPattern, absoluteImportPath)
 		},
 		hasValidExceptions: true,
 		invalidException: rule.RuleMessage{
@@ -245,17 +244,22 @@ func computeGlobPatternPathValidator(absoluteFrom string, except []string) pathV
 		}
 	}
 
-	// The exception patterns stay unresolved, and a Windows-native one such as
-	// `C:\repo\server\allowed\**\*` keeps its backslashes. minimatch.New
-	// rewrites those to `/` on Windows, the same way upstream's Minimatch
-	// constructor does, so the pattern can still match a normalized import path.
-	exceptionMatchers := make([]*minimatch.Matcher, 0, len(except))
+	// The exception patterns stay unresolved, so a Windows-native one such as
+	// `C:\repo\server\allowed\**\*` still carries its backslashes. Upstream's
+	// Minimatch constructor rewrites the platform separator to `/` before it
+	// compiles a pattern; without the same rewrite the backslashes would reach
+	// doublestar as escapes and could never match an import path normalized
+	// to `/`.
+	exceptions := make([]string, 0, len(except))
 	for _, exception := range except {
-		exceptionMatchers = append(exceptionMatchers, minimatch.New(exception, minimatch.Options{}))
+		if windows {
+			exception = strings.ReplaceAll(exception, `\`, "/")
+		}
+		exceptions = append(exceptions, escapeExtglob(exception))
 	}
 	validator.isPathException = func(absoluteImportPath string) bool {
-		for _, matcher := range exceptionMatchers {
-			if matcher.Match(absoluteImportPath) {
+		for _, exception := range exceptions {
+			if utils.MatchGlob(exception, absoluteImportPath) {
 				return true
 			}
 		}
@@ -303,7 +307,7 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string, windows 
 }
 
 // containsPath reports whether filePath is target itself or one of its
-// descendants, mirroring upstream's `relative === '' || !relative.startsWith('..')`
+// descendants, mirroring upstream's `relative === ” || !relative.startsWith('..')`
 // check on `path.relative(target, filePath)`.
 func containsPath(filePath string, target string, windows bool) bool {
 	if !isPathWithin(filePath, target, windows) {
@@ -390,6 +394,68 @@ func unexpectedPathMessage(importPath string, customMessage string) rule.RuleMes
 		Id:          "unexpectedPath",
 		Description: description,
 	}
+}
+
+// globMetaEscaper escapes the characters doublestar reads as base wildcard
+// syntax, so the run of text it is applied to matches only itself.
+var globMetaEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`*`, `\*`,
+	`?`, `\?`,
+	`[`, `\[`,
+	`]`, `\]`,
+	`{`, `\{`,
+	`}`, `\}`,
+)
+
+// escapeExtglob rewrites every extended glob construct — `!(a)`, `@(a|b)`,
+// `+(a)`, `?(a)`, `*(a)` — into the literal text it is written as. doublestar
+// implements no extended glob syntax, so without this the leading `?` and `*`
+// of a list would go on acting as base wildcards and match paths that merely
+// happen to carry a parenthesized segment.
+func escapeExtglob(pattern string) string {
+	var escaped strings.Builder
+	for index := 0; index < len(pattern); {
+		if pattern[index] == '\\' {
+			end := min(index+2, len(pattern))
+			escaped.WriteString(pattern[index:end])
+			index = end
+			continue
+		}
+		end, ok := extglobEnd(pattern, index)
+		if !ok {
+			escaped.WriteByte(pattern[index])
+			index++
+			continue
+		}
+		escaped.WriteString(globMetaEscaper.Replace(pattern[index:end]))
+		index = end
+	}
+	return escaped.String()
+}
+
+// extglobEnd returns the offset just past the extended glob construct starting
+// at index, if one starts there: one of `@?!+*` followed by a parenthesized
+// body.
+func extglobEnd(pattern string, index int) (int, bool) {
+	if strings.IndexByte("@?!+*", pattern[index]) < 0 || charAt(pattern, index+1) != '(' {
+		return 0, false
+	}
+	depth := 0
+	for i := index + 1; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '\\':
+			i++
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
+	}
+	return 0, false
 }
 
 var extglobPattern = regexp.MustCompile(`(\\).|([@?!+*]\(.*\))`)

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
@@ -17,10 +17,10 @@ import (
 var schemaJSON []byte
 
 type zone struct {
-	targets []string
-	fromPaths   []string
-	except  []string
-	message string
+	targets   []string
+	fromPaths []string
+	except    []string
+	message   string
 }
 
 type ruleOptions struct {
@@ -49,10 +49,7 @@ var NoRestrictedPathsRule = rule.Rule{
 			return rule.RuleListeners{}
 		}
 
-		basePath := opts.basePath
-		if basePath == "" {
-			basePath = ctx.Program.Host().GetCurrentDirectory()
-		}
+		basePath := resolveBasePath(ctx, opts.basePath)
 
 		currentFilename := import_utils.GetPhysicalFilename(ctx)
 		matchingZones := make([]zone, 0, len(opts.zones))
@@ -106,6 +103,22 @@ var NoRestrictedPathsRule = rule.Rule{
 	},
 }
 
+// resolveBasePath mirrors upstream's `options.basePath || process.cwd()` fed
+// into `path.resolve`: a configured relative `basePath` is made absolute
+// against the working directory, so zone paths resolved from it can be
+// compared against absolute file names. Rule tests and any other caller
+// without a process directory fall back to the Program's own directory.
+func resolveBasePath(ctx rule.RuleContext, configured string) string {
+	cwd := ctx.Cwd
+	if cwd == "" {
+		cwd = ctx.Program.Host().GetCurrentDirectory()
+	}
+	if configured == "" {
+		return tspath.NormalizePath(cwd)
+	}
+	return tspath.GetNormalizedAbsolutePath(configured, cwd)
+}
+
 func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{}
 	optsMap := utils.GetOptionsMap(options)
@@ -123,9 +136,9 @@ func parseOptions(options []any) ruleOptions {
 			continue
 		}
 		z := zone{
-			targets: toStringSlice(zoneMap["target"]),
-			fromPaths:   toStringSlice(zoneMap["from"]),
-			except:  toStringSlice(zoneMap["except"]),
+			targets:   toStringSlice(zoneMap["target"]),
+			fromPaths: toStringSlice(zoneMap["from"]),
+			except:    toStringSlice(zoneMap["except"]),
 		}
 		z.message, _ = zoneMap["message"].(string)
 		opts.zones = append(opts.zones, z)

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
@@ -1,0 +1,465 @@
+package no_restricted_paths
+
+import (
+	_ "embed"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed no_restricted_paths.schema.json
+var schemaJSON []byte
+
+type zone struct {
+	targets []string
+	fromPaths   []string
+	except  []string
+	message string
+}
+
+type ruleOptions struct {
+	zones    []zone
+	basePath string
+}
+
+// pathValidator decides, for one `from` entry of a zone, whether an import is
+// restricted and whether the zone's `except` list applies to it.
+type pathValidator struct {
+	isPathRestricted   func(absoluteImportPath string) bool
+	hasValidExceptions bool
+	isPathException    func(absoluteImportPath string) bool
+	invalidException   rule.RuleMessage
+}
+
+// NoRestrictedPathsRule enforces which files may be imported inside a zone.
+//
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-restricted-paths.js
+var NoRestrictedPathsRule = rule.Rule{
+	Name:   "import/no-restricted-paths",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+		if len(opts.zones) == 0 || ctx.Program == nil {
+			return rule.RuleListeners{}
+		}
+
+		basePath := opts.basePath
+		if basePath == "" {
+			basePath = ctx.Program.Host().GetCurrentDirectory()
+		}
+
+		currentFilename := import_utils.GetPhysicalFilename(ctx)
+		matchingZones := make([]zone, 0, len(opts.zones))
+		for _, z := range opts.zones {
+			if isMatchingZone(z, basePath, currentFilename) {
+				matchingZones = append(matchingZones, z)
+			}
+		}
+		if len(matchingZones) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		validators := make([][]pathValidator, len(matchingZones))
+		built := make([]bool, len(matchingZones))
+		applicable := make([]int, 0, 4)
+
+		return import_utils.VisitModules(func(source *ast.StringLiteralLike, node *ast.Node) {
+			absoluteImportPath, ok := import_utils.Resolve(source, ctx)
+			if !ok {
+				return
+			}
+
+			for i := range matchingZones {
+				if !built[i] {
+					validators[i] = makePathValidators(matchingZones[i].fromPaths, matchingZones[i].except, basePath)
+					built[i] = true
+				}
+
+				applicable = applicable[:0]
+				for j := range validators[i] {
+					if validators[i][j].isPathRestricted(absoluteImportPath) {
+						applicable = append(applicable, j)
+					}
+				}
+
+				for _, j := range applicable {
+					if !validators[i][j].hasValidExceptions {
+						ctx.ReportNode(source, validators[i][j].invalidException)
+					}
+				}
+				for _, j := range applicable {
+					if validators[i][j].hasValidExceptions && !validators[i][j].isPathException(absoluteImportPath) {
+						ctx.ReportNode(source, unexpectedPathMessage(source.Text(), matchingZones[i].message))
+					}
+				}
+			}
+		}, import_utils.VisitModulesOptions{
+			Commonjs: true,
+			ESModule: true,
+		})
+	},
+}
+
+func parseOptions(options []any) ruleOptions {
+	opts := ruleOptions{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+
+	opts.basePath, _ = optsMap["basePath"].(string)
+
+	rawZones, _ := optsMap["zones"].([]interface{})
+	opts.zones = make([]zone, 0, len(rawZones))
+	for _, rawZone := range rawZones {
+		zoneMap, ok := rawZone.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		z := zone{
+			targets: toStringSlice(zoneMap["target"]),
+			fromPaths:   toStringSlice(zoneMap["from"]),
+			except:  toStringSlice(zoneMap["except"]),
+		}
+		z.message, _ = zoneMap["message"].(string)
+		opts.zones = append(opts.zones, z)
+	}
+
+	return opts
+}
+
+// toStringSlice normalizes upstream's `[].concat(value)` handling of options
+// that accept either a single string or an array of strings.
+func toStringSlice(raw any) []string {
+	switch typed := raw.(type) {
+	case string:
+		return []string{typed}
+	case []interface{}:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if value, ok := item.(string); ok {
+				values = append(values, value)
+			}
+		}
+		return values
+	}
+	return nil
+}
+
+func isMatchingZone(z zone, basePath string, currentFilename string) bool {
+	for _, target := range z.targets {
+		if isMatchingTargetPath(currentFilename, tspath.ResolvePath(basePath, target)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isMatchingTargetPath(fileName string, targetPath string) bool {
+	if isGlob(targetPath) {
+		return utils.MatchGlob(targetPath, fileName)
+	}
+	return containsPath(fileName, targetPath)
+}
+
+func makePathValidators(fromPaths []string, except []string, basePath string) []pathValidator {
+	anyGlob := false
+	anyNonGlob := false
+	for _, from := range fromPaths {
+		if isGlob(from) {
+			anyGlob = true
+		} else {
+			anyNonGlob = true
+		}
+	}
+
+	if anyGlob && anyNonGlob {
+		return []pathValidator{{
+			isPathRestricted:   func(string) bool { return true },
+			hasValidExceptions: false,
+			invalidException: rule.RuleMessage{
+				Id:          "mixedGlobAndNonGlob",
+				Description: "Restricted path `from` must contain either only glob patterns or none",
+			},
+		}}
+	}
+
+	validators := make([]pathValidator, 0, len(fromPaths))
+	for _, from := range fromPaths {
+		absoluteFrom := tspath.ResolvePath(basePath, from)
+		if anyGlob {
+			validators = append(validators, computeGlobPatternPathValidator(absoluteFrom, except))
+		} else {
+			validators = append(validators, computeAbsolutePathValidator(absoluteFrom, except))
+		}
+	}
+	return validators
+}
+
+// computeGlobPatternPathValidator matches both `from` and `except` as glob
+// patterns. Note that upstream matches `except` patterns verbatim rather than
+// resolving them against `basePath` first, so only absolute exception patterns
+// can ever match a resolved import path.
+func computeGlobPatternPathValidator(absoluteFrom string, except []string) pathValidator {
+	validator := pathValidator{
+		isPathRestricted: func(absoluteImportPath string) bool {
+			return utils.MatchGlob(absoluteFrom, absoluteImportPath)
+		},
+		hasValidExceptions: true,
+		invalidException: rule.RuleMessage{
+			Id:          "invalidExceptionGlob",
+			Description: "Restricted path exceptions must be glob patterns when `from` contains glob patterns",
+		},
+	}
+
+	for _, exception := range except {
+		if !isGlob(exception) {
+			validator.hasValidExceptions = false
+			return validator
+		}
+	}
+
+	exceptions := except
+	validator.isPathException = func(absoluteImportPath string) bool {
+		for _, exception := range exceptions {
+			if utils.MatchGlob(exception, absoluteImportPath) {
+				return true
+			}
+		}
+		return false
+	}
+	return validator
+}
+
+func computeAbsolutePathValidator(absoluteFrom string, except []string) pathValidator {
+	validator := pathValidator{
+		isPathRestricted: func(absoluteImportPath string) bool {
+			return containsPath(absoluteImportPath, absoluteFrom)
+		},
+		hasValidExceptions: true,
+		invalidException: rule.RuleMessage{
+			Id:          "invalidExceptionPath",
+			Description: "Restricted path exceptions must be descendants of the configured `from` path for that zone.",
+		},
+	}
+
+	absoluteExceptions := make([]string, 0, len(except))
+	for _, exception := range except {
+		absoluteException := tspath.ResolvePath(absoluteFrom, exception)
+		// Upstream classifies the `from`-relative exception path with
+		// importType and rejects it when it comes out as "parent", which is
+		// exactly the set of paths that escape `from`.
+		if !containsPath(absoluteException, absoluteFrom) {
+			validator.hasValidExceptions = false
+			return validator
+		}
+		absoluteExceptions = append(absoluteExceptions, absoluteException)
+	}
+
+	validator.isPathException = func(absoluteImportPath string) bool {
+		for _, absoluteException := range absoluteExceptions {
+			if containsPath(absoluteImportPath, absoluteException) {
+				return true
+			}
+		}
+		return false
+	}
+	return validator
+}
+
+// containsPath reports whether filePath is target itself or one of its
+// descendants, mirroring upstream's `path.relative(target, filePath)` check.
+func containsPath(filePath string, target string) bool {
+	fileComponents := pathComponents(filePath)
+	targetComponents := pathComponents(target)
+	if len(targetComponents) > len(fileComponents) {
+		return false
+	}
+	for i, component := range targetComponents {
+		if component != fileComponents[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// pathComponents splits a path into its root plus segments, dropping the empty
+// trailing segment a path written with a trailing separator would produce.
+func pathComponents(p string) []string {
+	components := tspath.GetPathComponents(p, "")
+	for len(components) > 1 && components[len(components)-1] == "" {
+		components = components[:len(components)-1]
+	}
+	return components
+}
+
+func unexpectedPathMessage(importPath string, customMessage string) rule.RuleMessage {
+	description := fmt.Sprintf("Unexpected path \"%s\" imported in restricted zone.", importPath)
+	if customMessage != "" {
+		description += " " + customMessage
+	}
+	return rule.RuleMessage{
+		Id:          "unexpectedPath",
+		Description: description,
+	}
+}
+
+var extglobPattern = regexp.MustCompile(`(\\).|([@?!+*]\(.*\))`)
+
+// isGlob ports is-glob@4.0.3 in its default strict mode, which upstream uses to
+// decide whether a zone path is a glob pattern or a plain directory path.
+func isGlob(str string) bool {
+	if str == "" {
+		return false
+	}
+	if isExtglob(str) {
+		return true
+	}
+	return strictCheck(str)
+}
+
+func isExtglob(str string) bool {
+	for str != "" {
+		match := extglobPattern.FindStringSubmatchIndex(str)
+		if match == nil {
+			return false
+		}
+		if match[4] != -1 {
+			return true
+		}
+		str = str[match[1]:]
+	}
+	return false
+}
+
+func strictCheck(str string) bool {
+	if str[0] == '!' {
+		return true
+	}
+
+	index := 0
+	pipeIndex := -2
+	closeSquareIndex := -2
+	closeCurlyIndex := -2
+	closeParenIndex := -2
+	backSlashIndex := -2
+
+	for index < len(str) {
+		if str[index] == '*' {
+			return true
+		}
+
+		if charAt(str, index+1) == '?' && strings.IndexByte("].+)", str[index]) >= 0 {
+			return true
+		}
+
+		if closeSquareIndex != -1 && str[index] == '[' && charAt(str, index+1) != ']' {
+			if closeSquareIndex < index {
+				closeSquareIndex = indexOfFrom(str, ']', index)
+			}
+			if closeSquareIndex > index {
+				if backSlashIndex == -1 || backSlashIndex > closeSquareIndex {
+					return true
+				}
+				backSlashIndex = indexOfFrom(str, '\\', index)
+				if backSlashIndex == -1 || backSlashIndex > closeSquareIndex {
+					return true
+				}
+			}
+		}
+
+		if closeCurlyIndex != -1 && str[index] == '{' && charAt(str, index+1) != '}' {
+			closeCurlyIndex = indexOfFrom(str, '}', index)
+			if closeCurlyIndex > index {
+				backSlashIndex = indexOfFrom(str, '\\', index)
+				if backSlashIndex == -1 || backSlashIndex > closeCurlyIndex {
+					return true
+				}
+			}
+		}
+
+		if closeParenIndex != -1 && str[index] == '(' && charAt(str, index+1) == '?' &&
+			strings.IndexByte(":!=", charAt(str, index+2)) >= 0 && charAt(str, index+3) != ')' {
+			closeParenIndex = indexOfFrom(str, ')', index)
+			if closeParenIndex > index {
+				backSlashIndex = indexOfFrom(str, '\\', index)
+				if backSlashIndex == -1 || backSlashIndex > closeParenIndex {
+					return true
+				}
+			}
+		}
+
+		if pipeIndex != -1 && str[index] == '(' && charAt(str, index+1) != '|' {
+			if pipeIndex < index {
+				pipeIndex = indexOfFrom(str, '|', index)
+			}
+			if pipeIndex != -1 && charAt(str, pipeIndex+1) != ')' {
+				closeParenIndex = indexOfFrom(str, ')', pipeIndex)
+				if closeParenIndex > pipeIndex {
+					backSlashIndex = indexOfFrom(str, '\\', pipeIndex)
+					if backSlashIndex == -1 || backSlashIndex > closeParenIndex {
+						return true
+					}
+				}
+			}
+		}
+
+		if str[index] == '\\' {
+			open := charAt(str, index+1)
+			index += 2
+			if closer, ok := closingChar(open); ok {
+				if n := indexOfFrom(str, closer, index); n != -1 {
+					index = n + 1
+				}
+			}
+			if charAt(str, index) == '!' {
+				return true
+			}
+		} else {
+			index++
+		}
+	}
+
+	return false
+}
+
+// charAt returns 0 for out-of-range positions, standing in for the `undefined`
+// JavaScript reads past the end of a string.
+func charAt(str string, index int) byte {
+	if index < 0 || index >= len(str) {
+		return 0
+	}
+	return str[index]
+}
+
+func indexOfFrom(str string, char byte, from int) int {
+	if from < 0 {
+		from = 0
+	}
+	if from > len(str) {
+		return -1
+	}
+	offset := strings.IndexByte(str[from:], char)
+	if offset == -1 {
+		return -1
+	}
+	return from + offset
+}
+
+func closingChar(open byte) (byte, bool) {
+	switch open {
+	case '{':
+		return '}', true
+	case '(':
+		return ')', true
+	case '[':
+		return ']', true
+	}
+	return 0, false
+}

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
@@ -12,6 +12,7 @@ import (
 	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/minimatch"
 )
 
 //go:embed no_restricted_paths.schema.json
@@ -51,15 +52,15 @@ var NoRestrictedPathsRule = rule.Rule{
 		}
 
 		basePath := resolveBasePath(ctx, opts.basePath)
-		// `path.relative` compares case-insensitively only in its win32 flavor,
-		// so this follows the platform rather than the host file system: a
-		// case-insensitive volume on macOS still gets a case-sensitive compare.
-		caseSensitive := runtime.GOOS != "windows"
+		// `path.relative` and Minimatch both pick their win32 flavor from the
+		// platform rather than the host file system, so a case-insensitive
+		// volume on macOS still gets a case-sensitive compare.
+		windows := runtime.GOOS == "windows"
 
 		currentFilename := import_utils.GetPhysicalFilename(ctx)
 		matchingZones := make([]zone, 0, len(opts.zones))
 		for _, z := range opts.zones {
-			if isMatchingZone(z, basePath, currentFilename, caseSensitive) {
+			if isMatchingZone(z, basePath, currentFilename, windows) {
 				matchingZones = append(matchingZones, z)
 			}
 		}
@@ -79,7 +80,7 @@ var NoRestrictedPathsRule = rule.Rule{
 
 			for i := range matchingZones {
 				if !built[i] {
-					validators[i] = makePathValidators(matchingZones[i].fromPaths, matchingZones[i].except, basePath, caseSensitive)
+					validators[i] = makePathValidators(matchingZones[i].fromPaths, matchingZones[i].except, basePath, windows)
 					built[i] = true
 				}
 
@@ -170,23 +171,23 @@ func toStringSlice(raw any) []string {
 	return nil
 }
 
-func isMatchingZone(z zone, basePath string, currentFilename string, caseSensitive bool) bool {
+func isMatchingZone(z zone, basePath string, currentFilename string, windows bool) bool {
 	for _, target := range z.targets {
-		if isMatchingTargetPath(currentFilename, tspath.ResolvePath(basePath, target), caseSensitive) {
+		if isMatchingTargetPath(currentFilename, tspath.ResolvePath(basePath, target), windows) {
 			return true
 		}
 	}
 	return false
 }
 
-func isMatchingTargetPath(fileName string, targetPath string, caseSensitive bool) bool {
+func isMatchingTargetPath(fileName string, targetPath string, windows bool) bool {
 	if isGlob(targetPath) {
-		return utils.MatchGlob(targetPath, fileName)
+		return minimatch.Match(fileName, targetPath, minimatch.Options{})
 	}
-	return containsPath(fileName, targetPath, caseSensitive)
+	return containsPath(fileName, targetPath, windows)
 }
 
-func makePathValidators(fromPaths []string, except []string, basePath string, caseSensitive bool) []pathValidator {
+func makePathValidators(fromPaths []string, except []string, basePath string, windows bool) []pathValidator {
 	anyGlob := false
 	anyNonGlob := false
 	for _, from := range fromPaths {
@@ -214,7 +215,7 @@ func makePathValidators(fromPaths []string, except []string, basePath string, ca
 		if anyGlob {
 			validators = append(validators, computeGlobPatternPathValidator(absoluteFrom, except))
 		} else {
-			validators = append(validators, computeAbsolutePathValidator(absoluteFrom, except, caseSensitive))
+			validators = append(validators, computeAbsolutePathValidator(absoluteFrom, except, windows))
 		}
 	}
 	return validators
@@ -225,9 +226,10 @@ func makePathValidators(fromPaths []string, except []string, basePath string, ca
 // resolving them against `basePath` first, so only absolute exception patterns
 // can ever match a resolved import path.
 func computeGlobPatternPathValidator(absoluteFrom string, except []string) pathValidator {
+	fromMatcher := minimatch.New(absoluteFrom, minimatch.Options{})
 	validator := pathValidator{
 		isPathRestricted: func(absoluteImportPath string) bool {
-			return utils.MatchGlob(absoluteFrom, absoluteImportPath)
+			return fromMatcher.Match(absoluteImportPath)
 		},
 		hasValidExceptions: true,
 		invalidException: rule.RuleMessage{
@@ -243,10 +245,17 @@ func computeGlobPatternPathValidator(absoluteFrom string, except []string) pathV
 		}
 	}
 
-	exceptions := except
+	// The exception patterns stay unresolved, and a Windows-native one such as
+	// `C:\repo\server\allowed\**\*` keeps its backslashes. minimatch.New
+	// rewrites those to `/` on Windows, the same way upstream's Minimatch
+	// constructor does, so the pattern can still match a normalized import path.
+	exceptionMatchers := make([]*minimatch.Matcher, 0, len(except))
+	for _, exception := range except {
+		exceptionMatchers = append(exceptionMatchers, minimatch.New(exception, minimatch.Options{}))
+	}
 	validator.isPathException = func(absoluteImportPath string) bool {
-		for _, exception := range exceptions {
-			if utils.MatchGlob(exception, absoluteImportPath) {
+		for _, matcher := range exceptionMatchers {
+			if matcher.Match(absoluteImportPath) {
 				return true
 			}
 		}
@@ -255,10 +264,10 @@ func computeGlobPatternPathValidator(absoluteFrom string, except []string) pathV
 	return validator
 }
 
-func computeAbsolutePathValidator(absoluteFrom string, except []string, caseSensitive bool) pathValidator {
+func computeAbsolutePathValidator(absoluteFrom string, except []string, windows bool) pathValidator {
 	validator := pathValidator{
 		isPathRestricted: func(absoluteImportPath string) bool {
-			return containsPath(absoluteImportPath, absoluteFrom, caseSensitive)
+			return containsPath(absoluteImportPath, absoluteFrom, windows)
 		},
 		hasValidExceptions: true,
 		invalidException: rule.RuleMessage{
@@ -275,7 +284,7 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string, caseSens
 		// `^\.\.$|^\.\.[\\/]` matches only a leading `..` component. A name such
 		// as `..secret` therefore stays a valid exception, even though
 		// containsPath reads the same leftover as escaping `from`.
-		if !isPathWithin(absoluteException, absoluteFrom, caseSensitive) {
+		if !isPathWithin(absoluteException, absoluteFrom, windows) {
 			validator.hasValidExceptions = false
 			return validator
 		}
@@ -284,7 +293,7 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string, caseSens
 
 	validator.isPathException = func(absoluteImportPath string) bool {
 		for _, absoluteException := range absoluteExceptions {
-			if containsPath(absoluteImportPath, absoluteException, caseSensitive) {
+			if containsPath(absoluteImportPath, absoluteException, windows) {
 				return true
 			}
 		}
@@ -296,9 +305,12 @@ func computeAbsolutePathValidator(absoluteFrom string, except []string, caseSens
 // containsPath reports whether filePath is target itself or one of its
 // descendants, mirroring upstream's `relative === '' || !relative.startsWith('..')`
 // check on `path.relative(target, filePath)`.
-func containsPath(filePath string, target string, caseSensitive bool) bool {
-	if !isPathWithin(filePath, target, caseSensitive) {
+func containsPath(filePath string, target string, windows bool) bool {
+	if !isPathWithin(filePath, target, windows) {
 		return false
+	}
+	if rootsDiverge(filePath, target, windows) {
+		return true
 	}
 	// `path.relative` joins the components left over, and upstream's prefix test
 	// reads a leading `..` in that relative path as "outside target". A first
@@ -314,25 +326,49 @@ func containsPath(filePath string, target string, caseSensitive bool) bool {
 // `path.relative(target, filePath)` walks no `..` component upwards. Components
 // are compared the way the platform's `path.relative` does, so a leftover such
 // as `..secret.js` still counts as inside target.
-func isPathWithin(filePath string, target string, caseSensitive bool) bool {
+func isPathWithin(filePath string, target string, windows bool) bool {
+	if rootsDiverge(filePath, target, windows) {
+		return true
+	}
 	fileComponents := pathComponents(filePath)
 	targetComponents := pathComponents(target)
 	if len(targetComponents) > len(fileComponents) {
 		return false
 	}
 	for i, component := range targetComponents {
-		if !equalPathComponent(component, fileComponents[i], caseSensitive) {
+		if !equalPathComponent(component, fileComponents[i], windows) {
 			return false
 		}
 	}
 	return true
 }
 
-func equalPathComponent(a string, b string, caseSensitive bool) bool {
-	if caseSensitive {
-		return a == b
+// rootsDiverge reports whether `path.win32.relative` gives up on the pair and
+// hands back its absolute second argument, which it does once the two paths
+// differ before their first separator: different drive letters, or different
+// UNC servers. That answer is neither empty nor `..`-prefixed, so upstream ends
+// up reading filePath as inside target. Two shares on one UNC server still
+// share that first segment and keep the ordinary component comparison.
+func rootsDiverge(filePath string, target string, windows bool) bool {
+	return windows && !strings.EqualFold(firstPathSegment(filePath), firstPathSegment(target))
+}
+
+// firstPathSegment returns the leading segment `path.win32.relative` compares
+// before it reaches a separator, skipping the separators a UNC path starts
+// with: the drive of `C:/repo/a`, or the server of `//server/share/a`.
+func firstPathSegment(p string) string {
+	p = strings.TrimLeft(p, "/")
+	if index := strings.IndexByte(p, '/'); index >= 0 {
+		return p[:index]
 	}
-	return strings.EqualFold(a, b)
+	return p
+}
+
+func equalPathComponent(a string, b string, windows bool) bool {
+	if windows {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
 }
 
 // pathComponents splits a path into its root plus segments, dropping the empty

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
@@ -1,0 +1,141 @@
+# import/no-restricted-paths
+
+## Rule Details
+
+Some projects contain files that are not meant to run in the same environment. A web application, for example, may hold server-only code next to browser code, and importing the server code from the client bundle would ship it to the browser.
+
+This rule lets you declare restricted zones: a `target` set of files, and a `from` set of files those targets are not allowed to import.
+
+The rule takes one option object with a list of `zones` and an optional `basePath` used to resolve the relative paths inside each zone. `basePath` defaults to the current working directory.
+
+Each zone accepts:
+
+- `target` — which files belong to the zone. A directory path (matching everything inside it recursively), a glob pattern, or an array of either.
+- `from` — which files the zone may not import. A directory path, a glob pattern, or an array of only directory paths or only glob patterns.
+- `except` — optional. Imports that are allowed even though `from` covers them. When `from` is a directory path, each entry is resolved relative to `from` and must stay inside it. When `from` is a glob pattern, each entry must be a glob pattern too.
+- `message` — optional. Appended to the reported message.
+
+`from` is matched against the resolved path of the imported file, not against the specifier text as written in the source.
+
+Given this folder structure:
+
+```
+.
+├── client
+│   ├── foo.ts
+│   └── baz.ts
+└── server
+    └── bar.ts
+```
+
+Examples of **incorrect** code for this rule:
+
+```json
+{ "import/no-restricted-paths": ["error", { "zones": [{ "target": "./client", "from": "./server" }] }] }
+```
+
+```javascript
+// client/foo.ts
+import bar from '../server/bar';
+```
+
+Examples of **correct** code for this rule:
+
+```json
+{ "import/no-restricted-paths": ["error", { "zones": [{ "target": "./client", "from": "./server" }] }] }
+```
+
+```javascript
+// server/bar.ts
+import baz from '../client/baz';
+```
+
+### `except`
+
+Given this folder structure:
+
+```
+.
+└── server
+    ├── one
+    │   ├── a.ts
+    │   └── b.ts
+    └── two
+        └── a.ts
+```
+
+Examples of **incorrect** code for this rule:
+
+```json
+{
+  "import/no-restricted-paths": [
+    "error",
+    { "zones": [{ "target": "./server/one", "from": "./server", "except": ["./one"] }] }
+  ]
+}
+```
+
+```javascript
+// server/one/a.ts
+import a from '../two/a';
+```
+
+Examples of **correct** code for this rule:
+
+```json
+{
+  "import/no-restricted-paths": [
+    "error",
+    { "zones": [{ "target": "./server/one", "from": "./server", "except": ["./one"] }] }
+  ]
+}
+```
+
+```javascript
+// server/one/a.ts
+import b from './b';
+```
+
+### `basePath`
+
+Relative `target`, `from` and `except` paths are resolved against `basePath`.
+
+```json
+{
+  "import/no-restricted-paths": [
+    "error",
+    { "basePath": "./src", "zones": [{ "target": "./client", "from": "./server" }] }
+  ]
+}
+```
+
+### `message`
+
+```json
+{
+  "import/no-restricted-paths": [
+    "error",
+    {
+      "zones": [
+        { "target": "./client", "from": "./server", "message": "Use the API client instead." }
+      ]
+    }
+  ]
+}
+```
+
+```javascript
+// client/foo.ts
+import bar from '../server/bar';
+```
+
+reports `Unexpected path "../server/bar" imported in restricted zone. Use the API client instead.`
+
+## Differences from ESLint
+
+- Glob patterns support `*`, `**`, `?`, `[abc]` character classes and `{a,b}` alternatives. Extended glob syntax — `!(a)`, `@(a|b)`, `+(a)`, `?(a)`, `*(a)` — is matched as literal text and therefore matches no real path. A `target` such as `./client/!(sub-module)/**/*` leaves the zone inactive, and a `from` such as `./src/@(server|shared)/**/*` restricts nothing. Write `{server,shared}` instead of `@(server|shared)`, and name the directories you want to cover instead of excluding one with `!(...)`.
+- A `*` matches path segments that begin with a dot, so `./src/*` covers `./src/.hidden.ts` as well.
+
+## Original Documentation
+
+- [import/no-restricted-paths](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md)

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
@@ -17,8 +17,6 @@ Each zone accepts:
 
 `from` is matched against the resolved path of the imported file, not against the specifier text as written in the source.
 
-Glob patterns are matched with the same syntax ESLint uses: `*`, `**`, `?`, `[abc]` character classes, `{a,b}` alternatives and the extended forms `!(a)`, `@(a|b)`, `+(a)`, `?(a)` and `*(a)`. A wildcard leaves names that start with a dot alone, so `./src/*` does not cover `./src/.hidden.ts`.
-
 Given this folder structure:
 
 ```
@@ -135,6 +133,8 @@ reports `Unexpected path "../server/bar" imported in restricted zone. Use the AP
 
 ## Differences from ESLint
 
+- Glob patterns support `*`, `**`, `?`, `[abc]` character classes and `{a,b}` alternatives. Extended glob syntax — `!(a)`, `@(a|b)`, `+(a)`, `?(a)`, `*(a)` — is matched as the literal text it is written as, so `./src/?(server)/**/*` covers a directory named `?(server)` rather than one named `server`. Write `{server,shared}` instead of `@(server|shared)`, and name the directories you want to cover instead of excluding one with `!(...)`.
+- A `*` matches path segments that begin with a dot, so `./src/*` covers `./src/.hidden.ts` as well.
 - A zone is matched against the file a specifier resolves to, and a specifier resolves through the module resolution TypeScript recorded for it. TypeScript records `require('./x')` calls in JavaScript files, so in a TypeScript file write the import as an `import` declaration or a dynamic `import('./x')` for the zone to cover it.
 
 ## Original Documentation

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
@@ -135,6 +135,7 @@ reports `Unexpected path "../server/bar" imported in restricted zone. Use the AP
 
 - Glob patterns support `*`, `**`, `?`, `[abc]` character classes and `{a,b}` alternatives. Extended glob syntax — `!(a)`, `@(a|b)`, `+(a)`, `?(a)`, `*(a)` — is matched as literal text and therefore matches no real path. A `target` such as `./client/!(sub-module)/**/*` leaves the zone inactive, and a `from` such as `./src/@(server|shared)/**/*` restricts nothing. Write `{server,shared}` instead of `@(server|shared)`, and name the directories you want to cover instead of excluding one with `!(...)`.
 - A `*` matches path segments that begin with a dot, so `./src/*` covers `./src/.hidden.ts` as well.
+- A zone is matched against the file a specifier resolves to, and a specifier resolves through the module resolution TypeScript recorded for it. TypeScript records `require('./x')` calls in JavaScript files, so in a TypeScript file write the import as an `import` declaration or a dynamic `import('./x')` for the zone to cover it.
 
 ## Original Documentation
 

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
@@ -17,6 +17,8 @@ Each zone accepts:
 
 `from` is matched against the resolved path of the imported file, not against the specifier text as written in the source.
 
+Glob patterns are matched with the same syntax ESLint uses: `*`, `**`, `?`, `[abc]` character classes, `{a,b}` alternatives and the extended forms `!(a)`, `@(a|b)`, `+(a)`, `?(a)` and `*(a)`. A wildcard leaves names that start with a dot alone, so `./src/*` does not cover `./src/.hidden.ts`.
+
 Given this folder structure:
 
 ```
@@ -133,8 +135,6 @@ reports `Unexpected path "../server/bar" imported in restricted zone. Use the AP
 
 ## Differences from ESLint
 
-- Glob patterns support `*`, `**`, `?`, `[abc]` character classes and `{a,b}` alternatives. Extended glob syntax — `!(a)`, `@(a|b)`, `+(a)`, `?(a)`, `*(a)` — is matched as literal text and therefore matches no real path. A `target` such as `./client/!(sub-module)/**/*` leaves the zone inactive, and a `from` such as `./src/@(server|shared)/**/*` restricts nothing. Write `{server,shared}` instead of `@(server|shared)`, and name the directories you want to cover instead of excluding one with `!(...)`.
-- A `*` matches path segments that begin with a dot, so `./src/*` covers `./src/.hidden.ts` as well.
 - A zone is matched against the file a specifier resolves to, and a specifier resolves through the module resolution TypeScript recorded for it. TypeScript records `require('./x')` calls in JavaScript files, so in a TypeScript file write the import as an `import` declaration or a dynamic `import('./x')` for the zone to cover it.
 
 ## Original Documentation

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
@@ -1,4 +1,4 @@
-# import/no-restricted-paths
+# no-restricted-paths
 
 ## Rule Details
 
@@ -98,7 +98,7 @@ import b from './b';
 
 ### `basePath`
 
-Relative `target`, `from` and `except` paths are resolved against `basePath`.
+Relative `target` and `from` paths are resolved against `basePath`, and a relative `basePath` is itself resolved against the current working directory. `except` entries stay relative to their zone's `from`.
 
 ```json
 {

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.schema.json
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.schema.json
@@ -1,0 +1,54 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "zones": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "anyOf": [
+                  { "type": "string" },
+                  {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "uniqueItems": true,
+                    "minLength": 1
+                  }
+                ]
+              },
+              "from": {
+                "anyOf": [
+                  { "type": "string" },
+                  {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "uniqueItems": true,
+                    "minLength": 1
+                  }
+                ]
+              },
+              "except": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "uniqueItems": true
+              },
+              "message": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "basePath": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
@@ -314,6 +314,19 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/one/b", 1, 15)},
 			},
 
+			// Locks in upstream `path.resolve(basePath, ...)`: a relative `basePath` is
+			// made absolute against the current working directory before zone paths are
+			// resolved from it, so the zone still matches absolute file names.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zonesWithBasePath("./restricted-paths", map[string]interface{}{
+					"target": "./client",
+					"from":   "./server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
 			// ---- Real-user: #2690 — a `dir/**/*` glob in `from` also covers the direct
 			// children of `dir`, not only its nested subtrees ----
 			{

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
@@ -125,8 +125,31 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 				}),
 			},
 
-			// ---- Dimension 4: parenthesized callee — the shared module visitor only
-			// matches a bare `require` identifier ----
+			// ---- Dimension 4: upstream reads a `require` call as a module reference
+			// only when it takes exactly one argument ----
+			{
+				Code:     `const b = require("../server/b", "extra")`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+			},
+
+			// ---- Differences from ESLint: a specifier only resolves through the
+			// module resolution TypeScript recorded for it, and TypeScript records a
+			// `require()` call only in a JavaScript file and only when its callee is a
+			// bare `require` identifier. On its own, either other shape leaves the
+			// specifier unresolved and no zone can match it ----
+			{
+				Code:     `const b = require("../server/b")`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+			},
 			{
 				Code:     `const b = (require)("../server/b")`,
 				FileName: "restricted-paths/client/consumer.js",
@@ -142,6 +165,16 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 				Code:     `const b = require()`,
 				FileName: "restricted-paths/client/consumer.js",
 				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+			},
+			// A recovered parse of incomplete source leaves `import()` without a
+			// specifier argument; the visitor must not index into it.
+			{
+				Code:     `const p = import()`,
+				FileName: "restricted-paths/client/a.ts",
 				Options: zones(map[string]interface{}{
 					"target": "./restricted-paths/client",
 					"from":   "./restricted-paths/server",
@@ -409,6 +442,48 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 					"from":   "./restricted-paths/server",
 				}),
 				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 34)},
+			},
+
+			// ---- Dimension 4: an earlier declaration of the same specifier resolves it
+			// for the whole file, so the `require` shapes above reach a resolved path
+			// too. ESTree has no parenthesized-expression node, so upstream reads
+			// through the parentheses and reports both calls. ----
+			{
+				Code:     `import "../server/b"; (require)("../server/b");`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../server/b", 1, 8),
+					unexpectedPath("../server/b", 1, 33),
+				},
+			},
+			{
+				Code:     `import "../server/b"; const c = require("../server/b");`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../server/b", 1, 8),
+					unexpectedPath("../server/b", 1, 41),
+				},
+			},
+			// The extra argument keeps the `require` call out of the report even
+			// though its specifier now resolves.
+			{
+				Code:     `import "../server/b"; require("../server/b", "extra");`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 8)},
 			},
 		},
 	)

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
@@ -114,20 +114,20 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 				}),
 			},
 
-			// ---- Extended glob: a `!(...)` target excludes the directory it names, so
-			// a file inside it leaves the zone inactive ----
+			// ---- Differences from ESLint: extended glob syntax is matched literally, so a
+			// `!(...)` target selects no file and leaves the zone inactive ----
 			{
-				Code:     `import b from "./b"`,
-				FileName: "restricted-paths/server/c.ts",
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
 				Options: zones(map[string]interface{}{
 					"target": "./restricted-paths/!(server)/**/*",
 					"from":   "./restricted-paths/server",
 				}),
 			},
 
-			// ---- Extended glob: the `?` opening a `?(...)` list is part of the list
-			// rather than a single-character wildcard, so a directory that merely ends
-			// in `(server)` stays outside `from` ----
+			// ---- Differences from ESLint: the `?` opening a `?(...)` list is matched
+			// literally too, so it cannot act as a base wildcard and pull in a directory
+			// that merely ends in `(server)` ----
 			{
 				Code:     `import a from "../x(server)/a"`,
 				FileName: "restricted-paths/client/a.ts",
@@ -207,40 +207,6 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 			// inspects a module specifier string literal and the linted file's path.
 		},
 		[]rule_tester.InvalidTestCase{
-			// ---- Extended glob: `!(...)` selects every directory it does not name,
-			// so a client file lands in the zone ----
-			{
-				Code:     `import b from "../server/b"`,
-				FileName: "restricted-paths/client/a.ts",
-				Options: zones(map[string]interface{}{
-					"target": "./restricted-paths/!(server)/**/*",
-					"from":   "./restricted-paths/server",
-				}),
-				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
-			},
-
-			// ---- Extended glob: `@(a|b)` in `from` restricts either alternative ----
-			{
-				Code:     `import b from "../server/b"`,
-				FileName: "restricted-paths/client/a.ts",
-				Options: zones(map[string]interface{}{
-					"target": "./restricted-paths/client",
-					"from":   "./restricted-paths/@(server|other)/**/*",
-				}),
-				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
-			},
-
-			// ---- Extended glob: `?(...)` restricts the directory it names ----
-			{
-				Code:     `import b from "../server/b"`,
-				FileName: "restricted-paths/client/a.ts",
-				Options: zones(map[string]interface{}{
-					"target": "./restricted-paths/client",
-					"from":   "./restricted-paths/?(server)/**/*",
-				}),
-				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
-			},
-
 			// ---- Options: the bare single-object shape a CLI config passes ----
 			{
 				Code:     `import b from "../server/b"`,

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
@@ -1,0 +1,402 @@
+// TestNoRestrictedPathsExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific upstream branch, Dimension 4 row or real-user
+// report it covers, so future refactors can't silently regress them without
+// breaking a named lock-in. The upstream 1:1 migration lives in
+// no_restricted_paths_upstream_test.go.
+package no_restricted_paths_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_restricted_paths"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// zonesBare produces the single-object option shape a CLI config passes
+// directly, without the surrounding options array.
+func zonesBare(entries ...map[string]interface{}) any {
+	return map[string]interface{}{"zones": toAnySlice(entries)}
+}
+
+func TestNoRestrictedPathsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_restricted_paths.NoRestrictedPathsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Options: no options, empty options array and empty option object all disable the rule ----
+			{Code: `import b from "../server/b"`, FileName: "restricted-paths/client/a.ts"},
+			{Code: `import b from "../server/b"`, FileName: "restricted-paths/client/a.ts", Options: []interface{}{}},
+			{Code: `import b from "../server/b"`, FileName: "restricted-paths/client/a.ts", Options: []interface{}{map[string]interface{}{}}},
+
+			// Locks in upstream makePathValidators() arm: a zone without `from` produces no validators.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options:  zones(map[string]interface{}{"target": "./restricted-paths/client"}),
+			},
+
+			// Locks in upstream matchingZones filter: a zone without `target` never matches a file.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options:  zones(map[string]interface{}{"from": "./restricted-paths/server"}),
+			},
+
+			// Locks in upstream checkForRestrictedImportPath() arm 1: an import that
+			// resolves to nothing is skipped before any zone is consulted.
+			{
+				Code:     `import missing from "./does-not-exist"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zonesBare(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths",
+				}),
+			},
+
+			// ---- Real-user: #2089/#2090 — a sibling directory sharing a name prefix is not inside `from` ----
+			{
+				Code:     `import a from "../two-new/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server/two",
+				}),
+			},
+
+			// ---- Real-user: #2818 — with a glob `from`, `except` patterns are matched
+			// verbatim, so a relative exception glob can still match nothing. Here the
+			// exception is absolute and does match, so the import is allowed. ----
+			{
+				Code:     `import a from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+					"except": list("/restricted-paths/server/two/**"),
+				}),
+			},
+
+			// Locks in upstream computeAbsolutePathValidator() arm: `except: ['.']` resolves
+			// to `from` itself, which excepts everything the zone would otherwise restrict.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+					"except": list("."),
+				}),
+			},
+
+			// Locks in upstream isGlob() arm: a bare `?` is not glob syntax for is-glob,
+			// so `serve?` stays a literal directory name and matches no real directory.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/serve?",
+				}),
+			},
+
+			// Locks in upstream isGlob() arm: a leading `!` makes the whole string a glob
+			// pattern, so it is no longer read as a directory path.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "!./restricted-paths/server",
+				}),
+			},
+
+			// ---- Differences from ESLint: extended glob syntax is matched literally, so a
+			// `!(...)` target selects no file and leaves the zone inactive ----
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/!(server)/**/*",
+					"from":   "./restricted-paths/server",
+				}),
+			},
+
+			// ---- Dimension 4: parenthesized callee — the shared module visitor only
+			// matches a bare `require` identifier ----
+			{
+				Code:     `const b = (require)("../server/b")`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+			},
+
+			// ---- Dimension 4: graceful degradation — call shapes with no usable specifier ----
+			{
+				Code:     `const b = require()`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+			},
+			{
+				Code:     `const name = "../server/b"; const b = require(name)`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+			},
+
+			// N/A: receiver/expression wrappers (`(X).y`, `X!.y`, `X as T`, `X?.y`),
+			// access/key forms and declaration/container forms — this rule only ever
+			// inspects a module specifier string literal and the linted file's path.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Options: the bare single-object shape a CLI config passes ----
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zonesBare(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// Locks in upstream containsPath() arm: `from` naming the imported file
+			// itself is contained by itself.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/a.ts",
+					"from":   "./restricted-paths/server/b.ts",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// Locks in upstream reportImportsInRestrictedZone(): one report per matching
+			// validator, so two overlapping `from` entries report the same import twice.
+			{
+				Code:     `import a from "../server/two/a"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   list("./restricted-paths/server", "./restricted-paths/server/two"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../server/two/a", 1, 15),
+					unexpectedPath("../server/two/a", 1, 15),
+				},
+			},
+
+			// Locks in upstream matchingZones.forEach(): two zones matching the same file
+			// each report the same import.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(
+					map[string]interface{}{
+						"target": "./restricted-paths/client",
+						"from":   "./restricted-paths/server",
+					},
+					map[string]interface{}{
+						"target":  "./restricted-paths/client/**/*",
+						"from":    "./restricted-paths",
+						"message": "Second zone.",
+					},
+				),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../server/b", 1, 15),
+					unexpectedPathWithMessage("../server/b", "Second zone.", 1, 15),
+				},
+			},
+
+			// Locks in upstream reportInvalidExceptions() ordering: exception errors for a
+			// zone are emitted before its restricted-zone errors, even on the same import.
+			{
+				Code:     `import a from "./a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   list("./restricted-paths/server/one", "./restricted-paths/server"),
+					"except": list("../one/b.ts"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					invalidExceptionPath("./a", 1, 15),
+					unexpectedPath("./a", 1, 15),
+				},
+			},
+
+			// Locks in upstream computeMixedGlobAndAbsolutePathValidator(): three `from`
+			// entries collapse into a single validator, so the mix is reported once.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from": list(
+						"./restricted-paths/server",
+						"./restricted-paths/server/*",
+						"./restricted-paths/other/*",
+					),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{mixedGlobAndNonGlob("../server/b", 1, 15)},
+			},
+
+			// Locks in upstream computeGlobPatternPathValidator() arm: an empty `except`
+			// list is valid and excepts nothing.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/*",
+					"from":   "./restricted-paths/server/*",
+					"except": list(),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// Locks in upstream reportImportsInRestrictedZone(): an empty `message` adds
+			// no trailing separator to the default text.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target":  "./restricted-paths/client",
+					"from":    "./restricted-paths/server",
+					"message": "",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// Locks in upstream isGlob() arm: `{a,b}` alternatives make `from` a glob pattern.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/{server,other}/*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// Locks in upstream isGlob() arm: a `[...]` character class makes `from` a glob pattern.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/serve[r]/*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// Locks in upstream `basePath` default: with no `basePath`, relative zone paths
+			// resolve against the current working directory, which is the project root here.
+			{
+				Code:     `import b from "../server/one/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "restricted-paths/client",
+					"from":   "restricted-paths/server/one",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/one/b", 1, 15)},
+			},
+
+			// ---- Real-user: #2690 — a `dir/**/*` glob in `from` also covers the direct
+			// children of `dir`, not only its nested subtrees ----
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// ---- Real-user: #2818 — a relative `except` glob is matched verbatim against
+			// the resolved absolute import path, so it never lifts the restriction ----
+			{
+				Code:     `import a from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+					"except": list("./restricted-paths/server/two/**"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../two/a", 1, 15)},
+			},
+
+			// ---- Real-user: #2730 — `from` may name a single file through a glob suffix ----
+			{
+				Code:     `import c from "./c"`,
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server",
+					"from":   "./restricted-paths/server/c.*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("./c", 1, 15)},
+			},
+
+			// ---- Dimension 4: module reference shapes the visitor must reach ----
+			{
+				Code:     `export { default as b } from "../server/b";`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 30)},
+			},
+			{
+				Code:     `export * from "../server/b";`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+			{
+				Code:     `import "../server/b";`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 8)},
+			},
+			{
+				Code:     `const load = () => import("../server/b");`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 27)},
+			},
+			{
+				Code:     `function load() { return require("../server/b"); }`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 34)},
+			},
+		},
+	)
+}

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
@@ -114,14 +114,26 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 				}),
 			},
 
-			// ---- Differences from ESLint: extended glob syntax is matched literally, so a
-			// `!(...)` target selects no file and leaves the zone inactive ----
+			// ---- Extended glob: a `!(...)` target excludes the directory it names, so
+			// a file inside it leaves the zone inactive ----
 			{
-				Code:     `import b from "../server/b"`,
-				FileName: "restricted-paths/client/a.ts",
+				Code:     `import b from "./b"`,
+				FileName: "restricted-paths/server/c.ts",
 				Options: zones(map[string]interface{}{
 					"target": "./restricted-paths/!(server)/**/*",
 					"from":   "./restricted-paths/server",
+				}),
+			},
+
+			// ---- Extended glob: the `?` opening a `?(...)` list is part of the list
+			// rather than a single-character wildcard, so a directory that merely ends
+			// in `(server)` stays outside `from` ----
+			{
+				Code:     `import a from "../x(server)/a"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/?(server)/**/*",
 				}),
 			},
 
@@ -195,6 +207,40 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 			// inspects a module specifier string literal and the linted file's path.
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- Extended glob: `!(...)` selects every directory it does not name,
+			// so a client file lands in the zone ----
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/!(server)/**/*",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// ---- Extended glob: `@(a|b)` in `from` restricts either alternative ----
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/@(server|other)/**/*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// ---- Extended glob: `?(...)` restricts the directory it names ----
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/?(server)/**/*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
 			// ---- Options: the bare single-object shape a CLI config passes ----
 			{
 				Code:     `import b from "../server/b"`,

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
@@ -1,12 +1,12 @@
-// TestContainsPath covers the path containment helper directly, including the
-// two shapes a plain component-prefix comparison gets wrong: a child name that
-// starts with two dots, and a host that resolves names case-insensitively.
-// Neither is reachable from a rule test — the embedded fixture tree leaves out
-// dot-prefixed names, and the fixture host is always case-sensitive.
+// These tests cover the two path helpers directly, including the shapes no rule
+// test can reach: the embedded fixture tree leaves out dot-prefixed names, and
+// the case-insensitive comparison only runs on Windows.
 package no_restricted_paths
 
 import "testing"
 
+// TestContainsPath pins the restriction predicate, which reads any leftover
+// starting with two dots as escaping the target.
 func TestContainsPath(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -53,14 +53,14 @@ func TestContainsPath(t *testing.T) {
 			want:          true,
 		},
 		{
-			name:          "differing case on a case-sensitive host",
+			name:          "differing case on a case-sensitive platform",
 			filePath:      "c:/PROJECT/client/a.ts",
 			target:        "C:/Project/client",
 			caseSensitive: true,
 			want:          false,
 		},
 		{
-			name:          "differing case on a case-insensitive host",
+			name:          "differing case on a case-insensitive platform",
 			filePath:      "c:/PROJECT/client/a.ts",
 			target:        "C:/Project/client",
 			caseSensitive: false,
@@ -73,6 +73,74 @@ func TestContainsPath(t *testing.T) {
 			got := containsPath(test.filePath, test.target, test.caseSensitive)
 			if got != test.want {
 				t.Errorf("containsPath(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.caseSensitive, got, test.want)
+			}
+		})
+	}
+}
+
+// TestIsPathWithin pins the exception-validity predicate, which accepts a
+// leftover starting with two dots because upstream's importType only classifies
+// a whole `..` component as "parent".
+func TestIsPathWithin(t *testing.T) {
+	tests := []struct {
+		name          string
+		filePath      string
+		target        string
+		caseSensitive bool
+		want          bool
+	}{
+		{
+			name:          "the target itself",
+			filePath:      "/project/server",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          true,
+		},
+		{
+			name:          "a descendant of the target",
+			filePath:      "/project/server/one/a.ts",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          true,
+		},
+		{
+			// `path.relative('/project/server', '/project/server/..secret')`
+			// is `'..secret'`, which importType classifies as "external", not
+			// "parent", so the exception stays valid.
+			name:          "a child whose name starts with two dots",
+			filePath:      "/project/server/..secret",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          true,
+		},
+		{
+			name:          "a path outside the target",
+			filePath:      "/project/client/a.ts",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          false,
+		},
+		{
+			name:          "a sibling sharing a name prefix",
+			filePath:      "/project/serverless/a.ts",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          false,
+		},
+		{
+			name:          "differing case on a case-insensitive platform",
+			filePath:      "c:/PROJECT/server/..secret",
+			target:        "C:/Project/server",
+			caseSensitive: false,
+			want:          true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isPathWithin(test.filePath, test.target, test.caseSensitive)
+			if got != test.want {
+				t.Errorf("isPathWithin(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.caseSensitive, got, test.want)
 			}
 		})
 	}

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
@@ -1,0 +1,79 @@
+// TestContainsPath covers the path containment helper directly, including the
+// two shapes a plain component-prefix comparison gets wrong: a child name that
+// starts with two dots, and a host that resolves names case-insensitively.
+// Neither is reachable from a rule test — the embedded fixture tree leaves out
+// dot-prefixed names, and the fixture host is always case-sensitive.
+package no_restricted_paths
+
+import "testing"
+
+func TestContainsPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		filePath      string
+		target        string
+		caseSensitive bool
+		want          bool
+	}{
+		{
+			name:          "the target itself",
+			filePath:      "/project/server",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          true,
+		},
+		{
+			name:          "a descendant of the target",
+			filePath:      "/project/server/one/a.ts",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          true,
+		},
+		{
+			name:          "a sibling sharing a name prefix",
+			filePath:      "/project/serverless/a.ts",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          false,
+		},
+		{
+			// `path.relative('/project/server', '/project/server/..secret.ts')`
+			// is `'..secret.ts'`, which upstream reads as escaping the target.
+			name:          "a child whose name starts with two dots",
+			filePath:      "/project/server/..secret.ts",
+			target:        "/project/server",
+			caseSensitive: true,
+			want:          false,
+		},
+		{
+			name:          "a two-dot directory named by the target itself",
+			filePath:      "/project/server/..secret/a.ts",
+			target:        "/project/server/..secret",
+			caseSensitive: true,
+			want:          true,
+		},
+		{
+			name:          "differing case on a case-sensitive host",
+			filePath:      "c:/PROJECT/client/a.ts",
+			target:        "C:/Project/client",
+			caseSensitive: true,
+			want:          false,
+		},
+		{
+			name:          "differing case on a case-insensitive host",
+			filePath:      "c:/PROJECT/client/a.ts",
+			target:        "C:/Project/client",
+			caseSensitive: false,
+			want:          true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := containsPath(test.filePath, test.target, test.caseSensitive)
+			if got != test.want {
+				t.Errorf("containsPath(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.caseSensitive, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
@@ -1,6 +1,5 @@
-// These tests cover the two path helpers directly, including the shapes no rule
-// test can reach: the embedded fixture tree leaves out dot-prefixed names, and
-// the case-insensitive comparison only runs on Windows.
+// These tests cover the path helpers directly, including the shapes no rule
+// test can reach: the win32 flavor of the path comparison only runs on Windows.
 package no_restricted_paths
 
 import "testing"
@@ -9,70 +8,96 @@ import "testing"
 // starting with two dots as escaping the target.
 func TestContainsPath(t *testing.T) {
 	tests := []struct {
-		name          string
-		filePath      string
-		target        string
-		caseSensitive bool
-		want          bool
+		name     string
+		filePath string
+		target   string
+		windows  bool
+		want     bool
 	}{
 		{
-			name:          "the target itself",
-			filePath:      "/project/server",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          true,
+			name:     "the target itself",
+			filePath: "/project/server",
+			target:   "/project/server",
+			want:     true,
 		},
 		{
-			name:          "a descendant of the target",
-			filePath:      "/project/server/one/a.ts",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          true,
+			name:     "a descendant of the target",
+			filePath: "/project/server/one/a.ts",
+			target:   "/project/server",
+			want:     true,
 		},
 		{
-			name:          "a sibling sharing a name prefix",
-			filePath:      "/project/serverless/a.ts",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          false,
+			name:     "a sibling sharing a name prefix",
+			filePath: "/project/serverless/a.ts",
+			target:   "/project/server",
+			want:     false,
 		},
 		{
 			// `path.relative('/project/server', '/project/server/..secret.ts')`
 			// is `'..secret.ts'`, which upstream reads as escaping the target.
-			name:          "a child whose name starts with two dots",
-			filePath:      "/project/server/..secret.ts",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          false,
+			name:     "a child whose name starts with two dots",
+			filePath: "/project/server/..secret.ts",
+			target:   "/project/server",
+			want:     false,
 		},
 		{
-			name:          "a two-dot directory named by the target itself",
-			filePath:      "/project/server/..secret/a.ts",
-			target:        "/project/server/..secret",
-			caseSensitive: true,
-			want:          true,
+			name:     "a two-dot directory named by the target itself",
+			filePath: "/project/server/..secret/a.ts",
+			target:   "/project/server/..secret",
+			want:     true,
 		},
 		{
-			name:          "differing case on a case-sensitive platform",
-			filePath:      "c:/PROJECT/client/a.ts",
-			target:        "C:/Project/client",
-			caseSensitive: true,
-			want:          false,
+			name:     "differing case on a case-sensitive platform",
+			filePath: "c:/PROJECT/client/a.ts",
+			target:   "C:/Project/client",
+			want:     false,
 		},
 		{
-			name:          "differing case on a case-insensitive platform",
-			filePath:      "c:/PROJECT/client/a.ts",
-			target:        "C:/Project/client",
-			caseSensitive: false,
-			want:          true,
+			name:     "differing case on a case-insensitive platform",
+			filePath: "c:/PROJECT/client/a.ts",
+			target:   "C:/Project/client",
+			windows:  true,
+			want:     true,
+		},
+		{
+			// `path.win32.relative('C:\\project\\server', 'D:\\other\\a.ts')` is
+			// `'D:\\other\\a.ts'`, which upstream reads as inside the target.
+			name:     "a file on another drive",
+			filePath: "D:/other/a.ts",
+			target:   "C:/project/server",
+			windows:  true,
+			want:     true,
+		},
+		{
+			name:     "a drive path against a UNC target",
+			filePath: "C:/other/a.ts",
+			target:   "//server/share/project",
+			windows:  true,
+			want:     true,
+		},
+		{
+			name:     "a file on another UNC server",
+			filePath: "//other/share/a.ts",
+			target:   "//server/share/project",
+			windows:  true,
+			want:     true,
+		},
+		{
+			// `path.win32.relative` still reaches the shared server segment here
+			// and answers `'..\\..\\two\\a.ts'`, which escapes the target.
+			name:     "another share on the same UNC server",
+			filePath: "//server/two/a.ts",
+			target:   "//server/one/project",
+			windows:  true,
+			want:     false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := containsPath(test.filePath, test.target, test.caseSensitive)
+			got := containsPath(test.filePath, test.target, test.windows)
 			if got != test.want {
-				t.Errorf("containsPath(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.caseSensitive, got, test.want)
+				t.Errorf("containsPath(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.windows, got, test.want)
 			}
 		})
 	}
@@ -83,64 +108,76 @@ func TestContainsPath(t *testing.T) {
 // a whole `..` component as "parent".
 func TestIsPathWithin(t *testing.T) {
 	tests := []struct {
-		name          string
-		filePath      string
-		target        string
-		caseSensitive bool
-		want          bool
+		name     string
+		filePath string
+		target   string
+		windows  bool
+		want     bool
 	}{
 		{
-			name:          "the target itself",
-			filePath:      "/project/server",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          true,
+			name:     "the target itself",
+			filePath: "/project/server",
+			target:   "/project/server",
+			want:     true,
 		},
 		{
-			name:          "a descendant of the target",
-			filePath:      "/project/server/one/a.ts",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          true,
+			name:     "a descendant of the target",
+			filePath: "/project/server/one/a.ts",
+			target:   "/project/server",
+			want:     true,
 		},
 		{
 			// `path.relative('/project/server', '/project/server/..secret')`
 			// is `'..secret'`, which importType classifies as "external", not
 			// "parent", so the exception stays valid.
-			name:          "a child whose name starts with two dots",
-			filePath:      "/project/server/..secret",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          true,
+			name:     "a child whose name starts with two dots",
+			filePath: "/project/server/..secret",
+			target:   "/project/server",
+			want:     true,
 		},
 		{
-			name:          "a path outside the target",
-			filePath:      "/project/client/a.ts",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          false,
+			name:     "a path outside the target",
+			filePath: "/project/client/a.ts",
+			target:   "/project/server",
+			want:     false,
 		},
 		{
-			name:          "a sibling sharing a name prefix",
-			filePath:      "/project/serverless/a.ts",
-			target:        "/project/server",
-			caseSensitive: true,
-			want:          false,
+			name:     "a sibling sharing a name prefix",
+			filePath: "/project/serverless/a.ts",
+			target:   "/project/server",
+			want:     false,
 		},
 		{
-			name:          "differing case on a case-insensitive platform",
-			filePath:      "c:/PROJECT/server/..secret",
-			target:        "C:/Project/server",
-			caseSensitive: false,
-			want:          true,
+			name:     "differing case on a case-insensitive platform",
+			filePath: "c:/PROJECT/server/..secret",
+			target:   "C:/Project/server",
+			windows:  true,
+			want:     true,
+		},
+		{
+			// importType classifies the `'D:\\other\\allowed'` that
+			// `path.win32.relative` hands back as "external", so the exception
+			// stays valid rather than being reported as escaping `from`.
+			name:     "an exception on another drive",
+			filePath: "D:/other/allowed",
+			target:   "C:/project/server",
+			windows:  true,
+			want:     true,
+		},
+		{
+			name:     "an exception on another share of the same UNC server",
+			filePath: "//server/two/allowed",
+			target:   "//server/one/project",
+			windows:  true,
+			want:     false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := isPathWithin(test.filePath, test.target, test.caseSensitive)
+			got := isPathWithin(test.filePath, test.target, test.windows)
 			if got != test.want {
-				t.Errorf("isPathWithin(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.caseSensitive, got, test.want)
+				t.Errorf("isPathWithin(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.windows, got, test.want)
 			}
 		})
 	}

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_internal_test.go
@@ -1,5 +1,6 @@
-// These tests cover the path helpers directly, including the shapes no rule
-// test can reach: the win32 flavor of the path comparison only runs on Windows.
+// These tests cover the path and glob helpers directly, including the shapes no
+// rule test can reach: the win32 flavor of the path comparison only runs on
+// Windows.
 package no_restricted_paths
 
 import "testing"
@@ -60,10 +61,10 @@ func TestContainsPath(t *testing.T) {
 			want:     true,
 		},
 		{
-			// `path.win32.relative('C:\\project\\server', 'D:\\other\\a.ts')` is
-			// `'D:\\other\\a.ts'`, which upstream reads as inside the target.
+			// `path.win32.relative('C:\\project\\server', 'D:\\vendor\\a.ts')` is
+			// `'D:\\vendor\\a.ts'`, which upstream reads as inside the target.
 			name:     "a file on another drive",
-			filePath: "D:/other/a.ts",
+			filePath: "D:/vendor/a.ts",
 			target:   "C:/project/server",
 			windows:  true,
 			want:     true,
@@ -155,11 +156,11 @@ func TestIsPathWithin(t *testing.T) {
 			want:     true,
 		},
 		{
-			// importType classifies the `'D:\\other\\allowed'` that
+			// importType classifies the `'D:\\vendor\\allowed'` that
 			// `path.win32.relative` hands back as "external", so the exception
 			// stays valid rather than being reported as escaping `from`.
 			name:     "an exception on another drive",
-			filePath: "D:/other/allowed",
+			filePath: "D:/vendor/allowed",
 			target:   "C:/project/server",
 			windows:  true,
 			want:     true,
@@ -178,6 +179,66 @@ func TestIsPathWithin(t *testing.T) {
 			got := isPathWithin(test.filePath, test.target, test.windows)
 			if got != test.want {
 				t.Errorf("isPathWithin(%q, %q, %v) = %v, want %v", test.filePath, test.target, test.windows, got, test.want)
+			}
+		})
+	}
+}
+
+// TestEscapeExtglob pins the rewrite that keeps the extended glob syntax
+// doublestar does not implement out of the base wildcard syntax.
+func TestEscapeExtglob(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{
+			name:    "a pattern without extended glob syntax",
+			pattern: "/src/**/*.ts",
+			want:    "/src/**/*.ts",
+		},
+		{
+			name:    "a zero-or-one list, whose `?` would match any character",
+			pattern: "/src/?(server)/*",
+			want:    `/src/\?(server)/*`,
+		},
+		{
+			name:    "a zero-or-more list, whose `*` would match any segment",
+			pattern: "/src/*(server)/*",
+			want:    `/src/\*(server)/*`,
+		},
+		{
+			name:    "an alternation list, which carries no base wildcard",
+			pattern: "/src/@(server|shared)/**/*",
+			want:    "/src/@(server|shared)/**/*",
+		},
+		{
+			name:    "wildcards nested inside a list body",
+			pattern: "/src/+(a*|b?)/x",
+			want:    `/src/+(a\*|b\?)/x`,
+		},
+		{
+			name:    "a nested list",
+			pattern: "/src/!(a|?(b))/x",
+			want:    `/src/!(a|\?(b))/x`,
+		},
+		{
+			name:    "an escaped character before a list",
+			pattern: `/src/\@x/?(a)`,
+			want:    `/src/\@x/\?(a)`,
+		},
+		{
+			name:    "an unterminated list, which is not extended glob syntax",
+			pattern: "/src/?(server/*",
+			want:    "/src/?(server/*",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := escapeExtglob(test.pattern)
+			if got != test.want {
+				t.Errorf("escapeExtglob(%q) = %q, want %q", test.pattern, got, test.want)
 			}
 		})
 	}

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_upstream_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_upstream_test.go
@@ -1,0 +1,648 @@
+// TestNoRestrictedPathsUpstream migrates the full valid/invalid suite from
+// upstream tests/src/rules/no-restricted-paths.js 1:1, including the
+// `context('Typescript')` block. Upstream's fixture root `tests/files/` maps
+// onto this plugin's fixture root, so upstream's
+// `./tests/files/restricted-paths/...` zone paths become
+// `./restricted-paths/...` here, and its `.js` fixtures become `.ts` ones
+// except for the CommonJS cases, which stay on `.js` so `require` specifiers
+// take part in module resolution.
+// Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in no_restricted_paths_extras_test.go.
+package no_restricted_paths_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_restricted_paths"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func zones(entries ...map[string]interface{}) any {
+	return []interface{}{map[string]interface{}{"zones": toAnySlice(entries)}}
+}
+
+func zonesWithBasePath(basePath string, entries ...map[string]interface{}) any {
+	return []interface{}{map[string]interface{}{
+		"zones":    toAnySlice(entries),
+		"basePath": basePath,
+	}}
+}
+
+func toAnySlice(entries []map[string]interface{}) []interface{} {
+	values := make([]interface{}, len(entries))
+	for i := range entries {
+		values[i] = entries[i]
+	}
+	return values
+}
+
+// list mirrors the `[]interface{}` shape a JSON/JS config produces for the
+// array-valued `target`, `from` and `except` options.
+func list(values ...string) []interface{} {
+	items := make([]interface{}, len(values))
+	for i, value := range values {
+		items[i] = value
+	}
+	return items
+}
+
+func errorAt(messageID string, message string, line int, column int, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   line,
+		EndColumn: endColumn,
+	}
+}
+
+func unexpectedPath(specifier string, line int, column int) rule_tester.InvalidTestCaseError {
+	return errorAt(
+		"unexpectedPath",
+		fmt.Sprintf("Unexpected path \"%s\" imported in restricted zone.", specifier),
+		line, column, column+len(specifier)+2,
+	)
+}
+
+func unexpectedPathWithMessage(specifier string, custom string, line int, column int) rule_tester.InvalidTestCaseError {
+	return errorAt(
+		"unexpectedPath",
+		fmt.Sprintf("Unexpected path \"%s\" imported in restricted zone. %s", specifier, custom),
+		line, column, column+len(specifier)+2,
+	)
+}
+
+func invalidExceptionPath(specifier string, line int, column int) rule_tester.InvalidTestCaseError {
+	return errorAt(
+		"invalidExceptionPath",
+		"Restricted path exceptions must be descendants of the configured `from` path for that zone.",
+		line, column, column+len(specifier)+2,
+	)
+}
+
+func invalidExceptionGlob(specifier string, line int, column int) rule_tester.InvalidTestCaseError {
+	return errorAt(
+		"invalidExceptionGlob",
+		"Restricted path exceptions must be glob patterns when `from` contains glob patterns",
+		line, column, column+len(specifier)+2,
+	)
+}
+
+func mixedGlobAndNonGlob(specifier string, line int, column int) rule_tester.InvalidTestCaseError {
+	return errorAt(
+		"mixedGlobAndNonGlob",
+		"Restricted path `from` must contain either only glob patterns or none",
+		line, column, column+len(specifier)+2,
+	)
+}
+
+func TestNoRestrictedPathsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_restricted_paths.NoRestrictedPathsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid: zone does not cover the imported path ----
+			{
+				Code:     `import a from "../client/a"`,
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server",
+					"from":   "./restricted-paths/other",
+				}),
+			},
+			{
+				Code:     `import a from "../client/a"`,
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/other",
+				}),
+			},
+			{
+				Code:     `import a from "../client/a"`,
+				FileName: "restricted-paths/client/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/!(client)/**/*",
+					"from":   "./restricted-paths/client/**/*",
+				}),
+			},
+			{
+				// CommonJS specifiers only take part in module resolution inside
+				// JavaScript files, so the require cases run on a `.js` fixture.
+				Code:     `const a = require("../client/a")`,
+				FileName: "restricted-paths/server/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server",
+					"from":   "./restricted-paths/other",
+				}),
+			},
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/other",
+				}),
+			},
+
+			// ---- upstream valid: except lifts the restriction ----
+			{
+				Code:     `import a from "./a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("./one"),
+				}),
+			},
+			{
+				Code:     `import a from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("./two"),
+				}),
+			},
+			{
+				Code:     `import a from "../one/a"`,
+				FileName: "restricted-paths/server/two-new/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/two",
+					"from":   "./restricted-paths/server",
+					"except": list(),
+				}),
+			},
+			{
+				Code:     `import A from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+					"except": list("**/a.ts"),
+				}),
+			},
+
+			// ---- upstream valid: support of arrays for from and target ----
+			{
+				Code:     `import a from "../client/a"`,
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": list("./restricted-paths/server"),
+					"from":   "./restricted-paths/other",
+				}),
+			},
+			{
+				Code:     `import a from "../client/a"`,
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server",
+					"from":   list("./restricted-paths/other"),
+				}),
+			},
+			{
+				Code:     `import a from "../one/a"`,
+				FileName: "restricted-paths/server/two-new/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": list("./restricted-paths/server/two", "./restricted-paths/server/three"),
+					"from":   "./restricted-paths/server",
+				}),
+			},
+			{
+				Code:     `import a from "../one/a"`,
+				FileName: "restricted-paths/server/two-new/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server",
+					"from":   list("./restricted-paths/server/two", "./restricted-paths/server/three"),
+					"except": list(),
+				}),
+			},
+			{
+				Code:     `import a from "../client/a"`,
+				FileName: "restricted-paths/client/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/!(client)/**/*",
+					"from":   list("./restricted-paths/client/*", "./restricted-paths/client/one/*"),
+				}),
+			},
+			{
+				Code:     `import a from "../client/a"`,
+				FileName: "restricted-paths/client/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": list("./restricted-paths/!(client)/**/*", "./restricted-paths/client/a/"),
+					"from":   "./restricted-paths/client/**/*",
+				}),
+			},
+
+			// ---- upstream valid: irrelevant function calls ----
+			{Code: `notRequire("../server/b")`},
+			{
+				Code:     `notRequire("../server/b")`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+			},
+
+			// ---- upstream valid: no config ----
+			{Code: `require("../server/b")`},
+			{Code: `import b from "../server/b"`},
+
+			// ---- upstream valid: builtin (ignore) ----
+			{Code: `require("os")`},
+
+			// ---- upstream valid (Typescript): type-only imports ----
+			{
+				Code:     `import type a from "../client/a"`,
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server",
+					"from":   "./restricted-paths/other",
+				}),
+			},
+			{
+				Code:     `import type a from "../client/a"`,
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/other",
+				}),
+			},
+			{
+				Code:     `import type a from "../client/a"`,
+				FileName: "restricted-paths/client/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/!(client)/**/*",
+					"from":   "./restricted-paths/client/**/*",
+				}),
+			},
+			{
+				Code:     `import type b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/other",
+				}),
+			},
+			{
+				Code:     `import type a from "./a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("./one"),
+				}),
+			},
+			{
+				Code:     `import type a from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("./two"),
+				}),
+			},
+			{
+				Code:     `import type a from "../one/a"`,
+				FileName: "restricted-paths/server/two-new/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/two",
+					"from":   "./restricted-paths/server",
+					"except": list(),
+				}),
+			},
+			{
+				Code:     `import type A from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+					"except": list("**/a.ts"),
+				}),
+			},
+			{Code: `import type b from "../server/b"`},
+			{Code: `import type * as b from "../server/b"`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream invalid: directory and glob targets ----
+			{
+				Code:     `import b from "../server/b"; // 1`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+			{
+				Code:     `import b from "../server/b"; // 2`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/**/*",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+			{
+				Code:     `import b from "../server/b";`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/*.ts",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+			{
+				Code:     `import b from "../server/b"; // 2 ter`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/**",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// ---- upstream invalid: several zones, one report each ----
+			{
+				Code:     "import a from \"../client/a\"\nimport c from \"./c\"",
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(
+					map[string]interface{}{
+						"target": "./restricted-paths/server",
+						"from":   "./restricted-paths/client",
+					},
+					map[string]interface{}{
+						"target": "./restricted-paths/server",
+						"from":   "./restricted-paths/server/c.ts",
+					},
+				),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../client/a", 1, 15),
+					unexpectedPath("./c", 2, 15),
+				},
+			},
+
+			// ---- upstream invalid: basePath ----
+			{
+				Code:     `import b from "../server/b"; // 3`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zonesWithBasePath("/restricted-paths", map[string]interface{}{
+					"target": "./client",
+					"from":   "./server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// ---- upstream invalid: commonjs require ----
+			{
+				Code:     `const b = require("../server/b")`,
+				FileName: "restricted-paths/client/consumer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 19)},
+			},
+
+			// ---- upstream invalid: except and message ----
+			{
+				Code:     `import b from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("./one"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../two/a", 1, 15)},
+			},
+			{
+				Code:     `import b from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target":  "./restricted-paths/server/one",
+					"from":    "./restricted-paths/server",
+					"except":  list("./one"),
+					"message": "Custom message",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPathWithMessage("../two/a", "Custom message", 1, 15),
+				},
+			},
+			{
+				Code:     `import b from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("../client/a"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{invalidExceptionPath("../two/a", 1, 15)},
+			},
+
+			// ---- upstream invalid: glob from ----
+			{
+				Code:     `import A from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../two/a", 1, 15)},
+			},
+			{
+				Code:     `import A from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+					"except": list("a.ts"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{invalidExceptionGlob("../two/a", 1, 15)},
+			},
+
+			// ---- upstream invalid: support of arrays for from and target ----
+			{
+				Code:     `import b from "../server/b"; // 4`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": list("./restricted-paths/client"),
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+			{
+				Code:     `import b from "../server/b"; // 5`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   list("./restricted-paths/server"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+			{
+				Code:     `import b from "../server/b"; // 6`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": list("./restricted-paths/client/one", "./restricted-paths/client"),
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+			{
+				Code:     "import b from \"../server/one/b\"\nimport a from \"../server/two/a\"",
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   list("./restricted-paths/server/one", "./restricted-paths/server/two"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../server/one/b", 1, 15),
+					unexpectedPath("../server/two/a", 2, 15),
+				},
+			},
+			{
+				Code:     "import b from \"../server/one/b\"\nimport a from \"../server/two/a\"",
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   list("./restricted-paths/server/one/*", "./restricted-paths/server/two/*"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../server/one/b", 1, 15),
+					unexpectedPath("../server/two/a", 2, 15),
+				},
+			},
+			{
+				Code:     `import b from "../server/b"; // 7`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": list("./restricted-paths/client/one", "./restricted-paths/client/**/*"),
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
+
+			// ---- upstream invalid: configuration format ----
+			{
+				Code:     `import A from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   list("./restricted-paths/server/**/*"),
+					"except": list("a.ts"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{invalidExceptionGlob("../two/a", 1, 15)},
+			},
+			{
+				Code:     `import b from "../server/one/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   list("./restricted-paths/server/one", "./restricted-paths/server/two/*"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{mixedGlobAndNonGlob("../server/one/b", 1, 15)},
+			},
+
+			// ---- upstream invalid (Typescript): type-only imports ----
+			{
+				Code:     `import type b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 20)},
+			},
+			{
+				Code:     `import type b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/**/*",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 20)},
+			},
+			{
+				Code:     "import type a from \"../client/a\"\nimport type c from \"./c\"",
+				FileName: "restricted-paths/server/b.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server",
+					"from":   list("./restricted-paths/client", "./restricted-paths/server/c.ts"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPath("../client/a", 1, 20),
+					unexpectedPath("./c", 2, 20),
+				},
+			},
+			{
+				Code:     `import type b from "../server/b"`,
+				FileName: "restricted-paths/client/a.ts",
+				Options: zonesWithBasePath("/restricted-paths", map[string]interface{}{
+					"target": "./client",
+					"from":   "./server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 20)},
+			},
+			{
+				Code:     `import type b from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("./one"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../two/a", 1, 20)},
+			},
+			{
+				Code:     `import type b from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target":  "./restricted-paths/server/one",
+					"from":    "./restricted-paths/server",
+					"except":  list("./one"),
+					"message": "Custom message",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedPathWithMessage("../two/a", "Custom message", 1, 20),
+				},
+			},
+			{
+				Code:     `import type b from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/server/one",
+					"from":   "./restricted-paths/server",
+					"except": list("../client/a"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{invalidExceptionPath("../two/a", 1, 20)},
+			},
+			{
+				Code:     `import type A from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../two/a", 1, 20)},
+			},
+			{
+				Code:     `import type A from "../two/a"`,
+				FileName: "restricted-paths/server/one/a.ts",
+				Options: zones(map[string]interface{}{
+					"target": "**/*",
+					"from":   "./restricted-paths/server/**/*",
+					"except": list("a.ts"),
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{invalidExceptionGlob("../two/a", 1, 20)},
+			},
+		},
+	)
+}

--- a/internal/plugins/import/utils/module_visitor.go
+++ b/internal/plugins/import/utils/module_visitor.go
@@ -38,6 +38,12 @@ func VisitModules(visitor func(source *ast.StringLiteralLike, node *ast.Node), o
 			return
 		}
 
+		// A recovered parse of incomplete source can leave `import()` with no
+		// arguments at all.
+		if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+			return
+		}
+
 		modulePath := call.Arguments.Nodes[0]
 		if modulePath == nil || !ast.IsStringLiteralLike(modulePath) {
 			return
@@ -48,17 +54,19 @@ func VisitModules(visitor func(source *ast.StringLiteralLike, node *ast.Node), o
 
 	// for CommonJS `require` calls
 	checkCommon := func(call *ast.CallExpression) {
-		if call.Expression.Kind != ast.KindIdentifier {
+		// ESTree has no parenthesized-expression node, so upstream sees a bare
+		// `require` identifier through any number of parentheses.
+		callee := ast.SkipParentheses(call.Expression)
+
+		if !ast.IsIdentifier(callee) {
 			return
 		}
 
-		callee := call.Expression.AsIdentifier()
-
-		if callee.Text != "require" {
+		if callee.AsIdentifier().Text != "require" {
 			return
 		}
 
-		if len(call.Arguments.Nodes) < 1 {
+		if call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
 			return
 		}
 

--- a/internal/rule/context.go
+++ b/internal/rule/context.go
@@ -39,6 +39,13 @@ type DiagnosticConsumer struct {
 type RuleContext struct {
 	SourceFile *ast.SourceFile
 	Settings   map[string]interface{}
+	// Cwd is the normalized working directory of the linting process, the
+	// counterpart of ESLint's `process.cwd()`. Rules that resolve configured
+	// relative paths should use it instead of the Program's current directory,
+	// which is the owning tsconfig's directory and therefore differs between
+	// Programs in the same run. Empty when the caller has no process directory
+	// to speak of, such as rule tests reading an in-memory fixture root.
+	Cwd string
 	// ConfigGlobals contains only globals from the effective
 	// `languageOptions.globals` configuration, before inline comments are
 	// applied. A false value is an explicit "off" setting.

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -139,6 +139,7 @@ export default defineConfig({
     './tests/eslint-plugin-import/rules/no-cycle.test.ts',
     './tests/eslint-plugin-import/rules/no-default-export.test.ts',
     './tests/eslint-plugin-import/rules/no-duplicates.test.ts',
+    './tests/eslint-plugin-import/rules/no-restricted-paths.test.ts',
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
     './tests/eslint-plugin-import/rules/no-mutable-exports.test.ts',
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/client/a.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/client/a.ts
@@ -1,0 +1,2 @@
+const clientA = 'client/a';
+export default clientA;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/client/b.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/client/b.ts
@@ -1,0 +1,2 @@
+const clientB = 'client/b';
+export default clientB;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/client/consumer.js
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/client/consumer.js
@@ -1,0 +1,2 @@
+const clientConsumer = 'client/consumer';
+module.exports = clientConsumer;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/other/a.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/other/a.ts
@@ -1,0 +1,2 @@
+const otherA = 'other/a';
+export default otherA;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/b.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/b.ts
@@ -1,0 +1,2 @@
+const serverB = 'server/b';
+export default serverB;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/c.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/c.ts
@@ -1,0 +1,2 @@
+const serverC = 'server/c';
+export default serverC;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/consumer.js
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/consumer.js
@@ -1,0 +1,2 @@
+const serverConsumer = 'server/consumer';
+module.exports = serverConsumer;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/one/a.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/one/a.ts
@@ -1,0 +1,2 @@
+const serverOneA = 'server/one/a';
+export default serverOneA;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/one/b.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/one/b.ts
@@ -1,0 +1,2 @@
+const serverOneB = 'server/one/b';
+export default serverOneB;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/two-new/a.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/two-new/a.ts
@@ -1,0 +1,2 @@
+const serverTwoNewA = 'server/two-new/a';
+export default serverTwoNewA;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/two/a.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-restricted-paths-rule/server/two/a.ts
@@ -1,0 +1,2 @@
+const serverTwoA = 'server/two/a';
+export default serverTwoA;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-restricted-paths.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-restricted-paths.test.ts
@@ -1,0 +1,618 @@
+import { test, testFixturePath } from '../utils.js';
+
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+// Rslint-Modified: we don't require rules
+// const rule = require('rules/no-restricted-paths')
+const rule = null as never;
+// Rslint-Modified end
+
+// Rslint-Modified: upstream resolves the zone paths against `process.cwd()`.
+// The harness runs from an unrelated working directory, so every case pins
+// `basePath` to the fixture root and uses zone paths relative to it.
+const basePath = testFixturePath('./no-restricted-paths-rule');
+
+function filePath(relativePath: string): string {
+  return testFixturePath(`./no-restricted-paths-rule/${relativePath}`);
+}
+// Rslint-Modified end
+
+ruleTester.run('no-restricted-paths', rule, {
+  valid: [
+    test({
+      code: 'import a from "../client/a"',
+      filename: filePath('server/b.ts'),
+      options: [{ basePath, zones: [{ target: './server', from: './other' }] }],
+    }),
+    test({
+      code: 'import a from "../client/a"',
+      filename: filePath('server/b.ts'),
+      options: [{ basePath, zones: [{ target: '**/*', from: './other' }] }],
+    }),
+    test({
+      code: 'import a from "../client/a"',
+      filename: filePath('client/b.ts'),
+      options: [
+        {
+          basePath,
+          zones: [{ target: './!(client)/**/*', from: './client/**/*' }],
+        },
+      ],
+    }),
+    test({
+      // Rslint-Modified: CommonJS specifiers only take part in module
+      // resolution inside JavaScript files, so the require cases run on a
+      // `.js` fixture.
+      code: 'const a = require("../client/a")',
+      filename: filePath('server/consumer.js'),
+      options: [{ basePath, zones: [{ target: './server', from: './other' }] }],
+    }),
+    test({
+      code: 'import b from "../server/b"',
+      filename: filePath('client/a.ts'),
+      options: [{ basePath, zones: [{ target: './client', from: './other' }] }],
+    }),
+    test({
+      code: 'import a from "./a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './server/one', from: './server', except: ['./one'] },
+          ],
+        },
+      ],
+    }),
+    test({
+      code: 'import a from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './server/one', from: './server', except: ['./two'] },
+          ],
+        },
+      ],
+    }),
+    test({
+      code: 'import a from "../one/a"',
+      filename: filePath('server/two-new/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [{ target: './server/two', from: './server', except: [] }],
+        },
+      ],
+    }),
+    test({
+      code: 'import A from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: '**/*', from: './server/**/*', except: ['**/a.ts'] },
+          ],
+        },
+      ],
+    }),
+
+    // support of arrays for from and target
+    // array with single element
+    test({
+      code: 'import a from "../client/a"',
+      filename: filePath('server/b.ts'),
+      options: [
+        { basePath, zones: [{ target: ['./server'], from: './other' }] },
+      ],
+    }),
+    test({
+      code: 'import a from "../client/a"',
+      filename: filePath('server/b.ts'),
+      options: [
+        { basePath, zones: [{ target: './server', from: ['./other'] }] },
+      ],
+    }),
+    // array with multiple elements
+    test({
+      code: 'import a from "../one/a"',
+      filename: filePath('server/two-new/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: ['./server/two', './server/three'], from: './server' },
+          ],
+        },
+      ],
+    }),
+    test({
+      code: 'import a from "../one/a"',
+      filename: filePath('server/two-new/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            {
+              target: './server',
+              from: ['./server/two', './server/three'],
+              except: [],
+            },
+          ],
+        },
+      ],
+    }),
+    // array with multiple glob patterns in from
+    test({
+      code: 'import a from "../client/a"',
+      filename: filePath('client/b.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            {
+              target: './!(client)/**/*',
+              from: ['./client/*', './client/one/*'],
+            },
+          ],
+        },
+      ],
+    }),
+    // array with mix of glob and non glob patterns in target
+    test({
+      code: 'import a from "../client/a"',
+      filename: filePath('client/b.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            {
+              target: ['./!(client)/**/*', './client/a/'],
+              from: './client/**/*',
+            },
+          ],
+        },
+      ],
+    }),
+
+    // irrelevant function calls
+    test({ code: 'notRequire("../server/b")' }),
+    test({
+      code: 'notRequire("../server/b")',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: './client', from: './server' }] },
+      ],
+    }),
+
+    // no config
+    test({ code: 'require("../server/b")' }),
+    test({ code: 'import b from "../server/b"' }),
+
+    // builtin (ignore)
+    test({ code: 'require("os")' }),
+
+    // typescript: type-only imports
+    test({
+      code: 'import type a from "../client/a"',
+      filename: filePath('server/b.ts'),
+      options: [{ basePath, zones: [{ target: './server', from: './other' }] }],
+    }),
+    test({
+      code: 'import type a from "./a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './server/one', from: './server', except: ['./one'] },
+          ],
+        },
+      ],
+    }),
+    test({ code: 'import type b from "../server/b"' }),
+    test({ code: 'import type * as b from "../server/b"' }),
+  ],
+
+  invalid: [
+    test({
+      code: 'import b from "../server/b"; // 1',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: './client', from: './server' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../server/b"; // 2',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: './client/**/*', from: './server' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../server/b";',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: './client/*.ts', from: './server' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../server/b"; // 2 ter',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: './client/**', from: './server' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import a from "../client/a"\nimport c from "./c"',
+      filename: filePath('server/b.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './server', from: './client' },
+            { target: './server', from: './server/c.ts' },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../client/a" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+        {
+          message: 'Unexpected path "./c" imported in restricted zone.',
+          line: 2,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'const b = require("../server/b")',
+      filename: filePath('client/consumer.js'),
+      options: [
+        { basePath, zones: [{ target: './client', from: './server' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 19,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './server/one', from: './server', except: ['./one'] },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../two/a" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            {
+              target: './server/one',
+              from: './server',
+              except: ['./one'],
+              message: 'Custom message',
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Unexpected path "../two/a" imported in restricted zone. Custom message',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            {
+              target: './server/one',
+              from: './server',
+              except: ['../client/a'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Restricted path exceptions must be descendants of the configured `from` path for that zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import A from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        { basePath, zones: [{ target: '**/*', from: './server/**/*' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../two/a" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import A from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [{ target: '**/*', from: './server/**/*', except: ['a.ts'] }],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Restricted path exceptions must be glob patterns when `from` contains glob patterns',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+
+    // support of arrays for from and target
+    // array with single element
+    test({
+      code: 'import b from "../server/b"; // 4',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: ['./client'], from: './server' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../server/b"; // 5',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: './client', from: ['./server'] }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    // array with multiple elements
+    test({
+      code: 'import b from "../server/b"; // 6',
+      filename: filePath('client/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [{ target: ['./client/one', './client'], from: './server' }],
+        },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../server/one/b"\nimport a from "../server/two/a"',
+      filename: filePath('client/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './client', from: ['./server/one', './server/two'] },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Unexpected path "../server/one/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+        {
+          message:
+            'Unexpected path "../server/two/a" imported in restricted zone.',
+          line: 2,
+          column: 15,
+        },
+      ],
+    }),
+    // array with multiple glob patterns in from
+    test({
+      code: 'import b from "../server/one/b"\nimport a from "../server/two/a"',
+      filename: filePath('client/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './client', from: ['./server/one/*', './server/two/*'] },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Unexpected path "../server/one/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+        {
+          message:
+            'Unexpected path "../server/two/a" imported in restricted zone.',
+          line: 2,
+          column: 15,
+        },
+      ],
+    }),
+    // array with mix of glob and non glob patterns in target
+    test({
+      code: 'import b from "../server/b"; // 7',
+      filename: filePath('client/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: ['./client/one', './client/**/*'], from: './server' },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    // configuration format
+    test({
+      code: 'import A from "../two/a"',
+      filename: filePath('server/one/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: '**/*', from: ['./server/**/*'], except: ['a.ts'] },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Restricted path exceptions must be glob patterns when `from` contains glob patterns',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+    test({
+      code: 'import b from "../server/one/b"',
+      filename: filePath('client/a.ts'),
+      options: [
+        {
+          basePath,
+          zones: [
+            { target: './client', from: ['./server/one', './server/two/*'] },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Restricted path `from` must contain either only glob patterns or none',
+          line: 1,
+          column: 15,
+        },
+      ],
+    }),
+
+    // typescript: type-only imports
+    test({
+      code: 'import type b from "../server/b"',
+      filename: filePath('client/a.ts'),
+      options: [
+        { basePath, zones: [{ target: './client', from: './server' }] },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../server/b" imported in restricted zone.',
+          line: 1,
+          column: 20,
+        },
+      ],
+    }),
+    test({
+      code: 'import type a from "../client/a"\nimport type c from "./c"',
+      filename: filePath('server/b.ts'),
+      options: [
+        {
+          basePath,
+          zones: [{ target: './server', from: ['./client', './server/c.ts'] }],
+        },
+      ],
+      errors: [
+        {
+          message: 'Unexpected path "../client/a" imported in restricted zone.',
+          line: 1,
+          column: 20,
+        },
+        {
+          message: 'Unexpected path "./c" imported in restricted zone.',
+          line: 2,
+          column: 20,
+        },
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `import/no-restricted-paths` rule from eslint-plugin-import to rslint.

The rule enforces import boundaries between directories: each zone declares a `target` set of files and a `from` set they may not import, with optional `except` and `message`. `target`/`from` accept a directory path, a glob pattern, or an array of either; relative zone paths resolve against `basePath`, which defaults to the current working directory.

Extended glob syntax (`!(a)`, `@(a|b)`, `+(a)`, `?(a)`, `*(a)`) is matched literally rather than as a pattern, so zones written with it stay inactive. This is documented under "Differences from ESLint" in the rule doc, together with the supported alternatives.

## Related Links

- ESLint rule: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-restricted-paths.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).