### PR TITLE
feat: add demand-driven RefStore facts

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -252,6 +252,7 @@ Rules are defined in `internal/rule/rule.go`:
 type Rule struct {
     Name             string
     RequiresTypeInfo bool
+    Needs            RuleNeeds
     Run              func(ctx RuleContext, options []any) RuleListeners
 }
 
@@ -301,6 +302,7 @@ func (*RuleContext) ReportNodeWithDeferredFixesAndSuggestions(
 func (*RuleContext) ReportRangeWithDeferredFixesAndSuggestions(
     ..., func() []RuleFix, func() []RuleSuggestion,
 )
+func (RuleContext) RequestRefs(needs RefNeeds) bool
 ```
 
 The linter creates one short-lived `CommentStore` per file. `Comments.All()`
@@ -309,25 +311,66 @@ for the first consumer; later consumers share that list. A source without `//`
 or `/*` takes a cheap byte-scan fast path. Inline-global parsing first checks
 for an exact raw-text directive candidate, so ordinary files do not force
 comment collection.
-The linter also creates one shared `RefStore` handle per file. Its candidate
-identifier walk is deferred until the first reference query, and binder name
-resolution is then performed once per queried symbol name. Rules query it with
-binder declaration symbols instead of repeating AST walks or TypeChecker
-lookups; files whose rules never request references do not materialize the
-index. `Resolve` (identifier → symbol) and `References` (symbol → identifiers)
-try the binder scope walk first, which answers most queries without ever
-touching the TypeChecker; when the binder can't place an identifier — a
-symbol declared outside the file (cross-file, `.d.ts`, standard-library
-globals) — `Resolve` falls back to the TypeChecker, at the cost of a round
-trip for that identifier, and `References` picks up that same fallback
-automatically when queried with a symbol `Resolve` obtained that way. Without
-a TypeChecker (`NewRefStore`'s third argument is `nil`), that fallback is a
-no-op and both methods only ever see symbols declared in the current file.
-`ResolveInFile` is the explicit binder-only forward lookup: it never takes the
-TypeChecker fallback even when one is available. ESLint scope rules such as
-`no-undef` use this path so DOM/lib, ambient `.d.ts`, and cross-file TypeScript
-symbols cannot make their result depend on whether the file happened to receive
-a checker.
+The linter also creates one shared `RefStore` handle per file. It is the single
+owner for authored binding occurrences, explicit lexical references and
+syntax-only import provenance; there is no parallel BindingStore or ScopeStore.
+The direct APIs expose neutral facts — read/write role, value/type/namespace
+space, exact declaration occurrence, syntactic container helpers, nearest
+function/outside-function-body relationships and local import syntax — but
+deliberately do not decide whether a binding is used, captured, shadowed or
+exported. These syntactic containers are not an ESLint Scope/Variable model;
+computed names, function-name scopes and parameter environments remain visible
+as syntax for a consumer to interpret. A parameter property exposes distinct
+lexical-parameter and class-member symbol identities. Import facts never
+resolve a module or follow an alias target and are independent of ModuleGraph.
+Nodes passed to direct node APIs must belong to the store's source file; the hot
+query path does not add an ancestor walk solely to validate that precondition.
+Raw TypeScript binder identities are also not a drop-in replacement for
+typescript-eslint Variables: class inner/outer name scopes, `with`, Annex-B
+block functions and namespace-member scopes can require a later compatible
+view to split or reinterpret one binder symbol. Scope-sensitive rule migrations
+must validate that view against scope-manager rather than infer `used`,
+`shadowed` or `captured` directly from these facts.
+
+Rules declare a static `Rule.Needs.Refs` ceiling and call `RequestRefs` during
+`Rule.Run` only for files that need a complete collection. After all rule
+initializers run, the linter activates one private Identifier observer on its
+existing enter traversal when at least one request is active. The normal
+traversal then collects each requested feature once per file for all requesting
+rules. No request selects the original traversal path: there is no observer,
+collection map or per-node branch. Declaration/import observation stores only
+compact name-node slices; full fact structs and their syntactic ancestor fields
+materialize once, on the first complete query, and are then shared.
+
+Only the linter retains the `RefCollector`/`RefObserver` traversal control
+capability. `RuleContext` exposes the same single `RefStore` for requests and
+queries, but a rule cannot seal a partial stream as complete; the collector
+owns no second store or analysis data. A complete-file query made before
+traversal finishes discards the partial logical collection, reuses its allocated
+storage and performs a complete prepass over every currently streaming feature;
+partial or live results are never returned. Existing rules need no metadata
+migration: the compatible lazy prepass remains available to any caller of
+`References`, `BindingDeclarations` or `ImportBindings`.
+
+`--timing` continues to attribute only each rule's `Run` and registered
+listeners. The shared Identifier observer is intentionally not charged to the
+first requesting rule and cannot be isolated without per-node clocks or double
+counting. Queries, lazy materialization and an early-query fallback still run
+inside — and are charged to — the listener that invokes them. Any rule
+migration must therefore validate end-to-end traversal/wall time (and fallback
+rate), not claim framework savings from its per-rule timing line alone.
+
+Reference name resolution remains lazy per queried symbol name. `Resolve`
+(identifier → symbol) and `References` (symbol → identifiers) try the binder
+scope walk first, which answers most queries without touching the TypeChecker;
+when the binder cannot place an identifier — a symbol declared outside the file
+(cross-file, `.d.ts`, standard-library globals) — `Resolve` falls back to the
+TypeChecker and `References` preserves that identity. Raw declarations in a
+global script or an external module's `declare global` block are reconciled to
+their checker-merged global identity only when queried. `ResolveInFile` remains
+the explicit binder-only lookup and never takes that fallback. The RefStore
+does not add a general per-node resolution cache: binder-local,
+checker-fallback and checker-merged reverse-index identities remain separate.
 Config resolution normalizes the per-file `ecmaVersion` into `LanguageOptions`;
 its zero value means the moving `latest` edition. The linter uses it to build
 one `Globals` value for each native rule context. `Globals` owns the
@@ -400,8 +443,15 @@ This allows one AST traversal to serve many rules.
 - **OnExit**: synthetic listener kind created by `ListenerOnExit(kind)`
 - **OnAllowPattern**: synthetic listener kind used for pattern/destructuring contexts
 - **OnNotAllowPattern**: synthetic listener kind used for non-pattern contexts of the same AST shape
+- **OnFileFinalize**: dedicated once-per-file event dispatched after all real
+  node enter/exit callbacks and after RefStore collection is complete
 
-Those synthetic kinds are defined by offsetting real `ast.Kind` values. They are a rule-framework dispatch mechanism, not native ts-go node kinds.
+Those synthetic kinds are a rule-framework dispatch mechanism, not native
+ts-go node kinds. `OnFileFinalize` is intentionally not
+`ListenerOnExit(ast.KindSourceFile)`: the SourceFile root is outside the normal
+node-listener traversal. Finalizers run before timing merge and listener-registry
+reset, so their work retains normal rule ordering, attribution and per-file
+lifetime.
 
 ## 7. Diagnostics & Autofixes
 
@@ -1082,7 +1132,12 @@ goroutines remain outside that guarantee.
 - **Buffered Diagnostic Collection**: CLI mode funnels diagnostics through a buffered channel before formatting, which reduces contention between lint tasks and output handling
 - **On-Demand AST Encoding**: API/WASM responses only include encoded source files when `IncludeEncodedSourceFiles` is requested
 - **Lazy Shared Comments**: each file owns one `CommentStore`; directive consumers and comment-aware rules materialize its canonical comment list only when needed and reuse the result. Rule-specific text checks avoid scanner work when their comment syntax cannot occur
-- **Lazy Shared References**: each file exposes one `RefStore`; its candidate identifier walk is deferred until first use, and each queried symbol name is binder-resolved once for reuse across native rules
+- **Demand-Driven Shared Reference Facts**: each file exposes one `RefStore`.
+  Legacy complete queries use a lazy prepass; declared per-file requests collect
+  references, binding occurrences and import provenance through the existing
+  Identifier dispatch during the main traversal. No-request files add no
+  listener or collection allocation, and each queried symbol name remains
+  binder-resolved once for reuse across native rules
 - **Task-Local Listener Reuse**: each checker-shard task owns one sparse listener registry and reuses its map and per-kind slice capacity across that task's serial files. Registries are never shared across tasks or requests
 - **Direct Rule Reporting Methods**: each rule context stores one compact immutable reporter state; its reporting methods replace the former family of per-rule bound closures
 - **Demand-Driven Native Edits**: native consumers explicitly request optional
@@ -1293,10 +1348,13 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │  Match Config Shape -> Reuse/Merge Immutable Config and Enabled Rules        │
 │            │                                                                 │
 │            ▼                                                                 │
-│  Run Rule Initializers -> Register Listeners                                 │
+│  Run Rule Initializers -> Register Listeners / RefStore Requests             │
 │            │                                                                 │
 │            ▼                                                                 │
-│  Single DFS AST Traversal -> Listener Dispatch                               │
+│  Single DFS AST Traversal -> Listener Dispatch / Requested Ref Facts         │
+│            │                                                                 │
+│            ▼                                                                 │
+│  Complete Shared Ref Facts -> File Finalizers                                │
 │            │                                                                 │
 │            ▼                                                                 │
 │  Native Edit Demand -> Report / Suppress -> Deferred Edit Materialization    │
@@ -1374,12 +1432,15 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 - **Program Registry**: Run-scoped set of Programs keyed by normalized declared tsconfig path, plus the governing configs and project declaration order associated with each Program
 - **project.Session**: ts-go project manager used by LSP for inferred/configured projects and overlays
 - **Rule Context**: Runtime environment through which a rule reads file/program/checker state and reports findings
+- **RefStore**: Per-file owner of binder resolution, explicit references,
+  authored binding occurrences and syntax-only import provenance; complete
+  collections are lazy or gathered on demand during the linter traversal
 - **RuleFix**: Text edit represented as a range plus replacement text; fixes are merged and applied after diagnostics are collected
 - **Rule Registry**: Shared registry of rule implementations and config-to-rule resolution logic; the registry is implemented in `internal/config/rule_registry.go` and populated by `RegisterAllRules()` in `internal/config/config.go`
 - **RuleSuggestion**: Suggested edit attached to a diagnostic that is surfaced to the user but not treated as a default autofix
 - **Severity**: Effective diagnostic level for a configured rule, such as `off`, `warn`, or `error`
 - **Source Code Fixer**: Fix-application layer that merges non-overlapping `RuleFix` edits and rewrites file contents
-- **Synthetic Listener Kind**: rslint-defined pseudo-kind such as `OnExit`, `OnAllowPattern`, or `OnNotAllowPattern` used to distinguish traversal contexts beyond raw AST kinds
+- **Synthetic Listener Kind**: rslint-defined pseudo-kind such as `OnExit`, `OnAllowPattern`, `OnNotAllowPattern`, or `OnFileFinalize` used to distinguish traversal contexts beyond raw AST kinds
 - **TypeChecker**: ts-go semantic engine acquired from a `Program` and used by type-aware rules for symbol and type queries
 - **Type-aware Rule**: Rule that requires the TypeChecker and semantic information
 - **TypeScript-Go**: Go port of the TypeScript compiler that supplies AST, checker, Program, project/session, scanner, and VFS

--- a/internal/config/file_resolver_shape_test.go
+++ b/internal/config/file_resolver_shape_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -292,6 +293,7 @@ type configuredRuleView struct {
 	globals            map[string]utils.GlobalAccess
 	severity           int
 	requiresTypeInfo   bool
+	needs              rule.RuleNeeds
 	isEslintPluginRule bool
 	options            []any
 	hasRun             bool
@@ -306,6 +308,7 @@ func configuredRuleViews(rules []linter.ConfiguredRule) []configuredRuleView {
 			globals:            configuredRule.Globals,
 			severity:           int(configuredRule.Severity),
 			requiresTypeInfo:   configuredRule.RequiresTypeInfo,
+			needs:              configuredRule.Needs,
 			isEslintPluginRule: configuredRule.IsEslintPluginRule,
 			options:            configuredRule.Options,
 			hasRun:             configuredRule.Run != nil,

--- a/internal/config/rule_registry.go
+++ b/internal/config/rule_registry.go
@@ -87,6 +87,7 @@ func (r *RuleRegistry) GetEnabledRulesForMergedConfig(mergedConfig *MergedConfig
 					Globals:            globals,
 					Severity:           ruleConfig.GetSeverity(),
 					RequiresTypeInfo:   ruleImpl.RequiresTypeInfo,
+					Needs:              ruleImpl.Needs,
 					IsEslintPluginRule: ruleImpl.IsEslintPluginRule,
 					Options:            options,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/config/rule_registry_test.go
+++ b/internal/config/rule_registry_test.go
@@ -692,6 +692,24 @@ func TestFileConfigResolver_MatchesRegistryAndFiltersTypeAwareRules(t *testing.T
 	}
 }
 
+func TestRuleRegistryPropagatesRuleNeeds(t *testing.T) {
+	registry := NewRuleRegistry()
+	needs := rule.RuleNeeds{Refs: rule.RefNeedReferences | rule.RefNeedBindingDeclarations}
+	registry.Register("needs-test", rule.Rule{
+		Name:  "needs-test",
+		Needs: needs,
+		Run: func(rule.RuleContext, []any) rule.RuleListeners {
+			return nil
+		},
+	})
+	configured := registry.GetEnabledRulesForMergedConfig(&MergedConfig{
+		Rules: map[string]*RuleConfig{"needs-test": {Level: "error"}},
+	}, false)
+	if len(configured) != 1 || configured[0].Needs != needs {
+		t.Fatalf("configured Needs = %#v, want %#v", configured, needs)
+	}
+}
+
 func TestFileConfigResolver_ConcurrentAccess(t *testing.T) {
 	RegisterAllRules()
 

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -99,8 +99,9 @@ type programLintResult struct {
 }
 
 type listenerRegistry struct {
-	byKind      map[ast.Kind][]func(node *ast.Node)
-	activeKinds []ast.Kind
+	byKind            map[ast.Kind][]func(node *ast.Node)
+	activeKinds       []ast.Kind
+	hasFileFinalizers bool
 }
 
 func newListenerRegistry() listenerRegistry {
@@ -116,6 +117,9 @@ func (r *listenerRegistry) add(kind ast.Kind, listener func(node *ast.Node)) {
 		r.activeKinds = append(r.activeKinds, kind)
 	}
 	r.byKind[kind] = append(listeners, listener)
+	if kind == rule.ListenerOnFileFinalize() {
+		r.hasFileFinalizers = true
+	}
 }
 
 func (r *listenerRegistry) listeners(kind ast.Kind) []func(node *ast.Node) {
@@ -132,6 +136,7 @@ func (r *listenerRegistry) reset() {
 		r.byKind[kind] = listeners[:0]
 	}
 	r.activeKinds = r.activeKinds[:0]
+	r.hasFileFinalizers = false
 }
 
 // runLintRulesInProgram lints files in a single Program. Files are filtered
@@ -209,8 +214,9 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 		// identifiers the binder scope walk can't resolve (declared outside
 		// this file); nil there just disables the fallback.
 		var refs *rule.RefStore
+		var refCollector rule.RefCollector
 		if opts.Program != nil {
-			refs = rule.NewRefStore(file, opts.Program.Options(), fileChecker)
+			refs, refCollector = rule.NewRefStoreWithCollector(file, opts.Program.Options(), fileChecker)
 		}
 
 		// One lazy byte-order-mark answer shared by every rule in this file.
@@ -222,7 +228,10 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 			sourceBOM = rule.NewSourceBOM(opts.Program.Host().FS(), file.FileName())
 		}
 
-		for ruleIndex, r := range rules {
+		var declaredRefNeeds rule.RefNeeds
+		for ruleIndex := range rules {
+			r := &rules[ruleIndex]
+			declaredRefNeeds |= r.Needs.Refs
 			ctx := rule.RuleContext{
 				SourceFile:     file,
 				Cwd:            opts.Cwd,
@@ -234,9 +243,10 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 				BOM:            sourceBOM,
 				TypeChecker:    fileChecker,
 				DisableManager: disableManager,
-			}.WithDiagnosticConsumer(
+			}.WithRuleConfiguration(
 				r.Name,
 				r.Severity,
+				r.Needs,
 				consumer,
 			)
 
@@ -262,9 +272,34 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 			}
 		}
 
+		// A dynamic request from Rule.Run selects one private observer on the
+		// existing Identifier enter path. Files without a request retain the
+		// original enter function: no observer, per-node branch, collection map,
+		// or allocation. Legacy rules may continue to query RefStore lazily
+		// without declaring Needs.
+		var refObserver rule.RefObserver
+		if declaredRefNeeds != 0 {
+			refObserver = refCollector.Start()
+		}
+		var fileFinalizers []func(node *ast.Node)
+		if registeredListeners.hasFileFinalizers {
+			fileFinalizers = registeredListeners.listeners(rule.ListenerOnFileFinalize())
+		}
+
 		runListeners := func(kind ast.Kind, node *ast.Node) {
 			for _, listener := range registeredListeners.listeners(kind) {
 				listener(node)
+			}
+		}
+		runEnterListeners := runListeners
+		if refObserver.Active() {
+			runEnterListeners = func(kind ast.Kind, node *ast.Node) {
+				for _, listener := range registeredListeners.listeners(kind) {
+					listener(node)
+				}
+				if kind == ast.KindIdentifier {
+					refObserver.Observe(node)
+				}
 			}
 		}
 
@@ -285,7 +320,7 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 		var childVisitor ast.Visitor
 		var patternVisitor func(node *ast.Node)
 		patternVisitor = func(node *ast.Node) {
-			runListeners(node.Kind, node)
+			runEnterListeners(node.Kind, node)
 			kind := rule.ListenerOnAllowPattern(node.Kind)
 			runListeners(kind, node)
 
@@ -316,7 +351,7 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 			runListeners(rule.ListenerOnExit(node.Kind), node)
 		}
 		childVisitor = func(node *ast.Node) bool {
-			runListeners(node.Kind, node)
+			runEnterListeners(node.Kind, node)
 
 			switch node.Kind {
 			case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
@@ -340,6 +375,15 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 			return false
 		}
 		file.Node.ForEachChild(childVisitor)
+		if refObserver.Active() {
+			refCollector.Complete()
+		}
+		// File finalizers run after every real-node enter/exit listener and
+		// after RefStore is complete, but before timing merge and registry
+		// reset so they retain ordinary rule ordering and attribution.
+		for _, finalize := range fileFinalizers {
+			finalize(file.AsNode())
+		}
 		if opts.Timing != nil {
 			opts.Timing.addFile(file.FileName(), rules, ruleDurations)
 		}

--- a/internal/linter/linter_no_ref_request_benchmark_test.go
+++ b/internal/linter/linter_no_ref_request_benchmark_test.go
@@ -1,0 +1,98 @@
+package linter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var benchmarkProgramResultSink programLintResult
+
+// createLinterBenchmarkProgram performs all filesystem, parse, bind, and plan
+// setup before benchmark timers start. It deliberately returns exact target
+// paths so bundled libraries never enter the measured lint pass.
+func createLinterBenchmarkProgram(
+	b *testing.B,
+	sources map[string]string,
+) (*compiler.Program, []string) {
+	b.Helper()
+	dir := b.TempDir()
+	includes := make([]string, 0, len(sources))
+	targets := make([]string, 0, len(sources))
+	for name, source := range sources {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+			b.Fatal(err)
+		}
+		includes = append(includes, "./"+name)
+		targets = append(targets, tspath.NormalizePath(path))
+	}
+	tsconfig := `{"include":["` + strings.Join(includes, `","`) + `"]}`
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(tsconfig), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	program, err := utils.CreateProgram(true, fs, dir, "tsconfig.json", utils.CreateCompilerHost(dir, fs))
+	if err != nil {
+		b.Fatal(err)
+	}
+	return program, targets
+}
+
+func benchmarkProgramLintOptions(
+	program *compiler.Program,
+	targets []string,
+	rules []ConfiguredRule,
+) runProgramOptions {
+	opts := runProgramOptions{
+		Program:         program,
+		TargetFiles:     targets,
+		HasTargetFiles:  true,
+		ExcludePaths:    []string{},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return rules },
+	}
+	plan := prepareProgramLintPlan(opts)
+	opts.PreparedPlan = &plan
+	return opts
+}
+
+// BenchmarkLinterNoRefRequestsManySmallFiles is intentionally compatible with
+// the pre-RefCollector main branch. It is the cross-revision zero-consumer
+// guard: the measured rules neither declare nor request RefStore collection.
+func BenchmarkLinterNoRefRequestsManySmallFiles(b *testing.B) {
+	sources := make(map[string]string, 128)
+	for index := range 128 {
+		sources[fmt.Sprintf("file_%03d.ts", index)] = fmt.Sprintf("export const value%d = %d;\n", index, index)
+	}
+	program, targets := createLinterBenchmarkProgram(b, sources)
+	rules := []ConfiguredRule{{
+		Name:     "benchmark/no-op",
+		Severity: rule.SeverityError,
+		Run:      func(rule.RuleContext) rule.RuleListeners { return nil },
+	}}
+	opts := benchmarkProgramLintOptions(program, targets, rules)
+	consumer := rule.DiagnosticConsumer{Report: func(rule.RuleDiagnostic) {}}
+	benchmarkProgramResultSink = runLintRulesInProgram(opts, consumer)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		benchmarkProgramResultSink = runLintRulesInProgram(opts, consumer)
+	}
+}

--- a/internal/linter/linter_ref_store_benchmark_test.go
+++ b/internal/linter/linter_ref_store_benchmark_test.go
@@ -1,0 +1,186 @@
+package linter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+var (
+	benchmarkReferenceCountSink   int
+	benchmarkDeclarationCountSink int
+	benchmarkImportCountSink      int
+)
+
+type refBenchmarkQuery uint8
+
+const (
+	refBenchmarkReferences refBenchmarkQuery = iota
+	refBenchmarkDeclarations
+	refBenchmarkImports
+	refBenchmarkAll
+)
+
+func benchmarkRefRule(query refBenchmarkQuery, streaming bool, fallbackAt int) ConfiguredRule {
+	var needs rule.RefNeeds
+	switch query {
+	case refBenchmarkReferences:
+		needs = rule.RefNeedReferences
+	case refBenchmarkDeclarations:
+		needs = rule.RefNeedBindingDeclarations
+	case refBenchmarkImports:
+		needs = rule.RefNeedImportBindings
+	case refBenchmarkAll:
+		needs = rule.RefNeedsAll
+	default:
+		panic("unknown RefStore benchmark query")
+	}
+
+	configured := ConfiguredRule{
+		Name:     "benchmark/ref-store",
+		Severity: rule.SeverityError,
+		Run: func(ctx rule.RuleContext) rule.RuleListeners {
+			if streaming {
+				ctx.RequestRefs(needs)
+			}
+			tracked := ctx.SourceFile.Locals["tracked"]
+			queryStore := func() {
+				switch query {
+				case refBenchmarkReferences:
+					benchmarkReferenceCountSink = len(ctx.Refs.References(tracked))
+				case refBenchmarkDeclarations:
+					benchmarkDeclarationCountSink = len(ctx.Refs.BindingDeclarations())
+				case refBenchmarkImports:
+					benchmarkImportCountSink = len(ctx.Refs.ImportBindings())
+				case refBenchmarkAll:
+					benchmarkReferenceCountSink = len(ctx.Refs.References(tracked))
+					benchmarkDeclarationCountSink = len(ctx.Refs.BindingDeclarations())
+					benchmarkImportCountSink = len(ctx.Refs.ImportBindings())
+				}
+			}
+
+			listeners := rule.RuleListeners{
+				rule.ListenerOnFileFinalize(): func(*ast.Node) { queryStore() },
+			}
+			if fallbackAt > 0 {
+				seen := 0
+				listeners[ast.KindIdentifier] = func(*ast.Node) {
+					seen++
+					if seen == fallbackAt {
+						queryStore()
+					}
+				}
+			}
+			return listeners
+		},
+	}
+	if streaming {
+		configured.Needs = rule.RuleNeeds{Refs: needs}
+	}
+	return configured
+}
+
+func runRefStoreBenchmark(
+	b *testing.B,
+	programOptions runProgramOptions,
+	rules []ConfiguredRule,
+) {
+	programOptions.GetRulesForFile = func(*ast.SourceFile) []ConfiguredRule { return rules }
+	plan := prepareProgramLintPlan(programOptions)
+	programOptions.PreparedPlan = &plan
+	consumer := rule.DiagnosticConsumer{Report: func(rule.RuleDiagnostic) {}}
+	benchmarkProgramResultSink = runLintRulesInProgram(programOptions, consumer)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		benchmarkProgramResultSink = runLintRulesInProgram(programOptions, consumer)
+	}
+}
+
+func BenchmarkLinterRefStoreReferenceCollection(b *testing.B) {
+	source := `export {};
+let tracked = 0;
+function work(input: number) {
+` + strings.Repeat("  tracked += input;\n  consume(tracked, input);\n", 1000) + "}\n"
+	program, targets := createLinterBenchmarkProgram(b, map[string]string{"large.ts": source})
+	file := program.GetSourceFile(targets[0])
+	if file == nil || file.Locals["tracked"] == nil {
+		b.Fatal("benchmark source was not bound")
+	}
+	identifierCount := 0
+	var countIdentifiers func(*ast.Node) bool
+	countIdentifiers = func(node *ast.Node) bool {
+		if node.Kind == ast.KindIdentifier {
+			identifierCount++
+		}
+		node.ForEachChild(countIdentifiers)
+		return false
+	}
+	file.AsNode().ForEachChild(countIdentifiers)
+	base := runProgramOptions{
+		Program:        program,
+		TargetFiles:    targets,
+		HasTargetFiles: true,
+		ExcludePaths:   []string{},
+		SingleThreaded: true,
+	}
+
+	for _, testCase := range []struct {
+		name       string
+		streaming  bool
+		fallbackAt int
+	}{
+		{name: "finalize/lazy-prepass"},
+		{name: "finalize/streaming", streaming: true},
+		{name: "fallback-10pct/lazy-prepass", fallbackAt: identifierCount / 10},
+		{name: "fallback-10pct/streaming", streaming: true, fallbackAt: identifierCount / 10},
+		{name: "fallback-50pct/lazy-prepass", fallbackAt: identifierCount / 2},
+		{name: "fallback-50pct/streaming", streaming: true, fallbackAt: identifierCount / 2},
+		{name: "fallback-90pct/lazy-prepass", fallbackAt: identifierCount * 9 / 10},
+		{name: "fallback-90pct/streaming", streaming: true, fallbackAt: identifierCount * 9 / 10},
+	} {
+		b.Run(testCase.name, func(b *testing.B) {
+			rules := []ConfiguredRule{benchmarkRefRule(refBenchmarkReferences, testCase.streaming, testCase.fallbackAt)}
+			runRefStoreBenchmark(b, base, rules)
+		})
+	}
+}
+
+func BenchmarkLinterRefStoreFactCollections(b *testing.B) {
+	var source strings.Builder
+	source.WriteString("export {};\nlet tracked = 0;\n")
+	for index := range 300 {
+		fmt.Fprintf(&source, "import { value as imported%d } from './missing%d';\n", index, index)
+	}
+	for index := range 1000 {
+		fmt.Fprintf(&source, "const local%d = imported%d; tracked += local%d;\n", index, index%300, index)
+	}
+	program, targets := createLinterBenchmarkProgram(b, map[string]string{"facts.ts": source.String()})
+	base := runProgramOptions{
+		Program:        program,
+		TargetFiles:    targets,
+		HasTargetFiles: true,
+		ExcludePaths:   []string{},
+		SingleThreaded: true,
+	}
+
+	for _, query := range []struct {
+		name  string
+		query refBenchmarkQuery
+	}{
+		{name: "declarations", query: refBenchmarkDeclarations},
+		{name: "imports", query: refBenchmarkImports},
+		{name: "all", query: refBenchmarkAll},
+	} {
+		b.Run(query.name+"/lazy-prepass", func(b *testing.B) {
+			runRefStoreBenchmark(b, base, []ConfiguredRule{benchmarkRefRule(query.query, false, 0)})
+		})
+		b.Run(query.name+"/streaming", func(b *testing.B) {
+			runRefStoreBenchmark(b, base, []ConfiguredRule{benchmarkRefRule(query.query, true, 0)})
+		})
+	}
+}

--- a/internal/linter/linter_ref_store_lifecycle_test.go
+++ b/internal/linter/linter_ref_store_lifecycle_test.go
@@ -1,0 +1,198 @@
+package linter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func TestRefStoreCollectionCompletesBeforeFileFinalize(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const value = 1; consume(value);",
+	})
+	var events []string
+	sourceFileExitCalls := 0
+	makeRule := func(name string, request bool) ConfiguredRule {
+		configured := ConfiguredRule{
+			Name:     name,
+			Severity: rule.SeverityWarning,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				events = append(events, name+":run")
+				if request && !ctx.RequestRefs(rule.RefNeedReferences) {
+					t.Fatal("linter context omitted RefStore")
+				}
+				return rule.RuleListeners{
+					ast.KindIdentifier: func(node *ast.Node) {
+						if node.Text() == "value" {
+							events = append(events, name+":identifier")
+						}
+					},
+					rule.ListenerOnExit(ast.KindIdentifier): func(node *ast.Node) {
+						if node.Text() == "value" {
+							events = append(events, name+":identifier-exit")
+						}
+					},
+					rule.ListenerOnExit(ast.KindSourceFile): func(*ast.Node) {
+						sourceFileExitCalls++
+					},
+					rule.ListenerOnFileFinalize(): func(file *ast.Node) {
+						events = append(events, name+":finalize")
+						if !request {
+							return
+						}
+						var valueNodes []*ast.Node
+						var visit func(*ast.Node) bool
+						visit = func(node *ast.Node) bool {
+							if node.Kind == ast.KindIdentifier && node.Text() == "value" {
+								valueNodes = append(valueNodes, node)
+							}
+							node.ForEachChild(visit)
+							return false
+						}
+						file.ForEachChild(visit)
+						if len(valueNodes) != 2 {
+							t.Fatalf("value nodes = %d, want declaration and reference", len(valueNodes))
+						}
+						got := ctx.Refs.References(valueNodes[0].Parent.Symbol())
+						if len(got) != 1 || got[0] != valueNodes[1] {
+							t.Fatalf("finalize References = %v, want complete reference %v", got, valueNodes[1])
+						}
+					},
+				}
+			},
+		}
+		if request {
+			configured.Needs = rule.RuleNeeds{Refs: rule.RefNeedReferences}
+		}
+		return configured
+	}
+
+	_, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{paths["a.ts"]}},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{makeRule("a", true), makeRule("b", false)}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	if sourceFileExitCalls != 0 {
+		t.Fatalf("ListenerOnExit(SourceFile) calls = %d, want 0", sourceFileExitCalls)
+	}
+	want := []string{
+		"a:run", "b:run",
+		"a:identifier", "b:identifier", "a:identifier-exit", "b:identifier-exit",
+		"a:identifier", "b:identifier", "a:identifier-exit", "b:identifier-exit",
+		"a:finalize", "b:finalize",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestFileFinalizeRunsOnceForEveryFileIncludingEmpty(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"empty.ts": "",
+		"value.ts": "const value = 1;",
+	})
+	finalized := make(map[string]int)
+
+	_, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{paths["empty.ts"], paths["value.ts"]}},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{{
+				Name: "finalize",
+				Run: func(rule.RuleContext) rule.RuleListeners {
+					return rule.RuleListeners{
+						rule.ListenerOnFileFinalize(): func(file *ast.Node) {
+							finalized[file.AsSourceFile().FileName()]++
+						},
+					}
+				},
+			}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	for _, name := range []string{"empty.ts", "value.ts"} {
+		if got := finalized[paths[name]]; got != 1 {
+			t.Errorf("%s finalize calls = %d, want 1", name, got)
+		}
+	}
+}
+
+func TestRefStoreCollectionCoversPatternTraversalExactlyOnce(t *testing.T) {
+	const source = `
+let outerKey, innerKey, nestedTarget, consume, recursiveKey;
+let recursiveTarget, recursiveSource, target, sourceValue, shared;
+({
+  [outerKey]: { [innerKey]: nestedTarget },
+  [consume((({ [recursiveKey]: recursiveTarget } = recursiveSource)))]: target,
+} = sourceValue);
+({ [shared]: shared } = shared);
+`
+	program, paths := createTestProgramWithFiles(t, map[string]string{"pattern.ts": source})
+	wantNames := []string{
+		"outerKey", "innerKey", "nestedTarget", "consume", "recursiveKey",
+		"recursiveTarget", "recursiveSource", "target", "sourceValue",
+		"shared",
+	}
+
+	_, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{paths["pattern.ts"]}},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{{
+				Name:  "pattern-ref-facts",
+				Needs: rule.RuleNeeds{Refs: rule.RefNeedReferences | rule.RefNeedBindingDeclarations},
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					ctx.RequestRefs(rule.RefNeedReferences | rule.RefNeedBindingDeclarations)
+					return rule.RuleListeners{
+						rule.ListenerOnFileFinalize(): func(*ast.Node) {
+							declarations := make(map[string]*ast.Symbol)
+							for _, declaration := range ctx.Refs.BindingDeclarations() {
+								if declaration.Symbol != nil {
+									declarations[declaration.Name.Text()] = declaration.Symbol
+								}
+							}
+							for _, name := range wantNames {
+								symbol := declarations[name]
+								if symbol == nil {
+									t.Errorf("missing streamed declaration for %q", name)
+									continue
+								}
+								references := ctx.Refs.References(symbol)
+								wantCount := 1
+								if name == "shared" {
+									wantCount = 3
+								}
+								if len(references) != wantCount {
+									t.Errorf("%s references = %v, want exactly %d", name, references, wantCount)
+									continue
+								}
+								for index, reference := range references {
+									if reference.Text() != name || index > 0 && references[index-1].Pos() >= reference.Pos() {
+										t.Errorf("%s references are not unique source order: %v", name, references)
+										break
+									}
+								}
+							}
+						},
+					}
+				},
+			}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+}

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -334,15 +334,19 @@ func TestListenerRegistryResetReleasesAndReusesListeners(t *testing.T) {
 	registry.add(ast.KindIdentifier, func(*ast.Node) { calls = append(calls, "first") })
 	registry.add(ast.KindIdentifier, func(*ast.Node) { calls = append(calls, "second") })
 	registry.add(rule.ListenerOnExit(ast.KindIdentifier), func(*ast.Node) { calls = append(calls, "exit") })
+	registry.add(rule.ListenerOnFileFinalize(), func(*ast.Node) { calls = append(calls, "finalize") })
 
-	if len(registry.activeKinds) != 2 {
-		t.Fatalf("activeKinds has %d entries, want 2", len(registry.activeKinds))
+	if len(registry.activeKinds) != 3 || !registry.hasFileFinalizers {
+		t.Fatalf("registry active state = (%d, %v), want 3 kinds with a finalizer", len(registry.activeKinds), registry.hasFileFinalizers)
 	}
 	identifierCapacity := cap(registry.byKind[ast.KindIdentifier])
 	registry.reset()
 
 	if len(registry.activeKinds) != 0 {
 		t.Fatalf("activeKinds has %d entries after reset, want 0", len(registry.activeKinds))
+	}
+	if registry.hasFileFinalizers {
+		t.Fatal("registry retained the file-finalizer fast-path flag after reset")
 	}
 	for kind, listeners := range registry.byKind {
 		if len(listeners) != 0 {

--- a/internal/linter/timing.go
+++ b/internal/linter/timing.go
@@ -16,11 +16,12 @@ type RuleTiming struct {
 	// Kind is RuleKindNative or RuleKindJS, depending on which side
 	// executed the rule.
 	Kind string
-	// Time is the total time spent in the rule: building its listeners
-	// (Run) plus every listener invocation during AST traversal, including
-	// any diagnostics/fix construction those listeners perform. Files are
-	// linted by parallel workers, so the sum over all rules can exceed the
-	// run's wall-clock time.
+	// Time is the total time spent in the rule: building its listeners (Run)
+	// plus every listener invocation during AST traversal and file finalization,
+	// including diagnostics, fixes, and shared-fact queries those listeners
+	// perform. Framework observers shared by several rules are not attributed to
+	// an arbitrary first consumer. Files are linted by parallel workers, so the
+	// sum over all rules can exceed the run's wall-clock time.
 	Time time.Duration
 	// Files is the number of distinct files the rule executed on. A file
 	// re-linted by --fix passes counts once, while its time keeps accruing.

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -22,6 +22,9 @@ type ConfiguredRule struct {
 	Globals          map[string]utils.GlobalAccess
 	Severity         rule.DiagnosticSeverity
 	RequiresTypeInfo bool
+	// Needs is the rule's static shared-analysis capability ceiling. The rule
+	// still opts individual files in dynamically from Rule.Run.
+	Needs rule.RuleNeeds
 	// IsEslintPluginRule marks a rule that executes in the Node plugin-lint
 	// worker (mounted via the config's object-form `plugins`) rather than natively
 	// in Go. The linter splits these out and dispatches them; its Run is a

--- a/internal/rule/context.go
+++ b/internal/rule/context.go
@@ -56,11 +56,12 @@ type RuleContext struct {
 	// utils.ForEachComment. The first consumer computes the list and every
 	// later consumer for this file reuses it.
 	Comments *CommentStore
-	// Refs lazily provides the per-file identifier-reference index. Rules
-	// that need "all references to this declared symbol" should query this
-	// instead of walking the AST and calling TypeChecker.GetSymbolAtLocation
-	// per identifier. Keys are binder symbols (node.Symbol()); see RefStore.
-	// Nil when no program is available.
+	// Refs is the single per-file owner of explicit references, authored
+	// binding occurrences, and syntax-only import provenance. Complete-file
+	// collections stay lazy unless a rule declares and requests them; direct
+	// node queries do not require a request. Reference keys are binder symbols
+	// (node.Symbol()); see RefStore for identity boundaries. Nil when no program
+	// is available.
 	Refs *RefStore
 	// BOM lazily answers whether this file's source text began with a byte
 	// order mark. Rules read it through [RuleContext.HasBOM]; nil answers
@@ -72,13 +73,44 @@ type RuleContext struct {
 	reporter       ruleContextReporter
 }
 
+// WithRuleNeeds binds the static RefStore capability ceiling declared by one
+// rule for a directly constructed context. The linter uses the combined
+// WithRuleConfiguration path to avoid a second RuleContext value copy.
+func (ctx RuleContext) WithRuleNeeds(needs RuleNeeds) RuleContext {
+	if !needs.Refs.IsValid() {
+		panic("rule: invalid RefStore needs")
+	}
+	ctx.reporter.refNeeds = needs.Refs
+	return ctx
+}
+
+// RequestRefs opts the current file into complete-file RefStore collection.
+// needs must be a subset of the rule's declared Rule.Needs. Calls made during
+// Rule.Run are collected by the linter's existing traversal; a later call is
+// correctness-safe but falls back to a complete lazy prepass.
+func (ctx RuleContext) RequestRefs(needs RefNeeds) bool {
+	if !needs.IsValid() {
+		panic("rule: invalid RefStore request")
+	}
+	if needs&^ctx.reporter.refNeeds != 0 {
+		panic("rule: requested undeclared RefStore needs")
+	}
+	if ctx.Refs == nil {
+		return false
+	}
+	ctx.Refs.request(needs)
+	return true
+}
+
 // ruleContextReporter is immutable after Rule.Run starts. Keeping only the
 // rule-specific metadata here avoids allocating a family of bound reporting
 // closures for every rule context.
 type ruleContextReporter struct {
 	ruleName string
 	severity DiagnosticSeverity
-	consumer DiagnosticConsumer
+	demand   EditDemand
+	refNeeds RefNeeds
+	report   func(RuleDiagnostic)
 }
 
 // WithReporter returns a context configured to report diagnostics for one
@@ -111,16 +143,45 @@ func (ctx RuleContext) WithDiagnosticConsumer(
 	if !consumer.Demand.IsValid() {
 		panic("rule: invalid edit demand")
 	}
-	ctx.reporter = ruleContextReporter{
-		ruleName: ruleName,
-		severity: severity,
-		consumer: consumer,
+	ctx.reporter.ruleName = ruleName
+	ctx.reporter.severity = severity
+	ctx.reporter.demand = consumer.Demand
+	ctx.reporter.report = consumer.Report
+	return ctx
+}
+
+// WithRuleConfiguration binds both the rule's shared-analysis ceiling and its
+// diagnostic consumer in one context copy. The linter uses this combined path
+// for every configured rule; compatibility callers that do not declare shared
+// needs continue to use WithDiagnosticConsumer.
+func (ctx RuleContext) WithRuleConfiguration(
+	ruleName string,
+	severity DiagnosticSeverity,
+	needs RuleNeeds,
+	consumer DiagnosticConsumer,
+) RuleContext {
+	if ctx.SourceFile == nil {
+		panic("rule: reporter requires a source file")
 	}
+	if consumer.Report == nil {
+		panic("rule: reporter requires a diagnostic handler")
+	}
+	if !consumer.Demand.IsValid() {
+		panic("rule: invalid edit demand")
+	}
+	if !needs.Refs.IsValid() {
+		panic("rule: invalid RefStore needs")
+	}
+	ctx.reporter.ruleName = ruleName
+	ctx.reporter.severity = severity
+	ctx.reporter.demand = consumer.Demand
+	ctx.reporter.refNeeds = needs.Refs
+	ctx.reporter.report = consumer.Report
 	return ctx
 }
 
 func (ctx *RuleContext) requireReporter() {
-	if ctx.reporter.consumer.Report == nil {
+	if ctx.reporter.report == nil {
 		panic("rule: uninitialized RuleContext reporter")
 	}
 }
@@ -133,7 +194,7 @@ func (ctx *RuleContext) shouldReportRange(textRange core.TextRange) bool {
 
 func (ctx *RuleContext) emitRange(textRange core.TextRange, msg RuleMessage, fixes *[]RuleFix, suggestions *[]RuleSuggestion) {
 	reporter := &ctx.reporter
-	reporter.consumer.Report(RuleDiagnostic{
+	reporter.report(RuleDiagnostic{
 		RuleName:    reporter.ruleName,
 		Range:       textRange,
 		Message:     msg,
@@ -173,10 +234,10 @@ func (ctx *RuleContext) reportRange(textRange core.TextRange, msg RuleMessage, f
 	if !ctx.shouldReportRange(textRange) {
 		return
 	}
-	if ctx.reporter.consumer.Demand&EditDemandAutofix == 0 {
+	if ctx.reporter.demand&EditDemandAutofix == 0 {
 		fixes = nil
 	}
-	if ctx.reporter.consumer.Demand&EditDemandSuggestion == 0 {
+	if ctx.reporter.demand&EditDemandSuggestion == 0 {
 		suggestions = nil
 	}
 	ctx.emitRange(textRange, msg, fixes, suggestions)
@@ -187,7 +248,7 @@ func (ctx *RuleContext) reportRangeWithDeferredFixes(textRange core.TextRange, m
 		return
 	}
 
-	if ctx.reporter.consumer.Demand&EditDemandAutofix != 0 {
+	if ctx.reporter.demand&EditDemandAutofix != 0 {
 		built := build()
 		if len(built) > 0 {
 			ctx.emitRangeWithFixes(textRange, msg, built)
@@ -202,7 +263,7 @@ func (ctx *RuleContext) reportRangeWithDeferredSuggestions(textRange core.TextRa
 		return
 	}
 
-	if ctx.reporter.consumer.Demand&EditDemandSuggestion != 0 {
+	if ctx.reporter.demand&EditDemandSuggestion != 0 {
 		built := build()
 		if len(built) > 0 {
 			ctx.emitRangeWithSuggestions(textRange, msg, built)
@@ -223,12 +284,12 @@ func (ctx *RuleContext) reportRangeWithDeferredFixesAndSuggestions(
 	}
 
 	var fixes []RuleFix
-	if ctx.reporter.consumer.Demand&EditDemandAutofix != 0 {
+	if ctx.reporter.demand&EditDemandAutofix != 0 {
 		fixes = buildFixes()
 	}
 
 	var suggestions []RuleSuggestion
-	if ctx.reporter.consumer.Demand&EditDemandSuggestion != 0 {
+	if ctx.reporter.demand&EditDemandSuggestion != 0 {
 		suggestions = buildSuggestions()
 	}
 

--- a/internal/rule/ref_facts.go
+++ b/internal/rule/ref_facts.go
@@ -1,0 +1,496 @@
+package rule
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// RefNeeds is a set of complete-file collections a rule may request from the
+// per-file RefStore. Direct node queries such as Resolve and ReferenceFacts do
+// not require a collection need.
+type RefNeeds uint8
+
+const (
+	RefNeedReferences RefNeeds = 1 << iota
+	RefNeedBindingDeclarations
+	RefNeedImportBindings
+
+	RefNeedsAll = RefNeedReferences | RefNeedBindingDeclarations | RefNeedImportBindings
+)
+
+// IsValid reports whether needs contains only supported RefStore features.
+func (needs RefNeeds) IsValid() bool {
+	return needs&^RefNeedsAll == 0
+}
+
+// RuleNeeds declares the shared-analysis capabilities a rule may dynamically
+// request for a file. It is deliberately an extensible wrapper rather than a
+// second analysis store.
+type RuleNeeds struct {
+	Refs RefNeeds
+}
+
+// ReferenceAccess describes the lexical access performed by a reference.
+// Type-only references are reads in this lexical sense even though they do not
+// read a runtime value.
+type ReferenceAccess uint8
+
+const (
+	ReferenceAccessRead ReferenceAccess = 1 << iota
+	ReferenceAccessWrite
+)
+
+// ReferenceSpace identifies the declaration spaces in which a reference may
+// resolve. Flags may be combined for constructs such as a regular local export.
+type ReferenceSpace uint8
+
+const (
+	ReferenceSpaceValue ReferenceSpace = 1 << iota
+	ReferenceSpaceType
+	ReferenceSpaceNamespace
+)
+
+// ReferenceSyntax records syntax distinctions that commonly affect rule
+// policy without baking those policies (used, captured, shadowed, and so on)
+// into RefStore.
+type ReferenceSyntax uint16
+
+const (
+	ReferenceSyntaxTypePosition ReferenceSyntax = 1 << iota
+	ReferenceSyntaxTypeQuery
+	ReferenceSyntaxLocalExport
+	ReferenceSyntaxShorthand
+	ReferenceSyntaxJSXTag
+)
+
+// ReferenceFacts is a syntax-only description of one explicit lexical
+// reference. It never performs checker resolution and contains no rule-level
+// conclusion such as whether the reference makes a binding "used". The two
+// Syntactic*Container fields are direct AST-helper results, not an ESLint scope
+// or an execution-context claim. NearestFunction may therefore be a method
+// whose computed name contains Node; OutsideFunctionBody records that exact
+// syntax relationship without calling the reference a parameter/signature use.
+type ReferenceFacts struct {
+	Node                    *ast.Node
+	Access                  ReferenceAccess
+	Space                   ReferenceSpace
+	Syntax                  ReferenceSyntax
+	SyntacticBlockContainer *ast.Node
+	SyntacticScopeContainer *ast.Node
+	NearestFunction         *ast.Node
+	OutsideFunctionBody     bool
+}
+
+// BindingDeclarationFacts describes one authored binding occurrence. Symbol is
+// the lexical/type binder identity used by RefStore; declaration merging may
+// therefore produce multiple facts that share a Symbol. A TypeScript parameter
+// property has a second class-member identity in MemberSymbol; all other
+// declarations leave MemberSymbol nil. The two Syntactic*Container fields are
+// exact AST-helper results, not a claim that RefStore has constructed a
+// complete ESLint scope or Variable object.
+// NearestFunction includes a function declaration/expression that owns Name;
+// OutsideFunctionBody says Name is outside that function's Body. Neither field
+// identifies the ESLint scope that owns the binding.
+type BindingDeclarationFacts struct {
+	Name                    *ast.Node
+	Declaration             *ast.Node
+	RootDeclaration         *ast.Node
+	Symbol                  *ast.Symbol
+	MemberSymbol            *ast.Symbol
+	SyntacticBlockContainer *ast.Node
+	SyntacticScopeContainer *ast.Node
+	NearestFunction         *ast.Node
+	OutsideFunctionBody     bool
+}
+
+// ImportBindingKind identifies the syntax that declares a local import alias.
+type ImportBindingKind uint8
+
+const (
+	ImportBindingDefault ImportBindingKind = iota + 1
+	ImportBindingNamed
+	ImportBindingNamespace
+	ImportBindingEquals
+)
+
+// ImportBinding is syntax-only provenance for a local import binding. It never
+// resolves the module, follows the alias target, or consults ModuleGraph.
+type ImportBinding struct {
+	Kind            ImportBindingKind
+	Declaration     *ast.Node
+	Specifier       *ast.Node
+	LocalName       *ast.Node
+	Symbol          *ast.Symbol
+	ModuleSpecifier *ast.Node
+	ImportedName    string
+	TypeOnly        bool
+}
+
+// ReferenceFacts returns neutral syntax and container facts for an explicit
+// lexical reference. node must belong to this store's source file. A
+// syntactically valid but unresolved identifier still returns ok=true.
+// Declaration names, property labels, re-export names, intrinsic JSX tags,
+// and other non-reference positions return ok=false.
+func (s *RefStore) ReferenceFacts(node *ast.Node) (facts ReferenceFacts, ok bool) {
+	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
+		return ReferenceFacts{}, false
+	}
+
+	facts.Node = node
+	facts.Access = ReferenceAccessRead
+	if isWriteReference(node) {
+		facts.Access = ReferenceAccessWrite
+		if isReadWriteReference(node) {
+			facts.Access |= ReferenceAccessRead
+		}
+	}
+
+	facts.Space = referenceSpace(node)
+
+	typeOnlyExport := node.Parent != nil && node.Parent.Kind == ast.KindExportSpecifier &&
+		ast.IsTypeOnlyImportOrExportDeclaration(node.Parent)
+	if ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node) ||
+		isTypeOnlyPropertyAccessQualifier(node) || typeOnlyExport {
+		facts.Syntax |= ReferenceSyntaxTypePosition
+	}
+	if ast.IsPartOfTypeQuery(node) {
+		facts.Syntax |= ReferenceSyntaxTypeQuery
+	}
+	if parent := node.Parent; parent != nil {
+		switch parent.Kind {
+		case ast.KindExportSpecifier:
+			if !utils.IsReExportSpecifier(parent) {
+				facts.Syntax |= ReferenceSyntaxLocalExport
+			}
+		case ast.KindShorthandPropertyAssignment:
+			facts.Syntax |= ReferenceSyntaxShorthand
+		}
+	}
+	if isJSXTagReference(node) {
+		facts.Syntax |= ReferenceSyntaxJSXTag
+	}
+
+	facts.SyntacticBlockContainer = ast.GetEnclosingBlockScopeContainer(node)
+	facts.SyntacticScopeContainer = utils.FindEnclosingScope(node)
+	facts.NearestFunction = ast.FindAncestor(node.Parent, ast.IsFunctionLike)
+	if facts.NearestFunction != nil {
+		facts.OutsideFunctionBody = isOutsideFunctionBody(node, facts.NearestFunction)
+	}
+	return facts, true
+}
+
+// referenceSpace describes the syntactic lookup spaces requested by a
+// reference. It intentionally does not derive these flags by intersecting
+// referenceMeaning with SymbolFlagsValue/Type/Namespace: TypeScript's symbol
+// flag groups overlap (for example, class flags belong to both Value and Type)
+// and every resolver meaning also carries SymbolFlagsAlias.
+func referenceSpace(node *ast.Node) ReferenceSpace {
+	parent := node.Parent
+	if parent != nil && parent.Kind == ast.KindTypePredicate {
+		return ReferenceSpaceValue
+	}
+	if parent != nil && parent.Kind == ast.KindExportAssignment {
+		return ReferenceSpaceValue | ReferenceSpaceType | ReferenceSpaceNamespace
+	}
+	if parent != nil && parent.Kind == ast.KindExportSpecifier {
+		if ast.IsTypeOnlyImportOrExportDeclaration(parent) {
+			return ReferenceSpaceType | ReferenceSpaceNamespace
+		}
+		return ReferenceSpaceValue | ReferenceSpaceType | ReferenceSpaceNamespace
+	}
+
+	entity := node
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindQualifiedName {
+		entity = entity.Parent
+	}
+	if entity.Parent != nil && entity.Parent.Kind == ast.KindImportEqualsDeclaration &&
+		entity.Parent.AsImportEqualsDeclaration().ModuleReference == entity {
+		return ReferenceSpaceValue | ReferenceSpaceType | ReferenceSpaceNamespace
+	}
+	if isTypeOnlyPropertyAccessQualifier(node) {
+		return ReferenceSpaceNamespace
+	}
+	if ast.IsExpressionNode(node) {
+		return ReferenceSpaceValue
+	}
+	if parent != nil && parent.Kind == ast.KindQualifiedName && parent.AsQualifiedName().Left == node {
+		return ReferenceSpaceNamespace
+	}
+	if ast.IsPartOfTypeNode(node) {
+		return ReferenceSpaceType
+	}
+	return ReferenceSpaceValue
+}
+
+// BindingDeclaration returns facts for one authored declaration identifier.
+// name must belong to this store's source file. It is a direct query and never
+// builds the complete-file declaration list.
+func (s *RefStore) BindingDeclaration(name *ast.Node) (BindingDeclarationFacts, bool) {
+	if s == nil {
+		return BindingDeclarationFacts{}, false
+	}
+	return bindingDeclarationFacts(name)
+}
+
+// BindingDeclarations returns every authored lexical, type, import, and enum
+// declaration identifier in source order. Class/object members are properties,
+// not lexical bindings; `export as namespace` and the `global` token of a
+// `declare global` block are augmentation syntax, so none is included. A
+// parameter property contributes its parameter binding and exposes its second
+// class-member identity on that fact. Treat the returned slice as read-only.
+func (s *RefStore) BindingDeclarations() []BindingDeclarationFacts {
+	if s == nil {
+		return nil
+	}
+	s.ensureBuilt(RefNeedBindingDeclarations)
+	if s.facts == nil {
+		return nil
+	}
+	facts := s.facts
+	if facts.materializedNeeds&RefNeedBindingDeclarations == 0 {
+		if facts.materialized == nil {
+			facts.materialized = &materializedRefFacts{}
+		}
+		declarations := make([]BindingDeclarationFacts, 0, len(facts.declarationNames))
+		for _, name := range facts.declarationNames {
+			if declaration, ok := bindingDeclarationFacts(name); ok {
+				declarations = append(declarations, declaration)
+			}
+		}
+		facts.materialized.declarations = declarations
+		facts.declarationNames = nil
+		facts.materializedNeeds |= RefNeedBindingDeclarations
+	}
+	return facts.materialized.declarations
+}
+
+// ImportBinding returns syntax-only import provenance for a local import
+// declaration identifier or for an explicit reference to that binding. node
+// must belong to this store's source file. Reference lookup is binder-only;
+// this method never resolves a module target.
+func (s *RefStore) ImportBinding(node *ast.Node) (ImportBinding, bool) {
+	if s == nil || node == nil || node.Kind != ast.KindIdentifier {
+		return ImportBinding{}, false
+	}
+	if binding, ok := importBindingFacts(node); ok {
+		return binding, true
+	}
+	if !isReferencePosition(node) {
+		return ImportBinding{}, false
+	}
+	sym := s.ResolveInFile(node)
+	if sym == nil {
+		return ImportBinding{}, false
+	}
+	for _, declaration := range sym.Declarations {
+		if name := declaration.Name(); name != nil {
+			if binding, ok := importBindingFacts(name); ok && binding.Symbol == sym {
+				return binding, true
+			}
+		}
+	}
+	return ImportBinding{}, false
+}
+
+// ImportBindings returns every local binding from ECMAScript/TypeScript import
+// declarations in source order, including the re-parsed form of JSDoc
+// `@import`. Treat the returned slice as read-only. Module resolution is never
+// performed.
+func (s *RefStore) ImportBindings() []ImportBinding {
+	if s == nil {
+		return nil
+	}
+	s.ensureBuilt(RefNeedImportBindings)
+	if s.facts == nil {
+		return nil
+	}
+	facts := s.facts
+	if facts.materializedNeeds&RefNeedImportBindings == 0 {
+		if facts.materialized == nil {
+			facts.materialized = &materializedRefFacts{}
+		}
+		imports := make([]ImportBinding, 0, len(facts.importNames))
+		for _, name := range facts.importNames {
+			if binding, ok := importBindingFacts(name); ok {
+				imports = append(imports, binding)
+			}
+		}
+		facts.materialized.imports = imports
+		facts.importNames = nil
+		facts.materializedNeeds |= RefNeedImportBindings
+	}
+	return facts.materialized.imports
+}
+
+func bindingDeclarationFacts(name *ast.Node) (BindingDeclarationFacts, bool) {
+	if name == nil || name.Kind != ast.KindIdentifier || !isBindingDeclarationIdentifier(name) {
+		return BindingDeclarationFacts{}, false
+	}
+	declaration := name.Parent
+	root := ast.GetRootDeclaration(declaration)
+	if root == nil {
+		root = declaration
+	}
+	function := ast.FindAncestor(name.Parent, ast.IsFunctionLike)
+	symbol := utils.BindingNameSymbol(name)
+	var memberSymbol *ast.Symbol
+	if declaration.Kind == ast.KindParameter && declaration.Parent != nil &&
+		ast.IsParameterPropertyDeclaration(declaration, declaration.Parent) {
+		memberSymbol = symbol
+		symbol = declaration.Parent.Locals()[name.Text()]
+	}
+	return BindingDeclarationFacts{
+		Name:                    name,
+		Declaration:             declaration,
+		RootDeclaration:         root,
+		Symbol:                  symbol,
+		MemberSymbol:            memberSymbol,
+		SyntacticBlockContainer: ast.GetEnclosingBlockScopeContainer(declaration),
+		SyntacticScopeContainer: utils.FindEnclosingScope(declaration),
+		NearestFunction:         function,
+		OutsideFunctionBody:     function != nil && isOutsideFunctionBody(name, function),
+	}, true
+}
+
+// isBindingDeclarationIdentifier is the exact declaration taxonomy exposed by
+// BindingDeclarations. The shared utility covers regular JavaScript and
+// TypeScript declarations; JSDoc typedef/callback syntax is re-parsed as a
+// JSTypeAliasDeclaration and needs the explicit final case. Property/member
+// names and NamespaceExportDeclaration aliases deliberately remain excluded.
+func isBindingDeclarationIdentifier(node *ast.Node) bool {
+	if node != nil && node.Parent != nil && node.Parent.Kind == ast.KindModuleDeclaration &&
+		ast.IsGlobalScopeAugmentation(node.Parent) {
+		return false
+	}
+	if node != nil && node.Parent != nil && node.Parent.Kind == ast.KindFunctionDeclaration &&
+		node.Parent.Flags&ast.NodeFlagsReparsed != 0 && node.Parent.Name() == node {
+		// A JSDoc @overload signature clones the implementation's name into a
+		// synthetic FunctionDeclaration even though the tag did not author a
+		// second name occurrence.
+		return false
+	}
+	if utils.IsDeclarationIdentifier(node) {
+		return true
+	}
+	return node != nil && node.Parent != nil && node.Parent.Kind == ast.KindJSTypeAliasDeclaration &&
+		node.Parent.Name() == node
+}
+
+func importBindingFacts(name *ast.Node) (ImportBinding, bool) {
+	if name == nil || name.Kind != ast.KindIdentifier || name.Parent == nil || name.Parent.Name() != name {
+		return ImportBinding{}, false
+	}
+
+	specifier := name.Parent
+	binding := ImportBinding{
+		Specifier: specifier,
+		LocalName: name,
+		Symbol:    utils.BindingNameSymbol(name),
+	}
+
+	switch specifier.Kind {
+	case ast.KindImportClause:
+		binding.Kind = ImportBindingDefault
+		binding.ImportedName = "default"
+	case ast.KindImportSpecifier:
+		binding.Kind = ImportBindingNamed
+		importSpecifier := specifier.AsImportSpecifier()
+		imported := importSpecifier.PropertyName
+		if imported == nil {
+			imported = importSpecifier.Name()
+		}
+		if imported != nil {
+			binding.ImportedName = imported.Text()
+		}
+	case ast.KindNamespaceImport:
+		binding.Kind = ImportBindingNamespace
+		binding.ImportedName = "*"
+	case ast.KindImportEqualsDeclaration:
+		binding.Kind = ImportBindingEquals
+		declaration := specifier.AsImportEqualsDeclaration()
+		binding.Declaration = specifier
+		binding.TypeOnly = declaration.IsTypeOnly
+		if moduleReference := declaration.ModuleReference; moduleReference != nil && moduleReference.Kind == ast.KindExternalModuleReference {
+			binding.ModuleSpecifier = moduleReference.AsExternalModuleReference().Expression
+		}
+		return binding, true
+	default:
+		return ImportBinding{}, false
+	}
+
+	binding.TypeOnly = ast.IsTypeOnlyImportOrExportDeclaration(specifier)
+	for current := specifier.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindImportDeclaration || current.Kind == ast.KindJSImportDeclaration {
+			binding.Declaration = current
+			binding.ModuleSpecifier = current.AsImportDeclaration().ModuleSpecifier
+			return binding, true
+		}
+		if current.Kind == ast.KindSourceFile {
+			break
+		}
+	}
+	return ImportBinding{}, false
+}
+
+func isReadWriteReference(node *ast.Node) bool {
+	current := transparentReferenceTarget(node)
+	parent := current.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindBinaryExpression:
+		binary := parent.AsBinaryExpression()
+		return binary.Left == current && binary.OperatorToken.Kind != ast.KindEqualsToken &&
+			ast.IsAssignmentOperator(binary.OperatorToken.Kind)
+	case ast.KindPrefixUnaryExpression:
+		unary := parent.AsPrefixUnaryExpression()
+		return unary.Operand == current &&
+			(unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken)
+	case ast.KindPostfixUnaryExpression:
+		unary := parent.AsPostfixUnaryExpression()
+		return unary.Operand == current &&
+			(unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken)
+	}
+	return false
+}
+
+func isWriteReference(node *ast.Node) bool {
+	return utils.IsWriteReference(transparentReferenceTarget(node))
+}
+
+// transparentReferenceTarget returns the outer expression that remains the
+// same assignment target as node. The shared IsWriteReference already handles
+// most wrappers recursively; normalizing here also covers SatisfiesExpression,
+// which TypeScript accepts and erases around assignment targets.
+func transparentReferenceTarget(node *ast.Node) *ast.Node {
+	current := node
+	for current.Parent != nil {
+		parent := current.Parent
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression, ast.KindNonNullExpression,
+			ast.KindAsExpression, ast.KindTypeAssertionExpression, ast.KindSatisfiesExpression:
+			if parent.Expression() != current {
+				return current
+			}
+			current = parent
+		default:
+			return current
+		}
+	}
+	return current
+}
+
+func isOutsideFunctionBody(node *ast.Node, function *ast.Node) bool {
+	body := function.Body()
+	return body == nil || !ast.IsNodeDescendantOf(node, body)
+}
+
+func isJSXTagReference(node *ast.Node) bool {
+	entity := node
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindPropertyAccessExpression &&
+		entity.Parent.AsPropertyAccessExpression().Expression == entity {
+		entity = entity.Parent
+	}
+	return ast.IsJsxTagName(entity)
+}

--- a/internal/rule/ref_facts_test.go
+++ b/internal/rule/ref_facts_test.go
@@ -1,0 +1,556 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+)
+
+func TestRefStoreReferenceFactsAccessAndSignature(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/reference-facts.ts", core.ScriptKindTS, `
+export {};
+let target = 0;
+const key = "key", fallback = 1, source = {}, delta = 1, values = [];
+({ [key]: target = fallback } = source);
+target += delta;
+target++;
+for (target of values) {}
+type TargetType = typeof target;
+`)
+
+	var got []ReferenceFacts
+	for _, node := range identifiers(sourceFile.AsNode(), "target") {
+		if facts, ok := refs.ReferenceFacts(node); ok {
+			got = append(got, facts)
+		}
+	}
+	if len(got) != 5 {
+		t.Fatalf("reference facts = %d, want 5", len(got))
+	}
+	wantAccess := []ReferenceAccess{
+		ReferenceAccessWrite,
+		ReferenceAccessRead | ReferenceAccessWrite,
+		ReferenceAccessRead | ReferenceAccessWrite,
+		ReferenceAccessWrite,
+		ReferenceAccessRead,
+	}
+	for index, facts := range got {
+		if facts.Access != wantAccess[index] {
+			t.Errorf("reference %d access = %v, want %v", index, facts.Access, wantAccess[index])
+		}
+		if facts.Node == nil || facts.SyntacticBlockContainer == nil || facts.SyntacticScopeContainer == nil {
+			t.Errorf("reference %d omitted its node/container facts: %#v", index, facts)
+		}
+	}
+	last := got[len(got)-1]
+	if last.Syntax&ReferenceSyntaxTypeQuery == 0 || last.Syntax&ReferenceSyntaxTypePosition == 0 {
+		t.Fatalf("typeof reference syntax = %v, want type-query and type-position", last.Syntax)
+	}
+	if last.Space&ReferenceSpaceValue == 0 {
+		t.Fatalf("typeof reference space = %v, want value-capable", last.Space)
+	}
+}
+
+func TestRefStoreReferenceFactsSeeThroughSatisfiesAssignmentTargets(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/satisfies-write.ts", core.ScriptKindTS, `
+let target = 0;
+(target satisfies number) = 1;
+(target satisfies number) += 1;
+`)
+	target := identifiers(sourceFile.AsNode(), "target")
+	if len(target) != 3 {
+		t.Fatalf("target occurrences = %d, want declaration and two writes", len(target))
+	}
+	want := []ReferenceAccess{
+		ReferenceAccessWrite,
+		ReferenceAccessRead | ReferenceAccessWrite,
+	}
+	for index, node := range target[1:] {
+		facts, ok := refs.ReferenceFacts(node)
+		if !ok || facts.Access != want[index] {
+			t.Errorf("satisfies target %d facts = %#v, %v; want access %v", index, facts, ok, want[index])
+		}
+	}
+}
+
+func TestRefStoreReferenceFactsDistinguishParameterEnvironment(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/parameter-environment.ts", core.ScriptKindTS, `
+export {};
+const outer = 1;
+function f(value = outer) {
+  var outer = 2;
+  return outer;
+}
+`)
+	outer := identifiers(sourceFile.AsNode(), "outer")
+	if len(outer) != 4 {
+		t.Fatalf("outer occurrences = %d, want 4", len(outer))
+	}
+	initializerFacts, ok := refs.ReferenceFacts(outer[1])
+	if !ok || !initializerFacts.OutsideFunctionBody {
+		t.Fatalf("parameter initializer facts = %#v, want function-signature reference", initializerFacts)
+	}
+	bodyFacts, ok := refs.ReferenceFacts(outer[3])
+	if !ok || bodyFacts.OutsideFunctionBody {
+		t.Fatalf("body facts = %#v, want body reference", bodyFacts)
+	}
+	if initializerFacts.NearestFunction == nil || initializerFacts.NearestFunction != bodyFacts.NearestFunction {
+		t.Fatal("initializer and body should share the enclosing function while retaining environment distinction")
+	}
+
+	topLevel := outer[0].Parent.Symbol()
+	bodySymbol := outer[2].Parent.Symbol()
+	if topLevel == nil || bodySymbol == nil {
+		t.Fatal("fixture declarations were not bound")
+	}
+	if refs.Resolve(outer[1]) != topLevel {
+		t.Fatal("parameter initializer resolved to the function-body var instead of the outer binding")
+	}
+	if refs.Resolve(outer[3]) != bodySymbol {
+		t.Fatal("body reference did not resolve to the function-body var")
+	}
+	if got := refs.References(topLevel); len(got) != 1 || got[0] != outer[1] {
+		t.Fatalf("outer binding references = %v, want parameter initializer", got)
+	}
+	if got := refs.References(bodySymbol); len(got) != 1 || got[0] != outer[3] {
+		t.Fatalf("body binding references = %v, want return reference", got)
+	}
+}
+
+func TestRefStoreReferenceFactsMarkExpressionShapedTypePositions(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/type-position-facts.ts", core.ScriptKindTS, `
+namespace N { export interface T {}; export class Base {} }
+class Implements implements N.T {}
+interface Extends extends N.T {}
+class RuntimeExtends extends N.Base {}
+type Foo = {};
+export type { Foo };
+export { type Foo as Alias };
+`)
+
+	namespaceUses := identifiers(sourceFile.AsNode(), "N")
+	if len(namespaceUses) != 4 {
+		t.Fatalf("N occurrences = %d, want declaration plus three uses", len(namespaceUses))
+	}
+	for index, node := range namespaceUses[1:] {
+		facts, ok := refs.ReferenceFacts(node)
+		if !ok {
+			t.Fatalf("N use %d has no reference facts", index)
+		}
+		wantType := index < 2
+		if got := facts.Syntax&ReferenceSyntaxTypePosition != 0; got != wantType {
+			t.Errorf("N use %d type-position = %v, want %v (facts=%#v)", index, got, wantType, facts)
+		}
+	}
+
+	fooUses := identifiers(sourceFile.AsNode(), "Foo")
+	if len(fooUses) != 3 {
+		t.Fatalf("Foo occurrences = %d, want declaration plus two local type exports", len(fooUses))
+	}
+	for index, node := range fooUses[1:] {
+		facts, ok := refs.ReferenceFacts(node)
+		if !ok || facts.Syntax&(ReferenceSyntaxLocalExport|ReferenceSyntaxTypePosition) !=
+			ReferenceSyntaxLocalExport|ReferenceSyntaxTypePosition || facts.Space&ReferenceSpaceValue != 0 {
+			t.Errorf("Foo type export %d facts = %#v, %v", index, facts, ok)
+		}
+	}
+}
+
+func TestRefStoreReferenceFactsKeepComputedNamesSyntactic(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/computed-name-facts.ts", core.ScriptKindTS, `
+const key = "method";
+class C { [key]() {} }
+`)
+	key := identifiers(sourceFile.AsNode(), "key")
+	if len(key) != 2 {
+		t.Fatalf("key occurrences = %d, want declaration and computed-name use", len(key))
+	}
+	facts, ok := refs.ReferenceFacts(key[1])
+	if !ok || facts.NearestFunction == nil || facts.NearestFunction.Kind != ast.KindMethodDeclaration ||
+		!facts.OutsideFunctionBody {
+		t.Fatalf("computed-name facts = %#v, %v; want exact outside-method-body syntax", facts, ok)
+	}
+}
+
+func TestRefStoreJSXReferenceFactsAreExplicitOnly(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/reference-facts.tsx", core.ScriptKindTSX, `
+import React from "react";
+const Component = () => null;
+declare const NS: any;
+const view = <><Component /><NS.Component /><div /><Foo-bar /><foo:bar /></>;
+`)
+
+	tests := []struct {
+		name      string
+		wantFacts int
+		wantJSX   bool
+	}{
+		{name: "Component", wantFacts: 1, wantJSX: true},
+		{name: "NS", wantFacts: 1, wantJSX: true},
+		{name: "div"},
+		{name: "Foo-bar"},
+		{name: "foo"},
+		{name: "bar"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			count := 0
+			for _, node := range identifiers(sourceFile.AsNode(), testCase.name) {
+				facts, ok := refs.ReferenceFacts(node)
+				if !ok {
+					continue
+				}
+				count++
+				if testCase.wantJSX && facts.Syntax&ReferenceSyntaxJSXTag == 0 {
+					t.Errorf("%s facts omit JSX-tag syntax", testCase.name)
+				}
+			}
+			if count != testCase.wantFacts {
+				t.Fatalf("%s reference facts = %d, want %d", testCase.name, count, testCase.wantFacts)
+			}
+		})
+	}
+	react := identifiers(sourceFile.AsNode(), "React")
+	if len(react) != 1 {
+		t.Fatalf("React occurrences = %d, want only the import binding", len(react))
+	}
+	if binding, ok := refs.ImportBinding(react[0]); !ok || binding.ImportedName != "default" {
+		t.Fatalf("React import binding = %#v, %v", binding, ok)
+	}
+	if got := refs.References(react[0].Parent.Symbol()); len(got) != 0 {
+		t.Fatalf("React references = %v, want no synthesized JSX factory reference", got)
+	}
+}
+
+func TestRefStoreImportBindingsPreserveLocalAliases(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/import-bindings.ts", core.ScriptKindTS, `
+import Default, * as NS from "m";
+import { Foo, Bar as Baz, type Qux as Q } from "m";
+import type TypeDefault from "m";
+import Alias = require("m");
+Default(); NS.value; Foo(); Baz();
+`)
+
+	bindings := refs.ImportBindings()
+	if len(bindings) != 7 {
+		t.Fatalf("import bindings = %d, want 7: %#v", len(bindings), bindings)
+	}
+	want := []struct {
+		local    string
+		imported string
+		kind     ImportBindingKind
+		typeOnly bool
+	}{
+		{local: "Default", imported: "default", kind: ImportBindingDefault},
+		{local: "NS", imported: "*", kind: ImportBindingNamespace},
+		{local: "Foo", imported: "Foo", kind: ImportBindingNamed},
+		{local: "Baz", imported: "Bar", kind: ImportBindingNamed},
+		{local: "Q", imported: "Qux", kind: ImportBindingNamed, typeOnly: true},
+		{local: "TypeDefault", imported: "default", kind: ImportBindingDefault, typeOnly: true},
+		{local: "Alias", kind: ImportBindingEquals},
+	}
+	for index, expected := range want {
+		got := bindings[index]
+		if got.LocalName.Text() != expected.local || got.ImportedName != expected.imported ||
+			got.Kind != expected.kind || got.TypeOnly != expected.typeOnly {
+			t.Errorf("binding %d = (%s, %s, %v, typeOnly=%v), want (%s, %s, %v, typeOnly=%v)",
+				index, got.LocalName.Text(), got.ImportedName, got.Kind, got.TypeOnly,
+				expected.local, expected.imported, expected.kind, expected.typeOnly)
+		}
+		if got.Symbol == nil || got.Declaration == nil || got.Specifier == nil ||
+			got.ModuleSpecifier == nil || got.ModuleSpecifier.Text() != "m" {
+			t.Errorf("binding %d omitted syntax provenance: %#v", index, got)
+		}
+	}
+
+	defaultOccurrences := identifiers(sourceFile.AsNode(), "Default")
+	if len(defaultOccurrences) != 2 {
+		t.Fatalf("Default occurrences = %d, want 2", len(defaultOccurrences))
+	}
+	fromReference, ok := refs.ImportBinding(defaultOccurrences[1])
+	if !ok || fromReference.LocalName != defaultOccurrences[0] {
+		t.Fatalf("ImportBinding(reference) = %#v, %v; want Default declaration", fromReference, ok)
+	}
+	bar := identifiers(sourceFile.AsNode(), "Bar")
+	if len(bar) != 1 {
+		t.Fatalf("Bar occurrences = %d, want imported-side name only", len(bar))
+	}
+	if _, ok := refs.ImportBinding(bar[0]); ok {
+		t.Fatal("imported-side property name must not be treated as a local import binding")
+	}
+	if bindings[2].Symbol == bindings[3].Symbol {
+		t.Fatal("different local aliases were merged by import provenance")
+	}
+}
+
+func TestRefStoreImportBindingsDoNotMergeAliasesOfSameTarget(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/import-alias-identity.ts", core.ScriptKindTS, `
+import { Foo as A, Foo as B } from "m";
+type TA = A;
+A();
+B();
+`)
+	a := identifiers(sourceFile.AsNode(), "A")
+	b := identifiers(sourceFile.AsNode(), "B")
+	if len(a) != 3 || len(b) != 2 {
+		t.Fatalf("alias occurrences = A:%d B:%d, want 3 and 2", len(a), len(b))
+	}
+	aBinding, aOK := refs.ImportBinding(a[0])
+	bBinding, bOK := refs.ImportBinding(b[0])
+	if !aOK || !bOK || aBinding.Symbol == nil || bBinding.Symbol == nil || aBinding.Symbol == bBinding.Symbol {
+		t.Fatalf("local import identities were not kept separate: A=%#v B=%#v", aBinding, bBinding)
+	}
+	if got := refs.References(aBinding.Symbol); len(got) != 2 || got[0] != a[1] || got[1] != a[2] {
+		t.Fatalf("A references = %v, want type and value uses", got)
+	}
+	if got := refs.References(bBinding.Symbol); len(got) != 1 || got[0] != b[1] {
+		t.Fatalf("B references = %v, want only B call", got)
+	}
+	if typeFacts, ok := refs.ReferenceFacts(a[1]); !ok || typeFacts.Space&ReferenceSpaceType == 0 {
+		t.Fatalf("type alias reference facts = %#v, %v", typeFacts, ok)
+	}
+	if valueFacts, ok := refs.ReferenceFacts(a[2]); !ok || valueFacts.Space&ReferenceSpaceValue == 0 {
+		t.Fatalf("call reference facts = %#v, %v", valueFacts, ok)
+	}
+}
+
+func TestRefStoreImportBindingsIncludeReparsedJSDocImports(t *testing.T) {
+	_, refs := newBoundRefStore(t, "/jsdoc-import.js", core.ScriptKindJS, `
+/** @import { Source as Local } from "module-name" */
+/** @type {Local} */
+let value;
+`)
+	bindings := refs.ImportBindings()
+	if len(bindings) != 1 {
+		t.Fatalf("JSDoc import bindings = %#v, want one Local alias", bindings)
+	}
+	binding := bindings[0]
+	if binding.LocalName.Text() != "Local" || binding.ImportedName != "Source" ||
+		!binding.TypeOnly || binding.ModuleSpecifier == nil || binding.ModuleSpecifier.Text() != "module-name" {
+		t.Fatalf("JSDoc import binding = %#v, want type-only Source as Local provenance", binding)
+	}
+}
+
+func TestRefStoreBindingDeclarationsKeepOccurrences(t *testing.T) {
+	_, refs := newBoundRefStore(t, "/binding-declarations.ts", core.ScriptKindTS, `
+export {};
+interface Merged {}
+const Merged = 1;
+const { nested: local = Merged } = source;
+function named(parameter: typeof Merged) { return local + parameter; }
+`)
+
+	declarations := refs.BindingDeclarations()
+	byName := make(map[string][]BindingDeclarationFacts)
+	for _, declaration := range declarations {
+		byName[declaration.Name.Text()] = append(byName[declaration.Name.Text()], declaration)
+		if declaration.Declaration == nil || declaration.RootDeclaration == nil ||
+			declaration.SyntacticBlockContainer == nil || declaration.SyntacticScopeContainer == nil {
+			t.Errorf("declaration omitted exact occurrence/container facts: %#v", declaration)
+		}
+	}
+	if len(byName["Merged"]) != 2 {
+		t.Fatalf("Merged declaration occurrences = %d, want interface and const", len(byName["Merged"]))
+	}
+	if len(byName["local"]) != 1 || byName["local"][0].Declaration.Kind != ast.KindBindingElement {
+		t.Fatalf("local declaration = %#v, want BindingElement occurrence", byName["local"])
+	}
+	if len(byName["parameter"]) != 1 || !byName["parameter"][0].OutsideFunctionBody {
+		t.Fatalf("parameter declaration = %#v, want function-signature occurrence", byName["parameter"])
+	}
+}
+
+func TestRefStoreBindingDeclarationsPreserveNamedExpressionBindings(t *testing.T) {
+	_, refs := newBoundRefStore(t, "/named-expression-bindings.ts", core.ScriptKindTS, `
+export {};
+const holder = function inner() { return inner; };
+const ClassHolder = class Inner { method() { return Inner; } };
+`)
+	declarations := refs.BindingDeclarations()
+	byName := make(map[string]BindingDeclarationFacts)
+	for _, declaration := range declarations {
+		byName[declaration.Name.Text()] = declaration
+	}
+	for _, name := range []string{"inner", "Inner"} {
+		declaration, ok := byName[name]
+		if !ok || declaration.Symbol == nil {
+			t.Fatalf("named expression binding %q = %#v, want raw binder symbol", name, declaration)
+		}
+		references := refs.References(declaration.Symbol)
+		if len(references) != 1 || references[0].Text() != name {
+			t.Fatalf("%s references = %v, want its inner self-reference", name, references)
+		}
+	}
+}
+
+func TestRefStoreBindingDeclarationSeparatesParameterPropertyIdentities(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/parameter-property-binding.ts", core.ScriptKindTS, `
+class C {
+  constructor(public parameter: number) { consume(parameter); }
+}
+`)
+	parameter := identifiers(sourceFile.AsNode(), "parameter")
+	if len(parameter) != 2 {
+		t.Fatalf("parameter occurrences = %d, want declaration and body use", len(parameter))
+	}
+	facts, ok := refs.BindingDeclaration(parameter[0])
+	if !ok || facts.Symbol == nil || facts.MemberSymbol == nil || facts.Symbol == facts.MemberSymbol {
+		t.Fatalf("parameter-property facts = %#v, %v; want distinct lexical/member identities", facts, ok)
+	}
+	if resolved := refs.Resolve(parameter[1]); resolved != facts.Symbol {
+		t.Fatalf("body use resolved to %p, want lexical parameter symbol %p", resolved, facts.Symbol)
+	}
+	if got := refs.References(facts.Symbol); len(got) != 1 || got[0] != parameter[1] {
+		t.Fatalf("lexical parameter references = %v, want body use", got)
+	}
+	if got := refs.References(facts.MemberSymbol); len(got) != 0 {
+		t.Fatalf("member identity references = %v, want no lexical references", got)
+	}
+
+	var listed *BindingDeclarationFacts
+	declarations := refs.BindingDeclarations()
+	for index := range declarations {
+		declaration := &declarations[index]
+		if declaration.Name == parameter[0] {
+			listed = declaration
+			break
+		}
+	}
+	if listed == nil || listed.Symbol != facts.Symbol || listed.MemberSymbol != facts.MemberSymbol {
+		t.Fatalf("listed parameter-property facts = %#v, want direct-query identities %#v", listed, facts)
+	}
+}
+
+func TestRefStoreBindingDeclarationsDocumentDeclarationBoundary(t *testing.T) {
+	t.Run("JSDoc type alias", func(t *testing.T) {
+		_, refs := newBoundRefStore(t, "/jsdoc-bindings.js", core.ScriptKindJS, `
+/** @typedef {number} JSDocType */
+`)
+		declarations := refs.BindingDeclarations()
+		if len(declarations) != 1 || declarations[0].Name.Text() != "JSDocType" || declarations[0].Symbol == nil {
+			t.Fatalf("binding declarations = %#v, want re-parsed JSDoc type alias", declarations)
+		}
+	})
+
+	t.Run("augmentation syntax", func(t *testing.T) {
+		_, refs := newBoundRefStore(t, "/augmentation-bindings.d.ts", core.ScriptKindTS, `
+export {};
+export as namespace GlobalAlias;
+declare global { var augmented: number; }
+`)
+		declarations := refs.BindingDeclarations()
+		if len(declarations) != 1 || declarations[0].Name.Text() != "augmented" {
+			t.Fatalf("binding declarations = %#v, want augmented and no augmentation sentinels", declarations)
+		}
+	})
+}
+
+func TestRefStoreBindingDeclarationsExcludeSyntheticJSDocOverloadNames(t *testing.T) {
+	_, refs := newBoundRefStore(t, "/jsdoc-overload.js", core.ScriptKindJS, `
+/**
+ * @overload
+ * @param {string} value
+ * @returns {string}
+ */
+/** @param {unknown} value */
+function overloaded(value) { return value; }
+`)
+	count := 0
+	for _, declaration := range refs.BindingDeclarations() {
+		if declaration.Name.Text() == "overloaded" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("overloaded binding occurrences = %d, want only the authored implementation name", count)
+	}
+}
+
+func TestRefStoreReferencesReconcileGlobalAugmentationIdentity(t *testing.T) {
+	sourceFile, refs, cleanup := newCheckedRefStore(t, `
+export {};
+declare global {
+  interface Map<K, V> { custom: true }
+  type Inside = Map<string, string>;
+}
+type Outside = Map<string, string>;
+`)
+	defer cleanup()
+	mapNames := identifiers(sourceFile.AsNode(), "Map")
+	if len(mapNames) != 3 {
+		t.Fatalf("Map occurrences = %d, want declaration plus inside/outside uses", len(mapNames))
+	}
+	declaration, ok := refs.BindingDeclaration(mapNames[0])
+	resolved := refs.Resolve(mapNames[2])
+	if !ok || declaration.Symbol == nil || resolved == nil || declaration.Symbol == resolved {
+		t.Fatalf("augmentation identities = declaration %#v resolved %p, want distinct raw/merged symbols", declaration, resolved)
+	}
+	if got := refs.References(declaration.Symbol); len(got) != 2 || got[0] != mapNames[1] || got[1] != mapNames[2] {
+		t.Fatalf("raw augmentation references = %v, want source-ordered inside/outside uses", got)
+	}
+	if got := refs.References(resolved); len(got) != 2 || got[0] != mapNames[1] || got[1] != mapNames[2] {
+		t.Fatalf("merged augmentation references = %v, want same complete bucket", got)
+	}
+}
+
+func TestRefStoreReferenceFactsDoNotRequireCheckerResolution(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/unresolved-reference-facts.ts", core.ScriptKindTS, `
+export {};
+window;
+const object = { window: 1 };
+`)
+	window := identifiers(sourceFile.AsNode(), "window")
+	if len(window) != 2 {
+		t.Fatalf("window occurrences = %d, want unresolved use and property label", len(window))
+	}
+	if refs.Resolve(window[0]) != nil {
+		t.Fatal("binder-only fixture unexpectedly resolved window")
+	}
+	if facts, ok := refs.ReferenceFacts(window[0]); !ok || facts.Node != window[0] {
+		t.Fatalf("unresolved explicit reference facts = %#v, %v", facts, ok)
+	}
+	if _, ok := refs.ReferenceFacts(window[1]); ok {
+		t.Fatal("property label was accepted as an explicit reference")
+	}
+}
+
+func TestRefStoreReferenceFactsExcludeConstAssertionSentinel(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/const-assertion.ts", core.ScriptKindTS, `
+const value = {} as const;
+`)
+	constNames := identifiers(sourceFile.AsNode(), "const")
+	if len(constNames) != 1 {
+		t.Fatalf("const assertion identifiers = %d, want one parser sentinel", len(constNames))
+	}
+	if _, ok := refs.ReferenceFacts(constNames[0]); ok {
+		t.Fatal("const assertion sentinel was treated as a lexical reference")
+	}
+	if refs.Resolve(constNames[0]) != nil || refs.ResolveInFile(constNames[0]) != nil {
+		t.Fatal("const assertion sentinel unexpectedly resolved")
+	}
+}
+
+func TestRefStoreReferenceFactsDistinguishLocalAndReExports(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/export-reference-facts.ts", core.ScriptKindTS, `
+const value = 1;
+export { value as alias };
+export { foreign as externalAlias } from "m";
+`)
+	value := identifiers(sourceFile.AsNode(), "value")
+	if len(value) != 2 {
+		t.Fatalf("value occurrences = %d, want declaration and local export", len(value))
+	}
+	facts, ok := refs.ReferenceFacts(value[1])
+	if !ok || facts.Syntax&ReferenceSyntaxLocalExport == 0 ||
+		facts.Space != ReferenceSpaceValue|ReferenceSpaceType|ReferenceSpaceNamespace {
+		t.Fatalf("local export facts = %#v, %v", facts, ok)
+	}
+	for _, name := range []string{"alias", "foreign", "externalAlias"} {
+		for _, node := range identifiers(sourceFile.AsNode(), name) {
+			if _, ok := refs.ReferenceFacts(node); ok {
+				t.Errorf("%s export label/re-export name was treated as a local reference", name)
+			}
+		}
+	}
+}

--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -5,12 +5,14 @@ import (
 	"github.com/microsoft/typescript-go/shim/binder"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// RefStore owns the per-file identifier-reference index for one linted source
-// file: given a symbol declared in the file, it returns every identifier that
-// references it, in source order.
+// RefStore is the single owner of per-file reference, binding-declaration, and
+// import-provenance facts for one linted source file. Its reference index maps
+// a declaration symbol to every explicit identifier that references it, in
+// source order.
 //
 // References are resolved with the binder's NameResolver — the same scope walk
 // the checker performs for identifiers. Resolve tries this scope walk first;
@@ -25,27 +27,42 @@ import (
 // References resolves symbols the same way internally, so it can return
 // identifiers referencing a symbol obtained from the checker fallback too; for
 // a symbol declared in this file the binder scope walk already answers for
-// every identifier sharing its name, the one exception being a global script
-// file's top-level symbols, which cost one checker call each to normalize
-// onto their merged identity (see mergedSymbol).
+// every identifier sharing its name. Global-script top-level symbols and raw
+// declarations inside an external module's `declare global` augmentation cost
+// one checker call when queried to reconcile their merged identity (see
+// mergedSymbol and globalAugmentationSymbol).
 //
 // The store deals in raw binder symbols: query it with the symbol attached to
 // a declaration node (node.Symbol()), not with checker.GetSymbolAtLocation
 // results, which may be checker-merged and compare unequal — except for
 // symbols Resolve obtained through the checker fallback itself, and for a
-// global script file's top-level declarations, whose raw and merged
-// identities the store reconciles (see mergedSymbol).
+// global script top-level / `declare global` declarations, whose raw and
+// merged identities the store reconciles.
 //
-// Collection is lazy twice over: the single AST walk that gathers candidate
-// identifiers runs on first use, and name resolution runs once per queried
-// symbol name, so a rule asking about `x` never pays for resolving unrelated
+// Collection is demand-driven. Existing callers retain the lazy full-file
+// prepass on first complete query. Rules that declare and request RefNeeds can
+// instead have the linter collect the same neutral facts during its ordinary
+// traversal. A complete query made before that traversal finishes falls back
+// to a full prepass and never exposes partial data. Name resolution remains
+// lazy per queried symbol name, so asking about `x` does not resolve unrelated
 // identifiers. A RefStore belongs to one lintFile invocation and is therefore
 // used serially by that file's rule initializers and listeners.
+//
+// Every node passed to a node-to-fact or node-to-symbol method must belong to
+// this store's source file. References deliberately accepts symbols originating
+// outside the file because checker fallback can resolve ambient/cross-file
+// declarations. The hot query path does not repeat an ancestor walk merely to
+// validate this file-ownership precondition.
 type RefStore struct {
 	sourceFile *ast.SourceFile
 	resolver   binder.NameResolver
 	tc         *checker.Checker
-	walked     bool
+
+	requestsOpen bool
+	state        refCollectionState
+	requested    RefNeeds
+	streaming    RefNeeds
+	built        RefNeeds
 	// candidates maps identifier text to the reference-position identifiers
 	// still awaiting resolution; entries move into refs on first query.
 	candidates map[string][]*ast.Node
@@ -53,16 +70,110 @@ type RefStore struct {
 	// merged maps a raw binder symbol onto the checker-merged symbol that
 	// refs is keyed by for it; see mergedSymbol.
 	merged map[*ast.Symbol]*ast.Symbol
+	// facts is allocated only when a declaration/import candidate is actually
+	// observed. Keeping these new collections behind one pointer preserves the
+	// zero-consumer RefStore allocation class and the existing References maps.
+	facts *refFactsIndex
 }
 
-// NewRefStore creates the reference index for one source file. options must
+type refCollectionState uint8
+
+const (
+	refCollectionCold refCollectionState = iota
+	refCollectionStreaming
+	refCollectionPrepass
+	refCollectionCompleteByStream
+	refCollectionCompleteByPrepass
+)
+
+type refFactsIndex struct {
+	declarationNames  []*ast.Node
+	importNames       []*ast.Node
+	materialized      *materializedRefFacts
+	materializedNeeds RefNeeds
+}
+
+type materializedRefFacts struct {
+	declarations []BindingDeclarationFacts
+	imports      []ImportBinding
+}
+
+// NewRefStore creates the shared RefStore facts for one source file. options must
 // be the file's program options (the resolver consults script target and
 // module settings during scope walks). tc is the file's TypeChecker, used as
 // a fallback by Resolve for identifiers the binder scope walk can't place,
 // and by References when asked about a symbol that fallback produced; nil
 // disables both (Resolve then never falls back, and References behaves as if
-// every such symbol were never queried).
+// every such symbol were never queried). Nodes passed to its node-to-fact or
+// node-to-symbol methods must belong to sourceFile.
 func NewRefStore(sourceFile *ast.SourceFile, options *core.CompilerOptions, tc *checker.Checker) *RefStore {
+	return newRefStore(sourceFile, options, tc)
+}
+
+// RefCollector is the linter-only traversal control plane for a RefStore. It
+// is intentionally not reachable from RuleContext: rules can request and
+// query facts, but cannot seal an in-progress collection and accidentally
+// publish partial data as complete. The collector owns no analysis data; its
+// one pointer refers to the same RefStore rules query.
+type RefCollector struct {
+	store *RefStore
+}
+
+// RefObserver is the allocation-free Identifier observation token returned to
+// the linter by RefCollector.Start. Its fields are private so rules cannot
+// manufacture an observer for the RefStore held by RuleContext.
+type RefObserver struct {
+	store *RefStore
+	needs RefNeeds
+}
+
+// Active reports whether this file requested an incremental collection.
+func (observer RefObserver) Active() bool {
+	return observer.store != nil
+}
+
+// Observe records one Identifier dispatched by the linter. After an early
+// complete-query fallback, the state guard makes all remaining calls no-ops.
+func (observer RefObserver) Observe(node *ast.Node) {
+	if observer.store.state != refCollectionStreaming {
+		return
+	}
+	s := observer.store
+	switch observer.needs {
+	case RefNeedReferences:
+		s.collectReferenceIdentifier(node)
+	case RefNeedBindingDeclarations:
+		s.collectDeclarationIdentifier(node)
+	case RefNeedImportBindings:
+		s.collectImportIdentifier(node)
+	case RefNeedReferences | RefNeedBindingDeclarations:
+		s.collectReferenceIdentifier(node)
+		s.collectDeclarationIdentifier(node)
+	case RefNeedReferences | RefNeedImportBindings:
+		s.collectReferenceIdentifier(node)
+		s.collectImportIdentifier(node)
+	case RefNeedBindingDeclarations | RefNeedImportBindings:
+		s.collectDeclarationIdentifier(node)
+		s.collectImportIdentifier(node)
+	case RefNeedsAll:
+		s.collectReferenceIdentifier(node)
+		s.collectDeclarationIdentifier(node)
+		s.collectImportIdentifier(node)
+	}
+}
+
+// NewRefStoreWithCollector creates a RefStore together with the traversal
+// controller the linter must retain privately for that store.
+func NewRefStoreWithCollector(
+	sourceFile *ast.SourceFile,
+	options *core.CompilerOptions,
+	tc *checker.Checker,
+) (*RefStore, RefCollector) {
+	store := newRefStore(sourceFile, options, tc)
+	return store, RefCollector{store: store}
+}
+
+func newRefStore(sourceFile *ast.SourceFile, options *core.CompilerOptions, tc *checker.Checker) *RefStore {
 	resolver := binder.NameResolver{CompilerOptions: options}
 	if ast.IsGlobalSourceFile(sourceFile.AsNode()) {
 		// A script file's own top-level locals are never consulted by the
@@ -73,9 +184,10 @@ func NewRefStore(sourceFile *ast.SourceFile, options *core.CompilerOptions, tc *
 		resolver.Globals = sourceFile.Locals
 	}
 	return &RefStore{
-		sourceFile: sourceFile,
-		resolver:   resolver,
-		tc:         tc,
+		sourceFile:   sourceFile,
+		resolver:     resolver,
+		tc:           tc,
+		requestsOpen: true,
 	}
 }
 
@@ -87,10 +199,7 @@ func (s *RefStore) References(sym *ast.Symbol) []*ast.Node {
 	if s == nil || sym == nil {
 		return nil
 	}
-	if !s.walked {
-		s.walked = true
-		s.collectCandidates()
-	}
+	s.ensureBuilt(RefNeedReferences)
 	s.resolvePending(sym.Name)
 	// A symbol's name is not always the name its references are written with:
 	// `export default function foo() {}` binds the declaration to an export
@@ -104,8 +213,54 @@ func (s *RefStore) References(sym *ast.Symbol) []*ast.Node {
 	}
 	if merged, ok := s.merged[sym]; ok {
 		sym = merged
+	} else if merged := s.globalAugmentationSymbol(sym); merged != sym {
+		sym = merged
 	}
 	return s.refs[sym]
+}
+
+// globalAugmentationSymbol reconciles a raw binder symbol declared inside an
+// external module's `declare global` block with the checker-merged global
+// identity used by references outside that block. Unlike ordinary module-local
+// symbols, the binder resolver cannot reach the augmentation export from the
+// file's outer lexical scope. Restricting the checker lookup to this syntax
+// keeps the normal module References path binder-only.
+func (s *RefStore) globalAugmentationSymbol(sym *ast.Symbol) *ast.Symbol {
+	if s.tc == nil || !isGlobalAugmentationBinderSymbol(sym) {
+		return sym
+	}
+	var name *ast.Node
+	for _, declaration := range sym.Declarations {
+		name = declaration.Name()
+		if name != nil {
+			break
+		}
+	}
+	if name == nil {
+		return sym
+	}
+	merged := s.tc.GetSymbolAtLocation(name)
+	if merged == nil || merged == sym || !sharesDeclaration(merged, sym) {
+		merged = sym
+	}
+	if s.merged == nil {
+		s.merged = make(map[*ast.Symbol]*ast.Symbol)
+	}
+	s.merged[sym] = merged
+	return merged
+}
+
+func isGlobalAugmentationBinderSymbol(sym *ast.Symbol) bool {
+	parent := sym.Parent
+	if parent == nil || parent.Name != ast.InternalSymbolNameGlobal {
+		return false
+	}
+	for _, declaration := range parent.Declarations {
+		if ast.IsGlobalScopeAugmentation(declaration) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolvePending resolves every not-yet-resolved candidate identifier spelled
@@ -127,6 +282,9 @@ func (s *RefStore) resolvePending(name string) {
 			target = s.mergedSymbol(target, id)
 		}
 		if target != nil {
+			if s.refs == nil {
+				s.refs = make(map[*ast.Symbol][]*ast.Node)
+			}
 			s.refs[target] = append(s.refs[target], id)
 		}
 	}
@@ -145,11 +303,16 @@ func (s *RefStore) resolvePending(name string) {
 // whichever half happens to match the queried identity, so normalize onto the
 // checker's identity here and record the mapping for References to follow.
 //
-// Only a symbol the resolver found in the file's own globals table can be
-// merged this way, so every symbol of a module file and every nested scope
-// skips the checker round trip; the rest pay it once per symbol.
+// Only a symbol in a global script's file-globals table or inside `declare
+// global` can be merged this way, so ordinary module/local symbols skip the
+// checker round trip; the exceptional symbols pay it once each.
 func (s *RefStore) mergedSymbol(sym *ast.Symbol, at *ast.Node) *ast.Symbol {
-	if s.tc == nil || s.resolver.Globals == nil || s.resolver.Globals[sym.Name] != sym {
+	if s.tc == nil {
+		return sym
+	}
+	isGlobalScriptTopLevel := s.resolver.Globals != nil && s.resolver.Globals[sym.Name] == sym
+	isGlobalAugmentation := isGlobalAugmentationBinderSymbol(sym)
+	if !isGlobalScriptTopLevel && !isGlobalAugmentation {
 		return sym
 	}
 	if merged, ok := s.merged[sym]; ok {
@@ -187,7 +350,8 @@ func sharesDeclaration(a, b *ast.Symbol) bool {
 // NewRefStore, it falls back to the checker. That fallback is a real
 // TypeChecker round-trip, unlike the binder-only common path.
 //
-// Returns nil for identifiers that aren't reference positions (declaration
+// node must belong to this store's source file. Returns nil for identifiers
+// that aren't reference positions (declaration
 // names, property keys, import bindings, re-export/alias-label names, labels,
 // intrinsic JSX tags — see isReferencePosition) and for names that don't
 // resolve to any symbol.
@@ -207,7 +371,8 @@ func (s *RefStore) Resolve(node *ast.Node) *ast.Symbol {
 // TypeChecker to supply a declaration from lib files, ambient .d.ts files, or
 // another source file.
 //
-// Imported bindings and declarations authored in this source file are still
+// node must belong to this store's source file. Imported bindings and
+// declarations authored in this source file are still
 // visible because their binder symbols live in the file's own scope graph.
 // This distinction is required by ESLint-compatible rules such as no-undef:
 // their answer must not change merely because rslint happened to construct a
@@ -295,21 +460,197 @@ func outerExportScopeLocation(node *ast.Node) *ast.Node {
 	return nil
 }
 
-// collectCandidates walks the file once and buckets by name every identifier
-// that occupies a reference position.
-func (s *RefStore) collectCandidates() {
-	s.candidates = make(map[string][]*ast.Node)
-	s.refs = make(map[*ast.Symbol][]*ast.Node)
+// request records a per-file dynamic collection request. Rule.Run calls are
+// accumulated before traversal. A late request cannot install a listener into
+// an active registry safely, so it takes the correctness-preserving full-scan
+// fallback instead.
+func (s *RefStore) request(needs RefNeeds) {
+	if s == nil || needs == 0 {
+		return
+	}
+	if s.requestsOpen {
+		s.requested |= needs
+		return
+	}
+	s.ensureBuilt(needs)
+}
+
+// Start closes the Rule.Run request window and returns the private Identifier
+// observer the linter should use for this file. An inactive observer means no
+// rule requested a complete-file collection.
+func (collector RefCollector) Start() RefObserver {
+	s := collector.store
+	if s == nil {
+		return RefObserver{}
+	}
+	s.requestsOpen = false
+	missing := s.requested &^ s.built
+	if missing == 0 {
+		return RefObserver{}
+	}
+	return s.startCollection(missing)
+}
+
+// startCollection is the requested-only slow path, split out so the common
+// zero-request Start remains small enough for the compiler to inline.
+func (s *RefStore) startCollection(missing RefNeeds) RefObserver {
+	if s.state == refCollectionPrepass {
+		panic("rule: RefStore collection started during a prepass")
+	}
+	s.clearFeatures(missing)
+	s.streaming = missing
+	s.state = refCollectionStreaming
+
+	if !missing.IsValid() {
+		panic("rule: invalid RefStore collection needs")
+	}
+	return RefObserver{store: s, needs: missing}
+}
+
+// Complete seals incremental collection. Complete-file queries made by
+// ListenerOnFileFinalize callbacks can therefore never observe partial state.
+func (collector RefCollector) Complete() {
+	s := collector.store
+	if s == nil {
+		return
+	}
+	s.requestsOpen = false
+	if s.state != refCollectionStreaming {
+		return
+	}
+	s.built |= s.streaming
+	s.streaming = 0
+	s.state = refCollectionCompleteByStream
+}
+
+// ensureBuilt guarantees that every requested collection is complete. If an
+// incremental traversal is still in progress, partial buckets are cleared in
+// place and repopulated from the file root so no query can return a partial or
+// later-mutating result.
+func (s *RefStore) ensureBuilt(needs RefNeeds) {
+	if needs == 0 || s.built&needs == needs {
+		return
+	}
+	if s.state == refCollectionPrepass {
+		panic("rule: reentrant RefStore prepass")
+	}
+
+	missing := needs &^ s.built
+	if s.state == refCollectionStreaming {
+		missing |= s.streaming
+	}
+	s.clearFeatures(missing)
+	s.state = refCollectionPrepass
+	s.collectFeatures(missing)
+	s.built |= missing
+	s.streaming &^= missing
+	s.state = refCollectionCompleteByPrepass
+}
+
+// collectFeatures walks the file once and derives all requested feature sets
+// from Identifier nodes. It is used only by the lazy/early-query fallback.
+func (s *RefStore) collectFeatures(needs RefNeeds) {
 	var visit func(n *ast.Node) bool
 	visit = func(n *ast.Node) bool {
-		if n.Kind == ast.KindIdentifier && isReferencePosition(n) {
-			text := n.Text()
-			s.candidates[text] = append(s.candidates[text], n)
+		if n.Kind == ast.KindIdentifier {
+			s.collectIdentifier(n, needs)
 		}
 		n.ForEachChild(visit)
 		return false
 	}
 	s.sourceFile.AsNode().ForEachChild(visit)
+}
+
+func (s *RefStore) collectIdentifier(node *ast.Node, needs RefNeeds) {
+	if needs&RefNeedReferences != 0 {
+		s.collectReferenceIdentifier(node)
+	}
+	if needs&RefNeedBindingDeclarations != 0 {
+		s.collectDeclarationIdentifier(node)
+	}
+	if needs&RefNeedImportBindings != 0 {
+		s.collectImportIdentifier(node)
+	}
+}
+
+func (s *RefStore) collectReferenceIdentifier(node *ast.Node) {
+	if !isReferencePosition(node) {
+		return
+	}
+	if s.candidates == nil {
+		s.candidates = make(map[string][]*ast.Node)
+	}
+	text := node.Text()
+	s.candidates[text] = append(s.candidates[text], node)
+}
+
+func (s *RefStore) collectDeclarationIdentifier(node *ast.Node) {
+	if isBindingDeclarationIdentifier(node) {
+		facts := s.ensureFacts()
+		facts.declarationNames = append(facts.declarationNames, node)
+	}
+}
+
+func (s *RefStore) collectImportIdentifier(node *ast.Node) {
+	if isImportBindingIdentifier(node) {
+		facts := s.ensureFacts()
+		facts.importNames = append(facts.importNames, node)
+	}
+}
+
+func isImportBindingIdentifier(node *ast.Node) bool {
+	if node.Parent == nil || node.Parent.Name() != node {
+		return false
+	}
+	switch node.Parent.Kind {
+	case ast.KindImportClause, ast.KindImportSpecifier, ast.KindNamespaceImport, ast.KindImportEqualsDeclaration:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *RefStore) ensureFacts() *refFactsIndex {
+	if s.facts == nil {
+		s.facts = &refFactsIndex{}
+	}
+	return s.facts
+}
+
+// clearFeatures resets only incomplete collections and retains their backing
+// storage for an early-query fallback. Completed feature slices/maps are never
+// modified after they may have been returned to callers.
+func (s *RefStore) clearFeatures(needs RefNeeds) {
+	if needs&RefNeedReferences != 0 {
+		if s.candidates != nil {
+			for name, candidates := range s.candidates {
+				s.candidates[name] = candidates[:0]
+			}
+		}
+		if s.refs != nil {
+			clear(s.refs)
+		}
+		if s.merged != nil {
+			clear(s.merged)
+		}
+	}
+	if s.facts == nil {
+		return
+	}
+	if needs&RefNeedBindingDeclarations != 0 {
+		s.facts.declarationNames = s.facts.declarationNames[:0]
+		if materialized := s.facts.materialized; materialized != nil {
+			materialized.declarations = nil
+		}
+		s.facts.materializedNeeds &^= RefNeedBindingDeclarations
+	}
+	if needs&RefNeedImportBindings != 0 {
+		s.facts.importNames = s.facts.importNames[:0]
+		if materialized := s.facts.materialized; materialized != nil {
+			materialized.imports = nil
+		}
+		s.facts.materializedNeeds &^= RefNeedImportBindings
+	}
 }
 
 // isReferencePosition reports whether an identifier can reference a symbol
@@ -319,6 +660,11 @@ func (s *RefStore) collectCandidates() {
 // ExportSpecifier case below.
 func isReferencePosition(n *ast.Node) bool {
 	p := n.Parent
+	if n.Text() == "const" && p != nil && p.Parent != nil && ast.IsConstAssertion(p.Parent) {
+		// The identifier-shaped type in `expr as const` is a parser sentinel,
+		// not a lexical lookup (NameResolver has the same explicit exclusion).
+		return false
+	}
 	if p != nil && p.Kind == ast.KindShorthandPropertyAssignment && p.AsShorthandPropertyAssignment().Name() == n {
 		// `{x}` reads x as an expression, and `({x} = obj)` writes to x once
 		// the object literal is reinterpreted as an assignment pattern;
@@ -388,10 +734,9 @@ func isReferencePosition(n *ast.Node) bool {
 		return false
 	}
 	if ast.IsJsxTagName(n) {
-		// Lowercase tag names are JSX intrinsics (`<div>`), not identifier
-		// references; uppercase ones reference a component value.
-		text := n.Text()
-		return len(text) > 0 && (text[0] < 'a' || text[0] > 'z')
+		// Intrinsics include lowercase HTML names and custom-element names
+		// containing a dash, regardless of their first character.
+		return !scanner.IsIntrinsicJsxName(n.Text())
 	}
 	return true
 }

--- a/internal/rule/ref_store_collection_test.go
+++ b/internal/rule/ref_store_collection_test.go
@@ -1,0 +1,264 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+)
+
+func TestRefStoreStreamingEarlyQueryNeverReturnsPartial(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/streaming-early.ts", core.ScriptKindTS,
+		"export {}; let x = 0, y = 0; consume(x); consume(x); consume(y); consume(x);")
+	x := identifiers(sourceFile.AsNode(), "x")
+	if len(x) != 4 {
+		t.Fatalf("x occurrences = %d, want declaration plus three references", len(x))
+	}
+	sym := x[0].Parent.Symbol()
+	if sym == nil {
+		t.Fatal("x declaration has no symbol")
+	}
+
+	refs.request(RefNeedReferences)
+	collector := RefCollector{store: refs}
+	observe := collector.Start()
+	if !observe.Active() || refs.state != refCollectionStreaming {
+		t.Fatalf("collector Start state = %v, want streaming", refs.state)
+	}
+	observe.Observe(x[0])
+	observe.Observe(x[1])
+	first := refs.References(sym)
+	if len(first) != 3 || first[0] != x[1] || first[1] != x[2] || first[2] != x[3] {
+		t.Fatalf("early References = %v, want all future references %v", first, x[1:])
+	}
+	if refs.state != refCollectionCompleteByPrepass {
+		t.Fatalf("early query state = %v, want complete-by-prepass", refs.state)
+	}
+
+	for _, node := range identifiers(sourceFile.AsNode(), "consume") {
+		observe.Observe(node)
+	}
+	for _, node := range x[2:] {
+		observe.Observe(node)
+	}
+	collector.Complete()
+	second := refs.References(sym)
+	if len(second) != len(first) {
+		t.Fatalf("post-traversal References = %v, want stable early snapshot %v", second, first)
+	}
+	for index := range first {
+		if first[index] != second[index] {
+			t.Fatalf("post-traversal reference %d changed", index)
+		}
+	}
+	y := identifiers(sourceFile.AsNode(), "y")
+	if len(y) != 2 {
+		t.Fatalf("y occurrences = %d, want declaration and reference", len(y))
+	}
+	if got := refs.References(y[0].Parent.Symbol()); len(got) != 1 || got[0] != y[1] {
+		t.Fatalf("different-name References after early fallback = %v, want y reference", got)
+	}
+}
+
+func TestRefStoreStreamingCompletesAllRequestedCollections(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/streaming-all.ts", core.ScriptKindTS, `
+import { value as imported } from "m";
+const local = imported;
+consume(local);
+`)
+	refs.request(RefNeedsAll)
+	collector := RefCollector{store: refs}
+	observe := collector.Start()
+	if !observe.Active() {
+		t.Fatal("requested features did not start collection")
+	}
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindIdentifier {
+			observe.Observe(node)
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	collector.Complete()
+	collector.Complete()
+	if refs.state != refCollectionCompleteByStream || refs.built != RefNeedsAll {
+		t.Fatalf("completed state = %v, built = %v; want stream/all", refs.state, refs.built)
+	}
+	if got := refs.BindingDeclarations(); len(got) != 2 {
+		t.Fatalf("binding declarations = %d, want imported and local", len(got))
+	}
+	if got := refs.ImportBindings(); len(got) != 1 || got[0].LocalName.Text() != "imported" {
+		t.Fatalf("import bindings = %#v, want imported", got)
+	}
+	local := identifiers(sourceFile.AsNode(), "local")
+	if got := refs.References(local[0].Parent.Symbol()); len(got) != 1 || got[0] != local[1] {
+		t.Fatalf("local references = %v, want final consume reference", got)
+	}
+}
+
+func TestRefStoreNoRequestKeepsCollectionsCold(t *testing.T) {
+	_, refs := newBoundRefStore(t, "/cold.ts", core.ScriptKindTS, "const value = 1; consume(value);")
+	if observe := (RefCollector{store: refs}).Start(); observe.Active() {
+		t.Fatal("store without a dynamic request started collection")
+	}
+	if refs.state != refCollectionCold || refs.candidates != nil || refs.refs != nil || refs.merged != nil || refs.facts != nil {
+		t.Fatalf("cold store materialized collection state: %#v", refs)
+	}
+}
+
+func TestRefStoreLateRequestUsesCompletePrepass(t *testing.T) {
+	_, refs := newBoundRefStore(t, "/late-request.ts", core.ScriptKindTS,
+		"import { value } from 'm'; const local = value;")
+	if observe := (RefCollector{store: refs}).Start(); observe.Active() {
+		t.Fatal("store unexpectedly started before a request")
+	}
+	refs.request(RefNeedBindingDeclarations | RefNeedImportBindings)
+	if refs.state != refCollectionCompleteByPrepass {
+		t.Fatalf("late request state = %v, want complete-by-prepass", refs.state)
+	}
+	if len(refs.BindingDeclarations()) != 2 || len(refs.ImportBindings()) != 1 {
+		t.Fatal("late request did not build complete declaration/import facts")
+	}
+}
+
+func TestRefStoreBuildsMixedPrepassAndStreamingStages(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/mixed-stages.ts", core.ScriptKindTS, `
+import { value as imported } from "m";
+const local = imported;
+consume(local);
+`)
+	declarations := refs.BindingDeclarations()
+	if len(declarations) != 2 {
+		t.Fatalf("prepass declarations = %d, want imported and local", len(declarations))
+	}
+	refs.request(RefNeedReferences | RefNeedImportBindings)
+	collector := RefCollector{store: refs}
+	observer := collector.Start()
+	if !observer.Active() {
+		t.Fatal("missing reference/import features did not start streaming")
+	}
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindIdentifier {
+			observer.Observe(node)
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	collector.Complete()
+	if len(refs.ImportBindings()) != 1 || len(refs.BindingDeclarations()) != len(declarations) {
+		t.Fatal("later feature build changed an already-materialized declaration collection")
+	}
+	local := identifiers(sourceFile.AsNode(), "local")
+	if got := refs.References(local[0].Parent.Symbol()); len(got) != 1 || got[0] != local[1] {
+		t.Fatalf("mixed-stage references = %v, want local use", got)
+	}
+}
+
+func TestRefStoreLateFeatureRequestDuringStreamingFallsBackAtomically(t *testing.T) {
+	sourceFile, refs := newBoundRefStore(t, "/streaming-late-feature.ts", core.ScriptKindTS, `
+import { value as imported } from "m";
+const local = imported;
+consume(local);
+`)
+	refs.request(RefNeedReferences)
+	collector := RefCollector{store: refs}
+	observer := collector.Start()
+	if !observer.Active() {
+		t.Fatal("reference collection did not start")
+	}
+	first := identifiers(sourceFile.AsNode(), "imported")[0]
+	observer.Observe(first)
+	refs.request(RefNeedImportBindings)
+	if refs.state != refCollectionCompleteByPrepass || refs.built != RefNeedReferences|RefNeedImportBindings {
+		t.Fatalf("late feature request state=%v built=%v, want atomic full prepass", refs.state, refs.built)
+	}
+	observer.Observe(identifiers(sourceFile.AsNode(), "local")[1])
+	collector.Complete()
+	if got := refs.ImportBindings(); len(got) != 1 || got[0].LocalName != first {
+		t.Fatalf("late-request imports = %#v, want complete import collection", got)
+	}
+	local := identifiers(sourceFile.AsNode(), "local")
+	if got := refs.References(local[0].Parent.Symbol()); len(got) != 1 || got[0] != local[1] {
+		t.Fatalf("late-request references = %v, want complete local use", got)
+	}
+}
+
+func TestRefStoreEarlyFactMaterializationNeverReturnsLiveSlices(t *testing.T) {
+	for _, firstQuery := range []RefNeeds{RefNeedBindingDeclarations, RefNeedImportBindings} {
+		name := "declarations"
+		if firstQuery == RefNeedImportBindings {
+			name = "imports"
+		}
+		t.Run(name, func(t *testing.T) {
+			sourceFile, refs := newBoundRefStore(t, "/early-facts.ts", core.ScriptKindTS, `
+import { a as A, b as B } from "m";
+const local = A;
+consume(local, B);
+`)
+			refs.request(RefNeedBindingDeclarations | RefNeedImportBindings)
+			collector := RefCollector{store: refs}
+			observer := collector.Start()
+			if !observer.Active() {
+				t.Fatal("fact collection did not start")
+			}
+			localBindings := identifiers(sourceFile.AsNode(), "A")
+			if len(localBindings) != 2 {
+				t.Fatal("fixture did not expose the A binding and its use")
+			}
+			// Seed both streaming fact slices with a real local import binding;
+			// the early query must discard that partial prefix before rebuilding.
+			observer.Observe(localBindings[0])
+
+			var firstDeclaration *BindingDeclarationFacts
+			var firstImport *ImportBinding
+			if firstQuery == RefNeedBindingDeclarations {
+				got := refs.BindingDeclarations()
+				if len(got) != 3 {
+					t.Fatalf("early declarations = %d, want A, B, local", len(got))
+				}
+				firstDeclaration = &got[0]
+			} else {
+				got := refs.ImportBindings()
+				if len(got) != 2 {
+					t.Fatalf("early imports = %d, want A and B", len(got))
+				}
+				firstImport = &got[0]
+			}
+			if refs.state != refCollectionCompleteByPrepass {
+				t.Fatalf("early fact query state = %v, want full-prepass completion", refs.state)
+			}
+
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindIdentifier {
+					observer.Observe(node)
+				}
+				node.ForEachChild(visit)
+				return false
+			}
+			sourceFile.AsNode().ForEachChild(visit)
+			collector.Complete()
+			if firstQuery == RefNeedBindingDeclarations {
+				got := refs.BindingDeclarations()
+				if len(got) != 3 || &got[0] != firstDeclaration {
+					t.Fatal("post-traversal declaration slice changed after publication")
+				}
+				if len(refs.ImportBindings()) != 2 {
+					t.Fatal("sibling import feature was not completed by atomic fallback")
+				}
+			} else {
+				got := refs.ImportBindings()
+				if len(got) != 2 || &got[0] != firstImport {
+					t.Fatal("post-traversal import slice changed after publication")
+				}
+				if len(refs.BindingDeclarations()) != 3 {
+					t.Fatal("sibling declaration feature was not completed by atomic fallback")
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -16,7 +16,7 @@ import (
 // and per-file locals the way the linter guarantees before constructing a
 // RefStore in production), and returns both the bound source file and its
 // RefStore for direct inspection.
-func newBoundRefStore(t *testing.T, fileName string, scriptKind core.ScriptKind, source string) (*ast.SourceFile, *RefStore) {
+func newBoundRefStore(t testing.TB, fileName string, scriptKind core.ScriptKind, source string) (*ast.SourceFile, *RefStore) {
 	t.Helper()
 	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
 		FileName: fileName,

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -101,6 +101,7 @@ const (
 	lastOnAllowPatternOnExitTokenKind    ast.Kind = 4000
 	lastOnNotAllowPatternTokenKind       ast.Kind = 5000
 	lastOnNotAllowPatternOnExitTokenKind ast.Kind = 6000
+	listenerOnFileFinalizeKind           ast.Kind = lastOnNotAllowPatternOnExitTokenKind + 1
 )
 
 func ListenerOnExit(kind ast.Kind) ast.Kind {
@@ -115,11 +116,24 @@ func ListenerOnNotAllowPattern(kind ast.Kind) ast.Kind {
 	return kind + lastOnAllowPatternOnExitTokenKind
 }
 
+// ListenerOnFileFinalize returns the dedicated per-file finalize event kind.
+// The linter dispatches it once after all real-node enter/exit listeners and
+// after shared RefStore collection is complete. It is intentionally distinct
+// from ListenerOnExit(ast.KindSourceFile): the SourceFile root is not part of
+// the ordinary listener traversal.
+func ListenerOnFileFinalize() ast.Kind {
+	return listenerOnFileFinalizeKind
+}
+
 type RuleListeners map[ast.Kind](func(node *ast.Node))
 
 type Rule struct {
 	Name             string
 	RequiresTypeInfo bool
+	// Needs declares the upper bound of shared analyses this rule may request
+	// for an individual file. Declaration alone does not materialize anything;
+	// Rule.Run opts a file in through the corresponding RuleContext request.
+	Needs RuleNeeds
 	// IsEslintPluginRule marks a placeholder rule whose actual execution
 	// happens in a Node worker — an ESLint-plugin rule mounted via the
 	// config's object-form `plugins`. Its Run is a no-op in Go; the linter
@@ -141,6 +155,7 @@ func CreateRule(r Rule) Rule {
 	return Rule{
 		Name:             "@typescript-eslint/" + r.Name,
 		RequiresTypeInfo: r.RequiresTypeInfo,
+		Needs:            r.Needs,
 		Schema:           r.Schema,
 		Run:              r.Run,
 	}

--- a/internal/rule/rule_needs_test.go
+++ b/internal/rule/rule_needs_test.go
@@ -1,0 +1,81 @@
+package rule
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+)
+
+func TestCreateRulePreservesNeeds(t *testing.T) {
+	needs := RuleNeeds{Refs: RefNeedReferences | RefNeedImportBindings}
+	created := CreateRule(Rule{Name: "example", Needs: needs})
+	if created.Needs != needs {
+		t.Fatalf("CreateRule Needs = %v, want %v", created.Needs, needs)
+	}
+}
+
+func TestRuleNeedsFitExistingReporterLayout(t *testing.T) {
+	type legacyReporter struct {
+		_ string
+		DiagnosticSeverity
+		DiagnosticConsumer
+	}
+	if got, want := unsafe.Sizeof(ruleContextReporter{}), unsafe.Sizeof(legacyReporter{}); got != want {
+		t.Fatalf("ruleContextReporter size = %d, want legacy size %d", got, want)
+	}
+}
+
+func TestRefStoreZeroConsumerLayoutAndControlPlane(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) == 8 && unsafe.Sizeof(RefStore{}) > 160 {
+		t.Fatalf("RefStore size = %d, exceeds the existing 160-byte allocation class", unsafe.Sizeof(RefStore{}))
+	}
+	storeType := reflect.TypeOf((*RefStore)(nil))
+	for _, name := range []string{"Start", "Observe", "Complete", "StartCollection", "ObserveIdentifier", "CompleteCollection"} {
+		if _, ok := storeType.MethodByName(name); ok {
+			t.Fatalf("RefStore exposes traversal control method %s to RuleContext consumers", name)
+		}
+	}
+	contextType := reflect.TypeOf(RuleContext{})
+	collectorType := reflect.TypeOf(RefCollector{})
+	observerType := reflect.TypeOf(RefObserver{})
+	for index := range contextType.NumField() {
+		fieldType := contextType.Field(index).Type
+		if fieldType == collectorType || fieldType == observerType {
+			t.Fatalf("RuleContext exposes RefStore traversal control through field %s", contextType.Field(index).Name)
+		}
+	}
+}
+
+func TestFileFinalizeKindDoesNotOverlapListenerRanges(t *testing.T) {
+	lastSyntheticExit := ListenerOnExit(ListenerOnNotAllowPattern(ast.KindCount - 1))
+	if ListenerOnFileFinalize() <= lastSyntheticExit {
+		t.Fatalf("file-finalize kind %d overlaps synthetic listener range ending at %d", ListenerOnFileFinalize(), lastSyntheticExit)
+	}
+}
+
+func TestRuleContextRefRequestsValidateRuleCeiling(t *testing.T) {
+	_, refs := newBoundRefStore(t, "/request-context.ts", core.ScriptKindTS, "const value = 1;")
+	ctx := RuleContext{Refs: refs}.WithRuleNeeds(RuleNeeds{
+		Refs: RefNeedReferences | RefNeedImportBindings,
+	})
+	if !ctx.RequestRefs(RefNeedReferences) || refs.requested != RefNeedReferences {
+		t.Fatalf("declared request was not recorded: %v", refs.requested)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("undeclared RefStore request did not panic")
+		}
+	}()
+	ctx.RequestRefs(RefNeedBindingDeclarations)
+}
+
+func TestRuleContextRefRequestWithoutStoreReturnsFalse(t *testing.T) {
+	ctx := RuleContext{}.WithRuleNeeds(RuleNeeds{Refs: RefNeedReferences})
+	if ctx.RequestRefs(RefNeedReferences) {
+		t.Fatal("request without a RefStore returned true")
+	}
+}

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -218,6 +218,7 @@ func RunRuleTester(root Root, tsconfigPath string, t *testing.T, r *rule.Rule, v
 						LanguageOptions: languageOptions,
 						Globals:         globals,
 						Severity:        rule.SeverityError,
+						Needs:           r.Needs,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {
 							return r.Run(ctx, options)
 						},

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -166,6 +166,7 @@ fieldset
 figcaption
 fileless
 finalizer
+finalizers
 fixall
 flaggable
 flowto
@@ -401,6 +402,7 @@ Prag
 preact
 prebundle
 predeclare
+prepass
 preresolved
 Prettier
 prioritises


### PR DESCRIPTION
## Summary

- Extend the single per-file `RefStore` with neutral reference, authored-binding, and syntax-only import facts; no parallel binding/scope store is introduced.
- Add static `RuleNeeds` ceilings plus per-file `RequestRefs` demand. A private linter collector can gather requested facts during the existing traversal, then seal them before a dedicated file-finalize listener.
- Preserve legacy lazy queries and correctness-safe early-query fallback. Partial/live collections are never published, and zero-request files keep the original traversal path.
- Document raw TypeScript symbol and ESLint scope boundaries, parameter-property dual identities, and shared-observer timing attribution.
- This PR migrates no production rules and does not touch ModuleGraph or `import/no-cycle`.

## Benchmarks

Apple M1 Max, `-cpu=1`, paired against `origin/main` (`25db8e9f`):

- Zero-request 128-small-file guard: paired directions were +0.29% and -0.75%; both sides were exactly 58,528 B/op and 794 allocs/op.
- Finalize-safe streaming: references -3.05%, binding declarations -8.92%, imports -12.07%, all facts -14.91%; every lazy/streaming pair had identical B/op and allocs/op.
- Early-query fallback overhead: +2.42% at 10%, +8.68% at 50%, +15.50% at 90%. Future migrations must veto streaming when representative configurations show meaningful fallback and must use end-to-end wall/alloc measurements rather than only a per-rule `--timing` line.

## Test Plan

- `go test ./internal/rule -run` with the RefStore, facts, lifecycle, needs, reporter-layout, and request-ceiling test set
- `go test ./internal/linter -run` with RefStore lifecycle, traversal, listener-registry, and timing tests
- `go test -p 1 ./internal/config -run ^TestRuleRegistryPropagatesRuleNeeds$ -count=1`
- `pnpm exec prettier --check architecture.md`
- Linter-level zero-request, references/fallback, and facts benchmarks with `-benchmem`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).