### PR TITLE
perf: improve no-self-assign performance

### DIFF
--- a/internal/rules/no_self_assign/no_self_assign.go
+++ b/internal/rules/no_self_assign/no_self_assign.go
@@ -2,6 +2,8 @@ package no_self_assign
 
 import (
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -35,8 +37,9 @@ var NoSelfAssignRule = rule.Rule{
 				}
 
 				eachSelfAssignment(binExpr.Left, binExpr.Right, opts.props, func(rightNode *ast.Node) {
-					name := getNodeText(ctx.SourceFile, rightNode)
-					ctx.ReportNode(rightNode, rule.RuleMessage{
+					reportRange := utils.TrimNodeTextRange(ctx.SourceFile, rightNode)
+					name := removeWhitespace(ctx.SourceFile.Text()[reportRange.Pos():reportRange.End()])
+					ctx.ReportRange(reportRange, rule.RuleMessage{
 						Id:          "selfAssignment",
 						Description: "'" + name + "' is assigned to itself.",
 					})
@@ -63,12 +66,62 @@ func parseOptions(opts any) selfAssignOptions {
 	return result
 }
 
-// getNodeText returns the source text of a node, with whitespace removed.
-func getNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
-	trimmed := utils.TrimNodeTextRange(sourceFile, node)
-	text := sourceFile.Text()[trimmed.Pos():trimmed.End()]
-	// Remove internal whitespace to normalize e.g. "a . b" -> "a.b"
-	return strings.Join(strings.Fields(text), "")
+// removeWhitespace normalizes node text such as "a . b" to "a.b" without
+// allocating when the usual compact spelling contains no whitespace. Source
+// text is overwhelmingly ASCII, so only non-ASCII bytes enter unicode.IsSpace.
+func removeWhitespace(text string) string {
+	firstWhitespace := -1
+	for i := 0; i < len(text); {
+		if text[i] < utf8.RuneSelf {
+			if isASCIIWhitespace(text[i]) {
+				firstWhitespace = i
+				break
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if unicode.IsSpace(r) {
+			firstWhitespace = i
+			break
+		}
+		i += size
+	}
+	if firstWhitespace < 0 {
+		return text
+	}
+
+	var result strings.Builder
+	result.Grow(len(text) - 1)
+	result.WriteString(text[:firstWhitespace])
+	for i := firstWhitespace; i < len(text); {
+		if text[i] < utf8.RuneSelf {
+			if !isASCIIWhitespace(text[i]) {
+				result.WriteByte(text[i])
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if !unicode.IsSpace(r) {
+			// Copy the original bytes so malformed UTF-8 is preserved instead of
+			// being rewritten as the replacement rune.
+			result.WriteString(text[i : i+size])
+		}
+		i += size
+	}
+	return result.String()
+}
+
+func isASCIIWhitespace(ch byte) bool {
+	return ch == ' ' || ch >= '\t' && ch <= '\r'
+}
+
+const maxLinearObjectProperties = 32
+
+type namedObjectProperty struct {
+	name  string
+	value *ast.Node
 }
 
 // eachSelfAssignment recursively compares the left and right nodes of an assignment,
@@ -152,41 +205,7 @@ func eachSelfAssignment(left *ast.Node, right *ast.Node, props bool, report func
 			}
 		}
 
-		for _, lProp := range leftObj.Properties.Nodes {
-			// Handle spread on left: {...x} = {...y}
-			if lProp.Kind == ast.KindSpreadAssignment {
-				// Find corresponding spread on right, but only after startJ
-				for j := startJ; j < len(rightProps); j++ {
-					rProp := rightProps[j]
-					if rProp.Kind == ast.KindSpreadAssignment {
-						eachSelfAssignment(lProp.AsSpreadAssignment().Expression, rProp.AsSpreadAssignment().Expression, props, report)
-						break
-					}
-				}
-				continue
-			}
-
-			lName := getPropertyKeyName(lProp)
-			if lName == "" {
-				continue
-			}
-
-			// Find matching property on right, starting after the last spread
-			for j := startJ; j < len(rightProps); j++ {
-				rProp := rightProps[j]
-				if rProp.Kind == ast.KindSpreadAssignment {
-					continue
-				}
-
-				rName := getPropertyKeyName(rProp)
-				if rName == lName {
-					lValue := getPropertyValue(lProp)
-					rValue := getPropertyValue(rProp)
-					eachSelfAssignment(lValue, rValue, props, report)
-					break
-				}
-			}
-		}
+		compareObjectProperties(leftObj.Properties.Nodes, rightProps[startJ:], props, report)
 
 	// MemberExpression (PropertyAccessExpression or ElementAccessExpression) with props option.
 	// Unlike destructuring patterns above, member expressions are compared as a whole
@@ -202,32 +221,101 @@ func eachSelfAssignment(left *ast.Node, right *ast.Node, props bool, report func
 	}
 }
 
-// getPropertyKeyName returns the static property name for a property assignment or shorthand property.
-func getPropertyKeyName(prop *ast.Node) string {
+// compareObjectProperties compares properties after the right-hand side's last
+// spread. Small patterns stay allocation-free; larger patterns build a compact
+// name index so adversarial or generated destructuring assignments remain
+// linear instead of repeatedly scanning the right-hand side.
+func compareObjectProperties(leftProps, rightProps []*ast.Node, props bool, report func(*ast.Node)) {
+	if len(rightProps) <= maxLinearObjectProperties {
+		var properties [maxLinearObjectProperties]namedObjectProperty
+		propertyCount := 0
+		for _, rightProp := range rightProps {
+			name, ok := getPropertyKeyName(rightProp)
+			if !ok {
+				continue
+			}
+			properties[propertyCount] = namedObjectProperty{
+				name:  name,
+				value: getPropertyValue(rightProp),
+			}
+			propertyCount++
+		}
+
+		for _, leftProp := range leftProps {
+			leftName, ok := getPropertyKeyName(leftProp)
+			if !ok {
+				continue
+			}
+			leftValue := getPropertyValue(leftProp)
+			for i := range propertyCount {
+				if properties[i].name == leftName {
+					eachSelfAssignment(leftValue, properties[i].value, props, report)
+				}
+			}
+		}
+		return
+	}
+
+	nextProperty := make([]int, len(rightProps))
+	propertiesByName := make(map[string]int, len(rightProps))
+	for i := len(rightProps) - 1; i >= 0; i-- {
+		name, ok := getPropertyKeyName(rightProps[i])
+		if !ok {
+			continue
+		}
+		next := -1
+		if head, exists := propertiesByName[name]; exists {
+			next = head
+		}
+		nextProperty[i] = next
+		propertiesByName[name] = i
+	}
+
+	for _, leftProp := range leftProps {
+		name, ok := getPropertyKeyName(leftProp)
+		if !ok {
+			continue
+		}
+		leftValue := getPropertyValue(leftProp)
+		i, exists := propertiesByName[name]
+		if !exists {
+			continue
+		}
+		for i >= 0 {
+			eachSelfAssignment(leftValue, getPropertyValue(rightProps[i]), props, report)
+			i = nextProperty[i]
+		}
+	}
+}
+
+// getPropertyKeyName returns the static property name for a property assignment
+// or shorthand property. The boolean distinguishes a valid empty-string key
+// from a property whose name cannot be determined statically.
+func getPropertyKeyName(prop *ast.Node) (string, bool) {
 	if prop == nil {
-		return ""
+		return "", false
 	}
 
 	switch prop.Kind {
 	case ast.KindPropertyAssignment:
 		nameNode := prop.AsPropertyAssignment().Name()
 		if nameNode == nil {
-			return ""
+			return "", false
 		}
 		name, ok := utils.GetStaticPropertyName(nameNode)
 		if !ok {
-			return ""
+			return "", false
 		}
-		return name
+		return name, true
 
 	case ast.KindShorthandPropertyAssignment:
 		nameNode := prop.AsShorthandPropertyAssignment().Name()
 		if nameNode == nil {
-			return ""
+			return "", false
 		}
-		return nameNode.Text()
+		return nameNode.Text(), true
 	}
-	return ""
+	return "", false
 }
 
 // getPropertyValue returns the value node for a property assignment or shorthand property.

--- a/internal/rules/no_self_assign/no_self_assign_test.go
+++ b/internal/rules/no_self_assign/no_self_assign_test.go
@@ -81,6 +81,12 @@ func TestNoSelfAssignRule(t *testing.T) {
 					{MessageId: "selfAssignment", Line: 1, Column: 5},
 				},
 			},
+			{
+				Code: `\u0061 = \u0061`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "selfAssignment", Message: "'\\u0061' is assigned to itself.", Line: 1, Column: 10},
+				},
+			},
 
 			// Array destructuring
 			{
@@ -221,6 +227,61 @@ func TestNoSelfAssignRule(t *testing.T) {
 				Code: `({a, b} = {a, ...x, b})`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "selfAssignment", Line: 1, Column: 21},
+				},
+			},
+			// Continue past an earlier same-name property whose value differs.
+			// ESLint compares every matching right-hand property, including duplicates.
+			{
+				Code: `({a} = {a: other, a, a})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "selfAssignment", Message: "'a' is assigned to itself.", Line: 1, Column: 19},
+					{MessageId: "selfAssignment", Message: "'a' is assigned to itself.", Line: 1, Column: 22},
+				},
+			},
+			// Only properties after the final spread have a statically known value.
+			{
+				Code: `({a} = {a, ...source, a: other, a})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "selfAssignment", Line: 1, Column: 33},
+				},
+			},
+			// An empty string is a valid static property name, not the sentinel for
+			// an unknown computed property.
+			{
+				Code: `({"": value} = {"": value})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "selfAssignment", Message: "'value' is assigned to itself.", Line: 1, Column: 21},
+				},
+			},
+			// Exercise the allocation-free cached path with reversed properties.
+			// Message text verifies that report order still follows left-hand
+			// property order.
+			{
+				Code: `({p00: v00, p01: v01, p02: v02, p03: v03, p04: v04, p05: v05, p06: v06, p07: v07, p08: v08, p09: v09, p10: v10, p11: v11, p12: v12, p13: v13, p14: v14, p15: v15} = {p15: v15, p14: v14, p13: v13, p12: v12, p11: v11, p10: v10, p09: v09, p08: v08, p07: v07, p06: v06, p05: v05, p04: v04, p03: v03, p02: v02, p01: v01, p00: v00})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "selfAssignment", Message: "'v00' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v01' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v02' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v03' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v04' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v05' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v06' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v07' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v08' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v09' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v10' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v11' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v12' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v13' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v14' is assigned to itself."},
+					{MessageId: "selfAssignment", Message: "'v15' is assigned to itself."},
+				},
+			},
+			// Thirty-three right-hand properties cross the indexing threshold.
+			{
+				Code: `({target} = {p00: v00, p01: v01, p02: v02, p03: v03, p04: v04, p05: v05, p06: v06, p07: v07, p08: v08, p09: v09, p10: v10, p11: v11, p12: v12, p13: v13, p14: v14, p15: v15, p16: v16, p17: v17, p18: v18, p19: v19, p20: v20, p21: v21, p22: v22, p23: v23, p24: v24, p25: v25, p26: v26, p27: v27, p28: v28, p29: v29, p30: v30, p31: v31, target})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "selfAssignment", Message: "'target' is assigned to itself."},
 				},
 			},
 


### PR DESCRIPTION
## Summary

- Reuse the diagnostic range and remove message-text whitespace without allocating on compact source, cutting the common report path from 4/4/5 allocations to 2/2/3.
- Cache right-hand object properties for small destructuring assignments and use an order-preserving name index above 32 properties, avoiding repeated quadratic scans for large generated patterns.
- Match ESLint for duplicate right-hand properties and empty-string static keys while preserving spread boundaries, report order, and escaped identifier spelling.

### Benchmark

Apple M1 Max, darwin/arm64, Go 1.26.1. Values are medians of 8 runs with `-benchtime=500ms -count=8 -cpu=1`; the temporary Go benchmark was not committed.

| Case | Before | After | Change | Allocations |
| --- | ---: | ---: | ---: | ---: |
| 32-property object, reversed matches | 3.336 us/op | 2.919 us/op | -12.5% | 0 B / 0 -> 0 B / 0 |
| 128-property object, reversed matches | 41.221 us/op | 8.628 us/op | -79.1% | 0 B / 0 -> 7,592 B / 4 |
| 128-property object, no matches | 60.052 us/op | 7.178 us/op | -88.0% | 0 B / 0 -> 7,592 B / 4 |
| Identifier report | 253.6 ns/op | 169.2 ns/op | -33.3% | 368 B / 4 -> 192 B / 2 |
| Compact member report | 336.7 ns/op | 232.2 ns/op | -31.0% | 384 B / 4 -> 208 B / 2 |
| Spaced member report | 443.2 ns/op | 277.7 ns/op | -37.3% | 464 B / 5 -> 232 B / 3 |

The large-object path intentionally trades four bounded index allocations for linear lookup. Patterns with at most 32 right-hand properties remain allocation-free.

Validation:

- `go test ./internal/rules/no_self_assign -run '^TestNoSelfAssignRule$' -count=1`
- `pnpm check-spell`
- `pnpm format:check`
- `golangci-lint run ./internal/rules/no_self_assign`
- Differential attack against a linear reference for every size from 33 through 128, plus exact diagnostic comparison with ESLint 10.7.0 for duplicate keys, spread boundaries, empty keys, and escaped identifiers

## Related Links

- https://eslint.org/docs/latest/rules/no-self-assign

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
