### PR TITLE
ci: increase Windows Go package parallelism to 32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           # The Windows runner can exhaust its commit limit with up to 64
           # package builds/test binaries in flight. Keep every package and
           # test, but cap inter-package concurrency to bound peak memory use.
-          $packageParallelism = 16
+          $packageParallelism = 32
 
           # Pre-build shared dependencies to warm the build cache
           go build -p $packageParallelism ./cmd/... ./internal/...


### PR DESCRIPTION
## Summary

- Increase Windows Go inter-package build and test parallelism from 16 to 32.
- Keep the existing 64-package batching and failure propagation unchanged.
- Validated with `git diff --check` and `pnpm exec prettier --check .github/workflows/ci.yml`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).