### PR TITLE
perf: cache directory block decisions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -734,6 +734,11 @@ func normalizePattern(pattern string) string {
 // aligns with ESLint v10: `dir/**` blocks directory traversal entirely, and
 // `!` negation cannot undo it.
 func isDirBlockedByIgnores(filePath string, patterns []IgnorePattern, cwd string) bool {
+	dirPath, ok := ignoreDirectoryPath(filePath, cwd)
+	return ok && isDirAbsolutelyBlocked(dirPath, patterns)
+}
+
+func ignoreDirectoryPath(filePath string, cwd string) (string, bool) {
 	var dirPath string
 	if cwd != "" {
 		dirPath = normalizePath(tspath.GetDirectoryPath(filePath), cwd)
@@ -743,9 +748,36 @@ func isDirBlockedByIgnores(filePath string, patterns []IgnorePattern, cwd string
 	dirPath = strings.ReplaceAll(dirPath, "\\", "/")
 	dirPath = strings.TrimSuffix(dirPath, "/")
 	if dirPath == "" || dirPath == "." {
+		return "", false
+	}
+	return dirPath, true
+}
+
+// directoryBlockMatcher caches path-only directory decisions for one immutable
+// ignore-pattern set and cwd. The exact lexical parent is the key: no case,
+// separator, realpath, or filesystem equivalence is introduced by the cache.
+type directoryBlockMatcher struct {
+	patterns []IgnorePattern
+	cwd      string
+	results  publishOnceCache[string, bool]
+}
+
+func newDirectoryBlockMatcher(patterns []IgnorePattern, cwd string) *directoryBlockMatcher {
+	if len(patterns) == 0 {
+		return nil
+	}
+	return &directoryBlockMatcher{patterns: patterns, cwd: cwd}
+}
+
+func (matcher *directoryBlockMatcher) blocksFileDirectory(filePath string) bool {
+	if matcher == nil {
 		return false
 	}
-	return isDirAbsolutelyBlocked(dirPath, patterns)
+	lexicalDirectory := tspath.GetDirectoryPath(filePath)
+	return matcher.results.getOrInit(lexicalDirectory, func() bool {
+		dirPath, ok := ignoreDirectoryPath(filePath, matcher.cwd)
+		return ok && isDirAbsolutelyBlocked(dirPath, matcher.patterns)
+	})
 }
 
 // normalizePath converts file path to be relative to cwd for consistent matching
@@ -864,7 +896,7 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 // patterns supplied by the caller, so repeated calls against the same config
 // (one per lint target) don't re-parse the same ignore pattern strings.
 func (config RslintConfig) getConfigForFileWithIgnores(filePath string, cwd string, globalIgnorePatterns []IgnorePattern) *MergedConfig {
-	key, matched := config.matchConfigEntries(filePath, cwd, globalIgnorePatterns, nil)
+	key, matched := config.matchConfigEntries(filePath, cwd, globalIgnorePatterns, nil, nil)
 	if !matched {
 		return nil
 	}

--- a/internal/config/config_resolution.go
+++ b/internal/config/config_resolution.go
@@ -44,9 +44,18 @@ func (config RslintConfig) matchConfigEntries(
 	cwd string,
 	globalIgnorePatterns []IgnorePattern,
 	entryIgnorePatterns [][]IgnorePattern,
+	directoryBlocks *directoryBlockMatcher,
 ) (configMatchKey, bool) {
-	if len(globalIgnorePatterns) > 0 && isDirBlockedByIgnores(filePath, globalIgnorePatterns, cwd) {
-		return configMatchKey{}, false
+	if len(globalIgnorePatterns) > 0 {
+		var blocked bool
+		if directoryBlocks == nil {
+			blocked = isDirBlockedByIgnores(filePath, globalIgnorePatterns, cwd)
+		} else {
+			blocked = directoryBlocks.blocksFileDirectory(filePath)
+		}
+		if blocked {
+			return configMatchKey{}, false
+		}
 	}
 	matchPath := newFileMatchPath(filePath, cwd)
 	if len(globalIgnorePatterns) > 0 && matchPath.isIgnored(globalIgnorePatterns) {

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -158,6 +158,7 @@ func discoverLintTargetsWithStopDirs(
 
 	filesPatterns := collectLintFilePatterns(config)
 	filesMatcher := buildFilesMatcher(filesPatterns)
+	directoryBlocks := newDirectoryBlockMatcher(globalIgnores, configMatchDir)
 
 	var allowFileSet map[string]string
 	if allowFiles != nil {
@@ -192,7 +193,7 @@ func discoverLintTargetsWithStopDirs(
 		})
 	}
 	isGloballyIgnored := func(matchPath string) bool {
-		return isDirBlockedByIgnores(matchPath, globalIgnores, configMatchDir) ||
+		return directoryBlocks.blocksFileDirectory(matchPath) ||
 			isFileIgnored(matchPath, globalIgnores, configMatchDir)
 	}
 

--- a/internal/config/file_resolver.go
+++ b/internal/config/file_resolver.go
@@ -20,6 +20,7 @@ type FileConfigResolver struct {
 	// call is pure waste at thousands-of-files scale.
 	globalIgnorePatterns []IgnorePattern
 	entryIgnorePatterns  [][]IgnorePattern
+	directoryBlocks      *directoryBlockMatcher
 
 	filePlans  publishOnceCache[string, *effectiveConfigPlan]
 	shapePlans publishOnceCache[configMatchKey, *effectiveConfigPlan]
@@ -27,12 +28,14 @@ type FileConfigResolver struct {
 
 // NewFileConfigResolver creates a per-run resolver for one config root.
 func NewFileConfigResolver(config RslintConfig, cwd string, enforcePlugins bool) *FileConfigResolver {
+	globalIgnorePatterns := extractConfigIgnores(config)
 	return &FileConfigResolver{
 		config:               config,
 		cwd:                  cwd,
 		enforcePlugins:       enforcePlugins,
-		globalIgnorePatterns: extractConfigIgnores(config),
+		globalIgnorePatterns: globalIgnorePatterns,
 		entryIgnorePatterns:  parseEntryIgnorePatterns(config),
+		directoryBlocks:      newDirectoryBlockMatcher(globalIgnorePatterns, cwd),
 	}
 }
 
@@ -63,6 +66,7 @@ func (r *FileConfigResolver) planForFile(filePath string) *effectiveConfigPlan {
 			r.cwd,
 			r.globalIgnorePatterns,
 			r.entryIgnorePatterns,
+			r.directoryBlocks,
 		)
 		if !matched {
 			return nil

--- a/internal/config/file_resolver_shape_test.go
+++ b/internal/config/file_resolver_shape_test.go
@@ -286,6 +286,35 @@ func TestFileConfigResolverConcurrentShapePublication(t *testing.T) {
 	}
 }
 
+func TestFileConfigResolverConcurrentDirectoryBlockCache(t *testing.T) {
+	config := RslintConfig{
+		{Ignores: []string{"dist/**"}},
+		{Files: []string{"**/*.ts"}, Settings: Settings{}},
+	}
+	resolver := NewFileConfigResolver(config, "/repo", false)
+
+	var waitGroup sync.WaitGroup
+	results := make(chan *MergedConfig, 128)
+	for index := range 128 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			results <- resolver.ConfigForFile(fmt.Sprintf("/repo/src/pkg/file-%d.ts", index))
+		}()
+	}
+	waitGroup.Wait()
+	close(results)
+	for merged := range results {
+		if merged == nil {
+			t.Fatal("non-ignored file resolved to nil config")
+		}
+	}
+
+	if merged := resolver.ConfigForFile("/repo/dist/pkg/blocked.ts"); merged != nil {
+		t.Fatal("directory-blocked file resolved to a config")
+	}
+}
+
 type configuredRuleView struct {
 	name               string
 	settings           map[string]interface{}

--- a/internal/config/ignore_pattern.go
+++ b/internal/config/ignore_pattern.go
@@ -519,30 +519,66 @@ func gitIgnoreNodeGlob(pattern IgnorePattern) string {
 // `!` and file-level patterns are excluded by Kind. Shared by GetConfigForFile
 // (lint) and canPruneDir (walk).
 func isDirAbsolutelyBlocked(dirPath string, patterns []IgnorePattern) bool {
+	var candidates []string
+	firstPattern := true
 	for i := range patterns {
 		p := patterns[i]
 		if p.Negated || p.Kind != dirAbsoluteBlock {
 			continue
 		}
-		if ignorePatternMatches(p, dirPath) || ignorePatternMatches(p, dirPath+"/x") {
-			return true
-		}
-		// Split+Join enumerated the prefixes ending immediately before every
-		// slash. Scan those same boundaries so each prefix is a zero-copy view
-		// into dirPath instead of allocating a segment slice and joined string.
-		for slash := strings.IndexByte(dirPath, '/'); slash >= 0; {
-			partial := dirPath[:slash]
-			if ignorePatternMatches(p, partial) || ignorePatternMatches(p, partial+"/x") {
+		// Preserve the allocation-free early-match path for the common single
+		// pattern case. Build reusable candidates only when another positive
+		// directory pattern would otherwise repeat every synthetic `/x` value.
+		if firstPattern {
+			firstPattern = false
+			if directoryPatternAbsolutelyBlocks(p, dirPath) {
 				return true
 			}
-			next := strings.IndexByte(dirPath[slash+1:], '/')
-			if next < 0 {
-				break
+			continue
+		}
+		if candidates == nil {
+			candidates = directoryBlockCandidates(dirPath)
+		}
+		for _, candidate := range candidates {
+			if ignorePatternMatches(p, candidate) {
+				return true
 			}
-			slash += next + 1
 		}
 	}
 	return false
+}
+
+func directoryPatternAbsolutelyBlocks(pattern IgnorePattern, dirPath string) bool {
+	if ignorePatternMatches(pattern, dirPath) || ignorePatternMatches(pattern, dirPath+"/x") {
+		return true
+	}
+	for slash := strings.IndexByte(dirPath, '/'); slash >= 0; {
+		partial := dirPath[:slash]
+		if ignorePatternMatches(pattern, partial) || ignorePatternMatches(pattern, partial+"/x") {
+			return true
+		}
+		next := strings.IndexByte(dirPath[slash+1:], '/')
+		if next < 0 {
+			break
+		}
+		slash += next + 1
+	}
+	return false
+}
+
+func directoryBlockCandidates(dirPath string) []string {
+	candidates := make([]string, 0, 2+2*strings.Count(dirPath, "/"))
+	candidates = append(candidates, dirPath, dirPath+"/x")
+	for slash := strings.IndexByte(dirPath, '/'); slash >= 0; {
+		partial := dirPath[:slash]
+		candidates = append(candidates, partial, partial+"/x")
+		next := strings.IndexByte(dirPath[slash+1:], '/')
+		if next < 0 {
+			break
+		}
+		slash += next + 1
+	}
+	return candidates
 }
 
 // canPruneDir reports whether a directory walk may skip dirPath entirely. It is

--- a/internal/config/ignore_pattern_test.go
+++ b/internal/config/ignore_pattern_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/config/gitignore"
 	"gotest.tools/v3/assert"
 )
@@ -389,6 +390,50 @@ func TestIsDirAbsolutelyBlocked_AncestorScan(t *testing.T) {
 		parsed := ParseIgnorePatterns(c.ignores)
 		if got := isDirAbsolutelyBlocked(c.dir, parsed); got != c.want {
 			t.Errorf("%s: isDirAbsolutelyBlocked(%q, %v) = %v, want %v", c.name, c.dir, c.ignores, got, c.want)
+		}
+	}
+}
+
+func TestDirectoryBlockMatcherCachesLexicalDirectory(t *testing.T) {
+	patterns := ParseIgnorePatterns([]string{"dist/**", "**/build", "!dist/keep.ts"})
+	tests := []struct {
+		name      string
+		cwd       string
+		filePaths []string
+	}{
+		{"unix", "/repo", []string{
+			"/repo/src/a.ts",
+			"/repo/src/b.ts",
+			"/repo/dist/a.ts",
+			"/repo/dist/b.ts",
+		}},
+		{"windows separators", `C:\repo`, []string{
+			`C:\repo\src\a.ts`,
+			`C:\repo\src\b.ts`,
+			"C:/repo/src/c.ts",
+		}},
+		{"relative root", "", []string{"a.ts", "b.ts"}},
+	}
+
+	for _, test := range tests {
+		matcher := newDirectoryBlockMatcher(patterns, test.cwd)
+		uniqueDirectories := make(map[string]struct{})
+		for _, filePath := range test.filePaths {
+			got := matcher.blocksFileDirectory(filePath)
+			want := isDirBlockedByIgnores(filePath, patterns, test.cwd)
+			if got != want {
+				t.Errorf("%s filePath=%q cwd=%q: cached=%v direct=%v", test.name, filePath, test.cwd, got, want)
+			}
+			uniqueDirectories[tspath.GetDirectoryPath(filePath)] = struct{}{}
+		}
+
+		cacheEntries := 0
+		matcher.results.entries.Range(func(_, _ any) bool {
+			cacheEntries++
+			return true
+		})
+		if cacheEntries != len(uniqueDirectories) {
+			t.Fatalf("%s cache entries = %d, want one per lexical directory (%d)", test.name, cacheEntries, len(uniqueDirectories))
 		}
 	}
 }

--- a/internal/config/resolution_cache.go
+++ b/internal/config/resolution_cache.go
@@ -14,6 +14,11 @@ type publishOnceEntry[V any] struct {
 }
 
 func (cache *publishOnceCache[K, V]) getOrInit(key K, init func() V) V {
+	if actual, ok := cache.entries.Load(key); ok {
+		// A stored entry may still be initializing; OnceValue waits for its
+		// published result and preserves panic replay semantics.
+		return actual.(*publishOnceEntry[V]).value() //nolint:forcetypeassert
+	}
 	candidate := &publishOnceEntry[V]{value: sync.OnceValue(init)}
 	actual, _ := cache.entries.LoadOrStore(key, candidate)
 	// entries is private and every stored value is a publishOnceEntry[V].


### PR DESCRIPTION
## Summary

- Cache repeated directory-block decisions within immutable config resolver and discovery lifetimes.
- Reuse ordered directory match candidates and avoid cache-hit initializer construction while preserving existing ignore semantics.
- Improve `BenchmarkDirectionBlockSharedDirectory` from 9,708 ns/op to 71.26 ns/op (-99.27%) and from 23 to 1 allocations/op.
- Improve `BenchmarkDirectionBlockCandidateReuse` from 16,759 ns/op to 14,525 ns/op (-13.33%) and from 48 to 12 allocations/op.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
