### PR TITLE
test: cover computed assignment keys in core rules

### DIFF
--- a/internal/rules/curly/curly_extras_computed_assignment_key_test.go
+++ b/internal/rules/curly/curly_extras_computed_assignment_key_test.go
@@ -1,0 +1,31 @@
+// TestCurlyComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package curly
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCurlyComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&CurlyRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `({ [(() => { if (condition) action(); })()]: target } = source);`,
+				Output: []string{`({ [(() => { if (condition) {action();} })()]: target } = source);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 29, EndLine: 1, EndColumn: 38},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/eqeqeq/eqeqeq_extras_test.go
+++ b/internal/rules/eqeqeq/eqeqeq_extras_test.go
@@ -1,0 +1,40 @@
+// TestEqeqeqComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package eqeqeq
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestEqeqeqComputedAssignmentKey(t *testing.T) {
+	const code = `({ [(() => { left == right; })()]: target } = source);`
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&EqeqeqRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: code,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Line:      1,
+						Column:    19,
+						EndLine:   1,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "replaceOperator", Output: `({ [(() => { left === right; })()]: target } = source);`},
+						},
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_console/no_console_extras_test.go
+++ b/internal/rules/no_console/no_console_extras_test.go
@@ -1,0 +1,30 @@
+// TestNoConsoleComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package no_console
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConsoleComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoConsoleRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `({ [(() => { console.log(value); })()]: target } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14, EndLine: 1, EndColumn: 25},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_debugger/no_debugger_extras_test.go
+++ b/internal/rules/no_debugger/no_debugger_extras_test.go
@@ -1,0 +1,30 @@
+// TestNoDebuggerComputedAssignmentKey locks in rule behavior inside an
+// evaluated computed property name of a destructuring assignment target. The
+// shared traversal contract is covered by internal/linter; this test protects
+// the rule's listener-to-diagnostic integration.
+package no_debugger
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDebuggerComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoDebuggerRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `({ [(() => { debugger; })()]: target } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-debugger", Line: 1, Column: 14, EndLine: 1, EndColumn: 23},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_empty/no_empty_extras_test.go
+++ b/internal/rules/no_empty/no_empty_extras_test.go
@@ -1,0 +1,30 @@
+// TestNoEmptyComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package no_empty
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEmptyComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEmptyRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `({ [(() => { if (condition) {} })()]: target } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29, EndLine: 1, EndColumn: 31},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_eval/no_eval_extras_test.go
+++ b/internal/rules/no_eval/no_eval_extras_test.go
@@ -1,0 +1,30 @@
+// TestNoEvalComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package no_eval
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEvalComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEvalRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `({ [(() => { eval(code); })()]: target } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14, EndLine: 1, EndColumn: 18},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_unreachable_loop/no_unreachable_loop_extras_test.go
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop_extras_test.go
@@ -258,6 +258,14 @@ func TestNoUnreachableLoopExtras(t *testing.T) {
 			},
 
 			// ---- Dimension 4: nesting / traversal boundaries ----
+			// Computed property names in assignment patterns are evaluated
+			// expressions, so loops inside them must reach this rule's listeners.
+			{
+				Code: `({ [(() => { for (;;) break; })()]: target } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 14, EndLine: 1, EndColumn: 29},
+				},
+			},
 			// A loop in a nested function belongs to that function's code path,
 			// not the enclosing loop's, so neither verdict leaks into the other.
 			{

--- a/internal/rules/no_var/no_var_extras_test.go
+++ b/internal/rules/no_var/no_var_extras_test.go
@@ -1,0 +1,32 @@
+// TestNoVarComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package no_var
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoVarComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoVarRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				// The self-reference deliberately makes var→let unsafe, so this
+				// regression test asserts only diagnostics rather than edit behavior.
+				Code: `({ [(() => { var value = value; })()]: target } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedVar", Line: 1, Column: 14, EndLine: 1, EndColumn: 32},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/one_var/one_var_extras_test.go
+++ b/internal/rules/one_var/one_var_extras_test.go
@@ -1,0 +1,33 @@
+// TestOneVarComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package one_var
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestOneVarComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&OneVarRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `({ [(() => {
+switch (value) { case 1: var first; var second; break; }
+})()]: target } = source);`,
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "combine", Line: 2, Column: 37, EndLine: 2, EndColumn: 48},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/strict/strict_extras_test.go
+++ b/internal/rules/strict/strict_extras_test.go
@@ -1,0 +1,31 @@
+// TestStrictComputedAssignmentKey locks in rule behavior inside an evaluated
+// computed property name of a destructuring assignment target. The shared
+// traversal contract is covered by internal/linter; this test protects the
+// rule's listener-to-diagnostic integration.
+package strict
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestStrictComputedAssignmentKey(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&StrictRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    `({ [(() => { 'use strict'; run(); })()]: target } = source);`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "never", Line: 1, Column: 14, EndLine: 1, EndColumn: 27},
+				},
+			},
+		},
+	)
+}


### PR DESCRIPTION
## Summary

Add rule-owned regression coverage for rules whose listeners can run inside evaluated computed property names of destructuring assignment targets. This complements #1584 without adding framework workarounds or changing rule implementations.

| Coverage area | Rules | Assertion |
| --- | --- | --- |
| Declarations and statements | `no-var`, `no-debugger`, `no-empty`, `one-var` | Exact diagnostic count, message ID, and range |
| Expressions | `no-console`, `eqeqeq`, `no-eval` | Exact diagnostic count, message ID, and range; `eqeqeq` also checks its suggestion output |
| Control flow and directives | `curly`, `strict`, `no-unreachable-loop` | Exact diagnostic count, message ID, and range; `curly` also checks autofix output |

| Regression proof | Result |
| --- | --- |
| Current `main` with #1584 | All 10 rule-level regressions pass |
| Same tests with the #1584 traversal lines temporarily removed | All 10 fail with zero diagnostics |

The `no-unreachable-loop` case is part of its existing extras test. It does not add a standalone file or overlap the hunks changed by #1581.

No changes are made to `internal/linter`, rule implementations, benchmarks, documentation, or `PORT_RULE.md`.

## Related Links

- Follow-up coverage for #1584
- Merge-compatible with #1581

## Validation

| Check | Result |
| --- | --- |
| Focused computed-assignment-key tests across 10 rule packages | Passed, including `-shuffle=on` |
| Full tests for the 10 changed rule packages | Passed |
| Go lint limited to the 10 changed packages | Passed (`0 issues`) |
| Three-way merge with the current #1581 head | Clean; both sets of extras tests are retained |
| `pnpm -w run check-spell` | Passed |
| `pnpm format:check` | Passed |
| `pnpm typecheck` | Passed |
| `pnpm lint` | Passed (`0 errors`; existing warnings only) |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
