### PR TITLE
feat: port rule no-return-await

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -93,6 +93,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_imports"
 	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_syntax"
 	"github.com/web-infra-dev/rslint/internal/rules/no_return_assign"
+	"github.com/web-infra-dev/rslint/internal/rules/no_return_await"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_compare"
@@ -235,6 +236,7 @@ func GetAllRules() []rule.Rule {
 		radix.RadixRule,
 		no_regex_spaces.NoRegexSpacesRule,
 		no_return_assign.NoReturnAssignRule,
+		no_return_await.NoReturnAwaitRule,
 		no_script_url.NoScriptUrlRule,
 		no_self_assign.NoSelfAssignRule,
 		no_self_compare.NoSelfCompareRule,

--- a/internal/rules/no_return_await/no_return_await.go
+++ b/internal/rules/no_return_await/no_return_await.go
@@ -1,0 +1,143 @@
+package no_return_await
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildRedundantUseOfAwaitMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "redundantUseOfAwait",
+		Description: "Redundant use of `await` on a return value.",
+	}
+}
+
+func buildRemoveAwaitMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeAwait",
+		Description: "Remove redundant `await`.",
+	}
+}
+
+// effectiveParent returns the nearest ancestor of node that is not a
+// ParenthesizedExpression, together with the child that ancestor actually sees.
+// ESTree drops parentheses entirely, so upstream's `node.parent` checks compare
+// against the unwrapped expression; tsgo keeps them as real nodes.
+func effectiveParent(node *ast.Node) (child *ast.Node, parent *ast.Node) {
+	child = utils.OutermostParenthesizedExpression(node)
+	return child, child.Parent
+}
+
+// hasErrorHandler determines whether a thrown error from this node will be
+// caught/handled within this function rather than immediately halting it. A
+// statement in a `try` block always has an error handler; a statement in a
+// `catch` clause only has one when a `finally` block follows.
+func hasErrorHandler(node *ast.Node) bool {
+	for ancestor := node; ancestor != nil && !ast.IsFunctionOrSourceFile(ancestor); ancestor = ancestor.Parent {
+		parent := ancestor.Parent
+		if parent == nil || !ast.IsTryStatement(parent) {
+			continue
+		}
+
+		try := parent.AsTryStatement()
+		if ancestor == try.TryBlock {
+			return true
+		}
+		if ancestor == try.CatchClause && try.FinallyBlock != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// isInTailCallPosition reports whether the value of node is the value the
+// enclosing function resolves with. `return` arguments (and concise arrow
+// bodies) can be complex expressions, so an `await` is only redundant when it
+// sits on the branch that actually produces the returned value.
+func isInTailCallPosition(node *ast.Node) bool {
+	child, parent := effectiveParent(node)
+	if parent == nil {
+		return false
+	}
+
+	switch parent.Kind {
+	case ast.KindArrowFunction:
+		return parent.Body() == child
+	case ast.KindReturnStatement:
+		return !hasErrorHandler(parent)
+	case ast.KindConditionalExpression:
+		conditional := parent.AsConditionalExpression()
+		if conditional.WhenTrue == child || conditional.WhenFalse == child {
+			return isInTailCallPosition(parent)
+		}
+	case ast.KindBinaryExpression:
+		// ESTree's LogicalExpression and SequenceExpression both collapse into
+		// BinaryExpression here, so branch on the operator. A comma chain is
+		// left-associative, which makes "is the last expression" equivalent to
+		// "is the right operand".
+		binary := parent.AsBinaryExpression()
+		if binary.Right != child {
+			return false
+		}
+		switch binary.OperatorToken.Kind {
+		case ast.KindAmpersandAmpersandToken,
+			ast.KindBarBarToken,
+			ast.KindQuestionQuestionToken,
+			ast.KindCommaToken:
+			return isInTailCallPosition(parent)
+		}
+	}
+
+	return false
+}
+
+// https://eslint.org/docs/latest/rules/no-return-await
+var NoReturnAwaitRule = rule.Rule{
+	Name:   "no-return-await",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		sourceFile := ctx.SourceFile
+
+		buildRemoveAwaitSuggestion := func(node *ast.Node) []rule.RuleSuggestion {
+			text := sourceFile.Text()
+			awaitRange := scanner.GetRangeOfTokenAtPosition(sourceFile, node.Pos())
+
+			// Upstream compares the first two tokens of the await expression;
+			// removing `await` across a line break would join the two lines.
+			lineMap := sourceFile.ECMALineMap()
+			awaitLine := scanner.ComputeLineOfPosition(lineMap, awaitRange.Pos())
+			operandLine := scanner.ComputeLineOfPosition(lineMap, scanner.SkipTrivia(text, awaitRange.End()))
+			if awaitLine != operandLine {
+				return nil
+			}
+
+			// A single space right after the keyword is consumed along with it,
+			// so `return await bar()` becomes `return bar()` rather than
+			// `return  bar()`.
+			end := awaitRange.End()
+			if end < len(text) && text[end] == ' ' {
+				end++
+			}
+
+			return []rule.RuleSuggestion{{
+				Message:  buildRemoveAwaitMessage(),
+				FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(core.NewTextRange(awaitRange.Pos(), end))},
+			}}
+		}
+
+		return rule.RuleListeners{
+			ast.KindAwaitExpression: func(node *ast.Node) {
+				if !isInTailCallPosition(node) || hasErrorHandler(node) {
+					return
+				}
+
+				ctx.ReportNodeWithDeferredSuggestions(node, buildRedundantUseOfAwaitMessage(), func() []rule.RuleSuggestion {
+					return buildRemoveAwaitSuggestion(node)
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_return_await/no_return_await.md
+++ b/internal/rules/no_return_await/no_return_await.md
@@ -1,0 +1,58 @@
+# no-return-await
+
+## Rule Details
+
+Disallows `return await` inside an `async` function. Awaiting a promise only to hand it straight back to the caller adds an extra microtask tick without changing the resolved value, so the `await` can be dropped.
+
+The `await` is only redundant when it sits on the branch that actually produces the returned value — the argument of a `return`, the body of a concise arrow function, either branch of a conditional, the right side of `&&` / `||` / `??`, or the last expression of a comma sequence.
+
+An `await` inside a `try` block, or inside a `catch` clause that is followed by `finally`, is **not** reported: removing it there would move rejection handling outside the enclosing error handler and change control flow.
+
+Each report carries a suggestion that removes the `await` keyword. The suggestion is omitted when the keyword and its operand sit on different lines, since removing it would join the two lines.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+async function foo() {
+  return await bar();
+}
+
+async function baz() {
+  return (a && (await bar()));
+}
+
+async function qux() {
+  return cond ? await bar() : b;
+}
+
+const quux = async () => await bar();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+async function foo() {
+  const result = await bar();
+  return result;
+}
+
+async function baz() {
+  return bar();
+}
+
+async function qux() {
+  return (await bar()) || a;
+}
+
+async function quux() {
+  try {
+    return await bar();
+  } catch (e) {
+    handle(e);
+  }
+}
+```
+
+## Original Documentation
+
+- [ESLint no-return-await](https://eslint.org/docs/latest/rules/no-return-await)

--- a/internal/rules/no_return_await/no_return_await_extras_test.go
+++ b/internal/rules/no_return_await/no_return_await_extras_test.go
@@ -133,7 +133,7 @@ func TestNoReturnAwaitExtras(t *testing.T) {
 }`},
 			// Locks in upstream isInTailCallPosition() arm 3: the conditional test is not in tail position
 			{Code: `async () => (await bar() ? a : b)`},
-			// Locks in upstream hasErrorHandler(): a catch clause without a finalizer keeps the report
+			// Locks in upstream hasErrorHandler(): a catch clause with a finalizer suppresses the report
 			{Code: `async function foo() {
 	try {}
 	catch (e) {

--- a/internal/rules/no_return_await/no_return_await_extras_test.go
+++ b/internal/rules/no_return_await/no_return_await_extras_test.go
@@ -1,0 +1,1084 @@
+// TestNoReturnAwaitExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+//
+// N/A: the Dimension 4 access/key-form rows (identifier vs string vs numeric vs
+// private vs computed keys, element access) don't apply — this rule never
+// inspects property names.
+package no_return_await
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoReturnAwaitExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoReturnAwaitRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TS non-null assertion wraps the await ----
+			{Code: `async function foo() {
+	return (await bar())!;
+}`},
+			// ---- Dimension 4: TS `as` wraps the await ----
+			{Code: `async function foo() {
+	return (await bar()) as unknown;
+}`},
+			// ---- Dimension 4: TS `satisfies` wraps the await ----
+			{Code: `async function foo() {
+	return (await bar()) satisfies unknown;
+}`},
+			// ---- Dimension 4: optional member access wraps the await ----
+			{Code: `async function foo() {
+	return (await bar())?.x;
+}`},
+			// ---- Dimension 4: try block nested in a catch clause ----
+			{Code: `async function foo() {
+	try {}
+	catch (e) {
+		try {
+			return await bar();
+		} catch (e) {}
+	}
+}`},
+			// ---- Dimension 4: bare return ----
+			{Code: `async function foo() {
+	return;
+}`},
+			// ---- Dimension 4: empty function body ----
+			{Code: `async function foo() {}`},
+			// ---- Dimension 4: empty arrow body ----
+			{Code: `async () => {};`},
+			// ---- Dimension 4: `for await` is not an await expression ----
+			{Code: `async function foo() {
+	for await (const x of y) {}
+}`},
+			// ---- Dimension 4: top-level await is not in a tail call position ----
+			{Code: `await bar();`},
+			// ---- Dimension 4: spread assignment in an object literal ----
+			{Code: `async function foo() {
+	return { ...(await bar()) };
+}`},
+			// ---- Dimension 4: spread element in an array literal ----
+			{Code: `async function foo() {
+	return [...(await bar())];
+}`},
+			// Locks in upstream isInTailCallPosition() arm 4: `??` left operand is not in tail position
+			{Code: `async function foo() {
+	return (await bar() ?? a);
+}`},
+			// Locks in upstream isInTailCallPosition() arm 5: a non-final comma operand is not in tail position
+			{Code: `async function foo() {
+	return (a, await bar(), b);
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: a call argument is not in tail position
+			{Code: `async function foo() {
+	return baz(await bar());
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: a callee is not in tail position
+			{Code: `async function foo() {
+	return (await bar())();
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: an arithmetic operand is not in tail position
+			{Code: `async function foo() {
+	return (a + await bar());
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: a unary operand is not in tail position
+			{Code: `async function foo() {
+	return void await bar();
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: a template substitution is not in tail position
+			{Code: "async function foo() {\n\treturn `${await bar()}`;\n}"},
+			// Locks in upstream isInTailCallPosition() default arm: an array element is not in tail position
+			{Code: `async function foo() {
+	return [await bar()];
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: a property value is not in tail position
+			{Code: `async function foo() {
+	return { a: await bar() };
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: an assignment target is not in tail position
+			{Code: `async function foo() {
+	let a;
+	return (a = await bar());
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: `&&=` is an assignment, not a logical expression
+			{Code: `async function foo() {
+	let a;
+	return (a &&= await bar());
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: `||=` is an assignment, not a logical expression
+			{Code: `async function foo() {
+	let a;
+	return (a ||= await bar());
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: `??=` is an assignment, not a logical expression
+			{Code: `async function foo() {
+	let a;
+	return (a ??= await bar());
+}`},
+			// Locks in upstream isInTailCallPosition() default arm: a yielded await is not in tail position
+			{Code: `async function* foo() {
+	yield await bar();
+}`},
+			// Locks in upstream isInTailCallPosition() arm 3: the conditional test is not in tail position
+			{Code: `async () => (await bar() ? a : b)`},
+			// Locks in upstream hasErrorHandler(): a catch clause without a finalizer keeps the report
+			{Code: `async function foo() {
+	try {}
+	catch (e) {
+		return await bar();
+	}
+	finally {}
+}`},
+			// Locks in upstream hasErrorHandler(): a try block followed by only a finalizer is an error handler
+			{Code: `async function foo() {
+	try {
+		return await bar();
+	} finally {}
+}`},
+			// ---- Real-user: eslint#15447 — `yield await` stays unreported ----
+			{Code: `async function* foo() {
+	yield await promise;
+}`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized await as a concise arrow body ----
+			{
+				Code: `async () => (await bar())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      1,
+						Column:    14,
+						EndLine:   1,
+						EndColumn: 25,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async () => (bar())`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: multi-level parenthesized await as a concise arrow body ----
+			{
+				Code: `async () => ((await bar()))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      1,
+						Column:    15,
+						EndLine:   1,
+						EndColumn: 26,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async () => ((bar()))`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: parenthesized await as a return argument ----
+			{
+				Code: `async function foo() {
+	return (await bar());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    10,
+						EndLine:   2,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (bar());
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: multi-level parenthesized await as a return argument ----
+			{
+				Code: `async function foo() {
+	return ((await bar()));
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    11,
+						EndLine:   2,
+						EndColumn: 22,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return ((bar()));
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: parenthesized await as the last comma operand ----
+			{
+				Code: `async function foo() {
+	return (a, (await bar()));
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    14,
+						EndLine:   2,
+						EndColumn: 25,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (a, (bar()));
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: parenthesized comma sequence as a return argument ----
+			{
+				Code: `async function foo() {
+	return ((a, await bar()));
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    14,
+						EndLine:   2,
+						EndColumn: 25,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return ((a, bar()));
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: parenthesized comma sequence as a concise arrow body ----
+			{
+				Code: `async () => ((a, await bar()))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      1,
+						Column:    18,
+						EndLine:   1,
+						EndColumn: 29,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async () => ((a, bar()))`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: TS non-null assertion inside the await operand ----
+			{
+				Code: `async function foo() {
+	return await bar()!;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return bar()!;
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: optional call inside the await operand ----
+			{
+				Code: `async function foo() {
+	return await bar?.();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 22,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return bar?.();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: async function expression ----
+			{
+				Code: `const foo = async function () {
+	return await bar();
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `const foo = async function () {
+	return bar();
+};`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: async method ----
+			{
+				Code: `class C {
+	async m() {
+		return await bar();
+	}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      3,
+						Column:    10,
+						EndLine:   3,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `class C {
+	async m() {
+		return bar();
+	}
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: async static method ----
+			{
+				Code: `class C {
+	static async m() {
+		return await bar();
+	}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      3,
+						Column:    10,
+						EndLine:   3,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `class C {
+	static async m() {
+		return bar();
+	}
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: class field holding an async arrow ----
+			{
+				Code: `class C {
+	m = async () => await bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    18,
+						EndLine:   2,
+						EndColumn: 29,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `class C {
+	m = async () => bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: async object-literal method ----
+			{
+				Code: `const o = {
+	async m() {
+		return await bar();
+	},
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      3,
+						Column:    10,
+						EndLine:   3,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `const o = {
+	async m() {
+		return bar();
+	},
+};`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: async generator ----
+			{
+				Code: `async function* foo() {
+	return await bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function* foo() {
+	return bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: async method inside a try block is its own function boundary ----
+			{
+				Code: `async function foo() {
+	try {
+		class C {
+			async m() {
+				return await bar();
+			}
+		}
+	} catch (e) {}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      5,
+						Column:    12,
+						EndLine:   5,
+						EndColumn: 23,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	try {
+		class C {
+			async m() {
+				return bar();
+			}
+		}
+	} catch (e) {}
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: async object method inside a try block is its own function boundary ----
+			{
+				Code: `async function foo() {
+	try {
+		const o = {
+			async m() {
+				return await bar();
+			},
+		};
+	} catch (e) {}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      5,
+						Column:    12,
+						EndLine:   5,
+						EndColumn: 23,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	try {
+		const o = {
+			async m() {
+				return bar();
+			},
+		};
+	} catch (e) {}
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: three levels of nested conditionals ----
+			{
+				Code: `async function foo() {
+	return (a ? (b ? (c ? await bar() : d) : e) : f);
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    24,
+						EndLine:   2,
+						EndColumn: 35,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (a ? (b ? (c ? bar() : d) : e) : f);
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: rest element in a binding pattern ----
+			{
+				Code: `async function foo({ ...rest }) {
+	return await bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo({ ...rest }) {
+	return bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: overload signature has no body ----
+			{
+				Code: `function foo(): Promise<void>;
+async function foo(): Promise<void> {
+	return await bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      3,
+						Column:    9,
+						EndLine:   3,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `function foo(): Promise<void>;
+async function foo(): Promise<void> {
+	return bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: abstract member has no body ----
+			{
+				Code: `abstract class C {
+	abstract m(): Promise<void>;
+	async n() {
+		return await bar();
+	}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      4,
+						Column:    10,
+						EndLine:   4,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `abstract class C {
+	abstract m(): Promise<void>;
+	async n() {
+		return bar();
+	}
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: only the outer function body is in tail position ----
+			{
+				Code: `async function foo() {
+	const g = async () => {
+		await bar();
+	};
+	return await baz();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      5,
+						Column:    9,
+						EndLine:   5,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	const g = async () => {
+		await bar();
+	};
+	return baz();
+}`},
+						},
+					},
+				},
+			},
+			// Locks in upstream isInTailCallPosition() arm 4: `??` right operand recurses
+			{
+				Code: `async function foo() {
+	return (a ?? await bar());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    15,
+						EndLine:   2,
+						EndColumn: 26,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (a ?? bar());
+}`},
+						},
+					},
+				},
+			},
+			// Locks in upstream isInTailCallPosition() arm 5: only the final comma operand is reported
+			{
+				Code: `async function foo() {
+	return (await bar(), await baz());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    23,
+						EndLine:   2,
+						EndColumn: 34,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (await bar(), baz());
+}`},
+						},
+					},
+				},
+			},
+			// Locks in upstream isInTailCallPosition() default arm: an inner await is not in tail position
+			{
+				Code: `async function foo() {
+	return await await bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 26,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return await bar();
+}`},
+						},
+					},
+				},
+			},
+			// Locks in upstream isInTailCallPosition() arm 3: both conditional branches are reported
+			{
+				Code: `async function foo() {
+	return (a ? await bar() : await baz());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    14,
+						EndLine:   2,
+						EndColumn: 25,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (a ? bar() : await baz());
+}`},
+						},
+					},
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    28,
+						EndLine:   2,
+						EndColumn: 39,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (a ? await bar() : baz());
+}`},
+						},
+					},
+				},
+			},
+			// Locks in upstream hasErrorHandler(): a finally block is not an error handler
+			{
+				Code: `async function foo() {
+	try {
+		baz();
+	} finally {
+		return await bar();
+	}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      5,
+						Column:    10,
+						EndLine:   5,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	try {
+		baz();
+	} finally {
+		return bar();
+	}
+}`},
+						},
+					},
+				},
+			},
+			// Locks in upstream hasErrorHandler(): only the return inside the catch clause is reported
+			{
+				Code: `async function foo() {
+	try {
+		return await bar();
+	} catch (e) {
+		return await baz();
+	}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      5,
+						Column:    10,
+						EndLine:   5,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	try {
+		return await bar();
+	} catch (e) {
+		return baz();
+	}
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 3: a tab after the keyword is not trimmed ----
+			{
+				Code: `async function foo() {
+	return await	bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return 	bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 3: only one of two spaces after the keyword is trimmed ----
+			{
+				Code: `async function foo() {
+	return await  bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return  bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 3: a comment right after the keyword is preserved ----
+			{
+				Code: `async function foo() {
+	return await/* c */bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   2,
+						EndColumn: 26,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return /* c */bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 3: a line break between the keyword and its operand drops the suggestion ----
+			{
+				Code: `async function foo() {
+	return await
+		bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    9,
+						EndLine:   3,
+						EndColumn: 8,
+					},
+				},
+			},
+			// ---- Real-user: eslint#8255 — an earlier `await` in the body does not exempt the return ----
+			{
+				Code: `async function foo() {
+	await baz();
+	return await bar();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      3,
+						Column:    9,
+						EndLine:   3,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	await baz();
+	return bar();
+}`},
+						},
+					},
+				},
+			},
+			// ---- Real-user: eslint#10835 — only the right operand of `||` is redundant ----
+			{
+				Code: `async function foo(a, b) {
+	return await a || await b;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    20,
+						EndLine:   2,
+						EndColumn: 27,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo(a, b) {
+	return await a || b;
+}`},
+						},
+					},
+				},
+			},
+			// ---- Real-user: eslint#7594 — comma sequence starting with a non-await operand ----
+			{
+				Code: `async function foo() {
+	return (0, await bar());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    13,
+						EndLine:   2,
+						EndColumn: 24,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (0, bar());
+}`},
+						},
+					},
+				},
+			},
+			// ---- Real-user: eslint#7594 — conditional alternate holding a comma sequence ----
+			{
+				Code: `async function foo() {
+	return (0 ? 1 : (2, 3, await bar()));
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Message:   "Redundant use of `await` on a return value.",
+						Line:      2,
+						Column:    25,
+						EndLine:   2,
+						EndColumn: 36,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `async function foo() {
+	return (0 ? 1 : (2, 3, bar()));
+}`},
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func TestNoReturnAwaitEditDemand(t *testing.T) {
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"async function suggested() {\n\treturn await bar();\n}\nasync function multiline() {\n\treturn await\n\t\tbaz();\n}\n",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoReturnAwaitRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoReturnAwaitRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Message.Id != "redundantUseOfAwait" {
+				t.Fatalf(
+					"demand %d diagnostic %d: message id = %q, want redundantUseOfAwait",
+					demand,
+					index,
+					diagnostic.Message.Id,
+				)
+			}
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index, allEditsDiagnostic := range allEdits {
+		for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly[index],
+			rule.EditDemandAutofix:    autofixOnly[index],
+			rule.EditDemandSuggestion: suggestionOnly[index],
+		} {
+			if got, want := withoutEdits(diagnostic), withoutEdits(allEditsDiagnostic); !reflect.DeepEqual(got, want) {
+				t.Errorf(
+					"diagnostic %d demand %d changed identity:\ngot  %#v\nwant %#v",
+					index,
+					demand,
+					got,
+					want,
+				)
+			}
+		}
+		if diagnosticsOnly[index].Suggestions != nil || autofixOnly[index].Suggestions != nil {
+			t.Errorf("diagnostic %d: non-suggestion demand materialized suggestions", index)
+		}
+		if !reflect.DeepEqual(suggestionOnly[index].Suggestions, allEditsDiagnostic.Suggestions) {
+			t.Errorf("diagnostic %d: suggestion and all-edits demands produced different suggestions", index)
+		}
+	}
+
+	if allEdits[0].Suggestions == nil || len(*allEdits[0].Suggestions) != 1 {
+		t.Error("same-line await did not produce exactly one suggestion")
+	}
+	if allEdits[1].Suggestions != nil {
+		t.Error("await split across lines unexpectedly produced a suggestion")
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{
+		diagnosticsOnly,
+		autofixOnly,
+		suggestionOnly,
+		allEdits,
+	} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.FixesPtr != nil {
+				t.Errorf("diagnostic %d: suggestion-only rule materialized autofixes", index)
+			}
+		}
+	}
+}

--- a/internal/rules/no_return_await/no_return_await_upstream_test.go
+++ b/internal/rules/no_return_await/no_return_await_upstream_test.go
@@ -1,0 +1,1011 @@
+// TestNoReturnAwaitUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/no-return-await.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in the
+// no_return_await_extras_test.go file.
+package no_return_await
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoReturnAwaitUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoReturnAwaitRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+async function foo() {
+	await bar(); return;
+}
+`},
+			{Code: `
+async function foo() {
+	const x = await bar(); return x;
+}
+`},
+			{Code: `
+async () => { return bar(); }
+`},
+			{Code: `
+async () => bar()
+`},
+			{Code: `
+async function foo() {
+if (a) {
+		if (b) {
+			return bar();
+		}
+	}
+}
+`},
+			{Code: `
+async () => {
+if (a) {
+		if (b) {
+			return bar();
+		}
+	}
+}
+`},
+			{Code: `
+async function foo() {
+	return (await bar() && a);
+}
+`},
+			{Code: `
+async function foo() {
+	return (await bar() || a);
+}
+`},
+			{Code: `
+async function foo() {
+	return (a && await baz() && b);
+}
+`},
+			{Code: `
+async function foo() {
+	return (await bar(), a);
+}
+`},
+			{Code: `
+async function foo() {
+	return (await baz(), await bar(), a);
+}
+`},
+			{Code: `
+async function foo() {
+	return (a, b, (await bar(), c));
+}
+`},
+			{Code: `
+async function foo() {
+	return (await bar() ? a : b);
+}
+`},
+			{Code: `
+async function foo() {
+	return ((a && await bar()) ? b : c);
+}
+`},
+			{Code: `
+async function foo() {
+	return (baz() ? (await bar(), a) : b);
+}
+`},
+			{Code: `
+async function foo() {
+	return (baz() ? (await bar() && a) : b);
+}
+`},
+			{Code: `
+async function foo() {
+	return (baz() ? a : (await bar(), b));
+}
+`},
+			{Code: `
+async function foo() {
+	return (baz() ? a : (await bar() && b));
+}
+`},
+			{Code: `
+async () => (await bar(), a)
+`},
+			{Code: `
+async () => (await bar() && a)
+`},
+			{Code: `
+async () => (await bar() || a)
+`},
+			{Code: `
+async () => (a && await bar() && b)
+`},
+			{Code: `
+async () => (await baz(), await bar(), a)
+`},
+			{Code: `
+async () => (a, b, (await bar(), c))
+`},
+			{Code: `
+async () => (await bar() ? a : b)
+`},
+			{Code: `
+async () => ((a && await bar()) ? b : c)
+`},
+			{Code: `
+async () => (baz() ? (await bar(), a) : b)
+`},
+			{Code: `
+async () => (baz() ? (await bar() && a) : b)
+`},
+			{Code: `
+async () => (baz() ? a : (await bar(), b))
+`},
+			{Code: `
+async () => (baz() ? a : (await bar() && b))
+`},
+			{Code: `
+          async function foo() {
+            try {
+              return await bar();
+            } catch (e) {
+              baz();
+            }
+          }
+        `},
+			{Code: `
+          async function foo() {
+            try {
+              return await bar();
+            } finally {
+              baz();
+            }
+          }
+        `},
+			{Code: `
+          async function foo() {
+            try {}
+            catch (e) {
+              return await bar();
+            } finally {
+              baz();
+            }
+          }
+        `},
+			{Code: `
+          async function foo() {
+            try {
+              try {}
+              finally {
+                return await bar();
+              }
+            } finally {
+              baz();
+            }
+          }
+        `},
+			{Code: `
+          async function foo() {
+            try {
+              try {}
+              catch (e) {
+                return await bar();
+              }
+            } finally {
+              baz();
+            }
+          }
+        `},
+			{Code: `
+          async function foo() {
+            try {
+              return (a, await bar());
+            } catch (e) {
+              baz();
+            }
+          }
+        `},
+			{Code: `
+          async function foo() {
+            try {
+              return (qux() ? await bar() : b);
+            } catch (e) {
+              baz();
+            }
+          }
+        `},
+			{Code: `
+          async function foo() {
+            try {
+              return (a && await bar());
+            } catch (e) {
+              baz();
+            }
+          }
+        `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+async function foo() {
+	return await bar();
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    9,
+						EndLine:   3,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return bar();
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return await(bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    9,
+						EndLine:   3,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (a, await bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    13,
+						EndLine:   3,
+						EndColumn: 24,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (a, bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (a, b, await bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    16,
+						EndLine:   3,
+						EndColumn: 27,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (a, b, bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (a && await bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    15,
+						EndLine:   3,
+						EndColumn: 26,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (a && bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (a && b && await bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    20,
+						EndLine:   3,
+						EndColumn: 31,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (a && b && bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (a || await bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    15,
+						EndLine:   3,
+						EndColumn: 26,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (a || bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (a, b, (c, d, await bar()));
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    23,
+						EndLine:   3,
+						EndColumn: 34,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (a, b, (c, d, bar()));
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (a, b, (c && await bar()));
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    22,
+						EndLine:   3,
+						EndColumn: 33,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (a, b, (c && bar()));
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (await baz(), b, await bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    26,
+						EndLine:   3,
+						EndColumn: 37,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (await baz(), b, bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (baz() ? await bar() : b);
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    18,
+						EndLine:   3,
+						EndColumn: 29,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (baz() ? bar() : b);
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (baz() ? a : await bar());
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    22,
+						EndLine:   3,
+						EndColumn: 33,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (baz() ? a : bar());
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (baz() ? (a, await bar()) : b);
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    22,
+						EndLine:   3,
+						EndColumn: 33,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (baz() ? (a, bar()) : b);
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (baz() ? a : (b, await bar()));
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    26,
+						EndLine:   3,
+						EndColumn: 37,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (baz() ? a : (b, bar()));
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (baz() ? (a && await bar()) : b);
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    24,
+						EndLine:   3,
+						EndColumn: 35,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (baz() ? (a && bar()) : b);
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+	return (baz() ? a : (b && await bar()));
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    28,
+						EndLine:   3,
+						EndColumn: 39,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+	return (baz() ? a : (b && bar()));
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => { return await bar(); }
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 33,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => { return bar(); }
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => await bar()
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      2,
+						Column:    13,
+						EndLine:   2,
+						EndColumn: 24,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => bar()
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => (a, b, await bar())
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      2,
+						Column:    20,
+						EndLine:   2,
+						EndColumn: 31,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => (a, b, bar())
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => (a && await bar())
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      2,
+						Column:    19,
+						EndLine:   2,
+						EndColumn: 30,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => (a && bar())
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => (baz() ? await bar() : b)
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      2,
+						Column:    22,
+						EndLine:   2,
+						EndColumn: 33,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => (baz() ? bar() : b)
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => (baz() ? a : (b, await bar()))
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      2,
+						Column:    30,
+						EndLine:   2,
+						EndColumn: 41,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => (baz() ? a : (b, bar()))
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => (baz() ? a : (b && await bar()))
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      2,
+						Column:    32,
+						EndLine:   2,
+						EndColumn: 43,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => (baz() ? a : (b && bar()))
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async function foo() {
+if (a) {
+		if (b) {
+			return await bar();
+		}
+	}
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      5,
+						Column:    11,
+						EndLine:   5,
+						EndColumn: 22,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async function foo() {
+if (a) {
+		if (b) {
+			return bar();
+		}
+	}
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+async () => {
+if (a) {
+		if (b) {
+			return await bar();
+		}
+	}
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      5,
+						Column:    11,
+						EndLine:   5,
+						EndColumn: 22,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+async () => {
+if (a) {
+		if (b) {
+			return bar();
+		}
+	}
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              async function foo() {
+                try {}
+                finally {
+                  return await bar();
+                }
+              }
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      5,
+						Column:    26,
+						EndLine:   5,
+						EndColumn: 37,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+              async function foo() {
+                try {}
+                finally {
+                  return bar();
+                }
+              }
+            `},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              async function foo() {
+                try {}
+                catch (e) {
+                  return await bar();
+                }
+              }
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      5,
+						Column:    26,
+						EndLine:   5,
+						EndColumn: 37,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+              async function foo() {
+                try {}
+                catch (e) {
+                  return bar();
+                }
+              }
+            `},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              try {
+                async function foo() {
+                  return await bar();
+                }
+              } catch (e) {}
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      4,
+						Column:    26,
+						EndLine:   4,
+						EndColumn: 37,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+              try {
+                async function foo() {
+                  return bar();
+                }
+              } catch (e) {}
+            `},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              try {
+                async () => await bar();
+              } catch (e) {}
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    29,
+						EndLine:   3,
+						EndColumn: 40,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+              try {
+                async () => bar();
+              } catch (e) {}
+            `},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              async function foo() {
+                try {}
+                catch (e) {
+                  try {}
+                  catch (e) {
+                    return await bar();
+                  }
+                }
+              }
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      7,
+						Column:    28,
+						EndLine:   7,
+						EndColumn: 39,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+              async function foo() {
+                try {}
+                catch (e) {
+                  try {}
+                  catch (e) {
+                    return bar();
+                  }
+                }
+              }
+            `},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              async function foo() {
+                return await new Promise(resolve => {
+                  resolve(5);
+                });
+              }
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    24,
+						EndLine:   5,
+						EndColumn: 19,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+              async function foo() {
+                return new Promise(resolve => {
+                  resolve(5);
+                });
+              }
+            `},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              async () => {
+                return await (
+                  foo()
+                )
+              };
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    24,
+						EndLine:   5,
+						EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeAwait", Output: `
+              async () => {
+                return (
+                  foo()
+                )
+              };
+            `},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+              async function foo() {
+                return await // Test
+                  5;
+              }
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "redundantUseOfAwait",
+						Line:      3,
+						Column:    24,
+						EndLine:   4,
+						EndColumn: 20,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -482,6 +482,7 @@ export default defineConfig({
     './tests/eslint/rules/no-with.test.ts',
     './tests/eslint/rules/no-proto.test.ts',
     './tests/eslint/rules/no-return-assign.test.ts',
+    './tests/eslint/rules/no-return-await.test.ts',
     './tests/eslint/rules/no-self-compare.test.ts',
     './tests/eslint/rules/no-sequences.test.ts',
     './tests/eslint/rules/strict.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-return-await.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-return-await.test.ts.snap
@@ -1,0 +1,1004 @@
+// Rstest Snapshot v1
+
+exports[`no-return-await > invalid 1`] = `
+{
+  "code": "
+async function foo() {
+	return await bar();
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 2`] = `
+{
+  "code": "
+async function foo() {
+	return await(bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 3`] = `
+{
+  "code": "
+async function foo() {
+	return (a, await bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 4`] = `
+{
+  "code": "
+async function foo() {
+	return (a, b, await bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 5`] = `
+{
+  "code": "
+async function foo() {
+	return (a && await bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 6`] = `
+{
+  "code": "
+async function foo() {
+	return (a && b && await bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 7`] = `
+{
+  "code": "
+async function foo() {
+	return (a || await bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 8`] = `
+{
+  "code": "
+async function foo() {
+	return (a, b, (c, d, await bar()));
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 23,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 9`] = `
+{
+  "code": "
+async function foo() {
+	return (a, b, (c && await bar()));
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 10`] = `
+{
+  "code": "
+async function foo() {
+	return (await baz(), b, await bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 26,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 11`] = `
+{
+  "code": "
+async function foo() {
+	return (baz() ? await bar() : b);
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 12`] = `
+{
+  "code": "
+async function foo() {
+	return (baz() ? a : await bar());
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 13`] = `
+{
+  "code": "
+async function foo() {
+	return (baz() ? (a, await bar()) : b);
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 14`] = `
+{
+  "code": "
+async function foo() {
+	return (baz() ? a : (b, await bar()));
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 26,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 15`] = `
+{
+  "code": "
+async function foo() {
+	return (baz() ? (a && await bar()) : b);
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 16`] = `
+{
+  "code": "
+async function foo() {
+	return (baz() ? a : (b && await bar()));
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 28,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 17`] = `
+{
+  "code": "
+async () => { return await bar(); }
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 18`] = `
+{
+  "code": "
+async () => await bar()
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 19`] = `
+{
+  "code": "
+async () => (a, b, await bar())
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 20`] = `
+{
+  "code": "
+async () => (a && await bar())
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 21`] = `
+{
+  "code": "
+async () => (baz() ? await bar() : b)
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 22`] = `
+{
+  "code": "
+async () => (baz() ? a : (b, await bar()))
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 23`] = `
+{
+  "code": "
+async () => (baz() ? a : (b && await bar()))
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 2,
+        },
+        "start": {
+          "column": 32,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 24`] = `
+{
+  "code": "
+async function foo() {
+if (a) {
+		if (b) {
+			return await bar();
+		}
+	}
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 25`] = `
+{
+  "code": "
+async () => {
+if (a) {
+		if (b) {
+			return await bar();
+		}
+	}
+}
+",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 26`] = `
+{
+  "code": "
+              async function foo() {
+                try {}
+                finally {
+                  return await bar();
+                }
+              }
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 5,
+        },
+        "start": {
+          "column": 26,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 27`] = `
+{
+  "code": "
+              async function foo() {
+                try {}
+                catch (e) {
+                  return await bar();
+                }
+              }
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 5,
+        },
+        "start": {
+          "column": 26,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 28`] = `
+{
+  "code": "
+              try {
+                async function foo() {
+                  return await bar();
+                }
+              } catch (e) {}
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 4,
+        },
+        "start": {
+          "column": 26,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 29`] = `
+{
+  "code": "
+              try {
+                async () => await bar();
+              } catch (e) {}
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 29,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 30`] = `
+{
+  "code": "
+              async function foo() {
+                try {}
+                catch (e) {
+                  try {}
+                  catch (e) {
+                    return await bar();
+                  }
+                }
+              }
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 7,
+        },
+        "start": {
+          "column": 28,
+          "line": 7,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 31`] = `
+{
+  "code": "
+              async function foo() {
+                return await new Promise(resolve => {
+                  resolve(5);
+                });
+              }
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 5,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 32`] = `
+{
+  "code": "
+              async () => {
+                return await (
+                  foo()
+                )
+              };
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-await > invalid 33`] = `
+{
+  "code": "
+              async function foo() {
+                return await // Test
+                  5;
+              }
+            ",
+  "diagnostics": [
+    {
+      "message": "Redundant use of \`await\` on a return value.",
+      "messageId": "redundantUseOfAwait",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-return-await.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-return-await.test.ts
@@ -1,0 +1,180 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-return-await', {
+  valid: [
+    '\nasync function foo() {\n\tawait bar(); return;\n}\n',
+    '\nasync function foo() {\n\tconst x = await bar(); return x;\n}\n',
+    '\nasync () => { return bar(); }\n',
+    '\nasync () => bar()\n',
+    '\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n',
+    '\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n',
+    '\nasync function foo() {\n\treturn (await bar() && a);\n}\n',
+    '\nasync function foo() {\n\treturn (await bar() || a);\n}\n',
+    '\nasync function foo() {\n\treturn (a && await baz() && b);\n}\n',
+    '\nasync function foo() {\n\treturn (await bar(), a);\n}\n',
+    '\nasync function foo() {\n\treturn (await baz(), await bar(), a);\n}\n',
+    '\nasync function foo() {\n\treturn (a, b, (await bar(), c));\n}\n',
+    '\nasync function foo() {\n\treturn (await bar() ? a : b);\n}\n',
+    '\nasync function foo() {\n\treturn ((a && await bar()) ? b : c);\n}\n',
+    '\nasync function foo() {\n\treturn (baz() ? (await bar(), a) : b);\n}\n',
+    '\nasync function foo() {\n\treturn (baz() ? (await bar() && a) : b);\n}\n',
+    '\nasync function foo() {\n\treturn (baz() ? a : (await bar(), b));\n}\n',
+    '\nasync function foo() {\n\treturn (baz() ? a : (await bar() && b));\n}\n',
+    '\nasync () => (await bar(), a)\n',
+    '\nasync () => (await bar() && a)\n',
+    '\nasync () => (await bar() || a)\n',
+    '\nasync () => (a && await bar() && b)\n',
+    '\nasync () => (await baz(), await bar(), a)\n',
+    '\nasync () => (a, b, (await bar(), c))\n',
+    '\nasync () => (await bar() ? a : b)\n',
+    '\nasync () => ((a && await bar()) ? b : c)\n',
+    '\nasync () => (baz() ? (await bar(), a) : b)\n',
+    '\nasync () => (baz() ? (await bar() && a) : b)\n',
+    '\nasync () => (baz() ? a : (await bar(), b))\n',
+    '\nasync () => (baz() ? a : (await bar() && b))\n',
+    '\n          async function foo() {\n            try {\n              return await bar();\n            } catch (e) {\n              baz();\n            }\n          }\n        ',
+    '\n          async function foo() {\n            try {\n              return await bar();\n            } finally {\n              baz();\n            }\n          }\n        ',
+    '\n          async function foo() {\n            try {}\n            catch (e) {\n              return await bar();\n            } finally {\n              baz();\n            }\n          }\n        ',
+    '\n          async function foo() {\n            try {\n              try {}\n              finally {\n                return await bar();\n              }\n            } finally {\n              baz();\n            }\n          }\n        ',
+    '\n          async function foo() {\n            try {\n              try {}\n              catch (e) {\n                return await bar();\n              }\n            } finally {\n              baz();\n            }\n          }\n        ',
+    '\n          async function foo() {\n            try {\n              return (a, await bar());\n            } catch (e) {\n              baz();\n            }\n          }\n        ',
+    '\n          async function foo() {\n            try {\n              return (qux() ? await bar() : b);\n            } catch (e) {\n              baz();\n            }\n          }\n        ',
+    '\n          async function foo() {\n            try {\n              return (a && await bar());\n            } catch (e) {\n              baz();\n            }\n          }\n        ',
+  ],
+  invalid: [
+    {
+      code: '\nasync function foo() {\n\treturn await bar();\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 9 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn await(bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 9 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (a, await bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 13 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (a, b, await bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 16 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (a && await bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 15 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (a && b && await bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 20 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (a || await bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 15 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (a, b, (c, d, await bar()));\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 23 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (a, b, (c && await bar()));\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 22 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (await baz(), b, await bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 26 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (baz() ? await bar() : b);\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 18 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (baz() ? a : await bar());\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 22 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (baz() ? (a, await bar()) : b);\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 22 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (baz() ? a : (b, await bar()));\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 26 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (baz() ? (a && await bar()) : b);\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 24 }],
+    },
+    {
+      code: '\nasync function foo() {\n\treturn (baz() ? a : (b && await bar()));\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 28 }],
+    },
+    {
+      code: '\nasync () => { return await bar(); }\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 2, column: 22 }],
+    },
+    {
+      code: '\nasync () => await bar()\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 2, column: 13 }],
+    },
+    {
+      code: '\nasync () => (a, b, await bar())\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 2, column: 20 }],
+    },
+    {
+      code: '\nasync () => (a && await bar())\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 2, column: 19 }],
+    },
+    {
+      code: '\nasync () => (baz() ? await bar() : b)\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 2, column: 22 }],
+    },
+    {
+      code: '\nasync () => (baz() ? a : (b, await bar()))\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 2, column: 30 }],
+    },
+    {
+      code: '\nasync () => (baz() ? a : (b && await bar()))\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 2, column: 32 }],
+    },
+    {
+      code: '\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 5, column: 11 }],
+    },
+    {
+      code: '\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 5, column: 11 }],
+    },
+    {
+      code: '\n              async function foo() {\n                try {}\n                finally {\n                  return await bar();\n                }\n              }\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 5, column: 26 }],
+    },
+    {
+      code: '\n              async function foo() {\n                try {}\n                catch (e) {\n                  return await bar();\n                }\n              }\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 5, column: 26 }],
+    },
+    {
+      code: '\n              try {\n                async function foo() {\n                  return await bar();\n                }\n              } catch (e) {}\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 4, column: 26 }],
+    },
+    {
+      code: '\n              try {\n                async () => await bar();\n              } catch (e) {}\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 29 }],
+    },
+    {
+      code: '\n              async function foo() {\n                try {}\n                catch (e) {\n                  try {}\n                  catch (e) {\n                    return await bar();\n                  }\n                }\n              }\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 7, column: 28 }],
+    },
+    {
+      code: '\n              async function foo() {\n                return await new Promise(resolve => {\n                  resolve(5);\n                });\n              }\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 24 }],
+    },
+    {
+      code: '\n              async () => {\n                return await (\n                  foo()\n                )\n              };\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 24 }],
+    },
+    {
+      code: '\n              async function foo() {\n                return await // Test\n                  5;\n              }\n            ',
+      errors: [{ messageId: 'redundantUseOfAwait', line: 3, column: 24 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-return-await` rule from ESLint to rslint.

The rule reports `await` on a value that is returned straight to the caller — the argument of a `return`, a concise arrow body, either branch of a conditional, the right side of `&&` / `||` / `??`, or the last expression of a comma sequence. An `await` inside a `try` block, or inside a `catch` clause followed by `finally`, is left alone because removing it would move rejection handling outside the enclosing error handler. Each report carries a suggestion that removes the keyword, omitted when the keyword and its operand sit on different lines.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-return-await
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-return-await.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).