### PR TITLE
fix: harden rstest valid-title handling

### DIFF
--- a/internal/plugins/rstest/rules/valid_title/valid_title.go
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.go
@@ -349,9 +349,8 @@ func isArrayParameterizedRegistration(parsed *rstestUtils.ParsedRstestFnCall, ca
 }
 
 var (
-	reDupPrefix = regexp.MustCompile(`^([\x60'"]).+? `)
-	reAccOpen   = regexp.MustCompile(`^([\x60'"]) +`)
-	reAccClose  = regexp.MustCompile(` +([\x60'"])$`)
+	reAccOpen  = regexp.MustCompile(`^([\x60'"]) +`)
+	reAccClose = regexp.MustCompile(` +([\x60'"])$`)
 	// D1: the accepted specifiers are Rstest's, not jest's. formatRegExp is
 	// /%[sdjifoOc%]/ (packages/core/src/runtime/util.ts:159 at rstest c4b67c72)
 	// and %# / %$ are substituted ahead of it by formatName, so `%p` — valid to
@@ -367,8 +366,23 @@ func accidentalSpaceReplacement(rawSrc string) string {
 	return s
 }
 
-func duplicatePrefixReplacement(rawSrc string) string {
-	return reDupPrefix.ReplaceAllString(rawSrc, "$1")
+func duplicatePrefixReplacement(rawSrc string, fnName string) (string, bool) {
+	if fnName == "" || len(rawSrc) < len(fnName)+3 {
+		return "", false
+	}
+	prefixEnd := 1 + len(fnName)
+	if rawSrc[len(rawSrc)-1] != rawSrc[0] {
+		return "", false
+	}
+	switch rawSrc[0] {
+	case '`', '\'', '"':
+	default:
+		return "", false
+	}
+	if rawSrc[prefixEnd] != ' ' || !strings.EqualFold(rawSrc[1:prefixEnd], fnName) {
+		return "", false
+	}
+	return rawSrc[:1] + rawSrc[prefixEnd+1:], true
 }
 
 func regexpToMessagePattern(re *regexp2.Regexp) string {
@@ -512,24 +526,30 @@ var ValidTitleRule = rule.Rule{
 					}
 				}
 
-				// D4: no f/x prefix to trim. Rstest has neither fit/xit nor
-				// fdescribe/xdescribe, so Name is already the bare API name.
-				// D5: Name is the semantic name, which survives both import
-				// aliases and same-file const aliases, so `const t = test.skip;
-				// t('test foo')` reports where jest — whose parser does not
-				// follow that alias — reports nothing.
+				// Playwright exposes describe registrations through test.describe.
+				// The parser keeps Name as the root API ("test") while Kind records
+				// the registration kind, so describe titles must use the describe
+				// matcher group and prefix. Test registrations still use Name to
+				// distinguish test from it after import or same-file alias resolution.
 				fnName := parsed.Name
+				if parsed.Kind == rstestUtils.RstestFnTypeDescribe {
+					fnName = "describe"
+				}
 				firstTok := title
 				if i := strings.IndexByte(title, ' '); i >= 0 {
 					firstTok = title[:i]
 				}
 				if strings.EqualFold(firstTok, fnName) {
 					raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, arg, false)
-					fix := duplicatePrefixReplacement(raw)
-					ctx.ReportNodeWithFixes(arg, rule.RuleMessage{
+					msg := rule.RuleMessage{
 						Id:          "duplicatePrefix",
 						Description: "should not have duplicate prefix",
-					}, rule.RuleFixReplace(ctx.SourceFile, arg, fix))
+					}
+					if fix, ok := duplicatePrefixReplacement(raw, fnName); ok {
+						ctx.ReportNodeWithFixes(arg, msg, rule.RuleFixReplace(ctx.SourceFile, arg, fix))
+					} else {
+						ctx.ReportNode(arg, msg)
+					}
 				}
 
 				if me := matcherFor(fnName, co.mustNotMatch); utils.Regexp2MatchString(me.re, title) {

--- a/internal/plugins/rstest/rules/valid_title/valid_title_test.go
+++ b/internal/plugins/rstest/rules/valid_title/valid_title_test.go
@@ -51,6 +51,19 @@ rstest.test("case", () => {});`},
 api.test("case", () => {});`},
 		{Code: `import { test } from "@rstest/playwright";
 test("case", () => {});`},
+		{Code: `import { test } from "@rstest/playwright";
+test.describe("test authentication", () => {});`},
+		{
+			Code: `import { test } from "@rstest/playwright";
+test.describe("suite", () => {});`,
+			Options: []interface{}{map[string]interface{}{
+				"mustNotMatch": map[string]interface{}{"test": "^suite$"},
+				"mustMatch": map[string]interface{}{
+					"describe": "^suite$",
+					"test":     "^case$",
+				},
+			}},
+		},
 
 		// A factory call is not a registration, so its first argument — here a
 		// fixtures object — must not be taken for a title.
@@ -366,6 +379,46 @@ testThat("foo works", () => {});`},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
 		},
 		{
+			Code: `import { test } from "@rstest/playwright";
+test.describe("describe authentication", () => {});`,
+			Output: []string{`import { test } from "@rstest/playwright";
+test.describe("authentication", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code: `import { test } from "@rstest/playwright";
+const suite = test.describe.only;
+suite("describe authentication", () => {});`,
+			Output: []string{`import { test } from "@rstest/playwright";
+const suite = test.describe.only;
+suite("authentication", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		// Detection uses the decoded title, but a fix is only safe when the raw
+		// source spells both the prefix and its separating space literally.
+		{
+			Code:   `test("test\u0020auth flow", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   `test("test\u0020auth", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   `test("te\u0073t auth flow", () => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   `test("test auth\u0020flow", () => {});`,
+			Output: []string{`test("auth\u0020flow", () => {});`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
+			Code:   "test(`TEST authentication`, () => {});",
+			Output: []string{"test(`authentication`, () => {});"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
+		},
+		{
 			Code:   `it("it foo", () => {});`,
 			Output: []string{`it("foo", () => {});`},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "duplicatePrefix"}},
@@ -542,6 +595,28 @@ test.each(entries)(".add(%i, %z)", (a, b, expected) => {});`,
 			Code:    `describe.skip("the test", () => {});`,
 			Options: []interface{}{map[string]interface{}{"mustMatch": map[string]interface{}{"describe": patHashTag}}},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "mustMatch"}},
+		},
+		{
+			Code: `import { test } from "@rstest/playwright";
+test.describe("suite", () => {});`,
+			Options: []interface{}{map[string]interface{}{
+				"mustNotMatch": map[string]interface{}{"describe": "^suite$"},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mustNotMatch",
+				Message:   "describe should not match /^suite$/u",
+			}},
+		},
+		{
+			Code: `import { test } from "@rstest/playwright";
+test.describe("suite", () => {});`,
+			Options: []interface{}{map[string]interface{}{
+				"mustMatch": map[string]interface{}{"describe": "^ok$"},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mustMatch",
+				Message:   "describe should match /^ok$/u",
+			}},
 		},
 		// D5: the groups are keyed by the API being registered, so a renamed
 		// import is still matched against the `test` group.


### PR DESCRIPTION
## Summary

- classify Playwright test.describe registrations as describe blocks for duplicate-prefix checks and matcher options
- only attach duplicate-prefix fixes when the raw source contains a verifiable literal prefix boundary
- add regression coverage for aliases, matcher grouping, escaped separators, and safe fixes

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).