### PR TITLE
feat(rstest): add valid-title rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_title"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -16,5 +17,6 @@ func GetAllRules() []rule.Rule {
 		no_disabled_tests.NoDisabledTestsRule,
 		no_identical_title.NoIdenticalTitleRule,
 		no_mocks_import.NoMocksImportRule,
+		valid_title.ValidTitleRule,
 	}
 }

--- a/internal/plugins/rstest/rules/valid_title/valid_title.go
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.go
@@ -1,0 +1,591 @@
+// Package valid_title ports eslint-plugin-jest's valid-title to Rstest.
+//
+// The rule body is deliberately independent of the jest implementation rather
+// than shared: almost every step of it is a "report or not" branch, and four of
+// those branches take different values on Rstest (see the D1-D5 comments
+// below). Only the deterministic primitives — regexp compilation, whitespace
+// classification, text ranges — are reused, from internal/utils.
+package valid_title
+
+import (
+	_ "embed"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed valid_title.schema.json
+var schemaJSON []byte
+
+type matcherEntry struct {
+	re *regexp2.Regexp
+	// customText non-empty ⇒ use mustMatchCustom / mustNotMatchCustom
+	customText string
+}
+
+type matchersByFn struct {
+	describe matcherEntry
+	test     matcherEntry
+	it       matcherEntry
+}
+
+type compiledOptions struct {
+	ignoreSpaces             bool
+	ignoreTypeOfDescribeName bool
+	ignoreTypeOfTestName     bool
+	disallowedConcat         *regexp2.Regexp
+	invalidPatterns          []invalidPattern
+	mustNotMatch             matchersByFn
+	mustMatch                matchersByFn
+}
+
+type invalidPattern struct {
+	optionPath string
+	pattern    string
+	err        error
+}
+
+func firstOptionMap(options []any) map[string]interface{} {
+	if len(options) == 0 {
+		return nil
+	}
+	m, ok := options[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return m
+}
+
+func boolFromMap(m map[string]interface{}, key string, def bool) bool {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return def
+	}
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return def
+}
+
+func compileRE2(pat string) (*regexp2.Regexp, error) {
+	re, err := utils.CompileRegexp2(pat, utils.JSUnicodeRegexOptions)
+	if err != nil {
+		return nil, err
+	}
+	return re, nil
+}
+
+func compileMatcherPatterns(raw interface{}, optionPath string) (matchersByFn, []invalidPattern) {
+	out := matchersByFn{}
+	var invalids []invalidPattern
+	if raw == nil {
+		return out, nil
+	}
+
+	setAll := func(e matcherEntry) {
+		out.describe, out.test, out.it = e, e, e
+	}
+
+	switch x := raw.(type) {
+	case string:
+		if x == "" {
+			break
+		}
+		if re, err := compileRE2(x); err != nil {
+			invalids = append(invalids, invalidPattern{
+				optionPath: optionPath,
+				pattern:    x,
+				err:        err,
+			})
+		} else if re != nil {
+			setAll(matcherEntry{re: re})
+		}
+	case []interface{}:
+		me := matcherEntry{}
+		if len(x) >= 1 {
+			if s, ok := x[0].(string); ok && s != "" {
+				re, err := compileRE2(s)
+				if err != nil {
+					invalids = append(invalids, invalidPattern{
+						optionPath: optionPath,
+						pattern:    s,
+						err:        err,
+					})
+				} else {
+					me.re = re
+				}
+			}
+		}
+		if len(x) >= 2 {
+			if s, ok := x[1].(string); ok {
+				me.customText = s
+			}
+		}
+		if me.re != nil {
+			setAll(me)
+		}
+	case map[string]interface{}:
+		for _, key := range []string{"describe", "test", "it"} {
+			if v, ok := x[key]; ok {
+				invalids = append(invalids, fillMatcherField(&out, key, v, optionPath+"."+key)...)
+			}
+		}
+	}
+	return out, invalids
+}
+
+func fillMatcherField(ms *matchersByFn, key string, raw interface{}, optionPath string) []invalidPattern {
+	e := matcherEntry{}
+	var invalids []invalidPattern
+
+	switch x := raw.(type) {
+	case string:
+		if x == "" {
+			break
+		}
+		re, err := compileRE2(x)
+		if err != nil {
+			invalids = append(invalids, invalidPattern{
+				optionPath: optionPath,
+				pattern:    x,
+				err:        err,
+			})
+		} else {
+			e.re = re
+		}
+	case []interface{}:
+		if len(x) >= 1 {
+			if s, ok := x[0].(string); ok && s != "" {
+				re, err := compileRE2(s)
+				if err != nil {
+					invalids = append(invalids, invalidPattern{
+						optionPath: optionPath,
+						pattern:    s,
+						err:        err,
+					})
+				} else {
+					e.re = re
+				}
+			}
+		}
+		if len(x) >= 2 {
+			if s, ok := x[1].(string); ok {
+				e.customText = s
+			}
+		}
+	}
+
+	switch key {
+	case "describe":
+		ms.describe = e
+	case "test":
+		ms.test = e
+	case "it":
+		ms.it = e
+	}
+
+	return invalids
+}
+
+func parseCompiledOptions(options []any) compiledOptions {
+	m := firstOptionMap(options)
+	if m == nil {
+		return compiledOptions{}
+	}
+
+	co := compiledOptions{
+		ignoreSpaces:             boolFromMap(m, "ignoreSpaces", false),
+		ignoreTypeOfDescribeName: boolFromMap(m, "ignoreTypeOfDescribeName", false),
+		ignoreTypeOfTestName:     boolFromMap(m, "ignoreTypeOfTestName", false),
+	}
+
+	if dw, ok := m["disallowedWords"]; ok && dw != nil {
+		co.disallowedConcat, co.invalidPatterns = compileDisallowedWords(dw, co.invalidPatterns)
+	}
+
+	if mn, ok := m["mustNotMatch"]; ok {
+		var invalids []invalidPattern
+		co.mustNotMatch, invalids = compileMatcherPatterns(mn, "mustNotMatch")
+		co.invalidPatterns = append(co.invalidPatterns, invalids...)
+	}
+	if mm, ok := m["mustMatch"]; ok {
+		var invalids []invalidPattern
+		co.mustMatch, invalids = compileMatcherPatterns(mm, "mustMatch")
+		co.invalidPatterns = append(co.invalidPatterns, invalids...)
+	}
+
+	return co
+}
+
+func compileDisallowedWords(raw interface{}, invalids []invalidPattern) (*regexp2.Regexp, []invalidPattern) {
+	items, ok := raw.([]interface{})
+	if !ok || len(items) == 0 {
+		return nil, invalids
+	}
+	parts := make([]string, 0, len(items))
+	for _, it := range items {
+		w, ok := it.(string)
+		if ok && w != "" {
+			parts = append(parts, w)
+		}
+	}
+	if len(parts) == 0 {
+		return nil, invalids
+	}
+	pattern := "(?i)\\b(" + strings.Join(parts, "|") + ")\\b"
+	re, err := compileRE2(pattern)
+	if err != nil {
+		invalids = append(invalids, invalidPattern{
+			optionPath: "disallowedWords",
+			pattern:    pattern,
+			err:        err,
+		})
+		return nil, invalids
+	}
+	return re, invalids
+}
+
+func binaryExprContainsStringLit(n *ast.Node) bool {
+	if n == nil || n.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	be := n.AsBinaryExpression()
+	if be == nil || be.OperatorToken == nil {
+		return false
+	}
+	if ast.IsLogicalOrCoalescingBinaryOperator(be.OperatorToken.Kind) ||
+		ast.IsAssignmentOperator(be.OperatorToken.Kind) ||
+		be.OperatorToken.Kind == ast.KindCommaToken {
+		return false
+	}
+	if ast.IsStringLiteralLike(be.Left) {
+		return true
+	}
+	if ast.IsStringLiteralLike(be.Right) {
+		return true
+	}
+	return binaryExprContainsStringLit(be.Left)
+}
+
+// rawTemplateLiteralText returns the contents of a template literal that has no
+// substitutions. The range has to come from TrimNodeTextRange first: ast.Pos()
+// includes leading trivia, so stripping the backticks by offsetting Pos()
+// directly would cut into a comment or whitespace instead.
+func rawTemplateLiteralText(sourceFile *ast.SourceFile, node *ast.Node) string {
+	if sourceFile == nil {
+		return ""
+	}
+	r := utils.TrimNodeTextRange(sourceFile, node)
+	start := r.Pos()
+	end := r.End()
+	sourceText := sourceFile.Text()
+	if sourceText == "" || start+1 >= end-1 {
+		return ""
+	}
+	if end-1 > len(sourceText) || start+1 < 0 {
+		return ""
+	}
+	return sourceText[start+1 : end-1]
+}
+
+func staticTitle(sourceFile *ast.SourceFile, n *ast.Node) (string, bool) {
+	if n == nil {
+		return "", false
+	}
+	switch n.Kind {
+	case ast.KindStringLiteral:
+		return n.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return rawTemplateLiteralText(sourceFile, n), true
+	default:
+		return "", false
+	}
+}
+
+// matcherFor keys the mustMatch / mustNotMatch groups off the semantic API name
+// (D5), so an aliased registration is grouped by what it registers rather than
+// by the local identifier. Unlike the jest implementation there is no fallback
+// group: a future root API would otherwise silently inherit the `it` patterns.
+func matcherFor(fnName string, ms matchersByFn) matcherEntry {
+	switch fnName {
+	case "describe":
+		return ms.describe
+	case "test":
+		return ms.test
+	case "it":
+		return ms.it
+	default:
+		return matcherEntry{}
+	}
+}
+
+// isArrayParameterizedRegistration reports whether this registration is the
+// outer call of an array-based `.each` / `.for` factory, which is the only shape
+// whose title goes through Rstest's printf formatting.
+//
+// D2: `.for` formats its title with the same formatName as `.each`
+// (packages/core/src/runtime/runner/runtime.ts:466-576 at rstest c4b67c72), so
+// both are covered — jest has no `.for` at all.
+//
+// D3: the jest implementation walks MemberEntries looking for `each`. That view
+// is call-site only and goes empty once the factory is reached through an alias,
+// so the shape of the callee is used instead: a tagged-template table
+// (test.each`…`) interpolates with $var and is skipped, exactly as upstream
+// skips it.
+func isArrayParameterizedRegistration(parsed *rstestUtils.ParsedRstestFnCall, call *ast.CallExpression) bool {
+	if parsed == nil || !parsed.IsParameterized() || call == nil {
+		return false
+	}
+	callee := ast.SkipParentheses(call.Expression)
+	return callee != nil && callee.Kind == ast.KindCallExpression
+}
+
+var (
+	reDupPrefix = regexp.MustCompile(`^([\x60'"]).+? `)
+	reAccOpen   = regexp.MustCompile(`^([\x60'"]) +`)
+	reAccClose  = regexp.MustCompile(` +([\x60'"])$`)
+	// D1: the accepted specifiers are Rstest's, not jest's. formatRegExp is
+	// /%[sdjifoOc%]/ (packages/core/src/runtime/util.ts:159 at rstest c4b67c72)
+	// and %# / %$ are substituted ahead of it by formatName, so `%p` — valid to
+	// jest — is left verbatim by Rstest, while `%O` and `%c` — reported by jest
+	// — are expanded by formatTemplate.
+	// cspell:ignore sdjifo
+	reEachInvalidSpecifier = regexp.MustCompile(`%[^sdjifoOc#$%]`)
+)
+
+func accidentalSpaceReplacement(rawSrc string) string {
+	s := reAccOpen.ReplaceAllString(rawSrc, "$1")
+	s = reAccClose.ReplaceAllString(s, "$1")
+	return s
+}
+
+func duplicatePrefixReplacement(rawSrc string) string {
+	return reDupPrefix.ReplaceAllString(rawSrc, "$1")
+}
+
+func regexpToMessagePattern(re *regexp2.Regexp) string {
+	if re == nil {
+		return ""
+	}
+	src := re.String()
+	return "/" + strings.ReplaceAll(src, "/", "\\/") + "/u"
+}
+
+func eachInvalidSpecifier(title string) string {
+	s := strings.ReplaceAll(title, "%%", "")
+	return reEachInvalidSpecifier.FindString(s)
+}
+
+func rstestEmptyFunctionName(kind rstestUtils.RstestFnType) string {
+	if kind == rstestUtils.RstestFnTypeDescribe {
+		return "describe"
+	}
+	return "test"
+}
+
+// ValidTitleRule enforces rstest/valid-title.
+var ValidTitleRule = rule.Rule{
+	Name:   "rstest/valid-title",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		co := parseCompiledOptions(options)
+		if len(co.invalidPatterns) > 0 {
+			for _, bad := range co.invalidPatterns {
+				ctx.ReportRange(core.NewTextRange(0, 0), rule.RuleMessage{
+					Id: "invalidPattern",
+					Description: fmt.Sprintf(
+						"Invalid regular expression in `%s` option: `%s`: %s",
+						bad.optionPath, bad.pattern, bad.err.Error(),
+					),
+				})
+			}
+			return rule.RuleListeners{}
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				// The wider entry point: import.meta.rstest.test(...) and
+				// @rstest/playwright are official registration shapes, and a
+				// title rule holds for them just as it does for @rstest/core.
+				// The two older rules in this plugin use the narrow
+				// ParseRstestFnCall, which is a historical choice rather than a
+				// contract.
+				parsed := rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx)
+				if parsed == nil {
+					return
+				}
+				if parsed.Kind != rstestUtils.RstestFnTypeDescribe && parsed.Kind != rstestUtils.RstestFnTypeTest {
+					return
+				}
+
+				call := node.AsCallExpression()
+				if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				arg := call.Arguments.Nodes[0]
+
+				title, ok := staticTitle(ctx.SourceFile, arg)
+				if !ok {
+					if binaryExprContainsStringLit(arg) {
+						return
+					}
+					ignored := false
+					if parsed.Kind == rstestUtils.RstestFnTypeDescribe && co.ignoreTypeOfDescribeName {
+						ignored = true
+					}
+					if parsed.Kind == rstestUtils.RstestFnTypeTest && co.ignoreTypeOfTestName {
+						ignored = true
+					}
+					if !ignored && arg.Kind != ast.KindTemplateExpression {
+						ctx.ReportNodeWithFixes(arg, rule.RuleMessage{
+							Id:          "titleMustBeString",
+							Description: "Title must be a string",
+						})
+					}
+					return
+				}
+
+				if title == "" {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "emptyTitle",
+						Description: rstestEmptyFunctionName(parsed.Kind) + " should not have an empty title",
+						Data: map[string]string{
+							"rstestFunctionName": rstestEmptyFunctionName(parsed.Kind),
+						},
+					})
+					return
+				}
+
+				if isArrayParameterizedRegistration(parsed, call) {
+					if spec := eachInvalidSpecifier(title); spec != "" {
+						ctx.ReportNode(arg, rule.RuleMessage{
+							Id:          "invalidEachSpecifier",
+							Description: fmt.Sprintf("%q is not a valid format specifier", spec),
+							Data:        map[string]string{"specifier": spec},
+						})
+					}
+				}
+
+				if co.disallowedConcat != nil {
+					m, err := co.disallowedConcat.FindStringMatch(title)
+					if err == nil && m != nil {
+						g := m.GroupByNumber(1)
+						if g != nil && g.String() != "" {
+							word := g.String()
+							ctx.ReportNode(arg, rule.RuleMessage{
+								Id:          "disallowedWord",
+								Description: fmt.Sprintf("%q is not allowed in test titles", word),
+								Data:        map[string]string{"word": word},
+							})
+							return
+						}
+					}
+				}
+
+				// accidentalSpace and duplicatePrefix both fall through, so a
+				// title like ' describe foo' reports twice. That is upstream
+				// behaviour (valid-title.ts:304-333).
+				if !co.ignoreSpaces {
+					trimmed := strings.TrimFunc(title, utils.IsStrWhiteSpace)
+					if len(trimmed) != len(title) {
+						raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, arg, false)
+						fix := accidentalSpaceReplacement(raw)
+						if fix == raw {
+							ctx.ReportNode(arg, rule.RuleMessage{
+								Id:          "accidentalSpace",
+								Description: "should not have leading or trailing spaces",
+							})
+						} else {
+							ctx.ReportNodeWithFixes(arg, rule.RuleMessage{
+								Id:          "accidentalSpace",
+								Description: "should not have leading or trailing spaces",
+							}, rule.RuleFixReplace(ctx.SourceFile, arg, fix))
+						}
+					}
+				}
+
+				// D4: no f/x prefix to trim. Rstest has neither fit/xit nor
+				// fdescribe/xdescribe, so Name is already the bare API name.
+				// D5: Name is the semantic name, which survives both import
+				// aliases and same-file const aliases, so `const t = test.skip;
+				// t('test foo')` reports where jest — whose parser does not
+				// follow that alias — reports nothing.
+				fnName := parsed.Name
+				firstTok := title
+				if i := strings.IndexByte(title, ' '); i >= 0 {
+					firstTok = title[:i]
+				}
+				if strings.EqualFold(firstTok, fnName) {
+					raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, arg, false)
+					fix := duplicatePrefixReplacement(raw)
+					ctx.ReportNodeWithFixes(arg, rule.RuleMessage{
+						Id:          "duplicatePrefix",
+						Description: "should not have duplicate prefix",
+					}, rule.RuleFixReplace(ctx.SourceFile, arg, fix))
+				}
+
+				if me := matcherFor(fnName, co.mustNotMatch); utils.Regexp2MatchString(me.re, title) {
+					buildMustNotReport(ctx, arg, fnName, me)
+					return
+				}
+
+				me := matcherFor(fnName, co.mustMatch)
+				if me.re != nil && !utils.Regexp2MatchString(me.re, title) {
+					buildMustMatchReport(ctx, arg, fnName, me)
+				}
+			},
+		}
+	},
+}
+
+func buildMustNotReport(ctx rule.RuleContext, arg *ast.Node, rstestFnName string, me matcherEntry) {
+	if me.customText != "" {
+		ctx.ReportNode(arg, rule.RuleMessage{
+			Id:          "mustNotMatchCustom",
+			Description: me.customText,
+			Data: map[string]string{
+				"message": me.customText,
+			},
+		})
+		return
+	}
+	patStr := regexpToMessagePattern(me.re)
+	ctx.ReportNode(arg, rule.RuleMessage{
+		Id:          "mustNotMatch",
+		Description: fmt.Sprintf("%s should not match %s", rstestFnName, patStr),
+		Data: map[string]string{
+			"rstestFunctionName": rstestFnName,
+			"pattern":            patStr,
+		},
+	})
+}
+
+func buildMustMatchReport(ctx rule.RuleContext, arg *ast.Node, rstestFnName string, me matcherEntry) {
+	if me.customText != "" {
+		ctx.ReportNode(arg, rule.RuleMessage{
+			Id:          "mustMatchCustom",
+			Description: me.customText,
+			Data: map[string]string{
+				"message": me.customText,
+			},
+		})
+		return
+	}
+	patStr := regexpToMessagePattern(me.re)
+	ctx.ReportNode(arg, rule.RuleMessage{
+		Id:          "mustMatch",
+		Description: fmt.Sprintf("%s should match %s", rstestFnName, patStr),
+		Data: map[string]string{
+			"rstestFunctionName": rstestFnName,
+			"pattern":            patStr,
+		},
+	})
+}

--- a/internal/plugins/rstest/rules/valid_title/valid_title.md
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.md
@@ -1,0 +1,160 @@
+# valid-title
+
+## Rule Details
+
+Enforce valid titles on Rstest `describe`, `test`, and `it` blocks. Titles should be informative strings, follow project conventions you configure, and use only the `printf`-style placeholders that Rstest actually expands in array-based `.each` / `.for` titles.
+
+This rule checks that titles are:
+
+- not empty (including empty template literals),
+- string literals (unless relaxed via options),
+- not accidentally prefixed with the block keyword (for example `test('test foo')`),
+- free of leading or trailing whitespace (unless `ignoreSpaces` is enabled),
+- using only valid `printf` specifiers for array-based `.each` / `.for` table names,
+- not matching `disallowedWords` (whole-word, case-insensitive) when that option is set,
+- satisfying `mustMatch` / `mustNotMatch` patterns when configured (per `describe` / `test` / `it` or a single global pattern).
+
+Auto-fix is available for accidental surrounding spaces and duplicate keyword prefixes.
+
+**`emptyTitle`**
+
+Examples of **incorrect** code:
+
+```js
+describe('', () => {});
+it('', () => {});
+test('', () => {});
+```
+
+Examples of **correct** code:
+
+```js
+describe('suite', () => {});
+it('does something', () => {});
+test('works', () => {});
+```
+
+**`titleMustBeString`**
+
+Use string literals for titles unless `ignoreTypeOfDescribeName` or `ignoreTypeOfTestName` is `true`.
+
+Examples of **incorrect** code:
+
+```js
+it(123, () => {});
+describe(myFunction, () => {});
+```
+
+Examples of **correct** code:
+
+```js
+it('is a string', () => {});
+describe('suite', () => {});
+```
+
+**`invalidEachSpecifier`**
+
+Titles of array-based `.each` and `.for` registrations are formatted at runtime. After a single `%`, only `s`, `d`, `j`, `i`, `f`, `o`, `O`, `c`, `#`, and `$` are accepted, and `%%` denotes a literal percent.
+
+Examples of **incorrect** code:
+
+```js
+test.each([[1, 2]])('.add(%I, %I)', (a, b) => {
+  expect(a + b).toBe(3);
+});
+```
+
+Examples of **correct** code:
+
+```js
+test.each([[1, 2]])('.add(%i, %i)', (a, b) => {
+  expect(a + b).toBe(3);
+});
+```
+
+Tagged-template tables are not checked, because they interpolate with `$name` rather than `printf` specifiers and a bare `%` in them is literal text:
+
+```js
+test.each`
+  a    | b
+  ${1} | ${2}
+`('returns $a and $b', ({ a, b }) => {});
+```
+
+**`duplicatePrefix`**
+
+Examples of **incorrect** code:
+
+```js
+test('test foo', () => {});
+it('it foo', () => {});
+describe('describe foo', () => {
+  it('bar', () => {});
+});
+```
+
+Examples of **correct** code:
+
+```js
+test('foo', () => {});
+it('foo', () => {});
+describe('foo', () => {
+  it('bar', () => {});
+});
+```
+
+**`accidentalSpace`**
+
+Examples of **incorrect** code:
+
+```js
+test(' foo', () => {});
+it('foo ', () => {});
+```
+
+Examples of **correct** code:
+
+```js
+test('foo', () => {});
+it('foo', () => {});
+```
+
+<!-- cspell:ignore sdjifo -->
+
+### Differences from `jest/valid-title`
+
+The rule is otherwise a port of `jest/valid-title`, with three differences that follow from how Rstest itself behaves.
+
+**The set of valid `printf` specifiers is Rstest's, not Jest's.** Rstest formats parameterized titles with Node's `util.format` semantics (`formatRegExp` is `/%[sdjifoOc%]/`), while Jest uses its own `pretty-format` placeholder set. So:
+
+| Title | `jest/valid-title` | `rstest/valid-title` |
+| --- | :---: | :---: |
+| `test.each([])('%p', fn)` | valid | **reported** — Rstest leaves `%p` in the title verbatim |
+| `test.each([])('%O', fn)` | reported | **valid** — Rstest expands it |
+| `test.each([])('%c', fn)` | reported | **valid** — Rstest expands it |
+
+**`.for` titles are checked too.** Rstest has both `.each` and `.for`, and both format their titles the same way. Jest has no `.for`.
+
+**There are no `f` / `x` prefixed aliases.** Rstest provides no `fit`, `xit`, `xtest`, `fdescribe`, or `xdescribe`, so the keyword compared against the title is always the API being registered — `test`, `it`, or `describe` — even when it was imported or aliased under another name. `import { it as xit } from '@rstest/core'; xit('it works', fn)` is reported, and `mustMatch: { test: … }` applies to `import { test as check } …; check(…)`.
+
+### Options
+
+```ts
+interface Options {
+  ignoreSpaces?: boolean;
+  ignoreTypeOfDescribeName?: boolean;
+  ignoreTypeOfTestName?: boolean;
+  disallowedWords?: string[];
+  mustNotMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
+  mustMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
+}
+```
+
+- **`ignoreSpaces`** (default `false`): skip leading/trailing space checks.
+- **`ignoreTypeOfDescribeName`** / **`ignoreTypeOfTestName`** (default `false`): allow non-string first arguments for `describe` or `test`/`it` respectively.
+- **`disallowedWords`**: list of words that must not appear as whole words in titles (case-insensitive).
+- **`mustMatch`** / **`mustNotMatch`**: ECMAScript regular expressions as strings, either one pattern for all block kinds or an object keyed by `describe`, `test`, and `it`. You can pass a two-element array `[pattern, customMessage]` to surface `*Custom` message variants.
+
+## Original Documentation
+
+- [jest/valid-title](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-title.md)

--- a/internal/plugins/rstest/rules/valid_title/valid_title.schema.json
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.schema.json
@@ -1,0 +1,94 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "ignoreSpaces": {
+          "type": "boolean",
+          "default": false
+        },
+        "ignoreTypeOfDescribeName": {
+          "type": "boolean",
+          "default": false
+        },
+        "ignoreTypeOfTestName": {
+          "type": "boolean",
+          "default": false
+        },
+        "disallowedWords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mustMatch": {
+          "$ref": "#/definitions/matcher"
+        },
+        "mustNotMatch": {
+          "$ref": "#/definitions/matcher"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1,
+  "definitions": {
+    "matcher": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/patternWithMessage"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "describe": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/patternWithMessage"
+                }
+              ]
+            },
+            "test": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/patternWithMessage"
+                }
+              ]
+            },
+            "it": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/patternWithMessage"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "patternWithMessage": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "maxItems": 2,
+      "additionalItems": false
+    }
+  }
+}

--- a/internal/plugins/rstest/rules/valid_title/valid_title_test.go
+++ b/internal/plugins/rstest/rules/valid_title/valid_title_test.go
@@ -1,0 +1,618 @@
+package valid_title_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_title"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	patMustNotHashBad = `(?:#(?!unit|e2e))\w+`
+	patMustMatchHash  = `^[^#]+$|(?:#(?:unit|e2e))`
+	patHashTag        = `#(?:unit|integration|e2e)`
+)
+
+func TestValidTitleRule(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// Registration shapes: all three overloads keep the title at
+		// arguments[0], so none of them changes what this rule reads.
+		{Code: `test("case", () => {});`},
+		{Code: `it("case", () => {});`},
+		{Code: `describe("suite", () => {});`},
+		{Code: `test("case", { timeout: 100 }, () => {});`},
+		{Code: `test("case", () => {}, 500);`},
+		{Code: `describe("suite");`},
+		{Code: `describe();`},
+		{Code: `test();`},
+		{Code: "test(`case`, () => {});"},
+		{Code: "test(`case ${x}`, () => {});"},
+		{Code: `test("a" + b, () => {});`},
+		{Code: `test("is" + " a " + " string", () => {});`},
+		{Code: `test("is a string" + suffix, () => {});`},
+		{Code: `test(foo - "bar", () => {});`},
+		{Code: `test.concurrent("case", () => {});`},
+		{Code: `describe.skip("suite", () => {});`},
+		{Code: `test.skipIf(cond)("case", () => {});`},
+
+		// API sources.
+		{Code: `import { test } from "@rstest/core";
+test("case", () => {});`},
+		{Code: `import { test as check } from "@rstest/core";
+check("case", () => {});`},
+		{Code: `const { describe } = require("@rstest/core");
+describe("suite", () => {});`},
+		{Code: `import * as rstest from "@rstest/core";
+rstest.test("case", () => {});`},
+		{Code: `import.meta.rstest.test("case", () => {});`},
+		{Code: `const api = import.meta.rstest;
+api.test("case", () => {});`},
+		{Code: `import { test } from "@rstest/playwright";
+test("case", () => {});`},
+
+		// A factory call is not a registration, so its first argument — here a
+		// fixtures object — must not be taken for a title.
+		{Code: `const myTest = test.extend({ fixture: 1 });`},
+		{Code: `const myTest = test.extend({ fixture: 1 });
+myTest("case", () => {});`},
+		{Code: `const cases = test.each([1, 2]);`},
+
+		// Not Rstest.
+		{Code: `import { test } from "vitest";
+test("test foo", () => {});`},
+		{Code: `import { test } from "@jest/globals";
+test("test foo", () => {});`},
+		{Code: `import { test } from "@playwright/test";
+test("test foo", () => {});`},
+		{Code: `import { test } from "node:test";
+test("test foo", () => {});`},
+		{Code: `const test = createRunner();
+test("test foo", () => {});`},
+		{Code: `someFn("test foo", function () {})`},
+		{Code: `someFn("", function () {})`},
+
+		// Titles that merely contain the keyword.
+		{Code: `test("foo test", () => {});`},
+		{Code: `it("foos it correctly", () => {});`},
+		{Code: `describe("foo", () => {
+  it("describes things correctly", () => {});
+});`},
+
+		{
+			Code:    "test(`GIVEN... \n  `, () => {});",
+			Options: []interface{}{map[string]interface{}{"ignoreSpaces": true}},
+		},
+		{
+			Code:    `describe(myFunction, () => {});`,
+			Options: []interface{}{map[string]interface{}{"ignoreTypeOfDescribeName": true}},
+		},
+		{
+			Code:    `test(String(/.+/), () => {});`,
+			Options: []interface{}{map[string]interface{}{"ignoreTypeOfTestName": true}},
+		},
+		{
+			Code:    `const foo = "my-title"; test(foo, () => {});`,
+			Options: []interface{}{map[string]interface{}{"ignoreTypeOfTestName": true}},
+		},
+
+		// mustMatch / disallowedWords non-triggering shapes.
+		{
+			Code:    `it("correctly sets the value", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{}}},
+		},
+		{
+			Code:    `it("correctly sets the value", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": ` `}},
+		},
+		{
+			Code:    `it("correctly sets the value #unit", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": patHashTag}},
+		},
+		{
+			Code:    `it("correctly sets the value", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{"test": patHashTag}}},
+		},
+		{
+			Code: `describe("things to test", () => {
+  describe("unit tests #unit", () => {
+    it("is true", () => {});
+  });
+
+  describe("e2e tests #e2e", () => {
+    it("is another test #rstest4life", () => {});
+  });
+});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{"test": patMustMatchHash}}},
+		},
+
+		// Percent signs outside of a parameterized registration are plain text.
+		{Code: `test("returns 100%", () => {});`},
+		{Code: `test("returns a %percent", () => {});`},
+
+		// D1, positive side: Rstest's formatRegExp.
+		{Code: `test.each([])("%s %d %i %f %j %o", () => {});`},
+		{Code: `test.each([])("%O", () => {});`},
+		{Code: `test.each([])("%c", () => {});`},
+		{Code: `test.each([])("%# %$", () => {});`},
+		{Code: `test.each([])("%%", () => {});`},
+		{Code: `test.each([])("x%%y", () => {});`},
+		{Code: `test.each([])("%int", () => {});`},
+		{Code: `test.only.each([])("%%%%", () => {});`},
+		{
+			Code: `test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+])(".add(%i, %i) = %i", (a, b, expected) => {});`,
+		},
+		{
+			Code: `describe.skip.each([
+  [1, 1, 2],
+])(".add(%i, %i)", (a, b, expected) => {});`,
+		},
+		{Code: `test.each([{ a: 1, b: 1 }])(".add($a, $b)", ({ a, b }) => {});`},
+
+		// D2, positive side: .for goes through the same formatName.
+		{Code: `test.for([])("%s", () => {});`},
+		{Code: `describe.for([])("%O", () => {});`},
+
+		// D3: a tagged-template table interpolates with $var, so its title is
+		// not printf-formatted and bare percent signs are literal.
+		{Code: "test.each`\n  a    | b\n  ${1} | ${2}\n`(\"returns $a and $b\", ({ a, b }) => {});"},
+		{Code: "test.each`\n  a\n  ${1}\n`(\"100%coverage\", ({ a }) => {});"},
+
+		// Known gap, shared with the jest rule: a factory stored in a variable
+		// loses the syntactic evidence that the title is printf-formatted.
+		{Code: `const f = test.each([1]);
+f("%z", () => {});`},
+
+		// A non-parameterized factory must not be mistaken for one just because
+		// its callee is also a call expression.
+		{Code: `test.runIf(cond)("case", () => {});`},
+		{Code: `test.skipIf(cond)("%z", () => {});`},
+	}
+	for _, param := range []string{"s", "d", "i", "f", "j", "o", "O", "c", "#", "$"} {
+		valid = append(valid,
+			rule_tester.ValidTestCase{Code: fmt.Sprintf(`test.each([])("%%%s", () => {})`, param)},
+			rule_tester.ValidTestCase{Code: fmt.Sprintf(`test.each([])("%%%%%s", () => {})`, param)},
+			rule_tester.ValidTestCase{Code: fmt.Sprintf(`test.each([])("%%%s!", () => {})`, param)},
+			rule_tester.ValidTestCase{Code: fmt.Sprintf(`test.for([])("%%%s", () => {})`, param)},
+		)
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// invalidPattern short-circuits the whole rule.
+		{
+			Code:    `it("it foo", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": "(unclosed"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalidPattern",
+				Message:   "Invalid regular expression in `mustMatch` option: `(unclosed`: error parsing regexp: missing closing ) in `(unclosed`",
+				Line:      1,
+				Column:    1,
+			}},
+		},
+		{
+			Code:    `it("it foo", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustNotMatch": map[string]interface{}{"describe": "(unterminated"}}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalidPattern",
+				Message:   "Invalid regular expression in `mustNotMatch.describe` option: `(unterminated`: error parsing regexp: missing closing ) in `(unterminated`",
+				Line:      1,
+				Column:    1,
+			}},
+		},
+		{
+			Code:    `it("it foo", () => {});`,
+			Options: []interface{}{map[string]interface{}{"disallowedWords": []interface{}{"ok", "(unterminated"}}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalidPattern",
+				Message:   "Invalid regular expression in `disallowedWords` option: `(?i)\\b(ok|(unterminated)\\b`: error parsing regexp: missing closing ) in `(?i)\\b(ok|(unterminated)\\b`",
+				Line:      1,
+				Column:    1,
+			}},
+		},
+
+		// disallowedWord reports and returns, so accidentalSpace on the same
+		// title stays silent.
+		{
+			Code:    `test("the correct way to properly handle all things", () => {});`,
+			Options: []interface{}{map[string]interface{}{"disallowedWords": []interface{}{"correct", "properly", "all"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "disallowedWord"}},
+		},
+		{
+			Code:    `it("has ALL the things", () => {});`,
+			Options: []interface{}{map[string]interface{}{"disallowedWords": []interface{}{"all"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "disallowedWord"}},
+		},
+		{
+			Code:    "test(`that the value is set properly `, () => {});",
+			Options: []interface{}{map[string]interface{}{"disallowedWords": []interface{}{"properly"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "disallowedWord"}},
+		},
+
+		// titleMustBeString.
+		{
+			Code:   `test(123, () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `test(myTitle, () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `test(String(/.+/), () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `test(1 + 2 + 3, () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		// A logical operator is not concatenation, so the string literal in it
+		// does not make the title static.
+		{
+			Code:   `test("a" || "b", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `test(cond && "b", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `test(x = "foo", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `describe(myFunction, () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `describe.skip(123, () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `test.each([])(1, () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:   `test.for([])(1, () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		// The two ignoreTypeOf options are keyed off the block kind, so the one
+		// for describe does not relax a test title.
+		{
+			Code:    `test.skip(123, () => {});`,
+			Options: []interface{}{map[string]interface{}{"ignoreTypeOfDescribeName": true}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+		{
+			Code:    `describe(myFunction, () => {});`,
+			Options: []interface{}{map[string]interface{}{"ignoreTypeOfTestName": true}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "titleMustBeString"}},
+		},
+
+		// emptyTitle reports on the whole call, not on the argument.
+		{
+			Code: `describe("", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "emptyTitle",
+				Message:   "describe should not have an empty title",
+				Line:      1,
+				Column:    1,
+			}},
+		},
+		{
+			Code: `test("", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "emptyTitle",
+				Message:   "test should not have an empty title",
+			}},
+		},
+		{
+			Code: `it("", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "emptyTitle",
+				Message:   "test should not have an empty title",
+			}},
+		},
+		{
+			Code:   "test(``, () => {});",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "emptyTitle"}},
+		},
+		{
+			Code:   `import.meta.rstest.describe("", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "emptyTitle"}},
+		},
+
+		// accidentalSpace.
+		{
+			Code:   `describe(" foo", () => {});`,
+			Output: []string{`describe("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "accidentalSpace"}},
+		},
+		{
+			Code:   `test("foo foe fum ", () => {});`,
+			Output: []string{`test("foo foe fum", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "accidentalSpace"}},
+		},
+		{
+			Code:   "test(` foo bar bang  `, () => {});",
+			Output: []string{"test(`foo bar bang`, () => {});"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "accidentalSpace"}},
+		},
+		{
+			Code:   `describe.each()(" foo", () => {});`,
+			Output: []string{`describe.each()("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "accidentalSpace"}},
+		},
+		{
+			Code: `import { test as testThat } from "@rstest/core";
+testThat("foo works ", () => {});`,
+			Output: []string{`import { test as testThat } from "@rstest/core";
+testThat("foo works", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "accidentalSpace"}},
+		},
+
+		// duplicatePrefix.
+		{
+			Code:   `describe("describe foo", () => {});`,
+			Output: []string{`describe("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   `test("test foo", () => {});`,
+			Output: []string{`test("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   `it("it foo", () => {});`,
+			Output: []string{`it("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   `it("it foos it correctly", () => {});`,
+			Output: []string{`it("foos it correctly", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   "describe('describe \tfoo', () => {})",
+			Output: []string{"describe('\tfoo', () => {})"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		// D4/D5: the prefix is compared against the API being registered, not
+		// against the local identifier. Renaming `it` to `xit` on import does
+		// not turn `it works` into a valid title, and Rstest has no `xit` of
+		// its own for the jest rule's f/x prefix trimming to apply to.
+		{
+			Code: `import { it as xit } from "@rstest/core";
+xit("it works", () => {});`,
+			Output: []string{`import { it as xit } from "@rstest/core";
+xit("works", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		// D5: the Rstest parser follows same-file const aliases, so this is a
+		// test registration with a duplicated prefix. The jest parser does not
+		// follow the alias and reports nothing here.
+		{
+			Code: `const t = test.skip;
+t("test foo", () => {});`,
+			Output: []string{`const t = test.skip;
+t("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		// accidentalSpace does not return, so a title that both has a stray
+		// space and repeats the keyword reports twice. A *leading* space would
+		// instead hide duplicatePrefix, because the first word of " describe
+		// foo" is the empty string.
+		{
+			Code:   `describe("describe foo ", () => {});`,
+			Output: []string{`describe("describe foo", () => {});`, `describe("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "accidentalSpace"},
+				{MessageId: "duplicatePrefix"},
+			},
+		},
+		{
+			Code:   `describe(" describe foo", () => {});`,
+			Output: []string{`describe("describe foo", () => {});`, `describe("foo", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "accidentalSpace"}},
+		},
+
+		// invalidEachSpecifier.
+		{
+			Code: `test.each([])("%z", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalidEachSpecifier",
+				Message:   `"%z" is not a valid format specifier`,
+			}},
+		},
+		{
+			Code:   `test.each([])("%s+%z", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		{
+			Code:   `test.each([])("%%%z", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		// D1: %p is a jest pretty-format placeholder. Rstest's formatRegExp has
+		// no `p`, so the specifier survives into the reported title verbatim.
+		{
+			Code: `test.each([])("%p", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalidEachSpecifier",
+				Message:   `"%p" is not a valid format specifier`,
+			}},
+		},
+		{
+			Code:   `test.each([[1, 2]])(".add(%i, %p)", (a, b) => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		// D2: .for formats its title the same way .each does.
+		{
+			Code:   `test.for([])("%z", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		{
+			Code:   `describe.for([])("%z", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		{
+			Code:   `test.for([])("%p", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		{
+			Code:   `test.skip.each([])("%z", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		{
+			Code:   `describe.each()("%z", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+		{
+			Code: `const entries = [[1, 1, 2]];
+test.each(entries)(".add(%i, %z)", (a, b, expected) => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		},
+
+		// mustNotMatch / mustMatch, including the custom-message variants.
+		{
+			Code: `describe("things to test", () => {
+  describe("unit tests #unit", () => {
+    it("is true", () => {});
+  });
+
+  describe("e2e tests #e4e", () => {
+    it("is another test #e2e #rstest4life", () => {});
+  });
+});`,
+			Options: []interface{}{map[string]interface{}{
+				"mustNotMatch": patMustNotHashBad,
+				"mustMatch":    patMustMatchHash,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "mustNotMatch"},
+				{MessageId: "mustNotMatch"},
+			},
+		},
+		{
+			Code: `describe("things to test", () => {
+  describe("e2e tests #e4e", () => {
+    it("is another test #e2e #rstest4life", () => {});
+  });
+});`,
+			Options: []interface{}{map[string]interface{}{
+				"mustNotMatch": []interface{}{patMustNotHashBad, `Please include "#unit" or "#e2e" in titles`},
+				"mustMatch":    []interface{}{patMustMatchHash, `Please include "#unit" or "#e2e" in titles`},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "mustNotMatchCustom", Message: `Please include "#unit" or "#e2e" in titles`},
+				{MessageId: "mustNotMatchCustom", Message: `Please include "#unit" or "#e2e" in titles`},
+			},
+		},
+		{
+			Code: `describe("things to test", () => {
+  describe("e2e tests #e4e", () => {
+    it("is another test #e2e #rstest4life", () => {});
+  });
+});`,
+			Options: []interface{}{map[string]interface{}{
+				"mustNotMatch": map[string]interface{}{"describe": patMustNotHashBad},
+				"mustMatch":    map[string]interface{}{"it": patMustMatchHash},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "mustNotMatch"}},
+		},
+		{
+			Code:    `test("the correct way to properly handle all things", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": patHashTag}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mustMatch",
+				Message:   `test should match /#(?:unit|integration|e2e)/u`,
+			}},
+		},
+		{
+			Code:    `describe("the test", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{"describe": patHashTag}}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mustMatch",
+				Message:   `describe should match /#(?:unit|integration|e2e)/u`,
+			}},
+		},
+		{
+			Code:    `describe.skip("the test", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{"describe": patHashTag}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "mustMatch"}},
+		},
+		// D5: the groups are keyed by the API being registered, so a renamed
+		// import is still matched against the `test` group.
+		{
+			Code: `import { test as check } from "@rstest/core";
+check("wrong", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{"test": "^ok"}}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mustMatch",
+				Message:   `test should match /^ok/u`,
+			}},
+		},
+		// `it` and `test` are separate groups, as they are upstream.
+		{
+			Code:    `it("wrong", () => {});`,
+			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{"it": "^ok"}}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mustMatch",
+				Message:   `it should match /^ok/u`,
+			}},
+		},
+	}
+	for _, letter := range []string{"P", "S", "D", "I", "F", "J", "Z"} {
+		invalid = append(invalid, rule_tester.InvalidTestCase{
+			Code:   fmt.Sprintf(`test.each([])("%%%s", () => {})`, letter),
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidEachSpecifier"}},
+		})
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&valid_title.ValidTitleRule,
+		valid,
+		invalid,
+	)
+}
+
+// TestValidTitleMatcherSchema locks in the shape of the `mustMatch` /
+// `mustNotMatch` options, which is copied byte for byte from the jest rule.
+func TestValidTitleMatcherSchema(t *testing.T) {
+	valid := []any{
+		"^\\d+", // one pattern for every block kind
+		[]any{"^\\d+", "titles must start with a number"},     // pattern with a custom message
+		map[string]any{"describe": "^\\d+", "it": []any{"x"}}, // per-block-kind patterns
+	}
+	for _, matcher := range valid {
+		for _, key := range []string{"mustMatch", "mustNotMatch"} {
+			options := []any{map[string]any{key: matcher}}
+			if err := valid_title.ValidTitleRule.Schema.Validate(options); err != nil {
+				t.Errorf("expected %s: %v to pass schema validation, got: %v", key, matcher, err)
+			}
+		}
+	}
+
+	invalid := []any{
+		42,                             // neither a pattern nor a per-kind map
+		[]any{},                        // a pattern is required
+		[]any{"a", "b", "c"},           // at most a pattern and a message
+		map[string]any{"describe": 42}, // a per-kind value is still a pattern
+	}
+	for _, matcher := range invalid {
+		options := []any{map[string]any{"mustMatch": matcher}}
+		if err := valid_title.ValidTitleRule.Schema.Validate(options); err == nil {
+			t.Errorf("expected mustMatch: %v to fail schema validation", matcher)
+		}
+	}
+
+	options := []any{map[string]any{"mustAlsoMatch": "^\\d+"}}
+	if err := valid_title.ValidTitleRule.Schema.Validate(options); err == nil {
+		t.Error("expected an unknown option name to fail schema validation")
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -553,6 +553,7 @@ export default defineConfig({
     './tests/rstest/rules/no-disabled-tests.test.ts',
     './tests/rstest/rules/no-identical-title.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
+    './tests/rstest/rules/valid-title.test.ts',
 
     // eslint-plugin-promise
     './tests/eslint-plugin-promise/rules/always-return.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -80,6 +80,7 @@ describe('defineConfig and config presets', () => {
       'rstest/no-disabled-tests': 'warn',
       'rstest/no-identical-title': 'error',
       'rstest/no-mocks-import': 'error',
+      'rstest/valid-title': 'error',
     });
   });
 });

--- a/packages/rslint-test-tools/tests/rstest/rules/valid-title.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/valid-title.test.ts
@@ -1,0 +1,117 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('valid-title', {} as never, {
+  valid: [
+    {
+      code: 'test("does something", () => {});',
+    },
+    {
+      code: 'describe("suite", () => { it("works", () => {}); });',
+    },
+    // Rstest expands %O and %c, unlike jest
+    {
+      code: 'test.each([])("%O and %c", () => {});',
+    },
+    {
+      code: 'test.for([{ a: 1 }])("adds $a", () => {});',
+    },
+    {
+      code: 'import { test } from "vitest";\ntest("test foo", () => {});',
+    },
+    {
+      code: 'it("has a #unit tag", () => {});',
+      options: [{ mustMatch: '#(?:unit|e2e)' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'test("", () => {});',
+      errors: [
+        {
+          messageId: 'emptyTitle',
+          message: 'test should not have an empty title',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: 'describe(123, () => {});',
+      errors: [{ messageId: 'titleMustBeString', line: 1, column: 10 }],
+    },
+    {
+      code: 'test(" foo", () => {});',
+      output: 'test("foo", () => {});',
+      errors: [{ messageId: 'accidentalSpace', line: 1, column: 6 }],
+    },
+    {
+      code: 'test("test foo", () => {});',
+      output: 'test("foo", () => {});',
+      errors: [{ messageId: 'duplicatePrefix', line: 1, column: 6 }],
+    },
+    // %p is a jest placeholder that Rstest does not expand
+    {
+      code: 'test.each([])("%p", () => {});',
+      errors: [
+        {
+          messageId: 'invalidEachSpecifier',
+          message: '"%p" is not a valid format specifier',
+        },
+      ],
+    },
+    // .for formats its title the same way .each does
+    {
+      code: 'test.for([])("%z", () => {});',
+      errors: [{ messageId: 'invalidEachSpecifier' }],
+    },
+    {
+      code: 'test("the correct way", () => {});',
+      options: [{ disallowedWords: ['correct'] }],
+      errors: [{ messageId: 'disallowedWord' }],
+    },
+    {
+      code: 'test("nope", () => {});',
+      options: [{ mustMatch: '^ok' }],
+      errors: [{ messageId: 'mustMatch', message: 'test should match /^ok/u' }],
+    },
+    {
+      code: 'describe("nope", () => {});',
+      options: [{ mustNotMatch: ['^nope', 'describe titles must be useful'] }],
+      errors: [
+        {
+          messageId: 'mustNotMatchCustom',
+          message: 'describe titles must be useful',
+        },
+      ],
+    },
+    {
+      code: 'describe("nope", () => {});',
+      options: [{ mustNotMatch: '^nope' }],
+      errors: [
+        {
+          messageId: 'mustNotMatch',
+          message: 'describe should not match /^nope/u',
+        },
+      ],
+    },
+    {
+      code: 'test("nope", () => {});',
+      options: [{ mustMatch: ['^ok', 'titles must start with "ok"'] }],
+      errors: [
+        {
+          messageId: 'mustMatchCustom',
+          message: 'titles must start with "ok"',
+        },
+      ],
+    },
+    // A pattern that does not compile is reported once, and no other diagnostic
+    // is produced.
+    {
+      code: 'test("test foo", () => {});',
+      options: [{ mustMatch: '(unclosed' }],
+      errors: [{ messageId: 'invalidPattern', line: 1, column: 1 }],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -8,6 +8,7 @@ const recommended: RslintConfigEntry = {
     'rstest/no-disabled-tests': 'warn',
     'rstest/no-identical-title': 'error',
     'rstest/no-mocks-import': 'error',
+    'rstest/valid-title': 'error',
   },
 };
 


### PR DESCRIPTION
## Summary

Ports `jest/valid-title` to the rstest plugin, registered in the recommended preset as `error` to match the jest preset and upstream `eslint-plugin-jest`. All ten messages, all six options (`ignoreSpaces`, `ignoreTypeOfDescribeName`, `ignoreTypeOfTestName`, `disallowedWords`, `mustMatch`, `mustNotMatch`) and the two fixers are carried over, with the option schema copied unchanged.

## Related Links

Related https://github.com/web-infra-dev/rslint/issues/935

## Divergence

**Format specifiers follow the Rstest runtime, not Jest's.** Rstest formats parameterized titles with Node `util.format` semantics — its `formatRegExp` is `/%[sdjifoOc%]/` — whereas Jest uses its own `pretty-format` placeholder set. So `test.each([])('%p', fn)` is reported here and accepted by `jest/valid-title`, because Rstest leaves `%p` in the title verbatim; `%O` and `%c` go the other way, being expanded by Rstest and reported by Jest.

**`.for` titles are checked alongside `.each`.** Rstest has both, and both format the title through the same `formatName`. Jest has no `.for`.

**There is no `f` / `x` prefix to strip.** Rstest ships no `fit`, `xit`, `xtest`, `fdescribe` or `xdescribe`, so the keyword compared against the title is always the API being registered rather than the local name it was imported under. `import { it as xit } from '@rstest/core'; xit('it works', fn)` is reported as a duplicate prefix, and `mustMatch: { test: … }` applies to `import { test as check } …; check(…)`.
