### PR TITLE
test: pass the process cwd to lintSingleFile in the unicode-bom test

### DIFF
--- a/internal/lsp/unicode_bom_test.go
+++ b/internal/lsp/unicode_bom_test.go
@@ -111,7 +111,7 @@ func TestUnicodeBomIsNotServedToEditors(t *testing.T) {
 			resolver := config.NewFileConfigResolver(cfg, dir, false)
 
 			served := lintSingleFile(
-				program, sourceFile, file, true, resolver, rule.EditDemandAll, context.Background(),
+				program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, context.Background(),
 			).Diagnostics
 
 			if len(served) != 0 {
@@ -157,7 +157,7 @@ func TestOtherRulesStillRunInTheEditor(t *testing.T) {
 	resolver := config.NewFileConfigResolver(cfg, dir, false)
 
 	served := lintSingleFile(
-		program, sourceFile, file, true, resolver, rule.EditDemandAll, context.Background(),
+		program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, context.Background(),
 	).Diagnostics
 
 	byRule := make(map[string][]rule.RuleFix, len(served))


### PR DESCRIPTION
#1561 added a `processCwd` parameter to `lintSingleFile`; #1560 added `internal/lsp/unicode_bom_test.go` against the previous signature. Both were green on their own branches, and merging them broke the `internal/lsp` test build on main.

Pass the fixture directory at both call sites.