### PR TITLE
perf(jest,rstest): optimize no-conditional-expect rule

### DIFF
--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
@@ -103,10 +103,12 @@ var NoConditionalExpectRule = shared.NewRule(shared.Config{
 	Prepare: func(ctx rule.RuleContext) shared.Runtime {
 		return shared.Runtime{
 			TestCallbackFunctions: collectTestFunctionCallbacks(ctx),
-			ClassifyCall: func(node *ast.Node) (bool, bool) {
+			ClassifyCall: func(node *ast.Node, checkExpect bool) (bool, bool) {
 				parsed := jestUtils.ParseJestFnCall(node, ctx)
 				return parsed != nil && parsed.Kind == jestUtils.JestFnTypeTest,
-					parsed != nil && parsed.Kind == jestUtils.JestFnTypeExpect
+					checkExpect &&
+						parsed != nil &&
+						parsed.Kind == jestUtils.JestFnTypeExpect
 			},
 		}
 	},

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -792,6 +792,12 @@ it("case", cb);`},
 				},
 			},
 			{
+				Code: `expect(value).catch(() => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
 				Code: `
         it('works', async () => {
           await somePromise.catch(error => expect(error).toBeInstanceOf(Error));

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
@@ -7,16 +7,28 @@ import (
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_conditional_expect"
 )
 
+func sourceMayContainConditionalRstestExpect(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	_, ok := sourceFile.Identifiers["expect"]
+	return ok
+}
+
 var NoConditionalExpectRule = shared.NewRule(shared.Config{
 	Name: "rstest/no-conditional-expect",
 	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		if !sourceMayContainConditionalRstestExpect(ctx.SourceFile) {
+			return shared.Runtime{Skip: true}
+		}
 		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
 		return shared.Runtime{
 			TestCallbackFunctions: callbacks.Functions,
-			ClassifyCall: func(node *ast.Node) (bool, bool) {
-				parsed := callbacks.ParseFnCall(node)
-				return parsed != nil && parsed.Kind == rstestUtils.RstestFnTypeTest,
-					rstestUtils.IsRstestExpectCall(node, ctx, callbacks)
+			ClassifyCall: func(node *ast.Node, checkExpect bool) (bool, bool) {
+				return callbacks.TestCalls[node],
+					checkExpect &&
+						callbacks.IsExpectCandidate(node) &&
+						rstestUtils.IsRstestExpectCall(node, ctx, callbacks)
 			},
 		}
 	},

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect_test.go
@@ -137,6 +137,12 @@ let state;`},
 				},
 			},
 			{
+				Code: `expect(value).catch(() => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
 				// An unresolvable timeout in the third position must not stop the
 				// second argument from being treated as the callback.
 				Code: `test("case", ({ expect }) => { if (condition) expect(value).toBe(1); }, TIMEOUT);`,
@@ -178,6 +184,24 @@ test("case", () => { if (condition) check(value).toBe(1); });`,
 				Code: `import * as rstest from "@rstest/core";
 rstest.test("case", () => {
   if (condition) rstest.expect(value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import * as rstest from "@rstest/core";
+rstest["test"]("case", () => {
+  if (condition) rstest["expect"](value).toBe(1);
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import { test, expect as \u0063heck } from "@rstest/core";
+test("case", () => {
+  if (condition) \u0063heck(value).toBe(1);
 });`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "conditionalExpect"},
@@ -316,6 +340,17 @@ playwright.test("case", async ({ page }) => {
 				Code: `const forCase = test.for([{ enabled: true }]);
 forCase("case", (row, context) => {
   if (row.enabled) context.expect(row).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "conditionalExpect"},
+				},
+			},
+			{
+				Code: `import { test as importedTest, expect as importedExpect } from "@rstest/core";
+const testAlias = importedTest;
+const testCase = testAlias;
+testCase("case", () => {
+  if (condition) importedExpect(value).toBe(1);
 });`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "conditionalExpect"},

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -137,8 +137,88 @@ func IsRstestExpectCall(
 	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
 		return false
 	}
-	_, ok := rstestExpectMemberIndex(node, testFramework.GetMemberEntries(node), ctx, callbacks)
+	if isImportMetaRstestExpectCall(node) {
+		return true
+	}
+	entries := firstRstestExpectEntries(node)
+	if entries.count == 0 || entries.first == nil || entries.first.Kind != ast.KindIdentifier {
+		return false
+	}
+	_, ok := rstestExpectRootIndex(entries.first, entries.secondName, entries.count > 1, ctx, callbacks)
 	return ok
+}
+
+type rstestExpectEntries struct {
+	first      *ast.Node
+	secondName string
+	count      uint8
+}
+
+func (entries *rstestExpectEntries) append(name string, node *ast.Node) {
+	if name == "" {
+		return
+	}
+	switch entries.count {
+	case 0:
+		entries.first = node
+	case 1:
+		entries.secondName = name
+	}
+	if entries.count < 2 {
+		entries.count++
+	}
+}
+
+func firstRstestExpectEntries(node *ast.Node) rstestExpectEntries {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return rstestExpectEntries{}
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return rstestExpectEntries{
+			first: node,
+			count: 1,
+		}
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		entries := firstRstestExpectEntries(property.Expression)
+		name := property.Name()
+		if name != nil {
+			switch name.Kind {
+			case ast.KindIdentifier:
+				entries.append(name.AsIdentifier().Text, name)
+			case ast.KindPrivateIdentifier:
+				entries.append(name.AsPrivateIdentifier().Text, name)
+			}
+		}
+		return entries
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		entries := firstRstestExpectEntries(element.Expression)
+		name := ast.SkipParentheses(element.ArgumentExpression)
+		if name == nil {
+			return rstestExpectEntries{}
+		}
+		switch name.Kind {
+		case ast.KindIdentifier:
+			entries.append(name.AsIdentifier().Text, name)
+		case ast.KindStringLiteral:
+			entries.append(name.AsStringLiteral().Text, name)
+		case ast.KindNoSubstitutionTemplateLiteral:
+			entries.append(name.AsNoSubstitutionTemplateLiteral().Text, name)
+		default:
+			return rstestExpectEntries{}
+		}
+		return entries
+	case ast.KindCallExpression:
+		return firstRstestExpectEntries(node.AsCallExpression().Expression)
+	case ast.KindTaggedTemplateExpression:
+		return firstRstestExpectEntries(node.AsTaggedTemplateExpression().Tag)
+	default:
+		return rstestExpectEntries{}
+	}
 }
 
 // ParseRstestExpectCall parses node as a Rstest expect call, resolving the
@@ -276,11 +356,46 @@ func rstestExpectMemberIndex(
 	if len(entries) == 0 || entries[0].Node == nil || entries[0].Node.Kind != ast.KindIdentifier {
 		return 0, false
 	}
-	root := entries[0].Node
-	if index, ok := contextExpectMemberIndex(root, entries, ctx, callbacks); ok {
-		return index, true
+	secondName := ""
+	if len(entries) > 1 {
+		secondName = entries[1].Name
 	}
-	return importedOrGlobalExpectMemberIndex(root, entries, ctx)
+	return rstestExpectRootIndex(entries[0].Node, secondName, len(entries) > 1, ctx, callbacks)
+}
+
+func rstestExpectRootIndex(
+	root *ast.Node,
+	secondName string,
+	hasSecond bool,
+	ctx rule.RuleContext,
+	callbacks RstestTestCallbacks,
+) (int, bool) {
+	if root == nil || root.Kind != ast.KindIdentifier {
+		return 0, false
+	}
+	localName := root.AsIdentifier().Text
+	if ctx.TypeChecker == nil {
+		return 0, localName == "expect"
+	}
+	symbol := ctx.TypeChecker.GetSymbolAtLocation(root)
+	if symbol == nil {
+		return 0, localName == "expect"
+	}
+	kind, ok := callbacks.expectRoots[symbol]
+	if !ok {
+		kind = classifyRstestExpectRoot(localName, root, symbol, ctx, callbacks)
+		if callbacks.expectRoots != nil {
+			callbacks.expectRoots[symbol] = kind
+		}
+	}
+	switch kind {
+	case rstestExpectRootDirect:
+		return 0, true
+	case rstestExpectRootReceiver:
+		return 1, hasSecond && secondName == "expect"
+	default:
+		return 0, false
+	}
 }
 
 func classifyRstestExpectCall(
@@ -567,56 +682,36 @@ func isMemberAccessNode(node *ast.Node) bool {
 	}
 }
 
-// contextExpectMemberIndex resolves expect calls that come from a test context
-// parameter: ({ expect }) => expect(x)... at index 0, ctx => ctx.expect(x)...
-// at index 1.
-func contextExpectMemberIndex(
+type rstestExpectRootKind uint8
+
+const (
+	rstestExpectRootNone rstestExpectRootKind = iota
+	rstestExpectRootDirect
+	rstestExpectRootReceiver
+)
+
+func classifyRstestExpectRoot(
+	localName string,
 	root *ast.Node,
-	entries []testFramework.MemberEntry,
+	symbol *ast.Symbol,
 	ctx rule.RuleContext,
 	callbacks RstestTestCallbacks,
-) (int, bool) {
-	if ctx.TypeChecker == nil {
-		return 0, false
-	}
-	symbol := ctx.TypeChecker.GetSymbolAtLocation(root)
-	if symbol == nil {
-		return 0, false
-	}
+) rstestExpectRootKind {
 	if callbacks.ContextExpectNames[symbol] {
-		return 0, true
+		return rstestExpectRootDirect
 	}
-	if callbacks.ContextReceivers[symbol] &&
-		len(entries) > 1 &&
-		entries[1].Name == "expect" {
-		return 1, true
-	}
-	return 0, false
-}
-
-// importedOrGlobalExpectMemberIndex resolves expect calls whose root is an
-// import, a global, a require binding, an import.meta.rstest alias, or a
-// module namespace: direct bindings put expect at index 0, receiver objects at
-// index 1.
-func importedOrGlobalExpectMemberIndex(
-	root *ast.Node,
-	entries []testFramework.MemberEntry,
-	ctx rule.RuleContext,
-) (int, bool) {
-	localName := root.AsIdentifier().Text
-	var symbol *ast.Symbol
-	if ctx.TypeChecker != nil {
-		symbol = ctx.TypeChecker.GetSymbolAtLocation(root)
+	if callbacks.ContextReceivers[symbol] {
+		return rstestExpectRootReceiver
 	}
 
 	if name, _, ok := resolveImportMetaRstestBinding(symbol); ok {
-		return 0, name == "expect"
+		if name == "expect" {
+			return rstestExpectRootDirect
+		}
+		return rstestExpectRootNone
 	}
 	if isImportMetaRstestObjectAlias(symbol) {
-		if len(entries) > 1 && entries[1].Name == "expect" {
-			return 1, true
-		}
-		return 0, false
+		return rstestExpectRootReceiver
 	}
 
 	for _, module := range []string{RstestImportModule, RstestPlaywrightImportModule} {
@@ -628,15 +723,13 @@ func importedOrGlobalExpectMemberIndex(
 			module,
 		)
 		if name == "expect" {
-			return 0, true
+			return rstestExpectRootDirect
 		}
-		if testFramework.IsModuleNamespaceSymbol(symbol, module) &&
-			len(entries) > 1 &&
-			entries[1].Name == "expect" {
-			return 1, true
+		if testFramework.IsModuleNamespaceSymbol(symbol, module) {
+			return rstestExpectRootReceiver
 		}
 	}
-	return 0, false
+	return rstestExpectRootNone
 }
 
 func isImportMetaRstestExpectCall(node *ast.Node) bool {

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -4,41 +4,16 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
 type RstestTestCallbacks struct {
 	Functions          map[*ast.Node]bool
+	TestCalls          map[*ast.Node]bool
 	ContextReceivers   map[*ast.Symbol]bool
 	ContextExpectNames map[*ast.Symbol]bool
-	fnCalls            *rstestFnCallCache
-}
-
-// rstestFnCallCache memoizes call parsing so that the collection walk and the
-// rule traversal that follows it do not each parse every call expression.
-type rstestFnCallCache struct {
-	ctx    rule.RuleContext
-	parsed map[*ast.Node]*ParsedRstestFnCall
-}
-
-func (cache *rstestFnCallCache) parse(node *ast.Node) *ParsedRstestFnCall {
-	if cache == nil {
-		return nil
-	}
-	if parsed, ok := cache.parsed[node]; ok {
-		return parsed
-	}
-	parsed := ParseRstestFnCallWithOfficialExtensions(node, cache.ctx)
-	cache.parsed[node] = parsed
-	return parsed
-}
-
-// ParseFnCall parses node the way CollectRstestTestCallbacks did, reusing the
-// cached result when the collection walk already visited node.
-func (callbacks RstestTestCallbacks) ParseFnCall(node *ast.Node) *ParsedRstestFnCall {
-	if callbacks.fnCalls == nil {
-		return nil
-	}
-	return callbacks.fnCalls.parse(node)
+	ExpectRootNames    map[string]bool
+	expectRoots        map[*ast.Symbol]rstestExpectRootKind
 }
 
 type rstestCallbackInfo struct {
@@ -47,14 +22,14 @@ type rstestCallbackInfo struct {
 }
 
 func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
+	candidateNames := collectRstestCallCandidateNames(ctx.SourceFile)
 	result := RstestTestCallbacks{
 		Functions:          map[*ast.Node]bool{},
+		TestCalls:          map[*ast.Node]bool{},
 		ContextReceivers:   map[*ast.Symbol]bool{},
 		ContextExpectNames: map[*ast.Symbol]bool{},
-		fnCalls: &rstestFnCallCache{
-			ctx:    ctx,
-			parsed: map[*ast.Node]*ParsedRstestFnCall{},
-		},
+		ExpectRootNames:    candidateNames.expect,
+		expectRoots:        map[*ast.Symbol]rstestExpectRootKind{},
 	}
 	pending := map[string][]*ParsedRstestFnCall{}
 
@@ -64,13 +39,17 @@ func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
 			return
 		}
 		if node.Kind == ast.KindCallExpression {
-			parsed := result.fnCalls.parse(node)
-			if parsed != nil && parsed.Kind == RstestFnTypeTest {
-				info := resolveRstestTestCallback(ctx, node.AsCallExpression())
-				if info.functionNode != nil {
-					recordRstestCallback(ctx, &result, info.functionNode, parsed)
-				} else if info.name != "" {
-					pending[info.name] = append(pending[info.name], parsed)
+			root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+			if root == nil || candidateNames.test[root.AsIdentifier().Text] {
+				parsed := ParseRstestFnCallWithOfficialExtensions(node, ctx)
+				if parsed != nil && parsed.Kind == RstestFnTypeTest {
+					result.TestCalls[node] = true
+					info := resolveRstestTestCallback(ctx, node.AsCallExpression())
+					if info.functionNode != nil {
+						recordRstestCallback(ctx, &result, info.functionNode, parsed)
+					} else if info.name != "" {
+						pending[info.name] = append(pending[info.name], parsed)
+					}
 				}
 			}
 		}
@@ -87,6 +66,191 @@ func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
 		resolvePendingRstestCallbacks(ctx, &result, pending)
 	}
 	return result
+}
+
+func (callbacks RstestTestCallbacks) IsExpectCandidate(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	return root == nil ||
+		root.Kind != ast.KindIdentifier ||
+		callbacks.ExpectRootNames[root.AsIdentifier().Text]
+}
+
+type rstestAliasCandidate struct {
+	localName string
+	rootName  string
+}
+
+type rstestCallCandidateNames struct {
+	test   map[string]bool
+	expect map[string]bool
+}
+
+func collectRstestCallCandidateNames(sourceFile *ast.SourceFile) rstestCallCandidateNames {
+	candidates := rstestCallCandidateNames{
+		test: map[string]bool{
+			"test": true,
+			"it":   true,
+		},
+		expect: map[string]bool{
+			"expect": true,
+		},
+	}
+	if sourceFile == nil {
+		return candidates
+	}
+
+	aliases := make([]rstestAliasCandidate, 0)
+	var visit func(*ast.Node)
+	visit = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		switch node.Kind {
+		case ast.KindImportDeclaration:
+			collectRstestImportCandidates(node.AsImportDeclaration(), candidates)
+		case ast.KindVariableDeclaration:
+			collectRstestVariableCandidates(node, candidates, &aliases)
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return false
+		})
+	}
+	visit(sourceFile.Node.AsNode())
+
+	for changed := true; changed; {
+		changed = false
+		for _, alias := range aliases {
+			if !candidates.test[alias.localName] && candidates.test[alias.rootName] {
+				candidates.test[alias.localName] = true
+				changed = true
+			}
+			if !candidates.expect[alias.localName] && candidates.expect[alias.rootName] {
+				candidates.expect[alias.localName] = true
+				changed = true
+			}
+		}
+	}
+	return candidates
+}
+
+func collectRstestImportCandidates(
+	declaration *ast.ImportDeclaration,
+	candidates rstestCallCandidateNames,
+) {
+	if declaration == nil ||
+		declaration.ModuleSpecifier == nil ||
+		!isRstestImportModule(declaration.ModuleSpecifier.Text()) ||
+		declaration.ImportClause == nil ||
+		declaration.ImportClause.IsTypeOnly() {
+		return
+	}
+	clause := declaration.ImportClause.AsImportClause()
+	if clause == nil || clause.NamedBindings == nil {
+		return
+	}
+	switch clause.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		namespace := clause.NamedBindings.AsNamespaceImport()
+		if namespace != nil && namespace.Name() != nil {
+			localName := namespace.Name().Text()
+			candidates.test[localName] = true
+			candidates.expect[localName] = true
+		}
+	case ast.KindNamedImports:
+		named := clause.NamedBindings.AsNamedImports()
+		if named == nil || named.Elements == nil {
+			return
+		}
+		for _, element := range named.Elements.Nodes {
+			specifier := element.AsImportSpecifier()
+			if specifier == nil || specifier.IsTypeOnly || specifier.Name() == nil {
+				continue
+			}
+			importedName := specifier.Name().Text()
+			if specifier.PropertyName != nil {
+				importedName = specifier.PropertyName.Text()
+			}
+			localName := specifier.Name().Text()
+			switch importedName {
+			case "test", "it":
+				candidates.test[localName] = true
+			case "expect":
+				candidates.expect[localName] = true
+			}
+		}
+	}
+}
+
+func collectRstestVariableCandidates(
+	node *ast.Node,
+	candidates rstestCallCandidateNames,
+	aliases *[]rstestAliasCandidate,
+) {
+	if node == nil || node.Kind != ast.KindVariableDeclaration {
+		return
+	}
+	declaration := node.AsVariableDeclaration()
+	if declaration == nil || declaration.Name() == nil || declaration.Initializer == nil {
+		return
+	}
+	name := declaration.Name()
+	initializer := ast.SkipParentheses(declaration.Initializer)
+	if name.Kind == ast.KindObjectBindingPattern &&
+		(isRstestRequireCall(initializer) || isImportMetaRstest(initializer)) {
+		pattern := name.AsBindingPattern()
+		if pattern == nil || pattern.Elements == nil {
+			return
+		}
+		for _, element := range pattern.Elements.Nodes {
+			binding := element.AsBindingElement()
+			if binding == nil || binding.Name() == nil || binding.Name().Kind != ast.KindIdentifier {
+				continue
+			}
+			importedName := binding.Name().Text()
+			if binding.PropertyName != nil {
+				importedName = binding.PropertyName.Text()
+			}
+			localName := binding.Name().Text()
+			switch importedName {
+			case "test", "it":
+				candidates.test[localName] = true
+			case "expect":
+				candidates.expect[localName] = true
+			}
+		}
+		return
+	}
+	if name.Kind != ast.KindIdentifier || node.Parent == nil ||
+		node.Parent.Kind != ast.KindVariableDeclarationList ||
+		node.Parent.Flags&ast.NodeFlagsConst == 0 {
+		return
+	}
+	localName := name.AsIdentifier().Text
+	if isRstestRequireCall(initializer) || isImportMetaRstest(initializer) {
+		candidates.test[localName] = true
+		candidates.expect[localName] = true
+		return
+	}
+	root := testFramework.ResolveFirstIdentifier(initializer)
+	if root != nil && root.Kind == ast.KindIdentifier {
+		*aliases = append(*aliases, rstestAliasCandidate{
+			localName: localName,
+			rootName:  root.AsIdentifier().Text,
+		})
+	}
+}
+
+func isRstestRequireCall(node *ast.Node) bool {
+	return testFramework.IsModuleRequireCall(node, RstestImportModule) ||
+		testFramework.IsModuleRequireCall(node, RstestPlaywrightImportModule)
+}
+
+func isRstestImportModule(name string) bool {
+	return name == RstestImportModule || name == RstestPlaywrightImportModule
 }
 
 func resolveRstestTestCallback(
@@ -235,6 +399,7 @@ func recordRstestCallback(
 	name := parameter.Name()
 	switch name.Kind {
 	case ast.KindIdentifier:
+		result.ExpectRootNames[name.AsIdentifier().Text] = true
 		if symbol := ctx.TypeChecker.GetSymbolAtLocation(name); symbol != nil {
 			result.ContextReceivers[symbol] = true
 		}
@@ -262,6 +427,7 @@ func recordRstestCallback(
 			if propertyName != "expect" {
 				continue
 			}
+			result.ExpectRootNames[binding.Name().AsIdentifier().Text] = true
 			if symbol := ctx.TypeChecker.GetSymbolAtLocation(binding.Name()); symbol != nil {
 				result.ContextExpectNames[symbol] = true
 			}

--- a/internal/plugins/rstest/utils/test_callback_candidate_test.go
+++ b/internal/plugins/rstest/utils/test_callback_candidate_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+func TestCollectRstestCallCandidateNames(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(
+		ast.SourceFileParseOptions{
+			FileName: "/candidate.test.ts",
+			Path:     "/candidate.test.ts",
+		},
+		`import { test as importedTest, expect as importedExpect } from "@rstest/core";
+const testAlias = importedTest;
+const testCase = testAlias;
+const expectAlias = importedExpect;
+const check = expectAlias;`,
+		core.ScriptKindTS,
+	)
+	candidates := collectRstestCallCandidateNames(sourceFile)
+	for _, name := range []string{"importedTest", "testAlias", "testCase"} {
+		if !candidates.test[name] {
+			t.Errorf("test candidate %q was not propagated", name)
+		}
+	}
+	for _, name := range []string{"importedExpect", "expectAlias", "check"} {
+		if !candidates.expect[name] {
+			t.Errorf("expect candidate %q was not propagated", name)
+		}
+	}
+}

--- a/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
@@ -18,16 +18,14 @@
 package no_conditional_expect
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
 type Runtime struct {
 	TestCallbackFunctions map[*ast.Node]bool
-	ClassifyCall          func(*ast.Node) (isTest bool, isExpect bool)
+	ClassifyCall          func(*ast.Node, bool) (isTest bool, isExpect bool)
+	Skip                  bool
 }
 
 type Config struct {
@@ -46,19 +44,41 @@ func isPromiseCatchCall(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return false
 	}
-	name := calleeChainName(node.AsCallExpression().Expression)
-	return name == "catch" || strings.HasSuffix(name, ".catch")
+	return trailingCalleeName(node.AsCallExpression().Expression) == "catch"
 }
 
-// calleeChainName is deliberately member-entry based rather than
-// testFramework.CalleeChainName, which is a different function despite the
-// name: CalleeChainName drops a property segment whose left side failed to
-// resolve, so foo[dynamic]().catch(fn) yields "" there and would stop being
-// reported, while member entries still yield "catch". This rule only needs the
-// trailing segment, so keep it on GetMemberEntries.
-func calleeChainName(node *ast.Node) string {
-	entries := testFramework.GetMemberEntries(node)
-	return testFramework.JoinMemberEntries(entries)
+func trailingCalleeName(node *ast.Node) string {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text
+	case ast.KindPropertyAccessExpression:
+		name := node.AsPropertyAccessExpression().Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text
+		}
+	case ast.KindElementAccessExpression:
+		name := ast.SkipParentheses(node.AsElementAccessExpression().ArgumentExpression)
+		if name == nil {
+			return ""
+		}
+		switch name.Kind {
+		case ast.KindIdentifier:
+			return name.AsIdentifier().Text
+		case ast.KindStringLiteral:
+			return name.AsStringLiteral().Text
+		case ast.KindNoSubstitutionTemplateLiteral:
+			return name.AsNoSubstitutionTemplateLiteral().Text
+		}
+	case ast.KindCallExpression:
+		return trailingCalleeName(node.AsCallExpression().Expression)
+	case ast.KindTaggedTemplateExpression:
+		return trailingCalleeName(node.AsTaggedTemplateExpression().Tag)
+	}
+	return ""
 }
 
 func isConditionalNode(node *ast.Node) bool {
@@ -86,10 +106,13 @@ func NewRule(config Config) rule.Rule {
 		Schema: rule.EmptyArraySchema,
 		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 			runtime := config.Prepare(ctx)
+			if runtime.Skip {
+				return rule.RuleListeners{}
+			}
 			testCaseDepth := 0
 			conditionalDepth := 0
 			promiseCatchDepth := 0
-			callExpressionFrames := map[*ast.Node]callExpressionFrame{}
+			var callExpressionFrames map[*ast.Node]callExpressionFrame
 
 			inTestCase := func() bool {
 				return testCaseDepth > 0
@@ -155,13 +178,21 @@ func NewRule(config Config) rule.Rule {
 				ast.KindCallExpression: func(node *ast.Node) {
 					isTest := false
 					isExpect := false
-					if runtime.ClassifyCall != nil {
-						isTest, isExpect = runtime.ClassifyCall(node)
-					}
 					isCatch := isPromiseCatchCall(node)
-					callExpressionFrames[node] = callExpressionFrame{
-						isTest:  isTest,
-						isCatch: isCatch,
+					if runtime.ClassifyCall != nil {
+						checkExpect := isCatch ||
+							inPromiseCatch() ||
+							(inTestCase() && conditionalDepth > 0)
+						isTest, isExpect = runtime.ClassifyCall(node, checkExpect)
+					}
+					if isTest || isCatch {
+						if callExpressionFrames == nil {
+							callExpressionFrames = make(map[*ast.Node]callExpressionFrame)
+						}
+						callExpressionFrames[node] = callExpressionFrame{
+							isTest:  isTest,
+							isCatch: isCatch,
+						}
 					}
 
 					if isTest {
@@ -181,8 +212,9 @@ func NewRule(config Config) rule.Rule {
 					}
 				},
 				rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
-					frame, ok := callExpressionFrames[node]
-					if ok {
+					frame := callExpressionFrame{}
+					if callExpressionFrames != nil {
+						frame = callExpressionFrames[node]
 						delete(callExpressionFrames, node)
 					}
 					if frame.isTest {


### PR DESCRIPTION
## Summary

- Add conservative source-level and API-root fast paths that skip Rstest callback collection and expect parsing when a file or call cannot contribute to `no-conditional-expect`.
- Preserve the existing parser- and symbol-based analysis for every potential Rstest test or expect candidate, including imports, require bindings, namespace access, `import.meta.rstest`, aliases, and test-context expect.
- Defer expect classification until the shared Jest/Rstest traversal reaches a conditional or promise-catch context where the rule can actually report.
- Avoid full member-chain construction when detecting `.catch()` calls and lazily allocate call frames only for test and catch calls.
- Add regression coverage for computed access, Unicode aliases, multi-level test aliases, context expect, and expect chains ending in `.catch()`.

## Performance

Measured with `--timing` over all `*.test.*`, `*.spec.*`, and configured in-source test files in six Rstack repositories. Each result is the median rule time from seven runs using the same `2190a4f6` baseline. The benchmark covers 1,913 files in total.

All 168 diagnostics were structurally identical before and after the optimization, including rule, file, range, and message.

| Repository | Test Files | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Rspack | 146 | 1.1ms | 0.6ms | 1.83× |
| Rsbuild | 613 | 31.2ms | 6.3ms | 4.95× |
| Rslib | 115 | 9.4ms | 2.8ms | 3.36× |
| Rspress | 134 | 14.1ms | 2.8ms | 5.04× |
| Rsdoctor | 82 | 3.6ms | 1.8ms | 2.00× |
| Rstest | 823 | 54.0ms | 13.9ms | 3.88× |
| **Combined** | **1,913** | **113.4ms** | **28.2ms** | **4.02×** |

Synthetic microbenchmarks used during validation show the effect on CPU time and allocations:

| Scenario | Before | After | Speedup | Memory | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: |
| Ordinary calls without assertion candidates | 424µs/op | 16.2µs/op | 26.10× | 196,376 → 512 B/op | 4,046 → 5 allocs/op |
| Typical test files | 174µs/op | 72.6µs/op | 2.40× | 67,312 → 29,224 B/op | 900 → 157 allocs/op |
| Aliases and test context | 213µs/op | 139µs/op | 1.54× | 129,384 → 58,952 B/op | 1,868 → 669 allocs/op |
