### PR TITLE
fix: prevent prefer-array-some panic and reduce listener work

### DIFF
--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -71,6 +71,16 @@ var PreferArraySomeRule = rule.Rule{
 // ---- `.find()` / `.findLast()` ----
 
 func checkFindCall(ctx rule.RuleContext, node *ast.Node) {
+	if !isPotentialFindMethodCall(node) {
+		return
+	}
+
+	comparison := comparisonParent(node)
+	isBooleanUse := comparison != nil || isBooleanExpression(ctx, node) || isControlFlowTest(node)
+	if !isBooleanUse && !isVariableDeclarationInitializer(node) {
+		return
+	}
+
 	minArgs := 1
 	maxArgs := 2
 	call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
@@ -88,22 +98,16 @@ func checkFindCall(ctx rule.RuleContext, node *ast.Node) {
 		return
 	}
 
-	if isKnownNonIndexedCollection(ctx, call.Object) {
-		return
-	}
-
-	isCompare := isCheckingUndefined(node)
-	if !isCompare &&
-		!isBooleanExpression(ctx, node) &&
-		!isControlFlowTest(node) &&
-		!isFindResultVariableUsedOnlyAsBoolean(ctx, node, call) {
+	if isBooleanUse {
+		if isKnownNonIndexedCollection(ctx, call.Object) {
+			return
+		}
+	} else if !isFindResultVariableUsedOnlyAsBoolean(ctx, node, call) {
 		return
 	}
 
 	methodNode := call.Property
 	method := methodNode.AsIdentifier().Text
-
-	comparison := comparisonParent(node) // non-nil only when isCompare
 
 	ctx.ReportNodeWithDeferredSuggestions(methodNode, messageArraySome(method), func() []rule.RuleSuggestion {
 		// Removing the comparison would drop comments between the call and the
@@ -111,7 +115,7 @@ func checkFindCall(ctx rule.RuleContext, node *ast.Node) {
 		// case. Checked inside the builder so lint-only runs never materialize
 		// the comment list — returning no suggestions reports exactly what
 		// ReportNode would.
-		if isCompare && utils.HasCommentInSpan(
+		if comparison != nil && utils.HasCommentInSpan(
 			ctx.Comments.All(),
 			parenthesizedEnd(ctx, node),
 			comparison.End(),
@@ -120,7 +124,7 @@ func checkFindCall(ctx rule.RuleContext, node *ast.Node) {
 		}
 
 		fixes := []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, methodNode, "some")}
-		if isCompare {
+		if comparison != nil {
 			// Remove the `== undefined` / `!== null` tail.
 			parenEnd := parenthesizedEnd(ctx, node)
 			fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(parenEnd, comparison.End())))
@@ -139,16 +143,46 @@ func checkFindCall(ctx rule.RuleContext, node *ast.Node) {
 	})
 }
 
+// isPotentialFindMethodCall is a conservative, allocation-free initial filter for
+// the CallExpression listener. MatchDotMethodCall still owns the optional-call,
+// argument-count, spread, and parenthesized-callee checks.
+func isPotentialFindMethodCall(node *ast.Node) bool {
+	if node == nil || !ast.IsCallExpression(node) {
+		return false
+	}
+	expression := node.AsCallExpression().Expression
+	if expression == nil {
+		return false
+	}
+	callee := ast.SkipParentheses(expression)
+	if callee == nil || !ast.IsPropertyAccessExpression(callee) {
+		return false
+	}
+	name := callee.AsPropertyAccessExpression().Name()
+	if name == nil || !ast.IsIdentifier(name) {
+		return false
+	}
+	method := name.AsIdentifier().Text
+	return method == "find" || method == "findLast"
+}
+
+func isVariableDeclarationInitializer(node *ast.Node) bool {
+	declarator := node.Parent
+	return declarator != nil && ast.IsVariableDeclaration(declarator) &&
+		declarator.AsVariableDeclaration().Initializer == node
+}
+
 // comparisonParent returns the BinaryExpression comparing `node` against
-// undefined / null (per isCheckingUndefined), skipping parentheses around the
-// call. Returns nil when node is not the left operand of such a comparison.
+// undefined / null, skipping parentheses around the call. Returns nil when
+// node is not the left operand of such a comparison.
 func comparisonParent(node *ast.Node) *ast.Node {
 	parent := effectiveParent(node)
 	if parent == nil || !ast.IsBinaryExpression(parent) {
 		return nil
 	}
 	bin := parent.AsBinaryExpression()
-	if ast.SkipParentheses(bin.Left) != node {
+	if bin.Left == nil || bin.Right == nil || bin.OperatorToken == nil ||
+		ast.SkipParentheses(bin.Left) != node {
 		return nil
 	}
 	right := bin.Right
@@ -165,22 +199,12 @@ func comparisonParent(node *ast.Node) *ast.Node {
 	return nil
 }
 
-// isCheckingUndefined mirrors upstream: the call is the left operand of a
-// comparison against `undefined` (`==`/`!=`/`===`/`!==`) or `null` (`==`/`!=`).
-// Yoda comparisons (`undefined !== foo.find()`) are intentionally not matched.
-func isCheckingUndefined(node *ast.Node) bool {
-	return comparisonParent(node) != nil
-}
-
 // isFindResultVariableUsedOnlyAsBoolean mirrors upstream's helper: a
 // `const x = arr.find(fn)` whose every read is used as a boolean. Requires the
 // receiver to be a known array (upstream `isArray`), a plain single-name
 // `const` binding that isn't exported, and ≥1 reference — all of which must be
 // boolean-position reads.
 func isFindResultVariableUsedOnlyAsBoolean(ctx rule.RuleContext, callExpression *ast.Node, call unicornutil.DotMethodCall) bool {
-	if !isArray(ctx, call.Object) {
-		return false
-	}
 	if ctx.Refs == nil {
 		return false
 	}
@@ -216,6 +240,9 @@ func isFindResultVariableUsedOnlyAsBoolean(ctx rule.RuleContext, callExpression 
 	if statement.ModifierFlags()&ast.ModifierFlagsExport != 0 {
 		return false
 	}
+	if !isArray(ctx, call.Object) {
+		return false
+	}
 
 	sym := declarator.Symbol()
 	if sym == nil {
@@ -242,16 +269,6 @@ func checkFindIndexComparison(ctx rule.RuleContext, node *ast.Node) bool {
 		return false
 	}
 
-	argsLen := 1
-	call, ok := unicornutil.MatchDotMethodCall(bin.Left, unicornutil.DotMethodCallOptions{
-		Methods:             []string{"findIndex", "findLastIndex"},
-		ArgumentsLength:     &argsLen,
-		RejectSpreadElement: true,
-	})
-	if !ok {
-		return false
-	}
-
 	operator := bin.OperatorToken.Kind
 	rhsMatches := false
 	switch operator {
@@ -262,6 +279,16 @@ func checkFindIndexComparison(ctx rule.RuleContext, node *ast.Node) bool {
 		rhsMatches = isLiteralZero(bin.Right)
 	}
 	if !rhsMatches {
+		return false
+	}
+
+	argsLen := 1
+	call, ok := unicornutil.MatchDotMethodCall(bin.Left, unicornutil.DotMethodCallOptions{
+		Methods:             []string{"findIndex", "findLastIndex"},
+		ArgumentsLength:     &argsLen,
+		RejectSpreadElement: true,
+	})
+	if !ok {
 		return false
 	}
 
@@ -297,6 +324,9 @@ func checkFindIndexComparison(ctx rule.RuleContext, node *ast.Node) bool {
 // isNegativeOne matches `-1` (with any parenthesized / spaced form of the `1`).
 // tsgo models `-1` as PrefixUnaryExpression(minus, NumericLiteral "1").
 func isNegativeOne(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
 	node = ast.SkipParentheses(node)
 	if node == nil || node.Kind != ast.KindPrefixUnaryExpression {
 		return false
@@ -305,12 +335,18 @@ func isNegativeOne(node *ast.Node) bool {
 	if unary.Operator != ast.KindMinusToken {
 		return false
 	}
+	if unary.Operand == nil {
+		return false
+	}
 	operand := ast.SkipParentheses(unary.Operand)
 	return operand != nil && operand.Kind == ast.KindNumericLiteral &&
 		utils.NormalizeNumericLiteral(operand.AsNumericLiteral().Text) == "1"
 }
 
 func isLiteralZero(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
 	node = ast.SkipParentheses(node)
 	return node != nil && node.Kind == ast.KindNumericLiteral &&
 		utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text) == "0"
@@ -671,6 +707,9 @@ var typedArrayNames = []string{
 // to `getTypeScriptType`. `targetNames` and `nonTargetNames` are the type-name
 // sets that resolve to target / non-target respectively.
 func classifyReceiver(ctx rule.RuleContext, node *ast.Node, targetNames, nonTargetNames *utils.Set[string]) typeClass {
+	if node == nil {
+		return classUnknown
+	}
 	node = ast.SkipParentheses(node)
 	if node == nil {
 		return classUnknown
@@ -724,6 +763,9 @@ func classifyReceiver(ctx rule.RuleContext, node *ast.Node, targetNames, nonTarg
 // a plain identifier name are resolved (matching upstream's getTypeFromVariable
 // preconditions).
 func constInitializer(ctx rule.RuleContext, idNode *ast.Node) *ast.Node {
+	if ctx.Refs == nil || idNode == nil {
+		return nil
+	}
 	sym := ctx.Refs.Resolve(idNode)
 	if sym == nil || len(sym.Declarations) != 1 {
 		return nil
@@ -737,7 +779,8 @@ func constInitializer(ctx rule.RuleContext, idNode *ast.Node) *ast.Node {
 		return nil
 	}
 	varDecl := decl.AsVariableDeclaration()
-	if varDecl.Name() == nil || !ast.IsIdentifier(varDecl.Name()) || varDecl.Type != nil {
+	if varDecl.Name() == nil || !ast.IsIdentifier(varDecl.Name()) ||
+		varDecl.Type != nil || varDecl.Initializer == nil {
 		return nil
 	}
 	return ast.SkipParentheses(varDecl.Initializer)

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
@@ -97,6 +97,13 @@ func TestPreferArraySomeExtras(t *testing.T) {
 			Code:   `if ((foo).find(fn)) {}`,
 			Errors: []rule_tester.InvalidTestCaseError{findErrorExtras(`if ((foo).some(fn)) {}`)},
 		},
+		// A `for…of` const binding has no VariableDeclaration initializer. Its
+		// inferred array type still makes the boolean `.find()` use reportable.
+		{
+			Code:   `declare const arrays: number[][]; declare const fn: (value: number) => boolean; for (const array of arrays) { if (array.find(fn)) {} }`,
+			Tsx:    false,
+			Errors: []rule_tester.InvalidTestCaseError{findErrorExtras(`declare const arrays: number[][]; declare const fn: (value: number) => boolean; for (const array of arrays) { if (array.some(fn)) {} }`)},
+		},
 		// Double-parenthesized call in a control-flow test.
 		{
 			Code:   `if (((foo.find(fn)))) {}`,


### PR DESCRIPTION
## Summary

- Fix a nil-pointer panic in `unicorn/prefer-array-some` when an identifier resolves to a `const` declaration without an initializer, including `for...of` bindings.
- Add conservative early filters before generic method matching and type classification while preserving existing diagnostics, fixes, and suggestions.
- Add focused regression coverage and adversarially verify optional calls and members, computed access, spreads, explicit type arguments, comparison forms, comments, receiver types, and edit-demand behavior.

### Go benchmark

Package-local benchmark on Apple M1 Max with `GOMAXPROCS=1`, 128 candidates per scenario, `-benchmem -benchtime=250ms -count=5`; values are medians.

| Case | ns/op before → after | Change | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| CallAndBinaryNoMatch / DiagnosticsOnly | `197447 → 172325` | 12.7% faster | `30936 → 30936` | `318 → 318` |
| ConstResultValueUse / DiagnosticsOnly | `317237 → 303497` | 4.3% faster | `108008 → 108008` | `751 → 751` |
| BooleanFind / DiagnosticsOnly | `150987 → 157176` | 4.1% slower | `100568 → 100568` | `830 → 830` |
| BooleanFind / AllEdits | `214350 → 218207` | 1.8% slower | `184536 → 184536` | `1726 → 1726` |
| FindIndex / DiagnosticsOnly | `164050 → 167177` | 1.9% slower | `100568 → 100568` | `830 → 830` |
| FindIndex / AllEdits | `203492 → 205339` | 0.9% slower | `154840 → 154840` | `1342 → 1342` |
| FilterLength / DiagnosticsOnly | `134054 → 134415` | 0.3% slower | `51416 → 51416` | `446 → 446` |
| FilterLength / AllEdits | `198068 → 200957` | 1.5% slower | `146648 → 146648` | `1214 → 1214` |
| ConstResultBooleanReads / DiagnosticsOnly | `356617 → 343196` | 3.8% faster | `177640 → 177640` | `1263 → 1263` |
| ConstResultBooleanReads / AllEdits | `424668 → 428637` | 0.9% slower | `261608 → 261608` | `2159 → 2159` |

The common call/binary no-match path improves by 12.7%, while const value-use and boolean-read early exits improve by 4.3% and 3.8%. Byte and allocation counts are unchanged in every case.

Correctness checks:

- `go test ./internal/plugins/unicorn/rules/prefer_array_some -count=3`
- Scoped golangci-lint for `./internal/plugins/unicorn/rules/prefer_array_some/...`
- `pnpm run check-spell`
- `pnpm run format:check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
