### PR TITLE
fix: preserve type parameter comments

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -595,7 +595,8 @@ func removeTypeParameterFix(sourceFile *ast.SourceFile, container *ast.Node, typ
 	index := slices.Index(typeParams, typeParamNode)
 	if index == 0 {
 		commaEnd := findTokenEnd(sourceFile, paramRange.End(), ast.KindCommaToken)
-		nextStart := scanner.SkipTrivia(sourceFile.Text(), commaEnd)
+		nextParamStart := utils.TrimNodeTextRange(sourceFile, typeParams[1]).Pos()
+		nextStart := utils.SkipLeadingWhitespace(sourceFile.Text(), commaEnd, nextParamStart)
 		return rule.RuleFixRemoveRange(core.NewTextRange(paramRange.Pos(), nextStart))
 	}
 

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
@@ -190,6 +190,29 @@ declare function hold<T>(x: Holder<((T))>): void;
 		{Code: "declare function patternKeyed<T>(x: number): { [k: `a${string}`]: T };"},
 		{Code: `declare function symbolKeyedParam<T>(x: { [k: symbol]: T }): void;`},
 	}, []rule_tester.InvalidTestCase{
+		// A comment after the separator belongs to the following type parameter.
+		// Removing the first parameter must preserve it, matching upstream.
+		{
+			Code: `function f<T, /* keep */ U>(x: T, y: U): U { return y; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `function f</* keep */ U>(x: unknown, y: U): U { return y; }`,
+				}},
+			}},
+		},
+		{
+			Code: "function f<T, // keep\n U>(x: T, y: U): U { return y; }",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    "function f<// keep\n U>(x: unknown, y: U): U { return y; }",
+				}},
+			}},
+		},
+
 		// ---- Branch lock-in: isDirectGenericTypeArgumentUsage() paren peeling ----
 		// Peeling the ParenthesizedType must not lose the Array/ReadonlyArray
 		// exclusion: `Array<(T)>` still defers to the type-checker phase, which


### PR DESCRIPTION
## Summary

- Preserve comments between a removed first type parameter and the following type parameter instead of treating them as removable trivia.
- Add regression coverage for both block and line comments in suggestion output.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).