### PR TITLE
perf(rstest): optimize no-interpolation-in-snapshots rule and improve test call infrastructure

### DIFF
--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
@@ -101,14 +101,29 @@ func resolvePendingTestCallbackNames(
 var NoConditionalExpectRule = shared.NewRule(shared.Config{
 	Name: "jest/no-conditional-expect",
 	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		// The shared traversal calls IsTestCall and, only when an assertion can
+		// report, IsExpectCall consecutively for the same node. This one-entry
+		// cache avoids parsing that node twice; a miss only affects performance.
+		var lastNode *ast.Node
+		var lastParsed *jestUtils.ParsedJestFnCall
+		parseCall := func(node *ast.Node) *jestUtils.ParsedJestFnCall {
+			if node == lastNode {
+				return lastParsed
+			}
+			parsed := jestUtils.ParseJestFnCall(node, ctx)
+			lastNode = node
+			lastParsed = parsed
+			return parsed
+		}
 		return shared.Runtime{
 			TestCallbackFunctions: collectTestFunctionCallbacks(ctx),
-			ClassifyCall: func(node *ast.Node, checkExpect bool) (bool, bool) {
-				parsed := jestUtils.ParseJestFnCall(node, ctx)
-				return parsed != nil && parsed.Kind == jestUtils.JestFnTypeTest,
-					checkExpect &&
-						parsed != nil &&
-						parsed.Kind == jestUtils.JestFnTypeExpect
+			IsTestCall: func(node *ast.Node) bool {
+				parsed := parseCall(node)
+				return parsed != nil && parsed.Kind == jestUtils.JestFnTypeTest
+			},
+			IsExpectCall: func(node *ast.Node) bool {
+				parsed := parseCall(node)
+				return parsed != nil && parsed.Kind == jestUtils.JestFnTypeExpect
 			},
 		}
 	},

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.go
@@ -21,14 +21,14 @@ var NoConditionalExpectRule = shared.NewRule(shared.Config{
 		if !sourceMayContainConditionalRstestExpect(ctx.SourceFile) {
 			return shared.Runtime{Skip: true}
 		}
-		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return shared.Runtime{
-			TestCallbackFunctions: callbacks.Functions,
-			ClassifyCall: func(node *ast.Node, checkExpect bool) (bool, bool) {
-				return callbacks.TestCalls[node],
-					checkExpect &&
-						callbacks.IsExpectCandidate(node) &&
-						rstestUtils.IsRstestExpectCall(node, ctx, callbacks)
+			TestCallbackFunctions: analysis.Callbacks().Functions,
+			IsTestCall: func(node *ast.Node) bool {
+				return analysis.ParseTestCall(node) != nil
+			},
+			IsExpectCall: func(node *ast.Node) bool {
+				return analysis.IsExpectCall(node)
 			},
 		}
 	},

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
@@ -1,6 +1,8 @@
 package no_interpolation_in_snapshots
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
@@ -61,14 +63,85 @@ func getInlineSnapshotArgument(ctx rule.RuleContext, matcherName string, call *a
 	}
 }
 
+func sourceMayContainInterpolatedSnapshot(sourceFile *ast.SourceFile) bool {
+	return sourceFile == nil || strings.Contains(sourceFile.Text(), "${")
+}
+
+func mayContainInterpolatedInlineSnapshot(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if isInlineSnapshotMatcherCallee(call.Expression) &&
+			hasInterpolatedTemplateArgument(call.Arguments) {
+			return true
+		}
+		return mayContainInterpolatedInlineSnapshot(call.Expression)
+	case ast.KindPropertyAccessExpression:
+		return mayContainInterpolatedInlineSnapshot(
+			node.AsPropertyAccessExpression().Expression,
+		)
+	case ast.KindElementAccessExpression:
+		return mayContainInterpolatedInlineSnapshot(
+			node.AsElementAccessExpression().Expression,
+		)
+	default:
+		return false
+	}
+}
+
+func isInlineSnapshotMatcherCallee(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	name := ""
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		if property.Name() != nil {
+			name = property.Name().Text()
+		}
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		name, _ = internalUtils.GetStaticStringLiteralValue(
+			ast.SkipParentheses(element.ArgumentExpression),
+		)
+	}
+	return rstestUtils.RSTEST_INLINE_SNAPSHOT_MATCHERS[name]
+}
+
+func hasInterpolatedTemplateArgument(arguments *ast.NodeList) bool {
+	if arguments == nil {
+		return false
+	}
+	for _, argument := range arguments.Nodes {
+		argument = ast.SkipParentheses(argument)
+		if argument != nil && argument.Kind == ast.KindTemplateExpression {
+			return true
+		}
+	}
+	return false
+}
+
 var NoInterpolationInSnapshotsRule = rule.Rule{
 	Name:   "rstest/no-interpolation-in-snapshots",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		if !sourceMayContainInterpolatedSnapshot(ctx.SourceFile) {
+			return rule.RuleListeners{}
+		}
 		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
+				if rstestUtils.FindTopMostCallExpression(node) != node ||
+					!mayContainInterpolatedInlineSnapshot(node) {
+					return
+				}
 				parsed := analysis.ParseExpectCall(node)
 				if parsed == nil {
 					return

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
@@ -65,13 +65,11 @@ var NoInterpolationInSnapshotsRule = rule.Rule{
 	Name:   "rstest/no-interpolation-in-snapshots",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// expect bound to a test context parameter — test("x", ({ expect }) => ...)
-		// — can only be recognized through the collected callbacks.
-		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				parsed := analysis.ParseExpectCall(node)
 				if parsed == nil {
 					return
 				}

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_internal_test.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_internal_test.go
@@ -1,0 +1,112 @@
+package no_interpolation_in_snapshots
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+)
+
+func TestSourceMayContainInterpolatedSnapshot(t *testing.T) {
+	for _, testCase := range []struct {
+		source string
+		want   bool
+	}{
+		{source: `expect(value).toMatchInlineSnapshot("plain")`, want: false},
+		{source: "expect(value).toMatchInlineSnapshot(`${value}`)", want: true},
+		{source: `const text = "${notCode}"`, want: true},
+	} {
+		sourceFile := parser.ParseSourceFile(
+			ast.SourceFileParseOptions{
+				FileName: "/source.test.ts",
+				Path:     "/source.test.ts",
+			},
+			testCase.source,
+			core.ScriptKindTS,
+		)
+		if got := sourceMayContainInterpolatedSnapshot(sourceFile); got != testCase.want {
+			t.Errorf(
+				"sourceMayContainInterpolatedSnapshot(%q) = %t, want %t",
+				testCase.source,
+				got,
+				testCase.want,
+			)
+		}
+	}
+}
+
+func TestMayContainInterpolatedInlineSnapshot(t *testing.T) {
+	for _, testCase := range []struct {
+		source string
+		want   bool
+	}{
+		{
+			source: "expect(value).toMatchInlineSnapshot(`${value}`)",
+			want:   true,
+		},
+		{
+			source: "expect(value)[\"toMatchInlineSnapshot\"](`${value}`)",
+			want:   true,
+		},
+		{
+			source: "expect(value).to.be.a(\"string\").and.toMatchInlineSnapshot(`${value}`)",
+			want:   true,
+		},
+		{
+			source: "expect(value).toMatchInlineSnapshot((`${value}`))",
+			want:   true,
+		},
+		{
+			source: "expect(value).toThrowErrorMatchingInlineSnapshot(`${value}`)",
+			want:   true,
+		},
+		{
+			source: "expect(value).toMatchInlineSnapshot(\"plain\", `case ${id}`)",
+			want:   true,
+		},
+		{
+			source: "expect(value).toMatchSnapshot(`${value}`)",
+			want:   false,
+		},
+		{
+			source: "custom.toMatchInlineSnapshot(`${value}`)",
+			want:   true,
+		},
+		{
+			source: "expect(value).toBe(`${value}`)",
+			want:   false,
+		},
+	} {
+		sourceFile := parser.ParseSourceFile(
+			ast.SourceFileParseOptions{
+				FileName: "/source.test.ts",
+				Path:     "/source.test.ts",
+			},
+			testCase.source,
+			core.ScriptKindTS,
+		)
+		var outerCall *ast.Node
+		var visit func(*ast.Node) bool
+		visit = func(node *ast.Node) bool {
+			if node.Kind == ast.KindCallExpression &&
+				rstestUtils.FindTopMostCallExpression(node) == node {
+				outerCall = node
+			}
+			return node.ForEachChild(visit)
+		}
+		sourceFile.Node.ForEachChild(visit)
+		if outerCall == nil {
+			t.Fatalf("call not found for %q", testCase.source)
+		}
+		if got := mayContainInterpolatedInlineSnapshot(outerCall); got != testCase.want {
+			t.Errorf(
+				"mayContainInterpolatedInlineSnapshot(%q) = %t, want %t",
+				testCase.source,
+				got,
+				testCase.want,
+			)
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
@@ -220,8 +220,8 @@ func TestNoInterpolationInSnapshotsRule(t *testing.T) {
 				},
 			},
 
-			// The test context is the only expect source that cannot be resolved
-			// without CollectRstestTestCallbacks.
+			// The test context is the only expect source that requires
+			// RstestCallAnalysis.Callbacks to discover the local root.
 			{
 				Code: "test(\"case\", ctx => ctx.expect(value).toMatchInlineSnapshot(`${interpolated}`));",
 				Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/plugins/rstest/rules/valid_title/valid_title.go
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.go
@@ -423,6 +423,7 @@ var ValidTitleRule = rule.Rule{
 			}
 			return rule.RuleListeners{}
 		}
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
@@ -432,7 +433,7 @@ var ValidTitleRule = rule.Rule{
 				// The two older rules in this plugin use the narrow
 				// ParseRstestFnCall, which is a historical choice rather than a
 				// contract.
-				parsed := rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx)
+				parsed := analysis.ParseFnCall(node)
 				if parsed == nil {
 					return
 				}

--- a/internal/plugins/rstest/utils/call_analysis.go
+++ b/internal/plugins/rstest/utils/call_analysis.go
@@ -1,0 +1,395 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type RstestCallAnalysis struct {
+	ctx         rule.RuleContext
+	candidates  map[string]rstestCandidateKind
+	fnCalls     map[*ast.Node]*ParsedRstestFnCall
+	expectCalls map[*ast.Node]*ParsedRstestExpectCall
+	isExpect    map[*ast.Node]bool
+	expectRoots map[*ast.Symbol]rstestExpectRootKind
+	calls       []*ast.Node
+	functions   map[string]*ast.Node
+	callbacks   RstestTestCallbacks
+	callbacksOK bool
+	hasTests    bool
+}
+
+// NewRstestCallAnalysis creates one file-scoped owner for Rstest call
+// candidates and semantic parse caches.
+func NewRstestCallAnalysis(ctx rule.RuleContext) *RstestCallAnalysis {
+	analysis := &RstestCallAnalysis{
+		ctx:         ctx,
+		candidates:  cloneRstestCandidateSeeds(),
+		fnCalls:     map[*ast.Node]*ParsedRstestFnCall{},
+		expectCalls: map[*ast.Node]*ParsedRstestExpectCall{},
+		isExpect:    map[*ast.Node]bool{},
+		expectRoots: map[*ast.Symbol]rstestExpectRootKind{},
+		functions:   map[string]*ast.Node{},
+	}
+	analysis.indexSourceFile()
+	return analysis
+}
+
+// ParseFnCall parses any Rstest registration, reusing a cached result and
+// computing misses instead of depending on a previous collector traversal.
+func (analysis *RstestCallAnalysis) ParseFnCall(node *ast.Node) *ParsedRstestFnCall {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return nil
+	}
+	if !analysis.isFnCallCandidate(node) {
+		return nil
+	}
+	return analysis.parseFnCallCandidate(node)
+}
+
+func (analysis *RstestCallAnalysis) parseFnCallCandidate(
+	node *ast.Node,
+) *ParsedRstestFnCall {
+	if parsed, ok := analysis.fnCalls[node]; ok {
+		return parsed
+	}
+	parsed := ParseRstestFnCallWithOfficialExtensions(node, analysis.ctx)
+	analysis.fnCalls[node] = parsed
+	return parsed
+}
+
+// ParseTestCall is the test-only fast path used by callback collectors.
+func (analysis *RstestCallAnalysis) ParseTestCall(node *ast.Node) *ParsedRstestFnCall {
+	if !analysis.isTestCandidate(node) {
+		return nil
+	}
+	parsed := analysis.parseFnCallCandidate(node)
+	if parsed == nil || parsed.Kind != RstestFnTypeTest {
+		return nil
+	}
+	return parsed
+}
+
+func (analysis *RstestCallAnalysis) IsExpectCall(node *ast.Node) bool {
+	// Test-context expect names are discovered while collecting callbacks, so
+	// callbacks must be complete before the candidate gate runs. Reordering
+	// these calls would silently reject ctx.expect and destructured aliases.
+	analysis.Callbacks()
+	if !analysis.isExpectCandidate(node) {
+		return false
+	}
+	if result, ok := analysis.isExpect[node]; ok {
+		return result
+	}
+	result := isRstestExpectCall(node, analysis)
+	analysis.isExpect[node] = result
+	return result
+}
+
+// ParseExpectCall keeps a separate full-parse cache from the cheap identity
+// cache used by IsExpectCall. The full parse resolves matcher and modifier
+// chains; the identity path deliberately avoids those allocations.
+func (analysis *RstestCallAnalysis) ParseExpectCall(
+	node *ast.Node,
+) *ParsedRstestExpectCall {
+	// See IsExpectCall: callback collection widens the expect candidate set.
+	analysis.Callbacks()
+	if !analysis.isExpectCandidate(node) {
+		return nil
+	}
+	if parsed, ok := analysis.expectCalls[node]; ok {
+		return parsed
+	}
+	parsed := parseRstestExpectCall(node, analysis)
+	analysis.expectCalls[node] = parsed
+	analysis.isExpect[node] = parsed != nil
+	return parsed
+}
+
+func (analysis *RstestCallAnalysis) Callbacks() RstestTestCallbacks {
+	return *analysis.callbacksRef()
+}
+
+func (analysis *RstestCallAnalysis) callbacksRef() *RstestTestCallbacks {
+	if !analysis.callbacksOK {
+		if analysis.hasTests {
+			analysis.callbacks = collectRstestTestCallbacks(analysis)
+		} else {
+			analysis.callbacks = newRstestTestCallbacks()
+		}
+		analysis.callbacksOK = true
+	}
+	return &analysis.callbacks
+}
+
+// isFnCallCandidate reports whether syntax and local aliases permit any Rstest
+// registration kind at node.
+func (analysis *RstestCallAnalysis) isFnCallCandidate(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	return root == nil ||
+		root.Kind != ast.KindIdentifier ||
+		analysis.candidates[root.AsIdentifier().Text]&rstestCandidateFn != 0
+}
+
+// isTestCandidate reports whether syntax and local aliases permit a Rstest test
+// registration at node.
+func (analysis *RstestCallAnalysis) isTestCandidate(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	return root == nil ||
+		root.Kind != ast.KindIdentifier ||
+		analysis.candidates[root.AsIdentifier().Text]&rstestCandidateTest != 0
+}
+
+// isExpectCandidate reports whether syntax and local aliases permit a Rstest
+// expect root at node.
+func (analysis *RstestCallAnalysis) isExpectCandidate(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	return root == nil ||
+		root.Kind != ast.KindIdentifier ||
+		analysis.candidates[root.AsIdentifier().Text]&rstestCandidateExpect != 0
+}
+
+func (analysis *RstestCallAnalysis) addExpectRootName(name string) {
+	if name != "" {
+		analysis.candidates[name] |= rstestCandidateExpect
+	}
+}
+
+type rstestAliasCandidate struct {
+	localName string
+	rootName  string
+}
+
+type rstestCandidateKind uint8
+
+const (
+	rstestCandidateFn rstestCandidateKind = 1 << iota
+	rstestCandidateTest
+	rstestCandidateExpect
+)
+
+const rstestCandidateAll = rstestCandidateFn | rstestCandidateTest | rstestCandidateExpect
+
+func cloneRstestCandidateSeeds() map[string]rstestCandidateKind {
+	candidates := make(
+		map[string]rstestCandidateKind,
+		len(rstestDirectAPIStates)+1,
+	)
+	for name, states := range rstestDirectAPIStates {
+		kind := rstestCandidateFn
+		for _, state := range states {
+			switch state {
+			case rstestAPITest, rstestAPITestWithExtend, rstestAPIParameterizedTest:
+				kind |= rstestCandidateTest
+			}
+		}
+		candidates[name] = kind
+	}
+	candidates["expect"] = rstestCandidateExpect
+	return candidates
+}
+
+func (analysis *RstestCallAnalysis) indexSourceFile() {
+	if analysis.ctx.SourceFile == nil {
+		return
+	}
+	aliases := make([]rstestAliasCandidate, 0)
+	var visit func(*ast.Node)
+	visit = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		switch node.Kind {
+		case ast.KindImportDeclaration:
+			analysis.collectImportCandidates(node.AsImportDeclaration())
+		case ast.KindVariableDeclaration:
+			analysis.collectVariableCandidates(node, &aliases)
+			analysis.recordFunction(node)
+		case ast.KindFunctionDeclaration:
+			analysis.recordFunction(node)
+		case ast.KindCallExpression:
+			analysis.calls = append(analysis.calls, node)
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return false
+		})
+	}
+	visit(analysis.ctx.SourceFile.Node.AsNode())
+
+	for changed := true; changed; {
+		changed = false
+		for _, alias := range aliases {
+			kind := analysis.candidates[alias.localName] |
+				analysis.candidates[alias.rootName]
+			if kind != analysis.candidates[alias.localName] {
+				analysis.candidates[alias.localName] = kind
+				changed = true
+			}
+		}
+	}
+	for _, call := range analysis.calls {
+		if analysis.isTestCandidate(call) {
+			analysis.hasTests = true
+			break
+		}
+	}
+}
+
+func (analysis *RstestCallAnalysis) collectImportCandidates(
+	declaration *ast.ImportDeclaration,
+) {
+	if declaration == nil ||
+		declaration.ModuleSpecifier == nil ||
+		!isRstestImportModule(declaration.ModuleSpecifier.Text()) ||
+		declaration.ImportClause == nil ||
+		declaration.ImportClause.IsTypeOnly() {
+		return
+	}
+	clause := declaration.ImportClause.AsImportClause()
+	if clause == nil || clause.NamedBindings == nil {
+		return
+	}
+	switch clause.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		namespace := clause.NamedBindings.AsNamespaceImport()
+		if namespace != nil && namespace.Name() != nil {
+			analysis.candidates[namespace.Name().Text()] |= rstestCandidateAll
+		}
+	case ast.KindNamedImports:
+		named := clause.NamedBindings.AsNamedImports()
+		if named == nil || named.Elements == nil {
+			return
+		}
+		for _, element := range named.Elements.Nodes {
+			specifier := element.AsImportSpecifier()
+			if specifier == nil || specifier.IsTypeOnly || specifier.Name() == nil {
+				continue
+			}
+			importedName := specifier.Name().Text()
+			if specifier.PropertyName != nil {
+				importedName = specifier.PropertyName.Text()
+			}
+			analysis.candidates[specifier.Name().Text()] |=
+				rstestImportedCandidateKind(importedName)
+		}
+	}
+}
+
+func (analysis *RstestCallAnalysis) collectVariableCandidates(
+	node *ast.Node,
+	aliases *[]rstestAliasCandidate,
+) {
+	if node == nil || node.Kind != ast.KindVariableDeclaration {
+		return
+	}
+	declaration := node.AsVariableDeclaration()
+	if declaration == nil || declaration.Name() == nil || declaration.Initializer == nil {
+		return
+	}
+	name := declaration.Name()
+	initializer := ast.SkipParentheses(declaration.Initializer)
+	if name.Kind == ast.KindObjectBindingPattern &&
+		(isRstestRequireCall(initializer) || isImportMetaRstest(initializer)) {
+		pattern := name.AsBindingPattern()
+		if pattern == nil || pattern.Elements == nil {
+			return
+		}
+		for _, element := range pattern.Elements.Nodes {
+			binding := element.AsBindingElement()
+			if binding == nil || binding.Name() == nil || binding.Name().Kind != ast.KindIdentifier {
+				continue
+			}
+			importedName := binding.Name().Text()
+			if binding.PropertyName != nil {
+				importedName = binding.PropertyName.Text()
+			}
+			analysis.candidates[binding.Name().Text()] |=
+				rstestImportedCandidateKind(importedName)
+		}
+		return
+	}
+	if name.Kind != ast.KindIdentifier || node.Parent == nil ||
+		node.Parent.Kind != ast.KindVariableDeclarationList ||
+		node.Parent.Flags&ast.NodeFlagsConst == 0 {
+		return
+	}
+	localName := name.AsIdentifier().Text
+	if isRstestRequireCall(initializer) || isImportMetaRstest(initializer) {
+		analysis.candidates[localName] |= rstestCandidateAll
+		return
+	}
+	root := testFramework.ResolveFirstIdentifier(initializer)
+	if root != nil && root.Kind == ast.KindIdentifier {
+		*aliases = append(*aliases, rstestAliasCandidate{
+			localName: localName,
+			rootName:  root.AsIdentifier().Text,
+		})
+	}
+}
+
+func (analysis *RstestCallAnalysis) recordFunction(node *ast.Node) {
+	name := ""
+	var function *ast.Node
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		declaration := node.AsFunctionDeclaration()
+		if declaration != nil && declaration.Name() != nil {
+			name = declaration.Name().Text()
+			function = node
+		}
+	case ast.KindVariableDeclaration:
+		declaration := node.AsVariableDeclaration()
+		if declaration != nil &&
+			declaration.Name() != nil &&
+			declaration.Name().Kind == ast.KindIdentifier &&
+			declaration.Initializer != nil {
+			initializer := ast.SkipParentheses(declaration.Initializer)
+			if ast.IsFunctionExpressionOrArrowFunction(initializer) {
+				name = declaration.Name().AsIdentifier().Text
+				function = initializer
+			}
+		}
+	}
+	if function != nil && analysis.functions[name] == nil {
+		analysis.functions[name] = function
+	}
+}
+
+func isRstestRequireCall(node *ast.Node) bool {
+	return testFramework.IsModuleRequireCall(node, RstestImportModule) ||
+		testFramework.IsModuleRequireCall(node, RstestPlaywrightImportModule)
+}
+
+func isRstestImportModule(name string) bool {
+	return name == RstestImportModule || name == RstestPlaywrightImportModule
+}
+
+func isRstestRegistrationName(name string) bool {
+	return directRstestAPIState(rstestProfileCore, name) != rstestAPIInvalid ||
+		directRstestAPIState(rstestProfilePlaywright, name) != rstestAPIInvalid
+}
+
+func rstestImportedCandidateKind(name string) rstestCandidateKind {
+	kind := rstestCandidateKind(0)
+	if isRstestRegistrationName(name) {
+		kind |= rstestCandidateFn
+	}
+	if name == "test" || name == "it" {
+		kind |= rstestCandidateTest
+	}
+	if name == "expect" {
+		kind |= rstestCandidateExpect
+	}
+	return kind
+}

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -4,7 +4,6 @@ import (
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/web-infra-dev/rslint/internal/rule"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
@@ -78,7 +77,7 @@ type ParsedRstestExpectMatcher struct {
 
 // ParsedRstestExpectCall describes one Rstest expect call.
 //
-// Contract: ParseRstestExpectCall returns nil if and only if the node is not a
+// Contract: RstestCallAnalysis.ParseExpectCall returns nil if and only if the node is not a
 // Rstest expect call (which includes calls in the middle of a larger chain);
 // once a node is recognized as an expect call the parse always succeeds and
 // broken chains are reported through Reason instead of a nil result. This
@@ -129,10 +128,9 @@ type ParsedRstestExpectCall struct {
 	trailingMembers int
 }
 
-func IsRstestExpectCall(
+func isRstestExpectCall(
 	node *ast.Node,
-	ctx rule.RuleContext,
-	callbacks RstestTestCallbacks,
+	analysis *RstestCallAnalysis,
 ) bool {
 	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
 		return false
@@ -144,7 +142,12 @@ func IsRstestExpectCall(
 	if entries.count == 0 || entries.first == nil || entries.first.Kind != ast.KindIdentifier {
 		return false
 	}
-	_, ok := rstestExpectRootIndex(entries.first, entries.secondName, entries.count > 1, ctx, callbacks)
+	_, ok := rstestExpectRootIndex(
+		entries.first,
+		entries.secondName,
+		entries.count > 1,
+		analysis,
+	)
 	return ok
 }
 
@@ -221,20 +224,16 @@ func firstRstestExpectEntries(node *ast.Node) rstestExpectEntries {
 	}
 }
 
-// ParseRstestExpectCall parses node as a Rstest expect call, resolving the
-// entry kind, the modifier chain and the matcher. See ParsedRstestExpectCall
-// for the nil contract.
-func ParseRstestExpectCall(
+func parseRstestExpectCall(
 	node *ast.Node,
-	ctx rule.RuleContext,
-	callbacks RstestTestCallbacks,
+	analysis *RstestCallAnalysis,
 ) *ParsedRstestExpectCall {
 	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
 		return nil
 	}
 	expression := findTopMostRstestExpectExpression(node)
 	entries := testFramework.GetMemberEntries(expression)
-	expectIndex, ok := rstestExpectMemberIndex(node, entries, ctx, callbacks)
+	expectIndex, ok := rstestExpectMemberIndex(node, entries, analysis)
 	if !ok {
 		return nil
 	}
@@ -341,8 +340,7 @@ func findTopMostRstestExpectExpression(node *ast.Node) *ast.Node {
 func rstestExpectMemberIndex(
 	node *ast.Node,
 	entries []testFramework.MemberEntry,
-	ctx rule.RuleContext,
-	callbacks RstestTestCallbacks,
+	analysis *RstestCallAnalysis,
 ) (int, bool) {
 	if isImportMetaRstestExpectCall(node) {
 		// GetMemberEntries cannot represent the import.meta prefix and starts
@@ -360,20 +358,25 @@ func rstestExpectMemberIndex(
 	if len(entries) > 1 {
 		secondName = entries[1].Name
 	}
-	return rstestExpectRootIndex(entries[0].Node, secondName, len(entries) > 1, ctx, callbacks)
+	return rstestExpectRootIndex(
+		entries[0].Node,
+		secondName,
+		len(entries) > 1,
+		analysis,
+	)
 }
 
 func rstestExpectRootIndex(
 	root *ast.Node,
 	secondName string,
 	hasSecond bool,
-	ctx rule.RuleContext,
-	callbacks RstestTestCallbacks,
+	analysis *RstestCallAnalysis,
 ) (int, bool) {
 	if root == nil || root.Kind != ast.KindIdentifier {
 		return 0, false
 	}
 	localName := root.AsIdentifier().Text
+	ctx := analysis.ctx
 	if ctx.TypeChecker == nil {
 		return 0, localName == "expect"
 	}
@@ -381,12 +384,15 @@ func rstestExpectRootIndex(
 	if symbol == nil {
 		return 0, localName == "expect"
 	}
-	kind, ok := callbacks.expectRoots[symbol]
+	kind, ok := analysis.expectRoots[symbol]
 	if !ok {
-		kind = classifyRstestExpectRoot(localName, root, symbol, ctx, callbacks)
-		if callbacks.expectRoots != nil {
-			callbacks.expectRoots[symbol] = kind
-		}
+		kind = classifyRstestExpectRoot(
+			localName,
+			root,
+			symbol,
+			analysis,
+		)
+		analysis.expectRoots[symbol] = kind
 	}
 	switch kind {
 	case rstestExpectRootDirect:
@@ -694,9 +700,10 @@ func classifyRstestExpectRoot(
 	localName string,
 	root *ast.Node,
 	symbol *ast.Symbol,
-	ctx rule.RuleContext,
-	callbacks RstestTestCallbacks,
+	analysis *RstestCallAnalysis,
 ) rstestExpectRootKind {
+	callbacks := analysis.callbacksRef()
+	ctx := analysis.ctx
 	if callbacks.ContextExpectNames[symbol] {
 		return rstestExpectRootDirect
 	}

--- a/internal/plugins/rstest/utils/parse_rstest_expect_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect_test.go
@@ -77,10 +77,10 @@ var expectParseProbe = rule.Rule{
 	Name:             "rstest/expect-parse-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
-		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				parsed := analysis.ParseExpectCall(node)
 				if parsed == nil {
 					return
 				}
@@ -94,10 +94,10 @@ var expectChainParseProbe = rule.Rule{
 	Name:             "rstest/expect-chain-parse-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
-		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				parsed := analysis.ParseExpectCall(node)
 				if parsed == nil {
 					return
 				}
@@ -117,10 +117,10 @@ func parsedExpectError(message string) []rule_tester.InvalidTestCaseError {
 var expectEntryInvariantProbe = rule.Rule{
 	Name: "rstest/probe-expect-entry-invariant",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				parsed := analysis.ParseExpectCall(node)
 				if parsed == nil {
 					return
 				}
@@ -750,10 +750,10 @@ var expectAwaitProbe = rule.Rule{
 	Name:             "rstest/expect-await-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
-		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestExpectCall(node, ctx, callbacks)
+				parsed := analysis.ParseExpectCall(node)
 				if parsed == nil {
 					return
 				}
@@ -770,10 +770,10 @@ var expectIdentityProbe = rule.Rule{
 	Name:             "rstest/expect-identity-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
-		callbacks := rstestUtils.CollectRstestTestCallbacks(ctx)
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				if rstestUtils.IsRstestExpectCall(node, ctx, callbacks) {
+				if analysis.IsExpectCall(node) {
 					ctx.ReportNode(node, probeMessage("expectCall", "expect=true"))
 				}
 			},

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -512,25 +512,40 @@ func isConstRstestVariableDeclaration(declaration *ast.Node) bool {
 }
 
 func directRstestAPIState(profile rstestAPIProfile, name string) rstestAPIState {
-	switch name {
-	case "test", "it":
-		if profile == rstestProfilePlaywright && name == "it" {
-			return rstestAPIInvalid
-		}
-		return rstestAPITestWithExtend
-	case "describe":
-		return rstestAPIDescribe
-	default:
-		// Both profiles expose the same four hooks: @rstest/playwright
-		// re-exports them (packages/playwright/src/index.ts:2-9). Hooks accept
-		// no chained members, which holds by construction: applyRstestChainPart
-		// has no rstestAPIHook branch, so any member invalidates the chain.
-		if testFramework.IsHookName(name) {
-			return rstestAPIHook
-		}
+	states, ok := rstestDirectAPIStates[name]
+	if !ok {
 		return rstestAPIInvalid
 	}
+	return states[profile]
 }
+
+var rstestDirectAPIStates = func() map[string][2]rstestAPIState {
+	states := map[string][2]rstestAPIState{
+		"test": {
+			rstestProfileCore:       rstestAPITestWithExtend,
+			rstestProfilePlaywright: rstestAPITestWithExtend,
+		},
+		"it": {
+			rstestProfileCore:       rstestAPITestWithExtend,
+			rstestProfilePlaywright: rstestAPIInvalid,
+		},
+		"describe": {
+			rstestProfileCore:       rstestAPIDescribe,
+			rstestProfilePlaywright: rstestAPIDescribe,
+		},
+	}
+	// Both profiles expose the same four hooks: @rstest/playwright re-exports
+	// them (packages/playwright/src/index.ts:2-9). Hooks accept no chained
+	// members, which holds by construction: applyRstestChainPart has no
+	// rstestAPIHook branch, so any member invalidates the chain.
+	for _, name := range testFramework.HooksOrder {
+		states[name] = [2]rstestAPIState{
+			rstestProfileCore:       rstestAPIHook,
+			rstestProfilePlaywright: rstestAPIHook,
+		}
+	}
+	return states
+}()
 
 func applyRstestChainPart(profile rstestAPIProfile, state rstestAPIState, part rstestChainPart) rstestAPIState {
 	switch state {

--- a/internal/plugins/rstest/utils/test_callback.go
+++ b/internal/plugins/rstest/utils/test_callback.go
@@ -4,16 +4,12 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
-	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
 type RstestTestCallbacks struct {
 	Functions          map[*ast.Node]bool
-	TestCalls          map[*ast.Node]bool
 	ContextReceivers   map[*ast.Symbol]bool
 	ContextExpectNames map[*ast.Symbol]bool
-	ExpectRootNames    map[string]bool
-	expectRoots        map[*ast.Symbol]rstestExpectRootKind
 }
 
 type rstestCallbackInfo struct {
@@ -21,236 +17,41 @@ type rstestCallbackInfo struct {
 	name         string
 }
 
-func CollectRstestTestCallbacks(ctx rule.RuleContext) RstestTestCallbacks {
-	candidateNames := collectRstestCallCandidateNames(ctx.SourceFile)
-	result := RstestTestCallbacks{
+func newRstestTestCallbacks() RstestTestCallbacks {
+	return RstestTestCallbacks{
 		Functions:          map[*ast.Node]bool{},
-		TestCalls:          map[*ast.Node]bool{},
 		ContextReceivers:   map[*ast.Symbol]bool{},
 		ContextExpectNames: map[*ast.Symbol]bool{},
-		ExpectRootNames:    candidateNames.expect,
-		expectRoots:        map[*ast.Symbol]rstestExpectRootKind{},
 	}
+}
+
+func collectRstestTestCallbacks(analysis *RstestCallAnalysis) RstestTestCallbacks {
+	ctx := analysis.ctx
+	result := newRstestTestCallbacks()
 	pending := map[string][]*ParsedRstestFnCall{}
 
-	var visit func(*ast.Node)
-	visit = func(node *ast.Node) {
-		if node == nil {
-			return
-		}
-		if node.Kind == ast.KindCallExpression {
-			root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
-			if root == nil || candidateNames.test[root.AsIdentifier().Text] {
-				parsed := ParseRstestFnCallWithOfficialExtensions(node, ctx)
-				if parsed != nil && parsed.Kind == RstestFnTypeTest {
-					result.TestCalls[node] = true
-					info := resolveRstestTestCallback(ctx, node.AsCallExpression())
-					if info.functionNode != nil {
-						recordRstestCallback(ctx, &result, info.functionNode, parsed)
-					} else if info.name != "" {
-						pending[info.name] = append(pending[info.name], parsed)
-					}
-				}
+	for _, node := range analysis.calls {
+		parsed := analysis.ParseTestCall(node)
+		if parsed != nil {
+			info := resolveRstestTestCallback(ctx, node.AsCallExpression())
+			if info.functionNode != nil {
+				recordRstestCallback(analysis, &result, info.functionNode, parsed)
+			} else if info.name != "" {
+				pending[info.name] = append(pending[info.name], parsed)
 			}
 		}
-		node.ForEachChild(func(child *ast.Node) bool {
-			visit(child)
-			return false
-		})
 	}
 
-	if ctx.SourceFile != nil {
-		visit(ctx.SourceFile.Node.AsNode())
-	}
-	if len(pending) > 0 {
-		resolvePendingRstestCallbacks(ctx, &result, pending)
+	for name, parsedCalls := range pending {
+		function := analysis.functions[name]
+		if function == nil {
+			continue
+		}
+		for _, parsed := range parsedCalls {
+			recordRstestCallback(analysis, &result, function, parsed)
+		}
 	}
 	return result
-}
-
-func (callbacks RstestTestCallbacks) IsExpectCandidate(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindCallExpression {
-		return false
-	}
-	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
-	return root == nil ||
-		root.Kind != ast.KindIdentifier ||
-		callbacks.ExpectRootNames[root.AsIdentifier().Text]
-}
-
-type rstestAliasCandidate struct {
-	localName string
-	rootName  string
-}
-
-type rstestCallCandidateNames struct {
-	test   map[string]bool
-	expect map[string]bool
-}
-
-func collectRstestCallCandidateNames(sourceFile *ast.SourceFile) rstestCallCandidateNames {
-	candidates := rstestCallCandidateNames{
-		test: map[string]bool{
-			"test": true,
-			"it":   true,
-		},
-		expect: map[string]bool{
-			"expect": true,
-		},
-	}
-	if sourceFile == nil {
-		return candidates
-	}
-
-	aliases := make([]rstestAliasCandidate, 0)
-	var visit func(*ast.Node)
-	visit = func(node *ast.Node) {
-		if node == nil {
-			return
-		}
-		switch node.Kind {
-		case ast.KindImportDeclaration:
-			collectRstestImportCandidates(node.AsImportDeclaration(), candidates)
-		case ast.KindVariableDeclaration:
-			collectRstestVariableCandidates(node, candidates, &aliases)
-		}
-		node.ForEachChild(func(child *ast.Node) bool {
-			visit(child)
-			return false
-		})
-	}
-	visit(sourceFile.Node.AsNode())
-
-	for changed := true; changed; {
-		changed = false
-		for _, alias := range aliases {
-			if !candidates.test[alias.localName] && candidates.test[alias.rootName] {
-				candidates.test[alias.localName] = true
-				changed = true
-			}
-			if !candidates.expect[alias.localName] && candidates.expect[alias.rootName] {
-				candidates.expect[alias.localName] = true
-				changed = true
-			}
-		}
-	}
-	return candidates
-}
-
-func collectRstestImportCandidates(
-	declaration *ast.ImportDeclaration,
-	candidates rstestCallCandidateNames,
-) {
-	if declaration == nil ||
-		declaration.ModuleSpecifier == nil ||
-		!isRstestImportModule(declaration.ModuleSpecifier.Text()) ||
-		declaration.ImportClause == nil ||
-		declaration.ImportClause.IsTypeOnly() {
-		return
-	}
-	clause := declaration.ImportClause.AsImportClause()
-	if clause == nil || clause.NamedBindings == nil {
-		return
-	}
-	switch clause.NamedBindings.Kind {
-	case ast.KindNamespaceImport:
-		namespace := clause.NamedBindings.AsNamespaceImport()
-		if namespace != nil && namespace.Name() != nil {
-			localName := namespace.Name().Text()
-			candidates.test[localName] = true
-			candidates.expect[localName] = true
-		}
-	case ast.KindNamedImports:
-		named := clause.NamedBindings.AsNamedImports()
-		if named == nil || named.Elements == nil {
-			return
-		}
-		for _, element := range named.Elements.Nodes {
-			specifier := element.AsImportSpecifier()
-			if specifier == nil || specifier.IsTypeOnly || specifier.Name() == nil {
-				continue
-			}
-			importedName := specifier.Name().Text()
-			if specifier.PropertyName != nil {
-				importedName = specifier.PropertyName.Text()
-			}
-			localName := specifier.Name().Text()
-			switch importedName {
-			case "test", "it":
-				candidates.test[localName] = true
-			case "expect":
-				candidates.expect[localName] = true
-			}
-		}
-	}
-}
-
-func collectRstestVariableCandidates(
-	node *ast.Node,
-	candidates rstestCallCandidateNames,
-	aliases *[]rstestAliasCandidate,
-) {
-	if node == nil || node.Kind != ast.KindVariableDeclaration {
-		return
-	}
-	declaration := node.AsVariableDeclaration()
-	if declaration == nil || declaration.Name() == nil || declaration.Initializer == nil {
-		return
-	}
-	name := declaration.Name()
-	initializer := ast.SkipParentheses(declaration.Initializer)
-	if name.Kind == ast.KindObjectBindingPattern &&
-		(isRstestRequireCall(initializer) || isImportMetaRstest(initializer)) {
-		pattern := name.AsBindingPattern()
-		if pattern == nil || pattern.Elements == nil {
-			return
-		}
-		for _, element := range pattern.Elements.Nodes {
-			binding := element.AsBindingElement()
-			if binding == nil || binding.Name() == nil || binding.Name().Kind != ast.KindIdentifier {
-				continue
-			}
-			importedName := binding.Name().Text()
-			if binding.PropertyName != nil {
-				importedName = binding.PropertyName.Text()
-			}
-			localName := binding.Name().Text()
-			switch importedName {
-			case "test", "it":
-				candidates.test[localName] = true
-			case "expect":
-				candidates.expect[localName] = true
-			}
-		}
-		return
-	}
-	if name.Kind != ast.KindIdentifier || node.Parent == nil ||
-		node.Parent.Kind != ast.KindVariableDeclarationList ||
-		node.Parent.Flags&ast.NodeFlagsConst == 0 {
-		return
-	}
-	localName := name.AsIdentifier().Text
-	if isRstestRequireCall(initializer) || isImportMetaRstest(initializer) {
-		candidates.test[localName] = true
-		candidates.expect[localName] = true
-		return
-	}
-	root := testFramework.ResolveFirstIdentifier(initializer)
-	if root != nil && root.Kind == ast.KindIdentifier {
-		*aliases = append(*aliases, rstestAliasCandidate{
-			localName: localName,
-			rootName:  root.AsIdentifier().Text,
-		})
-	}
-}
-
-func isRstestRequireCall(node *ast.Node) bool {
-	return testFramework.IsModuleRequireCall(node, RstestImportModule) ||
-		testFramework.IsModuleRequireCall(node, RstestPlaywrightImportModule)
-}
-
-func isRstestImportModule(name string) bool {
-	return name == RstestImportModule || name == RstestPlaywrightImportModule
 }
 
 func resolveRstestTestCallback(
@@ -318,63 +119,13 @@ func resolveRstestCallbackArgument(ctx rule.RuleContext, argument *ast.Node) rst
 	return rstestCallbackInfo{}
 }
 
-func resolvePendingRstestCallbacks(
-	ctx rule.RuleContext,
-	result *RstestTestCallbacks,
-	pending map[string][]*ParsedRstestFnCall,
-) {
-	var visit func(*ast.Node)
-	visit = func(node *ast.Node) {
-		if node == nil {
-			return
-		}
-
-		name := ""
-		var function *ast.Node
-		switch node.Kind {
-		case ast.KindFunctionDeclaration:
-			declaration := node.AsFunctionDeclaration()
-			if declaration != nil && declaration.Name() != nil {
-				name = declaration.Name().Text()
-				function = node
-			}
-		case ast.KindVariableDeclaration:
-			declaration := node.AsVariableDeclaration()
-			if declaration != nil && declaration.Name() != nil && declaration.Name().Kind == ast.KindIdentifier {
-				name = declaration.Name().AsIdentifier().Text
-				if declaration.Initializer != nil {
-					initializer := ast.SkipParentheses(declaration.Initializer)
-					if ast.IsFunctionExpressionOrArrowFunction(initializer) {
-						function = initializer
-					}
-				}
-			}
-		}
-
-		if function != nil {
-			for _, parsed := range pending[name] {
-				recordRstestCallback(ctx, result, function, parsed)
-			}
-			delete(pending, name)
-		}
-
-		node.ForEachChild(func(child *ast.Node) bool {
-			visit(child)
-			return false
-		})
-	}
-
-	if ctx.SourceFile != nil {
-		visit(ctx.SourceFile.Node.AsNode())
-	}
-}
-
 func recordRstestCallback(
-	ctx rule.RuleContext,
+	analysis *RstestCallAnalysis,
 	result *RstestTestCallbacks,
 	function *ast.Node,
 	parsed *ParsedRstestFnCall,
 ) {
+	ctx := analysis.ctx
 	if function == nil {
 		return
 	}
@@ -393,13 +144,16 @@ func recordRstestCallback(
 		return
 	}
 	parameter := parameters[contextIndex].AsParameterDeclaration()
-	if parameter == nil || parameter.Name() == nil || ctx.TypeChecker == nil {
+	if parameter == nil || parameter.Name() == nil {
 		return
 	}
 	name := parameter.Name()
 	switch name.Kind {
 	case ast.KindIdentifier:
-		result.ExpectRootNames[name.AsIdentifier().Text] = true
+		analysis.addExpectRootName(name.AsIdentifier().Text)
+		if ctx.TypeChecker == nil {
+			return
+		}
 		if symbol := ctx.TypeChecker.GetSymbolAtLocation(name); symbol != nil {
 			result.ContextReceivers[symbol] = true
 		}
@@ -427,7 +181,10 @@ func recordRstestCallback(
 			if propertyName != "expect" {
 				continue
 			}
-			result.ExpectRootNames[binding.Name().AsIdentifier().Text] = true
+			analysis.addExpectRootName(binding.Name().AsIdentifier().Text)
+			if ctx.TypeChecker == nil {
+				continue
+			}
 			if symbol := ctx.TypeChecker.GetSymbolAtLocation(binding.Name()); symbol != nil {
 				result.ContextExpectNames[symbol] = true
 			}

--- a/internal/plugins/rstest/utils/test_callback_candidate_test.go
+++ b/internal/plugins/rstest/utils/test_callback_candidate_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
-func TestCollectRstestCallCandidateNames(t *testing.T) {
+func TestRstestCallAnalysisCandidateNames(t *testing.T) {
 	sourceFile := parser.ParseSourceFile(
 		ast.SourceFileParseOptions{
 			FileName: "/candidate.test.ts",
@@ -21,15 +23,192 @@ const expectAlias = importedExpect;
 const check = expectAlias;`,
 		core.ScriptKindTS,
 	)
-	candidates := collectRstestCallCandidateNames(sourceFile)
+	analysis := NewRstestCallAnalysis(rule.RuleContext{SourceFile: sourceFile})
 	for _, name := range []string{"importedTest", "testAlias", "testCase"} {
-		if !candidates.test[name] {
+		if analysis.candidates[name]&rstestCandidateFn == 0 {
+			t.Errorf("registration candidate %q was not propagated", name)
+		}
+		if analysis.candidates[name]&rstestCandidateTest == 0 {
 			t.Errorf("test candidate %q was not propagated", name)
 		}
 	}
 	for _, name := range []string{"importedExpect", "expectAlias", "check"} {
-		if !candidates.expect[name] {
+		if analysis.candidates[name]&rstestCandidateExpect == 0 {
 			t.Errorf("expect candidate %q was not propagated", name)
+		}
+	}
+}
+
+func TestRstestCallAnalysisParseFnCallComputesCacheMiss(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(
+		ast.SourceFileParseOptions{
+			FileName: "/callbacks.test.ts",
+			Path:     "/callbacks.test.ts",
+		},
+		`test("late", () => {});
+describe("late suite", () => {});
+beforeEach(() => {});`,
+		core.ScriptKindTS,
+	)
+	analysis := NewRstestCallAnalysis(rule.RuleContext{SourceFile: sourceFile})
+	lateCalls := make([]*ast.Node, 0, 3)
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression {
+			lateCalls = append(lateCalls, node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.Node.ForEachChild(visit)
+	if len(lateCalls) != 3 {
+		t.Fatalf("found %d late calls, want 3", len(lateCalls))
+	}
+	if len(analysis.fnCalls) != 0 {
+		t.Fatalf("analysis eagerly parsed %d calls, want 0", len(analysis.fnCalls))
+	}
+
+	wantKinds := []RstestFnType{
+		RstestFnTypeTest,
+		RstestFnTypeDescribe,
+		RstestFnTypeHook,
+	}
+	for index, lateCall := range lateCalls {
+		parsed := analysis.ParseFnCall(lateCall)
+		if parsed == nil || parsed.Kind != wantKinds[index] {
+			t.Fatalf("cache miss %d parsed as %#v, want %q", index, parsed, wantKinds[index])
+		}
+		if cached := analysis.ParseFnCall(lateCall); cached != parsed {
+			t.Fatalf("second parse %d did not reuse the cached result", index)
+		}
+	}
+}
+
+func TestRstestCallAnalysisCallbacksWidenExpectCandidates(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(
+		ast.SourceFileParseOptions{
+			FileName: "/context.test.ts",
+			Path:     "/context.test.ts",
+		},
+		`test("context", ({ expect: check }) => {
+  check(1).toBe(1);
+});`,
+		core.ScriptKindTS,
+	)
+	analysis := NewRstestCallAnalysis(rule.RuleContext{SourceFile: sourceFile})
+	var checkCall *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression {
+			root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+			if root != nil && root.Kind == ast.KindIdentifier &&
+				root.AsIdentifier().Text == "check" {
+				checkCall = node
+				return true
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.Node.ForEachChild(visit)
+	if checkCall == nil {
+		t.Fatal("context expect call not found")
+	}
+	if analysis.isExpectCandidate(checkCall) {
+		t.Fatal("context expect was a candidate before callbacks were collected")
+	}
+	analysis.Callbacks()
+	if !analysis.isExpectCandidate(checkCall) {
+		t.Fatal("callbacks did not add the context expect candidate")
+	}
+}
+
+func TestRstestCallAnalysisCallbacksSkipFilesWithoutTests(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(
+		ast.SourceFileParseOptions{
+			FileName: "/expect-only.test.ts",
+			Path:     "/expect-only.test.ts",
+		},
+		`expect(value).toBe(1); helper();`,
+		core.ScriptKindTS,
+	)
+	analysis := NewRstestCallAnalysis(rule.RuleContext{SourceFile: sourceFile})
+	if analysis.hasTests {
+		t.Fatal("expect-only file unexpectedly has a test candidate")
+	}
+	callbacks := analysis.Callbacks()
+	if len(analysis.fnCalls) != 0 {
+		t.Fatalf("callbacks parsed %d calls without a test candidate", len(analysis.fnCalls))
+	}
+	if len(callbacks.Functions) != 0 ||
+		len(callbacks.ContextReceivers) != 0 ||
+		len(callbacks.ContextExpectNames) != 0 {
+		t.Fatalf("callbacks = %#v, want empty maps", callbacks)
+	}
+}
+
+func TestRstestCallAnalysisParseExpectCallFillsIdentityCache(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(
+		ast.SourceFileParseOptions{
+			FileName: "/expect-cache.test.ts",
+			Path:     "/expect-cache.test.ts",
+		},
+		`expect(value).toBe(1);`,
+		core.ScriptKindTS,
+	)
+	analysis := NewRstestCallAnalysis(rule.RuleContext{SourceFile: sourceFile})
+	var expectCall *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression &&
+			FindTopMostCallExpression(node) == node {
+			expectCall = node
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.Node.ForEachChild(visit)
+	if expectCall == nil {
+		t.Fatal("expect call not found")
+	}
+	if parsed := analysis.ParseExpectCall(expectCall); parsed == nil {
+		t.Fatal("full expect parse returned nil")
+	}
+	if result, ok := analysis.isExpect[expectCall]; !ok || !result {
+		t.Fatalf("identity cache = (%t, %t), want (true, true)", result, ok)
+	}
+}
+
+func TestRstestCandidateSeedsMatchDirectRegistrationNames(t *testing.T) {
+	actual := cloneRstestCandidateSeeds()
+	if len(actual) != len(rstestDirectAPIStates)+1 {
+		t.Fatalf(
+			"seed count = %d, want %d",
+			len(actual),
+			len(rstestDirectAPIStates)+1,
+		)
+	}
+	for name, states := range rstestDirectAPIStates {
+		kind := actual[name]
+		if kind&rstestCandidateFn == 0 {
+			t.Errorf("registration %q is missing from seeds", name)
+		}
+		for profile, state := range states {
+			if directRstestAPIState(rstestAPIProfile(profile), name) != state {
+				t.Errorf(
+					"profile %d registration %q = %d, want %d",
+					profile,
+					name,
+					directRstestAPIState(rstestAPIProfile(profile), name),
+					state,
+				)
+			}
+		}
+	}
+	if actual["expect"] != rstestCandidateExpect {
+		t.Errorf("expect seed = %b, want %b", actual["expect"], rstestCandidateExpect)
+	}
+	for _, hook := range testFramework.HooksOrder {
+		if actual[hook]&rstestCandidateFn == 0 {
+			t.Errorf("hook %q is missing from registration seeds", hook)
 		}
 	}
 }

--- a/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/utils/test_framework/rules/no_conditional_expect/no_conditional_expect.go
@@ -24,7 +24,8 @@ import (
 
 type Runtime struct {
 	TestCallbackFunctions map[*ast.Node]bool
-	ClassifyCall          func(*ast.Node, bool) (isTest bool, isExpect bool)
+	IsTestCall            func(*ast.Node) bool
+	IsExpectCall          func(*ast.Node) bool
 	Skip                  bool
 }
 
@@ -177,13 +178,9 @@ func NewRule(config Config) rule.Rule {
 
 				ast.KindCallExpression: func(node *ast.Node) {
 					isTest := false
-					isExpect := false
 					isCatch := isPromiseCatchCall(node)
-					if runtime.ClassifyCall != nil {
-						checkExpect := isCatch ||
-							inPromiseCatch() ||
-							(inTestCase() && conditionalDepth > 0)
-						isTest, isExpect = runtime.ClassifyCall(node, checkExpect)
+					if runtime.IsTestCall != nil {
+						isTest = runtime.IsTestCall(node)
 					}
 					if isTest || isCatch {
 						if callExpressionFrames == nil {
@@ -201,7 +198,12 @@ func NewRule(config Config) rule.Rule {
 					if isCatch {
 						promiseCatchDepth++
 					}
-					if !isExpect {
+					checkExpect := isCatch ||
+						inPromiseCatch() ||
+						(inTestCase() && conditionalDepth > 0)
+					if !checkExpect ||
+						runtime.IsExpectCall == nil ||
+						!runtime.IsExpectCall(node) {
 						return
 					}
 					if inTestCase() && conditionalDepth > 0 {


### PR DESCRIPTION
## Summary

- Follow up on #1643 by centralizing Rstest call candidates, registration parsing, expect parsing, expect-root classification, and test-context callback discovery in a single file-scoped `RstestCallAnalysis`.
- Restore clear infrastructure boundaries: `RstestTestCallbacks` is pure callback/context data, expect candidate guards and caches stay inside the analysis object, registration seeds share the parser's direct-API source of truth, and callback discovery reuses one source-file index instead of performing additional full-tree walks.
- Optimize `rstest/no-interpolation-in-snapshots` with conservative source-level and call-shape fast paths. Files without `${` skip the rule entirely, and calls without an inline snapshot matcher plus an interpolated template argument skip full Rstest expect parsing.
- Preserve the existing parser-based source, matcher, Chai-chain, and overload analysis for every potential inline snapshot candidate.

## Performance

Measured with `--timing` over all `*.test.*`, `*.spec.*`, and configured in-source test files in six Rstack repositories. Each result is the median `rstest/no-interpolation-in-snapshots` rule time from 15 alternating baseline/candidate runs using the same latest-main baseline. The benchmark covers 1,913 files in total.

All 168 diagnostics were structurally identical before and after the optimization, including rule, file, range, and message.

| Repository | Test Files | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Rspack | 146 | 0.7ms | 0.1ms | 7.00× |
| Rsbuild | 613 | 18.6ms | 0.6ms | 31.00× |
| Rslib | 115 | 4.9ms | 0.2ms | 24.50× |
| Rspress | 134 | 7.8ms | 0.6ms | 13.00× |
| Rsdoctor | 82 | 2.1ms | 0.3ms | 7.00× |
| Rstest | 823 | 24.0ms | 1.6ms | 15.00× |
| **Combined** | **1,913** | **58.1ms** | **3.4ms** | **17.09×** |

A separate single-threaded benchmark that enables only `rstest/no-interpolation-in-snapshots` over the 823-file Rstest repository improves from `23.4ms` to `1.7ms`, a **13.76× speedup**.
