### PR TITLE
perf: optimize max-params parameter checks

### DIFF
--- a/internal/rules/max_params/max_params.go
+++ b/internal/rules/max_params/max_params.go
@@ -19,12 +19,17 @@ var MaxParamsRule = rule.Rule{
 		check := func(node *ast.Node) {
 			params := node.Parameters()
 			effective := len(params)
-			if thisParam := ast.GetThisParameter(node); thisParam != nil {
+			if effective <= opts.max {
+				return
+			}
+			if effective != 0 {
 				switch opts.countThis {
 				case countThisNever:
-					effective--
+					if ast.IsThisParameter(params[0]) {
+						effective--
+					}
 				case countThisExceptVoid:
-					if utils.IsThisVoidParameter(thisParam) {
+					if utils.IsThisVoidParameter(params[0]) {
 						effective--
 					}
 				}

--- a/internal/rules/max_params/max_params_extras_test.go
+++ b/internal/rules/max_params/max_params_extras_test.go
@@ -81,6 +81,11 @@ func TestMaxParamsExtras(t *testing.T) {
 
 			// ---- Real-user: eslint/eslint#20107 countThis never for typed this ----
 			{Code: "function doSomething(this: MyType, param1: unknown, param2: unknown): unknown {}", Options: option(map[string]interface{}{"max": 2, "countThis": "never"})},
+
+			// Reporting remains suppressible after the parameter-count fast path.
+			{Code: "/* eslint-disable test */\nfunction f(a, b, c, d) {}"},
+			{Code: "// eslint-disable-next-line test\nfunction f(a, b, c, d) {}"},
+			{Code: "function f(a, b, c, d) {} // eslint-disable-line test"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: declaration/container forms ----
@@ -296,6 +301,14 @@ func TestMaxParamsExtras(t *testing.T) {
 				Code:    `app.get("/users/:id", function routeHandler(req, res, next, logger) { res.end(); });`,
 				Options: option(map[string]interface{}{"max": 3}),
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'routeHandler'", 4, 3)}},
+			},
+			// A scoped enable resumes reporting without changing the diagnostic.
+			{
+				Code: "/* eslint-disable test */\n" +
+					"function hidden(a, b, c, d) {}\n" +
+					"/* eslint-enable test */\n" +
+					"function visible(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'visible'", 4, 3), Line: 4, Column: 1}},
 			},
 		},
 	)


### PR DESCRIPTION
## Summary

- Return before inspecting a TypeScript `this` parameter when the raw parameter count is already within the configured maximum.
- Reuse the parameter slice's first element for `countThis` handling instead of asking the AST for the same parameter list again.
- Add focused block, line, next-line, and re-enable directive coverage.

### Go benchmark

Methodology: Apple M1 Max, Go 1.26.1, `-cpu=1`, six 300 ms samples per case. The table reports medians from this identical before/after command:

```sh
go test ./internal/rules/max_params -run '^$' -bench '^BenchmarkMaxParamsRule$' -benchmem -benchtime=300ms -count=6 -cpu=1
```

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Setup/default | `317.25 → 323.15` | `416 → 416` | `4 → 4` |
| Setup/countThis never | `352.65 → 357.55` | `416 → 416` | `4 → 4` |
| No match/zero | `4.82 → 2.90` | `0 → 0` | `0 → 0` |
| No match/at limit | `9.33 → 2.91` | `0 → 0` | `0 → 0` |
| No match/arrow at limit | `9.32 → 2.90` | `0 → 0` | `0 → 0` |
| Ignored/maximum zero | `9.32 → 3.00` | `0 → 0` | `0 → 0` |
| Ignored/this never | `9.68 → 7.80` | `0 → 0` | `0 → 0` |
| Ignored/void this | `16.77 → 10.01` | `0 → 0` | `0 → 0` |
| Diagnostic/named | `609.75 → 646.40` | `568 → 568` | `10 → 10` |
| Diagnostic/function expression | `431.95 → 449.40` | `424 → 424` | `6 → 6` |
| Diagnostic/arrow | `386.25 → 420.95` | `320 → 320` | `6 → 6` |
| Diagnostic/method | `620.75 → 621.90` | `520 → 520` | `10 → 10` |
| Diagnostic/constructor | `437.40 → 442.60` | `416 → 416` | `5 → 5` |
| Diagnostic/function type | `418.70 → 498.85` | `424 → 424` | `6 → 6` |
| Autofix demand | `683.40 → 1010.45` | `568 → 568` | `10 → 10` |
| Suggestion demand | `651.05 → 3059.00` | `568 → 568` | `10 → 10` |
| Count-this diagnostic | `592.95 → 1538.00` | `496 → 496` | `10 → 10` |
| Suppressed diagnostic | `695.85 → 956.15` | `568 → 568` | `10 → 10` |

The later after samples showed broad timing variance across otherwise unchanged diagnostic controls; allocation counts stayed identical. The optimized no-match and ignored paths consistently improve while preserving zero allocations.

Correctness checks:

- `go test ./internal/rules/max_params -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/max_params/...`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
