### PR TITLE
perf: optimize max-lines-per-function fast paths

### DIFF
--- a/internal/rules/max_lines_per_function/max_lines_per_function.go
+++ b/internal/rules/max_lines_per_function/max_lines_per_function.go
@@ -18,11 +18,9 @@ var MaxLinesPerFunctionRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
-		var comments []*ast.CommentRange
-		if opts.skipComments {
-			comments = ctx.Comments.All()
-		}
-		state := newLineState(ctx.SourceFile, comments, opts.skipComments, opts.skipBlankLines)
+		sourceFile := ctx.SourceFile
+		text := sourceFile.Text()
+		state := &lineState{}
 
 		process := func(node *ast.Node) {
 			// Overload signatures, abstract / declare members, and TS interface
@@ -36,8 +34,23 @@ var MaxLinesPerFunctionRule = rule.Rule{
 				return
 			}
 
-			textRange, startLine, endLine := state.nodeLineRange(node)
-			lineCount := state.countLines(startLine, endLine)
+			startPos := scanner.GetTokenPosOfNode(node, sourceFile, false)
+			endPos := node.End()
+			textRange := core.NewTextRange(startPos, endPos)
+			lineCount := 0
+			if len(state.lineStarts) == 0 && opts.max >= 1 && isSingleLineRange(text, startPos, endPos) {
+				lineCount = 1
+			} else {
+				if len(state.lineStarts) == 0 {
+					var comments []*ast.CommentRange
+					if opts.skipComments {
+						comments = ctx.Comments.All()
+					}
+					state.initialize(sourceFile, comments, opts.skipComments, opts.skipBlankLines)
+				}
+				startLine, endLine := state.lineRange(startPos, endPos)
+				lineCount = state.countLines(startLine, endLine)
+			}
 
 			if lineCount > opts.max {
 				name := upperCaseFirst(utils.GetFunctionNameWithKind(node))
@@ -61,6 +74,16 @@ var MaxLinesPerFunctionRule = rule.Rule{
 			ast.KindConstructor:         process,
 		}
 	},
+}
+
+// isSingleLineRange reports whether a validated source range contains no
+// ECMAScript line terminator. A single-line function always counts as exactly
+// one line, even when comment or blank-line skipping is enabled, so callers can
+// avoid materializing the source file's line map and comment table entirely.
+// Synthetic or otherwise unusual ranges retain the established line-map path.
+func isSingleLineRange(text string, startPos, endPos int) bool {
+	return startPos >= 0 && endPos >= startPos && endPos <= len(text) &&
+		!utils.ContainsLineTerminator(text, startPos, endPos)
 }
 
 type maxLinesPerFunctionOptions struct {
@@ -145,7 +168,6 @@ func isIIFE(node *ast.Node) bool {
 // each function's line count into a pair of indexed lookups. This is especially
 // important for nested functions, whose source ranges overlap.
 type lineState struct {
-	sourceFile        *ast.SourceFile
 	text              string
 	lineStarts        []core.TextPos
 	nLines            int
@@ -156,27 +178,24 @@ type lineState struct {
 	countedLinePrefix []int
 }
 
-func newLineState(
+func (s *lineState) initialize(
 	sourceFile *ast.SourceFile,
 	sourceComments []*ast.CommentRange,
 	skipComments bool,
 	skipBlankLines bool,
-) *lineState {
+) {
 	text := sourceFile.Text()
 	lineStarts := scanner.GetECMALineStarts(sourceFile)
 	if len(lineStarts) == 0 {
 		lineStarts = []core.TextPos{0}
 	}
 	nLines := len(lineStarts)
-	state := &lineState{
-		sourceFile:     sourceFile,
-		text:           text,
-		lineStarts:     lineStarts,
-		nLines:         nLines,
-		skipBlankLines: skipBlankLines,
-	}
+	s.text = text
+	s.lineStarts = lineStarts
+	s.nLines = nLines
+	s.skipBlankLines = skipBlankLines
 	if !skipComments && !skipBlankLines {
-		return state
+		return
 	}
 
 	if skipComments {
@@ -192,7 +211,7 @@ func newLineState(
 		}
 		comments = append(comments, sourceComments...)
 		if len(comments) == 0 {
-			return state
+			return
 		}
 
 		fullLineComment := make([]bool, nLines)
@@ -207,7 +226,7 @@ func newLineState(
 			startLine := scanner.ComputeLineOfPosition(lineStarts, cmt.Pos())
 			endLine := scanner.ComputeLineOfPosition(lineStarts, cmt.End()-1)
 			for line := max(startLine, 0); line <= endLine && line < nLines; line++ {
-				coversWholeLine := state.commentCoversWholeLine(cmt, startLine, endLine, line)
+				coversWholeLine := s.commentCoversWholeLine(cmt, startLine, endLine, line)
 				if coversWholeLine != fullLineComment[line] {
 					if coversWholeLine {
 						fullLineCommentCount++
@@ -219,26 +238,21 @@ func newLineState(
 			}
 		}
 		if fullLineCommentCount > 0 {
-			state.fullLineComment = fullLineComment
+			s.fullLineComment = fullLineComment
 		}
 	}
-	return state
 }
 
-// nodeLineRange returns the inclusive 0-indexed line range of the node,
-// excluding any leading trivia. Mirrors ESLint's `node.loc.start.line` /
-// `node.loc.end.line` (which are based on the first / last source token of
-// the node).
-func (s *lineState) nodeLineRange(node *ast.Node) (core.TextRange, int, int) {
-	startPos := scanner.GetTokenPosOfNode(node, s.sourceFile, false)
-	endPos := node.End()
+// lineRange returns the inclusive 0-indexed line range for an already-trimmed
+// source range. Mirrors ESLint's `node.loc.start.line` / `node.loc.end.line`.
+func (s *lineState) lineRange(startPos, endPos int) (int, int) {
 	startLine := scanner.ComputeLineOfPosition(s.lineStarts, startPos)
 	endLineIdx := endPos - 1
 	if endLineIdx < startPos {
 		endLineIdx = startPos
 	}
 	endLine := scanner.ComputeLineOfPosition(s.lineStarts, endLineIdx)
-	return core.NewTextRange(startPos, endPos), startLine, endLine
+	return startLine, endLine
 }
 
 func (s *lineState) countLines(startLine, endLine int) int {

--- a/internal/rules/max_lines_per_function/max_lines_per_function_test.go
+++ b/internal/rules/max_lines_per_function/max_lines_per_function_test.go
@@ -4,7 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -2061,4 +2065,225 @@ return x + y;
 			},
 		},
 	)
+}
+
+func TestMaxLinesPerFunctionLazyLineStateParity(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxLinesPerFunctionRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `declare function signature(): void;
+(function () { return 1; })();`,
+				Options: map[string]interface{}{"max": 0, "IIFEs": false},
+			},
+			{
+				Code: "function singleLine() { return 1; }",
+				Options: map[string]interface{}{
+					"max":            1,
+					"skipBlankLines": true,
+					"skipComments":   true,
+				},
+			},
+			{
+				Code:    "function split() {\u2028return 1;\u2029}",
+				Options: 3,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `/** docs */
+function one() { return 1; }`,
+				Options: map[string]interface{}{
+					"max":            0,
+					"skipBlankLines": true,
+					"skipComments":   true,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Function 'one' has too many lines (1). Maximum allowed is 0.",
+						Line:      2,
+						Column:    1,
+						EndLine:   2,
+						EndColumn: 29,
+					},
+				},
+			},
+			{
+				Code: `declare function signature(): void;
+(function () { return 0; })();
+function short() { return 1; }
+function long() {
+// comment
+
+return 1;
+}`,
+				Options: map[string]interface{}{
+					"max":            2,
+					"IIFEs":          false,
+					"skipBlankLines": true,
+					"skipComments":   true,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Function 'long' has too many lines (3). Maximum allowed is 2.",
+						Line:      4,
+						Column:    1,
+						EndLine:   8,
+						EndColumn: 2,
+					},
+				},
+			},
+			{
+				Code:    "function split() {\u2028return 1;\u2029}",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Function 'split' has too many lines (3). Maximum allowed is 2.",
+					},
+				},
+			},
+		},
+	)
+}
+
+func TestMaxLinesPerFunctionDisableDirectives(t *testing.T) {
+	for _, testCase := range []struct {
+		name            string
+		code            string
+		wantDiagnostics int
+	}{
+		{
+			name: "scoped block",
+			code: `/* rslint-disable max-lines-per-function */
+function blockDisabled() {}
+/* rslint-enable max-lines-per-function */`,
+		},
+		{
+			name: "next line",
+			code: `/* eslint-disable-next-line max-lines-per-function */
+function lineDisabled() {}`,
+		},
+		{
+			name: "different rule",
+			code: `/* eslint-disable-next-line another-rule */
+function enabled() {}`,
+			wantDiagnostics: 1,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/disable-directive.ts",
+				Path:     "/disable-directive.ts",
+			}, testCase.code, core.ScriptKindTS)
+			node := sourceFile.Statements.Nodes[0]
+			comments := rule.NewCommentStore(sourceFile)
+			diagnostics := 0
+			ctx := rule.RuleContext{
+				SourceFile:     sourceFile,
+				Comments:       comments,
+				DisableManager: rule.NewDisableManager(sourceFile, comments),
+			}.WithDiagnosticConsumer(
+				MaxLinesPerFunctionRule.Name,
+				rule.SeverityWarning,
+				rule.DiagnosticConsumer{
+					Report: func(rule.RuleDiagnostic) {
+						diagnostics++
+					},
+				},
+			)
+
+			listener := MaxLinesPerFunctionRule.Run(ctx, []any{0})[node.Kind]
+			listener(node)
+			if diagnostics != testCase.wantDiagnostics {
+				t.Fatalf("diagnostics = %d, want %d", diagnostics, testCase.wantDiagnostics)
+			}
+		})
+	}
+}
+
+func TestMaxLinesPerFunctionEditDemandParity(t *testing.T) {
+	const code = "function one() { return 1; }"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, code, core.ScriptKindTS)
+	node := sourceFile.Statements.Nodes[0]
+
+	for _, testCase := range []struct {
+		name   string
+		demand rule.EditDemand
+	}{
+		{name: "diagnostics only", demand: rule.EditDemandNone},
+		{name: "autofix", demand: rule.EditDemandAutofix},
+		{name: "suggestions", demand: rule.EditDemandSuggestion},
+		{name: "all edits", demand: rule.EditDemandAll},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			comments := rule.NewCommentStore(sourceFile)
+			var diagnostics []rule.RuleDiagnostic
+			ctx := rule.RuleContext{
+				SourceFile:     sourceFile,
+				Comments:       comments,
+				DisableManager: rule.NewDisableManager(sourceFile, comments),
+			}.WithDiagnosticConsumer(
+				MaxLinesPerFunctionRule.Name,
+				rule.SeverityWarning,
+				rule.DiagnosticConsumer{
+					Demand: testCase.demand,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				},
+			)
+
+			listener := MaxLinesPerFunctionRule.Run(ctx, []any{0})[node.Kind]
+			listener(node)
+
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+			}
+			diagnostic := diagnostics[0]
+			if diagnostic.Range != core.NewTextRange(0, len(code)) {
+				t.Fatalf("range = %v, want [0,%d)", diagnostic.Range, len(code))
+			}
+			if diagnostic.Message.Description != "Function 'one' has too many lines (1). Maximum allowed is 0." {
+				t.Fatalf("message = %q", diagnostic.Message.Description)
+			}
+			if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+				t.Fatalf("unexpected edit artifacts: fixes=%v suggestions=%v", diagnostic.FixesPtr, diagnostic.Suggestions)
+			}
+		})
+	}
+}
+
+func TestIsSingleLineRange(t *testing.T) {
+	for _, testCase := range []struct {
+		name             string
+		text             string
+		startPos, endPos int
+		want             bool
+	}{
+		{name: "ASCII", text: "function f() {}", startPos: 0, endPos: 15, want: true},
+		{name: "range after line break", text: "before\nfunction f() {}", startPos: 7, endPos: 22, want: true},
+		{name: "LF", text: "a\nb", startPos: 0, endPos: 3},
+		{name: "CR", text: "a\rb", startPos: 0, endPos: 3},
+		{name: "line separator", text: "a\u2028b", startPos: 0, endPos: 5},
+		{name: "paragraph separator", text: "a\u2029b", startPos: 0, endPos: 5},
+		{name: "empty", text: "abc", startPos: 1, endPos: 1, want: true},
+		{name: "synthetic start", text: "abc", startPos: -1, endPos: 3},
+		{name: "end past source", text: "abc", startPos: 0, endPos: 4},
+		{name: "reversed", text: "abc", startPos: 2, endPos: 1},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := isSingleLineRange(testCase.text, testCase.startPos, testCase.endPos); got != testCase.want {
+				t.Fatalf("isSingleLineRange(%q, %d, %d) = %v, want %v", testCase.text, testCase.startPos, testCase.endPos, got, testCase.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Defer line-map construction and comment collection until the first relevant multi-line function.
- Count validated single-line function ranges directly before line state is initialized, while preserving the established line-map fallback for synthetic or unusual ranges.
- Add focused parity coverage for options, exact ranges, ECMAScript line terminators, ignored IIFEs/bodyless declarations, disable directives, and every edit-demand mode.

### Benchmark

Apple M1 Max, darwin/arm64. Values are medians of 5 samples with a fresh parsed source file per iteration; parsing/setup runs outside the timer so each timed rule run starts with a cold source-file line map. The temporary benchmark file is not committed.

Command: `go test ./internal/rules/max_lines_per_function -run '^$' -bench '^BenchmarkMaxLinesPerFunction$' -benchmem -benchtime=300x -count=5`

| Case | Time before → after | Change | Memory before → after | Allocations before → after |
| --- | ---: | ---: | ---: | ---: |
| No functions | `14924 → 1813 ns/op` | `-87.9%` | `2592 → 560 B/op` | `6 → 5` |
| Many short multi-line functions, no match | `7057 → 7639 ns/op` | `+8.3%` | `1440 → 1456 B/op` | `6 → 6` |
| Many single-line functions, no match | `12170 → 7945 ns/op` | `-34.7%` | `1120 → 560 B/op` | `6 → 5` |
| Single-line diagnostics with `max: 0` | `31422 → 31944 ns/op` | `+1.7%` | `12659 → 12678 B/op` | `518 → 518` |
| Diagnostics only | `46781 → 47883 ns/op` | `+2.4%` | `8111 → 8119 B/op` | `135 → 135` |
| All edit demand | `46000 → 47075 ns/op` | `+2.3%` | `8095 → 8118 B/op` | `135 → 135` |
| Ignored IIFEs | `4711 → 2203 ns/op` | `-53.2%` | `1440 → 560 B/op` | `6 → 5` |
| Bodyless declarations | `9852 → 2981 ns/op` | `-69.7%` | `1120 → 560 B/op` | `6 → 5` |
| Skip blank lines | `61550 → 62140 ns/op` | `+1.0%` | `58464 → 58480 B/op` | `10 → 10` |
| Skip comments and blank lines | `3390515 → 3457629 ns/op` | `+2.0%` | `4284540 → 4284553 B/op` | `80351 → 80351` |

The initialized line-state controls keep the same allocation counts; their small timing movements overlap the raw sample ranges. The optimized no-work and single-line paths avoid the cold line-map allocation entirely.

Validation:

- `go test ./internal/rules/max_lines_per_function -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/max_lines_per_function/...`
- `git diff --check`

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
