### PR TITLE
perf: optimize curly hot paths

### DIFF
--- a/internal/rules/curly/curly.go
+++ b/internal/rules/curly/curly.go
@@ -54,6 +54,10 @@ func parseOptions(options any) curlyOptions {
 	return opts
 }
 
+func (o curlyOptions) allMode() bool {
+	return !o.multiOnly && !o.multiLine && !o.multiOrNest
+}
+
 // expectation is a tri-state mirroring ESLint's `expected` (true / false / null).
 type expectation int
 
@@ -89,11 +93,27 @@ var CurlyRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		c := &curlyChecker{
-			ctx:     ctx,
-			sf:      ctx.SourceFile,
-			text:    ctx.SourceFile.Text(),
-			lineMap: ctx.SourceFile.ECMALineMap(),
-			opts:    parseOptions(options),
+			ctx:  ctx,
+			sf:   ctx.SourceFile,
+			text: ctx.SourceFile.Text(),
+			opts: parseOptions(options),
+		}
+
+		// The default/"all" mode only checks whether each body is a block. Keep
+		// it off the multi-mode path, which also inspects statements, tokens,
+		// comments, and lines. "all" plus "consistent" has the same semantics.
+		if c.opts.allMode() {
+			// Reuse one bound listener so setup does not allocate one closure per
+			// supported statement kind on every file.
+			listener := c.checkAllStatement
+			return rule.RuleListeners{
+				ast.KindIfStatement:    listener,
+				ast.KindWhileStatement: listener,
+				ast.KindDoStatement:    listener,
+				ast.KindForStatement:   listener,
+				ast.KindForInStatement: listener,
+				ast.KindForOfStatement: listener,
+			}
 		}
 
 		return rule.RuleListeners{
@@ -117,7 +137,53 @@ var CurlyRule = rule.Rule{
 	},
 }
 
+func (c *curlyChecker) checkAllStatement(node *ast.Node) {
+	switch node.Kind {
+	case ast.KindIfStatement:
+		c.checkAllIfStatement(node)
+	case ast.KindWhileStatement:
+		c.checkAllBody(node.AsWhileStatement().Statement, "while", true)
+	case ast.KindDoStatement:
+		c.checkAllBody(node.AsDoStatement().Statement, "do", false)
+	case ast.KindForStatement:
+		c.checkAllBody(node.AsForStatement().Statement, "for", true)
+	case ast.KindForInStatement:
+		c.checkAllBody(node.AsForInOrOfStatement().Statement, "for-in", false)
+	case ast.KindForOfStatement:
+		c.checkAllBody(node.AsForInOrOfStatement().Statement, "for-of", false)
+	}
+}
+
+func (c *curlyChecker) checkAllIfStatement(node *ast.Node) {
+	parent := node.Parent
+	isElseIf := parent != nil && parent.Kind == ast.KindIfStatement &&
+		parent.AsIfStatement().ElseStatement == node
+	if isElseIf {
+		return
+	}
+
+	for current := node; current != nil; current = current.AsIfStatement().ElseStatement {
+		ifStmt := current.AsIfStatement()
+		c.checkAllBody(ifStmt.ThenStatement, "if", true)
+		alt := ifStmt.ElseStatement
+		if alt != nil && alt.Kind != ast.KindIfStatement {
+			c.checkAllBody(alt, "else", false)
+			break
+		}
+	}
+}
+
+func (c *curlyChecker) checkAllBody(body *ast.Node, name string, condition bool) {
+	if body.Kind == ast.KindBlock {
+		return
+	}
+	c.reportMissingBraces(body, name, condition)
+}
+
 func (c *curlyChecker) lineOf(pos int) int {
+	if c.lineMap == nil {
+		c.lineMap = c.sf.ECMALineMap()
+	}
 	return scanner.ComputeLineOfPosition(c.lineMap, pos)
 }
 
@@ -130,13 +196,27 @@ func (c *curlyChecker) checkIfStatement(node *ast.Node) {
 	if isElseIf {
 		return
 	}
-	for _, pc := range c.prepareIfChecks(node) {
+
+	if !c.opts.consistent {
+		for current := node; current != nil; current = current.AsIfStatement().ElseStatement {
+			ifStmt := current.AsIfStatement()
+			c.check(c.prepareCheck(current, ifStmt.ThenStatement, "if", true))
+			alt := ifStmt.ElseStatement
+			if alt != nil && alt.Kind != ast.KindIfStatement {
+				c.check(c.prepareCheck(current, alt, "else", false))
+				break
+			}
+		}
+		return
+	}
+
+	for _, pc := range c.prepareConsistentIfChecks(node) {
 		c.check(pc)
 	}
 }
 
-func (c *curlyChecker) prepareIfChecks(node *ast.Node) []preparedCheck {
-	checks := []preparedCheck{}
+func (c *curlyChecker) prepareConsistentIfChecks(node *ast.Node) []preparedCheck {
+	checks := make([]preparedCheck, 0, 2)
 
 	for current := node; current != nil; current = current.AsIfStatement().ElseStatement {
 		ifStmt := current.AsIfStatement()
@@ -148,31 +228,29 @@ func (c *curlyChecker) prepareIfChecks(node *ast.Node) []preparedCheck {
 		}
 	}
 
-	if c.opts.consistent {
-		// If any node should have, or already has, braces then they all must.
-		anyExpected := false
-		for _, pc := range checks {
-			var v bool
-			switch pc.expected {
-			case expectBraces:
-				v = true
-			case expectNoBraces:
-				v = false
-			default:
-				v = pc.actual
-			}
-			if v {
-				anyExpected = true
-				break
-			}
+	// If any node should have, or already has, braces then they all must.
+	anyExpected := false
+	for _, pc := range checks {
+		var v bool
+		switch pc.expected {
+		case expectBraces:
+			v = true
+		case expectNoBraces:
+			v = false
+		default:
+			v = pc.actual
 		}
-		target := expectNoBraces
-		if anyExpected {
-			target = expectBraces
+		if v {
+			anyExpected = true
+			break
 		}
-		for i := range checks {
-			checks[i].expected = target
-		}
+	}
+	target := expectNoBraces
+	if anyExpected {
+		target = expectBraces
+	}
+	for i := range checks {
+		checks[i].expected = target
 	}
 
 	return checks
@@ -232,24 +310,35 @@ func (c *curlyChecker) check(pc preparedCheck) {
 		return
 	}
 
-	bodyRange := utils.TrimNodeTextRange(c.sf, pc.body)
-
 	if wantBraces {
-		fixText := "{" + c.text[bodyRange.Pos():bodyRange.End()] + "}"
-		c.ctx.ReportRangeWithFixes(
-			bodyRange,
-			c.message(true, pc.condition, pc.name),
-			rule.RuleFixReplaceRange(bodyRange, fixText),
-		)
+		c.reportMissingBraces(pc.body, pc.name, pc.condition)
 		return
 	}
 
 	// Unnecessary braces: body is a block statement.
-	if fix, ok := c.buildRemoveBracesFix(pc.node, pc.body, bodyRange); ok {
-		c.ctx.ReportRangeWithFixes(bodyRange, c.message(false, pc.condition, pc.name), fix)
-	} else {
-		c.ctx.ReportRange(bodyRange, c.message(false, pc.condition, pc.name))
-	}
+	bodyRange := utils.TrimNodeTextRange(c.sf, pc.body)
+	c.ctx.ReportRangeWithDeferredFixes(
+		bodyRange,
+		c.message(false, pc.condition, pc.name),
+		func() []rule.RuleFix {
+			if fix, ok := c.buildRemoveBracesFix(pc.node, pc.body, bodyRange); ok {
+				return []rule.RuleFix{fix}
+			}
+			return nil
+		},
+	)
+}
+
+func (c *curlyChecker) reportMissingBraces(body *ast.Node, name string, condition bool) {
+	bodyRange := utils.TrimNodeTextRange(c.sf, body)
+	c.ctx.ReportRangeWithDeferredFixes(
+		bodyRange,
+		c.message(true, condition, name),
+		func() []rule.RuleFix {
+			fixText := "{" + c.text[bodyRange.Pos():bodyRange.End()] + "}"
+			return []rule.RuleFix{rule.RuleFixReplaceRange(bodyRange, fixText)}
+		},
+	)
 }
 
 func (c *curlyChecker) message(missing, condition bool, name string) rule.RuleMessage {

--- a/internal/rules/curly/curly_extras_test.go
+++ b/internal/rules/curly/curly_extras_test.go
@@ -19,9 +19,15 @@
 package curly
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -85,6 +91,8 @@ func TestCurlyExtras(t *testing.T) {
 			// (no native rule does), so invalid combos degrade instead of erroring.
 			// `["consistent"]` alone has no multi* mode → behaves like "all". ----
 			{Code: "if (a) { b() }", Options: []interface{}{"consistent"}},
+			// Explicit "all" + "consistent" is also just "all".
+			{Code: "if (a) { b() } else { c() }", Options: []interface{}{"all", "consistent"}},
 			// Unknown 2nd option is ignored → behaves like plain "multi".
 			{Code: "if (a) b()", Options: []interface{}{"multi", "foo"}},
 
@@ -126,6 +134,15 @@ func TestCurlyExtras(t *testing.T) {
 			{Code: "do { f(); g(); } while (x)", Options: "multi"},
 		},
 		[]rule_tester.InvalidTestCase{
+			{
+				Code:    "if (a) b(); else c();",
+				Output:  []string{"if (a) {b();} else {c();}"},
+				Options: []interface{}{"all", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 18, EndLine: 1, EndColumn: 22},
+				},
+			},
 			// ---- Real-user/tsgo: as-cast body, braces unnecessary under multi ----
 			{
 				Code:    "if (foo) { x = y as Foo; }",
@@ -661,4 +678,80 @@ func TestCurlyExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 17}}},
 		},
 	)
+}
+
+func TestCurlyEditDemandPreservesDiagnostics(t *testing.T) {
+	testCases := []struct {
+		name        string
+		code        string
+		options     []any
+		wantAutofix bool
+		wantFixText string
+	}{
+		{
+			name:        "missing braces",
+			code:        "if (condition) action();",
+			wantAutofix: true,
+			wantFixText: "{action();}",
+		},
+		{
+			name:        "removable braces",
+			code:        "if (condition) { action(); }",
+			options:     []any{"multi"},
+			wantAutofix: true,
+			wantFixText: " action(); ",
+		},
+		{
+			name:    "unsafe brace removal",
+			code:    "if (condition) { action() } next()",
+			options: []any{"multi"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/curly-edit-demand.ts",
+				Path:     tspath.Path("/curly-edit-demand.ts"),
+			}, testCase.code, core.ScriptKindTS)
+
+			run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+				comments := rule.NewCommentStore(sourceFile)
+				var diagnostics []rule.RuleDiagnostic
+				ctx := rule.RuleContext{
+					SourceFile:     sourceFile,
+					Comments:       comments,
+					DisableManager: rule.NewDisableManager(sourceFile, comments),
+				}.WithDiagnosticConsumer(CurlyRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+					Demand: demand,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				})
+
+				statement := sourceFile.Statements.Nodes[0]
+				CurlyRule.Run(ctx, testCase.options)[statement.Kind](statement)
+				if len(diagnostics) != 1 {
+					t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+				}
+				return diagnostics[0]
+			}
+
+			diagnosticOnly := run(rule.EditDemandNone)
+			withAutofix := run(rule.EditDemandAutofix)
+			if diagnosticOnly.Range != withAutofix.Range ||
+				!reflect.DeepEqual(diagnosticOnly.Message, withAutofix.Message) {
+				t.Fatalf("diagnostic changed with edit demand: without=%#v with=%#v", diagnosticOnly, withAutofix)
+			}
+			if diagnosticOnly.FixesPtr != nil {
+				t.Fatalf("diagnostics-only consumer received fixes: %#v", diagnosticOnly.Fixes())
+			}
+			if got := len(withAutofix.Fixes()); (got != 0) != testCase.wantAutofix {
+				t.Fatalf("autofix count = %d, want autofix %v", got, testCase.wantAutofix)
+			}
+			if testCase.wantAutofix && withAutofix.Fixes()[0].Text != testCase.wantFixText {
+				t.Fatalf("fix text = %q, want %q", withAutofix.Fixes()[0].Text, testCase.wantFixText)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Add a fast path for the default `all` mode that avoids preparing temporary checks for every matched statement.
- Reuse one listener, initialize the line map lazily, and defer fix text/ASI work until fixes are requested.
- Keep the optimization inside the `curly` rule and preserve existing option, diagnostic, and autofix behavior.

### Performance

Go benchmarks used a parsed synthetic TypeScript workload, `-benchtime=1s -count=10 -cpu=1`:

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| Default mode, valid source | 26.049 us/op | 5.426 us/op | -79.17% |
| Missing braces, diagnostics only | 234.0 us/op | 178.8 us/op | -23.58% |
| Missing braces, autofix | 234.1 us/op | 217.1 us/op | -7.28% |
| Removable blocks, diagnostics only | 391.8 us/op | 172.7 us/op | -55.93% |

On the default valid path, allocations fell from 201 to 4 allocs/op and from 22,016 to 432 B/op.

The real-repository benchmark used the VS Code 1.128.0 workload, 10,501 files, and the native JavaScript config:

| Listener attribution | Before | After | Change |
| --- | ---: | ---: | ---: |
| Full 27-rule config | 183.7 ms | 6.5 ms | -96.46% |
| Per file | 17.494 us | 0.619 us | -96.46% |

The before value is the handoff document's full-config attribution baseline. A separate after-only single-rule run reported 6.7 ms listener time and `5.510 +/- 0.086 s` hyperfine wall time across 10 runs (min 5.362 s, max 5.630 s). Since there is no before hyperfine result, no wall-time improvement is claimed.

### Validation

- `go test ./internal/rules/curly -count=3`
- `go test -race ./internal/rules/curly -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/rules/curly/...`

The real-repository full and single-rule runs both linted 10,501 files with zero diagnostics.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
