### PR TITLE
fix: resolve type-only heritage qualifiers in RefStore

### DIFF
--- a/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of_test.go
+++ b/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of_test.go
@@ -306,6 +306,13 @@ for (let i = 0; i < arr.length; i++) {
 for (let i = 0; i < arr.length; i++) {
   const x: typeof i = arr[i];
 }`},
+		// A class `extends` expression uses its qualifier at runtime.
+		{Code: `
+namespace i { export class Y {} }
+for (let i = 0; i < arr.length; i++) {
+  console.log(arr[i]);
+  class X extends i.Y {}
+}`},
 		// ======== A `var` redeclaration writes the same function-scoped index ========
 		{Code: `
 for (var i = 0; i < arr.length; i++) {
@@ -342,6 +349,18 @@ for (var i = 0; i < arr.length; i++) {
   console.log(arr[i]);
 }`},
 	}, []rule_tester.InvalidTestCase{
+		// ---- A type-only heritage qualifier resolves in namespace space ----
+		{
+			Code: `
+namespace i { export interface Y {} }
+for (let i = 0; i < arr.length; i++) {
+  console.log(arr[i]);
+  class X implements i.Y {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 3, Column: 1, EndLine: 6, EndColumn: 2},
+			},
+		},
 		// ---- A `var` redeclaration that assigns nothing ----
 		{
 			Code: `

--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -421,6 +421,14 @@ func referenceMeaning(n *ast.Node) ast.SymbolFlags {
 		entity.Parent.AsImportEqualsDeclaration().ModuleReference == entity {
 		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
 	}
+	// Heritage clauses parse dotted names as PropertyAccessExpressions rather
+	// than QualifiedNames. In a type-only heritage position, the root of that
+	// property-access chain still names a namespace and must skip a same-named
+	// value binding. A class `extends` expression is not part of a type node, so
+	// it deliberately continues to the value-space branch below.
+	if isTypeOnlyPropertyAccessQualifier(n) {
+		return ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+	}
 	if ast.IsExpressionNode(n) {
 		return ast.SymbolFlagsValue | ast.SymbolFlagsAlias
 	}
@@ -433,4 +441,20 @@ func referenceMeaning(n *ast.Node) ast.SymbolFlags {
 		return ast.SymbolFlagsType | ast.SymbolFlagsAlias
 	}
 	return ast.SymbolFlagsValue | ast.SymbolFlagsAlias
+}
+
+// isTypeOnlyPropertyAccessQualifier reports whether n is the lexical root of
+// an expression-shaped qualified name used as a type. TypeScript represents
+// `N.T` in `class C implements N.T` and `interface I extends N.T` with a
+// PropertyAccessExpression, even though N has namespace meaning there.
+func isTypeOnlyPropertyAccessQualifier(n *ast.Node) bool {
+	entity := n
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindPropertyAccessExpression {
+		access := entity.Parent.AsPropertyAccessExpression()
+		if access == nil || access.Expression != entity {
+			break
+		}
+		entity = entity.Parent
+	}
+	return entity != n && ast.IsPartOfTypeNode(entity)
 }

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -912,6 +912,171 @@ func TestRefStoreResolveNoCheckerFallback(t *testing.T) {
 	}
 }
 
+func TestRefStoreTypeOnlyHeritageQualifierSkipsValueShadow(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "class implements",
+			source: `
+export {};
+namespace N { export interface T {} }
+function f() {
+	let N = 0;
+	class C implements N.T {}
+}`,
+		},
+		{
+			name: "interface extends",
+			source: `
+export {};
+namespace N { export interface T {} }
+function f() {
+	let N = 0;
+	interface I extends N.T {}
+}`,
+		},
+		{
+			name: "nested qualifier",
+			source: `
+export {};
+namespace N { export namespace Inner { export interface T {} } }
+function f() {
+	let N = 0;
+	class C implements N.Inner.T {}
+}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile, refs := newBoundRefStore(t, "/type-only-heritage.ts", core.ScriptKindTS, test.source)
+			occurrences := identifiers(sourceFile.AsNode(), "N")
+			if len(occurrences) != 3 {
+				t.Fatalf("identifier occurrences = %d, want 3", len(occurrences))
+			}
+
+			namespace := occurrences[0].Parent.Symbol()
+			localValue := occurrences[1].Parent.Symbol()
+			use := occurrences[2]
+			if namespace == nil || localValue == nil {
+				t.Fatal("declaration identifier has no bound symbol")
+			}
+			if got := refs.Resolve(use); got != namespace {
+				t.Fatalf("Resolve(heritage qualifier) = %v, want namespace %v", got, namespace)
+			}
+			if got := refs.References(namespace); len(got) != 1 || got[0] != use {
+				t.Fatalf("References(namespace) = %v, want [%v]", got, use)
+			}
+			if got := refs.References(localValue); len(got) != 0 {
+				t.Fatalf("References(local value) = %v, want none", got)
+			}
+		})
+	}
+}
+
+func TestRefStoreExpressionShapedTypeQualifierPreservesValueContexts(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{
+			// Unlike `implements` and an interface's `extends`, a class
+			// `extends` expression executes at runtime.
+			name: "class extends",
+			source: `
+export {};
+namespace N { export class Base {} }
+function f() {
+	const N = { Base: class {} };
+	class C extends N.Base {}
+	}`,
+		},
+		{
+			// A type query names the runtime value even though the query itself
+			// is type syntax.
+			name: "type query",
+			source: `
+export {};
+namespace N { export const value = 1; }
+function f() {
+	const N = { value: 1 };
+	type T = typeof N.value;
+}`,
+		},
+		{
+			// An arbitrary expression inside `implements` is still a value use;
+			// only a pure dotted entity name acts as a namespace qualifier.
+			name: "call expression in implements",
+			source: `
+export {};
+namespace N { export interface T {} }
+function f() {
+	function N() { return { T: class {} }; }
+	class C implements N().T {}
+}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile, refs := newBoundRefStore(t, "/value-qualifier.ts", core.ScriptKindTS, test.source)
+			occurrences := identifiers(sourceFile.AsNode(), "N")
+			if len(occurrences) != 3 {
+				t.Fatalf("identifier occurrences = %d, want 3", len(occurrences))
+			}
+			namespace := occurrences[0].Parent.Symbol()
+			localValue := occurrences[1].Parent.Symbol()
+			use := occurrences[2]
+			if namespace == nil || localValue == nil {
+				t.Fatal("declaration identifier has no bound symbol")
+			}
+			if got := refs.Resolve(use); got != localValue {
+				t.Fatalf("Resolve(value qualifier) = %v, want local value %v", got, localValue)
+			}
+			if got := refs.References(localValue); len(got) != 1 || got[0] != use {
+				t.Fatalf("References(local value) = %v, want [%v]", got, use)
+			}
+			if got := refs.References(namespace); len(got) != 0 {
+				t.Fatalf("References(namespace) = %v, want none", got)
+			}
+		})
+	}
+}
+
+func TestRefStoreTypeOnlyHeritageQualifierCheckerFallbackRespectsMeaning(t *testing.T) {
+	// The binder cannot see namespaces declared in lib files. Its namespace
+	// lookup must fall back to a meaning-aware checker lookup rather than let
+	// GetSymbolAtLocation select the same-named local value.
+	sourceFile, refs, done := newCheckedRefStore(t, `
+export {};
+function f() {
+	let Intl = 0;
+	class C implements Intl.CollatorOptions {}
+}`)
+	defer done()
+
+	occurrences := identifiers(sourceFile.AsNode(), "Intl")
+	if len(occurrences) != 2 {
+		t.Fatalf("identifier occurrences = %d, want 2", len(occurrences))
+	}
+	localValue := occurrences[0].Parent.Symbol()
+	use := occurrences[1]
+	if localValue == nil {
+		t.Fatal("local declaration identifier has no bound symbol")
+	}
+	target := refs.Resolve(use)
+	if target == nil || target == localValue {
+		t.Fatalf("Resolve(heritage qualifier) = %v, want the global Intl namespace", target)
+	}
+	if target.Flags&(ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias) == 0 {
+		t.Fatalf("resolved checker symbol flags = %v, want a namespace-capable symbol", target.Flags)
+	}
+	if got := refs.References(target); len(got) != 1 || got[0] != use {
+		t.Fatalf("References(global namespace) = %v, want [%v]", got, use)
+	}
+	if got := refs.References(localValue); len(got) != 0 {
+		t.Fatalf("References(local value) = %v, want none", got)
+	}
+}
+
 func TestRefStoreMergedGlobalSymbolIdentity(t *testing.T) {
 	// A global script file's `interface Map` merges with lib.d.ts's `Map`,
 	// and the two reference sites below reach that one declaration by


### PR DESCRIPTION
## Summary

- Resolve dotted qualifiers in type-only heritage clauses through namespace space in RefStore.
- Preserve value-space resolution for class extends, type queries, and arbitrary heritage expressions.
- Add direct RefStore coverage plus a prefer-for-of regression test.

## Related Links

- Follow-up to #1591.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).