### PR TITLE
test(vscode): stabilize parent-ignore catalog regression

### DIFF
--- a/packages/vscode-extension/__tests__/fixtures-jsconfig/parent-ignore-catalog-probe/index.ts
+++ b/packages/vscode-extension/__tests__/fixtures-jsconfig/parent-ignore-catalog-probe/index.ts
@@ -1,0 +1,1 @@
+console.log('nested');

--- a/packages/vscode-extension/__tests__/fixtures-jsconfig/parent-ignore-catalog-probe/rslint.config.mjs
+++ b/packages/vscode-extension/__tests__/fixtures-jsconfig/parent-ignore-catalog-probe/rslint.config.mjs
@@ -1,0 +1,6 @@
+import fs from 'node:fs';
+
+const loadMarker = new URL('./config-loads.txt', import.meta.url);
+fs.appendFileSync(loadMarker, 'x');
+
+export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];

--- a/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
@@ -332,10 +332,10 @@ export default [{
     const rootConfigPath = path.join(root, 'rslint.config.js');
     const originalRootConfig = fs.readFileSync(rootConfigPath, 'utf8');
     const nestedDir = path.join(root, 'parent-ignore-catalog-probe');
-    const nestedConfigPath = path.join(nestedDir, 'rslint.config.mjs');
     const nestedFilePath = path.join(nestedDir, 'index.ts');
     const loadMarkerPath = path.join(nestedDir, 'config-loads.txt');
     const rootDoc = await openFixture('index.ts');
+    let nestedDoc: vscode.TextDocument | undefined;
 
     const ignoredRootConfig = originalRootConfig
       .replace(
@@ -349,25 +349,19 @@ export default [{
 
     await withFailClosedCleanup(
       async () => {
-        fs.mkdirSync(nestedDir, { recursive: true });
-        fs.writeFileSync(nestedFilePath, 'console.log("nested");\n', 'utf8');
-        fs.writeFileSync(
-          nestedConfigPath,
-          `import fs from 'node:fs';
-fs.appendFileSync(${JSON.stringify(loadMarkerPath)}, 'x');
-export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
-`,
-          'utf8',
-        );
-
-        const nestedDoc =
-          await vscode.workspace.openTextDocument(nestedFilePath);
+        nestedDoc = await vscode.workspace.openTextDocument(nestedFilePath);
         await vscode.window.showTextDocument(nestedDoc);
         await waitForDiagnostics(nestedDoc, (diagnostics) =>
           diagnostics.some((diagnostic) =>
             diagnostic.message.includes('Unexpected console statement'),
           ),
         );
+        assert.notStrictEqual(
+          fs.readFileSync(loadMarkerPath, 'utf8'),
+          '',
+          'The nested config evaluation probe must be armed before refresh',
+        );
+        fs.writeFileSync(loadMarkerPath, '', 'utf8');
 
         await vscode.window.showTextDocument(rootDoc);
         const parentApplied = waitForDiagnostics(rootDoc, (diagnostics) =>
@@ -388,7 +382,7 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
 
         assert.strictEqual(
           fs.readFileSync(loadMarkerPath, 'utf8'),
-          'x',
+          '',
           'The ignored nested candidate must not be evaluated again',
         );
         assert.ok(
@@ -401,19 +395,32 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
         );
       },
       async () => {
-        const restored = waitForDiagnostics(
-          rootDoc,
-          (diagnostics) =>
-            diagnostics.some((diagnostic) =>
-              diagnostic.message.includes('no-unsafe-member-access'),
-            ) &&
-            !diagnostics.some((diagnostic) =>
-              diagnostic.message.includes('no-explicit-any'),
-            ),
+        await withFailClosedCleanup(
+          async () => closeTextEditor(nestedDoc),
+          async () => {
+            await withFailClosedCleanup(
+              async () => {
+                const restored = waitForDiagnostics(
+                  rootDoc,
+                  (diagnostics) =>
+                    diagnostics.some((diagnostic) =>
+                      diagnostic.message.includes('no-unsafe-member-access'),
+                    ) &&
+                    !diagnostics.some((diagnostic) =>
+                      diagnostic.message.includes('no-explicit-any'),
+                    ),
+                );
+                fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+                await restored;
+              },
+              async () => {
+                fs.rmSync(loadMarkerPath, { force: true });
+              },
+              'Parent-ignore catalog state cleanup',
+            );
+          },
+          'Parent-ignore catalog resource cleanup',
         );
-        fs.rmSync(nestedDir, { recursive: true, force: true });
-        fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
-        await restored;
       },
       'Parent-ignore catalog test',
     );


### PR DESCRIPTION
## Summary

- Stabilize the parent-global-ignore catalog regression test by keeping its nested config and source in the isolated fixture before the Extension Host starts.
- Preserve the product assertions with an observable config-evaluation marker: prove the nested config is initially active, then prove the parent ignore clears its diagnostics without evaluating the ignored candidate again.
- Close the exact nested editor and restore the root config/marker with fail-closed cleanup so failures cannot contaminate later tests.

The previous setup created a directory and nested config back-to-back after the recursive VS Code watcher had started. On Linux, the underlying Parcel watcher can observe the parent directory before it has attached to the new subtree and permanently miss the immediately-created config event. That left the test waiting for diagnostics that would never arrive; it was not a slow lint transaction.

## Related Links

- [Failing GitHub Actions job](https://github.com/web-infra-dev/rslint/actions/runs/30998275922/job/92280578366)
- [VS Code #227252: recursive watcher misses files created by mkdir -p](https://github.com/microsoft/vscode/issues/227252)
- [Parcel watcher #97: directories created with mkdir -p are not recursively watched on Linux](https://github.com/parcel-bundler/watcher/issues/97)

## Testing

- `pnpm check-spell`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm --filter rslint test`
- Repeated JS config suite stress runs, including two clean runs after the final cleanup-order fix
- Go lint scope: no changed Go files or Go modules, so no Go packages were eligible for the requested scoped lint

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
