### PR TITLE
fix: align error-message static evaluation

### DIFF
--- a/internal/plugins/unicorn/rules/error_message/error_message.go
+++ b/internal/plugins/unicorn/rules/error_message/error_message.go
@@ -69,7 +69,7 @@ var ErrorMessageRule = rule.Rule{
 	Name:   "unicorn/error-message",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		staticStrings := utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile)
+		staticStrings := utils.NewStaticStringEvaluatorWithReferenceResolver(ctx.TypeChecker, ctx.SourceFile, ctx.Refs)
 
 		checkExpression := func(node *ast.Node) {
 			if ast.IsOptionalChain(node) {
@@ -145,13 +145,12 @@ var ErrorMessageRule = rule.Rule{
 				return
 			}
 
-			val, ok := staticStrings.EvalValue(argNode)
-			if !ok {
+			strVal, valueKind := staticStrings.EvalStringValue(argNode)
+			if valueKind == utils.StaticEvalUnknown {
 				return
 			}
 
-			strVal, isString := val.(string)
-			if !isString {
+			if valueKind == utils.StaticEvalNonString {
 				ctx.ReportNode(argNode, notStringMessage)
 				return
 			}

--- a/internal/plugins/unicorn/rules/error_message/error_message.md
+++ b/internal/plugins/unicorn/rules/error_message/error_message.md
@@ -31,5 +31,5 @@ new SuppressedError(error, suppressed, 'message');
 
 ## Original Documentation
 
-- [eslint-plugin-unicorn: error-message](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/error-message.md)
-- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/error-message.js)
+- [eslint-plugin-unicorn: error-message](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/error-message.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/error-message.js)

--- a/internal/plugins/unicorn/rules/error_message/error_message_extras_test.go
+++ b/internal/plugins/unicorn/rules/error_message/error_message_extras_test.go
@@ -74,10 +74,30 @@ func TestErrorMessageExtras(t *testing.T) {
 			jsValid("new Error({...foo}.msg)"),
 			jsValid("new Error(msg += '')"),
 			jsValid("new Error(['a', 'b'].join(''))"),
+			jsValid("new Error([].join(separator))"),
 			jsValid("let Object = {freeze: x => x};\nnew Error(Object.freeze({msg: ''}).msg)"),
+
+			// ---- Mutable aggregate bindings are not stale-folded ----
+			jsValid("const message = [''];\nmessage[0] = 'ok';\nnew Error(message[0])"),
+			jsValid("const message = [''];\nmessage.fill('ok');\nnew Error(message[0])"),
+			jsValid("const method = 'fill';\nconst message = [''];\nmessage[method]('ok');\nnew Error(message[0])"),
+			jsValid("const message = [''];\nmessage[0] += 'ok';\nnew Error(message[0])"),
+			jsValid("const message = [''];\nmessage.join = () => 'ok';\nnew Error(message.join())"),
+			jsValid("const data = {message: ''};\ndata.message = 'ok';\nnew Error(data.message)"),
+
+			// ---- Object literal __proto__ keeps prototype-setter semantics ----
+			jsValid("new Error(({__proto__: {message: 'ok'}}).message)"),
+			jsValid("new Error(({\"__proto__\": {message: 'ok'}}).message)"),
+			jsValid("new Error(String(({__proto__: null})))"),
+			jsValid("new Error(String(({__proto__: 1})))"),
+			jsValid("new Error(({__proto__: /ok/}).source)"),
+
+			// ---- Aggregate assignment snapshots are not folded across later arguments ----
+			jsValid("let value;\nnew Error((value = ['']).join(value[0] = 'ok'))"),
 
 			// ---- A folded array in a template coerces via Array.prototype.join ----
 			jsValid("new Error(`${[1, 2]}`)"),
+			jsValid("new Error([null, undefined].join())"),
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: Parenthesized receiver ----
@@ -108,6 +128,11 @@ func TestErrorMessageExtras(t *testing.T) {
 			invalid("throw new Error({1e3: ''}[1000])", "{1e3: ''}[1000]", messageIDEmpty, msgEmpty),
 			invalid("throw new Error(Object.seal({msg: ''}).msg)", "Object.seal({msg: ''}).msg", messageIDEmpty, msgEmpty),
 			invalid("throw new Error(Object.preventExtensions({msg: 1}).msg)", "Object.preventExtensions({msg: 1}).msg", messageIDNotString, msgNotString),
+			invalid("throw new Error(String?.(''))", "String?.('')", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(Object?.freeze({msg: ''}).msg)", "Object?.freeze({msg: ''}).msg", messageIDEmpty, msgEmpty),
+			invalid("const S = String;\nthrow new Error(S(''))", "S('')", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(Object['freeze']({msg: ''}).msg)", "Object['freeze']({msg: ''}).msg", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(String['raw']``)", "String['raw']``", messageIDEmpty, msgEmpty),
 
 			// ---- Reading a key that is not there folds to `undefined` ----
 			invalid("throw new Error({}.msg)", "{}.msg", messageIDNotString, msgNotString),
@@ -117,6 +142,26 @@ func TestErrorMessageExtras(t *testing.T) {
 
 			// ---- A folded array in a template coerces via Array.prototype.join ----
 			invalid("throw new Error(`${[]}`)", "`${[]}`", messageIDEmpty, msgEmpty),
+
+			// ---- Static Array#join calls ----
+			invalid("throw new Error([].join())", "[].join()", messageIDEmpty, msgEmpty),
+			invalid("throw new Error([''].join())", "[''].join()", messageIDEmpty, msgEmpty),
+			invalid("throw new Error([null, undefined].join(''))", "[null, undefined].join('')", messageIDEmpty, msgEmpty),
+			invalid("const parts = [''];\nthrow new Error(parts.join())", "parts.join()", messageIDEmpty, msgEmpty),
+			invalid("const parts = [''];\nparts.slice();\nthrow new Error(parts[0])", "parts[0]", messageIDEmpty, msgEmpty),
+			invalid("throw new Error([[]].join())", "[[]].join()", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(['', '', ''].join(''))", "['', '', ''].join('')", messageIDEmpty, msgEmpty),
+			invalid("throw new Error([].join(undefined))", "[].join(undefined)", messageIDEmpty, msgEmpty),
+
+			// ---- Object literal __proto__ prototype lookup ----
+			invalid("throw new Error(({__proto__: {message: ''}}).message)", "({__proto__: {message: ''}}).message", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(({__proto__: {__proto__: {message: ''}}}).message)", "({__proto__: {__proto__: {message: ''}}}).message", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(({__proto__: {message: 1}}).message)", "({__proto__: {message: 1}}).message", messageIDNotString, msgNotString),
+			invalid("throw new Error(({__proto__: null}).message)", "({__proto__: null}).message", messageIDNotString, msgNotString),
+			invalid("throw new Error(({__proto__: 1}).message)", "({__proto__: 1}).message", messageIDNotString, msgNotString),
+			invalid("throw new Error(({__proto__: ['']})[0])", "({__proto__: ['']})[0]", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(({__proto__: {message: 'ok'}, message: ''}).message)", "({__proto__: {message: 'ok'}, message: ''}).message", messageIDEmpty, msgEmpty),
+			invalid("throw new Error(({['__proto__']: {message: 'ok'}}).message)", "({['__proto__']: {message: 'ok'}}).message", messageIDNotString, msgNotString),
 
 			// ---- A non-canonical index string is an ordinary property, not an array index ----
 			invalid("throw new Error(['msg']['00'])", "['msg']['00']", messageIDNotString, msgNotString),

--- a/internal/plugins/unicorn/rules/error_message/error_message_upstream_test.go
+++ b/internal/plugins/unicorn/rules/error_message/error_message_upstream_test.go
@@ -1,6 +1,6 @@
 // TestErrorMessageUpstream migrates the full valid/invalid suite from upstream
-// test/error-message.js 1:1. Position assertions cover line/column for every
-// invalid case. rslint-specific lock-in cases live in the
+// v73.0.0 test/error-message.js 1:1. Position assertions cover line/column for
+// every invalid case. rslint-specific lock-in cases live in the
 // error_message_extras_test.go file.
 package error_message_test
 

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -14,12 +14,13 @@ import (
 // Create one evaluator per linted file; it keeps write-reference and recursion
 // state for that file.
 type StaticStringEvaluator struct {
-	typeChecker       *checker.Checker
-	sourceFile        *ast.SourceFile
-	evaluator         evaluator.Evaluator
-	resolving         map[*ast.Symbol]bool
-	writeRefsComputed bool
-	writeRefs         map[*ast.Symbol]bool
+	typeChecker            *checker.Checker
+	sourceFile             *ast.SourceFile
+	referenceResolver      StaticReferenceResolver
+	evaluator              evaluator.Evaluator
+	resolving              map[*ast.Symbol]bool
+	referenceFlagsComputed bool
+	referenceFlags         map[*ast.Symbol]staticReferenceFlags
 }
 
 func NewStaticStringEvaluator(typeChecker *checker.Checker) *StaticStringEvaluator {
@@ -27,10 +28,26 @@ func NewStaticStringEvaluator(typeChecker *checker.Checker) *StaticStringEvaluat
 }
 
 func NewStaticStringEvaluatorWithSourceFile(typeChecker *checker.Checker, sourceFile *ast.SourceFile) *StaticStringEvaluator {
+	return NewStaticStringEvaluatorWithReferenceResolver(typeChecker, sourceFile, nil)
+}
+
+// StaticReferenceResolver is the subset of rule.RefStore used by the evaluator.
+// Supplying it reuses the linter's binder-based symbol resolution while the
+// evaluator performs its single mutation scan.
+type StaticReferenceResolver interface {
+	Resolve(node *ast.Node) *ast.Symbol
+}
+
+func NewStaticStringEvaluatorWithReferenceResolver(
+	typeChecker *checker.Checker,
+	sourceFile *ast.SourceFile,
+	referenceResolver StaticReferenceResolver,
+) *StaticStringEvaluator {
 	staticEvaluator := &StaticStringEvaluator{
-		typeChecker: typeChecker,
-		sourceFile:  sourceFile,
-		resolving:   map[*ast.Symbol]bool{},
+		typeChecker:       typeChecker,
+		sourceFile:        sourceFile,
+		referenceResolver: referenceResolver,
+		resolving:         map[*ast.Symbol]bool{},
 	}
 	staticEvaluator.evaluator = evaluator.NewEvaluator(staticEvaluator.evaluateEntity, ast.OEKAssertions)
 	return staticEvaluator
@@ -39,17 +56,37 @@ func NewStaticStringEvaluatorWithSourceFile(typeChecker *checker.Checker, source
 type staticNullValue struct{}
 type staticUndefinedValue struct{}
 
-// staticObjectValue and staticArrayValue hold folded object and array literals.
-// They exist so member access can be resolved on them; neither converts to a
-// string, so a rule that asks for a string value still gets "not statically
-// known".
+// staticStringNode keeps literal strings backed by their existing AST node so
+// nested aggregate evaluation doesn't allocate an interface box per literal.
+type staticStringNode ast.Node
+
+// staticObjectValue and staticArrayValue hold folded object and array literals
+// so member access and JavaScript's default string coercion can be modeled.
 type staticObjectValue struct {
-	properties map[string]any
+	property        staticObjectProperty
+	extraProperties []staticObjectProperty
+	propertyCount   int
+	prototype       any
+	prototypeSet    bool
+}
+
+type staticObjectProperty struct {
+	name  string
+	value any
 }
 
 type staticArrayValue struct {
-	elements []any
+	length   int
+	inline   [2]any
+	overflow []any
 }
+
+type staticReferenceFlags uint8
+
+const (
+	staticReferenceWrite staticReferenceFlags = 1 << iota
+	staticReferencePropertyMutation
+)
 
 // objectPassThroughMethods are the `Object` methods that return their argument
 // unchanged, so folding can see through them.
@@ -59,10 +96,25 @@ var objectPassThroughMethods = map[string]bool{
 	"seal":              true,
 }
 
+// Static evaluation must not turn a compact expression into an unbounded
+// allocation. The limit is deliberately much larger than a useful diagnostic
+// message while still bounding nested Array#join coercion.
+const maxStaticStringLength = 1 << 20
+
 type staticEvalResult struct {
 	value any
 	ok    bool
 }
+
+// StaticEvalValueKind classifies a static evaluation result for callers that
+// only need to distinguish strings from known non-strings and unknown values.
+type StaticEvalValueKind uint8
+
+const (
+	StaticEvalUnknown StaticEvalValueKind = iota
+	StaticEvalString
+	StaticEvalNonString
+)
 
 // Eval returns the static string value of node, if it can be determined. It
 // covers the string-producing subset of ESLint's getStaticValue that rules use
@@ -78,8 +130,7 @@ func (staticEvaluator *StaticStringEvaluator) Eval(node *ast.Node) (string, bool
 	if !result.ok {
 		return "", false
 	}
-	value, ok := result.value.(string)
-	return value, ok
+	return staticValueAsString(result.value)
 }
 
 // EvalValue returns the static value of node if it can be determined, regardless
@@ -93,7 +144,45 @@ func (staticEvaluator *StaticStringEvaluator) EvalValue(node *ast.Node) (any, bo
 	if !result.ok {
 		return nil, false
 	}
+	if value, ok := staticValueAsString(result.value); ok {
+		return value, true
+	}
 	return result.value, true
+}
+
+// EvalStringValue returns a string without boxing it into an interface, or
+// classifies the result as a known non-string or an unknown value.
+func (staticEvaluator *StaticStringEvaluator) EvalStringValue(node *ast.Node) (string, StaticEvalValueKind) {
+	if staticEvaluator == nil || node == nil {
+		return "", StaticEvalUnknown
+	}
+
+	node = SkipAssertionsAndParens(node)
+	if node == nil {
+		return "", StaticEvalUnknown
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text, StaticEvalString
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text, StaticEvalString
+	case ast.KindCallExpression:
+		if value, matched, ok := staticEvaluator.evalArrayJoin(node); matched {
+			if ok {
+				return value, StaticEvalString
+			}
+			return "", StaticEvalUnknown
+		}
+	}
+
+	result := staticEvaluator.evalValue(node)
+	if !result.ok {
+		return "", StaticEvalUnknown
+	}
+	if value, ok := staticValueAsString(result.value); ok {
+		return value, StaticEvalString
+	}
+	return "", StaticEvalNonString
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEvalResult {
@@ -103,10 +192,8 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 	}
 
 	switch node.Kind {
-	case ast.KindStringLiteral:
-		return staticEvalResult{value: node.AsStringLiteral().Text, ok: true}
-	case ast.KindNoSubstitutionTemplateLiteral:
-		return staticEvalResult{value: node.AsNoSubstitutionTemplateLiteral().Text, ok: true}
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
+		return staticEvalResult{value: (*staticStringNode)(node), ok: true}
 	case ast.KindTrueKeyword:
 		return staticEvalResult{value: true, ok: true}
 	case ast.KindFalseKeyword:
@@ -147,6 +234,9 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 		if result := staticEvaluator.evalStringCall(node); result.ok {
 			return result
 		}
+		if result := staticEvaluator.evalArrayJoinCall(node); result.ok {
+			return result
+		}
 		if result := staticEvaluator.evalObjectPassThroughCall(node); result.ok {
 			return result
 		}
@@ -167,7 +257,21 @@ func (staticEvaluator *StaticStringEvaluator) evalIdentifier(node *ast.Node) sta
 
 	staticEvaluator.resolving[symbol] = true
 	defer delete(staticEvaluator.resolving, symbol)
-	return staticEvaluator.evalValue(initializer)
+
+	if isAggregateLiteral(initializer) && staticEvaluator.hasPropertyMutation(symbol) {
+		return staticEvalResult{}
+	}
+	result := staticEvaluator.evalValue(initializer)
+	if result.ok && staticValueIsAggregate(result.value) &&
+		!isAggregateLiteral(initializer) && staticEvaluator.hasPropertyMutation(symbol) {
+		return staticEvalResult{}
+	}
+	return result
+}
+
+func isAggregateLiteral(node *ast.Node) bool {
+	node = SkipAssertionsAndParens(node)
+	return node != nil && (node.Kind == ast.KindObjectLiteralExpression || node.Kind == ast.KindArrayLiteralExpression)
 }
 
 // ResolveIdentifierInitializer resolves an identifier to a stable variable
@@ -192,7 +296,7 @@ func (staticEvaluator *StaticStringEvaluator) resolveIdentifierInitializer(node 
 		return nil, nil, false
 	}
 
-	symbol := GetReferenceSymbol(expr, staticEvaluator.typeChecker)
+	symbol := staticEvaluator.referenceSymbol(expr)
 	if symbol == nil || len(symbol.Declarations) != 1 {
 		return nil, nil, false
 	}
@@ -261,7 +365,13 @@ func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Nod
 
 	switch binary.OperatorToken.Kind {
 	case ast.KindEqualsToken:
-		return staticEvaluator.evalValue(binary.Right)
+		result := staticEvaluator.evalValue(binary.Right)
+		if result.ok && staticValueIsAggregate(result.value) {
+			// The assigned aggregate can be mutated by another operand or call
+			// argument before the containing expression consumes it.
+			return staticEvalResult{}
+		}
+		return result
 	case ast.KindBarBarToken:
 		left := staticEvaluator.evalValue(binary.Left)
 		if !left.ok {
@@ -303,10 +413,10 @@ func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Nod
 		if !left.ok || !right.ok {
 			return staticEvalResult{}
 		}
-		if _, ok := left.value.(string); ok {
+		if staticValueIsString(left.value) {
 			return staticEvaluator.concatStaticValues(left.value, right.value)
 		}
-		if _, ok := right.value.(string); ok {
+		if staticValueIsString(right.value) {
 			return staticEvaluator.concatStaticValues(left.value, right.value)
 		}
 	}
@@ -369,7 +479,7 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteral(node *ast.Node) 
 		return staticEvalResult{}
 	}
 
-	properties := map[string]any{}
+	value := &staticObjectValue{}
 	for _, property := range object.Properties.Nodes {
 		var valueNode *ast.Node
 		switch property.Kind {
@@ -381,7 +491,104 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteral(node *ast.Node) 
 			return staticEvalResult{}
 		}
 
+		if isObjectLiteralPrototypeSetter(property) {
+			propertyValue := staticEvaluator.evalValue(valueNode)
+			if !propertyValue.ok {
+				return staticEvalResult{}
+			}
+			switch propertyValue.value.(type) {
+			case *staticObjectValue, *staticArrayValue:
+				value.prototype = propertyValue.value
+				value.prototypeSet = true
+			case staticNullValue:
+				value.prototype = nil
+				value.prototypeSet = true
+			default:
+				// JavaScript ignores primitive prototype-setter values.
+			}
+			continue
+		}
+
 		key, ok := staticEvaluator.evalPropertyKey(property.Name())
+		if !ok {
+			return staticEvalResult{}
+		}
+		propertyValue := staticEvaluator.evalValue(valueNode)
+		if !propertyValue.ok {
+			return staticEvalResult{}
+		}
+		value.addProperty(key, propertyValue.value)
+	}
+	return staticEvalResult{value: value, ok: true}
+}
+
+func (value *staticObjectValue) addProperty(name string, propertyValue any) {
+	property := staticObjectProperty{name: name, value: propertyValue}
+	if value.propertyCount == 0 {
+		value.property = property
+	} else {
+		value.extraProperties = append(value.extraProperties, property)
+	}
+	value.propertyCount++
+}
+
+func isObjectLiteralPrototypeSetter(property *ast.Node) bool {
+	return property != nil && property.Kind == ast.KindPropertyAssignment && ast.IsProtoSetter(property.Name())
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalObjectLiteralMember(node *ast.Node, key string) staticEvalResult {
+	object := node.AsObjectLiteralExpression()
+	if object == nil || object.Properties == nil {
+		return staticEvalResult{}
+	}
+
+	var ownValue staticEvalResult
+	ownFound := false
+	prototypeValue := staticEvalResult{value: staticUndefinedValue{}, ok: true}
+	prototypeSet := false
+	for _, property := range object.Properties.Nodes {
+		var valueNode *ast.Node
+		switch property.Kind {
+		case ast.KindPropertyAssignment:
+			valueNode = property.AsPropertyAssignment().Initializer
+		case ast.KindShorthandPropertyAssignment:
+			valueNode = property.Name()
+		default:
+			return staticEvalResult{}
+		}
+
+		if isObjectLiteralPrototypeSetter(property) {
+			prototypeNode := SkipAssertionsAndParens(valueNode)
+			if prototypeNode != nil && prototypeNode.Kind == ast.KindObjectLiteralExpression {
+				prototypeValue = staticEvaluator.evalObjectLiteralMember(prototypeNode, key)
+				if !prototypeValue.ok {
+					return staticEvalResult{}
+				}
+				prototypeSet = true
+				continue
+			}
+
+			value := staticEvaluator.evalValue(valueNode)
+			if !value.ok {
+				return staticEvalResult{}
+			}
+			switch value.value.(type) {
+			case *staticObjectValue, *staticArrayValue:
+				prototypeValue = staticMemberValue(value.value, key)
+				if !prototypeValue.ok {
+					return staticEvalResult{}
+				}
+				prototypeSet = true
+			case staticNullValue:
+				prototypeValue = staticEvalResult{value: staticUndefinedValue{}, ok: true}
+				prototypeSet = true
+			default:
+				// JavaScript ignores primitive prototype-setter values.
+			}
+			continue
+		}
+
+		propertyKey, ok := staticEvaluator.evalPropertyKey(property.Name())
 		if !ok {
 			return staticEvalResult{}
 		}
@@ -389,9 +596,19 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteral(node *ast.Node) 
 		if !value.ok {
 			return staticEvalResult{}
 		}
-		properties[key] = value.value
+		if propertyKey == key {
+			ownValue = value
+			ownFound = true
+		}
 	}
-	return staticEvalResult{value: staticObjectValue{properties: properties}, ok: true}
+
+	if ownFound {
+		return ownValue
+	}
+	if prototypeSet {
+		return prototypeValue
+	}
+	return staticEvalResult{value: staticUndefinedValue{}, ok: true}
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalArrayLiteral(node *ast.Node) staticEvalResult {
@@ -400,22 +617,40 @@ func (staticEvaluator *StaticStringEvaluator) evalArrayLiteral(node *ast.Node) s
 		return staticEvalResult{}
 	}
 
-	elements := make([]any, 0, len(array.Elements.Nodes))
-	for _, element := range array.Elements.Nodes {
+	arrayValue := &staticArrayValue{length: len(array.Elements.Nodes)}
+	if arrayValue.length > len(arrayValue.inline) {
+		arrayValue.overflow = make([]any, arrayValue.length-len(arrayValue.inline))
+	}
+	for i, element := range array.Elements.Nodes {
 		if element.Kind == ast.KindOmittedExpression {
-			elements = append(elements, staticUndefinedValue{})
+			arrayValue.set(i, staticUndefinedValue{})
 			continue
 		}
 		if element.Kind == ast.KindSpreadElement {
 			return staticEvalResult{}
 		}
-		value := staticEvaluator.evalValue(element)
-		if !value.ok {
+		elementValue := staticEvaluator.evalValue(element)
+		if !elementValue.ok {
 			return staticEvalResult{}
 		}
-		elements = append(elements, value.value)
+		arrayValue.set(i, elementValue.value)
 	}
-	return staticEvalResult{value: staticArrayValue{elements: elements}, ok: true}
+	return staticEvalResult{value: arrayValue, ok: true}
+}
+
+func (value *staticArrayValue) set(index int, element any) {
+	if index < len(value.inline) {
+		value.inline[index] = element
+		return
+	}
+	value.overflow[index-len(value.inline)] = element
+}
+
+func (value *staticArrayValue) element(index int) any {
+	if index < len(value.inline) {
+		return value.inline[index]
+	}
+	return value.overflow[index-len(value.inline)]
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalPropertyKey(name *ast.Node) (string, bool) {
@@ -453,35 +688,16 @@ func (staticEvaluator *StaticStringEvaluator) evalPropertyKey(name *ast.Node) (s
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalMemberAccess(node *ast.Node) staticEvalResult {
-	var objectNode *ast.Node
-	var key string
-
-	switch node.Kind {
-	case ast.KindPropertyAccessExpression:
-		access := node.AsPropertyAccessExpression()
-		if access == nil || access.QuestionDotToken != nil ||
-			access.Name() == nil || access.Name().Kind != ast.KindIdentifier {
-			return staticEvalResult{}
-		}
-		objectNode = access.Expression
-		key = access.Name().AsIdentifier().Text
-	case ast.KindElementAccessExpression:
-		access := node.AsElementAccessExpression()
-		if access == nil || access.QuestionDotToken != nil {
-			return staticEvalResult{}
-		}
-		argument := staticEvaluator.evalValue(access.ArgumentExpression)
-		if !argument.ok {
-			return staticEvalResult{}
-		}
-		value, ok := staticValueToString(argument.value)
-		if !ok {
-			return staticEvalResult{}
-		}
-		objectNode = access.Expression
-		key = value
-	default:
+	objectNode := AccessExpressionObject(node)
+	if objectNode == nil {
 		return staticEvalResult{}
+	}
+	key, ok := staticEvaluator.evalAccessExpressionKey(node)
+	if !ok {
+		return staticEvalResult{}
+	}
+	if literal := SkipAssertionsAndParens(objectNode); literal != nil && literal.Kind == ast.KindObjectLiteralExpression {
+		return staticEvaluator.evalObjectLiteralMember(literal, key)
 	}
 
 	object := staticEvaluator.evalValue(objectNode)
@@ -491,6 +707,20 @@ func (staticEvaluator *StaticStringEvaluator) evalMemberAccess(node *ast.Node) s
 	return staticMemberValue(object.value, key)
 }
 
+func (staticEvaluator *StaticStringEvaluator) evalAccessExpressionKey(node *ast.Node) (string, bool) {
+	if key, ok := AccessExpressionStaticName(node); ok {
+		return key, true
+	}
+	if node == nil || node.Kind != ast.KindElementAccessExpression {
+		return "", false
+	}
+	argument := staticEvaluator.evalValue(node.AsElementAccessExpression().ArgumentExpression)
+	if !argument.ok {
+		return "", false
+	}
+	return staticValueToString(argument.value)
+}
+
 // staticMemberValue reads key off a folded object or array literal. Reading a
 // key that isn't there yields `undefined`, as it would at runtime. A key an
 // array inherits — `length`, `join` — stays unresolved, because folding it
@@ -498,12 +728,15 @@ func (staticEvaluator *StaticStringEvaluator) evalMemberAccess(node *ast.Node) s
 // carry.
 func staticMemberValue(object any, key string) staticEvalResult {
 	switch object := object.(type) {
-	case staticObjectValue:
-		if value, ok := object.properties[key]; ok {
+	case *staticObjectValue:
+		if value, ok := staticObjectOwnProperty(object, key); ok {
 			return staticEvalResult{value: value, ok: true}
 		}
+		if object.prototypeSet && object.prototype != nil {
+			return staticMemberValue(object.prototype, key)
+		}
 		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
-	case staticArrayValue:
+	case *staticArrayValue:
 		index, ok := staticArrayIndex(key)
 		if !ok {
 			if staticNumberShapedKey(key) {
@@ -511,12 +744,24 @@ func staticMemberValue(object any, key string) staticEvalResult {
 			}
 			return staticEvalResult{}
 		}
-		if index >= len(object.elements) {
+		if index >= object.length {
 			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
 		}
-		return staticEvalResult{value: object.elements[index], ok: true}
+		return staticEvalResult{value: object.element(index), ok: true}
 	}
 	return staticEvalResult{}
+}
+
+func staticObjectOwnProperty(object *staticObjectValue, key string) (any, bool) {
+	for i := len(object.extraProperties) - 1; i >= 0; i-- {
+		if object.extraProperties[i].name == key {
+			return object.extraProperties[i].value, true
+		}
+	}
+	if object.propertyCount > 0 && object.property.name == key {
+		return object.property.value, true
+	}
+	return nil, false
 }
 
 // staticNumberShapedKey reports whether key opens the way a number's string
@@ -560,44 +805,148 @@ func staticArrayIndex(key string) (int, bool) {
 // evalObjectPassThroughCall folds `Object.freeze(x)` and its siblings to the
 // value of x.
 func (staticEvaluator *StaticStringEvaluator) evalObjectPassThroughCall(node *ast.Node) staticEvalResult {
-	call := node.AsCallExpression()
-	if call == nil || call.QuestionDotToken != nil {
+	argument, ok := staticEvaluator.objectPassThroughArgument(node)
+	if !ok {
 		return staticEvalResult{}
+	}
+	return staticEvaluator.evalValue(argument)
+}
+
+func (staticEvaluator *StaticStringEvaluator) objectPassThroughArgument(node *ast.Node) (*ast.Node, bool) {
+	call := node.AsCallExpression()
+	if call == nil {
+		return nil, false
 	}
 
 	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
-	if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
-		return staticEvalResult{}
+	if callee == nil || !ast.IsAccessExpression(callee) {
+		return nil, false
+	}
+	methodName, ok := staticEvaluator.evalAccessExpressionKey(callee)
+	if !ok || !objectPassThroughMethods[methodName] {
+		return nil, false
 	}
 
-	propertyAccess := callee.AsPropertyAccessExpression()
-	if propertyAccess == nil || propertyAccess.QuestionDotToken != nil ||
-		propertyAccess.Name() == nil || propertyAccess.Name().Kind != ast.KindIdentifier ||
-		!objectPassThroughMethods[propertyAccess.Name().AsIdentifier().Text] {
-		return staticEvalResult{}
-	}
-
-	object := ast.SkipOuterExpressions(propertyAccess.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	object := SkipAssertionsAndParens(AccessExpressionObject(callee))
 	if !isIdentifierWithText(object, "Object") || IsShadowed(object, "Object") {
-		return staticEvalResult{}
+		return nil, false
 	}
 
 	args := node.Arguments()
 	if len(args) == 0 || ast.IsSpreadElement(args[0]) {
-		return staticEvalResult{}
+		return nil, false
 	}
-	return staticEvaluator.evalValue(args[0])
+	return args[0], true
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalArrayJoinCall(node *ast.Node) staticEvalResult {
+	value, _, ok := staticEvaluator.evalArrayJoin(node)
+	return staticEvalResult{value: value, ok: ok}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalArrayJoin(node *ast.Node) (value string, matched bool, ok bool) {
+	call := node.AsCallExpression()
+	if call == nil {
+		return "", false, false
+	}
+
+	callee := SkipAssertionsAndParens(call.Expression)
+	if callee == nil || !ast.IsAccessExpression(callee) {
+		return "", false, false
+	}
+	methodName, nameOK := staticEvaluator.evalAccessExpressionKey(callee)
+	if !nameOK || methodName != "join" {
+		return "", false, false
+	}
+
+	receiverNode := AccessExpressionObject(callee)
+	if literal := SkipAssertionsAndParens(receiverNode); literal != nil && literal.Kind == ast.KindArrayLiteralExpression {
+		arrayLiteral := literal.AsArrayLiteralExpression()
+		if arrayLiteral != nil && arrayLiteral.Elements != nil &&
+			len(arrayLiteral.Elements.Nodes) <= len((staticArrayValue{}).inline) {
+			array, arrayOK := staticEvaluator.evalInlineArrayLiteral(literal)
+			if !arrayOK {
+				return "", true, false
+			}
+			separator, separatorOK := staticEvaluator.evalArrayJoinSeparator(node)
+			if !separatorOK {
+				return "", true, false
+			}
+			value, ok := staticArrayJoin(&array, separator)
+			return value, true, ok
+		}
+	}
+
+	receiver := staticEvaluator.evalValue(receiverNode)
+	if !receiver.ok {
+		return "", true, false
+	}
+	array, arrayOK := receiver.value.(*staticArrayValue)
+	if !arrayOK {
+		return "", true, false
+	}
+
+	separator, separatorOK := staticEvaluator.evalArrayJoinSeparator(node)
+	if !separatorOK {
+		return "", true, false
+	}
+	value, ok = staticArrayJoin(array, separator)
+	return value, true, ok
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalInlineArrayLiteral(node *ast.Node) (staticArrayValue, bool) {
+	literal := node.AsArrayLiteralExpression()
+	if literal == nil || literal.Elements == nil || len(literal.Elements.Nodes) > len((staticArrayValue{}).inline) {
+		return staticArrayValue{}, false
+	}
+
+	value := staticArrayValue{length: len(literal.Elements.Nodes)}
+	for i, element := range literal.Elements.Nodes {
+		if element.Kind == ast.KindOmittedExpression {
+			value.set(i, staticUndefinedValue{})
+			continue
+		}
+		if element.Kind == ast.KindSpreadElement {
+			return staticArrayValue{}, false
+		}
+		elementValue := staticEvaluator.evalValue(element)
+		if !elementValue.ok {
+			return staticArrayValue{}, false
+		}
+		value.set(i, elementValue.value)
+	}
+	return value, true
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalArrayJoinSeparator(node *ast.Node) (string, bool) {
+	separator := ","
+	for i, argumentNode := range node.Arguments() {
+		if ast.IsSpreadElement(argumentNode) {
+			return "", false
+		}
+		argument := staticEvaluator.evalValue(argumentNode)
+		if !argument.ok {
+			return "", false
+		}
+		if i == 0 && !staticValueUndefined(argument.value) {
+			var ok bool
+			separator, ok = staticValueToString(argument.value)
+			if !ok {
+				return "", false
+			}
+		}
+	}
+	return separator, true
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalStringCall(node *ast.Node) staticEvalResult {
 	call := node.AsCallExpression()
-	if call == nil || call.QuestionDotToken != nil {
+	if call == nil {
 		return staticEvalResult{}
 	}
 
 	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
-	if callee == nil || callee.Kind != ast.KindIdentifier ||
-		callee.AsIdentifier().Text != "String" || IsShadowed(callee, "String") {
+	if !staticEvaluator.isBuiltinStringValue(callee, map[*ast.Symbol]bool{}) {
 		return staticEvalResult{}
 	}
 
@@ -637,18 +986,14 @@ func (staticEvaluator *StaticStringEvaluator) evalStringRawTag(node *ast.Node) s
 
 func (staticEvaluator *StaticStringEvaluator) isStringRawTag(tag *ast.Node) bool {
 	tag = ast.SkipOuterExpressions(tag, ast.OEKParentheses|ast.OEKAssertions)
-	if tag == nil || tag.Kind != ast.KindPropertyAccessExpression {
+	if tag == nil || !ast.IsAccessExpression(tag) {
 		return false
 	}
-
-	propertyAccess := tag.AsPropertyAccessExpression()
-	if propertyAccess == nil || propertyAccess.QuestionDotToken != nil ||
-		!isIdentifierWithText(propertyAccess.Name(), "raw") {
+	propertyName, ok := staticEvaluator.evalAccessExpressionKey(tag)
+	if !ok || propertyName != "raw" {
 		return false
 	}
-
-	object := ast.SkipOuterExpressions(propertyAccess.Expression, ast.OEKParentheses|ast.OEKAssertions)
-	return staticEvaluator.isBuiltinStringValue(object, map[*ast.Symbol]bool{})
+	return staticEvaluator.isBuiltinStringValue(AccessExpressionObject(tag), map[*ast.Symbol]bool{})
 }
 
 func (staticEvaluator *StaticStringEvaluator) isBuiltinStringValue(node *ast.Node, resolvingAliases map[*ast.Symbol]bool) bool {
@@ -684,7 +1029,13 @@ func (staticEvaluator *StaticStringEvaluator) evalWithTsgo(node *ast.Node) (resu
 
 func (staticEvaluator *StaticStringEvaluator) evaluateEntity(expr *ast.Node, location *ast.Node) evaluator.Result {
 	result := staticEvaluator.evalIdentifier(expr)
-	if !result.ok || !staticValueIsTsgoSafe(result.value) {
+	if !result.ok {
+		return evaluator.Result{}
+	}
+	if value, ok := staticValueAsString(result.value); ok {
+		return evaluator.Result{Value: value}
+	}
+	if !staticValueIsTsgoSafe(result.value) {
 		return evaluator.Result{}
 	}
 
@@ -695,24 +1046,63 @@ func (staticEvaluator *StaticStringEvaluator) hasWrites(symbol *ast.Symbol) bool
 	if staticEvaluator.sourceFile == nil || staticEvaluator.typeChecker == nil {
 		return true
 	}
-	if !staticEvaluator.writeRefsComputed {
-		staticEvaluator.computeWriteRefs()
-	}
-	return staticEvaluator.writeRefs[symbol]
+	return staticEvaluator.referenceFlagsFor(symbol)&staticReferenceWrite != 0
 }
 
-func (staticEvaluator *StaticStringEvaluator) computeWriteRefs() {
-	staticEvaluator.writeRefsComputed = true
-	staticEvaluator.writeRefs = map[*ast.Symbol]bool{}
+func (staticEvaluator *StaticStringEvaluator) hasPropertyMutation(symbol *ast.Symbol) bool {
+	if staticEvaluator.sourceFile == nil || staticEvaluator.typeChecker == nil {
+		return true
+	}
+	return staticEvaluator.referenceFlagsFor(symbol)&staticReferencePropertyMutation != 0
+}
+
+func (staticEvaluator *StaticStringEvaluator) referenceFlagsFor(symbol *ast.Symbol) staticReferenceFlags {
+	if !staticEvaluator.referenceFlagsComputed {
+		staticEvaluator.computeReferenceFlags()
+	}
+	return staticEvaluator.referenceFlags[symbol]
+}
+
+type staticMutationCandidate struct {
+	reference *ast.Node
+	access    *ast.Node
+}
+
+func (staticEvaluator *StaticStringEvaluator) computeReferenceFlags() {
+	staticEvaluator.referenceFlagsComputed = true
+	staticEvaluator.referenceFlags = nil
+	var mutationCandidates []staticMutationCandidate
 
 	var visit func(node *ast.Node)
 	visit = func(node *ast.Node) {
 		if node == nil {
 			return
 		}
-		if node.Kind == ast.KindIdentifier && IsWriteReference(node) {
-			if symbol := GetReferenceSymbol(node, staticEvaluator.typeChecker); symbol != nil {
-				staticEvaluator.writeRefs[symbol] = true
+		if node.Kind == ast.KindIdentifier && !IsNonReferenceIdentifier(node) {
+			if IsWriteReference(node) {
+				staticEvaluator.markReference(node, staticReferenceWrite)
+			}
+			parent := node.Parent
+			mayStartAccess := parent != nil && (ast.IsAccessExpression(parent) ||
+				ast.IsOuterExpression(parent, skipTransparentKinds))
+			if mayStartAccess {
+				access, outer := outermostAccessFromReference(node)
+				if access != nil && outer.Parent != nil {
+					if ast.IsAssignmentTarget(outer) {
+						staticEvaluator.markReference(node, staticReferencePropertyMutation)
+					} else if outer.Parent.Kind == ast.KindCallExpression {
+						call := outer.Parent.AsCallExpression()
+						if call.Expression == outer {
+							if methodName, ok := AccessExpressionStaticName(access); ok {
+								if isMutatingArrayMethod(methodName) {
+									staticEvaluator.markReference(node, staticReferencePropertyMutation)
+								}
+							} else {
+								mutationCandidates = append(mutationCandidates, staticMutationCandidate{reference: node, access: access})
+							}
+						}
+					}
+				}
 			}
 		}
 		node.ForEachChild(func(child *ast.Node) bool {
@@ -721,15 +1111,87 @@ func (staticEvaluator *StaticStringEvaluator) computeWriteRefs() {
 		})
 	}
 	visit(&staticEvaluator.sourceFile.Node)
+
+	for _, candidate := range mutationCandidates {
+		if methodName, ok := staticEvaluator.evalAccessExpressionKey(candidate.access); ok && isMutatingArrayMethod(methodName) {
+			staticEvaluator.markReference(candidate.reference, staticReferencePropertyMutation)
+		}
+	}
+}
+
+func (staticEvaluator *StaticStringEvaluator) markReference(node *ast.Node, flag staticReferenceFlags) {
+	if symbol := staticEvaluator.referenceSymbol(node); symbol != nil {
+		if staticEvaluator.referenceFlags == nil {
+			staticEvaluator.referenceFlags = make(map[*ast.Symbol]staticReferenceFlags, 8)
+		}
+		staticEvaluator.referenceFlags[symbol] |= flag
+	}
+}
+
+func (staticEvaluator *StaticStringEvaluator) referenceSymbol(node *ast.Node) *ast.Symbol {
+	if staticEvaluator.referenceResolver != nil {
+		if symbol := staticEvaluator.referenceResolver.Resolve(node); symbol != nil {
+			return symbol
+		}
+	}
+	return GetReferenceSymbol(node, staticEvaluator.typeChecker)
+}
+
+func outermostAccessFromReference(node *ast.Node) (access *ast.Node, outer *ast.Node) {
+	outer = node
+	for outer.Parent != nil {
+		parent := outer.Parent
+		if ast.IsOuterExpression(parent, skipTransparentKinds) && parent.Expression() == outer {
+			outer = parent
+			continue
+		}
+		if ast.IsAccessExpression(parent) && AccessExpressionObject(parent) == outer {
+			access = parent
+			outer = parent
+			continue
+		}
+		break
+	}
+	return access, outer
+}
+
+func isMutatingArrayMethod(name string) bool {
+	switch name {
+	case "copyWithin", "fill", "pop", "push", "reverse", "shift", "sort", "splice", "unshift":
+		return true
+	default:
+		return false
+	}
 }
 
 func staticValueIsTsgoSafe(value any) bool {
 	switch value.(type) {
-	case bool, staticNullValue, staticUndefinedValue, staticObjectValue, staticArrayValue:
+	case bool, staticNullValue, staticUndefinedValue, *staticStringNode, *staticObjectValue, *staticArrayValue:
 		return false
 	default:
 		return value != nil
 	}
+}
+
+func staticValueAsString(value any) (string, bool) {
+	switch value := value.(type) {
+	case string:
+		return value, true
+	case *staticStringNode:
+		node := (*ast.Node)(value)
+		switch node.Kind {
+		case ast.KindStringLiteral:
+			return node.AsStringLiteral().Text, true
+		case ast.KindNoSubstitutionTemplateLiteral:
+			return node.AsNoSubstitutionTemplateLiteral().Text, true
+		}
+	}
+	return "", false
+}
+
+func staticValueIsString(value any) bool {
+	_, ok := staticValueAsString(value)
+	return ok
 }
 
 func staticValueNullish(value any) bool {
@@ -741,15 +1203,32 @@ func staticValueNullish(value any) bool {
 	}
 }
 
+func staticValueUndefined(value any) bool {
+	_, ok := value.(staticUndefinedValue)
+	return ok
+}
+
+func staticValueIsAggregate(value any) bool {
+	switch value.(type) {
+	case *staticObjectValue, *staticArrayValue:
+		return true
+	default:
+		return false
+	}
+}
+
 func staticValueTruthy(value any) (truthy bool, ok bool) {
 	switch value := value.(type) {
 	case string:
 		return value != "", true
+	case *staticStringNode:
+		stringValue, _ := staticValueAsString(value)
+		return stringValue != "", true
 	case bool:
 		return value, true
 	case staticNullValue, staticUndefinedValue:
 		return false, true
-	case staticObjectValue, staticArrayValue:
+	case *staticObjectValue, *staticArrayValue:
 		return true, true
 	default:
 		return evaluatorBool(func() bool { return evaluator.IsTruthy(value) })
@@ -760,6 +1239,8 @@ func staticValueToString(value any) (string, bool) {
 	switch value := value.(type) {
 	case string:
 		return value, true
+	case *staticStringNode:
+		return staticValueAsString(value)
 	case bool:
 		if value {
 			return "true", true
@@ -769,14 +1250,13 @@ func staticValueToString(value any) (string, bool) {
 		return "null", true
 	case staticUndefinedValue:
 		return "undefined", true
-	case staticArrayValue:
+	case *staticArrayValue:
 		return staticArrayToString(value)
-	case staticObjectValue:
-		// A plain object's default ToString is "[object Object]", but a
-		// folded object literal can't tell whether a property overrides
-		// toString/Symbol.toPrimitive; callers only need to know that the
-		// value is not a string.
-		return "", false
+	case *staticObjectValue:
+		if _, overridesToString := staticObjectOwnProperty(value, "toString"); overridesToString || value.prototypeSet {
+			return "", false
+		}
+		return "[object Object]", true
 	default:
 		return evaluatorString(func() string { return evaluator.AnyToString(value) })
 	}
@@ -785,9 +1265,53 @@ func staticValueToString(value any) (string, bool) {
 // staticArrayToString implements `Array.prototype.join(',')`, which is what
 // an array coerces to via the default ToString. Nullish elements fold to "",
 // not "null"/"undefined" as a direct string conversion would give.
-func staticArrayToString(value staticArrayValue) (string, bool) {
-	parts := make([]string, len(value.elements))
-	for i, element := range value.elements {
+func staticArrayToString(value *staticArrayValue) (string, bool) {
+	return staticArrayJoin(value, ",")
+}
+
+func staticArrayJoin(value *staticArrayValue, separator string) (string, bool) {
+	if value == nil || value.length < 0 {
+		return "", false
+	}
+	var builder strings.Builder
+	capacity := 0
+	if value.length > 1 {
+		separatorCount := value.length - 1
+		if len(separator) > 0 && separatorCount > maxStaticStringLength/len(separator) {
+			return "", false
+		}
+		capacity = separatorCount * len(separator)
+	}
+	for i := range value.length {
+		element := value.element(i)
+		elementLength := 0
+		switch element := element.(type) {
+		case string:
+			elementLength = len(element)
+		case *staticStringNode:
+			stringValue, _ := staticValueAsString(element)
+			elementLength = len(stringValue)
+		case bool:
+			if element {
+				elementLength = len("true")
+			} else {
+				elementLength = len("false")
+			}
+		}
+		if elementLength > maxStaticStringLength-capacity {
+			return "", false
+		}
+		capacity += elementLength
+	}
+	builder.Grow(capacity)
+	for i := range value.length {
+		element := value.element(i)
+		if i > 0 {
+			if len(separator) > maxStaticStringLength-builder.Len() {
+				return "", false
+			}
+			builder.WriteString(separator)
+		}
 		if staticValueNullish(element) {
 			continue
 		}
@@ -795,9 +1319,12 @@ func staticArrayToString(value staticArrayValue) (string, bool) {
 		if !ok {
 			return "", false
 		}
-		parts[i] = part
+		if len(part) > maxStaticStringLength-builder.Len() {
+			return "", false
+		}
+		builder.WriteString(part)
 	}
-	return strings.Join(parts, ","), true
+	return builder.String(), true
 }
 
 func evaluatorBool(fn func() bool) (value bool, ok bool) {

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -60,7 +61,43 @@ func TestStaticStringEvaluator(t *testing.T) {
 		"let letValue = \"then\";\n" +
 		"const letUse = letValue;\n" +
 		"const numeric = 1 + 2;\n" +
-		"const unknownUse = unknownValue;\n"
+		"const unknownUse = unknownValue;\n" +
+		"const stableArray = [\"\", \"message\"];\n" +
+		"const stableArrayUse = stableArray[0];\n" +
+		"const writtenArray = [\"\"];\n" +
+		"writtenArray[0] = \"message\";\n" +
+		"const writtenArrayUse = writtenArray[0];\n" +
+		"const filledArray = [\"\"];\n" +
+		"filledArray.fill(\"message\");\n" +
+		"const filledArrayUse = filledArray[0];\n" +
+		"const mutationMethod = \"fill\";\n" +
+		"const computedMutatedArray = [\"\"];\n" +
+		"computedMutatedArray[mutationMethod](\"message\");\n" +
+		"const computedMutatedArrayUse = computedMutatedArray[0];\n" +
+		"const updatedArray = [\"\"];\n" +
+		"updatedArray[0] += \"message\";\n" +
+		"const updatedArrayUse = updatedArray[0];\n" +
+		"const slicedArray = [\"\"];\n" +
+		"slicedArray.slice();\n" +
+		"const slicedArrayUse = slicedArray[0];\n" +
+		"const writtenObject = {message: \"\"};\n" +
+		"writtenObject.message = \"message\";\n" +
+		"const writtenObjectUse = writtenObject.message;\n" +
+		"const protoMessage = ({__proto__: {message: \"message\"}}).message;\n" +
+		"const quotedProtoMessage = ({\"__proto__\": {message: \"message\"}}).message;\n" +
+		"const ownProtoMessage = ({__proto__: {message: \"message\"}, message: \"\"}).message;\n" +
+		"const computedProtoMessage = ({[\"__proto__\"]: {message: \"message\"}}).message;\n" +
+		"const nullProtoString = String(({__proto__: null}));\n" +
+		"const emptyJoin = [].join();\n" +
+		"const joined = [\"error\", \"message\"].join(\": \");\n" +
+		"const nestedEmptyJoin = [[]].join();\n" +
+		"const overflowEmptyJoin = [\"\", \"\", \"\"].join(\"\");\n" +
+		"const undefinedSeparatorJoin = [].join(undefined);\n" +
+		"const boundJoinArray = [\"\"];\n" +
+		"const boundJoin = boundJoinArray.join();\n" +
+		"const mutatedJoinArray = [\"\"];\n" +
+		"mutatedJoinArray.fill(\"message\");\n" +
+		"const mutatedJoin = mutatedJoinArray.join();\n"
 
 	fs := NewOverlayVFS(rootDir.FS, map[string]string{filePath: code})
 	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
@@ -117,6 +154,25 @@ func TestStaticStringEvaluator(t *testing.T) {
 		{name: "letUse", want: "then", ok: true},
 		{name: "numeric"},
 		{name: "unknownUse"},
+		{name: "stableArrayUse", want: "", ok: true},
+		{name: "writtenArrayUse"},
+		{name: "filledArrayUse"},
+		{name: "computedMutatedArrayUse"},
+		{name: "updatedArrayUse"},
+		{name: "slicedArrayUse", want: "", ok: true},
+		{name: "writtenObjectUse"},
+		{name: "protoMessage", want: "message", ok: true},
+		{name: "quotedProtoMessage", want: "message", ok: true},
+		{name: "ownProtoMessage", want: "", ok: true},
+		{name: "computedProtoMessage"},
+		{name: "nullProtoString"},
+		{name: "emptyJoin", want: "", ok: true},
+		{name: "joined", want: "error: message", ok: true},
+		{name: "nestedEmptyJoin", want: "", ok: true},
+		{name: "overflowEmptyJoin", want: "", ok: true},
+		{name: "undefinedSeparatorJoin", want: "", ok: true},
+		{name: "boundJoin", want: "", ok: true},
+		{name: "mutatedJoin"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -128,7 +184,43 @@ func TestStaticStringEvaluator(t *testing.T) {
 	}
 }
 
-func findVariableInitializer(t *testing.T, sourceFile *ast.SourceFile, bindingName string) *ast.Node {
+func TestIsMutatingArrayMethod(t *testing.T) {
+	for _, name := range []string{
+		"copyWithin",
+		"fill",
+		"pop",
+		"push",
+		"reverse",
+		"shift",
+		"sort",
+		"splice",
+		"unshift",
+	} {
+		if !isMutatingArrayMethod(name) {
+			t.Errorf("isMutatingArrayMethod(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", "concat", "join", "map", "slice"} {
+		if isMutatingArrayMethod(name) {
+			t.Errorf("isMutatingArrayMethod(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestStaticArrayJoinRejectsExcessiveOutput(t *testing.T) {
+	value := &staticArrayValue{
+		length:   2048,
+		overflow: make([]any, 2046),
+	}
+	for index := range value.length {
+		value.set(index, staticUndefinedValue{})
+	}
+	if _, ok := staticArrayJoin(value, strings.Repeat("x", 1024)); ok {
+		t.Fatal("staticArrayJoin accepted output above the static string limit")
+	}
+}
+
+func findVariableInitializer(t testing.TB, sourceFile *ast.SourceFile, bindingName string) *ast.Node {
 	t.Helper()
 
 	var initializer *ast.Node


### PR DESCRIPTION
## Summary

- Align `unicorn/error-message` with eslint-plugin-unicorn v73.0.0: empty schema, builtin constructors, message argument positions, diagnostics, spread/optional handling, documentation, and the complete upstream valid/invalid suite.
- Prevent stale aggregate snapshots after direct element/property writes and mutating array calls, reusing rslint reference resolution and tsgo AST helpers instead of introducing a general-purpose interpreter.
- Safely fold static `Array#join` calls, including sparse/nullish/nested array coercion, with a 1 MiB output cap.
- Preserve object-literal `__proto__` setter semantics and statically resolve known object, array, and null prototype chains, while keeping computed `['__proto__']` as an own property.

## Related Links

- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/error-message.js
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/test/error-message.js
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/error-message.md

## Verification

- Targeted Go tests for the evaluator, rule, and all direct evaluator consumers.
- Targeted npm compatibility test for `eslint-plugin-unicorn/error-message`.
- `check-spell`, `format:check`, and changed-package Go lint.
- Direct comparison against upstream v73 for prototype-chain empty/non-string values, nested and null prototypes, array prototypes, and own-property precedence.
- Temporary edge-dense benchmark (not committed), with `GOMAXPROCS=1`: median 143.3 µs/op versus 143.6 µs/op on latest `main` (effectively unchanged); 11.1 KB/op versus 37.2 KB/op and 113 versus 360 allocations (about -70%).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
