### PR TITLE
refactor: remove legacy rule options compatibility code

### DIFF
--- a/internal/config/all_rules_schema_test.go
+++ b/internal/config/all_rules_schema_test.go
@@ -10,10 +10,18 @@ import (
 // user's config); this sweep front-loads that failure into CI, playing the
 // role a MustCompile-at-init would — without making every rslint process pay
 // startup compilation for hundreds of schemas.
+//
+// It also enforces that every registered rule declares a schema. Only
+// ESLint-plugin placeholder rules run without one — the Node worker's own
+// ESLint validates their options.
 func TestAllRules_DeclaredSchemasCompile(t *testing.T) {
 	RegisterAllRules()
 	for name, ruleImpl := range GlobalRuleRegistry.GetAllRules() {
+		if ruleImpl.IsEslintPluginRule {
+			continue
+		}
 		if ruleImpl.Schema == nil {
+			t.Errorf("rule %s declares no options schema; every registered rule must declare one", name)
 			continue
 		}
 		if _, err := ruleImpl.Schema.Compile(); err != nil {

--- a/internal/config/validate_rule_options.go
+++ b/internal/config/validate_rule_options.go
@@ -33,12 +33,12 @@ func (e RuleOptionsError) Error() string {
 //
 // It is meant to run as a separate step right after configuration is
 // resolved and before linting starts, so a bad config fails fast instead of
-// surfacing mid-lint. Validation is skipped for rules that declare no schema
-// yet (rule.Rule.Schema == nil — the pre-framework status quo), for rules
-// not present in the registry (unknown names are not an error here — making
-// them fatal is planned separately), and for disabled ("off") entries.
-// ESLint-plugin rules mounted via the config's object-form `plugins` never
-// carry a Go schema; the Node worker's own ESLint validates their options.
+// surfacing mid-lint. Validation is skipped for rules not present in the
+// registry (unknown names are not an error here — making them fatal is
+// planned separately) and for disabled ("off") entries. ESLint-plugin rules
+// mounted via the config's object-form `plugins` are registered without a Go
+// schema (rule.Rule.Schema == nil) and are skipped too; the Node worker's
+// own ESLint validates their options.
 //
 // Each entry's options are validated independently, mirroring ESLint, which
 // validates every config array element's options rather than only the final

--- a/internal/plugins/import/rules/first/first.go
+++ b/internal/plugins/import/rules/first/first.go
@@ -185,7 +185,11 @@ func checkFirst(ctx rule.RuleContext, options []any) {
 		return
 	}
 
-	absoluteFirst := utils.GetOptionsString(options) == "absolute-first"
+	absoluteFirst := false
+	if len(options) > 0 {
+		mode, _ := options[0].(string)
+		absoluteFirst = mode == "absolute-first"
+	}
 	body := statements.Nodes
 
 	nonImportCount := 0

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.go
@@ -126,10 +126,10 @@ func resolveBasePath(ctx rule.RuleContext, configured string) string {
 
 func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{}
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	optsMap, _ := options[0].(map[string]any)
 
 	opts.basePath, _ = optsMap["basePath"].(string)
 

--- a/internal/plugins/jest/rules/require_hook/require_hook.go
+++ b/internal/plugins/jest/rules/require_hook/require_hook.go
@@ -1,12 +1,17 @@
 package require_hook
 
 import (
+	_ "embed"
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
-	"strings"
 )
+
+//go:embed require_hook.schema.json
+var schemaJSON []byte
 
 func buildUseHookMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -33,17 +38,13 @@ func parseAllowedFunctionCalls(raw any) []string {
 	return out
 }
 
-func parseOptions(options any) Options {
+func parseOptions(options []any) Options {
 	opts := Options{AllowedFunctionCalls: nil}
-	if options == nil {
+	if len(options) == 0 {
 		return opts
 	}
 
-	optArray := rule.NormalizeOptions(options)
-	if len(optArray) == 0 {
-		return opts
-	}
-	optsMap, ok := optArray[0].(map[string]interface{})
+	optsMap, ok := options[0].(map[string]interface{})
 	if !ok {
 		return opts
 	}
@@ -182,9 +183,9 @@ func checkBlockBody(ctx rule.RuleContext, body []*ast.Node, allowedFunctionCalls
 }
 
 var RequireHookRule = rule.Rule{
-	Name: "jest/require-hook",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/require-hook",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		if ctx.SourceFile != nil && ctx.SourceFile.Statements != nil {

--- a/internal/plugins/jest/rules/require_hook/require_hook.schema.json
+++ b/internal/plugins/jest/rules/require_hook/require_hook.schema.json
@@ -1,0 +1,19 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowedFunctionCalls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/require_top_level_describe/require_top_level_describe.go
+++ b/internal/plugins/jest/rules/require_top_level_describe/require_top_level_describe.go
@@ -19,13 +19,13 @@ type options struct {
 	MaxNumberOfTopLevelDescribes int
 }
 
-func parseOptions(raw any) options {
+func parseOptions(rawOptions []any) options {
 	opts := options{MaxNumberOfTopLevelDescribes: math.MaxInt}
-	m := internalUtils.GetOptionsMap(raw)
-	if m == nil {
+	if len(rawOptions) == 0 {
 		return opts
 	}
 
+	m, _ := rawOptions[0].(map[string]any)
 	if n, ok := internalUtils.CoerceInt(m["maxNumberOfTopLevelDescribes"]); ok && n >= 1 {
 		opts.MaxNumberOfTopLevelDescribes = n
 	}
@@ -62,8 +62,8 @@ var (
 var RequireTopLevelDescribeRule = rule.Rule{
 	Name:   "jest/require-top-level-describe",
 	Schema: rule.NewSchema(schemaJSON),
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		opts := parseOptions(rule.LegacyUnwrapOptions(_options))
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 		numberOfDescribeBlocks := 0
 		numberOfTopLevelDescribeBlocks := 0
 

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
@@ -43,10 +43,9 @@ type RestrictPlusOperandsOptions struct {
 }
 
 func parseOptions(options []any) RestrictPlusOperandsOptions {
-	opts, ok := rule.LegacyUnwrapOptions(options).(RestrictPlusOperandsOptions)
-	if !ok {
-		opts = RestrictPlusOperandsOptions{}
-		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+	opts := RestrictPlusOperandsOptions{}
+	if len(options) > 0 {
+		if optsMap, ok := options[0].(map[string]any); ok {
 			if value, ok := optsMap["allowAny"].(bool); ok {
 				opts.AllowAny = utils.Ref(value)
 			}

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
@@ -36,7 +36,6 @@ func TestParseOptions(t *testing.T) {
 			skipCompoundAssignments: value("skipCompoundAssignments", got.SkipCompoundAssignments),
 		}
 	}
-	boolRef := func(value bool) *bool { return &value }
 	tests := []struct {
 		name    string
 		options []any
@@ -64,18 +63,6 @@ func TestParseOptions(t *testing.T) {
 				allowNumberAndString:    true,
 				allowRegExp:             true,
 				skipCompoundAssignments: true,
-			},
-		},
-		{
-			name: "typed partial overrides",
-			options: []any{RestrictPlusOperandsOptions{
-				AllowBoolean:         boolRef(false),
-				AllowNumberAndString: boolRef(false),
-			}},
-			want: optionValues{
-				allowAny:     true,
-				allowNullish: true,
-				allowRegExp:  true,
 			},
 		},
 	}

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.go
@@ -12,7 +12,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 //go:embed filename_case.schema.json
@@ -87,10 +86,10 @@ type options struct {
 func parseOptions(rawOpts []any) options {
 	opts := options{caseCount: 1, multipleFileExtensions: true}
 	opts.cases[0] = allCases[2] // kebabCase
-	optsMap := utils.GetOptionsMap(rawOpts)
-	if optsMap == nil {
+	if len(rawOpts) == 0 {
 		return opts
 	}
+	optsMap, _ := rawOpts[0].(map[string]any)
 
 	if v, ok := optsMap["case"].(string); ok {
 		if c, found := caseForKey(v); found {

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.go
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.go
@@ -152,10 +152,10 @@ func parseOptions(rawOptions []any) options {
 		exclude:         utils.NewSetFromItems[string](),
 	}
 
-	optsMap := utils.GetOptionsMap(rawOptions)
-	if optsMap == nil {
+	if len(rawOptions) == 0 {
 		return opts
 	}
+	optsMap, _ := rawOptions[0].(map[string]any)
 
 	if useErrorIsError, ok := optsMap["useErrorIsError"].(bool); ok {
 		opts.useErrorIsError = useErrorIsError

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
@@ -363,7 +363,8 @@ func buildFixes(node *ast.Node, match flattenMatch, ctx rule.RuleContext) []rule
 
 func parseFunctions(options []any) []string {
 	functions := make([]string, 0, len(lodashFlattenFunctions))
-	if optionsMap := utils.GetOptionsMap(options); optionsMap != nil {
+	if len(options) > 0 {
+		optionsMap, _ := options[0].(map[string]any)
 		functions = append(functions, utils.ToStringSlice(optionsMap["functions"])...)
 	}
 	return append(functions, lodashFlattenFunctions...)

--- a/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.go
+++ b/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.go
@@ -90,10 +90,10 @@ func parseOptions(options []any) preferNumberPropertiesOptions {
 		checkInfinity: false,
 		checkNaN:      true,
 	}
-	optionsMap := utils.GetOptionsMap(options)
-	if optionsMap == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	optionsMap, _ := options[0].(map[string]any)
 	if value, ok := optionsMap["checkInfinity"].(bool); ok {
 		opts.checkInfinity = value
 	}

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
@@ -66,10 +66,10 @@ type options struct {
 
 func parseOptions(rawOptions []any) options {
 	opts := options{minimumItems: 0}
-	optsMap := utils.GetOptionsMap(rawOptions)
-	if optsMap == nil {
+	if len(rawOptions) == 0 {
 		return opts
 	}
+	optsMap, _ := rawOptions[0].(map[string]any)
 	if value, ok := optsMap["minimumItems"]; ok {
 		if number, ok := utils.CoerceIntegral(value); ok {
 			opts.minimumItems = number

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -54,13 +54,8 @@ func ParseSeverity(level string) DiagnosticSeverity {
 }
 
 // NormalizeOptions returns a rule's options in ESLint context.options form
-// ([]any). config.parseArrayRuleConfig never collapses RuleConfig.Options, but
-// LegacyUnwrapOptions (the compatibility shim for pre-migration `parseOptions
-// any` bodies) does — a rule that round-trips through it and then wants the
-// eslint-format array back (e.g. reads optArray[0]) would silently miss a
-// single-option config otherwise. Re-wrapping a bare value lets every caller
-// read options[0] uniformly, whether the option arrived wrapped (multi-option
-// or an explicit array) or unwrapped (a single option).
+// ([]any): an array value passes through as-is, and a bare value is wrapped
+// as a single-element array so every caller reads options[0] uniformly.
 //
 // It returns an empty (non-nil) slice when no options were configured, so both
 // native rules (which key on `len == 0 → defaults`) and the eslint-plugin host
@@ -74,24 +69,6 @@ func NormalizeOptions(raw any) []any {
 		return arr
 	}
 	return []any{raw}
-}
-
-// LegacyUnwrapOptions is NormalizeOptions' inverse: it collapses a rule's options
-// array (Run's []any parameter — ESLint's context.options, the config array
-// after the severity level) back to the single bare value most existing rule
-// implementations parse. Empty → nil; a single element → that element;
-// otherwise the slice itself. This is the compatibility shim old
-// `parseOptions(options any)` bodies call so they don't need to change beyond
-// their Run signature.
-func LegacyUnwrapOptions(options []any) any {
-	switch len(options) {
-	case 0:
-		return nil
-	case 1:
-		return options[0]
-	default:
-		return options
-	}
 }
 
 const (
@@ -130,9 +107,9 @@ type Rule struct {
 	// linting starts, filling schema-declared `default` values into the
 	// options in place the way ajv's `useDefaults` does for ESLint (see
 	// [Schema.Validate]). Rules that take no options should set it to the
-	// shared [EmptyArraySchema]. nil means the rule has not declared a schema
-	// yet (most rules, until migrated one-by-one): its options pass through
-	// unvalidated, exactly as before the schema framework existed.
+	// shared [EmptyArraySchema]. Every registered rule must declare a schema;
+	// only ESLint-plugin placeholder rules (whose options the Node worker's
+	// own ESLint validates) leave it nil.
 	Schema *Schema
 	Run    func(ctx RuleContext, options []any) RuleListeners
 }

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -138,8 +138,8 @@ type ESLintTestSuite struct {
 // rule whose defaults live in its schema sees them in tests too, exactly as it
 // would at runtime.
 //
-// Rules that declare no schema yet run whatever the test case passes,
-// preserving the pre-schema behavior.
+// Ad-hoc rules constructed directly in tests may declare no schema; they run
+// whatever the test case passes, unvalidated.
 //
 // It is exported so test harnesses that call a rule's Run directly instead of
 // going through [RunRuleTester] (e.g. to inspect diagnostics across multiple

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -543,23 +543,6 @@ func CoerceIntegral(v any) (int, bool) {
 	return CoerceInt(v)
 }
 
-// GetOptionsString extracts a string option from the weakly-typed options parameter.
-// It handles both direct string format ("value") and array format (["value"]).
-func GetOptionsString(opts any) string {
-	if opts == nil {
-		return ""
-	}
-	if s, ok := opts.(string); ok {
-		return s
-	}
-	if arr, ok := opts.([]interface{}); ok && len(arr) > 0 {
-		if s, ok := arr[0].(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
 // ToStringSlice converts a weakly-typed JSON array ([]interface{}) to []string,
 // extracting only the string elements. Returns nil if the input is nil, not an array,
 // or contains no strings. Useful for parsing rule options from JSON config.

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -458,8 +458,6 @@ func Must[T any](v T, err error) T {
 	return v
 }
 
-// GetOptionsMap extracts a map[string]interface{} from rule options.
-// It handles both array format [{ option: value }] and direct object format { option: value }.
 // ExtractRegexPatternAndFlags splits a RegularExpressionLiteral's text (e.g. "/pattern/gi")
 // into the pattern and flags portions. Returns ("", "") for malformed input.
 func ExtractRegexPatternAndFlags(text string) (pattern string, flags string) {
@@ -473,43 +471,18 @@ func ExtractRegexPatternAndFlags(text string) (pattern string, flags string) {
 	return text[1 : lastSlash+1], text[lastSlash+2:]
 }
 
-func GetOptionsMap(opts any) map[string]interface{} {
-	if opts == nil {
-		return nil
-	}
-
-	var optsMap map[string]interface{}
-	if arr, ok := opts.([]interface{}); ok && len(arr) > 0 {
-		optsMap, _ = arr[0].(map[string]interface{})
-	} else {
-		optsMap, _ = opts.(map[string]interface{})
-	}
-
-	return optsMap
-}
-
-// ResolveLegacyMaxOption resolves ESLint's legacy maximum/max option shape.
-// It handles number forms (`3` / `[3]`) plus object forms (`{max: 3}` /
-// `[{maximum: 3}]`). `maximum` wins only when it coerces to a non-zero number;
-// otherwise `max` is used. If either key is present but neither yields a
-// numeric threshold, ESLint ends up comparing against `undefined`, which never
-// reports; MaxInt gives the same observable behavior in Go.
-func ResolveLegacyMaxOption(options any, defaultMax int) int {
-	if options == nil {
-		return defaultMax
-	}
-	if arr, ok := options.([]interface{}); ok {
-		if len(arr) == 0 {
-			return defaultMax
-		}
-		if n, ok := CoerceInt(arr[0]); ok {
-			return n
-		}
-	} else if n, ok := CoerceInt(options); ok {
+// ResolveLegacyMaxOption resolves ESLint's legacy maximum/max option shape:
+// the single option element is either a bare number (`3`) or an object
+// (`{max: 3}` / `{maximum: 3}`). `maximum` wins only when it coerces to a
+// non-zero number; otherwise `max` is used. If either key is present but
+// neither yields a numeric threshold, ESLint ends up comparing against
+// `undefined`, which never reports; MaxInt gives the same observable behavior
+// in Go.
+func ResolveLegacyMaxOption(option any, defaultMax int) int {
+	if n, ok := CoerceInt(option); ok {
 		return n
 	}
-
-	m := GetOptionsMap(options)
+	m, _ := option.(map[string]interface{})
 	if m == nil {
 		return defaultMax
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -294,13 +294,12 @@ func TestResolveLegacyMaxOption(t *testing.T) {
 		want       int
 	}{
 		{name: "nil uses default", defaultMax: 3, want: 3},
-		{name: "empty array uses default", options: []interface{}{}, defaultMax: 3, want: 3},
 		{name: "bare number", options: 4, defaultMax: 3, want: 4},
-		{name: "array number", options: []interface{}{float64(5)}, defaultMax: 3, want: 5},
-		{name: "bare max object", options: map[string]interface{}{"max": 6}, defaultMax: 3, want: 6},
-		{name: "array maximum object", options: []interface{}{map[string]interface{}{"maximum": 7, "max": 1}}, defaultMax: 3, want: 7},
-		{name: "zero maximum falls through to max", options: []interface{}{map[string]interface{}{"maximum": 0, "max": 8}}, defaultMax: 3, want: 8},
-		{name: "zero maximum without fallback disables", options: []interface{}{map[string]interface{}{"maximum": 0}}, defaultMax: 3, want: math.MaxInt},
+		{name: "json-decoded number", options: float64(5), defaultMax: 3, want: 5},
+		{name: "max object", options: map[string]interface{}{"max": 6}, defaultMax: 3, want: 6},
+		{name: "maximum wins over max", options: map[string]interface{}{"maximum": 7, "max": 1}, defaultMax: 3, want: 7},
+		{name: "zero maximum falls through to max", options: map[string]interface{}{"maximum": 0, "max": 8}, defaultMax: 3, want: 8},
+		{name: "zero maximum without fallback disables", options: map[string]interface{}{"maximum": 0}, defaultMax: 3, want: math.MaxInt},
 		{name: "nonnumeric max disables", options: map[string]interface{}{"max": "wide"}, defaultMax: 3, want: math.MaxInt},
 		{name: "object without max keys uses default", options: map[string]interface{}{"foo": 1}, defaultMax: 3, want: 3},
 	}


### PR DESCRIPTION
## Summary

Step 5 of #1216: the schema-driven options path is now the only path.

Migrates the last rules off the legacy option shapes:

- `jest/require-hook` — the only registered rule without an options schema; adds `require_hook.schema.json` matching upstream eslint-plugin-jest.
- `jest/require-top-level-describe`.
- `@typescript-eslint/restrict-plus-operands` — drops the branch that accepted a Go struct as the option value; only its own test used it.
- `import/first`, `import/no-restricted-paths` and five unicorn rules — read `options[0]` directly.

Removes the compatibility shims, which now have no callers: `rule.LegacyUnwrapOptions`, `utils.GetOptionsMap` and `utils.GetOptionsString`. The dead array branch in `utils.ResolveLegacyMaxOption` goes too — it only ever receives a single option element.

`TestAllRules_DeclaredSchemasCompile` now fails a registered rule that declares no schema, so the legacy path cannot reappear. ESLint-plugin placeholder rules stay exempt; the Node worker's own ESLint validates their options.

## Related Links

- Tracking issue: #1216

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
