### PR TITLE
fix(linter): traverse computed assignment keys

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -287,6 +287,12 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 			case ast.KindSpreadElement, ast.KindSpreadAssignment:
 				patternVisitor(node.Expression())
 			case ast.KindPropertyAssignment:
+				// A computed property name is evaluated as an expression; it is
+				// not part of the assignment target. Visit it through the normal
+				// path before propagating pattern context to the initializer.
+				if name := node.Name(); name != nil && ast.IsComputedPropertyName(name) {
+					childVisitor(name)
+				}
 				patternVisitor(node.Initializer())
 			default:
 				node.ForEachChild(childVisitor)

--- a/internal/linter/linter_pattern_traversal_test.go
+++ b/internal/linter/linter_pattern_traversal_test.go
@@ -1,0 +1,197 @@
+package linter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func runPatternTraversalTest(t *testing.T, source string, listeners rule.RuleListeners) {
+	t.Helper()
+
+	program, paths := createTestProgramWithFiles(t, map[string]string{"input.ts": source})
+	_, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{paths["input.ts"]}},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{{
+				Name:     "pattern-traversal",
+				Severity: rule.SeverityWarning,
+				Run: func(rule.RuleContext) rule.RuleListeners {
+					return listeners
+				},
+			}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+}
+
+func TestPatternTraversalVisitsComputedAssignmentKeyAsExpression(t *testing.T) {
+	var events []string
+	recordIdentifier := func(suffix string) func(*ast.Node) {
+		return func(node *ast.Node) {
+			events = append(events, "identifier:"+node.AsIdentifier().Text+suffix)
+		}
+	}
+
+	runPatternTraversalTest(t, `({ [key()]: target } = source);`, rule.RuleListeners{
+		ast.KindComputedPropertyName: func(*ast.Node) {
+			events = append(events, "computed:enter")
+		},
+		rule.ListenerOnAllowPattern(ast.KindComputedPropertyName): func(*ast.Node) {
+			events = append(events, "computed:pattern-enter")
+		},
+		rule.ListenerOnExit(rule.ListenerOnAllowPattern(ast.KindComputedPropertyName)): func(*ast.Node) {
+			events = append(events, "computed:pattern-exit")
+		},
+		rule.ListenerOnExit(ast.KindComputedPropertyName): func(*ast.Node) {
+			events = append(events, "computed:exit")
+		},
+		ast.KindCallExpression: func(*ast.Node) {
+			events = append(events, "call:enter")
+		},
+		rule.ListenerOnAllowPattern(ast.KindCallExpression): func(*ast.Node) {
+			events = append(events, "call:pattern-enter")
+		},
+		rule.ListenerOnExit(ast.KindCallExpression): func(*ast.Node) {
+			events = append(events, "call:exit")
+		},
+		ast.KindIdentifier: recordIdentifier(":enter"),
+		rule.ListenerOnAllowPattern(ast.KindIdentifier):                      recordIdentifier(":pattern-enter"),
+		rule.ListenerOnExit(rule.ListenerOnAllowPattern(ast.KindIdentifier)): recordIdentifier(":pattern-exit"),
+		rule.ListenerOnExit(ast.KindIdentifier):                              recordIdentifier(":exit"),
+	})
+
+	want := []string{
+		"computed:enter",
+		"call:enter",
+		"identifier:key:enter",
+		"identifier:key:exit",
+		"call:exit",
+		"computed:exit",
+		"identifier:target:enter",
+		"identifier:target:pattern-enter",
+		"identifier:target:pattern-exit",
+		"identifier:target:exit",
+		"identifier:source:enter",
+		"identifier:source:exit",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("listener events = %#v, want %#v", events, want)
+	}
+}
+
+func TestPatternTraversalVisitsNestedComputedAssignmentKeysOnce(t *testing.T) {
+	ordinary := make(map[string]int)
+	patterns := make(map[string]int)
+	computed := 0
+	computedPatterns := 0
+
+	runPatternTraversalTest(t, `({
+  [outerKey]: { [innerKey]: nestedTarget },
+  [consume((({ [recursiveKey]: recursiveTarget } = recursiveSource)))]: target,
+} = source);`, rule.RuleListeners{
+		ast.KindComputedPropertyName: func(*ast.Node) {
+			computed++
+		},
+		rule.ListenerOnAllowPattern(ast.KindComputedPropertyName): func(*ast.Node) {
+			computedPatterns++
+		},
+		ast.KindIdentifier: func(node *ast.Node) {
+			ordinary[node.AsIdentifier().Text]++
+		},
+		rule.ListenerOnAllowPattern(ast.KindIdentifier): func(node *ast.Node) {
+			patterns[node.AsIdentifier().Text]++
+		},
+	})
+
+	wantOrdinary := map[string]int{
+		"outerKey":        1,
+		"innerKey":        1,
+		"nestedTarget":    1,
+		"consume":         1,
+		"recursiveKey":    1,
+		"recursiveTarget": 1,
+		"recursiveSource": 1,
+		"target":          1,
+		"source":          1,
+	}
+	wantPatterns := map[string]int{
+		"nestedTarget":    1,
+		"recursiveTarget": 1,
+		"target":          1,
+	}
+	if computed != 4 || computedPatterns != 0 {
+		t.Errorf("computed-key visits = (%d ordinary, %d pattern), want (4, 0)", computed, computedPatterns)
+	}
+	if !reflect.DeepEqual(ordinary, wantOrdinary) {
+		t.Errorf("ordinary identifier visits = %#v, want %#v", ordinary, wantOrdinary)
+	}
+	if !reflect.DeepEqual(patterns, wantPatterns) {
+		t.Errorf("pattern identifier visits = %#v, want %#v", patterns, wantPatterns)
+	}
+}
+
+func TestPatternTraversalKeepsObjectExpressionsInsideComputedKeysOutOfPatternContext(t *testing.T) {
+	allowPattern := 0
+	notAllowPattern := 0
+
+	runPatternTraversalTest(t, `({ [({ [valueKey]: value })]: target } = source);`, rule.RuleListeners{
+		rule.ListenerOnAllowPattern(ast.KindObjectLiteralExpression): func(*ast.Node) {
+			allowPattern++
+		},
+		rule.ListenerOnNotAllowPattern(ast.KindObjectLiteralExpression): func(*ast.Node) {
+			notAllowPattern++
+		},
+	})
+
+	if allowPattern != 1 || notAllowPattern != 1 {
+		t.Fatalf("object contexts = (%d pattern, %d expression), want (1, 1)", allowPattern, notAllowPattern)
+	}
+}
+
+func TestPatternTraversalComputedKeyRouteMatrix(t *testing.T) {
+	keys := map[string]struct{}{
+		"directKey": {},
+		"arrayKey":  {},
+		"forOfKey":  {},
+		"forInKey":  {},
+		"arrowKey":  {},
+		"classKey":  {},
+	}
+	ordinary := make(map[string]int, len(keys))
+	patterns := make(map[string]int, len(keys))
+	record := func(counts map[string]int) func(*ast.Node) {
+		return func(node *ast.Node) {
+			name := node.AsIdentifier().Text
+			if _, tracked := keys[name]; tracked {
+				counts[name]++
+			}
+		}
+	}
+
+	runPatternTraversalTest(t, `
+({ [directKey]: directTarget } = source);
+([{ [arrayKey]: arrayTarget }] = source);
+for ({ [forOfKey]: forOfTarget } of source) {}
+for ({ [forInKey]: forInTarget } in source) {}
+({ [(() => arrowKey)()]: arrowTarget } = source);
+({ [class { [classKey]() {} }]: classTarget } = source);
+`, rule.RuleListeners{
+		ast.KindIdentifier: record(ordinary),
+		rule.ListenerOnAllowPattern(ast.KindIdentifier): record(patterns),
+	})
+
+	for name := range keys {
+		if ordinary[name] != 1 || patterns[name] != 0 {
+			t.Errorf("%s visits = (%d ordinary, %d pattern), want (1, 0)", name, ordinary[name], patterns[name])
+		}
+	}
+}

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.go
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.go
@@ -455,9 +455,7 @@ var NoUnusedPrivateClassMembersRule = rule.CreateRule(rule.Rule{
 
 		// handlePropAccess and handleElemAccess process a single
 		// PropertyAccessExpression / ElementAccessExpression as a reference
-		// to a tracked class member. Extracted so the BinaryExpression /
-		// PropertyAssignment workaround below can re-trigger them on
-		// computed-key subtrees that the linter's patternVisitor skips.
+		// to a tracked class member.
 		var handlePropAccess func(node *ast.Node)
 		var handleElemAccess func(node *ast.Node)
 		handlePropAccess = func(node *ast.Node) {
@@ -510,28 +508,6 @@ var NoUnusedPrivateClassMembersRule = rule.CreateRule(rule.Rule{
 			}
 		}
 
-		// scanComputedKey walks `node` looking for member accesses the
-		// linter's patternVisitor would have skipped (it never descends
-		// into the *key* of a `[ expr ]: target` element when the parent
-		// OLE is an assignment target). Each PropertyAccess / ElementAccess
-		// encountered is replayed through the normal handlers.
-		var scanComputedKey func(*ast.Node)
-		scanComputedKey = func(n *ast.Node) {
-			if n == nil {
-				return
-			}
-			switch n.Kind {
-			case ast.KindPropertyAccessExpression:
-				handlePropAccess(n)
-			case ast.KindElementAccessExpression:
-				handleElemAccess(n)
-			}
-			n.ForEachChild(func(child *ast.Node) bool {
-				scanComputedKey(child)
-				return false
-			})
-		}
-
 		return rule.RuleListeners{
 			// Class scopes.
 			ast.KindClassDeclaration:                      pushClassScope,
@@ -572,34 +548,6 @@ var NoUnusedPrivateClassMembersRule = rule.CreateRule(rule.Rule{
 			// tracked member.
 			ast.KindPropertyAccessExpression: handlePropAccess,
 			ast.KindElementAccessExpression:  handleElemAccess,
-
-			// Workaround for the linter's destructuring walker. patternVisitor
-			// on a PropertyAssignment visits only the *Initializer* (target);
-			// the *Name* (e.g. `[this.#x]:` ) is silently dropped. Without
-			// this listener, member accesses inside a computed destructuring
-			// key would never reach the standard PAE / EAE handlers above.
-			// We scan the name ONLY when the surrounding OLE is itself an
-			// assignment target — value-context property assignments
-			// continue to be walked by the linter as usual, so no
-			// double-counting occurs.
-			ast.KindPropertyAssignment: func(node *ast.Node) {
-				pa := node.AsPropertyAssignment()
-				if pa == nil {
-					return
-				}
-				name := pa.Name()
-				if name == nil || name.Kind != ast.KindComputedPropertyName {
-					return
-				}
-				parent := node.Parent
-				if parent == nil || parent.Kind != ast.KindObjectLiteralExpression {
-					return
-				}
-				if !ast.IsAssignmentTarget(parent) {
-					return
-				}
-				scanComputedKey(name)
-			},
 
 			ast.KindVariableDeclaration: func(node *ast.Node) {
 				vd := node.AsVariableDeclaration()

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
@@ -84,43 +84,12 @@ var NoUnusedPrivateClassMembersRule = rule.Rule{
 			member.isUsed = true
 		}
 
-		var scanComputedKey func(node *ast.Node)
-		scanComputedKey = func(node *ast.Node) {
-			if node == nil {
-				return
-			}
-			if node.Kind == ast.KindPrivateIdentifier {
-				handlePrivateIdentifier(node)
-			}
-			node.ForEachChild(func(child *ast.Node) bool {
-				scanComputedKey(child)
-				return false
-			})
-		}
-
 		return rule.RuleListeners{
 			ast.KindClassDeclaration:                      pushClass,
 			rule.ListenerOnExit(ast.KindClassDeclaration): popClass,
 			ast.KindClassExpression:                       pushClass,
 			rule.ListenerOnExit(ast.KindClassExpression):  popClass,
 			ast.KindPrivateIdentifier:                     handlePrivateIdentifier,
-			ast.KindPropertyAssignment: func(node *ast.Node) {
-				property := node.AsPropertyAssignment()
-				if property == nil {
-					return
-				}
-				name := property.Name()
-				if name == nil || name.Kind != ast.KindComputedPropertyName {
-					return
-				}
-				parent := node.Parent
-				if parent == nil || parent.Kind != ast.KindObjectLiteralExpression || !ast.IsAssignmentTarget(parent) {
-					return
-				}
-				// The generic PrivateIdentifier listener can miss computed keys in
-				// destructuring assignment patterns, so scan that key explicitly.
-				scanComputedKey(name)
-			},
 		}
 	},
 }

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
@@ -213,7 +213,7 @@ class C {
     }
 }`},
 
-			// ---- tsgo AST quirk: nested destructuring computed keys are reads ----
+			// ---- Nested destructuring computed keys are reads ----
 			{Code: `
 class C {
     #key;

--- a/internal/rules/no_useless_assignment/no_useless_assignment.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.go
@@ -29,7 +29,7 @@ var NoUselessAssignmentRule = rule.Rule{
 		var byRoot map[*ast.Node][]rawAssignment
 		var rootOrder []*ast.Node
 		collect := func(node *ast.Node) {
-			collectAssignment(&ctx, node, func(raw rawAssignment) {
+			collectAssignmentNode(&ctx, node, func(raw rawAssignment) {
 				if byRoot == nil {
 					byRoot = make(map[*ast.Node][]rawAssignment)
 				}
@@ -96,19 +96,9 @@ func reportAssignments(
 	}
 }
 
-// collectAssignment reports every variable write represented by node. The
-// shared linter traversal supplies each candidate node, avoiding a second
-// rule-owned walk over the file.
-func collectAssignment(ctx *rule.RuleContext, node *ast.Node, emit func(rawAssignment)) {
-	collectAssignmentNode(ctx, node, emit)
-	if node.Kind == ast.KindBinaryExpression {
-		binary := node.AsBinaryExpression()
-		if ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
-			collectSkippedPatternAssignments(ctx, binary.Left, emit)
-		}
-	}
-}
-
+// collectAssignmentNode reports every variable write represented by node. The
+// shared linter traversal supplies each candidate node, including assignments
+// inside computed property names of assignment patterns.
 func collectAssignmentNode(ctx *rule.RuleContext, node *ast.Node, emit func(rawAssignment)) {
 	add := func(target *ast.Node) {
 		forEachTargetIdentifier(target, func(identifier *ast.Node) {
@@ -142,46 +132,6 @@ func collectAssignmentNode(ctx *rule.RuleContext, node *ast.Node, emit func(rawA
 	case ast.KindPostfixUnaryExpression:
 		add(node.AsPostfixUnaryExpression().Operand)
 	}
-}
-
-// The linter's pattern traversal deliberately skips computed property names
-// on assignment targets. Collect writes inside those expressions here; every
-// other target subtree is already dispatched through the shared traversal.
-func collectSkippedPatternAssignments(ctx *rule.RuleContext, node *ast.Node, emit func(rawAssignment)) {
-	if node == nil {
-		return
-	}
-	switch node.Kind {
-	case ast.KindObjectLiteralExpression:
-		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
-			switch property.Kind {
-			case ast.KindPropertyAssignment:
-				assignment := property.AsPropertyAssignment()
-				if name := assignment.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
-					collectAssignmentSubtree(ctx, name.AsComputedPropertyName().Expression, emit)
-				}
-				collectSkippedPatternAssignments(ctx, assignment.Initializer, emit)
-			case ast.KindSpreadAssignment:
-				collectSkippedPatternAssignments(ctx, property.AsSpreadAssignment().Expression, emit)
-			}
-		}
-	case ast.KindArrayLiteralExpression:
-		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
-			collectSkippedPatternAssignments(ctx, element, emit)
-		}
-	case ast.KindSpreadElement:
-		collectSkippedPatternAssignments(ctx, node.AsSpreadElement().Expression, emit)
-	}
-}
-
-func collectAssignmentSubtree(ctx *rule.RuleContext, node *ast.Node, emit func(rawAssignment)) {
-	var visit func(*ast.Node) bool
-	visit = func(current *ast.Node) bool {
-		collectAssignmentNode(ctx, current, emit)
-		current.ForEachChild(visit)
-		return false
-	}
-	visit(node)
 }
 
 // forEachTargetIdentifier yields every identifier an assignment target writes

--- a/internal/rules/no_useless_computed_key/no_useless_computed_key.go
+++ b/internal/rules/no_useless_computed_key/no_useless_computed_key.go
@@ -133,9 +133,9 @@ var NoUselessComputedKeyRule = rule.Rule{
 		// PropertyDeclaration / BindingElement), determines whether it has
 		// a useless computed key, and reports + fixes accordingly.
 		//
-		// Listening on containers (not ComputedPropertyName) is required so
-		// the rule also fires inside destructuring patterns: rslint's
-		// `patternVisitor` does not recurse into property-name positions.
+		// Listening on containers (not ComputedPropertyName) keeps the node to
+		// report and fix available and lets the rule distinguish object,
+		// destructuring, and class-member semantics directly.
 		check := func(container *ast.Node, cpn *ast.Node) {
 			computed := cpn.AsComputedPropertyName()
 			if computed == nil || computed.Expression == nil {


### PR DESCRIPTION
## Summary

- Traverse computed property names on destructuring assignment targets through the normal expression visitor while keeping property initializers in pattern context.
- Remove now-redundant computed-key rescans from `no-useless-assignment` and the core/TypeScript `no-unused-private-class-members` rules.
- Add adversarial traversal coverage for exact-once dispatch, enter/exit ordering, expression-vs-pattern context, nested assignment patterns, arrays, `for-in`/`for-of`, arrow functions, and class computed keys.

Focused validation:

- `go test -count=1 ./internal/linter ./internal/rules/no_useless_assignment ./internal/rules/no_useless_computed_key ./internal/rules/no_unused_private_class_members ./internal/plugins/typescript/rules/no_unused_private_class_members`
- Changed-package `golangci-lint`: 0 issues
- `pnpm typecheck`, `pnpm lint`, `pnpm -w run check-spell`, and `pnpm format:check`

## Related Links

- Follow-up rule PR: https://github.com/web-infra-dev/rslint/pull/1581

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
