### PR TITLE
feat(typescript-eslint): port rule no-unnecessary-type-parameters

### DIFF
--- a/internal/plugins/typescript/all.go
+++ b/internal/plugins/typescript/all.go
@@ -76,6 +76,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_constraint"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_conversion"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_parameters"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_argument"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_call"
@@ -211,6 +212,7 @@ func GetAllRules() []rule.Rule {
 		no_unnecessary_type_assertion.NoUnnecessaryTypeAssertionRule,
 		no_unnecessary_type_constraint.NoUnnecessaryTypeConstraintRule,
 		no_unnecessary_type_conversion.NoUnnecessaryTypeConversionRule,
+		no_unnecessary_type_parameters.NoUnnecessaryTypeParametersRule,
 		no_unsafe_argument.NoUnsafeArgumentRule,
 		no_unsafe_assignment.NoUnsafeAssignmentRule,
 		no_unsafe_call.NoUnsafeCallRule,

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -171,11 +171,18 @@ func isDirectGenericTypeArgumentUsage(identNode *ast.Node) bool {
 	if immediateParent == nil || immediateParent.Kind != ast.KindTypeReference {
 		return false
 	}
-	grandparent := skipUnionIntersectionUpward(immediateParent.Parent)
+	// ESLint's AST has no parenthesized-type node, so in `Foo<(T)>` the bare
+	// reference is what its type-argument list holds. Peel tsgo's wrappers to
+	// reach the node that actually sits in the list.
+	argument := immediateParent
+	for argument.Parent != nil && argument.Parent.Kind == ast.KindParenthesizedType {
+		argument = argument.Parent
+	}
+	grandparent := skipUnionIntersectionUpward(argument.Parent)
 	if grandparent == nil || !canHaveTypeArgumentsList(grandparent.Kind) {
 		return false
 	}
-	if !slices.Contains(grandparent.TypeArguments(), immediateParent) {
+	if !slices.Contains(grandparent.TypeArguments(), argument) {
 		return false
 	}
 	// The Array<T>/ReadonlyArray<T> exclusion only makes sense for an actual
@@ -409,9 +416,19 @@ func collectTypeParameterUsageCounts(tc *checker.Checker, node *ast.Node, foundI
 					}
 					visitType(template, false, false)
 				}
+				// A key remapped through `as` is a signature position like any
+				// other. A mapped type's name type is internal to the checker,
+				// so upstream — which only has the public ts.Type surface —
+				// never descends here and reads a type parameter spelled only
+				// in an `as` clause as unused.
 				visitType(checker.Checker_getNameTypeFromMappedType(tc, t), false, false)
 			}
 
+			// Every index signature instantiates its value type once per key,
+			// so all of them count as multiple uses. The public ts.Type
+			// surface only offers getStringIndexType/getNumberIndexType, so
+			// upstream sees no use at all in a symbol-keyed or pattern-keyed
+			// signature.
 			for _, info := range checker.Checker_getIndexInfosOfType(tc, t) {
 				visitType(info.ValueType(), true, false)
 			}
@@ -461,19 +478,10 @@ func buildReplaceWithConstraintFixes(ctx rule.RuleContext, container *ast.Node, 
 			constraintText = utils.TrimmedNodeText(sourceFile, unwrappedConstraint)
 		}
 	}
-	isComplexConstraint := unwrappedConstraint != nil &&
-		(unwrappedConstraint.Kind == ast.KindUnionType ||
-			unwrappedConstraint.Kind == ast.KindIntersectionType ||
-			unwrappedConstraint.Kind == ast.KindConditionalType)
-
 	fixes := make([]rule.RuleFix, 0, len(ctx.Refs.References(sym))+1)
 	for _, refNode := range ctx.Refs.References(sym) {
 		text := constraintText
-		// Substituting a union/intersection/conditional constraint into an
-		// array/indexed-access/intersection/union position needs parens to
-		// avoid changing what the surrounding type means, e.g. replacing T in
-		// `T[]` with `string | number` must produce `(string | number)[]`.
-		if isComplexConstraint && isWrapBoundaryKind(effectiveGrandparentKind(refNode)) {
+		if constraintNeedsParentheses(refNode, unwrappedConstraint) {
 			text = "(" + constraintText + ")"
 		}
 		fixes = append(fixes, rule.RuleFixReplace(sourceFile, refNode, text))
@@ -483,31 +491,89 @@ func buildReplaceWithConstraintFixes(ctx rule.RuleContext, container *ast.Node, 
 	return fixes
 }
 
-func isWrapBoundaryKind(kind ast.Kind) bool {
-	switch kind {
-	case ast.KindArrayType, ast.KindIndexedAccessType, ast.KindIntersectionType, ast.KindUnionType:
+// Binding levels of the TypeScript type grammar, loosest first. A constraint
+// written at a level looser than its substitution site accepts has to be
+// parenthesized or the surrounding operators re-associate: replacing T in
+// `T[]` with `readonly string[]` must yield `(readonly string[])[]`, since
+// `readonly string[][]` is an array of `string[]` instead.
+const (
+	precLoose        = iota // conditional, function and constructor types
+	precUnion               // `A | B`
+	precIntersection        // `A & B`
+	precTypeOperator        // `keyof A`, `readonly A`, `unique symbol`
+	precPostfix             // `A[]`, `A[B]`, and every primary type
+)
+
+func typePrecedence(node *ast.Node) int {
+	switch node.Kind {
+	case ast.KindConditionalType, ast.KindFunctionType, ast.KindConstructorType:
+		return precLoose
+	case ast.KindUnionType:
+		return precUnion
+	case ast.KindIntersectionType:
+		return precIntersection
+	case ast.KindTypeOperator:
+		return precTypeOperator
+	}
+	return precPostfix
+}
+
+// constraintNeedsParentheses reports whether constraint, written in place of
+// a reference to the type parameter, has to be wrapped to keep its meaning.
+func constraintNeedsParentheses(refNode *ast.Node, constraint *ast.Node) bool {
+	if constraint == nil {
+		return false
+	}
+	reference := refNode.Parent
+	if reference == nil {
+		return false
+	}
+	site := reference.Parent
+	if site == nil || site.Kind == ast.KindParenthesizedType {
+		// The position already carries parentheses of its own.
+		return false
+	}
+	if typePrecedence(constraint) < requiredPrecedence(site, reference) {
 		return true
+	}
+	// Upstream wraps a union, intersection or conditional constraint in these
+	// positions whether or not the grammar asks for it. Keep those parentheses
+	// so the suggestion reads the same as ESLint's.
+	switch constraint.Kind {
+	case ast.KindUnionType, ast.KindIntersectionType, ast.KindConditionalType:
+		switch site.Kind {
+		case ast.KindArrayType, ast.KindIndexedAccessType, ast.KindIntersectionType, ast.KindUnionType:
+			return true
+		}
 	}
 	return false
 }
 
-// effectiveGrandparentKind mirrors upstream's `referenceNode.parent.parent`
-// (referenceNode being the TSTypeReference wrapping the identifier): the
-// node two levels above the identifier, skipping any tsgo
-// ParenthesizedType wrappers ESLint's flattened AST doesn't have.
-func effectiveGrandparentKind(identNode *ast.Node) ast.Kind {
-	parent := identNode.Parent
-	if parent == nil {
-		return ast.KindUnknown
+// requiredPrecedence returns the tightest binding a type must have to sit at
+// child's position within site without parentheses.
+func requiredPrecedence(site *ast.Node, child *ast.Node) int {
+	switch site.Kind {
+	case ast.KindArrayType:
+		return precPostfix
+	case ast.KindIndexedAccessType:
+		// Only the object half is a postfix operand; the index sits inside
+		// brackets, which accept any type.
+		if site.AsIndexedAccessTypeNode().ObjectType == child {
+			return precPostfix
+		}
+	case ast.KindTypeOperator, ast.KindIntersectionType:
+		return precTypeOperator
+	case ast.KindUnionType:
+		return precIntersection
+	case ast.KindConditionalType:
+		// The check and extends halves are parsed without conditional and
+		// function types; the branches take a full type.
+		conditional := site.AsConditionalTypeNode()
+		if conditional.CheckType == child || conditional.ExtendsType == child {
+			return precUnion
+		}
 	}
-	grandparent := parent.Parent
-	for grandparent != nil && grandparent.Kind == ast.KindParenthesizedType {
-		grandparent = grandparent.Parent
-	}
-	if grandparent == nil {
-		return ast.KindUnknown
-	}
-	return grandparent.Kind
+	return precLoose
 }
 
 // removeTypeParameterFix removes typeParamNode from container's `<...>`

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -200,6 +200,7 @@ func isDirectGenericTypeArgumentUsage(identNode *ast.Node) bool {
 func canHaveTypeArgumentsList(kind ast.Kind) bool {
 	switch kind {
 	case ast.KindTypeReference, ast.KindExpressionWithTypeArguments,
+		ast.KindImportType, ast.KindTypeQuery,
 		ast.KindCallExpression, ast.KindNewExpression, ast.KindTaggedTemplateExpression,
 		ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement:
 		return true
@@ -325,10 +326,15 @@ func collectTypeParameterUsageCounts(tc *checker.Checker, node *ast.Node, foundI
 			if sym == nil || len(sym.Declarations) == 0 {
 				return
 			}
-			declTypeParam := sym.Declarations[0].AsTypeParameterDeclaration()
-			if declTypeParam == nil {
+			// A polymorphic `this` type also carries TypeFlagsTypeParameter, but
+			// its symbol is the declaring class/interface, so its first
+			// declaration is not a type parameter. Such a type contributes no
+			// count and has no constraint or default to recurse into.
+			decl := sym.Declarations[0]
+			if !ast.IsTypeParameterDeclaration(decl) {
 				return
 			}
+			declTypeParam := decl.AsTypeParameterDeclaration()
 			nameNode := declTypeParam.Name()
 			if nameNode != nil {
 				incrementIdentifierCount(nameNode, assumeMultipleUses)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -1,0 +1,548 @@
+package no_unnecessary_type_parameters
+
+import (
+	"math"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var replaceUsagesWithConstraintMessage = rule.RuleMessage{
+	Id:          "replaceUsagesWithConstraint",
+	Description: "Replace all usages of type parameter with its constraint.",
+}
+
+func buildSoleMessage(name, descriptor, uses string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "sole",
+		Description: "Type parameter " + name + " is " + uses + " in the " + descriptor + " signature.",
+		Data: map[string]string{
+			"name":       name,
+			"descriptor": descriptor,
+			"uses":       uses,
+		},
+	}
+}
+
+var NoUnnecessaryTypeParametersRule = rule.CreateRule(rule.Rule{
+	Name:             "no-unnecessary-type-parameters",
+	RequiresTypeInfo: true,
+	Schema:           rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		checkFunctionNode := func(node *ast.Node) { checkNode(ctx, node, "function") }
+		checkClassNode := func(node *ast.Node) { checkNode(ctx, node, "class") }
+
+		return rule.RuleListeners{
+			// Mirrors upstream's selector groups. TSConstructSignatureDeclaration
+			// (interface `new <T>(): T`) is deliberately omitted: upstream's own
+			// selector list excludes it too, so it is never checked.
+			ast.KindArrowFunction:       checkFunctionNode,
+			ast.KindFunctionDeclaration: checkFunctionNode,
+			ast.KindFunctionExpression:  checkFunctionNode,
+			// tsgo represents a method's value directly on the MethodDeclaration
+			// node (no separate FunctionExpression/TSEmptyBodyFunctionExpression
+			// wrapper the way ESTree does), so this single kind covers both.
+			ast.KindMethodDeclaration: checkFunctionNode,
+			ast.KindCallSignature:     checkFunctionNode,
+			ast.KindConstructorType:   checkFunctionNode,
+			ast.KindFunctionType:      checkFunctionNode,
+			ast.KindMethodSignature:   checkFunctionNode,
+			ast.KindClassDeclaration:  checkClassNode,
+			ast.KindClassExpression:   checkClassNode,
+		}
+	},
+})
+
+func checkNode(ctx rule.RuleContext, node *ast.Node, descriptor string) {
+	typeParams := node.TypeParameters()
+	if len(typeParams) == 0 {
+		return
+	}
+
+	// Lazily resolved: only pay for the type-checker walk when at least one
+	// type parameter isn't already proven repeated by the cheap AST check.
+	var counts map[*ast.Node]int
+
+	for _, typeParamNode := range typeParams {
+		typeParam := typeParamNode.AsTypeParameterDeclaration()
+		if typeParam == nil {
+			continue
+		}
+		nameNode := typeParam.Name()
+		if nameNode == nil || !ast.IsIdentifier(nameNode) {
+			continue
+		}
+		sym := typeParamNode.Symbol()
+		if sym == nil {
+			continue
+		}
+
+		if isTypeParameterRepeatedInAST(ctx, typeParamNode, node, sym) {
+			continue
+		}
+
+		if counts == nil {
+			counts = countTypeParameterUsage(ctx.TypeChecker, node)
+		}
+		useCount := counts[nameNode]
+		if useCount == 0 || useCount > 2 {
+			continue
+		}
+
+		uses := "used only once"
+		if useCount == 1 {
+			uses = "never used"
+		}
+
+		msg := buildSoleMessage(nameNode.AsIdentifier().Text, descriptor, uses)
+		container := node
+		ctx.ReportNodeWithDeferredSuggestions(typeParamNode, msg, func() []rule.RuleSuggestion {
+			return []rule.RuleSuggestion{{
+				Message:  replaceUsagesWithConstraintMessage,
+				FixesArr: buildReplaceWithConstraintFixes(ctx, container, typeParamNode, typeParam, sym),
+			}}
+		})
+	}
+}
+
+// isTypeParameterRepeatedInAST is the cheap syntactic shortcut: if the type
+// parameter is textually referenced at least twice within its own declaring
+// signature (excluding its own declaration and anything past the function
+// body / end of signature), it's provably not "sole" and the type-checker
+// walk can be skipped entirely.
+func isTypeParameterRepeatedInAST(ctx rule.RuleContext, typeParamNode *ast.Node, container *ast.Node, sym *ast.Symbol) bool {
+	cutoff := declaringSignatureEnd(container)
+	total := 0
+	for _, ref := range ctx.Refs.References(sym) {
+		// References inside the type parameter's own declaration (e.g. a
+		// self-referential constraint like `T extends Foo<T>`) don't count.
+		if ref.Pos() < typeParamNode.End() && ref.End() > typeParamNode.Pos() {
+			continue
+		}
+		// References outside the declaring signature (i.e. only reachable
+		// from the function body) don't count either.
+		if ref.Pos() > cutoff {
+			continue
+		}
+		if isDirectGenericTypeArgumentUsage(ref) {
+			return true
+		}
+		total++
+		if total >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+// declaringSignatureEnd returns the position past which a reference no
+// longer belongs to node's own declaring signature: the start of its body
+// (function-like with an implementation, or a class's member list), the end
+// of an explicit return-type annotation when there's no body, or unbounded
+// when neither exists.
+func declaringSignatureEnd(node *ast.Node) int {
+	if body := node.Body(); body != nil {
+		return body.Pos()
+	}
+	if ast.IsClassLike(node) {
+		if members := node.MemberList(); members != nil {
+			return members.Pos()
+		}
+	}
+	if returnType := node.Type(); returnType != nil {
+		return returnType.End()
+	}
+	return math.MaxInt
+}
+
+// isDirectGenericTypeArgumentUsage reports whether identNode — a bare
+// reference to the type parameter used as a type (`T`) — sits directly as a
+// type argument of an outer generic type reference, e.g. the T in `Map<T,
+// V>` or `Foo<T>`. Such a usage is treated as an automatic "used multiple
+// times", mirroring upstream, unless the outer reference is `Array<T>` /
+// `ReadonlyArray<T>`, which defer to the more precise type-checker phase.
+func isDirectGenericTypeArgumentUsage(identNode *ast.Node) bool {
+	immediateParent := identNode.Parent
+	if immediateParent == nil || immediateParent.Kind != ast.KindTypeReference {
+		return false
+	}
+	grandparent := skipUnionIntersectionUpward(immediateParent.Parent)
+	if grandparent == nil || !canHaveTypeArgumentsList(grandparent.Kind) {
+		return false
+	}
+	if !slices.Contains(grandparent.TypeArguments(), immediateParent) {
+		return false
+	}
+	// The Array<T>/ReadonlyArray<T> exclusion only makes sense for an actual
+	// type reference (e.g. `Foo<T>`), not for a type argument attached to a
+	// call/new/tagged-template/JSX expression (e.g. `foo<T>()`).
+	if grandparent.Kind == ast.KindTypeReference {
+		outerName := grandparent.AsTypeReferenceNode().TypeName
+		if outerName != nil && outerName.Kind == ast.KindIdentifier {
+			switch outerName.AsIdentifier().Text {
+			case "Array", "ReadonlyArray":
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// canHaveTypeArgumentsList reports whether kind is a node that can directly
+// own a `<...>` type-argument list — matching every construct ESLint
+// represents via a TSTypeParameterInstantiation wrapper: generic type
+// references, and generic call/new/tagged-template/JSX expressions.
+func canHaveTypeArgumentsList(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindTypeReference, ast.KindExpressionWithTypeArguments,
+		ast.KindCallExpression, ast.KindNewExpression, ast.KindTaggedTemplateExpression,
+		ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement:
+		return true
+	}
+	return false
+}
+
+func skipUnionIntersectionUpward(node *ast.Node) *ast.Node {
+	for node != nil && (node.Kind == ast.KindUnionType || node.Kind == ast.KindIntersectionType) {
+		node = node.Parent
+	}
+	return node
+}
+
+// countTypeParameterUsage resolves, for every type parameter reachable from
+// node, how many times the type checker sees it used across the signature
+// (including inferred return types). For a class, every member contributes
+// (with generic type-argument usages always treated as "multiple"); for a
+// function-like node, only its own signature contributes.
+func countTypeParameterUsage(tc *checker.Checker, node *ast.Node) map[*ast.Node]int {
+	counts := make(map[*ast.Node]int)
+
+	if ast.IsClassLike(node) {
+		for _, typeParamNode := range node.TypeParameters() {
+			collectTypeParameterUsageCounts(tc, typeParamNode, counts, true)
+		}
+		if members := node.MemberList(); members != nil {
+			for _, member := range members.Nodes {
+				collectTypeParameterUsageCounts(tc, member, counts, true)
+			}
+		}
+	} else {
+		collectTypeParameterUsageCounts(tc, node, counts, false)
+	}
+
+	return counts
+}
+
+// collectTypeParameterUsageCounts walks the resolved type graph rooted at
+// node, incrementing foundIdentifierUsages for every type-parameter
+// declaration identifier it encounters. Each type parameter always
+// contributes a baseline "self" count of 1 (from being enumerated as one of
+// its declaring signature's own type parameters, see the
+// `signature.TypeParameters()` walk in visitSignature and the class
+// self-visit loop in countTypeParameterUsage); every further occurrence adds
+// 1 (or 2, when assumeMultipleUses applies) on top of that baseline. A final
+// count of 1 or 2 is "sole"; 3 or more means it's genuinely used more than
+// once.
+//
+// fromClass marks members visited on behalf of a class: type-reference type
+// arguments always count as multiple use there, since a class's type
+// parameters are shared across every member.
+func collectTypeParameterUsageCounts(tc *checker.Checker, node *ast.Node, foundIdentifierUsages map[*ast.Node]int, fromClass bool) {
+	visitedProperties := make(map[*checker.Type]bool)
+	visitedConstraints := make(map[*ast.Node]bool)
+	visitedDefault := false
+	typeUsages := make(map[*checker.Type]int)
+	functionLikeType := false
+
+	incrementIdentifierCount := func(id *ast.Node, assumeMultipleUses bool) {
+		value := 1
+		if assumeMultipleUses {
+			value = 2
+		}
+		foundIdentifierUsages[id] += value
+	}
+
+	// incrementTypeUsages guards against unbounded recursion on recursive
+	// generic types (e.g. `type T = { [P in keyof T]: T }`): once a type has
+	// been seen more than 9 times, every referenced type parameter has
+	// already been counted enough to qualify as used, so visiting stops.
+	incrementTypeUsages := func(t *checker.Type) int {
+		typeUsages[t]++
+		return typeUsages[t]
+	}
+
+	var visitType func(t *checker.Type, assumeMultipleUses bool, isReturnType bool)
+
+	visitSymbolsListOnce := func(owner *checker.Type, symbols []*ast.Symbol, assumeMultipleUses bool) {
+		if visitedProperties[owner] {
+			return
+		}
+		visitedProperties[owner] = true
+		for _, sym := range symbols {
+			visitType(tc.GetTypeOfSymbol(sym), assumeMultipleUses, false)
+		}
+	}
+
+	visitTypesList := func(types []*checker.Type, assumeMultipleUses bool) {
+		for _, t := range types {
+			visitType(t, assumeMultipleUses, false)
+		}
+	}
+
+	visitSignature := func(sig *checker.Signature) {
+		if sig == nil {
+			return
+		}
+		if this := sig.ThisParameter(); this != nil {
+			visitType(tc.GetTypeOfSymbol(this), false, false)
+		}
+		for _, param := range sig.Parameters() {
+			visitType(tc.GetTypeOfSymbol(param), false, false)
+		}
+		for _, typeParam := range sig.TypeParameters() {
+			visitType(typeParam, false, false)
+		}
+		returnType := tc.GetReturnTypeOfSignature(sig)
+		if predicate := tc.GetTypePredicateOfSignature(sig); predicate != nil && predicate.Type() != nil {
+			returnType = predicate.Type()
+		}
+		visitType(returnType, false, true)
+	}
+
+	visitType = func(t *checker.Type, assumeMultipleUses bool, isReturnType bool) {
+		if t == nil || incrementTypeUsages(t) > 9 {
+			return
+		}
+
+		switch {
+		case utils.IsTypeParameter(t):
+			sym := t.Symbol()
+			if sym == nil || len(sym.Declarations) == 0 {
+				return
+			}
+			declTypeParam := sym.Declarations[0].AsTypeParameterDeclaration()
+			if declTypeParam == nil {
+				return
+			}
+			nameNode := declTypeParam.Name()
+			if nameNode != nil {
+				incrementIdentifierCount(nameNode, assumeMultipleUses)
+			}
+			// Resolve the constraint/default through the checker on t itself
+			// (not by re-resolving the raw declaration node) so a mapped
+			// type's own bound type parameter (`K` in `{ [K in T]: ... }`)
+			// picks up whatever substitution applies to this specific
+			// instantiation, e.g. when reached through an inferred return
+			// type of a call to another generic function.
+			if declTypeParam.Constraint != nil && !visitedConstraints[declTypeParam.Constraint] {
+				visitedConstraints[declTypeParam.Constraint] = true
+				visitType(tc.GetConstraintOfTypeParameter(t), false, false)
+			}
+			if declTypeParam.DefaultType != nil && !visitedDefault {
+				visitedDefault = true
+				visitType(tc.GetDefaultFromTypeParameter(t), false, false)
+			}
+
+		case t.Alias() != nil && t.Alias().TypeArguments() != nil:
+			// A generic type-alias reference like `Exclude<T, null>`. We don't
+			// descend into the alias's own definition, so it's safest to assume
+			// every argument is used multiple times.
+			visitTypesList(t.Alias().TypeArguments(), true)
+
+		case utils.IsUnionType(t) || utils.IsIntersectionType(t):
+			visitTypesList(t.Types(), assumeMultipleUses)
+
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsIndexedAccess):
+			iat := t.AsIndexedAccessType()
+			visitType(iat.ObjectType(), assumeMultipleUses, false)
+			visitType(iat.IndexType(), assumeMultipleUses, false)
+
+		case utils.IsTypeReference(t):
+			target := t.Target()
+			for _, typeArgument := range checker.Checker_getTypeArguments(tc, t) {
+				thisAssumeMultipleUses := fromClass || assumeMultipleUses
+				if !thisAssumeMultipleUses {
+					switch {
+					case checker.IsTupleType(target):
+						thisAssumeMultipleUses = isReturnType && !target.AsTupleType().IsReadonly()
+					case tc.IsArrayType(target):
+						sym := t.Symbol()
+						thisAssumeMultipleUses = isReturnType && sym != nil && sym.Name == "Array"
+					default:
+						thisAssumeMultipleUses = true
+					}
+				}
+				visitType(typeArgument, thisAssumeMultipleUses, isReturnType)
+			}
+
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsTemplateLiteral):
+			for _, subType := range t.AsTemplateLiteralType().Types() {
+				visitType(subType, assumeMultipleUses, false)
+			}
+
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsConditional):
+			ct := t.AsConditionalType()
+			visitType(ct.CheckType(), assumeMultipleUses, false)
+			visitType(ct.ExtendsType(), assumeMultipleUses, false)
+
+		case utils.IsObjectType(t):
+			properties := checker.Checker_getPropertiesOfType(tc, t)
+			visitSymbolsListOnce(t, properties, false)
+
+			if checker.Type_objectFlags(t)&checker.ObjectFlagsMapped != 0 {
+				visitType(checker.Checker_getTypeParameterFromMappedType(tc, t), false, false)
+				if len(properties) == 0 {
+					template := checker.Checker_getTemplateTypeFromMappedType(tc, t)
+					if template == nil {
+						template = checker.Checker_getConstraintTypeFromMappedType(tc, t)
+					}
+					visitType(template, false, false)
+				}
+				visitType(checker.Checker_getNameTypeFromMappedType(tc, t), false, false)
+			}
+
+			for _, info := range checker.Checker_getIndexInfosOfType(tc, t) {
+				visitType(info.ValueType(), true, false)
+			}
+
+			for _, sig := range utils.GetCallSignatures(tc, t) {
+				functionLikeType = true
+				visitSignature(sig)
+			}
+			for _, sig := range utils.GetConstructSignatures(tc, t) {
+				functionLikeType = true
+				visitSignature(sig)
+			}
+
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsIndex):
+			// `keyof T`.
+			visitType(t.AsIndexType().Target(), assumeMultipleUses, false)
+
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsStringMapping):
+			// `Uppercase<T>` / `Lowercase<T>` / `Capitalize<T>` / `Uncapitalize<T>`.
+			visitType(t.AsStringMappingType().Target(), assumeMultipleUses, false)
+		}
+	}
+
+	if node.Kind == ast.KindCallSignature || node.Kind == ast.KindConstructor {
+		functionLikeType = true
+		visitSignature(tc.GetSignatureFromDeclaration(node))
+	}
+	if !functionLikeType {
+		visitType(tc.GetTypeAtLocation(node), false, false)
+	}
+}
+
+// buildReplaceWithConstraintFixes builds the suggestion that replaces every
+// use of the type parameter with its constraint (or "unknown" when it has
+// none) and removes the type parameter from the declaration. Unlike
+// detection, which only looks at the declaring signature, this replaces
+// every reference reachable from the type parameter's declaration,
+// including uses inside a function body.
+func buildReplaceWithConstraintFixes(ctx rule.RuleContext, container *ast.Node, typeParamNode *ast.Node, typeParam *ast.TypeParameterDeclaration, sym *ast.Symbol) []rule.RuleFix {
+	sourceFile := ctx.SourceFile
+
+	constraintText := "unknown"
+	var unwrappedConstraint *ast.Node
+	if typeParam.Constraint != nil {
+		unwrappedConstraint = ast.SkipTypeParentheses(typeParam.Constraint)
+		if unwrappedConstraint.Kind != ast.KindAnyKeyword {
+			constraintText = utils.TrimmedNodeText(sourceFile, unwrappedConstraint)
+		}
+	}
+	isComplexConstraint := unwrappedConstraint != nil &&
+		(unwrappedConstraint.Kind == ast.KindUnionType ||
+			unwrappedConstraint.Kind == ast.KindIntersectionType ||
+			unwrappedConstraint.Kind == ast.KindConditionalType)
+
+	fixes := make([]rule.RuleFix, 0, len(ctx.Refs.References(sym))+1)
+	for _, refNode := range ctx.Refs.References(sym) {
+		text := constraintText
+		// Substituting a union/intersection/conditional constraint into an
+		// array/indexed-access/intersection/union position needs parens to
+		// avoid changing what the surrounding type means, e.g. replacing T in
+		// `T[]` with `string | number` must produce `(string | number)[]`.
+		if isComplexConstraint && isWrapBoundaryKind(effectiveGrandparentKind(refNode)) {
+			text = "(" + constraintText + ")"
+		}
+		fixes = append(fixes, rule.RuleFixReplace(sourceFile, refNode, text))
+	}
+
+	fixes = append(fixes, removeTypeParameterFix(sourceFile, container, typeParamNode))
+	return fixes
+}
+
+func isWrapBoundaryKind(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindArrayType, ast.KindIndexedAccessType, ast.KindIntersectionType, ast.KindUnionType:
+		return true
+	}
+	return false
+}
+
+// effectiveGrandparentKind mirrors upstream's `referenceNode.parent.parent`
+// (referenceNode being the TSTypeReference wrapping the identifier): the
+// node two levels above the identifier, skipping any tsgo
+// ParenthesizedType wrappers ESLint's flattened AST doesn't have.
+func effectiveGrandparentKind(identNode *ast.Node) ast.Kind {
+	parent := identNode.Parent
+	if parent == nil {
+		return ast.KindUnknown
+	}
+	grandparent := parent.Parent
+	for grandparent != nil && grandparent.Kind == ast.KindParenthesizedType {
+		grandparent = grandparent.Parent
+	}
+	if grandparent == nil {
+		return ast.KindUnknown
+	}
+	return grandparent.Kind
+}
+
+// removeTypeParameterFix removes typeParamNode from container's `<...>`
+// clause: the whole clause when it's the only type parameter, otherwise
+// typeParamNode plus its separating comma.
+func removeTypeParameterFix(sourceFile *ast.SourceFile, container *ast.Node, typeParamNode *ast.Node) rule.RuleFix {
+	typeParams := container.TypeParameters()
+	paramRange := utils.TrimNodeTextRange(sourceFile, typeParamNode)
+
+	if len(typeParams) == 1 {
+		list := container.TypeParameterList()
+		start, end, ok := utils.RangeEnclosingDelimiters(sourceFile.Text(), list.Pos(), list.End(), '<', '>')
+		if !ok {
+			return rule.RuleFixRemoveRange(paramRange)
+		}
+		return rule.RuleFixRemoveRange(core.NewTextRange(start, end))
+	}
+
+	index := slices.Index(typeParams, typeParamNode)
+	if index == 0 {
+		commaEnd := findTokenEnd(sourceFile, paramRange.End(), ast.KindCommaToken)
+		nextStart := scanner.SkipTrivia(sourceFile.Text(), commaEnd)
+		return rule.RuleFixRemoveRange(core.NewTextRange(paramRange.Pos(), nextStart))
+	}
+
+	commaStart := findTokenStart(sourceFile, typeParams[index-1].End(), ast.KindCommaToken)
+	return rule.RuleFixRemoveRange(core.NewTextRange(commaStart, paramRange.End()))
+}
+
+func findTokenStart(sourceFile *ast.SourceFile, from int, kind ast.Kind) int {
+	s := scanner.GetScannerForSourceFile(sourceFile, from)
+	for s.Token() != kind && s.Token() != ast.KindEndOfFile {
+		s.Scan()
+	}
+	return s.TokenStart()
+}
+
+func findTokenEnd(sourceFile *ast.SourceFile, from int, kind ast.Kind) int {
+	s := scanner.GetScannerForSourceFile(sourceFile, from)
+	for s.Token() != kind && s.Token() != ast.KindEndOfFile {
+		s.Scan()
+	}
+	return s.TokenEnd()
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.md
@@ -1,0 +1,48 @@
+# no-unnecessary-type-parameters
+
+## Rule Details
+
+Disallows type parameters that aren't used multiple times in a function, method, or class signature. A type parameter relates two or more positions in a signature; if it only appears once, it isn't relating anything, and the concrete type it stands for can be written directly instead.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+function second<A, B>(a: A, b: B): B {
+  return b;
+}
+
+function parseJSON<T>(input: string): T {
+  return JSON.parse(input);
+}
+
+function printProperty<T, K extends keyof T>(obj: T, key: K) {
+  console.log(obj[key]);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+function second<B>(a: unknown, b: B): B {
+  return b;
+}
+
+function parseJSON(input: string): unknown {
+  return JSON.parse(input);
+}
+
+// T appears twice: once as the parameter type, once as the return type.
+function identity<T>(arg: T): T {
+  return arg;
+}
+
+// T appears twice: `keyof T` and the inferred return type (`T[K]`).
+// K appears twice: `key: K` and the inferred return type (`T[K]`).
+function getProperty<T, K extends keyof T>(obj: T, key: K) {
+  return obj[key];
+}
+```
+
+## Original Documentation
+
+[typescript-eslint: no-unnecessary-type-parameters](https://typescript-eslint.io/rules/no-unnecessary-type-parameters)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.md
@@ -43,6 +43,12 @@ function getProperty<T, K extends keyof T>(obj: T, key: K) {
 }
 ```
 
+## Differences from ESLint
+
+rslint resolves a few signature positions that the TypeScript public API keeps out of reach of upstream `@typescript-eslint/no-unnecessary-type-parameters`, and counts a type parameter appearing there as used. That makes for slightly fewer reports, all of them ones upstream raises in error.
+
+The `replaceUsagesWithConstraint` suggestion parenthesizes the constraint wherever the type grammar calls for it, so applying it always leaves you with the same type the code had before.
+
 ## Original Documentation
 
 [typescript-eslint: no-unnecessary-type-parameters](https://typescript-eslint.io/rules/no-unnecessary-type-parameters)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
@@ -1,0 +1,471 @@
+// TestNoUnnecessaryTypeParametersExtras locks in branches and edge shapes
+// that the upstream test suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk
+// it covers, so future refactors can't silently regress them without
+// breaking a named lock-in.
+package no_unnecessary_type_parameters
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryTypeParametersExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryTypeParametersRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 1: AST node types ----
+		{Code: `
+// Async function: T used in param and (via await) the resolved return type.
+async function identity<T>(arg: T): Promise<T> {
+  return arg;
+}
+`},
+		{Code: `
+// Generator function: T used in the yielded value type and the parameter.
+function* gen<T>(seed: T): Generator<T> {
+  yield seed;
+}
+`},
+		{Code: `
+// Async generator.
+async function* gen<T>(seed: T): AsyncGenerator<T> {
+  yield seed;
+}
+`},
+
+		// ---- Dimension 4: TSConstructSignatureDeclaration is never checked ----
+		// Locks in upstream's selector list omission of
+		// TSConstructSignatureDeclaration: even a type parameter used only
+		// once in an interface's construct signature must never be reported,
+		// because the rule's selectors never visit this node kind at all.
+		{Code: `
+interface I {
+  new <T>(value: T): void;
+}
+`},
+
+		// ---- Real-user: typescript-eslint/typescript-eslint#9961 (open) ----
+		// Upstream's own class handling has a known, intentionally-unfixed
+		// false positive: a class whose single member uses T only once is
+		// still reported, even though (unlike a bare function) a reader might
+		// expect per-member reasoning. rslint matches this for parity — see
+		// the invalid cases below for the interface contrast this issue
+		// documents (interface member usage is correctly NOT reported).
+		{Code: `
+interface ValueInterface<T> {
+  value: T;
+}
+`},
+
+		// ---- Real-user: typescript-eslint/typescript-eslint#11528 (not planned) ----
+		// The maintainers confirmed this specific shape is intentional: TData
+		// used as a direct generic argument of the *return type* (IError<TData>)
+		// counts as "used multiple times" via the AST-level direct-generic-
+		// argument shortcut, even though it's spelled only once. See the
+		// invalid case below for the sibling shape from the same thread that
+		// the maintainers confirmed SHOULD still be reported (TData used only
+		// in the return type itself, with no other signature position).
+		{Code: `
+interface IError<TData> {
+  error: true;
+  data: TData;
+}
+
+declare const checkIsError: <TData>(anything: unknown) => anything is IError<TData>;
+
+const extractErrorData = <TData,>(error?: unknown): IError<TData> | null => {
+  return checkIsError<TData>(error) ? error : null;
+};
+`},
+
+		// ---- Branch lock-in: isTypeParameterRepeatedInAST self-reference exclusion ----
+		// Locks in upstream isTypeParameterRepeatedInAST() arm: a reference to
+		// T inside T's own constraint clause doesn't count toward repetition,
+		// so this needs the type-checker phase; T's constraint (Base<T>) and
+		// its use as a direct generic argument there both correctly resolve
+		// to "used multiple times" once the checker phase runs.
+		{Code: `
+interface Base<T> {
+  value: T;
+}
+declare function recursive<T extends Base<T>>(x: T): T;
+`},
+
+		// ---- Branch lock-in: countTypeParameterUsage() KindConstructor arm ----
+		// A class's constructor is a member visited with fromClass=true; the
+		// special functionLikeType branch (visitSignature via
+		// GetSignatureFromDeclaration) must fire for it rather than
+		// GetTypeAtLocation, or the class's own T count comes out too low.
+		{Code: `
+class Box<T> {
+  value: T;
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+`},
+
+		// ---- Branch lock-in: collectTypeParameterUsageCounts() readonly array vs mutable array ----
+		{Code: `declare function makeReadonlyArrayParam<T>(input: readonly T[]): T;`},
+		{Code: `
+// Mutable array used as a parameter (not a return type) counts as single-use,
+// matching upstream's isReturnType-gated special case for Array/ReadonlyArray.
+declare function identityArray<T>(input: T[]): T[];
+`},
+
+		// ---- Branch lock-in: generic type-alias reference (type.aliasTypeArguments) ----
+		{Code: `
+type Wrapper<T> = { value: T };
+declare function wrap<T>(value: T): Wrapper<T>;
+`},
+
+		// ---- Dimension 4: private identifier / computed key on a class ----
+		{Code: `
+class Container<T> {
+  #value: T;
+  constructor(value: T) {
+    this.#value = value;
+  }
+  get(): T {
+    return this.#value;
+  }
+}
+`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Real-user: typescript-eslint/typescript-eslint#11528 (not planned) ----
+		// The maintainers confirmed this sibling shape from the same thread
+		// SHOULD be reported: TData appears only in the return type itself
+		// (not as a generic argument of some other type there); a call inside
+		// the body passing TData explicitly doesn't count, since body usage
+		// is outside the declaring signature.
+		{
+			Code: `
+interface IError<TData> {
+  error: true;
+  data: TData;
+}
+
+declare const checkIsError: <TData>(anything: unknown) => anything is IError<TData>;
+
+const extractErrorData = <TData,>(error?: unknown): TData | null => {
+  return checkIsError<TData>(error) ? error.data : null;
+};
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      9,
+				Column:    27,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+interface IError<TData> {
+  error: true;
+  data: TData;
+}
+
+declare const checkIsError: <TData>(anything: unknown) => anything is IError<TData>;
+
+const extractErrorData = (error?: unknown): unknown | null => {
+  return checkIsError<unknown>(error) ? error.data : null;
+};
+`,
+				}},
+			}},
+		},
+
+		// ---- Dimension 4: TS non-null assertion receiver on a reference ----
+		{
+			Code: `declare function get<T>(): T!;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get(): unknown!;`,
+				}},
+			}},
+		},
+
+		// ---- Dimension 4: parenthesized receiver, single and multi-level ----
+		{
+			Code: `declare function get<T>(): (T);`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get(): (unknown);`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function get<T>(): ((T));`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get(): ((unknown));`,
+				}},
+			}},
+		},
+
+		// ---- Real-user: typescript-eslint/typescript-eslint#9961 (open) ----
+		// Class member usages (get accessor and method) still get reported
+		// even though the constrained value is only ever read, matching
+		// upstream's acknowledged-but-unfixed class-member false positive.
+		{
+			Code: `
+class ValueClassGetter<T> {
+  get value(): T {
+    return null!;
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the class signature.",
+				Line:      2,
+				Column:    24,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class ValueClassGetter {
+  get value(): unknown {
+    return null!;
+  }
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+class ValueClassMethod<T> {
+  getValue(): T {
+    return null!;
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    24,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class ValueClassMethod {
+  getValue(): unknown {
+    return null!;
+  }
+}
+`,
+				}},
+			}},
+		},
+
+		// ---- Dimension 2: deeply nested (3+ levels) function scoping ----
+		// Only the innermost `identity`'s own T is reported; the outer two
+		// same-named T's are each used twice in their own signatures (param +
+		// return) and must not "bleed" into each other's counts.
+		{
+			Code: `
+function outer<T>(a: T): T {
+  function middle<T>(b: T): T {
+    function identity<T>(c: T): void {}
+    return b;
+  }
+  return a;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the function signature.",
+				Line:      4,
+				Column:    23,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function outer<T>(a: T): T {
+  function middle<T>(b: T): T {
+    function identity(c: unknown): void {}
+    return b;
+  }
+  return a;
+}
+`,
+				}},
+			}},
+		},
+
+		// ---- Dimension 4: graceful degradation — overload signature (body-absent) ----
+		{
+			Code: `
+declare class Store {
+  get<T>(key: string): T;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    7,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+declare class Store {
+  get(key: string): unknown;
+}
+`,
+				}},
+			}},
+		},
+
+		// ---- Branch lock-in: buildReplaceWithConstraintFixes() union constraint
+		// needs parens when substituted into an intersection position ----
+		{
+			Code: `
+function f<T extends string | number>(x: T & { tag: true }): void {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function f(x: (string | number) & { tag: true }): void {}
+`,
+				}},
+			}},
+		},
+
+		// ---- Branch lock-in: buildReplaceWithConstraintFixes() union constraint
+		// needs parens when substituted into an indexed-access position ----
+		{
+			Code: `
+type Lookup = { a: 1; b: 2 };
+function f<T extends 'a' | 'b'>(x: Lookup[T]): void {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+type Lookup = { a: 1; b: 2 };
+function f(x: Lookup[('a' | 'b')]): void {}
+`,
+				}},
+			}},
+		},
+
+		// ---- Branch lock-in: no constraint at all replaces with "unknown" ----
+		{
+			Code: `function bare<T>(x: T) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `function bare(x: unknown) {}`,
+				}},
+			}},
+		},
+	})
+}
+
+// TestNoUnnecessaryTypeParametersEditDemand exercises the four edit-demand
+// modes for a representative diagnostic (a sole-use suggestion), asserting
+// diagnostic count/message/range are unaffected by demand while the
+// suggestion artifact only materializes when requested (the rule has no
+// autofix, only a suggestion).
+func TestNoUnnecessaryTypeParametersEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"declare function take<T>(param: T): void;\n",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:             NoUnnecessaryTypeParametersRule.Name,
+					Severity:         rule.SeverityError,
+					RequiresTypeInfo: NoUnnecessaryTypeParametersRule.RequiresTypeInfo,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUnnecessaryTypeParametersRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+		rule.EditDemandAll:        run(rule.EditDemandAll),
+	}
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+
+	want := withoutEdits(diagnostics[rule.EditDemandAll][0])
+	for demand, got := range diagnostics {
+		if got := withoutEdits(got[0]); !reflect.DeepEqual(got, want) {
+			t.Errorf("diagnostic changed for demand %d:\ngot:  %#v\nwant: %#v", demand, got, want)
+		}
+		if got[0].FixesPtr != nil {
+			t.Errorf("demand %d unexpectedly has autofixes (rule only has suggestions)", demand)
+		}
+	}
+
+	suggestionOnly := diagnostics[rule.EditDemandSuggestion][0].Suggestions
+	allEdits := diagnostics[rule.EditDemandAll][0].Suggestions
+	if suggestionOnly == nil || !reflect.DeepEqual(suggestionOnly, allEdits) {
+		t.Fatalf("suggestions differ between suggestion-only and all-edits demand")
+	}
+	if len(*suggestionOnly) != 1 || (*suggestionOnly)[0].Message.Id != "replaceUsagesWithConstraint" {
+		t.Fatalf("suggestions = %#v, want 1 replaceUsagesWithConstraint suggestion", *suggestionOnly)
+	}
+	if diagnostics[rule.EditDemandNone][0].Suggestions != nil ||
+		diagnostics[rule.EditDemandAutofix][0].Suggestions != nil {
+		t.Errorf("suggestions attached without suggestion demand")
+	}
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
@@ -159,7 +159,85 @@ declare function f<T>(b: Box<T>): void;
 declare function g<U>(u: U): U;
 declare function f<T>(x: typeof g<T>): void;
 `},
+
+		// ---- Branch lock-in: isDirectGenericTypeArgumentUsage() paren peeling ----
+		// tsgo wraps `(T)` in a ParenthesizedType that ESLint's AST doesn't
+		// have, so the node sitting in the outer type-argument list is that
+		// wrapper rather than the reference itself. Both nesting depths must
+		// still register as a direct generic-argument use.
+		{Code: `class Boxes<T> extends Array<(T)> {}`},
+		{Code: `
+interface Holder<A> {
+  value: A;
+}
+declare function hold<T>(x: Holder<((T))>): void;
+`},
+
+		// ---- Deliberate divergence: mapped-type `as` clause counts as a use ----
+		// A key remapped through `as` is a real signature position, so T relating
+		// the parameter to the remapped key is not a lone use. ESLint misses this
+		// because its type walk never descends into a mapped type's name type,
+		// and reports T here.
+		{Code: `<T extends string>(t: T) => t as { [K in 'a' as T]: 0 };`},
+
+		// ---- Deliberate divergence: every index signature counts, not just
+		// string/number ----
+		// An index signature instantiates its value type once per key, so T is
+		// used many times over. ESLint can only read the string and number index
+		// types, so it counts symbol-keyed and pattern-keyed signatures as no use
+		// at all and reports T here, suggesting a fix that erases the type.
+		{Code: `declare function symbolKeyed<T>(x: number): { [k: symbol]: T };`},
+		{Code: "declare function patternKeyed<T>(x: number): { [k: `a${string}`]: T };"},
+		{Code: `declare function symbolKeyedParam<T>(x: { [k: symbol]: T }): void;`},
 	}, []rule_tester.InvalidTestCase{
+		// ---- Branch lock-in: isDirectGenericTypeArgumentUsage() paren peeling ----
+		// Peeling the ParenthesizedType must not lose the Array/ReadonlyArray
+		// exclusion: `Array<(T)>` still defers to the type-checker phase, which
+		// counts a mutable array parameter as a single use.
+		{
+			Code: `declare function collect<T>(x: Array<(T)>): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the function signature.",
+				Line:      1,
+				Column:    26,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function collect(x: Array<(unknown)>): void;`,
+				}},
+			}},
+		},
+
+		// ---- Deliberate divergence: mapped-type `as` clause counts as a use ----
+		// The counterpart to the valid case above: with the parameter list no
+		// longer mentioning U, the `as` clause is U's only position, so it is
+		// reported as used only once. ESLint reports it as never used.
+		{
+			Code: `declare function remap<T extends string, U extends string>(x: number): { [K in T as U]: 0 };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Message:   "Type parameter T is used only once in the function signature.",
+					Line:      1,
+					Column:    24,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function remap<U extends string>(x: number): { [K in string as U]: 0 };`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Message:   "Type parameter U is used only once in the function signature.",
+					Line:      1,
+					Column:    42,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function remap<T extends string>(x: number): { [K in T as string]: 0 };`,
+					}},
+				},
+			},
+		},
+
 		// ---- Dimension 4: polymorphic `this` type in a class member ----
 		// Regression lock-in: `this` types reach the type-parameter branch of the
 		// type walk with a class symbol, whose first declaration is a
@@ -447,6 +525,92 @@ function f<T extends 'a' | 'b'>(x: Lookup[T]): void {}
 type Lookup = { a: 1; b: 2 };
 function f(x: Lookup[('a' | 'b')]): void {}
 `,
+				}},
+			}},
+		},
+
+		// ---- Deliberate divergence: the constraint is parenthesized whenever
+		// the type grammar demands it, not only for unions, intersections and
+		// conditionals ----
+		// A function, constructor or type-operator constraint binds looser than
+		// the array, indexed-access and `keyof` positions it can land in, so it
+		// needs the same treatment. ESLint checks only the three complex kinds
+		// and emits `() => void[]`, `readonly string[][]` and
+		// `keyof string | number`, each of which denotes a different type than
+		// the code being replaced.
+		{
+			Code: `declare function callbacks<T extends () => void>(x: T[]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    28,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function callbacks(x: (() => void)[]): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function ctors<T extends new () => void>(x: T[]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    24,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function ctors(x: (new () => void)[]): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function frozen<T extends readonly string[]>(x: T[]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    25,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function frozen(x: (readonly string[])[]): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function keys<T extends string | number>(x: keyof T): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    23,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function keys(x: keyof (string | number)): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function check<T extends () => void>(x: T extends object ? 1 : 2): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    24,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function check(x: (() => void) extends object ? 1 : 2): void;`,
+				}},
+			}},
+		},
+		{
+			// A type query is already a primary type, so the array position
+			// takes it as written.
+			Code: `declare const seed: string;
+declare function seeded<T extends typeof seed>(x: T[]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    25,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare const seed: string;
+declare function seeded(x: typeof seed[]): void;`,
 				}},
 			}},
 		},

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
@@ -136,7 +136,90 @@ class Container<T> {
   }
 }
 `},
+
+		// ---- Dimension 4: polymorphic `this` type in a member signature ----
+		// A `this` type carries the same type-parameter type flag as a real type
+		// parameter, but its symbol is the declaring interface, so its first
+		// declaration is not a type parameter declaration. It must be skipped
+		// rather than blindly treated as one. Here T is used twice, so nothing
+		// is reported; see the invalid cases for the single-use counterpart.
+		{Code: `
+interface Box<T> {
+  value: T;
+  take(value: T): void;
+  self(): this;
+}
+declare function f<T>(b: Box<T>): void;
+`},
+
+		// ---- Branch lock-in: canHaveTypeArgumentsList() TypeQuery arm ----
+		// `typeof g<T>` attaches its type arguments to a TypeQuery rather than a
+		// TypeReference; T must still register as a direct generic-argument use.
+		{Code: `
+declare function g<U>(u: U): U;
+declare function f<T>(x: typeof g<T>): void;
+`},
 	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: polymorphic `this` type in a class member ----
+		// Regression lock-in: `this` types reach the type-parameter branch of the
+		// type walk with a class symbol, whose first declaration is a
+		// ClassDeclaration. Reporting T here (used only once, in `value: T`)
+		// matches ESLint; the `this` return contributes nothing.
+		{
+			Code: `
+class Box<T> {
+  value: T;
+  self(): this {
+    return this;
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the class signature.",
+				Line:      2,
+				Column:    11,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class Box {
+  value: unknown;
+  self(): this {
+    return this;
+  }
+}
+`,
+				}},
+			}},
+		},
+		// The same shape with an inferred (rather than annotated) `this` return.
+		{
+			Code: `
+class Box<T> {
+  value: T;
+  self() {
+    return this;
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    11,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class Box {
+  value: unknown;
+  self() {
+    return this;
+  }
+}
+`,
+				}},
+			}},
+		},
+
 		// ---- Real-user: typescript-eslint/typescript-eslint#11528 (not planned) ----
 		// The maintainers confirmed this sibling shape from the same thread
 		// SHOULD be reported: TData appears only in the return type itself

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_upstream_test.go
@@ -1,0 +1,1741 @@
+// TestNoUnnecessaryTypeParametersUpstream migrates the full valid/invalid
+// suite from upstream typescript-eslint's
+// packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in the
+// no_unnecessary_type_parameters_extras_test.go file.
+package no_unnecessary_type_parameters
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryTypeParametersUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryTypeParametersRule, []rule_tester.ValidTestCase{
+		{Code: `
+class ClassyArray<T> {
+  arr: T[];
+}
+`},
+		{Code: `
+class ClassyArray<T> {
+  value1: T;
+  value2: T;
+}
+`},
+		{Code: `
+class ClassyArray<T> {
+  arr: T[];
+  constructor(arr: T[]) {
+    this.arr = arr;
+  }
+}
+`},
+		{Code: `
+class ClassyArray<T> {
+  arr: T[];
+  workWith(value: T) {
+    this.arr.indexOf(value);
+  }
+}
+`},
+		{Code: `
+abstract class ClassyArray<T> {
+  arr: T[];
+  abstract workWith(value: T): void;
+}
+`},
+		{Code: `
+class Box<T> {
+  val: T | null = null;
+  get() {
+    return this.val;
+  }
+}
+`},
+		{Code: `
+class Joiner<T extends string | number> {
+  join(els: T[]) {
+    return els.map(el => '' + el).join(',');
+  }
+}
+`},
+		{Code: `
+declare class Foo {
+  getProp<T>(this: Record<'prop', T>): T;
+}
+`},
+		{Code: `type Fn = <T>(input: T) => T;`},
+		{Code: `type Fn = <T extends string>(input: T) => T;`},
+		{Code: "type Fn = <T extends string>(input: T) => `a${T}b`;"},
+		{Code: `type Fn = new <T>(input: T) => T;`},
+		{Code: `type Fn = <T>(input: T) => typeof input;`},
+		{Code: `type Fn = <T>(input: T) => keyof typeof input;`},
+		{Code: `type Fn = <T>(input: Partial<T>) => typeof input;`},
+		{Code: `type Fn = <T>(input: Partial<T>) => input is T;`},
+		{Code: `type Fn = <T>(input: T) => { [K in keyof T]: K };`},
+		{Code: `type Fn = <T>(input: T) => { [K in keyof T as K]: string };`},
+		{Code: "type Fn = <T>(input: T) => { [K in keyof T as `${K & string}`]: string };"},
+		{Code: `type Fn = <T>(input: T) => Partial<T>;`},
+		{Code: `type Fn = <T>(input: { [i: number]: T }) => T;`},
+		{Code: `type Fn = <T>(input: { [i: number]: T }) => Partial<T>;`},
+		{Code: `type Fn = <T>(input: { [i: string]: T }) => Partial<T>;`},
+		{Code: `type Fn = <T>(input: T) => { [i: number]: T };`},
+		{Code: `type Fn = <T>(input: T) => { [i: string]: T };`},
+		{Code: "type Fn = <T extends unknown[]>(input: T) => Omit<T, 'length'>;"},
+		{Code: `
+interface I {
+  <T>(value: T): T;
+}
+`},
+		{Code: `
+interface I {
+  new <T>(value: T): T;
+}
+`},
+		{Code: `
+function identity<T>(arg: T): T {
+  return arg;
+}
+`},
+		{Code: `
+function printProperty<T>(obj: T, key: keyof T) {
+  console.log(obj[key]);
+}
+`},
+		{Code: `
+function getProperty<T, K extends keyof T>(obj: T, key: K) {
+  return obj[key];
+}
+`},
+		{Code: `
+function box<T>(val: T) {
+  return { val };
+}
+`},
+		{Code: `
+function doStuff<K, V>(map: Map<K, V>, key: K) {
+  let v = map.get(key);
+  v = 1;
+  map.set(key, v);
+  return v;
+}
+`},
+		{Code: `
+function makeMap<K, V>() {
+  return new Map<K, V>();
+}
+`},
+		{Code: `
+function makeMap<K, V>(ks: K[], vs: V[]) {
+  const r = new Map<K, V>();
+  ks.forEach((k, i) => {
+    r.set(k, vs[i]);
+  });
+  return r;
+}
+`},
+		{Code: `
+function arrayOfPairs<T>() {
+  return [] as [T, T][];
+}
+`},
+		{Code: `
+function isNonNull<T>(v: T): v is Exclude<T, null> {
+  return v !== null;
+}
+`},
+		{Code: `
+function both<Args extends unknown[]>(
+  fn1: (...args: Args) => void,
+  fn2: (...args: Args) => void,
+): (...args: Args) => void {
+  return function (...args: Args) {
+    fn1(...args);
+    fn2(...args);
+  };
+}
+`},
+		{Code: `
+function lengthyIdentity<T extends { length: number }>(x: T) {
+  return x;
+}
+`},
+		{Code: `
+interface Lengthy {
+  length: number;
+}
+function lengthyIdentity<T extends Lengthy>(x: T) {
+  return x;
+}
+`},
+		{Code: `
+function ItemComponent<T>(props: { item: T; onSelect: (item: T) => void }) {}
+`},
+		{Code: `
+interface ItemProps<T> {
+  item: readonly T;
+  onSelect: (item: T) => void;
+}
+function ItemComponent<T>(props: ItemProps<T>) {}
+`},
+		{Code: `
+declare namespace React {
+  interface RefObject<T> {
+    current: T | null;
+  }
+}
+function useFocus<T extends HTMLOrSVGElement>(): [
+  React.RefObject<T>,
+  () => void,
+];
+`},
+		{Code: `
+function findFirstResult<U>(
+  inputs: unknown[],
+  getResult: (t: unknown) => U | undefined,
+): U | undefined;
+`},
+		{Code: `
+function findFirstResult<T, U>(
+  inputs: T[],
+  getResult: (t: T) => () => [U | undefined],
+): () => [U | undefined];
+`},
+		{Code: `
+function getData<T>(url: string): Promise<T | null> {
+  return Promise.resolve(null);
+}
+`},
+		{Code: `
+function getData<T>(url: string): Promise<T extends null ? T : null> {
+  return Promise.resolve(null);
+}
+`},
+		{Code: "function getData<T extends string>(url: string): Promise<`a${T}b`> {\n  return Promise.resolve(null);\n}\n"},
+		{Code: `
+async function getData<T>(url: string): Promise<T | null> {
+  return null;
+}
+`},
+		{Code: `declare function get(): void;`},
+		{Code: `declare function get<T>(param: T[]): T;`},
+		{Code: `declare function box<T>(val: T): { val: T };`},
+		{Code: `declare function identity<T>(param: T): T;`},
+		{Code: `declare function compare<T>(param1: T, param2: T): boolean;`},
+		{Code: `declare function example<T>(a: Set<T>): T;`},
+		{Code: `declare function example<T>(a: Set<T>, b: T[]): void;`},
+		{Code: `declare function example<T>(a: Map<T, T>): void;`},
+		{Code: `declare function example<T, U extends T>(t: T, u: U): U;`},
+		{Code: `declare function makeSet<K>(): Set<K>;`},
+		{Code: `declare function makeSet<K>(): [Set<K>];`},
+		{Code: `declare function makeSets<K>(): Set<K>[];`},
+		{Code: `declare function makeSets<K>(): [Set<K>][];`},
+		{Code: `declare function makeMap<K, V>(): Map<K, V>;`},
+		{Code: `declare function makeMap<K, V>(): [Map<K, V>];`},
+		{Code: `declare function makeArray<T>(): T[];`},
+		{Code: `declare function makeArrayNullish<T>(): (T | null)[];`},
+		{Code: `declare function makeTupleMulti<T>(): [T | null, T | null];`},
+		{Code: `declare function takeTupleMulti<T>(input: [T, T]): void;`},
+		{Code: `declare function takeTupleMultiNullish<T>(input: [T | null, T | null]): void;`},
+		{Code: `declare function arrayOfPairs<T>(): [T, T][];`},
+		{Code: `declare function fetchJson<T>(url: string): Promise<T>;`},
+		{Code: `declare function fetchJsonTuple<T>(url: string): Promise<[T]>;`},
+		{Code: `declare function fn<T>(input: T): 0 extends 0 ? T : never;`},
+		{Code: `
+declare namespace React {
+  interface RefObject<T> {
+    current: T | null;
+  }
+}
+declare function useFocus<T extends HTMLOrSVGElement>(): [React.RefObject<T>];
+`},
+		{Code: `
+declare namespace React {
+  interface RefObject<T> {
+    current: T | null;
+  }
+}
+declare function useFocus<T extends HTMLOrSVGElement>(): {
+  ref: React.RefObject<T>;
+};
+`},
+		{Code: `
+interface TwoMethods<T> {
+  a(x: T): void;
+  b(x: T): void;
+}
+
+declare function two<T>(props: TwoMethods<T>): void;
+`},
+		{Code: `
+type Obj = { a: string };
+
+declare function hasOwnProperty<K extends keyof Obj>(
+  obj: Obj,
+  key: K,
+): obj is Obj & { [key in K]-?: Obj[key] };
+`},
+		{Code: `
+type AsMutable<T extends readonly unknown[]> = {
+  -readonly [Key in keyof T]: T[Key];
+};
+
+declare function makeMutable<T>(input: T): MakeMutable<T>;
+`},
+		{Code: `
+type AsMutable<T extends readonly unknown[]> = {
+  -readonly [Key in keyof T]: T[Key];
+};
+
+declare function makeMutable<T>(input: T): MakeMutable<typeof input>;
+`},
+		{Code: `
+type ValueNulls<U extends string> = {} & {
+  [P in U]: null;
+};
+
+declare function invert<T extends string>(obj: T): ValueNulls<T>;
+`},
+		{Code: `
+interface Middle {
+  inner: boolean;
+}
+
+type Conditional<T extends Middle> = {} & (T['inner'] extends true ? {} : {});
+
+function withMiddle<T extends Middle = Middle>(options: T): Conditional<T> {
+  return options;
+}
+`},
+		{Code: `
+import * as ts from 'typescript';
+
+declare function forEachReturnStatement<T>(
+  body: ts.Block,
+  visitor: (stmt: ts.ReturnStatement) => T,
+): T | undefined;
+`},
+		{Code: `
+declare enum AST_NODE_TYPES {
+  A = 'A',
+  B = 'B',
+}
+declare namespace TSESTree {
+  interface Node {
+    type: AST_NODE_TYPES;
+  }
+}
+
+declare const isNodeOfType: <NodeType extends AST_NODE_TYPES>(
+  nodeType: NodeType,
+) => node is Extract<TSESTree.Node, { type: NodeType }>;
+`},
+		{Code: `
+declare enum AST_NODE_TYPES {
+  A = 'A',
+  B = 'B',
+}
+declare namespace TSESTree {
+  interface Node {
+    type: AST_NODE_TYPES;
+  }
+}
+
+const isNodeOfType =
+  <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>
+  (
+    node: TSESTree.Node | null,
+  ): node is Extract<TSESTree.Node, { type: NodeType }> =>
+    node?.type === nodeType;
+`},
+		{Code: `
+declare enum AST_TOKEN_TYPES {
+  A = 'A',
+  B = 'B',
+}
+declare namespace TSESTree {
+  interface Token {
+    type: AST_TOKEN_TYPES;
+  }
+}
+
+export const isNotTokenOfTypeWithConditions =
+  <
+    TokenType extends AST_TOKEN_TYPES,
+    ExtractedToken extends Extract<TSESTree.Token, { type: TokenType }>,
+    Conditions extends Partial<ExtractedToken>,
+  >(
+    tokenType: TokenType,
+    conditions: Conditions,
+  ): ((
+    token: TSESTree.Token | null | undefined,
+  ) => token is Exclude<TSESTree.Token, Conditions & ExtractedToken>) =>
+  (token): token is Exclude<TSESTree.Token, Conditions & ExtractedToken> =>
+    tokenType in conditions;
+`},
+		{Code: `
+type Foo<T, S> = S extends 'somebody'
+  ? T extends 'once'
+    ? 'told'
+    : 'me'
+  : never;
+
+declare function foo<T>(data: T): <S>(other: S) => Foo<T, S>;
+`},
+		{Code: `
+type Foo<T, S> = S extends 'somebody'
+  ? T extends 'once'
+    ? 'told'
+    : 'me'
+  : never;
+
+declare function foo<T>(data: T): <S>(other: S) => Foo<S, T>;
+`},
+		{Code: `
+declare function mapObj<K extends string, V>(
+  obj: { [key in K]?: V },
+  fn: (key: K, val: V) => number,
+): number[];
+`},
+		{Code: `
+declare function mappedReturnType<T extends string>(
+  x: T,
+): { [K in T]: Capitalize<K> };
+
+function inferredMappedReturnType<T extends string>(x: T) {
+  return mappedReturnType(x);
+}
+`},
+		{Code: `
+declare function mappedReturnType<T extends string>(
+  x: T,
+): { [K in T]: Capitalize<K> };
+
+function inferredMappedReturnType<T extends string>(x: T) {
+  return () => mappedReturnType(x);
+}
+`},
+		{Code: `
+declare function mappedReturnType<T extends string>(
+  x: T,
+): { [K in T]: Capitalize<K> };
+
+function inferredMappedReturnType<T extends string>(x: T) {
+  return [{ value: () => mappedReturnType(x) }];
+}
+`},
+		{Code: `
+type Identity<T> = T;
+
+type Mapped<T, Value> = Identity<{ [P in keyof T]: Value }>;
+
+declare function sillyFoo<Data, Value>(
+  c: Value,
+): (data: Data) => Mapped<Data, Value>;
+`},
+		{Code: `
+type Silly<T> = { [P in keyof T]: T[P] };
+
+type SillyFoo<T, Value> = Silly<{ [P in keyof T]: Value }>;
+
+type Foo<T, Value> = { [P in keyof T]: Value };
+
+declare function foo<T, Constant>(data: T, c: Constant): Foo<T, Constant>;
+declare function foo<T, Constant>(c: Constant): (data: T) => Foo<T, Constant>;
+
+declare function sillyFoo<T, Constant>(
+  data: T,
+  c: Constant,
+): SillyFoo<T, Constant>;
+declare function sillyFoo<T, Constant>(
+  c: Constant,
+): (data: T) => SillyFoo<T, Constant>;
+`},
+		{Code: `
+const f = <T,>(setValue: (v: T) => void, getValue: () => NoInfer<T>) => {};
+`},
+		{Code: `
+const f = <T,>(
+  setValue: (v: T) => NoInfer<T>,
+  getValue: (v: NoInfer<T>) => NoInfer<T>,
+) => {};
+`},
+		{Code: "<T extends string>(t: T) => t as { [K in 'a' as T]: 0 };"},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `const func = <T,>(param: T) => null;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const func = (param: unknown) => null;`,
+				}},
+			}},
+		},
+		{
+			Code: `const func = <T,>(param: [T]) => null;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const func = (param: [unknown]) => null;`,
+				}},
+			}},
+		},
+		{
+			Code: `const func = <T,>(param: T[]) => null;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const func = (param: unknown[]) => null;`,
+				}},
+			}},
+		},
+		{
+			Code: `const f1 = <T,>(): T => {};`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the function signature.",
+				Line:      1,
+				Column:    13,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const f1 = (): unknown => {};`,
+				}},
+			}},
+		},
+		{
+			Code: `
+interface I {
+  <T>(value: T): void;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    4,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+interface I {
+  (value: unknown): void;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+interface I {
+  m<T>(x: T): void;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    5,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+interface I {
+  m(x: unknown): void;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+class Joiner<T extends string | number> {
+  join(el: T, other: string) {
+    return [el, other].join(',');
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the class signature.",
+				Line:      2,
+				Column:    14,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class Joiner {
+  join(el: string | number, other: string) {
+    return [el, other].join(',');
+  }
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+declare class C<V> {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter V is never used in the class signature.",
+				Line:      2,
+				Column:    17,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+declare class C {}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+declare class C<T, U> {
+  method(param: T): U;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Line:      2,
+					Column:    17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+declare class C<U> {
+  method(param: unknown): U;
+}
+`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      2,
+					Column:    20,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+declare class C<T> {
+  method(param: T): unknown;
+}
+`,
+					}},
+				},
+			},
+		},
+		{
+			Code: `
+declare class C {
+  method<T, U>(param: T): U;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Line:      3,
+					Column:    10,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+declare class C {
+  method<U>(param: unknown): U;
+}
+`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      3,
+					Column:    13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+declare class C {
+  method<T>(param: T): unknown;
+}
+`,
+					}},
+				},
+			},
+		},
+		{
+			Code: `
+declare class C {
+  prop: <P>() => P;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    10,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+declare class C {
+  prop: () => unknown;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+declare class Foo {
+  foo<T>(this: T): void;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    7,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+declare class Foo {
+  foo(this: unknown): void;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function third<A, B, C>(a: A, b: B, c: C): C {
+  return c;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Line:      2,
+					Column:    16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+function third<B, C>(a: unknown, b: B, c: C): C {
+  return c;
+}
+`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      2,
+					Column:    19,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+function third<A, C>(a: A, b: unknown, c: C): C {
+  return c;
+}
+`,
+					}},
+				},
+			},
+		},
+		{
+			Code: `
+function foo<T>(_: T) {
+  const x: T = null!;
+  const y: T = null!;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    14,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function foo(_: unknown) {
+  const x: unknown = null!;
+  const y: unknown = null!;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function foo<T>(_: T): void {
+  const x: T = null!;
+  const y: T = null!;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    14,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function foo(_: unknown): void {
+  const x: unknown = null!;
+  const y: unknown = null!;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function foo<T>(_: T): <T>(input: T) => T {
+  const x: T = null!;
+  const y: T = null!;
+  return null!;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    14,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function foo(_: unknown): <T>(input: T) => T {
+  const x: unknown = null!;
+  const y: unknown = null!;
+  return null!;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function foo<T>(_: T) {
+  function withX(): T {
+    return null!;
+  }
+  function withY(): T {
+    return null!;
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    14,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function foo(_: unknown) {
+  function withX(): unknown {
+    return null!;
+  }
+  function withY(): unknown {
+    return null!;
+  }
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function parseYAML<T>(input: string): T {
+  return input as any as T;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function parseYAML(input: string): unknown {
+  return input as any as unknown;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function printProperty<T, K extends keyof T>(obj: T, key: K) {
+  console.log(obj[key]);
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    27,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function printProperty<T>(obj: T, key: keyof T) {
+  console.log(obj[key]);
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function fn<T>(param: string) {
+  let v: T = null!;
+  return v;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    13,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function fn(param: string) {
+  let v: unknown = null!;
+  return v;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function both<
+  Args extends unknown[],
+  CB1 extends (...args: Args) => void,
+  CB2 extends (...args: Args) => void,
+>(fn1: CB1, fn2: CB2): (...args: Args) => void {
+  return function (...args: Args) {
+    fn1(...args);
+    fn2(...args);
+  };
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Line:      4,
+					Column:    3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+function both<
+  Args extends unknown[],
+  CB2 extends (...args: Args) => void,
+>(fn1: (...args: Args) => void, fn2: CB2): (...args: Args) => void {
+  return function (...args: Args) {
+    fn1(...args);
+    fn2(...args);
+  };
+}
+`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      5,
+					Column:    3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+function both<
+  Args extends unknown[],
+  CB1 extends (...args: Args) => void,
+>(fn1: CB1, fn2: (...args: Args) => void): (...args: Args) => void {
+  return function (...args: Args) {
+    fn1(...args);
+    fn2(...args);
+  };
+}
+`,
+					}},
+				},
+			},
+		},
+		{
+			Code: `
+function getLength<T extends { length: number }>(x: T) {
+  return x.length;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function getLength(x: { length: number }) {
+  return x.length;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+interface Lengthy {
+  length: number;
+}
+function getLength<T extends Lengthy>(x: T) {
+  return x.length;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      5,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+interface Lengthy {
+  length: number;
+}
+function getLength(x: Lengthy) {
+  return x.length;
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function get<T>(): unknown;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is never used in the function signature.",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get(): unknown;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function get<T>(): T;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get(): unknown;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function get<T extends object>(): T;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get(): object;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function take<T>(param: T): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    23,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function take(param: unknown): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function take<T extends object>(param: T): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    23,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function take(param: object): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function take<T, U = T>(param1: T, param2: U): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    26,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function take<T>(param1: T, param2: unknown): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function take<T, U extends T>(param: T): U;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    26,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function take<T>(param: T): T;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function take<T, U extends T>(param: U): U;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    23,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function take<U extends unknown>(param: U): U;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function get<T, U = T>(param: U): U;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get<U = unknown>(param: U): U;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function get<T, U extends T = T>(param: T): U;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    25,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function get<T>(param: T): T;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function compare<T, U extends T>(param1: T, param2: U): boolean;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    29,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function compare<T>(param1: T, param2: T): boolean;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function get<T>(param: <U, V>(param: U) => V): T;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Line:      1,
+					Column:    22,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function get(param: <U, V>(param: U) => V): unknown;`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      1,
+					Column:    33,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function get<T>(param: <V>(param: unknown) => V): T;`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      1,
+					Column:    36,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function get<T>(param: <U>(param: U) => unknown): T;`,
+					}},
+				},
+			},
+		},
+		{
+			Code: `declare function get<T>(param: <T, U>(param: T) => U): T;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Line:      1,
+					Column:    22,
+					EndColumn: 23,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function get(param: <T, U>(param: T) => U): unknown;`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      1,
+					Column:    33,
+					EndColumn: 34,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function get<T>(param: <U>(param: unknown) => U): T;`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      1,
+					Column:    36,
+					EndColumn: 37,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output:    `declare function get<T>(param: <T>(param: T) => unknown): T;`,
+					}},
+				},
+			},
+		},
+		{
+			Code: `declare function makeReadonlyArray<T>(): readonly T[];`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    36,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function makeReadonlyArray(): readonly unknown[];`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function makeReadonlyTuple<T>(): readonly [T];`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    36,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function makeReadonlyTuple(): readonly [unknown];`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function makeReadonlyTupleNullish<T>(): readonly [T | null];`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    43,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function makeReadonlyTupleNullish(): readonly [unknown | null];`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function takeArray<T>(input: T[]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    28,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function takeArray(input: unknown[]): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function takeArrayNullish<T>(input: (T | null)[]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    35,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function takeArrayNullish(input: (unknown | null)[]): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function takeTuple<T>(input: [T]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    28,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function takeTuple(input: [unknown]): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function takeTupleMultiUnrelated<T>(input: [T, number]): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    42,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `declare function takeTupleMultiUnrelated(input: [unknown, number]): void;`,
+				}},
+			}},
+		},
+		{
+			Code: `
+declare function takeTupleMultiUnrelatedNullish<T>(
+  input: [T | null, null],
+): void;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    49,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+declare function takeTupleMultiUnrelatedNullish(
+  input: [unknown | null, null],
+): void;
+`,
+				}},
+			}},
+		},
+		{
+			Code: `type Fn = <T>() => T;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `type Fn = () => unknown;`,
+				}},
+			}},
+		},
+		{
+			Code: `type Fn = <T>() => [];`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is never used in the function signature.",
+				Line:      1,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `type Fn = () => [];`,
+				}},
+			}},
+		},
+		{
+			Code: `
+type Other = 0;
+type Fn = <T>() => Other;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+type Other = 0;
+type Fn = () => Other;
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+type Other = 0 | 1;
+type Fn = <T>() => Other;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+type Other = 0 | 1;
+type Fn = () => Other;
+`,
+				}},
+			}},
+		},
+		{
+			Code: `type Fn = <U>(param: U) => void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `type Fn = (param: unknown) => void;`,
+				}},
+			}},
+		},
+		{
+			Code: `type Ctr = new <T>() => T;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    17,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `type Ctr = new () => unknown;`,
+				}},
+			}},
+		},
+		{
+			Code: `type Fn = <T>() => { [K in keyof T]: K };`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `type Fn = () => { [K in keyof unknown]: K };`,
+				}},
+			}},
+		},
+		{
+			Code: "type Fn = <T>() => { [K in 'a']: T };",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    "type Fn = () => { [K in 'a']: unknown };",
+				}},
+			}},
+		},
+		{
+			Code: `type Fn = <T>(value: unknown) => value is T;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `type Fn = (value: unknown) => value is unknown;`,
+				}},
+			}},
+		},
+		{
+			Code: "type Fn = <T extends string>() => `a${T}b`;",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    "type Fn = () => `a${string}b`;",
+				}},
+			}},
+		},
+		{
+			Code: `
+declare function mapObj<K extends string, V>(
+  obj: { [key in K]?: V },
+  fn: (key: K) => number,
+): number[];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    43,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+declare function mapObj<K extends string>(
+  obj: { [key in K]?: unknown },
+  fn: (key: K) => number,
+): number[];
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+declare function setItem<T>(T): T;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    26,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+declare function setItem(T): unknown;
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+interface StorageService {
+  setItem<T>({ key: string, value: T }): Promise<void>;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is never used in the function signature.",
+				Line:      3,
+				Column:    11,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+interface StorageService {
+  setItem({ key: string, value: T }): Promise<void>;
+}
+`,
+				}},
+			}},
+		},
+		{
+			// Not an important case in isolation, but used as a doc example of
+			// code that gets flagged despite arguably not needing to be: see
+			// the rule's "Differences from ESLint" note.
+			Code: `
+type Compute<A> = A extends Function ? A : { [K in keyof A]: Compute<A[K]> };
+type Equal<X, Y> =
+  (<T1>() => T1 extends Compute<X> ? 1 : 2) extends
+    (<T2>() => T2 extends Compute<Y> ? 1 : 2)
+  ? true
+  : false;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "sole",
+					Line:      4,
+					Column:    5,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+type Compute<A> = A extends Function ? A : { [K in keyof A]: Compute<A[K]> };
+type Equal<X, Y> =
+  (() => unknown extends Compute<X> ? 1 : 2) extends
+    (<T2>() => T2 extends Compute<Y> ? 1 : 2)
+  ? true
+  : false;
+`,
+					}},
+				},
+				{
+					MessageId: "sole",
+					Line:      5,
+					Column:    7,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "replaceUsagesWithConstraint",
+						Output: `
+type Compute<A> = A extends Function ? A : { [K in keyof A]: Compute<A[K]> };
+type Equal<X, Y> =
+  (<T1>() => T1 extends Compute<X> ? 1 : 2) extends
+    (() => unknown extends Compute<Y> ? 1 : 2)
+  ? true
+  : false;
+`,
+					}},
+				},
+			},
+		},
+		{
+			Code: `
+function f<T extends any>(x: T): void {
+  // @ts-expect-error
+  x.notAMethod();
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function f(x: unknown): void {
+  // @ts-expect-error
+  x.notAMethod();
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+class Joiner {
+  join<T extends number>(els: T[]) {
+    return els.map(el => '' + el).join(',');
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Column:    8,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class Joiner {
+  join(els: number[]) {
+    return els.map(el => '' + el).join(',');
+  }
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function join<T extends string | number>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function join(els: (string | number)[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function join<T extends string & number>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function join(els: (string & number)[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function join<T extends (string & number) | boolean>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function join(els: ((string & number) | boolean)[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function join<T extends (string | number)>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function join(els: (string | number)[]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+function join<T extends { hoge: string } | { hoge: number }>(els: T['hoge'][]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    15,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+function join(els: ({ hoge: string } | { hoge: number })['hoge'][]) {
+  return els.map(el => '' + el).join(',');
+}
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+type A = string;
+type B = string;
+type C = string;
+declare function f<T extends A | B>(): T & C;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      5,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+type A = string;
+type B = string;
+type C = string;
+declare function f(): (A | B) & C;
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+type A = string;
+type B = string;
+type C = string;
+type D = string;
+declare function f<T extends (A extends B ? C : D)>(): T | null;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      6,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+type A = string;
+type B = string;
+type C = string;
+type D = string;
+declare function f(): (A extends B ? C : D) | null;
+`,
+				}},
+			}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_upstream_test.go
@@ -482,7 +482,6 @@ const f = <T,>(
   getValue: (v: NoInfer<T>) => NoInfer<T>,
 ) => {};
 `},
-		{Code: "<T extends string>(t: T) => t as { [K in 'a' as T]: 0 };"},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `const func = <T,>(param: T) => null;`,

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_upstream_test.go
@@ -325,9 +325,15 @@ declare enum AST_NODE_TYPES {
   B = 'B',
 }
 declare namespace TSESTree {
-  interface Node {
-    type: AST_NODE_TYPES;
+  interface NodeA {
+    type: AST_NODE_TYPES.A;
+    a: string;
   }
+  interface NodeB {
+    type: AST_NODE_TYPES.B;
+    b: number;
+  }
+  type Node = NodeA | NodeB;
 }
 
 declare const isNodeOfType: <NodeType extends AST_NODE_TYPES>(
@@ -340,9 +346,15 @@ declare enum AST_NODE_TYPES {
   B = 'B',
 }
 declare namespace TSESTree {
-  interface Node {
-    type: AST_NODE_TYPES;
+  interface NodeA {
+    type: AST_NODE_TYPES.A;
+    a: string;
   }
+  interface NodeB {
+    type: AST_NODE_TYPES.B;
+    b: number;
+  }
+  type Node = NodeA | NodeB;
 }
 
 const isNodeOfType =
@@ -358,9 +370,15 @@ declare enum AST_TOKEN_TYPES {
   B = 'B',
 }
 declare namespace TSESTree {
-  interface Token {
-    type: AST_TOKEN_TYPES;
+  interface TokenA {
+    type: AST_TOKEN_TYPES.A;
+    a: string;
   }
+  interface TokenB {
+    type: AST_TOKEN_TYPES.B;
+    b: number;
+  }
+  type Token = TokenA | TokenB;
 }
 
 export const isNotTokenOfTypeWithConditions =

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -361,7 +361,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-unnecessary-type-assertion.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-type-constraint.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-type-conversion.test.ts',
-    // './tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts',
+    './tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-argument.test.ts',
     // './tests/typescript-eslint/rules/no-unsafe-assignment.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-call.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-parameters.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-parameters.test.ts.snap
@@ -1,0 +1,2044 @@
+// Rstest Snapshot v1
+
+exports[`no-unnecessary-type-parameters > invalid 1`] = `
+{
+  "code": "const func = <T,>(param: T) => null;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 2`] = `
+{
+  "code": "const func = <T,>(param: [T]) => null;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 3`] = `
+{
+  "code": "const func = <T,>(param: T[]) => null;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 4`] = `
+{
+  "code": "const f1 = <T,>(): T => {};",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 5`] = `
+{
+  "code": "
+        interface I {
+          <T>(value: T): void;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 6`] = `
+{
+  "code": "
+        interface I {
+          m<T>(x: T): void;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 7`] = `
+{
+  "code": "
+        class Joiner<T extends string | number> {
+          join(el: T, other: string) {
+            return [el, other].join(',');
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the class signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 8`] = `
+{
+  "code": "
+        declare class C<V> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter V is never used in the class signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 25,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 9`] = `
+{
+  "code": "
+        declare class C<T, U> {
+          method(param: T): U;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the class signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 25,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter U is used only once in the class signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 2,
+        },
+        "start": {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 10`] = `
+{
+  "code": "
+        declare class C {
+          method<T, U>(param: T): U;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 11`] = `
+{
+  "code": "
+        declare class C {
+          prop: <P>() => P;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter P is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 12`] = `
+{
+  "code": "
+        declare class Foo {
+          foo<T>(this: T): void;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 13`] = `
+{
+  "code": "
+        function third<A, B, C>(a: A, b: B, c: C): C {
+          return c;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter A is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 24,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter B is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 2,
+        },
+        "start": {
+          "column": 27,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 14`] = `
+{
+  "code": "
+        function foo<T>(_: T) {
+          const x: T = null!;
+          const y: T = null!;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 15`] = `
+{
+  "code": "
+        function foo<T>(_: T): void {
+          const x: T = null!;
+          const y: T = null!;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 16`] = `
+{
+  "code": "
+function foo<T>(_: T): <T>(input: T) => T {
+  const x: T = null!;
+  const y: T = null!;
+  return null!;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 17`] = `
+{
+  "code": "
+        function foo<T>(_: T) {
+          function withX(): T {
+            return null!;
+          }
+          function withY(): T {
+            return null!;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 18`] = `
+{
+  "code": "
+        function parseYAML<T>(input: string): T {
+          return input as any as T;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 2,
+        },
+        "start": {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 19`] = `
+{
+  "code": "
+        function printProperty<T, K extends keyof T>(obj: T, key: K) {
+          console.log(obj[key]);
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter K is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 2,
+        },
+        "start": {
+          "column": 35,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 20`] = `
+{
+  "code": "
+        function fn<T>(param: string) {
+          let v: T = null!;
+          return v;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 21`] = `
+{
+  "code": "
+        function both<
+          Args extends unknown[],
+          CB1 extends (...args: Args) => void,
+          CB2 extends (...args: Args) => void,
+        >(fn1: CB1, fn2: CB2): (...args: Args) => void {
+          return function (...args: Args) {
+            fn1(...args);
+            fn2(...args);
+          };
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter CB1 is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 4,
+        },
+        "start": {
+          "column": 11,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter CB2 is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 22`] = `
+{
+  "code": "
+        function getLength<T extends { length: number }>(x: T) {
+          return x.length;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 2,
+        },
+        "start": {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 23`] = `
+{
+  "code": "
+        interface Lengthy {
+          length: number;
+        }
+        function getLength<T extends Lengthy>(x: T) {
+          return x.length;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 5,
+        },
+        "start": {
+          "column": 28,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 24`] = `
+{
+  "code": "declare function get<T>(): unknown;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is never used in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 25`] = `
+{
+  "code": "declare function get<T>(): T;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 26`] = `
+{
+  "code": "declare function get<T extends object>(): T;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 27`] = `
+{
+  "code": "declare function take<T>(param: T): void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 28`] = `
+{
+  "code": "declare function take<T extends object>(param: T): void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 29`] = `
+{
+  "code": "declare function take<T, U = T>(param1: T, param2: U): void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 30`] = `
+{
+  "code": "declare function take<T, U extends T>(param: T): U;",
+  "diagnostics": [
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 31`] = `
+{
+  "code": "declare function take<T, U extends T>(param: U): U;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 32`] = `
+{
+  "code": "declare function get<T, U = T>(param: U): U;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 33`] = `
+{
+  "code": "declare function get<T, U extends T = T>(param: T): U;",
+  "diagnostics": [
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 34`] = `
+{
+  "code": "declare function compare<T, U extends T>(param1: T, param2: U): boolean;",
+  "diagnostics": [
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 35`] = `
+{
+  "code": "declare function get<T>(param: <U, V>(param: U) => V): T;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter V is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 36`] = `
+{
+  "code": "declare function get<T>(param: <T, U>(param: T) => U): T;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 37`] = `
+{
+  "code": "declare function makeReadonlyArray<T>(): readonly T[];",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 38`] = `
+{
+  "code": "declare function makeReadonlyTuple<T>(): readonly [T];",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 39`] = `
+{
+  "code": "declare function makeReadonlyTupleNullish<T>(): readonly [T | null];",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 40`] = `
+{
+  "code": "declare function takeArray<T>(input: T[]): void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 41`] = `
+{
+  "code": "declare function takeArrayNullish<T>(input: (T | null)[]): void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 42`] = `
+{
+  "code": "declare function takeTuple<T>(input: [T]): void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 43`] = `
+{
+  "code": "declare function takeTupleMultiUnrelated<T>(input: [T, number]): void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 44`] = `
+{
+  "code": "
+        declare function takeTupleMultiUnrelatedNullish<T>(
+          input: [T | null, null],
+        ): void;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 2,
+        },
+        "start": {
+          "column": 57,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 45`] = `
+{
+  "code": "type Fn = <T>() => T;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 46`] = `
+{
+  "code": "type Fn = <T>() => [];",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is never used in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 47`] = `
+{
+  "code": "
+        type Other = 0;
+        type Fn = <T>() => Other;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is never used in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 48`] = `
+{
+  "code": "
+        type Other = 0 | 1;
+        type Fn = <T>() => Other;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is never used in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 49`] = `
+{
+  "code": "type Fn = <U>(param: U) => void;",
+  "diagnostics": [
+    {
+      "message": "Type parameter U is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 50`] = `
+{
+  "code": "type Ctr = new <T>() => T;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 51`] = `
+{
+  "code": "type Fn = <T>() => { [K in keyof T]: K };",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 52`] = `
+{
+  "code": "type Fn = <T>() => { [K in 'a']: T };",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 53`] = `
+{
+  "code": "type Fn = <T>(value: unknown) => value is T;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 54`] = `
+{
+  "code": "type Fn = <T extends string>() => \`a\${T}b\`;",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 55`] = `
+{
+  "code": "
+        declare function mapObj<K extends string, V>(
+          obj: { [key in K]?: V },
+          fn: (key: K) => number,
+        ): number[];
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter V is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 2,
+        },
+        "start": {
+          "column": 51,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 56`] = `
+{
+  "code": "
+declare function setItem<T>(T): T;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 2,
+        },
+        "start": {
+          "column": 26,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 57`] = `
+{
+  "code": "
+interface StorageService {
+  setItem<T>({ key: string, value: T }): Promise<void>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is never used in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 58`] = `
+{
+  "code": "
+type Compute<A> = A extends Function ? A : { [K in keyof A]: Compute<A[K]> };
+type Equal<X, Y> =
+  (<T1>() => T1 extends Compute<X> ? 1 : 2) extends
+    (<T2>() => T2 extends Compute<Y> ? 1 : 2)
+  ? true
+  : false;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T1 is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+    {
+      "message": "Type parameter T2 is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 59`] = `
+{
+  "code": "
+function f<T extends any>(x: T): void {
+  // @ts-expect-error
+  x.notAMethod();
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 60`] = `
+{
+  "code": "
+class Joiner {
+  join<T extends number>(els: T[]) {
+    return els.map(el => '' + el).join(',');
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 61`] = `
+{
+  "code": "
+function join<T extends string | number>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 62`] = `
+{
+  "code": "
+function join<T extends string & number>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 63`] = `
+{
+  "code": "
+function join<T extends (string & number) | boolean>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 64`] = `
+{
+  "code": "
+function join<T extends (string | number)>(els: T[]) {
+  return els.map(el => '' + el).join(',');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 65`] = `
+{
+  "code": "
+function join<T extends { hoge: string } | { hoge: number }>(els: T['hoge'][]) {
+  return els.map(el => '' + el).join(',');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 66`] = `
+{
+  "code": "
+type A = string;
+type B = string;
+type C = string;
+declare function f<T extends A | B>(): T & C;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 5,
+        },
+        "start": {
+          "column": 20,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-parameters > invalid 67`] = `
+{
+  "code": "
+type A = string;
+type B = string;
+type C = string;
+type D = string;
+declare function f<T extends A extends B ? C : D>(): T | null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type parameter T is used only once in the function signature.",
+      "messageId": "sole",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 6,
+        },
+        "start": {
+          "column": 20,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-parameters",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts
@@ -313,9 +313,15 @@ ruleTester.run('no-unnecessary-type-parameters', {
         B = 'B',
       }
       declare namespace TSESTree {
-        interface Node {
-          type: AST_NODE_TYPES;
+        interface NodeA {
+          type: AST_NODE_TYPES.A;
+          a: string;
         }
+        interface NodeB {
+          type: AST_NODE_TYPES.B;
+          b: number;
+        }
+        type Node = NodeA | NodeB;
       }
 
       declare const isNodeOfType: <NodeType extends AST_NODE_TYPES>(
@@ -328,9 +334,15 @@ ruleTester.run('no-unnecessary-type-parameters', {
         B = 'B',
       }
       declare namespace TSESTree {
-        interface Node {
-          type: AST_NODE_TYPES;
+        interface NodeA {
+          type: AST_NODE_TYPES.A;
+          a: string;
         }
+        interface NodeB {
+          type: AST_NODE_TYPES.B;
+          b: number;
+        }
+        type Node = NodeA | NodeB;
       }
 
       const isNodeOfType =
@@ -346,9 +358,15 @@ ruleTester.run('no-unnecessary-type-parameters', {
         B = 'B',
       }
       declare namespace TSESTree {
-        interface Token {
-          type: AST_TOKEN_TYPES;
+        interface TokenA {
+          type: AST_TOKEN_TYPES.A;
+          a: string;
         }
+        interface TokenB {
+          type: AST_TOKEN_TYPES.B;
+          b: number;
+        }
+        type Token = TokenA | TokenB;
       }
 
       export const isNotTokenOfTypeWithConditions =

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts
@@ -308,14 +308,30 @@ ruleTester.run('no-unnecessary-type-parameters', {
       ): T | undefined;
     `,
     `
-      import type { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/types';
+      declare enum AST_NODE_TYPES {
+        A = 'A',
+        B = 'B',
+      }
+      declare namespace TSESTree {
+        interface Node {
+          type: AST_NODE_TYPES;
+        }
+      }
 
       declare const isNodeOfType: <NodeType extends AST_NODE_TYPES>(
         nodeType: NodeType,
       ) => node is Extract<TSESTree.Node, { type: NodeType }>;
     `,
     `
-      import type { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/types';
+      declare enum AST_NODE_TYPES {
+        A = 'A',
+        B = 'B',
+      }
+      declare namespace TSESTree {
+        interface Node {
+          type: AST_NODE_TYPES;
+        }
+      }
 
       const isNodeOfType =
         <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>
@@ -325,7 +341,15 @@ ruleTester.run('no-unnecessary-type-parameters', {
           node?.type === nodeType;
     `,
     `
-      import type { AST_TOKEN_TYPES, TSESTree } from '@typescript-eslint/types';
+      declare enum AST_TOKEN_TYPES {
+        A = 'A',
+        B = 'B',
+      }
+      declare namespace TSESTree {
+        interface Token {
+          type: AST_TOKEN_TYPES;
+        }
+      }
 
       export const isNotTokenOfTypeWithConditions =
         <

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -569,6 +569,7 @@ typescriptutil
 unaliased
 unbnound
 uncast
+Uncapitalize
 unconfig
 unconfigured
 undefinded

--- a/shim/checker/extra-shim.json
+++ b/shim/checker/extra-shim.json
@@ -27,7 +27,11 @@
       "getWidenedType",
       "isTypeAssignableTo",
       "isTypeStrictSubtypeOf",
-      "getIndexInfosOfType"
+      "getIndexInfosOfType",
+      "getTypeParameterFromMappedType",
+      "getConstraintTypeFromMappedType",
+      "getNameTypeFromMappedType",
+      "getTemplateTypeFromMappedType"
     ]
   },
   "ExtraFields": {

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -103,6 +103,14 @@ func Checker_getReturnTypeOfSignature(recv *checker.Checker, sig *checker.Signat
 func Checker_getApparentType(recv *checker.Checker, t *checker.Type) *checker.Type
 //go:linkname Checker_getTypeArguments github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeArguments
 func Checker_getTypeArguments(recv *checker.Checker, t *checker.Type) []*checker.Type
+//go:linkname Checker_getTypeParameterFromMappedType github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeParameterFromMappedType
+func Checker_getTypeParameterFromMappedType(recv *checker.Checker, t *checker.Type) *checker.Type
+//go:linkname Checker_getConstraintTypeFromMappedType github.com/microsoft/typescript-go/internal/checker.(*Checker).getConstraintTypeFromMappedType
+func Checker_getConstraintTypeFromMappedType(recv *checker.Checker, t *checker.Type) *checker.Type
+//go:linkname Checker_getNameTypeFromMappedType github.com/microsoft/typescript-go/internal/checker.(*Checker).getNameTypeFromMappedType
+func Checker_getNameTypeFromMappedType(recv *checker.Checker, t *checker.Type) *checker.Type
+//go:linkname Checker_getTemplateTypeFromMappedType github.com/microsoft/typescript-go/internal/checker.(*Checker).getTemplateTypeFromMappedType
+func Checker_getTemplateTypeFromMappedType(recv *checker.Checker, t *checker.Type) *checker.Type
 //go:linkname Checker_getTypeFromTypeNode github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeFromTypeNode
 func Checker_getTypeFromTypeNode(recv *checker.Checker, node *ast.Node) *checker.Type
 //go:linkname Checker_isArrayType github.com/microsoft/typescript-go/internal/checker.(*Checker).isArrayType


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-unnecessary-type-parameters` rule from typescript-eslint to rslint.

Flags type parameters on functions, methods, and classes that aren't used more than once in the signature, since a type parameter used only once doesn't relate anything and can be replaced by its constraint (or `unknown`).

Behavior matches upstream except where upstream is limited by the TypeScript public API and rslint is not: a mapped type's `as` clause and index signatures with symbol or pattern keys count as uses here, so those false positives are not reported. The `replaceUsagesWithConstraint` suggestion also parenthesizes the constraint wherever the type grammar requires it, keeping the replacement the same type as the code it replaces. Both are described in the rule docs.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/no-unnecessary-type-parameters
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
