### PR TITLE
perf: optimize no-non-null-assertion reporting

### DIFF
--- a/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion.go
+++ b/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion.go
@@ -2,6 +2,7 @@ package no_non_null_assertion
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -21,6 +22,94 @@ func isAssignmentTarget(node *ast.Node) bool {
 	return false
 }
 
+func nonNullAssertionTokenRange(sourceFile *ast.SourceFile, node *ast.Node, expression *ast.Node) core.TextRange {
+	end := node.End()
+	start := end - 1
+	text := sourceFile.Text()
+	// Parsed non-null expressions end at their invariant ASCII `!` token. Keep
+	// the scanner fallback for synthetic, reparsed, or otherwise unusual nodes.
+	if start >= 0 && start >= expression.End() && end <= len(text) && text[start] == '!' {
+		return core.NewTextRange(start, end)
+	}
+	s := scanner.GetScannerForSourceFile(sourceFile, expression.End())
+	return s.TokenRange()
+}
+
+func singleOptionalChainSuggestion(suggestMsg rule.RuleMessage, fix rule.RuleFix) []rule.RuleSuggestion {
+	return []rule.RuleSuggestion{{
+		Message:  suggestMsg,
+		FixesArr: []rule.RuleFix{fix},
+	}}
+}
+
+func buildOptionalChainSuggestions(
+	sourceFile *ast.SourceFile,
+	node *ast.Node,
+	suggestMsg rule.RuleMessage,
+) []rule.RuleSuggestion {
+	expression := node.AsNonNullExpression().Expression
+	parent := node.Parent
+	if parent == nil {
+		return nil
+	}
+
+	switch parent.Kind {
+	case ast.KindPropertyAccessExpression:
+		if parent.Expression() != node || isAssignmentTarget(parent) {
+			return nil
+		}
+		if parent.AsPropertyAccessExpression().QuestionDotToken != nil {
+			return singleOptionalChainSuggestion(
+				suggestMsg,
+				rule.RuleFixRemoveRange(nonNullAssertionTokenRange(sourceFile, node, expression)),
+			)
+		}
+
+		// Dot notation (x!.y) removes ! and replaces . with ?.; scan only
+		// when the consumer actually requests suggestions.
+		dotScanner := scanner.GetScannerForSourceFile(sourceFile, expression.End())
+		dotScanner.Scan()
+		exclamRange := nonNullAssertionTokenRange(sourceFile, node, expression)
+		return []rule.RuleSuggestion{{
+			Message: suggestMsg,
+			FixesArr: []rule.RuleFix{
+				rule.RuleFixRemoveRange(exclamRange),
+				rule.RuleFixReplaceRange(dotScanner.TokenRange(), "?."),
+			},
+		}}
+	case ast.KindElementAccessExpression:
+		if parent.Expression() != node || isAssignmentTarget(parent) {
+			return nil
+		}
+		if parent.AsElementAccessExpression().QuestionDotToken != nil {
+			return singleOptionalChainSuggestion(
+				suggestMsg,
+				rule.RuleFixRemoveRange(nonNullAssertionTokenRange(sourceFile, node, expression)),
+			)
+		}
+		return singleOptionalChainSuggestion(
+			suggestMsg,
+			rule.RuleFixReplaceRange(nonNullAssertionTokenRange(sourceFile, node, expression), "?."),
+		)
+	case ast.KindCallExpression:
+		if parent.Expression() != node || isAssignmentTarget(parent) {
+			return nil
+		}
+		if parent.AsCallExpression().QuestionDotToken != nil {
+			return singleOptionalChainSuggestion(
+				suggestMsg,
+				rule.RuleFixRemoveRange(nonNullAssertionTokenRange(sourceFile, node, expression)),
+			)
+		}
+		return singleOptionalChainSuggestion(
+			suggestMsg,
+			rule.RuleFixReplaceRange(nonNullAssertionTokenRange(sourceFile, node, expression), "?."),
+		)
+	default:
+		return nil
+	}
+}
+
 var NoNonNullAssertionRule = rule.CreateRule(rule.Rule{
 	Name:   "no-non-null-assertion",
 	Schema: rule.EmptyArraySchema,
@@ -36,83 +125,9 @@ var NoNonNullAssertionRule = rule.CreateRule(rule.Rule{
 
 		return rule.RuleListeners{
 			ast.KindNonNullExpression: func(node *ast.Node) {
-				expression := node.AsNonNullExpression().Expression
-				parent := node.Parent
-
-				// Get the ! token range using scanner
-				exclamScanner := scanner.GetScannerForSourceFile(ctx.SourceFile, expression.End())
-				exclamRange := exclamScanner.TokenRange()
-
-				// Check if we can provide an optional chain suggestion
-				var suggestion *rule.RuleSuggestion
-
-				if parent.Kind == ast.KindPropertyAccessExpression && parent.Expression() == node {
-					propAccess := parent.AsPropertyAccessExpression()
-
-					// Don't suggest if this is an assignment target
-					if !isAssignmentTarget(parent) {
-						if propAccess.QuestionDotToken != nil {
-							// Already optional (x!?.y) → just remove !
-							suggestion = &rule.RuleSuggestion{
-								Message:  suggestMsg,
-								FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(exclamRange)},
-							}
-						} else {
-							// Dot notation (x!.y) → remove ! and replace . with ?.
-							exclamScanner.Scan() // advance to . token
-							dotRange := exclamScanner.TokenRange()
-							suggestion = &rule.RuleSuggestion{
-								Message: suggestMsg,
-								FixesArr: []rule.RuleFix{
-									rule.RuleFixRemoveRange(exclamRange),
-									rule.RuleFixReplaceRange(dotRange, "?."),
-								},
-							}
-						}
-					}
-				} else if parent.Kind == ast.KindElementAccessExpression && parent.Expression() == node {
-					elemAccess := parent.AsElementAccessExpression()
-
-					if !isAssignmentTarget(parent) {
-						if elemAccess.QuestionDotToken != nil {
-							// Already optional (x!?.[y]) → just remove !
-							suggestion = &rule.RuleSuggestion{
-								Message:  suggestMsg,
-								FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(exclamRange)},
-							}
-						} else {
-							// Computed access (x![y]) → replace ! with ?.
-							suggestion = &rule.RuleSuggestion{
-								Message:  suggestMsg,
-								FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(exclamRange, "?.")},
-							}
-						}
-					}
-				} else if parent.Kind == ast.KindCallExpression && parent.Expression() == node {
-					callExpr := parent.AsCallExpression()
-
-					if !isAssignmentTarget(parent) {
-						if callExpr.QuestionDotToken != nil {
-							// Already optional (x!?.()) → just remove !
-							suggestion = &rule.RuleSuggestion{
-								Message:  suggestMsg,
-								FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(exclamRange)},
-							}
-						} else {
-							// Call (x!()) → replace ! with ?.
-							suggestion = &rule.RuleSuggestion{
-								Message:  suggestMsg,
-								FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(exclamRange, "?.")},
-							}
-						}
-					}
-				}
-
-				if suggestion != nil {
-					ctx.ReportNodeWithSuggestions(node, msg, *suggestion)
-				} else {
-					ctx.ReportNode(node, msg)
-				}
+				ctx.ReportNodeWithDeferredSuggestions(node, msg, func() []rule.RuleSuggestion {
+					return buildOptionalChainSuggestions(ctx.SourceFile, node, suggestMsg)
+				})
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion_test.go
+++ b/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion_test.go
@@ -1,9 +1,14 @@
 package no_non_null_assertion
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -331,5 +336,226 @@ func TestNoNonNullAssertionRule(t *testing.T) {
 				},
 			},
 		},
+		// Assignment targets are diagnosed without an unsafe optional-chain suggestion.
+		{
+			Code: `x!.y.z = value;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noNonNull",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 3,
+				},
+			},
+		},
+		// Trivia between the assertion and property token stays in place.
+		{
+			Code: "x!\n// comment\n.y;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noNonNull",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "suggestOptionalChain",
+							Output:    "x\n// comment\n?.y;",
+						},
+					},
+				},
+			},
+		},
+		// Computed access keeps intervening comments after replacing the assertion.
+		{
+			Code: "x!\n/* comment */ [y];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noNonNull",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "suggestOptionalChain",
+							Output:    "x?.\n/* comment */ [y];",
+						},
+					},
+				},
+			},
+		},
 	})
+}
+
+func parseNoNonNullAssertionSource(code string) *ast.SourceFile {
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/source.ts",
+		Path:     "/source.ts",
+	}, code, core.ScriptKindTS)
+}
+
+func runNoNonNullAssertionWithDemand(
+	t *testing.T,
+	code string,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	sourceFile := parseNoNonNullAssertionSource(code)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 6)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(
+		NoNonNullAssertionRule.Name,
+		rule.SeverityError,
+		rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	)
+
+	listener := NoNonNullAssertionRule.Run(ctx, nil)[ast.KindNonNullExpression]
+	if listener == nil {
+		t.Fatal("expected non-null-expression listener")
+	}
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindNonNullExpression {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
+}
+
+func TestNoNonNullAssertionEditDemand(t *testing.T) {
+	const code = `plain!;
+property!.value;
+optional!?.value;
+element![key];
+callback!();
+target!.value.deep = replacement;`
+
+	diagnosticsOnly := runNoNonNullAssertionWithDemand(t, code, rule.EditDemandNone)
+	autofixDemand := runNoNonNullAssertionWithDemand(t, code, rule.EditDemandAutofix)
+	suggestionDemand := runNoNonNullAssertionWithDemand(t, code, rule.EditDemandSuggestion)
+	if len(diagnosticsOnly) != 6 || len(autofixDemand) != 6 || len(suggestionDemand) != 6 {
+		t.Fatalf(
+			"diagnostic counts = %d, %d, and %d, want 6",
+			len(diagnosticsOnly),
+			len(autofixDemand),
+			len(suggestionDemand),
+		)
+	}
+
+	for index := range diagnosticsOnly {
+		if diagnosticsOnly[index].FixesPtr != nil || diagnosticsOnly[index].Suggestions != nil {
+			t.Fatalf("diagnostics-only result %d unexpectedly materialized edits", index)
+		}
+		if autofixDemand[index].FixesPtr != nil || autofixDemand[index].Suggestions != nil {
+			t.Fatalf("autofix-demand result %d unexpectedly materialized edits", index)
+		}
+		if diagnosticsOnly[index].Range != suggestionDemand[index].Range ||
+			diagnosticsOnly[index].Message.Id != suggestionDemand[index].Message.Id ||
+			diagnosticsOnly[index].Message.Description != suggestionDemand[index].Message.Description {
+			t.Fatalf("diagnostic %d changed when suggestions were requested", index)
+		}
+	}
+
+	if suggestionDemand[0].Suggestions != nil || suggestionDemand[5].Suggestions != nil {
+		t.Fatalf("plain and assignment diagnostics should not suggest: %#v, %#v", suggestionDemand[0], suggestionDemand[5])
+	}
+	wantFixes := []struct {
+		index        int
+		sourceTexts  []string
+		replacements []string
+	}{
+		{index: 1, sourceTexts: []string{"!", "."}, replacements: []string{"", "?."}},
+		{index: 2, sourceTexts: []string{"!"}, replacements: []string{""}},
+		{index: 3, sourceTexts: []string{"!"}, replacements: []string{"?."}},
+		{index: 4, sourceTexts: []string{"!"}, replacements: []string{"?."}},
+	}
+	for _, want := range wantFixes {
+		diagnostic := suggestionDemand[want.index]
+		if diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != 1 {
+			t.Fatalf("diagnostic %d suggestions = %#v, want one", want.index, diagnostic.Suggestions)
+		}
+		suggestion := (*diagnostic.Suggestions)[0]
+		if suggestion.Message.Id != "suggestOptionalChain" || len(suggestion.FixesArr) != len(want.sourceTexts) {
+			t.Fatalf("diagnostic %d suggestion = %#v", want.index, suggestion)
+		}
+		for fixIndex, fix := range suggestion.FixesArr {
+			sourceText := diagnostic.SourceFile.Text()[fix.Range.Pos():fix.Range.End()]
+			if sourceText != want.sourceTexts[fixIndex] || fix.Text != want.replacements[fixIndex] {
+				t.Fatalf(
+					"diagnostic %d fix %d = replace %q with %q, want %q with %q",
+					want.index,
+					fixIndex,
+					sourceText,
+					fix.Text,
+					want.sourceTexts[fixIndex],
+					want.replacements[fixIndex],
+				)
+			}
+		}
+	}
+}
+
+func TestNoNonNullAssertionDisableDirectives(t *testing.T) {
+	const code = `// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+line!.value;
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+scoped![key];
+/* eslint-enable @typescript-eslint/no-non-null-assertion */
+reported!;`
+
+	diagnostics := runNoNonNullAssertionWithDemand(t, code, rule.EditDemandSuggestion)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want only the enabled assertion", len(diagnostics))
+	}
+	if got := diagnostics[0].SourceFile.Text()[diagnostics[0].Range.Pos():diagnostics[0].Range.End()]; got != "reported!" {
+		t.Fatalf("reported range text = %q, want %q", got, "reported!")
+	}
+}
+
+func TestNonNullAssertionTokenRangeFallback(t *testing.T) {
+	const code = `value!.property;`
+	sourceFile := parseNoNonNullAssertionSource(code)
+	var assertion *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindNonNullExpression {
+			assertion = node
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if assertion == nil {
+		t.Fatal("test setup did not find a non-null assertion")
+	}
+
+	expression := assertion.AsNonNullExpression().Expression
+	wantStart := strings.Index(code, "!")
+	want := core.NewTextRange(wantStart, wantStart+1)
+	if got := nonNullAssertionTokenRange(sourceFile, assertion, expression); got != want {
+		t.Fatalf("fast-path range = %#v, want %#v", got, want)
+	}
+
+	original := assertion.Loc
+	for _, malformedEnd := range []int{0, len(code)} {
+		assertion.Loc = core.NewTextRange(original.Pos(), malformedEnd)
+		if got := nonNullAssertionTokenRange(sourceFile, assertion, expression); got != want {
+			t.Fatalf("fallback range with end %d = %#v, want %#v", malformedEnd, got, want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer optional-chain suggestion eligibility checks and fix construction until the diagnostic consumer requests suggestions.
- Use a validated one-byte range for the invariant `!` token, with the original scanner behavior as a fallback for unusual AST nodes.
- Preserve diagnostic and suggestion behavior across property, optional property, element, call, assignment-target, trivia, and disable-directive cases.

## Related Links

<!--- Provide links of related issues or pages -->

N/A

## Go Benchmark

The temporary package-local benchmark parsed each fixture once, invoked the rule listener with the named edit demand, and collected five `-benchmem` samples per case. The benchmark source was removed after measurement.

Command:

```sh
go test ./internal/plugins/typescript/rules/no_non_null_assertion -run '^$' -bench '^BenchmarkNoNonNullAssertion$' -benchmem -count=5
```

| Case (5-sample mean) | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| DiagnosticsPlain | `135.840 → 80.884` | `320 → 160` | `2 → 1` |
| DiagnosticsSuggestionCandidate | `225.280 → 91.888` | `456 → 160` | `5 → 1` |
| AutofixDemandSuggestionCandidate | `223.380 → 94.650` | `456 → 160` | `5 → 1` |
| SuggestionsProperty | `222.840 → 216.140` | `456 → 456` | `5 → 5` |
| SuggestionsOptionalProperty | `240.260 → 151.500` | `432 → 272` | `5 → 4` |
| SuggestionsElement | `226.300 → 150.880` | `432 → 272` | `5 → 4` |
| SuggestionsCall | `540.680 → 151.800` | `432 → 272` | `5 → 4` |
| AssignmentTarget | `222.460 → 90.626` | `320 → 160` | `2 → 1` |
| NoMatch | `0.663 → 0.658` | `0 → 0` | `0 → 0` |

Correctness checks:

- `go test ./internal/plugins/typescript/rules/no_non_null_assertion -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_non_null_assertion/...`
- `git diff --check`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
