### PR TITLE
perf: optimize explicit function return type

### DIFF
--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
@@ -72,8 +72,9 @@ func parseOptions(rawOpts []any) options {
 }
 
 type functionInfo struct {
-	node    *ast.Node
-	returns []*ast.Node
+	needsReturnType      bool
+	hasReturn            bool
+	returnsOnlyFunctions bool
 }
 
 var ExplicitFunctionReturnTypeRule = rule.CreateRule(rule.Rule{
@@ -84,19 +85,26 @@ var ExplicitFunctionReturnTypeRule = rule.CreateRule(rule.Rule{
 
 func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 	opts := parseOptions(rawOptions)
-	functionStack := make([]*functionInfo, 0)
+	var functionStack []functionInfo
 
 	enterFunction := func(node *ast.Node) {
-		functionStack = append(functionStack, &functionInfo{node: node})
+		functionStack = append(functionStack, functionInfo{
+			needsReturnType: node.Body() != nil &&
+				node.Type() == nil &&
+				node.Kind != ast.KindConstructor &&
+				node.Kind != ast.KindSetAccessor,
+			returnsOnlyFunctions: true,
+		})
 	}
 
-	popFunctionInfo := func() *functionInfo {
+	popFunctionInfo := func() (functionInfo, bool) {
 		if len(functionStack) == 0 {
-			return nil
+			return functionInfo{}, false
 		}
-		info := functionStack[len(functionStack)-1]
-		functionStack = functionStack[:len(functionStack)-1]
-		return info
+		last := len(functionStack) - 1
+		info := functionStack[last]
+		functionStack = functionStack[:last]
+		return info, true
 	}
 
 	report := func(node *ast.Node) {
@@ -107,29 +115,14 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		})
 	}
 
-	// checkFunctionReturnType checks the common validity conditions:
-	// - allowHigherOrderFunctions + doesImmediatelyReturnFunctionExpression
-	// - has explicit return type
-	// - is constructor or setter
+	// checkFunctionReturnType checks whether the function needs a return type,
+	// including the allowHigherOrderFunctions exemption.
 	// Returns true if the function is valid (no error should be reported).
-	checkFunctionReturnType := func(info *functionInfo) bool {
-		node := info.node
-		// Skip bodyless functions: declare functions, abstract methods, overload signatures.
-		// ESLint models these as TSDeclareFunction / TSAbstractMethodDefinition which are
-		// separate node types not visited by the rule. In tsgo they share the same Kind.
-		if node.Body() == nil {
+	checkFunctionReturnType := func(node *ast.Node, info functionInfo) bool {
+		if !info.needsReturnType {
 			return true
 		}
-		if opts.allowHigherOrderFunctions && typescriptutil.DoesImmediatelyReturnFunctionExpression(node, info.returns) {
-			return true
-		}
-		if node.Type() != nil {
-			return true
-		}
-		if node.Kind == ast.KindConstructor || node.Kind == ast.KindSetAccessor {
-			return true
-		}
-		return false
+		return opts.allowHigherOrderFunctions && doesImmediatelyReturnFunctionExpression(node, info)
 	}
 
 	isAllowedFunction := func(node *ast.Node) bool {
@@ -147,8 +140,8 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 
 	// exitFunctionExpression handles ArrowFunction and FunctionExpression exit
 	exitFunctionExpression := func(node *ast.Node) {
-		info := popFunctionInfo()
-		if info == nil {
+		info, ok := popFunctionInfo()
+		if !ok {
 			return
 		}
 
@@ -177,15 +170,15 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 			return
 		}
 
-		if !checkFunctionReturnType(info) {
+		if !checkFunctionReturnType(node, info) {
 			report(node)
 		}
 	}
 
 	// exitFunctionDeclaration handles FunctionDeclaration exit
 	exitFunctionDeclaration := func(node *ast.Node) {
-		info := popFunctionInfo()
-		if info == nil {
+		info, ok := popFunctionInfo()
+		if !ok {
 			return
 		}
 		if isAllowedFunction(node) {
@@ -194,15 +187,15 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		if opts.allowTypedFunctionExpressions && node.Type() != nil {
 			return
 		}
-		if !checkFunctionReturnType(info) {
+		if !checkFunctionReturnType(node, info) {
 			report(node)
 		}
 	}
 
 	// exitMethodOrAccessor handles MethodDeclaration and GetAccessor exit
 	exitMethodOrAccessor := func(node *ast.Node) {
-		info := popFunctionInfo()
-		if info == nil {
+		info, ok := popFunctionInfo()
+		if !ok {
 			return
 		}
 		if isAllowedFunction(node) {
@@ -219,7 +212,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 			}
 		}
 
-		if !checkFunctionReturnType(info) {
+		if !checkFunctionReturnType(node, info) {
 			report(node)
 		}
 	}
@@ -250,12 +243,31 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 
 		// Return statement listener
 		ast.KindReturnStatement: func(node *ast.Node) {
-			if len(functionStack) > 0 {
-				info := functionStack[len(functionStack)-1]
-				info.returns = append(info.returns, node)
+			if len(functionStack) == 0 || !opts.allowHigherOrderFunctions {
+				return
+			}
+			info := &functionStack[len(functionStack)-1]
+			if !info.needsReturnType {
+				return
+			}
+			info.hasReturn = true
+			if info.returnsOnlyFunctions {
+				argument := node.Expression()
+				info.returnsOnlyFunctions = argument != nil &&
+					typescriptutil.IsFunction(ast.SkipParentheses(argument))
 			}
 		},
 	}
+}
+
+func doesImmediatelyReturnFunctionExpression(node *ast.Node, info functionInfo) bool {
+	if node.Kind == ast.KindArrowFunction {
+		body := node.AsArrowFunction().Body
+		if body != nil && body.Kind != ast.KindBlock {
+			return typescriptutil.IsFunction(ast.SkipParentheses(body))
+		}
+	}
+	return info.hasReturn && info.returnsOnlyFunctions
 }
 
 // isIIFE checks if a function node is the callee of an immediately invoked call expression.

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type_test.go
@@ -3,7 +3,11 @@ package explicit_function_return_type
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -1566,4 +1570,112 @@ const foo = () => {};
 			},
 		},
 	})
+}
+
+func TestReturnTrackingAndEditDemandParity(t *testing.T) {
+	const code = `
+function mixed(flag: boolean) {
+  if (flag) return (): void => {};
+  return 0;
+}
+
+function allFunctions(flag: boolean) {
+  if (flag) return ((): void => {});
+  function nested(): number { return 1; }
+  return function (): void {};
+}
+
+function bare(flag: boolean) {
+  if (flag) return;
+  return (): void => {};
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function lineDisabled() {
+  return 1;
+}
+
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+function scopedDisabled() {
+  return 1;
+}
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
+`
+
+	demands := []struct {
+		name   string
+		demand rule.EditDemand
+	}{
+		{name: "diagnostics only", demand: rule.EditDemandNone},
+		{name: "autofix", demand: rule.EditDemandAutofix},
+		{name: "suggestions", demand: rule.EditDemandSuggestion},
+		{name: "all edits", demand: rule.EditDemandAll},
+	}
+	for _, testCase := range demands {
+		t.Run(testCase.name, func(t *testing.T) {
+			diagnostics := runExplicitFunctionReturnTypeWithDemand(t, code, testCase.demand)
+			if len(diagnostics) != 2 {
+				t.Fatalf("diagnostics = %#v, want 2", diagnostics)
+			}
+			for index, wantHead := range []string{"function mixed", "function bare"} {
+				diagnostic := diagnostics[index]
+				if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != wantHead {
+					t.Errorf("diagnostic %d range text = %q, want %q", index, got, wantHead)
+				}
+				if diagnostic.Message.Id != "missingReturnType" ||
+					diagnostic.Message.Description != "Missing return type on function." ||
+					diagnostic.RuleName != ExplicitFunctionReturnTypeRule.Name ||
+					diagnostic.Severity != rule.SeverityError {
+					t.Errorf("diagnostic %d identity = %#v", index, diagnostic)
+				}
+				if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+					t.Errorf("diagnostic %d unexpectedly materialized edits: %#v", index, diagnostic)
+				}
+			}
+		})
+	}
+}
+
+func runExplicitFunctionReturnTypeWithDemand(
+	t *testing.T,
+	code string,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/source.ts",
+		Path:     "/source.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 2)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(
+		ExplicitFunctionReturnTypeRule.Name,
+		rule.SeverityError,
+		rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	)
+
+	listeners := ExplicitFunctionReturnTypeRule.Run(ctx, nil)
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		node.ForEachChild(visit)
+		if listener := listeners[rule.ListenerOnExit(node.Kind)]; listener != nil {
+			listener(node)
+		}
+		return false
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
 }


### PR DESCRIPTION
## Summary

- Replace per-function heap objects and retained return-node slices with a value stack that summarizes whether direct returns are exclusively function expressions.
- Precompute whether a function can require a return type, avoiding higher-order return analysis for bodyless declarations, explicitly typed functions, constructors, and setters.
- Add focused parity coverage for mixed/all/bare returns, nested-function isolation, exact diagnostics, edit-demand behavior, and disable directives.

### Go benchmark

Methodology: a temporary package-local benchmark parsed each source once, traversed 32 functions per case, and ran the rule with identical inputs, options, and edit demands before and after. Command: `go test ./internal/plugins/typescript/rules/explicit_function_return_type -run '^$' -bench '^BenchmarkExplicitFunctionReturnType$' -benchmem -benchtime=300ms -count=5`. Values below are medians of five samples; the temporary benchmark source was removed after measurement.

| Case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Diagnostics only | 19003 → 16619 (-12.55%) | 13336 → 11592 | 177 → 81 |
| Autofix demand | 19004 → 16606 (-12.62%) | 13336 → 11592 | 177 → 81 |
| Suggestion demand | 19107 → 16578 (-13.24%) | 13336 → 11592 | 177 → 81 |
| Explicit return type / no match | 11973 → 9738 (-18.67%) | 3096 → 1352 | 113 → 17 |
| Higher-order allowed | 9953 → 7726 (-22.38%) | 3624 → 1352 | 114 → 17 |
| Ignored without type parameters | 11517 → 9710 (-15.69%) | 3096 → 1352 | 113 → 17 |
| Typed expression allowed | 6861 → 6458 (-5.87%) | 2328 → 1352 | 49 → 17 |
| No-functions control | 3321 → 3366 (+1.36%) | 1296 → 1344 | 16 → 16 |

Correctness checks:

- `go test ./internal/plugins/typescript/rules/explicit_function_return_type -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/explicit_function_return_type/...`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
