### PR TITLE
feat: support client-specified LSP config path

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -560,6 +560,12 @@ config/ownership catalog and observes `.gitignore` sources during the same
 directory walk. Explicit loading first selects the exact module unconditionally,
 then freezes that invocation-wide owner's Git projection with the same frontier
 without probing nested config candidates. Neither path collects lint targets.
+For LSP, the client's first `rslint/configRefresh` may include one absolute
+`configPath`. The server fixes that optional path for its lifetime: later client
+refreshes must repeat the same choice, while Go-owned `.gitignore` refreshes
+reuse it internally. Changing between automatic discovery and an explicit path,
+or changing the path itself, requires a new server process. Explicit LSP mode
+uses only the selected JS/TS module and does not load JSON fallback config.
 Go owns candidate discovery, default exclusions, config hierarchy, authored and
 Git directory reachability, the frozen Git projection for each owner, and final
 effective IDs. Node only
@@ -722,9 +728,13 @@ The transport and target phase differ by surface:
   every recorded server-open session for that runtime before LanguageClient
   replays `didOpen`, so the replacement process receives each still-open owned
   document exactly once.
-- Each selected runtime starts `rslint/configRefresh`, and Go scans that
-  process's workspace-folder cwd with a
-  transaction-scoped cached VFS. Go sends
+- Each selected runtime starts `rslint/configRefresh`. With no `configPath`, Go
+  scans that process's workspace-folder cwd with a transaction-scoped cached
+  VFS. A client may instead repeat one fixed absolute JS/TS `configPath` on
+  every refresh; Go loads exactly that module while retaining the process cwd
+  as its invocation-wide matching root. The client owns change notifications
+  for the explicit path, while Go's existing `.gitignore` watcher refreshes
+  the already-fixed source. Go sends
   `rslint/loadConfigs` and
   `rslint/activateConfigs`, then commits or aborts the matching plugin-host state
   through `rslint/commitConfigs` / `rslint/abortConfigs`. `fresh` loads cache-bust the config entry

--- a/internal/config/discovery/protocol.go
+++ b/internal/config/discovery/protocol.go
@@ -6,7 +6,7 @@ import (
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 )
 
-const ConfigDiscoveryProtocolVersion = 1
+const ConfigDiscoveryProtocolVersion = 2
 
 type ConfigModuleLoadMode string
 

--- a/internal/lsp/config_discovery.go
+++ b/internal/lsp/config_discovery.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"path"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/microsoft/typescript-go/shim/bundled"
@@ -30,8 +32,29 @@ const (
 )
 
 type configRefreshRequest struct {
-	ProtocolVersion int    `json:"protocolVersion"`
-	Reason          string `json:"reason"`
+	ProtocolVersion int                       `json:"protocolVersion"`
+	Reason          string                    `json:"reason"`
+	ConfigPath      optionalConfigRefreshPath `json:"configPath"`
+}
+
+// optionalConfigRefreshPath preserves the distinction between an absent
+// configPath (automatic discovery) and an invalid explicit null value.
+type optionalConfigRefreshPath struct {
+	Value   string
+	Present bool
+}
+
+func (path *optionalConfigRefreshPath) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return errors.New("configPath must be a string when present")
+	}
+	var value string
+	if err := stdjson.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("configPath must be a string: %w", err)
+	}
+	path.Value = value
+	path.Present = true
+	return nil
 }
 
 type configRefreshResponse struct {
@@ -285,33 +308,100 @@ type lspDiscoveredConfigSnapshot struct {
 	usableLastGood      bool
 }
 
-func (s *Server) handleConfigRefresh(ctx context.Context, params any) (configRefreshResponse, error) {
-	var request configRefreshRequest
-	data, err := stdjson.Marshal(params)
-	if err != nil {
-		return configRefreshResponse{}, fmt.Errorf("marshal config refresh params: %w", err)
-	}
-	if err := stdjson.Unmarshal(data, &request); err != nil {
-		return configRefreshResponse{}, fmt.Errorf("parse config refresh params: %w", err)
-	}
+func (s *Server) handleConfigRefresh(ctx context.Context, request configRefreshRequest) (configRefreshResponse, error) {
 	if request.ProtocolVersion != discovery.ConfigDiscoveryProtocolVersion {
 		return configRefreshResponse{}, fmt.Errorf(
-			"unsupported config refresh protocol %d",
+			"%w: unsupported config refresh protocol %d; expected %d",
+			lsproto.ErrorCodeInvalidParams,
 			request.ProtocolVersion,
+			discovery.ConfigDiscoveryProtocolVersion,
 		)
 	}
 	switch request.Reason {
 	case "initial", "config-change", "gitignore-change", "dependency-change":
 	default:
-		return configRefreshResponse{}, fmt.Errorf("unsupported config refresh reason %q", request.Reason)
+		return configRefreshResponse{}, fmt.Errorf(
+			"%w: unsupported config refresh reason %q",
+			lsproto.ErrorCodeInvalidParams,
+			request.Reason,
+		)
 	}
 	if s.fs == nil {
 		return configRefreshResponse{}, errors.New("config refresh requires a filesystem")
+	}
+	if err := ctx.Err(); err != nil {
+		return configRefreshResponse{}, err
+	}
+
+	configPath := ""
+	if request.ConfigPath.Present {
+		var err error
+		configPath, err = normalizeLSPExplicitConfigPath(request.ConfigPath.Value)
+		if err != nil {
+			return configRefreshResponse{}, fmt.Errorf("%w: %w", lsproto.ErrorCodeInvalidParams, err)
+		}
+	}
+	if !s.configRefreshInitialized {
+		if request.Reason != "initial" {
+			return configRefreshResponse{}, fmt.Errorf(
+				"%w: the first config refresh must use reason %q",
+				lsproto.ErrorCodeInvalidParams,
+				"initial",
+			)
+		}
+		s.configRefreshInitialized = true
+		s.configRefreshConfigPath = configPath
+	} else {
+		lockedExplicit := s.configRefreshConfigPath != ""
+		if request.ConfigPath.Present != lockedExplicit ||
+			(lockedExplicit && !lspConfigPathsEqual(configPath, s.configRefreshConfigPath, s.fs)) {
+			return configRefreshResponse{}, fmt.Errorf(
+				"%w: config path selection is fixed for this server process; restart the server to change it",
+				lsproto.ErrorCodeInvalidParams,
+			)
+		}
 	}
 	// Set this before doing fallible discovery: a failed initial transaction is
 	// still proof that the client installed the reverse handlers, and a later
 	// config or config-scoped .gitignore event must retry while keeping last-good.
 	s.configDiscoveryActive = true
+	return s.refreshConfig(ctx)
+}
+
+func normalizeLSPExplicitConfigPath(configPath string) (string, error) {
+	if configPath == "" {
+		return "", errors.New("configPath must not be empty")
+	}
+	if strings.IndexByte(configPath, 0) >= 0 {
+		return "", errors.New("configPath must not contain NUL")
+	}
+	if strings.HasPrefix(strings.ToLower(configPath), "file:") {
+		return "", errors.New("configPath must be a native filesystem path, not a URI")
+	}
+	if !tspath.PathIsAbsolute(configPath) {
+		return "", fmt.Errorf("configPath must be absolute: %q", configPath)
+	}
+	normalized := tspath.NormalizePath(configPath)
+	switch path.Ext(normalized) {
+	case ".js", ".mjs", ".cjs", ".ts", ".mts", ".cts":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("configPath must name a JS/TS config module: %q", configPath)
+	}
+}
+
+func lspConfigPathsEqual(left string, right string, fsys vfs.FS) bool {
+	caseSensitive := fsys == nil || fsys.UseCaseSensitiveFileNames()
+	return lspLexicalPathID(left, caseSensitive) == lspLexicalPathID(right, caseSensitive)
+}
+
+// refreshConfig rebuilds the config transaction selected by the client's
+// initial refresh. Internal file watchers call this directly so they cannot
+// reinterpret an omitted wire configPath as automatic discovery.
+func (s *Server) refreshConfig(ctx context.Context) (configRefreshResponse, error) {
+	if !s.configRefreshInitialized {
+		return configRefreshResponse{}, errors.New("config refresh source is not initialized")
+	}
 
 	// cachedvfs is intentionally scoped to one generation. A long-lived cache
 	// would make file creation/deletion and .gitignore edits invisible to later
@@ -319,11 +409,22 @@ func (s *Server) handleConfigRefresh(ctx context.Context, params any) (configRef
 	// generation's path identity snapshot.
 	snapshotFS := newConfigSnapshotFS(bundled.WrapFS(cachedvfs.From(s.fs)))
 	loader := &lspConfigModuleLoader{server: s}
-	catalog, err := discovery.DiscoverAutomatic(ctx, snapshotFS, loader, discovery.ConfigDiscoveryRequest{
-		CWD:         tspath.NormalizePath(s.cwd),
-		ImplicitCWD: true,
-		Fresh:       true,
-	})
+	cwd := tspath.NormalizePath(s.cwd)
+	var catalog *discovery.ConfigCatalog
+	var err error
+	if s.configRefreshConfigPath == "" {
+		catalog, err = discovery.DiscoverAutomatic(ctx, snapshotFS, loader, discovery.ConfigDiscoveryRequest{
+			CWD:         cwd,
+			ImplicitCWD: true,
+			Fresh:       true,
+		})
+	} else {
+		catalog, err = discovery.LoadExplicitConfig(ctx, snapshotFS, loader, discovery.ExplicitConfigRequest{
+			CWD:        cwd,
+			ConfigPath: s.configRefreshConfigPath,
+			Fresh:      true,
+		})
+	}
 	recoveredUnavailable := false
 	var unavailableCause error
 	if err != nil {
@@ -351,6 +452,7 @@ func (s *Server) handleConfigRefresh(ctx context.Context, params any) (configRef
 			Configs:            make(map[string]config.RslintConfig),
 			EffectiveConfigIDs: []string{},
 			Failures:           append([]discovery.ConfigFailure(nil), allFailed.Failures...),
+			Explicit:           s.configRefreshConfigPath != "",
 		}
 		recoveredUnavailable = true
 	} else if s.configDiscoveryHasLastGood {
@@ -533,6 +635,12 @@ func (s *Server) prepareDiscoveredConfigSnapshot(
 	// by their discovery generation; unavailable boundaries intentionally remain
 	// empty and only stop JSON fallback ownership.
 	snapshot.ownerResolver = config.NewConfigOwnerResolver(snapshot.configs, fsys)
+	if catalog.Explicit {
+		// An explicit JS/TS config is invocation-wide and owns the cwd. JSON is
+		// not part of this mode, so an unrelated JSON file must not make the
+		// selected module's transaction fail.
+		return snapshot, nil
+	}
 
 	jsonConfig, jsonPath, jsonTsConfigs, err := loadJSONConfigFallbackWithFS(s.cwd, fsys)
 	if err != nil {

--- a/internal/lsp/config_discovery_test.go
+++ b/internal/lsp/config_discovery_test.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -74,12 +75,27 @@ func newConfigRefreshTestServer(t *testing.T) (*Server, <-chan *lsproto.Message,
 }
 
 func startConfigRefreshForTest(s *Server, reason string) <-chan configRefreshTestResult {
+	return startConfigRefreshRequestForTest(s, configRefreshRequest{
+		ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
+		Reason:          reason,
+	})
+}
+
+func startExplicitConfigRefreshForTest(s *Server, reason string, configPath string) <-chan configRefreshTestResult {
+	return startConfigRefreshRequestForTest(s, configRefreshRequest{
+		ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
+		Reason:          reason,
+		ConfigPath: optionalConfigRefreshPath{
+			Value:   configPath,
+			Present: true,
+		},
+	})
+}
+
+func startConfigRefreshRequestForTest(s *Server, request configRefreshRequest) <-chan configRefreshTestResult {
 	result := make(chan configRefreshTestResult, 1)
 	go func() {
-		response, err := s.handleConfigRefresh(context.Background(), map[string]any{
-			"protocolVersion": discovery.ConfigDiscoveryProtocolVersion,
-			"reason":          reason,
-		})
+		response, err := s.handleConfigRefresh(context.Background(), request)
 		result <- configRefreshTestResult{response: response, err: err}
 	}()
 	return result
@@ -240,6 +256,24 @@ func awaitConfigRefreshResult(t *testing.T, result <-chan configRefreshTestResul
 	}
 }
 
+func completeSuccessfulConfigRefreshForTest(
+	t *testing.T,
+	s *Server,
+	outgoing <-chan *lsproto.Message,
+	entries config.RslintConfig,
+) discovery.ConfigLoadBatchRequest {
+	t.Helper()
+	loadMessage := nextConfigReverseRequest(t, outgoing, methodLoadConfigs)
+	loadRequest, loadResponse := loadedConfigResponse(t, loadMessage, entries)
+	respondToConfigReverseRequest(t, s, loadMessage, loadResponse, nil)
+	activationMessage := nextConfigReverseRequest(t, outgoing, methodActivateConfigs)
+	_, activationResponse := activationResponseForRequest(t, activationMessage, true)
+	respondToConfigReverseRequest(t, s, activationMessage, activationResponse, nil)
+	commitMessage := nextConfigReverseRequest(t, outgoing, methodCommitConfigs)
+	respondToConfigReverseRequest(t, s, commitMessage, commitResponseForRequest(t, commitMessage, true), nil)
+	return loadRequest
+}
+
 func writeConfigCandidate(t *testing.T, root string) {
 	t.Helper()
 	if err := os.WriteFile(
@@ -259,6 +293,10 @@ func installLastGoodConfig(s *Server, root string) {
 	s.tsConfigPathsByConfig = map[string][]string{root: nil}
 	s.eslintPluginConfigGeneration = "last-good"
 	s.configDiscoveryHasLastGood = true
+	// Tests using this helper model a catalog committed by an earlier automatic
+	// initial refresh, then exercise a later config/dependency/watch refresh.
+	s.configRefreshInitialized = true
+	s.configRefreshConfigPath = ""
 }
 
 func TestHandleConfigRefreshCommitsFilesystemPathCatalog(t *testing.T) {
@@ -319,6 +357,214 @@ func TestHandleConfigRefreshCommitsFilesystemPathCatalog(t *testing.T) {
 	registered, ok := config.GlobalRuleRegistry.GetRule(pluginRuleName)
 	if !ok || !registered.IsEslintPluginRule {
 		t.Fatalf("plugin placeholder %q was not registered: %+v", pluginRuleName, registered)
+	}
+}
+
+func TestConfigRefreshRequestPreservesConfigPathPresence(t *testing.T) {
+	tests := []struct {
+		name        string
+		params      string
+		wantPresent bool
+		wantPath    string
+		wantError   bool
+	}{
+		{name: "absent", params: `{"protocolVersion":2,"reason":"initial"}`},
+		{name: "string", params: `{"protocolVersion":2,"reason":"initial","configPath":"/repo/custom.config.mjs"}`, wantPresent: true, wantPath: "/repo/custom.config.mjs"},
+		{name: "null", params: `{"protocolVersion":2,"reason":"initial","configPath":null}`, wantError: true},
+		{name: "number", params: `{"protocolVersion":2,"reason":"initial","configPath":42}`, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := []byte(`{"jsonrpc":"2.0","id":1,"method":"rslint/configRefresh","params":` + test.params + `}`)
+			var message lsproto.Message
+			if err := json.Unmarshal(data, &message); err != nil {
+				t.Fatalf("unmarshal request: %v", err)
+			}
+			request, err := decodeParams[configRefreshRequest](message.AsRequest())
+			if test.wantError {
+				if err == nil {
+					t.Fatal("invalid configPath decoded successfully")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decode configRefresh: %v", err)
+			}
+			if request.ConfigPath.Present != test.wantPresent || request.ConfigPath.Value != test.wantPath {
+				t.Fatalf("decoded configPath = %+v", request.ConfigPath)
+			}
+		})
+	}
+}
+
+func TestNormalizeLSPExplicitConfigPath(t *testing.T) {
+	root := t.TempDir()
+	for _, extension := range []string{".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"} {
+		configPath := filepath.Join(root, "custom.config"+extension)
+		if got, err := normalizeLSPExplicitConfigPath(configPath); err != nil || got != tspath.NormalizePath(configPath) {
+			t.Fatalf("normalize %q = %q, %v", configPath, got, err)
+		}
+	}
+	for _, configPath := range []string{
+		"",
+		"relative.config.mjs",
+		"file:///repo/custom.config.mjs",
+		filepath.Join(root, "rslint.jsonc"),
+		filepath.Join(root, "custom.config.MJS"),
+		filepath.Join(root, "custom.config.mjs") + "\x00suffix",
+	} {
+		if _, err := normalizeLSPExplicitConfigPath(configPath); err == nil {
+			t.Fatalf("invalid configPath %q was accepted", configPath)
+		}
+	}
+}
+
+func TestHandleConfigRefreshRequiresInitialBeforeMutation(t *testing.T) {
+	s, _, _ := newConfigRefreshTestServer(t)
+	_, err := s.handleConfigRefresh(context.Background(), configRefreshRequest{
+		ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
+		Reason:          "config-change",
+	})
+	if err == nil || !errors.Is(err, lsproto.ErrorCodeInvalidParams) {
+		t.Fatalf("configRefresh error = %v, want InvalidParams", err)
+	}
+	if s.configRefreshInitialized || s.configDiscoveryActive {
+		t.Fatal("non-initial refresh mutated config source state")
+	}
+}
+
+func TestHandleConfigRefreshUsesFixedExplicitConfig(t *testing.T) {
+	config.RegisterAllRules()
+	s, outgoing, root := newConfigRefreshTestServer(t)
+	writeConfigCandidate(t, root)
+	if err := os.WriteFile(filepath.Join(root, "rslint.jsonc"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	externalRoot := t.TempDir()
+	configPath := filepath.Join(externalRoot, "generated-rstack-config.cjs")
+	if err := os.WriteFile(configPath, []byte("module.exports = [];\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := startExplicitConfigRefreshForTest(s, "initial", configPath)
+	loadRequest := completeSuccessfulConfigRefreshForTest(t, s, outgoing, config.RslintConfig{{
+		Rules: config.Rules{"no-debugger": "error"},
+	}})
+	if completed := awaitConfigRefreshResult(t, initial); completed.err != nil {
+		t.Fatalf("explicit initial refresh failed: %v", completed.err)
+	}
+	if len(loadRequest.Candidates) != 1 || loadRequest.Candidates[0].ConfigPath != tspath.NormalizePath(configPath) {
+		t.Fatalf("explicit candidates = %+v, want only %q", loadRequest.Candidates, configPath)
+	}
+	if loadRequest.Candidates[0].ConfigDirectory != root {
+		t.Fatalf("explicit configDirectory = %q, want cwd %q", loadRequest.Candidates[0].ConfigDirectory, root)
+	}
+	if !s.configRefreshInitialized || s.configRefreshConfigPath != tspath.NormalizePath(configPath) {
+		t.Fatalf("fixed config path = %q, initialized=%t", s.configRefreshConfigPath, s.configRefreshInitialized)
+	}
+	if s.rslintConfigPath != "" || len(s.jsonConfig) != 0 {
+		t.Fatalf("explicit config retained JSON fallback: path=%q config=%+v", s.rslintConfigPath, s.jsonConfig)
+	}
+	if value, found := configRuleValue(s.jsConfigs[root], "no-debugger"); !found || value != "error" {
+		t.Fatalf("explicit config was not committed at cwd: %+v", s.jsConfigs)
+	}
+
+	reload := startExplicitConfigRefreshForTest(s, "config-change", configPath)
+	reloadRequest := completeSuccessfulConfigRefreshForTest(t, s, outgoing, config.RslintConfig{{
+		Rules: config.Rules{"no-console": "error"},
+	}})
+	if completed := awaitConfigRefreshResult(t, reload); completed.err != nil {
+		t.Fatalf("same-path refresh failed: %v", completed.err)
+	}
+	if len(reloadRequest.Candidates) != 1 || reloadRequest.Candidates[0].ConfigPath != tspath.NormalizePath(configPath) {
+		t.Fatalf("same-path candidates = %+v", reloadRequest.Candidates)
+	}
+
+	gitignorePath := filepath.Join(root, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte("generated/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	watchResult := make(chan error, 1)
+	go func() {
+		watchResult <- s.handleDidChangeWatchedFiles(context.Background(), &lsproto.DidChangeWatchedFilesParams{
+			Changes: []*lsproto.FileEvent{{
+				Uri:  documentURIFromPath(gitignorePath),
+				Type: lsproto.FileChangeTypeChanged,
+			}},
+		})
+	}()
+	watchRequest := completeSuccessfulConfigRefreshForTest(t, s, outgoing, config.RslintConfig{{
+		Rules: config.Rules{"no-console": "error"},
+	}})
+	if err := <-watchResult; err != nil {
+		t.Fatalf("explicit .gitignore refresh failed: %v", err)
+	}
+	if len(watchRequest.Candidates) != 1 || watchRequest.Candidates[0].ConfigPath != tspath.NormalizePath(configPath) {
+		t.Fatalf("explicit watcher candidates = %+v", watchRequest.Candidates)
+	}
+
+	for _, request := range []configRefreshRequest{
+		{ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion, Reason: "config-change"},
+		{
+			ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
+			Reason:          "config-change",
+			ConfigPath: optionalConfigRefreshPath{
+				Value:   filepath.Join(externalRoot, "other.config.cjs"),
+				Present: true,
+			},
+		},
+	} {
+		if _, err := s.handleConfigRefresh(context.Background(), request); err == nil || !errors.Is(err, lsproto.ErrorCodeInvalidParams) {
+			t.Fatalf("changed selection error = %v, want InvalidParams", err)
+		}
+	}
+	select {
+	case message := <-outgoing:
+		t.Fatalf("rejected selection started reverse request: %+v", message)
+	default:
+	}
+}
+
+func TestHandleConfigRefreshKeepsExplicitPathAfterInitialLoadFailure(t *testing.T) {
+	config.RegisterAllRules()
+	s, outgoing, root := newConfigRefreshTestServer(t)
+	configPath := filepath.Join(t.TempDir(), "generated-rstack-config.mjs")
+	if err := os.WriteFile(configPath, []byte("export default [];\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := startExplicitConfigRefreshForTest(s, "initial", configPath)
+	loadMessage := nextConfigReverseRequest(t, outgoing, methodLoadConfigs)
+	loadRequest, loadResponse := failedConfigResponse(t, loadMessage, "synthetic explicit load failure")
+	respondToConfigReverseRequest(t, s, loadMessage, loadResponse, nil)
+	activationMessage := nextConfigReverseRequest(t, outgoing, methodActivateConfigs)
+	_, activationResponse := activationResponseForRequest(t, activationMessage, true)
+	respondToConfigReverseRequest(t, s, activationMessage, activationResponse, nil)
+	commitMessage := nextConfigReverseRequest(t, outgoing, methodCommitConfigs)
+	respondToConfigReverseRequest(t, s, commitMessage, commitResponseForRequest(t, commitMessage, true), nil)
+	completed := awaitConfigRefreshResult(t, initial)
+	if completed.err != nil {
+		t.Fatalf("initial explicit failure stopped the LSP: %v", completed.err)
+	}
+	if completed.response.TransactionID != loadRequest.TransactionID {
+		t.Fatalf("explicit recovery response = %+v", completed.response)
+	}
+	if s.configRefreshConfigPath != tspath.NormalizePath(configPath) || !s.configRefreshInitialized {
+		t.Fatalf("failed initial load lost fixed path: path=%q initialized=%t", s.configRefreshConfigPath, s.configRefreshInitialized)
+	}
+	if _, unavailable := s.jsUnavailableConfigs[root]; !unavailable || s.configDiscoveryHasLastGood {
+		t.Fatalf("explicit failure state: unavailable=%t lastGood=%t", unavailable, s.configDiscoveryHasLastGood)
+	}
+	if _, err := s.handleConfigRefresh(context.Background(), configRefreshRequest{
+		ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
+		Reason:          "config-change",
+	}); err == nil || !errors.Is(err, lsproto.ErrorCodeInvalidParams) {
+		t.Fatalf("explicit path omission error = %v, want InvalidParams", err)
+	}
+	select {
+	case message := <-outgoing:
+		t.Fatalf("omitted explicit path started reverse request: %+v", message)
+	default:
 	}
 }
 
@@ -1158,9 +1404,9 @@ func TestConfigRefreshProtocolRegistration(t *testing.T) {
 func TestHandleConfigRefreshRejectsInvalidProtocolWithoutMutation(t *testing.T) {
 	s := newTestServer()
 	s.eslintPluginConfigGeneration = "last-good"
-	_, err := s.handleConfigRefresh(context.Background(), map[string]any{
-		"protocolVersion": discovery.ConfigDiscoveryProtocolVersion + 1,
-		"reason":          "initial",
+	_, err := s.handleConfigRefresh(context.Background(), configRefreshRequest{
+		ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion + 1,
+		Reason:          "initial",
 	})
 	if err == nil || !strings.Contains(err.Error(), "unsupported config refresh protocol") {
 		t.Fatalf("configRefresh error = %v", err)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -180,6 +180,12 @@ type Server struct {
 	// extension remains the sole refresh owner for workspace/descendant JS and
 	// JSON changes.
 	configDiscoveryActive bool
+	// configRefreshInitialized records that the client has chosen this process's
+	// invocation-wide config source. configRefreshConfigPath is empty for
+	// automatic discovery and otherwise contains one immutable normalized
+	// explicit JS/TS config path. Changing that choice requires a new process.
+	configRefreshInitialized bool
+	configRefreshConfigPath  string
 	// configDiscoveryHasLastGood distinguishes a committed catalog with at
 	// least one usable JS config from an empty catalog or the synthetic
 	// unavailable boundaries used to keep LSP alive when every JS config is

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -311,7 +311,8 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, params *lsprot
 			needsAncestorJSConfigRefresh = true
 		}
 	}
-	if (needsIgnoreRefresh || needsAncestorJSConfigRefresh) && s.configDiscoveryActive {
+	needsAutomaticAncestorRefresh := needsAncestorJSConfigRefresh && s.configRefreshConfigPath == ""
+	if (needsIgnoreRefresh || needsAutomaticAncestorRefresh) && s.configDiscoveryActive {
 		// didChangeWatchedFiles and configRefresh are both blocking methods, so
 		// this direct call stays on the server's serialized dispatch loop and
 		// cannot race an extension-initiated transaction. JSON fallback is part
@@ -319,13 +320,10 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, params *lsprot
 		// active, otherwise a later JS activation failure could leave half of a
 		// rejected generation live.
 		reason := "gitignore-change"
-		if needsAncestorJSConfigRefresh {
+		if needsAutomaticAncestorRefresh {
 			reason = "config-change"
 		}
-		_, err := s.handleConfigRefresh(ctx, configRefreshRequest{
-			ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
-			Reason:          reason,
-		})
+		_, err := s.refreshConfig(ctx)
 		if err == nil {
 			return nil
 		}

--- a/packages/rslint/src/config/config-discovery-protocol.ts
+++ b/packages/rslint/src/config/config-discovery-protocol.ts
@@ -11,7 +11,7 @@
  * transport boundary.
  */
 
-export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 1 as const;
+export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 2 as const;
 
 export type ConfigModuleLoadMode = 'cached' | 'fresh';
 

--- a/packages/rslint/tests/fixtures/fake-config-activation-race.cjs
+++ b/packages/rslint/tests/fixtures/fake-config-activation-race.cjs
@@ -26,7 +26,7 @@ function onMessage(msg) {
       kind: 'loadConfigs',
       id: 200,
       data: {
-        protocolVersion: 1,
+        protocolVersion: 2,
         transactionId: 'cli-prepare-race',
         loadMode: 'cached',
         candidates: [
@@ -45,7 +45,7 @@ function onMessage(msg) {
       kind: 'activateConfigs',
       id: 201,
       data: {
-        protocolVersion: 1,
+        protocolVersion: 2,
         transactionId: 'cli-prepare-race',
         effectiveConfigIds: ['root'],
       },

--- a/packages/rslint/tests/fixtures/fake-exit-during-config-activation.cjs
+++ b/packages/rslint/tests/fixtures/fake-exit-during-config-activation.cjs
@@ -42,7 +42,7 @@ function onMessage(message) {
       kind: 'loadConfigs',
       id: 300,
       data: {
-        protocolVersion: 1,
+        protocolVersion: 2,
         transactionId: 'cli-exit-during-prepare',
         loadMode: 'cached',
         candidates: [
@@ -61,7 +61,7 @@ function onMessage(message) {
       kind: 'activateConfigs',
       id: 301,
       data: {
-        protocolVersion: 1,
+        protocolVersion: 2,
         transactionId: 'cli-exit-during-prepare',
         effectiveConfigIds: ['root'],
       },

--- a/packages/vscode-extension/__tests__/suite-jsconfig/core-resolver.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/core-resolver.test.ts
@@ -105,7 +105,7 @@ suite('local core resolver', () => {
       fs.writeFile(
         path.join(packageDirectory, 'config-loader.js'),
         [
-          'export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 1;',
+          'export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 2;',
           'export class ConfigModuleHost {}',
           `export function resolveRslintBinary() { return ${JSON.stringify(binaryPath)}; }`,
         ].join('\n'),

--- a/packages/vscode-extension/__tests__/suite-jsconfig/runtime-manager.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/runtime-manager.test.ts
@@ -45,7 +45,7 @@ class FakeResolver implements RuntimeCoreResolver {
       packageDirectory: `/core/${identity}`,
       version: identity,
       binaryPath: `/core/${identity}/rslint`,
-      protocolVersion: 1,
+      protocolVersion: 2,
     } as CoreInstallation;
     return {
       key: `${workspaceFolder.uri}\0${identity}`,

--- a/packages/vscode-extension/src/Rslint.ts
+++ b/packages/vscode-extension/src/Rslint.ts
@@ -62,6 +62,8 @@ export type ConfigRefreshReason =
 interface ConfigRefreshRequest {
   protocolVersion: number;
   reason: ConfigRefreshReason;
+  /** Absolute JS/TS config module path; this client omits it for automatic discovery. */
+  configPath?: string;
 }
 
 export type ConfigRefreshRequester = (


### PR DESCRIPTION
## Summary

Support a client-specified absolute JS/TS config path through the LSP config refresh protocol while preserving automatic discovery when omitted.

For rstack integration:

1. Generate the rslint config shim, such as dist/rslintConfig.js.
2. Send its absolute path in the initial refresh request:

    {
      "protocolVersion": 2,
      "reason": "initial",
      "configPath": "/absolute/path/to/dist/rslintConfig.js"
    }

3. Repeat the same configPath for config-change or dependency-change refreshes and after regenerating the shim.
4. After the language server restarts, send another initial request with the same path. Omit configPath to retain normal automatic discovery.

## Related Links

- Related issue: #1534

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).