### PR TITLE
perf: reuse normalized paths during config matching

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -760,6 +760,34 @@ func normalizePathWithCaseSensitivity(filePath, cwd string, useCaseSensitive boo
 	}))
 }
 
+// fileMatchPath keeps the path representations shared by config-entry
+// selectors and file-level ignores for one resolution. It initializes lazily
+// so directory-blocked files and entries without path matchers do no extra
+// normalization work.
+type fileMatchPath struct {
+	original   string
+	cwd        string
+	normalized string
+	unix       string
+	ready      bool
+}
+
+func newFileMatchPath(filePath string, cwd string) fileMatchPath {
+	return fileMatchPath{original: filePath, cwd: cwd}
+}
+
+func (path *fileMatchPath) normalizedPaths() (string, string) {
+	if !path.ready {
+		path.normalized = path.original
+		if path.cwd != "" {
+			path.normalized = normalizePath(path.original, path.cwd)
+		}
+		path.unix = strings.ReplaceAll(path.normalized, "\\", "/")
+		path.ready = true
+	}
+	return path.normalized, path.unix
+}
+
 // MergedConfig is the final computed configuration for a single file
 type MergedConfig struct {
 	Rules           map[string]*RuleConfig
@@ -861,14 +889,19 @@ func hasFileSelectors(entry ConfigEntry) bool {
 }
 
 func isFileMatchedByConfigEntry(filePath string, entry ConfigEntry, cwd string) bool {
-	if isFileMatched(filePath, entry.Files, cwd) {
+	matchPath := newFileMatchPath(filePath, cwd)
+	return matchPath.matchesConfigEntry(entry)
+}
+
+func (path *fileMatchPath) matchesConfigEntry(entry ConfigEntry) bool {
+	if path.matchesAny(entry.Files) {
 		return true
 	}
 	for _, group := range entry.FilePatternGroups {
 		// ESLint treats an empty nested selector as a vacuously true AND group.
 		matched := true
 		for _, pattern := range group {
-			if !isSingleFilePatternMatched(filePath, pattern, cwd) {
+			if !path.matchesSingle(pattern) {
 				matched = false
 				break
 			}
@@ -928,8 +961,13 @@ func cloneConfigValue(value any) any {
 
 // isFileMatched checks if a file matches any of the given glob patterns
 func isFileMatched(filePath string, patterns []string, cwd string) bool {
+	matchPath := newFileMatchPath(filePath, cwd)
+	return matchPath.matchesAny(patterns)
+}
+
+func (path *fileMatchPath) matchesAny(patterns []string) bool {
 	for _, pattern := range patterns {
-		if isSingleFilePatternMatched(filePath, pattern, cwd) {
+		if path.matchesSingle(pattern) {
 			return true
 		}
 	}
@@ -937,12 +975,17 @@ func isFileMatched(filePath string, patterns []string, cwd string) bool {
 }
 
 func isSingleFilePatternMatched(filePath string, pattern string, cwd string) bool {
+	matchPath := newFileMatchPath(filePath, cwd)
+	return matchPath.matchesSingle(pattern)
+}
+
+func (path *fileMatchPath) matchesSingle(pattern string) bool {
 	negated := false
 	for strings.HasPrefix(pattern, "!") {
 		negated = !negated
 		pattern = strings.TrimPrefix(pattern, "!")
 	}
-	matched := isPositiveFilePatternMatched(filePath, pattern, cwd)
+	matched := path.matchesPositive(pattern)
 	if negated {
 		return !matched
 	}
@@ -950,24 +993,23 @@ func isSingleFilePatternMatched(filePath string, pattern string, cwd string) boo
 }
 
 func isPositiveFilePatternMatched(filePath string, pattern string, cwd string) bool {
-	var normalizedPath string
-	if cwd != "" {
-		normalizedPath = normalizePath(filePath, cwd)
-	} else {
-		normalizedPath = filePath
-	}
+	matchPath := newFileMatchPath(filePath, cwd)
+	return matchPath.matchesPositive(pattern)
+}
+
+func (path *fileMatchPath) matchesPositive(pattern string) bool {
+	normalizedPath, unixPath := path.normalizedPaths()
 
 	normalizedPattern := normalizePattern(pattern)
 
 	if utils.MatchGlob(normalizedPattern, normalizedPath) {
 		return true
 	}
-	if normalizedPath != filePath {
-		if utils.MatchGlob(normalizedPattern, filePath) {
+	if normalizedPath != path.original {
+		if utils.MatchGlob(normalizedPattern, path.original) {
 			return true
 		}
 	}
-	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
 	if unixPath != normalizedPath {
 		if utils.MatchGlob(normalizedPattern, unixPath) {
 			return true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -974,11 +974,6 @@ func (path *fileMatchPath) matchesAny(patterns []string) bool {
 	return false
 }
 
-func isSingleFilePatternMatched(filePath string, pattern string, cwd string) bool {
-	matchPath := newFileMatchPath(filePath, cwd)
-	return matchPath.matchesSingle(pattern)
-}
-
 func (path *fileMatchPath) matchesSingle(pattern string) bool {
 	negated := false
 	for strings.HasPrefix(pattern, "!") {
@@ -990,11 +985,6 @@ func (path *fileMatchPath) matchesSingle(pattern string) bool {
 		return !matched
 	}
 	return matched
-}
-
-func isPositiveFilePatternMatched(filePath string, pattern string, cwd string) bool {
-	matchPath := newFileMatchPath(filePath, cwd)
-	return matchPath.matchesPositive(pattern)
 }
 
 func (path *fileMatchPath) matchesPositive(pattern string) bool {

--- a/internal/config/config_resolution.go
+++ b/internal/config/config_resolution.go
@@ -45,9 +45,11 @@ func (config RslintConfig) matchConfigEntries(
 	globalIgnorePatterns []IgnorePattern,
 	entryIgnorePatterns [][]IgnorePattern,
 ) (configMatchKey, bool) {
-	if len(globalIgnorePatterns) > 0 &&
-		(isDirBlockedByIgnores(filePath, globalIgnorePatterns, cwd) ||
-			isFileIgnored(filePath, globalIgnorePatterns, cwd)) {
+	if len(globalIgnorePatterns) > 0 && isDirBlockedByIgnores(filePath, globalIgnorePatterns, cwd) {
+		return configMatchKey{}, false
+	}
+	matchPath := newFileMatchPath(filePath, cwd)
+	if len(globalIgnorePatterns) > 0 && matchPath.isIgnored(globalIgnorePatterns) {
 		return configMatchKey{}, false
 	}
 
@@ -63,12 +65,12 @@ func (config RslintConfig) matchConfigEntries(
 		if isGlobalIgnoreEntry(entry) {
 			continue
 		}
-		if hasFileSelectors(entry) && !isFileMatchedByConfigEntry(filePath, entry, cwd) {
+		if hasFileSelectors(entry) && !matchPath.matchesConfigEntry(entry) {
 			continue
 		}
 
 		ignores := entryIgnorePatternsAt(entryIgnorePatterns, index, entry)
-		if isFileIgnored(filePath, ignores, cwd) {
+		if len(ignores) > 0 && matchPath.isIgnored(ignores) {
 			continue
 		}
 

--- a/internal/config/file_match_path_test.go
+++ b/internal/config/file_match_path_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// These helpers freeze the pre-reuse path preparation. The lower-level glob
+// and ignore evaluators are intentionally shared so this oracle isolates the
+// behavior changed by fileMatchPath.
+func preReusePositiveFilePatternMatched(filePath string, pattern string, cwd string) bool {
+	normalizedPath := filePath
+	if cwd != "" {
+		normalizedPath = normalizePath(filePath, cwd)
+	}
+	normalizedPattern := normalizePattern(pattern)
+	if utils.MatchGlob(normalizedPattern, normalizedPath) {
+		return true
+	}
+	if normalizedPath != filePath && utils.MatchGlob(normalizedPattern, filePath) {
+		return true
+	}
+	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
+	return unixPath != normalizedPath && utils.MatchGlob(normalizedPattern, unixPath)
+}
+
+func preReuseSingleFilePatternMatched(filePath string, pattern string, cwd string) bool {
+	negated := false
+	for strings.HasPrefix(pattern, "!") {
+		negated = !negated
+		pattern = strings.TrimPrefix(pattern, "!")
+	}
+	matched := preReusePositiveFilePatternMatched(filePath, pattern, cwd)
+	if negated {
+		return !matched
+	}
+	return matched
+}
+
+func preReuseFileIgnored(filePath string, patterns []IgnorePattern, cwd string) bool {
+	if cwd == "" {
+		return isFileIgnoredNormalized(filePath, strings.ReplaceAll(filePath, "\\", "/"), patterns)
+	}
+	normalizedPath := normalizePath(filePath, cwd)
+	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
+	if pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
+		normalizedPath = normalizePathWithCaseSensitivity(filePath, cwd, false)
+		unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
+	}
+	return isFileIgnoredNormalized(normalizedPath, unixPath, patterns)
+}
+
+func TestFileMatchPathMatchesPreReuseBehavior(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		cwd      string
+	}{
+		{name: "posix within cwd", filePath: "/repo/src/app.ts", cwd: "/repo"},
+		{name: "posix outside cwd", filePath: "/other/src/app.ts", cwd: "/repo"},
+		{name: "relative normalized", filePath: "./src/../src/app.ts", cwd: "/repo"},
+		{name: "empty cwd windows separators", filePath: `src\windows\app.ts`, cwd: ""},
+		{name: "windows drive case", filePath: "C:/Users/Project/src/App.ts", cwd: "c:/users/project"},
+		{name: "windows backslashes", filePath: `C:\Users\Project\src\App.ts`, cwd: `c:\users\project`},
+		{name: "unc share case", filePath: "//SERVER/Share/Repo/src/App.ts", cwd: "//server/share/repo"},
+		{name: "empty path", filePath: "", cwd: ""},
+	}
+	selectorPatterns := []string{
+		"src/**/*.ts",
+		"**/app.ts",
+		"C:/Users/Project/src/*.ts",
+		`src\windows\*.ts`,
+		"!!src/**",
+		"!!!**/*.test.ts",
+		"",
+	}
+	ignoreSets := [][]IgnorePattern{
+		nil,
+		ParseIgnorePatterns([]string{"**/*.ts"}),
+		ParseIgnorePatterns([]string{"src/**", "!src/app.ts"}),
+	}
+	caseInsensitive := ParseIgnorePatterns([]string{"SRC/GENERATED/**", "src/app.ts"})
+	for index := range caseInsensitive {
+		caseInsensitive[index].CaseInsensitive = true
+	}
+	ignoreSets = append(ignoreSets, caseInsensitive)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchPath := newFileMatchPath(test.filePath, test.cwd)
+			for _, pattern := range selectorPatterns {
+				want := preReuseSingleFilePatternMatched(test.filePath, pattern, test.cwd)
+				if got := matchPath.matchesSingle(pattern); got != want {
+					t.Fatalf("selector %q: got %v, want %v", pattern, got, want)
+				}
+			}
+			for _, patterns := range ignoreSets {
+				want := preReuseFileIgnored(test.filePath, patterns, test.cwd)
+				if got := matchPath.isIgnored(patterns); got != want {
+					t.Fatalf("ignores %#v: got %v, want %v", patterns, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestFileMatchPathPreservesLazyAndNestedSelectorSemantics(t *testing.T) {
+	matchPath := newFileMatchPath("/repo/src/app.ts", "/repo")
+	if matchPath.isIgnored(nil) || matchPath.matchesAny(nil) {
+		t.Fatal("empty matcher unexpectedly matched")
+	}
+	if !matchPath.matchesConfigEntry(ConfigEntry{FilePatternGroups: [][]string{{}}}) {
+		t.Fatal("empty nested selector must remain vacuously true")
+	}
+	if matchPath.ready {
+		t.Fatal("empty matchers must not normalize the file path")
+	}
+
+	entry := ConfigEntry{FilePatternGroups: [][]string{{"src/**", "**/*.ts", "!**/*.test.ts"}}}
+	if !matchPath.matchesConfigEntry(entry) {
+		t.Fatal("nested AND selector unexpectedly rejected matching file")
+	}
+	if !matchPath.ready {
+		t.Fatal("non-empty selector did not prepare the file path")
+	}
+}
+
+func TestFileMatchPathCaseInsensitiveFallbackDoesNotLeak(t *testing.T) {
+	const filePath = "/Repo/src/file.ts"
+	const cwd = "/repo"
+	matchPath := newFileMatchPath(filePath, cwd)
+	baseNormalized, baseUnix := matchPath.normalizedPaths()
+	fallbackNormalized := normalizePathWithCaseSensitivity(filePath, cwd, false)
+	if fallbackNormalized == baseNormalized {
+		t.Fatalf("attack fixture did not exercise fallback: both normalized to %q", baseNormalized)
+	}
+
+	caseInsensitive := ParseIgnorePatterns([]string{"src/other.ts"})
+	caseInsensitive[0].CaseInsensitive = true
+	if matchPath.isIgnored(caseInsensitive) {
+		t.Fatal("non-matching case-insensitive pattern unexpectedly ignored file")
+	}
+	if matchPath.normalized != baseNormalized || matchPath.unix != baseUnix {
+		t.Fatalf("fallback polluted cached path: got (%q, %q), want (%q, %q)",
+			matchPath.normalized, matchPath.unix, baseNormalized, baseUnix)
+	}
+
+	caseSensitive := []IgnorePattern{{Glob: baseNormalized}}
+	if got, want := matchPath.isIgnored(caseSensitive), preReuseFileIgnored(filePath, caseSensitive, cwd); got != want || !got {
+		t.Fatalf("case-sensitive matcher after fallback: got %v, want %v", got, want)
+	}
+}
+
+func FuzzFileMatchPathMatchesPreReuse(f *testing.F) {
+	f.Add("/repo/src/app.ts", "/repo", "!!src/**/*.ts", "src/**", false)
+	f.Add(`C:\Users\Project\src\App.ts`, `c:\users\project`, "src/**/*.ts", "SRC/**", true)
+	f.Add("//SERVER/Share/Repo/src/App.ts", "//server/share/repo", "**/*.ts", "src/**", true)
+	f.Add(`src\windows\app.ts`, "", "src/**/*.ts", "src/**", false)
+
+	f.Fuzz(func(t *testing.T, filePath string, cwd string, selector string, ignore string, caseInsensitive bool) {
+		if len(filePath) > 256 || len(cwd) > 256 || len(selector) > 256 || len(ignore) > 256 {
+			t.Skip()
+		}
+		matchPath := newFileMatchPath(filePath, cwd)
+		if got, want := matchPath.matchesSingle(selector), preReuseSingleFilePatternMatched(filePath, selector, cwd); got != want {
+			t.Fatalf("selector mismatch: file=%q cwd=%q selector=%q got=%v want=%v",
+				filePath, cwd, selector, got, want)
+		}
+		patterns := ParseIgnorePatterns([]string{ignore})
+		patterns[0].CaseInsensitive = caseInsensitive
+		if got, want := matchPath.isIgnored(patterns), preReuseFileIgnored(filePath, patterns, cwd); got != want {
+			t.Fatalf("ignore mismatch: file=%q cwd=%q ignore=%q insensitive=%v got=%v want=%v",
+				filePath, cwd, ignore, caseInsensitive, got, want)
+		}
+	})
+}

--- a/internal/config/ignore_pattern.go
+++ b/internal/config/ignore_pattern.go
@@ -198,18 +198,22 @@ func ParseIgnorePatterns(raw []string) []IgnorePattern {
 // re-includes), aligned with ESLint v10. Matches only the cwd-relative path —
 // never the absolute path — so `**/`-prefixed patterns can't hit system dirs.
 func isFileIgnored(filePath string, patterns []IgnorePattern, cwd string) bool {
-	if cwd == "" {
-		return isFileIgnoredSimple(filePath, patterns)
+	matchPath := newFileMatchPath(filePath, cwd)
+	return matchPath.isIgnored(patterns)
+}
+
+func (path *fileMatchPath) isIgnored(patterns []IgnorePattern) bool {
+	if len(patterns) == 0 {
+		return false
 	}
-	normalizedPath := normalizePath(filePath, cwd)
-	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
-	if pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
+	normalizedPath, unixPath := path.normalizedPaths()
+	if path.cwd != "" && pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
 		// On Windows and case-insensitive macOS volumes, callers may supply a
 		// canonical path whose drive/share or directory casing differs from
 		// cwd. A case-sensitive relative conversion then manufactures ../ even
 		// though both paths name the same tree. Re-resolve only on that uncommon
 		// fallback so the normal hot path pays no extra pattern scan.
-		normalizedPath = normalizePathWithCaseSensitivity(filePath, cwd, false)
+		normalizedPath = normalizePathWithCaseSensitivity(path.original, path.cwd, false)
 		unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
 	}
 	return isFileIgnoredNormalized(normalizedPath, unixPath, patterns)


### PR DESCRIPTION
## Summary

- Reuse one lazily normalized file path across config selectors and ignore matchers during config resolution.
- Preserve selector, ignore, nested-group, and case-insensitive fallback semantics with regression and fuzz coverage.
- Reduce the native no-rule control workload used to isolate this module's overhead from `5,194.2 ms` to `4,329.3 ms` (`16.65%`).

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
