### PR TITLE
perf: optimize no-restricted-syntax matching

### DIFF
--- a/internal/rules/no_restricted_syntax/matcher.go
+++ b/internal/rules/no_restricted_syntax/matcher.go
@@ -57,7 +57,7 @@ func collectKinds(sel selector, s *kindSet) {
 			s.markUniverse()
 			return
 		}
-		ks := kindsForEstreeName(v.Name)
+		ks := v.Kinds
 		if ks == nil {
 			// Unknown ESTree name — collapse to the empty set so that this
 			// selector is never registered. The user's selector simply
@@ -101,7 +101,7 @@ func collectKinds(sel selector, s *kindSet) {
 func matches(sel selector, node *ast.Node, mc *matchContext) bool {
 	switch v := sel.(type) {
 	case identifierSelector:
-		return matchesIdentifier(v.Name, node)
+		return matchesIdentifier(v, node)
 	case classSelector:
 		if !matches(v.Inner, node, mc) {
 			return false
@@ -138,11 +138,11 @@ func matches(sel selector, node *ast.Node, mc *matchContext) bool {
 // matchesIdentifier evaluates the bare type-name portion of a selector.
 // "*" matches everything; ESTree-mapped names match their tsgo kinds with
 // extra refinement for kinds that fuse multiple ESTree shapes.
-func matchesIdentifier(name string, node *ast.Node) bool {
-	if name == "*" {
+func matchesIdentifier(sel identifierSelector, node *ast.Node) bool {
+	if sel.Name == "*" {
 		return true
 	}
-	ks := kindsForEstreeName(name)
+	ks := sel.Kinds
 	if ks == nil {
 		return false
 	}
@@ -156,7 +156,7 @@ func matchesIdentifier(name string, node *ast.Node) bool {
 	if !matchedKind {
 		return false
 	}
-	return refineEstreeMatch(name, node)
+	return refineEstreeMatch(sel.Name, node)
 }
 
 // refineEstreeMatch tightens the tsgo→ESTree match for kinds that tsgo
@@ -335,6 +335,20 @@ func matchesClass(node *ast.Node, class string) bool {
 // matchesAttr resolves the attribute path against the node and compares
 // the obtained value with the operator/right-hand side of the selector.
 func matchesAttr(node *ast.Node, path []string, op attrOp, value attrValue, mc *matchContext) bool {
+	if (op == attrEqual || op == attrNotEqual) &&
+		(value.Kind == attrValueString || value.Kind == attrValueIdent || value.Kind == attrValueRegex) {
+		if text, ok, handled := lookupStringAttrPath(node, path, mc); handled {
+			if !ok {
+				return false
+			}
+			equal := attrStringEquals(text, value)
+			if op == attrNotEqual {
+				return !equal
+			}
+			return equal
+		}
+	}
+
 	val, ok := lookupAttrPath(node, path, mc)
 	if op == attrPresent {
 		// Presence: any non-zero, non-nil value passes.
@@ -347,6 +361,54 @@ func matchesAttr(node *ast.Node, path []string, op attrOp, value attrValue, mc *
 		return false
 	}
 	return compareAttr(val, op, value)
+}
+
+// lookupStringAttrPath avoids boxing the overwhelmingly common string-valued
+// selector paths (for example object.name, callee.property.name, and operator).
+// handled is false when the path reaches a non-string ESTree facade, in which
+// case the generic interface-based resolver retains the exact behavior.
+func lookupStringAttrPath(node *ast.Node, path []string, mc *matchContext) (text string, ok bool, handled bool) {
+	if len(path) == 0 {
+		return "", false, false
+	}
+
+	var current interface{} = node
+	for index, segment := range path {
+		if index != len(path)-1 {
+			next, found := stepAttrPath(current, segment, mc)
+			if !found {
+				return "", false, true
+			}
+			current = next
+			continue
+		}
+
+		switch value := current.(type) {
+		case *ast.Node:
+			if value == nil {
+				return "", false, true
+			}
+			switch segment {
+			case "name":
+				name, found := readNameAttr(value)
+				if !found {
+					return "", false, true
+				}
+				return attrAsString(name), true, true
+			case "operator":
+				text, found := readOperatorAttrString(value)
+				return text, found, true
+			case "type":
+				return estreeNameForKind(value), true, true
+			}
+		case metaIdentifier:
+			if segment == "name" {
+				return value.name, true, true
+			}
+		}
+		return "", false, false
+	}
+	return "", false, false
 }
 
 // matchesCombinator handles `>` (parent), descendant, `+` (prev sibling),
@@ -636,13 +698,31 @@ func attrEquals(left interface{}, right attrValue) bool {
 	case attrValueIdent:
 		return attrAsString(left) == right.Ident
 	case attrValueRegex:
-		s := attrAsString(left)
-		re, err := regexp2.Compile(right.Regex, regexpFlags(right.Flags))
-		if err != nil {
+		return attrStringEquals(attrAsString(left), right)
+	}
+	return false
+}
+
+func attrStringEquals(left string, right attrValue) bool {
+	switch right.Kind {
+	case attrValueString:
+		return left == right.Str
+	case attrValueIdent:
+		return left == right.Ident
+	case attrValueRegex:
+		if right.regexPrefix != "" && !strings.HasPrefix(left, right.regexPrefix) {
 			return false
 		}
-		ok, _ := re.MatchString(s)
-		return ok
+		re := right.compiledRegex
+		if re == nil {
+			var err error
+			re, err = regexp2.Compile(right.Regex, regexpFlags(right.Flags))
+			if err != nil {
+				return false
+			}
+		}
+		matched, err := re.MatchString(left)
+		return err == nil && matched
 	}
 	return false
 }
@@ -1283,6 +1363,14 @@ func readRawAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
 }
 
 func readOperatorAttr(node *ast.Node) (interface{}, bool) {
+	text, ok := readOperatorAttrString(node)
+	if !ok {
+		return nil, false
+	}
+	return text, true
+}
+
+func readOperatorAttrString(node *ast.Node) (string, bool) {
 	switch node.Kind {
 	case ast.KindBinaryExpression:
 		return operatorTokenText(node.AsBinaryExpression().OperatorToken.Kind), true
@@ -1305,7 +1393,7 @@ func readOperatorAttr(node *ast.Node) (interface{}, bool) {
 	case ast.KindYieldExpression:
 		return "yield", true
 	}
-	return nil, false
+	return "", false
 }
 
 func operatorTokenText(k ast.Kind) string {

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.go
@@ -2,6 +2,9 @@ package no_restricted_syntax
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
+	"sync"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -19,54 +22,48 @@ import (
 var NoRestrictedSyntaxRule = rule.Rule{
 	Name: "no-restricted-syntax",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		entries := parseRuleOptions(options)
-		if len(entries) == 0 {
+		plan := cachedRulePlan(_options)
+		if len(plan.buckets) == 0 {
 			return rule.RuleListeners{}
 		}
 
 		mc := &matchContext{sf: ctx.SourceFile}
 
-		// Build per-kind buckets of (selector, message) entries. Selectors
-		// whose `candidate kinds` is the universe land in everyKindBucket
-		// and are evaluated on every visit.
-		perKind := make(map[ast.Kind][]ruleEntry)
-		var everyKind []ruleEntry
-		for _, e := range entries {
-			ks := candidateKinds(e.compiled)
-			if ks.universe {
-				everyKind = append(everyKind, e)
-				continue
-			}
-			for k := range ks.kinds {
-				perKind[k] = append(perKind[k], e)
-			}
-		}
-
-		// Merge the universe-of-kinds bucket into every kind we listen on.
-		// allInterestingKinds is the set we register for `*` / pure
-		// attribute selectors; kinds outside it that already have a
-		// per-kind bucket still keep their bucket (the universe matchers
-		// just don't apply there).
-		if len(everyKind) > 0 {
-			for _, k := range allInterestingKinds {
-				perKind[k] = append(perKind[k], everyKind...)
-			}
-		}
-
-		visit := func(node *ast.Node, bucket []ruleEntry) {
-			for _, e := range bucket {
-				if matches(e.compiled, node, mc) {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "restrictedSyntax",
-						Description: e.formatMessage(),
-					})
+		visit := func(node *ast.Node, bucket *ruleBucket) {
+			first, second, useAll := bucket.candidates(node, mc)
+			if useAll {
+				for index := range bucket.entries {
+					bucket.matchAndReport(index, node, mc, &ctx)
 				}
+				return
+			}
+
+			// Both candidate lists retain option order. Merge them so a
+			// dispatch hit cannot reorder diagnostics relative to selectors
+			// that do not participate in the index.
+			left, right := 0, 0
+			for left < len(first) || right < len(second) {
+				var index int
+				switch {
+				case right == len(second):
+					index = first[left]
+					left++
+				case left == len(first):
+					index = second[right]
+					right++
+				case first[left] < second[right]:
+					index = first[left]
+					left++
+				default:
+					index = second[right]
+					right++
+				}
+				bucket.matchAndReport(index, node, mc, &ctx)
 			}
 		}
 
-		listeners := rule.RuleListeners{}
-		for k, bucket := range perKind {
+		listeners := make(rule.RuleListeners, len(plan.buckets))
+		for k, bucket := range plan.buckets {
 			listeners[k] = func(node *ast.Node) {
 				visit(node, bucket)
 			}
@@ -81,6 +78,269 @@ type ruleEntry struct {
 	selector string
 	compiled selector
 	message  string
+}
+
+const maxCachedRulePlans = 64
+
+type rulePlan struct {
+	// options keeps the backing array alive while its address identifies this
+	// normalized config in rulePlanCache. Rule options are immutable after
+	// config resolution.
+	options []any
+	buckets map[ast.Kind]*ruleBucket
+}
+
+type rulePlanCacheKey struct {
+	options uintptr
+	length  int
+}
+
+var emptyRulePlan = &rulePlan{}
+
+var rulePlanCache = struct {
+	sync.RWMutex
+	entries map[rulePlanCacheKey]*rulePlan
+	order   []rulePlanCacheKey
+}{
+	entries: make(map[rulePlanCacheKey]*rulePlan),
+	order:   make([]rulePlanCacheKey, 0, maxCachedRulePlans),
+}
+
+func cachedRulePlan(options []any) *rulePlan {
+	if len(options) == 0 {
+		return emptyRulePlan
+	}
+	key := rulePlanCacheKey{
+		options: reflect.ValueOf(options).Pointer(),
+		length:  len(options),
+	}
+
+	rulePlanCache.RLock()
+	plan := rulePlanCache.entries[key]
+	rulePlanCache.RUnlock()
+	if plan != nil {
+		return plan
+	}
+
+	plan = buildRulePlan(options)
+	rulePlanCache.Lock()
+	if cached := rulePlanCache.entries[key]; cached != nil {
+		rulePlanCache.Unlock()
+		return cached
+	}
+	if len(rulePlanCache.order) == maxCachedRulePlans {
+		oldest := rulePlanCache.order[0]
+		delete(rulePlanCache.entries, oldest)
+		copy(rulePlanCache.order, rulePlanCache.order[1:])
+		rulePlanCache.order[len(rulePlanCache.order)-1] = key
+	} else {
+		rulePlanCache.order = append(rulePlanCache.order, key)
+	}
+	rulePlanCache.entries[key] = plan
+	rulePlanCache.Unlock()
+	return plan
+}
+
+func buildRulePlan(options []any) *rulePlan {
+	plan := &rulePlan{options: options}
+	entries := parseRuleOptions(rule.LegacyUnwrapOptions(options))
+	if len(entries) == 0 {
+		return plan
+	}
+
+	// Build per-kind buckets of (selector, message) entries. Selectors whose
+	// candidate kinds are the universe land in everyKind and are evaluated on
+	// every interesting visit.
+	perKind := make(map[ast.Kind][]ruleEntry)
+	var everyKind []ruleEntry
+	for _, entry := range entries {
+		kinds := candidateKinds(entry.compiled)
+		if kinds.universe {
+			everyKind = append(everyKind, entry)
+			continue
+		}
+		for kind := range kinds.kinds {
+			perKind[kind] = append(perKind[kind], entry)
+		}
+	}
+	if len(everyKind) > 0 {
+		for _, kind := range allInterestingKinds {
+			perKind[kind] = append(perKind[kind], everyKind...)
+		}
+	}
+
+	plan.buckets = make(map[ast.Kind]*ruleBucket, len(perKind))
+	for kind, entries := range perKind {
+		bucket := buildRuleBucket(entries)
+		plan.buckets[kind] = &bucket
+	}
+	return plan
+}
+
+type ruleBucket struct {
+	entries  []ruleEntry
+	dispatch *stringAttrDispatch
+}
+
+type stringAttrDispatch struct {
+	path     []string
+	byValue  map[string][]int
+	fallback []int
+}
+
+type dispatchAttr struct {
+	path  []string
+	key   string
+	value string
+}
+
+type dispatchStat struct {
+	path   []string
+	count  int
+	values map[string]struct{}
+}
+
+func buildRuleBucket(entries []ruleEntry) ruleBucket {
+	bucket := ruleBucket{entries: entries}
+
+	stats := make(map[string]*dispatchStat)
+	for _, entry := range entries {
+		attrs := collectDispatchAttrs(entry.compiled, nil)
+		for index, attr := range attrs {
+			duplicate := false
+			for previous := range index {
+				if attrs[previous].key == attr.key {
+					duplicate = true
+					break
+				}
+			}
+			if duplicate {
+				continue
+			}
+			stat := stats[attr.key]
+			if stat == nil {
+				stat = &dispatchStat{
+					path:   attr.path,
+					values: make(map[string]struct{}),
+				}
+				stats[attr.key] = stat
+			}
+			stat.count++
+			stat.values[attr.value] = struct{}{}
+		}
+	}
+
+	bestKey := ""
+	bestCount, bestValues := 0, 0
+	for key, stat := range stats {
+		valueCount := len(stat.values)
+		if stat.count > bestCount ||
+			(stat.count == bestCount && valueCount > bestValues) ||
+			(stat.count == bestCount && valueCount == bestValues && (bestKey == "" || key < bestKey)) {
+			bestKey = key
+			bestCount = stat.count
+			bestValues = valueCount
+		}
+	}
+	if bestCount == 0 || (bestCount == 1 && !supportsSingleDispatch(stats[bestKey].path)) {
+		return bucket
+	}
+
+	dispatch := &stringAttrDispatch{
+		path:     stats[bestKey].path,
+		byValue:  make(map[string][]int, bestValues),
+		fallback: make([]int, 0, len(entries)-bestCount),
+	}
+	for index, entry := range entries {
+		value, ok := dispatchValueForPath(entry.compiled, bestKey)
+		if !ok {
+			dispatch.fallback = append(dispatch.fallback, index)
+			continue
+		}
+		dispatch.byValue[value] = append(dispatch.byValue[value], index)
+	}
+	bucket.dispatch = dispatch
+	return bucket
+}
+
+func supportsSingleDispatch(path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	switch path[len(path)-1] {
+	case "name", "operator", "type":
+		return true
+	default:
+		return false
+	}
+}
+
+func collectDispatchAttrs(sel selector, attrs []dispatchAttr) []dispatchAttr {
+	switch value := sel.(type) {
+	case attrSelector:
+		attrs = collectDispatchAttrs(value.Inner, attrs)
+		if value.Op == attrEqual {
+			if expected, ok := exactStringValue(value.Value); ok {
+				attrs = append(attrs, dispatchAttr{
+					path:  value.Path,
+					key:   strings.Join(value.Path, "\x00"),
+					value: expected,
+				})
+			}
+		}
+	case classSelector:
+		attrs = collectDispatchAttrs(value.Inner, attrs)
+	case combinatorSelector:
+		attrs = collectDispatchAttrs(value.Right, attrs)
+	case combinedPseudo:
+		attrs = collectDispatchAttrs(value.Inner, attrs)
+	}
+	return attrs
+}
+
+func exactStringValue(value attrValue) (string, bool) {
+	switch value.Kind {
+	case attrValueString:
+		return value.Str, true
+	case attrValueIdent:
+		return value.Ident, true
+	default:
+		return "", false
+	}
+}
+
+func dispatchValueForPath(sel selector, pathKey string) (string, bool) {
+	for _, attr := range collectDispatchAttrs(sel, nil) {
+		if attr.key == pathKey {
+			return attr.value, true
+		}
+	}
+	return "", false
+}
+
+func (bucket *ruleBucket) candidates(node *ast.Node, mc *matchContext) (first, second []int, useAll bool) {
+	if bucket.dispatch == nil {
+		return nil, nil, true
+	}
+	value, ok, handled := lookupStringAttrPath(node, bucket.dispatch.path, mc)
+	if !handled {
+		return nil, nil, true
+	}
+	if !ok {
+		return bucket.dispatch.fallback, nil, false
+	}
+	return bucket.dispatch.fallback, bucket.dispatch.byValue[value], false
+}
+
+func (bucket *ruleBucket) matchAndReport(index int, node *ast.Node, mc *matchContext, ctx *rule.RuleContext) {
+	entry := &bucket.entries[index]
+	if !matches(entry.compiled, node, mc) {
+		return
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "restrictedSyntax",
+		Description: entry.formatMessage(),
+	})
 }
 
 func (e ruleEntry) formatMessage() string {

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
@@ -1,6 +1,8 @@
 package no_restricted_syntax
 
 import (
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
@@ -923,4 +925,193 @@ func TestNoRestrictedSyntaxRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoRestrictedSyntaxOptimizedDispatch(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoRestrictedSyntaxRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `class C {}`,
+				Options: []interface{}{
+					"ClassDeclaration[superClass.name='Base']",
+					"ClassDeclaration[superClass.name='Other']",
+				},
+			},
+			{
+				Code: `let value;`,
+				Options: []interface{}{
+					"VariableDeclarator[init.name='foo']",
+					"VariableDeclarator[init.name='bar']",
+				},
+			},
+			{
+				Code: `value instanceof CustomEvent;`,
+				Options: []interface{}{
+					`BinaryExpression[operator='instanceof'][right.name=/^HTML\w+/]`,
+					`BinaryExpression[operator='instanceof'][right.name=/^SVG\w+/]`,
+				},
+			},
+			{
+				Code: `document['body'];`,
+				Options: []interface{}{
+					`MemberExpression[property.name='body']`,
+					`MemberExpression[property.name='head']`,
+				},
+			},
+			{
+				Code:    `new Promise(resolve => resolve());`,
+				Options: []interface{}{`NewExpression[callee.object.name='Intl']`},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `foo;`,
+				Options: []interface{}{
+					map[string]interface{}{"selector": `Identifier[name=/^f/]`, "message": "regex start"},
+					map[string]interface{}{"selector": `Identifier[name='foo']`, "message": "exact"},
+					map[string]interface{}{"selector": `Identifier[name=/o$/]`, "message": "regex end"},
+					map[string]interface{}{"selector": `Identifier[name='bar']`, "message": "other exact"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "regex start"},
+					{MessageId: "restrictedSyntax", Message: "exact"},
+					{MessageId: "restrictedSyntax", Message: "regex end"},
+				},
+			},
+			{
+				Code: `foo();`,
+				Options: []interface{}{
+					`CallExpression[callee.property.name='query']`,
+					map[string]interface{}{"selector": `CallExpression[callee.name=/^foo$/]`, "message": "fallback"},
+					`CallExpression[callee.property.name='find']`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "fallback"},
+				},
+			},
+			{
+				Code: `'foo';`,
+				Options: []interface{}{
+					`Literal[value='foo']`,
+					`Literal[value='bar']`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal[value='foo']' is not allowed."},
+				},
+			},
+			{
+				Code: `document.body;`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"selector": `MemberExpression[object.name='document'][property.name='body']`,
+						"message":  "first duplicate",
+					},
+					map[string]interface{}{
+						"selector": `MemberExpression[object.name='document'][property.name='body']`,
+						"message":  "second duplicate",
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "first duplicate"},
+					{MessageId: "restrictedSyntax", Message: "second duplicate"},
+				},
+			},
+			{
+				Code: `value instanceof HTMLDivElement;`,
+				Options: []interface{}{
+					`BinaryExpression[operator='instanceof'][right.name=/^HTML\w+/]`,
+					`BinaryExpression[operator='instanceof'][right.name=/^SVG\w+/]`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'BinaryExpression[operator='instanceof'][right.name=/^HTML\\w+/]' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `new Intl.DateTimeFormat();`,
+				Options: []interface{}{`NewExpression[callee.object.name='Intl']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'NewExpression[callee.object.name='Intl']' is not allowed.",
+					},
+				},
+			},
+		},
+	)
+}
+
+func TestNoRestrictedSyntaxDispatchPlanning(t *testing.T) {
+	binaryEntries := []ruleEntry{
+		buildEntryFromString(`BinaryExpression[operator='instanceof'][right.name='MouseEvent']`),
+		buildEntryFromString(`BinaryExpression[operator='instanceof'][right.name=/^HTML\w+/]`),
+		buildEntryFromString(`BinaryExpression[operator='instanceof'][right.name=/^SVG\w+/]`),
+		buildEntryFromString(`BinaryExpression[operator='instanceof'][right.name='KeyboardEvent']`),
+		buildEntryFromString(`BinaryExpression[operator='instanceof'][right.name='PointerEvent']`),
+		buildEntryFromString(`BinaryExpression[operator='instanceof'][right.name='DragEvent']`),
+	}
+	binaryBucket := buildRuleBucket(binaryEntries)
+	if binaryBucket.dispatch == nil || len(binaryBucket.dispatch.path) != 1 || binaryBucket.dispatch.path[0] != "operator" {
+		t.Fatalf("binary dispatch path is %v, want operator", binaryBucket.dispatch)
+	}
+
+	singleBucket := buildRuleBucket([]ruleEntry{
+		buildEntryFromString(`NewExpression[callee.object.name='Intl']`),
+	})
+	if singleBucket.dispatch == nil || len(singleBucket.dispatch.path) != 3 ||
+		singleBucket.dispatch.path[0] != "callee" ||
+		singleBucket.dispatch.path[1] != "object" ||
+		singleBucket.dispatch.path[2] != "name" {
+		t.Fatalf("single-selector dispatch path is %v, want callee.object.name", singleBucket.dispatch)
+	}
+
+	unsupportedBucket := buildRuleBucket([]ruleEntry{
+		buildEntryFromString(`Literal[value='text']`),
+	})
+	if unsupportedBucket.dispatch != nil {
+		t.Fatalf("unsupported single-selector path unexpectedly built dispatch %v", unsupportedBucket.dispatch)
+	}
+}
+
+func TestNoRestrictedSyntaxRulePlanCache(t *testing.T) {
+	options := []any{
+		"Identifier[name='target']",
+		"Identifier[name='other']",
+	}
+	want := cachedRulePlan(options)
+
+	var waitGroup sync.WaitGroup
+	for range 32 {
+		waitGroup.Go(func() {
+			if got := cachedRulePlan(options); got != want {
+				t.Errorf("concurrent cache lookup returned plan %p, want %p", got, want)
+			}
+		})
+	}
+	waitGroup.Wait()
+
+	anchors := make([][]any, 0, maxCachedRulePlans+16)
+	for index := range maxCachedRulePlans + 16 {
+		entryOptions := []any{"Identifier[name='entry" + strconv.Itoa(index) + "']"}
+		anchors = append(anchors, entryOptions)
+		cachedRulePlan(entryOptions)
+	}
+	if len(anchors) != maxCachedRulePlans+16 {
+		t.Fatal("cache anchors were not retained")
+	}
+
+	rulePlanCache.RLock()
+	defer rulePlanCache.RUnlock()
+	if len(rulePlanCache.entries) > maxCachedRulePlans {
+		t.Fatalf("rule plan cache has %d entries, want at most %d", len(rulePlanCache.entries), maxCachedRulePlans)
+	}
+	if len(rulePlanCache.order) != len(rulePlanCache.entries) {
+		t.Fatalf("cache order has %d entries for %d plans", len(rulePlanCache.order), len(rulePlanCache.entries))
+	}
 }

--- a/internal/rules/no_restricted_syntax/parser.go
+++ b/internal/rules/no_restricted_syntax/parser.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/dlclark/regexp2"
 )
 
 // parseSelector parses an ESLint selector string into a selector tree.
@@ -142,17 +144,17 @@ func (p *parser) parseSequence() (selector, error) {
 		return nil, errors.New("unexpected end of selector")
 	case c == '*':
 		p.pos++
-		head = identifierSelector{Name: "*"}
+		head = newIdentifierSelector("*")
 	case c == '.' || c == '[' || c == ':':
 		// Filters without an explicit head — equivalent to `*` followed by
 		// the filter.
-		head = identifierSelector{Name: "*"}
+		head = newIdentifierSelector("*")
 	case isIdentStart(c):
 		name, err := p.parseIdent()
 		if err != nil {
 			return nil, err
 		}
-		head = identifierSelector{Name: name}
+		head = newIdentifierSelector(name)
 	default:
 		return nil, fmt.Errorf("unexpected character %q at position %d", c, p.pos)
 	}
@@ -184,6 +186,10 @@ func (p *parser) parseSequence() (selector, error) {
 		}
 	}
 	return head, nil
+}
+
+func newIdentifierSelector(name string) identifierSelector {
+	return identifierSelector{Name: name, Kinds: kindsForEstreeName(name)}
 }
 
 func (p *parser) parseIdent() (string, error) {
@@ -316,7 +322,14 @@ func (p *parser) parseAttrValue() (attrValue, error) {
 		if err != nil {
 			return attrValue{}, err
 		}
-		return attrValue{Kind: attrValueRegex, Regex: pat, Flags: flags}, nil
+		compiled, _ := regexp2.Compile(pat, regexpFlags(flags))
+		return attrValue{
+			Kind:          attrValueRegex,
+			Regex:         pat,
+			Flags:         flags,
+			compiledRegex: compiled,
+			regexPrefix:   anchoredLiteralPrefix(pat, flags),
+		}, nil
 	case c == '-' || (c >= '0' && c <= '9'):
 		num, err := p.parseNumber()
 		if err != nil {
@@ -339,6 +352,26 @@ func (p *parser) parseAttrValue() (attrValue, error) {
 		return attrValue{Kind: attrValueIdent, Ident: ident}, nil
 	}
 	return attrValue{}, fmt.Errorf("unexpected attribute value at position %d", p.pos)
+}
+
+// anchoredLiteralPrefix extracts only the plainly literal ASCII prefix from a
+// start-anchored, case-sensitive, single-line pattern. It is a conservative
+// rejection hint: an empty result keeps the full regexp path, while a non-empty
+// result must prefix every possible match.
+func anchoredLiteralPrefix(pattern, flags string) string {
+	if !strings.HasPrefix(pattern, "^") || strings.ContainsAny(flags, "im") {
+		return ""
+	}
+	end := 1
+	for end < len(pattern) {
+		c := pattern[end]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_' || c == ' ' || c == '-' {
+			end++
+			continue
+		}
+		break
+	}
+	return pattern[1:end]
 }
 
 func (p *parser) parseString(quote byte) (string, error) {

--- a/internal/rules/no_restricted_syntax/selector.go
+++ b/internal/rules/no_restricted_syntax/selector.go
@@ -1,5 +1,10 @@
 package no_restricted_syntax
 
+import (
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
 // selector models the subset of the ESLint / esquery selector grammar that the
 // rule needs in order to evaluate user-supplied patterns. Each variant is a
 // node in the parsed selector tree. The matcher in selector_matcher.go walks
@@ -12,7 +17,8 @@ type selector interface {
 // is the wildcard. ESTree type names map to one or more tsgo ast.Kind values
 // via estreeKindMap in selector_mapping.go.
 type identifierSelector struct {
-	Name string
+	Name  string
+	Kinds []ast.Kind
 }
 
 func (identifierSelector) isSelector() {}
@@ -54,13 +60,15 @@ const (
 )
 
 type attrValue struct {
-	Kind  attrValueKind
-	Str   string
-	Num   float64
-	Bool  bool
-	Regex string
-	Flags string
-	Ident string
+	Kind          attrValueKind
+	Str           string
+	Num           float64
+	Bool          bool
+	Regex         string
+	Flags         string
+	Ident         string
+	compiledRegex *regexp2.Regexp
+	regexPrefix   string
 }
 
 // attrSelector matches a node whose attribute (a dotted path inside the


### PR DESCRIPTION
## Summary

- Optimize no-restricted-syntax selector planning and matching at the rule layer.
- Cache parsed rule plans, precompile regular expressions and selector prefixes, and dispatch candidate selectors by AST kind and exact string attributes.
- Prefer the exact BinaryExpression operator dispatch path found by profiling, while preserving name lookup semantics including JSX facades.
- Add focused correctness coverage for nested name paths, missing properties, dispatch planning, and unsupported single-selector fallback.

### Benchmarks

#### Go benchmark

Original main to this PR, using focused no-restricted-syntax benchmarks:

| Scenario | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Run | 82,937.3 ns/op | 441.3 ns/op | -99.47% |
| Match | 4,485,368.5 ns/op | 98,967 ns/op | -97.79% |
| RunAndMatch | 4,612,145.8 ns/op | 101,301.9 ns/op | -97.80% |

For the final dispatch refinement, a benchmark modeled on the profiled BinaryExpression distribution improved as follows:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Time | 446,781 ns/op | 103,125 ns/op | -76.92% |
| Memory | 85,760 B/op | 7,680 B/op | -91.04% |
| Allocations | 5,360 allocs/op | 480 allocs/op | -91.04% |

#### VS Code benchmark repository

Measured on 10,501 files with only no-restricted-syntax enabled through the benchmark repository JavaScript (.mjs) rslint config:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Listener time | 1186.1 ms | 222.2 ms | -81.27% |
| Whole-run hyperfine | 7.183 +/- 0.226 s | 5.814 +/- 0.211 s | -19.06% |

For the final operator/name dispatch refinement, seven alternating A/B pairs measured a listener median improvement from 229.4 to 223.3 ms (-2.66%), with a paired median of -1.11%. Its incremental whole-run wall-time difference is below measurement noise.

### Validation

- Added focused cases to the existing no_restricted_syntax_test.go; no standalone test file was added.
- Ran differential and adversarial selector-plan checks, including 500 randomized plans.
- go test ./internal/rules/no_restricted_syntax -count=1
- go test -race ./internal/rules/no_restricted_syntax -count=1
- pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/rules/no_restricted_syntax/... (0 issues)
- pnpm run check-spell
- pnpm run format:check

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No user-facing behavior or configuration changed.