### PR TITLE
fix(cfg): lay out a for statement's incrementor before its body

### DIFF
--- a/internal/rules/no_unreachable_loop/no_unreachable_loop_extras_test.go
+++ b/internal/rules/no_unreachable_loop/no_unreachable_loop_extras_test.go
@@ -406,6 +406,27 @@ func TestNoUnreachableLoopExtras(t *testing.T) {
 				},
 			},
 
+			// ---- A `for` incrementor inside a `try` block ----
+			// The incrementor is laid out before the body, so it is one of the
+			// throwable nodes the `try` block forks on even when the body always
+			// leaves the loop abruptly; the `catch` clause and the loop after
+			// the statement stay reachable.
+			{
+				Code: `function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) {} for (var v of items) { return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 22, EndLine: 1, EndColumn: 54},
+					{MessageId: "invalid", Line: 1, Column: 80, EndLine: 1, EndColumn: 114},
+				},
+			},
+			// Without an incrementor the `try` block holds no throwable node,
+			// so nothing reaches the `catch` clause or the code after it.
+			{
+				Code: `function f() { try { for (var i = 0;;) { break; } return 1; } catch (e) {} for (var v of items) { return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalid", Line: 1, Column: 22, EndLine: 1, EndColumn: 50},
+				},
+			},
+
 			// ---- Labelled jump targets ----
 			{
 				Code: `outer: { for (;;) break outer; }`,

--- a/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
@@ -180,6 +180,11 @@ class C { handler(@Body(pipe) _b: unknown) {} }`},
 			{Code: `function f(c, v) { a: b: c2: while (c()) { console.log(v); v = 1; continue b; } }`},
 			{Code: `function f(c, v) { outer: inner: while (c()) { v = 1; break outer; } console.log(v); }`},
 			{Code: `function f(v) { outer: inner: { v = 1; break outer; } console.log(v); }`},
+
+			// ---- A `for` whose head has no incrementor leaves the `try` block
+			// with no throwable node, so nothing reaches the `catch` clause and
+			// the code after it is never analysed ----
+			{Code: `function f() { try { for (var i = 0;;) { break; } return 1; } catch (e) {} let x = 1; x = 2; return x; }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: parenthesized assignment target ----
@@ -507,6 +512,17 @@ var obj;`,
 				Code: `function f(fn) { let x = 1; console.log(x); ({ a: x } = fn(x)); }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unnecessaryAssignment", Line: 1, Column: 51, EndLine: 1, EndColumn: 52},
+				},
+			},
+
+			// ---- A `for` incrementor inside a `try` block is laid out before
+			// the body, so it is one of the throwable nodes the block forks on
+			// even when the body always leaves the loop abruptly; the code after
+			// the `catch` clause stays reachable and is analysed ----
+			{
+				Code: `function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) {} let x = 1; x = 2; return x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 84, EndLine: 1, EndColumn: 85},
 				},
 			},
 

--- a/internal/rules/no_useless_return/no_useless_return_extras_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_extras_test.go
@@ -43,6 +43,12 @@ func TestNoUselessReturnExtras(t *testing.T) {
 			{Code: `function middleware(req, res, next) { if (!req.user) { res.sendStatus(401); return; } next(); }`},
 			// ---- Real-user: guard clause that is the whole body of the branch ----
 			{Code: `function render(props) { if (!props.visible) return; draw(props); }`},
+			// ---- A `for` whose head has no incrementor leaves the `try` block
+			// with no throwable node, so nothing reaches the `catch` clause ----
+			{Code: `function f() { try { for (var i = 0;;) { break; } return 1; } catch (e) { return; } }`},
+			// ---- The incrementor is laid out where the walk stands, so inside
+			// code nothing reaches it forks nothing either ----
+			{Code: `function f() { throw e; try { for (var i = 0;; i++) { break; } return 1; } catch (e) { return; } }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: declaration / container forms — a code path root of every shape the rule can report in ----
@@ -219,6 +225,16 @@ func TestNoUselessReturnExtras(t *testing.T) {
 				Output: []string{`async function load() { try { setBusy(true);  } finally { setBusy(false); } }`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unnecessaryReturn", Line: 1, Column: 46, EndLine: 1, EndColumn: 53},
+				},
+			},
+			// ---- A `for` incrementor inside a `try` block is laid out before
+			// the body, so it is one of the throwable nodes the block forks on
+			// even when the body always leaves the loop abruptly ----
+			{
+				Code:   `function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) { return; } }`,
+				Output: []string{`function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) {  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryReturn", Line: 1, Column: 79, EndLine: 1, EndColumn: 86},
 				},
 			},
 			// ---- Real-user: eslint#8026 — the fix must not clash with a no-else-return fix on the same if ----

--- a/internal/utils/cfg/cfg.go
+++ b/internal/utils/cfg/cfg.go
@@ -233,6 +233,15 @@ func (b *Builder[E]) makeUnreachable() {
 	b.cur = next
 }
 
+// enterDisconnected makes blk current when the position the walk stands at is
+// one control arrives at, rather than when an edge into blk already is. It is
+// how a block whose only edge in is laid out later still gets laid out here,
+// which is the order ESLint traverses one in.
+func (b *Builder[E]) enterDisconnected(blk *Block[E]) {
+	blk.hasIncoming = blk.hasIncoming || b.cur.Reachable
+	b.enter(blk)
+}
+
 func (b *Builder[E]) read(node *ast.Node) {
 	if b.hooks.Read != nil {
 		b.hooks.Read(b, node)

--- a/internal/utils/cfg/statements.go
+++ b/internal/utils/cfg/statements.go
@@ -240,9 +240,15 @@ func (b *Builder[E]) forStatement(node *ast.Node) {
 	body := b.newBlock()
 	b.link(testEnd, body)
 
+	// The incrementor runs after the body and is laid out before it, so a body
+	// that always leaves abruptly does not make it unreachable and lose the
+	// fork a throwable node in it makes.
 	update := test
 	if stmt.Incrementor != nil {
 		update = b.newBlock()
+		b.enterDisconnected(update)
+		b.expr(stmt.Incrementor)
+		b.link(b.cur, test)
 	}
 
 	b.pushJump(node, after, update, node)
@@ -251,12 +257,6 @@ func (b *Builder[E]) forStatement(node *ast.Node) {
 	b.loop(node)
 	b.link(b.cur, update)
 	b.popJump()
-
-	if stmt.Incrementor != nil {
-		b.enter(update)
-		b.expr(stmt.Incrementor)
-		b.link(b.cur, test)
-	}
 
 	b.enter(after)
 }


### PR DESCRIPTION
## Summary

Stacked on #1583 — the diff here is only this fix.

A `for` statement's incrementor was laid out after the body. When the body always leaves abruptly, the incrementor block had no reachable predecessor, so a throwable node in it made no fork to the enclosing `catch` — leaving the whole `catch` clause and everything after the `try` statement unreachable.

ESLint visits the incrementor in traversal order, before the body, and gives it the reachability of the position the traversal stands at (`ForkContext.makeDisconnected`). `enterDisconnected` does the same here: it lays a block out where the traversal is, while the only edge into it is added later from the end of the body. The graph's edges are unchanged.

```js
// no-useless-return: ESLint reports the `return` in the catch, rslint reports nothing
function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) { return; } }

// no-unreachable-loop: ESLint reports both loops, rslint only the first
function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) {} for (var v of items) { return 1; } }

// no-useless-assignment: ESLint reports `let x = 1`, rslint reports nothing
function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) {} let x = 1; x = 2; return x; }
```

Verified over 1680 generated programs (`for` head × body × `try` wrapper × trailing code), differentially against ESLint 10.7 on both reports and `--fix` output: 0 mismatches after the change. Before it: 25 for `no-unreachable-loop`, 55 for `no-useless-assignment`, 45 for `no-useless-return`.

## Related Links

Reported on #1583.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
