### PR TITLE
feat(rstest): add no-interpolation-in-snapshots rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_interpolation_in_snapshots"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -15,6 +16,7 @@ func GetAllRules() []rule.Rule {
 		no_conditional_expect.NoConditionalExpectRule,
 		no_disabled_tests.NoDisabledTestsRule,
 		no_identical_title.NoIdenticalTitleRule,
+		no_interpolation_in_snapshots.NoInterpolationInSnapshotsRule,
 		no_mocks_import.NoMocksImportRule,
 	}
 }

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
@@ -1,0 +1,59 @@
+package no_interpolation_in_snapshots
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildNoInterpolationMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noInterpolation",
+		Description: "Do not use string interpolation inside of snapshots",
+	}
+}
+
+var NoInterpolationInSnapshotsRule = rule.Rule{
+	Name:   "rstest/no-interpolation-in-snapshots",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		// expect bound to a test context parameter — test("x", ({ expect }) => ...)
+		// — can only be recognized through the collected callbacks.
+		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				if parsed == nil {
+					return
+				}
+
+				// Chai permits several assertions in one chain, so every matcher is
+				// checked rather than just the first one.
+				for _, matcher := range parsed.Matchers {
+					// RSTEST_INLINE_SNAPSHOT_MATCHERS, deliberately not
+					// RSTEST_SNAPSHOT_MATCHERS: toMatchSnapshot, matchSnapshot and
+					// Rstest's own toMatchFileSnapshot keep their expected value
+					// outside the source file, where interpolation is legitimate —
+					// toMatchFileSnapshot even takes a path as its first argument.
+					if !rstestUtils.RSTEST_INLINE_SNAPSHOT_MATCHERS[matcher.Name] {
+						continue
+					}
+					// Property-style Chai assertions carry no call and hence no
+					// arguments to interpolate into.
+					call := matcher.Entry.Call
+					if call == nil {
+						continue
+					}
+					// Both overloads of the inline snapshot matchers may hold the
+					// snapshot in arguments[0] or arguments[1], so all are checked.
+					for _, arg := range call.Arguments() {
+						if arg := ast.SkipParentheses(arg); arg != nil && arg.Kind == ast.KindTemplateExpression {
+							ctx.ReportNode(arg, buildNoInterpolationMessage())
+						}
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
@@ -1,0 +1,75 @@
+# no-interpolation-in-snapshots
+
+## Rule Details
+
+Disallow string interpolation inside inline snapshots. The expected value of an inline snapshot lives in the source file, and updating snapshots rewrites that literal — so the interpolation is evaluated away and silently lost. Overload dynamic properties with a property matcher instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import { expect } from '@rstest/core';
+
+expect(something).toMatchInlineSnapshot(
+  `Object {
+    property: ${interpolated}
+  }`,
+);
+
+expect(something).toMatchInlineSnapshot(
+  { other: expect.any(Number) },
+  `Object {
+    other: Any<Number>,
+    property: ${interpolated}
+  }`,
+);
+
+expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
+  `${interpolated}`,
+);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import { expect } from '@rstest/core';
+
+expect(something).toMatchInlineSnapshot();
+
+expect(something).toMatchInlineSnapshot(
+  `Object {
+    property: 1
+  }`,
+);
+
+expect(something).toMatchInlineSnapshot(
+  { property: expect.any(Date) },
+  `Object {
+    property: Any<Date>
+  }`,
+);
+
+expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot();
+
+expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
+  `Error Message`,
+);
+```
+
+## Only inline snapshots are checked
+
+The rule covers `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` only. Every other snapshot matcher keeps its expected value outside the source file, so nothing rewrites its arguments and interpolation is harmless:
+
+- `toMatchSnapshot` and its Chai-style alias `matchSnapshot`
+- `toThrowErrorMatchingSnapshot`
+- `toMatchFileSnapshot`
+
+`toMatchFileSnapshot` deserves a special mention: it has no Jest counterpart, and its first argument is a **file path**, so interpolating it is the intended usage rather than a mistake.
+
+```javascript
+// correct — the argument is a path, not a snapshot
+await expect(data).toMatchFileSnapshot(`./__snapshots__/${name}.json`);
+```
+
+## Original Documentation
+
+- [jest/no-interpolation-in-snapshots](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md)

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
@@ -1,0 +1,250 @@
+package no_interpolation_in_snapshots_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_interpolation_in_snapshots"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoInterpolationInSnapshotsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_interpolation_in_snapshots.NoInterpolationInSnapshotsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect("something").toEqual("else");`},
+			{Code: `expect(something).toMatchInlineSnapshot();`},
+			{Code: "expect(something).toMatchInlineSnapshot(`No interpolation`);"},
+			{Code: "expect(something).toMatchInlineSnapshot({}, `No interpolation`);"},
+			{Code: `expect(something);`},
+			{Code: `expect(something).not;`},
+			{Code: `expect.hasAssertions();`},
+			{Code: "myObjectWants.toMatchInlineSnapshot({}, `${interpolated}`);"},
+			{Code: "myObjectWants.toMatchInlineSnapshot({}, `${interpolated1} ${interpolated2}`);"},
+			{Code: "toMatchInlineSnapshot({}, `${interpolated}`);"},
+			{Code: "toMatchInlineSnapshot({}, `${interpolated1} ${interpolated2}`);"},
+			{Code: `expect(something).toThrowErrorMatchingInlineSnapshot();`},
+			{Code: "expect(something).toThrowErrorMatchingInlineSnapshot(`No interpolation`);"},
+
+			// Snapshot matchers whose expected value lives outside the source
+			// file: updating them never rewrites the argument, so interpolation
+			// is legitimate.
+			{Code: "expect(something).toMatchSnapshot(`${interpolated}`);"},
+			{Code: "expect(something).matchSnapshot(`${interpolated}`);"},
+			{Code: `expect(something).toThrowErrorMatchingSnapshot();`},
+			// toMatchFileSnapshot is Rstest-only and takes a *path* as its first
+			// argument — interpolating the file name is the intended usage. This
+			// case pins down that the rule consults
+			// RSTEST_INLINE_SNAPSHOT_MATCHERS and not RSTEST_SNAPSHOT_MATCHERS,
+			// which does contain toMatchFileSnapshot.
+			{Code: "test(\"case\", async () => {\n  await expect(data).toMatchFileSnapshot(`./__snapshots__/${name}.json`);\n});"},
+
+			// Not a Rstest expect.
+			{Code: "import { expect } from \"vitest\";\nexpect(something).toMatchInlineSnapshot(`${interpolated}`);"},
+			{Code: "import { expect } from \"@jest/globals\";\nexpect(something).toMatchInlineSnapshot(`${interpolated}`);"},
+			{Code: "const expect = createAssertionLibrary();\nexpect(something).toMatchInlineSnapshot(`${interpolated}`);"},
+
+			// A property-style Chai assertion has no arguments to interpolate into.
+			{Code: `expect(something).to.be.ok;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "expect(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    41,
+						EndColumn: 58,
+					},
+				},
+			},
+			{
+				Code: "expect(something).not.toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    45,
+						EndColumn: 62,
+					},
+				},
+			},
+			{
+				Code: "expect(something).toMatchInlineSnapshot({}, `${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    45,
+						EndColumn: 62,
+					},
+				},
+			},
+			{
+				Code: "expect(something).not.toMatchInlineSnapshot({}, `${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    49,
+						EndColumn: 66,
+					},
+				},
+			},
+			{
+				Code: "expect(something).toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    54,
+						EndColumn: 71,
+					},
+				},
+			},
+			{
+				Code: "expect(something).not.toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    58,
+						EndColumn: 75,
+					},
+				},
+			},
+			{
+				Code: "expect(something).toMatchInlineSnapshot(`${first}`, `${second}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    41,
+						EndColumn: 51,
+					},
+					{
+						MessageId: "noInterpolation",
+						Column:    53,
+						EndColumn: 64,
+					},
+				},
+			},
+			{
+				Code: "expect(something)[\"toMatchInlineSnapshot\"](`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    44,
+						EndColumn: 61,
+					},
+				},
+			},
+			// Parenthesized argument: SkipParentheses still reaches the template.
+			{
+				Code: "expect(something).toMatchInlineSnapshot((`${interpolated}`));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    42,
+						EndColumn: 59,
+					},
+				},
+			},
+
+			// Rstest-specific expect sources (AGENTS.md §2.4).
+			{
+				Code: "import { expect } from \"@rstest/core\";\nexpect(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Line: 2, Column: 41},
+				},
+			},
+			{
+				Code: "import { expect as check } from \"@rstest/core\";\ncheck(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Line: 2, Column: 40},
+				},
+			},
+			{
+				Code: "const { expect } = require(\"@rstest/core\");\nexpect(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Line: 2, Column: 41},
+				},
+			},
+			{
+				Code: "import * as rstest from \"@rstest/core\";\nrstest.expect(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Line: 2, Column: 48},
+				},
+			},
+			{
+				Code: "import.meta.rstest.expect(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 60},
+				},
+			},
+			{
+				Code: "if (import.meta.rstest) {\n  const api = import.meta.rstest;\n  api.expect(something).toMatchInlineSnapshot(`${interpolated}`);\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Line: 3},
+				},
+			},
+			{
+				Code: "import { expect } from \"@rstest/playwright\";\nexpect(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Line: 2, Column: 41},
+				},
+			},
+
+			// The test context is the only expect source that cannot be resolved
+			// without CollectRstestTestCallbacks.
+			{
+				Code: "test(\"case\", ctx => ctx.expect(value).toMatchInlineSnapshot(`${interpolated}`));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 61},
+				},
+			},
+			{
+				Code: "test(\"case\", ({ expect }) => expect(value).toMatchInlineSnapshot(`${interpolated}`));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 66},
+				},
+			},
+			{
+				Code: "test(\"case\", ({ expect: check }) => check(value).toMatchInlineSnapshot(`${interpolated}`));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 72},
+				},
+			},
+
+			// Rstest-specific chain shapes.
+			{
+				Code: "expect.soft(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 46},
+				},
+			},
+			{
+				// expect.poll omits the snapshot matchers at the type level, but
+				// the rule judges interpolation, not API legality.
+				Code: "expect.poll(getValue).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 45},
+				},
+			},
+			{
+				// A forgotten expect(x) is valid-expect's business; the
+				// interpolation is still reported.
+				Code: "expect.toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 30},
+				},
+			},
+			{
+				// Chai allows several assertions per chain, so the matcher walk
+				// must not stop at the first one. Reverting the rule to
+				// parsed.Matcher makes exactly this case pass silently.
+				Code: "expect(something).to.be.a(\"string\").and.toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInterpolation", Column: 63},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -552,6 +552,7 @@ export default defineConfig({
     './tests/rstest/rules/no-conditional-expect.test.ts',
     './tests/rstest/rules/no-disabled-tests.test.ts',
     './tests/rstest/rules/no-identical-title.test.ts',
+    './tests/rstest/rules/no-interpolation-in-snapshots.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
 
     // eslint-plugin-promise

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -79,6 +79,7 @@ describe('defineConfig and config presets', () => {
       'rstest/no-conditional-expect': 'error',
       'rstest/no-disabled-tests': 'warn',
       'rstest/no-identical-title': 'error',
+      'rstest/no-interpolation-in-snapshots': 'error',
       'rstest/no-mocks-import': 'error',
     });
   });

--- a/packages/rslint-test-tools/tests/rstest/rules/no-interpolation-in-snapshots.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-interpolation-in-snapshots.test.ts
@@ -1,0 +1,32 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-interpolation-in-snapshots', {} as never, {
+  valid: [
+    {
+      code: 'expect(something).toMatchInlineSnapshot(`No interpolation`);',
+    },
+    {
+      // toMatchFileSnapshot takes a path, so interpolation is intended
+      code: 'test("case", async () => { await expect(data).toMatchFileSnapshot(`./__snapshots__/${name}.json`); });',
+    },
+    {
+      code: 'import { expect } from "vitest";\nexpect(something).toMatchInlineSnapshot(`${interpolated}`);',
+    },
+  ],
+  invalid: [
+    {
+      code: 'expect(something).toMatchInlineSnapshot(`${interpolated}`);',
+      errors: [{ messageId: 'noInterpolation', line: 1, column: 41 }],
+    },
+    {
+      code: 'expect(something).toThrowErrorMatchingInlineSnapshot(`${interpolated}`);',
+      errors: [{ messageId: 'noInterpolation', line: 1, column: 54 }],
+    },
+    {
+      code: 'test("case", ({ expect }) => expect(value).toMatchInlineSnapshot(`${interpolated}`));',
+      errors: [{ messageId: 'noInterpolation', line: 1, column: 66 }],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -7,6 +7,7 @@ const recommended: RslintConfigEntry = {
     'rstest/no-conditional-expect': 'error',
     'rstest/no-disabled-tests': 'warn',
     'rstest/no-identical-title': 'error',
+    'rstest/no-interpolation-in-snapshots': 'error',
     'rstest/no-mocks-import': 'error',
   },
 };


### PR DESCRIPTION
## Summary

Ports `jest/no-interpolation-in-snapshots` to the rstest plugin, registered in the recommended preset as `error` to match the jest preset and upstream `eslint-plugin-jest`. Single `noInterpolation` message, no options, no fixer.

## Related Links

Related https://github.com/web-infra-dev/rslint/issues/935

## Divergence

Compared to Jest, Rstest adds two snapshot matchers that are **not** inline — `toMatchFileSnapshot`, whose first argument is a file path, and `matchSnapshot`, a Chai-style alias of `toMatchSnapshot` — so interpolating into either is legitimate and this rule ignores both.
