### PR TITLE
perf: optimize jsx-no-literals

### DIFF
--- a/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.go
+++ b/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -64,14 +65,27 @@ func (c *ruleConfig) hasElementOverrides() bool {
 	return len(c.elementOverrides) > 0
 }
 
+// listenerRequirements identifies AST kinds that can produce a diagnostic for
+// this configuration. JSX text is always relevant, but the other literal kinds
+// are opt-in. Avoiding listeners for them is important because ordinary source
+// files contain many StringLiteral nodes that cannot affect the default rule.
+func (c *ruleConfig) listenerRequirements() (stringLiterals, templates, attributes bool) {
+	stringLiterals = c.base.noStrings || c.base.noAttributeStrings
+	templates = c.base.noStrings
+	attributes = c.base.noStrings || len(c.base.restrictedAttributes) > 0
+	for _, override := range c.elementOverrides {
+		stringLiterals = stringLiterals || override.noStrings || override.noAttributeStrings
+		templates = templates || override.noStrings
+		attributes = attributes || override.noStrings || len(override.restrictedAttributes) > 0
+	}
+	return stringLiterals, templates, attributes
+}
+
 func parseConfig(options []any) ruleConfig {
 	cfg := ruleConfig{
 		base: elementConfig{
-			configType:           configTypeElement,
-			allowedStrings:       map[string]struct{}{},
-			restrictedAttributes: map[string]struct{}{},
+			configType: configTypeElement,
 		},
-		elementOverrides: map[string]*elementConfig{},
 	}
 	if len(options) == 0 {
 		return cfg
@@ -90,8 +104,6 @@ func parseConfig(options []any) ruleConfig {
 		child := &elementConfig{
 			configType:            configTypeOverride,
 			name:                  elementName,
-			allowedStrings:        map[string]struct{}{},
-			restrictedAttributes:  map[string]struct{}{},
 			applyToNestedElements: true,
 		}
 		populateElementConfig(child, childMap)
@@ -102,6 +114,9 @@ func parseConfig(options []any) ruleConfig {
 		if v, ok := childMap["applyToNestedElements"]; ok {
 			child.applyToNestedElements = truthyBool(v)
 		}
+		if cfg.elementOverrides == nil {
+			cfg.elementOverrides = make(map[string]*elementConfig, len(rawOverrides))
+		}
 		cfg.elementOverrides[elementName] = child
 	}
 	return cfg
@@ -111,21 +126,24 @@ func populateElementConfig(c *elementConfig, m map[string]interface{}) {
 	c.noStrings, _ = m["noStrings"].(bool)
 	c.ignoreProps, _ = m["ignoreProps"].(bool)
 	c.noAttributeStrings, _ = m["noAttributeStrings"].(bool)
-	populateStringSetFromMap(m, "allowedStrings", c.allowedStrings)
-	populateStringSetFromMap(m, "restrictedAttributes", c.restrictedAttributes)
+	populateStringSetFromMap(m, "allowedStrings", &c.allowedStrings)
+	populateStringSetFromMap(m, "restrictedAttributes", &c.restrictedAttributes)
 }
 
 // populateStringSetFromMap reads the array-of-strings option at `key` from
 // `source`, trims each entry, and inserts it into `target`. Mirrors upstream's
 // `new Set(map(iterFrom(config.<key>), trimIfString))` shape.
-func populateStringSetFromMap(source map[string]interface{}, key string, target map[string]struct{}) {
+func populateStringSetFromMap(source map[string]interface{}, key string, target *map[string]struct{}) {
 	arr, ok := source[key].([]interface{})
 	if !ok {
 		return
 	}
 	for _, s := range arr {
 		if str, ok := s.(string); ok {
-			target[strings.TrimSpace(str)] = struct{}{}
+			if *target == nil {
+				*target = make(map[string]struct{}, len(arr))
+			}
+			(*target)[strings.TrimSpace(str)] = struct{}{}
 		}
 	}
 }
@@ -249,6 +267,15 @@ func isViableTextNode(rawText, cookedText string, parentKind ast.Kind, cfg *elem
 		return standard
 	}
 	return standard && parentKind != ast.KindJsxExpression
+}
+
+func isRelevantStringLiteralParent(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindJsxAttribute, ast.KindJsxElement, ast.KindJsxExpression, ast.KindJsxFragment:
+		return true
+	default:
+		return false
+	}
 }
 
 // elementNameInfo carries the simple + dotted display name of a JSX element's
@@ -387,7 +414,7 @@ func formatMessage(messageId string, text, attribute, element string) string {
 	return ""
 }
 
-func reportLiteralNode(ctx rule.RuleContext, node *ast.Node, messageId string, cfg *elementConfig, text string) {
+func literalMessage(messageId string, cfg *elementConfig, text string) rule.RuleMessage {
 	element := ""
 	if cfg.configType == configTypeOverride {
 		element = cfg.name
@@ -397,11 +424,19 @@ func reportLiteralNode(ctx rule.RuleContext, node *ast.Node, messageId string, c
 	if element != "" {
 		data["element"] = element
 	}
-	ctx.ReportNode(node, rule.RuleMessage{
+	return rule.RuleMessage{
 		Id:          messageId,
 		Description: desc,
 		Data:        data,
-	})
+	}
+}
+
+func reportLiteralNode(ctx rule.RuleContext, node *ast.Node, messageId string, cfg *elementConfig, text string) {
+	ctx.ReportNode(node, literalMessage(messageId, cfg, text))
+}
+
+func reportLiteralRange(ctx rule.RuleContext, textRange core.TextRange, messageId string, cfg *elementConfig, text string) {
+	ctx.ReportRange(textRange, literalMessage(messageId, cfg, text))
 }
 
 func reportRestrictedAttribute(ctx rule.RuleContext, attrNode *ast.Node, valueText, attribute string, cfg *elementConfig) {
@@ -602,6 +637,10 @@ func handleJsxAttribute(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, r
 // literals (the JSXAttribute handler owns that report); replicated here via
 // the parent-kind check inside `isStandardJSXNode`.
 func handleStringLiteral(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, renamedImports map[string]string) {
+	parent := parentIgnoringBinaryAndParens(node)
+	if parent == nil || !isRelevantStringLiteralParent(parent.Kind) {
+		return
+	}
 	resolved := resolveOverride(node, cfg, renamedImports)
 	if resolved == nil {
 		resolved = &cfg.base
@@ -610,13 +649,15 @@ func handleStringLiteral(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, 
 	if hasJSXContent && shouldAllowElement(resolved) {
 		return
 	}
-	parent := parentIgnoringBinaryAndParens(node)
-	if parent == nil {
+	cooked := node.AsStringLiteral().Text
+	if !isStandardJSXNode(cooked, parent.Kind, resolved) || (!resolved.noStrings && parent.Kind == ast.KindJsxExpression) {
 		return
 	}
-	cooked := node.AsStringLiteral().Text
 	rawSource := trimmedSource(ctx, node)
-	if !isViableTextNode(rawSource, cooked, parent.Kind, resolved) {
+	if _, allowed := resolved.allowedStrings[strings.TrimSpace(rawSource)]; allowed {
+		return
+	}
+	if _, allowed := resolved.allowedStrings[strings.TrimSpace(cooked)]; allowed {
 		return
 	}
 	// Upstream gates the report on `hasJSXParentOrGrandParent || !config.ignoreProps`
@@ -630,6 +671,14 @@ func handleStringLiteral(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, 
 }
 
 func handleJsxText(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, renamedImports map[string]string) {
+	jt := node.AsJsxText()
+	if jt.ContainsOnlyTriviaWhiteSpaces {
+		return
+	}
+	parent := node.Parent
+	if parent == nil {
+		return
+	}
 	resolved := resolveOverride(node, cfg, renamedImports)
 	if resolved == nil {
 		resolved = &cfg.base
@@ -637,26 +686,32 @@ func handleJsxText(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, rename
 	if shouldAllowElement(resolved) {
 		return
 	}
-	jt := node.AsJsxText()
-	if jt.ContainsOnlyTriviaWhiteSpaces {
-		return
-	}
 	// tsgo's JsxText.Text is the raw source text — HTML entities like
 	// `&mdash;` stay encoded (decoding happens later, during JSX transform).
 	// ESLint's espree+acorn-jsx feeds the rule a decoded `node.value`, so to
 	// keep `allowedStrings` lookups byte-equivalent we decode here. The raw
-	// form is still checked separately via `rawSource` below.
+	// form is still checked separately via `rawSource` below. Use JsxText.Text
+	// directly: scanner-based token trimming is invalid in JSX text because
+	// text such as `// {marker}` is not a JavaScript comment. Treating it as
+	// one can advance the trimmed start beyond this node's end and panic.
 	cooked := html.UnescapeString(jt.Text)
-	rawSource := trimmedSource(ctx, node)
-	parent := node.Parent
-	if parent == nil {
-		return
-	}
+	rawSource := strings.TrimSpace(jt.Text)
 	if !isViableTextNode(rawSource, cooked, parent.Kind, resolved) {
 		return
 	}
 	hasJSXContent := hasJSXContentParentOrGrandParent(node)
-	reportLiteralNode(ctx, node, defaultMessageId(hasJSXContent, resolved), resolved, rawSource)
+	startOffset := strings.Index(jt.Text, rawSource)
+	if startOffset < 0 {
+		startOffset = 0
+	}
+	start := node.Pos() + startOffset
+	reportLiteralRange(
+		ctx,
+		core.NewTextRange(start, start+len(rawSource)),
+		defaultMessageId(hasJSXContent, resolved),
+		resolved,
+		rawSource,
+	)
 }
 
 // handleTemplate handles upstream's TemplateLiteral listener for both
@@ -702,26 +757,32 @@ var JsxNoLiteralsRule = rule.Rule{
 		var renamedImports map[string]string
 		if cfg.hasElementOverrides() {
 			renamedImports = collectRenamedImports(ctx.SourceFile)
-		} else {
-			renamedImports = map[string]string{}
 		}
 
-		return rule.RuleListeners{
-			ast.KindStringLiteral: func(node *ast.Node) {
-				handleStringLiteral(ctx, node, &cfg, renamedImports)
-			},
+		stringLiterals, templates, attributes := cfg.listenerRequirements()
+		listeners := rule.RuleListeners{
 			ast.KindJsxText: func(node *ast.Node) {
 				handleJsxText(ctx, node, &cfg, renamedImports)
 			},
-			ast.KindNoSubstitutionTemplateLiteral: func(node *ast.Node) {
-				handleTemplate(ctx, node, &cfg, renamedImports)
-			},
-			ast.KindTemplateExpression: func(node *ast.Node) {
-				handleTemplate(ctx, node, &cfg, renamedImports)
-			},
-			ast.KindJsxAttribute: func(node *ast.Node) {
-				handleJsxAttribute(ctx, node, &cfg, renamedImports)
-			},
 		}
+		if stringLiterals {
+			listeners[ast.KindStringLiteral] = func(node *ast.Node) {
+				handleStringLiteral(ctx, node, &cfg, renamedImports)
+			}
+		}
+		if templates {
+			listeners[ast.KindNoSubstitutionTemplateLiteral] = func(node *ast.Node) {
+				handleTemplate(ctx, node, &cfg, renamedImports)
+			}
+			listeners[ast.KindTemplateExpression] = func(node *ast.Node) {
+				handleTemplate(ctx, node, &cfg, renamedImports)
+			}
+		}
+		if attributes {
+			listeners[ast.KindJsxAttribute] = func(node *ast.Node) {
+				handleJsxAttribute(ctx, node, &cfg, renamedImports)
+			}
+		}
+		return listeners
 	},
 }

--- a/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals_test.go
+++ b/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals_test.go
@@ -139,7 +139,7 @@ class Comp1 extends Component {
   {intl.formatText(message)}
 </Foo>
 `,
-			Tsx: true,
+			Tsx:     true,
 			Options: map[string]interface{}{"noStrings": true, "ignoreProps": true},
 		},
 		{
@@ -148,7 +148,7 @@ class Comp1 extends Component {
   {translate('my.translate.key')}
 </Foo>
 `,
-			Tsx: true,
+			Tsx:     true,
 			Options: map[string]interface{}{"noStrings": true, "ignoreProps": true},
 		},
 
@@ -169,14 +169,14 @@ class Comp1 extends Component {
   }
 }
 `,
-			Tsx: true,
+			Tsx:     true,
 			Options: map[string]interface{}{"noStrings": true, "ignoreProps": true},
 		},
 
 		// ---- Template literals in non-JSX contexts are ignored ----
 		{
-			Code: "\nclass Comp1 extends Component {\n  render() {\n    let foo = `bar`;\n    return <div />;\n  }\n}\n",
-			Tsx:  true,
+			Code:    "\nclass Comp1 extends Component {\n  render() {\n    let foo = `bar`;\n    return <div />;\n  }\n}\n",
+			Tsx:     true,
 			Options: map[string]interface{}{"noStrings": true},
 		},
 
@@ -1371,7 +1371,7 @@ export const WithAttributesAndChildren = ({}) => (
 `,
 			Tsx: true,
 			Options: map[string]interface{}{
-				"allowedStrings": []interface{}{"foo"},
+				"allowedStrings":   []interface{}{"foo"},
 				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{}},
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
@@ -1789,6 +1789,15 @@ export const WithAttributesAndChildren = ({}) => (
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+			},
+		},
+		// `//` is ordinary text in JSX, but a JavaScript-mode scanner treats it
+		// as a line comment and can skip past the JsxText node's end.
+		{
+			Code: "<div>\n  // {EXISTING_CODE_MARKER}<br />\n</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "//"`, Line: 2, Column: 3, EndLine: 2, EndColumn: 5},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Fix react/jsx-no-literals panics on comment-like JSX text and report the exact text range.
- Skip literal listeners that cannot produce diagnostics for the active options, short-circuit unrelated string literals, and lazily allocate optional config maps.
- Add regression coverage for the panic and diagnostic range.

### Rule benchmark

Temporary package-local Go benchmark using the default configuration, 2,000 ordinary string literals, and one JSX text node. Results are medians from five samples with memory reporting enabled.

| Case | Time before → after | Bytes before → after | Allocations before → after |
| --- | ---: | ---: | ---: |
| Rule initialization | 447.1 → 219.2 ns/op (-51.0%) | 800 → 480 B/op (-40.0%) | 13 → 5 (-61.5%) |
| Default AST traversal | 270481 → 54903 ns/op (-79.7%) | 320577 → 416 B/op (-99.9%) | 2004 → 3 (-99.9%) |

The temporary benchmark code was removed before committing.

### Validation

- Target Go package tests passed with three repetitions.
- Target JavaScript compatibility tests passed.
- Target package incremental Go lint passed with zero issues.
- Spell and formatting checks passed.
- Adversarial review verified the regression diagnostic is anchored exactly to the JSX text.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
