### PR TITLE
fix: stabilize main branch CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,13 @@ jobs:
         if: matrix.runner == 'rspack-windows-2022-large'
         shell: pwsh
         run: |
+          # The Windows runner can exhaust its commit limit with up to 64
+          # package builds/test binaries in flight. Keep every package and
+          # test, but cap inter-package concurrency to bound peak memory use.
+          $packageParallelism = 16
+
           # Pre-build shared dependencies to warm the build cache
-          go build ./cmd/... ./internal/...
+          go build -p $packageParallelism ./cmd/... ./internal/...
 
           $packages = go list ./cmd/... ./internal/... | Where-Object { $_ -ne "" }
           $batchSize = 64
@@ -76,7 +81,7 @@ jobs:
 
             if ($batch.Count -ge $batchSize) {
               Write-Host "Running batch of $($batch.Count) packages..."
-              go test -p 64 -count=1 $batch
+              go test -p $packageParallelism -count=1 $batch
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
               $batch = @()
             }
@@ -85,7 +90,7 @@ jobs:
           # Run remaining packages
           if ($batch.Count -gt 0) {
             Write-Host "Running final batch of $($batch.Count) packages..."
-            go test -p 64 -count=1 $batch
+            go test -p $packageParallelism -count=1 $batch
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
@@ -2,7 +2,6 @@ package restrict_plus_operands
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -41,26 +40,6 @@ type RestrictPlusOperandsOptions struct {
 	AllowNumberAndString    *bool `json:"allowNumberAndString"`
 	AllowRegExp             *bool `json:"allowRegExp"`
 	SkipCompoundAssignments *bool `json:"skipCompoundAssignments"`
-}
-
-func parseOptions(options []any) RestrictPlusOperandsOptions {
-	opts := RestrictPlusOperandsOptions{
-		AllowAny:                utils.Ref(true),
-		AllowBoolean:            utils.Ref(true),
-		AllowNullish:            utils.Ref(true),
-		AllowNumberAndString:    utils.Ref(true),
-		AllowRegExp:             utils.Ref(true),
-		SkipCompoundAssignments: utils.Ref(false),
-	}
-	if len(options) == 0 {
-		return opts
-	}
-	if optsMap, ok := options[0].(map[string]interface{}); ok {
-		if optsJSON, err := json.Marshal(optsMap); err == nil {
-			_ = json.Unmarshal(optsJSON, &opts)
-		}
-	}
-	return opts
 }
 
 func parseOptions(options []any) RestrictPlusOperandsOptions {

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
@@ -7,6 +7,88 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+func TestParseOptions(t *testing.T) {
+	type optionValues struct {
+		allowAny                bool
+		allowBoolean            bool
+		allowNullish            bool
+		allowNumberAndString    bool
+		allowRegExp             bool
+		skipCompoundAssignments bool
+	}
+	resolve := func(t *testing.T, options []any) optionValues {
+		t.Helper()
+		got := parseOptions(options)
+		value := func(name string, pointer *bool) bool {
+			t.Helper()
+			if pointer == nil {
+				t.Fatalf("resolved option %s is nil", name)
+				return false
+			}
+			return *pointer
+		}
+		return optionValues{
+			allowAny:                value("allowAny", got.AllowAny),
+			allowBoolean:            value("allowBoolean", got.AllowBoolean),
+			allowNullish:            value("allowNullish", got.AllowNullish),
+			allowNumberAndString:    value("allowNumberAndString", got.AllowNumberAndString),
+			allowRegExp:             value("allowRegExp", got.AllowRegExp),
+			skipCompoundAssignments: value("skipCompoundAssignments", got.SkipCompoundAssignments),
+		}
+	}
+	boolRef := func(value bool) *bool { return &value }
+	tests := []struct {
+		name    string
+		options []any
+		want    optionValues
+	}{
+		{
+			name: "defaults",
+			want: optionValues{
+				allowAny:             true,
+				allowBoolean:         true,
+				allowNullish:         true,
+				allowNumberAndString: true,
+				allowRegExp:          true,
+			},
+		},
+		{
+			name: "serialized partial overrides",
+			options: []any{map[string]interface{}{
+				"allowAny":                false,
+				"allowNullish":            false,
+				"skipCompoundAssignments": true,
+			}},
+			want: optionValues{
+				allowBoolean:            true,
+				allowNumberAndString:    true,
+				allowRegExp:             true,
+				skipCompoundAssignments: true,
+			},
+		},
+		{
+			name: "typed partial overrides",
+			options: []any{RestrictPlusOperandsOptions{
+				AllowBoolean:         boolRef(false),
+				AllowNumberAndString: boolRef(false),
+			}},
+			want: optionValues{
+				allowAny:     true,
+				allowNullish: true,
+				allowRegExp:  true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolve(t, test.options); got != test.want {
+				t.Fatalf("resolved options = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestRestrictPlusOperandsRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RestrictPlusOperandsRule, []rule_tester.ValidTestCase{
 		{Code: "let x = 5;"},
@@ -1362,9 +1444,8 @@ const f = (a: any, b: unknown) => a + b;
 	})
 }
 
-// TestRestrictPlusOperandsSerializedOptions exercises the map-shaped options
-// produced by JS/JSON configs. The main suite uses typed Go options, which does
-// not cover the runtime config path used by presets.
+// TestRestrictPlusOperandsSerializedOptions exercises the strict preset's
+// map-shaped options together, including the compound-assignment escape hatch.
 func TestRestrictPlusOperandsSerializedOptions(t *testing.T) {
 	strictOptions := map[string]interface{}{
 		"allowAny":             false,

--- a/internal/utils/parallel_program_fs_test.go
+++ b/internal/utils/parallel_program_fs_test.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
-	"time"
 
 	"github.com/microsoft/typescript-go/shim/vfs"
 )
@@ -42,92 +41,101 @@ func (f *parallelProgramTestFS) WriteFile(path string, content string) error {
 }
 
 type blockingRealpathQuery struct {
-	calls   atomic.Int32
-	started chan struct{}
-	release chan struct{}
+	calls       atomic.Int32
+	release     chan struct{}
+	releaseOnce sync.Once
 }
 
 func newBlockingRealpathQuery() *blockingRealpathQuery {
 	return &blockingRealpathQuery{
-		started: make(chan struct{}, 64),
 		release: make(chan struct{}),
 	}
 }
 
 func (q *blockingRealpathQuery) run(path string) string {
 	q.calls.Add(1)
-	q.started <- struct{}{}
 	<-q.release
 	return path
+}
+
+func (q *blockingRealpathQuery) releaseAll() {
+	q.releaseOnce.Do(func() { close(q.release) })
 }
 
 func TestParallelProgramFSCoalescesConcurrentRealpathMisses(t *testing.T) {
 	t.Parallel()
 
-	gate := newBlockingRealpathQuery()
-	cached := newParallelProgramFS(&parallelProgramTestFS{realpath: gate.run})
+	synctest.Test(t, func(t *testing.T) {
+		gate := newBlockingRealpathQuery()
+		defer gate.releaseAll()
+		cached := newParallelProgramFS(&parallelProgramTestFS{realpath: gate.run})
 
-	const workers = 32
-	start := make(chan struct{})
-	var ready sync.WaitGroup
-	ready.Add(workers)
-	results := make(chan string, workers)
-	for range workers {
-		go func() {
-			ready.Done()
-			<-start
-			results <- cached.Realpath("/same/exact/path")
-		}()
-	}
-	ready.Wait()
-	close(start)
-
-	select {
-	case <-gate.started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("underlying Realpath did not start")
-	}
-	// Keep the owner blocked long enough for every ready goroutine to reach
-	// the cache. A cache stampede would be visible in calls.
-	time.Sleep(50 * time.Millisecond)
-	if got := gate.calls.Load(); got != 1 {
-		t.Fatalf("underlying calls while cold query is blocked = %d, want 1", got)
-	}
-	close(gate.release)
-
-	for range workers {
-		if got := <-results; got != "/same/exact/path" {
-			t.Fatalf("Realpath result = %q", got)
+		const workers = 32
+		start := make(chan struct{})
+		var ready sync.WaitGroup
+		ready.Add(workers)
+		results := make(chan string, workers)
+		for range workers {
+			go func() {
+				ready.Done()
+				<-start
+				results <- cached.Realpath("/same/exact/path")
+			}()
 		}
-	}
-	if got := cached.Realpath("/same/exact/path"); got != "/same/exact/path" {
-		t.Fatalf("warm Realpath result = %q", got)
-	}
-	if got := gate.calls.Load(); got != 1 {
-		t.Fatalf("underlying calls after warm query = %d, want 1", got)
-	}
+		ready.Wait()
+		close(start)
+
+		// Wait until the owner is blocked in the underlying filesystem and all
+		// other goroutines are blocked on its flight. This observes the same
+		// state as a sleep, without depending on host scheduling speed.
+		synctest.Wait()
+		if got := gate.calls.Load(); got != 1 {
+			t.Fatalf("underlying calls while cold query is blocked = %d, want 1", got)
+		}
+		gate.releaseAll()
+
+		for range workers {
+			if got := <-results; got != "/same/exact/path" {
+				t.Fatalf("Realpath result = %q", got)
+			}
+		}
+		if got := cached.Realpath("/same/exact/path"); got != "/same/exact/path" {
+			t.Fatalf("warm Realpath result = %q", got)
+		}
+		if got := gate.calls.Load(); got != 1 {
+			t.Fatalf("underlying calls after warm query = %d, want 1", got)
+		}
+	})
 }
 
 func TestParallelProgramFSDoesNotSerializeDifferentPaths(t *testing.T) {
 	t.Parallel()
 
-	gate := newBlockingRealpathQuery()
-	cached := newParallelProgramFS(&parallelProgramTestFS{realpath: gate.run})
-	results := make(chan string, 2)
-	go func() { results <- cached.Realpath("/first") }()
-	go func() { results <- cached.Realpath("/second") }()
+	synctest.Test(t, func(t *testing.T) {
+		gate := newBlockingRealpathQuery()
+		defer gate.releaseAll()
+		cached := newParallelProgramFS(&parallelProgramTestFS{realpath: gate.run})
+		results := make(chan string, 2)
+		go func() { results <- cached.Realpath("/first") }()
+		go func() { results <- cached.Realpath("/second") }()
 
-	for range 2 {
-		select {
-		case <-gate.started:
-		case <-time.After(2 * time.Second):
-			t.Fatal("different paths were serialized behind one query")
+		// Both goroutines must independently reach the underlying filesystem
+		// before either query is released. synctest makes that observation
+		// independent of runner load while retaining the concurrency assertion.
+		synctest.Wait()
+		if got := gate.calls.Load(); got != 2 {
+			t.Fatalf("concurrent underlying calls for different paths = %d, want 2", got)
 		}
-	}
-	close(gate.release)
-	for range 2 {
-		<-results
-	}
+		gate.releaseAll()
+
+		seen := make(map[string]bool, 2)
+		for range 2 {
+			seen[<-results] = true
+		}
+		if !seen["/first"] || !seen["/second"] || len(seen) != 2 {
+			t.Fatalf("Realpath results for different paths = %v", seen)
+		}
+	})
 }
 
 func TestParallelProgramFSPanicReleasesWaitersAndRetries(t *testing.T) {


### PR DESCRIPTION
## Summary

- Cap inter-package Go build and test parallelism at 16 on Windows to bound peak memory use while preserving the package list, batching, `-count=1`, and failure propagation.
- Replace wall-clock sleeps and timeouts in the `ParallelProgramFS` concurrency tests with `testing/synctest`, while retaining explicit assertions for request coalescing, per-path concurrency, call counts, and exact results.
- Remove the duplicated `parseOptions` definition currently breaking `main`, and cover defaults, serialized map options, and typed partial options with focused tests.

### Validation

- `go test -count=1000 -run "^TestParallelProgramFS(CoalescesConcurrentRealpathMisses|DoesNotSerializeDifferentPaths)$" ./internal/utils`
- `go test -count=1000 -run "^TestParseOptions$" ./internal/plugins/typescript/rules/restrict_plus_operands`
- `go test -p 16 -count=1 ./internal/utils ./internal/plugins/typescript/rules/restrict_plus_operands`
- `go test -race -count=1 ./internal/utils ./internal/plugins/typescript/rules/restrict_plus_operands`
- `go vet ./internal/utils ./internal/plugins/typescript/rules/restrict_plus_operands`
- Workflow Prettier and YAML parsing checks, plus `git diff --check`.
- Adversarial mutations were verified to fail for same-path stampedes, cross-path serialization/cache-key collisions, incorrect results, ignored serialized options, ignored typed options, and corrupted defaults.

## Related Links

- https://github.com/web-infra-dev/rslint/actions/runs/31178399406/job/92869131501
- https://github.com/web-infra-dev/rslint/actions/runs/31178399406/job/92865578380

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).