### PR TITLE
perf: optimize prefer-destructuring checks

### DIFF
--- a/internal/rules/prefer_destructuring/prefer_destructuring.go
+++ b/internal/rules/prefer_destructuring/prefer_destructuring.go
@@ -83,12 +83,16 @@ func preferDestructuringMessage(kind string) rule.RuleMessage {
 	}
 }
 
-func identifierName(node *ast.Node) string {
-	if node == nil {
-		return ""
+func skipParentheses(node *ast.Node) *ast.Node {
+	if node != nil && node.Kind == ast.KindParenthesizedExpression {
+		return ast.SkipParentheses(node)
 	}
-	node = ast.SkipParentheses(node)
-	if !ast.IsIdentifier(node) {
+	return node
+}
+
+func identifierName(node *ast.Node) string {
+	node = skipParentheses(node)
+	if node == nil || node.Kind != ast.KindIdentifier {
 		return ""
 	}
 	return node.AsIdentifier().Text
@@ -98,7 +102,7 @@ func matchingObjectPropertyName(node *ast.Node) (string, bool) {
 	switch node.Kind {
 	case ast.KindPropertyAccessExpression:
 		name := node.AsPropertyAccessExpression().Name()
-		if name == nil || !ast.IsIdentifier(name) {
+		if name == nil || name.Kind != ast.KindIdentifier {
 			return "", false
 		}
 		return name.AsIdentifier().Text, true
@@ -107,11 +111,11 @@ func matchingObjectPropertyName(node *ast.Node) (string, bool) {
 		if argument == nil {
 			return "", false
 		}
-		argument = ast.SkipParentheses(argument)
+		argument = skipParentheses(argument)
 		// Keep this narrower than utils.AccessExpressionStaticName: ESLint's
 		// same-name branch accepts string Literals, but not template literals,
 		// numeric keys, dynamic expressions, or TypeScript assertions.
-		if !ast.IsStringLiteral(argument) {
+		if argument.Kind != ast.KindStringLiteral {
 			return "", false
 		}
 		return argument.AsStringLiteral().Text, true
@@ -122,12 +126,12 @@ func matchingObjectPropertyName(node *ast.Node) (string, bool) {
 
 func shouldFix(leftNode, rightNode *ast.Node) bool {
 	leftName := identifierName(leftNode)
-	if leftName == "" || !ast.IsPropertyAccessExpression(rightNode) {
+	if leftName == "" || rightNode.Kind != ast.KindPropertyAccessExpression {
 		return false
 	}
 	name := rightNode.AsPropertyAccessExpression().Name()
 	return name != nil &&
-		ast.IsIdentifier(name) &&
+		name.Kind == ast.KindIdentifier &&
 		leftName == name.AsIdentifier().Text
 }
 
@@ -147,7 +151,7 @@ func objectDestructuringFix(
 	// receiver for both source text and comment accounting. Since that receiver
 	// is nested inside the declarator, a comment in either surrounding gap is
 	// exactly a comment the replacement would discard.
-	objectNode = ast.SkipParentheses(objectNode)
+	objectNode = skipParentheses(objectNode)
 	reportRange := utils.TrimNodeTextRange(ctx.SourceFile, reportNode)
 	objectRange := utils.TrimNodeTextRange(ctx.SourceFile, objectNode)
 	comments := ctx.Comments.All()
@@ -199,26 +203,29 @@ func performCheck(
 	// them. Only parentheses are transparent here: TypeScript assertions
 	// around the whole RHS remain non-member expressions, matching
 	// @typescript-eslint/parser's ESTree output.
-	rightNode = ast.SkipParentheses(rightNode)
-	if !ast.IsAccessExpression(rightNode) {
+	rightNode = skipParentheses(rightNode)
+	if rightNode.Kind != ast.KindPropertyAccessExpression &&
+		rightNode.Kind != ast.KindElementAccessExpression {
 		return
 	}
 
 	// ESLint sees an optional member expression behind a ChainExpression and
 	// deliberately ignores it because the equivalent destructuring can throw.
-	if ast.IsOptionalChain(rightNode) {
+	// At this point the node is known to be an access expression, so the flag is
+	// equivalent to ast.IsOptionalChain without another shim call.
+	if rightNode.Flags&ast.NodeFlagsOptionalChain != 0 {
 		return
 	}
 
 	if rightNode.Kind == ast.KindPropertyAccessExpression {
 		name := rightNode.AsPropertyAccessExpression().Name()
-		if name != nil && ast.IsPrivateIdentifier(name) {
+		if name != nil && name.Kind == ast.KindPrivateIdentifier {
 			return
 		}
 	}
 
 	objectNode := utils.AccessExpressionObject(rightNode)
-	if objectNode != nil && ast.SkipParentheses(objectNode).Kind == ast.KindSuperKeyword {
+	if objectNode != nil && skipParentheses(objectNode).Kind == ast.KindSuperKeyword {
 		return
 	}
 
@@ -283,10 +290,14 @@ var PreferDestructuringRule = rule.Rule{
 				)
 			},
 			ast.KindBinaryExpression: func(node *ast.Node) {
-				if !ast.IsAssignmentExpression(node, true) {
+				assignment := node.AsBinaryExpression()
+				// Most binary expressions are not assignments. Keep the complete
+				// predicate for `=` so legal TypeScript targets and recovery nodes
+				// retain their existing behavior.
+				if assignment.OperatorToken.Kind != ast.KindEqualsToken ||
+					!ast.IsAssignmentExpression(node, true) {
 					return
 				}
-				assignment := node.AsBinaryExpression()
 				performCheck(ctx, opts, assignment.Left, assignment.Right, node, false)
 			},
 		}

--- a/internal/rules/prefer_destructuring/prefer_destructuring_extras_test.go
+++ b/internal/rules/prefer_destructuring/prefer_destructuring_extras_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -336,6 +338,58 @@ func TestPreferDestructuringEditDemand(t *testing.T) {
 				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
 			}
 		}
+	}
+}
+
+func TestPreferDestructuringDisableDirectives(t *testing.T) {
+	t.Parallel()
+
+	const code = `const line = object.line; // eslint-disable-line prefer-destructuring
+// eslint-disable-next-line prefer-destructuring
+const next = object.next;
+/* eslint-disable prefer-destructuring */
+const scoped = object.scoped;
+/* eslint-enable prefer-destructuring */
+const kept = object.kept;`
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/disable-directives.ts",
+		Path:     "/disable-directives.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(
+		PreferDestructuringRule.Name,
+		rule.SeverityError,
+		rule.DiagnosticConsumer{
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	)
+
+	listeners := PreferDestructuringRule.Run(ctx, nil)
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want one unsuppressed report", len(diagnostics))
+	}
+	diagnostic := diagnostics[0]
+	if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != "kept = object.kept" {
+		t.Fatalf("diagnostic range text = %q, want unsuppressed declaration", got)
+	}
+	if diagnostic.Message.Id != "preferDestructuring" ||
+		diagnostic.Message.Description != "Use object destructuring." {
+		t.Fatalf("diagnostic message = %#v", diagnostic.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Avoid cross-package AST helper calls on the common non-parenthesized and non-access paths by using equivalent node-kind and optional-chain flag checks.
- Reject non-`=` binary expressions before retaining the full assignment predicate for valid TypeScript targets and recovery nodes.
- Preserve diagnostics, messages, ranges, autofixes, option behavior, comments, and disable directives; add focused line, next-line, and scoped suppression coverage.

### Go benchmark

Command:

```sh
go test ./internal/rules/prefer_destructuring -run '^$' -bench '^BenchmarkPreferDestructuringRule$' -benchmem -count=6 -benchtime=500ms
```

The temporary package-local benchmark linted prebuilt 64-statement inputs for each path. Values below are the median of six samples. The after diagnostics-only samples contained one 43,514 ns/op high value; it was retained and the benchmark was not rerun.

| Case | ns/op before → after | Time | B/op before → after | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Object diagnostics | 31,472 → 30,474 | -3.17% | 36,992 → 36,991 | 294 → 294 |
| Object autofix | 54,327 → 51,954.5 | -4.37% | 82,575.5 → 82,570 | 742 → 742 |
| Wrong suggestion demand | 31,387 → 30,500 | -2.83% | 36,992 → 36,991 | 294 → 294 |
| Array diagnostics | 30,506.5 → 29,765.5 | -2.43% | 36,479 → 36,479 | 294 → 294 |
| Assignment diagnostics | 30,479.5 → 30,003 | -1.56% | 36,991 → 36,991 | 294 → 294 |
| Renamed diagnostics | 30,208.5 → 29,377 | -2.75% | 36,991 → 36,991 | 294 → 294 |
| Comment-blocked autofix | 201,807.5 → 196,908.5 | -2.43% | 273,233 → 273,230 | 5,776 → 5,776 |
| Binary non-assignment | 23,429 → 22,557.5 | -3.72% | 3,196 → 3,195 | 38 → 38 |
| Compound assignment | 10,753.5 → 10,701 | -0.49% | 3,189 → 3,189 | 38 → 38 |
| No match | 13,609 → 13,252.5 | -2.62% | 3,191 → 3,190 | 38 → 38 |
| Ignored object option | 12,841 → 12,298 | -4.23% | 3,190 → 3,190 | 38 → 38 |

Correctness checks:

- `go test ./internal/rules/prefer_destructuring -count=3`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/prefer_destructuring/...`
- `pnpm run check-spell`
- `pnpm run format:check`
- `git diff --check`

The temporary benchmark source was deleted and is not part of this PR.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
