### PR TITLE
test: build the no-undef nil-checker program from the embedded fixtures root

### DIFF
--- a/internal/rules/no_undef/no_undef_nil_tc_test.go
+++ b/internal/rules/no_undef/no_undef_nil_tc_test.go
@@ -20,7 +20,7 @@ import (
 func TestNoUndefRuleNilTypeChecker(t *testing.T) {
 	t.Parallel()
 	rootDir := fixtures.GetRootDir()
-	filePath := tspath.ResolvePath(rootDir, "no-undef-nil-tc.ts")
+	filePath := tspath.ResolvePath(rootDir.Dir, "no-undef-nil-tc.ts")
 	code := `var declaredLocal = 1; declaredLocal;
 console.log(1);
 Promise.resolve();
@@ -30,9 +30,9 @@ myOffGlobal;
 var myOffLocal = 1; myOffLocal;
 undeclaredName123;
 `
-	fs := utils.NewOverlayVFSForFile(filePath, code)
+	fs := utils.NewOverlayVFS(rootDir.FS, map[string]string{filePath: code})
 	program, err := utils.CreateProgram(
-		true, fs, rootDir, "tsconfig.json", utils.CreateCompilerHost(rootDir, fs),
+		true, fs, rootDir.Dir, "tsconfig.json", utils.CreateCompilerHost(rootDir.Dir, fs),
 	)
 	if err != nil {
 		t.Fatalf("CreateProgram: %v", err)


### PR DESCRIPTION
## Summary

`TestNoUndefRuleNilTypeChecker` passes `fixtures.GetRootDir()` straight into `tspath.ResolvePath`, `utils.CreateProgram` and `utils.CreateCompilerHost`, which take a string cwd. `GetRootDir` returns an `embedfs.Root`, so `internal/rules/no_undef` fails to compile and both `Test Go` and the `golangci-lint` step of `Lint&Check` fail on main.

Take the cwd from `rootDir.Dir` and build the overlay on `rootDir.FS` instead of `NewOverlayVFSForFile`, which reads the real filesystem and would not find the embedded `tsconfig.json`.

`go test ./internal/rules/no_undef` passes.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
