### PR TITLE
feat: port rule no-unreachable-loop

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -111,6 +111,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unneeded_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unreachable"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unreachable_loop"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
@@ -280,6 +281,7 @@ func GetAllRules() []rule.Rule {
 		no_unsafe_finally.NoUnsafeFinallyRule,
 		no_unmodified_loop_condition.NoUnmodifiedLoopConditionRule,
 		no_unreachable.NoUnreachableRule,
+		no_unreachable_loop.NoUnreachableLoopRule,
 		require_atomic_updates.RequireAtomicUpdatesRule,
 		object_shorthand.ObjectShorthandRule,
 		no_unused_expressions.NoUnusedExpressionsRule,

--- a/internal/rules/no_unreachable_loop/no_unreachable_loop.go
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop.go
@@ -1,0 +1,154 @@
+package no_unreachable_loop
+
+import (
+	_ "embed"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/cfg"
+)
+
+//go:embed no_unreachable_loop.schema.json
+var schemaJSON []byte
+
+var invalidLoop = rule.RuleMessage{
+	Id:          "invalid",
+	Description: "Invalid loop. Its body allows only one iteration.",
+}
+
+// https://eslint.org/docs/latest/rules/no-unreachable-loop
+var NoUnreachableLoopRule = rule.Rule{
+	Name:   "no-unreachable-loop",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		// Only the code paths that contain a loop worth checking need a graph.
+		var rootOrder []*ast.Node
+		seen := make(map[*ast.Node]bool)
+		collect := func(node *ast.Node) {
+			if slices.Contains(opts.ignore, node.Kind) {
+				return
+			}
+			root := cfg.RootOf(node)
+			if root == nil || seen[root] {
+				return
+			}
+			seen[root] = true
+			rootOrder = append(rootOrder, root)
+		}
+
+		listeners := rule.RuleListeners{
+			ast.KindWhileStatement: collect,
+			ast.KindDoStatement:    collect,
+			ast.KindForStatement:   collect,
+			ast.KindForInStatement: collect,
+			ast.KindForOfStatement: collect,
+		}
+		statements := ctx.SourceFile.Statements
+		if statements == nil || len(statements.Nodes) == 0 {
+			return listeners
+		}
+		lastTopLevelNode := statements.Nodes[len(statements.Nodes)-1]
+		listeners[rule.ListenerOnExit(lastTopLevelNode.Kind)] = func(node *ast.Node) {
+			if node == lastTopLevelNode {
+				reportLoops(&ctx, rootOrder, opts)
+			}
+		}
+		return listeners
+	},
+}
+
+// reportLoops lays out each collected code path and reports the loops nothing
+// ever re-enters. ESLint collects across the whole file and reports at the end,
+// so the reports are ordered by position rather than by code path.
+func reportLoops(ctx *rule.RuleContext, rootOrder []*ast.Node, opts ruleOptions) {
+	var reports []*ast.Node
+	for _, root := range rootOrder {
+		reports = append(reports, singleIterationLoops(root, opts)...)
+	}
+	slices.SortFunc(reports, func(a, b *ast.Node) int { return a.Pos() - b.Pos() })
+	for _, loop := range reports {
+		ctx.ReportNode(loop, invalidLoop)
+	}
+}
+
+// singleIterationLoops returns the loops in root whose body allows only one
+// iteration: control reaches the loop, but never flows back into it for a
+// second one. A loop the code path never reaches is left alone — whether its
+// body could repeat says nothing useful about code that does not run.
+//
+// NOTE: Unlike ESLint, a loop wrapped in more than one label repeats when a
+// `continue` names any of them. ESLint attaches only the innermost label to the
+// loop, so `outer: inner: while (foo) { continue outer; }` looks to it like a
+// loop nothing re-enters; internal/utils/cfg keeps the edge, so the loop is
+// accepted.
+//
+// NOTE: Unlike ESLint, a `continue` in a `finally` block repeats the enclosing
+// loop even when the `try` it belongs to can only be left abruptly. That
+// `continue` overrides the pending `return` or `throw`, so `for (;;) { try {
+// return; } finally { continue; } }` really does start a second iteration;
+// ESLint reports it because the loop is missing from the jump's target
+// segments.
+func singleIterationLoops(root *ast.Node, opts ruleOptions) []*ast.Node {
+	var candidates []*ast.Node
+	repeats := make(map[*ast.Node]bool)
+	cfg.Build(root, cfg.Hooks[struct{}]{
+		Statement: func(_ *cfg.Builder[struct{}], node *ast.Node) {
+			if !isLoop(node) || slices.Contains(opts.ignore, node.Kind) {
+				return
+			}
+			if _, known := repeats[node]; !known {
+				// A loop inside a `finally` block is laid out twice; the
+				// candidate list holds it once.
+				candidates = append(candidates, node)
+				repeats[node] = false
+			}
+		},
+		Loop: func(_ *cfg.Builder[struct{}], loop *ast.Node) {
+			repeats[loop] = true
+		},
+	})
+	return slices.DeleteFunc(candidates, func(loop *ast.Node) bool { return repeats[loop] })
+}
+
+func isLoop(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindWhileStatement, ast.KindDoStatement, ast.KindForStatement,
+		ast.KindForInStatement, ast.KindForOfStatement:
+		return true
+	}
+	return false
+}
+
+// loopKinds maps the names the `ignore` option uses — ESLint's ESTree node
+// types — onto the syntax kinds they correspond to.
+var loopKinds = map[string]ast.Kind{
+	"WhileStatement":   ast.KindWhileStatement,
+	"DoWhileStatement": ast.KindDoStatement,
+	"ForStatement":     ast.KindForStatement,
+	"ForInStatement":   ast.KindForInStatement,
+	"ForOfStatement":   ast.KindForOfStatement,
+}
+
+type ruleOptions struct {
+	ignore []ast.Kind
+}
+
+func parseOptions(options []any) ruleOptions {
+	opts := ruleOptions{}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+	ignore, _ := optsMap["ignore"].([]interface{})
+	for _, item := range ignore {
+		name, _ := item.(string)
+		if kind, ok := loopKinds[name]; ok {
+			opts.ignore = append(opts.ignore, kind)
+		}
+	}
+	return opts
+}

--- a/internal/rules/no_unreachable_loop/no_unreachable_loop.md
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop.md
@@ -1,0 +1,82 @@
+# no-unreachable-loop
+
+## Rule Details
+
+Disallows a loop whose body can never run a second time. Every path through the
+body leaves the loop — by `break`, `return`, or `throw` — so the loop is a
+conditional block written as a loop, and the extra iterations it looks like it
+performs never happen. That is usually a mistake: a `break` that belongs inside
+an `if`, a `return` that should collect results instead of leaving on the first
+element, or a condition that was never finished.
+
+A loop iterates again as soon as one path flows back into it, so a `break` or
+`return` guarded by an `if` is fine. A loop the surrounding code can never reach
+is left alone.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+for (let i = 0; i < arr.length; i++) {
+	console.log(arr[i]);
+	break;
+}
+
+while (foo) {
+	doSomething(foo);
+	foo = foo.parent;
+	return;
+}
+
+function find(arr, target) {
+	for (const item of arr) {
+		return item === target;
+	}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+for (let i = 0; i < arr.length; i++) {
+	console.log(arr[i]);
+}
+
+while (foo) {
+	if (bar) {
+		break;
+	}
+	foo = foo.parent;
+}
+
+function find(arr, target) {
+	for (const item of arr) {
+		if (item === target) {
+			return item;
+		}
+	}
+}
+```
+
+## Options
+
+This rule accepts an options object with one property:
+
+### `ignore`
+
+An array of loop types to leave unchecked. Each entry is one of
+`"WhileStatement"`, `"DoWhileStatement"`, `"ForStatement"`,
+`"ForInStatement"`, or `"ForOfStatement"`. It defaults to an empty array.
+
+`{ "ignore": ["ForInStatement", "ForOfStatement"] }` allows the idiom that
+reads only the first entry of a collection:
+
+```javascript
+/* eslint no-unreachable-loop: ["error", { "ignore": ["ForInStatement", "ForOfStatement"] }] */
+
+function firstKey(obj) {
+	for (const key in obj) {
+		return key;
+	}
+	return null;
+}
+```

--- a/internal/rules/no_unreachable_loop/no_unreachable_loop.schema.json
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop.schema.json
@@ -1,0 +1,26 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "ignore": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "WhileStatement",
+              "DoWhileStatement",
+              "ForStatement",
+              "ForInStatement",
+              "ForOfStatement"
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/no_unreachable_loop/no_unreachable_loop_extras_test.go
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop_extras_test.go
@@ -1,0 +1,500 @@
+package no_unreachable_loop
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnreachableLoopExtras covers what the upstream suite cannot: the tsgo
+// node shapes ESTree has no analog for, the code path roots and try/finally
+// layouts internal/utils/cfg lays out differently, every arm of the upstream
+// source its own tests leave untouched, and code shapes real projects write.
+// Every verdict below was taken from ESLint itself, except the six marked as
+// intentional differences.
+func TestNoUnreachableLoopExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnreachableLoopRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: parenthesized and type-wrapped iterables ----
+			// tsgo keeps parentheses and TS type expressions as nodes of their
+			// own; the loop shape underneath has to be recognised through them.
+			{Code: `for (const x of (arr)) foo(x);`},
+			{Code: `for (const x of arr as any[]) foo(x);`},
+
+			// ---- Dimension 4: optional chain ----
+			{Code: `for (const x of obj?.items ?? []) foo(x);`},
+
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `for (const x of arr);`},
+			{Code: `for (const x of arr) {}`},
+
+			// ---- Dimension 4: nesting / traversal boundaries ----
+			// A loop reached only through a `finally` block, which internal/utils/cfg
+			// lays out twice — once for normal completion and once for the path
+			// that leaves the statement abruptly.
+			{Code: `function f() { try { g(); } finally { for (;;) foo(); } }`},
+			{Code: `for (;;) { try { foo(); } finally { continue; } }`},
+			{Code: `outer: { for (;;) foo(); }`},
+
+			// Locks in upstream onCodePathSegmentLoop()'s third state: the loop
+			// event has no entry in loopsByTargetSegments. A `continue` in a
+			// `do`…`while` restarts it at its test, which is not the node the
+			// next iteration begins at — the test passing is what repeats it.
+			{Code: `outer: do { continue outer; } while (a);`},
+			{Code: `do { continue; } while (false);`},
+			{Code: `do { continue; } while (a);`},
+			{Code: `do { foo(); } while (false);`},
+
+			// Locks in upstream onCodePathSegmentLoop() arm `node ===
+			// ContinueStatement`, reached from inside a `switch`, and the
+			// unlabelled `break` that leaves only the `switch`.
+			{Code: `for (;;) { switch (a) { case 1: break; } }`},
+			{Code: `for (;;) { switch (a) { case 1: continue; } }`},
+
+			// A suspended generator or awaited promise resumes in the loop, so
+			// the body still completes.
+			{Code: `function* g() { for (;;) { yield 1; } }`},
+			{Code: `async function f() { for (;;) { await x; } }`},
+
+			// Locks in upstream's `isAnySegmentReachable` gate: a loop the code
+			// path never reaches is not a candidate, however its body looks.
+			{Code: `function f() { return; for (;;) break; }`},
+			{Code: `function f() { throw e; while (a) break; }`},
+			{Code: `while (true); for (;;) break;`},
+			{Code: `while (1n); for (;;) break;`},
+			{Code: `while (0x1n); for (;;) break;`},
+			{Code: `while (0x10000000000000000n); for (;;) break;`},
+
+			// ---- Real-user: reading only the first entry of a collection ----
+			// The idiom the `ignore` option exists for.
+			{
+				Code:    `function firstKey(obj) { for (const k in obj) { return k; } return null; }`,
+				Options: map[string]interface{}{"ignore": []interface{}{"ForInStatement"}},
+			},
+
+			// ---- Real-user: a guard that only sometimes leaves the loop ----
+			{Code: `for (const x of items) { if (x.done) break; visit(x); }`},
+			{Code: `function find(items, t) { for (const x of items) { if (x === t) return x; } }`},
+			{Code: `async function retry(n) { for (let i = 0; i < n; i++) { try { return await run(); } catch (e) { continue; } } }`},
+
+			// ---- Intentional difference from ESLint ----
+			// A `continue` naming a label the loop carries alongside another one
+			// still starts a new iteration, so the loop is not limited to one.
+			// ESLint reports these: its code path analysis attaches only the
+			// innermost label to the loop, so the jump misses the loop it names.
+			{Code: `outer: inner: while (a) { continue outer; }`},
+			{Code: `outer: inner: do { continue outer; } while (a);`},
+			{Code: `a: b: c: for (;;) { continue a; }`},
+			{Code: `outer: inner: for (const x of arr) { continue outer; }`},
+
+			// ---- Intentional difference from ESLint ----
+			// A `continue` in a `finally` block overrides the `return` or `throw`
+			// that left the `try`, so control really does flow back into the loop
+			// and a second iteration begins. ESLint reports these; its code path
+			// analysis leaves the loop out of the jump's target segments once the
+			// `try` can only be left abruptly.
+			{Code: `function f() { for (;;) { try { return; } finally { continue; } } }`},
+			{Code: `for (;;) { try { throw e; } finally { continue; } }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized and type-wrapped iterables ----
+			{
+				Code: `for (const x of (arr)) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code: `for (const x of ((arr))) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 32},
+				},
+			},
+			{
+				Code: `while ((a)) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code: `for (const x of arr!) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				Code: `for (const x of arr as any[]) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code: `for (const x of (arr satisfies string[])) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 49},
+				},
+			},
+
+			// ---- Dimension 4: optional chain ----
+			{
+				Code: `for (const x of obj?.items ?? []) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 41},
+				},
+			},
+			{
+				Code: `for (const x of obj?.get?.() ?? []) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 43},
+				},
+			},
+
+			// ---- Dimension 4: binding and assignment target forms ----
+			// N/A: identifier / string-literal / numeric-literal / private /
+			// computed key forms — a loop has no key or member name to match on.
+			{
+				Code: `for (const [a, b] of pairs) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code: `for (const { a } of items) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `for (const { a = 1 } of items) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				Code: `for (const [a, ...rest] of items) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 41},
+				},
+			},
+			{
+				Code: `for (obj[key] of items) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code: `for (obj.prop in items) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 31},
+				},
+			},
+
+			// ---- Dimension 4: declaration / container forms ----
+			// Every kind of code path root internal/utils/cfg lays out separately.
+			{
+				Code: `const f = () => { for (;;) break; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 19, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `const f = async () => { for await (const x of s) break; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 25, EndLine: 1, EndColumn: 56},
+				},
+			},
+			{
+				Code: `const o = { m() { for (;;) break; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 19, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `class C { m() { for (;;) break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 17, EndLine: 1, EndColumn: 32},
+				},
+			},
+			{
+				Code: `class C { get p() { for (;;) break; return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 21, EndLine: 1, EndColumn: 36},
+				},
+			},
+			{
+				Code: `class C { static { for (;;) break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 20, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code: `class C { p = (() => { for (;;) break; })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 24, EndLine: 1, EndColumn: 39},
+				},
+			},
+			{
+				Code: `function* g() { for (;;) break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 17, EndLine: 1, EndColumn: 32},
+				},
+			},
+			{
+				Code: `async function* g() { for await (const x of s) break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 23, EndLine: 1, EndColumn: 54},
+				},
+			},
+			{
+				Code: `const C = class { m() { for (;;) break; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 25, EndLine: 1, EndColumn: 40},
+				},
+			},
+
+			// ---- Dimension 4: nesting / traversal boundaries ----
+			// A loop in a nested function belongs to that function's code path,
+			// not the enclosing loop's, so neither verdict leaks into the other.
+			{
+				Code: `for (;;) { (function () { for (;;) break; })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 27, EndLine: 1, EndColumn: 42},
+				},
+			},
+			{
+				Code: `for (;;) { (function () { for (;;) foo(); })(); break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 57},
+				},
+			},
+			// Reports from separate code paths are ordered by position, not by
+			// the order the code paths were laid out.
+			{
+				Code: `function a() { for (;;) break; } for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 16, EndLine: 1, EndColumn: 31},
+					{MessageId: "invalid", Line: 1, Column: 34, EndLine: 1, EndColumn: 49},
+				},
+			},
+			{
+				Code: `for (;;) { foo(); } function a() { for (;;) break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 36, EndLine: 1, EndColumn: 51},
+				},
+			},
+
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code: `for (const {} of arr) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				Code: `lbl: for (;;) break lbl;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 6, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// N/A: autofix boundaries (Dimension 3) — this rule only reports.
+
+			// ---- A zero test in every BigInt spelling ----
+			// A falsy test leaves the loop, so what follows it stays reachable
+			// and is a candidate of its own.
+			{
+				Code: `while (0n); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 13, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				Code: `while (0x0n); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 15, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code: `while (0X0n); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 15, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code: `while (0x00n); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 16, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code: `while (0x0_0n); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 17, EndLine: 1, EndColumn: 32},
+				},
+			},
+			{
+				Code: `while (0b0n); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 15, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code: `while (0o0n); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 15, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code: `for (;0x0n;); for (;;) break;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 15, EndLine: 1, EndColumn: 30},
+				},
+			},
+
+			// ---- A loop that a `finally` block lays out twice ----
+			// The second copy runs on the path that leaves the `try` statement
+			// abruptly; the loop is one candidate, not two.
+			{
+				Code: `function f() { try { g(); } finally { for (;;) break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 39, EndLine: 1, EndColumn: 54},
+				},
+			},
+			{
+				Code: `function f() { try { return g(); } finally { for (;;) break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 46, EndLine: 1, EndColumn: 61},
+				},
+			},
+			{
+				Code: `function f() { for (;;) { try { break; } catch (e) { continue; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 16, EndLine: 1, EndColumn: 67},
+				},
+			},
+			{
+				Code: `for (;;) { try { foo(); } finally { break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 47},
+				},
+			},
+
+			// ---- Labelled jump targets ----
+			{
+				Code: `outer: { for (;;) break outer; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 10, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code: `outer: for (;;) { inner: for (;;) { continue outer; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 26, EndLine: 1, EndColumn: 54},
+				},
+			},
+			{
+				Code: `outer: for (;;) { for (;;) { break outer; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 8, EndLine: 1, EndColumn: 46},
+					{MessageId: "invalid", Line: 1, Column: 19, EndLine: 1, EndColumn: 44},
+				},
+			},
+
+			// Locks in upstream isLoopingTarget()'s DoWhileStatement arm: the
+			// loop repeats from its test, so a body that never reaches the test
+			// is the only way a `do`…`while` runs once.
+			{
+				Code: `do { break; } while (false);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 29},
+				},
+			},
+
+			// A `switch` every clause of which exits leaves nothing to fall
+			// through to the end of the body.
+			{
+				Code: `function f() { for (;;) { switch (a) { case 1: return; default: throw e; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 16, EndLine: 1, EndColumn: 77},
+				},
+			},
+			{
+				Code: `function* g() { for (;;) { yield 1; break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 17, EndLine: 1, EndColumn: 45},
+				},
+			},
+			{
+				Code: `async function f() { for (;;) { await x; break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 22, EndLine: 1, EndColumn: 50},
+				},
+			},
+
+			// ---- Every arm of the `ignore` option ----
+			{
+				Code:    `while (a) break;`,
+				Options: map[string]interface{}{"ignore": []interface{}{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    `while (a) break; for (;;) break;`,
+				Options: map[string]interface{}{"ignore": []interface{}{"ForStatement"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    `while (a) break; do break; while (b);`,
+				Options: map[string]interface{}{"ignore": []interface{}{"WhileStatement"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 18, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// An ignored loop still shapes the code path around the loops that
+			// are checked.
+			{
+				Code:    `for (;;) { while (a) break; break; }`,
+				Options: map[string]interface{}{"ignore": []interface{}{"WhileStatement"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 37},
+				},
+			},
+
+			// A loop after a `break` is unreachable and so not a candidate; the
+			// loop around it still is.
+			{
+				Code: `for (;;) { break; while (a) break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 1, EndLine: 1, EndColumn: 37},
+				},
+			},
+
+			// ---- Real-user: reading only the first entry of a collection ----
+			{
+				Code: `function firstKey(obj) { for (const k in obj) { return k; } return null; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 26, EndLine: 1, EndColumn: 60},
+				},
+			},
+			{
+				Code: `function hasAny(obj) { for (const k in obj) { return true; } return false; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 24, EndLine: 1, EndColumn: 61},
+				},
+			},
+			{
+				Code: `function first(gen) { for (const v of gen()) { return v; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 23, EndLine: 1, EndColumn: 59},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_unreachable_loop/no_unreachable_loop_upstream_test.go
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop_upstream_test.go
@@ -1,0 +1,364 @@
+package no_unreachable_loop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// loopTemplates, validLoopBodies, and invalidLoopBodies mirror upstream's
+// tests/lib/rules/no-unreachable-loop.js, which builds its basic cases as the
+// cross product of every loop shape and every body.
+var loopTemplates = []struct {
+	kind      string
+	templates []string
+}{
+	{"WhileStatement", []string{
+		"while (a) <body>",
+		"while (a && b) <body>",
+	}},
+	{"DoWhileStatement", []string{
+		"do <body> while (a)",
+		"do <body> while (a && b)",
+	}},
+	{"ForStatement", []string{
+		"for (a; b; c) <body>",
+		"for (var i = 0; i < a.length; i++) <body>",
+		"for (; b; c) <body>",
+		"for (; b < foo; c++) <body>",
+		"for (a; ; c) <body>",
+		"for (a = 0; ; c++) <body>",
+		"for (a; b;) <body>",
+		"for (a = 0; b < foo; ) <body>",
+		"for (; ; c) <body>",
+		"for (; ; c++) <body>",
+		"for (; b;) <body>",
+		"for (; b < foo; ) <body>",
+		"for (a; ;) <body>",
+		"for (a = 0; ;) <body>",
+		"for (;;) <body>",
+	}},
+	{"ForInStatement", []string{
+		"for (a in b) <body>",
+		"for (a in f(b)) <body>",
+		"for (var a in b) <body>",
+		"for (let a in f(b)) <body>",
+	}},
+	{"ForOfStatement", []string{
+		"for (a of b) <body>",
+		"for (a of f(b)) <body>",
+		"for ({ a, b } of c) <body>",
+		"for (var a of f(b)) <body>",
+		"async function foo() { for await (const a of b) <body> }",
+	}},
+}
+
+var validLoopBodies = []string{
+	";",
+	"{}",
+	"{ bar(); }",
+	"continue;",
+	"{ continue; }",
+	"{ if (foo) break; }",
+	"{ if (foo) { return; } bar(); }",
+	"{ if (foo) { bar(); } else { break; } }",
+	"{ if (foo) { continue; } return; }",
+	"{ switch (foo) { case 1: return; } }",
+	"{ switch (foo) { case 1: break; default: return; } }",
+	"{ switch (foo) { case 1: continue; default: return; } throw err; }",
+	"{ try { return bar(); } catch (e) {} }",
+
+	// unreachable break
+	"{ continue; break; }",
+
+	// functions in loops
+	"() => a;",
+	"{ () => a }",
+	"(() => a)();",
+	"{ (() => a)() }",
+
+	// loops in loops
+	"while (a);",
+	"do ; while (a)",
+	"for (a; b; c);",
+	"for (; b;);",
+	"for (; ; c) if (foo) break;",
+	"for (;;) if (foo) break;",
+	"while (true) if (foo) break;",
+	"while (foo) if (bar) return;",
+	"for (a in b);",
+	"for (a of b);",
+}
+
+var invalidLoopBodies = []string{
+	"break;",
+	"{ break; }",
+	"return;",
+	"{ return; }",
+	"throw err;",
+	"{ throw err; }",
+	"{ foo(); break; }",
+	"{ break; foo(); }",
+	"if (foo) break; else return;",
+	"{ if (foo) { return; } else { break; } bar(); }",
+	"{ if (foo) { return; } throw err; }",
+	"{ switch (foo) { default: throw err; } }",
+	"{ switch (foo) { case 1: throw err; default: return; } }",
+	"{ switch (foo) { case 1: something(); default: return; } }",
+	"{ try { return bar(); } catch (e) { break; } }",
+
+	// unreachable continue
+	"{ break; continue; }",
+
+	// functions in loops
+	"{ () => a; break; }",
+	"{ (() => a)(); break; }",
+
+	// loops in loops
+	"{ while (a); break; }",
+	"{ do ; while (a) break; }",
+	"{ for (a; b; c); break; }",
+	"{ for (; b;); break; }",
+	"{ for (; ; c) if (foo) break; break; }",
+	"{ for(;;) if (foo) break; break; }",
+	"{ for (a in b); break; }",
+	"{ for (a of b); break; }",
+
+	// Additional cases where code path analysis detects unreachable code: after
+	// loops that don't have a test condition or have a constant truthy test
+	// condition, and at the same time don't have any exit statements in the
+	// body. These are special cases where this rule reports an error not
+	// because the outer loop's body exits in all paths, but because it has an
+	// infinite loop inside, thus it (the outer loop) cannot have more than one
+	// iteration.
+	"for (;;);",
+	"{ for (var i = 0; ; i< 10) { foo(); } }",
+	"while (true);",
+}
+
+// getSourceCode mirrors upstream's helper of the same name: a body that returns
+// needs a function around it, unless the template already provides one.
+func getSourceCode(template, body string) string {
+	loop := strings.Replace(template, "<body>", body, 1)
+	if strings.Contains(body, "return") && !strings.Contains(template, "function") {
+		return "function someFunc() { " + loop + " }"
+	}
+	return loop
+}
+
+func basicValidTests() []rule_tester.ValidTestCase {
+	var cases []rule_tester.ValidTestCase
+	for _, group := range loopTemplates {
+		for _, template := range group.templates {
+			for _, body := range validLoopBodies {
+				cases = append(cases, rule_tester.ValidTestCase{Code: getSourceCode(template, body)})
+			}
+		}
+	}
+	return cases
+}
+
+func basicInvalidTests() []rule_tester.InvalidTestCase {
+	var cases []rule_tester.InvalidTestCase
+	for _, group := range loopTemplates {
+		for _, template := range group.templates {
+			for _, body := range invalidLoopBodies {
+				cases = append(cases, rule_tester.InvalidTestCase{
+					Code:   getSourceCode(template, body),
+					Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalid"}},
+				})
+			}
+		}
+	}
+	return cases
+}
+
+func TestNoUnreachableLoopUpstream(t *testing.T) {
+	valid := append(basicValidTests(), []rule_tester.ValidTestCase{
+		// out of scope for the code path analysis and consequently out of scope for this rule
+		{Code: `while (false) { foo(); }`},
+		{Code: `while (bar) { foo(); if (true) { break; } }`},
+		{Code: `do foo(); while (false)`},
+		{Code: `for (x = 1; x < 10; i++) { if (x > 0) { foo(); throw err; } }`},
+		{Code: `for (x of []);`},
+		{Code: `for (x of [1]);`},
+
+		// doesn't report unreachable loop statements, regardless of whether they would be valid or not in a reachable position
+		{Code: `function foo() { return; while (a); }`},
+		{Code: `function foo() { return; while (a) break; }`},
+		{Code: `while(true); while(true);`},
+		{Code: `while(true); while(true) break;`},
+
+		// "ignore"
+		{
+			Code:    `while (a) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"WhileStatement"}},
+		},
+		{
+			Code:    `do break; while (a)`,
+			Options: map[string]interface{}{"ignore": []interface{}{"DoWhileStatement"}},
+		},
+		{
+			Code:    `for (a; b; c) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"ForStatement"}},
+		},
+		{
+			Code:    `for (a in b) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"ForInStatement"}},
+		},
+		{
+			Code:    `for (a of b) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"ForOfStatement"}},
+		},
+		{
+			Code:    `for (var key in obj) { hasEnumerableProperties = true; break; } for (const a of b) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"ForInStatement", "ForOfStatement"}},
+		},
+		{
+			Code: `while (a) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{
+				"WhileStatement",
+				"DoWhileStatement",
+				"ForStatement",
+				"ForInStatement",
+				"ForOfStatement",
+			}},
+		},
+	}...)
+
+	invalid := append(basicInvalidTests(), []rule_tester.InvalidTestCase{
+		// invalid loop nested in a valid loop (valid in valid, and valid in invalid are covered by basic tests)
+		{
+			Code: `while (foo) { for (a of b) { if (baz) { break; } else { throw err; } } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code: `lbl: for (var i = 0; i < 10; i++) { while (foo) break lbl; } /* outer is valid because inner can have 0 iterations */`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+
+		// invalid loop nested in another invalid loop
+		{
+			Code: `for (a in b) { while (foo) { if(baz) { break; } else { break; } } break; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+			},
+		},
+
+		// loop and nested loop both invalid because of the same exit statement
+		{
+			Code: `function foo() { for (var i = 0; i < 10; i++) { do { return; } while(i) } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code: `lbl: while(foo) { do { break lbl; } while(baz) }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+			},
+		},
+
+		// inner loop has continue, but to an outer loop
+		{
+			Code: `lbl: for (a in b) { while(foo) { continue lbl; } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+
+		// edge cases - inner loop has only one exit path, but at the same time it exits the outer loop in the first iteration
+		{
+			Code: `for (a of b) { for(;;) { if (foo) { throw err; } } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code: `function foo () { for (a in b) { while (true) { if (bar) { return; } } } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+
+		// edge cases where parts of the loops belong to the same code path segment, tests for false negatives
+		{
+			Code: `do for (var i = 1; i < 10; i++) break; while(foo)`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code: `do { for (var i = 1; i < 10; i++) continue; break; } while(foo)`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code: `for (;;) { for (var i = 1; i < 10; i ++) break; if (foo) break; continue; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid", Column: 12},
+			},
+		},
+
+		// "ignore"
+		{
+			Code:    `while (a) break; do break; while (b); for (;;) break; for (c in d) break; for (e of f) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code:    `while (a) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"DoWhileStatement"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code:    `do break; while (a)`,
+			Options: map[string]interface{}{"ignore": []interface{}{"WhileStatement"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code:    `for (a in b) break; for (c of d) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"ForStatement"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+				{MessageId: "invalid"},
+			},
+		},
+		{
+			Code:    `for (a in b) break; for (;;) break; for (c of d) break;`,
+			Options: map[string]interface{}{"ignore": []interface{}{"ForInStatement", "ForOfStatement"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalid"},
+			},
+		},
+	}...)
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnreachableLoopRule,
+		valid,
+		invalid,
+	)
+}

--- a/internal/utils/cfg/cfg.go
+++ b/internal/utils/cfg/cfg.go
@@ -48,15 +48,21 @@ type Graph[E any] struct {
 	Blocks []*Block[E]
 }
 
-// Hooks are the points where a consumer turns a reference into an event. Read
-// runs where node is evaluated as a read, Write where its value is stored; a
-// target that is read before it is written — a compound assignment, an update
-// expression, a destructuring element — sees both, in that order. Either may be
-// nil. Both are called only from a reachable position, so Builder.Emit always
-// lands somewhere.
+// Hooks are the points where a consumer turns a position in the walk into an
+// event. Every hook may be nil, and every one is called only from a position
+// control can reach, so Builder.Emit always lands somewhere.
+//
+// Read runs where node is evaluated as a read, Write where its value is stored;
+// a target that is read before it is written — a compound assignment, an update
+// expression, a destructuring element — sees both, in that order.
+//
+// Statement runs as each statement is reached, before it is laid out. Loop runs
+// where control flows back into a loop for another iteration of it.
 type Hooks[E any] struct {
-	Read  func(b *Builder[E], node *ast.Node)
-	Write func(b *Builder[E], node *ast.Node)
+	Read      func(b *Builder[E], node *ast.Node)
+	Write     func(b *Builder[E], node *ast.Node)
+	Statement func(b *Builder[E], node *ast.Node)
+	Loop      func(b *Builder[E], loop *ast.Node)
 }
 
 // tryPosition is where in a `try` statement construction currently is.
@@ -84,11 +90,15 @@ type tryFrame[E any] struct {
 // switch statements, and false for a labelled statement that wraps neither, so
 // an unlabelled `break` skips past it to the enclosing loop/switch. labels
 // holds every label the target answers to — a loop wrapped as
-// `outer: inner: while (…)` accepts both names.
+// `outer: inner: while (…)` accepts both names. loop names the loop a
+// `continue` starts another iteration of, and is nil where continuing does not
+// re-enter the loop's first node: a `do`…`while` continues into its test, which
+// may still end the loop.
 type jumpTarget[E any] struct {
 	labels     []string
 	breakTo    *Block[E]
 	continueTo *Block[E]
+	loop       *ast.Node
 	breakable  bool
 }
 
@@ -209,6 +219,18 @@ func (b *Builder[E]) read(node *ast.Node) {
 func (b *Builder[E]) write(node *ast.Node) {
 	if b.hooks.Write != nil {
 		b.hooks.Write(b, node)
+	}
+}
+
+func (b *Builder[E]) reachedStatement(node *ast.Node) {
+	if b.hooks.Statement != nil {
+		b.hooks.Statement(b, node)
+	}
+}
+
+func (b *Builder[E]) loop(node *ast.Node) {
+	if b.hooks.Loop != nil && b.cur != nil && node != nil {
+		b.hooks.Loop(b, node)
 	}
 }
 

--- a/internal/utils/cfg/helpers.go
+++ b/internal/utils/cfg/helpers.go
@@ -50,8 +50,7 @@ func isAlwaysTruthyTest(node *ast.Node) bool {
 	case ast.KindNumericLiteral:
 		return utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text) != "0"
 	case ast.KindBigIntLiteral:
-		text := node.AsBigIntLiteral().Text
-		return text != "0n" && text != "0"
+		return utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text) != "0"
 	case ast.KindStringLiteral:
 		return node.AsStringLiteral().Text != ""
 	}

--- a/internal/utils/cfg/statements.go
+++ b/internal/utils/cfg/statements.go
@@ -19,6 +19,7 @@ func (b *Builder[E]) statement(node *ast.Node) {
 	if node == nil || b.cur == nil {
 		return
 	}
+	b.reachedStatement(node)
 
 	switch node.Kind {
 	case ast.KindBlock:
@@ -178,9 +179,10 @@ func (b *Builder[E]) whileStatement(node *ast.Node) {
 	body := b.newBlock()
 	b.link(testEnd, body)
 
-	b.pushJump(node, after, test)
+	b.pushJump(node, after, test, node)
 	b.enter(body)
 	b.statement(stmt.Statement)
+	b.loop(node)
 	b.link(b.cur, test)
 	b.popJump()
 
@@ -194,7 +196,9 @@ func (b *Builder[E]) doStatement(node *ast.Node) {
 	test := b.newBlock()
 	after := b.newBlock()
 
-	b.pushJump(node, after, test)
+	// A `continue` restarts a `do`…`while` at its test, not at its body, so it
+	// is not what starts another iteration — the test passing is.
+	b.pushJump(node, after, test, nil)
 	b.enter(body)
 	b.statement(stmt.Statement)
 	b.link(b.cur, test)
@@ -203,6 +207,7 @@ func (b *Builder[E]) doStatement(node *ast.Node) {
 	b.enter(test)
 	b.expr(stmt.Expression)
 	if b.cur != nil {
+		b.loop(node)
 		b.link(b.cur, body)
 		if !isAlwaysTruthyTest(stmt.Expression) {
 			b.link(b.cur, after)
@@ -242,9 +247,10 @@ func (b *Builder[E]) forStatement(node *ast.Node) {
 		update = b.newBlock()
 	}
 
-	b.pushJump(node, after, update)
+	b.pushJump(node, after, update, node)
 	b.enter(body)
 	b.statement(stmt.Statement)
+	b.loop(node)
 	b.link(b.cur, update)
 	b.popJump()
 
@@ -270,7 +276,7 @@ func (b *Builder[E]) forInOfStatement(node *ast.Node) {
 	body := b.newBlock()
 	b.link(head, body)
 
-	b.pushJump(node, after, head)
+	b.pushJump(node, after, head, node)
 	b.enter(body)
 	if stmt.Initializer != nil {
 		// The loop variable takes its value from the iteration, so it binds
@@ -288,6 +294,7 @@ func (b *Builder[E]) forInOfStatement(node *ast.Node) {
 		}
 	}
 	b.statement(stmt.Statement)
+	b.loop(node)
 	b.link(b.cur, head)
 	b.popJump()
 
@@ -345,7 +352,7 @@ func (b *Builder[E]) switchStatement(node *ast.Node) {
 		}
 	}
 
-	b.pushJump(node, after, nil)
+	b.pushJump(node, after, nil, nil)
 	var fallthroughFrom *Block[E]
 	for i, clause := range clauses {
 		b.link(fallthroughFrom, bodies[i])
@@ -467,8 +474,8 @@ func (b *Builder[E]) labeledStatement(node *ast.Node) {
 	b.enter(after)
 }
 
-func (b *Builder[E]) pushJump(node *ast.Node, breakTo, continueTo *Block[E]) {
-	b.jumps = append(b.jumps, jumpTarget[E]{labels: labelsOf(node), breakTo: breakTo, continueTo: continueTo, breakable: true})
+func (b *Builder[E]) pushJump(node *ast.Node, breakTo, continueTo *Block[E], loop *ast.Node) {
+	b.jumps = append(b.jumps, jumpTarget[E]{labels: labelsOf(node), breakTo: breakTo, continueTo: continueTo, loop: loop, breakable: true})
 }
 
 func (b *Builder[E]) popJump() {
@@ -512,6 +519,7 @@ func (b *Builder[E]) makeContinue(label *ast.Node) {
 			continue
 		}
 		if name == "" || slices.Contains(target.labels, name) {
+			b.loop(target.loop)
 			b.link(b.cur, target.continueTo)
 			break
 		}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -440,6 +440,7 @@ export default defineConfig({
     './tests/eslint/rules/no-obj-calls.test.ts',
     './tests/eslint/rules/no-setter-return.test.ts',
     './tests/eslint/rules/no-unreachable.test.ts',
+    './tests/eslint/rules/no-unreachable-loop.test.ts',
     './tests/eslint/rules/no-unsafe-finally.test.ts',
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-throw-literal.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unreachable-loop.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unreachable-loop.test.ts.snap
@@ -1,0 +1,730 @@
+// Rstest Snapshot v1
+
+exports[`no-unreachable-loop > invalid 1`] = `
+{
+  "code": "while (a) break;",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 2`] = `
+{
+  "code": "do break; while (a)",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 3`] = `
+{
+  "code": "for (a; b; c) { foo(); break; }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 4`] = `
+{
+  "code": "for (;;) throw err;",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 5`] = `
+{
+  "code": "for (a in b) break;",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 6`] = `
+{
+  "code": "for (a of b) break;",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 7`] = `
+{
+  "code": "function someFunc() { while (a) { if (foo) { return; } else { break; } bar(); } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 8`] = `
+{
+  "code": "while (a) { switch (foo) { case 1: throw err; default: return; } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 9`] = `
+{
+  "code": "while (a) { try { return bar(); } catch (e) { break; } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 10`] = `
+{
+  "code": "while (a) for (;;);",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 11`] = `
+{
+  "code": "while (foo) { for (a of b) { if (baz) { break; } else { throw err; } } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 12`] = `
+{
+  "code": "lbl: for (var i = 0; i < 10; i++) { while (foo) break lbl; } /* outer is valid because inner can have 0 iterations */",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 13`] = `
+{
+  "code": "for (a in b) { while (foo) { if(baz) { break; } else { break; } } break; }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 14`] = `
+{
+  "code": "function foo() { for (var i = 0; i < 10; i++) { do { return; } while(i) } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 15`] = `
+{
+  "code": "lbl: while(foo) { do { break lbl; } while(baz) }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 16`] = `
+{
+  "code": "lbl: for (a in b) { while(foo) { continue lbl; } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 17`] = `
+{
+  "code": "for (a of b) { for(;;) { if (foo) { throw err; } } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 18`] = `
+{
+  "code": "function foo () { for (a in b) { while (true) { if (bar) { return; } } } }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 19`] = `
+{
+  "code": "do for (var i = 1; i < 10; i++) break; while(foo)",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 20`] = `
+{
+  "code": "do { for (var i = 1; i < 10; i++) continue; break; } while(foo)",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 21`] = `
+{
+  "code": "for (;;) { for (var i = 1; i < 10; i ++) break; if (foo) break; continue; }",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 22`] = `
+{
+  "code": "while (a) break; do break; while (b); for (;;) break; for (c in d) break; for (e of f) break;",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 94,
+          "line": 1,
+        },
+        "start": {
+          "column": 75,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 23`] = `
+{
+  "code": "while (a) break;",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable-loop > invalid 24`] = `
+{
+  "code": "for (a in b) break; for (;;) break; for (c of d) break;",
+  "diagnostics": [
+    {
+      "message": "Invalid loop. Its body allows only one iteration.",
+      "messageId": "invalid",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable-loop",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unreachable-loop.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unreachable-loop.test.ts
@@ -1,0 +1,187 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unreachable-loop', {
+  valid: [
+    // one body shape per loop kind
+    'while (a) { bar(); }',
+    'while (a) { continue; }',
+    'while (a) { if (foo) break; }',
+    'do { bar(); } while (a)',
+    'do { continue; } while (a)',
+    'for (a; b; c) { bar(); }',
+    'for (var i = 0; i < a.length; i++) { if (foo) break; }',
+    'for (;;) { continue; }',
+    'for (a in b) { bar(); }',
+    'for (a of b) { if (foo) break; }',
+    'async function foo() { for await (const a of b) { bar(); } }',
+    'function someFunc() { while (a) { if (foo) { return; } bar(); } }',
+    'while (a) { switch (foo) { case 1: continue; default: return; } throw err; }',
+    'while (a) { try { return bar(); } catch (e) {} }',
+
+    // out of scope for the code path analysis and consequently out of scope for this rule
+    'while (false) { foo(); }',
+    'while (bar) { foo(); if (true) { break; } }',
+    'do foo(); while (false)',
+    'for (x = 1; x < 10; i++) { if (x > 0) { foo(); throw err; } }',
+    'for (x of []);',
+    'for (x of [1]);',
+
+    // doesn't report unreachable loop statements, regardless of whether they would be valid or not in a reachable position
+    'function foo() { return; while (a); }',
+    'function foo() { return; while (a) break; }',
+    'while(true); while(true);',
+    'while(true); while(true) break;',
+
+    // "ignore"
+    {
+      code: 'while (a) break;',
+      options: [{ ignore: ['WhileStatement'] }] as any,
+    },
+    {
+      code: 'do break; while (a)',
+      options: [{ ignore: ['DoWhileStatement'] }] as any,
+    },
+    {
+      code: 'for (a; b; c) break;',
+      options: [{ ignore: ['ForStatement'] }] as any,
+    },
+    {
+      code: 'for (a in b) break;',
+      options: [{ ignore: ['ForInStatement'] }] as any,
+    },
+    {
+      code: 'for (a of b) break;',
+      options: [{ ignore: ['ForOfStatement'] }] as any,
+    },
+    {
+      code: 'for (var key in obj) { hasEnumerableProperties = true; break; } for (const a of b) break;',
+      options: [{ ignore: ['ForInStatement', 'ForOfStatement'] }] as any,
+    },
+  ],
+  invalid: [
+    // one body shape per loop kind
+    {
+      code: 'while (a) break;',
+      errors: [{ messageId: 'invalid', line: 1, column: 1, endColumn: 17 }],
+    },
+    {
+      code: 'do break; while (a)',
+      errors: [{ messageId: 'invalid', line: 1, column: 1, endColumn: 20 }],
+    },
+    {
+      code: 'for (a; b; c) { foo(); break; }',
+      errors: [{ messageId: 'invalid', line: 1, column: 1, endColumn: 32 }],
+    },
+    {
+      code: 'for (;;) throw err;',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'for (a in b) break;',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'for (a of b) break;',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'function someFunc() { while (a) { if (foo) { return; } else { break; } bar(); } }',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'while (a) { switch (foo) { case 1: throw err; default: return; } }',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'while (a) { try { return bar(); } catch (e) { break; } }',
+      errors: [{ messageId: 'invalid' }],
+    },
+
+    // an infinite loop inside means the outer loop cannot have more than one iteration
+    {
+      code: 'while (a) for (;;);',
+      errors: [{ messageId: 'invalid' }],
+    },
+
+    // invalid loop nested in a valid loop (valid in valid, and valid in invalid are covered by basic tests)
+    {
+      code: 'while (foo) { for (a of b) { if (baz) { break; } else { throw err; } } }',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'lbl: for (var i = 0; i < 10; i++) { while (foo) break lbl; } /* outer is valid because inner can have 0 iterations */',
+      errors: [{ messageId: 'invalid' }],
+    },
+
+    // invalid loop nested in another invalid loop
+    {
+      code: 'for (a in b) { while (foo) { if(baz) { break; } else { break; } } break; }',
+      errors: [{ messageId: 'invalid' }, { messageId: 'invalid' }],
+    },
+
+    // loop and nested loop both invalid because of the same exit statement
+    {
+      code: 'function foo() { for (var i = 0; i < 10; i++) { do { return; } while(i) } }',
+      errors: [{ messageId: 'invalid' }, { messageId: 'invalid' }],
+    },
+    {
+      code: 'lbl: while(foo) { do { break lbl; } while(baz) }',
+      errors: [{ messageId: 'invalid' }, { messageId: 'invalid' }],
+    },
+
+    // inner loop has continue, but to an outer loop
+    {
+      code: 'lbl: for (a in b) { while(foo) { continue lbl; } }',
+      errors: [{ messageId: 'invalid' }],
+    },
+
+    // edge cases - inner loop has only one exit path, but at the same time it exits the outer loop in the first iteration
+    {
+      code: 'for (a of b) { for(;;) { if (foo) { throw err; } } }',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'function foo () { for (a in b) { while (true) { if (bar) { return; } } } }',
+      errors: [{ messageId: 'invalid' }],
+    },
+
+    // edge cases where parts of the loops belong to the same code path segment, tests for false negatives
+    {
+      code: 'do for (var i = 1; i < 10; i++) break; while(foo)',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'do { for (var i = 1; i < 10; i++) continue; break; } while(foo)',
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'for (;;) { for (var i = 1; i < 10; i ++) break; if (foo) break; continue; }',
+      errors: [{ messageId: 'invalid', column: 12 }],
+    },
+
+    // "ignore"
+    {
+      code: 'while (a) break; do break; while (b); for (;;) break; for (c in d) break; for (e of f) break;',
+      options: [{ ignore: [] }] as any,
+      errors: [
+        { messageId: 'invalid' },
+        { messageId: 'invalid' },
+        { messageId: 'invalid' },
+        { messageId: 'invalid' },
+        { messageId: 'invalid' },
+      ],
+    },
+    {
+      code: 'while (a) break;',
+      options: [{ ignore: ['DoWhileStatement'] }] as any,
+      errors: [{ messageId: 'invalid' }],
+    },
+    {
+      code: 'for (a in b) break; for (;;) break; for (c of d) break;',
+      options: [{ ignore: ['ForInStatement', 'ForOfStatement'] }] as any,
+      errors: [{ messageId: 'invalid' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unreachable-loop` rule from ESLint. It reports a loop whose body allows only one iteration — control reaches the loop, but no path flows back into it.

- `internal/utils/cfg` gains the two hooks the rule needs: `Statement`, which runs as each statement is reached from a position control can reach, so an unreachable loop is never a candidate; and `Loop`, which runs where control flows back into a loop for another iteration — from the end of its body, from a `continue` naming it, or, for a `do`...`while`, from its test passing.
- `isAlwaysTruthyTest` stops reading BigInt literal text raw. A zero written in any base is falsy, but comparing against `"0n"` only recognised the decimal spelling, so `while (0x0n)` marked the loop infinite.

One behavioral difference from ESLint: a loop carrying more than one label repeats when a `continue` names any of them, so `outer: inner: while (a) { continue outer; }` is accepted.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-unreachable-loop
- Stacked on #1566, which extracts the control-flow graph this rule builds on.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
