### PR TITLE
perf: optimize no-unused-vars hot paths

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -40,11 +40,14 @@ type analysisContext struct {
 	seenMergedSymbols  map[*ast.Symbol]bool
 	reportedUnused     map[*ast.Node]bool
 	explicitExports    map[*ast.Node]explicitExportResult
-	parameterBounds    map[*ast.Node]parameterBoundary
+	parameterOwner     *ast.Node
+	parameterBoundary  parameterBoundary
 	fallbackInfos      map[*ast.Symbol]referenceInfo
 	fallbackCandidates map[string][]*ast.Node
 	jsxScanned         bool
 	globalSourceFile   bool
+	declarationFile    bool
+	sourceFile         *ast.SourceFile
 	firstJsx           *ast.Node
 	firstFragment      *ast.Node
 }
@@ -791,6 +794,12 @@ func isParameterInWithoutBodyDeclaration(node *ast.Node) bool {
 // (export =, export default, or export { ... }), non-exported declarations are
 // private and should be checked — return false for them.
 func isInsideAmbientModuleBlock(node *ast.Node, ac *analysisContext) bool {
+	// The parser propagates NodeFlagsAmbient to every node in a declaration
+	// file or `declare` context. Ordinary source nodes can therefore avoid all
+	// ancestor and source-file walks here.
+	if node == nil || node.Flags&ast.NodeFlagsAmbient == 0 {
+		return false
+	}
 	moduleBlock := ast.FindAncestorKind(node, ast.KindModuleBlock)
 	if moduleBlock == nil {
 		return false
@@ -801,11 +810,10 @@ func isInsideAmbientModuleBlock(node *ast.Node, ac *analysisContext) bool {
 		return false
 	}
 
-	// Check if the module declaration has the Ambient (declare) flag.
+	// Retain the explicit checks as a defensive guard around the parser flag:
+	// a declaration carrying its own `declare` modifier inside a non-ambient
+	// namespace must not make the whole namespace ambient.
 	isAmbient := ast.GetCombinedModifierFlags(moduleDecl)&ast.ModifierFlagsAmbient != 0
-	// Also check if any ancestor is a global scope augmentation (declare global { ... }).
-	// GetCombinedModifierFlags doesn't walk up through ModuleBlock→ModuleDeclaration,
-	// so we need to check ancestors explicitly.
 	if !isAmbient {
 		if ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
 			return ast.IsGlobalScopeAugmentation(n)
@@ -813,7 +821,6 @@ func isInsideAmbientModuleBlock(node *ast.Node, ac *analysisContext) bool {
 			isAmbient = true
 		}
 	}
-	// Also check if any ancestor ModuleDeclaration has the Ambient flag.
 	if !isAmbient {
 		if ast.FindAncestor(moduleDecl.Parent, func(n *ast.Node) bool {
 			return n.Kind == ast.KindModuleDeclaration &&
@@ -822,12 +829,8 @@ func isInsideAmbientModuleBlock(node *ast.Node, ac *analysisContext) bool {
 			isAmbient = true
 		}
 	}
-	// In .d.ts files, all declarations are implicitly ambient.
-	if !isAmbient {
-		sf := ast.GetSourceFileOfNode(node)
-		if sf != nil && sf.IsDeclarationFile {
-			isAmbient = true
-		}
+	if !isAmbient && ac.declarationFile {
+		isAmbient = true
 	}
 
 	if !isAmbient {
@@ -877,8 +880,7 @@ func containerHasExplicitExports(container *ast.Node, ac *analysisContext) bool 
 // - Top-level declarations with explicit exports are module-scoped → check
 // - Declarations inside namespaces are handled by isInsideAmbientModuleBlock
 func isInDtsWithoutExplicitExports(node *ast.Node, ac *analysisContext) bool {
-	sf := ast.GetSourceFileOfNode(node)
-	if sf == nil || !sf.IsDeclarationFile {
+	if !ac.declarationFile {
 		return false
 	}
 	// Find the containing scope: either a ModuleBlock or the SourceFile
@@ -889,7 +891,7 @@ func isInDtsWithoutExplicitExports(node *ast.Node, ac *analysisContext) bool {
 	}
 	// We're at the top level of a .d.ts file.
 	// Check if the source file has explicit exports.
-	return !containerHasExplicitExports(sf.AsNode(), ac)
+	return !containerHasExplicitExports(ac.sourceFile.AsNode(), ac)
 }
 
 func isTopLevelDeclaration(node *ast.Node) bool {
@@ -1030,10 +1032,10 @@ func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts *Config, w
 	return true, true
 }
 
-// isBeforeLastUsedParam checks if an unused parameter appears before a later
-// parameter that is used (or has a default value). Used for the "after-used"
-// args option: unused parameters before the last used one are allowed because
-// they serve as positional placeholders.
+// isBeforeLastUsedParam checks if a parameter appears before a later parameter
+// that is used (or has a default value). Used for the "after-used" args option:
+// parameters before the last used one cannot produce an unused diagnostic
+// because they serve as positional placeholders.
 func isBeforeLastUsedParam(ctx rule.RuleContext, paramNode *ast.Node, ac *analysisContext) bool {
 	if paramNode == nil || paramNode.Parent == nil {
 		return false
@@ -1045,24 +1047,30 @@ func isBeforeLastUsedParam(ctx rule.RuleContext, paramNode *ast.Node, ac *analys
 		return false
 	}
 
-	if boundary, ok := ac.parameterBounds[funcLike]; ok {
-		return boundary.lastUsed != nil && paramNode.Pos() < boundary.lastUsed.Pos()
+	if ac.parameterOwner == funcLike {
+		lastUsed := ac.parameterBoundary.lastUsed
+		return lastUsed != nil && paramNode.Pos() < lastUsed.Pos()
 	}
 
 	var lastUsed *ast.Node
-	for _, p := range params {
+	// Only the last used/defaulted parameter matters. Scanning backwards lets
+	// the common case (the final parameter is used) stop after one lookup.
+	for i := len(params) - 1; i >= 0; i-- {
+		p := params[i]
 		// A parameter with a default value (initializer) counts as a
 		// meaningful position marker. ESLint's after-used skips params
 		// before a later param that has a default value.
 		if p.AsNode().Initializer() != nil || isParamUsed(ctx, p.Name(), ac) {
 			lastUsed = p.AsNode()
+			break
 		}
 	}
 
-	if ac.parameterBounds == nil {
-		ac.parameterBounds = make(map[*ast.Node]parameterBoundary)
-	}
-	ac.parameterBounds[funcLike] = parameterBoundary{lastUsed: lastUsed}
+	// Parameters are normally visited consecutively. A single-entry cache
+	// avoids a per-file map; if a nested function in a default initializer
+	// interrupts that order, the outer boundary is simply recomputed.
+	ac.parameterOwner = funcLike
+	ac.parameterBoundary = parameterBoundary{lastUsed: lastUsed}
 	return lastUsed != nil && paramNode.Pos() < lastUsed.Pos()
 }
 
@@ -1897,6 +1905,15 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	if !opts.ReportUsedIgnorePattern && isDirectlyExported(definition) {
 		return
 	}
+	// Under after-used, a direct parameter before the last used/defaulted one
+	// cannot produce a diagnostic. Determine that boundary before resolving the
+	// current parameter's references. Reporting used ignored names is the one
+	// exception: it still needs the current parameter's usage information.
+	if !opts.ReportUsedIgnorePattern && opts.Args == "after-used" &&
+		definition != nil && definition.Kind == ast.KindParameter &&
+		isBeforeLastUsedParam(ctx, definition, ac) {
+		return
+	}
 
 	varInfo := &VariableInfo{
 		Variable:       nameNode,
@@ -1935,7 +1952,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 		onlyUsedAsType := true
 		for _, usage := range info.usages {
 			if usage.Pos() == varInfo.Variable.Pos() ||
-				(sym != nil && isSelfModifyingReference(usage, sym, ctx.TypeChecker, nameNode)) ||
+				(len(info.writeRefs) != 0 && sym != nil && isSelfModifyingReference(usage, sym, ctx.TypeChecker, nameNode)) ||
 				isInsideAnyOwnDeclaration(usage, allDecls) {
 				continue
 			}
@@ -2063,7 +2080,11 @@ var NoUnusedVarsRule = rule.CreateRule(rule.Rule{
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
 
-		ac := &analysisContext{globalSourceFile: ast.IsGlobalSourceFile(ctx.SourceFile.AsNode())}
+		ac := &analysisContext{
+			globalSourceFile: ast.IsGlobalSourceFile(ctx.SourceFile.AsNode()),
+			declarationFile:  ctx.SourceFile.IsDeclarationFile,
+			sourceFile:       ctx.SourceFile,
+		}
 		exportsCollected := false
 
 		var seenWithoutBodyFuncSymbols map[*ast.Symbol]bool

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_adversarial_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_adversarial_test.go
@@ -1,0 +1,270 @@
+package no_unused_vars
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnusedVarsAmbientFastPathMatchesLegacy attacks the NodeFlagsAmbient
+// fast path with ambient, non-ambient, nested, global-augmentation, and .d.ts
+// contexts. The optimized helper must remain equivalent to the former full
+// ancestor/source-file walk for every node in the corpus.
+func TestNoUnusedVarsAmbientFastPathMatchesLegacy(t *testing.T) {
+	testCases := []struct {
+		name     string
+		fileName string
+		code     string
+	}{
+		{
+			name:     "non-ambient namespace with local declare",
+			fileName: "/runtime.ts",
+			code: `namespace Runtime {
+  const ordinary = 1;
+  declare const locallyDeclared: number;
+  namespace Nested { const value = 1; }
+}`,
+		},
+		{
+			name:     "ambient namespace and explicit export boundary",
+			fileName: "/ambient.ts",
+			code: `declare namespace Ambient {
+  const publicValue: number;
+  namespace Nested { const nestedValue: number; }
+}
+export declare namespace PrivateAmbient {
+  const privateValue: number;
+  export {};
+}`,
+		},
+		{
+			name:     "global augmentation",
+			fileName: "/global.ts",
+			code: `export {};
+declare global {
+  const BUILD_HASH: string;
+  namespace GlobalNested { interface Value<T> { value: T } }
+}`,
+		},
+		{
+			name:     "declaration file",
+			fileName: "/types.d.ts",
+			code: `declare namespace PublicTypes {
+  type Name = string;
+}
+declare namespace PrivateTypes {
+  type Hidden = string;
+  export {};
+}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: testCase.fileName,
+				Path:     tspath.Path(testCase.fileName),
+			}, testCase.code, core.ScriptKindTS)
+			optimizedContext := &analysisContext{
+				declarationFile: sourceFile.IsDeclarationFile,
+				sourceFile:      sourceFile,
+			}
+			legacyContext := &analysisContext{}
+
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				gotAmbient := isInsideAmbientModuleBlock(node, optimizedContext)
+				wantAmbient := legacyIsInsideAmbientModuleBlock(node, legacyContext)
+				if gotAmbient != wantAmbient {
+					t.Fatalf(
+						"isInsideAmbientModuleBlock(%v at %d, flags=%v) = %v, legacy = %v",
+						node.Kind,
+						node.Pos(),
+						node.Flags,
+						gotAmbient,
+						wantAmbient,
+					)
+				}
+
+				gotDts := isInDtsWithoutExplicitExports(node, optimizedContext)
+				wantDts := legacyIsInDtsWithoutExplicitExports(node, legacyContext)
+				if gotDts != wantDts {
+					t.Fatalf(
+						"isInDtsWithoutExplicitExports(%v at %d, flags=%v) = %v, legacy = %v",
+						node.Kind,
+						node.Pos(),
+						node.Flags,
+						gotDts,
+						wantDts,
+					)
+				}
+
+				node.ForEachChild(visit)
+				return false
+			}
+			sourceFile.AsNode().ForEachChild(visit)
+		})
+	}
+}
+
+func legacyIsInsideAmbientModuleBlock(node *ast.Node, ac *analysisContext) bool {
+	moduleBlock := ast.FindAncestorKind(node, ast.KindModuleBlock)
+	if moduleBlock == nil {
+		return false
+	}
+	moduleDecl := moduleBlock.Parent
+	if moduleDecl == nil || moduleDecl.Kind != ast.KindModuleDeclaration {
+		return false
+	}
+
+	isAmbient := ast.GetCombinedModifierFlags(moduleDecl)&ast.ModifierFlagsAmbient != 0
+	if !isAmbient && ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+		return ast.IsGlobalScopeAugmentation(n)
+	}) != nil {
+		isAmbient = true
+	}
+	if !isAmbient && ast.FindAncestor(moduleDecl.Parent, func(n *ast.Node) bool {
+		return n.Kind == ast.KindModuleDeclaration &&
+			ast.HasSyntacticModifier(n, ast.ModifierFlagsAmbient)
+	}) != nil {
+		isAmbient = true
+	}
+	if !isAmbient {
+		sourceFile := ast.GetSourceFileOfNode(node)
+		isAmbient = sourceFile != nil && sourceFile.IsDeclarationFile
+	}
+	return isAmbient && !containerHasExplicitExports(moduleBlock, ac)
+}
+
+func legacyIsInDtsWithoutExplicitExports(node *ast.Node, ac *analysisContext) bool {
+	sourceFile := ast.GetSourceFileOfNode(node)
+	if sourceFile == nil || !sourceFile.IsDeclarationFile {
+		return false
+	}
+	if ast.FindAncestorKind(node, ast.KindModuleBlock) != nil {
+		return false
+	}
+	return !containerHasExplicitExports(sourceFile.AsNode(), ac)
+}
+
+// TestNoUnusedVarsSelfModificationRequiresWriteReference verifies the
+// invariant used to skip expensive self-modification analysis: every shape
+// that the analyzer classifies as self-modifying also exposes at least one
+// write reference for the same binding.
+func TestNoUnusedVarsSelfModificationRequiresWriteReference(t *testing.T) {
+	code := `export {};
+let direct = 0;
+direct = direct + 1;
+let compound = 0;
+(compound) += 1;
+let update = 0;
+(update)++;
+let call: any = 0;
+call = consume(call);
+let method: any[] = [];
+method = method.concat(method);
+let iife: any;
+iife = (function () { return iife(); })();
+let sequence: any;
+sequence = (0, function () { sequence(); });
+function mutateParameter(parameter: number) {
+  parameter = parameter + 1;
+}
+console.log(mutateParameter);
+`
+	program, sourceFile := createNoUnusedVarsProgram(t, "self-modification-invariant.ts", code)
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+	ctx := rule.RuleContext{
+		SourceFile:  sourceFile,
+		Program:     program,
+		TypeChecker: typeChecker,
+		Refs:        rule.NewRefStore(sourceFile, program.Options(), typeChecker),
+	}
+	globalSourceFile := ast.IsGlobalSourceFile(sourceFile.AsNode())
+	selfModifyingCount := 0
+
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindVariableDeclaration || node.Kind == ast.KindParameter {
+			nameNode := node.Name()
+			if nameNode != nil && ast.IsIdentifier(nameNode) {
+				rawSymbol := binderSymbolForDefinition(nameNode, node)
+				symbol := symbolForVariable(ctx, nameNode, node, rawSymbol, globalSourceFile)
+				info := classifyReferenceNodes(ctx.Refs.References(rawSymbol))
+				for _, usage := range info.usages {
+					if symbol != nil && isSelfModifyingReference(usage, symbol, typeChecker, nameNode) {
+						selfModifyingCount++
+						if len(info.writeRefs) == 0 {
+							t.Fatalf("self-modifying reference %q at %d has no write reference", nameNode.Text(), usage.Pos())
+						}
+					}
+				}
+			}
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if selfModifyingCount == 0 {
+		t.Fatal("adversarial corpus did not exercise a self-modifying reference")
+	}
+}
+
+// TestNoUnusedVarsSingleParameterBoundaryCache forces a nested function in a
+// default initializer to replace the single-entry cache before traversal
+// returns to later parameters of the outer function.
+func TestNoUnusedVarsSingleParameterBoundaryCache(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{{
+			Code: `function outer(
+  first: number,
+  interrupt = ((innerFirst: number, innerLast: number) => innerLast)(1, 2),
+  resumed: number,
+  finalUsed: number,
+) {
+  return finalUsed;
+}
+console.log(outer);`,
+		}},
+		nil,
+	)
+}
+
+// TestNoUnusedVarsAfterUsedEarlyExitGuardrails attacks the early after-used
+// exit with its important exception: a used prefix parameter that matches an
+// ignore pattern must still be reported when reportUsedIgnorePattern is on.
+func TestNoUnusedVarsAfterUsedEarlyExitGuardrails(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		nil,
+		[]rule_tester.InvalidTestCase{{
+			Code: `function consume(_prefix: number, finalUsed: number) {
+  return _prefix + finalUsed;
+}
+console.log(consume);`,
+			Options: map[string]interface{}{
+				"argsIgnorePattern":       "^_",
+				"reportUsedIgnorePattern": true,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "usedIgnoredVar",
+				Line:      1,
+				Column:    18,
+			}},
+		}},
+	)
+}


### PR DESCRIPTION
## Summary

- Optimize `typescript-eslint/no-unused-vars` hot paths while keeping the changes isolated to the rule package; shared `RefStore` behavior is unchanged.
- Cache source-file state, add ambient fast rejection, scan `after-used` parameter boundaries backwards, and skip eligible prefix parameters before resolving their references.
- Gate self-modification analysis on the presence of write references.
- Add adversarial coverage for ambient/d.ts equivalence, nested parameter-cache invalidation, ignore-pattern guardrails, and self-modifying references.

### Benchmark

Measured with a local benchmark harness that is not included in this PR. Apple M1 Max, darwin/arm64, `GOMAXPROCS=1`, `-benchtime=2s -count=8`, median:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| mixed | 1.350 ms/op | 1.230 ms/op | -8.9% |
| after-used-parameters | 0.896 ms/op | 0.557 ms/op | -37.9% |

Allocation results:

| Scenario | B/op | allocs/op |
| --- | ---: | ---: |
| mixed | ~443 KB → 442 KB | 4319 → 4120 |
| after-used-parameters | ~105 KB → 95.8 KB | 918 → 906 |

### Validation

- `go test ./internal/plugins/typescript/rules/no_unused_vars -count=1`
- `go test -race ./internal/plugins/typescript/rules/no_unused_vars -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_unused_vars/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
