### PR TITLE
perf: optimize new-for-builtins hot paths

### DIFF
--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
@@ -194,6 +194,7 @@ type ruleState struct {
 	ctx               rule.RuleContext
 	aliases           map[*ast.Node]aliasInfo
 	aliasesByID       map[string][]aliasInfo
+	aliasesBySymbol   map[*ast.Symbol]aliasInfo
 	collectingAliases bool
 
 	// Alias declarations and possibly aliased calls are collected by the
@@ -201,16 +202,19 @@ type ruleState struct {
 	aliasDeclarations         []*ast.Node
 	pendingExpressions        []*ast.Node
 	deferRemainingExpressions bool
+	deferredAliasNames        map[string]bool
 
 	// localRootNames is a cheap file-wide "may be shadowed" gate. Exact
 	// binding identity still comes from ctx.Refs at the call site.
 	localRootNames map[string]bool
+	localSymbols   map[*ast.Symbol]bool
 }
 
 type aliasInfo struct {
 	binding *ast.Node
 	scope   *ast.Node
 	path    []string
+	name    string
 }
 
 type reference struct {
@@ -280,7 +284,13 @@ func (state *ruleState) collectCallExpression(node *ast.Node) {
 	if call == nil {
 		return
 	}
-	if state.deferRemainingExpressions || state.shouldDeferExpression(call.Expression) {
+	if state.deferRemainingExpressions {
+		if state.shouldQueueExpression(call.Expression) {
+			state.pendingExpressions = append(state.pendingExpressions, node)
+		}
+		return
+	}
+	if state.shouldDeferExpression(call.Expression) {
 		state.deferRemainingExpressions = true
 		state.pendingExpressions = append(state.pendingExpressions, node)
 		return
@@ -293,7 +303,13 @@ func (state *ruleState) collectNewExpression(node *ast.Node) {
 	if newExpression == nil {
 		return
 	}
-	if state.deferRemainingExpressions || state.shouldDeferExpression(newExpression.Expression) {
+	if state.deferRemainingExpressions {
+		if state.shouldQueueExpression(newExpression.Expression) {
+			state.pendingExpressions = append(state.pendingExpressions, node)
+		}
+		return
+	}
+	if state.shouldDeferExpression(newExpression.Expression) {
 		state.deferRemainingExpressions = true
 		state.pendingExpressions = append(state.pendingExpressions, node)
 		return
@@ -310,7 +326,81 @@ func (state *ruleState) shouldDeferExpression(node *ast.Node) bool {
 	// A known global root with no local declaration cannot become an alias or
 	// shadow, so keep its original immediate reporting order. Everything else
 	// waits until alias collection is complete.
-	return !potentialReferenceRoots[name] || state.ctx.Refs == nil || state.localRootNames[name]
+	if potentialReferenceRoots[name] {
+		return state.ctx.Refs == nil || state.localRootNames[name]
+	}
+	if state.ctx.Refs == nil {
+		return true
+	}
+	if !symbolMayDeclareAlias(state.ctx.Refs.Resolve(root)) {
+		return false
+	}
+	state.markDeferredAliasName(name)
+	return true
+}
+
+func (state *ruleState) markDeferredAliasName(name string) {
+	if state.deferredAliasNames == nil {
+		state.deferredAliasNames = map[string]bool{}
+	}
+	state.deferredAliasNames[name] = true
+}
+
+// Once one expression must wait for alias collection, later diagnostics must
+// wait as well to preserve source order. Calls that cannot be a watched direct
+// path or a reference to an alias can still be discarded immediately.
+func (state *ruleState) shouldQueueExpression(node *ast.Node) bool {
+	root := expressionRootIdentifier(node)
+	if root == nil {
+		return false
+	}
+	name := root.AsIdentifier().Text
+	if !potentialReferenceRoots[name] {
+		if state.deferredAliasNames[name] {
+			return true
+		}
+		if state.ctx.Refs == nil {
+			return true
+		}
+		return symbolMayDeclareAlias(state.ctx.Refs.Resolve(root))
+	}
+	if state.localRootNames[name] {
+		return true
+	}
+
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindIdentifier {
+		return isWatchedBuiltin(name)
+	}
+	return globalObjectNames[name] || watchedNamespaces[name]
+}
+
+func symbolMayDeclareAlias(symbol *ast.Symbol) bool {
+	if symbol == nil {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		variableDeclaration := declaration
+		if variableDeclaration.Kind != ast.KindVariableDeclaration {
+			variableDeclaration = ast.FindAncestorKind(variableDeclaration, ast.KindVariableDeclaration)
+		}
+		if variableDeclaration == nil {
+			continue
+		}
+		variable := variableDeclaration.AsVariableDeclaration()
+		if variable == nil || variable.Name() == nil || variable.Initializer == nil {
+			continue
+		}
+		name := variable.Name()
+		if (name.Kind == ast.KindIdentifier || name.Kind == ast.KindObjectBindingPattern) &&
+			expressionRootIdentifier(variable.Initializer) != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (state *ruleState) checkCallExpression(node *ast.Node) {
@@ -325,7 +415,7 @@ func (state *ruleState) checkCallExpression(node *ast.Node) {
 	}
 
 	if disallowCallOrNewBuiltins[ref.name] {
-		state.ctx.ReportNode(node, messageDisallowCallOrNew(ref.name))
+		state.ctx.ReportRange(trimmedNodeRange(state.ctx.SourceFile, node), messageDisallowCallOrNew(ref.name))
 		return
 	}
 
@@ -348,8 +438,9 @@ func (state *ruleState) checkCallExpression(node *ast.Node) {
 		return
 	}
 
-	state.ctx.ReportNodeWithDeferredFixes(node, messageEnforce(ref.name), func() []rule.RuleFix {
-		return []rule.RuleFix{state.enforceNewFix(node)}
+	nodeRange := trimmedNodeRange(state.ctx.SourceFile, node)
+	state.ctx.ReportRangeWithDeferredFixes(nodeRange, messageEnforce(ref.name), func() []rule.RuleFix {
+		return []rule.RuleFix{state.enforceNewFix(nodeRange)}
 	})
 }
 
@@ -365,7 +456,7 @@ func (state *ruleState) checkNewExpression(node *ast.Node) {
 	}
 
 	if disallowCallOrNewBuiltins[ref.name] {
-		state.ctx.ReportNode(node, messageDisallowCallOrNew(ref.name))
+		state.ctx.ReportRange(trimmedNodeRange(state.ctx.SourceFile, node), messageDisallowCallOrNew(ref.name))
 		return
 	}
 
@@ -374,45 +465,46 @@ func (state *ruleState) checkNewExpression(node *ast.Node) {
 	}
 
 	message := messageDisallow(ref.name)
+	nodeRange := trimmedNodeRange(state.ctx.SourceFile, node)
 	if ref.name == "String" || ref.name == "Boolean" || ref.name == "Number" {
-		state.ctx.ReportNode(node, message)
+		state.ctx.ReportRange(nodeRange, message)
 		return
 	}
 
-	state.ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
-		return state.newToCallFixes(node, newExpression)
+	state.ctx.ReportRangeWithDeferredFixes(nodeRange, message, func() []rule.RuleFix {
+		return state.newToCallFixes(node, nodeRange, newExpression)
 	})
 }
 
 func (state *ruleState) reportDateCall(node *ast.Node, call *ast.CallExpression) {
 	message := rule.RuleMessage{Id: messageIDErrorDate, Description: messageDateDescription}
+	nodeRange := trimmedNodeRange(state.ctx.SourceFile, node)
 
 	hasArguments := call.Arguments != nil && len(call.Arguments.Nodes) > 0
 	if !hasArguments && !utils.HasCommentInsideNode(state.ctx.SourceFile, node) {
-		state.ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
-			return []rule.RuleFix{state.dateFix(node)}
+		state.ctx.ReportRangeWithDeferredFixes(nodeRange, message, func() []rule.RuleFix {
+			return []rule.RuleFix{state.dateFix(nodeRange)}
 		})
 		return
 	}
 
-	state.ctx.ReportNodeWithDeferredSuggestions(node, message, func() []rule.RuleSuggestion {
+	state.ctx.ReportRangeWithDeferredSuggestions(nodeRange, message, func() []rule.RuleSuggestion {
 		return []rule.RuleSuggestion{{
 			Message:  rule.RuleMessage{Id: messageIDSuggestionDate, Description: messageDateSuggestion},
-			FixesArr: []rule.RuleFix{state.dateFix(node)},
+			FixesArr: []rule.RuleFix{state.dateFix(nodeRange)},
 		}}
 	})
 }
 
-func (state *ruleState) dateFix(node *ast.Node) rule.RuleFix {
+func (state *ruleState) dateFix(nodeRange core.TextRange) rule.RuleFix {
 	return rule.RuleFixReplaceRange(
-		utils.TrimNodeTextRange(state.ctx.SourceFile, node),
-		state.dateReplacement(node),
+		nodeRange,
+		state.dateReplacement(nodeRange),
 	)
 }
 
-func (state *ruleState) newToCallFixes(node *ast.Node, newExpression *ast.NewExpression) []rule.RuleFix {
-	nodeRange := utils.TrimNodeTextRange(state.ctx.SourceFile, node)
-	expressionRange := utils.TrimNodeTextRange(state.ctx.SourceFile, newExpression.Expression)
+func (state *ruleState) newToCallFixes(node *ast.Node, nodeRange core.TextRange, newExpression *ast.NewExpression) []rule.RuleFix {
+	expressionRange := trimmedNodeRange(state.ctx.SourceFile, newExpression.Expression)
 	if nodeRange.Pos() >= expressionRange.Pos() {
 		return nil
 	}
@@ -467,7 +559,7 @@ func returnOrThrowParenthesesRanges(sourceFile *ast.SourceFile, statement *ast.N
 		return 0, 0, false
 	}
 
-	statementRange := utils.TrimNodeTextRange(sourceFile, statement)
+	statementRange := trimmedNodeRange(sourceFile, statement)
 	keywordLength := len("return")
 	if statement.Kind == ast.KindThrowStatement {
 		keywordLength = len("throw")
@@ -488,8 +580,7 @@ func returnOrThrowParenthesesRanges(sourceFile *ast.SourceFile, statement *ast.N
 	return opening, closing, true
 }
 
-func (state *ruleState) enforceNewFix(node *ast.Node) rule.RuleFix {
-	nodeRange := utils.TrimNodeTextRange(state.ctx.SourceFile, node)
+func (state *ruleState) enforceNewFix(nodeRange core.TextRange) rule.RuleFix {
 	text := "new "
 	source := state.ctx.SourceFile.Text()
 	if utils.NeedsLeadingSpaceForReplacement(source, nodeRange.Pos(), text) {
@@ -498,8 +589,7 @@ func (state *ruleState) enforceNewFix(node *ast.Node) rule.RuleFix {
 	return rule.RuleFixReplaceRange(core.NewTextRange(nodeRange.Pos(), nodeRange.Pos()), text)
 }
 
-func (state *ruleState) dateReplacement(node *ast.Node) string {
-	nodeRange := utils.TrimNodeTextRange(state.ctx.SourceFile, node)
+func (state *ruleState) dateReplacement(nodeRange core.TextRange) string {
 	if utils.NeedsLeadingSpaceForReplacement(state.ctx.SourceFile.Text(), nodeRange.Pos(), replacementStringNewDateCall) {
 		return " " + replacementStringNewDateCall
 	}
@@ -507,13 +597,32 @@ func (state *ruleState) dateReplacement(node *ast.Node) string {
 }
 
 func (state *ruleState) referenceFromExpression(node *ast.Node) (reference, bool) {
-	path, root, ok := state.expressionPath(node)
-	if !ok || len(path) == 0 {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return reference{}, false
+	}
+	if node.Kind == ast.KindIdentifier {
+		return state.referenceFromIdentifier(node)
+	}
+
+	root := expressionRootIdentifier(node)
+	if root == nil {
 		return reference{}, false
 	}
 	rootName := root.AsIdentifier().Text
 	hasAliases := len(state.aliasesByID[rootName]) > 0
 	if !potentialReferenceRoots[rootName] && !hasAliases {
+		return reference{}, false
+	}
+	// Every watched member path begins at a namespace, a conventional global
+	// object, or a local alias. Reject roots such as Promise in
+	// Promise.resolve() before allocating a path slice.
+	if !hasAliases && !globalObjectNames[rootName] && !watchedNamespaces[rootName] {
+		return reference{}, false
+	}
+
+	path, root, ok := state.expressionPath(node)
+	if !ok || len(path) == 0 {
 		return reference{}, false
 	}
 
@@ -535,6 +644,22 @@ func (state *ruleState) referenceFromExpression(node *ast.Node) (reference, bool
 	}
 	name, ok := watchedBuiltinName(global.path)
 	if !ok {
+		return reference{}, false
+	}
+	return reference{name: name}, true
+}
+
+func (state *ruleState) referenceFromIdentifier(node *ast.Node) (reference, bool) {
+	name := node.AsIdentifier().Text
+	if len(state.aliasesByID[name]) > 0 {
+		if info, ok := state.aliasInfoForIdentifier(node); ok {
+			if isWatchedBuiltin(info.name) {
+				return reference{name: info.name}, true
+			}
+			return reference{}, false
+		}
+	}
+	if !isWatchedBuiltin(name) || state.isLocalNonAliasIdentifier(node) {
 		return reference{}, false
 	}
 	return reference{name: name}, true
@@ -683,18 +808,25 @@ func (state *ruleState) registerAlias(binding *ast.Node, path []string, declarat
 	if state.aliases == nil {
 		state.aliases = map[*ast.Node]aliasInfo{}
 		state.aliasesByID = map[string][]aliasInfo{}
+		state.aliasesBySymbol = map[*ast.Symbol]aliasInfo{}
 	}
 
 	info := aliasInfo{
 		binding: binding,
 		scope:   state.aliasScopeForBinding(binding),
 		path:    slices.Clone(path),
+		name:    pathKey(path),
 	}
 
 	state.aliases[binding] = info
 	for _, declaration := range declarations {
 		if declaration != nil {
 			state.aliases[declaration] = info
+		}
+	}
+	if symbol := aliasBindingSymbol(binding); symbol != nil {
+		if _, exists := state.aliasesBySymbol[symbol]; !exists {
+			state.aliasesBySymbol[symbol] = info
 		}
 	}
 	state.aliasesByID[binding.AsIdentifier().Text] = append(state.aliasesByID[binding.AsIdentifier().Text], info)
@@ -775,23 +907,31 @@ func accessExpressionStaticName(node *ast.Node) (string, bool) {
 }
 
 func (state *ruleState) aliasPathForIdentifier(node *ast.Node) ([]string, bool) {
+	info, ok := state.aliasInfoForIdentifier(node)
+	if !ok {
+		return nil, false
+	}
+	return info.path, true
+}
+
+func (state *ruleState) aliasInfoForIdentifier(node *ast.Node) (aliasInfo, bool) {
 	node = utils.SkipAssertionsAndParens(node)
 	if node == nil || node.Kind != ast.KindIdentifier {
-		return nil, false
+		return aliasInfo{}, false
 	}
 	name := node.AsIdentifier().Text
 	infos := state.aliasesByID[name]
 	if len(infos) == 0 {
-		return nil, false
+		return aliasInfo{}, false
 	}
 
 	if !state.collectingAliases && state.ctx.Refs != nil {
 		if symbol := state.ctx.Refs.Resolve(node); symbol != nil {
 			info, ok := state.aliasInfoForBinderSymbol(symbol)
 			if !ok {
-				return nil, false
+				return aliasInfo{}, false
 			}
-			return slices.Clone(info.path), true
+			return info, true
 		}
 	}
 
@@ -800,17 +940,17 @@ func (state *ruleState) aliasPathForIdentifier(node *ast.Node) ([]string, bool) 
 		if symbol != nil {
 			for _, declaration := range symbol.Declarations {
 				if info, ok := state.aliases[declaration]; ok && state.aliasInfoApplies(node, info) {
-					return slices.Clone(info.path), true
+					return info, true
 				}
 			}
 		}
 	}
 	for i := len(infos) - 1; i >= 0; i-- {
 		if state.aliasInfoApplies(node, infos[i]) {
-			return slices.Clone(infos[i].path), true
+			return infos[i], true
 		}
 	}
-	return nil, false
+	return aliasInfo{}, false
 }
 
 func aliasBindingSymbol(binding *ast.Node) *ast.Symbol {
@@ -827,6 +967,9 @@ func aliasBindingSymbol(binding *ast.Node) *ast.Symbol {
 func (state *ruleState) aliasInfoForBinderSymbol(symbol *ast.Symbol) (aliasInfo, bool) {
 	if symbol == nil {
 		return aliasInfo{}, false
+	}
+	if info, ok := state.aliasesBySymbol[symbol]; ok {
+		return info, true
 	}
 	for _, declaration := range symbol.Declarations {
 		if info, ok := state.aliases[declaration]; ok {
@@ -986,9 +1129,17 @@ func (state *ruleState) isLocalNonAliasIdentifier(node *ast.Node) bool {
 		// additionally be declared in this file.
 		symbol := state.ctx.Refs.Resolve(node)
 		if symbol != nil {
+			if local, ok := state.localSymbols[symbol]; ok {
+				return local
+			}
 			// A resolved type-only symbol is authoritative. Falling through
 			// would scan the containing scope again for every reference.
-			return utils.IsValueSymbolDeclaredInFile(symbol, state.ctx.SourceFile)
+			local := utils.IsValueSymbolDeclaredInFile(symbol, state.ctx.SourceFile)
+			if state.localSymbols == nil {
+				state.localSymbols = map[*ast.Symbol]bool{}
+			}
+			state.localSymbols[symbol] = local
+			return local
 		}
 		// A namespace holding no value of its own is outside the binder's
 		// value lookup, and without a TypeChecker to fall back to Resolve
@@ -1123,6 +1274,10 @@ func pathKey(path []string) string {
 
 func appendPath(path []string, parts ...string) []string {
 	return append(slices.Clone(path), parts...)
+}
+
+func trimmedNodeRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	return core.NewTextRange(scanner.SkipTrivia(sourceFile.Text(), node.Pos()), node.End())
 }
 
 func sameLine(sourceFile *ast.SourceFile, a int, b int) bool {

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_internal_test.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestDeferredReportsPreserveDiagnostics(t *testing.T) {
@@ -102,7 +103,7 @@ func TestDeferredCollectionPreservesBindingTiming(t *testing.T) {
 
 	diagnostics := runRuleForTest(
 		t,
-		"const Alias = Array; Alias(); Map();",
+		"unresolved(); function helper() {} helper(); const Alias = Array; Alias(); Map();",
 		rule.EditDemandNone,
 	)
 	if len(diagnostics) != 2 {
@@ -320,6 +321,50 @@ func TestSourcePotentialReferenceGate(t *testing.T) {
 	sourceFile.Identifiers = nil
 	if !sourceHasPotentialReference(sourceFile) {
 		t.Fatal("sourceHasPotentialReference() must fail open without a parser identifier index")
+	}
+}
+
+func TestTrimmedNodeRangeMatchesCanonicalRange(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/new-for-builtins-range-test.ts",
+		Path:     tspath.Path("/new-for-builtins-range-test.ts"),
+	}, `/* leading call */ Array();
+		const value = new /* constructor */ (Symbol);
+		function make() {
+			return /* returned */ new
+				/* constructor */ BigInt;
+		}
+		function fail() {
+			throw /* thrown */ new Number(1);
+		}
+		const date = (
+			globalThis
+			/* member */ ["Date"]
+		)();`, core.ScriptKindTS)
+
+	nodes := map[*ast.Node]bool{}
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		switch node.Kind {
+		case ast.KindCallExpression:
+			nodes[node] = true
+			nodes[node.AsCallExpression().Expression] = true
+		case ast.KindNewExpression:
+			nodes[node] = true
+			nodes[node.AsNewExpression().Expression] = true
+		case ast.KindReturnStatement, ast.KindThrowStatement:
+			nodes[node] = true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if len(nodes) == 0 {
+		t.Fatal("expected range test nodes")
+	}
+	for node := range nodes {
+		if got, want := trimmedNodeRange(sourceFile, node), utils.TrimNodeTextRange(sourceFile, node); got != want {
+			t.Errorf("%s range = %v, want %v", node.Kind.String(), got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reject unwatched member roots before allocating expression paths, and add allocation-free fast paths for direct builtin and direct alias references.
- Use `ctx.Refs` to distinguish ordinary calls from bindings that may become tracked aliases, prune expressions that cannot report from the deferred EOF queue, and cache alias/local symbol results.
- Compute trivia-trimmed diagnostic ranges once and reuse them through deferred fixes and suggestions, without changing the rule framework.
- Add regression coverage for mixed ordinary/alias call ordering and verify the fast range matches the canonical range across comments, multiline expressions, calls, constructors, returns, and throws.

### Performance

Rule-layer Go benchmark on an Apple M1 Max with 2,000 calls per case; parsing and binding were outside the timed loop. Values are medians of 10 runs with `-benchtime=300ms -benchmem`. The first table uses `EditDemandNone`.

| Case | Before | After | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Candidate, no report | 428,556 ns/op | 330,122 ns/op | -23.0% | 96,840 → 872 | 4,011 → 11 |
| Early unrelated + candidate | 388,764 ns/op | 329,566 ns/op | -15.2% | 145,632 → 1,208 | 4,030 → 13 |
| Direct reports | 947,620 ns/op | 645,182 ns/op | -31.9% | 1,056,844 → 672,876 | 10,011 → 4,011 |
| Shadowed calls | 533,526 ns/op | 424,201 ns/op | -20.5% | 81,344 → 49,568 | 2,026 → 28 |
| Alias reports | 1,119,114 ns/op | 845,068 ns/op | -24.5% | 1,138,065 → 723,149 | 12,033 → 4,037 |

With fixes and suggestions requested (`EditDemandAll`):

| Case | Before | After | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Direct reports | 1,177,866 ns/op | 759,678 ns/op | -35.5% | 1,472,846 → 768,875 | 16,011 → 8,011 |
| Alias reports | 1,340,889 ns/op | 950,698 ns/op | -29.1% | 1,554,069 → 819,149 | 18,033 → 8,037 |

The benchmark-only code and profiles were removed before committing.

### Validation

- `go test ./internal/plugins/unicorn/rules/new_for_builtins -count=3`
- `go test ./internal/plugins/unicorn/rules/new_for_builtins -run '^$' -bench '^BenchmarkNewForBuiltins$' -benchmem -benchtime=300ms -count=10`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=main ./internal/plugins/unicorn/rules/new_for_builtins/...`

## Related Links

- Follow-up to #1446

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No user-facing behavior or API changed.
