### PR TITLE
fix(typescript-eslint): align type specifier matching

### DIFF
--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions_test.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions_test.go
@@ -66,6 +66,9 @@ func TestRestrictTemplateExpressionsRule(t *testing.T) {
 				Code: "class CustomError extends Error {}\nclass Deeper extends CustomError {}\ndeclare const arg: Deeper;\nconst msg = `arg = ${arg}`;\n",
 			},
 			{
+				Code: "interface Extra { extra: true }\ndeclare const Mixed: new () => Error & Extra;\nclass Derived extends Mixed {}\ndeclare const arg: Derived;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
 				Code: "declare const arg: object;\ndeclare function tag(strings: TemplateStringsArray, ...values: unknown[]): string;\nconst msg = tag`arg = ${arg}`;\n",
 			},
 			{
@@ -331,6 +334,20 @@ func TestRestrictTemplateExpressionsRule(t *testing.T) {
 						Line:      2,
 						Column:    22,
 						EndLine:   2,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:    "interface Demo { value: string }\ndeclare const arg: Demo;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{map[string]any{"from": "file", "name": "Demo", "path": ""}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidType",
+						Message:   "Invalid type \"Demo\" of template literal expression.",
+						Line:      3,
+						Column:    22,
+						EndLine:   3,
 						EndColumn: 25,
 					},
 				},

--- a/internal/utils/type_matches_specifier.go
+++ b/internal/utils/type_matches_specifier.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"weak"
 
 	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -70,6 +71,10 @@ type TypeOrValueSpecifier struct {
 	Path string `json:"path"`
 	// Can be used when From == TypeOrValueSpecifierFromPackage
 	Package string `json:"package"`
+	// pathProvided distinguishes an omitted path from an explicitly empty one.
+	// Both decode to Path == "", but upstream treats only the omitted form as
+	// matching declarations anywhere in the current project.
+	pathProvided bool
 }
 
 // UnmarshalJSON handles both string shorthand ("Promise") and object form
@@ -78,9 +83,15 @@ type TypeOrValueSpecifier struct {
 func (s *TypeOrValueSpecifier) UnmarshalJSON(data []byte) error {
 	var str string
 	if err := json.Unmarshal(data, &str); err == nil {
-		s.From = TypeOrValueSpecifierFromString
-		s.Name = NameList{str}
+		*s = TypeOrValueSpecifier{
+			From: TypeOrValueSpecifierFromString,
+			Name: NameList{str},
+		}
 		return nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
 	}
 	type Alias TypeOrValueSpecifier
 	var alias Alias
@@ -88,21 +99,15 @@ func (s *TypeOrValueSpecifier) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*s = TypeOrValueSpecifier(alias)
+	_, s.pathProvided = fields["path"]
 	return nil
 }
 
-func typeMatchesStringSpecifierWithCalleeNames(
+func specifierNameMatchesWithCalleeNames(
 	t *checker.Type,
 	names []string,
 	calleeNames []string,
 ) bool {
-	// Handle union types: all constituents must match the specifier
-	if parts := UnionTypeParts(t); len(parts) > 1 {
-		return Every(parts, func(part *checker.Type) bool {
-			return typeMatchesStringSpecifierWithCalleeNames(part, names, calleeNames)
-		})
-	}
-
 	alias := checker.Type_alias(t)
 	var symbol *ast.Symbol
 	if alias == nil {
@@ -130,8 +135,33 @@ func typeMatchesStringSpecifierWithCalleeNames(
 	return false
 }
 
+func typeMatchesInlineSpecifierWithCalleeNames(
+	t *checker.Type,
+	names []string,
+	calleeNames []string,
+) bool {
+	if parts := UnionTypeParts(t); len(parts) > 1 {
+		return Every(parts, func(part *checker.Type) bool {
+			return typeMatchesInlineSpecifierWithCalleeNames(part, names, calleeNames)
+		})
+	}
+	if IsIntrinsicErrorType(t) {
+		return false
+	}
+	if specifierNameMatchesWithCalleeNames(t, names, calleeNames) {
+		return true
+	}
+	if parts := IntersectionTypeParts(t); len(parts) > 1 {
+		return Some(parts, func(part *checker.Type) bool {
+			return typeMatchesInlineSpecifierWithCalleeNames(part, names, calleeNames)
+		})
+	}
+	return false
+}
+
 func typeDeclaredInFile(
 	relativePath string,
+	pathProvided bool,
 	declarationFiles []*ast.SourceFile,
 	program *compiler.Program,
 ) bool {
@@ -140,7 +170,7 @@ func typeDeclaredInFile(
 	canonical := func(fileName string) string {
 		return tspath.GetCanonicalFileName(fileName, useCaseSensitiveFileNames)
 	}
-	if relativePath == "" {
+	if !pathProvided {
 		return Some(declarationFiles, func(f *ast.SourceFile) bool {
 			return strings.HasPrefix(canonical(f.FileName()), canonical(cwd))
 		})
@@ -196,38 +226,70 @@ func typeDeclaredInDeclareModule(
 	})
 }
 
-// resolvedPackageName returns the package a declaration file belongs to, in the
-// "name/subpath" form module resolution records, such as "demo-pkg/index.d.ts"
-// or "@types/node/globals.d.ts". Workspace packages are symlinked into
-// node_modules and resolve to their real path, so the owning package is found
-// through the nearest enclosing package.json that names one instead of through
-// the file name.
-func resolvedPackageName(program *compiler.Program, fileName string) string {
-	directory := tspath.GetDirectoryPath(fileName)
-	for directory != "" {
-		packageDirectory := program.GetNearestAncestorDirectoryWithPackageJson(directory)
-		if packageDirectory == "" {
-			return ""
-		}
-		info := program.GetPackageJsonInfo(tspath.CombinePaths(packageDirectory, "package.json"))
-		if info.Exists() {
-			if name, ok := info.Contents.Name.GetValue(); ok && name != "" {
-				if subpath, nested := strings.CutPrefix(fileName, packageDirectory+"/"); nested {
-					return name + "/" + subpath
-				}
-				return name
+type sourceFilePackageNamesCacheEntry struct {
+	once  sync.Once
+	names map[tspath.Path][]string
+}
+
+// sourceFilePackageNamesCache reconstructs TypeScript's sourceFileToPackageName
+// data from TypeScript-Go's resolution caches. Its weak Program keys keep
+// repeated rule matches cheap without retaining old Programs after an LSP
+// rebuild.
+var sourceFilePackageNamesCache = struct {
+	sync.Mutex
+	entries map[weak.Pointer[compiler.Program]]*sourceFilePackageNamesCacheEntry
+}{
+	entries: make(map[weak.Pointer[compiler.Program]]*sourceFilePackageNamesCacheEntry),
+}
+
+func sourceFilePackageNames(program *compiler.Program) map[tspath.Path][]string {
+	key := weak.Make(program)
+	sourceFilePackageNamesCache.Lock()
+	entry := sourceFilePackageNamesCache.entries[key]
+	if entry == nil {
+		// Weak keys do not remove themselves from a map. Opportunistically prune
+		// entries whose Programs have been collected whenever a new one appears.
+		for candidate := range sourceFilePackageNamesCache.entries {
+			if candidate.Value() == nil {
+				delete(sourceFilePackageNamesCache.entries, candidate)
 			}
 		}
-		// A package.json without a name, such as the `{"type": "module"}` files
-		// dual-published packages drop into subdirectories, belongs to whichever
-		// named package encloses it.
-		parent := tspath.GetDirectoryPath(packageDirectory)
-		if parent == packageDirectory {
-			return ""
-		}
-		directory = parent
+		entry = &sourceFilePackageNamesCacheEntry{}
+		sourceFilePackageNamesCache.entries[key] = entry
 	}
-	return ""
+	sourceFilePackageNamesCache.Unlock()
+
+	entry.once.Do(func() {
+		entry.names = make(map[tspath.Path][]string)
+		addResolution := func(fileName string, packageID module.PackageId) {
+			if packageID.Name == "" {
+				return
+			}
+			file := program.GetSourceFileForResolvedModule(fileName)
+			if file == nil {
+				return
+			}
+			packageName := packageID.PackageName()
+			if !slices.Contains(entry.names[file.Path()], packageName) {
+				entry.names[file.Path()] = append(entry.names[file.Path()], packageName)
+			}
+		}
+		for _, resolutions := range program.GetResolvedModules() {
+			for _, resolution := range resolutions {
+				if resolution != nil {
+					addResolution(resolution.ResolvedFileName, resolution.PackageId)
+				}
+			}
+		}
+		for _, resolutions := range program.GetResolvedTypeReferenceDirectives() {
+			for _, resolution := range resolutions {
+				if resolution != nil {
+					addResolution(resolution.ResolvedFileName, resolution.PackageId)
+				}
+			}
+		}
+	})
+	return entry.names
 }
 
 // packageMatchers caches the compiled matcher per `package` specifier, which
@@ -262,9 +324,10 @@ func typeDeclaredInDeclarationFile(
 		if file == nil || !program.IsSourceFileFromExternalLibrary(file) {
 			continue
 		}
-		name := resolvedPackageName(program, file.FileName())
-		if name != "" && Regexp2MatchString(matcher, name) {
-			return true
+		for _, name := range sourceFilePackageNames(program)[file.Path()] {
+			if Regexp2MatchString(matcher, name) {
+				return true
+			}
 		}
 	}
 	return false
@@ -292,38 +355,54 @@ func typeMatchesSpecifier(
 			return typeMatchesSpecifier(part, specifier, program, calleeNames)
 		})
 	}
-
-	if !typeMatchesStringSpecifierWithCalleeNames(t, specifier.Name, calleeNames) {
+	if IsIntrinsicErrorType(t) {
 		return false
 	}
 
-	symbol := checker.Type_symbol(t)
-	if symbol == nil {
-		alias := checker.Type_alias(t)
-		if alias != nil {
-			symbol = alias.Symbol()
+	wholeTypeMatches := false
+	if specifierNameMatchesWithCalleeNames(t, specifier.Name, calleeNames) {
+		symbol := checker.Type_symbol(t)
+		if symbol == nil {
+			alias := checker.Type_alias(t)
+			if alias != nil {
+				symbol = alias.Symbol()
+			}
+		}
+		var declarations []*ast.Node
+		if symbol != nil {
+			declarations = symbol.Declarations
+		}
+		declarationFiles := Map(declarations, func(d *ast.Node) *ast.SourceFile {
+			return ast.GetSourceFileOfNode(d)
+		})
+
+		switch specifier.From {
+		case TypeOrValueSpecifierFromString:
+			wholeTypeMatches = true
+		case TypeOrValueSpecifierFromFile:
+			wholeTypeMatches = typeDeclaredInFile(
+				specifier.Path,
+				specifier.pathProvided || specifier.Path != "",
+				declarationFiles,
+				program,
+			)
+		case TypeOrValueSpecifierFromLib:
+			wholeTypeMatches = typeDeclaredInLib(declarationFiles, program)
+		case TypeOrValueSpecifierFromPackage:
+			wholeTypeMatches = typeDeclaredInPackageDeclarationFile(specifier.Package, declarations, declarationFiles, program)
+		default:
+			panic(fmt.Sprintf("unknown type specifier from: %v", specifier.From))
 		}
 	}
-	var declarations []*ast.Node
-	if symbol != nil {
-		declarations = symbol.Declarations
+	if wholeTypeMatches {
+		return true
 	}
-	declarationFiles := Map(declarations, func(d *ast.Node) *ast.SourceFile {
-		return ast.GetSourceFileOfNode(d)
-	})
-
-	switch specifier.From {
-	case TypeOrValueSpecifierFromString:
-		return true // string shorthand matches any origin; name already matched above
-	case TypeOrValueSpecifierFromFile:
-		return typeDeclaredInFile(specifier.Path, declarationFiles, program)
-	case TypeOrValueSpecifierFromLib:
-		return typeDeclaredInLib(declarationFiles, program)
-	case TypeOrValueSpecifierFromPackage:
-		return typeDeclaredInPackageDeclarationFile(specifier.Package, declarations, declarationFiles, program)
-	default:
-		panic(fmt.Sprintf("unknown type specifier from: %v", specifier.From))
+	if parts := IntersectionTypeParts(t); len(parts) > 1 {
+		return Some(parts, func(part *checker.Type) bool {
+			return typeMatchesSpecifier(part, specifier, program, calleeNames)
+		})
 	}
+	return false
 }
 
 func TypeMatchesSomeSpecifier(
@@ -345,17 +424,9 @@ func TypeMatchesSomeSpecifierWithCalleeNames(
 	program *compiler.Program,
 	calleeNames []string,
 ) bool {
-	for _, typePart := range IntersectionTypeParts(t) {
-		if IsIntrinsicErrorType(typePart) {
-			continue
-		}
-		if Some(specifiers, func(s TypeOrValueSpecifier) bool {
-			return typeMatchesSpecifier(t, s, program, calleeNames)
-		}) || typeMatchesStringSpecifierWithCalleeNames(t, inlineSpecifiers, calleeNames) {
-			return true
-		}
-	}
-	return false
+	return Some(specifiers, func(s TypeOrValueSpecifier) bool {
+		return typeMatchesSpecifier(t, s, program, calleeNames)
+	}) || typeMatchesInlineSpecifierWithCalleeNames(t, inlineSpecifiers, calleeNames)
 }
 
 // specifierStaticName is the name a specifier compares against when it matches

--- a/internal/utils/type_matches_specifier_test.go
+++ b/internal/utils/type_matches_specifier_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -41,8 +42,8 @@ func (f *symlinkVFS) Realpath(path string) string {
 	return f.FS.Realpath(path)
 }
 
-// typeOfTestAlias returns the type `type Test = ...` resolves to in fileName.
-func typeOfTestAlias(t *testing.T, program *compiler.Program, c *checker.Checker, fileName string) *checker.Type {
+// typeOfLastAlias returns the type of the last type alias declared in fileName.
+func typeOfLastAlias(t *testing.T, program *compiler.Program, c *checker.Checker, fileName string) *checker.Type {
 	t.Helper()
 	sourceFile := program.GetSourceFile(fileName)
 	assert.Assert(t, sourceFile != nil, "expected %s in the program", fileName)
@@ -55,9 +56,32 @@ func typeOfTestAlias(t *testing.T, program *compiler.Program, c *checker.Checker
 	}
 	assert.Assert(t, alias != nil, "expected a type alias declaration")
 
-	declared := c.GetTypeAtLocation(alias.AsTypeAliasDeclaration().Name())
+	return c.GetTypeAtLocation(alias.AsTypeAliasDeclaration().Name())
+}
+
+// typeOfTestAlias returns the type `type Test = ...` resolves to in fileName.
+func typeOfTestAlias(t *testing.T, program *compiler.Program, c *checker.Checker, fileName string) *checker.Type {
+	t.Helper()
+	declared := typeOfLastAlias(t, program, c, fileName)
 	assert.Assert(t, checker.Type_symbol(declared) != nil, "expected the alias to resolve to a symbol")
 	return declared
+}
+
+func firstVariableInitializer(t *testing.T, program *compiler.Program, fileName string) *ast.Node {
+	t.Helper()
+	sourceFile := program.GetSourceFile(fileName)
+	assert.Assert(t, sourceFile != nil, "expected %s in the program", fileName)
+	for _, statement := range sourceFile.Statements.Nodes {
+		if statement.Kind != ast.KindVariableStatement {
+			continue
+		}
+		declarations := statement.AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes
+		if len(declarations) > 0 {
+			return declarations[0].AsVariableDeclaration().Initializer
+		}
+	}
+	t.Fatal("expected a variable initializer")
+	return nil
 }
 
 func TestTypeMatchesSomeSpecifierFromPackage(t *testing.T) {
@@ -231,4 +255,146 @@ func TestTypeMatchesSomeSpecifierFromPackageIgnoresLocalTypes(t *testing.T) {
 		Name:    NameList{"Demo"},
 		Package: "demo-pkg",
 	}}, nil, program), false)
+}
+
+func TestTypeMatchesSomeSpecifierExpandsIntersections(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	filePath := resolve("file.ts")
+	fs := NewOverlayVFS(baseFS, map[string]string{
+		filePath: "interface Extra { extra: true }\ntype Test = Error & Extra;\n",
+	})
+
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	intersection := typeOfLastAlias(t, program, c, filePath)
+	assert.Equal(t, TypeMatchesSomeSpecifier(intersection, []TypeOrValueSpecifier{{
+		From: TypeOrValueSpecifierFromLib,
+		Name: NameList{"Error"},
+	}}, nil, program), true)
+}
+
+func TestTypeMatchesSomeSpecifierUsesResolutionPackageID(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	tests := []struct {
+		name            string
+		rootPackageJSON string
+		nestedPackage   string
+		wantMatch       bool
+	}{
+		{
+			name:            "named nested package does not replace entry package",
+			rootPackageJSON: `{"name":"demo-pkg","version":"1.0.0","types":"dist/index.d.ts"}`,
+			nestedPackage:   `{"name":"nested-pkg","version":"2.0.0"}`,
+			wantMatch:       true,
+		},
+		{
+			name:            "package without version has no package ID",
+			rootPackageJSON: `{"name":"demo-pkg","types":"dist/index.d.ts"}`,
+			nestedPackage:   `{"sideEffects":false}`,
+			wantMatch:       false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filePath := resolve("file.ts")
+			fs := NewOverlayVFS(baseFS, map[string]string{
+				filePath: "import { Demo, demoValue } from 'demo-pkg';\nconst value = demoValue;\ntype Test = Demo;\n",
+				resolve("node_modules/demo-pkg/package.json"):      test.rootPackageJSON,
+				resolve("node_modules/demo-pkg/dist/package.json"): test.nestedPackage,
+				resolve("node_modules/demo-pkg/dist/index.d.ts"):   "export declare class Demo {}\nexport declare function demoValue(): void;\n",
+			})
+
+			program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+			assert.NilError(t, err, "couldn't create program")
+			c, done := program.GetTypeChecker(t.Context())
+			defer done()
+
+			demo := typeOfTestAlias(t, program, c, filePath)
+			assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{{
+				From:    TypeOrValueSpecifierFromPackage,
+				Name:    NameList{"Demo"},
+				Package: "demo-pkg",
+			}}, nil, program), test.wantMatch)
+
+			valueNode := firstVariableInitializer(t, program, filePath)
+			assert.Equal(t, ValueMatchesSomeSpecifier(valueNode, []TypeOrValueSpecifier{{
+				From:    TypeOrValueSpecifierFromPackage,
+				Name:    NameList{"demoValue"},
+				Package: "demo-pkg",
+			}}, program, c.GetTypeAtLocation(valueNode)), test.wantMatch)
+		})
+	}
+}
+
+func TestTypeMatchesSomeSpecifierChecksWholeIntersectionBeforeConstituents(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	tests := []struct {
+		name string
+		code string
+		want bool
+	}{
+		{
+			name: "whole alias matches",
+			code: "type SafePromise = Promise<number> & { __safeBrand: string };\ntype Test = SafePromise;\n",
+			want: true,
+		},
+		{
+			name: "inlined alias is not a constituent",
+			code: "type SafePromise = Promise<number> & { __safeBrand: string };\ntype Test = SafePromise & {};\n",
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filePath := resolve("file.ts")
+			fs := NewOverlayVFS(baseFS, map[string]string{filePath: test.code})
+			program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+			assert.NilError(t, err, "couldn't create program")
+			c, done := program.GetTypeChecker(t.Context())
+			defer done()
+
+			intersection := typeOfLastAlias(t, program, c, filePath)
+			assert.Equal(t, TypeMatchesSomeSpecifier(intersection, []TypeOrValueSpecifier{{
+				From: TypeOrValueSpecifierFromFile,
+				Name: NameList{"SafePromise"},
+			}}, nil, program), test.want)
+		})
+	}
+}
+
+func TestTypeMatchesSomeSpecifierDistinguishesOmittedAndEmptyFilePath(t *testing.T) {
+	rootDir, resolve, baseFS := fixtureRoot()
+
+	filePath := resolve("file.ts")
+	fs := NewOverlayVFS(baseFS, map[string]string{
+		filePath: "interface Demo { value: string }\ntype Test = Demo;\n",
+	})
+
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	c, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	demo := typeOfTestAlias(t, program, c, filePath)
+	decode := func(raw string) TypeOrValueSpecifier {
+		t.Helper()
+		var specifier TypeOrValueSpecifier
+		assert.NilError(t, json.Unmarshal([]byte(raw), &specifier))
+		return specifier
+	}
+
+	assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{
+		decode(`{"from":"file","name":"Demo"}`),
+	}, nil, program), true)
+	assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{
+		decode(`{"from":"file","name":"Demo","path":""}`),
+	}, nil, program), false)
 }


### PR DESCRIPTION
## Summary

- expand intersection constituents only after checking the whole type, matching typescript-eslint semantics for aliases and inherited Error intersections
- determine declaration package ownership from TypeScript-Go module resolution package IDs instead of nearby package manifests
- preserve whether a file specifier explicitly provided path, including an empty string
- add shared Type/Value matcher regressions and restrict-template-expressions rule coverage

## Related Links

- Follow-up to #1558
- Related to #1598

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).