### PR TITLE
perf: optimize no-useless-rename hot paths

### DIFF
--- a/internal/rules/no_useless_rename/no_useless_rename.go
+++ b/internal/rules/no_useless_rename/no_useless_rename.go
@@ -33,272 +33,244 @@ func parseOptions(opts any) options {
 	return out
 }
 
+type noUselessRenameState struct {
+	ctx        rule.RuleContext
+	sourceText string
+}
+
+// hasCommentBytes reports whether `//` or `/*` appears in the byte range
+// [start, end). Scanner-based lookups are anchored at token boundaries and can
+// miss comments between these specific child nodes. The ranges here contain
+// only identifiers, punctuation, parentheses, and the `as` keyword, so a raw
+// scan cannot mistake string or regexp contents for comments.
+func (s *noUselessRenameState) hasCommentBytes(start, end int) bool {
+	if end > len(s.sourceText) {
+		end = len(s.sourceText)
+	}
+	for i := start; i+1 < end; i++ {
+		if s.sourceText[i] == '/' && (s.sourceText[i+1] == '/' || s.sourceText[i+1] == '*') {
+			return true
+		}
+	}
+	return false
+}
+
+// report emits a diagnostic and, when requested, replaces outerNode with the
+// source text at keepNode. keepThroughEnd retains the suffix from keepNode to
+// outerNode's end (used for a binding default such as `{foo: foo = 1}`).
+func (s *noUselessRenameState) report(
+	outerNode *ast.Node,
+	displayName string,
+	reportType string,
+	keepNode *ast.Node,
+	keepThroughEnd bool,
+) {
+	msg := rule.RuleMessage{
+		Id:          "unnecessarilyRenamed",
+		Description: reportType + " " + displayName + " unnecessarily renamed.",
+	}
+	outerRange := utils.TrimNodeTextRange(s.ctx.SourceFile, outerNode)
+	if keepNode == nil {
+		s.ctx.ReportRange(outerRange, msg)
+		return
+	}
+
+	s.ctx.ReportRangeWithDeferredFixes(outerRange, msg, func() []rule.RuleFix {
+		keepRange := utils.TrimNodeTextRange(s.ctx.SourceFile, keepNode)
+		if keepThroughEnd {
+			keepRange = core.NewTextRange(keepRange.Pos(), outerRange.End())
+		}
+		// Comments outside keepRange would be lost by the replacement, so the
+		// diagnostic remains intentionally unfixable in that case.
+		if s.hasCommentBytes(outerRange.Pos(), keepRange.Pos()) ||
+			s.hasCommentBytes(keepRange.End(), outerRange.End()) {
+			return nil
+		}
+		return []rule.RuleFix{
+			rule.RuleFixReplaceRange(outerRange, s.sourceText[keepRange.Pos():keepRange.End()]),
+		}
+	})
+}
+
+// checkImport handles `import { foo as foo } from '...'`.
+func (s *noUselessRenameState) checkImport(node *ast.Node) {
+	spec := node.AsImportSpecifier()
+	if spec.PropertyName == nil {
+		return
+	}
+	importedName, ok := utils.GetStaticPropertyName(spec.PropertyName)
+	if !ok {
+		return
+	}
+	local := spec.Name()
+	if importedName != local.AsIdentifier().Text {
+		return
+	}
+	s.report(node, importedName, "Import", local, false)
+}
+
+// checkExport handles `export { foo as foo }`.
+func (s *noUselessRenameState) checkExport(node *ast.Node) {
+	spec := node.AsExportSpecifier()
+	if spec.PropertyName == nil {
+		return
+	}
+	localName, ok := utils.GetStaticPropertyName(spec.PropertyName)
+	if !ok {
+		return
+	}
+	exportedName, ok := utils.GetStaticPropertyName(spec.Name())
+	if !ok || localName != exportedName {
+		return
+	}
+	s.report(node, localName, "Export", spec.PropertyName, false)
+}
+
+// checkBindingElement handles declaration patterns such as
+// `let {foo: foo} = value` and function parameters.
+func (s *noUselessRenameState) checkBindingElement(node *ast.Node) {
+	if node.Parent == nil || node.Parent.Kind != ast.KindObjectBindingPattern {
+		return
+	}
+	element := node.AsBindingElement()
+	if element.PropertyName == nil || element.PropertyName.Kind == ast.KindComputedPropertyName {
+		return
+	}
+	keyName, ok := utils.GetStaticPropertyName(element.PropertyName)
+	if !ok {
+		return
+	}
+	bindingName := element.Name()
+	if bindingName == nil || bindingName.Kind != ast.KindIdentifier ||
+		keyName != bindingName.AsIdentifier().Text {
+		return
+	}
+	// Retain any default initializer: `{foo: foo = 1}` becomes `{foo = 1}`.
+	s.report(node, keyName, "Destructuring assignment", bindingName, true)
+}
+
+// checkAssignmentProperty is registered only for object properties traversed
+// as assignment patterns, so ordinary object literals never enter this path.
+func (s *noUselessRenameState) checkAssignmentProperty(node *ast.Node) {
+	property := node.AsPropertyAssignment()
+	nameNode := property.Name()
+	if nameNode == nil || nameNode.Kind == ast.KindComputedPropertyName {
+		return
+	}
+	keyName, ok := utils.GetStaticPropertyName(nameNode)
+	if !ok || property.Initializer == nil {
+		return
+	}
+
+	// A default initializer is represented as BinaryExpression(=). Parentheses
+	// around the renamed identifier are otherwise transparent for comparison.
+	initializer := property.Initializer
+	targetIdentifier := initializer
+	hasDefault := false
+	if targetIdentifier.Kind == ast.KindBinaryExpression {
+		binary := targetIdentifier.AsBinaryExpression()
+		if binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
+			hasDefault = true
+			targetIdentifier = binary.Left
+		}
+	}
+	leftParenthesized := hasDefault && targetIdentifier.Kind == ast.KindParenthesizedExpression
+	targetIdentifier = ast.SkipParentheses(targetIdentifier)
+	if targetIdentifier == nil || targetIdentifier.Kind != ast.KindIdentifier ||
+		keyName != targetIdentifier.AsIdentifier().Text {
+		return
+	}
+
+	// `{foo: (foo) = value}` cannot become a shorthand property while keeping
+	// the parentheses, matching ESLint's diagnostic-without-fix behavior.
+	if leftParenthesized {
+		s.report(node, keyName, "Destructuring assignment", nil, false)
+		return
+	}
+	keepNode := targetIdentifier
+	if hasDefault {
+		keepNode = initializer
+	}
+	s.report(node, keyName, "Destructuring assignment", keepNode, false)
+}
+
+// checkWrappedAssignmentPattern continues the linter's allow-pattern walk
+// through syntax wrappers whose children are otherwise visited as ordinary
+// expressions. It is registered on the allow-pattern listener keys, so normal
+// parenthesized and non-null expressions do not enter this path.
+func (s *noUselessRenameState) checkWrappedAssignmentPattern(node *ast.Node) {
+	for node != nil && (node.Kind == ast.KindParenthesizedExpression || node.Kind == ast.KindNonNullExpression) {
+		node = node.Expression()
+	}
+	s.walkAssignmentPattern(node)
+}
+
+// checkIterationStatement covers assignment patterns used as for-in/of
+// initializers. The linter's dedicated allow-pattern traversal is initiated by
+// `=` assignments; iteration targets need this narrow rule-level entry point.
+func (s *noUselessRenameState) checkIterationStatement(node *ast.Node) {
+	s.walkAssignmentPattern(node.Initializer())
+}
+
+func (s *noUselessRenameState) walkAssignmentPattern(node *ast.Node) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindParenthesizedExpression, ast.KindNonNullExpression:
+		s.walkAssignmentPattern(node.Expression())
+	case ast.KindArrayLiteralExpression:
+		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
+			s.walkAssignmentPattern(element)
+		}
+	case ast.KindObjectLiteralExpression:
+		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
+			s.walkAssignmentPattern(property)
+		}
+	case ast.KindSpreadElement, ast.KindSpreadAssignment:
+		s.walkAssignmentPattern(node.Expression())
+	case ast.KindPropertyAssignment:
+		s.checkAssignmentProperty(node)
+		initializer := node.AsPropertyAssignment().Initializer
+		if initializer != nil && initializer.Kind == ast.KindBinaryExpression {
+			binary := initializer.AsBinaryExpression()
+			if binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
+				return
+			}
+		}
+		s.walkAssignmentPattern(initializer)
+	}
+}
+
 var NoUselessRenameRule = rule.Rule{
 	Name: "no-useless-rename",
-	Run: func(ctx rule.RuleContext, _optionsAny []any) rule.RuleListeners {
-		optionsAny := rule.LegacyUnwrapOptions(_optionsAny)
-		opts := parseOptions(optionsAny)
-		sf := ctx.SourceFile
-
-		// report emits the diagnostic, attaching an autofix when possible.
-		// - `outerNode`: the node whose range is replaced by the fix (the
-		//   BindingElement / PropertyAssignment / ImportSpecifier / ExportSpecifier).
-		// - `displayName`: the name shown in the message (corresponds to the
-		//   ESLint rule's `initial.name || initial.value`).
-		// - `reportType`: one of "Destructuring assignment" / "Import" / "Export".
-		// - `fix`: precomputed fix or nil.
-		report := func(outerNode *ast.Node, displayName, reportType string, fix *rule.RuleFix) {
-			msg := rule.RuleMessage{
-				Id:          "unnecessarilyRenamed",
-				Description: reportType + " " + displayName + " unnecessarily renamed.",
-			}
-			if fix != nil {
-				ctx.ReportNodeWithFixes(outerNode, msg, *fix)
-				return
-			}
-			ctx.ReportNode(outerNode, msg)
+	Run: func(ctx rule.RuleContext, optionsAny []any) rule.RuleListeners {
+		opts := parseOptions(rule.LegacyUnwrapOptions(optionsAny))
+		if opts.ignoreDestructuring && opts.ignoreImport && opts.ignoreExport {
+			return nil
 		}
 
-		// hasCommentBytes reports whether `//` or `/*` appears in the byte
-		// range [start, end). Scanner-based lookups (`utils.HasCommentsInRange`)
-		// are anchored at token boundaries and miss comments that sit between
-		// specific child nodes — here we just need to know whether the
-		// PropertyAssignment / BindingElement / specifier contains any
-		// comment between the "removed" prefix and the "kept" tail. Since
-		// these ranges only cover identifiers, colons, parentheses, and the
-		// `as` keyword, a raw byte scan can't be confused by string or regex
-		// literals the way it could in general code.
-		sourceText := sf.Text()
-		hasCommentBytes := func(start, end int) bool {
-			if end > len(sourceText) {
-				end = len(sourceText)
-			}
-			for i := start; i+1 < end; i++ {
-				if sourceText[i] == '/' && (sourceText[i+1] == '/' || sourceText[i+1] == '*') {
-					return true
-				}
-			}
-			return false
+		state := &noUselessRenameState{
+			ctx:        ctx,
+			sourceText: ctx.SourceFile.Text(),
 		}
-
-		// buildRangeFix replaces `outerRange` with the source text at
-		// `keepRange`. Returns nil if any comment sits in the portion of
-		// `outerRange` outside `keepRange` (the "removed" prefix
-		// [outer.Pos, keep.Pos) or suffix [keep.End, outer.End)) — dropping
-		// comments silently would lose information.
-		buildRangeFix := func(outerRange, keepRange core.TextRange) *rule.RuleFix {
-			if hasCommentBytes(outerRange.Pos(), keepRange.Pos()) {
-				return nil
-			}
-			if hasCommentBytes(keepRange.End(), outerRange.End()) {
-				return nil
-			}
-			text := sourceText[keepRange.Pos():keepRange.End()]
-			fix := rule.RuleFixReplaceRange(outerRange, text)
-			return &fix
+		listeners := make(rule.RuleListeners, 8)
+		if !opts.ignoreImport {
+			listeners[ast.KindImportSpecifier] = state.checkImport
 		}
-
-		// ---- ImportSpecifier: `import { foo as foo } from '...'` ----
-		// In tsgo's AST, `propertyName` is the name before `as` (= ESTree's
-		// `imported`), `name` is after `as` (= ESTree's `local`). ESLint only
-		// fires when an explicit `as` is written (imported.range !== local.range);
-		// tsgo encodes that as `propertyName != nil`.
-		checkImport := func(node *ast.Node) {
-			if opts.ignoreImport {
-				return
-			}
-			spec := node.AsImportSpecifier()
-			if spec == nil || spec.PropertyName == nil {
-				return
-			}
-			// `spec.PropertyName` is a ModuleExportName (Identifier | StringLiteral);
-			// `spec.Name()` is always an Identifier (the local binding).
-			// `utils.GetStaticPropertyName` resolves both to their canonical text.
-			importedName, ok := utils.GetStaticPropertyName(spec.PropertyName)
-			if !ok {
-				return
-			}
-			localName := spec.Name().AsIdentifier().Text
-			if importedName != localName {
-				return
-			}
-			outerRange := utils.TrimNodeTextRange(sf, node)
-			replRange := utils.TrimNodeTextRange(sf, spec.Name())
-			fix := buildRangeFix(outerRange, replRange)
-			report(node, importedName, "Import", fix)
+		if !opts.ignoreExport {
+			listeners[ast.KindExportSpecifier] = state.checkExport
 		}
-
-		// ---- ExportSpecifier: `export { foo as foo }` ----
-		// Both `propertyName` (before `as`) and `name` (after `as`) are
-		// ModuleExportName (Identifier | StringLiteral). ESLint only fires when
-		// `as` is explicit (local.range !== exported.range); in tsgo that's
-		// `propertyName != nil`.
-		checkExport := func(node *ast.Node) {
-			if opts.ignoreExport {
-				return
-			}
-			spec := node.AsExportSpecifier()
-			if spec == nil || spec.PropertyName == nil {
-				return
-			}
-			// Both ends are ModuleExportName — accept Identifier and StringLiteral.
-			localName, ok := utils.GetStaticPropertyName(spec.PropertyName)
-			if !ok {
-				return
-			}
-			exportedName, ok := utils.GetStaticPropertyName(spec.Name())
-			if !ok {
-				return
-			}
-			if localName != exportedName {
-				return
-			}
-			outerRange := utils.TrimNodeTextRange(sf, node)
-			replRange := utils.TrimNodeTextRange(sf, spec.PropertyName)
-			fix := buildRangeFix(outerRange, replRange)
-			report(node, localName, "Export", fix)
+		if !opts.ignoreDestructuring {
+			listeners[ast.KindBindingElement] = state.checkBindingElement
+			listeners[rule.ListenerOnAllowPattern(ast.KindPropertyAssignment)] = state.checkAssignmentProperty
+			checkWrappedPattern := state.checkWrappedAssignmentPattern
+			listeners[rule.ListenerOnAllowPattern(ast.KindParenthesizedExpression)] = checkWrappedPattern
+			listeners[rule.ListenerOnAllowPattern(ast.KindNonNullExpression)] = checkWrappedPattern
+			checkIteration := state.checkIterationStatement
+			listeners[ast.KindForInStatement] = checkIteration
+			listeners[ast.KindForOfStatement] = checkIteration
 		}
-
-		// ---- Destructuring declaration: `let {foo: foo} = obj;` / `function f({foo: foo}) {}` ----
-		// tsgo represents these as BindingElement children of ObjectBindingPattern.
-		// - `PropertyName` is the source key (before `:`); `Name()` is the binding
-		//   target (after `:`, an Identifier, another pattern, or a rest binding).
-		// - Rest elements and shorthand bindings have `PropertyName == nil`.
-		// - Computed keys can't be resolved statically — the rule skips them
-		//   (matching ESLint's `property.computed` check).
-		checkBindingElement := func(node *ast.Node) {
-			if opts.ignoreDestructuring {
-				return
-			}
-			// Parent guard: only object destructuring; array-binding elements
-			// don't carry a `propertyName` so this is belt-and-braces.
-			if node.Parent == nil || node.Parent.Kind != ast.KindObjectBindingPattern {
-				return
-			}
-			be := node.AsBindingElement()
-			if be == nil || be.PropertyName == nil {
-				return
-			}
-			// Skip computed property names — ESLint: "we have no idea if a
-			// rename is useless or not". `GetStaticPropertyName` can resolve
-			// `['foo']` statically, but the rule intentionally treats computed
-			// keys as opaque regardless of whether they're constant-foldable.
-			if be.PropertyName.Kind == ast.KindComputedPropertyName {
-				return
-			}
-			keyName, ok := utils.GetStaticPropertyName(be.PropertyName)
-			if !ok {
-				return
-			}
-			bindingName := be.Name()
-			if bindingName == nil || bindingName.Kind != ast.KindIdentifier {
-				return
-			}
-			if keyName != bindingName.AsIdentifier().Text {
-				return
-			}
-			// Replacement text runs from the binding name through the end of
-			// the element, so it includes any default (`= init`). For
-			// `{foo: foo = 1}` the output becomes `{foo = 1}`.
-			outerRange := utils.TrimNodeTextRange(sf, node)
-			nameRange := utils.TrimNodeTextRange(sf, bindingName)
-			keepRange := core.NewTextRange(nameRange.Pos(), outerRange.End())
-			fix := buildRangeFix(outerRange, keepRange)
-			report(node, keyName, "Destructuring assignment", fix)
-		}
-
-		// ---- Destructuring assignment pattern: `({foo: foo} = obj);` ----
-		// tsgo keeps the outer node as `ObjectLiteralExpression`; only the
-		// assignment context reclassifies it semantically. `ast.IsAssignmentTarget`
-		// walks up through parentheses / arrays / nested object literals to
-		// confirm we're in an assignment target position.
-		checkAssignmentProperty := func(node *ast.Node) {
-			if opts.ignoreDestructuring {
-				return
-			}
-			parent := node.Parent
-			if parent == nil || parent.Kind != ast.KindObjectLiteralExpression {
-				return
-			}
-			if !ast.IsAssignmentTarget(parent) {
-				return
-			}
-			pa := node.AsPropertyAssignment()
-			if pa == nil {
-				return
-			}
-			nameNode := pa.Name()
-			if nameNode == nil {
-				return
-			}
-			// Skip computed keys (see BindingElement branch for the rationale).
-			if nameNode.Kind == ast.KindComputedPropertyName {
-				return
-			}
-			keyName, ok := utils.GetStaticPropertyName(nameNode)
-			if !ok {
-				return
-			}
-			init := pa.Initializer
-			if init == nil {
-				return
-			}
-
-			// Classify the initializer:
-			//  - ParenthesizedExpression wrapping Identifier → useless rename
-			//    with no default; unwrap to reach the identifier.
-			//  - BinaryExpression(=) → destructuring default; treat like
-			//    ESLint's AssignmentPattern. The identifier being renamed
-			//    is the (unwrapped) left side.
-			//  - Anything else → not a rename.
-			targetIdent := init
-			hasDefault := false
-			if targetIdent.Kind == ast.KindBinaryExpression {
-				bin := targetIdent.AsBinaryExpression()
-				if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken {
-					hasDefault = true
-					targetIdent = bin.Left
-				}
-			}
-			// Autofix can't handle `({foo: (foo) = a} = obj)` — shorthand
-			// properties don't accept parenthesised identifiers. ESLint emits
-			// the diagnostic with a null fix in this case.
-			leftParenthesized := hasDefault && targetIdent.Kind == ast.KindParenthesizedExpression
-			targetIdent = ast.SkipParentheses(targetIdent)
-			if targetIdent == nil || targetIdent.Kind != ast.KindIdentifier {
-				return
-			}
-			if keyName != targetIdent.AsIdentifier().Text {
-				return
-			}
-
-			var fix *rule.RuleFix
-			if !leftParenthesized {
-				outerRange := utils.TrimNodeTextRange(sf, node)
-				// Replacement spans the logical "value" — either the bare
-				// identifier (no default) or the full `ident = init`
-				// expression. When the identifier sits inside explicit parens
-				// like `(foo)`, we deliberately take only the identifier's
-				// range so the emitted shorthand is `{foo}`, not `{(foo)}`.
-				var replRange core.TextRange
-				if hasDefault {
-					// Keep the full BinaryExpression range — this includes any
-					// default value. The left was not parenthesized (checked
-					// above), so emitting the raw text is safe.
-					replRange = utils.TrimNodeTextRange(sf, init)
-				} else {
-					replRange = utils.TrimNodeTextRange(sf, targetIdent)
-				}
-				fix = buildRangeFix(outerRange, replRange)
-			}
-			report(node, keyName, "Destructuring assignment", fix)
-		}
-
-		return rule.RuleListeners{
-			ast.KindImportSpecifier:    checkImport,
-			ast.KindExportSpecifier:    checkExport,
-			ast.KindBindingElement:     checkBindingElement,
-			ast.KindPropertyAssignment: checkAssignmentProperty,
-		}
+		return listeners
 	},
 }

--- a/internal/rules/no_useless_rename/no_useless_rename_test.go
+++ b/internal/rules/no_useless_rename/no_useless_rename_test.go
@@ -1,9 +1,13 @@
 package no_useless_rename
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -69,6 +73,7 @@ func TestNoUselessRenameRule(t *testing.T) {
 			{Code: `let {foo: foo} = obj;`, Options: map[string]interface{}{"ignoreDestructuring": true}},
 			{Code: `let {foo: foo, bar: baz} = obj;`, Options: map[string]interface{}{"ignoreDestructuring": true}},
 			{Code: `let {foo: foo, bar: bar} = obj;`, Options: map[string]interface{}{"ignoreDestructuring": true}},
+			{Code: `({foo: foo} = obj); for ({bar: bar} of values) {}`, Options: map[string]interface{}{"ignoreDestructuring": true}},
 
 			// ---- { ignoreImport: true } ----
 			{Code: `import {foo as foo} from 'foo';`, Options: map[string]interface{}{"ignoreImport": true}},
@@ -82,6 +87,19 @@ func TestNoUselessRenameRule(t *testing.T) {
 			{Code: `export {foo as foo} from 'foo';`, Options: map[string]interface{}{"ignoreExport": true}},
 			{Code: `export {foo as foo, bar as baz} from 'foo';`, Options: map[string]interface{}{"ignoreExport": true}},
 			{Code: `export {foo as foo, bar as bar} from 'foo';`, Options: map[string]interface{}{"ignoreExport": true}},
+
+			// When every category is ignored, Run returns no listeners.
+			{
+				Code: `import {foo as foo} from 'mod';
+export {foo as foo};
+const {foo: foo} = value;
+({foo: foo} = value);`,
+				Options: map[string]interface{}{
+					"ignoreDestructuring": true,
+					"ignoreImport":        true,
+					"ignoreExport":        true,
+				},
+			},
 
 			// ---- Extra coverage beyond ESLint's suite ----
 			// Numeric keys can't collide with identifier bindings — no rename.
@@ -942,15 +960,21 @@ func TestNoUselessRenameRule(t *testing.T) {
 					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 2, Column: 3},
 				},
 			},
-			// Nested assignment pattern — the inner ObjectLiteralExpression is
-			// not a direct LHS, but `ast.IsAssignmentTarget` walks up through
-			// PropertyAssignment / ObjectLiteralExpression to confirm the
-			// outer `=`. Tests that the listener fires on nested patterns.
+			// Nested assignment pattern — the linter's allow-pattern traversal
+			// propagates through the outer property into the inner object.
 			{
 				Code:   `({a: {foo: foo}} = obj);`,
 				Output: []string{`({a: {foo}} = obj);`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 7},
+				},
+			},
+			// Parentheses and TS non-null expressions can wrap a nested target.
+			{
+				Code:   `({a: (({foo: foo})!)} = obj);`,
+				Output: []string{`({a: (({foo})!)} = obj);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed."},
 				},
 			},
 			// Array-containing-object assignment pattern.
@@ -967,6 +991,24 @@ func TestNoUselessRenameRule(t *testing.T) {
 				Output: []string{`for ({foo} of arr) {}`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 7},
+				},
+			},
+			// `for-in` can also use a nested assignment pattern as its target.
+			{
+				Code:   `for ([{foo: foo}] in arr) {}`,
+				Output: []string{`for ([{foo}] in arr) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 8},
+				},
+			},
+			// Only walk the iteration target. The object literal in the default
+			// value is an expression and must not be treated as a nested pattern.
+			{
+				Code:   `for ({outer: {inner: inner}, kept: kept = {ignored: ignored}} of arr) {}`,
+				Output: []string{`for ({outer: {inner}, kept = {ignored: ignored}} of arr) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment inner unnecessarily renamed."},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment kept unnecessarily renamed."},
 				},
 			},
 			// TS: destructuring with a type annotation — the annotation is
@@ -1008,4 +1050,109 @@ func TestNoUselessRenameRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoUselessRenameEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`import { imported as imported } from 'module';
+export { imported as imported };
+const { binding: binding = fallback } = input;
+({ assigned: assigned = fallback, parenthesized: (parenthesized) = fallback } = input);
+({ commented/**/: commented } = input);`,
+		"no-useless-rename-edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoUselessRenameRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUselessRenameRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 6 {
+			t.Fatalf("demand %d: diagnostics = %d, want 6", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+	wantFixText := []string{"imported", "imported", "binding = fallback", "assigned = fallback", "", ""}
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index, wantText := range wantFixText {
+		wantIdentity := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, wantIdentity) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, wantIdentity)
+			}
+		}
+
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		for _, diagnostics := range [][]rule.RuleDiagnostic{
+			diagnosticsOnly,
+			autofixOnly,
+			suggestionOnly,
+			allEdits,
+		} {
+			if diagnostics[index].Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandAutofix: autofixOnly,
+			rule.EditDemandAll:     allEdits,
+		} {
+			fixes := diagnostics[index].FixesPtr
+			if wantText == "" {
+				if fixes != nil {
+					t.Fatalf("demand %d diagnostic %d: unexpected fixes %#v", demand, index, *fixes)
+				}
+				continue
+			}
+			if fixes == nil || len(*fixes) != 1 || (*fixes)[0].Text != wantText {
+				t.Fatalf("demand %d diagnostic %d: fixes = %#v, want one fix with text %q", demand, index, fixes, wantText)
+			}
+		}
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Errorf("diagnostic %d: autofix and all-edit fixes differ", index)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Skip ordinary object properties by registering assignment checks on the linter's allow-pattern listeners, while preserving nested, parenthesized, non-null, and `for-in`/`for-of` assignment patterns at the rule layer.
- Defer fix range/comment work until the diagnostic consumer requests autofixes, reuse the diagnostic range, and omit listeners for ignored categories.
- Add adversarial coverage for iteration targets, wrapped nested patterns, default-value expressions, all-ignore options, comment-suppressed fixes, and every edit-demand mode.

### Benchmark

Temporary benchmark only (not committed), run on Apple M1 Max, darwin/arm64, Go 1.26.1. Each result is the median of 10 runs with `-benchtime=1s`; the clean fixture contains 500 ordinary object literals / 2,000 properties, and the violation fixture contains 2,000 diagnostics across imports, exports, binding patterns, and assignment patterns.

| Case | Before ns/op | After ns/op | Time | Before B/op | After B/op | Bytes | Before allocs/op | After allocs/op | Allocs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Clean objects / diagnostics | 92,539 | 70,948 | -23.3% | 736 | 584 | -20.7% | 14 | 13 | -7.1% |
| Clean objects / autofix | 91,357 | 69,216 | -24.2% | 736 | 584 | -20.7% | 14 | 13 | -7.1% |
| Violations / diagnostics | 893,954 | 495,985 | -44.5% | 1,216,741 | 432,585 | -64.4% | 14,014 | 4,013 | -71.4% |
| Violations / autofix | 895,806 | 783,293 | -12.6% | 1,216,741 | 848,587 | -30.3% | 14,014 | 10,013 | -28.6% |

Validation:

- `go test ./internal/rules/no_useless_rename -run '^TestNoUselessRename(Rule|EditDemand)$' -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run internal/rules/no_useless_rename/no_useless_rename.go internal/rules/no_useless_rename/no_useless_rename_test.go`

`ctx.Refs` was evaluated but is not applicable: the rule compares names within the same syntax node and performs no symbol-reference lookup, so materializing the reference index would add work rather than replace it.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
