### PR TITLE
feat(jest,rstest): parse setup and teardown hooks

### DIFF
--- a/internal/plugins/jest/rules/no_hooks/no_hooks.go
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
 //go:embed no_hooks.schema.json
@@ -22,13 +23,6 @@ func buildErrorUnexpectedHookMessage(hook string) rule.RuleMessage {
 	}
 }
 
-var allowedHooks = map[string]bool{
-	"beforeEach": true,
-	"afterEach":  true,
-	"beforeAll":  true,
-	"afterAll":   true,
-}
-
 type Options struct {
 	Allow []string `json:"allow"`
 }
@@ -41,7 +35,7 @@ func parseAllowList(raw any) []string {
 	out := make([]string, 0, len(items))
 	for _, item := range items {
 		s, ok := item.(string)
-		if ok && allowedHooks[s] {
+		if ok && testFramework.IsHookName(s) {
 			out = append(out, s)
 		}
 	}

--- a/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.go
+++ b/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.go
@@ -4,6 +4,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
 func buildReorderHooksMessage(currentHook, previousHook string) rule.RuleMessage {
@@ -38,10 +39,10 @@ var PreferHooksInOrderRule = rule.Rule{
 
 				inHook = true
 				currentHook := jestFnCall.Name
-				currentHookIndex := utils.JestHookOrderIndex(currentHook)
+				currentHookIndex := testFramework.HookOrderIndex(currentHook)
 
 				if currentHookIndex < previousHookIndex {
-					ctx.ReportNode(node, buildReorderHooksMessage(currentHook, utils.JEST_HOOKS_ORDER[previousHookIndex]))
+					ctx.ReportNode(node, buildReorderHooksMessage(currentHook, testFramework.HooksOrder[previousHookIndex]))
 					return
 				}
 

--- a/internal/plugins/jest/utils/jest.go
+++ b/internal/plugins/jest/utils/jest.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"encoding/json"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -31,8 +30,6 @@ const (
 	JestFnTypeTest                = testFramework.FnKindTest
 	JestFnTypeUnknown             = testFramework.FnKindUnknown
 )
-
-var JEST_HOOKS_ORDER = []string{"beforeAll", "beforeEach", "afterEach", "afterAll"}
 
 var JEST_METHOD_NAMES = map[string]bool{
 	"afterAll":   true,
@@ -157,16 +154,11 @@ func GetJestKind(name string) JestFnType {
 	case "expect":
 		return JestFnTypeExpect
 	default:
-		if slices.Contains(JEST_HOOKS_ORDER, name) {
+		if testFramework.IsHookName(name) {
 			return JestFnTypeHook
 		}
 		return JestFnTypeUnknown
 	}
-}
-
-// JestHookOrderIndex returns the expected declaration order index for a Jest hook name, or -1 if unknown.
-func JestHookOrderIndex(name string) int {
-	return slices.Index(JEST_HOOKS_ORDER, name)
 }
 
 func GetJestFnMemberEntries(node *ast.Node) []ParsedJestFnMemberEntry {

--- a/internal/plugins/jest/utils/parse_jest_fn.go
+++ b/internal/plugins/jest/utils/parse_jest_fn.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -29,13 +28,16 @@ const (
 	jestGlobalsModule                = "@jest/globals"
 )
 
+// IsTypeOfJestFnCall reports whether node parses as a Jest call of one of the
+// given kinds. The kind matching is shared with rstest through
+// testFramework.IsCallOfKind; this owns the parse entry point.
 func IsTypeOfJestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...JestFnType) bool {
 	parsed := ParseJestFnCall(node, ctx)
-	if parsed == nil || len(kinds) == 0 {
+	if parsed == nil {
 		return false
 	}
 
-	return slices.Contains(kinds, parsed.Kind)
+	return testFramework.IsCallOfKind(&parsed.ParsedCall, kinds...)
 }
 
 func ParseJestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedJestFnCall {

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -57,9 +57,10 @@ const (
 	rstestProfilePlaywright
 )
 
-// ParseRstestFnCall parses a final Rstest test/describe registration call.
-// Factory calls such as test.each(cases), test.runIf(condition), and
-// test.extend(fixtures) are intentionally not returned.
+// ParseRstestFnCall parses a final Rstest test/describe/hook registration
+// call; callers distinguish the three through Kind. Factory calls such as
+// test.each(cases), test.runIf(condition), and test.extend(fixtures) are
+// intentionally not returned.
 func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall {
 	return parseRstestFnCall(node, ctx, false, false)
 }

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"slices"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -17,6 +19,7 @@ const (
 	rstestAPIDescribe
 	rstestAPIParameterizedTest
 	rstestAPIParameterizedDescribe
+	rstestAPIHook
 )
 
 type rstestInvocation uint8
@@ -68,6 +71,19 @@ func ParseRstestFnCallWithOfficialExtensions(
 	ctx rule.RuleContext,
 ) *ParsedRstestFnCall {
 	return parseRstestFnCall(node, ctx, true, true)
+}
+
+// IsTypeOfRstestFnCall reports whether node parses as a Rstest registration
+// call of one of the given kinds. Mirrors jest's IsTypeOfJestFnCall
+// (parse_jest_fn.go:32); it parses with official extensions enabled
+// (import.meta + playwright), the same choice RstestTestCallbacks.ParseFnCall
+// makes.
+func IsTypeOfRstestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...RstestFnType) bool {
+	parsed := ParseRstestFnCallWithOfficialExtensions(node, ctx)
+	if parsed == nil || len(kinds) == 0 {
+		return false
+	}
+	return slices.Contains(kinds, parsed.Kind)
 }
 
 func parseRstestFnCall(
@@ -129,6 +145,8 @@ func parseRstestFnCall(
 		resolved.kind = RstestFnTypeTest
 	case rstestAPIDescribe, rstestAPIParameterizedDescribe:
 		resolved.kind = RstestFnTypeDescribe
+	case rstestAPIHook:
+		resolved.kind = RstestFnTypeHook
 	default:
 		return nil
 	}
@@ -504,6 +522,13 @@ func directRstestAPIState(profile rstestAPIProfile, name string) rstestAPIState 
 	case "describe":
 		return rstestAPIDescribe
 	default:
+		// Both profiles expose the same four hooks: @rstest/playwright
+		// re-exports them (packages/playwright/src/index.ts:2-9). Hooks accept
+		// no chained members, which holds by construction: applyRstestChainPart
+		// has no rstestAPIHook branch, so any member invalidates the chain.
+		if RSTEST_HOOK_NAMES[name] {
+			return rstestAPIHook
+		}
 		return rstestAPIInvalid
 	}
 }

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -606,7 +606,12 @@ func applyResolvedRstestChainPart(resolved *rstestResolvedAPI, part rstestChainP
 	// test object it was read from, so the reported name and original node move
 	// to the member. Rules keyed on the hook name — prefer-hooks-in-order, for
 	// one — would otherwise see every Playwright hook as `test`.
-	if state == rstestAPIHook && resolved.state != rstestAPIHook {
+	//
+	// No guard against a hook→hook transition is needed: applyRstestChainPart
+	// has no rstestAPIHook branch, so a member applied to a hook always
+	// invalidates the chain and returns above. Reaching here with a hook state
+	// therefore means the member just introduced it.
+	if state == rstestAPIHook {
 		resolved.name = part.name
 		resolved.originalNode = part.node
 	}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -560,6 +560,22 @@ func applyRstestChainPart(profile rstestAPIProfile, state rstestAPIState, part r
 				return rstestAPIDescribe
 			}
 		}
+		// PlaywrightTest declares the four hooks as members of the test object,
+		// and extend() returns another PlaywrightTest, so `test.beforeEach()`
+		// and `test.extend(fixtures).beforeEach()` register a hook. This is a
+		// member lookup on the test object, not a modifier applied to an
+		// already resolved hook, which is why it is reached from the test state
+		// rather than from rstestAPIHook.
+		//
+		// Only rstestAPITestWithExtend qualifies: that state means the receiver
+		// is still a PlaywrightTest. Modifiers such as `.skip` or `.each(...)`
+		// leave rstestAPITest, and those results do not expose hooks.
+		if profile == rstestProfilePlaywright &&
+			state == rstestAPITestWithExtend &&
+			part.invocation == rstestNotInvoked &&
+			testFramework.IsHookName(part.name) {
+			return rstestAPIHook
+		}
 	case rstestAPIDescribe:
 		switch part.name {
 		case "only", "skip", "todo", "concurrent", "sequential":
@@ -584,6 +600,14 @@ func applyResolvedRstestChainPart(resolved *rstestResolvedAPI, part rstestChainP
 	if state == rstestAPIInvalid {
 		resolved.state = rstestAPIInvalid
 		return false
+	}
+	// `test.beforeEach()` resolves to the hook the member selects, not to the
+	// test object it was read from, so the reported name and original node move
+	// to the member. Rules keyed on the hook name — prefer-hooks-in-order, for
+	// one — would otherwise see every Playwright hook as `test`.
+	if state == rstestAPIHook && resolved.state != rstestAPIHook {
+		resolved.name = part.name
+		resolved.originalNode = part.node
 	}
 	resolved.state = state
 	// Only semantic conclusions are recorded here. This runs on the alias chain

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"slices"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -74,16 +72,16 @@ func ParseRstestFnCallWithOfficialExtensions(
 }
 
 // IsTypeOfRstestFnCall reports whether node parses as a Rstest registration
-// call of one of the given kinds. Mirrors jest's IsTypeOfJestFnCall
-// (parse_jest_fn.go:32); it parses with official extensions enabled
-// (import.meta + playwright), the same choice RstestTestCallbacks.ParseFnCall
-// makes.
+// call of one of the given kinds. What this plugin owns is the entry point:
+// parsing runs with official extensions enabled (import.meta + playwright),
+// the same choice RstestTestCallbacks.ParseFnCall makes. The kind matching
+// itself is shared with jest through testFramework.IsCallOfKind.
 func IsTypeOfRstestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...RstestFnType) bool {
 	parsed := ParseRstestFnCallWithOfficialExtensions(node, ctx)
-	if parsed == nil || len(kinds) == 0 {
+	if parsed == nil {
 		return false
 	}
-	return slices.Contains(kinds, parsed.Kind)
+	return testFramework.IsCallOfKind(&parsed.ParsedCall, kinds...)
 }
 
 func parseRstestFnCall(
@@ -526,7 +524,7 @@ func directRstestAPIState(profile rstestAPIProfile, name string) rstestAPIState 
 		// re-exports them (packages/playwright/src/index.ts:2-9). Hooks accept
 		// no chained members, which holds by construction: applyRstestChainPart
 		// has no rstestAPIHook branch, so any member invalidates the chain.
-		if RSTEST_HOOK_NAMES[name] {
+		if testFramework.IsHookName(name) {
 			return rstestAPIHook
 		}
 		return rstestAPIInvalid

--- a/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
@@ -150,28 +150,3 @@ func TestIsTypeOfRstestFnCall(t *testing.T) {
 		},
 	)
 }
-
-func TestRstestHookOrder(t *testing.T) {
-	if len(rstestUtils.RSTEST_HOOKS_ORDER) != 4 {
-		t.Errorf("expected 4 hooks in order table, got %d", len(rstestUtils.RSTEST_HOOKS_ORDER))
-	}
-	for i, name := range []string{"beforeAll", "beforeEach", "afterEach", "afterAll"} {
-		if got := rstestUtils.RstestHookOrderIndex(name); got != i {
-			t.Errorf("RstestHookOrderIndex(%q) = %d, expected %d", name, got, i)
-		}
-		if !rstestUtils.RSTEST_HOOK_NAMES[name] {
-			t.Errorf("RSTEST_HOOK_NAMES missing %q", name)
-		}
-	}
-	if len(rstestUtils.RSTEST_HOOK_NAMES) != 4 {
-		t.Errorf("expected 4 hook names, got %d", len(rstestUtils.RSTEST_HOOK_NAMES))
-	}
-	for _, name := range []string{"onTestFinished", "onTestFailed", "test", "describe"} {
-		if rstestUtils.RstestHookOrderIndex(name) != -1 {
-			t.Errorf("RstestHookOrderIndex(%q) should be -1", name)
-		}
-		if rstestUtils.RSTEST_HOOK_NAMES[name] {
-			t.Errorf("RSTEST_HOOK_NAMES must not contain %q", name)
-		}
-	}
-}

--- a/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
@@ -1,0 +1,177 @@
+package utils_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// hookParseProbe reports every parsed registration call with its kind and
+// resolved name, so invalid test cases assert exact parse results and valid
+// test cases assert that the parser returned nil.
+var hookParseProbe = rule.Rule{
+	Name:             "rstest/hook-parse-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx)
+				if parsed == nil {
+					return
+				}
+				ctx.ReportNode(node, probeMessage("parsedFn", fmt.Sprintf(
+					"kind=%s name=%s", parsed.Kind, parsed.Name,
+				)))
+			},
+		}
+	},
+}
+
+func parsedHookError(kind string, name string) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{{
+		MessageId: "parsedFn",
+		Message:   fmt.Sprintf("kind=%s name=%s", kind, name),
+	}}
+}
+
+func TestParseRstestFnCallHooks(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &hookParseProbe,
+		[]rule_tester.ValidTestCase{
+			// onTestFinished / onTestFailed are execution-time APIs, not hooks.
+			{Code: `onTestFinished(() => {});`},
+			{Code: `onTestFailed(() => {});`},
+			{Code: `import { onTestFinished } from '@rstest/core'; onTestFinished(() => {});`},
+			{Code: `import { onTestFailed } from '@rstest/core'; onTestFailed(() => {});`},
+			// Hooks accept no chained members.
+			{Code: `beforeAll.skip(() => {});`},
+			{Code: `beforeEach.each([1])(() => {});`},
+			// Foreign frameworks and shadowed locals must not resolve.
+			{Code: `import { beforeAll } from 'vitest'; beforeAll(() => {});`},
+			{Code: `import { beforeEach } from '@jest/globals'; beforeEach(() => {});`},
+			{Code: `const beforeAll = createHookRegistry(); beforeAll(() => {});`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// All four hooks as globals.
+			{Code: `beforeAll(() => {});`, Errors: parsedHookError("hook", "beforeAll")},
+			{Code: `beforeEach(() => {});`, Errors: parsedHookError("hook", "beforeEach")},
+			{Code: `afterEach(() => {});`, Errors: parsedHookError("hook", "afterEach")},
+			{Code: `afterAll(() => {});`, Errors: parsedHookError("hook", "afterAll")},
+			// With the optional timeout argument.
+			{Code: `beforeAll(() => {}, 1000);`, Errors: parsedHookError("hook", "beforeAll")},
+			// Source forms.
+			{
+				Code:   `import { beforeAll } from '@rstest/core'; beforeAll(() => {});`,
+				Errors: parsedHookError("hook", "beforeAll"),
+			},
+			{
+				Code:   `import { beforeEach as setup } from '@rstest/core'; setup(() => {});`,
+				Errors: parsedHookError("hook", "beforeEach"),
+			},
+			{
+				Code:   `import * as rstest from '@rstest/core'; rstest.afterEach(() => {});`,
+				Errors: parsedHookError("hook", "afterEach"),
+			},
+			{
+				Code:   `import.meta.rstest.beforeAll(() => {});`,
+				Errors: parsedHookError("hook", "beforeAll"),
+			},
+			{
+				Code:   `const { afterAll } = import.meta.rstest; afterAll(() => {});`,
+				Errors: parsedHookError("hook", "afterAll"),
+			},
+			{
+				Code:   `const setup = beforeAll; setup(() => {});`,
+				Errors: parsedHookError("hook", "beforeAll"),
+			},
+			{
+				Code:   `import { beforeAll } from '@rstest/playwright'; beforeAll(() => {});`,
+				Errors: parsedHookError("hook", "beforeAll"),
+			},
+			// Test and describe parsing is unchanged.
+			{Code: `test("case", () => {});`, Errors: parsedHookError("test", "test")},
+			{Code: `describe("suite", () => {});`, Errors: parsedHookError("describe", "describe")},
+		},
+	)
+}
+
+// hookKindProbe reports IsTypeOfRstestFnCall results for every parsed
+// registration call: single-kind, multi-kind variadic, and the zero-kind
+// degenerate form.
+var hookKindProbe = rule.Rule{
+	Name:             "rstest/hook-kind-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx) == nil {
+					return
+				}
+				ctx.ReportNode(node, probeMessage("kinds", fmt.Sprintf(
+					"hook=%t test=%t testOrHook=%t zeroKinds=%t",
+					rstestUtils.IsTypeOfRstestFnCall(node, ctx, rstestUtils.RstestFnTypeHook),
+					rstestUtils.IsTypeOfRstestFnCall(node, ctx, rstestUtils.RstestFnTypeTest),
+					rstestUtils.IsTypeOfRstestFnCall(node, ctx,
+						rstestUtils.RstestFnTypeTest, rstestUtils.RstestFnTypeHook),
+					rstestUtils.IsTypeOfRstestFnCall(node, ctx),
+				)))
+			},
+		}
+	},
+}
+
+func TestIsTypeOfRstestFnCall(t *testing.T) {
+	kindsError := func(message string) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{{MessageId: "kinds", Message: message}}
+	}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &hookKindProbe,
+		[]rule_tester.ValidTestCase{
+			{Code: `notAFnCall(() => {});`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `beforeEach(() => {});`,
+				Errors: kindsError("hook=true test=false testOrHook=true zeroKinds=false"),
+			},
+			{
+				Code:   `test("case", () => {});`,
+				Errors: kindsError("hook=false test=true testOrHook=true zeroKinds=false"),
+			},
+			{
+				Code:   `describe("suite", () => {});`,
+				Errors: kindsError("hook=false test=false testOrHook=false zeroKinds=false"),
+			},
+		},
+	)
+}
+
+func TestRstestHookOrder(t *testing.T) {
+	if len(rstestUtils.RSTEST_HOOKS_ORDER) != 4 {
+		t.Errorf("expected 4 hooks in order table, got %d", len(rstestUtils.RSTEST_HOOKS_ORDER))
+	}
+	for i, name := range []string{"beforeAll", "beforeEach", "afterEach", "afterAll"} {
+		if got := rstestUtils.RstestHookOrderIndex(name); got != i {
+			t.Errorf("RstestHookOrderIndex(%q) = %d, expected %d", name, got, i)
+		}
+		if !rstestUtils.RSTEST_HOOK_NAMES[name] {
+			t.Errorf("RSTEST_HOOK_NAMES missing %q", name)
+		}
+	}
+	if len(rstestUtils.RSTEST_HOOK_NAMES) != 4 {
+		t.Errorf("expected 4 hook names, got %d", len(rstestUtils.RSTEST_HOOK_NAMES))
+	}
+	for _, name := range []string{"onTestFinished", "onTestFailed", "test", "describe"} {
+		if rstestUtils.RstestHookOrderIndex(name) != -1 {
+			t.Errorf("RstestHookOrderIndex(%q) should be -1", name)
+		}
+		if rstestUtils.RSTEST_HOOK_NAMES[name] {
+			t.Errorf("RSTEST_HOOK_NAMES must not contain %q", name)
+		}
+	}
+}

--- a/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
@@ -51,6 +51,11 @@ func TestParseRstestFnCallHooks(t *testing.T) {
 			// Hooks accept no chained members.
 			{Code: `beforeAll.skip(() => {});`},
 			{Code: `beforeEach.each([1])(() => {});`},
+			// Hooks on the test object are Playwright-only, and only while the
+			// receiver is still a PlaywrightTest.
+			{Code: `import { test } from '@rstest/core'; test.beforeEach(() => {});`},
+			{Code: `import { test } from '@rstest/playwright'; test.skip.beforeEach(() => {});`},
+			{Code: `import { test } from '@rstest/playwright'; test.beforeEach.only(() => {});`},
 			// Foreign frameworks and shadowed locals must not resolve.
 			{Code: `import { beforeAll } from 'vitest'; beforeAll(() => {});`},
 			{Code: `import { beforeEach } from '@jest/globals'; beforeEach(() => {});`},
@@ -92,6 +97,28 @@ func TestParseRstestFnCallHooks(t *testing.T) {
 			{
 				Code:   `import { beforeAll } from '@rstest/playwright'; beforeAll(() => {});`,
 				Errors: parsedHookError("hook", "beforeAll"),
+			},
+			// PlaywrightTest exposes the four hooks as members, and extend()
+			// returns another PlaywrightTest.
+			{
+				Code:   `import { test } from '@rstest/playwright'; test.beforeAll(() => {});`,
+				Errors: parsedHookError("hook", "beforeAll"),
+			},
+			{
+				Code:   `import { test } from '@rstest/playwright'; test.beforeEach(() => {});`,
+				Errors: parsedHookError("hook", "beforeEach"),
+			},
+			{
+				Code:   `import { test } from '@rstest/playwright'; test.afterEach(() => {});`,
+				Errors: parsedHookError("hook", "afterEach"),
+			},
+			{
+				Code:   `import { test } from '@rstest/playwright'; test.afterAll(() => {});`,
+				Errors: parsedHookError("hook", "afterAll"),
+			},
+			{
+				Code:   `import { test } from '@rstest/playwright'; test.extend({}).beforeEach(() => {});`,
+				Errors: parsedHookError("hook", "beforeEach"),
 			},
 			// Test and describe parsing is unchanged.
 			{Code: `test("case", () => {});`, Errors: parsedHookError("test", "test")},
@@ -137,6 +164,10 @@ func TestIsTypeOfRstestFnCall(t *testing.T) {
 		[]rule_tester.InvalidTestCase{
 			{
 				Code:   `beforeEach(() => {});`,
+				Errors: kindsError("hook=true test=false testOrHook=true zeroKinds=false"),
+			},
+			{
+				Code:   `import { test } from '@rstest/playwright'; test.beforeEach(() => {});`,
 				Errors: kindsError("hook=true test=false testOrHook=true zeroKinds=false"),
 			},
 			{

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"slices"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -51,30 +49,6 @@ const (
 	RstestFnTypeHook     = testFramework.FnKindHook
 	RstestFnTypeTest     = testFramework.FnKindTest
 )
-
-// RSTEST_HOOK_NAMES lists the setup/teardown hooks. onTestFinished and
-// onTestFailed are deliberately absent: they are execution-time APIs called
-// inside a test body (RunnerAPI exposes them next to the hooks, but their
-// handlers run per test), so they must not parse as hooks.
-// Source: rstest c4b67c72 packages/core/src/types/api.ts:244-255 (RunnerAPI)
-// and packages/core/globals.d.ts; @rstest/playwright re-exports the same four
-// (packages/playwright/src/index.ts:2-9).
-var RSTEST_HOOK_NAMES = map[string]bool{
-	"afterAll":   true,
-	"afterEach":  true,
-	"beforeAll":  true,
-	"beforeEach": true,
-}
-
-// RSTEST_HOOKS_ORDER is the expected declaration order used by
-// prefer-hooks-in-order, mirroring jest's JEST_HOOKS_ORDER.
-var RSTEST_HOOKS_ORDER = []string{"beforeAll", "beforeEach", "afterEach", "afterAll"}
-
-// RstestHookOrderIndex returns the expected declaration order index for a
-// Rstest hook name, or -1 if unknown. Mirrors jest's JestHookOrderIndex.
-func RstestHookOrderIndex(name string) int {
-	return slices.Index(RSTEST_HOOKS_ORDER, name)
-}
 
 const (
 	RSTEST_GLOBAL_MODE = testFramework.ReferenceModeGlobal

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"slices"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -46,8 +48,33 @@ type ParsedRstestFnMemberEntry = testFramework.MemberEntry
 
 const (
 	RstestFnTypeDescribe = testFramework.FnKindDescribe
+	RstestFnTypeHook     = testFramework.FnKindHook
 	RstestFnTypeTest     = testFramework.FnKindTest
 )
+
+// RSTEST_HOOK_NAMES lists the setup/teardown hooks. onTestFinished and
+// onTestFailed are deliberately absent: they are execution-time APIs called
+// inside a test body (RunnerAPI exposes them next to the hooks, but their
+// handlers run per test), so they must not parse as hooks.
+// Source: rstest c4b67c72 packages/core/src/types/api.ts:244-255 (RunnerAPI)
+// and packages/core/globals.d.ts; @rstest/playwright re-exports the same four
+// (packages/playwright/src/index.ts:2-9).
+var RSTEST_HOOK_NAMES = map[string]bool{
+	"afterAll":   true,
+	"afterEach":  true,
+	"beforeAll":  true,
+	"beforeEach": true,
+}
+
+// RSTEST_HOOKS_ORDER is the expected declaration order used by
+// prefer-hooks-in-order, mirroring jest's JEST_HOOKS_ORDER.
+var RSTEST_HOOKS_ORDER = []string{"beforeAll", "beforeEach", "afterEach", "afterAll"}
+
+// RstestHookOrderIndex returns the expected declaration order index for a
+// Rstest hook name, or -1 if unknown. Mirrors jest's JestHookOrderIndex.
+func RstestHookOrderIndex(name string) int {
+	return slices.Index(RSTEST_HOOKS_ORDER, name)
+}
 
 const (
 	RSTEST_GLOBAL_MODE = testFramework.ReferenceModeGlobal

--- a/internal/utils/test_framework/types.go
+++ b/internal/utils/test_framework/types.go
@@ -1,6 +1,10 @@
 package test_framework
 
-import "github.com/microsoft/typescript-go/shim/ast"
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+)
 
 // FnKind classifies a parsed test-framework call without encoding one
 // framework's root names or aliases. Framework parsers may define additional
@@ -40,6 +44,40 @@ type ParsedCall struct {
 	Members       []string
 	MemberEntries []MemberEntry
 	Head          ParsedCallHead
+}
+
+// HooksOrder is the order setup/teardown hooks are expected to be declared in,
+// used by prefer-hooks-in-order. Jest and Rstest expose the same four hooks in
+// the same order; frameworks that differ should not reuse this.
+//
+// Rstest source: rstest c4b67c72 packages/core/src/types/api.ts:244-255
+// (RunnerAPI) and packages/core/globals.d.ts; @rstest/playwright re-exports the
+// same four (packages/playwright/src/index.ts:2-9). Rstest's onTestFinished and
+// onTestFailed are deliberately absent: they are execution-time APIs called
+// inside a test body, so they must not parse as hooks.
+var HooksOrder = []string{"beforeAll", "beforeEach", "afterEach", "afterAll"}
+
+// IsHookName reports whether name is one of HooksOrder.
+func IsHookName(name string) bool {
+	return slices.Contains(HooksOrder, name)
+}
+
+// HookOrderIndex returns the expected declaration order index for a hook name,
+// or -1 if it is not a hook.
+func HookOrderIndex(name string) int {
+	return slices.Index(HooksOrder, name)
+}
+
+// IsCallOfKind reports whether parsed resolved to one of kinds. It is the
+// shared body of jest's IsTypeOfJestFnCall and rstest's IsTypeOfRstestFnCall:
+// each plugin owns which parse entry point to call, this owns what the answer
+// means. An empty kinds list is false rather than "any kind", so a caller that
+// forgets its arguments does not silently match everything.
+func IsCallOfKind(parsed *ParsedCall, kinds ...FnKind) bool {
+	if parsed == nil || len(kinds) == 0 {
+		return false
+	}
+	return slices.Contains(kinds, parsed.Kind)
 }
 
 type ParsedCallHead struct {

--- a/internal/utils/test_framework/types_test.go
+++ b/internal/utils/test_framework/types_test.go
@@ -1,0 +1,57 @@
+package test_framework
+
+import "testing"
+
+func TestHooksOrder(t *testing.T) {
+	if len(HooksOrder) != 4 {
+		t.Fatalf("expected 4 hooks in order table, got %d", len(HooksOrder))
+	}
+
+	for i, name := range []string{"beforeAll", "beforeEach", "afterEach", "afterAll"} {
+		if got := HookOrderIndex(name); got != i {
+			t.Errorf("HookOrderIndex(%q) = %d, want %d", name, got, i)
+		}
+		if !IsHookName(name) {
+			t.Errorf("IsHookName(%q) = false, want true", name)
+		}
+	}
+
+	// onTestFinished / onTestFailed are Rstest execution-time APIs, and
+	// test / describe are registrations; none of them is a hook.
+	for _, name := range []string{"onTestFinished", "onTestFailed", "test", "describe", ""} {
+		if got := HookOrderIndex(name); got != -1 {
+			t.Errorf("HookOrderIndex(%q) = %d, want -1", name, got)
+		}
+		if IsHookName(name) {
+			t.Errorf("IsHookName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestIsCallOfKind(t *testing.T) {
+	test := &ParsedCall{Kind: FnKindTest}
+
+	tests := []struct {
+		name   string
+		parsed *ParsedCall
+		kinds  []FnKind
+		want   bool
+	}{
+		{"matches the only kind", test, []FnKind{FnKindTest}, true},
+		{"matches one of several", test, []FnKind{FnKindDescribe, FnKindTest}, true},
+		{"rejects other kinds", test, []FnKind{FnKindDescribe, FnKindHook}, false},
+		// Both guards matter: callers pass the result of a parse that may have
+		// failed, and an empty kinds list must not read as "any kind".
+		{"nil parse is false", nil, []FnKind{FnKindTest}, false},
+		{"no kinds is false", test, nil, false},
+		{"nil parse and no kinds is false", nil, nil, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsCallOfKind(test.parsed, test.kinds...); got != test.want {
+				t.Errorf("IsCallOfKind = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- extend `ParseRstestFnCall` to classify Rstest setup and teardown hooks
- add `IsTypeOfRstestFnCall` for kind-based call checks
- share the hook-order table and the call-kind matching with the jest plugin through `test_framework`

## Details

The parser now recognizes:

- `beforeAll`
- `beforeEach`
- `afterEach`
- `afterAll`

Hooks resolve through the existing Rstest API channels, including globals, named and aliased imports, namespaces, `import.meta.rstest`, const aliases, and `@rstest/playwright`.

Execution-time APIs such as `onTestFinished` and `onTestFailed` remain excluded. Hook member chains are also rejected because Rstest hooks do not expose test-style modifiers.

Existing parser consumers continue filtering by call kind and are unaffected.

## Shared with the jest plugin

Both additions would otherwise have been byte-identical copies of code jest already has, so they live in `internal/utils/test_framework` and jest was migrated onto them in the same PR rather than left on its duplicate.

**`HooksOrder` / `IsHookName` / `HookOrderIndex`** replace `JEST_HOOKS_ORDER` + `JestHookOrderIndex` and the Rstest hook-name table. Jest and Rstest expose the same four hooks in the same order; the source comment records the Rstest audit, including why `onTestFinished` / `onTestFailed` are absent. Call sites migrated: `GetJestKind`, `jest/prefer-hooks-in-order`, `directRstestAPIState`.

**`IsCallOfKind`** replaces the shared body of `IsTypeOfJestFnCall` and `IsTypeOfRstestFnCall`. Each plugin keeps its own wrapper because the parse entry point is genuinely plugin-owned — rstest parses with official extensions enabled (`import.meta` + playwright), jest does not. What is shared is only what counts as a match, and that carries two contracts worth single-sourcing: a failed parse is `false`, and an empty `kinds` list is `false` rather than "any kind". Neither was covered by a test before; `types_test.go` now pins both.

Jest behavior is unchanged — the delegations are pure moves, and `go test ./internal/plugins/jest/...` is green.
