### PR TITLE
fix: ignore interpolation in inline snapshot messages

### DIFF
--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
@@ -2,14 +2,62 @@ package no_interpolation_in_snapshots
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func buildNoInterpolationMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "noInterpolation",
 		Description: "Do not use string interpolation inside of snapshots",
+	}
+}
+
+func isStringSnapshotArgument(ctx rule.RuleContext, node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	if internalUtils.IsStringLiteralOrTemplate(node) {
+		return true
+	}
+	if ctx.TypeChecker == nil {
+		return false
+	}
+
+	t := internalUtils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)
+	return internalUtils.Every(internalUtils.UnionTypeParts(t), func(part *checker.Type) bool {
+		return internalUtils.IsTypeFlagSet(part, checker.TypeFlagsStringLike)
+	})
+}
+
+func getInlineSnapshotArgument(ctx rule.RuleContext, matcherName string, call *ast.Node) *ast.Node {
+	if call == nil {
+		return nil
+	}
+	arguments := call.Arguments()
+	if len(arguments) == 0 {
+		return nil
+	}
+
+	switch matcherName {
+	case "toThrowErrorMatchingInlineSnapshot":
+		return arguments[0]
+	case "toMatchInlineSnapshot":
+		// Rstest decides between (snapshot, message) and
+		// (properties, snapshot, message) from the first argument's runtime
+		// type.
+		if len(arguments) == 1 || isStringSnapshotArgument(ctx, arguments[0]) {
+			return arguments[0]
+		}
+		return arguments[1]
+	default:
+		return nil
 	}
 }
 
@@ -45,12 +93,16 @@ var NoInterpolationInSnapshotsRule = rule.Rule{
 					if call == nil {
 						continue
 					}
-					// Both overloads of the inline snapshot matchers may hold the
-					// snapshot in arguments[0] or arguments[1], so all are checked.
-					for _, arg := range call.Arguments() {
-						if arg := ast.SkipParentheses(arg); arg != nil && arg.Kind == ast.KindTemplateExpression {
-							ctx.ReportNode(arg, buildNoInterpolationMessage())
-						}
+					// Custom messages follow the snapshot argument and are never
+					// rewritten into the source file, so only inspect the argument
+					// selected by the matcher's overload.
+					arg := getInlineSnapshotArgument(ctx, matcher.Name, call)
+					if arg == nil {
+						continue
+					}
+					arg = ast.SkipParentheses(arg)
+					if arg.Kind == ast.KindTemplateExpression {
+						ctx.ReportNode(arg, buildNoInterpolationMessage())
 					}
 				}
 			},

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
@@ -53,6 +53,20 @@ expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot();
 expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
   `Error Message`,
 );
+
+// Custom messages are not snapshot content, so interpolation is allowed.
+expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
+  `Error Message`,
+  `case ${caseId}`,
+);
+
+expect(something).toMatchInlineSnapshot(
+  { property: expect.any(Date) },
+  `Object {
+    property: Any<Date>
+  }`,
+  `case ${caseId}`,
+);
 ```
 
 ## Only inline snapshots are checked

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
@@ -28,6 +28,10 @@ func TestNoInterpolationInSnapshotsRule(t *testing.T) {
 			{Code: "toMatchInlineSnapshot({}, `${interpolated1} ${interpolated2}`);"},
 			{Code: `expect(something).toThrowErrorMatchingInlineSnapshot();`},
 			{Code: "expect(something).toThrowErrorMatchingInlineSnapshot(`No interpolation`);"},
+			{Code: "expect(something).toThrowErrorMatchingInlineSnapshot(`No interpolation`, `case ${id}`);"},
+			{Code: "expect(something).toMatchInlineSnapshot({}, `No interpolation`, `case ${id}`);"},
+			{Code: "expect(something).toMatchInlineSnapshot(`No interpolation`, `case ${id}`);"},
+			{Code: "const snapshot: string = `No interpolation`;\nexpect(something).toMatchInlineSnapshot(snapshot, `case ${id}`);"},
 
 			// Snapshot matchers whose expected value lives outside the source
 			// file: updating them never rewrites the argument, so interpolation
@@ -119,10 +123,34 @@ func TestNoInterpolationInSnapshotsRule(t *testing.T) {
 						Column:    41,
 						EndColumn: 51,
 					},
+				},
+			},
+			{
+				Code: "expect(something).toMatchInlineSnapshot({}, `${snapshot}`, `case ${id}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "noInterpolation",
-						Column:    53,
-						EndColumn: 64,
+						Column:    45,
+						EndColumn: 58,
+					},
+				},
+			},
+			{
+				Code: "const properties = {};\nexpect(something).toMatchInlineSnapshot(properties, `${snapshot}`, `case ${id}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Line:      2,
+					},
+				},
+			},
+			{
+				Code: "expect(something).toThrowErrorMatchingInlineSnapshot(`${snapshot}`, `case ${id}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    54,
+						EndColumn: 67,
 					},
 				},
 			},

--- a/packages/rslint-test-tools/tests/rstest/rules/no-interpolation-in-snapshots.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-interpolation-in-snapshots.test.ts
@@ -8,6 +8,12 @@ ruleTester.run('no-interpolation-in-snapshots', {} as never, {
       code: 'expect(something).toMatchInlineSnapshot(`No interpolation`);',
     },
     {
+      code: 'expect(fn).toThrowErrorMatchingInlineSnapshot("snap", `case ${id}`);',
+    },
+    {
+      code: 'expect(value).toMatchInlineSnapshot({}, "snap", `case ${id}`);',
+    },
+    {
       // toMatchFileSnapshot takes a path, so interpolation is intended
       code: 'test("case", async () => { await expect(data).toMatchFileSnapshot(`./__snapshots__/${name}.json`); });',
     },
@@ -23,6 +29,10 @@ ruleTester.run('no-interpolation-in-snapshots', {} as never, {
     {
       code: 'expect(something).toThrowErrorMatchingInlineSnapshot(`${interpolated}`);',
       errors: [{ messageId: 'noInterpolation', line: 1, column: 54 }],
+    },
+    {
+      code: 'expect(something).toMatchInlineSnapshot({}, `${interpolated}`, `case ${id}`);',
+      errors: [{ messageId: 'noInterpolation', line: 1, column: 45 }],
     },
     {
       code: 'test("case", ({ expect }) => expect(value).toMatchInlineSnapshot(`${interpolated}`));',


### PR DESCRIPTION
## Summary

- inspect only the actual snapshot argument for Rstest inline snapshot matchers
- allow interpolated custom messages while continuing to report interpolation in snapshot content
- add Go and integration coverage for both inline snapshot matcher overloads

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).