### PR TITLE
perf: optimize no-unused-vars used bindings

### DIFF
--- a/internal/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/rules/no_unused_vars/no_unused_vars.go
@@ -956,7 +956,7 @@ func hasStaticInitBlock(classNode *ast.Node) bool {
 // ignore pattern, and whether the match should result in ignoring or
 // reporting (when reportUsedIgnorePattern is true and the variable is used).
 // Returns: (shouldIgnore bool, matchesPattern bool, matched variable type)
-func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts Config, writeRefs map[*ast.Symbol][]*ast.Node, sym *ast.Symbol) (bool, bool, variableType) {
+func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts *Config, writeRefs map[*ast.Symbol][]*ast.Node, sym *ast.Symbol) (bool, bool, variableType) {
 	var re *regexp2.Regexp
 	kind := variableTypeVariable
 	matched := false
@@ -1001,7 +1001,7 @@ func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts Config, wr
 	return true, true, kind
 }
 
-func ignorePatternAdditional(kind variableType, opts Config, used bool) string {
+func ignorePatternAdditional(kind variableType, opts *Config, used bool) string {
 	var description, pattern string
 	switch kind {
 	case variableTypeArrayDestructure:
@@ -1026,7 +1026,7 @@ func ignorePatternAdditional(kind variableType, opts Config, used bool) string {
 	return fmt.Sprintf(". Allowed unused %s must match /%s/u", description, pattern)
 }
 
-func definitionVariableType(definition *ast.Node, opts Config) variableType {
+func definitionVariableType(definition *ast.Node, opts *Config) variableType {
 	if opts.DestructuredArrayIgnorePattern != "" && isDirectArrayDestructuredIdentifier(definition) {
 		return variableTypeArrayDestructure
 	}
@@ -1941,7 +1941,7 @@ func isScriptGlobalDefinition(sourceFile *ast.SourceFile, definition *ast.Node) 
 //  5. Apply ignore patterns (varsIgnorePattern, argsIgnorePattern, etc.)
 //  6. Skip exports, "after-used" parameters, and option-specific suppressions
 //  7. Report at the last write-reference position (or declaration name as fallback)
-func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, definition *ast.Node, opts Config, ac *analysisContext) {
+func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, definition *ast.Node, opts *Config, ac *analysisContext) {
 	varInfo := &VariableInfo{
 		Variable:       nameNode,
 		Used:           false,
@@ -2029,24 +2029,33 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 		}
 	}
 
-	scriptGlobal := isScriptGlobalDefinition(ctx.SourceFile, definition)
-	// vars: "local" skips only the script global scope. ES module top-level
-	// bindings live in a module scope and must still be checked.
-	if opts.Vars == "local" && scriptGlobal {
-		return
-	}
-
 	if varInfo.OnlyUsedAsType {
 		// TypeScript's scope manager presents type references to ESLint's core
 		// rule as uses. Preserve that base-rule behavior.
 		varInfo.Used = true
 		varInfo.OnlyUsedAsType = false
 	}
+	// A used binding cannot produce a diagnostic unless the caller asks to
+	// report names that match an ignore pattern. Avoid category, export, and
+	// assignment analysis on the common path.
+	if varInfo.Used && !opts.ReportUsedIgnorePattern {
+		return
+	}
+
+	scriptGlobal := isScriptGlobalDefinition(ctx.SourceFile, definition)
+	// vars: "local" skips only the script global scope. ES module top-level
+	// bindings live in a module scope and must still be checked.
+	if opts.Vars == "local" && scriptGlobal {
+		return
+	}
 	// Check ignore patterns (varsIgnorePattern / argsIgnorePattern / caughtErrorsIgnorePattern).
 	// If the variable matches its category's pattern and is unused → ignore silently.
 	// If it matches but IS used and reportUsedIgnorePattern is true → report as usedIgnoredVar.
 	shouldIgnore, matchedPattern, matchedType := matchesIgnorePattern(name, varInfo, opts, ac.writeRefs, sym)
 	if shouldIgnore {
+		return
+	}
+	if varInfo.Used && !matchedPattern {
 		return
 	}
 
@@ -2140,7 +2149,8 @@ func newRule() rule.Rule {
 			if ctx.SourceFile == nil {
 				return rule.RuleListeners{}
 			}
-			opts := parseOptions(options)
+			parsedOptions := parseOptions(options)
+			opts := &parsedOptions
 			reporter := &diagnosticReporter{ctx: ctx}
 
 			ac := &analysisContext{

--- a/internal/rules/no_unused_vars/no_unused_vars_extras_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_extras_test.go
@@ -423,6 +423,56 @@ func TestNoUnusedVarsTypeOnlyLocalExports(t *testing.T) {
 	)
 }
 
+func TestNoUnusedVarsUsedFastPath(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `const used = 1; consume(used);`},
+			{
+				Code: `const _used = 1; consume(_used);`,
+				Options: map[string]interface{}{
+					"varsIgnorePattern":       "^_",
+					"reportUsedIgnorePattern": false,
+				},
+			},
+			{
+				Code: `function use(_arg) { consume(_arg); } use(1);`,
+				Options: map[string]interface{}{
+					"args":                    "all",
+					"argsIgnorePattern":       "^_",
+					"reportUsedIgnorePattern": false,
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `const _used = 1; consume(_used);`,
+				Options: map[string]interface{}{
+					"varsIgnorePattern":       "^_",
+					"reportUsedIgnorePattern": true,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUsedIgnoredError("_used", ". Used vars must not match /^_/u", 1, 7, 12),
+				},
+			},
+			{
+				Code: `function use(_arg) { consume(_arg); } use(1);`,
+				Options: map[string]interface{}{
+					"args":                    "all",
+					"argsIgnorePattern":       "^_",
+					"reportUsedIgnorePattern": true,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUsedIgnoredError("_arg", ". Used args must not match /^_/u", 1, 14, 18),
+				},
+			},
+		},
+	)
+}
+
 func TestNoUnusedVarsWithoutSourceFile(t *testing.T) {
 	t.Parallel()
 	listeners := NoUnusedVarsRule.Run(rule.RuleContext{}, nil)


### PR DESCRIPTION
## Summary

- Pass the parsed `no-unused-vars` configuration by pointer instead of copying it for every binding.
- Return as soon as a used binding cannot produce a diagnostic, avoiding ignore-category, export, write-reference, assignment, and message-suffix work on the common path.
- Preserve `reportUsedIgnorePattern` behavior and add focused valid/invalid coverage for used variables and parameters.

### Benchmark

Apple M1 Max (`darwin/arm64`). The package-local benchmark reused one parsed program, linted 32 bindings per case, used six samples per side, and ran with:

```sh
go test ./internal/rules/no_unused_vars -run '^$' -bench '^BenchmarkNoUnusedVars$' -benchmem -count=6
```

Values below are six-sample means. The temporary benchmark source was removed before commit.

| Scenario | ns/op before | ns/op after | Time | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: | ---: | ---: |
| Diagnostics only | 38,303.3 | 37,356.7 | -2.47% | 47,236 → 47,236 | 392 → 392 |
| Autofix demand | 37,919.0 | 37,436.3 | -1.27% | 47,236 → 47,236 | 392 → 392 |
| Suggestions | 106,518.2 | 104,435.2 | -1.96% | 193,986 → 193,986 | 1,574 → 1,574 |
| No match (all bindings used) | 28,499.2 | 24,403.3 | -14.37% | 11,160 → 11,160 | 131 → 131 |
| Ignored pattern | 18,159.7 | 17,941.8 | -1.20% | 11,384 → 11,384 | 155 → 155 |

Correctness and required checks:

- `go test ./internal/rules/no_unused_vars -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/no_unused_vars/...`
- `git diff --check`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
