### PR TITLE
perf: share prepared lint plans

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -916,8 +916,8 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
 4. **Lint Target Plan**: Go resolves a stable target set from CLI/API scope, the implicit default baseline, explicit config `files`, global ignores, and `.gitignore`
 5. **Program Registry**: plain lint builds each normalized tsconfig path declared by an active governing config once; `--type-check` and `--type-check-only` instead retain every project declared by the effective loaded config catalog. Shared declared paths preserve each active config association and declaration order. Planning fixes those identities and stable slots serially, then independent Programs fill the slots through a bounded worker pool.
 6. **Program Binding**: each target is bound by exact lexical or canonical filesystem identity to the first containing Program declared by its governing config; unbound targets, including projects with no tsconfig, are parsed through a non-project-backed fallback Program
-7. **Rule Resolution**: `getRulesForFile` resolves enabled rules from the stable lint-target path, never the Program source alias, and filters type-aware rules off no-type-info gap files
-8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. The CLI supplies a native edit demand independently of rule selection: diagnostics-only for plain lint, autofix-only for writable `--fix` passes, and diagnostics-only for the final verification pass. When `--type-check` is enabled, a separate program-wide pass over real tsconfig Programs aggregates `tsc --noEmit`-aligned diagnostics through `collectNoEmitDiagnostics()`
+7. **Rule Plan Preparation**: `PrepareLintPlan()` retains every selected file by Program and resolves each eligible file's complete rule set once from the stable lint-target path, never the Program source alias. The immutable result preserves syntax-error and zero-rule files for native accounting while exposing the non-empty file/rule projection needed by third-party plugin dispatch. CLI and native API reuse the same plan for plugin and native execution; LSP keeps its single-document `LintSingleFile` path.
+8. **Rule Execution**: `RunLinter()` schedules per-Program work over the prepared plan; the unexported `runLintRulesInProgram()` retains the existing TypeChecker-exclusive grouping and filters the native subset without resolving rules again. The CLI supplies a native edit demand independently of rule selection: diagnostics-only for plain lint, autofix-only for writable `--fix` passes, and diagnostics-only for the final verification pass. When `--type-check` is enabled, a separate program-wide pass over real tsconfig Programs aggregates `tsc --noEmit`-aligned diagnostics through `collectNoEmitDiagnostics()`
 9. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
 10. **Fix Passes**: CLI multi-pass `--fix` applies fixes, rebuilds real Programs, and rebinds the unchanged target plan after each pass; a file may move between a real Program and fallback as its import graph changes
 11. **Report Assembly**: the CLI builds one output report from the final post-fix diagnostics plus run metadata. Diagnostics carry an explicit lint or TypeScript origin, and the report computes error/warning/type-error counts once so the summary and exit policy use the same values; `--quiet` filters rendering only.
@@ -931,16 +931,21 @@ The main Go workload work groups and pools below honor `--singleThreaded`.
 The flag serializes these workload stages, but IPC transport, diagnostic
 collection, and plugin dispatch may still use infrastructure goroutines.
 
-1. **Linter work group** (`RunLinter()` via `core.NewWorkGroup`)
+1. **Lint-plan work group** (`PrepareLintPlan()` via `core.NewWorkGroup`)
+   - Resolves per-file rules into stable per-Program slots with at most
+     `min(GOMAXPROCS, selected file count)` workers.
+   - `--singleThreaded` resolves the same slots serially in Program/file order.
+
+2. **Linter work group** (`RunLinter()` via `core.NewWorkGroup`)
    - Schedules per-Program lint work; runs rules in parallel within a Program.
    - `--singleThreaded` collapses the work group to serial execution.
 
-2. **Type-check work group** (`runTypeCheckAcrossPrograms`)
+3. **Type-check work group** (`runTypeCheckAcrossPrograms`)
    - Schedules diagnostics for real tsconfig Programs and merges results in
      stable Program order.
    - `--singleThreaded` computes Program diagnostics serially.
 
-3. **Staged catalog discovery and Program creation**
+4. **Staged catalog discovery and Program creation**
    - A bounded Go worker pool scans one reachable sibling frontier at a time.
      Config-boundary nodes are suspended, batched after that frontier is
      processed, and resumed only after the Node result is merged.
@@ -966,7 +971,7 @@ collection, and plugin dispatch may still use infrastructure goroutines.
      worker and serializes module evaluation within each Node frontier batch.
      Coordinator batches and results remain ordered in either mode.
 
-4. **Lint-target directory walker** (`internal/config/file_discovery.go`)
+5. **Lint-target directory walker** (`internal/config/file_discovery.go`)
    - `DiscoverLintTargets` uses a fixed-size worker pool (`walkPool`) that
      walks the directory tree. `DiscoverLintFiles` is the path-only
      compatibility wrapper. Live goroutine count is capped at `workers`, not
@@ -985,7 +990,7 @@ collection, and plugin dispatch may still use infrastructure goroutines.
      scheduling-dependent non-determinism that a parallel walker would
      otherwise introduce.
 
-5. **Program source identity index** (`bindLintTargetPlan`)
+6. **Program source identity index** (`bindLintTargetPlan`)
    - Direct lexical Program lookups remain synchronous. The target identity
      maps are not allocated until one misses. The binder then builds the
      governing config's Program indexes in one canonicalization batch, reusing
@@ -1061,6 +1066,10 @@ goroutines remain outside that guarantee.
 - **Program-Level Parallelism**: configured Program construction uses a bounded, stable-slot worker pool, and `RunLinter` queues subsequent lint work per Program through `core.NewWorkGroup`; `--singleThreaded` forces both flows to run serially
 - **Single-Walk Rule Dispatch**: each file is traversed once, with rules registering listeners up front and sharing the same AST walk
 - **Early Filtering**: exact lint target plans, skip paths, global-ignore filters, and gap-file type filtering reduce work before listeners run
+- **Shared Prepared Lint Plan**: CLI and native API resolve each selected
+  file's complete rule set once into immutable per-Program slots. Native
+  execution and optional third-party plugin dispatch consume projections of the
+  same plan instead of repeating target collection or rule resolution
 
 ### Performance Optimizations
 
@@ -1084,9 +1093,9 @@ goroutines remain outside that guarantee.
 - **Exact Config-Shape Interning**: a `FileConfigResolver` parses global and
   entry-local ignores once, maps each exact file path to its complete matched
   flat-config entry bitset, and merges/prepares enabled rules once per unique
-  bitset. CLI/API native and third-party plugin collection can share the fully
-  published immutable plan. LSP keeps its existing per-document resolver
-  lifetime; per-file rule runtime state stays outside every plan.
+  bitset. The prepared lint plan references these published immutable rule
+  slices without moving per-file runtime state into the config cache. LSP keeps
+  its existing per-document resolver lifetime.
 
 ### Caching Strategy
 

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -606,8 +606,8 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		diagnosticCollector(diagnostic)
 	}
 
-	// Build one run descriptor shared by native lint and plugin target
-	// collection, keeping both paths on the exact same file/rule selection.
+	// Build one run descriptor and prepared plan shared by native lint and
+	// plugin dispatch, keeping both paths on the exact same file/rule selection.
 	runOpts := linter.RunLinterOptions{
 		Programs:       programs,
 		SingleThreaded: false, // Don't use single-threaded mode for IPC
@@ -672,6 +672,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			Report: diagnosticCollector,
 		},
 	}
+	runOpts.PreparedPlan = linter.PrepareLintPlan(runOpts)
 
 	// Metadata is the feature gate: without it there is no plugin target walk,
 	// goroutine, or reverse request. With metadata, dispatch starts before the
@@ -689,7 +690,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			}
 			pluginConfigDirByOwner = map[string]string{configDirectory: wireConfigDirectory}
 		}
-		pluginInputs := buildPluginFileInputs(runOpts, pluginConfigResolver{
+		pluginInputs := buildPluginFileInputs(runOpts.PreparedPlan, pluginConfigResolver{
 			lintResolver:           fileConfigResolver,
 			pluginConfigDirByOwner: pluginConfigDirByOwner,
 		})

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -984,19 +984,19 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			},
 		},
 	}
+	runOpts.PreparedPlan = linter.PrepareLintPlan(runOpts)
 	// Dispatch eslint-plugin rules to the Node worker in parallel with the
 	// native lint pass; results are awaited + merged before output / --fix.
 	// ONLY when plugins are actually configured — otherwise the whole reverse-
-	// dispatch (including buildPluginFileInputs' extra per-file rule resolution
-	// over every file) is skipped so the native-only path pays nothing for the
-	// feature.
+	// dispatch is skipped so the native-only path pays nothing for the feature.
+	// Both paths consume the same prepared file/rule plan.
 	hasEslintPlugins := len(eslintPlugins) > 0
 	pluginResolver := pluginConfigResolver{
 		lintResolver: fileConfigResolver,
 	}
 	var pluginCh <-chan []rule.RuleDiagnostic
 	if hasEslintPlugins {
-		pluginInputs := buildPluginFileInputs(runOpts, pluginResolver)
+		pluginInputs := buildPluginFileInputs(runOpts.PreparedPlan, pluginResolver)
 		pluginCh = dispatchPluginLintAsync(ctx, dispatch, pluginInputs, fix, pluginSuggestionsMode(fix), timingCollector)
 	}
 
@@ -1134,12 +1134,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 					},
 				},
 			}
+			fixRunOpts.PreparedPlan = linter.PrepareLintPlan(fixRunOpts)
 			// Re-dispatch plugin rules each pass (only when configured): the
 			// worker re-reads the post-fix file content, and merging here keeps
 			// plugin diagnostics from being lost when allDiags is replaced.
+			// Each pass prepares a fresh plan for the rebuilt target binding.
 			var fixPluginCh <-chan []rule.RuleDiagnostic
 			if hasEslintPlugins {
-				fixPluginInputs := buildPluginFileInputs(fixRunOpts, pluginConfigResolver{
+				fixPluginInputs := buildPluginFileInputs(fixRunOpts.PreparedPlan, pluginConfigResolver{
 					lintResolver: fixConfigResolver,
 				})
 				fixPluginCh = dispatchPluginLintAsync(ctx, dispatch, fixPluginInputs, fix, pluginSuggestionsMode(fix), timingCollector)

--- a/cmd/rslint/eslint_plugin.go
+++ b/cmd/rslint/eslint_plugin.go
@@ -40,13 +40,12 @@ func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *
 	return wireKey, resolver.ConfigForFile(configPath)
 }
 
-// buildPluginFileInputs collects, from RunLinter's lint targets, the files that
-// have eslint-plugin rules and assembles their dispatch inputs. It reuses
-// linter.CollectLintTargets so the dispatched file set matches the native pass
-// exactly, and reuses each target's already-loaded *ast.SourceFile as the
-// rebuild frame so Go never re-reads or re-decodes the file.
-func buildPluginFileInputs(runOpts linter.RunLinterOptions, resolver pluginConfigResolver) []linter.EslintPluginFileInput {
-	targets := linter.CollectLintTargets(runOpts)
+// buildPluginFileInputs projects third-party plugin inputs from the same
+// prepared file/rule plan consumed by native linting. Each target's already-
+// loaded *ast.SourceFile is reused as the rebuild frame, so Go never re-reads
+// or re-decodes the file.
+func buildPluginFileInputs(plan *linter.LintPlan, resolver pluginConfigResolver) []linter.EslintPluginFileInput {
+	targets := plan.Targets()
 	if len(targets) == 0 {
 		return nil
 	}

--- a/internal/linter/lint_plan.go
+++ b/internal/linter/lint_plan.go
@@ -1,0 +1,189 @@
+package linter
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// LintPlan is the immutable Phase 1 input shared by native lint execution and
+// host-side consumers such as third-party plugin dispatch. It preserves the
+// selected files per Program, including syntax-error and zero-rule files needed
+// for LintedFileCount, while resolving each eligible file's complete rule set
+// exactly once.
+type LintPlan struct {
+	programs []programLintPlan
+}
+
+type programLintPlan struct {
+	program *compiler.Program
+	files   []*ast.SourceFile
+	rules   [][]ConfiguredRule
+}
+
+type lintPlanFileRef struct {
+	programIndex int
+	fileIndex    int
+}
+
+// LintTarget is one non-syntax-error file paired with its non-empty configured
+// rule set. It is a projection of LintPlan for consumers that do not need
+// zero-rule files or per-Program execution metadata.
+type LintTarget struct {
+	File  *ast.SourceFile
+	Rules []ConfiguredRule
+}
+
+// PrepareLintPlan collects the Phase 1 target files and resolves their rules.
+// Rule resolution uses at most GOMAXPROCS workers unless SingleThreaded is set.
+// GetRulesForFile must therefore support concurrent calls whenever the caller
+// requests normal parallel execution, matching Consumer.Report's run-scoped
+// concurrency requirement.
+func PrepareLintPlan(opts RunLinterOptions) *LintPlan {
+	if opts.GetRulesForFile == nil {
+		return nil
+	}
+	if opts.ExcludePaths == nil {
+		opts.ExcludePaths = utils.ExcludePaths
+	}
+
+	plan := &LintPlan{programs: make([]programLintPlan, len(opts.Programs))}
+	programOpts := make([]runProgramOptions, len(opts.Programs))
+	totalFiles := 0
+	for programIndex := range opts.Programs {
+		programOpts[programIndex] = runProgramOptionsFor(opts, programIndex, nil)
+		plan.programs[programIndex] = newProgramLintPlan(programOpts[programIndex])
+		totalFiles += len(plan.programs[programIndex].files)
+	}
+
+	refs := make([]lintPlanFileRef, 0, totalFiles)
+	for programIndex, programPlan := range plan.programs {
+		for fileIndex := range programPlan.files {
+			refs = append(refs, lintPlanFileRef{
+				programIndex: programIndex,
+				fileIndex:    fileIndex,
+			})
+		}
+	}
+
+	resolve := func(ref lintPlanFileRef, ctx context.Context) {
+		programPlan := &plan.programs[ref.programIndex]
+		resolveProgramLintPlanFile(programOpts[ref.programIndex], programPlan, ref.fileIndex, ctx)
+	}
+
+	workerCount := min(runtime.GOMAXPROCS(0), len(refs))
+	if opts.SingleThreaded || workerCount < 2 {
+		ctx := context.Background()
+		for _, ref := range refs {
+			resolve(ref, ctx)
+		}
+		return plan
+	}
+
+	chunkSize := (len(refs) + workerCount - 1) / workerCount
+	work := core.NewWorkGroup(false)
+	for worker := range workerCount {
+		start := worker * chunkSize
+		end := min(start+chunkSize, len(refs))
+		if start >= end {
+			continue
+		}
+		chunk := refs[start:end]
+		work.Queue(func() {
+			ctx := context.Background()
+			for _, ref := range chunk {
+				resolve(ref, ctx)
+			}
+		})
+	}
+	work.RunAndWait()
+	return plan
+}
+
+func newProgramLintPlan(opts runProgramOptions) programLintPlan {
+	files := collectFilesToLint(opts)
+	return programLintPlan{
+		program: opts.Program,
+		files:   files,
+		rules:   make([][]ConfiguredRule, len(files)),
+	}
+}
+
+func prepareProgramLintPlan(opts runProgramOptions) programLintPlan {
+	plan := newProgramLintPlan(opts)
+	ctx := context.Background()
+	for fileIndex := range plan.files {
+		resolveProgramLintPlanFile(opts, &plan, fileIndex, ctx)
+	}
+	return plan
+}
+
+func resolveProgramLintPlanFile(opts runProgramOptions, plan *programLintPlan, fileIndex int, ctx context.Context) {
+	file := plan.files[fileIndex]
+	if shouldSkipRulesForSyntax(opts, file, ctx) {
+		return
+	}
+	plan.rules[fileIndex] = filterRulesForTypeInfo(
+		opts.GetRulesForFile(file),
+		file.FileName(),
+		opts.TypeInfoFiles,
+	)
+}
+
+// Targets returns the plan's plugin-facing projection in stable Program/file
+// order. The rule slices are shared immutable plan state and must be read-only.
+func (p *LintPlan) Targets() []LintTarget {
+	if p == nil {
+		return nil
+	}
+	var targets []LintTarget
+	for _, programPlan := range p.programs {
+		for fileIndex, file := range programPlan.files {
+			rules := programPlan.rules[fileIndex]
+			if len(rules) == 0 {
+				continue
+			}
+			targets = append(targets, LintTarget{File: file, Rules: rules})
+		}
+	}
+	return targets
+}
+
+func runProgramOptionsFor(opts RunLinterOptions, programIndex int, prepared *programLintPlan) runProgramOptions {
+	programOpts := runProgramOptions{
+		Program:              opts.Programs[programIndex],
+		Cwd:                  opts.Cwd,
+		ExcludePaths:         opts.ExcludePaths,
+		GetRulesForFile:      opts.GetRulesForFile,
+		CollectExecutedRules: true,
+		SyntaxErrorFiles:     opts.SyntaxErrorFiles,
+		SingleThreaded:       opts.SingleThreaded,
+		TypeInfoFiles:        opts.TypeInfoFiles,
+		Timing:               opts.Timing,
+		PreparedPlan:         prepared,
+	}
+	if prepared != nil {
+		return programOpts
+	}
+
+	if programIndex < len(opts.PerProgramFilter) {
+		programOpts.FileFilter = opts.PerProgramFilter[programIndex]
+	}
+	if opts.TargetFiles != nil {
+		programOpts.HasTargetFiles = true
+		if programIndex < len(opts.TargetFiles) {
+			programOpts.TargetFiles = opts.TargetFiles[programIndex]
+		}
+	} else {
+		programOpts.Scope = opts.Scope
+		programOpts.FileFilter = composeOwnedFilter(
+			programOpts.FileFilter,
+			buildOwnedFileSet(programOpts.Program),
+		)
+	}
+	return programOpts
+}

--- a/internal/linter/lint_plan_test.go
+++ b/internal/linter/lint_plan_test.go
@@ -1,0 +1,234 @@
+package linter
+
+import (
+	"reflect"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func TestPreparedLintPlanPreservesNativeSemanticsAndIsReused(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts":    "const a = 1;",
+		"bad.ts":  "const bad = 1;",
+		"gap.ts":  "const gap = 1;",
+		"zero.ts": "const zero = 1;",
+	})
+	targets := [][]string{{paths["a.ts"], paths["bad.ts"], paths["gap.ts"], paths["zero.ts"]}}
+	syntaxErrorFiles := map[string]struct{}{paths["bad.ts"]: {}}
+	typeInfoFiles := map[string]struct{}{paths["a.ts"]: {}}
+
+	newRuleHandler := func(calls map[string]int) RuleHandler {
+		return func(file *ast.SourceFile) []ConfiguredRule {
+			calls[file.FileName()]++
+			switch file.FileName() {
+			case paths["a.ts"]:
+				rules := noopRule()
+				return append(rules, ConfiguredRule{
+					Name:               "community/plugin-rule",
+					Severity:           rule.SeverityWarning,
+					IsEslintPluginRule: true,
+				})
+			case paths["gap.ts"]:
+				typeAwareRule := noopRule()[0]
+				typeAwareRule.Name = "type-aware-rule"
+				typeAwareRule.RequiresTypeInfo = true
+				return []ConfiguredRule{typeAwareRule}
+			default:
+				return nil
+			}
+		}
+	}
+
+	directCalls := make(map[string]int)
+	directResult, err := RunLinter(RunLinterOptions{
+		Programs:         []*compiler.Program{program},
+		SingleThreaded:   true,
+		TargetFiles:      targets,
+		GetRulesForFile:  newRuleHandler(directCalls),
+		TypeInfoFiles:    typeInfoFiles,
+		SyntaxErrorFiles: syntaxErrorFiles,
+	})
+	if err != nil {
+		t.Fatalf("direct RunLinter failed: %v", err)
+	}
+
+	preparedCalls := make(map[string]int)
+	preparedOpts := RunLinterOptions{
+		Programs:         []*compiler.Program{program},
+		SingleThreaded:   true,
+		TargetFiles:      targets,
+		GetRulesForFile:  newRuleHandler(preparedCalls),
+		TypeInfoFiles:    typeInfoFiles,
+		SyntaxErrorFiles: syntaxErrorFiles,
+	}
+	preparedOpts.PreparedPlan = PrepareLintPlan(preparedOpts)
+	pluginTargets := preparedOpts.PreparedPlan.Targets()
+	if len(pluginTargets) != 1 || pluginTargets[0].File.FileName() != paths["a.ts"] {
+		t.Fatalf("prepared plugin projection = %+v, want only a.ts", pluginTargets)
+	}
+	if len(pluginTargets[0].Rules) != 2 {
+		t.Fatalf("prepared a.ts rules = %d, want native and plugin rules", len(pluginTargets[0].Rules))
+	}
+
+	preparedResult, err := RunLinter(preparedOpts)
+	if err != nil {
+		t.Fatalf("prepared RunLinter failed: %v", err)
+	}
+	if !reflect.DeepEqual(preparedResult, directResult) {
+		t.Fatalf("prepared result = %#v, direct result = %#v", preparedResult, directResult)
+	}
+	if preparedResult.LintedFileCount != 4 {
+		t.Fatalf("prepared LintedFileCount = %d, want syntax and zero-rule files included", preparedResult.LintedFileCount)
+	}
+	if _, ok := preparedResult.ExecutedRules["community/plugin-rule"]; !ok {
+		t.Fatal("prepared ExecutedRules omitted the configured plugin rule")
+	}
+	if _, ok := preparedResult.ExecutedRules["type-aware-rule"]; ok {
+		t.Fatal("prepared ExecutedRules retained a type-aware rule for a gap file")
+	}
+	if !reflect.DeepEqual(preparedCalls, directCalls) {
+		t.Fatalf("prepared callback calls = %v, direct callback calls = %v", preparedCalls, directCalls)
+	}
+	if preparedCalls[paths["a.ts"]] != 1 || preparedCalls[paths["gap.ts"]] != 1 || preparedCalls[paths["zero.ts"]] != 1 {
+		t.Fatalf("prepared callback should run exactly once per eligible file, got %v", preparedCalls)
+	}
+	if preparedCalls[paths["bad.ts"]] != 0 {
+		t.Fatalf("prepared callback ran for syntax-error file: %v", preparedCalls)
+	}
+}
+
+func TestPrepareLintPlanParallelizesRuleResolution(t *testing.T) {
+	previousProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(previousProcs)
+
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+		"b.ts": "const b = 1;",
+		"c.ts": "const c = 1;",
+		"d.ts": "const d = 1;",
+	})
+	release := make(chan struct{})
+	twoActive := make(chan struct{})
+	done := make(chan *LintPlan, 1)
+	var active atomic.Int32
+	var signaled atomic.Bool
+
+	opts := RunLinterOptions{
+		Programs:    []*compiler.Program{program},
+		TargetFiles: [][]string{{paths["a.ts"], paths["b.ts"], paths["c.ts"], paths["d.ts"]}},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			if active.Add(1) >= 2 && signaled.CompareAndSwap(false, true) {
+				close(twoActive)
+			}
+			<-release
+			active.Add(-1)
+			return noopRule()
+		},
+		SyntaxErrorFiles: map[string]struct{}{},
+	}
+	go func() {
+		done <- PrepareLintPlan(opts)
+	}()
+
+	select {
+	case <-twoActive:
+		close(release)
+	case <-time.After(5 * time.Second):
+		close(release)
+		<-done
+		t.Fatal("rule resolution did not overlap across workers")
+	}
+	if plan := <-done; len(plan.Targets()) != 4 {
+		t.Fatalf("prepared targets = %d, want 4", len(plan.Targets()))
+	}
+}
+
+func TestPrepareLintPlanHonorsSingleThreadedOrder(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+		"b.ts": "const b = 1;",
+		"c.ts": "const c = 1;",
+	})
+	wantOrder := []string{paths["c.ts"], paths["a.ts"], paths["b.ts"]}
+	var gotOrder []string
+	plan := PrepareLintPlan(RunLinterOptions{
+		Programs:         []*compiler.Program{program},
+		SingleThreaded:   true,
+		TargetFiles:      [][]string{wantOrder},
+		SyntaxErrorFiles: map[string]struct{}{},
+		GetRulesForFile: func(file *ast.SourceFile) []ConfiguredRule {
+			gotOrder = append(gotOrder, file.FileName())
+			return noopRule()
+		},
+	})
+	if !reflect.DeepEqual(gotOrder, wantOrder) {
+		t.Fatalf("single-threaded resolution order = %v, want %v", gotOrder, wantOrder)
+	}
+	if gotTargets := plan.Targets(); len(gotTargets) != len(wantOrder) {
+		t.Fatalf("single-threaded prepared targets = %d, want %d", len(gotTargets), len(wantOrder))
+	}
+}
+
+func TestPreparedLintPlanPreservesSameFileAcrossPrograms(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"shared.ts": "const shared = 1;",
+	})
+	calls := 0
+	opts := RunLinterOptions{
+		Programs:         []*compiler.Program{program, program},
+		SingleThreaded:   true,
+		TargetFiles:      [][]string{{paths["shared.ts"]}, {paths["shared.ts"]}},
+		SyntaxErrorFiles: map[string]struct{}{},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			calls++
+			return noopRule()
+		},
+	}
+	opts.PreparedPlan = PrepareLintPlan(opts)
+	if targets := opts.PreparedPlan.Targets(); len(targets) != 2 {
+		t.Fatalf("prepared targets = %d, want one entry per Program", len(targets))
+	}
+	result, err := RunLinter(opts)
+	if err != nil {
+		t.Fatalf("RunLinter failed: %v", err)
+	}
+	if result.LintedFileCount != 2 {
+		t.Fatalf("LintedFileCount = %d, want one count per Program", result.LintedFileCount)
+	}
+	if calls != 2 {
+		t.Fatalf("GetRulesForFile calls = %d, want one per Program and no execution-time repeats", calls)
+	}
+}
+
+func TestRunLinterRejectsPreparedPlanForDifferentProgram(t *testing.T) {
+	programA, pathsA := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+	})
+	programB, pathsB := createTestProgramWithFiles(t, map[string]string{
+		"b.ts": "const b = 1;",
+	})
+	plan := PrepareLintPlan(RunLinterOptions{
+		Programs:         []*compiler.Program{programA},
+		SingleThreaded:   true,
+		TargetFiles:      [][]string{{pathsA["a.ts"]}},
+		SyntaxErrorFiles: map[string]struct{}{},
+		GetRulesForFile:  func(*ast.SourceFile) []ConfiguredRule { return noopRule() },
+	})
+	_, err := RunLinter(RunLinterOptions{
+		Programs:         []*compiler.Program{programB},
+		SingleThreaded:   true,
+		TargetFiles:      [][]string{{pathsB["b.ts"]}},
+		SyntaxErrorFiles: map[string]struct{}{},
+		GetRulesForFile:  func(*ast.SourceFile) []ConfiguredRule { return noopRule() },
+		PreparedPlan:     plan,
+	})
+	if err == nil {
+		t.Fatal("RunLinter accepted a prepared plan bound to a different Program")
+	}
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -89,6 +88,9 @@ type runProgramOptions struct {
 	// Timing, when non-nil, receives per-rule execution timings. nil disables
 	// instrumentation entirely (listeners are registered unwrapped).
 	Timing *TimingCollector
+	// PreparedPlan supplies the already-collected files and resolved rules for
+	// this Program. nil preserves the direct collection/callback path.
+	PreparedPlan *programLintPlan
 }
 
 type programLintResult struct {
@@ -152,10 +154,12 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 		return programLintResult{}
 	}
 
-	// Collect files to lint (applying all filters). Shared with
-	// CollectLintTargets so the eslint-plugin dispatch path observes the
-	// exact same file set as native linting.
-	filesToLint := collectFilesToLint(opts)
+	preparedPlan := opts.PreparedPlan
+	if preparedPlan == nil {
+		plan := prepareProgramLintPlan(opts)
+		preparedPlan = &plan
+	}
+	filesToLint := preparedPlan.files
 
 	result := programLintResult{lintedFileCount: int32(len(filesToLint))}
 
@@ -366,15 +370,8 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 	ctx := context.Background()
 	rulesByFile := make(map[*ast.SourceFile][]ConfiguredRule, len(filesToLint))
 	checkerGroups := make(map[*checker.Checker][]*ast.SourceFile)
-	for _, file := range filesToLint {
-		if shouldSkipRulesForSyntax(opts, file, ctx) {
-			continue
-		}
-		rules := filterRulesForTypeInfo(
-			getRulesForFile(file),
-			file.FileName(),
-			opts.TypeInfoFiles,
-		)
+	for fileIndex, file := range filesToLint {
+		rules := preparedPlan.rules[fileIndex]
 		if opts.CollectExecutedRules && len(rules) > 0 {
 			if result.executedRules == nil {
 				result.executedRules = make(map[string]struct{}, len(rules))
@@ -420,7 +417,7 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 
 // filterNativeRules removes Node-dispatched ESLint plugin placeholders from
 // the native pass without mutating the resolver's shared cached slice. The
-// original list remains available to CollectLintTargets for plugin dispatch.
+// prepared plan retains the original list for host-side plugin dispatch.
 func filterNativeRules(rules []ConfiguredRule) []ConfiguredRule {
 	firstPlugin := -1
 	for i, configuredRule := range rules {
@@ -477,6 +474,10 @@ func shouldSkipRulesForSyntax(opts runProgramOptions, file *ast.SourceFile, ctx 
 // group is created and no per-program goroutines are spawned. This is how
 // callers run a pure type-check pass (--type-check-only) without paying
 // lint-side setup cost.
+// When opts.PreparedPlan is present, Phase 1 consumes its stable per-Program
+// files and resolved rules without repeating target collection or invoking
+// GetRulesForFile. CLI/API hosts use this to share one plan with optional
+// third-party plugin dispatch; other callers retain the direct path.
 //
 // Phase 2 — type-check (skipped when opts.TypeCheck is false): each
 // non-skipped program is handed to runTypeCheckAcrossPrograms, which
@@ -502,38 +503,24 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 	// Phase 1: lint rules per program (parallel). Skipped when no rule
 	// handler was supplied — see doc above.
 	if opts.GetRulesForFile != nil {
+		if opts.PreparedPlan != nil {
+			if len(opts.PreparedPlan.programs) != len(opts.Programs) {
+				return nil, errors.New("linter: prepared lint plan does not match Programs")
+			}
+			for programIndex, programPlan := range opts.PreparedPlan.programs {
+				if programPlan.program != opts.Programs[programIndex] {
+					return nil, errors.New("linter: prepared lint plan does not match Programs")
+				}
+			}
+		}
 		programResults := make([]programLintResult, len(opts.Programs))
 		wg := core.NewWorkGroup(opts.SingleThreaded)
-		for i, program := range opts.Programs {
-			var perProgramFilter FileFilter
-			if i < len(opts.PerProgramFilter) {
-				perProgramFilter = opts.PerProgramFilter[i]
+		for i := range opts.Programs {
+			var prepared *programLintPlan
+			if opts.PreparedPlan != nil {
+				prepared = &opts.PreparedPlan.programs[i]
 			}
-			var targetFiles []string
-			if opts.TargetFiles != nil && i < len(opts.TargetFiles) {
-				targetFiles = opts.TargetFiles[i]
-			}
-			filter := perProgramFilter
-			if opts.TargetFiles == nil {
-				ownedFiles := buildOwnedFileSet(program)
-				filter = composeOwnedFilter(perProgramFilter, ownedFiles)
-			}
-
-			programOpts := runProgramOptions{
-				Program:              program,
-				Cwd:                  opts.Cwd,
-				Scope:                opts.Scope,
-				ExcludePaths:         opts.ExcludePaths,
-				FileFilter:           filter,
-				TargetFiles:          targetFiles,
-				HasTargetFiles:       opts.TargetFiles != nil,
-				GetRulesForFile:      opts.GetRulesForFile,
-				CollectExecutedRules: true,
-				SyntaxErrorFiles:     opts.SyntaxErrorFiles,
-				SingleThreaded:       opts.SingleThreaded,
-				TypeInfoFiles:        opts.TypeInfoFiles,
-				Timing:               opts.Timing,
-			}
+			programOpts := runProgramOptionsFor(opts, i, prepared)
 			programIndex := i
 			programOptions := programOpts
 			wg.Queue(func() {
@@ -565,10 +552,9 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 	}, nil
 }
 
-// collectFilesToLint applies the ExcludePaths / Scope / FileFilter layers
-// to a program's source files. Shared by runLintRulesInProgram (native
-// lint) and CollectLintTargets (eslint-plugin dispatch) so both observe an
-// identical file set.
+// collectFilesToLint applies the ExcludePaths / Scope / FileFilter layers to a
+// program's source files. PrepareLintPlan retains this exact result when native
+// execution and a host-side consumer need to share the same file/rule plan.
 func collectFilesToLint(opts runProgramOptions) []*ast.SourceFile {
 	if opts.HasTargetFiles {
 		return collectExactFilesToLint(opts)
@@ -639,115 +625,6 @@ func collectExactFilesToLint(opts runProgramOptions) []*ast.SourceFile {
 		filesToLint = append(filesToLint, file)
 	}
 	return filesToLint
-}
-
-// LintTarget is one file paired with the rules configured for it, as
-// resolved by RunLinterOptions.GetRulesForFile.
-type LintTarget struct {
-	File  *ast.SourceFile
-	Rules []ConfiguredRule
-}
-
-// CollectLintTargets resolves, for every file RunLinter would lint, the
-// rules configured for it — WITHOUT running them. The CLI/LSP host uses it
-// to split out eslint-plugin rules and dispatch them to the Node worker in
-// parallel with native linting, reusing the exact same file-set filtering
-// as RunLinter (exact TargetFiles when present, otherwise Scope / legacy
-// owned-file filtering, plus ExcludePaths and per-program filters).
-func CollectLintTargets(opts RunLinterOptions) []LintTarget {
-	if opts.GetRulesForFile == nil {
-		return nil
-	}
-	excludePaths := opts.ExcludePaths
-	if excludePaths == nil {
-		excludePaths = utils.ExcludePaths
-	}
-	var targets []LintTarget
-	for i, program := range opts.Programs {
-		var perProgramFilter FileFilter
-		if i < len(opts.PerProgramFilter) {
-			perProgramFilter = opts.PerProgramFilter[i]
-		}
-		var targetFiles []string
-		if opts.TargetFiles != nil && i < len(opts.TargetFiles) {
-			targetFiles = opts.TargetFiles[i]
-		}
-		filter := perProgramFilter
-		if opts.TargetFiles == nil {
-			filter = composeOwnedFilter(perProgramFilter, buildOwnedFileSet(program))
-		}
-		files := collectFilesToLint(runProgramOptions{
-			Program:          program,
-			Scope:            opts.Scope,
-			ExcludePaths:     excludePaths,
-			FileFilter:       filter,
-			TargetFiles:      targetFiles,
-			HasTargetFiles:   opts.TargetFiles != nil,
-			SyntaxErrorFiles: opts.SyntaxErrorFiles,
-			TypeInfoFiles:    opts.TypeInfoFiles,
-		})
-		targets = append(targets, collectLintTargetsForFiles(opts, program, files)...)
-	}
-	return targets
-}
-
-// collectLintTargetsForFiles resolves rules for one program's lint target
-// files in parallel. Unlike the real lint pass, this has no type-checker
-// affinity to preserve, so files are simply chunked evenly across goroutines.
-// This is what turns the serial per-file config/glob resolution — the
-// dominant cost on large repos with many ignore/files patterns — into a
-// wall-clock win before the real, already-parallel lint pass even starts.
-func collectLintTargetsForFiles(opts RunLinterOptions, program *compiler.Program, files []*ast.SourceFile) []LintTarget {
-	if len(files) == 0 {
-		return nil
-	}
-	shardCount := runtime.GOMAXPROCS(0)
-	if opts.SingleThreaded {
-		shardCount = 1
-	} else if shardCount > len(files) {
-		shardCount = len(files)
-	}
-	if shardCount < 1 {
-		shardCount = 1
-	}
-	chunkSize := (len(files) + shardCount - 1) / shardCount
-	shardResults := make([][]LintTarget, shardCount)
-
-	wg := core.NewWorkGroup(opts.SingleThreaded)
-	for shard := range shardCount {
-		start := shard * chunkSize
-		end := min(start+chunkSize, len(files))
-		if start >= end {
-			continue
-		}
-		shardIndex := shard
-		shardFiles := files[start:end]
-		wg.Queue(func() {
-			ctx := context.Background()
-			var result []LintTarget
-			for _, file := range shardFiles {
-				if shouldSkipRulesForSyntax(runProgramOptions{
-					Program:          program,
-					SyntaxErrorFiles: opts.SyntaxErrorFiles,
-				}, file, ctx) {
-					continue
-				}
-				rules := filterRulesForTypeInfo(opts.GetRulesForFile(file), file.FileName(), opts.TypeInfoFiles)
-				if len(rules) == 0 {
-					continue
-				}
-				result = append(result, LintTarget{File: file, Rules: rules})
-			}
-			shardResults[shardIndex] = result
-		})
-	}
-	wg.RunAndWait()
-
-	var targets []LintTarget
-	for _, result := range shardResults {
-		targets = append(targets, result...)
-	}
-	return targets
 }
 
 // LintSingleFile runs lint rules against a single file in a single program.

--- a/internal/linter/linter_allowfiles_test.go
+++ b/internal/linter/linter_allowfiles_test.go
@@ -247,16 +247,16 @@ func TestRunLinter_TargetFilesEmptyDoesNotScanProgram(t *testing.T) {
 		t.Fatalf("expected zero linted files for an empty target plan, got %d", result.LintedFileCount)
 	}
 
-	targets := CollectLintTargets(RunLinterOptions{
+	targets := PrepareLintPlan(RunLinterOptions{
 		Programs:       []*compiler.Program{program},
 		SingleThreaded: true,
 		TargetFiles:    [][]string{nil},
 		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
 			return noopRule()
 		},
-	})
+	}).Targets()
 	if len(targets) != 0 {
-		t.Fatalf("CollectLintTargets should also see zero files for an empty target plan, got %+v", targets)
+		t.Fatalf("PrepareLintPlan should also see zero files for an empty target plan, got %+v", targets)
 	}
 }
 
@@ -284,16 +284,16 @@ func TestRunLinter_TargetFilesCanSelectImportedNonRootFile(t *testing.T) {
 		t.Fatalf("expected only lib.ts to be linted, got %v", linted)
 	}
 
-	targets := CollectLintTargets(RunLinterOptions{
+	targets := PrepareLintPlan(RunLinterOptions{
 		Programs:       []*compiler.Program{program},
 		SingleThreaded: true,
 		TargetFiles:    [][]string{{target}},
 		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
 			return noopRule()
 		},
-	})
+	}).Targets()
 	if len(targets) != 1 || targets[0].File.FileName() != target || len(targets[0].Rules) == 0 {
-		t.Fatalf("CollectLintTargets should mirror native exact targeting, got %+v", targets)
+		t.Fatalf("PrepareLintPlan should mirror native exact targeting, got %+v", targets)
 	}
 }
 

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -88,6 +88,10 @@ type LintResult struct {
 //     (for example config global ignores). Entries within the slice
 //     may be nil individually.
 //   - GetRulesForFile=nil                 → no lint rules executed
+//   - PreparedPlan=nil                    → RunLinter collects targets and
+//     resolves rules through GetRulesForFile during the lint phase. Callers
+//     that need the same resolved targets before native execution may build a
+//     plan with PrepareLintPlan and pass it here.
 //   - SyntaxErrorFiles=nil                → RunLinter checks each lint target
 //     for syntax errors before resolving or running rules. A non-nil set means
 //     the caller already performed that check and names the invalid files.
@@ -129,7 +133,13 @@ type RunLinterOptions struct {
 	// Program membership. nil preserves the legacy Program scan.
 	TargetFiles [][]string
 
-	GetRulesForFile  RuleHandler
+	GetRulesForFile RuleHandler
+	// PreparedPlan, when non-nil, must have been built from these same Phase 1
+	// options with PrepareLintPlan. RunLinter consumes its per-Program files and
+	// resolved rules without collecting targets or calling GetRulesForFile again.
+	// The callback remains required to distinguish a lint pass from
+	// --type-check-only and to preserve the existing zero-value contract.
+	PreparedPlan     *LintPlan
 	TypeInfoFiles    map[string]struct{}
 	SyntaxErrorFiles map[string]struct{}
 	// Consumer owns diagnostic delivery and the optional edit artifacts needed


### PR DESCRIPTION
## Summary

- Prepare one immutable per-program lint plan and share it between plugin input preparation and native lint execution.
- Resolve per-file rule selections with bounded workers while preserving direct serial ordering for `--singleThreaded`.
- Rebuild the plan on every fix pass, preserve direct `RunLinter` behavior, and let the existing CLI/API multi-file paths share the result. The single-file LSP path remains unchanged.

Lint-plan preparation benchmark (30 alternating pairs, median):

| Workload | Serial preparation | Bounded-parallel preparation | Saved |
| --- | ---: | ---: | ---: |
| rsbuild | 34.20 ms | 7.36 ms | 26.84 ms (78.5%) |
| rspack | 11.56 ms | 2.47 ms | 9.09 ms (78.7%) |

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
