### PR TITLE
fix: decode restrict-plus-operands options

### DIFF
--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
@@ -38,33 +38,59 @@ type RestrictPlusOperandsOptions struct {
 	SkipCompoundAssignments *bool
 }
 
+func parseOptions(options []any) RestrictPlusOperandsOptions {
+	opts, ok := rule.LegacyUnwrapOptions(options).(RestrictPlusOperandsOptions)
+	if !ok {
+		opts = RestrictPlusOperandsOptions{}
+		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+			if value, ok := optsMap["allowAny"].(bool); ok {
+				opts.AllowAny = utils.Ref(value)
+			}
+			if value, ok := optsMap["allowBoolean"].(bool); ok {
+				opts.AllowBoolean = utils.Ref(value)
+			}
+			if value, ok := optsMap["allowNullish"].(bool); ok {
+				opts.AllowNullish = utils.Ref(value)
+			}
+			if value, ok := optsMap["allowNumberAndString"].(bool); ok {
+				opts.AllowNumberAndString = utils.Ref(value)
+			}
+			if value, ok := optsMap["allowRegExp"].(bool); ok {
+				opts.AllowRegExp = utils.Ref(value)
+			}
+			if value, ok := optsMap["skipCompoundAssignments"].(bool); ok {
+				opts.SkipCompoundAssignments = utils.Ref(value)
+			}
+		}
+	}
+
+	if opts.AllowAny == nil {
+		opts.AllowAny = utils.Ref(true)
+	}
+	if opts.AllowBoolean == nil {
+		opts.AllowBoolean = utils.Ref(true)
+	}
+	if opts.AllowNullish == nil {
+		opts.AllowNullish = utils.Ref(true)
+	}
+	if opts.AllowNumberAndString == nil {
+		opts.AllowNumberAndString = utils.Ref(true)
+	}
+	if opts.AllowRegExp == nil {
+		opts.AllowRegExp = utils.Ref(true)
+	}
+	if opts.SkipCompoundAssignments == nil {
+		opts.SkipCompoundAssignments = utils.Ref(false)
+	}
+
+	return opts
+}
+
 var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 	Name:             "restrict-plus-operands",
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(RestrictPlusOperandsOptions)
-		if !ok {
-			opts = RestrictPlusOperandsOptions{}
-		}
-		if opts.AllowAny == nil {
-			opts.AllowAny = utils.Ref(true)
-		}
-		if opts.AllowBoolean == nil {
-			opts.AllowBoolean = utils.Ref(true)
-		}
-		if opts.AllowNullish == nil {
-			opts.AllowNullish = utils.Ref(true)
-		}
-		if opts.AllowNumberAndString == nil {
-			opts.AllowNumberAndString = utils.Ref(true)
-		}
-		if opts.AllowRegExp == nil {
-			opts.AllowRegExp = utils.Ref(true)
-		}
-		if opts.SkipCompoundAssignments == nil {
-			opts.SkipCompoundAssignments = utils.Ref(false)
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		stringLikes := make([]string, 0, 5)
 		if *opts.AllowAny {

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
@@ -1362,3 +1362,75 @@ const f = (a: any, b: unknown) => a + b;
 		},
 	})
 }
+
+// TestRestrictPlusOperandsSerializedOptions exercises the map-shaped options
+// produced by JS/JSON configs. The main suite uses typed Go options, which does
+// not cover the runtime config path used by presets.
+func TestRestrictPlusOperandsSerializedOptions(t *testing.T) {
+	strictOptions := map[string]interface{}{
+		"allowAny":             false,
+		"allowBoolean":         false,
+		"allowNullish":         false,
+		"allowNumberAndString": false,
+		"allowRegExp":          false,
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RestrictPlusOperandsRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: "let value = ''; value += 1;",
+				Options: map[string]interface{}{
+					"allowNumberAndString":    false,
+					"skipCompoundAssignments": true,
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    "let value = 'x' + 1;",
+				Options: strictOptions,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mismatched",
+					Line:      1,
+					Column:    13,
+				}},
+			},
+			{
+				Code:    "declare const value: boolean;\nvalue + '';",
+				Options: strictOptions,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalid",
+					Line:      2,
+					Column:    1,
+				}},
+			},
+			{
+				Code:    "declare const value: null | undefined;\nvalue + '';",
+				Options: strictOptions,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalid",
+					Line:      2,
+					Column:    1,
+				}},
+			},
+			{
+				Code:    "declare const value: any;\nvalue + '';",
+				Options: strictOptions,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalid",
+					Line:      2,
+					Column:    1,
+				}},
+			},
+			{
+				Code:    "declare const value: RegExp;\nvalue + '';",
+				Options: strictOptions,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalid",
+					Line:      2,
+					Column:    1,
+				}},
+			},
+		},
+	)
+}


### PR DESCRIPTION
## Summary

- Decode map-shaped options passed through JS and JSON configuration.
- Preserve existing defaults and typed Go option compatibility.
- Add regression coverage for every strict allow flag and skipCompoundAssignments.

## Related Links

- https://typescript-eslint.io/rules/restrict-plus-operands/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).