### PR TITLE
feat(rstest): add expect assertion parser

### DIFF
--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -8,14 +8,23 @@ import (
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
-// RstestExpectEntry classifies which ExpectStatic surface a parsed expect call
-// goes through.
+// RstestExpectEntry names the assertion factory a parsed expect call went
+// through. The four factory values mirror eslint-plugin-vitest's
+// expectApiMethods plus its default expect(x) case.
+//
+// Everything the expect object exposes that is not an assertion factory —
+// expect.assertions(n), expect.unreachable(), expect.stringContaining(...),
+// expect.getState() — is RstestExpectEntryStatic. The parser deliberately does
+// not sub-classify those: telling a custom asymmetric matcher registered
+// through expect.extend apart from a forgotten expect(x) is not decidable from
+// one file, so the distinction is left to consumers, which have the member
+// name in Matcher and the tables in rstest_matchers.go to query. Jest and
+// vitest make the same call: neither classifies static members, both detect
+// them structurally (vitest's expectCall == null, our Head == nil).
 type RstestExpectEntry string
 
 const (
-	// RstestExpectEntryCall covers plain expect(x) chains, and also bare
-	// modifier chains such as expect.resolves.toBe(1) where the expect head was
-	// never invoked; the latter parse with Head == nil.
+	// RstestExpectEntryCall covers plain expect(x) chains.
 	RstestExpectEntryCall RstestExpectEntry = "expect"
 	// RstestExpectEntrySoft covers expect.soft(x) chains.
 	RstestExpectEntrySoft RstestExpectEntry = "soft"
@@ -23,19 +32,14 @@ const (
 	RstestExpectEntryPoll RstestExpectEntry = "poll"
 	// RstestExpectEntryElement covers expect.element(locator) chains.
 	RstestExpectEntryElement RstestExpectEntry = "element"
-	// RstestExpectEntryUnreachable covers expect.unreachable(...).
-	RstestExpectEntryUnreachable RstestExpectEntry = "unreachable"
-	// RstestExpectEntryAssertions covers expect.assertions(n) and
-	// expect.hasAssertions().
-	RstestExpectEntryAssertions RstestExpectEntry = "assertions"
-	// RstestExpectEntryAsymmetric covers static matcher value constructors:
-	// expect.stringContaining(...), expect.not.arrayContaining(...), and
-	// unknown static members, which may be custom asymmetric matchers
-	// registered through expect.extend.
-	RstestExpectEntryAsymmetric RstestExpectEntry = "asymmetric"
-	// RstestExpectEntryConfig covers runtime configuration members such as
-	// expect.extend(...) or expect.getState().
-	RstestExpectEntryConfig RstestExpectEntry = "config"
+	// RstestExpectEntryStatic covers every chain where no assertion factory was
+	// invoked: static members of the expect object such as
+	// expect.assertions(1), expect.stringContaining("a") and
+	// expect.not.arrayContaining([]), and bare modifier chains such as
+	// expect.resolves.toBe(1) whose expect(x) call the author forgot.
+	//
+	// Invariant: Entry == RstestExpectEntryStatic if and only if Head == nil.
+	RstestExpectEntryStatic RstestExpectEntry = "static"
 )
 
 // RstestExpectParseReason explains why a parsed expect call carries no
@@ -92,7 +96,10 @@ type ParsedRstestExpectCall struct {
 	// with a null expectCall. Consumers that need the factory arguments must
 	// check for nil.
 	Head *ast.Node
-	// Entry classifies the ExpectStatic surface the call goes through.
+	// Entry names the assertion factory, or RstestExpectEntryStatic when none
+	// was invoked. Head is nil exactly when Entry is RstestExpectEntryStatic,
+	// so either field answers "is this a real assertion"; Entry additionally
+	// says which factory.
 	Entry RstestExpectEntry
 	// Members contains the complete source chain after the resolved expect
 	// root, including assertion factories, Chai language chains, modifiers and
@@ -162,11 +169,15 @@ func ParseRstestExpectCall(
 // no-standalone-expect (src/rules/no-standalone-expect.ts:89-98). The member
 // count condition is upstream's members.length === 1: two-member forms such as
 // expect.not.stringContaining(...) or expect.soft(x).toBe(1) stay reportable.
+//
+// The check is structural on purpose and never consults a matcher-name table,
+// so a custom asymmetric matcher registered through expect.extend behaves like
+// a built-in one.
 func IsStaticRstestExpectCall(parsed *ParsedRstestExpectCall) bool {
 	return parsed != nil &&
 		!parsed.rootInvoked &&
 		parsed.trailingMembers == 1 &&
-		parsed.Entry != RstestExpectEntryAssertions
+		!RSTEST_EXPECT_ASSERTION_COUNT_MEMBERS[parsed.Matcher]
 }
 
 // ShouldRstestExpectBeAwaited reports whether the assertion produces a promise
@@ -314,7 +325,7 @@ func classifyRstestExpectCall(
 			// Static member access on the expect object. The chain keeps the
 			// member: the walk resolves it as the matcher (expect.assertions(1)
 			// yields Matcher "assertions"), matching jest and vitest.
-			parsed.Entry = classifyStaticExpectEntry(rest)
+			parsed.Entry = RstestExpectEntryStatic
 		}
 	}
 
@@ -351,37 +362,6 @@ func hasComputedDynamicRstestExpectMember(entries []testFramework.MemberEntry) b
 		}
 	}
 	return false
-}
-
-// classifyStaticExpectEntry names the ExpectStatic surface behind a not-invoked
-// expect root. rest is never empty here.
-func classifyStaticExpectEntry(rest []testFramework.MemberEntry) RstestExpectEntry {
-	name := rest[0].Name
-	switch {
-	case name == "unreachable":
-		return RstestExpectEntryUnreachable
-	case name == "assertions", name == "hasAssertions":
-		return RstestExpectEntryAssertions
-	case rstestExpectConfigMembers[name]:
-		return RstestExpectEntryConfig
-	case name == "not" && len(rest) > 1 && RSTEST_ASYMMETRIC_MATCHERS[rest[1].Name]:
-		// ExpectStatic.not.stringContaining(...): the static negation of an
-		// asymmetric matcher, unrelated to the Assertion.not modifier.
-		return RstestExpectEntryAsymmetric
-	case RSTEST_EXPECT_MODIFIER_NAMES[name]:
-		// expect.resolves.toBe(1) and friends: a bare modifier chain whose
-		// expect head was never invoked. It parses like a plain chain with a
-		// nil Head, mirroring vitest's null expectCall.
-		return RstestExpectEntryCall
-	case rstestExpectFactoryEntries[name] != "":
-		// A factory member that was not invoked, e.g. expect.soft.foo(1); the
-		// walk rejects the chain with modifier-unknown.
-		return rstestExpectFactoryEntries[name]
-	default:
-		// Known asymmetric matchers, plus unknown static members that may be
-		// custom asymmetric matchers registered through expect.extend.
-		return RstestExpectEntryAsymmetric
-	}
 }
 
 type rstestExpectChainKind uint8

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -54,6 +54,24 @@ const (
 	RstestExpectParseReasonModifierUnknown  RstestExpectParseReason = "modifier-unknown"
 )
 
+// RstestExpectMatcherKind records whether an assertion executes through a
+// method call or through a Chai property getter.
+type RstestExpectMatcherKind string
+
+const (
+	RstestExpectMatcherCall     RstestExpectMatcherKind = "call"
+	RstestExpectMatcherProperty RstestExpectMatcherKind = "property"
+)
+
+// ParsedRstestExpectMatcher describes one matcher in an assertion chain.
+// Chai permits multiple assertions in one chain, so callers that need the
+// complete chain should use ParsedRstestExpectCall.Matchers.
+type ParsedRstestExpectMatcher struct {
+	Name  string
+	Entry ParsedRstestFnMemberEntry
+	Kind  RstestExpectMatcherKind
+}
+
 // ParsedRstestExpectCall describes one Rstest expect call.
 //
 // Contract: ParseRstestExpectCall returns nil if and only if the node is not a
@@ -63,6 +81,10 @@ const (
 // deliberately improves on jest's ParseJestFnCall, which returns nil for
 // broken chains and forces valid-expect to re-derive the reason.
 type ParsedRstestExpectCall struct {
+	// Expression is the outermost assertion expression. It is a call for
+	// method-style chains and a member access for property-style Chai
+	// assertions such as expect(value).to.be.ok.
+	Expression *ast.Node
 	// Head is the assertion factory call: expect(x), expect.soft(x),
 	// expect.poll(fn) or expect.element(loc). It is nil for static member
 	// calls such as expect.assertions(1) and for bare modifier chains such as
@@ -72,6 +94,12 @@ type ParsedRstestExpectCall struct {
 	Head *ast.Node
 	// Entry classifies the ExpectStatic surface the call goes through.
 	Entry RstestExpectEntry
+	// Members contains the complete source chain after the resolved expect
+	// root, including assertion factories, Chai language chains, modifiers and
+	// every matcher.
+	Members []string
+	// MemberEntries parallels Members and carries the AST nodes.
+	MemberEntries []ParsedRstestFnMemberEntry
 	// Modifiers holds the modifier names before the matcher, in source order.
 	Modifiers []string
 	// ModifierEntries parallels Modifiers and carries the AST nodes.
@@ -82,6 +110,9 @@ type ParsedRstestExpectCall struct {
 	Matcher string
 	// MatcherEntry carries the matcher's AST node; nil when Reason is set.
 	MatcherEntry *ParsedRstestFnMemberEntry
+	// Matchers contains every matcher in source order. Matcher and MatcherEntry
+	// mirror the first element for compatibility with matcher-consuming rules.
+	Matchers []ParsedRstestExpectMatcher
 	// Reason explains why no matcher was resolved.
 	Reason RstestExpectParseReason
 
@@ -114,12 +145,13 @@ func ParseRstestExpectCall(
 	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
 		return nil
 	}
-	entries := testFramework.GetMemberEntries(node)
+	expression := findTopMostRstestExpectExpression(node)
+	entries := testFramework.GetMemberEntries(expression)
 	expectIndex, ok := rstestExpectMemberIndex(node, entries, ctx, callbacks)
 	if !ok {
 		return nil
 	}
-	return classifyRstestExpectCall(node, entries, expectIndex)
+	return classifyRstestExpectCall(expression, entries, expectIndex)
 }
 
 // IsStaticRstestExpectCall reports calls of a single static member on the
@@ -183,6 +215,34 @@ func FindTopMostCallExpression(node *ast.Node) *ast.Node {
 	return top
 }
 
+// findTopMostRstestExpectExpression extends the outermost call through a
+// trailing static member chain. This lets the CallExpression-only parser see
+// property-style Chai assertions such as expect(value).to.be.ok without
+// requiring rules to listen for member-access nodes.
+func findTopMostRstestExpectExpression(node *ast.Node) *ast.Node {
+	top := node
+	current := node
+	for parent := current.Parent; parent != nil; {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+		case ast.KindPropertyAccessExpression:
+			if parent.AsPropertyAccessExpression().Expression != current {
+				return top
+			}
+			top = parent
+		case ast.KindElementAccessExpression:
+			if parent.AsElementAccessExpression().Expression != current {
+				return top
+			}
+			top = parent
+		default:
+			return top
+		}
+		current, parent = parent, parent.Parent
+	}
+	return top
+}
+
 // rstestExpectMemberIndex resolves whether node is an expect call and where
 // the expect member sits in entries: 0 when the root identifier itself is
 // expect (imports, globals, destructured context), 1 when the root is a
@@ -213,17 +273,26 @@ func rstestExpectMemberIndex(
 }
 
 func classifyRstestExpectCall(
-	node *ast.Node,
+	expression *ast.Node,
 	entries []testFramework.MemberEntry,
 	expectIndex int,
 ) *ParsedRstestExpectCall {
 	expectEntry := entries[expectIndex]
 	rest := entries[expectIndex+1:]
 	parsed := &ParsedRstestExpectCall{
+		Expression:      expression,
 		Entry:           RstestExpectEntryCall,
 		Head:            expectEntry.Call,
 		rootInvoked:     expectEntry.Call != nil,
 		trailingMembers: len(rest),
+	}
+	if len(rest) > 0 {
+		parsed.Members = make([]string, len(rest))
+		parsed.MemberEntries = make([]ParsedRstestFnMemberEntry, len(rest))
+		for i, entry := range rest {
+			parsed.Members[i] = entry.Name
+			parsed.MemberEntries[i] = entry
+		}
 	}
 
 	chain := rest
@@ -249,14 +318,21 @@ func classifyRstestExpectCall(
 		}
 	}
 
-	modifierEntries, matcher, reason := findRstestExpectModifiersAndMatcher(chain)
+	modifierEntries, matchers, reason := findRstestExpectModifiersAndMatchers(
+		chain,
+		!parsed.rootInvoked && parsed.Head == nil,
+	)
 	parsed.Reason = reason
-	if reason == RstestExpectParseReasonMatcherNotFound && isMemberAccessNode(node.Parent) {
+	if reason == RstestExpectParseReasonMatcherNotFound &&
+		len(chain) > 0 &&
+		isMemberAccessNode(expression) &&
+		!hasComputedDynamicRstestExpectMember(chain) {
 		parsed.Reason = RstestExpectParseReasonMatcherNotCalled
 	}
-	if matcher != nil {
-		parsed.Matcher = matcher.Name
-		parsed.MatcherEntry = matcher
+	if len(matchers) > 0 {
+		parsed.Matchers = matchers
+		parsed.Matcher = matchers[0].Name
+		parsed.MatcherEntry = &parsed.Matchers[0].Entry
 		parsed.ModifierEntries = modifierEntries
 		if len(modifierEntries) > 0 {
 			parsed.Modifiers = make([]string, len(modifierEntries))
@@ -266,6 +342,15 @@ func classifyRstestExpectCall(
 		}
 	}
 	return parsed
+}
+
+func hasComputedDynamicRstestExpectMember(entries []testFramework.MemberEntry) bool {
+	for _, entry := range entries {
+		if entry.Node != nil && isComputedDynamicMemberName(entry.Node) {
+			return true
+		}
+	}
+	return false
 }
 
 // classifyStaticExpectEntry names the ExpectStatic surface behind a not-invoked
@@ -299,47 +384,84 @@ func classifyStaticExpectEntry(rest []testFramework.MemberEntry) RstestExpectEnt
 	}
 }
 
-// findRstestExpectModifiersAndMatcher locates the matcher — the first chain
-// member whose enclosing member access is invoked — and validates the
-// modifiers before it, mirroring Vitest's expect-chain validation: not may
-// appear at most once, and resolves / rejects may appear at most once in
-// total, regardless of their order.
-func findRstestExpectModifiersAndMatcher(entries []testFramework.MemberEntry) (
+type rstestExpectChainKind uint8
+
+const (
+	rstestExpectChainUnknown rstestExpectChainKind = iota
+	rstestExpectChainLanguage
+	rstestExpectChainModifier
+	rstestExpectChainMatcher
+)
+
+type rstestExpectChainEntry struct {
+	Entry       ParsedRstestFnMemberEntry
+	Kind        rstestExpectChainKind
+	MatcherKind RstestExpectMatcherKind
+}
+
+// findRstestExpectModifiersAndMatchers classifies the complete assertion
+// chain, returns every matcher in source order and validates the language and
+// modifier members around them. Matcher and MatcherEntry on the public result
+// continue to expose the first matcher for compatibility.
+func findRstestExpectModifiersAndMatchers(
+	entries []testFramework.MemberEntry,
+	isStaticExpectChain bool,
+) (
 	[]ParsedRstestFnMemberEntry,
-	*ParsedRstestFnMemberEntry,
+	[]ParsedRstestExpectMatcher,
 	RstestExpectParseReason,
 ) {
 	if len(entries) == 0 {
 		return nil, nil, RstestExpectParseReasonMatcherNotFound
 	}
 
-	modifiers := make([]ParsedRstestFnMemberEntry, 0, len(entries))
-	notCount := 0
-	promiseModifierCount := 0
-	for _, member := range entries {
+	chains := make([]rstestExpectChainEntry, len(entries))
+	matcherIndex := -1
+	for i, member := range entries {
 		if member.Node == nil {
 			return nil, nil, RstestExpectParseReasonModifierUnknown
 		}
 		if isComputedDynamicMemberName(member.Node) {
-			// expect(x)[matcherName](1): the member name cannot be resolved
-			// statically, so no matcher can be located.
 			return nil, nil, RstestExpectParseReasonMatcherNotFound
 		}
-		parent := member.Node.Parent
-		if parent == nil {
+		chains[i] = classifyRstestExpectChainEntry(
+			member,
+			isStaticExpectChain && i == 0,
+		)
+		if matcherIndex == -1 && chains[i].Kind == rstestExpectChainMatcher {
+			matcherIndex = i
+		}
+	}
+
+	modifierEnd := matcherIndex
+	if modifierEnd == -1 {
+		modifierEnd = len(chains)
+	}
+	modifiers := make([]ParsedRstestFnMemberEntry, 0, modifierEnd)
+	notCount := 0
+	promiseModifierCount := 0
+	for i := range modifierEnd {
+		chain := chains[i]
+		if chain.Kind == rstestExpectChainUnknown {
+			// With no matcher, an unknown terminal member may simply be a
+			// matcher whose call was omitted. Earlier unknown members make the
+			// chain invalid.
+			if matcherIndex == -1 && i == len(chains)-1 {
+				continue
+			}
+			return nil, nil, RstestExpectParseReasonModifierUnknown
+		}
+		if chain.Kind == rstestExpectChainLanguage {
+			if chain.Entry.Call != nil {
+				return nil, nil, RstestExpectParseReasonModifierUnknown
+			}
+			continue
+		}
+		if chain.Kind != rstestExpectChainModifier {
 			return nil, nil, RstestExpectParseReasonModifierUnknown
 		}
 
-		grandparent := ast.WalkUpParenthesizedExpressions(parent.Parent)
-		if grandparent != nil && grandparent.Kind == ast.KindCallExpression {
-			return modifiers, &member, RstestExpectParseReasonNone
-		}
-
-		if !RSTEST_EXPECT_MODIFIER_NAMES[member.Name] {
-			return nil, nil, RstestExpectParseReasonModifierUnknown
-		}
-
-		if member.Name == "not" {
+		if chain.Entry.Name == "not" {
 			notCount++
 			if notCount > 1 {
 				return nil, nil, RstestExpectParseReasonModifierUnknown
@@ -351,10 +473,89 @@ func findRstestExpectModifiersAndMatcher(entries []testFramework.MemberEntry) (
 			}
 		}
 
-		modifiers = append(modifiers, member)
+		modifiers = append(modifiers, chain.Entry)
 	}
 
-	return nil, nil, RstestExpectParseReasonMatcherNotFound
+	if matcherIndex == -1 {
+		return nil, nil, RstestExpectParseReasonMatcherNotFound
+	}
+
+	matchers := make([]ParsedRstestExpectMatcher, 0, len(chains)-matcherIndex)
+	for i := matcherIndex; i < len(chains); i++ {
+		chain := chains[i]
+		switch chain.Kind {
+		case rstestExpectChainMatcher:
+			matchers = append(matchers, ParsedRstestExpectMatcher{
+				Name:  chain.Entry.Name,
+				Entry: chain.Entry,
+				Kind:  chain.MatcherKind,
+			})
+		case rstestExpectChainLanguage:
+			if chain.Entry.Call != nil {
+				return nil, nil, RstestExpectParseReasonModifierUnknown
+			}
+		case rstestExpectChainModifier:
+			// Chai permits modifiers between assertions in a multi-matcher
+			// chain, e.g. .a("string").that.does.not.contain("x").
+		case rstestExpectChainUnknown:
+			return nil, nil, RstestExpectParseReasonModifierUnknown
+		}
+	}
+
+	return modifiers, matchers, RstestExpectParseReasonNone
+}
+
+func classifyRstestExpectChainEntry(
+	entry ParsedRstestFnMemberEntry,
+	isFirstStaticMember bool,
+) rstestExpectChainEntry {
+	name := entry.Name
+	if entry.Call != nil {
+		if isFirstStaticMember && name == "any" {
+			return rstestExpectChainEntry{
+				Entry:       entry,
+				Kind:        rstestExpectChainMatcher,
+				MatcherKind: RstestExpectMatcherCall,
+			}
+		}
+		if rstestChaiPropertyMatchers[name] ||
+			RSTEST_EXPECT_MODIFIER_NAMES[name] ||
+			(rstestChaiChainableMembers[name] && !rstestChaiDualRoleChains[name]) {
+			return rstestExpectChainEntry{
+				Entry: entry,
+				Kind:  rstestExpectChainLanguage,
+			}
+		}
+		return rstestExpectChainEntry{
+			Entry:       entry,
+			Kind:        rstestExpectChainMatcher,
+			MatcherKind: RstestExpectMatcherCall,
+		}
+	}
+
+	if rstestChaiPropertyMatchers[name] {
+		return rstestExpectChainEntry{
+			Entry:       entry,
+			Kind:        rstestExpectChainMatcher,
+			MatcherKind: RstestExpectMatcherProperty,
+		}
+	}
+	if rstestChaiChainableMembers[name] {
+		return rstestExpectChainEntry{
+			Entry: entry,
+			Kind:  rstestExpectChainLanguage,
+		}
+	}
+	if RSTEST_EXPECT_MODIFIER_NAMES[name] {
+		return rstestExpectChainEntry{
+			Entry: entry,
+			Kind:  rstestExpectChainModifier,
+		}
+	}
+	return rstestExpectChainEntry{
+		Entry: entry,
+		Kind:  rstestExpectChainUnknown,
+	}
 }
 
 // isComputedDynamicMemberName reports member name nodes that came from a

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -301,8 +301,9 @@ func classifyStaticExpectEntry(rest []testFramework.MemberEntry) RstestExpectEnt
 
 // findRstestExpectModifiersAndMatcher locates the matcher — the first chain
 // member whose enclosing member access is invoked — and validates the
-// modifiers before it, mirroring jest's FindExpectModifiersAndMatcher: no
-// modifier may repeat, and not may only follow resolves or rejects.
+// modifiers before it, mirroring Vitest's expect-chain validation: not may
+// appear at most once, and resolves / rejects may appear at most once in
+// total, regardless of their order.
 func findRstestExpectModifiersAndMatcher(entries []testFramework.MemberEntry) (
 	[]ParsedRstestFnMemberEntry,
 	*ParsedRstestFnMemberEntry,
@@ -313,6 +314,8 @@ func findRstestExpectModifiersAndMatcher(entries []testFramework.MemberEntry) (
 	}
 
 	modifiers := make([]ParsedRstestFnMemberEntry, 0, len(entries))
+	notCount := 0
+	promiseModifierCount := 0
 	for _, member := range entries {
 		if member.Node == nil {
 			return nil, nil, RstestExpectParseReasonModifierUnknown
@@ -332,21 +335,20 @@ func findRstestExpectModifiersAndMatcher(entries []testFramework.MemberEntry) (
 			return modifiers, &member, RstestExpectParseReasonNone
 		}
 
-		switch len(modifiers) {
-		case 0:
-			if !RSTEST_EXPECT_MODIFIER_NAMES[member.Name] {
-				return nil, nil, RstestExpectParseReasonModifierUnknown
-			}
-		case 1:
-			if member.Name != "not" {
-				return nil, nil, RstestExpectParseReasonModifierUnknown
-			}
-			first := modifiers[0].Name
-			if first != "rejects" && first != "resolves" {
-				return nil, nil, RstestExpectParseReasonModifierUnknown
-			}
-		default:
+		if !RSTEST_EXPECT_MODIFIER_NAMES[member.Name] {
 			return nil, nil, RstestExpectParseReasonModifierUnknown
+		}
+
+		if member.Name == "not" {
+			notCount++
+			if notCount > 1 {
+				return nil, nil, RstestExpectParseReasonModifierUnknown
+			}
+		} else {
+			promiseModifierCount++
+			if promiseModifierCount > 1 {
+				return nil, nil, RstestExpectParseReasonModifierUnknown
+			}
 		}
 
 		modifiers = append(modifiers, member)

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -1,40 +1,162 @@
 package utils
 
 import (
+	"slices"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
+
+// RstestExpectEntry classifies which ExpectStatic surface a parsed expect call
+// goes through.
+type RstestExpectEntry string
+
+const (
+	// RstestExpectEntryCall covers plain expect(x) chains, and also bare
+	// modifier chains such as expect.resolves.toBe(1) where the expect head was
+	// never invoked; the latter parse with Head == nil.
+	RstestExpectEntryCall RstestExpectEntry = "expect"
+	// RstestExpectEntrySoft covers expect.soft(x) chains.
+	RstestExpectEntrySoft RstestExpectEntry = "soft"
+	// RstestExpectEntryPoll covers expect.poll(fn) chains.
+	RstestExpectEntryPoll RstestExpectEntry = "poll"
+	// RstestExpectEntryElement covers expect.element(locator) chains.
+	RstestExpectEntryElement RstestExpectEntry = "element"
+	// RstestExpectEntryUnreachable covers expect.unreachable(...).
+	RstestExpectEntryUnreachable RstestExpectEntry = "unreachable"
+	// RstestExpectEntryAssertions covers expect.assertions(n) and
+	// expect.hasAssertions().
+	RstestExpectEntryAssertions RstestExpectEntry = "assertions"
+	// RstestExpectEntryAsymmetric covers static matcher value constructors:
+	// expect.stringContaining(...), expect.not.arrayContaining(...), and
+	// unknown static members, which may be custom asymmetric matchers
+	// registered through expect.extend.
+	RstestExpectEntryAsymmetric RstestExpectEntry = "asymmetric"
+	// RstestExpectEntryConfig covers runtime configuration members such as
+	// expect.extend(...) or expect.getState().
+	RstestExpectEntryConfig RstestExpectEntry = "config"
+)
+
+// RstestExpectParseReason explains why a parsed expect call carries no
+// matcher. The values and their triggers mirror eslint-plugin-jest and
+// eslint-plugin-vitest.
+type RstestExpectParseReason string
+
+const (
+	RstestExpectParseReasonNone            RstestExpectParseReason = ""
+	RstestExpectParseReasonMatcherNotFound RstestExpectParseReason = "matcher-not-found"
+	// RstestExpectParseReasonMatcherNotCalled reports chains that end on an
+	// member access that is never invoked, e.g. expect(x).toBe; — the mapping is
+	// the one jest/valid-expect and vitest apply: the matcher walk found
+	// nothing and the call itself sits under a member access.
+	RstestExpectParseReasonMatcherNotCalled RstestExpectParseReason = "matcher-not-called"
+	RstestExpectParseReasonModifierUnknown  RstestExpectParseReason = "modifier-unknown"
+)
+
+// ParsedRstestExpectCall describes one Rstest expect call.
+//
+// Contract: ParseRstestExpectCall returns nil if and only if the node is not a
+// Rstest expect call (which includes calls in the middle of a larger chain);
+// once a node is recognized as an expect call the parse always succeeds and
+// broken chains are reported through Reason instead of a nil result. This
+// deliberately improves on jest's ParseJestFnCall, which returns nil for
+// broken chains and forces valid-expect to re-derive the reason.
+type ParsedRstestExpectCall struct {
+	// Head is the assertion factory call: expect(x), expect.soft(x),
+	// expect.poll(fn) or expect.element(loc). It is nil for static member
+	// calls such as expect.assertions(1) and for bare modifier chains such as
+	// expect.resolves.toBe(1) — the same shapes eslint-plugin-vitest reports
+	// with a null expectCall. Consumers that need the factory arguments must
+	// check for nil.
+	Head *ast.Node
+	// Entry classifies the ExpectStatic surface the call goes through.
+	Entry RstestExpectEntry
+	// Modifiers holds the modifier names before the matcher, in source order.
+	Modifiers []string
+	// ModifierEntries parallels Modifiers and carries the AST nodes.
+	ModifierEntries []ParsedRstestFnMemberEntry
+	// Matcher is the resolved matcher name; empty when Reason is set. Static
+	// member calls resolve their member as the matcher (expect.assertions(1)
+	// has Matcher "assertions"), mirroring jest and vitest.
+	Matcher string
+	// MatcherEntry carries the matcher's AST node; nil when Reason is set.
+	MatcherEntry *ParsedRstestFnMemberEntry
+	// Reason explains why no matcher was resolved.
+	Reason RstestExpectParseReason
+
+	// rootInvoked and trailingMembers feed IsStaticRstestExpectCall, which
+	// needs the syntactic shape rather than the chain semantics.
+	rootInvoked     bool
+	trailingMembers int
+}
 
 func IsRstestExpectCall(
 	node *ast.Node,
 	ctx rule.RuleContext,
 	callbacks RstestTestCallbacks,
 ) bool {
-	if node == nil || node.Kind != ast.KindCallExpression || findTopMostCallExpression(node) != node {
+	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
 		return false
 	}
-
-	if isImportMetaRstestExpectCall(node) {
-		return true
-	}
-
-	entries := testFramework.GetMemberEntries(node)
-	if len(entries) == 0 || entries[0].Node == nil || entries[0].Node.Kind != ast.KindIdentifier {
-		return false
-	}
-
-	root := entries[0].Node
-	if isContextExpectRoot(root, entries, ctx, callbacks) {
-		return true
-	}
-	return isImportedOrGlobalExpectRoot(root, entries, ctx)
+	_, ok := rstestExpectMemberIndex(node, testFramework.GetMemberEntries(node), ctx, callbacks)
+	return ok
 }
 
-// findTopMostCallExpression walks up the call/member chain that node is the
+// ParseRstestExpectCall parses node as a Rstest expect call, resolving the
+// entry kind, the modifier chain and the matcher. See ParsedRstestExpectCall
+// for the nil contract.
+func ParseRstestExpectCall(
+	node *ast.Node,
+	ctx rule.RuleContext,
+	callbacks RstestTestCallbacks,
+) *ParsedRstestExpectCall {
+	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
+		return nil
+	}
+	entries := testFramework.GetMemberEntries(node)
+	expectIndex, ok := rstestExpectMemberIndex(node, entries, ctx, callbacks)
+	if !ok {
+		return nil
+	}
+	return classifyRstestExpectCall(node, entries, expectIndex)
+}
+
+// IsStaticRstestExpectCall reports calls of a single static member on the
+// expect object itself, e.g. expect.anything() or expect.getState(), which
+// rules like no-standalone-expect must not treat as standalone assertions.
+// expect.assertions(n) and expect.hasAssertions() are deliberately excluded —
+// they are misplaced outside test blocks — mirroring eslint-plugin-jest's
+// no-standalone-expect (src/rules/no-standalone-expect.ts:89-98). The member
+// count condition is upstream's members.length === 1: two-member forms such as
+// expect.not.stringContaining(...) or expect.soft(x).toBe(1) stay reportable.
+func IsStaticRstestExpectCall(parsed *ParsedRstestExpectCall) bool {
+	return parsed != nil &&
+		!parsed.rootInvoked &&
+		parsed.trailingMembers == 1 &&
+		parsed.Entry != RstestExpectEntryAssertions
+}
+
+// ShouldRstestExpectBeAwaited reports whether the assertion produces a promise
+// that valid-expect requires to be awaited or returned: any modifier other
+// than not (resolves / rejects), or a matcher the rule's asyncMatchers option
+// declares async. Mirrors jest's shouldBeAwaited (valid_expect.go).
+func ShouldRstestExpectBeAwaited(parsed *ParsedRstestExpectCall, asyncMatchers []string) bool {
+	if parsed == nil {
+		return false
+	}
+	for _, modifier := range parsed.Modifiers {
+		if modifier != "not" {
+			return true
+		}
+	}
+	return slices.Contains(asyncMatchers, parsed.Matcher)
+}
+
+// FindTopMostCallExpression walks up the call/member chain that node is the
 // head of. Ascending only continues while node stays on the callee side of its
 // parent: a call in argument or computed-key position heads its own chain.
-func findTopMostCallExpression(node *ast.Node) *ast.Node {
+func FindTopMostCallExpression(node *ast.Node) *ast.Node {
 	top := node
 	current := node
 	for parent := current.Parent; parent != nil; {
@@ -61,32 +183,243 @@ func findTopMostCallExpression(node *ast.Node) *ast.Node {
 	return top
 }
 
-func isContextExpectRoot(
+// rstestExpectMemberIndex resolves whether node is an expect call and where
+// the expect member sits in entries: 0 when the root identifier itself is
+// expect (imports, globals, destructured context), 1 when the root is a
+// receiver (namespace object, import.meta.rstest, test context).
+func rstestExpectMemberIndex(
+	node *ast.Node,
+	entries []testFramework.MemberEntry,
+	ctx rule.RuleContext,
+	callbacks RstestTestCallbacks,
+) (int, bool) {
+	if isImportMetaRstestExpectCall(node) {
+		// GetMemberEntries cannot represent the import.meta prefix and starts
+		// the chain at the rstest property, so expect sits at index 1.
+		if len(entries) > 1 && entries[1].Name == "expect" {
+			return 1, true
+		}
+		return 0, false
+	}
+
+	if len(entries) == 0 || entries[0].Node == nil || entries[0].Node.Kind != ast.KindIdentifier {
+		return 0, false
+	}
+	root := entries[0].Node
+	if index, ok := contextExpectMemberIndex(root, entries, ctx, callbacks); ok {
+		return index, true
+	}
+	return importedOrGlobalExpectMemberIndex(root, entries, ctx)
+}
+
+func classifyRstestExpectCall(
+	node *ast.Node,
+	entries []testFramework.MemberEntry,
+	expectIndex int,
+) *ParsedRstestExpectCall {
+	expectEntry := entries[expectIndex]
+	rest := entries[expectIndex+1:]
+	parsed := &ParsedRstestExpectCall{
+		Entry:           RstestExpectEntryCall,
+		Head:            expectEntry.Call,
+		rootInvoked:     expectEntry.Call != nil,
+		trailingMembers: len(rest),
+	}
+
+	chain := rest
+	if !parsed.rootInvoked {
+		if len(rest) == 0 {
+			// GetMemberEntries marks the last entry of a call's callee chain as
+			// invoked, so a top-most call whose expect root is not invoked always
+			// has trailing members. Defensive only.
+			return nil
+		}
+		if entry, ok := rstestExpectFactoryEntries[rest[0].Name]; ok && rest[0].Call != nil {
+			// expect.soft(x) / expect.poll(fn) / expect.element(loc): the factory
+			// call replaces expect(x) as the assertion head and the chain resumes
+			// after it.
+			parsed.Entry = entry
+			parsed.Head = rest[0].Call
+			chain = rest[1:]
+		} else {
+			// Static member access on the expect object. The chain keeps the
+			// member: the walk resolves it as the matcher (expect.assertions(1)
+			// yields Matcher "assertions"), matching jest and vitest.
+			parsed.Entry = classifyStaticExpectEntry(rest)
+		}
+	}
+
+	modifierEntries, matcher, reason := findRstestExpectModifiersAndMatcher(chain)
+	parsed.Reason = reason
+	if reason == RstestExpectParseReasonMatcherNotFound && isMemberAccessNode(node.Parent) {
+		parsed.Reason = RstestExpectParseReasonMatcherNotCalled
+	}
+	if matcher != nil {
+		parsed.Matcher = matcher.Name
+		parsed.MatcherEntry = matcher
+		parsed.ModifierEntries = modifierEntries
+		if len(modifierEntries) > 0 {
+			parsed.Modifiers = make([]string, len(modifierEntries))
+			for i, entry := range modifierEntries {
+				parsed.Modifiers[i] = entry.Name
+			}
+		}
+	}
+	return parsed
+}
+
+// classifyStaticExpectEntry names the ExpectStatic surface behind a not-invoked
+// expect root. rest is never empty here.
+func classifyStaticExpectEntry(rest []testFramework.MemberEntry) RstestExpectEntry {
+	name := rest[0].Name
+	switch {
+	case name == "unreachable":
+		return RstestExpectEntryUnreachable
+	case name == "assertions", name == "hasAssertions":
+		return RstestExpectEntryAssertions
+	case rstestExpectConfigMembers[name]:
+		return RstestExpectEntryConfig
+	case name == "not" && len(rest) > 1 && RSTEST_ASYMMETRIC_MATCHERS[rest[1].Name]:
+		// ExpectStatic.not.stringContaining(...): the static negation of an
+		// asymmetric matcher, unrelated to the Assertion.not modifier.
+		return RstestExpectEntryAsymmetric
+	case RSTEST_EXPECT_MODIFIER_NAMES[name]:
+		// expect.resolves.toBe(1) and friends: a bare modifier chain whose
+		// expect head was never invoked. It parses like a plain chain with a
+		// nil Head, mirroring vitest's null expectCall.
+		return RstestExpectEntryCall
+	case rstestExpectFactoryEntries[name] != "":
+		// A factory member that was not invoked, e.g. expect.soft.foo(1); the
+		// walk rejects the chain with modifier-unknown.
+		return rstestExpectFactoryEntries[name]
+	default:
+		// Known asymmetric matchers, plus unknown static members that may be
+		// custom asymmetric matchers registered through expect.extend.
+		return RstestExpectEntryAsymmetric
+	}
+}
+
+// findRstestExpectModifiersAndMatcher locates the matcher — the first chain
+// member whose enclosing member access is invoked — and validates the
+// modifiers before it, mirroring jest's FindExpectModifiersAndMatcher: no
+// modifier may repeat, and not may only follow resolves or rejects.
+func findRstestExpectModifiersAndMatcher(entries []testFramework.MemberEntry) (
+	[]ParsedRstestFnMemberEntry,
+	*ParsedRstestFnMemberEntry,
+	RstestExpectParseReason,
+) {
+	if len(entries) == 0 {
+		return nil, nil, RstestExpectParseReasonMatcherNotFound
+	}
+
+	modifiers := make([]ParsedRstestFnMemberEntry, 0, len(entries))
+	for _, member := range entries {
+		if member.Node == nil {
+			return nil, nil, RstestExpectParseReasonModifierUnknown
+		}
+		if isComputedDynamicMemberName(member.Node) {
+			// expect(x)[matcherName](1): the member name cannot be resolved
+			// statically, so no matcher can be located.
+			return nil, nil, RstestExpectParseReasonMatcherNotFound
+		}
+		parent := member.Node.Parent
+		if parent == nil {
+			return nil, nil, RstestExpectParseReasonModifierUnknown
+		}
+
+		grandparent := ast.WalkUpParenthesizedExpressions(parent.Parent)
+		if grandparent != nil && grandparent.Kind == ast.KindCallExpression {
+			return modifiers, &member, RstestExpectParseReasonNone
+		}
+
+		switch len(modifiers) {
+		case 0:
+			if !RSTEST_EXPECT_MODIFIER_NAMES[member.Name] {
+				return nil, nil, RstestExpectParseReasonModifierUnknown
+			}
+		case 1:
+			if member.Name != "not" {
+				return nil, nil, RstestExpectParseReasonModifierUnknown
+			}
+			first := modifiers[0].Name
+			if first != "rejects" && first != "resolves" {
+				return nil, nil, RstestExpectParseReasonModifierUnknown
+			}
+		default:
+			return nil, nil, RstestExpectParseReasonModifierUnknown
+		}
+
+		modifiers = append(modifiers, member)
+	}
+
+	return nil, nil, RstestExpectParseReasonMatcherNotFound
+}
+
+// isComputedDynamicMemberName reports member name nodes that came from a
+// computed element access with an identifier key, e.g. expect(x)[matcherName].
+// GetMemberEntries records the identifier's text as the member name, but the
+// runtime value is unknowable statically. String literal keys are fine.
+func isComputedDynamicMemberName(node *ast.Node) bool {
+	if node.Kind != ast.KindIdentifier {
+		return false
+	}
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	return parent != nil &&
+		parent.Kind == ast.KindElementAccessExpression &&
+		parent.AsElementAccessExpression().Expression != node
+}
+
+func isMemberAccessNode(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+// contextExpectMemberIndex resolves expect calls that come from a test context
+// parameter: ({ expect }) => expect(x)... at index 0, ctx => ctx.expect(x)...
+// at index 1.
+func contextExpectMemberIndex(
 	root *ast.Node,
 	entries []testFramework.MemberEntry,
 	ctx rule.RuleContext,
 	callbacks RstestTestCallbacks,
-) bool {
+) (int, bool) {
 	if ctx.TypeChecker == nil {
-		return false
+		return 0, false
 	}
 	symbol := ctx.TypeChecker.GetSymbolAtLocation(root)
 	if symbol == nil {
-		return false
+		return 0, false
 	}
 	if callbacks.ContextExpectNames[symbol] {
-		return true
+		return 0, true
 	}
-	return callbacks.ContextReceivers[symbol] &&
+	if callbacks.ContextReceivers[symbol] &&
 		len(entries) > 1 &&
-		entries[1].Name == "expect"
+		entries[1].Name == "expect" {
+		return 1, true
+	}
+	return 0, false
 }
 
-func isImportedOrGlobalExpectRoot(
+// importedOrGlobalExpectMemberIndex resolves expect calls whose root is an
+// import, a global, a require binding, an import.meta.rstest alias, or a
+// module namespace: direct bindings put expect at index 0, receiver objects at
+// index 1.
+func importedOrGlobalExpectMemberIndex(
 	root *ast.Node,
 	entries []testFramework.MemberEntry,
 	ctx rule.RuleContext,
-) bool {
+) (int, bool) {
 	localName := root.AsIdentifier().Text
 	var symbol *ast.Symbol
 	if ctx.TypeChecker != nil {
@@ -94,10 +427,13 @@ func isImportedOrGlobalExpectRoot(
 	}
 
 	if name, _, ok := resolveImportMetaRstestBinding(symbol); ok {
-		return name == "expect"
+		return 0, name == "expect"
 	}
 	if isImportMetaRstestObjectAlias(symbol) {
-		return len(entries) > 1 && entries[1].Name == "expect"
+		if len(entries) > 1 && entries[1].Name == "expect" {
+			return 1, true
+		}
+		return 0, false
 	}
 
 	for _, module := range []string{RstestImportModule, RstestPlaywrightImportModule} {
@@ -109,15 +445,15 @@ func isImportedOrGlobalExpectRoot(
 			module,
 		)
 		if name == "expect" {
-			return true
+			return 0, true
 		}
 		if testFramework.IsModuleNamespaceSymbol(symbol, module) &&
 			len(entries) > 1 &&
 			entries[1].Name == "expect" {
-			return true
+			return 1, true
 		}
 	}
-	return false
+	return 0, false
 }
 
 func isImportMetaRstestExpectCall(node *ast.Node) bool {

--- a/internal/plugins/rstest/utils/parse_rstest_expect_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect_test.go
@@ -111,6 +111,72 @@ func parsedExpectError(message string) []rule_tester.InvalidTestCaseError {
 	return []rule_tester.InvalidTestCaseError{{MessageId: "parsedExpect", Message: message}}
 }
 
+// expectEntryInvariantProbe reports only when Entry and Head disagree, so the
+// corpus below passes as valid test cases and any violation surfaces as an
+// unexpected error rather than as a diff a reader has to spot.
+var expectEntryInvariantProbe = rule.Rule{
+	Name: "rstest/probe-expect-entry-invariant",
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				if parsed == nil {
+					return
+				}
+				isStatic := parsed.Entry == rstestUtils.RstestExpectEntryStatic
+				if isStatic == (parsed.Head == nil) {
+					return
+				}
+				ctx.ReportNode(node, probeMessage("parsedExpect", fmt.Sprintf(
+					"invariant broken: entry=%s head=%t", parsed.Entry, parsed.Head != nil,
+				)))
+			},
+		}
+	},
+}
+
+// TestParseRstestExpectCallEntryInvariant pins the contract the entry kinds
+// exist to carry: Entry names a factory that actually ran, so it is static
+// exactly when there is no head. Rules rely on either field alone to decide
+// whether they are looking at a real assertion.
+func TestParseRstestExpectCallEntryInvariant(t *testing.T) {
+	shapes := []string{
+		`expect(x).toBe(1);`,
+		`expect(x).not.toBe(1);`,
+		`expect(x).resolves.not.toBe(1);`,
+		`expect(x).to.be.ok;`,
+		`expect(x);`,
+		`expect(x).not;`,
+		`expect.soft(x).toBe(1);`,
+		`expect.poll(fn).toBe(1);`,
+		`expect.element(l).toBeVisible();`,
+		`expect.soft.foo(1);`,
+		`expect.assertions(1);`,
+		`expect.hasAssertions();`,
+		`expect.unreachable();`,
+		`expect.getState();`,
+		`expect.extend({});`,
+		`expect.stringContaining("a");`,
+		`expect.not.stringContaining("a");`,
+		`expect.not.toBeDividedBy(5);`,
+		`expect.toBeFoo(1);`,
+		`expect.resolves.toBe(1);`,
+		`expect.not.resolves.toBe(1);`,
+		`expect.not.not.toBe(1);`,
+		`expect.not;`,
+	}
+	cases := make([]rule_tester.ValidTestCase, len(shapes))
+	for i, shape := range shapes {
+		cases[i] = rule_tester.ValidTestCase{Code: shape}
+	}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectEntryInvariantProbe,
+		cases,
+		[]rule_tester.InvalidTestCase{},
+	)
+}
+
 func TestParseRstestExpectCallEntries(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(), "tsconfig.json", t, &expectParseProbe,
@@ -138,56 +204,75 @@ func TestParseRstestExpectCallEntries(t *testing.T) {
 			},
 			{
 				Code:   `expect.unreachable();`,
-				Errors: parsedExpectError("entry=unreachable head=false modifiers=[] matcher=unreachable reason=none static=true"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=unreachable reason=none static=true"),
 			},
 			// assertion-count declarations are the one static form
 			// no-standalone-expect still reports, hence static=false.
 			{
 				Code:   `expect.assertions(1);`,
-				Errors: parsedExpectError("entry=assertions head=false modifiers=[] matcher=assertions reason=none static=false"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=assertions reason=none static=false"),
 			},
 			{
 				Code:   `expect.hasAssertions();`,
-				Errors: parsedExpectError("entry=assertions head=false modifiers=[] matcher=hasAssertions reason=none static=false"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=hasAssertions reason=none static=false"),
 			},
 			{
 				Code:   `expect.stringContaining("a");`,
-				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=stringContaining reason=none static=true"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=stringContaining reason=none static=true"),
 			},
 			{
 				Code:   `expect.anything();`,
-				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=anything reason=none static=true"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=anything reason=none static=true"),
 			},
 			{
 				Code:   `expect.any(String);`,
-				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=any reason=none static=true"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=any reason=none static=true"),
 			},
 			// ExpectStatic.not.<asymmetric> is the static negation, not the
 			// Assertion.not modifier; upstream parses it as modifier + matcher
 			// and its two members keep it reportable by no-standalone-expect.
 			{
 				Code:   `expect.not.stringContaining("a");`,
-				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[not] matcher=stringContaining reason=none static=false"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[not] matcher=stringContaining reason=none static=false"),
+			},
+			// A negated custom matcher parses identically to a negated
+			// built-in one. The parser does not consult
+			// RSTEST_ASYMMETRIC_MATCHERS, so a name it has never seen is not
+			// classified differently from one it has.
+			{
+				Code:   `expect.not.toBeDividedBy(5);`,
+				Errors: parsedExpectError("entry=static head=false modifiers=[not] matcher=toBeDividedBy reason=none static=false"),
 			},
 			{
 				Code:   `expect.addEqualityTesters([]);`,
-				Errors: parsedExpectError("entry=config head=false modifiers=[] matcher=addEqualityTesters reason=none static=true"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=addEqualityTesters reason=none static=true"),
 			},
 			{
 				Code:   `expect.extend({});`,
-				Errors: parsedExpectError("entry=config head=false modifiers=[] matcher=extend reason=none static=true"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=extend reason=none static=true"),
 			},
 			// Unknown static members may be custom asymmetric matchers
 			// registered through expect.extend.
 			{
 				Code:   `expect.toBeFoo(1);`,
-				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=toBeFoo reason=none static=true"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=toBeFoo reason=none static=true"),
 			},
-			// A bare modifier chain parses like a plain chain with no head,
-			// mirroring vitest's null expectCall.
+			// A bare modifier chain is static too: no assertion factory ran,
+			// mirroring vitest's null expectCall. Entry never claims a factory
+			// that was not invoked.
 			{
 				Code:   `expect.resolves.toBe(1);`,
-				Errors: parsedExpectError("entry=expect head=false modifiers=[resolves] matcher=toBe reason=none static=false"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[resolves] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect.not.resolves.toBe(1);`,
+				Errors: parsedExpectError("entry=static head=false modifiers=[not resolves] matcher=toBe reason=none static=false"),
+			},
+			// A factory member that is never called does not make the chain a
+			// factory chain either.
+			{
+				Code:   `expect.soft.toBe(1);`,
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher= reason=modifier-unknown static=false"),
 			},
 		},
 	)
@@ -293,10 +378,12 @@ func TestParseRstestExpectCallModifiersAndMatcher(t *testing.T) {
 				Code:   `expect.soft(x);`,
 				Errors: parsedExpectError("entry=soft head=true modifiers=[] matcher= reason=matcher-not-found static=true"),
 			},
-			// A factory member that is never invoked cannot start a chain.
+			// A factory member that is never invoked cannot start a chain, so
+			// the entry stays static rather than claiming a factory that never
+			// ran.
 			{
 				Code:   `expect.soft.foo(1);`,
-				Errors: parsedExpectError("entry=soft head=false modifiers=[] matcher= reason=modifier-unknown static=false"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher= reason=modifier-unknown static=false"),
 			},
 		},
 	)
@@ -607,7 +694,7 @@ func TestParseRstestExpectCallSources(t *testing.T) {
 			},
 			{
 				Code:   `import.meta.rstest.expect.assertions(1);`,
-				Errors: parsedExpectError("entry=assertions head=false modifiers=[] matcher=assertions reason=none static=false"),
+				Errors: parsedExpectError("entry=static head=false modifiers=[] matcher=assertions reason=none static=false"),
 			},
 			{
 				Code: `import { expect as check } from '@rstest/core'; check(1).to.be.ok;`,
@@ -757,8 +844,34 @@ func TestRstestMatcherTables(t *testing.T) {
 	if len(rstestUtils.RSTEST_BROWSER_ELEMENT_MATCHERS) != 21 {
 		t.Errorf("expected 21 browser element matchers, got %d", len(rstestUtils.RSTEST_BROWSER_ELEMENT_MATCHERS))
 	}
-	if len(rstestUtils.RSTEST_ASYMMETRIC_MATCHERS) != 10 {
-		t.Errorf("expected 10 asymmetric matchers, got %d", len(rstestUtils.RSTEST_ASYMMETRIC_MATCHERS))
+	// The asymmetric table answers "is this static member a known built-in
+	// value constructor". A count assertion would only ever be updated to
+	// match whatever the table says, so pin membership on both sides instead:
+	// value constructors in, assertion matchers and modifiers out.
+	for _, name := range []string{"stringContaining", "arrayContaining", "any", "anything"} {
+		if !rstestUtils.RSTEST_ASYMMETRIC_MATCHERS[name] {
+			t.Errorf("asymmetric matchers must contain %q", name)
+		}
+	}
+	for _, name := range []string{"toBe", "toEqual", "not", "resolves", "assertions", "soft"} {
+		if rstestUtils.RSTEST_ASYMMETRIC_MATCHERS[name] {
+			t.Errorf("asymmetric matchers must not contain %q", name)
+		}
+	}
+
+	for _, name := range []string{"assertions", "hasAssertions"} {
+		if !rstestUtils.RSTEST_EXPECT_ASSERTION_COUNT_MEMBERS[name] {
+			t.Errorf("assertion-count members must contain %q", name)
+		}
+	}
+	if len(rstestUtils.RSTEST_EXPECT_ASSERTION_COUNT_MEMBERS) != 2 {
+		t.Errorf("expected 2 assertion-count members, got %d", len(rstestUtils.RSTEST_EXPECT_ASSERTION_COUNT_MEMBERS))
+	}
+
+	for _, name := range []string{"extend", "getState", "setState", "addEqualityTesters", "addSnapshotSerializer"} {
+		if !rstestUtils.RSTEST_EXPECT_CONFIG_MEMBERS[name] {
+			t.Errorf("config members must contain %q", name)
+		}
 	}
 
 	if len(rstestUtils.RSTEST_POLL_EXCLUDED_MEMBERS) != 11 {

--- a/internal/plugins/rstest/utils/parse_rstest_expect_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect_test.go
@@ -1,0 +1,400 @@
+package utils_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// describeParsedExpect canonicalizes a parse result so the probe below can
+// assert the full contract — entry kind, head presence, modifiers, matcher,
+// reason and the static-call classification — through exact message matches.
+func describeParsedExpect(parsed *rstestUtils.ParsedRstestExpectCall) string {
+	reason := string(parsed.Reason)
+	if reason == "" {
+		reason = "none"
+	}
+	return fmt.Sprintf(
+		"entry=%s head=%t modifiers=[%s] matcher=%s reason=%s static=%t",
+		parsed.Entry,
+		parsed.Head != nil,
+		strings.Join(parsed.Modifiers, " "),
+		parsed.Matcher,
+		reason,
+		rstestUtils.IsStaticRstestExpectCall(parsed),
+	)
+}
+
+// expectParseProbe reports every parsed expect call with its canonical
+// description, so invalid test cases assert exact parse results and valid test
+// cases assert that ParseRstestExpectCall returned nil.
+var expectParseProbe = rule.Rule{
+	Name:             "rstest/expect-parse-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				if parsed == nil {
+					return
+				}
+				ctx.ReportNode(node, probeMessage("parsedExpect", describeParsedExpect(parsed)))
+			},
+		}
+	},
+}
+
+func parsedExpectError(message string) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{{MessageId: "parsedExpect", Message: message}}
+}
+
+func TestParseRstestExpectCallEntries(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectParseProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `expect(x).toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect.soft(x).toBe(1);`,
+				Errors: parsedExpectError("entry=soft head=true modifiers=[] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect['soft'](x).toBe(1);`,
+				Errors: parsedExpectError("entry=soft head=true modifiers=[] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect.poll(fn).toBe(1);`,
+				Errors: parsedExpectError("entry=poll head=true modifiers=[] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect.element(l).toBeVisible();`,
+				Errors: parsedExpectError("entry=element head=true modifiers=[] matcher=toBeVisible reason=none static=false"),
+			},
+			{
+				Code:   `expect.unreachable();`,
+				Errors: parsedExpectError("entry=unreachable head=false modifiers=[] matcher=unreachable reason=none static=true"),
+			},
+			// assertion-count declarations are the one static form
+			// no-standalone-expect still reports, hence static=false.
+			{
+				Code:   `expect.assertions(1);`,
+				Errors: parsedExpectError("entry=assertions head=false modifiers=[] matcher=assertions reason=none static=false"),
+			},
+			{
+				Code:   `expect.hasAssertions();`,
+				Errors: parsedExpectError("entry=assertions head=false modifiers=[] matcher=hasAssertions reason=none static=false"),
+			},
+			{
+				Code:   `expect.stringContaining("a");`,
+				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=stringContaining reason=none static=true"),
+			},
+			{
+				Code:   `expect.anything();`,
+				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=anything reason=none static=true"),
+			},
+			// ExpectStatic.not.<asymmetric> is the static negation, not the
+			// Assertion.not modifier; upstream parses it as modifier + matcher
+			// and its two members keep it reportable by no-standalone-expect.
+			{
+				Code:   `expect.not.stringContaining("a");`,
+				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[not] matcher=stringContaining reason=none static=false"),
+			},
+			{
+				Code:   `expect.addEqualityTesters([]);`,
+				Errors: parsedExpectError("entry=config head=false modifiers=[] matcher=addEqualityTesters reason=none static=true"),
+			},
+			{
+				Code:   `expect.extend({});`,
+				Errors: parsedExpectError("entry=config head=false modifiers=[] matcher=extend reason=none static=true"),
+			},
+			// Unknown static members may be custom asymmetric matchers
+			// registered through expect.extend.
+			{
+				Code:   `expect.toBeFoo(1);`,
+				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=toBeFoo reason=none static=true"),
+			},
+			// A bare modifier chain parses like a plain chain with no head,
+			// mirroring vitest's null expectCall.
+			{
+				Code:   `expect.resolves.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=false modifiers=[resolves] matcher=toBe reason=none static=false"),
+			},
+		},
+	)
+}
+
+func TestParseRstestExpectCallModifiersAndMatcher(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectParseProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `expect(x).not.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[not] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect(x).resolves.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[resolves] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect(x).rejects.toThrow();`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[rejects] matcher=toThrow reason=none static=false"),
+			},
+			{
+				Code:   `expect(x).resolves.not.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[resolves not] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect(x).rejects.not.toThrow();`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[rejects not] matcher=toThrow reason=none static=false"),
+			},
+			{
+				Code:   `expect(x).not.not.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
+			},
+			{
+				Code:   `expect(x).not.resolves.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
+			},
+			{
+				Code:   `expect(x).resolves.rejects.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
+			},
+			{
+				Code:   `expect(x).foo.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
+			},
+			// The matcher is the first invoked member, never simply the last
+			// member of the chain.
+			{
+				Code:   `expect(x).toBe(1).toString();`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect(x);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=matcher-not-found static=false"),
+			},
+			{
+				Code:   `expect(x).toBe;`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=matcher-not-called static=false"),
+			},
+			{
+				Code:   `expect(x).resolves;`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=matcher-not-called static=false"),
+			},
+			{
+				Code:   `(expect(x)).not.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[not] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect(x)['toBe'](1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher=toBe reason=none static=false"),
+			},
+			// A computed member with an identifier key cannot be resolved
+			// statically.
+			{
+				Code:   `expect(x)[matcherName](1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=matcher-not-found static=false"),
+			},
+			{
+				Code:   `expect(f).toHaveBeenCalledBefore(g);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher=toHaveBeenCalledBefore reason=none static=false"),
+			},
+			{
+				Code:   `expect(x).matchSnapshot();`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher=matchSnapshot reason=none static=false"),
+			},
+			// A factory call without a matcher is a broken chain, but still a
+			// single static member syntactically, so no-standalone-expect skips
+			// it — matching upstream, where the failed parse hides the call.
+			{
+				Code:   `expect.soft(x);`,
+				Errors: parsedExpectError("entry=soft head=true modifiers=[] matcher= reason=matcher-not-found static=true"),
+			},
+			// A factory member that is never invoked cannot start a chain.
+			{
+				Code:   `expect.soft.foo(1);`,
+				Errors: parsedExpectError("entry=soft head=false modifiers=[] matcher= reason=modifier-unknown static=false"),
+			},
+		},
+	)
+}
+
+func TestParseRstestExpectCallSources(t *testing.T) {
+	chain := "entry=expect head=true modifiers=[] matcher=toBe reason=none static=false"
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectParseProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `import { expect } from '@rstest/core'; expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `import { expect as check } from '@rstest/core'; check(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `const { expect } = require('@rstest/core'); expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `import * as rstest from '@rstest/core'; rstest.expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `import * as rstest from '@rstest/core'; rstest['expect'](1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `const rstest = require('@rstest/core'); rstest.expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `import.meta.rstest.expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `const { expect } = import.meta.rstest; expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `const api = import.meta.rstest; api.expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `test("t", (ctx) => { ctx.expect(1).toBe(1); });`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `test("t", ({ expect }) => { expect(1).toBe(1); });`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `test("t", ({ expect: check }) => { check(1).toBe(1); });`,
+				Errors: parsedExpectError(chain),
+			},
+			{
+				Code:   `import { expect } from '@rstest/playwright'; expect(1).toBe(1);`,
+				Errors: parsedExpectError(chain),
+			},
+			// The entry kinds resolve through receiver roots too.
+			{
+				Code:   `import * as rstest from '@rstest/core'; rstest.expect.soft(1).toBe(1);`,
+				Errors: parsedExpectError("entry=soft head=true modifiers=[] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `import.meta.rstest.expect.assertions(1);`,
+				Errors: parsedExpectError("entry=assertions head=false modifiers=[] matcher=assertions reason=none static=false"),
+			},
+		},
+	)
+}
+
+func TestParseRstestExpectCallIgnoresForeignExpect(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectParseProbe,
+		[]rule_tester.ValidTestCase{
+			{Code: `import { expect } from 'vitest'; expect(1).toBe(1);`},
+			{Code: `import { expect } from '@jest/globals'; expect(1).toBe(1);`},
+			{Code: `import { test, expect } from '@playwright/test'; expect(1).toBe(1);`},
+			{Code: `const expect = createAssertionLibrary(); expect(1).toBe(1);`},
+			{Code: `custom.expect(1).toBe(1);`},
+			{Code: `notExpect(1).toBe(1);`},
+			{Code: `test("t", () => {});`},
+			{Code: `describe("suite", () => {});`},
+			{Code: `Math.max(1, 2);`},
+		},
+		[]rule_tester.InvalidTestCase{},
+	)
+}
+
+// expectAwaitProbe reports ShouldRstestExpectBeAwaited with a fixed
+// asyncMatchers option of ["toResolve"].
+var expectAwaitProbe = rule.Rule{
+	Name:             "rstest/expect-await-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				if parsed == nil {
+					return
+				}
+				ctx.ReportNode(node, probeMessage("awaited", fmt.Sprintf(
+					"await=%t",
+					rstestUtils.ShouldRstestExpectBeAwaited(parsed, []string{"toResolve"}),
+				)))
+			},
+		}
+	},
+}
+
+func TestShouldRstestExpectBeAwaited(t *testing.T) {
+	awaited := []rule_tester.InvalidTestCaseError{{MessageId: "awaited", Message: "await=true"}}
+	notAwaited := []rule_tester.InvalidTestCaseError{{MessageId: "awaited", Message: "await=false"}}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectAwaitProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{Code: `expect(x).resolves.toBe(1);`, Errors: awaited},
+			{Code: `expect(x).rejects.not.toThrow();`, Errors: awaited},
+			{Code: `expect(x).toResolve();`, Errors: awaited},
+			{Code: `expect(x).not.toBe(1);`, Errors: notAwaited},
+			{Code: `expect(x).toBe(1);`, Errors: notAwaited},
+		},
+	)
+}
+
+func TestRstestMatcherTables(t *testing.T) {
+	if len(rstestUtils.RSTEST_MATCHER_ALIASES) != 11 {
+		t.Errorf("expected 11 matcher aliases, got %d", len(rstestUtils.RSTEST_MATCHER_ALIASES))
+	}
+	if got := rstestUtils.RSTEST_MATCHER_ALIASES["toBeCalled"]; got != "toHaveBeenCalled" {
+		t.Errorf("toBeCalled should map to toHaveBeenCalled, got %q", got)
+	}
+	for alias, canonical := range rstestUtils.RSTEST_MATCHER_ALIASES {
+		if _, isAlias := rstestUtils.RSTEST_MATCHER_ALIASES[canonical]; isAlias {
+			t.Errorf("canonical name %q (for alias %q) must not itself be an alias", canonical, alias)
+		}
+	}
+
+	if len(rstestUtils.RSTEST_INLINE_SNAPSHOT_MATCHERS) != 2 {
+		t.Errorf("expected 2 inline snapshot matchers, got %d", len(rstestUtils.RSTEST_INLINE_SNAPSHOT_MATCHERS))
+	}
+	for name := range rstestUtils.RSTEST_INLINE_SNAPSHOT_MATCHERS {
+		if !rstestUtils.RSTEST_SNAPSHOT_MATCHERS[name] {
+			t.Errorf("inline snapshot matcher %q missing from RSTEST_SNAPSHOT_MATCHERS", name)
+		}
+	}
+	if len(rstestUtils.RSTEST_SNAPSHOT_MATCHERS) != 6 {
+		t.Errorf("expected 6 snapshot matchers, got %d", len(rstestUtils.RSTEST_SNAPSHOT_MATCHERS))
+	}
+
+	if len(rstestUtils.RSTEST_BROWSER_ELEMENT_MATCHERS) != 21 {
+		t.Errorf("expected 21 browser element matchers, got %d", len(rstestUtils.RSTEST_BROWSER_ELEMENT_MATCHERS))
+	}
+	if len(rstestUtils.RSTEST_ASYMMETRIC_MATCHERS) != 10 {
+		t.Errorf("expected 10 asymmetric matchers, got %d", len(rstestUtils.RSTEST_ASYMMETRIC_MATCHERS))
+	}
+
+	if len(rstestUtils.RSTEST_POLL_EXCLUDED_MEMBERS) != 11 {
+		t.Errorf("expected 11 poll-excluded members, got %d", len(rstestUtils.RSTEST_POLL_EXCLUDED_MEMBERS))
+	}
+	for _, name := range []string{"resolves", "rejects", "toMatchInlineSnapshot"} {
+		if !rstestUtils.RSTEST_POLL_EXCLUDED_MEMBERS[name] {
+			t.Errorf("poll-excluded members must contain %q", name)
+		}
+	}
+}

--- a/internal/plugins/rstest/utils/parse_rstest_expect_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect_test.go
@@ -159,15 +159,27 @@ func TestParseRstestExpectCallModifiersAndMatcher(t *testing.T) {
 				Errors: parsedExpectError("entry=expect head=true modifiers=[rejects not] matcher=toThrow reason=none static=false"),
 			},
 			{
+				Code:   `expect(x).not.resolves.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[not resolves] matcher=toBe reason=none static=false"),
+			},
+			{
+				Code:   `expect(x).not.rejects.toThrow();`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[not rejects] matcher=toThrow reason=none static=false"),
+			},
+			{
 				Code:   `expect(x).not.not.toBe(1);`,
 				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
 			},
 			{
-				Code:   `expect(x).not.resolves.toBe(1);`,
+				Code:   `expect(x).resolves.rejects.toBe(1);`,
 				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
 			},
 			{
-				Code:   `expect(x).resolves.rejects.toBe(1);`,
+				Code:   `expect(x).resolves.resolves.toBe(1);`,
+				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
+			},
+			{
+				Code:   `expect(x).rejects.rejects.toThrow();`,
 				Errors: parsedExpectError("entry=expect head=true modifiers=[] matcher= reason=modifier-unknown static=false"),
 			},
 			{
@@ -350,6 +362,8 @@ func TestShouldRstestExpectBeAwaited(t *testing.T) {
 		[]rule_tester.InvalidTestCase{
 			{Code: `expect(x).resolves.toBe(1);`, Errors: awaited},
 			{Code: `expect(x).rejects.not.toThrow();`, Errors: awaited},
+			{Code: `expect(x).not.resolves.toBe(1);`, Errors: awaited},
+			{Code: `expect(x).not.rejects.toThrow();`, Errors: awaited},
 			{Code: `expect(x).toResolve();`, Errors: awaited},
 			{Code: `expect(x).not.toBe(1);`, Errors: notAwaited},
 			{Code: `expect(x).toBe(1);`, Errors: notAwaited},

--- a/internal/plugins/rstest/utils/parse_rstest_expect_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect_test.go
@@ -31,6 +31,45 @@ func describeParsedExpect(parsed *rstestUtils.ParsedRstestExpectCall) string {
 	)
 }
 
+func describeParsedExpectChain(parsed *rstestUtils.ParsedRstestExpectCall) string {
+	reason := string(parsed.Reason)
+	if reason == "" {
+		reason = "none"
+	}
+	matchers := make([]string, len(parsed.Matchers))
+	for i, matcher := range parsed.Matchers {
+		matchers[i] = fmt.Sprintf("%s:%s", matcher.Name, matcher.Kind)
+	}
+	return fmt.Sprintf(
+		"entry=%s head=%t expression=%s members=[%s] modifiers=[%s] matcher=%s matchers=[%s] reason=%s static=%t",
+		parsed.Entry,
+		parsed.Head != nil,
+		expectExpressionKind(parsed.Expression),
+		strings.Join(parsed.Members, " "),
+		strings.Join(parsed.Modifiers, " "),
+		parsed.Matcher,
+		strings.Join(matchers, " "),
+		reason,
+		rstestUtils.IsStaticRstestExpectCall(parsed),
+	)
+}
+
+func expectExpressionKind(node *ast.Node) string {
+	if node == nil {
+		return "nil"
+	}
+	switch node.Kind {
+	case ast.KindCallExpression:
+		return "call"
+	case ast.KindPropertyAccessExpression:
+		return "property"
+	case ast.KindElementAccessExpression:
+		return "element"
+	default:
+		return "other"
+	}
+}
+
 // expectParseProbe reports every parsed expect call with its canonical
 // description, so invalid test cases assert exact parse results and valid test
 // cases assert that ParseRstestExpectCall returned nil.
@@ -46,6 +85,23 @@ var expectParseProbe = rule.Rule{
 					return
 				}
 				ctx.ReportNode(node, probeMessage("parsedExpect", describeParsedExpect(parsed)))
+			},
+		}
+	},
+}
+
+var expectChainParseProbe = rule.Rule{
+	Name:             "rstest/expect-chain-parse-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				if parsed == nil {
+					return
+				}
+				ctx.ReportNode(node, probeMessage("parsedExpect", describeParsedExpectChain(parsed)))
 			},
 		}
 	},
@@ -101,6 +157,10 @@ func TestParseRstestExpectCallEntries(t *testing.T) {
 			{
 				Code:   `expect.anything();`,
 				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=anything reason=none static=true"),
+			},
+			{
+				Code:   `expect.any(String);`,
+				Errors: parsedExpectError("entry=asymmetric head=false modifiers=[] matcher=any reason=none static=true"),
 			},
 			// ExpectStatic.not.<asymmetric> is the static negation, not the
 			// Assertion.not modifier; upstream parses it as modifier + matcher
@@ -242,6 +302,246 @@ func TestParseRstestExpectCallModifiersAndMatcher(t *testing.T) {
 	)
 }
 
+func TestParseRstestExpectCallChaiMethods(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectChainParseProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `expect(x).to.equal(y);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to equal] modifiers=[] matcher=equal matchers=[equal:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(x).to.have.property("name");`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to have property] modifiers=[] matcher=property matchers=[property:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(x).to.deep.equal(y);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to deep equal] modifiers=[] matcher=equal matchers=[equal:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(x).to.have.any.keys("a", "b");`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to have any keys] modifiers=[] matcher=keys matchers=[keys:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(x).to.include("x");`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to include] modifiers=[] matcher=include matchers=[include:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(xs).to.include.members([x]);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to include members] modifiers=[] matcher=members matchers=[members:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(xs).to.have.lengthOf(3);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to have lengthOf] modifiers=[] matcher=lengthOf matchers=[lengthOf:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(xs).to.have.lengthOf.above(2);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to have lengthOf above] modifiers=[] matcher=above matchers=[above:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(Foo).itself.to.respondTo("bar");`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[itself to respondTo] modifiers=[] matcher=respondTo matchers=[respondTo:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect("hello").to.be.a("string").and.contain("hell");`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to be a and contain] modifiers=[] matcher=a matchers=[a:call contain:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect("hello").to.be.a("string").that.does.not.contain("world");`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to be a that does not contain] modifiers=[] matcher=a matchers=[a:call contain:call] reason=none static=false",
+				),
+			},
+		},
+	)
+}
+
+func TestParseRstestExpectCallChaiProperties(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectChainParseProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `expect(value).to.be.ok;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[to be ok] modifiers=[] matcher=ok matchers=[ok:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(value).to.not.be.ok;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[to not be ok] modifiers=[not] matcher=ok matchers=[ok:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(value).not.to.be.ok;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[not to be ok] modifiers=[not] matcher=ok matchers=[ok:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(value).to.be.true;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[to be true] modifiers=[] matcher=true matchers=[true:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(value).to.exist;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[to exist] modifiers=[] matcher=exist matchers=[exist:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(spy).to.have.been.called;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[to have been called] modifiers=[] matcher=called matchers=[called:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(spy).to.have.been.calledOnce;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[to have been calledOnce] modifiers=[] matcher=calledOnce matchers=[calledOnce:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(value)["to"]["be"]["ok"];`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=element members=[to be ok] modifiers=[] matcher=ok matchers=[ok:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(1).to.equal(1).and.be.ok;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[to equal and be ok] modifiers=[] matcher=equal matchers=[equal:call ok:property] reason=none static=false",
+				),
+			},
+		},
+	)
+}
+
+func TestParseRstestExpectCallChaiPromiseModifiers(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectChainParseProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `expect(p).resolves.to.equal(x);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[resolves to equal] modifiers=[resolves] matcher=equal matchers=[equal:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(p).not.resolves.to.be.ok;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[not resolves to be ok] modifiers=[not resolves] matcher=ok matchers=[ok:property] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(p).resolves.to.not.equal(x);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[resolves to not equal] modifiers=[resolves not] matcher=equal matchers=[equal:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(p).to.resolves.equal(x);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[to resolves equal] modifiers=[resolves] matcher=equal matchers=[equal:call] reason=none static=false",
+				),
+			},
+			{
+				Code: `expect(p).rejects.to.have.property("message");`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=call members=[rejects to have property] modifiers=[rejects] matcher=property matchers=[property:call] reason=none static=false",
+				),
+			},
+		},
+	)
+}
+
+func TestParseRstestExpectCallChaiInvalidChains(t *testing.T) {
+	invalid := "entry=expect head=true expression=call members=[%s] modifiers=[] matcher= matchers=[] reason=modifier-unknown static=false"
+	propertyInvalid := "entry=expect head=true expression=property members=[%s] modifiers=[] matcher= matchers=[] reason=modifier-unknown static=false"
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectChainParseProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `expect(x).to.be("string").that.does.not.contain("world");`,
+				Errors: parsedExpectError(fmt.Sprintf(invalid, "to be that does not contain")),
+			},
+			{
+				Code:   `expect(x).to.have.foo.equal(y);`,
+				Errors: parsedExpectError(fmt.Sprintf(invalid, "to have foo equal")),
+			},
+			{
+				Code:   `expect(x).to.be.a("string").that.foo.contain("x");`,
+				Errors: parsedExpectError(fmt.Sprintf(invalid, "to be a that foo contain")),
+			},
+			{
+				Code:   `expect(x).not().to.equal(y);`,
+				Errors: parsedExpectError(fmt.Sprintf(invalid, "not to equal")),
+			},
+			{
+				Code:   `expect(x).to();`,
+				Errors: parsedExpectError(fmt.Sprintf(invalid, "to")),
+			},
+			{
+				Code:   `expect(x).any(y);`,
+				Errors: parsedExpectError(fmt.Sprintf(invalid, "any")),
+			},
+			{
+				Code:   `expect(x).to.be.ok();`,
+				Errors: parsedExpectError(fmt.Sprintf(invalid, "to be ok")),
+			},
+			{
+				Code:   `expect(x).not.not.to.be.ok;`,
+				Errors: parsedExpectError(fmt.Sprintf(propertyInvalid, "not not to be ok")),
+			},
+			{
+				Code:   `expect(x).resolves.rejects.to.be.ok;`,
+				Errors: parsedExpectError(fmt.Sprintf(propertyInvalid, "resolves rejects to be ok")),
+			},
+			{
+				Code: `expect(x).unknownMatcher;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=property members=[unknownMatcher] modifiers=[] matcher= matchers=[] reason=matcher-not-called static=false",
+				),
+			},
+			{
+				Code:   `expect(x).foo.bar;`,
+				Errors: parsedExpectError(fmt.Sprintf(propertyInvalid, "foo bar")),
+			},
+			{
+				Code: `expect(x)[matcherName];`,
+				Errors: parsedExpectError(
+					"entry=expect head=true expression=element members=[matcherName] modifiers=[] matcher= matchers=[] reason=matcher-not-found static=false",
+				),
+			},
+		},
+	)
+}
+
 func TestParseRstestExpectCallSources(t *testing.T) {
 	chain := "entry=expect head=true modifiers=[] matcher=toBe reason=none static=false"
 	rule_tester.RunRuleTester(
@@ -309,6 +609,30 @@ func TestParseRstestExpectCallSources(t *testing.T) {
 				Code:   `import.meta.rstest.expect.assertions(1);`,
 				Errors: parsedExpectError("entry=assertions head=false modifiers=[] matcher=assertions reason=none static=false"),
 			},
+			{
+				Code: `import { expect as check } from '@rstest/core'; check(1).to.be.ok;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true modifiers=[] matcher=ok reason=none static=false",
+				),
+			},
+			{
+				Code: `import * as rstest from '@rstest/core'; rstest.expect(1).to.equal(1);`,
+				Errors: parsedExpectError(
+					"entry=expect head=true modifiers=[] matcher=equal reason=none static=false",
+				),
+			},
+			{
+				Code: `import.meta.rstest.expect(1).to.be.ok;`,
+				Errors: parsedExpectError(
+					"entry=expect head=true modifiers=[] matcher=ok reason=none static=false",
+				),
+			},
+			{
+				Code: `test("t", ({ expect }) => { expect(1).to.be.ok; });`,
+				Errors: parsedExpectError(
+					"entry=expect head=true modifiers=[] matcher=ok reason=none static=false",
+				),
+			},
 		},
 	)
 }
@@ -326,6 +650,8 @@ func TestParseRstestExpectCallIgnoresForeignExpect(t *testing.T) {
 			{Code: `test("t", () => {});`},
 			{Code: `describe("suite", () => {});`},
 			{Code: `Math.max(1, 2);`},
+			{Code: `import { expect } from 'vitest'; expect(1).to.be.ok;`},
+			{Code: `import { expect } from '@jest/globals'; expect(1).to.equal(1);`},
 		},
 		[]rule_tester.InvalidTestCase{},
 	)
@@ -353,6 +679,34 @@ var expectAwaitProbe = rule.Rule{
 	},
 }
 
+var expectIdentityProbe = rule.Rule{
+	Name:             "rstest/expect-identity-probe",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if rstestUtils.IsRstestExpectCall(node, ctx, callbacks) {
+					ctx.ReportNode(node, probeMessage("expectCall", "expect=true"))
+				}
+			},
+		}
+	},
+}
+
+func TestIsRstestExpectCallRecognizesChaiPropertyStyleOnce(t *testing.T) {
+	expectCall := []rule_tester.InvalidTestCaseError{{MessageId: "expectCall", Message: "expect=true"}}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &expectIdentityProbe,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{Code: `expect(value).to.be.ok;`, Errors: expectCall},
+			{Code: `expect(spy).to.have.been.calledOnce;`, Errors: expectCall},
+			{Code: `expect(value).to.equal(expected);`, Errors: expectCall},
+		},
+	)
+}
+
 func TestShouldRstestExpectBeAwaited(t *testing.T) {
 	awaited := []rule_tester.InvalidTestCaseError{{MessageId: "awaited", Message: "await=true"}}
 	notAwaited := []rule_tester.InvalidTestCaseError{{MessageId: "awaited", Message: "await=false"}}
@@ -364,7 +718,11 @@ func TestShouldRstestExpectBeAwaited(t *testing.T) {
 			{Code: `expect(x).rejects.not.toThrow();`, Errors: awaited},
 			{Code: `expect(x).not.resolves.toBe(1);`, Errors: awaited},
 			{Code: `expect(x).not.rejects.toThrow();`, Errors: awaited},
+			{Code: `expect(x).resolves.to.equal(1);`, Errors: awaited},
+			{Code: `expect(x).not.resolves.to.be.ok;`, Errors: awaited},
+			{Code: `expect(x).rejects.to.have.property("message");`, Errors: awaited},
 			{Code: `expect(x).toResolve();`, Errors: awaited},
+			{Code: `expect(x).to.be.ok;`, Errors: notAwaited},
 			{Code: `expect(x).not.toBe(1);`, Errors: notAwaited},
 			{Code: `expect(x).toBe(1);`, Errors: notAwaited},
 		},
@@ -410,5 +768,48 @@ func TestRstestMatcherTables(t *testing.T) {
 		if !rstestUtils.RSTEST_POLL_EXCLUDED_MEMBERS[name] {
 			t.Errorf("poll-excluded members must contain %q", name)
 		}
+	}
+
+	propertyMatchers := []string{
+		"ok",
+		"true",
+		"numeric",
+		"callable",
+		"false",
+		"null",
+		"undefined",
+		"NaN",
+		"exist",
+		"exists",
+		"empty",
+		"arguments",
+		"Arguments",
+		"iterable",
+		"extensible",
+		"sealed",
+		"frozen",
+		"finite",
+		"called",
+		"calledOnce",
+		"calledTwice",
+		"calledThrice",
+	}
+	for _, matcher := range propertyMatchers {
+		t.Run("property-"+matcher, func(t *testing.T) {
+			code := fmt.Sprintf("expect(value).to.%s;", matcher)
+			rule_tester.RunRuleTester(
+				fixtures.GetRootDir(), "tsconfig.json", t, &expectChainParseProbe,
+				[]rule_tester.ValidTestCase{},
+				[]rule_tester.InvalidTestCase{{
+					Code: code,
+					Errors: parsedExpectError(fmt.Sprintf(
+						"entry=expect head=true expression=property members=[to %s] modifiers=[] matcher=%s matchers=[%s:property] reason=none static=false",
+						matcher,
+						matcher,
+						matcher,
+					)),
+				}},
+			)
+		})
 	}
 }

--- a/internal/plugins/rstest/utils/rstest_matchers.go
+++ b/internal/plugins/rstest/utils/rstest_matchers.go
@@ -7,6 +7,7 @@ package utils
 // Baselines:
 //   - rstest commit c4b67c72
 //   - @vitest/expect 4.1.10 (rstest packages/core/package.json declares ^4.1.10)
+//   - Chai 6.2.2
 
 // RSTEST_EXPECT_MODIFIER_NAMES lists the assertion chain modifiers.
 // Source: rstest c4b67c72 packages/core/src/types/expect.ts:72-143 (Assertion
@@ -16,6 +17,103 @@ var RSTEST_EXPECT_MODIFIER_NAMES = map[string]bool{
 	"not":      true,
 	"rejects":  true,
 	"resolves": true,
+}
+
+// rstestChaiLanguageChains lists Chai's no-op language chains plus `itself`,
+// which sets a flag consumed by respondTo. They connect assertions but are
+// never matchers by themselves.
+// Source: chai@6.2.2 lib/chai/core/assertions.js (language chains and itself),
+// cross-checked against eslint-plugin-vitest@1.6.26
+// src/utils/parse-vitest-fn-call.ts.
+var rstestChaiLanguageChains = map[string]bool{
+	"also":   true,
+	"and":    true,
+	"at":     true,
+	"be":     true,
+	"been":   true,
+	"but":    true,
+	"does":   true,
+	"has":    true,
+	"have":   true,
+	"is":     true,
+	"itself": true,
+	"of":     true,
+	"same":   true,
+	"still":  true,
+	"that":   true,
+	"to":     true,
+	"which":  true,
+	"with":   true,
+}
+
+// rstestChaiFlagChains lists Chai properties that alter later matchers without
+// performing an assertion themselves.
+// Source: chai@6.2.2 lib/chai/core/assertions.js, cross-checked against
+// eslint-plugin-vitest@1.6.26 src/utils/parse-vitest-fn-call.ts.
+var rstestChaiFlagChains = map[string]bool{
+	"all":     true,
+	"any":     true,
+	"deep":    true,
+	"nested":  true,
+	"ordered": true,
+	"own":     true,
+}
+
+// rstestChaiDualRoleChains lists Chai chainable methods: an uncalled property
+// access configures or connects a later assertion, while invoking the same
+// member makes it the matcher.
+// Source: chai@6.2.2 lib/chai/core/assertions.js, cross-checked against
+// eslint-plugin-vitest@1.6.26 src/utils/parse-vitest-fn-call.ts.
+var rstestChaiDualRoleChains = map[string]bool{
+	"a":         true,
+	"an":        true,
+	"contain":   true,
+	"contains":  true,
+	"include":   true,
+	"includes":  true,
+	"length":    true,
+	"lengthOf":  true,
+	"respondTo": true,
+}
+
+// rstestChaiChainableMembers is the union of the language, flag and dual-role
+// tables. The source tables remain separate because classification depends on
+// whether a dual-role member is invoked.
+var rstestChaiChainableMembers = mergeRstestExpectNameSets(
+	rstestChaiLanguageChains,
+	rstestChaiFlagChains,
+	rstestChaiDualRoleChains,
+)
+
+// rstestChaiPropertyMatchers lists official getter assertions that execute
+// without a call expression. Unknown terminal properties are deliberately not
+// accepted because they may be misspelled method matchers.
+// Sources:
+//   - chai@6.2.2 lib/chai/core/assertions.js (core property assertions)
+//   - @vitest/expect@4.1.10 src/chai-style-assertions.ts (called properties)
+var rstestChaiPropertyMatchers = map[string]bool{
+	"Arguments":    true,
+	"NaN":          true,
+	"arguments":    true,
+	"callable":     true,
+	"called":       true,
+	"calledOnce":   true,
+	"calledThrice": true,
+	"calledTwice":  true,
+	"empty":        true,
+	"exist":        true,
+	"exists":       true,
+	"extensible":   true,
+	"false":        true,
+	"finite":       true,
+	"frozen":       true,
+	"iterable":     true,
+	"null":         true,
+	"numeric":      true,
+	"ok":           true,
+	"sealed":       true,
+	"true":         true,
+	"undefined":    true,
 }
 
 // RSTEST_MATCHER_ALIASES maps alias matchers to their canonical names.
@@ -153,4 +251,18 @@ var rstestExpectConfigMembers = map[string]bool{
 	"getState":              true,
 	"setState":              true,
 	"extend":                true,
+}
+
+func mergeRstestExpectNameSets(sets ...map[string]bool) map[string]bool {
+	size := 0
+	for _, set := range sets {
+		size += len(set)
+	}
+	merged := make(map[string]bool, size)
+	for _, set := range sets {
+		for name := range set {
+			merged[name] = true
+		}
+	}
+	return merged
 }

--- a/internal/plugins/rstest/utils/rstest_matchers.go
+++ b/internal/plugins/rstest/utils/rstest_matchers.go
@@ -1,0 +1,156 @@
+package utils
+
+// Constant tables for Rstest expect parsing. Every table is a snapshot of the
+// audited baselines below; re-verify each one when upgrading Rstest or
+// @vitest/expect.
+//
+// Baselines:
+//   - rstest commit c4b67c72
+//   - @vitest/expect 4.1.10 (rstest packages/core/package.json declares ^4.1.10)
+
+// RSTEST_EXPECT_MODIFIER_NAMES lists the assertion chain modifiers.
+// Source: rstest c4b67c72 packages/core/src/types/expect.ts:72-143 (Assertion
+// exposes not / resolves / rejects); the set and the legal combinations are
+// identical to Jest's.
+var RSTEST_EXPECT_MODIFIER_NAMES = map[string]bool{
+	"not":      true,
+	"rejects":  true,
+	"resolves": true,
+}
+
+// RSTEST_MATCHER_ALIASES maps alias matchers to their canonical names.
+// Source: @vitest/expect@4.1.10 dist/index.d.ts (JestAssertion), cross-checked
+// against eslint-plugin-vitest@1.6.26 no-alias-methods; the 11 pairs are
+// identical to Jest's.
+var RSTEST_MATCHER_ALIASES = map[string]string{
+	"toBeCalled":       "toHaveBeenCalled",
+	"toBeCalledTimes":  "toHaveBeenCalledTimes",
+	"toBeCalledWith":   "toHaveBeenCalledWith",
+	"lastCalledWith":   "toHaveBeenLastCalledWith",
+	"nthCalledWith":    "toHaveBeenNthCalledWith",
+	"toReturn":         "toHaveReturned",
+	"toReturnTimes":    "toHaveReturnedTimes",
+	"toReturnWith":     "toHaveReturnedWith",
+	"lastReturnedWith": "toHaveLastReturnedWith",
+	"nthReturnedWith":  "toHaveNthReturnedWith",
+	"toThrowError":     "toThrow",
+}
+
+// RSTEST_INLINE_SNAPSHOT_MATCHERS lists the snapshot matchers whose expected
+// value lives inline in the test file.
+// Source: rstest c4b67c72 packages/core/src/types/expect.ts:86-127; identical
+// to Jest's INLINE_SNAPSHOT_MATCHERS.
+var RSTEST_INLINE_SNAPSHOT_MATCHERS = map[string]bool{
+	"toMatchInlineSnapshot":              true,
+	"toThrowErrorMatchingInlineSnapshot": true,
+}
+
+// RSTEST_SNAPSHOT_MATCHERS lists every snapshot matcher, inline ones included.
+// Source: rstest c4b67c72 packages/core/src/types/expect.ts:86-127. Rstest
+// extends the Jest set with matchSnapshot (short alias of toMatchSnapshot) and
+// toMatchFileSnapshot.
+var RSTEST_SNAPSHOT_MATCHERS = map[string]bool{
+	"matchSnapshot":                      true,
+	"toMatchSnapshot":                    true,
+	"toMatchInlineSnapshot":              true,
+	"toThrowErrorMatchingSnapshot":       true,
+	"toThrowErrorMatchingInlineSnapshot": true,
+	"toMatchFileSnapshot":                true,
+}
+
+// RSTEST_BROWSER_ELEMENT_MATCHERS lists the matchers available on
+// expect.element(locator) chains in Browser Mode. They form a set independent
+// from Assertion; the parser resolves them through the same matcher walk and
+// this table only exists for consumers that need to query membership.
+// Source: rstest c4b67c72 packages/browser/src/augmentExpect.ts:3-58
+// (BrowserElementExpect).
+var RSTEST_BROWSER_ELEMENT_MATCHERS = map[string]bool{
+	"toBeVisible":      true,
+	"toBeHidden":       true,
+	"toBeEnabled":      true,
+	"toBeDisabled":     true,
+	"toBeChecked":      true,
+	"toBeUnchecked":    true,
+	"toBeAttached":     true,
+	"toBeDetached":     true,
+	"toBeEditable":     true,
+	"toBeFocused":      true,
+	"toBeEmpty":        true,
+	"toBeInViewport":   true,
+	"toHaveText":       true,
+	"toContainText":    true,
+	"toHaveValue":      true,
+	"toHaveId":         true,
+	"toHaveAttribute":  true,
+	"toHaveClass":      true,
+	"toHaveCount":      true,
+	"toHaveCSS":        true,
+	"toHaveJSProperty": true,
+}
+
+// RSTEST_ASYMMETRIC_MATCHERS lists the static value constructors on the expect
+// object: expect.<name>(...) builds a matcher value to pass into another
+// assertion instead of asserting by itself.
+// Source: @vitest/expect@4.1.10 dist/index.d.ts:183-262 — ExpectStatic
+// (anything / any), AsymmetricMatchersContaining (stringContaining /
+// stringMatching / objectContaining / arrayContaining / closeTo /
+// schemaMatching) and CustomMatcher (toSatisfy / toBeOneOf). toSatisfy and
+// toBeOneOf double as instance matchers; this table covers their static
+// asymmetric form.
+var RSTEST_ASYMMETRIC_MATCHERS = map[string]bool{
+	"anything":         true,
+	"any":              true,
+	"stringContaining": true,
+	"stringMatching":   true,
+	"objectContaining": true,
+	"arrayContaining":  true,
+	"closeTo":          true,
+	"schemaMatching":   true,
+	"toSatisfy":        true,
+	"toBeOneOf":        true,
+}
+
+// RSTEST_POLL_EXCLUDED_MEMBERS lists the Assertion members that the type of
+// expect.poll(...) removes. The parser records the set but does not enforce
+// it: writing expect.poll(fn).resolves.toBe(1) is a type error TypeScript
+// already reports, so the parser stays descriptive and future rules that want
+// the check query this table instead of re-auditing the source.
+// Source: rstest c4b67c72 packages/core/src/types/expect.ts:151-167 (the
+// Omit<...> on the poll return type).
+var RSTEST_POLL_EXCLUDED_MEMBERS = map[string]bool{
+	"rejects":                            true,
+	"resolves":                           true,
+	"toThrow":                            true,
+	"toThrowError":                       true,
+	"throw":                              true,
+	"throws":                             true,
+	"matchSnapshot":                      true,
+	"toMatchSnapshot":                    true,
+	"toMatchInlineSnapshot":              true,
+	"toThrowErrorMatchingSnapshot":       true,
+	"toThrowErrorMatchingInlineSnapshot": true,
+}
+
+// rstestExpectFactoryEntries maps the ExpectStatic members that, when invoked,
+// start an assertion chain of their own, replacing expect(x) as the head.
+// Source: rstest c4b67c72 packages/core/src/types/expect.ts:147-175 (soft /
+// poll) and packages/browser/src/augmentExpect.ts:59-62 (element).
+var rstestExpectFactoryEntries = map[string]RstestExpectEntry{
+	"soft":    RstestExpectEntrySoft,
+	"poll":    RstestExpectEntryPoll,
+	"element": RstestExpectEntryElement,
+}
+
+// rstestExpectConfigMembers lists the ExpectStatic members that configure the
+// expect runtime rather than asserting or building matcher values.
+// Source: rstest c4b67c72 packages/core/src/types/expect.ts:147-175
+// (addEqualityTesters / addSnapshotSerializer / getState / setState) and
+// @vitest/expect@4.1.10 dist/index.d.ts:183-191 (extend, inherited through
+// VitestExpectProperties).
+var rstestExpectConfigMembers = map[string]bool{
+	"addEqualityTesters":    true,
+	"addSnapshotSerializer": true,
+	"getState":              true,
+	"setState":              true,
+	"extend":                true,
+}

--- a/internal/plugins/rstest/utils/rstest_matchers.go
+++ b/internal/plugins/rstest/utils/rstest_matchers.go
@@ -186,9 +186,18 @@ var RSTEST_BROWSER_ELEMENT_MATCHERS = map[string]bool{
 	"toHaveJSProperty": true,
 }
 
-// RSTEST_ASYMMETRIC_MATCHERS lists the static value constructors on the expect
-// object: expect.<name>(...) builds a matcher value to pass into another
-// assertion instead of asserting by itself.
+// RSTEST_ASYMMETRIC_MATCHERS lists the built-in static value constructors on
+// the expect object: expect.<name>(...) builds a matcher value to pass into
+// another assertion instead of asserting by itself.
+//
+// The parser does not consult this table — a static member it does not
+// recognize could be a custom asymmetric matcher registered through
+// expect.extend or a forgotten expect(x), and one file cannot tell them apart.
+// The table is how a consumer asks the question the parser refuses to guess
+// at: given Entry == RstestExpectEntryStatic, is Matcher a *known* value
+// constructor? A miss means "unknown", not "not asymmetric" — including for
+// the negated form, where Modifiers is ["not"] and Matcher is the constructor
+// name (expect.not.arrayContaining([])).
 // Source: @vitest/expect@4.1.10 dist/index.d.ts:183-262 — ExpectStatic
 // (anything / any), AsymmetricMatchersContaining (stringContaining /
 // stringMatching / objectContaining / arrayContaining / closeTo /
@@ -239,13 +248,25 @@ var rstestExpectFactoryEntries = map[string]RstestExpectEntry{
 	"element": RstestExpectEntryElement,
 }
 
-// rstestExpectConfigMembers lists the ExpectStatic members that configure the
-// expect runtime rather than asserting or building matcher values.
+// RSTEST_EXPECT_ASSERTION_COUNT_MEMBERS lists the ExpectStatic members that
+// declare how many assertions a test must run. They are the one group of
+// static members that is misplaced outside a test block, which is why
+// IsStaticRstestExpectCall excludes them and why they are a table rather than
+// two string literals at the one call site.
+// Source: rstest c4b67c72 packages/core/src/types/expect.ts:147-175.
+var RSTEST_EXPECT_ASSERTION_COUNT_MEMBERS = map[string]bool{
+	"assertions":    true,
+	"hasAssertions": true,
+}
+
+// RSTEST_EXPECT_CONFIG_MEMBERS lists the ExpectStatic members that configure
+// the expect runtime rather than asserting or building matcher values.
+// Consumers reach it through Matcher when Entry is RstestExpectEntryStatic.
 // Source: rstest c4b67c72 packages/core/src/types/expect.ts:147-175
 // (addEqualityTesters / addSnapshotSerializer / getState / setState) and
 // @vitest/expect@4.1.10 dist/index.d.ts:183-191 (extend, inherited through
 // VitestExpectProperties).
-var rstestExpectConfigMembers = map[string]bool{
+var RSTEST_EXPECT_CONFIG_MEMBERS = map[string]bool{
 	"addEqualityTesters":    true,
 	"addSnapshotSerializer": true,
 	"getState":              true,

--- a/internal/plugins/rstest/utils/rstest_matchers.go
+++ b/internal/plugins/rstest/utils/rstest_matchers.go
@@ -10,8 +10,8 @@ package utils
 
 // RSTEST_EXPECT_MODIFIER_NAMES lists the assertion chain modifiers.
 // Source: rstest c4b67c72 packages/core/src/types/expect.ts:72-143 (Assertion
-// exposes not / resolves / rejects); the set and the legal combinations are
-// identical to Jest's.
+// exposes not / resolves / rejects). Legal combinations follow Vitest's
+// count-based validation: at most one not and one promise modifier.
 var RSTEST_EXPECT_MODIFIER_NAMES = map[string]bool{
 	"not":      true,
 	"rejects":  true,


### PR DESCRIPTION
## Summary

- add a shared parser for Rstest `expect` assertions
- resolve assertion factories, modifiers, matchers, static expect APIs, and malformed-chain reasons
- support Chai method, property, dual-role, and multi-matcher assertion chains
- add matcher metadata used by upcoming expect-consuming rules

## Details

The parser supports Rstest expect references from globals, imports, namespaces, `import.meta.rstest`, test contexts, and `@rstest/playwright`.

It parses:

- plain, soft, poll, and browser element assertions
- `not`, `resolves`, and `rejects` in Vitest-compatible order
- snapshot, asymmetric, browser element, and custom method matchers
- Chai chains such as:
  - `expect(value).to.equal(expected)`
  - `expect(value).to.have.property(name)`
  - `expect(value).to.be.ok`
  - `expect(spy).to.have.been.calledOnce`
  - multi-matcher chains such as `.a("string").and.contain("text")`
- incomplete or invalid chains through structured parse reasons

The existing `IsRstestExpectCall` API remains compatible with its current consumer.

## `Entry` names the assertion factory, and nothing else

`ParsedRstestExpectCall.Entry` has five values — `expect`, `soft`, `poll`, `element`, and `static` — with one invariant:

> `Entry == RstestExpectEntryStatic` if and only if `Head == nil`.

The four factory values are exactly `eslint-plugin-vitest`'s `expectApiMethods` (`element` / `poll` / `soft`, `parse-vitest-fn-call.ts:255`) plus its default `expect(x)` case. Everything else the expect object exposes — `expect.assertions(1)`, `expect.unreachable()`, `expect.stringContaining("a")`, `expect.getState()`, and bare modifier chains such as `expect.resolves.toBe(1)` where the author forgot `expect(x)` — is `static`.

An earlier revision of this branch sub-classified those into `unreachable` / `assertions` / `asymmetric` / `config`. That was dropped, for two reasons.

**It required guessing something undecidable.** `expect.not.toBeDividedBy(5)` is valid negated-asymmetric usage if `toBeDividedBy` came from `expect.extend`, and a forgotten `expect(x)` otherwise. `expect.extend` registers a custom matcher on both the assertion and the asymmetric surface, so the two readings are indistinguishable within one file, and cross-file `expect.extend` collection is out of scope. Classifying by a built-in name table meant custom matchers silently fell into the wrong bucket — and no table can be completed, since the names are arbitrary.

**Upstream does not have this axis.** Neither vitest nor jest classifies static expect members; both detect them structurally (vitest's `expectCall == null`, our `Head == nil`) and let rules match the member name themselves. vitest's only consumer of `expectApiName` is `valid-expect.ts:357`, checking for `poll` / `element`.

Consumers ask the specific questions through `Matcher` plus the tables in `rstest_matchers.go`:

| Question | How |
| --- | --- |
| Is this a real assertion? | `Head != nil` |
| Which factory? | `Entry` |
| `expect.assertions(1)`? | `RSTEST_EXPECT_ASSERTION_COUNT_MEMBERS[Matcher]` |
| A known built-in value constructor? | `RSTEST_ASYMMETRIC_MATCHERS[Matcher]` — a miss means *unknown*, not *not asymmetric* |
| A config call? | `RSTEST_EXPECT_CONFIG_MEMBERS[Matcher]` |
| A standalone fake assertion? | `IsStaticRstestExpectCall` — structural, never consults a name table |

This also removes a contradiction the wider enum allowed: `expect.resolves.toBe(1)` used to parse as `Entry == expect` with `Head == nil`, even though `expect` means the factory ran. That state is now unrepresentable, and a probe test pins the invariant across every chain shape (verified non-vacuous by mutating the assertion).

Net effect: `classifyStaticExpectEntry` and its seven cases are gone, `IsStaticRstestExpectCall` becomes a line-for-line match for jest's `IsStaticExpectMatcher`, and a custom matcher parses identically to a built-in one.
