### PR TITLE
perf: optimize parameter properties

### DIFF
--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties.go
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties.go
@@ -2,9 +2,7 @@ package parameter_properties
 
 import (
 	_ "embed"
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -18,16 +16,25 @@ var schemaJSON []byte
 // "readonly", "private", "protected", "public",
 // "private readonly", "protected readonly", "public readonly"
 
+type allowedModifier uint8
+
+const (
+	allowedReadonly allowedModifier = 1 << iota
+	allowedPrivate
+	allowedProtected
+	allowedPublic
+	allowedPrivateReadonly
+	allowedProtectedReadonly
+	allowedPublicReadonly
+)
+
 type options struct {
-	allow  map[string]bool
+	allow  allowedModifier
 	prefer string
 }
 
 func parseOptions(rawOpts []any) options {
-	o := options{
-		allow:  make(map[string]bool),
-		prefer: "class-property",
-	}
+	o := options{prefer: "class-property"}
 	if len(rawOpts) == 0 {
 		return o
 	}
@@ -35,7 +42,22 @@ func parseOptions(rawOpts []any) options {
 	if allow, ok := optsMap["allow"].([]interface{}); ok {
 		for _, a := range allow {
 			if s, ok := a.(string); ok {
-				o.allow[s] = true
+				switch s {
+				case "readonly":
+					o.allow |= allowedReadonly
+				case "private":
+					o.allow |= allowedPrivate
+				case "protected":
+					o.allow |= allowedProtected
+				case "public":
+					o.allow |= allowedPublic
+				case "private readonly":
+					o.allow |= allowedPrivateReadonly
+				case "protected readonly":
+					o.allow |= allowedProtectedReadonly
+				case "public readonly":
+					o.allow |= allowedPublicReadonly
+				}
 			}
 		}
 	}
@@ -45,37 +67,51 @@ func parseOptions(rawOpts []any) options {
 	return o
 }
 
-// getModifiers builds the ESLint-style modifier string (e.g. "public readonly") from a node's
-// accessibility and readonly flags. The result is used to match against the user's "allow" list.
-// NOTE: class_literal_property_style has a similar printNodeModifiers, but it also handles
-// "static" and serves a different purpose (generating replacement code text).
-func getModifiers(node *ast.Node) string {
-	var parts []string
-	flags := ast.GetCombinedModifierFlags(node)
+func (o options) allows(node *ast.Node) bool {
+	if o.allow == 0 {
+		return false
+	}
+
+	// Callers pass only parameter or property declarations, for which direct
+	// modifier flags are identical to combined modifier flags.
+	flags := node.ModifierFlags()
+	readonly := flags&ast.ModifierFlagsReadonly != 0
+	var modifier allowedModifier
 	if flags&ast.ModifierFlagsPublic != 0 {
-		parts = append(parts, "public")
+		if readonly {
+			modifier = allowedPublicReadonly
+		} else {
+			modifier = allowedPublic
+		}
 	} else if flags&ast.ModifierFlagsProtected != 0 {
-		parts = append(parts, "protected")
+		if readonly {
+			modifier = allowedProtectedReadonly
+		} else {
+			modifier = allowedProtected
+		}
 	} else if flags&ast.ModifierFlagsPrivate != 0 {
-		parts = append(parts, "private")
+		if readonly {
+			modifier = allowedPrivateReadonly
+		} else {
+			modifier = allowedPrivate
+		}
+	} else if readonly {
+		modifier = allowedReadonly
 	}
-	if flags&ast.ModifierFlagsReadonly != 0 {
-		parts = append(parts, "readonly")
-	}
-	return strings.Join(parts, " ")
+	return o.allow&modifier != 0
 }
 
 func buildPreferClassPropertyMessage(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "preferClassProperty",
-		Description: fmt.Sprintf("Property %s should be declared as a class property.", name),
+		Description: "Property " + name + " should be declared as a class property.",
 	}
 }
 
 func buildPreferParameterPropertyMessage(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "preferParameterProperty",
-		Description: fmt.Sprintf("Property %s should be declared as a parameter property.", name),
+		Description: "Property " + name + " should be declared as a parameter property.",
 	}
 }
 
@@ -97,11 +133,12 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 		if opts.prefer == "class-property" {
 			return rule.RuleListeners{
 				ast.KindParameter: func(node *ast.Node) {
-					if node.Parent == nil {
-						return
-					}
-					// Check if this parameter is a parameter property
-					if !ast.IsParameterPropertyDeclaration(node, node.Parent) {
+					// This is equivalent to IsParameterPropertyDeclaration for a
+					// KindParameter listener, ordered to reject non-constructor
+					// parameters before reading their modifier flags.
+					if node.Parent == nil ||
+						node.Parent.Kind != ast.KindConstructor ||
+						node.ModifierFlags()&ast.ModifierFlagsParameterPropertyModifier == 0 {
 						return
 					}
 
@@ -121,8 +158,7 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 						return
 					}
 
-					modifiers := getModifiers(node)
-					if opts.allow[modifiers] {
+					if opts.allows(node) {
 						return
 					}
 
@@ -135,16 +171,6 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 		// "parameter-property" mode: use a stack to handle nested classes.
 		// Each map tracks {name → propertyNodes} for the current class scope.
 		var propertyNodesByNameStack []map[string]*propertyNodes
-
-		getNodesByName := func(name string) *propertyNodes {
-			m := propertyNodesByNameStack[len(propertyNodesByNameStack)-1]
-			if existing, ok := m[name]; ok {
-				return existing
-			}
-			created := &propertyNodes{}
-			m[name] = created
-			return created
-		}
 
 		// typeAnnotationsMatch checks that both nodes either lack type annotations or
 		// have identical annotation text. ESLint compares getText(TSTypeAnnotation)
@@ -165,7 +191,7 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 		}
 
 		enterClass := func(node *ast.Node) {
-			propertyNodesByNameStack = append(propertyNodesByNameStack, make(map[string]*propertyNodes))
+			var propertyNodesByName map[string]*propertyNodes
 
 			// Process class body members (equivalent to ClassBody visitor in ESLint)
 			members := node.Members()
@@ -186,11 +212,21 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 					continue
 				}
 				// Skip if modifier is in allow list
-				if opts.allow[getModifiers(member)] {
+				if opts.allows(member) {
 					continue
 				}
-				getNodesByName(nameNode.AsIdentifier().Text).classProperty = member
+				if propertyNodesByName == nil {
+					propertyNodesByName = make(map[string]*propertyNodes)
+				}
+				name := nameNode.AsIdentifier().Text
+				nodes := propertyNodesByName[name]
+				if nodes == nil {
+					nodes = &propertyNodes{}
+					propertyNodesByName[name] = nodes
+				}
+				nodes.classProperty = member
 			}
+			propertyNodesByNameStack = append(propertyNodesByNameStack, propertyNodesByName)
 		}
 
 		exitClass := func(node *ast.Node) {
@@ -216,9 +252,11 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 					violations = append(violations, violation{name, nodes.classProperty})
 				}
 			}
-			sort.Slice(violations, func(i, j int) bool {
-				return violations[i].node.Pos() < violations[j].node.Pos()
-			})
+			if len(violations) > 1 {
+				sort.Slice(violations, func(i, j int) bool {
+					return violations[i].node.Pos() < violations[j].node.Pos()
+				})
+			}
 			for _, v := range violations {
 				ctx.ReportNode(v.node, buildPreferParameterPropertyMessage(v.name))
 			}
@@ -239,6 +277,10 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 			},
 			ast.KindConstructor: func(node *ast.Node) {
 				if len(propertyNodesByNameStack) == 0 {
+					return
+				}
+				propertyNodesByName := propertyNodesByNameStack[len(propertyNodesByNameStack)-1]
+				if len(propertyNodesByName) == 0 {
 					return
 				}
 
@@ -279,7 +321,9 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 					if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 						continue
 					}
-					getNodesByName(nameNode.AsIdentifier().Text).constructorParameter = param
+					if nodes := propertyNodesByName[nameNode.AsIdentifier().Text]; nodes != nil {
+						nodes.constructorParameter = param
+					}
 				}
 
 				// Scan leading statements of the form `this.X = Y` (where Y is an identifier).
@@ -331,7 +375,9 @@ var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
 						break
 					}
 					rightName := right.AsIdentifier().Text
-					getNodesByName(rightName).constructorAssignment = true
+					if nodes := propertyNodesByName[rightName]; nodes != nil {
+						nodes.constructorAssignment = true
+					}
 				}
 			},
 		}

--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties_test.go
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties_test.go
@@ -1,9 +1,14 @@
 package parameter_properties
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -60,6 +65,9 @@ class Foo {
 		// --- Semantically invalid: rest / destructured parameter properties ---
 		{Code: `class Foo { constructor(private ...name: string[]) {} }`},
 		{Code: `class Foo { constructor(private [test]: [string]) {} }`},
+
+		// A modifier outside a constructor does not create a parameter property.
+		{Code: `class Foo { method(private value: string) {} }`},
 
 		// ============================================================
 		// prefer: "parameter-property" — valid cases
@@ -456,6 +464,13 @@ class Foo {
 			Code:   "\nclass Foo {\n  constructor(public readonly name: string) {}\n}",
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
 		},
+		{
+			Code: `
+class Child extends Base {
+  constructor(override member: string) { super(); }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
 
 		// --- Mixed: one param-property + one plain ---
 		{
@@ -796,6 +811,18 @@ class Foo {
 			Options: map[string]interface{}{"prefer": "parameter-property"},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
 		},
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(unrelated: string, member: string) {
+    this.unrelated = unrelated;
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
 
 		// --- Property after constructor ---
 		{
@@ -980,4 +1007,101 @@ class Outer {
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 4, Column: 5}},
 		},
 	})
+}
+
+func runParameterPropertiesWithDemand(
+	t *testing.T,
+	code string,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/parameter-properties-demand.ts",
+		Path:     "/parameter-properties-demand.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(
+		ParameterPropertiesRule.Name,
+		rule.SeverityError,
+		rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	)
+	listeners := ParameterPropertiesRule.Run(ctx, options)
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		node.ForEachChild(visit)
+		if listener := listeners[rule.ListenerOnExit(node.Kind)]; listener != nil {
+			listener(node)
+		}
+		return false
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
+}
+
+func TestParameterPropertiesEditDemandAndSuppression(t *testing.T) {
+	const code = `class Foo { constructor(private member: string) {} }`
+	wantStart := strings.Index(code, "private")
+	wantRange := core.NewTextRange(wantStart, wantStart+len("private member: string"))
+
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		diagnostics := runParameterPropertiesWithDemand(t, code, nil, demand)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		diagnostic := diagnostics[0]
+		if diagnostic.Range != wantRange {
+			t.Fatalf("demand %d range = %#v, want %#v", demand, diagnostic.Range, wantRange)
+		}
+		if diagnostic.Message.Id != "preferClassProperty" ||
+			diagnostic.Message.Description != "Property member should be declared as a class property." {
+			t.Fatalf("demand %d message = %#v", demand, diagnostic.Message)
+		}
+		if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+			t.Fatalf("demand %d unexpectedly materialized edits", demand)
+		}
+	}
+
+	scopedDisabled := runParameterPropertiesWithDemand(
+		t,
+		"/* eslint-disable @typescript-eslint/parameter-properties */\n"+code,
+		nil,
+		rule.EditDemandAll,
+	)
+	if len(scopedDisabled) != 0 {
+		t.Fatalf("scoped-disabled diagnostics = %d, want 0", len(scopedDisabled))
+	}
+
+	const lineDisabled = `class Foo {
+  // eslint-disable-next-line @typescript-eslint/parameter-properties
+  member: string;
+  constructor(member: string) { this.member = member; }
+}`
+	lineDisabledDiagnostics := runParameterPropertiesWithDemand(
+		t,
+		lineDisabled,
+		[]any{map[string]interface{}{"prefer": "parameter-property"}},
+		rule.EditDemandAll,
+	)
+	if len(lineDisabledDiagnostics) != 0 {
+		t.Fatalf("line-disabled diagnostics = %d, want 0", len(lineDisabledDiagnostics))
+	}
 }


### PR DESCRIPTION
## Summary

- Replace the `allow` map and modifier-string construction with a compact modifier bitmask.
- Fast-reject non-constructor parameters before modifier checks and track only class-property candidates in `parameter-property` mode.
- Preserve messages, ranges, option behavior, nested-class handling, edit-demand behavior, and disable directives with focused tests.

### Go benchmark

Command:

```sh
go test ./internal/plugins/typescript/rules/parameter_properties -run ^$ -bench ^BenchmarkParameterProperties$ -benchmem -count=6
```

Values are arithmetic means across six samples.

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Matched diagnostics | `2710.2 → 1807.5` (`-33.3%`) | `2345 → 1984` | `36 → 18` |
| Autofix demand | `2716.2 → 1806.2` (`-33.5%`) | `2345 → 1984` | `36 → 18` |
| Suggestion demand | `2800.8 → 1810.7` (`-35.4%`) | `2345 → 1984` | `36 → 18` |
| Class-property no match | `721.4 → 679.1` (`-5.9%`) | `464 → 416` | `5 → 4` |
| Allowed modifier | `1658.3 → 971.6` (`-41.4%`) | `872 → 416` | `16 → 4` |
| Parameter-property match | `4758.3 → 3929.2` (`-17.4%`) | `2930 → 2776` | `51 → 44` |
| Parameter-property no match | `1996.8 → 1564.3` (`-21.7%`) | `976 → 880` | `20 → 17` |

### Validation

- `go test ./internal/plugins/typescript/rules/parameter_properties -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/parameter_properties/...`
- `git diff --check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).