### PR TITLE
fix: align core function display names with ESLint

### DIFF
--- a/internal/rules/complexity/complexity_test.go
+++ b/internal/rules/complexity/complexity_test.go
@@ -1420,7 +1420,7 @@ function b() { while (1) { while (2) { while (3) {} } } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "complex",
-						Message:   "Private method '#x' has a complexity of 2. Maximum allowed is 1.",
+						Message:   "Private method #x has a complexity of 2. Maximum allowed is 1.",
 					},
 				},
 			},
@@ -2061,7 +2061,7 @@ function c() { if (x) {} if (y) {} }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "complex",
-						Message:   "Static private method '#x' has a complexity of 2. Maximum allowed is 1.",
+						Message:   "Static private method #x has a complexity of 2. Maximum allowed is 1.",
 					},
 				},
 			},
@@ -2240,7 +2240,7 @@ function c() { if (x) {} if (y) {} }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "complex",
-						Message:   "Private getter '#x' has a complexity of 2. Maximum allowed is 1.",
+						Message:   "Private getter #x has a complexity of 2. Maximum allowed is 1.",
 					},
 				},
 			},

--- a/internal/rules/consistent_return/consistent_return_extras_function_names_test.go
+++ b/internal/rules/consistent_return/consistent_return_extras_function_names_test.go
@@ -1,0 +1,153 @@
+// TestConsistentReturnExtrasFunctionNames locks the public diagnostic text to
+// ESLint for function owners whose ESTree and tsgo parent shapes differ. The
+// three message IDs are all covered because they share the same display-name
+// helper but are emitted from different rule branches.
+package consistent_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestConsistentReturnExtrasFunctionNames(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ConsistentReturnRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			// ---- PrivateIdentifier: ESLint never quotes a private member name ----
+			{
+				Code: `class A { #foo() { if (a) return 1; return; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Private method #foo expected a return value.",
+					Line:      1,
+					Column:    37,
+					EndLine:   1,
+					EndColumn: 44,
+				}},
+			},
+			{
+				Code: `class A { #foo() { if (a) return; return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Private method #foo expected no return value.",
+					Line:      1,
+					Column:    35,
+					EndLine:   1,
+					EndColumn: 44,
+				}},
+			},
+
+			// ---- Parenthesized property values: ESTree removes every paren layer ----
+			{
+				Code: `({ foo: (() => { if (a) return 1; }) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of method 'foo'.",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `({ foo: ((() => { if (a) return 1; return; })) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Method 'foo' expected a return value.",
+					Line:      1,
+					Column:    36,
+					EndLine:   1,
+					EndColumn: 43,
+				}},
+			},
+			{
+				Code: `({ foo: ((() => { if (a) return; return 1; })) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Method 'foo' expected no return value.",
+					Line:      1,
+					Column:    34,
+					EndLine:   1,
+					EndColumn: 43,
+				}},
+			},
+			{
+				Code: `class C { static #f = ((() => { if (a) return 1; })) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of static private method #f.",
+					Line:      1,
+					Column:    28,
+					EndLine:   1,
+					EndColumn: 30,
+				}},
+			},
+
+			// ---- Auto-accessors: AccessorProperty is not a PropertyDefinition ----
+			{
+				Code: `class C { accessor x = () => { if (a) return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of arrow function.",
+					Line:      1,
+					Column:    27,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				Code: `class C { accessor x = () => { if (a) return 1; return; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturnValue",
+					Message:   "Arrow function expected a return value.",
+					Line:      1,
+					Column:    49,
+					EndLine:   1,
+					EndColumn: 56,
+				}},
+			},
+			{
+				Code: `class C { accessor x = () => { if (a) return; return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedReturnValue",
+					Message:   "Arrow function expected no return value.",
+					Line:      1,
+					Column:    47,
+					EndLine:   1,
+					EndColumn: 56,
+				}},
+			},
+			{
+				Code: `class C { static accessor #x = (async () => { if (a) return 1; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of async arrow function.",
+					Line:      1,
+					Column:    42,
+					EndLine:   1,
+					EndColumn: 44,
+				}},
+			},
+
+			// A TypeScript expression wrapper is visible in ESTree and must stop
+			// the owner walk; only parentheses are transparent.
+			{
+				Code: `class C { f = ((() => { if (a) return 1; }) as unknown) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingReturn",
+					Message:   "Expected to return a value at the end of arrow function.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 22,
+				}},
+			},
+		},
+	)
+}

--- a/internal/rules/consistent_return/consistent_return_extras_test.go
+++ b/internal/rules/consistent_return/consistent_return_extras_test.go
@@ -204,7 +204,7 @@ func TestConsistentReturnExtras(t *testing.T) {
 				Code: `class C { #foo() { if (a) return 1; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "missingReturn",
-					Message:   "Expected to return a value at the end of private method '#foo'.",
+					Message:   "Expected to return a value at the end of private method #foo.",
 					Line:      1,
 					Column:    11,
 					EndLine:   1,
@@ -362,7 +362,7 @@ func TestConsistentReturnExtras(t *testing.T) {
 				Code: `class C { get #foo() { if (a) return 1; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "missingReturn",
-					Message:   "Expected to return a value at the end of private getter '#foo'.",
+					Message:   "Expected to return a value at the end of private getter #foo.",
 					Line:      1,
 					Column:    15,
 					EndLine:   1,
@@ -441,7 +441,7 @@ func TestConsistentReturnExtras(t *testing.T) {
 				Code: `class C { static #foo() { if (a) return 1; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "missingReturn",
-					Message:   "Expected to return a value at the end of static private method '#foo'.",
+					Message:   "Expected to return a value at the end of static private method #foo.",
 					Line:      1,
 					Column:    18,
 					EndLine:   1,
@@ -452,7 +452,7 @@ func TestConsistentReturnExtras(t *testing.T) {
 				Code: `class C { static get #foo() { if (a) return 1; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "missingReturn",
-					Message:   "Expected to return a value at the end of static private getter '#foo'.",
+					Message:   "Expected to return a value at the end of static private getter #foo.",
 					Line:      1,
 					Column:    22,
 					EndLine:   1,
@@ -463,7 +463,7 @@ func TestConsistentReturnExtras(t *testing.T) {
 				Code: `class C { static async #foo() { if (a) return 1; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "missingReturn",
-					Message:   "Expected to return a value at the end of static private async method '#foo'.",
+					Message:   "Expected to return a value at the end of static private async method #foo.",
 					Line:      1,
 					Column:    24,
 					EndLine:   1,
@@ -531,7 +531,7 @@ func TestConsistentReturnExtras(t *testing.T) {
 				Code: `class C { static #f = () => { if (a) return 1; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "missingReturn",
-					Message:   "Expected to return a value at the end of static private method '#f'.",
+					Message:   "Expected to return a value at the end of static private method #f.",
 					Line:      1,
 					Column:    26,
 					EndLine:   1,

--- a/internal/rules/max_params/max_params_extras_test.go
+++ b/internal/rules/max_params/max_params_extras_test.go
@@ -102,7 +102,7 @@ func TestMaxParamsExtras(t *testing.T) {
 			},
 			{
 				Code:   "class C { static #method(a, b, c, d) {} }",
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Static private method '#method'", 4, 3), Line: 1, Column: 11}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Static private method #method", 4, 3), Line: 1, Column: 11}},
 			},
 			{
 				Code:   "class C { field = (a, b, c, d) => {}; }",
@@ -110,7 +110,7 @@ func TestMaxParamsExtras(t *testing.T) {
 			},
 			{
 				Code:   "class C { static #field = (a, b, c, d) => {}; }",
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Static private method '#field'", 4, 3)}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Static private method #field", 4, 3)}},
 			},
 			{
 				Code:   "const obj = { field: function(a, b, c, d) {} };",

--- a/internal/rules/require_await/require_await_extras_test.go
+++ b/internal/rules/require_await/require_await_extras_test.go
@@ -304,7 +304,7 @@ func TestRequireAwaitExtras(t *testing.T) {
 			{
 				Code: `class A { static async #secret() { return value; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					missingAwaitError("Static private async method '#secret' has no 'await' expression.", 1, 11, `class A { static #secret() { return value; } }`),
+					missingAwaitError("Static private async method #secret has no 'await' expression.", 1, 11, `class A { static #secret() { return value; } }`),
 				},
 			},
 		},

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -527,7 +527,9 @@ func GetFunctionNameWithKindCore(node *ast.Node) string {
 		return strings.Join(append(tokens, "method", "'constructor'"), " ")
 	}
 
-	parent := node.Parent
+	// ESTree does not expose parentheses as nodes, so a function value wrapped
+	// only in parentheses still has the surrounding property as its parent.
+	parent := ast.WalkUpParenthesizedExpressions(node.Parent)
 	if parent == nil {
 		return "function"
 	}
@@ -535,7 +537,7 @@ func GetFunctionNameWithKindCore(node *ast.Node) string {
 	tokens := []string{}
 
 	isClassMember := isCoreDirectClassMember(node)
-	isClassFieldValue := isCoreClassFieldInitializer(node)
+	isClassFieldValue := isCoreClassFieldInitializer(node, parent)
 	if isClassMember || isClassFieldValue {
 		owner := node
 		if isClassFieldValue {
@@ -595,7 +597,7 @@ func GetFunctionNameWithKindCore(node *ast.Node) string {
 func appendCoreFunctionNameFromOwner(tokens *[]string, owner *ast.Node, node *ast.Node) {
 	if name := owner.Name(); name != nil {
 		if name.Kind == ast.KindPrivateIdentifier {
-			*tokens = append(*tokens, fmt.Sprintf("'%s'", name.AsPrivateIdentifier().Text))
+			*tokens = append(*tokens, name.AsPrivateIdentifier().Text)
 			return
 		}
 		if s, ok := GetStaticPropertyName(name); ok {
@@ -634,14 +636,16 @@ func isCoreDirectClassMember(node *ast.Node) bool {
 	return false
 }
 
-func isCoreClassFieldInitializer(node *ast.Node) bool {
-	parent := node.Parent
-	if parent == nil || parent.Kind != ast.KindPropertyDeclaration {
+func isCoreClassFieldInitializer(node *ast.Node, parent *ast.Node) bool {
+	if parent == nil ||
+		parent.Kind != ast.KindPropertyDeclaration ||
+		ast.HasSyntacticModifier(parent, ast.ModifierFlagsAccessor) {
 		return false
 	}
 	switch node.Kind {
 	case ast.KindArrowFunction, ast.KindFunctionExpression:
-		return parent.AsPropertyDeclaration().Initializer == node
+		initializer := parent.AsPropertyDeclaration().Initializer
+		return initializer != nil && ast.SkipParentheses(initializer) == node
 	}
 	return false
 }

--- a/internal/utils/ts_eslint_test.go
+++ b/internal/utils/ts_eslint_test.go
@@ -1,0 +1,110 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+func TestGetFunctionNameWithKindCore(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		kind ast.Kind
+		want string
+	}{
+		{
+			name: "private method name is not quoted",
+			code: "class C { #method() {} }",
+			kind: ast.KindMethodDeclaration,
+			want: "private method #method",
+		},
+		{
+			name: "string key beginning with hash stays quoted",
+			code: "class C { '#method'() {} }",
+			kind: ast.KindMethodDeclaration,
+			want: "method '#method'",
+		},
+		{
+			name: "private getter name is not quoted",
+			code: "class C { get #value() {} }",
+			kind: ast.KindGetAccessor,
+			want: "private getter #value",
+		},
+		{
+			name: "parenthesized private class field arrow",
+			code: "class C { static #field = ((() => {})) }",
+			kind: ast.KindArrowFunction,
+			want: "static private method #field",
+		},
+		{
+			name: "parenthesized object property arrow",
+			code: "const value = { field: ((() => {})) };",
+			kind: ast.KindArrowFunction,
+			want: "method 'field'",
+		},
+		{
+			name: "parenthesized object property function",
+			code: "const value = { field: ((function named() {})) };",
+			kind: ast.KindFunctionExpression,
+			want: "method 'field'",
+		},
+		{
+			name: "parenthesized class field function",
+			code: "class C { field = ((function named() {})) }",
+			kind: ast.KindFunctionExpression,
+			want: "method 'field'",
+		},
+		{
+			name: "auto accessor arrow remains an arrow function",
+			code: "class C { accessor value = () => {} }",
+			kind: ast.KindArrowFunction,
+			want: "arrow function",
+		},
+		{
+			name: "parenthesized auto accessor function keeps its own name",
+			code: "class C { accessor value = (function named() {}) }",
+			kind: ast.KindFunctionExpression,
+			want: "function 'named'",
+		},
+		{
+			name: "auto accessor does not contribute static or private modifiers",
+			code: "class C { static accessor #value = (async () => {}) }",
+			kind: ast.KindArrowFunction,
+			want: "async arrow function",
+		},
+		{
+			name: "type assertion is not transparent",
+			code: "class C { field = ((() => {}) as unknown) }",
+			kind: ast.KindArrowFunction,
+			want: "arrow function",
+		},
+		{
+			name: "satisfies expression is not transparent",
+			code: "class C { field = ((() => {}) satisfies unknown) }",
+			kind: ast.KindArrowFunction,
+			want: "arrow function",
+		},
+		{
+			name: "comma expression is not transparent",
+			code: "const value = { field: (0, (() => {})) };",
+			kind: ast.KindArrowFunction,
+			want: "arrow function",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+				Path:     "/test.ts",
+			}, tt.code, core.ScriptKindTS)
+			node := findFirstNodeOfKind(t, sourceFile, tt.kind)
+			if got := GetFunctionNameWithKindCore(node); got != tt.want {
+				t.Fatalf("GetFunctionNameWithKindCore() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Align core function display names for private members, parenthesized property initializers, and TypeScript auto-accessors.
- Add direct helper coverage and consistent-return regression cases for all three diagnostic message IDs.
- Update the shared helper consumers to use ESLint-compatible private member text.

## Related Links

- Original consistent-return port: https://github.com/web-infra-dev/rslint/pull/1580
- ESLint consistent-return documentation: https://eslint.org/docs/latest/rules/consistent-return
- ESLint function-name helper: https://github.com/eslint/eslint/blob/main/lib/rules/utils/ast-utils.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).