### PR TITLE
perf: optimize require-optimization traversal

### DIFF
--- a/internal/plugins/react/rules/require_optimization/require_optimization.go
+++ b/internal/plugins/react/rules/require_optimization/require_optimization.go
@@ -311,31 +311,22 @@ var RequireOptimizationRule = rule.Rule{
 		// it falls back to a local-block scan when `ctx.TypeChecker` is
 		// nil.
 		//
-		// Results are memoized per node: the same node is queried during
-		// the top-level `collect` walk AND during every enclosing
-		// component's `markedFromSubtree` skip-check, and SFC detection
-		// internally walks the function body looking for JSX returns —
-		// without memoization the rule degrades to O(N²) on large files.
-		detectionCache := make(map[*ast.Node]bool)
+		// The component stack walk below visits each node once, so detection
+		// also runs once per node and needs no per-file memoization map.
 		isDetectedComponent := func(node *ast.Node) bool {
-			if cached, ok := detectionCache[node]; ok {
-				return cached
-			}
-			var result bool
 			switch node.Kind {
 			case ast.KindClassDeclaration, ast.KindClassExpression:
-				result = reactutil.ExtendsReactComponent(node, pragma)
+				return reactutil.ExtendsReactComponent(node, pragma)
 			case ast.KindObjectLiteralExpression:
-				result = reactutil.IsCreateReactClassObjectArg(node, pragma, createClass)
+				return reactutil.IsCreateReactClassObjectArg(node, pragma, createClass)
 			case ast.KindFunctionDeclaration,
 				ast.KindFunctionExpression,
 				ast.KindArrowFunction:
 				if isInClassDeclarationMethodBody(node) {
-					result = reactutil.IsStatelessReactComponentWithChecker(node, pragma, ctx.TypeChecker)
+					return reactutil.IsStatelessReactComponentWithChecker(node, pragma, ctx.TypeChecker)
 				}
 			}
-			detectionCache[node] = result
-			return result
+			return false
 		}
 
 		// classSelfMarked covers upstream's `ClassDeclaration(node)` listener
@@ -351,70 +342,6 @@ var RequireOptimizationRule = rule.Rule{
 			return hasPureRenderDecorator(c) ||
 				hasCustomDecorator(c, opts.AllowDecorators) ||
 				reactutil.ExtendsReactPureComponent(c, pragma)
-		}
-
-		// markedFromSubtree implements upstream's `mark-SCU-as-declared` walk-up
-		// resolution: any markSCU source node (ObjectExpression with
-		// SCU/PureRenderMixin, MethodDefinition with name SCU, ClassDeclaration
-		// with PureRender / custom-allow decorator) inside `self`'s subtree
-		// flows up the parent chain until it hits the nearest detected
-		// component. We mirror that with a pre-order subtree scan that
-		// PRUNES nested detected components — they would absorb the
-		// markSCU themselves before it reaches `self`.
-		//
-		// Verified empirically against eslint-plugin-react@latest:
-		//
-		//   class C extends React.Component {
-		//     init() {
-		//       const cfg = { shouldComponentUpdate() {} };  // marks C
-		//     }
-		//   }                                                  // not reported
-		//
-		//   class Outer extends React.Component {
-		//     build() {
-		//       class Inner extends React.Component { scu() {} }  // marks Inner
-		//     }
-		//   }                                                       // Outer reported
-		var markedFromSubtree func(self *ast.Node, current *ast.Node) bool
-		markedFromSubtree = func(self *ast.Node, current *ast.Node) bool {
-			// Skip the subtree of any OTHER detected component — its own
-			// markSCU events resolve to itself, not bubbling up to `self`.
-			if current != self && isDetectedComponent(current) {
-				return false
-			}
-
-			// markSCU source: any ObjectExpression with SCU/PureRenderMixin.
-			if current.Kind == ast.KindObjectLiteralExpression && objectDeclaresSCUOrMixin(current) {
-				return true
-			}
-			// markSCU source: any class member (MethodDef/Get/Set/Constructor)
-			// named shouldComponentUpdate.
-			if methodNameIsSCU(current) {
-				return true
-			}
-			// markSCU source: nested ClassDeclaration carrying PureRender or
-			// custom-allow decorator. Upstream's listener fires only on
-			// ClassDeclaration, so a nested ClassExpression with the same
-			// shape is NOT a markSCU source. Nested ClassDeclaration that
-			// itself extends PureComponent is already handled by the
-			// "skip detected component" guard above (it's a detected
-			// component, absorbs its own markSCU).
-			if current != self && current.Kind == ast.KindClassDeclaration {
-				if hasPureRenderDecorator(current) ||
-					hasCustomDecorator(current, opts.AllowDecorators) {
-					return true
-				}
-			}
-
-			found := false
-			current.ForEachChild(func(child *ast.Node) bool {
-				if markedFromSubtree(self, child) {
-					found = true
-					return true // early exit
-				}
-				return false
-			})
-			return found
 		}
 
 		report := func(c *ast.Node) {
@@ -434,34 +361,78 @@ var RequireOptimizationRule = rule.Rule{
 			}
 		}
 
-		// Single-pass collect-and-resolve. Done eagerly here (instead of via
-		// listeners + a SourceFile-exit hook) because rslint's visitor enters
-		// the SourceFile's children directly — the SourceFile node itself is
-		// never visited, so a `ListenerOnExit(KindSourceFile)` registration
-		// would silently never fire.
+		// Collect components and resolve markSCU ownership in one pre-order
+		// traversal. A mark source always belongs to the innermost active
+		// detected component, which is equivalent to upstream walking parents
+		// until it reaches the nearest component. Pushing a nested component
+		// before inspecting its own mark sources makes it absorb those sources
+		// instead of leaking them to its outer component.
+		type componentState struct {
+			node   *ast.Node
+			marked bool
+		}
+		var components []componentState
+		var activeComponents []int
+
 		var collect func(*ast.Node)
 		collect = func(n *ast.Node) {
 			if n == nil {
 				return
 			}
+
+			componentIndex := -1
 			if isDetectedComponent(n) {
-				if !classSelfMarked(n) && !markedFromSubtree(n, n) {
-					report(n)
-				}
-				// Continue walking — a detected component's subtree may
-				// contain further detected components (nested class /
-				// nested createReactClass) that need their own
-				// independent evaluation.
+				componentIndex = len(components)
+				components = append(components, componentState{
+					node:   n,
+					marked: classSelfMarked(n),
+				})
+				activeComponents = append(activeComponents, componentIndex)
 			}
+
+			if len(activeComponents) != 0 {
+				marksActiveComponent := false
+				switch n.Kind {
+				case ast.KindObjectLiteralExpression:
+					marksActiveComponent = objectDeclaresSCUOrMixin(n)
+				case ast.KindMethodDeclaration,
+					ast.KindGetAccessor,
+					ast.KindSetAccessor,
+					ast.KindConstructor:
+					marksActiveComponent = methodNameIsSCU(n)
+				case ast.KindClassDeclaration:
+					// A detected class is already the active component and
+					// classSelfMarked handled its own decorators. Only a
+					// non-component nested class can mark an outer component.
+					if componentIndex < 0 {
+						marksActiveComponent = hasPureRenderDecorator(n) ||
+							hasCustomDecorator(n, opts.AllowDecorators)
+					}
+				}
+				if marksActiveComponent {
+					activeIndex := activeComponents[len(activeComponents)-1]
+					components[activeIndex].marked = true
+				}
+			}
+
 			n.ForEachChild(func(c *ast.Node) bool {
 				collect(c)
 				return false
 			})
+
+			if componentIndex >= 0 {
+				activeComponents = activeComponents[:len(activeComponents)-1]
+			}
 		}
 		ctx.SourceFile.Node.ForEachChild(func(n *ast.Node) bool {
 			collect(n)
 			return false
 		})
+		for _, component := range components {
+			if !component.marked {
+				report(component.node)
+			}
+		}
 
 		return rule.RuleListeners{}
 	},

--- a/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
+++ b/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
@@ -1,6 +1,7 @@
 package require_optimization
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
@@ -2396,6 +2397,117 @@ class C extends Component {}`, Tsx: true},
 			},
 		},
 	})
+}
+
+func TestRequireOptimizationSinglePassOwnershipAndDemand(t *testing.T) {
+	t.Parallel()
+
+	const outer = `class Outer extends React.Component {
+  build() {
+    class Inner extends React.Component {}
+  }
+}`
+	const inner = `class Inner extends React.Component {}`
+	const code = outer + `
+class MarkedOuter extends React.Component {
+  build() {
+    class Helper {
+      shouldComponentUpdate() {}
+    }
+  }
+}
+// eslint-disable-next-line react/require-optimization
+class Disabled extends React.Component {}
+`
+
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir.Dir, "react.tsx")
+	fs := utils.NewOverlayVFS(rootDir.FS, map[string]string{filePath: code})
+	program, err := utils.CreateProgram(
+		true, fs, rootDir.Dir, "tsconfig.json", utils.CreateCompilerHost(rootDir.Dir, fs),
+	)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil {
+		t.Fatalf("source file not found for %s", filePath)
+	}
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	type diagnosticIdentity struct {
+		pos         int
+		end         int
+		messageID   string
+		description string
+	}
+	wantRanges := [][2]int{
+		{strings.Index(code, outer), strings.Index(code, outer) + len(outer)},
+		{strings.Index(code, inner), strings.Index(code, inner) + len(inner)},
+	}
+	var baseline []diagnosticIdentity
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := (rule.RuleContext{
+			SourceFile:     sourceFile,
+			Program:        program,
+			Settings:       map[string]interface{}{},
+			TypeChecker:    typeChecker,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}).WithDiagnosticConsumer(RequireOptimizationRule.Name, rule.SeverityWarning, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+
+		_ = RequireOptimizationRule.Run(ctx, nil)
+		if len(diagnostics) != len(wantRanges) {
+			t.Fatalf("demand %d: expected %d diagnostics, got %#v", demand, len(wantRanges), diagnostics)
+		}
+
+		identities := make([]diagnosticIdentity, len(diagnostics))
+		for i, diagnostic := range diagnostics {
+			if diagnostic.Range.Pos() != wantRanges[i][0] || diagnostic.Range.End() != wantRanges[i][1] {
+				t.Errorf(
+					"demand %d diagnostic %d: range = [%d,%d), want [%d,%d)",
+					demand,
+					i,
+					diagnostic.Range.Pos(),
+					diagnostic.Range.End(),
+					wantRanges[i][0],
+					wantRanges[i][1],
+				)
+			}
+			if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+				t.Errorf("demand %d diagnostic %d unexpectedly carried edits: %#v", demand, i, diagnostic)
+			}
+			identities[i] = diagnosticIdentity{
+				pos:         diagnostic.Range.Pos(),
+				end:         diagnostic.Range.End(),
+				messageID:   diagnostic.Message.Id,
+				description: diagnostic.Message.Description,
+			}
+		}
+
+		if baseline == nil {
+			baseline = identities
+			continue
+		}
+		for i := range baseline {
+			if identities[i] != baseline[i] {
+				t.Errorf("demand %d diagnostic %d = %#v, want %#v", demand, i, identities[i], baseline[i])
+			}
+		}
+	}
 }
 
 // TestRequireOptimizationRule_NilTypeChecker verifies the rule operates


### PR DESCRIPTION
## Summary

- Replace the per-component recursive subtree scans and all-node detection cache with one pre-order traversal and an active-component stack.
- Preserve nearest-component markSCU ownership, nested component isolation, diagnostic order and ranges, disable directives, and behavior across every edit demand.
- Add focused coverage for nested ownership, exact ranges, suppression, and edit artifact parity.
- Benchmark methodology: `go test ./internal/plugins/react/rules/require_optimization -run ^$ -bench ^BenchmarkRequireOptimizationRule$ -benchmem -benchtime=500ms -count=6` on Apple M1 Max; values below are arithmetic means of six samples.

| Case | ns/op before → after | Time | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: | ---: |
| Diagnostics only | 364235 → 49863 | -86.31% | 295977 → 1064 | 47 → 8 |
| Autofix demand | 366370 → 49777 | -86.41% | 295976 → 1064 | 47 → 8 |
| Suggestion demand | 400295 → 49423 | -87.65% | 295976 → 1064 | 47 → 8 |
| No match | 112314 → 16511 | -85.30% | 100072 → 48 | 24 → 1 |
| Late SCU marker | 364970 → 49452 | -86.45% | 295976 → 1064 | 47 → 8 |
| Allowed decorator | 36761 → 9693 | -73.63% | 37368 → 2216 | 16 → 9 |
| Nested components | 47980 → 10708 | -77.68% | 37368 → 2232 | 16 → 10 |

Validation:

- `go test ./internal/plugins/react/rules/require_optimization -count=3`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/react/rules/require_optimization/...`
- `pnpm run check-spell`
- `pnpm run format:check`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).