### PR TITLE
docs(website): group documentation sidebars

### DIFF
--- a/website/docs/en/config/_meta.json
+++ b/website/docs/en/config/_meta.json
@@ -1,5 +1,9 @@
 [
   {
+    "type": "section-header",
+    "label": "Basics"
+  },
+  {
     "type": "file",
     "name": "index",
     "label": "Overview"

--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -1,5 +1,9 @@
 [
   {
+    "type": "section-header",
+    "label": "Start"
+  },
+  {
     "type": "file",
     "name": "index",
     "label": "Getting Started"
@@ -8,6 +12,10 @@
     "type": "file",
     "name": "vscode-extension",
     "label": "VSCode Extension"
+  },
+  {
+    "type": "section-header",
+    "label": "Features"
   },
   {
     "type": "file",
@@ -23,6 +31,10 @@
     "type": "file",
     "name": "inline-directives",
     "label": "Inline Directives"
+  },
+  {
+    "type": "section-header",
+    "label": "Reference"
   },
   {
     "type": "file",

--- a/website/plugin-rule-manifest.ts
+++ b/website/plugin-rule-manifest.ts
@@ -227,7 +227,7 @@ function buildRuleDocContent(rule: RuleEntry): string {
  *
  * Generated structure:
  *   docs/en/rules/
- *     _meta.json                        ← Overview + one entry per group dir
+ *     _meta.json                        ← section headers + Overview + group dirs
  *     index.mdx                         ← already exists (Overview page)
  *     eslint/
  *       _meta.json                      ← lists individual rules
@@ -270,9 +270,11 @@ function writeRuleDocsToDir(rules: RuleEntry[]): void {
     return oa !== ob ? oa - ob : a.localeCompare(b);
   });
 
-  // Write top-level _meta.json: Overview + one dir per group
+  // Write top-level _meta.json: grouped overview + one dir per plugin
   const topMeta: unknown[] = [
+    { type: 'section-header', label: 'Rule Status' },
     { type: 'file', name: 'index', label: 'Overview' },
+    { type: 'section-header', label: 'Plugins' },
     ...sortedGroups.map(([slug]) => ({
       type: 'dir',
       name: slug,


### PR DESCRIPTION
## Summary

- Group the Guide sidebar into Start, Features, and Reference sections.
- Add a Basics section to the Configuration sidebar.
- Group the generated Rules sidebar into Rule Status and Plugins sections.
- Preserve all existing page order and URLs.

<img width="3042" height="1940" alt="image" src="https://github.com/user-attachments/assets/38e3eef6-1439-4e77-a19f-8a5352a38717" />


## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
