### PR TITLE
perf: optimize no-restricted-globals

### DIFF
--- a/internal/rules/no_restricted_globals/no_restricted_globals.go
+++ b/internal/rules/no_restricted_globals/no_restricted_globals.go
@@ -20,13 +20,21 @@ type globalEntry struct {
 	message    string
 }
 
+type sourceBindingState uint8
+
+const (
+	sourceBindingUnchecked sourceBindingState = iota
+	sourceBindingAbsent
+	sourceBindingPresent
+)
+
 type options struct {
 	restrictedGlobals map[string]globalEntry
 	checkGlobalObject bool
-	globalObjects     map[string]bool
+	globalObjects     map[string]sourceBindingState
 }
 
-func parseOptions(optionsList []any) options {
+func parseOptions(optionsList []any, sourceIdentifiers map[string]string) (options, bool) {
 	isGlobalsObject := false
 	var globalsObjectMap map[string]interface{}
 	if len(optionsList) > 0 {
@@ -60,15 +68,18 @@ func parseOptions(optionsList []any) options {
 	}
 
 	restrictedGlobals := make(map[string]globalEntry, len(rawGlobals))
+	mayUseRestrictedGlobal := sourceIdentifiers == nil
 	for _, item := range rawGlobals {
+		var name string
 		switch v := item.(type) {
 		case string:
 			if v == "" {
 				continue
 			}
-			restrictedGlobals[v] = globalEntry{}
+			name = v
+			restrictedGlobals[name] = globalEntry{}
 		case map[string]interface{}:
-			name, _ := v["name"].(string)
+			name, _ = v["name"].(string)
 			if name == "" {
 				continue
 			}
@@ -78,35 +89,56 @@ func parseOptions(optionsList []any) options {
 				restrictedGlobals[name] = globalEntry{}
 			}
 		}
+		if !mayUseRestrictedGlobal && name != "" {
+			_, mayUseRestrictedGlobal = sourceIdentifiers[name]
+		}
 	}
 
-	globalObjects := make(map[string]bool, len(defaultGlobalObjects)+len(userGlobalObjects))
-	for _, name := range defaultGlobalObjects {
-		globalObjects[name] = true
-	}
-	for _, name := range userGlobalObjects {
-		globalObjects[name] = true
+	var globalObjects map[string]sourceBindingState
+	if checkGlobalObject {
+		globalObjects = make(map[string]sourceBindingState, len(defaultGlobalObjects)+len(userGlobalObjects))
+		for _, name := range defaultGlobalObjects {
+			globalObjects[name] = sourceBindingUnchecked
+		}
+		for _, name := range userGlobalObjects {
+			globalObjects[name] = sourceBindingUnchecked
+		}
 	}
 
 	return options{
 		restrictedGlobals: restrictedGlobals,
 		checkGlobalObject: checkGlobalObject,
 		globalObjects:     globalObjects,
-	}
+	}, mayUseRestrictedGlobal
 }
 
 var NoRestrictedGlobalsRule = rule.Rule{
 	Name: "no-restricted-globals",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := parseOptions(options)
+		var sourceIdentifiers map[string]string
+		if ctx.SourceFile != nil {
+			sourceIdentifiers = ctx.SourceFile.Identifiers
+		}
+		opts, mayUseRestrictedGlobal := parseOptions(options, sourceIdentifiers)
 
 		// If no globals are restricted, there's nothing to check.
 		if len(opts.restrictedGlobals) == 0 {
-			return rule.RuleListeners{}
+			return nil
+		}
+		if opts.checkGlobalObject {
+			for name := range opts.globalObjects {
+				if !ctx.Globals.Access(name).IsDeclared() {
+					delete(opts.globalObjects, name)
+				} else if !mayUseRestrictedGlobal {
+					_, mayUseRestrictedGlobal = sourceIdentifiers[name]
+				}
+			}
+		}
+		if !mayUseRestrictedGlobal {
+			return nil
 		}
 
-		report := func(node *ast.Node, name string) {
-			entry := opts.restrictedGlobals[name]
+		report := func(node *ast.Node, name string, entry globalEntry) {
 			if entry.hasMessage {
 				ctx.ReportNode(node, rule.RuleMessage{
 					Id:          "customMessage",
@@ -126,6 +158,7 @@ var NoRestrictedGlobalsRule = rule.Rule{
 					return
 				}
 				name := node.Text()
+				entry, restricted := opts.restrictedGlobals[name]
 
 				// Direct reference to a restricted global identifier. ESLint's own
 				// "declared elsewhere" and "through" branches only require that the
@@ -133,19 +166,81 @@ var NoRestrictedGlobalsRule = rule.Rule{
 				// recognized global — so a configured global (even one set to
 				// `off`) can't suppress this rule, and "not locally shadowed" is
 				// the only check needed here.
-				if _, restricted := opts.restrictedGlobals[name]; restricted &&
-					!isInTypeContext(node) && !utils.IsShadowed(node, name) {
-					report(node, name)
+				if restricted && !isInTypeContext(node) && !utils.IsShadowed(node, name) {
+					report(node, name, entry)
 				}
 
 				// checkGlobalObject: `window.foo`, `self['foo']`, `globalThis.foo`, ...
-				if opts.checkGlobalObject && opts.globalObjects[name] &&
-					ctx.Globals.Access(name).IsDeclared() && !utils.IsShadowed(node, name) {
-					checkGlobalObjectAccess(node, name, opts, report)
+				if opts.checkGlobalObject {
+					if binding, globalObject := opts.globalObjects[name]; globalObject &&
+						isUnshadowedGlobalObject(opts.globalObjects, ctx.SourceFile, node, name, binding) {
+						checkGlobalObjectAccess(node, name, opts, report)
+					}
 				}
 			},
 		}
 	},
+}
+
+func isUnshadowedGlobalObject(
+	globalObjects map[string]sourceBindingState,
+	sourceFile *ast.SourceFile,
+	node *ast.Node,
+	name string,
+	binding sourceBindingState,
+) bool {
+	if binding == sourceBindingUnchecked {
+		if sourceHasValueBinding(sourceFile, name) {
+			binding = sourceBindingPresent
+		} else {
+			binding = sourceBindingAbsent
+		}
+		globalObjects[name] = binding
+	}
+	return binding == sourceBindingAbsent || !utils.IsShadowed(node, name)
+}
+
+// sourceHasValueBinding reports whether any lexical scope in sourceFile
+// declares name in the value namespace. The binder links locals containers in
+// source order, so a miss proves that no reference in the file can shadow the
+// configured global object. Files without binder metadata conservatively fall
+// back to the exact per-reference shadowing check.
+func sourceHasValueBinding(sourceFile *ast.SourceFile, name string) bool {
+	if sourceFile == nil || !sourceFile.IsBound() {
+		return true
+	}
+	for container := sourceFile.AsNode(); container != nil; {
+		data := container.LocalsContainerData()
+		if data == nil {
+			return true
+		}
+		if len(data.Locals) != 0 &&
+			utils.IsValueSymbolDeclaredInFile(data.Locals[name], sourceFile) {
+			return true
+		}
+		if (container.Kind == ast.KindFunctionExpression || container.Kind == ast.KindClassExpression) &&
+			container.Name() != nil && container.Name().Text() == name {
+			return true
+		}
+		container = data.NextContainer
+	}
+	return sourceHasNamedExpressionBinding(sourceFile, name)
+}
+
+func sourceHasNamedExpressionBinding(sourceFile *ast.SourceFile, name string) bool {
+	found := false
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if (node.Kind == ast.KindFunctionExpression || node.Kind == ast.KindClassExpression) &&
+			node.Name() != nil && node.Name().Text() == name {
+			found = true
+			return true
+		}
+		node.ForEachChild(visit)
+		return found
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return found
 }
 
 // checkGlobalObjectAccess walks up a chain of member accesses rooted at a
@@ -154,7 +249,7 @@ var NoRestrictedGlobalsRule = rule.Rule{
 // self-access hops, and reports the final accessed property if its name is
 // restricted. Mirrors ESLint's `astUtils.getVariableByName` + reference walk
 // in the rule's `Program:exit` handler.
-func checkGlobalObjectAccess(node *ast.Node, globalObjectName string, opts options, report func(*ast.Node, string)) {
+func checkGlobalObjectAccess(node *ast.Node, globalObjectName string, opts options, report func(*ast.Node, string, globalEntry)) {
 	parent := ast.WalkUpParenthesizedExpressions(node.Parent)
 	for utils.IsSpecificMemberAccess(parent, "", globalObjectName) {
 		parent = ast.WalkUpParenthesizedExpressions(parent.Parent)
@@ -164,8 +259,8 @@ func checkGlobalObjectAccess(node *ast.Node, globalObjectName string, opts optio
 	if !ok {
 		return
 	}
-	if _, restricted := opts.restrictedGlobals[propName]; restricted {
-		report(propNode, propName)
+	if entry, restricted := opts.restrictedGlobals[propName]; restricted {
+		report(propNode, propName, entry)
 	}
 }
 
@@ -206,6 +301,13 @@ func shouldSkip(node *ast.Node) bool {
 	if parent == nil {
 		return true
 	}
+	// Member names are a frequent collision with common restricted names such
+	// as `name` and `length`, and checking them does not require the broader
+	// declaration-name classification below.
+	if parent.Kind == ast.KindPropertyAccessExpression &&
+		parent.AsPropertyAccessExpression().Name() == node {
+		return true
+	}
 
 	// Skip declaration names (var/let/const/function/class/enum/import/
 	// parameter names, and member names: methods, properties, accessors,
@@ -213,12 +315,6 @@ func shouldSkip(node *ast.Node) bool {
 	// (`{foo}`) are declaration-shaped but also read the outer binding, so
 	// they must NOT be skipped.
 	if ast.IsDeclarationName(node) && parent.Kind != ast.KindShorthandPropertyAssignment {
-		return true
-	}
-
-	// Skip property names in member access (obj.prop -> skip "prop").
-	if parent.Kind == ast.KindPropertyAccessExpression &&
-		parent.AsPropertyAccessExpression().Name() == node {
 		return true
 	}
 

--- a/internal/rules/no_restricted_globals/no_restricted_globals_extras_test.go
+++ b/internal/rules/no_restricted_globals/no_restricted_globals_extras_test.go
@@ -20,6 +20,23 @@ func TestNoRestrictedGlobalsExtras(t *testing.T) {
 		t,
 		&NoRestrictedGlobalsRule,
 		[]rule_tester.ValidTestCase{
+			// ---- Optimization lock-in: a same-named binding anywhere in the file
+			// keeps global-object shadow checks lexical rather than file-wide ----
+			{
+				Code: `const f = function window() { window.foo(); };`,
+				Options: []interface{}{map[string]interface{}{
+					"globals": []interface{}{"foo"}, "checkGlobalObject": true,
+				}},
+				Globals: map[string]any{"window": "readonly"},
+			},
+			{
+				Code: `const C = class window { method() { return window.foo; } };`,
+				Options: []interface{}{map[string]interface{}{
+					"globals": []interface{}{"foo"}, "checkGlobalObject": true,
+				}},
+				Globals: map[string]any{"window": "readonly"},
+			},
+
 			// ---- Dimension 4: parenthesized / assertion-wrapped receiver ----
 			// ESLint's own astUtils.isSpecificMemberAccess / getStaticPropertyName
 			// also don't see through TSNonNullExpression or TSAsExpression (they
@@ -126,6 +143,43 @@ func TestNoRestrictedGlobalsExtras(t *testing.T) {
 			},
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- Optimization lock-in: SourceFile.Identifiers stores normalized
+			// names, so the whole-file candidate gate must retain escaped uses ----
+			{
+				Code:    `\u0066oo;`,
+				Options: []interface{}{"foo"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "defaultMessage", Line: 1, Column: 1, EndLine: 1, EndColumn: 9},
+				},
+			},
+
+			// ---- Optimization lock-in: the no-binding cache and the exact
+			// shadowed-binding fallback may coexist in one source file ----
+			{
+				Code: `window.foo();
+function f(window: any) { window.foo(); }
+window.foo();`,
+				Options: []interface{}{map[string]interface{}{
+					"globals": []interface{}{"foo"}, "checkGlobalObject": true,
+				}},
+				Globals: map[string]any{"window": "readonly"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "defaultMessage", Line: 1, Column: 8, EndLine: 1, EndColumn: 11},
+					{MessageId: "defaultMessage", Line: 3, Column: 8, EndLine: 3, EndColumn: 11},
+				},
+			},
+			{
+				Code: `interface window {}
+window.foo();`,
+				Options: []interface{}{map[string]interface{}{
+					"globals": []interface{}{"foo"}, "checkGlobalObject": true,
+				}},
+				Globals: map[string]any{"window": "readonly"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "defaultMessage", Line: 2, Column: 8, EndLine: 2, EndColumn: 11},
+				},
+			},
+
 			// ---- Dimension 4: parenthesized global-object receiver ----
 			{
 				Code:    `(window).foo()`,


### PR DESCRIPTION
## Summary

- Skip registering the rule listener when a source file contains none of the configured restricted identifiers.
- Fuse option parsing with candidate detection and avoid unused global-object state.
- Cache file-level binding information for global-object checks while preserving the exact shadowing fallback.
- Reduce repeated identifier work and add regression coverage for named expressions, Unicode escapes, mixed global/local references, and type-only declarations.

### Benchmark

Measured against the target rule-benchmark workload using its generated JavaScript configuration:

- 10,501 files across the three exact option groups (5,936 / 703 / 3,862 files).
- GOMAXPROCS=1.
- Alternating baseline/current runs; medians reported.
- Baseline and optimized versions both produced 0 diagnostics.

| Metric | Baseline | Optimized | Change |
| --- | ---: | ---: | ---: |
| Rule TimingCollector time | 182.7 ms | 172.5 ms | -5.58% |
| Full rule-only linter wall time | 552.0 ms | 549.1 ms | -0.53% |

Representative path benchmarks:

| Path | Baseline | Optimized | Change |
| --- | ---: | ---: | ---: |
| Real file without candidates | 30.59 µs | 15.09 µs | -50.67% |
| Real file with candidates | 35.12 µs | 34.78 µs | -0.98% |
| Large browser source | 1.993 ms | 1.969 ms | -1.22% |

### Validation

- GOMAXPROCS=2 go test -p=1 ./internal/rules/no_restricted_globals -count=1
- Adversarial differential comparison across 30 scope/declaration cases
- pnpm run check-spell
- pnpm run format:check
- pnpm exec golangci-lint run --new-from-rev=main ./internal/rules/no_restricted_globals/...

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
