### PR TITLE
feat: port rule consistent-return

### DIFF
--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"unicode"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -221,7 +220,7 @@ func computeFunctionValid(node *ast.Node, sf *ast.SourceFile, capIsConstructor b
 	if hasJSDocThisTag(node, sf) {
 		return true
 	}
-	if capIsConstructor && isES5Constructor(node) {
+	if capIsConstructor && utils.IsES5Constructor(node) {
 		return true
 	}
 	return !isDefaultThisBinding(node, capIsConstructor)
@@ -241,26 +240,6 @@ func hasThisParameter(node *ast.Node) bool {
 	return false
 }
 
-// isES5Constructor mirrors ESLint's `isES5Constructor`: a function with an
-// own name whose first character is an uppercase letter is treated as an
-// ES5 constructor under `capIsConstructor: true`. Anonymous functions
-// (no own name) fall through.
-func isES5Constructor(node *ast.Node) bool {
-	var name *ast.Node
-	switch node.Kind {
-	case ast.KindFunctionDeclaration:
-		name = node.AsFunctionDeclaration().Name()
-	case ast.KindFunctionExpression:
-		name = node.AsFunctionExpression().Name()
-	default:
-		return false
-	}
-	if name == nil || !ast.IsIdentifier(name) {
-		return false
-	}
-	return startsWithUpperCase(name.AsIdentifier().Text)
-}
-
 // hasOwnFunctionName reports whether the function has an `id`/name in
 // ESTree terms (used to gate ES5-constructor recognition for the uppercase-
 // variable / uppercase-assignment-target branches: a *named* function
@@ -272,18 +251,6 @@ func hasOwnFunctionName(node *ast.Node) bool {
 		return node.AsFunctionDeclaration().Name() != nil
 	case ast.KindFunctionExpression:
 		return node.AsFunctionExpression().Name() != nil
-	}
-	return false
-}
-
-// startsWithUpperCase mirrors ESLint's `s[0] !== s[0].toLocaleLowerCase()`:
-// the first rune is uppercase iff it has a different lowercase form. In
-// Unicode terms that's category Lu, plus the rare title-case category Lt
-// (e.g. `Ǆ`). Everything else — lower-case letters, non-cased letters,
-// digits, `_`, `$` — returns false in both halves.
-func startsWithUpperCase(s string) bool {
-	for _, r := range s {
-		return unicode.IsUpper(r) || unicode.IsTitle(r)
 	}
 	return false
 }
@@ -458,7 +425,7 @@ func isDefaultThisBinding(node *ast.Node, capIsConstructor bool) bool {
 					return false
 				}
 				if capIsConstructor && isAnonymous && ast.IsIdentifier(left) &&
-					startsWithUpperCase(left.AsIdentifier().Text) {
+					utils.StartsWithUpperCase(left.AsIdentifier().Text) {
 					// Foo = function(){} — assignment to an uppercase variable
 					// (anonymous function) is treated as an ES5 constructor.
 					return false
@@ -524,7 +491,7 @@ func isDefaultThisBinding(node *ast.Node, capIsConstructor bool) bool {
 			}
 			name := spa.Name()
 			if capIsConstructor && isAnonymous && name != nil && ast.IsIdentifier(name) &&
-				startsWithUpperCase(name.AsIdentifier().Text) {
+				utils.StartsWithUpperCase(name.AsIdentifier().Text) {
 				return false
 			}
 			return true
@@ -555,7 +522,7 @@ func isDefaultThisBinding(node *ast.Node, capIsConstructor bool) bool {
 			if capIsConstructor && isAnonymous {
 				name := vd.Name()
 				if name != nil && ast.IsIdentifier(name) &&
-					startsWithUpperCase(name.AsIdentifier().Text) {
+					utils.StartsWithUpperCase(name.AsIdentifier().Text) {
 					return false
 				}
 			}
@@ -569,7 +536,7 @@ func isDefaultThisBinding(node *ast.Node, capIsConstructor bool) bool {
 			if capIsConstructor && isAnonymous {
 				name := pd.Name()
 				if name != nil && ast.IsIdentifier(name) &&
-					startsWithUpperCase(name.AsIdentifier().Text) {
+					utils.StartsWithUpperCase(name.AsIdentifier().Text) {
 					return false
 				}
 			}
@@ -583,7 +550,7 @@ func isDefaultThisBinding(node *ast.Node, capIsConstructor bool) bool {
 			if capIsConstructor && isAnonymous {
 				name := be.Name()
 				if name != nil && ast.IsIdentifier(name) &&
-					startsWithUpperCase(name.AsIdentifier().Text) {
+					utils.StartsWithUpperCase(name.AsIdentifier().Text) {
 					return false
 				}
 			}

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/array_callback_return"
 	"github.com/web-infra-dev/rslint/internal/rules/arrow_body_style"
 	"github.com/web-infra-dev/rslint/internal/rules/complexity"
+	"github.com/web-infra-dev/rslint/internal/rules/consistent_return"
 	"github.com/web-infra-dev/rslint/internal/rules/constructor_super"
 	"github.com/web-infra-dev/rslint/internal/rules/curly"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case"
@@ -162,6 +163,7 @@ func GetAllRules() []rule.Rule {
 		array_callback_return.ArrayCallbackReturnRule,
 		arrow_body_style.ArrowBodyStyleRule,
 		complexity.ComplexityRule,
+		consistent_return.ConsistentReturnRule,
 		constructor_super.ConstructorSuperRule,
 		curly.CurlyRule,
 		default_case.DefaultCaseRule,

--- a/internal/rules/consistent_return/consistent_return.go
+++ b/internal/rules/consistent_return/consistent_return.go
@@ -207,7 +207,15 @@ func returnsValue(node *ast.Node, opts options) bool {
 // name starts with an uppercase letter, which ESLint reads as an ES5-style
 // constructor.
 func allowsImplicitReturn(node *ast.Node) bool {
-	return node.Kind == ast.KindConstructor || utils.IsES5Constructor(node)
+	return isClassConstructor(node) || utils.IsES5Constructor(node)
+}
+
+// isClassConstructor reports whether node is the class's own constructor. tsgo
+// parses a `static` member named `constructor` as a ConstructorDeclaration
+// too, and that one is an ordinary static method.
+func isClassConstructor(node *ast.Node) bool {
+	return node.Kind == ast.KindConstructor &&
+		!ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic)
 }
 
 func implicitReturnName(node *ast.Node) string {
@@ -238,10 +246,16 @@ func implicitReturnRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRa
 	case ast.KindArrowFunction:
 		return scanner.GetRangeOfTokenAtPosition(sourceFile, node.AsArrowFunction().EqualsGreaterThanToken.Pos())
 
-	case ast.KindMethodDeclaration, ast.KindConstructor:
+	case ast.KindMethodDeclaration:
 		// A class method and an object-literal shorthand method are both a
 		// keyed member upstream, reported on that key.
 		return memberKeyRange(sourceFile, node)
+
+	case ast.KindConstructor:
+		// A ConstructorDeclaration carries no name node, so its key is the
+		// token the modifiers end at: the `constructor` keyword, or the
+		// string that spells it.
+		return constructorKeyRange(sourceFile, node)
 
 	case ast.KindGetAccessor, ast.KindSetAccessor:
 		if node.Parent != nil && ast.IsClassLike(node.Parent) {
@@ -258,6 +272,14 @@ func implicitReturnRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRa
 		return utils.TrimNodeTextRange(sourceFile, name)
 	}
 	return openingKeywordRange(sourceFile, node)
+}
+
+func constructorKeyRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	pos := node.Pos()
+	if modifiers := node.Modifiers(); modifiers != nil && len(modifiers.Nodes) > 0 {
+		pos = modifiers.Nodes[len(modifiers.Nodes)-1].End()
+	}
+	return scanner.GetRangeOfTokenAtPosition(sourceFile, pos)
 }
 
 func memberKeyRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {

--- a/internal/rules/consistent_return/consistent_return.go
+++ b/internal/rules/consistent_return/consistent_return.go
@@ -1,0 +1,301 @@
+package consistent_return
+
+import (
+	_ "embed"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/cfg"
+)
+
+//go:embed consistent_return.schema.json
+var schemaJSON []byte
+
+func buildMissingReturnMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "missingReturn",
+		Description: "Expected to return a value at the end of " + name + ".",
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func buildMissingReturnValueMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "missingReturnValue",
+		Description: name + " expected a return value.",
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func buildUnexpectedReturnValueMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedReturnValue",
+		Description: name + " expected no return value.",
+		Data:        map[string]string{"name": name},
+	}
+}
+
+type options struct {
+	treatUndefinedAsUnspecified bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{treatUndefinedAsUnspecified: false}
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if value, ok := optsMap["treatUndefinedAsUnspecified"].(bool); ok {
+		opts.treatUndefinedAsUnspecified = value
+	}
+	return opts
+}
+
+// https://eslint.org/docs/latest/rules/consistent-return
+var ConsistentReturnRule = rule.Rule{
+	Name:   "consistent-return",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
+		opts := parseOptions(rule.LegacyUnwrapOptions(_options))
+
+		// Every diagnostic depends on the code path a `return` belongs to, so
+		// the returns are collected first and judged once the file is walked.
+		// Collecting them also bounds the cost of the reachability question:
+		// only a code path that returns a value ever needs a graph.
+		var returns []*ast.Node
+		listeners := rule.RuleListeners{
+			ast.KindReturnStatement: func(node *ast.Node) {
+				returns = append(returns, node)
+			},
+		}
+
+		statements := ctx.SourceFile.Statements
+		if statements == nil || len(statements.Nodes) == 0 {
+			return listeners
+		}
+		lastTopLevelNode := statements.Nodes[len(statements.Nodes)-1]
+		listeners[rule.ListenerOnExit(lastTopLevelNode.Kind)] = func(node *ast.Node) {
+			if node == lastTopLevelNode {
+				report(&ctx, returns, opts)
+			}
+		}
+		return listeners
+	},
+}
+
+// diagnostic is one pending report. ESLint emits the per-`return` reports while
+// it walks and the "missing return" reports at each function's exit, then sorts
+// everything by position before handing it to the user; collecting and sorting
+// here reproduces that order.
+type diagnostic struct {
+	textRange core.TextRange
+	message   rule.RuleMessage
+}
+
+// codePathInfo mirrors ESLint's `funcInfo`: the first `return` reached in a code
+// path decides whether every later one in it must also carry a value.
+type codePathInfo struct {
+	seenReturn     bool
+	hasReturnValue bool
+	name           string
+	build          func(string) rule.RuleMessage
+}
+
+func report(ctx *rule.RuleContext, returns []*ast.Node, opts options) {
+	infos := make(map[*ast.Node]*codePathInfo)
+	var rootOrder []*ast.Node
+	var diagnostics []diagnostic
+
+	// The returns arrive in source order, which is the order ESLint's traversal
+	// reaches them in. Consistency is decided by that order alone — a `return`
+	// no code path can reach still counts.
+	for _, node := range returns {
+		root := cfg.RootOf(node)
+		if root == nil || !isCheckedRoot(root) {
+			continue
+		}
+		info := infos[root]
+		if info == nil {
+			info = &codePathInfo{}
+			infos[root] = info
+			rootOrder = append(rootOrder, root)
+		}
+
+		hasReturnValue := returnsValue(node, opts)
+		if !info.seenReturn {
+			info.seenReturn = true
+			info.hasReturnValue = hasReturnValue
+			info.name = inconsistentReturnName(root)
+			if hasReturnValue {
+				info.build = buildMissingReturnValueMessage
+			} else {
+				info.build = buildUnexpectedReturnValueMessage
+			}
+			continue
+		}
+		if info.hasReturnValue != hasReturnValue {
+			diagnostics = append(diagnostics, diagnostic{
+				textRange: utils.TrimNodeTextRange(ctx.SourceFile, node),
+				message:   info.build(info.name),
+			})
+		}
+	}
+
+	for _, root := range rootOrder {
+		if !infos[root].hasReturnValue || allowsImplicitReturn(root) {
+			continue
+		}
+		if !cfg.Build(root, cfg.Hooks[struct{}]{}).EndReachable {
+			continue
+		}
+		diagnostics = append(diagnostics, diagnostic{
+			textRange: implicitReturnRange(ctx.SourceFile, root),
+			message:   buildMissingReturnMessage(implicitReturnName(root)),
+		})
+	}
+
+	slices.SortStableFunc(diagnostics, func(a, b diagnostic) int {
+		return a.textRange.Pos() - b.textRange.Pos()
+	})
+	for _, d := range diagnostics {
+		ctx.ReportRange(d.textRange, d.message)
+	}
+}
+
+// isCheckedRoot reports whether a code path root is one ESLint judges. Upstream
+// listens on `Program:exit` plus the three ESTree function types, which between
+// them cover the source file and every tsgo function-like kind. A class static
+// block and a class field initializer are left out, and neither may hold a
+// `return`.
+func isCheckedRoot(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindSourceFile,
+		ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+		ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		return true
+	}
+	return false
+}
+
+// returnsValue reports whether a `return` statement hands back a value. Under
+// `treatUndefinedAsUnspecified` the identifier `undefined` and any `void`
+// expression are read as handing back nothing.
+func returnsValue(node *ast.Node, opts options) bool {
+	expression := node.AsReturnStatement().Expression
+	if expression == nil {
+		return false
+	}
+	if !opts.treatUndefinedAsUnspecified {
+		return true
+	}
+	// ESTree has no parenthesis node, so `return (undefined)` reads the same as
+	// `return undefined` upstream.
+	expression = ast.SkipParentheses(expression)
+	if expression.Kind == ast.KindVoidExpression {
+		return false
+	}
+	return expression.Kind != ast.KindIdentifier || expression.AsIdentifier().Text != "undefined"
+}
+
+// allowsImplicitReturn reports whether a code path may end without a value even
+// though it returns one elsewhere: a class constructor, and a function whose own
+// name starts with an uppercase letter, which ESLint reads as an ES5-style
+// constructor.
+func allowsImplicitReturn(node *ast.Node) bool {
+	return node.Kind == ast.KindConstructor || utils.IsES5Constructor(node)
+}
+
+func implicitReturnName(node *ast.Node) string {
+	if node.Kind == ast.KindSourceFile {
+		return "program"
+	}
+	return utils.GetFunctionNameWithKindCore(node)
+}
+
+func inconsistentReturnName(node *ast.Node) string {
+	if node.Kind == ast.KindSourceFile {
+		return "Program"
+	}
+	return utils.UpperCaseFirstASCII(utils.GetFunctionNameWithKindCore(node))
+}
+
+// implicitReturnRange is where ESLint points the "missing return" report: the
+// `=>` of an arrow function, the key of a class member or of an object-literal
+// shorthand method, and otherwise the function's own name or the keyword that
+// opens it.
+func implicitReturnRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	switch node.Kind {
+	case ast.KindSourceFile:
+		// The head of the program. ESLint reports a bare line/column there,
+		// with no end position of its own.
+		return core.NewTextRange(0, 0)
+
+	case ast.KindArrowFunction:
+		return scanner.GetRangeOfTokenAtPosition(sourceFile, node.AsArrowFunction().EqualsGreaterThanToken.Pos())
+
+	case ast.KindMethodDeclaration, ast.KindConstructor:
+		// A class method and an object-literal shorthand method are both a
+		// keyed member upstream, reported on that key.
+		return memberKeyRange(sourceFile, node)
+
+	case ast.KindGetAccessor, ast.KindSetAccessor:
+		if node.Parent != nil && ast.IsClassLike(node.Parent) {
+			return memberKeyRange(sourceFile, node)
+		}
+		// An object-literal accessor is an ordinary property upstream, and the
+		// function it holds starts at the `(` of the parameter list.
+		if name := node.Name(); name != nil {
+			return scanner.GetRangeOfTokenAtPosition(sourceFile, name.End())
+		}
+	}
+
+	if name := ownFunctionName(node); name != nil {
+		return utils.TrimNodeTextRange(sourceFile, name)
+	}
+	return openingKeywordRange(sourceFile, node)
+}
+
+func memberKeyRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	name := node.Name()
+	if name == nil {
+		return utils.TrimNodeTextRange(sourceFile, node)
+	}
+	if name.Kind == ast.KindComputedPropertyName {
+		// Upstream reports the key expression itself, not the brackets.
+		name = ast.SkipParentheses(name.AsComputedPropertyName().Expression)
+	}
+	return utils.TrimNodeTextRange(sourceFile, name)
+}
+
+// ownFunctionName returns the name a function carries itself, which is the only
+// name upstream's `node.id` holds — a method's key and a variable the function
+// is assigned to are not it.
+func ownFunctionName(node *ast.Node) *ast.Node {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().Name()
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().Name()
+	}
+	return nil
+}
+
+// openingKeywordRange returns the token an anonymous function opens with:
+// `async` when it is async, `function` otherwise. `export` and `default` belong
+// to the surrounding declaration upstream, so they are stepped over.
+func openingKeywordRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	pos := node.Pos()
+	if modifiers := node.Modifiers(); modifiers != nil {
+		for _, modifier := range modifiers.Nodes {
+			if modifier.Kind == ast.KindExportKeyword || modifier.Kind == ast.KindDefaultKeyword {
+				pos = modifier.End()
+			}
+		}
+	}
+	return scanner.GetRangeOfTokenAtPosition(sourceFile, pos)
+}

--- a/internal/rules/consistent_return/consistent_return.md
+++ b/internal/rules/consistent_return/consistent_return.md
@@ -1,0 +1,96 @@
+# consistent-return
+
+## Rule Details
+
+This rule requires `return` statements to either always or never specify values.
+
+A function is inconsistent when one `return` in it hands back a value and
+another does not, or when it returns a value on one path and runs off the end of
+its body on another — because falling off the end hands back `undefined`.
+
+The check applies to each function on its own. A nested function is judged
+separately from the function that contains it, and the first `return` reached in
+a function sets the expectation for the rest of it.
+
+Two shapes are exempt from the "runs off the end" half of the check, because
+returning a value from them is how a constructor overrides the object being
+built: a class `constructor`, and a function whose own name starts with an
+uppercase letter.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function doSomething(condition) {
+  if (condition) {
+    return true;
+  } else {
+    return;
+  }
+}
+
+function doSomethingElse(condition) {
+  if (condition) {
+    return true;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function doSomething(condition) {
+  if (condition) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function Foo() {
+  if (!(this instanceof Foo)) {
+    return new Foo();
+  }
+}
+```
+
+## Options
+
+### `treatUndefinedAsUnspecified`
+
+When `true`, `return undefined;` and `return void 0;` are read as returning
+nothing, so they pair with a bare `return;`. It defaults to `false`.
+
+Examples of **correct** code for this rule with `{ "treatUndefinedAsUnspecified": true }`:
+
+```json
+{ "consistent-return": ["error", { "treatUndefinedAsUnspecified": true }] }
+```
+
+```javascript
+function doSomething(condition) {
+  if (condition) {
+    return undefined;
+  } else {
+    return;
+  }
+}
+```
+
+Examples of **incorrect** code for this rule with `{ "treatUndefinedAsUnspecified": true }`:
+
+```json
+{ "consistent-return": ["error", { "treatUndefinedAsUnspecified": true }] }
+```
+
+```javascript
+function doSomething(condition) {
+  if (condition) {
+    return true;
+  }
+  return undefined;
+}
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/consistent-return

--- a/internal/rules/consistent_return/consistent_return.schema.json
+++ b/internal/rules/consistent_return/consistent_return.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "treatUndefinedAsUnspecified": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/consistent_return/consistent_return_extras_test.go
+++ b/internal/rules/consistent_return/consistent_return_extras_test.go
@@ -70,6 +70,7 @@ func TestConsistentReturnExtras(t *testing.T) {
 			// ---- Locks in upstream checkLastSegment() arm 4: isClassConstructor ----
 			{Code: `class C { constructor() { if (a) return 1; } }`},
 			{Code: `const C = class { constructor() { if (a) return 1; } };`},
+			{Code: `class C { "constructor"() { if (a) return 1; } }`},
 
 			// ---- Locks in upstream ReturnStatement() arm: treatUndefinedAsUnspecified off by default ----
 			{Code: `function foo() { if (a) return undefined; return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
@@ -1041,6 +1042,53 @@ func TestConsistentReturnExtras(t *testing.T) {
 					Column:    44,
 					EndLine:   1,
 					EndColumn: 51,
+				}},
+			},
+
+			// A static member named `constructor` is an ordinary static method:
+			// tsgo parses it as a ConstructorDeclaration all the same.
+			{
+				Code: `class C { static constructor() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static method 'constructor'.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				Code: `class C { static "constructor"() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static method 'constructor'.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 31,
+				}},
+			},
+			{
+				Code: `class C { static async constructor() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static async method 'constructor'.",
+					Line:      1,
+					Column:    24,
+					EndLine:   1,
+					EndColumn: 35,
+				}},
+			},
+			{
+				Code: `class C { static constructor() { if (a) return 1; return; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Static method 'constructor' expected a return value.",
+					Line:      1,
+					Column:    51,
+					EndLine:   1,
+					EndColumn: 58,
 				}},
 			},
 

--- a/internal/rules/consistent_return/consistent_return_extras_test.go
+++ b/internal/rules/consistent_return/consistent_return_extras_test.go
@@ -1,0 +1,1411 @@
+package consistent_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestConsistentReturnExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in. Every
+// verdict below was read off ESLint itself.
+//
+// N/A rows of the Dimension 4 checklist:
+//   - Autofix boundaries: this rule emits no fix and no suggestion.
+//   - Element access (`X['y']`, `X[0]`) on a receiver: the rule never reads a
+//     member access, only a member's key and a `return` argument.
+func TestConsistentReturnExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ConsistentReturnRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: parenthesized return argument ----
+			{Code: `function foo() { if (a) return (undefined); return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+			{Code: `function foo() { if (a) return ((undefined)); return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+			{Code: `function foo() { if (a) return (void 0); return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+			{Code: `function foo() { if (a) return ((void 0)); return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+
+			// ---- Dimension 4: graceful degradation on body-less and empty forms ----
+			{Code: `declare function foo(): number;`},
+			{Code: `abstract class C { abstract foo(): number; }`},
+			{Code: `function foo() {}`},
+			{Code: `const f = () => a;`},
+			{Code: `const f = () => {};`},
+			{Code: `class C {}`},
+			{Code: `class C { static { } }`},
+			{Code: `const o = { ...spread };`},
+
+			// ---- Locks in upstream checkLastSegment() arm 1: hasReturnValue false leaves the end alone ----
+			{Code: `function foo() { if (a) return; }`},
+
+			// ---- Locks in upstream checkLastSegment() arm 2: the end of the code path is unreachable ----
+			{Code: `function foo() { if (a) return 1; throw new Error(); }`},
+			{Code: `function foo() { if (a) return 1; while (true) { } }`},
+			{Code: `function foo() { for (;;) { return 1; } }`},
+			{Code: `function foo() { do { return 1; } while (a); }`},
+			{Code: `function foo() { if (a) { return 1; } else { return 2; } }`},
+			{Code: `function foo() { if (a) { return 1; } else { throw 1; } }`},
+			{Code: `function foo() { switch (a) { case 1: return 1; default: return 2; } }`},
+			{Code: `function foo() { try { return 1; } catch (e) { return 2; } }`},
+			{Code: `function foo() { if (a) return 1; try { foo(); return 2; } catch (e) { return 3; } }`},
+			{Code: `function foo() { if (a) return 1; try { return 2; } catch (e) { } }`},
+			{Code: `function foo() { if (a) return 1; try { } finally { return 2; } }`},
+
+			// ---- Locks in upstream checkLastSegment() arm 3: isES5Constructor ----
+			{Code: `function Foo() { if (a) return 1; }`},
+			{Code: `const f = function Foo() { if (a) return 1; };`},
+			{Code: `const o = { foo: function Bar() { if (a) return 1; } };`},
+			{Code: `class C { foo = function Bar() { if (a) return 1; } }`},
+			{Code: `function Ábc() { if (a) return 1; }`},
+			{Code: `function ǅbc() { if (a) return 1; }`},
+			{Code: `function Ⅰ() { if (a) return 1; }`},
+			{Code: `async function Foo() { if (a) return 1; }`},
+			{Code: `function* Foo() { if (a) return 1; }`},
+
+			// ---- Locks in upstream checkLastSegment() arm 4: isClassConstructor ----
+			{Code: `class C { constructor() { if (a) return 1; } }`},
+			{Code: `const C = class { constructor() { if (a) return 1; } };`},
+
+			// ---- Locks in upstream ReturnStatement() arm: treatUndefinedAsUnspecified off by default ----
+			{Code: `function foo() { if (a) return undefined; return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+
+			// ---- Locks in upstream ReturnStatement() arm: `void` is read off the top-level operator only ----
+			{Code: `function foo() { if (a) return void foo(); return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+
+			// ---- Locks in upstream ReturnStatement() arm: isSpecificId is syntactic, not a lookup ----
+			{Code: `function foo() { var undefined = 1; if (a) return undefined; return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+
+			// ---- Real-user: eslint#8590 a switch with a default counts as returning ----
+			{Code: `function tes(a, b) { if (a) return 'Hello!'; switch (b) { case 1: return 'tada'; default: return 'boo'; } }`},
+
+			// ---- Options plumbing: every JSON shape a config can hand the rule ----
+			// The bare object is the single-option CLI shape; the one-element
+			// array is the rule_tester / multi-element shape. Both must reach
+			// the same option value.
+			{Code: `function foo() { if (a) return undefined; return; }`, Options: map[string]interface{}{"treatUndefinedAsUnspecified": true}},
+			{Code: `function foo() { if (a) return undefined; return; }`, Options: []interface{}{map[string]interface{}{"treatUndefinedAsUnspecified": true}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: TS type-expression wrappers around the return argument ----
+			{
+				Code:    `function foo() { if (a) return undefined as any; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    50,
+					EndLine:   1,
+					EndColumn: 57,
+				}},
+			},
+			{
+				Code:    `function foo() { if (a) return undefined satisfies unknown; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    61,
+					EndLine:   1,
+					EndColumn: 68,
+				}},
+			},
+			{
+				Code:    `function foo() { if (a) return undefined!; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    44,
+					EndLine:   1,
+					EndColumn: 51,
+				}},
+			},
+			{
+				Code:    `function foo() { if (a) return (void 0) as any; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    49,
+					EndLine:   1,
+					EndColumn: 56,
+				}},
+			},
+
+			// ---- Dimension 4: optional chain as the return argument ----
+			{
+				Code: `function foo() { if (a) return obj?.x; return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    40,
+					EndLine:   1,
+					EndColumn: 47,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return obj?.(); return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    41,
+					EndLine:   1,
+					EndColumn: 48,
+				}},
+			},
+
+			// ---- Dimension 4: key forms on a class member ----
+			{
+				Code: `class C { foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `class C { 'foo'() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 16,
+				}},
+			},
+			{
+				Code: `class C { 0() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method '0'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 12,
+				}},
+			},
+			{
+				Code: `class C { #foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of private method '#foo'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `class C { ['foo']() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 17,
+				}},
+			},
+			{
+				Code: "class C { [`foo`]() { if (a) return 1; } }",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 17,
+				}},
+			},
+			{
+				Code: `class C { [k]() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method.",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `class C { [(k)]() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method.",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+
+			// ---- Dimension 4: key forms on an object literal member ----
+			{
+				Code: `const o = { foo() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 16,
+				}},
+			},
+			{
+				Code: `const o = { 'foo'() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code: `const o = { 0() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method '0'.",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `const o = { ['foo']() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 19,
+				}},
+			},
+			{
+				Code: "const o = { [`foo`]() { if (a) return 1; } };",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 19,
+				}},
+			},
+			{
+				Code: `const o = { [k]() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method.",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `const o = { [(k)]() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method.",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 16,
+				}},
+			},
+
+			// ---- Dimension 4: accessors, in a class and in an object literal ----
+			{
+				Code: `class C { get foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of getter 'foo'.",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code: `class C { set foo(v) { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of setter 'foo'.",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code: `class C { get #foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of private getter '#foo'.",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 19,
+				}},
+			},
+			{
+				Code: `class C { get [k]() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of getter.",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 17,
+				}},
+			},
+			{
+				Code: `const o = { get foo() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of getter 'foo'.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+			{
+				Code: `const o = { set foo(v) { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of setter 'foo'.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+			{
+				Code: `const o = { get [k]() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of getter.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+			{
+				Code: `const o = { get [(k)]() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of getter.",
+					Line:      1,
+					Column:    22,
+					EndLine:   1,
+					EndColumn: 23,
+				}},
+			},
+
+			// ---- Dimension 4: static and private modifiers ----
+			{
+				Code: `class C { static foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static method 'foo'.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+			{
+				Code: `class C { static #foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static private method '#foo'.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 22,
+				}},
+			},
+			{
+				Code: `class C { static get #foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static private getter '#foo'.",
+					Line:      1,
+					Column:    22,
+					EndLine:   1,
+					EndColumn: 26,
+				}},
+			},
+			{
+				Code: `class C { static async #foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static private async method '#foo'.",
+					Line:      1,
+					Column:    24,
+					EndLine:   1,
+					EndColumn: 28,
+				}},
+			},
+
+			// ---- Dimension 4: declaration and container forms ----
+			{
+				Code: `const f = function () { if (a) return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 19,
+				}},
+			},
+			{
+				Code: `const f = function bar() { if (a) return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'bar'.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 23,
+				}},
+			},
+			{
+				Code: `const f = () => { if (a) return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of arrow function.",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 16,
+				}},
+			},
+			{
+				Code: `class C { f = () => { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'f'.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 20,
+				}},
+			},
+			{
+				Code: `class C { f = function () { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'f'.",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 23,
+				}},
+			},
+			{
+				Code: `class C { static #f = () => { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static private method '#f'.",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 28,
+				}},
+			},
+			{
+				Code: `const o = { foo: function () { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 26,
+				}},
+			},
+			{
+				Code: `const o = { foo: function bar() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    27,
+					EndLine:   1,
+					EndColumn: 30,
+				}},
+			},
+			{
+				Code: `const o = { foo: () => { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 23,
+				}},
+			},
+			{
+				Code: `const C = class { foo() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    19,
+					EndLine:   1,
+					EndColumn: 22,
+				}},
+			},
+			{
+				Code: `export default function () { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function.",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 24,
+				}},
+			},
+			{
+				Code: `export default async function () { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async function.",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+			{
+				Code: `export default function foo() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 28,
+				}},
+			},
+			{
+				Code: `export function foo() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 20,
+				}},
+			},
+
+			// ---- Dimension 4: async / generator / async generator variants ----
+			{
+				Code: `async function foo() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async function 'foo'.",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 19,
+				}},
+			},
+			{
+				Code: `function* foo() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of generator function 'foo'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `async function* foo() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async generator function 'foo'.",
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 20,
+				}},
+			},
+			{
+				Code: `const f = async () => { if (a) return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async arrow function.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 22,
+				}},
+			},
+			{
+				Code: `const f = async function () { if (a) return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async function.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 16,
+				}},
+			},
+			{
+				Code: `const f = function* () { if (a) return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of generator function.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 19,
+				}},
+			},
+			{
+				Code: `const o = { async foo() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async method 'foo'.",
+					Line:      1,
+					Column:    19,
+					EndLine:   1,
+					EndColumn: 22,
+				}},
+			},
+			{
+				Code: `const o = { *foo() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of generator method 'foo'.",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 17,
+				}},
+			},
+			{
+				Code: `const o = { async *foo() { if (a) return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async generator method 'foo'.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 23,
+				}},
+			},
+			{
+				Code: `class C { async *foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async generator method 'foo'.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+
+			// ---- Dimension 4: same-kind nesting, only the intended function matches ----
+			{
+				Code: `function outer() { if (a) return 1; function inner() { if (b) return 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'outer'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 15,
+				}, {
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'inner'.",
+					Line:      1,
+					Column:    46,
+					EndLine:   1,
+					EndColumn: 51,
+				}},
+			},
+			{
+				Code: `function outer() { return 1; function inner() { if (b) return 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'inner'.",
+					Line:      1,
+					Column:    39,
+					EndLine:   1,
+					EndColumn: 44,
+				}},
+			},
+			{
+				Code: `function outer() { if (a) return 1; function inner() { return; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'outer'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `class C { foo() { const f = () => { if (a) return 1; }; if (b) return 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+				}, {
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of arrow function.",
+					Line:      1,
+					Column:    32,
+					EndLine:   1,
+					EndColumn: 34,
+				}},
+			},
+			{
+				Code: `class C { foo() { if (a) return 1; class D { bar() { if (b) return 2; } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+				}, {
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'bar'.",
+					Line:      1,
+					Column:    46,
+					EndLine:   1,
+					EndColumn: 49,
+				}},
+			},
+			{
+				Code: `class C { static { const f = function () { if (a) return 1; }; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function.",
+					Line:      1,
+					Column:    30,
+					EndLine:   1,
+					EndColumn: 38,
+				}},
+			},
+			{
+				Code: `class C { p = { m() { if (a) return 1; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'm'.",
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code: `function foo() { return 1; function g() { return; return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Function 'g' expected no return value.",
+					Line:      1,
+					Column:    51,
+					EndLine:   1,
+					EndColumn: 60,
+				}},
+			},
+
+			// ---- Dimension 4: graceful degradation on body-less and empty forms ----
+			{
+				Code: `function foo(); function foo() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				Code: `class C { foo(): void; foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    24,
+					EndLine:   1,
+					EndColumn: 27,
+				}},
+			},
+			{
+				Code: `function foo({ a, ...rest }) { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+
+			// ---- Locks in upstream checkLastSegment() arm 1: hasReturnValue false leaves the end alone ----
+			{
+				Code: `function foo() { if (a) return; if (b) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Function 'foo' expected no return value.",
+					Line:      1,
+					Column:    40,
+					EndLine:   1,
+					EndColumn: 49,
+				}},
+			},
+
+			// ---- Locks in upstream checkLastSegment() arm 2: the end of the code path is unreachable ----
+			{
+				Code: `function foo() { if (a) return 1; while (true) { break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return 1; for (;;) { if (b) break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return 1; switch (a) { case 1: return 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return 1; try { } catch (e) { return 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return 1; try { foo(); } finally { } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return 1; label: { break label; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return 1; debugger; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+
+			// ---- Locks in upstream checkLastSegment() arm 3: isES5Constructor ----
+			{
+				Code: `function ábc() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'ábc'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				// A name outside the BMP is read as a lone surrogate, whose
+				// lowercase form is itself, so it is not an ES5 constructor.
+				Code: `function 𐐀() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function '𐐀'.",
+				}},
+			},
+			{
+				Code: `function $foo() { if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function '$foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `const Foo = function () { if (a) return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function.",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+			{
+				Code: `class C { Foo() { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'Foo'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+
+			// ---- Locks in upstream checkLastSegment() arm 4: isClassConstructor ----
+			{
+				Code: `class C { constructor() { if (a) return 1; return; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Constructor expected a return value.",
+					Line:      1,
+					Column:    44,
+					EndLine:   1,
+					EndColumn: 51,
+				}},
+			},
+
+			// ---- Locks in upstream ReturnStatement() arm: only the first return sets the expectation ----
+			{
+				Code: `function foo() { if (a) return 1; if (b) return; if (c) return 2; if (d) return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}, {
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    42,
+					EndLine:   1,
+					EndColumn: 49,
+				}, {
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    74,
+					EndLine:   1,
+					EndColumn: 81,
+				}},
+			},
+			{
+				Code: `function foo() { return; if (a) return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Function 'foo' expected no return value.",
+					Line:      1,
+					Column:    33,
+					EndLine:   1,
+					EndColumn: 42,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return 1; else return 2; return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    50,
+					EndLine:   1,
+					EndColumn: 57,
+				}},
+			},
+
+			// ---- Locks in upstream ReturnStatement() arm: treatUndefinedAsUnspecified off by default ----
+			{
+				Code: `function foo() { if (a) return undefined; return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    43,
+					EndLine:   1,
+					EndColumn: 50,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return void 0; return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    40,
+					EndLine:   1,
+					EndColumn: 47,
+				}},
+			},
+			{
+				Code:    `function foo() { if (a) return undefined; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": false},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    43,
+					EndLine:   1,
+					EndColumn: 50,
+				}},
+			},
+
+			// ---- Locks in upstream ReturnStatement() arm: `void` is read off the top-level operator only ----
+			{
+				Code:    `function foo() { if (a) return -void 0; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    41,
+					EndLine:   1,
+					EndColumn: 48,
+				}},
+			},
+			{
+				Code:    `function foo() { if (a) return typeof undefined; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    50,
+					EndLine:   1,
+					EndColumn: 57,
+				}},
+			},
+
+			// ---- Locks in upstream ReturnStatement() arm: isSpecificId is syntactic, not a lookup ----
+			{
+				Code:    `function foo() { if (a) return undefined2; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    44,
+					EndLine:   1,
+					EndColumn: 51,
+				}},
+			},
+
+			// ---- Locks in upstream ReturnStatement() arm: the Program code path names itself `Program` ----
+			{
+				Code: `if (a) { return 1; } return;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Program expected a return value.",
+					Line:      1,
+					Column:    22,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				Code: `if (a) { return; } return 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Program expected no return value.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+
+			// ---- Real-user: eslint#8179 void inside a ternary is still a value ----
+			{
+				Code:    `function test(input) { if (input) { return input === true ? void 0 : void 1; } return void false; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'test' expected a return value.",
+					Line:      1,
+					Column:    80,
+					EndLine:   1,
+					EndColumn: 98,
+				}},
+			},
+
+			// ---- Real-user: eslint#12865 an async function returning a promise on one path only ----
+			{
+				Code: `async function example() { if (something) { someSyncSideEffect(); return; } else { return new Promise(resolve => { someAsyncSideEffect(resolve); }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Async function 'example' expected no return value.",
+					Line:      1,
+					Column:    84,
+					EndLine:   1,
+					EndColumn: 149,
+				}},
+			},
+
+			// ---- Real-user: eslint#11371 a generator with a bare return alongside a value return ----
+			{
+				Code: `function* gen() { yield 1; if (a) return 1; return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Generator function 'gen' expected a return value.",
+					Line:      1,
+					Column:    45,
+					EndLine:   1,
+					EndColumn: 52,
+				}},
+			},
+
+			// ---- Real-user: express-style middleware that guards and falls through ----
+			{
+				Code: `function middleware(req, res, next) { if (!req.user) return res.status(401).send(); next(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'middleware'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 20,
+				}},
+			},
+
+			// ---- Real-user: a helper that ends by exiting the process still falls off the end ----
+			{
+				Code: `function foo() { if (a) return 1; process.exit(1); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+
+			// ---- Options plumbing: every JSON shape a config can hand the rule ----
+			// `treatUndefinedAsUnspecified` defaults to false, so an omitted
+			// option, an empty option object, and an explicit false all report
+			// the same diagnostic.
+			{
+				Code:    `function foo() { if (a) return undefined; return; }`,
+				Options: map[string]interface{}{"treatUndefinedAsUnspecified": false},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    43,
+					EndLine:   1,
+					EndColumn: 50,
+				}},
+			},
+			{
+				Code:    `function foo() { if (a) return undefined; return; }`,
+				Options: []interface{}{map[string]interface{}{"treatUndefinedAsUnspecified": false}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    43,
+					EndLine:   1,
+					EndColumn: 50,
+				}},
+			},
+			{
+				Code:    `function foo() { if (a) return undefined; return; }`,
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    43,
+					EndLine:   1,
+					EndColumn: 50,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return undefined; return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    43,
+					EndLine:   1,
+					EndColumn: 50,
+				}},
+			},
+
+			// ---- Dimension 4: positions on multi-line sources ----
+			{
+				Code: `function foo(a) {
+  if (a) {
+    return 1;
+  }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `class C {
+  bar() {
+    if (a) {
+      return 1;
+    }
+    return;
+  }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Method 'bar' expected a return value.",
+					Line:      6,
+					Column:    5,
+					EndLine:   6,
+					EndColumn: 12,
+				}},
+			},
+			{
+				Code: `const o = {
+  get thing() {
+    if (a) {
+      return 1;
+    }
+  },
+};
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of getter 'thing'.",
+					Line:      2,
+					Column:    12,
+					EndLine:   2,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `const f = (
+  a,
+  b,
+) => {
+  if (a) return 1;
+};
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of arrow function.",
+					Line:      4,
+					Column:    3,
+					EndLine:   4,
+					EndColumn: 5,
+				}},
+			},
+			{
+				Code: `function outer() {
+  if (a) return 1;
+  const inner = function () {
+    if (b) return 2;
+  };
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'outer'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 15,
+				}, {
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function.",
+					Line:      3,
+					Column:    17,
+					EndLine:   3,
+					EndColumn: 25,
+				}},
+			},
+		},
+	)
+}

--- a/internal/rules/consistent_return/consistent_return_upstream_test.go
+++ b/internal/rules/consistent_return/consistent_return_upstream_test.go
@@ -1,0 +1,311 @@
+package consistent_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestConsistentReturnUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/consistent-return.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in the
+// consistent_return_extras_test.go file.
+func TestConsistentReturnUpstream(t *testing.T) {
+	treatUndefinedAsUnspecified := map[string]interface{}{"treatUndefinedAsUnspecified": true}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ConsistentReturnRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `function foo() { return; }`},
+			{Code: `function foo() { if (true) return; }`},
+			{Code: `function foo() { if (true) return; else return; }`},
+			{Code: `function foo() { if (true) return true; else return false; }`},
+			{Code: `f(function() { return; })`},
+			{Code: `f(function() { if (true) return; })`},
+			{Code: `f(function() { if (true) return; else return; })`},
+			{Code: `f(function() { if (true) return true; else return false; })`},
+			{Code: `function foo() { function bar() { return true; } return; }`},
+			{Code: `function foo() { function bar() { return; } return false; }`},
+			{Code: `function Foo() { if (!(this instanceof Foo)) return new Foo(); }`},
+			{Code: `function foo() { if (true) return 5; else return undefined; }`},
+			{Code: `function foo() { if (true) return 5; else return void 0; }`},
+			{
+				Code:    `function foo() { if (true) return; else return undefined; }`,
+				Options: treatUndefinedAsUnspecified,
+			},
+			{
+				Code:    `function foo() { if (true) return; else return void 0; }`,
+				Options: treatUndefinedAsUnspecified,
+			},
+			{
+				Code:    `function foo() { if (true) return undefined; else return; }`,
+				Options: treatUndefinedAsUnspecified,
+			},
+			{
+				Code:    `function foo() { if (true) return undefined; else return void 0; }`,
+				Options: treatUndefinedAsUnspecified,
+			},
+			{
+				Code:    `function foo() { if (true) return void 0; else return; }`,
+				Options: treatUndefinedAsUnspecified,
+			},
+			{
+				Code:    `function foo() { if (true) return void 0; else return undefined; }`,
+				Options: treatUndefinedAsUnspecified,
+			},
+			{Code: `var x = () => {  return {}; };`},
+			// Upstream needs `ecmaFeatures.globalReturn` to parse a top-level
+			// `return`; tsgo parses one unconditionally.
+			{Code: `if (true) { return 1; } return 0;`},
+
+			// https://github.com/eslint/eslint/issues/7790
+			{Code: `class Foo { constructor() { if (true) return foo; } }`},
+			{Code: `var Foo = class { constructor() { if (true) return foo; } }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `function foo() { if (true) return true; else return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    46,
+					EndLine:   1,
+					EndColumn: 53,
+				}},
+			},
+			{
+				Code: `var foo = () => { if (true) return true; else return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Arrow function expected a return value.",
+					Line:      1,
+					Column:    47,
+					EndLine:   1,
+					EndColumn: 54,
+				}},
+			},
+			{
+				Code: `function foo() { if (true) return; else return false; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Function 'foo' expected no return value.",
+					Line:      1,
+					Column:    41,
+					EndLine:   1,
+					EndColumn: 54,
+				}},
+			},
+			{
+				Code: `f(function() { if (true) return true; else return; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function expected a return value.",
+					Line:      1,
+					Column:    44,
+					EndLine:   1,
+					EndColumn: 51,
+				}},
+			},
+			{
+				Code: `f(function() { if (true) return; else return false; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Function expected no return value.",
+					Line:      1,
+					Column:    39,
+					EndLine:   1,
+					EndColumn: 52,
+				}},
+			},
+			{
+				Code: `f(a => { if (true) return; else return false; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Arrow function expected no return value.",
+					Line:      1,
+					Column:    33,
+					EndLine:   1,
+					EndColumn: 46,
+				}},
+			},
+			{
+				Code:    `function foo() { if (true) return true; return undefined; }`,
+				Options: treatUndefinedAsUnspecified,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    41,
+					EndLine:   1,
+					EndColumn: 58,
+				}},
+			},
+			{
+				Code:    `function foo() { if (true) return true; return void 0; }`,
+				Options: treatUndefinedAsUnspecified,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Function 'foo' expected a return value.",
+					Line:      1,
+					Column:    41,
+					EndLine:   1,
+					EndColumn: 55,
+				}},
+			},
+			{
+				Code:    `function foo() { if (true) return undefined; return true; }`,
+				Options: treatUndefinedAsUnspecified,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Function 'foo' expected no return value.",
+					Line:      1,
+					Column:    46,
+					EndLine:   1,
+					EndColumn: 58,
+				}},
+			},
+			{
+				Code:    `function foo() { if (true) return void 0; return true; }`,
+				Options: treatUndefinedAsUnspecified,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Function 'foo' expected no return value.",
+					Line:      1,
+					Column:    43,
+					EndLine:   1,
+					EndColumn: 55,
+				}},
+			},
+			{
+				// Upstream needs `ecmaFeatures.globalReturn` here; tsgo parses a
+				// top-level `return` unconditionally.
+				Code: `if (true) { return 1; } return;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Program expected a return value.",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 32,
+				}},
+			},
+			{
+				Code: `function foo() { if (a) return true; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				Code: `function _foo() { if (a) return true; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function '_foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `f(function foo() { if (a) return true; });`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function 'foo'.",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `f(function() { if (a) return true; });`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of function.",
+					Line:      1,
+					Column:    3,
+					EndLine:   1,
+					EndColumn: 11,
+				}},
+			},
+			{
+				Code: `f(() => { if (a) return true; });`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of arrow function.",
+					Line:      1,
+					Column:    6,
+					EndLine:   1,
+					EndColumn: 8,
+				}},
+			},
+			{
+				Code: `var obj = {foo() { if (a) return true; }};`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `class A {foo() { if (a) return true; }};`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 13,
+				}},
+			},
+			{
+				// Upstream needs `ecmaFeatures.globalReturn` here; tsgo parses a
+				// top-level `return` unconditionally. Upstream reports a bare
+				// line/column with no end position; rslint reports the empty
+				// range at the head of the file.
+				Code: `if (a) return true;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of program.",
+					Line:      1,
+					Column:    1,
+				}},
+			},
+			{
+				Code: `class A { CapitalizedFunction() { if (a) return true; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'CapitalizedFunction'.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 30,
+				}},
+			},
+			{
+				Code: `({ constructor() { if (a) return true; } });`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'constructor'.",
+					Line:      1,
+					Column:    4,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+		},
+	)
+}

--- a/internal/utils/cfg/cfg.go
+++ b/internal/utils/cfg/cfg.go
@@ -62,8 +62,14 @@ func (blk *Block[E]) Index() int {
 // Graph is the control-flow graph of one code path root, unreachable blocks
 // included. Blocks[0] is the entry block; the rest are in construction order,
 // which no analysis should depend on.
+//
+// EndReachable reports whether control can run off the end of the root — the
+// question ESLint answers with `isAnySegmentReachable(codePath.currentSegments)`
+// at the root's `:exit`. It is false when every path out of the root returns,
+// throws, or loops forever.
 type Graph[E any] struct {
-	Blocks []*Block[E]
+	Blocks       []*Block[E]
+	EndReachable bool
 }
 
 // Hooks are the points where a consumer turns a position in the walk into an
@@ -167,7 +173,7 @@ func Build[E any](root *ast.Node, hooks Hooks[E]) *Graph[E] {
 		}
 	}
 
-	return &Graph[E]{Blocks: b.blocks}
+	return &Graph[E]{Blocks: b.blocks, EndReachable: b.cur.Reachable}
 }
 
 // parameter models a parameter binding: its default value is skipped when an

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -468,6 +470,40 @@ func GetFunctionNameWithKind(node *ast.Node) string {
 	}
 
 	return strings.Join(tokens, " ")
+}
+
+// IsES5Constructor mirrors ESLint's `astUtils.isES5Constructor`: a function
+// with a name of its own whose first character differs from its own lowercase
+// form is treated as an ES5-style constructor. Only a function declaration or
+// function expression can carry such a name; every other function-like node
+// (arrow, method, accessor) reports false.
+func IsES5Constructor(node *ast.Node) bool {
+	var name *ast.Node
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		name = node.AsFunctionDeclaration().Name()
+	case ast.KindFunctionExpression:
+		name = node.AsFunctionExpression().Name()
+	default:
+		return false
+	}
+	if name == nil || !ast.IsIdentifier(name) {
+		return false
+	}
+	return StartsWithUpperCase(name.AsIdentifier().Text)
+}
+
+// StartsWithUpperCase mirrors ESLint's `s[0] !== s[0].toLocaleLowerCase()`,
+// which reads the first UTF-16 code unit. A character counts when it has a
+// distinct lowercase form, so `Á` and the Roman numeral `Ⅰ` qualify while
+// `_` and `$` do not. A character outside the BMP is read as a lone surrogate,
+// which is its own lowercase form, so `𐐀` does not qualify.
+func StartsWithUpperCase(s string) bool {
+	r, _ := utf8.DecodeRuneInString(s)
+	if r > 0xFFFF {
+		return false
+	}
+	return unicode.ToLower(r) != r
 }
 
 // GetFunctionNameWithKindCore mirrors ESLint core's astUtils.getFunctionNameWithKind.

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -512,7 +512,19 @@ func StartsWithUpperCase(s string) bool {
 // as complexity and max-params rely on that narrower behavior for message text.
 func GetFunctionNameWithKindCore(node *ast.Node) string {
 	if node.Kind == ast.KindConstructor {
-		return "constructor"
+		if !ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic) {
+			return "constructor"
+		}
+		// tsgo parses a `static` member named `constructor` as a
+		// ConstructorDeclaration too, which every JS parser reads as an
+		// ordinary static method keyed `constructor`. A constructor's
+		// modifiers are not what ast.GetFunctionFlags looks at, so `async` is
+		// read here; `*constructor` parses as a method and never lands here.
+		tokens := []string{"static"}
+		if ast.HasSyntacticModifier(node, ast.ModifierFlagsAsync) {
+			tokens = append(tokens, "async")
+		}
+		return strings.Join(append(tokens, "method", "'constructor'"), " ")
 	}
 
 	parent := node.Parent

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -463,6 +463,7 @@ export default defineConfig({
     './tests/eslint/rules/no-alert.test.ts',
     './tests/eslint/rules/no-bitwise.test.ts',
     './tests/eslint/rules/complexity.test.ts',
+    './tests/eslint/rules/consistent-return.test.ts',
     './tests/eslint/rules/max-depth.test.ts',
     './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/max-lines-per-function.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/consistent-return.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/consistent-return.test.ts.snap
@@ -1,0 +1,547 @@
+// Rstest Snapshot v1
+
+exports[`consistent-return > invalid 1`] = `
+{
+  "code": "function foo() { if (true) return true; else return; }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' expected a return value.",
+      "messageId": "missingReturnValue",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 2`] = `
+{
+  "code": "var foo = () => { if (true) return true; else return; }",
+  "diagnostics": [
+    {
+      "message": "Arrow function expected a return value.",
+      "messageId": "missingReturnValue",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 3`] = `
+{
+  "code": "function foo() { if (true) return; else return false; }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' expected no return value.",
+      "messageId": "unexpectedReturnValue",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 4`] = `
+{
+  "code": "f(function() { if (true) return true; else return; })",
+  "diagnostics": [
+    {
+      "message": "Function expected a return value.",
+      "messageId": "missingReturnValue",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 5`] = `
+{
+  "code": "f(function() { if (true) return; else return false; })",
+  "diagnostics": [
+    {
+      "message": "Function expected no return value.",
+      "messageId": "unexpectedReturnValue",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 6`] = `
+{
+  "code": "f(a => { if (true) return; else return false; })",
+  "diagnostics": [
+    {
+      "message": "Arrow function expected no return value.",
+      "messageId": "unexpectedReturnValue",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 7`] = `
+{
+  "code": "function foo() { if (true) return true; return undefined; }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' expected a return value.",
+      "messageId": "missingReturnValue",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 8`] = `
+{
+  "code": "function foo() { if (true) return true; return void 0; }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' expected a return value.",
+      "messageId": "missingReturnValue",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 9`] = `
+{
+  "code": "function foo() { if (true) return undefined; return true; }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' expected no return value.",
+      "messageId": "unexpectedReturnValue",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 10`] = `
+{
+  "code": "function foo() { if (true) return void 0; return true; }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' expected no return value.",
+      "messageId": "unexpectedReturnValue",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 11`] = `
+{
+  "code": "if (true) { return 1; } return;",
+  "diagnostics": [
+    {
+      "message": "Program expected a return value.",
+      "messageId": "missingReturnValue",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 12`] = `
+{
+  "code": "function foo() { if (a) return true; }",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of function 'foo'.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 13`] = `
+{
+  "code": "function _foo() { if (a) return true; }",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of function '_foo'.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 14`] = `
+{
+  "code": "f(function foo() { if (a) return true; });",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of function 'foo'.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 15`] = `
+{
+  "code": "f(function() { if (a) return true; });",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of function.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 16`] = `
+{
+  "code": "f(() => { if (a) return true; });",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of arrow function.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 17`] = `
+{
+  "code": "var obj = {foo() { if (a) return true; }};",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of method 'foo'.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 18`] = `
+{
+  "code": "class A {foo() { if (a) return true; }};",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of method 'foo'.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 19`] = `
+{
+  "code": "if (a) return true;",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of program.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 20`] = `
+{
+  "code": "class A { CapitalizedFunction() { if (a) return true; } }",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of method 'CapitalizedFunction'.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-return > invalid 21`] = `
+{
+  "code": "({ constructor() { if (a) return true; } });",
+  "diagnostics": [
+    {
+      "message": "Expected to return a value at the end of method 'constructor'.",
+      "messageId": "missingReturn",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "consistent-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/consistent-return.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/consistent-return.test.ts
@@ -1,0 +1,141 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('consistent-return', {
+  valid: [
+    'function foo() { return; }',
+    'function foo() { if (true) return; }',
+    'function foo() { if (true) return; else return; }',
+    'function foo() { if (true) return true; else return false; }',
+    'f(function() { return; })',
+    'f(function() { if (true) return; })',
+    'f(function() { if (true) return; else return; })',
+    'f(function() { if (true) return true; else return false; })',
+    'function foo() { function bar() { return true; } return; }',
+    'function foo() { function bar() { return; } return false; }',
+    'function Foo() { if (!(this instanceof Foo)) return new Foo(); }',
+    'function foo() { if (true) return 5; else return undefined; }',
+    'function foo() { if (true) return 5; else return void 0; }',
+    {
+      code: 'function foo() { if (true) return; else return undefined; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+    },
+    {
+      code: 'function foo() { if (true) return; else return void 0; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+    },
+    {
+      code: 'function foo() { if (true) return undefined; else return; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+    },
+    {
+      code: 'function foo() { if (true) return undefined; else return void 0; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+    },
+    {
+      code: 'function foo() { if (true) return void 0; else return; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+    },
+    {
+      code: 'function foo() { if (true) return void 0; else return undefined; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+    },
+    'var x = () => {  return {}; };',
+    'if (true) { return 1; } return 0;',
+
+    // https://github.com/eslint/eslint/issues/7790
+    'class Foo { constructor() { if (true) return foo; } }',
+    'var Foo = class { constructor() { if (true) return foo; } }',
+  ],
+  invalid: [
+    {
+      code: 'function foo() { if (true) return true; else return; }',
+      errors: [{ messageId: 'missingReturnValue', column: 46 }],
+    },
+    {
+      code: 'var foo = () => { if (true) return true; else return; }',
+      errors: [{ messageId: 'missingReturnValue', column: 47 }],
+    },
+    {
+      code: 'function foo() { if (true) return; else return false; }',
+      errors: [{ messageId: 'unexpectedReturnValue', column: 41 }],
+    },
+    {
+      code: 'f(function() { if (true) return true; else return; })',
+      errors: [{ messageId: 'missingReturnValue', column: 44 }],
+    },
+    {
+      code: 'f(function() { if (true) return; else return false; })',
+      errors: [{ messageId: 'unexpectedReturnValue', column: 39 }],
+    },
+    {
+      code: 'f(a => { if (true) return; else return false; })',
+      errors: [{ messageId: 'unexpectedReturnValue', column: 33 }],
+    },
+    {
+      code: 'function foo() { if (true) return true; return undefined; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+      errors: [{ messageId: 'missingReturnValue', column: 41 }],
+    },
+    {
+      code: 'function foo() { if (true) return true; return void 0; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+      errors: [{ messageId: 'missingReturnValue', column: 41 }],
+    },
+    {
+      code: 'function foo() { if (true) return undefined; return true; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+      errors: [{ messageId: 'unexpectedReturnValue', column: 46 }],
+    },
+    {
+      code: 'function foo() { if (true) return void 0; return true; }',
+      options: [{ treatUndefinedAsUnspecified: true }] as any,
+      errors: [{ messageId: 'unexpectedReturnValue', column: 43 }],
+    },
+    {
+      code: 'if (true) { return 1; } return;',
+      errors: [{ messageId: 'missingReturnValue', column: 25 }],
+    },
+    {
+      code: 'function foo() { if (a) return true; }',
+      errors: [{ messageId: 'missingReturn', column: 10 }],
+    },
+    {
+      code: 'function _foo() { if (a) return true; }',
+      errors: [{ messageId: 'missingReturn', column: 10 }],
+    },
+    {
+      code: 'f(function foo() { if (a) return true; });',
+      errors: [{ messageId: 'missingReturn', column: 12 }],
+    },
+    {
+      code: 'f(function() { if (a) return true; });',
+      errors: [{ messageId: 'missingReturn', column: 3 }],
+    },
+    {
+      code: 'f(() => { if (a) return true; });',
+      errors: [{ messageId: 'missingReturn', column: 6 }],
+    },
+    {
+      code: 'var obj = {foo() { if (a) return true; }};',
+      errors: [{ messageId: 'missingReturn', column: 12 }],
+    },
+    {
+      code: 'class A {foo() { if (a) return true; }};',
+      errors: [{ messageId: 'missingReturn', column: 10 }],
+    },
+    {
+      code: 'if (a) return true;',
+      errors: [{ messageId: 'missingReturn', column: 1 }],
+    },
+    {
+      code: 'class A { CapitalizedFunction() { if (a) return true; } }',
+      errors: [{ messageId: 'missingReturn', column: 11 }],
+    },
+    {
+      code: '({ constructor() { if (a) return true; } });',
+      errors: [{ messageId: 'missingReturn', column: 4 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `consistent-return` rule from ESLint to rslint.

The rule requires every `return` in a function to either always or never carry a value, and reports a function that returns a value on one path but runs off the end of its body on another. A class `constructor` and a function whose own name starts with an uppercase letter are exempt from the run-off-the-end half of the check. The `treatUndefinedAsUnspecified` option reads `return undefined;` and `return void 0;` as returning nothing.

Reachability comes from the shared control-flow graph in `internal/utils/cfg`, which gains `Graph.EndReachable` — whether control can run off the end of a code path root, the question ESLint answers with `isAnySegmentReachable(codePath.currentSegments)` at the root's `:exit`. It reads the reachability of the block the walk ends in, which the `no-useless-return` port this one is stacked on settles for every block.

`utils.IsES5Constructor` is extracted from the typescript `no-invalid-this` rule so both rules share one implementation. The uppercase test behind it reads the first UTF-16 code unit, the way ESLint's `s[0] !== s[0].toLocaleLowerCase()` does: a character qualifies when it has a distinct lowercase form, so `Ⅰ` counts, while a character outside the BMP is read as a lone surrogate — its own lowercase form — so `𐐀` does not.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/consistent-return
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/consistent-return.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
