### PR TITLE
perf: optimize one-var scope tracking

### DIFF
--- a/internal/rules/one_var/one_var.go
+++ b/internal/rules/one_var/one_var.go
@@ -182,17 +182,13 @@ func optsKey(kind string) string {
 	return kind
 }
 
-// isRequireDecl reports whether the declarator's initializer is a `require(...)`
+// isRequireInitializer reports whether an initializer is a `require(...)`
 // call. Mirrors ESLint's `isRequire` (which looks at `init.callee.name` directly,
 // effectively ignoring parens because espree strips them). tsgo preserves
 // parens as explicit nodes, so we apply SkipParentheses on both the initializer
 // and the callee to match the effective ESLint behavior.
-func isRequireDecl(decl *ast.Node) bool {
-	vd := decl.AsVariableDeclaration()
-	if vd == nil || vd.Initializer == nil {
-		return false
-	}
-	init := ast.SkipParentheses(vd.Initializer)
+func isRequireInitializer(initializer *ast.Node) bool {
+	init := ast.SkipParentheses(initializer)
 	if init == nil || init.Kind != ast.KindCallExpression {
 		return false
 	}
@@ -225,9 +221,9 @@ func collectDeclarationStats(decls []*ast.Node, inspectRequires bool) declaratio
 			stats.uninitialized++
 		} else {
 			stats.initialized++
-		}
-		if inspectRequires && isRequireDecl(d) {
-			stats.requires++
+			if inspectRequires && isRequireInitializer(vd.Initializer) {
+				stats.requires++
+			}
 		}
 	}
 	return stats
@@ -850,65 +846,76 @@ var OneVarRule = rule.Rule{
 			}
 		}
 
-		startBlock := func(*ast.Node) {
-			if needsBlockScope {
-				blockStack = append(blockStack, blockScope{})
-			}
+		listenerCount := 1
+		if needsVarScope {
+			listenerCount += 16
 		}
-		endBlock := func(*ast.Node) {
-			if needsBlockScope && len(blockStack) > 0 {
-				blockStack = blockStack[:len(blockStack)-1]
-			}
+		if needsBlockScope {
+			listenerCount += 10
 		}
-		startFunction := func(*ast.Node) {
-			if needsVarScope {
+		listeners := make(rule.RuleListeners, listenerCount)
+		listeners[ast.KindVariableDeclarationList] = checkDeclList
+
+		if needsVarScope {
+			// Every function body that can contain declarations is visited as a
+			// KindBlock below. Concise arrow bodies cannot contain declarations,
+			// so function boundaries only need to maintain the var scope.
+			startFunction := func(*ast.Node) {
 				funcStack = append(funcStack, funcScope{})
 			}
-			startBlock(nil)
-		}
-		endFunction := func(*ast.Node) {
-			if needsVarScope && len(funcStack) > 0 {
-				funcStack = funcStack[:len(funcStack)-1]
+			endFunction := func(*ast.Node) {
+				if len(funcStack) > 0 {
+					funcStack = funcStack[:len(funcStack)-1]
+				}
 			}
-			endBlock(nil)
+
+			listeners[ast.KindFunctionDeclaration] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindFunctionDeclaration)] = endFunction
+			listeners[ast.KindFunctionExpression] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindFunctionExpression)] = endFunction
+			listeners[ast.KindArrowFunction] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindArrowFunction)] = endFunction
+			listeners[ast.KindMethodDeclaration] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindMethodDeclaration)] = endFunction
+			listeners[ast.KindGetAccessor] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindGetAccessor)] = endFunction
+			listeners[ast.KindSetAccessor] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindSetAccessor)] = endFunction
+			listeners[ast.KindConstructor] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindConstructor)] = endFunction
+			listeners[ast.KindClassStaticBlockDeclaration] = startFunction
+			listeners[rule.ListenerOnExit(ast.KindClassStaticBlockDeclaration)] = endFunction
 		}
 
-		return rule.RuleListeners{
-			ast.KindFunctionDeclaration:                              startFunction,
-			rule.ListenerOnExit(ast.KindFunctionDeclaration):         endFunction,
-			ast.KindFunctionExpression:                               startFunction,
-			rule.ListenerOnExit(ast.KindFunctionExpression):          endFunction,
-			ast.KindArrowFunction:                                    startFunction,
-			rule.ListenerOnExit(ast.KindArrowFunction):               endFunction,
-			ast.KindMethodDeclaration:                                startFunction,
-			rule.ListenerOnExit(ast.KindMethodDeclaration):           endFunction,
-			ast.KindGetAccessor:                                      startFunction,
-			rule.ListenerOnExit(ast.KindGetAccessor):                 endFunction,
-			ast.KindSetAccessor:                                      startFunction,
-			rule.ListenerOnExit(ast.KindSetAccessor):                 endFunction,
-			ast.KindConstructor:                                      startFunction,
-			rule.ListenerOnExit(ast.KindConstructor):                 endFunction,
-			ast.KindClassStaticBlockDeclaration:                      startFunction,
-			rule.ListenerOnExit(ast.KindClassStaticBlockDeclaration): endFunction,
+		if needsBlockScope {
+			startBlock := func(*ast.Node) {
+				blockStack = append(blockStack, blockScope{})
+			}
+			endBlock := func(*ast.Node) {
+				if len(blockStack) > 0 {
+					blockStack = blockStack[:len(blockStack)-1]
+				}
+			}
 
-			ast.KindBlock:                                startBlock,
-			rule.ListenerOnExit(ast.KindBlock):           endBlock,
-			ast.KindForStatement:                         startBlock,
-			rule.ListenerOnExit(ast.KindForStatement):    endBlock,
-			ast.KindForInStatement:                       startBlock,
-			rule.ListenerOnExit(ast.KindForInStatement):  endBlock,
-			ast.KindForOfStatement:                       startBlock,
-			rule.ListenerOnExit(ast.KindForOfStatement):  endBlock,
-			ast.KindSwitchStatement:                      startBlock,
-			rule.ListenerOnExit(ast.KindSwitchStatement): endBlock,
-			// NOTE: TypeScript `namespace N { ... }` and `declare module 'x' { ... }`
-			// have a TSModuleBlock body in the AST, but ESLint's one-var rule
-			// does NOT register any listener for it — declarations inside live
-			// in the enclosing function scope. Mirror upstream by NOT pushing
-			// a new scope on ModuleBlock entry. (Verified against ESLint v10.2.1
-			// on `namespace A { var a } namespace B { var a }` reports combine.)
-
-			ast.KindVariableDeclarationList: checkDeclList,
+			listeners[ast.KindBlock] = startBlock
+			listeners[rule.ListenerOnExit(ast.KindBlock)] = endBlock
+			listeners[ast.KindForStatement] = startBlock
+			listeners[rule.ListenerOnExit(ast.KindForStatement)] = endBlock
+			listeners[ast.KindForInStatement] = startBlock
+			listeners[rule.ListenerOnExit(ast.KindForInStatement)] = endBlock
+			listeners[ast.KindForOfStatement] = startBlock
+			listeners[rule.ListenerOnExit(ast.KindForOfStatement)] = endBlock
+			listeners[ast.KindSwitchStatement] = startBlock
+			listeners[rule.ListenerOnExit(ast.KindSwitchStatement)] = endBlock
 		}
+
+		// NOTE: TypeScript `namespace N { ... }` and `declare module 'x' { ... }`
+		// have a TSModuleBlock body in the AST, but ESLint's one-var rule
+		// does NOT register any listener for it — declarations inside live
+		// in the enclosing function scope. Mirror upstream by NOT pushing
+		// a new scope on ModuleBlock entry. (Verified against ESLint v10.2.1
+		// on `namespace A { var a } namespace B { var a }` reports combine.)
+
+		return listeners
 	},
 }

--- a/internal/rules/one_var/one_var_test.go
+++ b/internal/rules/one_var/one_var_test.go
@@ -2884,3 +2884,142 @@ func TestOneVarStatementLocalModesOnlyRegisterDeclarationListener(t *testing.T) 
 		})
 	}
 }
+
+func TestOneVarScopeModesOnlyRegisterRequiredBoundaryListeners(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name            string
+		options         []any
+		wantListeners   int
+		requireFunction bool
+		requireBlock    bool
+	}{
+		{
+			name: "var scope only",
+			options: []any{map[string]interface{}{
+				"var": modeAlways,
+			}},
+			wantListeners:   17,
+			requireFunction: true,
+		},
+		{
+			name: "block scope only",
+			options: []any{map[string]interface{}{
+				"let": modeAlways,
+			}},
+			wantListeners: 11,
+			requireBlock:  true,
+		},
+		{
+			name:            "var and block scopes",
+			options:         []any{modeAlways},
+			wantListeners:   27,
+			requireFunction: true,
+			requireBlock:    true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			listeners := OneVarRule.Run(rule.RuleContext{}, testCase.options)
+			if len(listeners) != testCase.wantListeners {
+				t.Fatalf("listeners = %d, want %d", len(listeners), testCase.wantListeners)
+			}
+			if got := listeners[ast.KindFunctionDeclaration] != nil; got != testCase.requireFunction {
+				t.Errorf("function listener present = %t, want %t", got, testCase.requireFunction)
+			}
+			if got := listeners[ast.KindBlock] != nil; got != testCase.requireBlock {
+				t.Errorf("block listener present = %t, want %t", got, testCase.requireBlock)
+			}
+		})
+	}
+}
+
+func TestOneVarBlockOnlyFunctionBodyScopes(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&OneVarRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `let outer; function inner() { let inner; }`,
+				Options: []interface{}{map[string]interface{}{
+					"let": modeAlways,
+				}},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `function outer() { let first; function inner() { let only; } let second; }`,
+				Output: nil,
+				Options: []interface{}{map[string]interface{}{
+					"let": modeAlways,
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "combine"},
+				},
+			},
+		},
+	)
+}
+
+func TestOneVarDisableDirectives(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name string
+		code string
+	}{
+		{
+			name: "next line",
+			code: "let first;\n/* eslint-disable-next-line one-var */\nlet second;",
+		},
+		{
+			name: "scoped",
+			code: "/* eslint-disable one-var */\nlet first;\nlet second;\n/* eslint-enable one-var */",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+			program, sourceFile, err := helper.CreateTestProgram(testCase.code, "disable-directives.ts", "tsconfig.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			diagnosticCount := 0
+			linter.LintSingleFile(linter.LintSingleFileOptions{
+				Program:      program,
+				File:         sourceFile.FileName(),
+				HasTypeInfo:  true,
+				ExcludePaths: []string{},
+				GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+					return []linter.ConfiguredRule{
+						{
+							Name:     OneVarRule.Name,
+							Severity: rule.SeverityError,
+							Run: func(ctx rule.RuleContext) rule.RuleListeners {
+								return OneVarRule.Run(ctx, []any{map[string]interface{}{
+									"let": modeAlways,
+								}})
+							},
+						},
+					}
+				},
+				Consumer: rule.DiagnosticConsumer{
+					Demand: rule.EditDemandNone,
+					Report: func(rule.RuleDiagnostic) {
+						diagnosticCount++
+					},
+				},
+			})
+
+			if diagnosticCount != 0 {
+				t.Fatalf("diagnostics = %d, want 0", diagnosticCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Keep lexical scope state on block listeners and function-scoped `var` state on function listeners, avoiding the redundant block push/pop at every function boundary.
- Register only the function or block boundary listeners required by the configured declaration kinds.
- Classify `require()` initializers without re-unwrapping declarators or inspecting uninitialized declarations.
- Add focused coverage for listener selection, nested block-only function scopes, and inline disable directives.

### Go benchmark

Apple M1 Max (`darwin/arm64`), medians of 6 samples per side:

```sh
go test ./internal/rules/one_var -run '^$' -bench '^BenchmarkOneVarRule$' -benchmem -benchtime=500ms -count=6
```

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Always diagnostics | 9804.5 → 9677.0 (-1.30%) | 8632 → 8488 | 107 → 106 |
| Always autofix | 12743.5 → 12598.5 (-1.14%) | 13616 → 13472 | 149 → 148 |
| Wrong suggestion demand | 9768.5 → 9659.5 (-1.12%) | 8632 → 8488 | 107 → 106 |
| Always no-match | 5878.5 → 5842.0 (-0.62%) | 4264 → 4120 | 75 → 74 |
| Ignored declaration kinds | 5539.0 → 4059.5 (-26.71%) | 4072 → 3832 | 70 → 57 |
| Never diagnostics control | 4003.5 → 4057.5 (+1.35%) | 5984 → 5984 | 55 → 55 |
| Never autofix control | 5215.0 → 5290.0 (+1.44%) | 8232 → 8232 | 84 → 84 |
| Consecutive diagnostics | 3929.0 → 3848.5 (-2.05%) | 5792 → 5792 | 53 → 53 |
| Separate requires | 5674.0 → 4305.0 (-24.13%) | 5312 → 5072 | 78 → 65 |

The statement-local `never` controls retain identical bytes and allocation counts; their small timing movement is consistent with benchmark noise.

### Validation

- `go test ./internal/rules/one_var -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/one_var/...`
- `git diff --check`
- Adversarial coverage for diagnostics, autofixes, wrong edit demand, nested function/block scopes, configured and ignored declaration kinds, `require()` grouping, and scoped/next-line disable directives

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
