### PR TITLE
feat: port rule no-useless-return

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -128,6 +128,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_escape"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
 	"github.com/web-infra-dev/rslint/internal/rules/object_shorthand"
@@ -301,6 +302,7 @@ func GetAllRules() []rule.Rule {
 		no_useless_catch.NoUselessCatchRule,
 		no_useless_escape.NoUselessEscapeRule,
 		no_useless_rename.NoUselessRenameRule,
+		no_useless_return.NoUselessReturnRule,
 		no_useless_constructor.NoUselessConstructorRule,
 		no_prototype_builtins.NoPrototypeBuiltinsRule,
 		require_await.RequireAwaitRule,

--- a/internal/rules/no_unreachable_loop/no_unreachable_loop.go
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop.go
@@ -121,8 +121,9 @@ func reportLoops(ctx *rule.RuleContext, rootOrder []*ast.Node, opts ruleOptions)
 
 // singleIterationLoops returns the loops in root whose body allows only one
 // iteration: control reaches the loop, but never flows back into it for a
-// second one. A loop the code path never reaches is left alone — whether its
-// body could repeat says nothing useful about code that does not run.
+// second one. Unreachable blocks are skipped — whether a loop that never runs
+// could repeat says nothing useful, and neither does a `continue` that never
+// runs.
 //
 // NOTE: A loop wrapped in more than one label repeats when a `continue` names
 // any of them. ESLint 10.8.0 reports the double-labelled `while` and `do` forms
@@ -143,7 +144,10 @@ func singleIterationLoops(root *ast.Node, opts ruleOptions) []*ast.Node {
 	var candidates []*ast.Node
 	repeats := make(map[*ast.Node]bool)
 	cfg.Build(root, cfg.Hooks[struct{}]{
-		Statement: func(_ *cfg.Builder[struct{}], node *ast.Node) {
+		Statement: func(b *cfg.Builder[struct{}], node *ast.Node) {
+			if !b.Current().Reachable {
+				return
+			}
 			bit := loopBitForKind(node.Kind)
 			if bit == 0 || opts.ignored&bit != 0 {
 				return
@@ -155,9 +159,12 @@ func singleIterationLoops(root *ast.Node, opts ruleOptions) []*ast.Node {
 				repeats[node] = false
 			}
 		},
-		Loop: func(_ *cfg.Builder[struct{}], loop *ast.Node) {
+		Loop: func(b *cfg.Builder[struct{}], loop *ast.Node) {
 			// Ignored loops are not candidates, so retaining their repeat edge
 			// is harmless and avoids another option lookup on this hot hook.
+			if !b.Current().Reachable {
+				return
+			}
 			repeats[loop] = true
 		},
 	})
@@ -168,8 +175,8 @@ func singleIterationLoopsDefault(root *ast.Node) []*ast.Node {
 	var candidates []*ast.Node
 	repeats := make(map[*ast.Node]bool)
 	cfg.Build(root, cfg.Hooks[struct{}]{
-		Statement: func(_ *cfg.Builder[struct{}], node *ast.Node) {
-			if !isLoop(node) {
+		Statement: func(b *cfg.Builder[struct{}], node *ast.Node) {
+			if !b.Current().Reachable || !isLoop(node) {
 				return
 			}
 			if _, known := repeats[node]; !known {
@@ -179,7 +186,10 @@ func singleIterationLoopsDefault(root *ast.Node) []*ast.Node {
 				repeats[node] = false
 			}
 		},
-		Loop: func(_ *cfg.Builder[struct{}], loop *ast.Node) {
+		Loop: func(b *cfg.Builder[struct{}], loop *ast.Node) {
+			if !b.Current().Reachable {
+				return
+			}
 			repeats[loop] = true
 		},
 	})

--- a/internal/rules/no_useless_assignment/liveness.go
+++ b/internal/rules/no_useless_assignment/liveness.go
@@ -47,22 +47,28 @@ type assignment struct {
 
 // hooks turns the graph builder's reference positions into events. An
 // identifier absent from both maps belongs to a variable this code path does
-// not track.
+// not track, and a reference in an unreachable block belongs to code that never
+// runs — neither says anything about the value an assignment leaves behind.
 func hooks(readNodes map[*ast.Node]*ast.Symbol, assignByIdent map[*ast.Node]*assignment) cfg.Hooks[event] {
 	return cfg.Hooks[event]{
 		Read: func(b *cfg.Builder[event], node *ast.Node) {
+			if !b.Current().Reachable {
+				return
+			}
 			if sym, ok := readNodes[node]; ok {
 				b.Emit(event{kind: eventRead, sym: sym})
 			}
 		},
 		Write: func(b *cfg.Builder[event], node *ast.Node) {
+			if !b.Current().Reachable {
+				return
+			}
 			a, ok := assignByIdent[node]
 			if !ok {
 				return
 			}
-			if blk, index := b.Emit(event{kind: eventWrite, sym: a.sym, assign: a}); blk != nil {
-				a.sites = append(a.sites, writeSite{blk: blk, index: index})
-			}
+			blk, index := b.Emit(event{kind: eventWrite, sym: a.sym, assign: a})
+			a.sites = append(a.sites, writeSite{blk: blk, index: index})
 		},
 	}
 }
@@ -135,6 +141,11 @@ func computeLiveness(blocks []*block, states []blockState, sym *ast.Symbol) {
 			state := &states[i]
 			liveOut := false
 			for _, successor := range blocks[i].Successors {
+				if !successor.Reachable {
+					// The code after an abrupt exit never runs, so a read in
+					// it keeps nothing alive.
+					continue
+				}
 				if states[successor.Index()].liveIn {
 					liveOut = true
 					break

--- a/internal/rules/no_useless_return/no_useless_return.go
+++ b/internal/rules/no_useless_return/no_useless_return.go
@@ -125,13 +125,17 @@ func uselessReturns(root *ast.Node) []*ast.Node {
 		},
 	})
 
+	w := walk{
+		root:        root,
+		leftThrough: make([]bool, len(graph.Blocks)),
+		seen:        make([]int, len(graph.Blocks)),
+	}
 	// A block that holds a bare return is one control left through, which is
 	// what lets the walk step from it into the code that no longer runs.
-	leftThrough := make(map[*block]bool)
 	for _, blk := range graph.Blocks {
 		for _, e := range blk.Events {
 			if e.kind == eventReturn {
-				leftThrough[blk] = true
+				w.leftThrough[blk.Index()] = true
 				break
 			}
 		}
@@ -140,7 +144,7 @@ func uselessReturns(root *ast.Node) []*ast.Node {
 	var reports []*ast.Node
 	for _, blk := range graph.Blocks {
 		for i, e := range blk.Events {
-			if e.kind == eventReturn && !runsAfter(root, blk, i, leftThrough) {
+			if e.kind == eventReturn && !w.runsAfter(blk, i) {
 				reports = append(reports, e.node)
 			}
 		}
@@ -148,43 +152,55 @@ func uselessReturns(root *ast.Node) []*ast.Node {
 	return reports
 }
 
+// walk answers one graph's returns. Its scratch is kept across them: seen holds
+// the round each block was last reached in, so a round costs no clearing pass
+// of its own, and frontier is refilled rather than reallocated.
+type walk struct {
+	root        *ast.Node
+	leftThrough []bool
+	seen        []int
+	round       int
+	frontier    []*block
+}
+
 // runsAfter reports whether a clearing statement stands anywhere the return
 // recorded at start.Events[index] leads to.
-func runsAfter(root *ast.Node, start *block, index int, leftThrough map[*block]bool) bool {
-	shields := shieldsOf(start.Events[index].node, root)
+func (w *walk) runsAfter(start *block, index int) bool {
+	shields := shieldsOf(start.Events[index].node, w.root)
 	if clearedBy(start.Events[index+1:], shields) {
 		return true
 	}
 
-	visited := map[*block]bool{start: true}
-	frontier := stepsFrom(start, leftThrough)
-	for len(frontier) > 0 {
-		blk := frontier[len(frontier)-1]
-		frontier = frontier[:len(frontier)-1]
-		if visited[blk] {
+	w.round++
+	w.seen[start.Index()] = w.round
+	w.frontier = w.frontier[:0]
+	w.step(start)
+	for len(w.frontier) > 0 {
+		blk := w.frontier[len(w.frontier)-1]
+		w.frontier = w.frontier[:len(w.frontier)-1]
+		if w.seen[blk.Index()] == w.round {
 			continue
 		}
-		visited[blk] = true
+		w.seen[blk.Index()] = w.round
 		if clearedBy(blk.Events, shields) {
 			return true
 		}
-		frontier = append(frontier, stepsFrom(blk, leftThrough)...)
+		w.step(blk)
 	}
 	return false
 }
 
-// stepsFrom returns the blocks the returns standing at blk still stand at. Code
+// step queues the blocks the returns standing at blk still stand at. Code
 // control reaches carries them along as usual; the code after an abrupt exit
 // carries them only where that exit was a return, so a `break` does not hand
 // them on to the statements it skips.
-func stepsFrom(blk *block, leftThrough map[*block]bool) []*block {
-	var steps []*block
+func (w *walk) step(blk *block) {
+	carries := !blk.Reachable || w.leftThrough[blk.Index()]
 	for _, next := range blk.Successors {
-		if next.Reachable || !blk.Reachable || leftThrough[blk] {
-			steps = append(steps, next)
+		if next.Reachable || carries {
+			w.frontier = append(w.frontier, next)
 		}
 	}
-	return steps
 }
 
 func clearedBy(events []event, shields []shield) bool {

--- a/internal/rules/no_useless_return/no_useless_return.go
+++ b/internal/rules/no_useless_return/no_useless_return.go
@@ -243,11 +243,26 @@ func clears(node *ast.Node) bool {
 		ast.KindTypeAliasDeclaration, ast.KindEnumDeclaration,
 		ast.KindModuleDeclaration, ast.KindImportEqualsDeclaration,
 		ast.KindMissingDeclaration:
-		return ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+		return hasExportKeyword(node)
 
 	default:
 		return true
 	}
+}
+
+// hasExportKeyword reports whether the declaration spells `export` in the
+// source. A dotted namespace such as `namespace N.M {}` nests a declaration of
+// its own for each name after the first, and tsgo gives those an `export`
+// modifier it synthesizes rather than one the source writes; only a written
+// `export` moves a declaration inside an `ExportNamedDeclaration`.
+func hasExportKeyword(node *ast.Node) bool {
+	modifiers := node.Modifiers()
+	if modifiers == nil {
+		return false
+	}
+	return slices.ContainsFunc(modifiers.Nodes, func(modifier *ast.Node) bool {
+		return modifier.Kind == ast.KindExportKeyword && modifier.Flags&ast.NodeFlagsReparsed == 0
+	})
 }
 
 // shield is one `try` block a return stands in. ESLint keeps such a return in

--- a/internal/rules/no_useless_return/no_useless_return.go
+++ b/internal/rules/no_useless_return/no_useless_return.go
@@ -21,25 +21,21 @@ var NoUselessReturnRule = rule.Rule{
 	Name:   "no-useless-return",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		var byRoot map[*ast.Node][]*ast.Node
+		// Only the code paths that hold a bare return need a graph.
 		var rootOrder []*ast.Node
+		seen := make(map[*ast.Node]bool)
 
 		listeners := rule.RuleListeners{
 			ast.KindReturnStatement: func(node *ast.Node) {
-				if !isBareReturn(node) {
+				if node.AsReturnStatement().Expression != nil {
 					return
 				}
 				root := cfg.RootOf(node)
-				if root == nil {
+				if root == nil || seen[root] {
 					return
 				}
-				if byRoot == nil {
-					byRoot = make(map[*ast.Node][]*ast.Node)
-				}
-				if _, seen := byRoot[root]; !seen {
-					rootOrder = append(rootOrder, root)
-				}
-				byRoot[root] = append(byRoot[root], node)
+				seen[root] = true
+				rootOrder = append(rootOrder, root)
 			},
 		}
 
@@ -50,30 +46,20 @@ var NoUselessReturnRule = rule.Rule{
 		lastTopLevelNode := statements.Nodes[len(statements.Nodes)-1]
 		listeners[rule.ListenerOnExit(lastTopLevelNode.Kind)] = func(node *ast.Node) {
 			if node == lastTopLevelNode {
-				reportUselessReturns(&ctx, byRoot, rootOrder)
+				reportUselessReturns(&ctx, rootOrder)
 			}
 		}
 		return listeners
 	},
 }
 
-// reportUselessReturns keeps the returns nothing runs after. ESLint reports one
-// code path at a time and its reports come out ordered by position, so the
-// collected returns are sorted before they are reported.
-func reportUselessReturns(ctx *rule.RuleContext, byRoot map[*ast.Node][]*ast.Node, rootOrder []*ast.Node) {
+// reportUselessReturns lays out each collected code path and reports the returns
+// nothing runs after. ESLint reports one code path at a time and its reports
+// come out ordered by position, so the collected returns are sorted first.
+func reportUselessReturns(ctx *rule.RuleContext, rootOrder []*ast.Node) {
 	var reports []*ast.Node
 	for _, root := range rootOrder {
-		reachable := reachableStatements(root)
-		for _, returnStatement := range byRoot[root] {
-			// A `return` nothing reaches says nothing about the code after it.
-			if !reachable[returnStatement] {
-				continue
-			}
-			walker := &walker{root: root, reachable: reachable, visited: map[*ast.Node]bool{}}
-			if !walker.runsAfter(returnStatement) {
-				reports = append(reports, returnStatement)
-			}
-		}
+		reports = append(reports, uselessReturns(root)...)
 	}
 	slices.SortFunc(reports, func(a, b *ast.Node) int { return a.Pos() - b.Pos() })
 	for _, returnStatement := range reports {
@@ -84,31 +70,193 @@ func reportUselessReturns(ctx *rule.RuleContext, byRoot map[*ast.Node][]*ast.Nod
 	}
 }
 
-// reachableStatements lays out one code path and collects the statements
-// control can reach. internal/utils/cfg stops laying a path out where it ends, so a
-// statement the hook never sees is one ESLint's code path analysis would place
-// on an unreachable segment.
-func reachableStatements(root *ast.Node) map[*ast.Node]bool {
-	reachable := make(map[*ast.Node]bool)
-	cfg.Build(root, cfg.Hooks[struct{}]{
-		Statement: func(_ *cfg.Builder[struct{}], node *ast.Node) {
-			reachable[node] = true
+// ---------------------------------------------------------------------------
+// what runs after a return
+// ---------------------------------------------------------------------------
+
+// event is what one statement means for the bare returns standing where it is
+// reached.
+type eventKind uint8
+
+const (
+	// eventReturn is a bare return, held until something clears it.
+	eventReturn eventKind = iota
+	// eventClear is a statement that stands where those returns do, which
+	// gives every one of them something it skips.
+	eventClear
+)
+
+type event struct {
+	kind eventKind
+	node *ast.Node
+}
+
+type block = cfg.Block[event]
+
+// uselessReturns returns the bare returns in root that nothing runs after.
+//
+// ESLint holds each bare return against the code path segment it stands on and
+// lets any statement on a segment that segment leads to clear it again —
+// deliberately reaching into the unreachable segments the return itself
+// created, which is the path the code would take without it. The same question
+// over a control-flow graph is whether any clearing statement stands in a block
+// the return's block leads to.
+func uselessReturns(root *ast.Node) []*ast.Node {
+	graph := cfg.Build(root, cfg.Hooks[event]{
+		Statement: func(b *cfg.Builder[event], node *ast.Node) {
+			if node.Kind != ast.KindReturnStatement {
+				if clears(node) {
+					b.Emit(event{kind: eventClear, node: node})
+				}
+				return
+			}
+			if node.AsReturnStatement().Expression != nil {
+				// The value it leaves with is what the earlier returns skip.
+				b.Emit(event{kind: eventClear, node: node})
+				return
+			}
+			// A `return` inside a loop leaves the loop, and one inside a
+			// `finally` block overrides the value the statement was leaving
+			// with, so neither is ever redundant. One control never reaches
+			// says nothing about the code around it.
+			if b.Current().Reachable && !isInLoop(node) && !isInFinally(node) {
+				b.Emit(event{kind: eventReturn, node: node})
+			}
 		},
 	})
-	return reachable
+
+	// A block that holds a bare return is one control left through, which is
+	// what lets the walk step from it into the code that no longer runs.
+	leftThrough := make(map[*block]bool)
+	for _, blk := range graph.Blocks {
+		for _, e := range blk.Events {
+			if e.kind == eventReturn {
+				leftThrough[blk] = true
+				break
+			}
+		}
+	}
+
+	var reports []*ast.Node
+	for _, blk := range graph.Blocks {
+		for i, e := range blk.Events {
+			if e.kind == eventReturn && !runsAfter(root, blk, i, leftThrough) {
+				reports = append(reports, e.node)
+			}
+		}
+	}
+	return reports
+}
+
+// runsAfter reports whether a clearing statement stands anywhere the return
+// recorded at start.Events[index] leads to.
+func runsAfter(root *ast.Node, start *block, index int, leftThrough map[*block]bool) bool {
+	shields := shieldsOf(start.Events[index].node, root)
+	if clearedBy(start.Events[index+1:], shields) {
+		return true
+	}
+
+	visited := map[*block]bool{start: true}
+	frontier := stepsFrom(start, leftThrough)
+	for len(frontier) > 0 {
+		blk := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		if visited[blk] {
+			continue
+		}
+		visited[blk] = true
+		if clearedBy(blk.Events, shields) {
+			return true
+		}
+		frontier = append(frontier, stepsFrom(blk, leftThrough)...)
+	}
+	return false
+}
+
+// stepsFrom returns the blocks the returns standing at blk still stand at. Code
+// control reaches carries them along as usual; the code after an abrupt exit
+// carries them only where that exit was a return, so a `break` does not hand
+// them on to the statements it skips.
+func stepsFrom(blk *block, leftThrough map[*block]bool) []*block {
+	var steps []*block
+	for _, next := range blk.Successors {
+		if next.Reachable || !blk.Reachable || leftThrough[blk] {
+			steps = append(steps, next)
+		}
+	}
+	return steps
+}
+
+func clearedBy(events []event, shields []shield) bool {
+	for _, e := range events {
+		if e.kind != eventClear {
+			continue
+		}
+		if !slices.ContainsFunc(shields, func(s shield) bool { return s.covers(e.node) }) {
+			return true
+		}
+	}
+	return false
+}
+
+// clears reports whether a statement standing where a bare return is pending
+// means something runs after that return.
+//
+// ESLint clears them on every statement node except `FunctionDeclaration`,
+// `BlockStatement`, and `BreakStatement` — a function declaration is hoisted
+// and runs either way, a block only holds statements of its own, and a break
+// merely goes to the next segment. Nothing clears them for the TypeScript-only
+// declarations either, because ESLint's listener list names ESTree types and
+// those parse to types of their own; an `export` modifier puts one back inside
+// an `ExportNamedDeclaration`, which does clear.
+func clears(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindBlock, ast.KindBreakStatement:
+		return false
+
+	case ast.KindExportAssignment:
+		// `export = x` is TypeScript's own; `export default x` is not.
+		return !node.AsExportAssignment().IsExportEquals
+
+	case ast.KindFunctionDeclaration, ast.KindInterfaceDeclaration,
+		ast.KindTypeAliasDeclaration, ast.KindEnumDeclaration,
+		ast.KindModuleDeclaration, ast.KindImportEqualsDeclaration,
+		ast.KindMissingDeclaration:
+		return ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+
+	default:
+		return true
+	}
+}
+
+// shield is one `try` block a return stands in. ESLint keeps such a return in
+// the pending list for as long as it is traversing the rest of that `try`
+// statement, so nothing in the `catch` clause or the `finally` block clears it.
+type shield struct {
+	statement *ast.Node
+	block     *ast.Node
+}
+
+// covers reports whether node stands in the part of the `try` statement that
+// follows the shielded block.
+func (s shield) covers(node *ast.Node) bool {
+	return node.Pos() >= s.block.End() && node.End() <= s.statement.End()
+}
+
+func shieldsOf(node *ast.Node, root *ast.Node) []shield {
+	var shields []shield
+	for current := node; current != nil && current != root && current.Parent != nil; current = current.Parent {
+		parent := current.Parent
+		if parent.Kind == ast.KindTryStatement && parent.AsTryStatement().TryBlock == current {
+			shields = append(shields, shield{statement: parent, block: current})
+		}
+	}
+	return shields
 }
 
 // ---------------------------------------------------------------------------
 // candidates
 // ---------------------------------------------------------------------------
-
-// isBareReturn reports whether node is a `return` with no value that ESLint
-// would consider redundant if nothing ran after it. A `return` inside a loop
-// leaves the loop, and one inside a `finally` block overrides the value the
-// statement was leaving with, so neither is ever redundant.
-func isBareReturn(node *ast.Node) bool {
-	return node.AsReturnStatement().Expression == nil && !isInLoop(node) && !isInFinally(node)
-}
 
 func isInLoop(node *ast.Node) bool {
 	for current := node; current != nil && !isFunction(current); current = current.Parent {
@@ -141,295 +289,6 @@ func isFunction(node *ast.Node) bool {
 		return true
 	}
 	return false
-}
-
-// ---------------------------------------------------------------------------
-// what runs after a return
-// ---------------------------------------------------------------------------
-
-// step is what scanning one statement says about the statements after it.
-type step int
-
-const (
-	// stepContinue: nothing ESLint counts as executed happened here.
-	stepContinue step = iota
-	// stepRuns: a statement runs after the return, so the return is used.
-	stepRuns
-	// stepStop: control does not carry the return past this statement.
-	stepStop
-)
-
-// walker answers "does anything run after this return" by following the code
-// path the return would have if it were deleted.
-//
-// ESLint answers the same question by attaching the return to its code path
-// segment and letting any statement on a segment the return can reach clear it
-// again — deliberately walking through the unreachable segments the return
-// itself created, which simulates the path the code would take without it.
-// internal/utils/cfg stops laying a path out at a `return`, so that continuation has
-// no edges in the graph and is followed over the syntax tree instead: from the
-// return outwards through its enclosing statements, into the statements that
-// follow each of them.
-type walker struct {
-	root      *ast.Node
-	reachable map[*ast.Node]bool
-	visited   map[*ast.Node]bool
-}
-
-// runsAfter reports whether a statement runs after node completes.
-func (w *walker) runsAfter(node *ast.Node) bool {
-	if w.visited[node] {
-		return false
-	}
-	w.visited[node] = true
-
-	for node != nil && node != w.root {
-		parent := node.Parent
-		if parent == nil {
-			return false
-		}
-
-		switch parent.Kind {
-		case ast.KindSourceFile:
-			runs, _ := w.scanFrom(parent.AsSourceFile().Statements, node)
-			return runs
-
-		case ast.KindBlock:
-			runs, stopped := w.scanFrom(parent.AsBlock().Statements, node)
-			if runs || stopped {
-				return runs
-			}
-
-		case ast.KindModuleBlock:
-			runs, stopped := w.scanFrom(parent.AsModuleBlock().Statements, node)
-			if runs || stopped {
-				return runs
-			}
-
-		case ast.KindCaseClause, ast.KindDefaultClause:
-			runs, stopped := w.scanFrom(parent.AsCaseOrDefaultClause().Statements, node)
-			if runs || stopped {
-				return runs
-			}
-			// Control falls out of a clause into the one after it.
-			caseBlock := parent.Parent
-			if caseBlock == nil || caseBlock.Kind != ast.KindCaseBlock {
-				return false
-			}
-			clauses := caseBlock.AsCaseBlock().Clauses.Nodes
-			index := slices.Index(clauses, parent)
-			if index < 0 {
-				return false
-			}
-			for _, later := range clauses[index+1:] {
-				runs, stopped := w.scanList(later.AsCaseOrDefaultClause().Statements, 0)
-				if runs || stopped {
-					return runs
-				}
-			}
-			node = caseBlock.Parent
-			continue
-
-		case ast.KindTryStatement:
-			try := parent.AsTryStatement()
-			// A return inside the `try` block keeps its place in the list
-			// while the `catch` clause and the `finally` block are traversed,
-			// so nothing in either of them clears it. A return in the `catch`
-			// clause is past that point, and the `finally` block does clear it.
-			if node == try.CatchClause && try.FinallyBlock != nil {
-				runs, stopped := w.scanList(try.FinallyBlock.AsBlock().Statements, 0)
-				if runs || stopped {
-					return runs
-				}
-			}
-
-		case ast.KindIfStatement, ast.KindLabeledStatement, ast.KindWithStatement,
-			ast.KindCatchClause:
-			// Nothing of these runs after the branch the return is in.
-
-		default:
-			// A function body, a class static block, or a loop the return
-			// leaves: the code path ends here.
-			return false
-		}
-
-		node = parent
-	}
-	return false
-}
-
-func (w *walker) scanFrom(list *ast.NodeList, after *ast.Node) (runs bool, stopped bool) {
-	if list == nil {
-		return false, false
-	}
-	index := slices.Index(list.Nodes, after)
-	if index < 0 {
-		return false, false
-	}
-	return w.scanList(list, index+1)
-}
-
-func (w *walker) scanList(list *ast.NodeList, start int) (runs bool, stopped bool) {
-	if list == nil || start < 0 || start > len(list.Nodes) {
-		return false, false
-	}
-	for _, statement := range list.Nodes[start:] {
-		switch w.scan(statement) {
-		case stepRuns:
-			return true, false
-		case stepStop:
-			return false, true
-		}
-	}
-	return false, false
-}
-
-// scan reports what one statement standing after the return means for it.
-//
-// ESLint clears a return on every statement node except `FunctionDeclaration`,
-// `BlockStatement`, and `BreakStatement` — a function declaration is hoisted
-// and runs either way, a block only contains statements, and a break merely
-// goes to the next segment. Nothing clears a return for the TypeScript-only
-// declarations either, because ESLint's listener list names ESTree types and
-// those parse to types of their own; an `export` modifier puts one back inside
-// an `ExportNamedDeclaration`, which does clear it.
-func (w *walker) scan(statement *ast.Node) step {
-	switch statement.Kind {
-	case ast.KindExportAssignment:
-		// `export = x` is TypeScript's own; `export default x` is not.
-		if statement.AsExportAssignment().IsExportEquals {
-			return stepContinue
-		}
-		return stepRuns
-
-	case ast.KindFunctionDeclaration, ast.KindInterfaceDeclaration,
-		ast.KindTypeAliasDeclaration, ast.KindEnumDeclaration,
-		ast.KindImportEqualsDeclaration, ast.KindMissingDeclaration:
-		if hasExportModifier(statement) {
-			return stepRuns
-		}
-		return stepContinue
-
-	case ast.KindModuleDeclaration:
-		if hasExportModifier(statement) {
-			return stepRuns
-		}
-		body := statement.AsModuleDeclaration().Body
-		for body != nil && body.Kind == ast.KindModuleDeclaration {
-			body = body.AsModuleDeclaration().Body
-		}
-		if body == nil || body.Kind != ast.KindModuleBlock {
-			return stepContinue
-		}
-		runs, stopped := w.scanList(body.AsModuleBlock().Statements, 0)
-		if runs {
-			return stepRuns
-		}
-		if stopped {
-			return stepStop
-		}
-		return stepContinue
-
-	case ast.KindBlock:
-		runs, stopped := w.scanList(statement.AsBlock().Statements, 0)
-		if runs {
-			return stepRuns
-		}
-		if stopped {
-			return stepStop
-		}
-		return stepContinue
-
-	case ast.KindReturnStatement:
-		if statement.AsReturnStatement().Expression != nil {
-			return stepRuns
-		}
-		// A `return` of its own carries the earlier one along, on the same
-		// "as if it were deleted" reading — unless this one is a return the
-		// rule never collects, which leaves nothing to carry it.
-		if w.reachable[statement] && !isBareReturn(statement) {
-			return stepStop
-		}
-		return stepContinue
-
-	case ast.KindBreakStatement:
-		if w.runsAfterBreak(statement, breakTarget(statement)) {
-			return stepRuns
-		}
-		if w.reachable[statement] {
-			return stepStop
-		}
-		// A break control never reaches goes to the next segment merely, so
-		// the return carries on past it.
-		return stepContinue
-
-	default:
-		return stepRuns
-	}
-}
-
-// runsAfterBreak follows a break out to the statement it leaves. On the way out
-// every `finally` block still runs, except where the return is inside the `try`
-// block that owns it and keeps its place in the list. A nil target is a break
-// with nothing to leave, which ends the code path where it stands.
-func (w *walker) runsAfterBreak(node *ast.Node, target *ast.Node) bool {
-	for current := node; current != nil && current != target && current != w.root; current = current.Parent {
-		parent := current.Parent
-		if parent == nil {
-			break
-		}
-		if parent.Kind != ast.KindTryStatement {
-			continue
-		}
-		try := parent.AsTryStatement()
-		if try.FinallyBlock == nil || current != try.CatchClause {
-			continue
-		}
-		runs, stopped := w.scanList(try.FinallyBlock.AsBlock().Statements, 0)
-		if runs {
-			return true
-		}
-		if stopped {
-			return false
-		}
-	}
-	if target == nil {
-		return false
-	}
-	return w.runsAfter(target)
-}
-
-func hasExportModifier(node *ast.Node) bool {
-	return ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
-}
-
-// breakTarget returns the statement a `break` leaves, so the walk can carry on
-// from after it.
-func breakTarget(node *ast.Node) *ast.Node {
-	label := node.AsBreakStatement().Label
-	name := ""
-	if label != nil {
-		name = label.Text()
-	}
-	for current := node.Parent; current != nil; current = current.Parent {
-		if isFunction(current) || current.Kind == ast.KindClassStaticBlockDeclaration ||
-			current.Kind == ast.KindSourceFile {
-			return nil
-		}
-		if name == "" {
-			switch current.Kind {
-			case ast.KindSwitchStatement, ast.KindWhileStatement, ast.KindDoStatement,
-				ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
-				return current
-			}
-			continue
-		}
-		if current.Kind == ast.KindLabeledStatement &&
-			current.AsLabeledStatement().Label.Text() == name {
-			return current
-		}
-	}
-	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/no_useless_return/no_useless_return.go
+++ b/internal/rules/no_useless_return/no_useless_return.go
@@ -234,6 +234,11 @@ func clears(node *ast.Node) bool {
 		// `export = x` is TypeScript's own; `export default x` is not.
 		return !node.AsExportAssignment().IsExportEquals
 
+	case ast.KindNamespaceExportDeclaration:
+		// `export as namespace X` spells its own `export`, so it stays a
+		// TypeScript-only node rather than moving inside an export wrapper.
+		return false
+
 	case ast.KindFunctionDeclaration, ast.KindInterfaceDeclaration,
 		ast.KindTypeAliasDeclaration, ast.KindEnumDeclaration,
 		ast.KindModuleDeclaration, ast.KindImportEqualsDeclaration,

--- a/internal/rules/no_useless_return/no_useless_return.go
+++ b/internal/rules/no_useless_return/no_useless_return.go
@@ -1,0 +1,476 @@
+package no_useless_return
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+
+	"github.com/web-infra-dev/rslint/internal/cfg"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var unnecessaryReturn = rule.RuleMessage{
+	Id:          "unnecessaryReturn",
+	Description: "Unnecessary return statement.",
+}
+
+// https://eslint.org/docs/latest/rules/no-useless-return
+var NoUselessReturnRule = rule.Rule{
+	Name:   "no-useless-return",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		var byRoot map[*ast.Node][]*ast.Node
+		var rootOrder []*ast.Node
+
+		listeners := rule.RuleListeners{
+			ast.KindReturnStatement: func(node *ast.Node) {
+				if !isBareReturn(node) {
+					return
+				}
+				root := cfg.RootOf(node)
+				if root == nil {
+					return
+				}
+				if byRoot == nil {
+					byRoot = make(map[*ast.Node][]*ast.Node)
+				}
+				if _, seen := byRoot[root]; !seen {
+					rootOrder = append(rootOrder, root)
+				}
+				byRoot[root] = append(byRoot[root], node)
+			},
+		}
+
+		statements := ctx.SourceFile.Statements
+		if statements == nil || len(statements.Nodes) == 0 {
+			return listeners
+		}
+		lastTopLevelNode := statements.Nodes[len(statements.Nodes)-1]
+		listeners[rule.ListenerOnExit(lastTopLevelNode.Kind)] = func(node *ast.Node) {
+			if node == lastTopLevelNode {
+				reportUselessReturns(&ctx, byRoot, rootOrder)
+			}
+		}
+		return listeners
+	},
+}
+
+// reportUselessReturns keeps the returns nothing runs after. ESLint reports one
+// code path at a time and its reports come out ordered by position, so the
+// collected returns are sorted before they are reported.
+func reportUselessReturns(ctx *rule.RuleContext, byRoot map[*ast.Node][]*ast.Node, rootOrder []*ast.Node) {
+	var reports []*ast.Node
+	for _, root := range rootOrder {
+		reachable := reachableStatements(root)
+		for _, returnStatement := range byRoot[root] {
+			// A `return` nothing reaches says nothing about the code after it.
+			if !reachable[returnStatement] {
+				continue
+			}
+			walker := &walker{root: root, reachable: reachable, visited: map[*ast.Node]bool{}}
+			if !walker.runsAfter(returnStatement) {
+				reports = append(reports, returnStatement)
+			}
+		}
+	}
+	slices.SortFunc(reports, func(a, b *ast.Node) int { return a.Pos() - b.Pos() })
+	for _, returnStatement := range reports {
+		node := returnStatement
+		ctx.ReportNodeWithDeferredFixes(node, unnecessaryReturn, func() []rule.RuleFix {
+			return buildFix(ctx.SourceFile, node)
+		})
+	}
+}
+
+// reachableStatements lays out one code path and collects the statements
+// control can reach. internal/cfg stops laying a path out where it ends, so a
+// statement the hook never sees is one ESLint's code path analysis would place
+// on an unreachable segment.
+func reachableStatements(root *ast.Node) map[*ast.Node]bool {
+	reachable := make(map[*ast.Node]bool)
+	cfg.Build(root, cfg.Hooks[struct{}]{
+		Statement: func(_ *cfg.Builder[struct{}], node *ast.Node) {
+			reachable[node] = true
+		},
+	})
+	return reachable
+}
+
+// ---------------------------------------------------------------------------
+// candidates
+// ---------------------------------------------------------------------------
+
+// isBareReturn reports whether node is a `return` with no value that ESLint
+// would consider redundant if nothing ran after it. A `return` inside a loop
+// leaves the loop, and one inside a `finally` block overrides the value the
+// statement was leaving with, so neither is ever redundant.
+func isBareReturn(node *ast.Node) bool {
+	return node.AsReturnStatement().Expression == nil && !isInLoop(node) && !isInFinally(node)
+}
+
+func isInLoop(node *ast.Node) bool {
+	for current := node; current != nil && !isFunction(current); current = current.Parent {
+		switch current.Kind {
+		case ast.KindWhileStatement, ast.KindDoStatement, ast.KindForStatement,
+			ast.KindForInStatement, ast.KindForOfStatement:
+			return true
+		}
+	}
+	return false
+}
+
+func isInFinally(node *ast.Node) bool {
+	for current := node; current != nil && current.Parent != nil && !isFunction(current); current = current.Parent {
+		if current.Parent.Kind == ast.KindTryStatement &&
+			current.Parent.AsTryStatement().FinallyBlock == current {
+			return true
+		}
+	}
+	return false
+}
+
+// isFunction covers the nodes ESLint's ESTree calls a function: a declaration,
+// an arrow, and the function expression a method, constructor, or accessor is
+// built from.
+func isFunction(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+		ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// what runs after a return
+// ---------------------------------------------------------------------------
+
+// step is what scanning one statement says about the statements after it.
+type step int
+
+const (
+	// stepContinue: nothing ESLint counts as executed happened here.
+	stepContinue step = iota
+	// stepRuns: a statement runs after the return, so the return is used.
+	stepRuns
+	// stepStop: control does not carry the return past this statement.
+	stepStop
+)
+
+// walker answers "does anything run after this return" by following the code
+// path the return would have if it were deleted.
+//
+// ESLint answers the same question by attaching the return to its code path
+// segment and letting any statement on a segment the return can reach clear it
+// again — deliberately walking through the unreachable segments the return
+// itself created, which simulates the path the code would take without it.
+// internal/cfg stops laying a path out at a `return`, so that continuation has
+// no edges in the graph and is followed over the syntax tree instead: from the
+// return outwards through its enclosing statements, into the statements that
+// follow each of them.
+type walker struct {
+	root      *ast.Node
+	reachable map[*ast.Node]bool
+	visited   map[*ast.Node]bool
+}
+
+// runsAfter reports whether a statement runs after node completes.
+func (w *walker) runsAfter(node *ast.Node) bool {
+	if w.visited[node] {
+		return false
+	}
+	w.visited[node] = true
+
+	for node != nil && node != w.root {
+		parent := node.Parent
+		if parent == nil {
+			return false
+		}
+
+		switch parent.Kind {
+		case ast.KindSourceFile:
+			runs, _ := w.scanFrom(parent.AsSourceFile().Statements, node)
+			return runs
+
+		case ast.KindBlock:
+			runs, stopped := w.scanFrom(parent.AsBlock().Statements, node)
+			if runs || stopped {
+				return runs
+			}
+
+		case ast.KindModuleBlock:
+			runs, stopped := w.scanFrom(parent.AsModuleBlock().Statements, node)
+			if runs || stopped {
+				return runs
+			}
+
+		case ast.KindCaseClause, ast.KindDefaultClause:
+			runs, stopped := w.scanFrom(parent.AsCaseOrDefaultClause().Statements, node)
+			if runs || stopped {
+				return runs
+			}
+			// Control falls out of a clause into the one after it.
+			caseBlock := parent.Parent
+			if caseBlock == nil || caseBlock.Kind != ast.KindCaseBlock {
+				return false
+			}
+			clauses := caseBlock.AsCaseBlock().Clauses.Nodes
+			index := slices.Index(clauses, parent)
+			if index < 0 {
+				return false
+			}
+			for _, later := range clauses[index+1:] {
+				runs, stopped := w.scanList(later.AsCaseOrDefaultClause().Statements, 0)
+				if runs || stopped {
+					return runs
+				}
+			}
+			node = caseBlock.Parent
+			continue
+
+		case ast.KindTryStatement:
+			try := parent.AsTryStatement()
+			// A return inside the `try` block keeps its place in the list
+			// while the `catch` clause and the `finally` block are traversed,
+			// so nothing in either of them clears it. A return in the `catch`
+			// clause is past that point, and the `finally` block does clear it.
+			if node == try.CatchClause && try.FinallyBlock != nil {
+				runs, stopped := w.scanList(try.FinallyBlock.AsBlock().Statements, 0)
+				if runs || stopped {
+					return runs
+				}
+			}
+
+		case ast.KindIfStatement, ast.KindLabeledStatement, ast.KindWithStatement,
+			ast.KindCatchClause:
+			// Nothing of these runs after the branch the return is in.
+
+		default:
+			// A function body, a class static block, or a loop the return
+			// leaves: the code path ends here.
+			return false
+		}
+
+		node = parent
+	}
+	return false
+}
+
+func (w *walker) scanFrom(list *ast.NodeList, after *ast.Node) (runs bool, stopped bool) {
+	if list == nil {
+		return false, false
+	}
+	index := slices.Index(list.Nodes, after)
+	if index < 0 {
+		return false, false
+	}
+	return w.scanList(list, index+1)
+}
+
+func (w *walker) scanList(list *ast.NodeList, start int) (runs bool, stopped bool) {
+	if list == nil || start < 0 || start > len(list.Nodes) {
+		return false, false
+	}
+	for _, statement := range list.Nodes[start:] {
+		switch w.scan(statement) {
+		case stepRuns:
+			return true, false
+		case stepStop:
+			return false, true
+		}
+	}
+	return false, false
+}
+
+// scan reports what one statement standing after the return means for it.
+//
+// ESLint clears a return on every statement node except `FunctionDeclaration`,
+// `BlockStatement`, and `BreakStatement` — a function declaration is hoisted
+// and runs either way, a block only contains statements, and a break merely
+// goes to the next segment. Nothing clears a return for the TypeScript-only
+// declarations either, because ESLint's listener list names ESTree types and
+// those parse to types of their own; an `export` modifier puts one back inside
+// an `ExportNamedDeclaration`, which does clear it.
+func (w *walker) scan(statement *ast.Node) step {
+	switch statement.Kind {
+	case ast.KindExportAssignment:
+		// `export = x` is TypeScript's own; `export default x` is not.
+		if statement.AsExportAssignment().IsExportEquals {
+			return stepContinue
+		}
+		return stepRuns
+
+	case ast.KindFunctionDeclaration, ast.KindInterfaceDeclaration,
+		ast.KindTypeAliasDeclaration, ast.KindEnumDeclaration,
+		ast.KindImportEqualsDeclaration, ast.KindMissingDeclaration:
+		if hasExportModifier(statement) {
+			return stepRuns
+		}
+		return stepContinue
+
+	case ast.KindModuleDeclaration:
+		if hasExportModifier(statement) {
+			return stepRuns
+		}
+		body := statement.AsModuleDeclaration().Body
+		for body != nil && body.Kind == ast.KindModuleDeclaration {
+			body = body.AsModuleDeclaration().Body
+		}
+		if body == nil || body.Kind != ast.KindModuleBlock {
+			return stepContinue
+		}
+		runs, stopped := w.scanList(body.AsModuleBlock().Statements, 0)
+		if runs {
+			return stepRuns
+		}
+		if stopped {
+			return stepStop
+		}
+		return stepContinue
+
+	case ast.KindBlock:
+		runs, stopped := w.scanList(statement.AsBlock().Statements, 0)
+		if runs {
+			return stepRuns
+		}
+		if stopped {
+			return stepStop
+		}
+		return stepContinue
+
+	case ast.KindReturnStatement:
+		if statement.AsReturnStatement().Expression != nil {
+			return stepRuns
+		}
+		// A `return` of its own carries the earlier one along, on the same
+		// "as if it were deleted" reading — unless this one is a return the
+		// rule never collects, which leaves nothing to carry it.
+		if w.reachable[statement] && !isBareReturn(statement) {
+			return stepStop
+		}
+		return stepContinue
+
+	case ast.KindBreakStatement:
+		if w.runsAfterBreak(statement, breakTarget(statement)) {
+			return stepRuns
+		}
+		if w.reachable[statement] {
+			return stepStop
+		}
+		// A break control never reaches goes to the next segment merely, so
+		// the return carries on past it.
+		return stepContinue
+
+	default:
+		return stepRuns
+	}
+}
+
+// runsAfterBreak follows a break out to the statement it leaves. On the way out
+// every `finally` block still runs, except where the return is inside the `try`
+// block that owns it and keeps its place in the list. A nil target is a break
+// with nothing to leave, which ends the code path where it stands.
+func (w *walker) runsAfterBreak(node *ast.Node, target *ast.Node) bool {
+	for current := node; current != nil && current != target && current != w.root; current = current.Parent {
+		parent := current.Parent
+		if parent == nil {
+			break
+		}
+		if parent.Kind != ast.KindTryStatement {
+			continue
+		}
+		try := parent.AsTryStatement()
+		if try.FinallyBlock == nil || current != try.CatchClause {
+			continue
+		}
+		runs, stopped := w.scanList(try.FinallyBlock.AsBlock().Statements, 0)
+		if runs {
+			return true
+		}
+		if stopped {
+			return false
+		}
+	}
+	if target == nil {
+		return false
+	}
+	return w.runsAfter(target)
+}
+
+func hasExportModifier(node *ast.Node) bool {
+	return ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+}
+
+// breakTarget returns the statement a `break` leaves, so the walk can carry on
+// from after it.
+func breakTarget(node *ast.Node) *ast.Node {
+	label := node.AsBreakStatement().Label
+	name := ""
+	if label != nil {
+		name = label.Text()
+	}
+	for current := node.Parent; current != nil; current = current.Parent {
+		if isFunction(current) || current.Kind == ast.KindClassStaticBlockDeclaration ||
+			current.Kind == ast.KindSourceFile {
+			return nil
+		}
+		if name == "" {
+			switch current.Kind {
+			case ast.KindSwitchStatement, ast.KindWhileStatement, ast.KindDoStatement,
+				ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
+				return current
+			}
+			continue
+		}
+		if current.Kind == ast.KindLabeledStatement &&
+			current.AsLabeledStatement().Label.Text() == name {
+			return current
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// fix
+// ---------------------------------------------------------------------------
+
+// buildFix removes the return statement. The edit spans the whole enclosing
+// function even though only the return is dropped from it, which is how ESLint
+// keeps this fix from being applied in the same pass as an overlapping one.
+func buildFix(sourceFile *ast.SourceFile, node *ast.Node) []rule.RuleFix {
+	if !isRemovable(node) || utils.HasCommentInsideNode(sourceFile, node) {
+		return nil
+	}
+	removed := utils.TrimNodeTextRange(sourceFile, node)
+	retained := retainedRange(sourceFile, node)
+	text := sourceFile.Text()
+	return []rule.RuleFix{rule.RuleFixReplaceRange(
+		retained,
+		text[retained.Pos():removed.Pos()]+text[removed.End():retained.End()],
+	)}
+}
+
+// isRemovable reports whether the return stands in a list of statements, so
+// dropping it leaves the code around it well formed.
+func isRemovable(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindSourceFile, ast.KindBlock, ast.KindCaseClause, ast.KindDefaultClause:
+		return true
+	}
+	return false
+}
+
+func retainedRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	for current := node; current != nil; current = current.Parent {
+		if isFunction(current) {
+			return utils.TrimNodeTextRange(sourceFile, current)
+		}
+	}
+	return core.NewTextRange(0, len(sourceFile.Text()))
+}

--- a/internal/rules/no_useless_return/no_useless_return.go
+++ b/internal/rules/no_useless_return/no_useless_return.go
@@ -331,9 +331,9 @@ func isFunction(node *ast.Node) bool {
 // fix
 // ---------------------------------------------------------------------------
 
-// buildFix removes the return statement. The edit spans the whole enclosing
-// function even though only the return is dropped from it, which is how ESLint
-// keeps this fix from being applied in the same pass as an overlapping one.
+// buildFix removes the return statement. The edit spans the enclosing function
+// even though only the return is dropped from it, which is how ESLint keeps
+// this fix from being applied in the same pass as an overlapping one.
 func buildFix(sourceFile *ast.SourceFile, node *ast.Node) []rule.RuleFix {
 	if !isRemovable(node) || utils.HasCommentInsideNode(sourceFile, node) {
 		return nil
@@ -361,11 +361,24 @@ func isRemovable(node *ast.Node) bool {
 	return false
 }
 
+// retainedRange spans the enclosing function, matching the range ESLint keeps
+// for the edit. tsgo folds a method's name and its function value into one
+// node, where ESTree splits them across a definition and an inner
+// FunctionExpression, so for those the range runs from the parameter list to
+// the end of the body: a computed key or a decorator holds its own functions,
+// and their returns get to be fixed in the same pass.
 func retainedRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
 	for current := node; current != nil; current = current.Parent {
-		if isFunction(current) {
-			return utils.TrimNodeTextRange(sourceFile, current)
+		if !isFunction(current) {
+			continue
 		}
+		switch current.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+			if pos, end, ok := utils.BodyLikeRange(current); ok {
+				return core.NewTextRange(pos, end)
+			}
+		}
+		return utils.TrimNodeTextRange(sourceFile, current)
 	}
 	return core.NewTextRange(0, len(sourceFile.Text()))
 }

--- a/internal/rules/no_useless_return/no_useless_return.go
+++ b/internal/rules/no_useless_return/no_useless_return.go
@@ -6,9 +6,9 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 
-	"github.com/web-infra-dev/rslint/internal/cfg"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/cfg"
 )
 
 var unnecessaryReturn = rule.RuleMessage{
@@ -85,7 +85,7 @@ func reportUselessReturns(ctx *rule.RuleContext, byRoot map[*ast.Node][]*ast.Nod
 }
 
 // reachableStatements lays out one code path and collects the statements
-// control can reach. internal/cfg stops laying a path out where it ends, so a
+// control can reach. internal/utils/cfg stops laying a path out where it ends, so a
 // statement the hook never sees is one ESLint's code path analysis would place
 // on an unreachable segment.
 func reachableStatements(root *ast.Node) map[*ast.Node]bool {
@@ -166,7 +166,7 @@ const (
 // segment and letting any statement on a segment the return can reach clear it
 // again — deliberately walking through the unreachable segments the return
 // itself created, which simulates the path the code would take without it.
-// internal/cfg stops laying a path out at a `return`, so that continuation has
+// internal/utils/cfg stops laying a path out at a `return`, so that continuation has
 // no edges in the graph and is followed over the syntax tree instead: from the
 // return outwards through its enclosing statements, into the statements that
 // follow each of them.

--- a/internal/rules/no_useless_return/no_useless_return.md
+++ b/internal/rules/no_useless_return/no_useless_return.md
@@ -1,0 +1,77 @@
+# no-useless-return
+
+## Rule Details
+
+A `return;` at the end of a function does the same thing as reaching the end of
+the function, so it can be dropped. This rule reports every `return` with no
+value that nothing runs after.
+
+A `return` that carries a value is left alone, and so is one inside a loop —
+which leaves the loop early — or inside a `finally` block, which replaces the
+value the statement was leaving with.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function foo() {
+  return;
+}
+
+function bar() {
+  doSomething();
+  return;
+}
+
+function baz() {
+  if (condition) {
+    doSomething();
+    return;
+  } else {
+    doSomethingElse();
+  }
+}
+
+function qux() {
+  switch (value) {
+    case 1:
+      doSomething();
+      return;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function foo() {
+  return 5;
+}
+
+function bar() {
+  if (condition) {
+    return;
+  }
+  doSomething();
+}
+
+function baz() {
+  for (const item of items) {
+    if (item.done) {
+      return;
+    }
+    process(item);
+  }
+}
+
+function qux() {
+  try {
+    return computeValue();
+  } finally {
+    return fallback;
+  }
+}
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-useless-return

--- a/internal/rules/no_useless_return/no_useless_return_extras_branches_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_extras_branches_test.go
@@ -298,6 +298,16 @@ export = 1;`},
 			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
 			{
 				Code: `if (c) { return; }
+export as namespace Lib;`,
+				Output: []string{`if (c) {  }
+export as namespace Lib;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code: `if (c) { return; }
 declare global {}`,
 				Output: []string{`if (c) {  }
 declare global {}`},

--- a/internal/rules/no_useless_return/no_useless_return_extras_branches_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_extras_branches_test.go
@@ -1,0 +1,613 @@
+package no_useless_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUselessReturnExtrasBranches gives every reachable arm of the upstream
+// rule source a minimum input, including the arms upstream's own suite never
+// reaches, so a future refactor cannot flip one of them silently. Each case
+// names the arm it locks in. Every verdict below was taken from ESLint itself.
+func TestNoUselessReturnExtrasBranches(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessReturnRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Locks in upstream ReturnStatement() arm 1: an argument marks the earlier returns used. ----
+			{Code: `function f() { if (c) { return; } return 5; }`},
+			// ---- Locks in upstream ReturnStatement() arm 2: isInLoop. ----
+			{Code: `function f() { while (c) { return; } }`},
+			// ---- Locks in upstream ReturnStatement() arm 2: isInLoop. ----
+			{Code: `function f() { do { return; } while (c); }`},
+			// ---- Locks in upstream ReturnStatement() arm 2: isInLoop. ----
+			{Code: `function f() { for (;;) { return; } }`},
+			// ---- Locks in upstream ReturnStatement() arm 2: isInLoop. ----
+			{Code: `function f() { for (const k in o) { return; } }`},
+			// ---- Locks in upstream ReturnStatement() arm 2: isInLoop. ----
+			{Code: `function f() { for (const k of o) { return; } }`},
+			// ---- Locks in upstream ReturnStatement() arm 2: isInLoop. ----
+			{Code: `function f() { for (;;) { if (c) { return; } } }`},
+			// ---- isInLoop crosses a class static block, so a loop outside the class still counts. ----
+			{Code: `function f() { for (;;) { class K { static { return; } } } }`},
+			// ---- Locks in upstream ReturnStatement() arm 3: isInFinally. ----
+			{Code: `function f() { try { g(); } finally { return; } }`},
+			// ---- Locks in upstream ReturnStatement() arm 3: isInFinally. ----
+			{Code: `function f() { try { g(); } finally { if (c) { return; } } }`},
+			// ---- Locks in upstream ReturnStatement() arm 4: a return nothing reaches is left alone. ----
+			{Code: `function f() { throw e; return; }`},
+			// ---- Locks in upstream ReturnStatement() arm 4: a return nothing reaches is left alone. ----
+			{Code: `function f() { while (true) { g(); } return; }`},
+			// ---- Locks in upstream ReturnStatement() arm 4: a return nothing reaches is left alone. ----
+			{Code: `function f() { if (c) return 1; else return 2; return; }`},
+			// ---- Locks in upstream ReturnStatement() arm 4: a return nothing reaches is left alone. ----
+			{Code: `function f() { return; return; post(); }`},
+			// ---- Locks in upstream markReturnStatementsOnCurrentSegmentsAsUsed exclusions: a function declaration is hoisted, so it does not use the return. ----
+			{Code: `function f() { return; function h() {} post(); }`},
+			// ---- A block does nothing on its own, but the statements in it do. ----
+			{Code: `function f() { return; { post(); } }`},
+			// ---- A break control reaches carries the return to what the break leaves. ----
+			{Code: `function f() { switch (s) { case 1: if (c) { return; } break; case 2: two(); } post(); }`},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{Code: `function f() { switch (s) { case 1: return; break; case 2: two(); } }`},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{Code: `function f() { l: { return; break l; } post(); }`},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{Code: `function f() { switch (s) { case 1: { return; } break; case 2: two(); } }`},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{Code: `function f() { switch (s) { case 1: l: { return; } break; case 2: two(); } }`},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{Code: `function f() { switch (s) { case 1: try { return; } catch (e) {} break; case 2: two(); } }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; ;; }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; debugger; }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; var v = 1; }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; class C {} }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; if (c) post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; while (c) post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; do post(); while (c); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; for (;;) post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; for (const k in o) post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; for (const k of o) post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; switch (s) {} }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; throw e; }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; try {} catch (e) {} }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; l: post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; with (o) post(); }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { return; return 5; }`},
+			// ---- Every statement kind ESLint does list clears the return. ----
+			{Code: `function f() { for (;;) { if (c) { return; } continue; } }`},
+			// ---- A namespace body is walked through, so a statement in it does clear the return. ----
+			{Code: `if (c) { return; }
+namespace N { post(); }`},
+			// ---- A namespace body is walked through, so a statement in it does clear the return. ----
+			{Code: `if (c) { return; }
+namespace N { namespace M { post(); } }`},
+			// ---- A namespace body is walked through, so a statement in it does clear the return. ----
+			{Code: `if (c) { return; }
+namespace N.M { post(); }`},
+			// ---- A namespace body is walked through, so a statement in it does clear the return. ----
+			{Code: `if (c) { return; }
+declare module 'x' { export const z: number; }`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export function h() {}`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export interface I {}`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export type T = 1;`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export enum E {}`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export namespace N {}`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export import q = require('y');`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export default 1;`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export {};`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+export * from 'x';`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
+import 'x';`},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{Code: `function f() { try { return; } finally { throw e; } post(); }`},
+			// ---- Past the `try` block the shield is gone: what follows the statement clears the return. ----
+			{Code: `function f() { try { return; } catch (e) { post(); } tail(); }`},
+			// ---- Past the `try` block the shield is gone: what follows the statement clears the return. ----
+			{Code: `function f() { try { if (c) { return; } } catch (e) { post(); } tail(); }`},
+			// ---- A return in the `catch` clause is not shielded from the `finally` block. ----
+			{Code: `function f() { try {} catch (e) { return; } finally { post(); } }`},
+			// ---- Locks in upstream getUselessReturns: a segment reached only through the branch that returned still carries the return. ----
+			{Code: `function f() { if (c) { return; } else { alt(); } tail(); }`},
+			// ---- Locks in upstream getUselessReturns: a segment reached only through the branch that returned still carries the return. ----
+			{Code: `function f() { if (c) { return; } if (d) { post(); } }`},
+			// ---- A switch clause falls through into the one after it. ----
+			{Code: `function f() { switch (s) { case 1: return; default: post(); } }`},
+			// ---- Locks in upstream makeBreak with no matching context: a break with nothing to leave still ends the path. ----
+			{Code: `function f() { return; break; tail(); }`},
+			// ---- A break out of a `try` still runs the `finally` on its way, unless the return is inside the `try` block it belongs to. ----
+			{Code: `function f() { try {} catch (e) { if (c) { return; } break; } finally { g(); } }`},
+			// ---- A break out of a `try` still runs the `finally` on its way, unless the return is inside the `try` block it belongs to. ----
+			{Code: `function f() { l1: { try {} catch (e) { if (c) { return; } break l1; } finally { g(); } } }`},
+			// ---- A break out of a `try` still runs the `finally` on its way, unless the return is inside the `try` block it belongs to. ----
+			{Code: `function f() { l1: { if (c) { return; } break l1; } tail(); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in upstream ReturnStatement() arm 1: an argument marks the earlier returns used. ----
+			{
+				Code:   `function f() { if (c) { return; } return; }`,
+				Output: []string{`function f() { if (c) {  } return; }`, `function f() { if (c) {  }  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 35, EndLine: 1, EndColumn: 42},
+				},
+			},
+			// ---- isInFinally stops at a function, so a return in a function inside the finally is still reported. ----
+			{
+				Code:   `function f() { try { g(); } finally { function inner() { return; } } }`,
+				Output: []string{`function f() { try { g(); } finally { function inner() {  } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 58, EndLine: 1, EndColumn: 65},
+				},
+			},
+			// ---- Locks in upstream ReturnStatement() arm 4: a return nothing reaches is left alone. ----
+			{
+				Code:   `function f() { return; return; }`,
+				Output: []string{`function f() {  return; }`, `function f() {   }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnCurrentSegmentsAsUsed exclusions: a function declaration is hoisted, so it does not use the return. ----
+			{
+				Code:   `function f() { return; function h() {} }`,
+				Output: []string{`function f() {  function h() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnCurrentSegmentsAsUsed exclusions: a function declaration is hoisted, so it does not use the return. ----
+			{
+				Code:   `function f() { return; function h() {} function i() {} }`,
+				Output: []string{`function f() {  function h() {} function i() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- A block does nothing on its own, but the statements in it do. ----
+			{
+				Code:   `function f() { return; { function h() {} } }`,
+				Output: []string{`function f() {  { function h() {} } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- A break control reaches carries the return to what the break leaves. ----
+			{
+				Code:   `function f() { switch (s) { case 1: if (c) { return; } break; case 2: two(); } }`,
+				Output: []string{`function f() { switch (s) { case 1: if (c) {  } break; case 2: two(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 46, EndLine: 1, EndColumn: 53},
+				},
+			},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{
+				Code: `function f() { switch (s) { case 1: { if (c) return; } break; case 2: two(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 46, EndLine: 1, EndColumn: 53},
+				},
+			},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{
+				Code:   `function f() { switch (s) { case 1: l: { if (c) break l; return; } break; case 2: two(); } }`,
+				Output: []string{`function f() { switch (s) { case 1: l: { if (c) break l;  } break; case 2: two(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 58, EndLine: 1, EndColumn: 65},
+				},
+			},
+			// ---- A break nothing reaches goes to the next segment merely. ----
+			{
+				Code: `function f() { switch (s) { case 1: try { if (c) return; } catch (e) {} break; case 2: two(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 50, EndLine: 1, EndColumn: 57},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code:   `function f() { return; interface I {} }`,
+				Output: []string{`function f() {  interface I {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code:   `function f() { return; type T = 1; }`,
+				Output: []string{`function f() {  type T = 1; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code:   `function f() { return; enum E {} }`,
+				Output: []string{`function f() {  enum E {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code:   `function f() { return; declare function q(): void; }`,
+				Output: []string{`function f() {  declare function q(): void; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code: `if (c) { return; }
+import q = require('y');`,
+				Output: []string{`if (c) {  }
+import q = require('y');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code: `if (c) { return; }
+export = 1;`,
+				Output: []string{`if (c) {  }
+export = 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code: `if (c) { return; }
+declare global {}`,
+				Output: []string{`if (c) {  }
+declare global {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code: `if (c) { return; }
+namespace N {}`,
+				Output: []string{`if (c) {  }
+namespace N {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code: `if (c) { return; }
+namespace N { type T = 1; }`,
+				Output: []string{`if (c) {  }
+namespace N { type T = 1; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- A TypeScript-only declaration is not one of the ESTree types ESLint lists, so it does not clear the return. ----
+			{
+				Code: `if (c) { return; }
+declare module 'x' {}`,
+				Output: []string{`if (c) {  }
+declare module 'x' {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{
+				Code:   `function f() { try { return; } catch (e) { post(); } }`,
+				Output: []string{`function f() { try {  } catch (e) { post(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{
+				Code:   `function f() { try { return; } finally { post(); } }`,
+				Output: []string{`function f() { try {  } finally { post(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{
+				Code:   `function f() { try { return; } catch (e) { return 5; } }`,
+				Output: []string{`function f() { try {  } catch (e) { return 5; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{
+				Code:   `function f() { try { return; } catch (e) { throw e; } }`,
+				Output: []string{`function f() { try {  } catch (e) { throw e; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{
+				Code:   `function f() { try { if (c) { return; } } catch (e) { post(); } }`,
+				Output: []string{`function f() { try { if (c) {  } } catch (e) { post(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 31, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{
+				Code:   `function f() { try { return; } catch (e) { try { post(); } catch (e2) {} } }`,
+				Output: []string{`function f() { try {  } catch (e) { try { post(); } catch (e2) {} } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Locks in upstream markReturnStatementsOnSegmentAsUsed arm 1: a return inside a `try` block survives everything in the `catch` clause and the `finally` block. ----
+			{
+				Code:   `function f() { try { try { return; } finally { post(); } } catch (e) {} }`,
+				Output: []string{`function f() { try { try {  } finally { post(); } } catch (e) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 28, EndLine: 1, EndColumn: 35},
+				},
+			},
+			// ---- A return in the `catch` clause is not shielded from the `finally` block. ----
+			{
+				Code:   `function f() { try {} catch (e) { return; } finally {} }`,
+				Output: []string{`function f() { try {} catch (e) {  } finally {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 35, EndLine: 1, EndColumn: 42},
+				},
+			},
+			// ---- A return in the `catch` clause is not shielded from the `finally` block. ----
+			{
+				Code:   `function f() { try {} catch (e) { return; } finally { return; post(); } }`,
+				Output: []string{`function f() { try {} catch (e) {  } finally { return; post(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 35, EndLine: 1, EndColumn: 42},
+				},
+			},
+			// ---- A return in the `catch` clause is not shielded from the `finally` block. ----
+			{
+				Code:   `function f() { try {} catch (e) { return; } }`,
+				Output: []string{`function f() { try {} catch (e) {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 35, EndLine: 1, EndColumn: 42},
+				},
+			},
+			// ---- Locks in upstream getUselessReturns: a segment reached only through the branch that returned still carries the return. ----
+			{
+				Code:   `function f() { if (c) { return; } else { alt(); } }`,
+				Output: []string{`function f() { if (c) {  } else { alt(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- Locks in upstream getUselessReturns: a segment reached only through the branch that returned still carries the return. ----
+			{
+				Code:   `function f() { if (c) alt(); else { return; } }`,
+				Output: []string{`function f() { if (c) alt(); else {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 37, EndLine: 1, EndColumn: 44},
+				},
+			},
+			// ---- A switch clause falls through into the one after it. ----
+			{
+				Code:   `function f() { switch (s) { case 1: return; case 2: } }`,
+				Output: []string{`function f() { switch (s) { case 1:  case 2: } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 37, EndLine: 1, EndColumn: 44},
+				},
+			},
+			// ---- A switch clause falls through into the one after it. ----
+			{
+				Code:   `function f() { switch (s) { default: return; } }`,
+				Output: []string{`function f() { switch (s) { default:  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 38, EndLine: 1, EndColumn: 45},
+				},
+			},
+			// ---- Locks in upstream isRemovable: only a statement in a statement list can be dropped. ----
+			{
+				Code: `function f() { if (c) return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// ---- Locks in upstream isRemovable: only a statement in a statement list can be dropped. ----
+			{
+				Code: `function f() { l: return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 19, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// ---- Locks in upstream isRemovable: only a statement in a statement list can be dropped. ----
+			{
+				Code: `function f() { with (o) return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- Locks in upstream isRemovable: only a statement in a statement list can be dropped. ----
+			{
+				Code:   `function f() { switch (s) { case 1: return; } }`,
+				Output: []string{`function f() { switch (s) { case 1:  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 37, EndLine: 1, EndColumn: 44},
+				},
+			},
+			// ---- Locks in upstream isRemovable: only a statement in a statement list can be dropped. ----
+			{
+				Code:   `class K { static { return; } }`,
+				Output: []string{`class K { static {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 20, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// ---- Locks in upstream fix(): a comment inside the return blocks the fix. ----
+			{
+				Code: `function f() { g(); return /* keep */; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 39},
+				},
+			},
+			// ---- Locks in upstream fix(): a comment inside the return blocks the fix. ----
+			{
+				Code:   `function f() { g(); return; /* after */ }`,
+				Output: []string{`function f() { g();  /* after */ }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+				},
+			},
+			// ---- Locks in upstream FixTracker.retainEnclosingFunction: returns in separate functions are fixed together, ones in the same function are not. ----
+			{
+				Code:   `function a() { return; } function b() { return; }`,
+				Output: []string{`function a() {  } function b() {  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 41, EndLine: 1, EndColumn: 48},
+				},
+			},
+			// ---- Locks in upstream FixTracker.retainEnclosingFunction: returns in separate functions are fixed together, ones in the same function are not. ----
+			{
+				Code:   `class K { m() { return; } n() { return; } }`,
+				Output: []string{`class K { m() {  } n() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 17, EndLine: 1, EndColumn: 24},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 33, EndLine: 1, EndColumn: 40},
+				},
+			},
+			// ---- Locks in upstream FixTracker.retainEnclosingFunction: returns in separate functions are fixed together, ones in the same function are not. ----
+			{
+				Code: `class K { static { return; } }
+class L { static { return; } }`,
+				Output: []string{`class K { static {  } }
+class L { static { return; } }`, `class K { static {  } }
+class L { static {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 20, EndLine: 1, EndColumn: 27},
+					{MessageId: "unnecessaryReturn", Line: 2, Column: 20, EndLine: 2, EndColumn: 27},
+				},
+			},
+			// ---- Locks in upstream FixTracker.retainEnclosingFunction: returns in separate functions are fixed together, ones in the same function are not. ----
+			{
+				Code:   `function f() { if (c) { return; } return; }`,
+				Output: []string{`function f() { if (c) {  } return; }`, `function f() { if (c) {  }  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 35, EndLine: 1, EndColumn: 42},
+				},
+			},
+			// ---- Locks in upstream makeBreak with no matching context: a break with nothing to leave still ends the path. ----
+			{
+				Code:   `function f() { if (c) { return; } break; tail(); }`,
+				Output: []string{`function f() { if (c) {  } break; tail(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- Locks in upstream makeBreak with no matching context: a break with nothing to leave still ends the path. ----
+			{
+				Code:   `function f() { if (c) { return; } break l9; tail(); }`,
+				Output: []string{`function f() { if (c) {  } break l9; tail(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- A break out of a `try` still runs the `finally` on its way, unless the return is inside the `try` block it belongs to. ----
+			{
+				Code:   `function f() { try { if (c) { return; } break; } finally { g(); } tail(); }`,
+				Output: []string{`function f() { try { if (c) {  } break; } finally { g(); } tail(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 31, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// ---- A break out of a `try` still runs the `finally` on its way, unless the return is inside the `try` block it belongs to. ----
+			{
+				Code:   `function f() { l1: { try { if (c) { return; } break l1; } finally { g(); } } }`,
+				Output: []string{`function f() { l1: { try { if (c) {  } break l1; } finally { g(); } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 37, EndLine: 1, EndColumn: 44},
+				},
+			},
+			// ---- A break out of a `try` still runs the `finally` on its way, unless the return is inside the `try` block it belongs to. ----
+			{
+				Code:   `function f() { try {} catch (e) { if (c) { return; } break; } finally { return; } tail(); }`,
+				Output: []string{`function f() { try {} catch (e) { if (c) {  } break; } finally { return; } tail(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 44, EndLine: 1, EndColumn: 51},
+				},
+			},
+			// ---- A break out of a `try` still runs the `finally` on its way, unless the return is inside the `try` block it belongs to. ----
+			{
+				Code:   `function f() { l1: { if (c) { return; } break l1; } }`,
+				Output: []string{`function f() { l1: { if (c) {  } break l1; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 31, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// ---- A return with no semicolon, and one the parser terminates for it. ----
+			{
+				Code:   `function f() { g(); return }`,
+				Output: []string{`function f() { g();  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// ---- A return with no semicolon, and one the parser terminates for it. ----
+			{
+				Code: `function f() {
+  g()
+  return
+}`,
+				Output: []string{`function f() {
+  g()
+  
+}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 3, Column: 3, EndLine: 3, EndColumn: 9},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_useless_return/no_useless_return_extras_branches_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_extras_branches_test.go
@@ -127,6 +127,9 @@ export enum E {}`},
 export namespace N {}`},
 			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
 			{Code: `if (c) { return; }
+export namespace N.M {}`},
+			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
+			{Code: `if (c) { return; }
 export import q = require('y');`},
 			// ---- An `export` modifier puts the declaration back into an ESTree export node, which does clear it. ----
 			{Code: `if (c) { return; }
@@ -331,6 +334,26 @@ namespace N {}`},
 namespace N { type T = 1; }`,
 				Output: []string{`if (c) {  }
 namespace N { type T = 1; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- The declaration a dotted namespace nests for each name after the first carries a synthesized `export`, not a written one. ----
+			{
+				Code: `if (c) { return; }
+namespace N.M {}`,
+				Output: []string{`if (c) {  }
+namespace N.M {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- The declaration a dotted namespace nests for each name after the first carries a synthesized `export`, not a written one. ----
+			{
+				Code: `if (c) { return; }
+declare namespace A.B.C {}`,
+				Output: []string{`if (c) {  }
+declare namespace A.B.C {}`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unnecessaryReturn", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
 				},

--- a/internal/rules/no_useless_return/no_useless_return_extras_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_extras_test.go
@@ -229,6 +229,182 @@ func TestNoUselessReturnExtras(t *testing.T) {
 					{MessageId: "unnecessaryReturn", Line: 1, Column: 34, EndLine: 1, EndColumn: 41},
 				},
 			},
+			// ---- Dimension 4: fix range — a computed key sits outside the method's retained range, so both returns go in one pass ----
+			{
+				Code:   `class K { [(() => { return; })()]() { return; } }`,
+				Output: []string{`class K { [(() => {  })()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 39, EndLine: 1, EndColumn: 46},
+				},
+			},
+			// ---- Dimension 4: fix range — a computed key sits outside the method's retained range, so both returns go in one pass ----
+			{
+				Code:   `const o = { [(() => { return; })()]() { return; } };`,
+				Output: []string{`const o = { [(() => {  })()]() {  } };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 41, EndLine: 1, EndColumn: 48},
+				},
+			},
+			// ---- Dimension 4: fix range — a computed key sits outside the method's retained range, so both returns go in one pass ----
+			{
+				Code:   `class K { get [(() => { return; })()]() { return; } }`,
+				Output: []string{`class K { get [(() => {  })()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 43, EndLine: 1, EndColumn: 50},
+				},
+			},
+			// ---- Dimension 4: fix range — a computed key sits outside the method's retained range, so both returns go in one pass ----
+			{
+				Code:   `class K { set [(() => { return; })()](v) { return; } }`,
+				Output: []string{`class K { set [(() => {  })()](v) {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 44, EndLine: 1, EndColumn: 51},
+				},
+			},
+			// ---- Dimension 4: fix range — a decorator sits outside the method's retained range, so both returns go in one pass ----
+			{
+				Code:   `class K { @dec(() => { return; }) m() { return; } }`,
+				Output: []string{`class K { @dec(() => {  }) m() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 24, EndLine: 1, EndColumn: 31},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 41, EndLine: 1, EndColumn: 48},
+				},
+			},
+			// ---- Dimension 4: fix range — a parameter decorator is inside the retained range, so its return waits for the next pass, as upstream does ----
+			{
+				Code: `class K { constructor(@dec(() => { return; }) x) { return; } }`,
+				Output: []string{
+					`class K { constructor(@dec(() => { return; }) x) {  } }`,
+					`class K { constructor(@dec(() => {  }) x) {  } }`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 36, EndLine: 1, EndColumn: 43},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 52, EndLine: 1, EndColumn: 59},
+				},
+			},
+			// ---- Dimension 4: fix range — a property's arrow keeps its own range, which never covered the computed key ----
+			{
+				Code:   `class K { [(() => { return; })()] = () => { return; }; }`,
+				Output: []string{`class K { [(() => {  })()] = () => {  }; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 45, EndLine: 1, EndColumn: 52},
+				},
+			},
+			// ---- Dimension 4: fix range — a chain of computed keys stays one pass however deep it goes ----
+			{
+				Code:   `class A { [(() => { class B { [(() => { class C { [(() => { return; })()]() { return; } } })()]() { return; } } })()]() { return; } }`,
+				Output: []string{`class A { [(() => { class B { [(() => { class C { [(() => {  })()]() {  } } })()]() {  } } })()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 61, EndLine: 1, EndColumn: 68},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 79, EndLine: 1, EndColumn: 86},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 101, EndLine: 1, EndColumn: 108},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 123, EndLine: 1, EndColumn: 130},
+				},
+			},
+			// ---- Dimension 4: fix range — the key's own return retains the whole key expression, so its nested method waits a pass, as upstream does ----
+			{
+				Code: `class K { [(() => { class I { [(() => { return; })()]() { return; } } return; })()]() { return; } }`,
+				Output: []string{
+					`class K { [(() => { class I { [(() => { return; })()]() { return; } }  })()]() {  } }`,
+					`class K { [(() => { class I { [(() => {  })()]() {  } }  })()]() {  } }`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 41, EndLine: 1, EndColumn: 48},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 59, EndLine: 1, EndColumn: 66},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 71, EndLine: 1, EndColumn: 78},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 89, EndLine: 1, EndColumn: 96},
+				},
+			},
+			// ---- Dimension 4: fix range — a key holding a function expression ----
+			{
+				Code:   `class K { [(function () { return; })()]() { return; } }`,
+				Output: []string{`class K { [(function () {  })()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 27, EndLine: 1, EndColumn: 34},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 45, EndLine: 1, EndColumn: 52},
+				},
+			},
+			// ---- Dimension 4: fix range — a key holding a method of its own ----
+			{
+				Code:   `class K { [({ m() { return; } }).m()]() { return; } }`,
+				Output: []string{`class K { [({ m() {  } }).m()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 43, EndLine: 1, EndColumn: 50},
+				},
+			},
+			// ---- Dimension 4: fix range — type parameters sit between the key and the parameter list ----
+			{
+				Code:   `class K { [(() => { return; })()]<T>() { return; } }`,
+				Output: []string{`class K { [(() => {  })()]<T>() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 42, EndLine: 1, EndColumn: 49},
+				},
+			},
+			// ---- Dimension 4: fix range — modifiers ahead of the key don't move the retained range ----
+			{
+				Code:   `class K { async [(() => { return; })()]() { return; } }`,
+				Output: []string{`class K { async [(() => {  })()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 27, EndLine: 1, EndColumn: 34},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 45, EndLine: 1, EndColumn: 52},
+				},
+			},
+			// ---- Dimension 4: fix range — modifiers ahead of the key don't move the retained range ----
+			{
+				Code:   `class K { *[(() => { return; })()]() { return; } }`,
+				Output: []string{`class K { *[(() => {  })()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 40, EndLine: 1, EndColumn: 47},
+				},
+			},
+			// ---- Dimension 4: fix range — an object literal accessor with a computed key ----
+			{
+				Code:   `const o = { get [(() => { return; })()]() { return; } };`,
+				Output: []string{`const o = { get [(() => {  })()]() {  } };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 27, EndLine: 1, EndColumn: 34},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 45, EndLine: 1, EndColumn: 52},
+				},
+			},
+			// ---- Dimension 4: fix range — a decorator and a computed key on the same accessor ----
+			{
+				Code:   `class K { @dec(() => { return; }) get [(() => { return; })()]() { return; } }`,
+				Output: []string{`class K { @dec(() => {  }) get [(() => {  })()]() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 24, EndLine: 1, EndColumn: 31},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 49, EndLine: 1, EndColumn: 56},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 67, EndLine: 1, EndColumn: 74},
+				},
+			},
+			// ---- Dimension 4: fix range — a default parameter value is inside the retained range, so its return waits for the next pass, as upstream does ----
+			{
+				Code: `class K { m(x = () => { return; }) { return; } }`,
+				Output: []string{
+					`class K { m(x = () => { return; }) {  } }`,
+					`class K { m(x = () => {  }) {  } }`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 38, EndLine: 1, EndColumn: 45},
+				},
+			},
+			// ---- Dimension 4: fix range — a return nested in the method body still retains the whole body ----
+			{
+				Code:   `class K { [(() => { return; })()]() { if (c) { return; } } }`,
+				Output: []string{`class K { [(() => {  })()]() { if (c) {  } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 48, EndLine: 1, EndColumn: 55},
+				},
+			},
 		},
 	)
 }

--- a/internal/rules/no_useless_return/no_useless_return_extras_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_extras_test.go
@@ -1,0 +1,331 @@
+package no_useless_return
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUselessReturnExtras locks in the edge shapes the upstream test suite
+// doesn't exercise: every code path root tsgo builds, the containers the walk
+// has to degrade gracefully on, and code shapes real projects write. Lock-ins
+// for the arms of the upstream source live in
+// no_useless_return_extras_branches_test.go. Every verdict below was taken from
+// ESLint itself.
+func TestNoUselessReturnExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessReturnRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: nesting / traversal boundaries — a nested code path keeps its own returns ----
+			{Code: `function outer() { if (c) { return; } const inner = () => { post(); }; }`},
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `function f() {}`},
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `const f = () => 5;`},
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `function f() { return; ; }`},
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `function f() { switch (s) {} }`},
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `function f() { if (c) { return; } switch (s) {} }`},
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `class K { static {} }`},
+			// ---- Real-user: Express-style middleware guard ----
+			{Code: `function middleware(req, res, next) { if (!req.user) { res.sendStatus(401); return; } next(); }`},
+			// ---- Real-user: guard clause that is the whole body of the branch ----
+			{Code: `function render(props) { if (!props.visible) return; draw(props); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `function f() { return; }`,
+				Output: []string{`function f() {  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `const f = function () { return; };`,
+				Output: []string{`const f = function () {  };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `const f = () => { return; };`,
+				Output: []string{`const f = () => {  };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 19, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `class K { m() { return; } }`,
+				Output: []string{`class K { m() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 17, EndLine: 1, EndColumn: 24},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `class K { constructor() { return; } }`,
+				Output: []string{`class K { constructor() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 27, EndLine: 1, EndColumn: 34},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `class K { get p() { return; } }`,
+				Output: []string{`class K { get p() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `class K { set p(v) { return; } }`,
+				Output: []string{`class K { set p(v) {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `class K { static m() { return; } }`,
+				Output: []string{`class K { static m() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 24, EndLine: 1, EndColumn: 31},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `class K { static { return; } }`,
+				Output: []string{`class K { static {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 20, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `class K { p = () => { return; }; }`,
+				Output: []string{`class K { p = () => {  }; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `const o = { m() { return; } };`,
+				Output: []string{`const o = { m() {  } };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 19, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `async function f() { return; }`,
+				Output: []string{`async function f() {  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `function* f() { return; }`,
+				Output: []string{`function* f() {  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 17, EndLine: 1, EndColumn: 24},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `async function* f() { return; }`,
+				Output: []string{`async function* f() {  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
+			{
+				Code:   `const f = async () => { return; };`,
+				Output: []string{`const f = async () => {  };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- Dimension 4: nesting / traversal boundaries — a nested code path keeps its own returns ----
+			{
+				Code:   `function outer() { pre(); function inner() { return; } }`,
+				Output: []string{`function outer() { pre(); function inner() {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 46, EndLine: 1, EndColumn: 53},
+				},
+			},
+			// ---- Dimension 4: nesting / traversal boundaries — a nested code path keeps its own returns ----
+			{
+				Code:   `function outer() { return; function inner() { post(); } }`,
+				Output: []string{`function outer() {  function inner() { post(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 20, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code:   `function f() { return; {} }`,
+				Output: []string{`function f() {  {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code:   `function f() { return; { { } } }`,
+				Output: []string{`function f() {  { { } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 16, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- Real-user: Express-style middleware guard ----
+			{
+				Code:   `function middleware(req, res, next) { if (!req.user) { res.sendStatus(401); return; } }`,
+				Output: []string{`function middleware(req, res, next) { if (!req.user) { res.sendStatus(401);  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 77, EndLine: 1, EndColumn: 84},
+				},
+			},
+			// ---- Real-user: event handler that bails out of a switch ----
+			{
+				Code:   `function onKey(e) { switch (e.key) { case 'Escape': close(); return; case 'Enter': submit(); return; } }`,
+				Output: []string{`function onKey(e) { switch (e.key) { case 'Escape': close(); return; case 'Enter': submit();  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 94, EndLine: 1, EndColumn: 101},
+				},
+			},
+			// ---- Real-user: cleanup wrapper — the finally block still runs, so the return in the try stays reported ----
+			{
+				Code:   `async function load() { try { setBusy(true); return; } finally { setBusy(false); } }`,
+				Output: []string{`async function load() { try { setBusy(true);  } finally { setBusy(false); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 46, EndLine: 1, EndColumn: 53},
+				},
+			},
+			// ---- Real-user: eslint#8026 — the fix must not clash with a no-else-return fix on the same if ----
+			{
+				Code:   `function foo() { if (c) { bar(); return; } else { baz(); } }`,
+				Output: []string{`function foo() { if (c) { bar();  } else { baz(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 34, EndLine: 1, EndColumn: 41},
+				},
+			},
+		},
+	)
+}
+
+// TestNoUselessReturnEditDemand checks that what the diagnostic says never
+// depends on whether its fix was asked for, and that the fix is built only when
+// it was.
+func TestNoUselessReturnEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`function first() { return; }
+function second() { if (c) return; }
+function third() { g(); return /* keep */; }`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoUselessReturnRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUselessReturnRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 3 {
+			t.Fatalf("demand %d: diagnostics = %d, want 3", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		want := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d diagnostic %d changed:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+	}
+
+	// Only the first return stands in a statement list and carries no comment.
+	wantFixes := []bool{true, false, false}
+	for index, wantFix := range wantFixes {
+		if got := autofixOnly[index].FixesPtr != nil; got != wantFix {
+			t.Errorf("autofix diagnostic %d fix presence = %t, want %t", index, got, wantFix)
+		}
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Errorf("autofix and all-edits diagnostic %d produced different fixes", index)
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{diagnosticsOnly, suggestionOnly} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.FixesPtr != nil {
+				t.Errorf("non-autofix diagnostic %d materialized fixes", index)
+			}
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Errorf("diagnostic %d materialized suggestions", index)
+			}
+		}
+	}
+}

--- a/internal/rules/no_useless_return/no_useless_return_upstream_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_upstream_test.go
@@ -1,0 +1,641 @@
+package no_useless_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUselessReturnUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/no-useless-return.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in the
+// no_useless_return_extras_test.go file.
+func TestNoUselessReturnUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessReturnRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `function foo() { return 5; }`},
+			{Code: `function foo() { return null; }`},
+			{Code: `function foo() { return doSomething(); }`},
+			{Code: `
+          function foo() {
+            if (bar) {
+              doSomething();
+              return;
+            } else {
+              doSomethingElse();
+            }
+            qux();
+          }
+        `},
+			{Code: `
+          function foo() {
+            switch (bar) {
+              case 1:
+                doSomething();
+                return;
+              default:
+                doSomethingElse();
+            }
+          }
+        `},
+			{Code: `
+          function foo() {
+            switch (bar) {
+              default:
+                doSomething();
+                return;
+              case 1:
+                doSomethingElse();
+            }
+          }
+        `},
+			{Code: `
+          function foo() {
+            switch (bar) {
+              case 1:
+                if (a) {
+                  doSomething();
+                  return;
+                } else {
+                  doSomething();
+                  return;
+                }
+              default:
+                doSomethingElse();
+            }
+          }
+        `},
+			{Code: `
+          function foo() {
+            for (var foo = 0; foo < 10; foo++) {
+              return;
+            }
+          }
+        `},
+			{Code: `
+          function foo() {
+            for (var foo in bar) {
+              return;
+            }
+          }
+        `},
+			{Code: `
+          function foo() {
+            try {
+              return 5;
+            } finally {
+              return; // This is allowed because it can override the returned value of 5
+            }
+          }
+        `},
+			{Code: `
+          function foo() {
+            try {
+              bar();
+              return;
+            } catch (err) {}
+            baz();
+          }
+        `},
+			{Code: `
+          function foo() {
+              if (something) {
+                  try {
+                      bar();
+                      return;
+                  } catch (err) {}
+              }
+              baz();
+          }
+        `},
+			{Code: `
+          function foo() {
+            return;
+            doSomething();
+          }
+        `},
+			{Code: `
+              function foo() {
+                for (var foo of bar) return;
+              }
+            `},
+			{Code: `() => { if (foo) return; bar(); }`},
+			{Code: `() => 5`},
+			{Code: `() => { return; doSomething(); }`},
+			{Code: `if (foo) { return; } doSomething();`},
+
+			// https://github.com/eslint/eslint/issues/7477
+			{Code: `
+          function foo() {
+            if (bar) return;
+            return baz;
+          }
+        `},
+			{Code: `
+          function foo() {
+            if (bar) {
+              return;
+            }
+            return baz;
+          }
+        `},
+			{Code: `
+          function foo() {
+            if (bar) baz();
+            else return;
+            return 5;
+          }
+        `},
+
+			// https://github.com/eslint/eslint/issues/7583
+			{Code: `
+          function foo() {
+            return;
+            while (foo) return;
+            foo;
+          }
+        `},
+
+			// https://github.com/eslint/eslint/issues/7855
+			{Code: `
+          try {
+            throw new Error('foo');
+            while (false);
+          } catch (err) {}
+        `},
+
+			// https://github.com/eslint/eslint/issues/11647
+			{Code: `
+          function foo(arg) {
+            throw new Error("Debugging...");
+            if (!arg) {
+              return;
+            }
+            console.log(arg);
+          }
+        `},
+
+			// https://github.com/eslint/eslint/pull/16996#discussion_r1138622844
+			{Code: `
+        function foo() {
+          try {
+              bar();
+              return;
+          } finally {
+              baz();
+          }
+          qux();
+        }
+        `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `function foo() { return; }`,
+				Output: []string{`function foo() {  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Message: "Unnecessary return statement.", Line: 1, Column: 18, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:   `function foo() { doSomething(); return; }`,
+				Output: []string{`function foo() { doSomething();  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 33, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:   `function foo() { if (condition) { bar(); return; } else { baz(); } }`,
+				Output: []string{`function foo() { if (condition) { bar();  } else { baz(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 42, EndLine: 1, EndColumn: 49},
+				},
+			},
+			{
+				// Removing the return would leave the `if` without a body, so
+				// there is no fix.
+				Code: `function foo() { if (foo) return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 27, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `function foo() { bar(); return/**/; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 1, EndColumn: 36},
+				},
+			},
+			{
+				Code: `function foo() { bar(); return//
+; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 25, EndLine: 2, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `foo(); return;`,
+				Output: []string{`foo(); `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:   `if (foo) { bar(); return; } else { baz(); }`,
+				Output: []string{`if (foo) { bar();  } else { baz(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 19, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                if (foo) {
+                  return;
+                }
+                return;
+              }
+            `,
+				// Each fix covers the whole function, so the second one waits
+				// for the pass after the first.
+				Output: []string{`
+              function foo() {
+                if (foo) {
+                  
+                }
+                return;
+              }
+            `, `
+              function foo() {
+                if (foo) {
+                  
+                }
+                
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 4, Column: 19, EndLine: 4, EndColumn: 26},
+					{MessageId: "unnecessaryReturn", Line: 6, Column: 17, EndLine: 6, EndColumn: 24},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    doSomething();
+                  default:
+                    doSomethingElse();
+                    return;
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    doSomething();
+                  default:
+                    doSomethingElse();
+                    
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 8, Column: 21, EndLine: 8, EndColumn: 28},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                switch (bar) {
+                  default:
+                    doSomething();
+                  case 1:
+                    doSomething();
+                    return;
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                switch (bar) {
+                  default:
+                    doSomething();
+                  case 1:
+                    doSomething();
+                    
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 8, Column: 21, EndLine: 8, EndColumn: 28},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    if (a) {
+                      doSomething();
+                      return;
+                    }
+                    break;
+                  default:
+                    doSomethingElse();
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    if (a) {
+                      doSomething();
+                      
+                    }
+                    break;
+                  default:
+                    doSomethingElse();
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 7, Column: 23, EndLine: 7, EndColumn: 30},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    if (a) {
+                      doSomething();
+                      return;
+                    } else {
+                      doSomething();
+                    }
+                    break;
+                  default:
+                    doSomethingElse();
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    if (a) {
+                      doSomething();
+                      
+                    } else {
+                      doSomething();
+                    }
+                    break;
+                  default:
+                    doSomethingElse();
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 7, Column: 23, EndLine: 7, EndColumn: 30},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    if (a) {
+                      doSomething();
+                      return;
+                    }
+                  default:
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                switch (bar) {
+                  case 1:
+                    if (a) {
+                      doSomething();
+                      
+                    }
+                  default:
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 7, Column: 23, EndLine: 7, EndColumn: 30},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                try {} catch (err) { return; }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                try {} catch (err) {  }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 3, Column: 38, EndLine: 3, EndColumn: 45},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                try {
+                  foo();
+                  return;
+                } catch (err) {
+                  return 5;
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                try {
+                  foo();
+                  
+                } catch (err) {
+                  return 5;
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 5, Column: 19, EndLine: 5, EndColumn: 26},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                  if (something) {
+                      try {
+                          bar();
+                          return;
+                      } catch (err) {}
+                  }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                  if (something) {
+                      try {
+                          bar();
+                          
+                      } catch (err) {}
+                  }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 6, Column: 27, EndLine: 6, EndColumn: 34},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                try {
+                  return;
+                } catch (err) {
+                  foo();
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                try {
+                  
+                } catch (err) {
+                  foo();
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 4, Column: 19, EndLine: 4, EndColumn: 26},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                  try {
+                      return;
+                  } finally {
+                      bar();
+                  }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                  try {
+                      
+                  } finally {
+                      bar();
+                  }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 4, Column: 23, EndLine: 4, EndColumn: 30},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                try {
+                  bar();
+                } catch (e) {
+                  try {
+                    baz();
+                    return;
+                  } catch (e) {
+                    qux();
+                  }
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                try {
+                  bar();
+                } catch (e) {
+                  try {
+                    baz();
+                    
+                  } catch (e) {
+                    qux();
+                  }
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 8, Column: 21, EndLine: 8, EndColumn: 28},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                try {} finally {}
+                return;
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                try {} finally {}
+                
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 4, Column: 17, EndLine: 4, EndColumn: 24},
+				},
+			},
+			{
+				Code: `
+              function foo() {
+                try {
+                  return 5;
+                } finally {
+                  function bar() {
+                    return;
+                  }
+                }
+              }
+            `,
+				Output: []string{`
+              function foo() {
+                try {
+                  return 5;
+                } finally {
+                  function bar() {
+                    
+                  }
+                }
+              }
+            `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 7, Column: 21, EndLine: 7, EndColumn: 28},
+				},
+			},
+			{
+				Code:   `() => { return; }`,
+				Output: []string{`() => {  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 9, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:   `function foo() { return; return; }`,
+				Output: []string{`function foo() {  return; }`, `function foo() {   }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 18, EndLine: 1, EndColumn: 25},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/cfg/cfg.go
+++ b/internal/utils/cfg/cfg.go
@@ -13,7 +13,10 @@
 //     for the path that leaves the `try` statement through `return`, `throw`,
 //     or a suspended `yield`; `break` and `continue` do not take that path;
 //   - `&&`, `||`, `??`, `?:`, optional chains, and destructuring defaults fork
-//     around the operand they may skip.
+//     around the operand they may skip;
+//   - the code after a `return`, `throw`, `break`, or `continue` is laid out in
+//     blocks nothing reaches rather than dropped, keeping the edge that leads
+//     into it.
 //
 // The graph carries no meaning of its own beyond that shape. A consumer names
 // an event type and supplies Hooks; the builder calls them where a reference is
@@ -27,10 +30,20 @@ import (
 )
 
 // Block is one basic block: the events its consumer recorded, in evaluation
-// order, and the blocks control can reach from it.
+// order, and the edges to and from it.
+//
+// Both edge lists span the whole graph, unreachable blocks included, so a walk
+// that only wants the code that runs skips the blocks whose Reachable is false.
 type Block[E any] struct {
-	Events     []E
-	Successors []*Block[E]
+	Events       []E
+	Successors   []*Block[E]
+	Predecessors []*Block[E]
+
+	// Reachable reports whether control can arrive here. The code after an
+	// abrupt exit is laid out in unreachable blocks rather than dropped, and a
+	// consumer's hooks run in them, so a rule can ask what would have run had
+	// the exit not been there.
+	Reachable bool
 
 	index       int
 	hasIncoming bool
@@ -42,15 +55,17 @@ func (blk *Block[E]) Index() int {
 	return blk.index
 }
 
-// Graph is the control-flow graph of one code path root. Blocks[0] is the entry
-// block; the rest are in construction order, which no analysis should depend on.
+// Graph is the control-flow graph of one code path root, unreachable blocks
+// included. Blocks[0] is the entry block; the rest are in construction order,
+// which no analysis should depend on.
 type Graph[E any] struct {
 	Blocks []*Block[E]
 }
 
 // Hooks are the points where a consumer turns a position in the walk into an
-// event. Every hook may be nil, and every one is called only from a position
-// control can reach, so Builder.Emit always lands somewhere.
+// event. Every hook may be nil, and every one is called from every position the
+// walk reaches, whether or not control can arrive there — a consumer that has
+// no use for unreachable code checks Builder.Current for it.
 //
 // Read runs where node is evaluated as a read, Write where its value is stored;
 // a target that is read before it is written — a compound assignment, an update
@@ -120,6 +135,7 @@ func Build[E any](root *ast.Node, hooks Hooks[E]) *Graph[E] {
 	b := &Builder[E]{hooks: hooks}
 	b.cur = b.newBlock()
 	b.cur.hasIncoming = true
+	b.cur.Reachable = true
 
 	switch root.Kind {
 	case ast.KindSourceFile:
@@ -153,9 +169,6 @@ func Build[E any](root *ast.Node, hooks Hooks[E]) *Graph[E] {
 // parameter models a parameter binding: its default value is skipped when an
 // argument was passed.
 func (b *Builder[E]) parameter(node *ast.Node) {
-	if b.cur == nil {
-		return
-	}
 	parameter := node.AsParameterDeclaration()
 	if parameter == nil {
 		return
@@ -168,19 +181,15 @@ func (b *Builder[E]) parameter(node *ast.Node) {
 // blocks
 // ---------------------------------------------------------------------------
 
-// Current returns the block being filled, or nil when the position is
-// unreachable.
+// Current returns the block being filled. Its Reachable field says whether the
+// position control is at is one control can arrive at.
 func (b *Builder[E]) Current() *Block[E] {
 	return b.cur
 }
 
 // Emit records one event in the current block and returns where it landed, so a
-// consumer can refer back to it. The block is nil when the position is
-// unreachable and nothing was recorded.
+// consumer can refer back to it.
 func (b *Builder[E]) Emit(e E) (*Block[E], int) {
-	if b.cur == nil {
-		return nil, 0
-	}
 	index := len(b.cur.Events)
 	b.cur.Events = append(b.cur.Events, e)
 	return b.cur, index
@@ -197,17 +206,28 @@ func (b *Builder[E]) link(from, to *Block[E]) {
 		return
 	}
 	from.Successors = append(from.Successors, to)
-	to.hasIncoming = true
+	to.Predecessors = append(to.Predecessors, from)
+	if from.Reachable {
+		to.hasIncoming = true
+	}
 }
 
-// enter makes blk the current block when something can reach it, and marks the
-// path unreachable otherwise.
+// enter makes blk the current block, reachable when something that runs leads
+// into it.
 func (b *Builder[E]) enter(blk *Block[E]) {
-	if blk.hasIncoming {
-		b.cur = blk
-	} else {
-		b.cur = nil
-	}
+	blk.Reachable = blk.hasIncoming
+	b.cur = blk
+}
+
+// makeUnreachable ends the path at the current block and carries the walk on in
+// a fresh block nothing reaches. The edge into it is recorded, but — unlike
+// every other edge — it does not make its target something control arrives at,
+// which is what leaving through it meant in the first place.
+func (b *Builder[E]) makeUnreachable() {
+	next := b.newBlock()
+	b.cur.Successors = append(b.cur.Successors, next)
+	next.Predecessors = append(next.Predecessors, b.cur)
+	b.cur = next
 }
 
 func (b *Builder[E]) read(node *ast.Node) {
@@ -229,7 +249,7 @@ func (b *Builder[E]) reachedStatement(node *ast.Node) {
 }
 
 func (b *Builder[E]) loop(node *ast.Node) {
-	if b.hooks.Loop != nil && b.cur != nil && node != nil {
+	if b.hooks.Loop != nil && node != nil {
 		b.hooks.Loop(b, node)
 	}
 }
@@ -273,7 +293,7 @@ func (b *Builder[E]) returnFrame() int {
 // a `try` that has a `finally`). Later throwable nodes in the same block reuse
 // that first fork, matching ESLint's approximation.
 func (b *Builder[E]) firstThrowableFork() {
-	if b.cur == nil {
+	if !b.cur.Reachable {
 		return
 	}
 	i := b.throwFrame()
@@ -289,7 +309,7 @@ func (b *Builder[E]) firstThrowableFork() {
 	b.link(b.cur, throwTarget(f))
 	next := b.newBlock()
 	b.link(b.cur, next)
-	b.cur = next
+	b.enter(next)
 }
 
 // snapshotForks records the "already forked" state of every enclosing `try` so

--- a/internal/utils/cfg/cfg.go
+++ b/internal/utils/cfg/cfg.go
@@ -30,19 +30,23 @@ import (
 )
 
 // Block is one basic block: the events its consumer recorded, in evaluation
-// order, and the edges to and from it.
+// order, and the blocks led to from it.
 //
-// Both edge lists span the whole graph, unreachable blocks included, so a walk
-// that only wants the code that runs skips the blocks whose Reachable is false.
+// Successors spans the whole graph, unreachable blocks included, so a walk that
+// only wants the code that runs skips the blocks whose Reachable is false.
 type Block[E any] struct {
-	Events       []E
-	Successors   []*Block[E]
-	Predecessors []*Block[E]
+	Events     []E
+	Successors []*Block[E]
 
 	// Reachable reports whether control can arrive here. The code after an
 	// abrupt exit is laid out in unreachable blocks rather than dropped, and a
 	// consumer's hooks run in them, so a rule can ask what would have run had
 	// the exit not been there.
+	//
+	// It is settled when the block is entered, from the edges that lead into
+	// it by then. Every block is entered after the edges that could make it
+	// reachable exist: a block only ever gains an edge afterwards from code
+	// laid out inside it, which is unreachable whenever the block itself is.
 	Reachable bool
 
 	index       int
@@ -206,14 +210,13 @@ func (b *Builder[E]) link(from, to *Block[E]) {
 		return
 	}
 	from.Successors = append(from.Successors, to)
-	to.Predecessors = append(to.Predecessors, from)
 	if from.Reachable {
 		to.hasIncoming = true
 	}
 }
 
-// enter makes blk the current block, reachable when something that runs leads
-// into it.
+// enter makes blk the current block and settles its reachability, so every edge
+// that could make it reachable has to be linked before it is entered.
 func (b *Builder[E]) enter(blk *Block[E]) {
 	blk.Reachable = blk.hasIncoming
 	b.cur = blk
@@ -222,11 +225,11 @@ func (b *Builder[E]) enter(blk *Block[E]) {
 // makeUnreachable ends the path at the current block and carries the walk on in
 // a fresh block nothing reaches. The edge into it is recorded, but — unlike
 // every other edge — it does not make its target something control arrives at,
-// which is what leaving through it meant in the first place.
+// which is what leaving through it meant in the first place. That is why the
+// block is never entered: its reachability is settled here, as false.
 func (b *Builder[E]) makeUnreachable() {
 	next := b.newBlock()
 	b.cur.Successors = append(b.cur.Successors, next)
-	next.Predecessors = append(next.Predecessors, b.cur)
 	b.cur = next
 }
 

--- a/internal/utils/cfg/expressions.go
+++ b/internal/utils/cfg/expressions.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (b *Builder[E]) expr(node *ast.Node) {
-	if node == nil || b.cur == nil {
+	if node == nil {
 		return
 	}
 
@@ -63,7 +63,7 @@ func (b *Builder[E]) expr(node *ast.Node) {
 // for. Statements and expressions are handled by their own walkers so control
 // flow inside them is still modelled.
 func (b *Builder[E]) visitUnknown(node *ast.Node) {
-	if node == nil || b.cur == nil {
+	if node == nil {
 		return
 	}
 	if ast.IsStatement(node) {
@@ -208,13 +208,13 @@ func (b *Builder[E]) accessOrCall(node *ast.Node) {
 }
 
 func (b *Builder[E]) forkOptionalChain(node *ast.Node) {
-	if b.cur == nil || len(b.chainJoins) == 0 || !ast.IsOptionalChainRoot(node) {
+	if len(b.chainJoins) == 0 || !ast.IsOptionalChainRoot(node) {
 		return
 	}
 	b.link(b.cur, b.chainJoins[len(b.chainJoins)-1])
 	next := b.newBlock()
 	b.link(b.cur, next)
-	b.cur = next
+	b.enter(next)
 }
 
 // typeArguments walks an explicit `<T>` argument list, so a `typeof x` inside

--- a/internal/utils/cfg/helpers.go
+++ b/internal/utils/cfg/helpers.go
@@ -20,9 +20,14 @@ func isBreakableStatement(node *ast.Node) bool {
 
 // labelsOf collects every label wrapped directly around a loop or switch, so
 // `outer: inner: while (…)` resolves `continue outer` and `break outer` as
-// well as `inner`. (ESLint's code path analysis attaches only the innermost
-// label and loses the back edge of a `continue` naming an outer one; this
-// builder keeps the edge.)
+// well as `inner`.
+//
+// Keeping the outer label is a known deviation. ESLint attaches only the
+// innermost one, so a `continue` naming an outer label finds no loop there and
+// its back edge is dropped. It surfaces where a loop's exit hangs off that edge
+// — a `do…while`, whose test runs only from it — leaving what follows the loop
+// reachable here and unreachable in ESLint, which `no-useless-return`,
+// `no-unreachable-loop` and `no-useless-assignment` all read.
 func labelsOf(node *ast.Node) []string {
 	var labels []string
 	current := node

--- a/internal/utils/cfg/patterns.go
+++ b/internal/utils/cfg/patterns.go
@@ -9,7 +9,7 @@ import (
 // target, and the throwable fork ESLint records for naming the target inside a
 // `try` block. Destructuring targets are laid out by patternBind instead.
 func (b *Builder[E]) patternReads(node *ast.Node) {
-	if node == nil || b.cur == nil {
+	if node == nil {
 		return
 	}
 	switch node.Kind {
@@ -48,7 +48,7 @@ func (b *Builder[E]) patternReads(node *ast.Node) {
 // patternWrites emits the write of an identifier assignment target after its
 // assigned expression. Member targets write no variable.
 func (b *Builder[E]) patternWrites(node *ast.Node) {
-	if node == nil || b.cur == nil {
+	if node == nil {
 		return
 	}
 	switch node.Kind {
@@ -77,7 +77,7 @@ func (b *Builder[E]) patternWrites(node *ast.Node) {
 // source order evaluates its computed key, forks around its default, and
 // writes its target.
 func (b *Builder[E]) patternBind(node *ast.Node) {
-	if node == nil || b.cur == nil {
+	if node == nil {
 		return
 	}
 	switch node.Kind {
@@ -165,7 +165,7 @@ func (b *Builder[E]) patternBind(node *ast.Node) {
 // value, which only runs when the incoming value is undefined, then the
 // target's own binding.
 func (b *Builder[E]) bindWithDefault(target *ast.Node, fallback *ast.Node) {
-	if fallback != nil && b.cur != nil {
+	if fallback != nil {
 		join := b.newBlock()
 		b.link(b.cur, join)
 		withFallback := b.newBlock()

--- a/internal/utils/cfg/statements.go
+++ b/internal/utils/cfg/statements.go
@@ -16,7 +16,7 @@ func (b *Builder[E]) statements(list *ast.NodeList) {
 }
 
 func (b *Builder[E]) statement(node *ast.Node) {
-	if node == nil || b.cur == nil {
+	if node == nil {
 		return
 	}
 	b.reachedStatement(node)
@@ -206,12 +206,10 @@ func (b *Builder[E]) doStatement(node *ast.Node) {
 
 	b.enter(test)
 	b.expr(stmt.Expression)
-	if b.cur != nil {
-		b.loop(node)
-		b.link(b.cur, body)
-		if !isAlwaysTruthyTest(stmt.Expression) {
-			b.link(b.cur, after)
-		}
+	b.loop(node)
+	b.link(b.cur, body)
+	if !isAlwaysTruthyTest(stmt.Expression) {
+		b.link(b.cur, after)
 	}
 
 	b.enter(after)
@@ -330,26 +328,18 @@ func (b *Builder[E]) switchStatement(node *ast.Node) {
 			defaultIndex = i
 			continue
 		}
-		if testCur == nil {
-			break
-		}
 		b.cur = testCur
 		b.expr(clause.AsCaseOrDefaultClause().Expression)
 		b.link(b.cur, bodies[i])
-		if b.cur == nil {
-			testCur = nil
-			continue
-		}
 		nextTest := b.newBlock()
 		b.link(b.cur, nextTest)
-		testCur = nextTest
+		b.enter(nextTest)
+		testCur = b.cur
 	}
-	if testCur != nil {
-		if defaultIndex >= 0 {
-			b.link(testCur, bodies[defaultIndex])
-		} else {
-			b.link(testCur, after)
-		}
+	if defaultIndex >= 0 {
+		b.link(testCur, bodies[defaultIndex])
+	} else {
+		b.link(testCur, after)
 	}
 
 	b.pushJump(node, after, nil, nil)
@@ -382,14 +372,15 @@ func (b *Builder[E]) tryStatement(node *ast.Node) {
 
 	b.statement(stmt.TryBlock)
 
+	// The normal completion of a `try` statement carries on from the end of its
+	// `try` block and from the end of its `catch` block, whether or not either
+	// of them is somewhere control arrives.
 	var normalEnds []*Block[E]
 	if hasCatch {
-		if b.cur != nil {
-			// ESLint routes the end of a `try` block into the `catch` block as
-			// well as past the statement.
-			b.link(b.cur, frame.catchEntry)
-			normalEnds = append(normalEnds, b.cur)
-		}
+		// ESLint routes the end of a `try` block into the `catch` block as well
+		// as past the statement.
+		b.link(b.cur, frame.catchEntry)
+		normalEnds = append(normalEnds, b.cur)
 		frame.position = posCatch
 		frame.thrownForked = false
 		b.enter(frame.catchEntry)
@@ -398,12 +389,8 @@ func (b *Builder[E]) tryStatement(node *ast.Node) {
 			b.patternBind(catchClause.VariableDeclaration.Name())
 		}
 		b.statement(catchClause.Block)
-		if b.cur != nil {
-			normalEnds = append(normalEnds, b.cur)
-		}
-	} else if b.cur != nil {
-		normalEnds = append(normalEnds, b.cur)
 	}
+	normalEnds = append(normalEnds, b.cur)
 
 	b.tryStack = b.tryStack[:len(b.tryStack)-1]
 
@@ -417,15 +404,13 @@ func (b *Builder[E]) tryStatement(node *ast.Node) {
 	}
 
 	snapshot := b.snapshotForks()
-	if len(normalEnds) > 0 {
-		normalEntry := b.newBlock()
-		for _, end := range normalEnds {
-			b.link(end, normalEntry)
-		}
-		b.enter(normalEntry)
-		b.statement(stmt.FinallyBlock)
-		b.link(b.cur, after)
+	normalEntry := b.newBlock()
+	for _, end := range normalEnds {
+		b.link(end, normalEntry)
 	}
+	b.enter(normalEntry)
+	b.statement(stmt.FinallyBlock)
+	b.link(b.cur, after)
 
 	if frame.finallyEntry.hasIncoming {
 		// The `finally` block also runs on the path that leaves the statement
@@ -434,7 +419,7 @@ func (b *Builder[E]) tryStatement(node *ast.Node) {
 		b.restoreForks(snapshot)
 		b.enter(frame.finallyEntry)
 		b.statement(stmt.FinallyBlock)
-		if b.cur != nil {
+		if b.cur.Reachable {
 			// A `return` inside this `try`/`catch` still needs to run every
 			// enclosing `finally` on its way out, not just this one — so this
 			// second copy's own abrupt exit must keep propagating outward.
@@ -483,7 +468,7 @@ func (b *Builder[E]) popJump() {
 }
 
 func (b *Builder[E]) makeBreak(label *ast.Node) {
-	if b.cur == nil {
+	if !b.cur.Reachable {
 		return
 	}
 	name := ""
@@ -502,11 +487,11 @@ func (b *Builder[E]) makeBreak(label *ast.Node) {
 		b.link(b.cur, target.breakTo)
 		break
 	}
-	b.cur = nil
+	b.makeUnreachable()
 }
 
 func (b *Builder[E]) makeContinue(label *ast.Node) {
-	if b.cur == nil {
+	if !b.cur.Reachable {
 		return
 	}
 	name := ""
@@ -524,11 +509,11 @@ func (b *Builder[E]) makeContinue(label *ast.Node) {
 			break
 		}
 	}
-	b.cur = nil
+	b.makeUnreachable()
 }
 
 func (b *Builder[E]) makeReturn() {
-	if b.cur == nil {
+	if !b.cur.Reachable {
 		return
 	}
 	if i := b.returnFrame(); i >= 0 {
@@ -536,11 +521,11 @@ func (b *Builder[E]) makeReturn() {
 		frame.returnedAny = true
 		b.link(b.cur, frame.finallyEntry)
 	}
-	b.cur = nil
+	b.makeUnreachable()
 }
 
 func (b *Builder[E]) makeThrow() {
-	if b.cur == nil {
+	if !b.cur.Reachable {
 		return
 	}
 	if i := b.throwFrame(); i >= 0 {
@@ -548,14 +533,14 @@ func (b *Builder[E]) makeThrow() {
 		frame.thrownAny = true
 		b.link(b.cur, throwTarget(frame))
 	}
-	b.cur = nil
+	b.makeUnreachable()
 }
 
 // makeYield mirrors ESLint's handling of a suspended generator: the caller may
 // resume it with `.return()` or `.throw()`, so both leaving paths are recorded
 // before the normal continuation resumes in a fresh block.
 func (b *Builder[E]) makeYield() {
-	if b.cur == nil {
+	if !b.cur.Reachable {
 		return
 	}
 	if i := b.returnFrame(); i >= 0 {
@@ -570,5 +555,5 @@ func (b *Builder[E]) makeYield() {
 	}
 	next := b.newBlock()
 	b.link(b.cur, next)
-	b.cur = next
+	b.enter(next)
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -453,6 +453,7 @@ export default defineConfig({
     './tests/eslint/rules/no-useless-catch.test.ts',
     './tests/eslint/rules/no-useless-escape.test.ts',
     './tests/eslint/rules/no-useless-rename.test.ts',
+    './tests/eslint/rules/no-useless-return.test.ts',
     './tests/eslint/rules/no-useless-constructor.test.ts',
     './tests/eslint/rules/no-prototype-builtins.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-return.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-return.test.ts.snap
@@ -1,0 +1,773 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-return > invalid 1`] = `
+{
+  "code": "function foo() { return; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 2`] = `
+{
+  "code": "function foo() { doSomething(); return; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 3`] = `
+{
+  "code": "function foo() { if (condition) { bar(); return; } else { baz(); } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 4`] = `
+{
+  "code": "function foo() { if (foo) return; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 5`] = `
+{
+  "code": "function foo() { bar(); return/**/; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 6`] = `
+{
+  "code": "function foo() { bar(); return//
+; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 7`] = `
+{
+  "code": "foo(); return;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 8`] = `
+{
+  "code": "if (foo) { bar(); return; } else { baz(); }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 9`] = `
+{
+  "code": "
+        function foo() {
+          if (foo) {
+            return;
+          }
+          return;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 10`] = `
+{
+  "code": "
+        function foo() {
+          switch (bar) {
+            case 1:
+              doSomething();
+            default:
+              doSomethingElse();
+              return;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 8,
+        },
+        "start": {
+          "column": 15,
+          "line": 8,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 11`] = `
+{
+  "code": "
+        function foo() {
+          switch (bar) {
+            default:
+              doSomething();
+            case 1:
+              doSomething();
+              return;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 8,
+        },
+        "start": {
+          "column": 15,
+          "line": 8,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 12`] = `
+{
+  "code": "
+        function foo() {
+          switch (bar) {
+            case 1:
+              if (a) {
+                doSomething();
+                return;
+              }
+              break;
+            default:
+              doSomethingElse();
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 7,
+        },
+        "start": {
+          "column": 17,
+          "line": 7,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 13`] = `
+{
+  "code": "
+        function foo() {
+          switch (bar) {
+            case 1:
+              if (a) {
+                doSomething();
+                return;
+              } else {
+                doSomething();
+              }
+              break;
+            default:
+              doSomethingElse();
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 7,
+        },
+        "start": {
+          "column": 17,
+          "line": 7,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 14`] = `
+{
+  "code": "
+        function foo() {
+          switch (bar) {
+            case 1:
+              if (a) {
+                doSomething();
+                return;
+              }
+            default:
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 7,
+        },
+        "start": {
+          "column": 17,
+          "line": 7,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 15`] = `
+{
+  "code": "
+        function foo() {
+          try {} catch (err) { return; }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 32,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 16`] = `
+{
+  "code": "
+        function foo() {
+          try {
+            foo();
+            return;
+          } catch (err) {
+            return 5;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 17`] = `
+{
+  "code": "
+        function foo() {
+          if (something) {
+            try {
+              bar();
+              return;
+            } catch (err) {}
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 6,
+        },
+        "start": {
+          "column": 15,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 18`] = `
+{
+  "code": "
+        function foo() {
+          try {
+            return;
+          } catch (err) {
+            foo();
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 19`] = `
+{
+  "code": "
+        function foo() {
+          try {
+            return;
+          } finally {
+            bar();
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 20`] = `
+{
+  "code": "
+        function foo() {
+          try {
+            bar();
+          } catch (e) {
+            try {
+              baz();
+              return;
+            } catch (e) {
+              qux();
+            }
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 8,
+        },
+        "start": {
+          "column": 15,
+          "line": 8,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 21`] = `
+{
+  "code": "
+        function foo() {
+          try {} finally {}
+          return;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 11,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 22`] = `
+{
+  "code": "
+        function foo() {
+          try {
+            return 5;
+          } finally {
+            function bar() {
+              return;
+            }
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 7,
+        },
+        "start": {
+          "column": 15,
+          "line": 7,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 23`] = `
+{
+  "code": "() => { return; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-return > invalid 24`] = `
+{
+  "code": "function foo() { return; return; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary return statement.",
+      "messageId": "unnecessaryReturn",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-return.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-return.test.ts
@@ -1,0 +1,405 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-return', {
+  valid: [
+    'function foo() { return 5; }',
+    'function foo() { return null; }',
+    'function foo() { return doSomething(); }',
+    `
+      function foo() {
+        if (bar) {
+          doSomething();
+          return;
+        } else {
+          doSomethingElse();
+        }
+        qux();
+      }
+    `,
+    `
+      function foo() {
+        switch (bar) {
+          case 1:
+            doSomething();
+            return;
+          default:
+            doSomethingElse();
+        }
+      }
+    `,
+    `
+      function foo() {
+        switch (bar) {
+          default:
+            doSomething();
+            return;
+          case 1:
+            doSomethingElse();
+        }
+      }
+    `,
+    `
+      function foo() {
+        switch (bar) {
+          case 1:
+            if (a) {
+              doSomething();
+              return;
+            } else {
+              doSomething();
+              return;
+            }
+          default:
+            doSomethingElse();
+        }
+      }
+    `,
+    `
+      function foo() {
+        for (var foo = 0; foo < 10; foo++) {
+          return;
+        }
+      }
+    `,
+    `
+      function foo() {
+        for (var foo in bar) {
+          return;
+        }
+      }
+    `,
+    `
+      function foo() {
+        try {
+          return 5;
+        } finally {
+          return;
+        }
+      }
+    `,
+    `
+      function foo() {
+        try {
+          bar();
+          return;
+        } catch (err) {}
+        baz();
+      }
+    `,
+    `
+      function foo() {
+        if (something) {
+          try {
+            bar();
+            return;
+          } catch (err) {}
+        }
+        baz();
+      }
+    `,
+    `
+      function foo() {
+        return;
+        doSomething();
+      }
+    `,
+    `
+      function foo() {
+        for (var foo of bar) return;
+      }
+    `,
+    '() => { if (foo) return; bar(); }',
+    '() => 5',
+    '() => { return; doSomething(); }',
+    'if (foo) { return; } doSomething();',
+    `
+      function foo() {
+        if (bar) return;
+        return baz;
+      }
+    `,
+    `
+      function foo() {
+        if (bar) {
+          return;
+        }
+        return baz;
+      }
+    `,
+    `
+      function foo() {
+        if (bar) baz();
+        else return;
+        return 5;
+      }
+    `,
+    `
+      function foo() {
+        return;
+        while (foo) return;
+        foo;
+      }
+    `,
+    `
+      try {
+        throw new Error('foo');
+        while (false);
+      } catch (err) {}
+    `,
+    `
+      function foo(arg) {
+        throw new Error('Debugging...');
+        if (!arg) {
+          return;
+        }
+        console.log(arg);
+      }
+    `,
+    `
+      function foo() {
+        try {
+          bar();
+          return;
+        } finally {
+          baz();
+        }
+        qux();
+      }
+    `,
+  ],
+  invalid: [
+    {
+      code: 'function foo() { return; }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'function foo() { doSomething(); return; }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'function foo() { if (condition) { bar(); return; } else { baz(); } }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'function foo() { if (foo) return; }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'function foo() { bar(); return/**/; }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'function foo() { bar(); return//\n; }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'foo(); return;',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'if (foo) { bar(); return; } else { baz(); }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          if (foo) {
+            return;
+          }
+          return;
+        }
+      `,
+      errors: [
+        { messageId: 'unnecessaryReturn' },
+        { messageId: 'unnecessaryReturn' },
+      ],
+    },
+    {
+      code: `
+        function foo() {
+          switch (bar) {
+            case 1:
+              doSomething();
+            default:
+              doSomethingElse();
+              return;
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          switch (bar) {
+            default:
+              doSomething();
+            case 1:
+              doSomething();
+              return;
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          switch (bar) {
+            case 1:
+              if (a) {
+                doSomething();
+                return;
+              }
+              break;
+            default:
+              doSomethingElse();
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          switch (bar) {
+            case 1:
+              if (a) {
+                doSomething();
+                return;
+              } else {
+                doSomething();
+              }
+              break;
+            default:
+              doSomethingElse();
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          switch (bar) {
+            case 1:
+              if (a) {
+                doSomething();
+                return;
+              }
+            default:
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          try {} catch (err) { return; }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          try {
+            foo();
+            return;
+          } catch (err) {
+            return 5;
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          if (something) {
+            try {
+              bar();
+              return;
+            } catch (err) {}
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          try {
+            return;
+          } catch (err) {
+            foo();
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          try {
+            return;
+          } finally {
+            bar();
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          try {
+            bar();
+          } catch (e) {
+            try {
+              baz();
+              return;
+            } catch (e) {
+              qux();
+            }
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          try {} finally {}
+          return;
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: `
+        function foo() {
+          try {
+            return 5;
+          } finally {
+            function bar() {
+              return;
+            }
+          }
+        }
+      `,
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: '() => { return; }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+    {
+      code: 'function foo() { return; return; }',
+      errors: [{ messageId: 'unnecessaryReturn' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-useless-return` rule from ESLint. It reports a bare `return` that nothing runs after, and fixes it by removing the statement.

Answering that means asking what would run after a `return` if the `return` were deleted — the question ESLint's code path analysis answers by keeping the unreachable segments an abrupt exit creates. `internal/utils/cfg` dropped that code instead of laying it out, so the graph builder changes with this port.

- `Block` gains `Reachable`. `Successors` spans the whole graph, unreachable blocks included; `Reachable` says which blocks run.
- `return`, `throw`, `break`, and `continue` carry the walk on into a fresh unreachable block rather than ending it, and do nothing where control already cannot arrive.
- `firstThrowableFork` no longer consumes a `try` frame's fork from an unreachable position, which would otherwise move the point at which a reachable statement forks to the handler.
- A `try` statement's normal-completion path is always laid out, including when its `try` block ends abruptly — that chain is what carries a `return` inside the `try` block past the statement.

Hooks now run in unreachable positions too, so a consumer with no use for them checks `Builder.Current().Reachable`. An edge out of an unreachable block never marks its target reachable, so the reachable subgraph is unchanged. `no-unreachable-loop` and `no-useless-assignment` skip unreachable blocks, which keeps the behavior they had — ESLint ignores unreachable code in both.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-return
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-return.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
