### PR TITLE
perf: optimize prefer-const reference tracking

### DIFF
--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -1,6 +1,8 @@
 package prefer_const
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -32,201 +34,306 @@ func parseOptions(opts any) preferConstOptions {
 }
 
 // candidateInfo holds information about a single binding name candidate.
+type candidateRef uint32
+
 type candidateInfo struct {
-	nameNode   *ast.Node
-	reportNode *ast.Node // node to report on (may differ from nameNode for uninitialized vars)
+	nameNode                    *ast.Node
+	declNode                    *ast.Node
+	symbol                      *ast.Symbol
+	reportNode                  *ast.Node // node to report on (may differ from nameNode for uninitialized vars)
+	nextCandidateWithSameSymbol candidateRef
+	hasInitializer              bool
+	seenPostDeclarationWrite    bool
+	readBeforeFirstAssign       bool
+}
+
+type destructuringGroup struct {
+	candidateStart int
+	candidateEnd   int
+}
+
+type declarationListInfo struct {
+	node           *ast.Node
+	candidateStart int
+	candidateEnd   int
+	allHaveInit    bool
+}
+
+type symbolInfo struct {
+	firstWrite    *ast.Node
+	candidateHead candidateRef // one-based candidate index; zero means no candidate
+	writeCount    uint8        // saturated at 2; the rule only distinguishes 0, 1, and multiple writes
+}
+
+// preferConstState derives the reference facts needed by this rule while the
+// linter performs its normal file traversal. Calling RefStore.References for
+// every binding would trigger a second whole-file walk that buckets all
+// reference-position identifiers, even though prefer-const only needs writes
+// and, for uninitialized bindings, reads before the first assignment.
+type preferConstState struct {
+	ctx              *rule.RuleContext
+	opts             preferConstOptions
+	destructuringAll bool
+	sourceText       string
+
+	declarationLists    []declarationListInfo
+	destructuringGroups []destructuringGroup
+	candidates          []candidateInfo
+	symbols             map[*ast.Symbol]symbolInfo
+	uninitializedNames  map[string]struct{}
 }
 
 // https://eslint.org/docs/latest/rules/prefer-const
 var PreferConstRule = rule.Rule{
 	Name: "prefer-const",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
+		sourceText := ctx.SourceFile.Text()
+		// A real let declaration necessarily contains this exact byte sequence.
+		// False positives (for example in comments) only take the normal path;
+		// false negatives are impossible, so this is safe as an early exit.
+		if !strings.Contains(sourceText, "let") {
+			return nil
+		}
+
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
-		destructuringAll := opts.destructuring == "all"
-		sourceText := ctx.SourceFile.Text()
+		state := preferConstState{
+			ctx:              &ctx,
+			opts:             opts,
+			destructuringAll: opts.destructuring == "all",
+			sourceText:       sourceText,
+		}
 
 		return rule.RuleListeners{
-			ast.KindVariableDeclarationList: func(node *ast.Node) {
-				declList := node.AsVariableDeclarationList()
-				if declList == nil || node.Flags&ast.NodeFlagsLet == 0 || declList.Declarations == nil {
-					return
-				}
-
-				// ESLint does not report prefer-const for regular for-loop initializer variables.
-				// Only for-in and for-of loop variables are checked.
-				if isInForStatement(node) {
-					return
-				}
-
-				isForInOrOf := isInForInOrOf(node)
-
-				// Collect candidates across ALL declarators in the VDL to determine
-				// if the entire VDL can be auto-fixed (let → const).
-				// Keep the common small declaration list on the stack.
-				var candidateBuffer [4]candidateInfo
-				allConstCandidates := candidateBuffer[:0]
-				totalBindings := 0
-				totalConstBindings := 0
-				allHaveInit := true
-
-				for _, decl := range declList.Declarations.Nodes {
-					varDecl := decl.AsVariableDeclaration()
-					if varDecl == nil || varDecl.Name() == nil {
-						continue
-					}
-
-					hasInit := varDecl.Initializer != nil || isForInOrOf
-					if !hasInit {
-						allHaveInit = false
-					}
-
-					// Collect reportable candidates directly into the declaration-list
-					// result. The overwhelmingly common identifier case avoids the
-					// temporary binding and reportable-candidate slices entirely.
-					nameNode := varDecl.Name()
-					candidateStart := len(allConstCandidates)
-					candidateCount := 0
-					if nameNode.Kind == ast.KindIdentifier {
-						if nameNode.Text() == "" {
-							continue
-						}
-						candidateCount = 1
-						candidate := candidateInfo{nameNode: nameNode}
-						if shouldReport(&candidate, decl, &ctx, opts, hasInit) {
-							allConstCandidates = append(allConstCandidates, candidate)
-						}
-					} else {
-						utils.CollectBindingNames(nameNode, func(ident *ast.Node, _ string) {
-							candidateCount++
-							candidate := candidateInfo{nameNode: ident}
-							if shouldReport(&candidate, decl, &ctx, opts, hasInit) {
-								allConstCandidates = append(allConstCandidates, candidate)
-							}
-						})
-					}
-					if candidateCount == 0 {
-						continue
-					}
-
-					totalBindings += candidateCount
-					constCandidateCount := len(allConstCandidates) - candidateStart
-
-					// Apply destructuring option
-					isDestructuring := nameNode.Kind == ast.KindObjectBindingPattern ||
-						nameNode.Kind == ast.KindArrayBindingPattern
-					if isDestructuring && destructuringAll {
-						// Only report if ALL candidates in the destructuring can be const
-						if constCandidateCount != candidateCount {
-							allConstCandidates = allConstCandidates[:candidateStart]
-							continue
-						}
-					}
-
-					// For destructuring: "all", also suppress uninitialized candidates
-					// whose write is in a destructuring assignment where not all targets
-					// can be const. ESLint groups by the destructuring write, not just
-					// the declaration pattern.
-					if destructuringAll {
-						writeIndex := candidateStart
-						for _, c := range allConstCandidates[candidateStart:] {
-							if c.reportNode != nil && !allDestructuringWriteTargetsConst(c.reportNode, &ctx) {
-								continue
-							}
-							allConstCandidates[writeIndex] = c
-							writeIndex++
-						}
-						allConstCandidates = allConstCandidates[:writeIndex]
-					}
-
-					totalConstBindings += len(allConstCandidates) - candidateStart
-				}
-
-				// Determine if auto-fix is possible: ALL bindings in the VDL must be
-				// const-eligible AND all declarators must have initializers.
-				// ESLint only auto-fixes when the entire `let` can become `const`.
-				// reportNode is set only for an uninitialized binding, so a candidate
-				// that would need its later assignment merged can never reach canFix.
-				canFix := allHaveInit && totalBindings > 0 && totalConstBindings == totalBindings
-
-				// Report the const candidates
-				var buildFix func() []rule.RuleFix
-				if canFix {
-					letStart := -1
-					buildFix = func() []rule.RuleFix {
-						if letStart < 0 {
-							letStart = scanner.SkipTrivia(sourceText, node.Pos())
-						}
-						letRange := node.Loc.WithPos(letStart).WithEnd(letStart + len("let"))
-						return []rule.RuleFix{rule.RuleFixReplaceRange(letRange, "const")}
-					}
-				}
-				for _, c := range allConstCandidates {
-					name := c.nameNode.Text()
-					reportOn := c.nameNode
-					if c.reportNode != nil {
-						reportOn = c.reportNode
-					}
-					msg := rule.RuleMessage{
-						Id:          "useConst",
-						Description: "'" + name + "' is never reassigned. Use 'const' instead.",
-					}
-					reportRange := reportOn.Loc.WithPos(scanner.SkipTrivia(sourceText, reportOn.Pos()))
-					if canFix {
-						ctx.ReportRangeWithDeferredFixes(reportRange, msg, buildFix)
-					} else {
-						ctx.ReportRange(reportRange, msg)
-					}
-				}
-			},
+			ast.KindVariableDeclarationList:        state.visitDeclarationList,
+			ast.KindIdentifier:                     state.visitIdentifier,
+			rule.ListenerOnExit(ast.KindEndOfFile): func(*ast.Node) { state.finish() },
 		}
 	},
 }
 
-// shouldReport determines whether a candidate should be reported as "use const".
-func shouldReport(c *candidateInfo, declNode *ast.Node, ctx *rule.RuleContext, opts preferConstOptions, hasInitializer bool) bool {
-	sym := utils.BindingNameSymbol(c.nameNode)
-	if sym == nil {
+func (s *preferConstState) visitDeclarationList(node *ast.Node) {
+	declList := node.AsVariableDeclarationList()
+	if declList == nil || node.Flags&ast.NodeFlagsLet == 0 || declList.Declarations == nil || isInForStatement(node) {
+		return
+	}
+
+	list := declarationListInfo{
+		node:           node,
+		candidateStart: len(s.candidates),
+		allHaveInit:    true,
+	}
+	isForInOrOf := isInForInOrOf(node)
+	for _, decl := range declList.Declarations.Nodes {
+		varDecl := decl.AsVariableDeclaration()
+		if varDecl == nil || varDecl.Name() == nil {
+			continue
+		}
+
+		hasInitializer := varDecl.Initializer != nil || isForInOrOf
+		if !hasInitializer {
+			list.allHaveInit = false
+		}
+		nameNode := varDecl.Name()
+		candidateStart := len(s.candidates)
+		if nameNode.Kind == ast.KindIdentifier {
+			if nameNode.Text() != "" {
+				s.addCandidate(nameNode, decl, hasInitializer)
+			}
+		} else {
+			utils.CollectBindingNames(nameNode, func(ident *ast.Node, _ string) {
+				s.addCandidate(ident, decl, hasInitializer)
+			})
+		}
+		candidateEnd := len(s.candidates)
+		if candidateEnd == candidateStart {
+			continue
+		}
+
+		if s.destructuringAll && (nameNode.Kind == ast.KindObjectBindingPattern || nameNode.Kind == ast.KindArrayBindingPattern) {
+			s.destructuringGroups = append(s.destructuringGroups, destructuringGroup{
+				candidateStart: candidateStart,
+				candidateEnd:   candidateEnd,
+			})
+		}
+	}
+	list.candidateEnd = len(s.candidates)
+	if list.candidateEnd != list.candidateStart {
+		s.declarationLists = append(s.declarationLists, list)
+	}
+}
+
+func (s *preferConstState) addCandidate(nameNode, declNode *ast.Node, hasInitializer bool) {
+	symbol := utils.BindingNameSymbol(nameNode)
+	candidate := candidateInfo{
+		nameNode:       nameNode,
+		declNode:       declNode,
+		symbol:         symbol,
+		hasInitializer: hasInitializer,
+	}
+	if symbol != nil {
+		if s.symbols == nil {
+			s.symbols = make(map[*ast.Symbol]symbolInfo)
+		}
+		info := s.symbols[symbol]
+		candidate.nextCandidateWithSameSymbol = info.candidateHead
+		info.candidateHead = candidateRef(len(s.candidates) + 1)
+		s.symbols[symbol] = info
+		if !hasInitializer {
+			if s.uninitializedNames == nil {
+				s.uninitializedNames = make(map[string]struct{})
+			}
+			s.uninitializedNames[nameNode.Text()] = struct{}{}
+		}
+	}
+	s.candidates = append(s.candidates, candidate)
+}
+
+func (s *preferConstState) visitIdentifier(node *ast.Node) {
+	isWrite := utils.IsWriteReference(node)
+	if !isWrite {
+		if _, ok := s.uninitializedNames[node.Text()]; !ok {
+			return
+		}
+	}
+
+	symbol := s.ctx.Refs.Resolve(node)
+	if symbol == nil {
+		return
+	}
+	info := s.symbols[symbol]
+	if isWrite {
+		// Count writes for every symbol, including writes that precede a let
+		// declaration and non-let targets that may share a destructuring write
+		// group with a candidate.
+		if s.symbols == nil {
+			s.symbols = make(map[*ast.Symbol]symbolInfo)
+		}
+		if info.firstWrite == nil {
+			info.firstWrite = node
+		}
+		if info.writeCount < 2 {
+			info.writeCount++
+		}
+		s.symbols[symbol] = info
+	}
+
+	for head := info.candidateHead; head != 0; {
+		candidate := &s.candidates[int(head)-1]
+		head = candidate.nextCandidateWithSameSymbol
+		if candidate.hasInitializer || node.Pos() < candidate.declNode.Pos() {
+			continue
+		}
+		if isWrite {
+			candidate.seenPostDeclarationWrite = true
+		} else if !candidate.seenPostDeclarationWrite {
+			candidate.readBeforeFirstAssign = true
+		}
+	}
+}
+
+func (s *preferConstState) finish() {
+	// Declaration lists and destructuring groups are appended in the same AST
+	// traversal order, so a single cursor can consume each sparse group once.
+	destructuringGroupIndex := 0
+	for i := range s.declarationLists {
+		s.finishDeclarationList(&s.declarationLists[i], &destructuringGroupIndex)
+	}
+}
+
+func (s *preferConstState) finishDeclarationList(list *declarationListInfo, destructuringGroupIndex *int) {
+	var candidateBuffer [4]int
+	constCandidates := candidateBuffer[:0]
+
+	for candidateIndex := list.candidateStart; candidateIndex < list.candidateEnd; {
+		groupStart := candidateIndex
+		groupEnd := candidateIndex + 1
+		requireAll := false
+		if *destructuringGroupIndex < len(s.destructuringGroups) {
+			group := s.destructuringGroups[*destructuringGroupIndex]
+			if group.candidateStart == candidateIndex {
+				groupEnd = group.candidateEnd
+				requireAll = true
+				*destructuringGroupIndex = *destructuringGroupIndex + 1
+			}
+		}
+
+		reportableStart := len(constCandidates)
+		for ; candidateIndex < groupEnd; candidateIndex++ {
+			if s.shouldReport(&s.candidates[candidateIndex]) {
+				constCandidates = append(constCandidates, candidateIndex)
+			}
+		}
+		if requireAll && len(constCandidates)-reportableStart != groupEnd-groupStart {
+			constCandidates = constCandidates[:reportableStart]
+		}
+	}
+
+	if s.destructuringAll {
+		writeIndex := 0
+		for _, index := range constCandidates {
+			candidate := &s.candidates[index]
+			if candidate.reportNode != nil && !s.allDestructuringWriteTargetsConst(candidate.reportNode) {
+				continue
+			}
+			constCandidates[writeIndex] = index
+			writeIndex++
+		}
+		constCandidates = constCandidates[:writeIndex]
+	}
+
+	totalBindings := list.candidateEnd - list.candidateStart
+	canFix := list.allHaveInit && totalBindings > 0 && len(constCandidates) == totalBindings
+	var buildFix func() []rule.RuleFix
+	if canFix {
+		letStart := -1
+		buildFix = func() []rule.RuleFix {
+			if letStart < 0 {
+				letStart = scanner.SkipTrivia(s.sourceText, list.node.Pos())
+			}
+			letRange := list.node.Loc.WithPos(letStart).WithEnd(letStart + len("let"))
+			return []rule.RuleFix{rule.RuleFixReplaceRange(letRange, "const")}
+		}
+	}
+	for _, index := range constCandidates {
+		candidate := &s.candidates[index]
+		reportOn := candidate.nameNode
+		if candidate.reportNode != nil {
+			reportOn = candidate.reportNode
+		}
+		msg := rule.RuleMessage{
+			Id:          "useConst",
+			Description: "'" + candidate.nameNode.Text() + "' is never reassigned. Use 'const' instead.",
+		}
+		reportRange := reportOn.Loc.WithPos(scanner.SkipTrivia(s.sourceText, reportOn.Pos()))
+		if canFix {
+			s.ctx.ReportRangeWithDeferredFixes(reportRange, msg, buildFix)
+		} else {
+			s.ctx.ReportRange(reportRange, msg)
+		}
+	}
+}
+
+func (s *preferConstState) shouldReport(candidate *candidateInfo) bool {
+	if candidate.symbol == nil {
 		return false
 	}
-	refs := ctx.Refs.References(sym)
-
-	if hasInitializer {
-		// Initialized candidates only need to know whether any later write
-		// exists, so stop at the first one.
-		return !hasWriteReference(refs)
+	info := s.symbols[candidate.symbol]
+	if candidate.hasInitializer {
+		return info.writeCount == 0
 	}
-
-	// Uninitialized candidates need the write count, first write, and whether
-	// a read precedes the first post-declaration write. Derive all three in a
-	// single pass over the source-ordered RefStore result.
-	references := summarizeReferences(refs, declNode.Pos())
-	if references.writeCount != 1 {
-		// 0 writes: never assigned, "let x;" alone is fine - don't report
-		// 2+ writes: truly reassigned - don't report
+	if info.writeCount != 1 {
 		return false
 	}
 
-	// Exactly 1 write: single assignment, could be "const x = ..."
-	// But only if the write is at the same block level as the declaration.
-	// If the write is inside a nested block (if, for, try, function, etc.),
-	// we can't safely convert to "const x = ..." because it would change semantics.
-	writeNode := findWriteInSameBlock(references.firstWrite, declNode, ctx)
+	writeNode := findWriteInSameBlock(info.firstWrite, candidate.declNode, s.ctx)
 	if writeNode == nil {
 		return false
 	}
-	// ESLint reports uninitialized variables at the write location when there's no read
-	// between declaration and write. If there IS a read before write, report at the declaration.
-	readBeforeAssign := references.readBeforeFirstAssign
-	if !readBeforeAssign {
-		c.reportNode = writeNode
+	if !candidate.readBeforeFirstAssign {
+		candidate.reportNode = writeNode
 	}
-
-	// Check ignoreReadBeforeAssign option
-	if opts.ignoreReadBeforeAssign && readBeforeAssign {
-		return false
-	}
-	return true
+	return !s.opts.ignoreReadBeforeAssign || !candidate.readBeforeFirstAssign
 }
 
 // isInForStatement checks if a VariableDeclarationList is the initializer of a regular for statement.
@@ -243,68 +350,6 @@ func isInForInOrOf(node *ast.Node) bool {
 		return false
 	}
 	return node.Parent.Kind == ast.KindForInStatement || node.Parent.Kind == ast.KindForOfStatement
-}
-
-// hasWriteReference reports whether RefStore found any write after excluding
-// declaration names. Shorthand destructuring names remain genuine writes.
-func hasWriteReference(refs []*ast.Node) bool {
-	for _, ref := range refs {
-		if utils.IsWriteReference(ref) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasMultipleWriteReferences(refs []*ast.Node) bool {
-	foundWrite := false
-	for _, ref := range refs {
-		if utils.IsWriteReference(ref) {
-			if foundWrite {
-				return true
-			}
-			foundWrite = true
-		}
-	}
-	return false
-}
-
-type referenceSummary struct {
-	firstWrite            *ast.Node
-	writeCount            int
-	readBeforeFirstAssign bool
-}
-
-// summarizeReferences classifies source-ordered references to an
-// uninitialized binding. Declaration names are absent from RefStore; shorthand
-// destructuring assignment names remain because they are genuine writes.
-func summarizeReferences(refs []*ast.Node, declPos int) referenceSummary {
-	var result referenceSummary
-	readAfterDeclaration := false
-	foundPostDeclWrite := false
-	for _, ref := range refs {
-		if utils.IsWriteReference(ref) {
-			result.writeCount++
-			if result.firstWrite == nil {
-				result.firstWrite = ref
-			}
-			if result.writeCount > 1 {
-				return result
-			}
-			if ref.Pos() >= declPos && !foundPostDeclWrite {
-				result.readBeforeFirstAssign = readAfterDeclaration
-				foundPostDeclWrite = true
-			}
-			continue
-		}
-		if ref.Pos() >= declPos && !foundPostDeclWrite {
-			readAfterDeclaration = true
-		}
-	}
-	if !foundPostDeclWrite {
-		result.readBeforeFirstAssign = readAfterDeclaration
-	}
-	return result
 }
 
 // findContainingBlock finds the nearest Block, SourceFile, ModuleBlock, CaseClause, or DefaultClause ancestor.
@@ -383,7 +428,7 @@ func findWriteInSameBlock(writeNode *ast.Node, declNode *ast.Node, ctx *rule.Rul
 // destructuring assignment containing writeNode have at most 1 write reference.
 // Used with destructuring: "all" to suppress reporting when not all variables in
 // the destructuring write group can be const.
-func allDestructuringWriteTargetsConst(writeNode *ast.Node, ctx *rule.RuleContext) bool {
+func (s *preferConstState) allDestructuringWriteTargetsConst(writeNode *ast.Node) bool {
 	assignExpr := ast.FindAncestor(writeNode, func(n *ast.Node) bool {
 		return ast.IsDestructuringAssignment(n)
 	})
@@ -397,15 +442,15 @@ func allDestructuringWriteTargetsConst(writeNode *ast.Node, ctx *rule.RuleContex
 		if !allConst {
 			return
 		}
-		// ctx.Refs.Resolve handles shorthand property names the same as
+		// RefStore.Resolve handles shorthand property names the same as
 		// plain identifiers (unlike checker.GetSymbolAtLocation, which
 		// resolves a shorthand name to the property symbol rather than the
 		// variable it reads/writes).
-		sym := ctx.Refs.Resolve(ident)
+		sym := s.ctx.Refs.Resolve(ident)
 		if sym == nil {
 			return
 		}
-		if hasMultipleWriteReferences(ctx.Refs.References(sym)) {
+		if s.symbols[sym].writeCount > 1 {
 			allConst = false
 		}
 	})

--- a/internal/rules/prefer_const/prefer_const_test.go
+++ b/internal/rules/prefer_const/prefer_const_test.go
@@ -291,6 +291,17 @@ func TestPreferConstRule(t *testing.T) {
 				Code:    `function f() { let a: any; let b: any; ({a, b} = ({} as any)); b = 1; void a; }`,
 				Options: map[string]interface{}{"destructuring": "all"},
 			},
+
+			// A write before the declaration still belongs to the binding and
+			// prevents initialized variables from being reported.
+			{Code: `x = 0; let x = 1;`},
+
+			// destructuring: "all" also considers writes to non-let targets in
+			// the same assignment group.
+			{
+				Code:    `function f() { let a: any; var b: any; ({a, b} = ({} as any)); b = 1; }`,
+				Options: map[string]interface{}{"destructuring": "all"},
+			},
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{
@@ -322,6 +333,25 @@ func TestPreferConstRule(t *testing.T) {
 			{
 				Code:   `let x = 1;`,
 				Output: []string{`const x = 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 5},
+				},
+			},
+
+			// Reads before an uninitialized declaration do not count as reads
+			// between that declaration and its only assignment.
+			{
+				Code: `void x; let x: any; x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 21},
+				},
+			},
+
+			// The binder resolves a write before an inner declaration to the
+			// future shadowing binding, not to the outer candidate.
+			{
+				Code:   `let x = 0; { x = 1; let x = 2; }`,
+				Output: []string{`const x = 0; { x = 1; let x = 2; }`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useConst", Line: 1, Column: 5},
 				},
@@ -416,6 +446,50 @@ func TestPreferConstRule(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useConst", Line: 1, Column: 5},
 					{MessageId: "useConst", Line: 1, Column: 12},
+				},
+			},
+
+			// destructuring: "all" tracks only the destructuring declarator's
+			// candidate range while preserving the shared declaration-list fix.
+			{
+				Code:    `let stable = 1, {a, b} = {a: 2, b: 3};`,
+				Output:  []string{`const stable = 1, {a, b} = {a: 2, b: 3};`},
+				Options: map[string]interface{}{"destructuring": "all"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 5},
+					{MessageId: "useConst", Line: 1, Column: 18},
+					{MessageId: "useConst", Line: 1, Column: 21},
+				},
+			},
+
+			// A partially eligible destructuring group does not suppress an
+			// independent identifier declarator in the same list.
+			{
+				Code:    `let stable = 1, {a, b} = {a: 2, b: 3}; b = 4;`,
+				Options: map[string]interface{}{"destructuring": "all"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 5},
+				},
+			},
+
+			// Multiple destructuring groups keep independent boundaries even
+			// when separated by a plain identifier declarator.
+			{
+				Code:    `let {a, b} = {a: 1, b: 2}, stable = 3, [c, d] = [4, 5]; b++; d++;`,
+				Options: map[string]interface{}{"destructuring": "all"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 28},
+				},
+			},
+
+			// destructuring: "any" keeps candidates independent instead of
+			// applying the all-candidates group constraint.
+			{
+				Code:    `let stable = 1, {a, b} = {a: 2, b: 3}; b = 4;`,
+				Options: map[string]interface{}{"destructuring": "any"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 5},
+					{MessageId: "useConst", Line: 1, Column: 18},
 				},
 			},
 


### PR DESCRIPTION
## Summary

- Track `prefer-const` references during the linter's normal traversal instead of asking `RefStore.References` to perform a second whole-file walk.
- Merge candidate heads and write facts into one compact per-symbol state, saturating write counts at the rule's required `0` / `1` / `multiple` states.
- Store declaration metadata as candidate ranges and allocate grouping metadata only for actual destructuring groups under `destructuring: "all"`.
- Keep the optimization entirely inside the rule, with no repository-specific paths or framework changes.

### Benchmarks

#### Go benchmark

Original `main` to this PR, using the focused `prefer-const` benchmark:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Time | 950,256 ns/op | 621,392.4 ns/op | -34.61% |
| Memory | 437,048 B/op | 319,384 B/op | -26.92% |
| Allocations | 3,695 allocs/op | 502 allocs/op | -86.41% |

The final rule-state compaction alone improved the paired main scenario from 654,728.8 to 621,392.4 ns/op (-5.09%), with memory dropping from 428,056 to 319,384 B/op (-25.39%). It also improved two less-dense variants:

| Scenario | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Sparse candidates | 545,486.0 ns/op | 519,707.2 ns/op | -4.73% |
| `destructuring: "any"` | 661,894.6 ns/op | 618,172.5 ns/op | -6.61% |

#### VS Code benchmark repository

Measured on 10,501 files with only `prefer-const` enabled through the benchmark repository's generated JavaScript (`.mjs`) rslint config:

- Stable listener samples after the change: 174.0-183.6 ms, median 176.3 ms.
- Initial listener baseline: 285.6 ms; the median is 38.27% lower.
- Baseline immediately before the final state compaction: 183.9 ms; the median is 4.13% lower.
- Whole-run hyperfine: 6.094 +/- 0.255 s (5.803-6.689 s), compared with the initial 6.031 +/- 0.342 s. The rule is only a small fraction of total repository time, so the end-to-end wall measurement does not resolve the rule-level improvement above its system noise.

### Validation

- Added focused cases to the existing `prefer_const_test.go`; no standalone test file was added.
- Compared the old and new implementations over 128 adversarial cases under both destructuring modes: all 314 diagnostics and fixes matched exactly, including positions, ranges, and replacement text.
- `go test ./internal/rules/prefer_const`
- `go test ./internal/rules/prefer_const -count=5`
- `go test -race ./internal/rules/prefer_const`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=HEAD ./internal/rules/prefer_const/...` (`0 issues`)

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No user-facing behavior or configuration changed.
