### PR TITLE
perf: optimize explicit member accessibility

### DIFF
--- a/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.go
+++ b/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.go
@@ -39,8 +39,7 @@ type options struct {
 
 func parseOptions(rawOpts []any) options {
 	opts := options{
-		accessibility:      levelExplicit,
-		ignoredMethodNames: map[string]bool{},
+		accessibility: levelExplicit,
 	}
 	if len(rawOpts) == 0 {
 		return opts
@@ -52,6 +51,9 @@ func parseOptions(rawOpts []any) options {
 	if v, ok := optsMap["ignoredMethodNames"].([]interface{}); ok {
 		for _, n := range v {
 			if s, ok := n.(string); ok {
+				if opts.ignoredMethodNames == nil {
+					opts.ignoredMethodNames = make(map[string]bool, len(v))
+				}
 				opts.ignoredMethodNames[s] = true
 			}
 		}
@@ -111,12 +113,12 @@ func requiresQuoting(s string) bool {
 	if s == "" {
 		return true
 	}
-	runes := []rune(s)
-	if !isIdentifierStart(runes[0]) {
-		return true
-	}
-	for _, r := range runes[1:] {
-		if !isIdentifierPart(r) {
+	for index, r := range s {
+		if index == 0 {
+			if !isIdentifierStart(r) {
+				return true
+			}
+		} else if !isIdentifierPart(r) {
 			return true
 		}
 	}
@@ -229,60 +231,54 @@ func methodOrPropertyHeadEnd(sf *ast.SourceFile, node *ast.Node) int {
 }
 
 // findPublicKeyword locates the `public` modifier on a class member or parameter
-// property and returns its keyword range, plus the range that an autofix should
-// remove (keyword + trailing whitespace, stopping at the first comment).
-func findPublicKeyword(sf *ast.SourceFile, node *ast.Node) (kwRange, removeRange core.TextRange, ok bool) {
+// property and returns its keyword range and source end. The latter lets the
+// autofix range remain deferred until a consumer requests fixes.
+func findPublicKeyword(sf *ast.SourceFile, node *ast.Node) (kwRange core.TextRange, keywordEnd int, ok bool) {
 	mods := node.Modifiers()
 	if mods == nil {
-		return core.TextRange{}, core.TextRange{}, false
+		return core.TextRange{}, 0, false
 	}
 	for _, m := range mods.Nodes {
 		if m.Kind != ast.KindPublicKeyword {
 			continue
 		}
-		kwRange = utils.TrimNodeTextRange(sf, m)
-		text := sf.Text()
-		end := m.End()
-		for end < len(text) {
-			c := text[end]
-			if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
-				end++
-				continue
-			}
-			break
-		}
-		removeRange = core.NewTextRange(kwRange.Pos(), end)
-		return kwRange, removeRange, true
+		return utils.TrimNodeTextRange(sf, m), m.End(), true
 	}
-	return core.TextRange{}, core.TextRange{}, false
+	return core.TextRange{}, 0, false
 }
 
-// accessibilityOf returns the explicit accessibility keyword on a node ("public",
-// "private", or "protected"), or "" when no accessibility modifier is present.
-// Uses HasSyntacticModifier — same convention as the rest of the plugin
-// (parameter_properties.go, member_ordering.go, etc.) — instead of walking the
-// modifier list manually.
-func accessibilityOf(node *ast.Node) string {
-	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPublic) {
+func publicRemovalRange(sf *ast.SourceFile, kwRange core.TextRange, keywordEnd int) core.TextRange {
+	text := sf.Text()
+	end := keywordEnd
+	for end < len(text) {
+		c := text[end]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			end++
+			continue
+		}
+		break
+	}
+	return core.NewTextRange(kwRange.Pos(), end)
+}
+
+// accessibilityOf returns the explicit accessibility keyword represented by
+// modifier flags, or "" when no accessibility modifier is present.
+func accessibilityOf(flags ast.ModifierFlags) string {
+	if flags&ast.ModifierFlagsPublic != 0 {
 		return "public"
 	}
-	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPrivate) {
+	if flags&ast.ModifierFlagsPrivate != 0 {
 		return "private"
 	}
-	if ast.HasSyntacticModifier(node, ast.ModifierFlagsProtected) {
+	if flags&ast.ModifierFlagsProtected != 0 {
 		return "protected"
 	}
 	return ""
 }
 
-func hasReadonlyModifier(node *ast.Node) bool {
-	return ast.HasSyntacticModifier(node, ast.ModifierFlagsReadonly)
-}
-
 // missingAccessibilitySuggestions returns the three "Add 'public/private/protected' "
-// suggestion fixes for a member or parameter-property node.
-func missingAccessibilitySuggestions(sf *ast.SourceFile, node *ast.Node) []rule.RuleSuggestion {
-	insertPos := memberHeadStart(sf, node)
+// suggestion fixes at a previously resolved member-head position.
+func missingAccessibilitySuggestions(insertPos int) []rule.RuleSuggestion {
 	insertRange := core.NewTextRange(insertPos, insertPos)
 	build := func(accessibility string) rule.RuleSuggestion {
 		return rule.RuleSuggestion{
@@ -334,18 +330,13 @@ var ExplicitMemberAccessibilityRule = rule.CreateRule(rule.Rule{
 		methodCheck := resolveCheck(baseCheck, opts.overrides.methods)
 		propCheck := resolveCheck(baseCheck, opts.overrides.properties)
 		paramPropCheck := resolveCheck(baseCheck, opts.overrides.parameterProperties)
+		if ctorCheck == levelOff && accessorCheck == levelOff && methodCheck == levelOff &&
+			propCheck == levelOff && paramPropCheck == levelOff {
+			return nil
+		}
 
 		checkMethod := func(node *ast.Node) {
-			if !isClassMember(node) {
-				return
-			}
-			nameNode := node.Name()
-			if nameNode != nil && nameNode.Kind == ast.KindPrivateIdentifier {
-				return
-			}
-
 			var check accessibilityLevel
-			nodeType := memberNodeType(node.Kind)
 			switch node.Kind {
 			case ast.KindMethodDeclaration:
 				check = methodCheck
@@ -356,38 +347,9 @@ var ExplicitMemberAccessibilityRule = rule.CreateRule(rule.Rule{
 			default:
 				check = methodCheck
 			}
-
-			methodName := getMemberName(sf, node)
-			if check == levelOff || opts.ignoredMethodNames[methodName] {
+			if check == levelOff {
 				return
 			}
-
-			accessibility := accessibilityOf(node)
-
-			if check == levelNoPublic && accessibility == "public" {
-				kwRange, removeRange, ok := findPublicKeyword(sf, node)
-				if !ok {
-					return
-				}
-				ctx.ReportRangeWithFixes(
-					kwRange,
-					buildUnwantedPublicAccessibilityMessage(nodeType, methodName),
-					rule.RuleFixRemoveRange(removeRange),
-				)
-				return
-			}
-			if check == levelExplicit && accessibility == "" {
-				start := memberHeadStart(sf, node)
-				end := methodOrPropertyHeadEnd(sf, node)
-				ctx.ReportRangeWithSuggestions(
-					core.NewTextRange(start, end),
-					buildMissingAccessibilityMessage(nodeType, methodName),
-					missingAccessibilitySuggestions(sf, node)...,
-				)
-			}
-		}
-
-		checkProperty := func(node *ast.Node) {
 			if !isClassMember(node) {
 				return
 			}
@@ -396,44 +358,118 @@ var ExplicitMemberAccessibilityRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			nodeType := "class property"
-			propertyName := getMemberName(sf, node)
-			accessibility := accessibilityOf(node)
+			accessibility := accessibilityOf(node.ModifierFlags())
+			switch check {
+			case levelNoPublic:
+				if accessibility != "public" {
+					return
+				}
+			case levelExplicit:
+				if accessibility != "" {
+					return
+				}
+			default:
+				return
+			}
+			methodName := getMemberName(sf, node)
+			if opts.ignoredMethodNames[methodName] {
+				return
+			}
+			nodeType := memberNodeType(node.Kind)
 
-			if propCheck == levelNoPublic && accessibility == "public" {
-				kwRange, removeRange, ok := findPublicKeyword(sf, node)
+			if check == levelNoPublic {
+				kwRange, keywordEnd, ok := findPublicKeyword(sf, node)
 				if !ok {
 					return
 				}
-				ctx.ReportRangeWithFixes(
+				ctx.ReportRangeWithDeferredFixes(
 					kwRange,
-					buildUnwantedPublicAccessibilityMessage(nodeType, propertyName),
-					rule.RuleFixRemoveRange(removeRange),
+					buildUnwantedPublicAccessibilityMessage(nodeType, methodName),
+					func() []rule.RuleFix {
+						return []rule.RuleFix{rule.RuleFixRemoveRange(publicRemovalRange(sf, kwRange, keywordEnd))}
+					},
 				)
 				return
 			}
-			if propCheck == levelExplicit && accessibility == "" {
-				start := memberHeadStart(sf, node)
-				end := methodOrPropertyHeadEnd(sf, node)
-				ctx.ReportRangeWithSuggestions(
-					core.NewTextRange(start, end),
-					buildMissingAccessibilityMessage(nodeType, propertyName),
-					missingAccessibilitySuggestions(sf, node)...,
-				)
+			start := memberHeadStart(sf, node)
+			end := methodOrPropertyHeadEnd(sf, node)
+			ctx.ReportRangeWithDeferredSuggestions(
+				core.NewTextRange(start, end),
+				buildMissingAccessibilityMessage(nodeType, methodName),
+				func() []rule.RuleSuggestion {
+					return missingAccessibilitySuggestions(start)
+				},
+			)
+		}
+
+		checkProperty := func(node *ast.Node) {
+			if propCheck == levelOff {
+				return
 			}
+			if !isClassMember(node) {
+				return
+			}
+			nameNode := node.Name()
+			if nameNode != nil && nameNode.Kind == ast.KindPrivateIdentifier {
+				return
+			}
+
+			accessibility := accessibilityOf(node.ModifierFlags())
+			switch propCheck {
+			case levelNoPublic:
+				if accessibility != "public" {
+					return
+				}
+			case levelExplicit:
+				if accessibility != "" {
+					return
+				}
+			default:
+				return
+			}
+			propertyName := getMemberName(sf, node)
+			const nodeType = "class property"
+
+			if propCheck == levelNoPublic {
+				kwRange, keywordEnd, ok := findPublicKeyword(sf, node)
+				if !ok {
+					return
+				}
+				ctx.ReportRangeWithDeferredFixes(
+					kwRange,
+					buildUnwantedPublicAccessibilityMessage(nodeType, propertyName),
+					func() []rule.RuleFix {
+						return []rule.RuleFix{rule.RuleFixRemoveRange(publicRemovalRange(sf, kwRange, keywordEnd))}
+					},
+				)
+				return
+			}
+			start := memberHeadStart(sf, node)
+			end := methodOrPropertyHeadEnd(sf, node)
+			ctx.ReportRangeWithDeferredSuggestions(
+				core.NewTextRange(start, end),
+				buildMissingAccessibilityMessage(nodeType, propertyName),
+				func() []rule.RuleSuggestion {
+					return missingAccessibilitySuggestions(start)
+				},
+			)
 		}
 
 		checkParameterProperty := func(node *ast.Node) {
-			if node.Parent == nil || !ast.IsParameterPropertyDeclaration(node, node.Parent) {
+			if paramPropCheck == levelOff || node.Parent == nil || node.Parent.Kind != ast.KindConstructor {
+				return
+			}
+			modifierFlags := node.ModifierFlags()
+			if modifierFlags&ast.ModifierFlagsParameterPropertyModifier == 0 {
 				return
 			}
 			paramName := node.Name()
 			if paramName == nil || paramName.Kind != ast.KindIdentifier {
 				return
 			}
-			nodeType := "parameter property"
+			const nodeType = "parameter property"
 			nodeName := paramName.AsIdentifier().Text
-			accessibility := accessibilityOf(node)
+			accessibility := accessibilityOf(modifierFlags)
 
 			switch paramPropCheck {
 			case levelExplicit:
@@ -442,37 +478,51 @@ var ExplicitMemberAccessibilityRule = rule.CreateRule(rule.Rule{
 				}
 				start := memberHeadStart(sf, node)
 				end := paramName.End()
-				ctx.ReportRangeWithSuggestions(
+				ctx.ReportRangeWithDeferredSuggestions(
 					core.NewTextRange(start, end),
 					buildMissingAccessibilityMessage(nodeType, nodeName),
-					missingAccessibilitySuggestions(sf, node)...,
+					func() []rule.RuleSuggestion {
+						return missingAccessibilitySuggestions(start)
+					},
 				)
 			case levelNoPublic:
 				// Upstream only flags `public readonly` parameter properties under
 				// no-public. A bare `public x` parameter would lose its parameter-
 				// property semantics if `public` were removed, so it is left alone.
-				if accessibility != "public" || !hasReadonlyModifier(node) {
+				if accessibility != "public" || modifierFlags&ast.ModifierFlagsReadonly == 0 {
 					return
 				}
-				kwRange, removeRange, ok := findPublicKeyword(sf, node)
+				kwRange, keywordEnd, ok := findPublicKeyword(sf, node)
 				if !ok {
 					return
 				}
-				ctx.ReportRangeWithFixes(
+				ctx.ReportRangeWithDeferredFixes(
 					kwRange,
 					buildUnwantedPublicAccessibilityMessage(nodeType, nodeName),
-					rule.RuleFixRemoveRange(removeRange),
+					func() []rule.RuleFix {
+						return []rule.RuleFix{rule.RuleFixRemoveRange(publicRemovalRange(sf, kwRange, keywordEnd))}
+					},
 				)
 			}
 		}
 
-		return rule.RuleListeners{
-			ast.KindMethodDeclaration:   checkMethod,
-			ast.KindConstructor:         checkMethod,
-			ast.KindGetAccessor:         checkMethod,
-			ast.KindSetAccessor:         checkMethod,
-			ast.KindPropertyDeclaration: checkProperty,
-			ast.KindParameter:           checkParameterProperty,
+		listeners := make(rule.RuleListeners, 6)
+		if methodCheck != levelOff {
+			listeners[ast.KindMethodDeclaration] = checkMethod
 		}
+		if ctorCheck != levelOff {
+			listeners[ast.KindConstructor] = checkMethod
+		}
+		if accessorCheck != levelOff {
+			listeners[ast.KindGetAccessor] = checkMethod
+			listeners[ast.KindSetAccessor] = checkMethod
+		}
+		if propCheck != levelOff {
+			listeners[ast.KindPropertyDeclaration] = checkProperty
+		}
+		if paramPropCheck != levelOff {
+			listeners[ast.KindParameter] = checkParameterProperty
+		}
+		return listeners
 	},
 })

--- a/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility_test.go
+++ b/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility_test.go
@@ -1,9 +1,15 @@
 package explicit_member_accessibility
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -769,7 +775,7 @@ class Test {
 		},
 		// Computed key from a template literal.
 		{
-			Code: "\nclass Test {\n  [`foo`] = 1;\n}\n      ",
+			Code:    "\nclass Test {\n  [`foo`] = 1;\n}\n      ",
 			Options: map[string]interface{}{"accessibility": "no-public"},
 		},
 		// ---- static + accessor / abstract + accessor + override ----
@@ -3722,4 +3728,177 @@ class Test {
 			},
 		},
 	})
+}
+
+func runExplicitMemberAccessibilityWithDemand(
+	t *testing.T,
+	code string,
+	rawOptions any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	options := rule_tester.ResolveTestCaseOptions(t, &ExplicitMemberAccessibilityRule, rawOptions)
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/source.ts",
+		Path:     "/source.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 4)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(
+		ExplicitMemberAccessibilityRule.Name,
+		rule.SeverityError,
+		rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	)
+
+	listeners := ExplicitMemberAccessibilityRule.Run(ctx, options)
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
+}
+
+func TestExplicitMemberAccessibilityEditDemand(t *testing.T) {
+	assertSameIdentity := func(left, right []rule.RuleDiagnostic) {
+		t.Helper()
+		if len(left) != len(right) {
+			t.Fatalf("diagnostic counts = %d and %d", len(left), len(right))
+		}
+		for index := range left {
+			if left[index].Range != right[index].Range ||
+				left[index].Message.Id != right[index].Message.Id ||
+				left[index].Message.Description != right[index].Message.Description ||
+				!reflect.DeepEqual(left[index].Message.Data, right[index].Message.Data) ||
+				left[index].RuleName != right[index].RuleName ||
+				left[index].Severity != right[index].Severity {
+				t.Fatalf("diagnostic %d changed identity:\nleft  %#v\nright %#v", index, left[index], right[index])
+			}
+		}
+	}
+	assertNoEdits := func(diagnostics []rule.RuleDiagnostic) {
+		t.Helper()
+		for index, diagnostic := range diagnostics {
+			if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+				t.Fatalf("diagnostic %d unexpectedly materialized edits: %#v", index, diagnostic)
+			}
+		}
+	}
+
+	const explicitCode = `class Example {
+  @decorator
+  static method() {}
+  property = 1;
+  constructor(readonly value: string) {}
+}`
+	diagnosticsOnly := runExplicitMemberAccessibilityWithDemand(t, explicitCode, nil, rule.EditDemandNone)
+	wrongAutofixDemand := runExplicitMemberAccessibilityWithDemand(t, explicitCode, nil, rule.EditDemandAutofix)
+	suggestions := runExplicitMemberAccessibilityWithDemand(t, explicitCode, nil, rule.EditDemandSuggestion)
+	allExplicitEdits := runExplicitMemberAccessibilityWithDemand(t, explicitCode, nil, rule.EditDemandAll)
+	if len(diagnosticsOnly) != 4 {
+		t.Fatalf("explicit diagnostic count = %d, want 4", len(diagnosticsOnly))
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{wrongAutofixDemand, suggestions, allExplicitEdits} {
+		assertSameIdentity(diagnosticsOnly, diagnostics)
+	}
+	assertNoEdits(diagnosticsOnly)
+	assertNoEdits(wrongAutofixDemand)
+	for _, diagnostics := range [][]rule.RuleDiagnostic{suggestions, allExplicitEdits} {
+		for diagnosticIndex, diagnostic := range diagnostics {
+			if diagnostic.FixesPtr != nil || diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != 3 {
+				t.Fatalf("diagnostic %d suggestion artifacts = %#v", diagnosticIndex, diagnostic)
+			}
+			for suggestionIndex, replacement := range []string{"public ", "private ", "protected "} {
+				suggestion := (*diagnostic.Suggestions)[suggestionIndex]
+				if len(suggestion.FixesArr) != 1 || suggestion.FixesArr[0].Text != replacement ||
+					suggestion.FixesArr[0].Range != core.NewTextRange(diagnostic.Range.Pos(), diagnostic.Range.Pos()) {
+					t.Fatalf("diagnostic %d suggestion %d = %#v", diagnosticIndex, suggestionIndex, suggestion)
+				}
+			}
+		}
+	}
+
+	const noPublicCode = `class Example {
+  public /* keep */ static property = 1;
+  public constructor(public /* keep */ readonly value: string) {}
+  public method() {}
+}`
+	noPublicOptions := map[string]any{"accessibility": "no-public"}
+	noPublicDiagnostics := runExplicitMemberAccessibilityWithDemand(t, noPublicCode, noPublicOptions, rule.EditDemandNone)
+	wrongSuggestionDemand := runExplicitMemberAccessibilityWithDemand(t, noPublicCode, noPublicOptions, rule.EditDemandSuggestion)
+	autofixes := runExplicitMemberAccessibilityWithDemand(t, noPublicCode, noPublicOptions, rule.EditDemandAutofix)
+	allNoPublicEdits := runExplicitMemberAccessibilityWithDemand(t, noPublicCode, noPublicOptions, rule.EditDemandAll)
+	if len(noPublicDiagnostics) != 4 {
+		t.Fatalf("no-public diagnostic count = %d, want 4", len(noPublicDiagnostics))
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{wrongSuggestionDemand, autofixes, allNoPublicEdits} {
+		assertSameIdentity(noPublicDiagnostics, diagnostics)
+	}
+	assertNoEdits(noPublicDiagnostics)
+	assertNoEdits(wrongSuggestionDemand)
+	for _, diagnostics := range [][]rule.RuleDiagnostic{autofixes, allNoPublicEdits} {
+		for diagnosticIndex, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil || diagnostic.FixesPtr == nil || len(*diagnostic.FixesPtr) != 1 ||
+				(*diagnostic.FixesPtr)[0].Text != "" {
+				t.Fatalf("diagnostic %d autofix artifacts = %#v", diagnosticIndex, diagnostic)
+			}
+		}
+	}
+	fixedSource, unapplied, fixed := linter.ApplyRuleFixes(noPublicCode, autofixes)
+	const wantFixedSource = `class Example {
+  /* keep */ static property = 1;
+  constructor(/* keep */ readonly value: string) {}
+  method() {}
+}`
+	if !fixed || len(unapplied) != 0 || fixedSource != wantFixedSource {
+		t.Fatalf("fixed source:\n%s\nwant:\n%s\nunapplied: %#v", fixedSource, wantFixedSource, unapplied)
+	}
+
+	const disabledCode = `class Example {
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  disabledMethod() {}
+  /* eslint-disable @typescript-eslint/explicit-member-accessibility */
+  disabledProperty = 1;
+  /* eslint-enable @typescript-eslint/explicit-member-accessibility */
+  reportedProperty = 2;
+}`
+	notSuppressed := runExplicitMemberAccessibilityWithDemand(t, disabledCode, nil, rule.EditDemandSuggestion)
+	if len(notSuppressed) != 1 || notSuppressed[0].Suggestions == nil ||
+		notSuppressed[0].Message.Description != "Missing accessibility modifier on class property reportedProperty." {
+		t.Fatalf("disable-directive diagnostics = %#v", notSuppressed)
+	}
+}
+
+func TestRequiresQuoting(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "", want: true},
+		{name: "_value"},
+		{name: "$value"},
+		{name: "éclair"},
+		{name: "变量1"},
+		{name: "1value", want: true},
+		{name: "foo-bar", want: true},
+		{name: "a·b", want: true},
+	}
+	for _, testCase := range tests {
+		if got := requiresQuoting(testCase.name); got != testCase.want {
+			t.Errorf("requiresQuoting(%q) = %v, want %v", testCase.name, got, testCase.want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer explicit-member-accessibility fixes and suggestions until the diagnostic consumer requests them.
- Avoid default-path allocations for ignored method names and rune conversion, reuse modifier flags, and omit listeners disabled by options.
- Preserve upstream-compatible diagnostics, ranges, messages, fixes, suggestions, and option behavior with focused regression coverage.

### Go benchmark

Command: `go test ./internal/plugins/typescript/rules/explicit_member_accessibility -run '^$' -bench '^BenchmarkExplicitMemberAccessibility$' -benchmem -count=5`

Values below are medians of five samples.

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Diagnostics only | 5731 → 2786 | 8656 → 2992 | 135 → 26 |
| Suggestions | 5753 → 6616 | 8656 → 7168 | 135 → 125 |
| Wrong-demand autofix | 5773 → 1964 | 8656 → 2992 | 135 → 26 |
| Autofix | 2420 → 2645 | 3312 → 3264 | 44 → 43 |
| No-public diagnostics only | 2463 → 2291 | 3312 → 2832 | 44 → 25 |
| Wrong-demand suggestion | 2499 → 1948 | 3312 → 2832 | 44 → 25 |
| No match | 675.6 → 478.1 | 848 → 640 | 8 → 6 |
| Ignored methods | 2495 → 1232 | 3600 → 1728 | 51 → 15 |
| All checks off | 656.2 → 111.9 | 848 → 176 | 8 → 1 |

The suggestion and autofix timing samples remain noisy, while both paths reduce allocations. The diagnostics-only and wrong-demand paths avoid materializing unused edit artifacts.

### Correctness

- `go test ./internal/plugins/typescript/rules/explicit_member_accessibility -count=3`
- Added coverage for edit-demand isolation, exact ranges, decorator/comment trivia, disabled listener combinations, ignored names, and no-public fixes.
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/explicit_member_accessibility/...`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; behavior is unchanged).
