### PR TITLE
perf: optimize no-array-index-key checks

### DIFF
--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key.go
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key.go
@@ -73,7 +73,12 @@ func isImportSpecifierFromReact(ctx rule.RuleContext, ident *ast.Node) bool {
 	}
 
 	if ctx.TypeChecker != nil {
-		symbol := ctx.TypeChecker.GetSymbolAtLocation(ident)
+		var symbol *ast.Symbol
+		if ctx.Refs != nil {
+			symbol = ctx.Refs.Resolve(ident)
+		} else {
+			symbol = ctx.TypeChecker.GetSymbolAtLocation(ident)
+		}
 		if symbol == nil {
 			return false
 		}
@@ -550,10 +555,9 @@ var NoArrayIndexKeyRule = rule.Rule{
 			ast.KindCallExpression: func(node *ast.Node) {
 				call := node.AsCallExpression()
 
-				if isCreateCloneElement(call.Expression) && call.Arguments != nil && len(call.Arguments.Nodes) > 1 {
-					if len(indexParamNames) == 0 {
-						return
-					}
+				if len(indexParamNames) > 0 &&
+					isCreateCloneElement(call.Expression) &&
+					call.Arguments != nil && len(call.Arguments.Nodes) > 1 {
 					checkObjectKeyProp(call.Arguments.Nodes[1])
 					return
 				}

--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
@@ -256,6 +256,38 @@ foo.map((baz, i) => cloneElement(someChild, { key: i }))
 		// stack is empty; the props-key check short-circuits.
 		{Code: `React.createElement('Foo', { key: i })`, Tsx: true},
 		{Code: `React.cloneElement(child, { key: i })`, Tsx: true},
+		{
+			Code: `
+import { cloneElement } from 'react';
+cloneElement(child, { key: i });
+`,
+			Tsx: true,
+		},
+		// A local declaration or parameter can shadow a top-level React
+		// import. The bare callee must resolve to that nearest binding and
+		// therefore is not treated as an imported React factory.
+		{
+			Code: `
+import { cloneElement } from 'react';
+foo.map((item, i) => {
+  const cloneElement = (...args) => args;
+  return cloneElement(item, { key: i });
+});
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+import { cloneElement } from 'react';
+foo.map((item, i) => {
+  function render(cloneElement) {
+    return cloneElement(item, { key: i });
+  }
+  return render((...args) => args);
+});
+`,
+			Tsx: true,
+		},
 		// Iterator with a `thisArg` third argument — `args[0]` is the
 		// callback, the third arg is irrelevant. Index named `i` lives
 		// on the stack inside the callback.
@@ -389,6 +421,17 @@ foo.map((baz, i) => cloneElement(someChild, { ...someChild.props, key: i }))
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noArrayIndex", Line: 4, Column: 72},
+			},
+		},
+		{
+			Code: `
+import { cloneElement as makeElement } from 'react';
+
+foo.map((baz, i) => makeElement(someChild, { key: i }))
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 4, Column: 51},
 			},
 		},
 


### PR DESCRIPTION
## Summary

- Skip React factory recognition for call expressions that are not inside a tracked iterator callback, avoiding unnecessary checker queries for ordinary calls.
- Resolve bare factory callees through the binder-backed reference store when available, while retaining the type-checker fallback.
- Add regression coverage for imported and aliased React factories plus local and parameter shadowing.

### Go benchmark

Methodology: compile the package-local `BenchmarkNoArrayIndexKey` against `origin/main` and this branch from the same temporary benchmark source, then run each binary with `GOMAXPROCS=1`, `-benchmem`, `-benchtime=200ms`, and `-count=5`. The table reports the median of five runs.

| Case | Before (ns/op) | After (ns/op) | Delta | Before / after (B/op) | Before / after (allocs/op) |
| --- | ---: | ---: | ---: | ---: | ---: |
| Outside iterator, identifier calls, diagnostics only | 115,270 | 94,252 | -18.23% | 31,552 / 31,552 | 334 / 334 |
| Outside iterator, member calls control, diagnostics only | 112,226 | 109,748 | -2.21% | 31,552 / 31,552 | 334 / 334 |
| Inside iterator, bare local factory, diagnostics only | 148,234 | 151,509 | +2.21% | 31,568 / 31,568 | 335 / 335 |
| Inside iterator, bare React import, diagnostics only | 126,638 | 127,064 | +0.34% | 41,808 / 41,808 | 399 / 399 |
| Inside iterator, bare React import, all edits | 125,946 | 124,753 | -0.95% | 41,808 / 41,808 | 399 / 399 |
| JSX diagnostic, diagnostics only | 110,970 | 113,938 | +2.67% | 41,808 / 41,808 | 399 / 399 |
| JSX diagnostic, all edits | 110,570 | 113,703 | +2.83% | 41,808 / 41,808 | 399 / 399 |

Allocations are unchanged in every benchmark case. Targeted rule tests pass, including the added import, alias, and shadowing regressions. Formatting, spell checking, targeted Go linting, and `git diff --check` also pass.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
