### PR TITLE
perf: optimize init-declarations reporting

### DIFF
--- a/internal/plugins/typescript/rules/init_declarations/init_declarations.go
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations.go
@@ -2,9 +2,9 @@ package init_declarations
 
 import (
 	_ "embed"
-	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -86,15 +86,50 @@ func checkVariableDeclarationList(ctx rule.RuleContext, node *ast.Node, opts ini
 		return
 	}
 
+	inForLoop := isForLoopParent(parent)
+
+	if opts.mode == "always" {
+		// Upstream considers every for-loop binding initialized, even without
+		// an explicit initializer. Skip the whole list before inspecting names.
+		if inForLoop {
+			return
+		}
+
+		for _, decl := range declList.Declarations.Nodes {
+			varDecl := decl.AsVariableDeclaration()
+			if varDecl == nil || varDecl.Initializer != nil {
+				continue
+			}
+
+			nameNode := varDecl.Name()
+			// Upstream only reports for `id.type === "Identifier"`;
+			// destructuring patterns are silently skipped.
+			if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+				continue
+			}
+
+			idName := nameNode.AsIdentifier().Text
+			ctx.ReportRange(identifierReportRange(ctx.SourceFile, nameNode, idName), buildMessage("initialized", idName))
+		}
+		return
+	}
+
+	// The remaining path is mode="never". Ignored loop initializers and
+	// constant bindings exempt the entire declaration list, so avoid walking
+	// each declarator in those common no-report cases.
+	if opts.ignoreForLoopInit && inForLoop {
+		return
+	}
+
 	// CONSTANT_BINDINGS in upstream = {const, using, await using}. They require
 	// an initializer at parse time, so "never" mode must never report them as
 	// `notInitialized`. utils.GetVarDeclListKind centralizes the
 	// `await using = NodeFlagsConst|NodeFlagsUsing` encoding so we don't have
 	// to repeat it here.
 	kind := utils.GetVarDeclListKind(node)
-	isConstantBinding := kind == "const" || kind == "using" || kind == "await using"
-
-	inForLoop := isForLoopParent(parent)
+	if kind == "const" || kind == "using" || kind == "await using" {
+		return
+	}
 
 	for _, decl := range declList.Declarations.Nodes {
 		varDecl := decl.AsVariableDeclaration()
@@ -102,65 +137,60 @@ func checkVariableDeclarationList(ctx rule.RuleContext, node *ast.Node, opts ini
 			continue
 		}
 
+		hasExplicitInit := varDecl.Initializer != nil
+		// Outside a for-loop, "never" only reports explicit initializers. A
+		// for-loop binding is initialized in the upstream sense even when its
+		// declarator has no initializer (`for (var x in xs)`).
+		if !hasExplicitInit && !inForLoop {
+			continue
+		}
+
 		nameNode := varDecl.Name()
-		// Upstream only reports for `id.type === "Identifier"`; destructuring
-		// patterns (`{a} = ...`, `[a] = ...`) are silently skipped.
 		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 			continue
 		}
+
 		idName := nameNode.AsIdentifier().Text
-
-		hasExplicitInit := varDecl.Initializer != nil
-		// Mirror ESLint's `isInitialized`: for-loop bindings are considered
-		// initialized regardless of `Initializer` — `for (var i;;)` should not
-		// trip "always", and `for (var x in arr)` should still trip "never".
-		initialized := hasExplicitInit || inForLoop
-
-		var messageId string
-		switch {
-		case opts.mode == "always" && !initialized:
-			messageId = "initialized"
-		case opts.mode == "never" && initialized && !isConstantBinding:
-			if opts.ignoreForLoopInit && inForLoop {
-				continue
-			}
-			messageId = "notInitialized"
-		}
-		if messageId == "" {
-			continue
-		}
-
-		msg := buildMessage(messageId, idName)
+		reportRange := identifierReportRange(ctx.SourceFile, nameNode, idName)
 
 		// Mirror typescript-eslint's `getReportLoc`: when the declarator has no
 		// explicit init, narrow the report to the identifier so the diagnostic
-		// doesn't underline a trailing type annotation. This covers BOTH paths
-		// that produce a no-init report:
-		//   - "always" + !initialized → "initialized"
-		//   - "never" + in-for-loop + Initializer==nil → "notInitialized"
-		//     (e.g. `for (var x: T;;)` or `for (var x in arr)`)
-		if !hasExplicitInit {
-			ctx.ReportNode(nameNode, msg)
-		} else {
+		// doesn't underline a trailing type annotation. An initialized
+		// declarator reports from the same identifier start through its init.
+		if hasExplicitInit {
 			// Declarator has an init expression — report the full declarator
 			// (id + type + init) to match upstream's diagnostic ranges.
-			ctx.ReportNode(decl, msg)
+			reportRange = core.NewTextRange(reportRange.Pos(), decl.End())
 		}
+		ctx.ReportRange(reportRange, buildMessage("notInitialized", idName))
 	}
 }
 
 func buildMessage(messageId, idName string) rule.RuleMessage {
 	var desc string
 	if messageId == "initialized" {
-		desc = fmt.Sprintf("Variable '%s' should be initialized on declaration.", idName)
+		desc = "Variable '" + idName + "' should be initialized on declaration."
 	} else {
-		desc = fmt.Sprintf("Variable '%s' should not be initialized on declaration.", idName)
+		desc = "Variable '" + idName + "' should not be initialized on declaration."
 	}
 	return rule.RuleMessage{
 		Id:          messageId,
 		Description: desc,
 		Data:        map[string]string{"idName": idName},
 	}
+}
+
+// identifierReportRange avoids rescanning the common plain-identifier path.
+// Escaped, synthetic, reparsed, malformed, or otherwise unusual identifiers
+// retain the scanner-based behavior through the validated fallback.
+func identifierReportRange(sourceFile *ast.SourceFile, nameNode *ast.Node, idName string) core.TextRange {
+	end := nameNode.End()
+	start := end - len(idName)
+	text := sourceFile.Text()
+	if idName != "" && start >= 0 && start <= end && end <= len(text) && text[start:end] == idName {
+		return core.NewTextRange(start, end)
+	}
+	return utils.TrimNodeTextRange(sourceFile, nameNode)
 }
 
 // isForLoopParent reports whether the VariableDeclarationList's parent is a

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations_extras_test.go
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations_extras_test.go
@@ -24,9 +24,15 @@
 package init_declarations
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -37,6 +43,12 @@ func TestInitDeclarationsExtras(t *testing.T) {
 		t,
 		&InitDeclarationsRule,
 		[]rule_tester.ValidTestCase{
+			// The optimized "always" path skips an entire for-loop declaration
+			// list, including a mix of initialized and uninitialized declarators.
+			{Code: `for (let i = 0, j; i < 1; i++) {}`, Options: arrayOption("always")},
+			// The optimized ignore path likewise skips the whole list in "never".
+			{Code: `for (let i = 0, j; i < 1; i++) {}`, Options: arrayOption("never", map[string]interface{}{"ignoreForLoopInit": true})},
+
 			// ---- Dimension 4: declaration/container forms — variable kind ----
 			// `using` / `await using` join const in CONSTANT_BINDINGS: they require
 			// an initializer at parse time, so "never" must not report them.
@@ -369,6 +381,34 @@ let result =
       `, Options: arrayOption("always")},
 		},
 		[]rule_tester.InvalidTestCase{
+			// Plain identifiers with leading trivia use the validated range fast
+			// path without inheriting the comment from the node's full start.
+			{
+				Code:    `let /*lead*/ plain: number;`,
+				Options: arrayOption("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "initialized", Line: 1, Column: 14, EndLine: 1, EndColumn: 19, Message: "Variable 'plain' should be initialized on declaration."},
+				},
+			},
+			// Escaped identifiers cannot use End-len(decodedName); they must retain
+			// the scanner fallback and underline the complete source token.
+			{
+				Code:    `let \u0066oo: number;`,
+				Options: arrayOption("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "initialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 13, Message: "Variable 'foo' should be initialized on declaration."},
+				},
+			},
+			// The "never" path starts a full-declarator range at the validated
+			// identifier token, excluding leading trivia just like ReportNode.
+			{
+				Code:    `let /*lead*/ value: number = 1;`,
+				Options: arrayOption("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notInitialized", Line: 1, Column: 14, EndLine: 1, EndColumn: 31, Message: "Variable 'value' should not be initialized on declaration."},
+				},
+			},
+
 			// ---- Dimension 4: declaration/container forms — let with type annotation ----
 			// Mirrors typescript-eslint's getReportLoc narrowing for "always":
 			// underlines only the identifier, not the trailing annotation.
@@ -695,7 +735,7 @@ function f(x: number) {
 			{
 				Code:    `const { x } = (obj as { x: number }), y = 1;`,
 				Options: arrayOption("never"),
-				Errors: []rule_tester.InvalidTestCaseError{},
+				Errors:  []rule_tester.InvalidTestCaseError{},
 			},
 
 			// Real-user: variable inside an IIFE's body still reports.
@@ -779,4 +819,81 @@ namespace Plain {
 			},
 		},
 	)
+}
+
+func TestInitDeclarationsEditDemandAndDisableParity(t *testing.T) {
+	const source = `let visible: number;
+// eslint-disable-next-line @typescript-eslint/init-declarations
+let nextLine: number;
+let sameLine: number; // eslint-disable-line @typescript-eslint/init-declarations
+/* eslint-disable @typescript-eslint/init-declarations */
+let scoped: number;
+/* eslint-enable @typescript-eslint/init-declarations */
+let visibleAgain: number;
+`
+
+	program, sourceFile, err := rule_tester.NewProgramHelper(fixtures.GetRootDir()).CreateTestProgram(source, "edit-demand.ts", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		demand rule.EditDemand
+	}{
+		{name: "diagnostics only", demand: rule.EditDemandNone},
+		{name: "autofix demand", demand: rule.EditDemandAutofix},
+		{name: "suggestion demand", demand: rule.EditDemandSuggestion},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var diagnostics []rule.RuleDiagnostic
+			_, err := linter.RunLinter(linter.RunLinterOptions{
+				Programs:       []*compiler.Program{program},
+				SingleThreaded: true,
+				TargetFiles:    [][]string{{sourceFile.FileName()}},
+				ExcludePaths:   []string{},
+				GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+					return []linter.ConfiguredRule{{
+						Name:     "@typescript-eslint/init-declarations",
+						Severity: rule.SeverityWarning,
+						Run: func(ctx rule.RuleContext) rule.RuleListeners {
+							return InitDeclarationsRule.Run(ctx, nil)
+						},
+					}}
+				},
+				Consumer: rule.DiagnosticConsumer{
+					Demand: test.demand,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(diagnostics) != 2 {
+				t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+			}
+			wantNames := []string{"visible", "visibleAgain"}
+			for index, diagnostic := range diagnostics {
+				name := wantNames[index]
+				start := strings.Index(source, "let "+name) + len("let ")
+				wantRange := core.NewTextRange(start, start+len(name))
+				if diagnostic.Range != wantRange {
+					t.Errorf("diagnostic %d range = %v, want %v", index, diagnostic.Range, wantRange)
+				}
+				if diagnostic.Message.Id != "initialized" ||
+					diagnostic.Message.Description != "Variable '"+name+"' should be initialized on declaration." ||
+					diagnostic.Message.Data["idName"] != name {
+					t.Errorf("diagnostic %d message changed: %#v", index, diagnostic.Message)
+				}
+				if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+					t.Errorf("diagnostic %d leaked edit artifacts under demand %v: %#v", index, test.demand, diagnostic)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Specialize the `always` and `never` paths so whole declaration lists can exit before unnecessary per-declarator work.
- Build identifier-dependent messages only for reportable declarations and replace formatting overhead with equivalent string construction.
- Use a validated plain-identifier range fast path while retaining the scanner fallback for escaped or unusual identifiers.
- Add coverage for loop/option fast paths, leading trivia, escaped identifiers, edit demands, and disable directives.

### Go benchmark

Command (5 samples per case):

```sh
go test ./internal/plugins/typescript/rules/init_declarations -run '^$' -bench '^BenchmarkInitDeclarations$' -benchmem -count=5
```

Values below are arithmetic means of the five saved samples.

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Default, diagnostics, matched | `30342.2 → 20904.0` | `40587 → 29320` | `358 → 230` |
| Default, autofix demand, matched | `30517.6 → 24071.2` | `40587 → 29320` | `358 → 230` |
| Default, suggestion demand, matched | `30672.8 → 23341.4` | `40587 → 29320` | `358 → 230` |
| Default, no match | `11112.0 → 10562.8` | `3720 → 3720` | `38 → 38` |
| Never, diagnostics, matched | `32084.0 → 25466.0` | `40587 → 29320` | `358 → 230` |
| Never, no match | `10932.6 → 9709.6` | `3720 → 3720` | `38 → 38` |
| Never, ignored loop initializer | `18604.8 → 17339.2` | `3720 → 3720` | `38 → 38` |
| Ambient control | `8929.0 → 8793.0` | `3720 → 3720` | `38 → 38` |
| Destructuring | `13002.2 → 11776.4` | `3720 → 3720` | `38 → 38` |

Matched diagnostic paths reduce memory by 27.8% and allocations by 35.8%; the no-match and control paths add no allocations or bytes.

Correctness was checked with the complete package suite repeated three times, including upstream compatibility cases and focused range, option, edit-demand, and disable-directive coverage. Spell checking, formatting, targeted `golangci-lint`, and `git diff --check` also pass.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; behavior is unchanged).
