### PR TITLE
perf: optimize member ordering checks

### DIFF
--- a/internal/plugins/typescript/rules/member_ordering/member_ordering.go
+++ b/internal/plugins/typescript/rules/member_ordering/member_ordering.go
@@ -66,7 +66,11 @@ const (
 
 // parsedConfig holds the parsed configuration for a single context
 type parsedConfig struct {
-	memberTypes      []interface{} // each element is either string or []string
+	memberTypes []interface{} // each element is either string or []string
+	// memberTypeRanks is shared by configurations that use the immutable default
+	// order. Custom orders retain linear lookup to avoid rebuilding an index for
+	// every file-level Rule.Run call.
+	memberTypeRanks  map[string]int
 	order            string
 	optionalityOrder string
 	neverCheck       bool
@@ -237,6 +241,33 @@ var defaultOrder = []interface{}{
 	"method",
 }
 
+func buildMemberTypeRanks(orderConfig []interface{}) map[string]int {
+	ranks := make(map[string]int, len(orderConfig))
+	for rank, configEntry := range orderConfig {
+		switch entry := configEntry.(type) {
+		case string:
+			if _, exists := ranks[entry]; !exists {
+				ranks[entry] = rank
+			}
+		case []string:
+			for _, memberType := range entry {
+				if _, exists := ranks[memberType]; !exists {
+					ranks[memberType] = rank
+				}
+			}
+		}
+	}
+	return ranks
+}
+
+var defaultMemberTypeRanks = buildMemberTypeRanks(defaultOrder)
+
+var defaultParsedConfig = parsedConfig{
+	memberTypes:     defaultOrder,
+	memberTypeRanks: defaultMemberTypeRanks,
+	order:           orderAsWritten,
+}
+
 // --- Options parsing ---
 
 type ruleOptions struct {
@@ -278,6 +309,7 @@ func parseConfig(val interface{}) *parsedConfig {
 		} else {
 			// If memberTypes not specified, use default
 			cfg.memberTypes = defaultOrder
+			cfg.memberTypeRanks = defaultMemberTypeRanks
 		}
 
 		if order, ok := v["order"].(string); ok {
@@ -314,10 +346,7 @@ func convertToMemberTypes(arr []interface{}) []interface{} {
 func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{}
 	if len(options) == 0 {
-		opts.defaultConfig = &parsedConfig{
-			memberTypes: defaultOrder,
-			order:       orderAsWritten,
-		}
+		opts.defaultConfig = &defaultParsedConfig
 		return opts
 	}
 	optsMap, _ := options[0].(map[string]interface{})
@@ -341,10 +370,7 @@ func parseOptions(options []any) ruleOptions {
 	// If no default config is set and no other config is set, use the default order
 	if opts.defaultConfig == nil && opts.classesConfig == nil && opts.classExpressionsConfig == nil &&
 		opts.interfacesConfig == nil && opts.typeLiteralsConfig == nil {
-		opts.defaultConfig = &parsedConfig{
-			memberTypes: defaultOrder,
-			order:       orderAsWritten,
-		}
+		opts.defaultConfig = &defaultParsedConfig
 	}
 
 	return opts
@@ -557,10 +583,19 @@ func isOverloadSignature(node *ast.Node) bool {
 
 // --- Ranking ---
 
-// getRankOrder finds the rank (index) of memberGroups in orderConfig
-func getRankOrder(memberGroups []string, orderConfig []interface{}) int {
+// getRankOrder finds the rank (index) of memberGroups in cfg.memberTypes.
+func getRankOrder(memberGroups []string, cfg *parsedConfig) int {
+	if cfg.memberTypeRanks != nil {
+		for _, group := range memberGroups {
+			if rank, exists := cfg.memberTypeRanks[group]; exists {
+				return rank
+			}
+		}
+		return -1
+	}
+
 	for _, group := range memberGroups {
-		for i, configEntry := range orderConfig {
+		for i, configEntry := range cfg.memberTypes {
 			switch entry := configEntry.(type) {
 			case string:
 				if entry == group {
@@ -585,10 +620,10 @@ func getRankOrder(memberGroups []string, orderConfig []interface{}) int {
 //	accessibility-scope-type → scope-type → accessibility-type → type
 //
 // Returns -1 for overload signatures (skipped), or orderConfig length - 1 for unknown types.
-func getRank(node *ast.Node, orderConfig []interface{}, supportsModifiers bool) int {
+func getRank(node *ast.Node, cfg *parsedConfig, supportsModifiers bool) int {
 	nodeType := getNodeType(node)
 	if nodeType == "" {
-		return len(orderConfig) - 1
+		return len(cfg.memberTypes) - 1
 	}
 
 	// Skip overload signatures
@@ -597,13 +632,14 @@ func getRank(node *ast.Node, orderConfig []interface{}, supportsModifiers bool) 
 	}
 
 	memberType := string(nodeType)
-	accessibility := getAccessibility(node)
-	scope := getScope(node)
-	decorated := ast.HasDecorators(node)
-
-	var memberGroups []string
+	var memberGroupBuffer [12]string
+	memberGroups := memberGroupBuffer[:0]
 
 	if supportsModifiers {
+		accessibility := getAccessibility(node)
+		scope := getScope(node)
+		decorated := ast.HasDecorators(node)
+
 		// Decorated variants
 		if decorated && canBeDecorated(nodeType) && accessibility != "#private" {
 			memberGroups = append(memberGroups, accessibility+"-decorated-"+memberType)
@@ -648,7 +684,7 @@ func getRank(node *ast.Node, orderConfig []interface{}, supportsModifiers bool) 
 		memberGroups = append(memberGroups, "signature")
 	}
 
-	return getRankOrder(memberGroups, orderConfig)
+	return getRankOrder(memberGroups, cfg)
 }
 
 // getLowestRank returns the human-readable name of the first group that should come
@@ -711,16 +747,44 @@ type memberInfo struct {
 	rank int
 }
 
+// checkGroupOrder validates as-written group order without collecting the
+// member names and groups only needed by alphabetical sorting.
+func checkGroupOrder(ctx rule.RuleContext, members []*ast.Node, cfg *parsedConfig, supportsModifiers bool) {
+	var previousRankBuffer [8]int
+	previousRanks := previousRankBuffer[:0]
+
+	for _, member := range members {
+		rank := getRank(member, cfg, supportsModifiers)
+		if rank == -1 {
+			continue
+		}
+
+		rankLastMember := -1
+		if len(previousRanks) > 0 {
+			rankLastMember = previousRanks[len(previousRanks)-1]
+		}
+
+		if rankLastMember >= 0 && rank < rankLastMember {
+			name := getMemberName(member)
+			rankName := getLowestRank(previousRanks, rank, cfg.memberTypes)
+			ctx.ReportNode(member, messageIncorrectGroupOrder(name, rankName))
+		} else if rank != rankLastMember {
+			previousRanks = append(previousRanks, rank)
+		}
+	}
+}
+
 // checkGroupSort validates that members appear in the correct group order.
 // previousRanks only accumulates strictly increasing ranks (like ESLint).
 // Returns groups of members (by rank) if valid, nil if errors were found.
-func checkGroupSort(ctx rule.RuleContext, members []*ast.Node, orderConfig []interface{}, supportsModifiers bool) [][]memberInfo {
-	var previousRanks []int
+func checkGroupSort(ctx rule.RuleContext, members []*ast.Node, cfg *parsedConfig, supportsModifiers bool) [][]memberInfo {
+	var previousRankBuffer [8]int
+	previousRanks := previousRankBuffer[:0]
 	var memberGroups [][]memberInfo
 	isCorrectlySorted := true
 
 	for _, member := range members {
-		rank := getRank(member, orderConfig, supportsModifiers)
+		rank := getRank(member, cfg, supportsModifiers)
 		if rank == -1 {
 			continue
 		}
@@ -735,7 +799,7 @@ func checkGroupSort(ctx rule.RuleContext, members []*ast.Node, orderConfig []int
 
 		if rankLastMember >= 0 && rank < rankLastMember {
 			// Out of order — report error but do NOT push this rank
-			rankName := getLowestRank(previousRanks, rank, orderConfig)
+			rankName := getLowestRank(previousRanks, rank, cfg.memberTypes)
 			ctx.ReportNode(member, messageIncorrectGroupOrder(name, rankName))
 			isCorrectlySorted = false
 		} else if rank == rankLastMember {
@@ -755,12 +819,12 @@ func checkGroupSort(ctx rule.RuleContext, members []*ast.Node, orderConfig []int
 }
 
 // groupMembersByType groups all members by their rank (not just consecutive)
-func groupMembersByType(members []*ast.Node, orderConfig []interface{}, supportsModifiers bool) [][]memberInfo {
+func groupMembersByType(members []*ast.Node, cfg *parsedConfig, supportsModifiers bool) [][]memberInfo {
 	rankMap := make(map[int][]memberInfo)
 	var rankOrder []int
 
 	for _, member := range members {
-		rank := getRank(member, orderConfig, supportsModifiers)
+		rank := getRank(member, cfg, supportsModifiers)
 		if rank == -1 {
 			continue
 		}
@@ -811,16 +875,19 @@ func checkOrder(ctx rule.RuleContext, memberSet []*ast.Node, allMembers []*ast.N
 	hasAlphaSort := cfg.order != "" && cfg.order != orderAsWritten
 
 	if cfg.memberTypes != nil {
-		groups := checkGroupSort(ctx, memberSet, cfg.memberTypes, supportsModifiers)
+		if !hasAlphaSort {
+			checkGroupOrder(ctx, memberSet, cfg, supportsModifiers)
+			return
+		}
+
+		groups := checkGroupSort(ctx, memberSet, cfg, supportsModifiers)
 		if groups == nil {
 			// Group sort failed — alpha sort on full members grouped by type (ESLint behavior)
-			if hasAlphaSort {
-				typeGroups := groupMembersByType(allMembers, cfg.memberTypes, supportsModifiers)
-				for _, group := range typeGroups {
-					checkAlphaSort(ctx, group, cfg.order)
-				}
+			typeGroups := groupMembersByType(allMembers, cfg, supportsModifiers)
+			for _, group := range typeGroups {
+				checkAlphaSort(ctx, group, cfg.order)
 			}
-		} else if hasAlphaSort {
+		} else {
 			// Group sort succeeded — alpha sort within each group
 			for _, group := range groups {
 				checkAlphaSort(ctx, group, cfg.order)

--- a/internal/plugins/typescript/rules/member_ordering/member_ordering_test.go
+++ b/internal/plugins/typescript/rules/member_ordering/member_ordering_test.go
@@ -1,9 +1,14 @@
 package member_ordering
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -1655,4 +1660,143 @@ interface Foo {
 			},
 		},
 	})
+}
+
+func runMemberOrderingWithDemand(
+	t *testing.T,
+	code string,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/source.ts",
+		Path:     "/source.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(MemberOrderingRule.Name, rule.SeverityWarning, rule.DiagnosticConsumer{
+		Demand: demand,
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	listeners := MemberOrderingRule.Run(ctx, options)
+
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
+}
+
+func TestMemberOrderingDiagnosticParity(t *testing.T) {
+	const code = `class Subject {
+  method() {}
+  // leading member trivia
+  alpha: number;
+  beta: number;
+}`
+
+	diagnosticsOnly := runMemberOrderingWithDemand(t, code, nil, rule.EditDemandNone)
+	allEdits := runMemberOrderingWithDemand(t, code, nil, rule.EditDemandAll)
+	configuredDefault := runMemberOrderingWithDemand(t, code, []any{map[string]interface{}{
+		"default": map[string]interface{}{"order": "as-written"},
+	}}, rule.EditDemandNone)
+	if len(diagnosticsOnly) != 2 || len(allEdits) != 2 || len(configuredDefault) != 2 {
+		t.Fatalf(
+			"diagnostic counts = %d, %d, and %d; want 2",
+			len(diagnosticsOnly),
+			len(allEdits),
+			len(configuredDefault),
+		)
+	}
+
+	wantMembers := []string{"alpha: number;", "beta: number;"}
+	for index, diagnostic := range diagnosticsOnly {
+		wantRange := core.NewTextRange(
+			strings.Index(code, wantMembers[index]),
+			strings.Index(code, wantMembers[index])+len(wantMembers[index]),
+		)
+		if diagnostic.Range != wantRange {
+			t.Errorf("diagnostic %d range = %#v, want %#v", index, diagnostic.Range, wantRange)
+		}
+		wantDescription := "Member " + strings.TrimSuffix(wantMembers[index], ": number;") +
+			" should be declared before all public instance method definitions."
+		if diagnostic.Message.Id != "incorrectGroupOrder" || diagnostic.Message.Description != wantDescription {
+			t.Errorf("diagnostic %d message = %#v, want %q", index, diagnostic.Message, wantDescription)
+		}
+		if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+			t.Errorf("diagnostic %d unexpectedly materialized edits", index)
+		}
+		if diagnostic.Range != allEdits[index].Range ||
+			diagnostic.Message.Id != allEdits[index].Message.Id ||
+			diagnostic.Message.Description != allEdits[index].Message.Description {
+			t.Errorf("diagnostic %d changed under all-edit demand", index)
+		}
+		if diagnostic.Range != configuredDefault[index].Range ||
+			diagnostic.Message.Id != configuredDefault[index].Message.Id ||
+			diagnostic.Message.Description != configuredDefault[index].Message.Description {
+			t.Errorf("diagnostic %d changed under an explicit default-order object", index)
+		}
+		if allEdits[index].FixesPtr != nil || allEdits[index].Suggestions != nil {
+			t.Errorf("all-edit diagnostic %d unexpectedly materialized edits", index)
+		}
+	}
+}
+
+func TestMemberOrderingDisableDirectives(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+	}{
+		{
+			name: "next line",
+			code: `class Subject {
+  method() {}
+  // rslint-disable-next-line @typescript-eslint/member-ordering
+  alpha: number;
+  beta: number;
+}`,
+		},
+		{
+			name: "line",
+			code: `class Subject {
+  method() {}
+  alpha: number; // rslint-disable-line @typescript-eslint/member-ordering
+  beta: number;
+}`,
+		},
+		{
+			name: "scoped",
+			code: `class Subject {
+  method() {}
+  /* rslint-disable @typescript-eslint/member-ordering */
+  alpha: number;
+  /* rslint-enable @typescript-eslint/member-ordering */
+  beta: number;
+}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := runMemberOrderingWithDemand(t, test.code, nil, rule.EditDemandNone)
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostic count = %d, want 1", len(diagnostics))
+			}
+			if got := test.code[diagnostics[0].Range.Pos():diagnostics[0].Range.End()]; got != "beta: number;" {
+				t.Fatalf("diagnostic range text = %q, want beta member", got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- reuse an indexed representation of the immutable default member order instead of scanning every configured group for every member
- avoid collecting member names and alphabetical-sort groups when the configured order is `as-written`
- skip class-only modifier and decorator analysis for interfaces and type literals
- preserve custom-order lookup semantics and add focused coverage for diagnostic ranges, messages, edit demand, explicit default configuration, and disable directives

### Go benchmark

Methodology: package-local listener benchmark over the same pre-parsed class/interface inputs, options, edit demands, and six repeated samples on both sides. Each run started with CPU idle of at least 70%.

```sh
go test ./internal/plugins/typescript/rules/member_ordering -run '^$' -bench '^BenchmarkMemberOrdering$' -benchmem -count=6
```

Values below are the median of six samples.

| Case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Default class | `8863 -> 3654` (`-58.77%`) | `7008 -> 1712` | `173 -> 72` |
| Default interface | `2319 -> 332.3` (`-85.67%`) | `1312 -> 0` | `29 -> 0` |
| Diagnostics only | `5553 -> 3402` (`-38.74%`) | `4275 -> 2449` | `106 -> 66` |
| All edit demand | `5568.5 -> 3419` (`-38.60%`) | `4275 -> 2449` | `106 -> 66` |
| Custom groups unmatched | `5421 -> 3372` (`-37.80%`) | `3952 -> 1328` | `141 -> 70` |
| Alphabetical-only control | `408.45 -> 413.15` (`+1.15%`) | `960 -> 960` | `4 -> 4` |
| Never-check control | `31.845 -> 32.895` (`+3.30%`) | `0 -> 0` | `0 -> 0` |
| Empty-member control | `4.222 -> 4.162` (`-1.43%`) | `0 -> 0` | `0 -> 0` |

The small timing variation in the alphabetical-only and never-check controls did not change their allocation counts; those controls do not execute the optimized ranking path.

Validation:

- `go test ./internal/plugins/typescript/rules/member_ordering -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/member_ordering/...`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
