### PR TITLE
perf: optimize no-explicit-any reporting

### DIFF
--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
@@ -4,7 +4,9 @@ import (
 	_ "embed"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 //go:embed no_explicit_any.schema.json
@@ -104,6 +106,20 @@ func isWithinKeyofAny(node *ast.Node) bool {
 	return typeOp != nil && typeOp.Operator == ast.KindKeyOfKeyword
 }
 
+func anyKeywordRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	const keyword = "any"
+	end := node.End()
+	start := end - len(keyword)
+	text := sourceFile.Text()
+	// Parsed keyword nodes end at the token boundary, so the validated suffix
+	// avoids rescanning leading trivia. Reparsed or synthetic nodes keep the
+	// scanner-backed behavior.
+	if start >= 0 && end <= len(text) && text[start:end] == keyword {
+		return core.NewTextRange(start, end)
+	}
+	return utils.TrimNodeTextRange(sourceFile, node)
+}
+
 var NoExplicitAnyRule = rule.CreateRule(rule.Rule{
 	Name:   "no-explicit-any",
 	Schema: rule.NewSchema(schemaJSON),
@@ -115,32 +131,44 @@ var NoExplicitAnyRule = rule.CreateRule(rule.Rule{
 				if opts.IgnoreRestArgs && isAnyInRestParameter(node) {
 					return
 				}
-				if isWithinKeyofAny(node) {
-					if opts.FixToUnknown {
-						ctx.ReportNodeWithFixes(node, buildUnexpectedAnyMessage(), rule.RuleFixReplace(ctx.SourceFile, node.Parent, "PropertyKey"))
-					} else {
-						ctx.ReportNodeWithSuggestions(node, buildUnexpectedAnyMessage(), rule.RuleSuggestion{
-							Message:  buildSuggestPropertyKeyMessage(),
-							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node.Parent, "PropertyKey")},
+
+				reportRange := anyKeywordRange(ctx.SourceFile, node)
+				isKeyofAny := isWithinKeyofAny(node)
+				if opts.FixToUnknown {
+					if isKeyofAny {
+						ctx.ReportRangeWithDeferredFixes(reportRange, buildUnexpectedAnyMessage(), func() []rule.RuleFix {
+							return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node.Parent, "PropertyKey")}
 						})
+						return
 					}
+					ctx.ReportRangeWithDeferredFixes(reportRange, buildUnexpectedAnyMessage(), func() []rule.RuleFix {
+						return []rule.RuleFix{rule.RuleFixReplaceRange(reportRange, "unknown")}
+					})
 					return
 				}
 
-				if opts.FixToUnknown {
-					ctx.ReportNodeWithFixes(node, buildUnexpectedAnyMessage(), rule.RuleFixReplace(ctx.SourceFile, node, "unknown"))
-				} else {
-					ctx.ReportNodeWithSuggestions(node, buildUnexpectedAnyMessage(),
-						rule.RuleSuggestion{
-							Message:  buildSuggestUnknownMessage(),
-							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, "unknown")},
-						},
-						rule.RuleSuggestion{
-							Message:  buildSuggestNeverMessage(),
-							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, "never")},
-						},
-					)
+				if isKeyofAny {
+					ctx.ReportRangeWithDeferredSuggestions(reportRange, buildUnexpectedAnyMessage(), func() []rule.RuleSuggestion {
+						return []rule.RuleSuggestion{{
+							Message:  buildSuggestPropertyKeyMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node.Parent, "PropertyKey")},
+						}}
+					})
+					return
 				}
+
+				ctx.ReportRangeWithDeferredSuggestions(reportRange, buildUnexpectedAnyMessage(), func() []rule.RuleSuggestion {
+					return []rule.RuleSuggestion{
+						{
+							Message:  buildSuggestUnknownMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(reportRange, "unknown")},
+						},
+						{
+							Message:  buildSuggestNeverMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(reportRange, "never")},
+						},
+					}
+				})
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any_test.go
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any_test.go
@@ -1,9 +1,14 @@
 package no_explicit_any
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -91,5 +96,150 @@ func TestNoExplicitAnyRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			Code:    `type T = keyof any;`,
+			Options: []interface{}{map[string]interface{}{"fixToUnknown": true}},
+			Output:  []string{`type T = PropertyKey;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedAny",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 19,
+				},
+			},
+		},
 	})
+}
+
+func parseNoExplicitAnySource(t *testing.T, code string) *ast.SourceFile {
+	t.Helper()
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/source.ts",
+		Path:     "/source.ts",
+	}, code, core.ScriptKindTS)
+}
+
+func runNoExplicitAnyWithDemand(
+	t *testing.T,
+	code string,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	sourceFile := parseNoExplicitAnySource(t, code)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 2)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(
+		NoExplicitAnyRule.Name,
+		rule.SeverityError,
+		rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	)
+
+	listener := NoExplicitAnyRule.Run(ctx, options)[ast.KindAnyKeyword]
+	if listener == nil {
+		t.Fatal("expected any-keyword listener")
+	}
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindAnyKeyword {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
+}
+
+func TestNoExplicitAnyEditDemand(t *testing.T) {
+	const code = `type Value = any; type Key = keyof any;`
+
+	diagnosticsOnly := runNoExplicitAnyWithDemand(t, code, nil, rule.EditDemandNone)
+	suggestions := runNoExplicitAnyWithDemand(t, code, nil, rule.EditDemandSuggestion)
+	if len(diagnosticsOnly) != 2 || len(suggestions) != 2 {
+		t.Fatalf("diagnostic counts = %d and %d, want 2", len(diagnosticsOnly), len(suggestions))
+	}
+	for index := range diagnosticsOnly {
+		if diagnosticsOnly[index].FixesPtr != nil || diagnosticsOnly[index].Suggestions != nil {
+			t.Fatalf("diagnostic %d unexpectedly materialized edits", index)
+		}
+		if diagnosticsOnly[index].Range != suggestions[index].Range ||
+			diagnosticsOnly[index].Message.Id != suggestions[index].Message.Id ||
+			diagnosticsOnly[index].Message.Description != suggestions[index].Message.Description {
+			t.Fatalf("diagnostic %d changed when suggestions were requested", index)
+		}
+	}
+	if suggestions[0].Suggestions == nil || len(*suggestions[0].Suggestions) != 2 {
+		t.Fatalf("plain any suggestions = %#v, want 2", suggestions[0].Suggestions)
+	}
+	if suggestions[1].Suggestions == nil || len(*suggestions[1].Suggestions) != 1 {
+		t.Fatalf("keyof any suggestions = %#v, want 1", suggestions[1].Suggestions)
+	}
+	if (*suggestions[0].Suggestions)[0].FixesArr[0].Text != "unknown" ||
+		(*suggestions[0].Suggestions)[1].FixesArr[0].Text != "never" ||
+		(*suggestions[1].Suggestions)[0].FixesArr[0].Text != "PropertyKey" {
+		t.Fatalf("unexpected suggestion replacements: %#v, %#v", suggestions[0].Suggestions, suggestions[1].Suggestions)
+	}
+
+	const triviaCode = `type Value = /* leading trivia */ any;`
+	withTrivia := runNoExplicitAnyWithDemand(t, triviaCode, nil, rule.EditDemandSuggestion)
+	if len(withTrivia) != 1 || withTrivia[0].Suggestions == nil || len(*withTrivia[0].Suggestions) != 2 {
+		t.Fatalf("trivia diagnostics = %#v, want one diagnostic with two suggestions", withTrivia)
+	}
+	wantStart := strings.Index(triviaCode, "any")
+	wantRange := core.NewTextRange(wantStart, wantStart+len("any"))
+	if withTrivia[0].Range != wantRange {
+		t.Fatalf("trivia diagnostic range = %#v, want %#v", withTrivia[0].Range, wantRange)
+	}
+	for index, suggestion := range *withTrivia[0].Suggestions {
+		if len(suggestion.FixesArr) != 1 || suggestion.FixesArr[0].Range != wantRange {
+			t.Fatalf("trivia suggestion %d fixes = %#v, want range %#v", index, suggestion.FixesArr, wantRange)
+		}
+	}
+
+	fixOptions := []any{map[string]interface{}{"fixToUnknown": true}}
+	withoutFixes := runNoExplicitAnyWithDemand(t, code, fixOptions, rule.EditDemandNone)
+	withFixes := runNoExplicitAnyWithDemand(t, code, fixOptions, rule.EditDemandAutofix)
+	withSuggestionDemand := runNoExplicitAnyWithDemand(t, code, fixOptions, rule.EditDemandSuggestion)
+	if len(withoutFixes) != 2 || len(withFixes) != 2 || len(withSuggestionDemand) != 2 {
+		t.Fatalf(
+			"fix-option diagnostic counts = %d, %d, and %d, want 2",
+			len(withoutFixes),
+			len(withFixes),
+			len(withSuggestionDemand),
+		)
+	}
+	for index, replacement := range []string{"unknown", "PropertyKey"} {
+		if withoutFixes[index].FixesPtr != nil || withoutFixes[index].Suggestions != nil {
+			t.Fatalf("diagnostic %d unexpectedly materialized fixes", index)
+		}
+		if withSuggestionDemand[index].FixesPtr != nil || withSuggestionDemand[index].Suggestions != nil {
+			t.Fatalf("diagnostic %d materialized edits for the wrong demand", index)
+		}
+		if withFixes[index].FixesPtr == nil || len(*withFixes[index].FixesPtr) != 1 ||
+			(*withFixes[index].FixesPtr)[0].Text != replacement {
+			t.Fatalf("diagnostic %d fixes = %#v, want %q", index, withFixes[index].FixesPtr, replacement)
+		}
+	}
+
+	suppressed := runNoExplicitAnyWithDemand(
+		t,
+		"// eslint-disable-next-line @typescript-eslint/no-explicit-any\ntype Value = any;",
+		nil,
+		rule.EditDemandSuggestion,
+	)
+	if len(suppressed) != 0 {
+		t.Fatalf("suppressed diagnostics = %d, want 0", len(suppressed))
+	}
 }


### PR DESCRIPTION
## Summary

- defer autofix and suggestion construction until the corresponding edit demand requests it
- use a validated fixed-width range for the ASCII any keyword, with the scanner-backed range helper as a safe fallback
- reuse the validated range for plain unknown and never replacements while preserving the parent replacement for keyof any
- add demand-sensitive, range, fix, suggestion, trivia, and disable-directive coverage

### Go benchmark

Package-local benchmarks were run with benchmem under stable idle conditions. This comparison isolates the final validated keyword-range and range-reuse optimization by comparing the deferred-report intermediate implementation with the final implementation.

| Case | Time before -> after | Delta | Bytes before -> after | Allocs before -> after |
| --- | ---: | ---: | ---: | ---: |
| Diagnostics only | 6665.5 -> 1399.7 ns/op | -79.0% | 10632 -> 392 B/op | 68 -> 4 |
| No matches | 234.3 -> 230.4 ns/op | -1.7% | 392 -> 392 B/op | 4 -> 4 |
| Suggestions | 25171.6 -> 9432.6 ns/op | -62.5% | 43912 -> 13192 B/op | 452 -> 260 |
| Fix diagnostics only | 6705.5 -> 1392.4 ns/op | -79.2% | 10632 -> 392 B/op | 68 -> 4 |
| Autofix | 14480.9 -> 4089.2 ns/op | -71.8% | 23944 -> 3464 B/op | 260 -> 132 |
| Ignored rest args | 495.4 -> 495.4 ns/op | 0.0% | 392 -> 392 B/op | 4 -> 4 |
| keyof any suggestions | 16914.4 -> 12409.6 ns/op | -26.6% | 28040 -> 17800 B/op | 324 -> 260 |

Validation completed:

- go test ./internal/plugins/typescript/rules/no_explicit_any -count=3
- pnpm run check-spell
- pnpm run format:check
- changed-package golangci-lint with --new-from-rev=origin/main
- git diff --check

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
