### PR TITLE
perf: optimize no-useless-assignment liveness

### DIFF
--- a/internal/rules/no_useless_assignment/liveness.go
+++ b/internal/rules/no_useless_assignment/liveness.go
@@ -1,5 +1,7 @@
 package no_useless_assignment
 
+// cspell:ignore worklist
+
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 
@@ -19,9 +21,8 @@ const (
 )
 
 type event struct {
-	kind   eventKind
-	sym    *ast.Symbol
-	assign *assignment
+	kind eventKind
+	sym  *ast.Symbol
 }
 
 type block = cfg.Block[event]
@@ -39,7 +40,12 @@ type writeSite struct {
 type assignment struct {
 	sym        *ast.Symbol
 	identifier *ast.Node
-	sites      []writeSite
+	// Most writes occur at exactly one CFG site. A finally block is copied for
+	// each completion path, so retain only those uncommon additional sites in a
+	// slice instead of allocating one for every assignment.
+	site            writeSite
+	additionalSites []writeSite
+	dead            bool
 	// silent marks an assignment that still overwrites the variable but is
 	// never reported, because it sits in a `try` block.
 	silent bool
@@ -67,8 +73,13 @@ func hooks(readNodes map[*ast.Node]*ast.Symbol, assignByIdent map[*ast.Node]*ass
 			if !ok {
 				return
 			}
-			blk, index := b.Emit(event{kind: eventWrite, sym: a.sym, assign: a})
-			a.sites = append(a.sites, writeSite{blk: blk, index: index})
+			blk, index := b.Emit(event{kind: eventWrite, sym: a.sym})
+			site := writeSite{blk: blk, index: index}
+			if a.site.blk == nil {
+				a.site = site
+			} else {
+				a.additionalSites = append(a.additionalSites, site)
+			}
 		},
 	}
 }
@@ -82,33 +93,120 @@ type blockState struct {
 	liveOut bool
 }
 
-// deadWrites reports, per assignment, whether every site of that assignment is
-// dead — no read of the variable is reachable before the value is overwritten.
-func deadWrites(graph *cfg.Graph[event], assignments []*assignment) map[*assignment]bool {
+// markDeadWrites records, per assignment, whether every site of that assignment
+// is dead — no read of the variable is reachable before the value is
+// overwritten.
+func markDeadWrites(graph *cfg.Graph[event], assignments []*assignment) {
 	bySymbol := make(map[*ast.Symbol][]*assignment)
 	for _, a := range assignments {
 		bySymbol[a.sym] = append(bySymbol[a.sym], a)
 	}
 
 	states := make([]blockState, len(graph.Blocks))
-	dead := make(map[*assignment]bool, len(assignments))
-	for sym, symAssignments := range bySymbol {
-		computeLiveness(graph.Blocks, states, sym)
-		for _, a := range symAssignments {
-			if len(a.sites) == 0 {
-				continue
-			}
-			isDead := true
-			for _, site := range a.sites {
-				if liveAfter(sym, site, states) {
-					isDead = false
-					break
-				}
-			}
-			dead[a] = isDead
+	if len(bySymbol) == 1 {
+		for sym, symAssignments := range bySymbol {
+			computeLiveness(graph.Blocks, states, sym)
+			markSymbolDead(symAssignments, states)
+		}
+	} else {
+		offsets, predecessors, queue := buildPredecessors(graph.Blocks)
+		for sym, symAssignments := range bySymbol {
+			computeLivenessWithWorklist(graph.Blocks, states, sym, offsets, predecessors, queue)
+			markSymbolDead(symAssignments, states)
 		}
 	}
-	return dead
+}
+
+func markSymbolDead(assignments []*assignment, states []blockState) {
+	for _, a := range assignments {
+		if a.site.blk == nil {
+			continue
+		}
+		isDead := !liveAfter(a.sym, a.site, states)
+		for _, site := range a.additionalSites {
+			if liveAfter(a.sym, site, states) {
+				isDead = false
+				break
+			}
+		}
+		a.dead = isDead
+	}
+}
+
+// buildPredecessors stores the reachable successor edges in reverse as a
+// compact adjacency list. scratch is reused as the per-symbol work queue.
+func buildPredecessors(blocks []*block) (offsets []int, predecessors []int, scratch []int) {
+	offsets = make([]int, len(blocks)+1)
+	for _, blk := range blocks {
+		for _, successor := range blk.Successors {
+			if successor.Reachable {
+				offsets[successor.Index()+1]++
+			}
+		}
+	}
+	for i := 1; i < len(offsets); i++ {
+		offsets[i] += offsets[i-1]
+	}
+
+	predecessors = make([]int, offsets[len(blocks)])
+	scratch = make([]int, len(blocks))
+	copy(scratch, offsets[:len(blocks)])
+	for predecessor, blk := range blocks {
+		for _, successor := range blk.Successors {
+			if !successor.Reachable {
+				continue
+			}
+			index := successor.Index()
+			predecessors[scratch[index]] = predecessor
+			scratch[index]++
+		}
+	}
+	return offsets, predecessors, scratch[:0]
+}
+
+// computeLivenessWithWorklist propagates liveness only through blocks whose
+// live-in state becomes true. This is equivalent to computeLiveness's monotone
+// fixed point, but avoids rescanning the whole graph for every tracked symbol.
+func computeLivenessWithWorklist(
+	blocks []*block,
+	states []blockState,
+	sym *ast.Symbol,
+	offsets []int,
+	predecessors []int,
+	queue []int,
+) {
+	queue = queue[:0]
+	for i, blk := range blocks {
+		var state blockState
+		for _, e := range blk.Events {
+			if e.sym != sym {
+				continue
+			}
+			if e.kind == eventRead {
+				state.use = true
+			} else {
+				state.def = true
+			}
+			break
+		}
+		state.liveIn = state.use
+		states[i] = state
+		if state.liveIn {
+			queue = append(queue, i)
+		}
+	}
+
+	for head := 0; head < len(queue); head++ {
+		blockIndex := queue[head]
+		for _, predecessor := range predecessors[offsets[blockIndex]:offsets[blockIndex+1]] {
+			state := &states[predecessor]
+			state.liveOut = true
+			if !state.liveIn && !state.def {
+				state.liveIn = true
+				queue = append(queue, predecessor)
+			}
+		}
+	}
 }
 
 // computeLiveness runs a backward liveness dataflow for one variable, filling

--- a/internal/rules/no_useless_assignment/no_useless_assignment.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.go
@@ -206,6 +206,7 @@ func analyzeRoot(
 	readNodes := make(map[*ast.Node]*ast.Symbol)
 	trackedState := make(map[*ast.Symbol]bool)
 	var assignments []*assignment
+	var readsScratch []*ast.Node
 
 	for _, raw := range raws {
 		tracked, known := trackedState[raw.sym]
@@ -216,7 +217,8 @@ func analyzeRoot(
 				// this same code path: a read from a nested function may run at
 				// any time, so no assignment to the variable can be proven
 				// unused.
-				reads := readReferences(ctx, raw.sym)
+				readsScratch = appendReadReferences(readsScratch[:0], ctx, raw.sym)
+				reads := readsScratch
 				if len(reads) == 0 {
 					// An entirely unread variable is `no-unused-vars`' business.
 					tracked = false
@@ -257,10 +259,10 @@ func analyzeRoot(
 
 	graph := cfg.Build(root, hooks(readNodes, assignByIdent))
 
-	dead := deadWrites(graph, assignments)
+	markDeadWrites(graph, assignments)
 	var reports []*ast.Node
 	for _, a := range assignments {
-		if !a.silent && dead[a] {
+		if !a.silent && a.dead {
 			reports = append(reports, a.identifier)
 		}
 	}
@@ -368,11 +370,11 @@ func collectLocallyExportedSymbols(ctx *rule.RuleContext) map[*ast.Symbol]bool {
 	return symbols
 }
 
-// readReferences returns the identifiers that read sym. A compound assignment
-// or an update expression reads its target before writing it, so those count
-// as reads too.
-func readReferences(ctx *rule.RuleContext, sym *ast.Symbol) []*ast.Node {
-	var reads []*ast.Node
+// appendReadReferences appends the identifiers that read sym to reads. A
+// compound assignment or an update expression reads its target before writing
+// it, so those count as reads too. The caller reuses reads across symbols in
+// one root to avoid allocating a short-lived slice for every binding.
+func appendReadReferences(reads []*ast.Node, ctx *rule.RuleContext, sym *ast.Symbol) []*ast.Node {
 	for _, ref := range ctx.Refs.References(sym) {
 		if !utils.IsWriteReference(ref) || isReadWriteReference(ref) {
 			reads = append(reads, ref)

--- a/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
@@ -129,6 +129,9 @@ class C { handler(@Body(pipe) _b: unknown) {} }`},
     v = arr;
   } finally { console.log(v); }
 }`},
+			// A finally write is copied into the returning and fallthrough CFG
+			// paths. A read on either copy keeps the assignment live.
+			{Code: `function f(c) { let v = 0; g(v); try { if (c) return; } finally { v = 1; } g(v); }`},
 
 			// ---- A TS assertion wrapper around an assignment target is not a
 			// pattern: the write is invisible to the rule, so it neither
@@ -523,6 +526,24 @@ var obj;`,
 				Code: `function f() { try { for (var i = 0;; i++) { break; } return 1; } catch (e) {} let x = 1; x = 2; return x; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unnecessaryAssignment", Line: 1, Column: 84, EndLine: 1, EndColumn: 85},
+				},
+			},
+
+			// Every copy of a finally write is dead here, so its inline site and
+			// additional site must agree on the report.
+			{
+				Code: `function f(c) { let v = 0; g(v); try { if (c) return; } finally { v = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 67, EndLine: 1, EndColumn: 68},
+				},
+			},
+			// Multiple live variables share the reverse CFG work queue. Only the
+			// two stores after the loop are dead.
+			{
+				Code: `function f(c) { let a = 0, b = 0; g(a, b); while (c()) { a = 1; b = 1; if (c()) continue; g(a, b); } a = 2; b = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 102, EndLine: 1, EndColumn: 103},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 109, EndLine: 1, EndColumn: 110},
 				},
 			},
 


### PR DESCRIPTION
## Summary

- Replace repeated whole-graph liveness scans for multi-symbol roots with a reverse work queue backed by compact predecessor storage.
- Inline the common single CFG write site, remove the unused assignment pointer from events, and reuse read-reference scratch storage.
- Keep the existing single-symbol analysis path and add focused multi-variable loop and duplicated-finally-site correctness coverage.

### Go benchmark

Command: go test ./internal/rules/no_useless_assignment -run ^$ -bench ^BenchmarkNoUselessAssignment$ -benchmem -count=5

The table reports the median of five samples from identical before and after inputs.

| Case | ns/op before -> after | B/op before -> after | allocs/op before -> after |
| --- | ---: | ---: | ---: |
| Diagnostics only | 29668 -> 28124 (-5.20%) | 20231 -> 18815 | 276 -> 247 |
| Autofix demand | 29809 -> 28147 (-5.58%) | 20231 -> 18815 | 276 -> 247 |
| Suggestion demand | 29712 -> 28116 (-5.37%) | 20231 -> 18815 | 276 -> 247 |
| Analyzed, no report | 4855 -> 5075 (+4.53%, overlapping samples) | 5665 -> 5449 | 85 -> 81 |
| Ignored nested read | 4062 -> 4171 (+2.68%) | 4505 -> 4505 | 61 -> 61 |
| Ignored export | 2698 -> 2748 (+1.85%) | 3616 -> 3616 | 48 -> 48 |
| No candidate writes | 2233 -> 2284 (+2.28%) | 3104 -> 3104 | 41 -> 41 |

The small timing movement in control cases also appears in paths untouched by the optimized analysis and has no memory regression. Matched paths consistently improve while allocating 1,416 fewer bytes and 29 fewer objects per operation.

Correctness was verified with the full no_useless_assignment package suite repeated three times, including the upstream suite, exact diagnostic ranges and messages, nested control flow, try/catch/finally behavior, exported and cross-root bindings, and the new focused work-queue cases. The rule has no options, autofixes, or suggestions.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).