### PR TITLE
perf: optimize no-deprecated lookups

### DIFF
--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
@@ -26,6 +26,29 @@ const (
 	maxConstantPropertyResolveDepth    = 8
 )
 
+type sourceDeprecationLookupKind uint8
+
+const (
+	sourceDeprecationAny sourceDeprecationLookupKind = iota
+	sourceDeprecationVariable
+	sourceDeprecationStructuralProperty
+	sourceDeprecationMethod
+	sourceDeprecationFunction
+	sourceDeprecationProperty
+)
+
+type sourceDeprecationLookupKey struct {
+	kind          sourceDeprecationLookupKind
+	name          string
+	argCount      int
+	matchArgCount bool
+}
+
+type sourceDeprecationInfo struct {
+	isDeprecated bool
+	reason       string
+}
+
 func buildDeprecatedMessage(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "deprecated",
@@ -1535,11 +1558,6 @@ func deprecatedFunctionInfoByNameInSource(ctx rule.RuleContext, name string, arg
 	return found && allDeprecated, reason
 }
 
-func deprecatedReasonByNameInSource(ctx rule.RuleContext, name string) string {
-	_, reason := deprecatedInfoByNameInSource(ctx, name, false)
-	return reason
-}
-
 func deprecatedPropertyInfoByNameInSource(ctx rule.RuleContext, name string) (bool, string) {
 	if ctx.TypeChecker == nil || ctx.SourceFile == nil || name == "" {
 		return false, ""
@@ -1704,6 +1722,38 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 			return rule.RuleListeners{}
 		}
 		allowSpecifiers := parseAllowSpecifiers(options)
+		var sourceDeprecationCache map[sourceDeprecationLookupKey]sourceDeprecationInfo
+		lookupSourceDeprecation := func(kind sourceDeprecationLookupKind, name string, argCount int, matchArgCount bool) (bool, string) {
+			key := sourceDeprecationLookupKey{
+				kind:          kind,
+				name:          name,
+				argCount:      argCount,
+				matchArgCount: matchArgCount,
+			}
+			if info, ok := sourceDeprecationCache[key]; ok {
+				return info.isDeprecated, info.reason
+			}
+			info := sourceDeprecationInfo{}
+			switch kind {
+			case sourceDeprecationAny:
+				info.isDeprecated, info.reason = deprecatedInfoByNameInSource(ctx, name, false)
+			case sourceDeprecationVariable:
+				info.isDeprecated, info.reason = deprecatedVariableInfoByNameInSource(ctx, name)
+			case sourceDeprecationStructuralProperty:
+				info.isDeprecated, info.reason = deprecatedStructuralPropertyInfoByNameInSource(ctx, name)
+			case sourceDeprecationMethod:
+				info.isDeprecated, info.reason = deprecatedMethodInfoByNameInSource(ctx, name, argCount, matchArgCount)
+			case sourceDeprecationFunction:
+				info.isDeprecated, info.reason = deprecatedFunctionInfoByNameInSource(ctx, name, argCount, matchArgCount)
+			case sourceDeprecationProperty:
+				info.isDeprecated, info.reason = deprecatedPropertyInfoByNameInSource(ctx, name)
+			}
+			if sourceDeprecationCache == nil {
+				sourceDeprecationCache = make(map[sourceDeprecationLookupKey]sourceDeprecationInfo)
+			}
+			sourceDeprecationCache[key] = info
+			return info.isDeprecated, info.reason
+		}
 		// A reference is allowed when the type at that location matches a
 		// specifier, or when the referenced value itself does — an export whose
 		// type carries a different name is only reachable through the latter.
@@ -1824,14 +1874,16 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 			}
 			return false
 		}
-		reportedRanges := map[string]bool{}
-		reportRange := func(diagnosticRange core.TextRange, message rule.RuleMessage) {
-			key := strconv.Itoa(diagnosticRange.Pos()) + ":" + strconv.Itoa(diagnosticRange.End())
-			if reportedRanges[key] {
-				return
+		var reportedRanges map[core.TextRange]struct{}
+		claimRange := func(diagnosticRange core.TextRange) bool {
+			if _, reported := reportedRanges[diagnosticRange]; reported {
+				return false
 			}
-			reportedRanges[key] = true
-			ctx.ReportRange(diagnosticRange, message)
+			if reportedRanges == nil {
+				reportedRanges = make(map[core.TextRange]struct{})
+			}
+			reportedRanges[diagnosticRange] = struct{}{}
+			return true
 		}
 		// Two parallel detection paths: (1) TypeScript's GetSuggestionDiagnostics for
 		// symbol/type-driven deprecations, and (2) AST listeners for cases the type
@@ -1884,6 +1936,9 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				} else if isAllowed(node) {
 					continue
 				}
+				if !claimRange(diagnosticRange) {
+					continue
+				}
 				message := buildDeprecatedMessage(name)
 				if reason := deprecatedReasonFromDiagnostic(diagnostic); reason != "" {
 					message = buildDeprecatedWithReasonMessage(name, reason)
@@ -1911,11 +1966,11 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 					}
 				}
 				if message.Id != "deprecatedWithReason" {
-					if reason := deprecatedReasonByNameInSource(ctx, name); reason != "" {
+					if _, reason := lookupSourceDeprecation(sourceDeprecationAny, name, 0, false); reason != "" {
 						message = buildDeprecatedWithReasonMessage(name, reason)
 					}
 				}
-				reportRange(diagnosticRange, message)
+				ctx.ReportRange(diagnosticRange, message)
 			}
 		}
 		checkIdentifier := func(node *ast.Node) {
@@ -1936,31 +1991,43 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 			}
 			reportName := name
 			isDeprecated, reason := getDeprecationReason(ctx, node)
-			if !isDeprecated && shouldUseDeprecatedVariableSourceFallback(node) && !isLocalNonDeprecatedSymbol(ctx, node) {
-				isDeprecated, reason = deprecatedVariableInfoByNameInSource(ctx, name)
+			localNonDeprecated := false
+			if !isDeprecated {
+				localNonDeprecated = isLocalNonDeprecatedSymbol(ctx, node)
 			}
-			if !isDeprecated && isPropertyAccessName(node) && !isLocalNonDeprecatedSymbol(ctx, node) {
-				isDeprecated, reason = deprecatedStructuralPropertyInfoByNameInSource(ctx, name)
+			if !isDeprecated && shouldUseDeprecatedVariableSourceFallback(node) && !localNonDeprecated {
+				isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationVariable, name, 0, false)
+			}
+			if !isDeprecated && isPropertyAccessName(node) && !localNonDeprecated {
+				isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationStructuralProperty, name, 0, false)
 				if !isDeprecated {
 					argCount, matchArgCount := propertyAccessCallArgCount(node)
-					isDeprecated, reason = deprecatedMethodInfoByNameInSource(ctx, name, argCount, matchArgCount)
+					isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationMethod, name, argCount, matchArgCount)
 					if isDeprecated && isPropertyAccessCalleeName(node) {
 						reportName = propertyAccessDisplayName(ctx.SourceFile, node)
 					}
 				}
 			}
-			if !isDeprecated && isBindingElementNameOrProperty(node) && !isLocalNonDeprecatedSymbol(ctx, node) {
-				isDeprecated, reason = deprecatedPropertyInfoByNameInSource(ctx, name)
+			if !isDeprecated && isBindingElementNameOrProperty(node) && !localNonDeprecated {
+				isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationProperty, name, 0, false)
 			}
-			if !isDeprecated && !isLocalNonDeprecatedSymbol(ctx, node) {
+			if !isDeprecated && !localNonDeprecated {
 				argCount, matchArgCount := callArgCountForIdentifierCallee(node)
 				if matchArgCount {
-					isDeprecated, reason = deprecatedFunctionInfoByNameInSource(ctx, name, argCount, true)
+					isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationFunction, name, argCount, true)
 				} else if isIdentifierTaggedTemplateTag(node) {
-					isDeprecated, reason = deprecatedFunctionInfoByNameInSource(ctx, name, 0, false)
+					isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationFunction, name, 0, false)
 				}
 			}
 			if !isDeprecated {
+				return
+			}
+			if isAllowed(node) {
+				return
+			}
+			trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			diagnosticRange := core.NewTextRange(trimmedRange.Pos(), trimmedRange.End())
+			if !claimRange(diagnosticRange) {
 				return
 			}
 			symbol := symbolAtLocation(ctx.TypeChecker, node)
@@ -1969,9 +2036,6 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 			}
 			if symbol != nil && symbol.ValueDeclaration != nil && symbol.ValueDeclaration.Kind == ast.KindBindingElement {
 				symbol = nil
-			}
-			if isAllowed(node) {
-				return
 			}
 			message := buildDeprecatedMessage(reportName)
 			if reason != "" {
@@ -1988,12 +2052,11 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				}
 			}
 			if message.Id != "deprecatedWithReason" {
-				if reasonByName := deprecatedReasonByNameInSource(ctx, name); reasonByName != "" {
+				if _, reasonByName := lookupSourceDeprecation(sourceDeprecationAny, name, 0, false); reasonByName != "" {
 					message = buildDeprecatedWithReasonMessage(reportName, reasonByName)
 				}
 			}
-			trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			reportRange(core.NewTextRange(trimmedRange.Pos(), trimmedRange.End()), message)
+			ctx.ReportRange(diagnosticRange, message)
 		}
 		return rule.RuleListeners{
 			ast.KindIdentifier: func(node *ast.Node) {
@@ -2056,12 +2119,17 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				isDeprecated := symbolIsDeprecated(ctx.TypeChecker, propertySymbol)
 				sourceDeprecated, sourceReason := false, ""
 				if !isDeprecated && propertySymbol == nil && attributesType != nil && !utils.IsTypeAnyType(attributesType) && !utils.IsTypeUnknownType(attributesType) {
-					sourceDeprecated, sourceReason = deprecatedPropertyInfoByNameInSource(ctx, nameText)
+					sourceDeprecated, sourceReason = lookupSourceDeprecation(sourceDeprecationProperty, nameText, 0, false)
 				}
 				if !isDeprecated && !sourceDeprecated {
 					return
 				}
 				if isAllowed(nameNode) {
+					return
+				}
+				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
+				diagnosticRange := core.NewTextRange(trimmedRange.Pos(), trimmedRange.End())
+				if !claimRange(diagnosticRange) {
 					return
 				}
 				message := buildDeprecatedMessage(nameText)
@@ -2076,8 +2144,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if message.Id != "deprecatedWithReason" && sourceReason != "" {
 					message = buildDeprecatedWithReasonMessage(nameText, sourceReason)
 				}
-				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
-				reportRange(core.NewTextRange(trimmedRange.Pos(), trimmedRange.End()), message)
+				ctx.ReportRange(diagnosticRange, message)
 			},
 			ast.KindElementAccessExpression: func(node *ast.Node) {
 				elementAccess := node.AsElementAccessExpression()
@@ -2097,12 +2164,17 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				isDeprecated := symbolIsDeprecated(ctx.TypeChecker, propertySymbol)
 				sourceDeprecated, sourceReason := false, ""
 				if !isDeprecated && propertySymbol == nil && objectType != nil && rawObjectType != nil && !utils.IsTypeAnyType(rawObjectType) && !utils.IsTypeUnknownType(rawObjectType) && !utils.IsTypeAnyType(objectType) && !utils.IsTypeUnknownType(objectType) {
-					sourceDeprecated, sourceReason = deprecatedStructuralPropertyInfoByNameInSource(ctx, propertyName)
+					sourceDeprecated, sourceReason = lookupSourceDeprecation(sourceDeprecationStructuralProperty, propertyName, 0, false)
 				}
 				if !isDeprecated && !sourceDeprecated {
 					return
 				}
 				if isObjectTypeAllowed(elementAccess.Expression) {
+					return
+				}
+				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, elementAccess.ArgumentExpression)
+				diagnosticRange := core.NewTextRange(trimmedRange.Pos(), trimmedRange.End())
+				if !claimRange(diagnosticRange) {
 					return
 				}
 				message := buildDeprecatedMessage(propertyName)
@@ -2117,8 +2189,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if message.Id != "deprecatedWithReason" && sourceReason != "" {
 					message = buildDeprecatedWithReasonMessage(propertyName, sourceReason)
 				}
-				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, elementAccess.ArgumentExpression)
-				reportRange(core.NewTextRange(trimmedRange.Pos(), trimmedRange.End()), message)
+				ctx.ReportRange(diagnosticRange, message)
 			},
 			ast.KindPropertyAccessExpression: func(node *ast.Node) {
 				access := node.AsPropertyAccessExpression()
@@ -2141,6 +2212,11 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if isAllowed(nameNode) {
 					return
 				}
+				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
+				diagnosticRange := core.NewTextRange(trimmedRange.Pos(), trimmedRange.End())
+				if !claimRange(diagnosticRange) {
+					return
+				}
 				_, reason := getDeprecationReason(ctx, nameNode)
 				message := buildDeprecatedMessage(name)
 				if reason != "" {
@@ -2154,12 +2230,11 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 					}
 				}
 				if message.Id != "deprecatedWithReason" {
-					if reasonByName := deprecatedReasonByNameInSource(ctx, name); reasonByName != "" {
+					if _, reasonByName := lookupSourceDeprecation(sourceDeprecationAny, name, 0, false); reasonByName != "" {
 						message = buildDeprecatedWithReasonMessage(name, reasonByName)
 					}
 				}
-				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
-				reportRange(core.NewTextRange(trimmedRange.Pos(), trimmedRange.End()), message)
+				ctx.ReportRange(diagnosticRange, message)
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
@@ -353,6 +353,62 @@ func TestNoDeprecatedReportsLetInitializedToUndefinedInTsxFixture(t *testing.T) 
 	}
 }
 
+func TestNoDeprecatedDeduplicatesExactRanges(t *testing.T) {
+	t.Parallel()
+	const code = `
+interface Legacy {
+  /** @deprecated Use current instead. */
+  old(): void;
+}
+declare const legacy: Legacy;
+legacy.old();
+legacy.old();
+`
+	diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+		"main.ts": code,
+	}, "main.ts", nil)
+	if len(diagnostics) != 2 {
+		t.Fatalf("expected 2 diagnostics, got %#v", diagnostics)
+	}
+	for index, diagnostic := range diagnostics {
+		if diagnostic.Message.Id != "deprecatedWithReason" ||
+			diagnostic.Message.Description != "`legacy.old` is deprecated. Use current instead." {
+			t.Fatalf("diagnostic %d message = %#v", index, diagnostic.Message)
+		}
+		if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != "old" {
+			t.Fatalf("diagnostic %d range text = %q, want old", index, got)
+		}
+		if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+			t.Fatalf("diagnostic %d unexpectedly included edits: %#v", index, diagnostic)
+		}
+	}
+}
+
+func TestNoDeprecatedRespectsScopedLineDisables(t *testing.T) {
+	t.Parallel()
+	const code = `
+interface Legacy {
+  /** @deprecated */
+  old(): void;
+}
+declare const legacy: Legacy;
+// eslint-disable-next-line test
+legacy.old();
+legacy.old(); // eslint-disable-line test
+legacy.old();
+`
+	diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+		"main.ts": code,
+	}, "main.ts", nil)
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
+	}
+	wantStart := strings.LastIndex(code, "old")
+	if diagnostics[0].Range.Pos() != wantStart || diagnostics[0].Range.End() != wantStart+len("old") {
+		t.Fatalf("diagnostic range = %#v, want [%d, %d)", diagnostics[0].Range, wantStart, wantStart+len("old"))
+	}
+}
+
 func TestNoDeprecatedIgnoresNameOnlyFallbackForElementAccessAndJsxAny(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Cache source-file deprecation fallback lookups by lookup kind, name, and call shape so repeated references do not repeatedly walk the full AST.
- Reuse each identifier's local non-deprecated result and claim lazy `TextRange` keys before constructing duplicate diagnostic messages.
- Add focused coverage for exact diagnostic ranges, message parity, duplicate detection paths, edit-free diagnostics, and scoped line disables.

The package-local benchmark prebuilt one type-aware program per case, then repeatedly linted the same file with only `@typescript-eslint/no-deprecated`, diagnostic-only edit demand, 64 matching or control statements, `-benchmem`, `-benchtime=300ms`, and `-count=5`. Values below are medians of the five samples.

| Case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Deprecated call | `81339 → 62248` (`-23.47%`) | `39480 → 29640` (`-24.92%`) | `1072 → 575` (`-46.36%`) |
| Deprecated property | `141158 → 99064` (`-29.82%`) | `59000 → 40392` (`-31.54%`) | `1596 → 639` (`-59.96%`) |
| No match | `62781 → 47967` (`-23.60%`) | `3456 → 3504` (`+1.39%`) | `49 → 51` (`+4.08%`) |
| Allowed deprecated call | `65635 → 58561` (`-10.78%`) | `11592 → 11640` (`+0.41%`) | `443 → 445` (`+0.45%`) |

Validation:

- `go test ./internal/plugins/typescript/rules/no_deprecated -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_deprecated/...`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
