### PR TITLE
perf: optimize no-magic-numbers checks

### DIFF
--- a/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.go
+++ b/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.go
@@ -32,9 +32,7 @@ type options struct {
 }
 
 func parseOptions(rawOpts []any) options {
-	opts := options{
-		ignore: make(map[string]bool),
-	}
+	opts := options{}
 	if len(rawOpts) == 0 {
 		return opts
 	}
@@ -67,6 +65,7 @@ func parseOptions(rawOpts []any) options {
 		opts.ignoreTypeIndexes = v
 	}
 	if arr, ok := optsMap["ignore"].([]interface{}); ok {
+		opts.ignore = make(map[string]bool, len(arr))
 		for _, item := range arr {
 			switch v := item.(type) {
 			case float64:
@@ -194,97 +193,95 @@ var useConstMessage = rule.RuleMessage{
 	Description: "Number constants declarations must use 'const'.",
 }
 
+func noMagicNumberMessage(raw string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          noMagicMessage.Id,
+		Description: "No magic number: " + raw + ".",
+	}
+}
+
 // NoMagicNumbersRule implements the @typescript-eslint/no-magic-numbers rule.
 var NoMagicNumbersRule = rule.CreateRule(rule.Rule{
 	Name:   "no-magic-numbers",
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
+		hasIgnoredValues := len(opts.ignore) != 0
 
 		handleNumericNode := func(node *ast.Node, isBigInt bool) {
-			raw := utils.TrimmedNodeText(ctx.SourceFile, node)
+			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			raw := ctx.SourceFile.Text()[nodeRange.Pos():nodeRange.End()]
 
 			// --- TS-specific checks (from @typescript-eslint extension) ---
-			var isAllowed *bool
-			trueVal := true
-			falseVal := false
+			isAllowed := false
+			hasAllowanceDecision := false
 
-			if opts.ignore[normalizeLiteralValue(node, raw, isBigInt)] {
-				isAllowed = &trueVal
+			if hasIgnoredValues && opts.ignore[normalizeLiteralValue(node, raw, isBigInt)] {
+				isAllowed = true
+				hasAllowanceDecision = true
 			}
 
-			if isAllowed == nil && isParentTSEnumDeclaration(node) {
-				if opts.ignoreEnums {
-					isAllowed = &trueVal
-				} else {
-					isAllowed = &falseVal
+			if !hasAllowanceDecision && isParentTSEnumDeclaration(node) {
+				isAllowed = opts.ignoreEnums
+				hasAllowanceDecision = true
+			}
+
+			if !hasAllowanceDecision && isTSNumericLiteralType(node) {
+				isAllowed = opts.ignoreNumericLiteralTypes
+				hasAllowanceDecision = true
+			}
+
+			if !hasAllowanceDecision && isAncestorTSIndexedAccessType(node) {
+				isAllowed = opts.ignoreTypeIndexes
+				hasAllowanceDecision = true
+			}
+
+			if !hasAllowanceDecision && isParentTSReadonlyPropertyDefinition(node) {
+				isAllowed = opts.ignoreReadonlyClassProperties
+				hasAllowanceDecision = true
+			}
+
+			if hasAllowanceDecision {
+				if isAllowed {
+					return
 				}
-			}
-
-			if isAllowed == nil && isTSNumericLiteralType(node) {
-				if opts.ignoreNumericLiteralTypes {
-					isAllowed = &trueVal
-				} else {
-					isAllowed = &falseVal
-				}
-			}
-
-			if isAllowed == nil && isAncestorTSIndexedAccessType(node) {
-				if opts.ignoreTypeIndexes {
-					isAllowed = &trueVal
-				} else {
-					isAllowed = &falseVal
-				}
-			}
-
-			if isAllowed == nil && isParentTSReadonlyPropertyDefinition(node) {
-				if opts.ignoreReadonlyClassProperties {
-					isAllowed = &trueVal
-				} else {
-					isAllowed = &falseVal
-				}
-			}
-
-			if isAllowed != nil && *isAllowed {
-				return
-			}
-
-			if isAllowed != nil && !*isAllowed {
 				// Report as TS violation: only prepend '-' for negative numbers (not '+')
-				reportNode := node
+				reportRange := nodeRange
 				reportRaw := raw
 				if unary, op := findUnaryParent(node); unary != nil && op == ast.KindMinusToken {
-					reportNode = unary
+					reportRange = utils.TrimNodeTextRange(ctx.SourceFile, unary)
 					reportRaw = "-" + raw
 				}
-				ctx.ReportNode(reportNode, rule.RuleMessage{
-					Id:          noMagicMessage.Id,
-					Description: strings.Replace(noMagicMessage.Description, "{{raw}}", reportRaw, 1),
-				})
+				ctx.ReportRange(reportRange, noMagicNumberMessage(reportRaw))
 				return
 			}
 
 			// --- Core ESLint base rule logic ---
 			fullNumberNode := node
+			fullNumberRange := nodeRange
 			fullRaw := raw
 			var numericValue float64
 			var bigintValue *big.Int
+			needsNumericValue := hasIgnoredValues || opts.ignoreArrayIndexes
 
-			if isBigInt {
-				text := strings.TrimSuffix(raw, "n")
-				bigintValue, _ = new(big.Int).SetString(text, 0)
-				if bigintValue == nil {
-					bigintValue = new(big.Int)
+			if needsNumericValue {
+				if isBigInt {
+					text := strings.TrimSuffix(raw, "n")
+					bigintValue, _ = new(big.Int).SetString(text, 0)
+					if bigintValue == nil {
+						bigintValue = new(big.Int)
+					}
+				} else {
+					numericValue, _ = parseRawNumericValue(raw)
 				}
-			} else {
-				numericValue, _ = parseRawNumericValue(raw)
 			}
 
 			// Detect unary +/- parent (through parentheses)
 			if unary, op := findUnaryParent(node); unary != nil {
 				fullNumberNode = unary
-				fullRaw = utils.TrimmedNodeText(ctx.SourceFile, unary)
-				if op == ast.KindMinusToken {
+				fullNumberRange = utils.TrimNodeTextRange(ctx.SourceFile, unary)
+				fullRaw = ctx.SourceFile.Text()[fullNumberRange.Pos():fullNumberRange.End()]
+				if needsNumericValue && op == ast.KindMinusToken {
 					if isBigInt {
 						bigintValue = new(big.Int).Neg(bigintValue)
 					} else {
@@ -300,14 +297,16 @@ var NoMagicNumbersRule = rule.CreateRule(rule.Rule{
 			}
 
 			// Check ignore list with the full (signed) value
-			var valueKey string
-			if isBigInt {
-				valueKey = "bigint:" + bigintValue.String()
-			} else {
-				valueKey = strconv.FormatFloat(numericValue, 'f', -1, 64)
-			}
-			if opts.ignore[valueKey] {
-				return
+			if hasIgnoredValues {
+				var valueKey string
+				if isBigInt {
+					valueKey = "bigint:" + bigintValue.String()
+				} else {
+					valueKey = strconv.FormatFloat(numericValue, 'f', -1, 64)
+				}
+				if opts.ignore[valueKey] {
+					return
+				}
 			}
 
 			// Always allow parseInt radix and JSX numbers
@@ -331,14 +330,11 @@ var NoMagicNumbersRule = rule.CreateRule(rule.Rule{
 				if opts.enforceConst {
 					declList := parent.Parent
 					if declList != nil && declList.Kind == ast.KindVariableDeclarationList && !ast.IsVarConst(declList) {
-						ctx.ReportNode(fullNumberNode, useConstMessage)
+						ctx.ReportRange(fullNumberRange, useConstMessage)
 					}
 				}
 			} else if !isOkParent(parent, opts.detectObjects) {
-				ctx.ReportNode(fullNumberNode, rule.RuleMessage{
-					Id:          noMagicMessage.Id,
-					Description: strings.Replace(noMagicMessage.Description, "{{raw}}", fullRaw, 1),
-				})
+				ctx.ReportRange(fullNumberRange, noMagicNumberMessage(fullRaw))
 			}
 		}
 

--- a/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers_test.go
+++ b/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers_test.go
@@ -249,6 +249,8 @@ type Foo = {
 		{Code: `var HOUR = 3600;`},
 		{Code: `foo[0xABn]`, Options: map[string]interface{}{"ignoreArrayIndexes": true}},
 		{Code: `foo[5.0000000000000001]`, Options: map[string]interface{}{"ignoreArrayIndexes": true}},
+		{Code: "// eslint-disable-next-line test\nf(42);"},
+		{Code: "/* eslint-disable test */\nf(42);\n/* eslint-enable test */"},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Core ESLint: enforceConst ----
 		{
@@ -781,5 +783,13 @@ type Foo = {
 		{Code: `var stats = {avg: 42};`, Options: map[string]interface{}{"detectObjects": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMagic", Message: "No magic number: 42."}}},
 		{Code: `min = 1;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMagic", Message: "No magic number: 1."}}},
 		{Code: `function f() { return 60; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMagic", Message: "No magic number: 60."}}},
+		{
+			Code: `f(/* leading trivia */ 42, /* unary */ -(7), /* bigint */ 9n);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noMagic", Message: "No magic number: 42.", Line: 1, Column: 24},
+				{MessageId: "noMagic", Message: "No magic number: -(7).", Line: 1, Column: 40},
+				{MessageId: "noMagic", Message: "No magic number: 9n.", Line: 1, Column: 59},
+			},
+		},
 	})
 }


### PR DESCRIPTION
## Summary

- Avoid allocating an ignore map when the option is absent.
- Skip numeric and BigInt normalization when no configured option needs the parsed value.
- Reuse exact trimmed source ranges for messages and reports instead of rescanning report nodes.
- Preserve option precedence, diagnostic messages and ranges, and disable-directive behavior.

### Go benchmark

Methodology: Apple M1 Max, darwin/arm64, `GOMAXPROCS=1`, 256 numeric literals per case, 200 ms benchtime, five samples. The table reports the median sample from:

```sh
GOMAXPROCS=1 go test ./internal/plugins/typescript/rules/no_magic_numbers -run ^$ -bench ^BenchmarkNoMagicNumbers$ -benchmem -benchtime=200ms -count=5
```

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Default matched / diagnostics | 387954 → 207033 | 297808 → 168048 | 2907 → 1626 |
| Default matched / autofix demand | 372611 → 206826 | 297808 → 168048 | 2907 → 1626 |
| Default matched / suggestion demand | 378159 → 214519 | 297808 → 168048 | 2907 → 1626 |
| BigInt matched / diagnostics | 297914 → 147394 | 154440 → 82712 | 3419 → 1114 |
| Default no-match / diagnostics | 258771 → 211675 | 162632 → 161560 | 1627 → 1370 |
| Ignore list / diagnostics | 232470 → 229320 | 163536 → 163536 | 1629 → 1629 |
| Ignore array indexes / diagnostics | 238480 → 209018 | 160936 → 160536 | 1291 → 1114 |
| Ignore numeric literal types / diagnostics | 228404 → 207367 | 162632 → 161560 | 1627 → 1370 |

Correctness coverage includes exact messages and ranges for leading trivia, unary expressions, and BigInt literals, plus line and scoped disable directives.

Validation:

- `go test ./internal/plugins/typescript/rules/no_magic_numbers -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_magic_numbers/...`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required; behavior is unchanged).