### PR TITLE
fix: align and optimize no-restricted-syntax

### DIFF
--- a/internal/rules/no_restricted_syntax/fields.go
+++ b/internal/rules/no_restricted_syntax/fields.go
@@ -14,6 +14,8 @@ func nodesAtField(parent *ast.Node, field string) []*ast.Node {
 		switch parent.Kind {
 		case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
 			return single(parent.Name())
+		case ast.KindImportAttribute:
+			return single(parent.AsImportAttribute().Name())
 		}
 	case "value":
 		switch parent.Kind {
@@ -21,6 +23,19 @@ func nodesAtField(parent *ast.Node, field string) []*ast.Node {
 			return single(parent.AsPropertyAssignment().Initializer)
 		case ast.KindPropertyDeclaration:
 			return single(parent.AsPropertyDeclaration().Initializer)
+		case ast.KindImportAttribute:
+			return single(parent.AsImportAttribute().Value)
+		}
+	case "attributes":
+		var attributes *ast.Node
+		switch parent.Kind {
+		case ast.KindImportDeclaration:
+			attributes = parent.AsImportDeclaration().Attributes
+		case ast.KindExportDeclaration:
+			attributes = parent.AsExportDeclaration().Attributes
+		}
+		if attributes != nil && attributes.AsImportAttributes().Attributes != nil {
+			return attributes.AsImportAttributes().Attributes.Nodes
 		}
 	case "id":
 		switch parent.Kind {
@@ -226,11 +241,14 @@ func nodesAtField(parent *ast.Node, field string) []*ast.Node {
 			return statements(parent.AsBindingPattern().Elements)
 		}
 	case "declarations":
-		if parent.Kind == ast.KindVariableStatement {
+		switch parent.Kind {
+		case ast.KindVariableStatement:
 			dl := parent.AsVariableStatement().DeclarationList
 			if dl != nil {
 				return statements(dl.AsVariableDeclarationList().Declarations)
 			}
+		case ast.KindVariableDeclarationList:
+			return statements(parent.AsVariableDeclarationList().Declarations)
 		}
 	case "specifiers":
 		switch parent.Kind {
@@ -282,6 +300,14 @@ func listChildrenOf(parent *ast.Node) [][]*ast.Node {
 		add(statements(parent.AsCaseBlock().Clauses))
 	case ast.KindVariableDeclarationList:
 		add(statements(parent.AsVariableDeclarationList().Declarations))
+	case ast.KindImportDeclaration:
+		if attributes := parent.AsImportDeclaration().Attributes; attributes != nil {
+			add(statements(attributes.AsImportAttributes().Attributes))
+		}
+	case ast.KindExportDeclaration:
+		if attributes := parent.AsExportDeclaration().Attributes; attributes != nil {
+			add(statements(attributes.AsImportAttributes().Attributes))
+		}
 	}
 	if isFunctionLikeForParams(parent) {
 		if params := parent.Parameters(); len(params) > 0 {
@@ -325,7 +351,5 @@ func statements(list *ast.NodeList) []*ast.Node {
 	if list == nil {
 		return nil
 	}
-	out := make([]*ast.Node, 0, len(list.Nodes))
-	out = append(out, list.Nodes...)
-	return out
+	return list.Nodes
 }

--- a/internal/rules/no_restricted_syntax/mapping.go
+++ b/internal/rules/no_restricted_syntax/mapping.go
@@ -1,6 +1,8 @@
 package no_restricted_syntax
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 )
 
@@ -47,7 +49,7 @@ var estreeKindMap = map[string][]ast.Kind{
 	// ESTree's VariableDeclaration is the statement-level node (`var a = 1;`).
 	// tsgo represents that with VariableStatement; the inner declarators
 	// become VariableDeclaration nodes (mapped as VariableDeclarator below).
-	"VariableDeclaration":     {ast.KindVariableStatement},
+	"VariableDeclaration":     {ast.KindVariableStatement, ast.KindVariableDeclarationList},
 	"VariableDeclarator":      {ast.KindVariableDeclaration},
 	"FunctionDeclaration":     {ast.KindFunctionDeclaration},
 	"FunctionExpression":      {ast.KindFunctionExpression},
@@ -69,6 +71,7 @@ var estreeKindMap = map[string][]ast.Kind{
 	"CallExpression":           {ast.KindCallExpression},
 	"ChainExpression":          {ast.KindPropertyAccessExpression, ast.KindElementAccessExpression, ast.KindCallExpression, ast.KindNonNullExpression},
 	"ConditionalExpression":    {ast.KindConditionalExpression},
+	"ImportExpression":         {ast.KindCallExpression},   // matcher checks the import callee
 	"LogicalExpression":        {ast.KindBinaryExpression}, // matcher checks operator
 	"MemberExpression":         {ast.KindPropertyAccessExpression, ast.KindElementAccessExpression},
 	"MetaProperty":             {ast.KindMetaProperty},
@@ -121,6 +124,7 @@ var estreeKindMap = map[string][]ast.Kind{
 
 	// Modules
 	"ImportDeclaration":        {ast.KindImportDeclaration},
+	"ImportAttribute":          {ast.KindImportAttribute},
 	"ImportSpecifier":          {ast.KindImportSpecifier},
 	"ImportDefaultSpecifier":   {ast.KindImportClause},
 	"ImportNamespaceSpecifier": {ast.KindNamespaceImport},
@@ -154,6 +158,19 @@ func kindsForEstreeName(name string) []ast.Kind {
 	return nil
 }
 
+var canonicalEstreeNames = func() map[string]string {
+	names := make(map[string]string, len(estreeKindMap))
+	for name := range estreeKindMap {
+		names[strings.ToLower(name)] = name
+	}
+	return names
+}()
+
+func canonicalEstreeName(name string) (string, bool) {
+	canonical, ok := canonicalEstreeNames[strings.ToLower(name)]
+	return canonical, ok
+}
+
 // allInterestingKinds is the universe of tsgo kinds the wildcard `*`
 // should listen on. We exclude pure trivia / token-only kinds the
 // framework's visitor never hands to listeners (e.g. punctuation) and
@@ -172,7 +189,6 @@ var allInterestingKinds = func() []ast.Kind {
 	// TypeScript-specific kinds that are common in real programs and
 	// that users might select with `*` ~ `*`-style wildcards.
 	extra := []ast.Kind{
-		ast.KindParenthesizedExpression,
 		ast.KindAsExpression,
 		ast.KindSatisfiesExpression,
 		ast.KindNonNullExpression,

--- a/internal/rules/no_restricted_syntax/matcher.go
+++ b/internal/rules/no_restricted_syntax/matcher.go
@@ -658,19 +658,6 @@ func hasDescendantMatching(node *ast.Node, sel selector, mc *matchContext) bool 
 	return found
 }
 
-// nodeIsAtField returns whether `node` is positioned at the named ESTree
-// field on `parent`. Resolution uses the field-mapping helpers (see
-// fields.go).
-func nodeIsAtField(node, parent *ast.Node, field string) bool {
-	candidates := nodesAtField(parent, field)
-	for _, c := range candidates {
-		if c == node {
-			return true
-		}
-	}
-	return false
-}
-
 func nodeIsAtFieldPath(node, ancestor *ast.Node, path []string) bool {
 	ancestor = unwrapEstreeNode(ancestor)
 	if len(path) == 0 {

--- a/internal/rules/no_restricted_syntax/matcher.go
+++ b/internal/rules/no_restricted_syntax/matcher.go
@@ -1,8 +1,11 @@
 package no_restricted_syntax
 
 import (
+	"math"
 	"strconv"
 	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -30,6 +33,9 @@ func newKindSet() *kindSet {
 }
 
 func (s *kindSet) addAll(ks []ast.Kind) {
+	if s.universe {
+		return
+	}
 	for _, k := range ks {
 		s.kinds[k] = struct{}{}
 	}
@@ -73,6 +79,8 @@ func collectKinds(sel selector, s *kindSet) {
 		// The right-hand side is the node being matched; the left side
 		// is an ancestor / sibling constraint we evaluate at match time.
 		collectKinds(v.Right, s)
+	case relativeSelector:
+		collectKinds(v.Inner, s)
 	case pseudoSelector:
 		switch v.Name {
 		case "is", "matches":
@@ -87,6 +95,8 @@ func collectKinds(sel selector, s *kindSet) {
 			s.markUniverse()
 		case "nth-child", "nth-last-child":
 			s.markUniverse()
+		case "statement", "expression", "declaration", "function", "pattern":
+			s.markUniverse()
 		}
 	case combinedPseudo:
 		collectKinds(v.Inner, s)
@@ -99,34 +109,42 @@ func collectKinds(sel selector, s *kindSet) {
 
 // matches reports whether sel matches the supplied tsgo AST node.
 func matches(sel selector, node *ast.Node, mc *matchContext) bool {
+	return matchesInScope(sel, node, mc, nil)
+}
+
+func matchesInScope(sel selector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node) bool {
 	switch v := sel.(type) {
 	case identifierSelector:
 		return matchesIdentifier(v, node)
 	case classSelector:
-		if !matches(v.Inner, node, mc) {
+		if !matchesInScope(v.Inner, node, mc, scopeRoot) {
 			return false
 		}
-		return matchesClass(node, v.Class)
+		return matchesClass(node, v.Path, scopeRoot)
 	case attrSelector:
-		if !matches(v.Inner, node, mc) {
+		if !matchesInScope(v.Inner, node, mc, scopeRoot) {
 			return false
 		}
 		return matchesAttr(node, v.Path, v.Op, v.Value, mc)
 	case combinatorSelector:
-		if !matches(v.Right, node, mc) {
+		if !matchesInScope(v.Right, node, mc, scopeRoot) {
 			return false
 		}
-		return matchesCombinator(v, node, mc)
+		return matchesCombinator(v, node, mc, scopeRoot)
+	case relativeSelector:
+		// Relative selectors are meaningful only as arguments to :has(),
+		// where the node on the left is the :has() subject.
+		return false
 	case pseudoSelector:
-		return matchesPseudo(v, node, mc)
+		return matchesPseudo(v, node, mc, scopeRoot)
 	case combinedPseudo:
-		if !matches(v.Inner, node, mc) {
+		if !matchesInScope(v.Inner, node, mc, scopeRoot) {
 			return false
 		}
-		return matchesPseudo(v.Pseudo, node, mc)
+		return matchesPseudo(v.Pseudo, node, mc, scopeRoot)
 	case unionSelector:
 		for _, a := range v.Selectors {
-			if matches(a, node, mc) {
+			if matchesInScope(a, node, mc, scopeRoot) {
 				return true
 			}
 		}
@@ -165,6 +183,17 @@ func matchesIdentifier(sel identifierSelector, node *ast.Node) bool {
 // / SequenceExpression — the operator decides which ESTree form it really is.
 func refineEstreeMatch(name string, node *ast.Node) bool {
 	switch name {
+	case "VariableDeclaration":
+		return node.Kind == ast.KindVariableStatement ||
+			node.Kind == ast.KindVariableDeclarationList && (node.Parent == nil || node.Parent.Kind != ast.KindVariableStatement)
+	case "CallExpression":
+		return node.Kind == ast.KindCallExpression &&
+			node.AsCallExpression().Expression != nil &&
+			node.AsCallExpression().Expression.Kind != ast.KindImportKeyword
+	case "ImportExpression":
+		return node.Kind == ast.KindCallExpression &&
+			node.AsCallExpression().Expression != nil &&
+			node.AsCallExpression().Expression.Kind == ast.KindImportKeyword
 	case "BinaryExpression":
 		return node.Kind == ast.KindBinaryExpression && isPlainBinaryOperator(node)
 	case "LogicalExpression":
@@ -324,12 +353,20 @@ func isAssignmentOperatorKind(k ast.Kind) bool {
 // matchesClass evaluates `Foo.bar` — Foo already matched by the inner
 // selector, here we check that the node sits at the named field of its
 // parent.
-func matchesClass(node *ast.Node, class string) bool {
-	parent := node.Parent
-	if parent == nil {
+func matchesClass(node *ast.Node, path []string, scopeRoot *ast.Node) bool {
+	if len(path) == 0 {
 		return false
 	}
-	return nodeIsAtField(node, parent, class)
+	// esquery selects exactly the Nth ESTree ancestor for an N-segment field
+	// path. Walk logical parents so tsgo-only wrappers do not shift that index.
+	ancestor := node
+	for range path {
+		ancestor = matchingParent(ancestor, scopeRoot)
+		if ancestor == nil {
+			return false
+		}
+	}
+	return nodeIsAtFieldPath(node, ancestor, path)
 }
 
 // matchesAttr resolves the attribute path against the node and compares
@@ -339,28 +376,35 @@ func matchesAttr(node *ast.Node, path []string, op attrOp, value attrValue, mc *
 		(value.Kind == attrValueString || value.Kind == attrValueIdent || value.Kind == attrValueRegex) {
 		if text, ok, handled := lookupStringAttrPath(node, path, mc); handled {
 			if !ok {
-				return false
+				return compareAttr(undefinedAttr{}, op, value)
 			}
-			equal := attrStringEquals(text, value)
-			if op == attrNotEqual {
-				return !equal
-			}
-			return equal
+			return compareStringAttr(text, op, value)
 		}
 	}
 
 	val, ok := lookupAttrPath(node, path, mc)
 	if op == attrPresent {
-		// Presence: any non-zero, non-nil value passes.
-		if !ok {
-			return false
-		}
-		return attrTruthy(val)
+		// esquery defines presence as a reachable, non-null property. Values
+		// such as false, 0, "", and empty arrays still count as present.
+		return ok && attrIsPresent(val)
 	}
 	if !ok {
-		return false
+		val = undefinedAttr{}
 	}
 	return compareAttr(val, op, value)
+}
+
+func attrIsPresent(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+	// A typed nil pointer stored in an interface is not equal to nil. AST
+	// optional fields commonly take that shape, but ESTree/esquery still sees
+	// them as null and therefore absent.
+	if node, ok := value.(*ast.Node); ok {
+		return node != nil
+	}
+	return true
 }
 
 // lookupStringAttrPath avoids boxing the overwhelmingly common string-valued
@@ -386,15 +430,22 @@ func lookupStringAttrPath(node *ast.Node, path []string, mc *matchContext) (text
 		switch value := current.(type) {
 		case *ast.Node:
 			if value == nil {
-				return "", false, true
+				// A present ESTree property whose value is null remains null when
+				// a deeper path is requested; use the generic resolver to retain
+				// that distinction from a missing (undefined) property.
+				return "", false, false
 			}
 			switch segment {
 			case "name":
-				name, found := readNameAttr(value)
-				if !found {
-					return "", false, true
+				switch value.Kind {
+				case ast.KindIdentifier:
+					return value.AsIdentifier().Text, true, true
+				case ast.KindPrivateIdentifier:
+					return value.AsPrivateIdentifier().Text, true, true
 				}
-				return attrAsString(name), true, true
+				// JSX name attributes resolve to nodes rather than strings, so
+				// let the generic resolver preserve that facade's semantics.
+				return "", false, false
 			case "operator":
 				text, found := readOperatorAttrString(value)
 				return text, found, true
@@ -414,9 +465,13 @@ func lookupStringAttrPath(node *ast.Node, path []string, mc *matchContext) (text
 // matchesCombinator handles `>` (parent), descendant, `+` (prev sibling),
 // `~` (any prior sibling). The right-hand side has already been verified
 // against the current node before this function is called.
-func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext) bool {
+func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node) bool {
 	switch c.Kind {
 	case combChild:
+		parent := matchingParent(node, scopeRoot)
+		if parent == nil {
+			return false
+		}
 		// ESTree wraps `export default <decl>` in an
 		// ExportDefaultDeclaration node. tsgo flattens this — a default-
 		// exported FunctionDeclaration / ClassDeclaration sits directly
@@ -429,25 +484,24 @@ func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext) b
 				return true
 			}
 		}
-		parent := node.Parent
-		if parent == nil {
+		return matchesInScope(c.Left, parent, mc, scopeRoot)
+	case combDescendant:
+		current := matchingParent(node, scopeRoot)
+		if current == nil {
 			return false
 		}
-		return matches(c.Left, parent, mc)
-	case combDescendant:
 		if isDefaultExportedDeclaration(node) && selectorMatchesVirtualExportDefault(c.Left) {
 			return true
 		}
-		current := node.Parent
 		for current != nil {
-			if matches(c.Left, current, mc) {
+			if matchesInScope(c.Left, current, mc, scopeRoot) {
 				return true
 			}
-			current = current.Parent
+			current = matchingParent(current, scopeRoot)
 		}
 		return false
 	case combAdjacent, combSibling:
-		parent := node.Parent
+		parent := matchingParent(node, scopeRoot)
 		if parent == nil {
 			return false
 		}
@@ -458,7 +512,7 @@ func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext) b
 		var siblings []*ast.Node
 		for _, list := range listChildrenOf(parent) {
 			for _, child := range list {
-				if child == node {
+				if unwrapEstreeNode(child) == node {
 					siblings = list
 					break
 				}
@@ -472,7 +526,7 @@ func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext) b
 		}
 		idx := -1
 		for i, sib := range siblings {
-			if sib == node {
+			if unwrapEstreeNode(sib) == node {
 				idx = i
 				break
 			}
@@ -481,10 +535,10 @@ func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext) b
 			return false
 		}
 		if c.Kind == combAdjacent {
-			return matches(c.Left, siblings[idx-1], mc)
+			return matchesInScope(c.Left, unwrapEstreeNode(siblings[idx-1]), mc, scopeRoot)
 		}
 		for i := idx - 1; i >= 0; i-- {
-			if matches(c.Left, siblings[i], mc) {
+			if matchesInScope(c.Left, unwrapEstreeNode(siblings[i]), mc, scopeRoot) {
 				return true
 			}
 		}
@@ -493,43 +547,95 @@ func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext) b
 	return false
 }
 
-func matchesPseudo(p pseudoSelector, node *ast.Node, mc *matchContext) bool {
+func matchesPseudo(p pseudoSelector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node) bool {
 	switch p.Name {
 	case "is", "matches":
 		for _, a := range p.Args {
-			if matches(a, node, mc) {
+			if matchesInScope(a, node, mc, scopeRoot) {
 				return true
 			}
 		}
 		return false
 	case "not":
 		for _, a := range p.Args {
-			if matches(a, node, mc) {
+			if matchesInScope(a, node, mc, scopeRoot) {
 				return false
 			}
 		}
 		return true
 	case "has":
 		for _, a := range p.Args {
-			if hasDescendantMatching(node, a, mc) {
+			if hasMatching(node, a, mc) {
 				return true
 			}
 		}
 		return false
 	case "nth-child":
-		idx, _ := nodeIndexInListField(node)
+		idx, _ := nodeIndexInListField(node, scopeRoot)
 		return idx >= 0 && idx == p.N-1
 	case "nth-last-child":
-		idx, total := nodeIndexInListField(node)
+		idx, total := nodeIndexInListField(node, scopeRoot)
 		if idx < 0 {
 			return false
 		}
 		return total-idx == p.N
+	case "statement", "expression", "declaration", "function", "pattern":
+		return matchesNodeClass(node, p.Name, scopeRoot)
 	}
 	return false
 }
 
+func matchesNodeClass(node *ast.Node, class string, scopeRoot *ast.Node) bool {
+	nodeType := estreeNameForKind(node)
+	switch class {
+	case "statement":
+		return strings.HasSuffix(nodeType, "Statement") || strings.HasSuffix(nodeType, "Declaration")
+	case "declaration":
+		return strings.HasSuffix(nodeType, "Declaration")
+	case "function":
+		return nodeType == "FunctionDeclaration" || nodeType == "FunctionExpression" || nodeType == "ArrowFunctionExpression"
+	case "expression", "pattern":
+		parent := matchingParent(node, scopeRoot)
+		isExpression := strings.HasSuffix(nodeType, "Expression") ||
+			strings.HasSuffix(nodeType, "Literal") ||
+			nodeType == "MetaProperty" ||
+			(nodeType == "Identifier" && (parent == nil || parent.Kind != ast.KindMetaProperty))
+		if class == "expression" {
+			return isExpression
+		}
+		return strings.HasSuffix(nodeType, "Pattern") || isExpression
+	}
+	return false
+}
+
+func hasMatching(node *ast.Node, sel selector, mc *matchContext) bool {
+	if relative, ok := sel.(relativeSelector); ok {
+		if relative.Kind != combChild {
+			return false
+		}
+		matched := false
+		var visitDirect func(child *ast.Node) bool
+		visitDirect = func(child *ast.Node) bool {
+			if isTransparentEstreeContainer(child) {
+				child.ForEachChild(visitDirect)
+				return matched
+			}
+			if matchesInScope(relative.Inner, child, mc, node) {
+				matched = true
+				return true
+			}
+			return false
+		}
+		node.ForEachChild(visitDirect)
+		return matched
+	}
+	return hasDescendantMatching(node, sel, mc)
+}
+
 func hasDescendantMatching(node *ast.Node, sel selector, mc *matchContext) bool {
+	if matchesInScope(sel, node, mc, node) {
+		return true
+	}
 	found := false
 	var visit func(n *ast.Node) bool
 	visit = func(n *ast.Node) bool {
@@ -537,7 +643,10 @@ func hasDescendantMatching(node *ast.Node, sel selector, mc *matchContext) bool 
 			return true
 		}
 		n.ForEachChild(func(child *ast.Node) bool {
-			if matches(sel, child, mc) {
+			if isTransparentEstreeContainer(child) {
+				return visit(child)
+			}
+			if matchesInScope(sel, child, mc, node) {
 				found = true
 				return true
 			}
@@ -562,6 +671,19 @@ func nodeIsAtField(node, parent *ast.Node, field string) bool {
 	return false
 }
 
+func nodeIsAtFieldPath(node, ancestor *ast.Node, path []string) bool {
+	ancestor = unwrapEstreeNode(ancestor)
+	if len(path) == 0 {
+		return unwrapEstreeNode(node) == ancestor
+	}
+	for _, child := range nodesAtField(ancestor, path[0]) {
+		if nodeIsAtFieldPath(node, unwrapEstreeNode(child), path[1:]) {
+			return true
+		}
+	}
+	return false
+}
+
 // lookupAttrPath walks `path` against `node` to fetch a comparable value.
 // Each segment may resolve to an inner node or a primitive. Intermediate
 // failures return ok=false.
@@ -578,7 +700,15 @@ func lookupAttrPath(node *ast.Node, path []string, mc *matchContext) (interface{
 }
 
 func stepAttrPath(current interface{}, segment string, mc *matchContext) (interface{}, bool) {
+	if current == nil {
+		// esquery's getPath short-circuits a null intermediate value and
+		// returns null, rather than converting it to undefined.
+		return nil, true
+	}
 	if n, ok := current.(*ast.Node); ok {
+		if n == nil {
+			return nil, true
+		}
 		return readNodeAttr(n, segment, mc)
 	}
 	if rf, ok := current.(regexFacade); ok {
@@ -610,77 +740,190 @@ func stepAttrPath(current interface{}, segment string, mc *matchContext) (interf
 			return float64(len(v)), true
 		}
 	}
+	if nodes, ok := current.([]*ast.Node); ok {
+		index, err := strconv.Atoi(segment)
+		if err != nil || index < 0 || index >= len(nodes) {
+			return nil, false
+		}
+		return nodes[index], true
+	}
 	return nil, false
 }
 
-// attrTruthy evaluates the truthiness of an attribute value the same way
-// JavaScript would, so that bare attribute presence (`[label]`) only
-// matches when the value is non-empty / non-zero / non-nil.
-func attrTruthy(v interface{}) bool {
-	if v == nil {
-		return false
+type undefinedAttr struct{}
+
+func compareStringAttr(left string, op attrOp, right attrValue) bool {
+	equal := attrStringEquals(left, right)
+	if op == attrNotEqual {
+		return !equal
 	}
-	switch x := v.(type) {
-	case bool:
-		return x
-	case string:
-		return x != ""
-	case float64:
-		return x != 0
-	case *ast.Node:
-		return x != nil
-	case []*ast.Node:
-		return len(x) > 0
-	}
-	return true
+	return equal
 }
 
 func compareAttr(left interface{}, op attrOp, right attrValue) bool {
 	switch op {
 	case attrEqual:
+		if right.Kind == attrValueRegex {
+			text, ok := left.(string)
+			return ok && attrStringEquals(text, right)
+		}
 		return attrEquals(left, right)
 	case attrNotEqual:
+		if right.Kind == attrValueRegex {
+			return !attrStringEquals(attrAsString(left), right)
+		}
 		return !attrEquals(left, right)
 	case attrLess, attrLessOrEqual, attrGreater, attrGreaterOrEqual:
-		l, ok := numericFromAttr(left)
+		comparison, ok := compareRelationalAttr(left, right)
 		if !ok {
-			return false
-		}
-		var r float64
-		switch right.Kind {
-		case attrValueNumber:
-			r = right.Num
-		default:
 			return false
 		}
 		switch op {
 		case attrLess:
-			return l < r
+			return comparison < 0
 		case attrLessOrEqual:
-			return l <= r
+			return comparison <= 0
 		case attrGreater:
-			return l > r
+			return comparison > 0
 		case attrGreaterOrEqual:
-			return l >= r
+			return comparison >= 0
 		}
 	}
 	return false
 }
 
-func numericFromAttr(v interface{}) (float64, bool) {
-	switch x := v.(type) {
-	case float64:
-		return x, true
-	case int:
-		return float64(x), true
-	case string:
-		n, err := strconv.ParseFloat(x, 64)
-		if err != nil {
-			return 0, false
-		}
-		return n, true
+func compareRelationalAttr(left interface{}, right attrValue) (int, bool) {
+	leftText, leftIsString, leftNumber, leftOK := leftRelationalPrimitive(left)
+	rightText, rightIsString, rightNumber, rightOK := rightRelationalPrimitive(right)
+	if !leftOK || !rightOK {
+		return 0, false
 	}
-	return 0, false
+	if leftIsString && rightIsString {
+		return compareJSStrings(leftText, rightText), true
+	}
+	if leftIsString {
+		leftNumber, leftOK = jsStringToNumber(leftText)
+	}
+	if rightIsString {
+		rightNumber, rightOK = jsStringToNumber(rightText)
+	}
+	if !leftOK || !rightOK || math.IsNaN(leftNumber) || math.IsNaN(rightNumber) {
+		return 0, false
+	}
+	switch {
+	case leftNumber < rightNumber:
+		return -1, true
+	case leftNumber > rightNumber:
+		return 1, true
+	default:
+		return 0, true
+	}
+}
+
+func leftRelationalPrimitive(value interface{}) (text string, isString bool, number float64, ok bool) {
+	switch typed := value.(type) {
+	case string:
+		return typed, true, 0, true
+	case float64:
+		return "", false, typed, true
+	case int:
+		return "", false, float64(typed), true
+	case bool:
+		if typed {
+			return "", false, 1, true
+		}
+		return "", false, 0, true
+	case nil:
+		return "", false, 0, true
+	case undefinedAttr:
+		return "", false, 0, false
+	case *ast.Node:
+		if typed == nil {
+			return "", false, 0, true
+		}
+		return attrAsString(typed), true, 0, true
+	case []*ast.Node, regexFacade, metaIdentifier:
+		return attrAsString(typed), true, 0, true
+	default:
+		return "", false, 0, false
+	}
+}
+
+func rightRelationalPrimitive(value attrValue) (text string, isString bool, number float64, ok bool) {
+	switch value.Kind {
+	case attrValueString:
+		return value.Str, true, 0, true
+	case attrValueIdent:
+		return value.Ident, true, 0, true
+	case attrValueNumber:
+		return "", false, value.Num, true
+	default:
+		return "", false, 0, false
+	}
+}
+
+func jsStringToNumber(value string) (float64, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, true
+	}
+	switch value {
+	case "Infinity", "+Infinity":
+		return math.Inf(1), true
+	case "-Infinity":
+		return math.Inf(-1), true
+	}
+	if len(value) > 2 && value[0] == '0' {
+		base := 0
+		switch value[1] {
+		case 'x', 'X':
+			base = 16
+		case 'b', 'B':
+			base = 2
+		case 'o', 'O':
+			base = 8
+		}
+		if base != 0 {
+			parsed, err := strconv.ParseUint(value[2:], base, 64)
+			return float64(parsed), err == nil
+		}
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	return parsed, err == nil && !math.IsNaN(parsed)
+}
+
+func compareJSStrings(left, right string) int {
+	if isASCII(left) && isASCII(right) {
+		return strings.Compare(left, right)
+	}
+	leftUnits := utf16.Encode([]rune(left))
+	rightUnits := utf16.Encode([]rune(right))
+	limit := min(len(leftUnits), len(rightUnits))
+	for index := range limit {
+		if leftUnits[index] < rightUnits[index] {
+			return -1
+		}
+		if leftUnits[index] > rightUnits[index] {
+			return 1
+		}
+	}
+	switch {
+	case len(leftUnits) < len(rightUnits):
+		return -1
+	case len(leftUnits) > len(rightUnits):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func isASCII(value string) bool {
+	for index := range len(value) {
+		if value[index] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
 }
 
 func attrEquals(left interface{}, right attrValue) bool {
@@ -688,15 +931,11 @@ func attrEquals(left interface{}, right attrValue) bool {
 	case attrValueString:
 		return attrAsString(left) == right.Str
 	case attrValueNumber:
-		n, ok := numericFromAttr(left)
-		return ok && n == right.Num
-	case attrValueBool:
-		b, ok := left.(bool)
-		return ok && b == right.Bool
-	case attrValueNull:
-		return left == nil
+		return attrAsString(left) == attrAsString(right.Num)
 	case attrValueIdent:
 		return attrAsString(left) == right.Ident
+	case attrValueType:
+		return attrTypeOf(left) == right.Ident
 	case attrValueRegex:
 		return attrStringEquals(attrAsString(left), right)
 	}
@@ -728,7 +967,7 @@ func attrStringEquals(left string, right attrValue) bool {
 }
 
 func regexpFlags(flags string) regexp2.RegexOptions {
-	var opts regexp2.RegexOptions
+	opts := regexp2.RegexOptions(regexp2.ECMAScript)
 	for _, c := range flags {
 		switch c {
 		case 'i':
@@ -737,6 +976,8 @@ func regexpFlags(flags string) regexp2.RegexOptions {
 			opts |= regexp2.Singleline
 		case 'm':
 			opts |= regexp2.Multiline
+		case 'u':
+			opts |= regexp2.Unicode
 		}
 	}
 	return opts
@@ -757,10 +998,51 @@ func attrAsString(v interface{}) string {
 			return strconv.FormatInt(int64(x), 10)
 		}
 		return strconv.FormatFloat(x, 'g', -1, 64)
+	case int:
+		return strconv.Itoa(x)
 	case nil:
-		return ""
+		return "null"
+	case undefinedAttr:
+		return "undefined"
+	case *ast.Node:
+		if x == nil {
+			return "null"
+		}
+		return "[object Object]"
+	case []*ast.Node:
+		if len(x) == 0 {
+			return ""
+		}
+		var text strings.Builder
+		text.Grow(len(x) * len("[object Object],"))
+		for index, node := range x {
+			if index > 0 {
+				text.WriteByte(',')
+			}
+			if node != nil {
+				text.WriteString("[object Object]")
+			}
+		}
+		return text.String()
+	case regexFacade, metaIdentifier:
+		return "[object Object]"
 	}
 	return ""
+}
+
+func attrTypeOf(v interface{}) string {
+	switch v.(type) {
+	case undefinedAttr:
+		return "undefined"
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case float64, int:
+		return "number"
+	default:
+		return "object"
+	}
 }
 
 // nodeIndexInListField returns (idx, total) for a node that sits inside
@@ -769,14 +1051,14 @@ func attrAsString(v interface{}) string {
 // `CallExpression.arguments`) — a node sitting at a scalar field
 // (`ExpressionStatement.expression`, `MemberExpression.object`) is not
 // considered a positional child and never matches.
-func nodeIndexInListField(node *ast.Node) (int, int) {
-	parent := node.Parent
+func nodeIndexInListField(node *ast.Node, scopeRoot *ast.Node) (int, int) {
+	parent := matchingParent(node, scopeRoot)
 	if parent == nil {
 		return -1, 0
 	}
 	for _, list := range listChildrenOf(parent) {
 		for i, child := range list {
-			if child == node {
+			if unwrapEstreeNode(child) == node {
 				return i, len(list)
 			}
 		}
@@ -866,13 +1148,71 @@ func unwrapExpression(node *ast.Node) *ast.Node {
 	}
 }
 
+func unwrapEstreeNode(node *ast.Node) *ast.Node {
+	for node != nil && node.Kind == ast.KindParenthesizedExpression {
+		node = node.AsParenthesizedExpression().Expression
+	}
+	return node
+}
+
+func isTransparentEstreeContainer(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindParenthesizedExpression, ast.KindImportAttributes:
+		return true
+	case ast.KindVariableDeclarationList:
+		return node.Parent != nil && node.Parent.Kind == ast.KindVariableStatement
+	}
+	return false
+}
+
+func estreeParent(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	parent := node.Parent
+	for parent != nil {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression, ast.KindImportAttributes:
+			// These are tsgo parser nodes without corresponding ESTree nodes.
+			parent = parent.Parent
+		case ast.KindVariableDeclarationList:
+			// A list under VariableStatement is a tsgo-only container. In a
+			// for-loop initializer, the list itself is ESTree's
+			// VariableDeclaration and must remain in the ancestry.
+			if parent.Parent != nil && parent.Parent.Kind == ast.KindVariableStatement {
+				parent = parent.Parent
+				continue
+			}
+			return parent
+		default:
+			return parent
+		}
+	}
+	return parent
+}
+
+func matchingParent(node *ast.Node, scopeRoot *ast.Node) *ast.Node {
+	if node == nil || scopeRoot == node {
+		return nil
+	}
+	return estreeParent(node)
+}
+
 // readNodeAttr extracts the named ESTree-style attribute from a tsgo node.
 // Centralising the field map here makes it easy to widen support without
 // rewriting the matcher.
 func readNodeAttr(node *ast.Node, name string, mc *matchContext) (interface{}, bool) {
+	if node == nil {
+		return nil, false
+	}
 	switch name {
 	case "type":
 		return estreeNameForKind(node), true
+	case "parent":
+		return estreeParent(node), true
 	case "name":
 		return readNameAttr(node)
 	case "value":
@@ -884,11 +1224,7 @@ func readNodeAttr(node *ast.Node, name string, mc *matchContext) (interface{}, b
 	case "kind":
 		return readKindAttr(node)
 	case "optional":
-		// ESTree's `optional` is true only on the link that carries the
-		// literal `?.` token (e.g. `foo?.bar`, not the trailing `.baz`
-		// in `foo?.bar.baz`). tsgo's IsOptionalChainRoot encodes the
-		// same condition.
-		return ast.IsOptionalChainRoot(node), true
+		return readOptionalAttr(node)
 	case "computed":
 		return readComputedAttr(node)
 	case "static":
@@ -1011,8 +1347,19 @@ func readAttributesAttr(node *ast.Node) (interface{}, bool) {
 		return node.AsJsxOpeningElement().Attributes, true
 	case ast.KindJsxSelfClosingElement:
 		return node.AsJsxSelfClosingElement().Attributes, true
+	case ast.KindImportDeclaration:
+		return importAttributes(node.AsImportDeclaration().Attributes), true
+	case ast.KindExportDeclaration:
+		return importAttributes(node.AsExportDeclaration().Attributes), true
 	}
 	return nil, false
+}
+
+func importAttributes(node *ast.Node) []*ast.Node {
+	if node == nil || node.AsImportAttributes().Attributes == nil {
+		return []*ast.Node{}
+	}
+	return node.AsImportAttributes().Attributes.Nodes
 }
 
 func readChildrenAttr(node *ast.Node) (interface{}, bool) {
@@ -1021,7 +1368,7 @@ func readChildrenAttr(node *ast.Node) (interface{}, bool) {
 		if c == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, c.Nodes...), true
+		return c.Nodes, true
 	}
 	return nil, false
 }
@@ -1173,6 +1520,10 @@ func estreeNameForKind(node *ast.Node) string {
 	case ast.KindCatchClause:
 		return "CatchClause"
 	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if call.Expression != nil && call.Expression.Kind == ast.KindImportKeyword {
+			return "ImportExpression"
+		}
 		return "CallExpression"
 	case ast.KindNewExpression:
 		return "NewExpression"
@@ -1296,6 +1647,8 @@ func estreeNameForKind(node *ast.Node) string {
 		return "ArrayPattern"
 	case ast.KindObjectBindingPattern:
 		return "ObjectPattern"
+	case ast.KindImportAttribute:
+		return "ImportAttribute"
 	}
 	return ""
 }
@@ -1351,15 +1704,45 @@ func readValueAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
 	// when uninitialised. tsgo's PropertyDeclaration uses Initializer.
 	case ast.KindPropertyDeclaration:
 		return unwrapExpression(node.AsPropertyDeclaration().Initializer), true
+	case ast.KindImportAttribute:
+		return unwrapExpression(node.AsImportAttribute().Value), true
 	}
 	return nil, false
 }
 
 func readRawAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
-	if mc == nil || mc.sf == nil {
+	if mc == nil || mc.sf == nil || !isEstreeLiteralKind(node.Kind) {
 		return nil, false
 	}
 	return scanner.GetSourceTextOfNodeFromSourceFile(mc.sf, node, false), true
+}
+
+func isEstreeLiteralKind(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword:
+		return true
+	}
+	return false
+}
+
+func readOptionalAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return ast.IsOptionalChainRoot(node), true
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if call.Expression != nil && call.Expression.Kind == ast.KindImportKeyword {
+			return nil, false
+		}
+		return ast.IsOptionalChainRoot(node), true
+	}
+	return nil, false
 }
 
 func readOperatorAttr(node *ast.Node) (interface{}, bool) {
@@ -1846,9 +2229,10 @@ func readParamsAttr(node *ast.Node) (interface{}, bool) {
 	// Treat nil and empty as the same — `[params.length=0]` should
 	// match a function-like with no parameters regardless of whether
 	// the underlying NodeList was allocated.
-	out := make([]*ast.Node, 0, len(params))
-	out = append(out, params...)
-	return out, true
+	if params == nil {
+		return []*ast.Node{}, true
+	}
+	return params, true
 }
 
 func readSourceAttr(node *ast.Node) (interface{}, bool) {
@@ -1857,6 +2241,11 @@ func readSourceAttr(node *ast.Node) (interface{}, bool) {
 		return unwrapExpression(node.AsImportDeclaration().ModuleSpecifier), true
 	case ast.KindExportDeclaration:
 		return unwrapExpression(node.AsExportDeclaration().ModuleSpecifier), true
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if call.Expression != nil && call.Expression.Kind == ast.KindImportKeyword && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+			return unwrapExpression(call.Arguments.Nodes[0]), true
+		}
 	}
 	return nil, false
 }
@@ -1864,7 +2253,11 @@ func readSourceAttr(node *ast.Node) (interface{}, bool) {
 func readCalleeAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
 	case ast.KindCallExpression:
-		return unwrapExpression(node.AsCallExpression().Expression), true
+		expression := node.AsCallExpression().Expression
+		if expression != nil && expression.Kind == ast.KindImportKeyword {
+			return nil, false
+		}
+		return unwrapExpression(expression), true
 	case ast.KindNewExpression:
 		return unwrapExpression(node.AsNewExpression().Expression), true
 	case ast.KindTaggedTemplateExpression:
@@ -1876,17 +2269,21 @@ func readCalleeAttr(node *ast.Node) (interface{}, bool) {
 func readArgumentsAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
 	case ast.KindCallExpression:
-		args := node.AsCallExpression().Arguments
+		call := node.AsCallExpression()
+		if call.Expression != nil && call.Expression.Kind == ast.KindImportKeyword {
+			return nil, false
+		}
+		args := call.Arguments
 		if args == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, args.Nodes...), true
+		return args.Nodes, true
 	case ast.KindNewExpression:
 		args := node.AsNewExpression().Arguments
 		if args == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, args.Nodes...), true
+		return args.Nodes, true
 	}
 	return nil, false
 }
@@ -1945,6 +2342,8 @@ func readKeyAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
 	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
 		return node.Name(), true
+	case ast.KindImportAttribute:
+		return node.AsImportAttribute().Name(), true
 	}
 	return nil, false
 }
@@ -2030,7 +2429,7 @@ func readConsequentAttr(node *ast.Node) (interface{}, bool) {
 		if stmts == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, stmts.Nodes...), true
+		return stmts.Nodes, true
 	}
 	return nil, false
 }
@@ -2068,25 +2467,25 @@ func readBodyAttr(node *ast.Node) (interface{}, bool) {
 		if stmts == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, stmts.Nodes...), true
+		return stmts.Nodes, true
 	case ast.KindSourceFile:
 		stmts := node.AsSourceFile().Statements
 		if stmts == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, stmts.Nodes...), true
+		return stmts.Nodes, true
 	case ast.KindClassDeclaration:
 		members := node.AsClassDeclaration().Members
 		if members == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, members.Nodes...), true
+		return members.Nodes, true
 	case ast.KindClassExpression:
 		members := node.AsClassExpression().Members
 		if members == nil {
 			return []*ast.Node{}, true
 		}
-		return append([]*ast.Node{}, members.Nodes...), true
+		return members.Nodes, true
 	}
 	return nil, false
 }
@@ -2131,7 +2530,7 @@ func readPrefixAttr(node *ast.Node) (interface{}, bool) {
 
 func readAsyncAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
-	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction, ast.KindMethodDeclaration:
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction:
 		return ast.HasSyntacticModifier(node, ast.ModifierFlagsAsync), true
 	}
 	return nil, false
@@ -2143,8 +2542,8 @@ func readGeneratorAttr(node *ast.Node) (interface{}, bool) {
 		return node.AsFunctionDeclaration().AsteriskToken != nil, true
 	case ast.KindFunctionExpression:
 		return node.AsFunctionExpression().AsteriskToken != nil, true
-	case ast.KindMethodDeclaration:
-		return node.AsMethodDeclaration().AsteriskToken != nil, true
+	case ast.KindArrowFunction:
+		return false, true
 	}
 	return nil, false
 }

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.go
@@ -2,8 +2,8 @@ package no_restricted_syntax
 
 import (
 	_ "embed"
-	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -18,8 +18,8 @@ var schemaJSON []byte
 //
 // Configuration mirrors ESLint: the rule accepts a list of strings or
 // `{ selector, message? }` objects. Each selector follows the esquery
-// grammar (the subset implemented in parser.go). At lint time every node
-// is matched against every parsed selector; each match produces one
+// grammar (the subset implemented in parser.go). Parsed selectors are indexed
+// by candidate kind and common string attributes; each match produces one
 // diagnostic with the user-supplied message (or a default).
 //
 // https://eslint.org/docs/latest/rules/no-restricted-syntax
@@ -35,20 +35,24 @@ var NoRestrictedSyntaxRule = rule.Rule{
 		mc := &matchContext{sf: ctx.SourceFile}
 
 		visit := func(node *ast.Node, bucket *ruleBucket) {
+			if isTransparentEstreeContainer(node) {
+				return
+			}
 			first, second, useAll := bucket.candidates(node, mc)
 			if useAll {
 				for index := range bucket.entries {
-					bucket.matchAndReport(index, node, mc, &ctx)
+					bucket.matchAndReport(index, node, mc, &ctx, false)
 				}
 				return
 			}
 
-			// Both candidate lists retain option order. Merge them so a
+			// Both candidate lists retain ESLint specificity order. Merge them so a
 			// dispatch hit cannot reorder diagnostics relative to selectors
 			// that do not participate in the index.
 			left, right := 0, 0
 			for left < len(first) || right < len(second) {
 				var index int
+				indexed := false
 				switch {
 				case right == len(second):
 					index = first[left]
@@ -56,14 +60,16 @@ var NoRestrictedSyntaxRule = rule.Rule{
 				case left == len(first):
 					index = second[right]
 					right++
+					indexed = true
 				case first[left] < second[right]:
 					index = first[left]
 					left++
 				default:
 					index = second[right]
 					right++
+					indexed = true
 				}
-				bucket.matchAndReport(index, node, mc, &ctx)
+				bucket.matchAndReport(index, node, mc, &ctx, indexed)
 			}
 		}
 
@@ -149,31 +155,28 @@ func cachedRulePlan(options []any) *rulePlan {
 func buildRulePlan(options []any) *rulePlan {
 	plan := &rulePlan{options: options}
 	entries := parseRuleOptions(options)
+	entries = deduplicateRuleEntries(entries)
+	sortRuleEntries(entries)
 	if len(entries) == 0 {
 		return plan
 	}
 
-	// Build per-kind buckets of (selector, message) entries. Selectors whose
-	// candidate kinds are the universe land in everyKind and are evaluated on
-	// every interesting visit.
+	// Build per-kind buckets in ESLint's specificity order. This order is
+	// observable when multiple selectors report the same node, including when
+	// a universe selector is interleaved with kind-specific selectors.
 	perKind := make(map[ast.Kind][]ruleEntry)
-	var everyKind []ruleEntry
 	for _, entry := range entries {
 		kinds := candidateKinds(entry.compiled)
 		if kinds.universe {
-			everyKind = append(everyKind, entry)
+			for _, kind := range allInterestingKinds {
+				perKind[kind] = append(perKind[kind], entry)
+			}
 			continue
 		}
 		for kind := range kinds.kinds {
 			perKind[kind] = append(perKind[kind], entry)
 		}
 	}
-	if len(everyKind) > 0 {
-		for _, kind := range allInterestingKinds {
-			perKind[kind] = append(perKind[kind], everyKind...)
-		}
-	}
-
 	plan.buckets = make(map[ast.Kind]*ruleBucket, len(perKind))
 	for kind, entries := range perKind {
 		bucket := buildRuleBucket(entries)
@@ -191,6 +194,7 @@ type stringAttrDispatch struct {
 	path     []string
 	byValue  map[string][]int
 	fallback []int
+	matched  []selector
 }
 
 type dispatchAttr struct {
@@ -255,6 +259,7 @@ func buildRuleBucket(entries []ruleEntry) ruleBucket {
 		path:     stats[bestKey].path,
 		byValue:  make(map[string][]int, bestValues),
 		fallback: make([]int, 0, len(entries)-bestCount),
+		matched:  make([]selector, len(entries)),
 	}
 	for index, entry := range entries {
 		value, ok := dispatchValueForPath(entry.compiled, bestKey)
@@ -262,6 +267,12 @@ func buildRuleBucket(entries []ruleEntry) ruleBucket {
 			dispatch.fallback = append(dispatch.fallback, index)
 			continue
 		}
+		stripped, ok := stripDispatchAttr(entry.compiled, bestKey, value)
+		if !ok {
+			dispatch.fallback = append(dispatch.fallback, index)
+			continue
+		}
+		dispatch.matched[index] = stripped
 		dispatch.byValue[value] = append(dispatch.byValue[value], index)
 	}
 	bucket.dispatch = dispatch
@@ -285,7 +296,7 @@ func collectDispatchAttrs(sel selector, attrs []dispatchAttr) []dispatchAttr {
 	case attrSelector:
 		attrs = collectDispatchAttrs(value.Inner, attrs)
 		if value.Op == attrEqual {
-			if expected, ok := exactStringValue(value.Value); ok {
+			if expected, ok := exactStringValue(value.Value); ok && expected != "undefined" {
 				attrs = append(attrs, dispatchAttr{
 					path:  value.Path,
 					key:   strings.Join(value.Path, "\x00"),
@@ -301,6 +312,36 @@ func collectDispatchAttrs(sel selector, attrs []dispatchAttr) []dispatchAttr {
 		attrs = collectDispatchAttrs(value.Inner, attrs)
 	}
 	return attrs
+}
+
+func stripDispatchAttr(sel selector, pathKey, expected string) (selector, bool) {
+	switch value := sel.(type) {
+	case attrSelector:
+		if inner, ok := stripDispatchAttr(value.Inner, pathKey, expected); ok {
+			value.Inner = inner
+			return value, true
+		}
+		actual, exact := exactStringValue(value.Value)
+		if value.Op == attrEqual && exact && actual == expected && strings.Join(value.Path, "\x00") == pathKey {
+			return value.Inner, true
+		}
+	case classSelector:
+		if inner, ok := stripDispatchAttr(value.Inner, pathKey, expected); ok {
+			value.Inner = inner
+			return value, true
+		}
+	case combinatorSelector:
+		if right, ok := stripDispatchAttr(value.Right, pathKey, expected); ok {
+			value.Right = right
+			return value, true
+		}
+	case combinedPseudo:
+		if inner, ok := stripDispatchAttr(value.Inner, pathKey, expected); ok {
+			value.Inner = inner
+			return value, true
+		}
+	}
+	return sel, false
 }
 
 func exactStringValue(value attrValue) (string, bool) {
@@ -337,9 +378,13 @@ func (bucket *ruleBucket) candidates(node *ast.Node, mc *matchContext) (first, s
 	return bucket.dispatch.fallback, bucket.dispatch.byValue[value], false
 }
 
-func (bucket *ruleBucket) matchAndReport(index int, node *ast.Node, mc *matchContext, ctx *rule.RuleContext) {
+func (bucket *ruleBucket) matchAndReport(index int, node *ast.Node, mc *matchContext, ctx *rule.RuleContext, indexed bool) {
 	entry := &bucket.entries[index]
-	if !matches(entry.compiled, node, mc) {
+	compiled := entry.compiled
+	if indexed && bucket.dispatch != nil && bucket.dispatch.matched[index] != nil {
+		compiled = bucket.dispatch.matched[index]
+	}
+	if !matches(compiled, node, mc) {
 		return
 	}
 	ctx.ReportNode(node, rule.RuleMessage{
@@ -349,10 +394,95 @@ func (bucket *ruleBucket) matchAndReport(index int, node *ast.Node, mc *matchCon
 }
 
 func (e ruleEntry) formatMessage() string {
-	if e.message != "" {
-		return e.message
+	return e.message
+}
+
+func deduplicateRuleEntries(entries []ruleEntry) []ruleEntry {
+	if len(entries) < 2 {
+		return entries
 	}
-	return fmt.Sprintf("Using '%s' is not allowed.", e.selector)
+	positions := make(map[string]int, len(entries))
+	result := make([]ruleEntry, 0, len(entries))
+	for _, entry := range entries {
+		if index, ok := positions[entry.selector]; ok {
+			result[index] = entry
+			continue
+		}
+		positions[entry.selector] = len(result)
+		result = append(result, entry)
+	}
+	return result
+}
+
+type selectorSpecificity struct {
+	attributes  int
+	identifiers int
+}
+
+func sortRuleEntries(entries []ruleEntry) {
+	if len(entries) < 2 {
+		return
+	}
+	specificities := make(map[string]selectorSpecificity, len(entries))
+	for _, entry := range entries {
+		specificities[entry.selector] = analyzeSelectorSpecificity(entry.compiled)
+	}
+	sort.Slice(entries, func(left, right int) bool {
+		a := specificities[entries[left].selector]
+		b := specificities[entries[right].selector]
+		if a.attributes != b.attributes {
+			return a.attributes < b.attributes
+		}
+		if a.identifiers != b.identifiers {
+			return a.identifiers < b.identifiers
+		}
+		return compareJSStrings(entries[left].selector, entries[right].selector) < 0
+	})
+}
+
+func analyzeSelectorSpecificity(sel selector) selectorSpecificity {
+	var result selectorSpecificity
+	var visit func(selector)
+	visit = func(current selector) {
+		switch value := current.(type) {
+		case identifierSelector:
+			if value.Name != "*" {
+				result.identifiers++
+			}
+		case attrSelector:
+			visit(value.Inner)
+			result.attributes++
+		case classSelector:
+			visit(value.Inner)
+			result.attributes++
+		case combinatorSelector:
+			visit(value.Left)
+			visit(value.Right)
+		case combinedPseudo:
+			visit(value.Inner)
+			visitPseudoSpecificity(value.Pseudo, &result, visit)
+		case pseudoSelector:
+			visitPseudoSpecificity(value, &result, visit)
+		case unionSelector:
+			for _, child := range value.Selectors {
+				visit(child)
+			}
+		}
+	}
+	visit(sel)
+	return result
+}
+
+func visitPseudoSpecificity(value pseudoSelector, result *selectorSpecificity, visit func(selector)) {
+	switch value.Name {
+	case "is", "matches", "not":
+		for _, child := range value.Args {
+			visit(child)
+		}
+	case "nth-child", "nth-last-child":
+		result.attributes++
+		// ESLint deliberately does not include selectors nested inside :has().
+	}
 }
 
 // parseRuleOptions turns the rule's options — a variadic list of selectors,
@@ -386,7 +516,7 @@ func buildEntryFromString(sel string) ruleEntry {
 	if err != nil {
 		return ruleEntry{selector: sel}
 	}
-	return ruleEntry{selector: sel, compiled: compiled}
+	return ruleEntry{selector: sel, compiled: compiled, message: defaultRuleMessage(sel)}
 }
 
 func buildEntryFromObject(m map[string]interface{}) (ruleEntry, bool) {
@@ -399,5 +529,12 @@ func buildEntryFromObject(m map[string]interface{}) (ruleEntry, bool) {
 		return ruleEntry{}, false
 	}
 	msg, _ := m["message"].(string)
+	if msg == "" {
+		msg = defaultRuleMessage(rawSel)
+	}
 	return ruleEntry{selector: rawSel, compiled: compiled, message: msg}, true
+}
+
+func defaultRuleMessage(selector string) string {
+	return "Using '" + selector + "' is not allowed."
 }

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.md
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.md
@@ -8,9 +8,8 @@ either a default or user-supplied message.
 
 This is the catch-all rule for restricting language constructs (e.g. banning
 `with`, banning `for-in`, requiring named function declarations) without
-having to write a dedicated rule. The selector grammar matches ESLint's, so
-selectors authored against ESLint's `no-restricted-syntax` configuration are
-expected to work unchanged in rslint.
+having to write a dedicated rule. The core selector grammar follows ESLint's
+esquery-based implementation.
 
 Examples of **incorrect** code for this rule:
 
@@ -71,14 +70,28 @@ configurations and in the upstream `no-restricted-syntax` test suite:
 
 - ESTree node names (e.g. `Identifier`, `FunctionDeclaration`, `BinaryExpression`).
 - Wildcard `*`.
-- Class selectors `.field` (e.g. `Literal.key`).
+- Field selectors, including nested fields (e.g. `Literal.key` and
+  `.body.declarations.init`).
 - Attribute selectors with presence (`[label]`), equality
   (`[name="x"]`, `[kind='using']`), inequality (`!=`), numeric comparisons
-  (`[params.length>2]`), and regex matching (`[regex.flags=/i/]`).
+  (`[params.length>2]`), numeric path segments (`[arguments.0.type='Literal']`),
+  `type(...)`, and regex matching (`[regex.flags=/i/]`). Attribute paths may
+  inspect ESLint's `parent` link.
 - Combinators `>` (direct child), descendant whitespace, `+`
   (adjacent sibling), `~` (general sibling).
 - Pseudo-classes `:is()`, `:matches()`, `:not()`, `:has()`,
-  `:first-child`, `:last-child`, `:nth-child(N)`, `:nth-last-child(N)`.
+  `:first-child`, `:last-child`, `:nth-child(N)`, `:nth-last-child(N)`, and
+  the semantic classes `:statement`, `:expression`, `:declaration`,
+  `:function`, and `:pattern`.
+
+### Known differences
+
+- esquery's subject indicator (`!`) is not implemented.
+- The ESTree facade covers standard JavaScript nodes and common TypeScript
+  shapes, but it does not yet expose every TS-ESTree-only node/field or every
+  virtual ESTree wrapper (for example `ClassBody`).
+- Invalid selectors are ignored by the runtime parser; ESLint normally rejects
+  them earlier during configuration validation.
 
 ## Original Documentation
 

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.md
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.md
@@ -84,14 +84,22 @@ configurations and in the upstream `no-restricted-syntax` test suite:
   the semantic classes `:statement`, `:expression`, `:declaration`,
   `:function`, and `:pattern`.
 
-### Known differences
+### Known differences from ESLint
 
-- esquery's subject indicator (`!`) is not implemented.
-- The ESTree facade covers standard JavaScript nodes and common TypeScript
-  shapes, but it does not yet expose every TS-ESTree-only node/field or every
-  virtual ESTree wrapper (for example `ClassBody`).
-- Invalid selectors are ignored by the runtime parser; ESLint normally rejects
-  them earlier during configuration validation.
+The following differences may affect an existing ESLint
+`no-restricted-syntax` configuration when it is used with rslint:
+
+- ESLint rejects the configuration when a selector has invalid syntax. rslint
+  currently skips that selector and continues with the remaining selectors, so
+  the restriction expressed by the invalid selector is not enforced.
+- Selectors for standard JavaScript nodes and commonly used TypeScript shapes
+  are supported. A selector that targets a TS-ESTree-only node or field may not
+  match yet. For example, `ClassBody > MethodDefinition` does not match because
+  tsgo does not expose `ClassBody` as a separate AST node. Such selectors can
+  therefore produce fewer diagnostics than the same ESLint configuration.
+- ESLint accepts esquery's `!` subject marker in selector listener names, for
+  example `!IfStatement > BlockStatement`. rslint does not currently support
+  this marker and skips selectors that use it.
 
 ## Original Documentation
 

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.md
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.md
@@ -84,22 +84,17 @@ configurations and in the upstream `no-restricted-syntax` test suite:
   the semantic classes `:statement`, `:expression`, `:declaration`,
   `:function`, and `:pattern`.
 
-### Known differences from ESLint
-
-The following differences may affect an existing ESLint
-`no-restricted-syntax` configuration when it is used with rslint:
+## Differences from ESLint
 
 - ESLint rejects the configuration when a selector has invalid syntax. rslint
-  currently skips that selector and continues with the remaining selectors, so
-  the restriction expressed by the invalid selector is not enforced.
-- Selectors for standard JavaScript nodes and commonly used TypeScript shapes
-  are supported. A selector that targets a TS-ESTree-only node or field may not
-  match yet. For example, `ClassBody > MethodDefinition` does not match because
-  tsgo does not expose `ClassBody` as a separate AST node. Such selectors can
-  therefore produce fewer diagnostics than the same ESLint configuration.
-- ESLint accepts esquery's `!` subject marker in selector listener names, for
-  example `!IfStatement > BlockStatement`. rslint does not currently support
-  this marker and skips selectors that use it.
+  ignores only that selector and continues with the remaining selectors, so
+  its restriction is not enforced.
+- Selectors that target TS-ESTree-only nodes or fields may report fewer
+  diagnostics than ESLint. For example, `ClassBody > MethodDefinition`
+  produces no diagnostics in rslint because tsgo has no separate `ClassBody`
+  node.
+- rslint ignores selectors using the `!` subject marker, such as
+  `!IfStatement > BlockStatement`, while ESLint accepts them.
 
 ## Original Documentation
 

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
@@ -5,9 +5,14 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	tsparser "github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
+
+const lazyMustBeWrappedSelector = `:matches(CallExpression[callee.object.name='React'][callee.property.name='lazy'], CallExpression[callee.name='lazy']):not([parent.callee.name='withSuspense'])`
 
 func TestNoRestrictedSyntaxRule(t *testing.T) {
 	rule_tester.RunRuleTester(
@@ -127,11 +132,11 @@ func TestNoRestrictedSyntaxRule(t *testing.T) {
 			// ============================================================
 			{
 				Code:    `function foo() {}`,
-				Options: []interface{}{"FunctionDeclaration[generator]"},
+				Options: []interface{}{"FunctionDeclaration[generator=true]"},
 			},
 			{
 				Code:    `function foo() {}`,
-				Options: []interface{}{"FunctionDeclaration[async]"},
+				Options: []interface{}{"FunctionDeclaration[async=true]"},
 			},
 
 			// ============================================================
@@ -253,6 +258,18 @@ func TestNoRestrictedSyntaxRule(t *testing.T) {
 			{
 				Code:    `clearTimeout(id);`,
 				Options: []interface{}{`CallExpression[callee.name='setTimeout']`},
+			},
+			{
+				Code: `
+const A = withSuspense(lazy(() => import('./a')));
+const B = withSuspense(React.lazy(() => import('./b')));
+`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"selector": lazyMustBeWrappedSelector,
+						"message":  "lazy must be wrapped by withSuspense",
+					},
+				},
 			},
 		},
 		[]rule_tester.InvalidTestCase{
@@ -794,6 +811,22 @@ func TestNoRestrictedSyntaxRule(t *testing.T) {
 					},
 				},
 			},
+			{
+				Code: `
+const A = lazy(() => import('./a'));
+const B = React.lazy(() => import('./b'));
+`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"selector": lazyMustBeWrappedSelector,
+						"message":  "lazy must be wrapped by withSuspense",
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "lazy must be wrapped by withSuspense"},
+					{MessageId: "restrictedSyntax", Message: "lazy must be wrapped by withSuspense"},
+				},
+			},
 
 			// ============================================================
 			// Real-world: forbid for-in
@@ -917,6 +950,291 @@ func TestNoRestrictedSyntaxRule(t *testing.T) {
 	)
 }
 
+func TestNoRestrictedSyntaxEsqueryParity(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoRestrictedSyntaxRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code:    `import('./static');`,
+				Options: []interface{}{"CallExpression"},
+			},
+			{
+				Code:    `import(source);`,
+				Options: []interface{}{`ImportExpression[callee]`},
+			},
+			{
+				Code:    `import(source);`,
+				Options: []interface{}{`ImportExpression[arguments]`},
+			},
+			{
+				Code:    `import('./static');`,
+				Options: []interface{}{`ImportExpression[source.type!='Literal']`},
+			},
+			{
+				Code:    `require('./static');`,
+				Options: []interface{}{`CallExpression[callee.name='require'][arguments.0.type!='Literal']`},
+			},
+			{
+				Code:    `const A = withSuspense((lazy(() => import('./a'))));`,
+				Options: []interface{}{lazyMustBeWrappedSelector},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[missing='value']`},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[optional]`},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[raw]`},
+			},
+			{
+				Code:    `class C { async method() {} }`,
+				Options: []interface{}{`MethodDefinition[async]`},
+			},
+			{
+				Code:    `const fn = function () {};`,
+				Options: []interface{}{`FunctionExpression[id]`},
+			},
+			{
+				Code:    `const fn = function () {};`,
+				Options: []interface{}{`FunctionExpression[id.name='fn']`},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[name='foo'][name='bar']`},
+			},
+			{
+				Code:    `function outer() { foo; }`,
+				Options: []interface{}{`BlockStatement:has(Program Identifier[name='foo'])`},
+			},
+			{
+				Code: `/* eslint-disable test */
+foo;`,
+				Options: []interface{}{`Identifier[name='foo']`},
+			},
+			{
+				Code: `// eslint-disable-next-line test
+foo;`,
+				Options: []interface{}{`Identifier[name='foo']`},
+			},
+			{
+				Code:    `foo; // eslint-disable-line test`,
+				Options: []interface{}{`Identifier[name='foo']`},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    `foo();`,
+				Options: []interface{}{"CallExpression"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `for (let index = 0; index < 1; index++) {}`,
+				Options: []interface{}{"VariableDeclaration"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `for (let index = 0; index < 1; index++) {}`,
+				Options: []interface{}{"ForStatement > VariableDeclaration"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `import(source);`,
+				Options: []interface{}{`ImportExpression[source.type!='Literal']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `import data from "./data.json" with { type: "json" };`,
+				Options: []interface{}{`ImportAttribute[key.name='type'][value.value='json']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `require(source);`,
+				Options: []interface{}{`CallExpression[callee.name='require'][arguments.0.type!='Literal']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `object.property;`,
+				Options: []interface{}{"MemberExpression[computed]"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `foo();`,
+				Options: []interface{}{"CallExpression[optional]"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `'text';`,
+				Options: []interface{}{"Literal[raw]"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `function regular() {}`,
+				Options: []interface{}{"FunctionDeclaration[async]"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const arrow = () => {};`,
+				Options: []interface{}{"ArrowFunctionExpression[generator]"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[missing!='value']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `foo();`,
+				Options: []interface{}{`CallExpression[callee.property.name='undefined']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const fn = function () {};`,
+				Options: []interface{}{`FunctionExpression[id=null]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const fn = function () {};`,
+				Options: []interface{}{`FunctionExpression[id.name=null]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const fn = function () {};`,
+				Options: []interface{}{`FunctionExpression[id.name=type(object)]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const fn = function () {};`,
+				Options: []interface{}{`FunctionExpression[id<1]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `function noArgs() {}`,
+				Options: []interface{}{`FunctionDeclaration[params='']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `function noArgs() {}`,
+				Options: []interface{}{`FunctionDeclaration[params<1]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const empty = "";`,
+				Options: []interface{}{`Literal[value<1]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[name<'z']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[name='foo'][name='foo']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code: `foo;`,
+				Options: []interface{}{
+					map[string]interface{}{"selector": `[name='foo']`, "message": "universe first"},
+					map[string]interface{}{"selector": `Identifier[name='foo']`, "message": "specific second"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "universe first"},
+					{MessageId: "restrictedSyntax", Message: "specific second"},
+				},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[name=type(string)]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`identifier[name='foo']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`#Identifier[name='foo']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `function f() {}`,
+				Options: []interface{}{":function"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const value = 42;`,
+				Options: []interface{}{`.body.declarations.init`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `x;`,
+				Options: []interface{}{`Identifier:has(Identifier[name='x'])`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `if (x) { y(); }`,
+				Options: []interface{}{`IfStatement:has(> Identifier[name='x'])`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `if ((x)) { y(); }`,
+				Options: []interface{}{`IfStatement:has(> Identifier[name='x'])`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `(foo);`,
+				Options: []interface{}{"*"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax"},
+					{MessageId: "restrictedSyntax"},
+				},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[name=/\u{66}oo/u]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const value = "\n";`,
+				Options: []interface{}{`Literal[value='\n']`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const slash = "/";`,
+				Options: []interface{}{`Literal[value=/[/]/]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code:    `const value = .5;`,
+				Options: []interface{}{`Literal[value=.5]`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+			{
+				Code: `foo;`,
+				Options: []interface{}{
+					map[string]interface{}{"selector": "Identifier", "message": "first"},
+					map[string]interface{}{"selector": "Identifier", "message": "last"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax", Message: "last"}},
+			},
+			{
+				Code:    `const A = withSuspense(memo(lazy(() => import('./a'))));`,
+				Options: []interface{}{lazyMustBeWrappedSelector},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "restrictedSyntax"}},
+			},
+		},
+	)
+}
+
 func TestNoRestrictedSyntaxOptimizedDispatch(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),
@@ -967,8 +1285,8 @@ func TestNoRestrictedSyntaxOptimizedDispatch(t *testing.T) {
 					map[string]interface{}{"selector": `Identifier[name='bar']`, "message": "other exact"},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "restrictedSyntax", Message: "regex start"},
 					{MessageId: "restrictedSyntax", Message: "exact"},
+					{MessageId: "restrictedSyntax", Message: "regex start"},
 					{MessageId: "restrictedSyntax", Message: "regex end"},
 				},
 			},
@@ -1006,7 +1324,6 @@ func TestNoRestrictedSyntaxOptimizedDispatch(t *testing.T) {
 					},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "restrictedSyntax", Message: "first duplicate"},
 					{MessageId: "restrictedSyntax", Message: "second duplicate"},
 				},
 			},
@@ -1067,6 +1384,57 @@ func TestNoRestrictedSyntaxDispatchPlanning(t *testing.T) {
 	if unsupportedBucket.dispatch != nil {
 		t.Fatalf("unsupported single-selector path unexpectedly built dispatch %v", unsupportedBucket.dispatch)
 	}
+}
+
+func TestNoRestrictedSyntaxDispatchMatchesFullMatcher(t *testing.T) {
+	entries := parseRuleOptions([]interface{}{
+		`Identifier[name='foo']`,
+		`Identifier[name='bar']`,
+		`Identifier[name=/^f/]`,
+		`Identifier[name='foo'][name='foo']`,
+		`Identifier[name='foo'][name='bar']`,
+		`Identifier[name='foo'][type='Identifier']`,
+		`Identifier[missing='undefined']`,
+	})
+	bucket := buildRuleBucket(entries)
+	if bucket.dispatch == nil {
+		t.Fatal("expected a string dispatch plan")
+	}
+
+	sourceFile := tsparser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/dispatch-attack.ts",
+		Path:     "/dispatch-attack.ts",
+	}, `foo; bar; function foo() {} object.foo;`, core.ScriptKindTS)
+	mc := &matchContext{sf: sourceFile}
+
+	var attack func(*ast.Node) bool
+	attack = func(node *ast.Node) bool {
+		full := make([]bool, len(entries))
+		optimized := make([]bool, len(entries))
+		for index := range entries {
+			full[index] = matches(entries[index].compiled, node, mc)
+		}
+
+		fallback, indexed, useAll := bucket.candidates(node, mc)
+		if useAll {
+			copy(optimized, full)
+		} else {
+			for _, index := range fallback {
+				optimized[index] = matches(entries[index].compiled, node, mc)
+			}
+			for _, index := range indexed {
+				optimized[index] = matches(bucket.dispatch.matched[index], node, mc)
+			}
+		}
+		for index := range entries {
+			if optimized[index] != full[index] {
+				t.Errorf("node %s selector %q: optimized=%v full=%v", node.Kind, entries[index].selector, optimized[index], full[index])
+			}
+		}
+		node.ForEachChild(attack)
+		return false
+	}
+	attack(sourceFile.AsNode())
 }
 
 func TestNoRestrictedSyntaxRulePlanCache(t *testing.T) {

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
-	tsparser "github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
@@ -1401,7 +1401,7 @@ func TestNoRestrictedSyntaxDispatchMatchesFullMatcher(t *testing.T) {
 		t.Fatal("expected a string dispatch plan")
 	}
 
-	sourceFile := tsparser.ParseSourceFile(ast.SourceFileParseOptions{
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
 		FileName: "/dispatch-attack.ts",
 		Path:     "/dispatch-attack.ts",
 	}, `foo; bar; function foo() {} object.foo;`, core.ScriptKindTS)

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/parser"
+	tsparser "github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
@@ -1401,7 +1401,7 @@ func TestNoRestrictedSyntaxDispatchMatchesFullMatcher(t *testing.T) {
 		t.Fatal("expected a string dispatch plan")
 	}
 
-	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+	sourceFile := tsparser.ParseSourceFile(ast.SourceFileParseOptions{
 		FileName: "/dispatch-attack.ts",
 		Path:     "/dispatch-attack.ts",
 	}, `foo; bar; function foo() {} object.foo;`, core.ScriptKindTS)

--- a/internal/rules/no_restricted_syntax/parser.go
+++ b/internal/rules/no_restricted_syntax/parser.go
@@ -163,12 +163,16 @@ func (p *parser) parseSequence() (selector, error) {
 		c := p.peek()
 		switch c {
 		case '.':
-			p.pos++
-			cls, err := p.parseIdent()
-			if err != nil {
-				return nil, err
+			path := make([]string, 0, 2)
+			for !p.eof() && p.peek() == '.' {
+				p.pos++
+				field, err := p.parseIdent()
+				if err != nil {
+					return nil, err
+				}
+				path = append(path, field)
 			}
-			head = classSelector{Inner: head, Class: cls}
+			head = classSelector{Inner: head, Path: path}
 		case '[':
 			attr, err := p.parseAttr(head)
 			if err != nil {
@@ -189,6 +193,10 @@ func (p *parser) parseSequence() (selector, error) {
 }
 
 func newIdentifierSelector(name string) identifierSelector {
+	name = strings.TrimPrefix(name, "#")
+	if canonical, ok := canonicalEstreeName(name); ok {
+		name = canonical
+	}
 	return identifierSelector{Name: name, Kinds: kindsForEstreeName(name)}
 }
 
@@ -259,7 +267,16 @@ func (p *parser) parseAttrPath() ([]string, error) {
 // them).
 func (p *parser) parseAttrPathSegment() (string, error) {
 	start := p.pos
-	if p.eof() || !isIdentStart(p.peek()) {
+	if p.eof() {
+		return "", fmt.Errorf("expected identifier in attribute path at position %d", p.pos)
+	}
+	if p.peek() >= '0' && p.peek() <= '9' {
+		for !p.eof() && p.peek() >= '0' && p.peek() <= '9' {
+			p.pos++
+		}
+		return p.src[start:p.pos], nil
+	}
+	if !isIdentStart(p.peek()) {
 		return "", fmt.Errorf("expected identifier in attribute path at position %d", p.pos)
 	}
 	p.pos++
@@ -322,7 +339,10 @@ func (p *parser) parseAttrValue() (attrValue, error) {
 		if err != nil {
 			return attrValue{}, err
 		}
-		compiled, _ := regexp2.Compile(pat, regexpFlags(flags))
+		compiled, compileErr := regexp2.Compile(pat, regexpFlags(flags))
+		if compileErr != nil {
+			return attrValue{}, fmt.Errorf("invalid regular expression: %w", compileErr)
+		}
 		return attrValue{
 			Kind:          attrValueRegex,
 			Regex:         pat,
@@ -330,7 +350,7 @@ func (p *parser) parseAttrValue() (attrValue, error) {
 			compiledRegex: compiled,
 			regexPrefix:   anchoredLiteralPrefix(pat, flags),
 		}, nil
-	case c == '-' || (c >= '0' && c <= '9'):
+	case c == '.' || (c >= '0' && c <= '9'):
 		num, err := p.parseNumber()
 		if err != nil {
 			return attrValue{}, err
@@ -341,17 +361,38 @@ func (p *parser) parseAttrValue() (attrValue, error) {
 		if err != nil {
 			return attrValue{}, err
 		}
-		switch ident {
-		case "true":
-			return attrValue{Kind: attrValueBool, Bool: true}, nil
-		case "false":
-			return attrValue{Kind: attrValueBool, Bool: false}, nil
-		case "null":
-			return attrValue{Kind: attrValueNull}, nil
+		if ident == "type" && !p.eof() && p.peek() == '(' {
+			typeName, err := p.parseTypeValue()
+			if err != nil {
+				return attrValue{}, err
+			}
+			return attrValue{Kind: attrValueType, Ident: typeName}, nil
 		}
 		return attrValue{Kind: attrValueIdent, Ident: ident}, nil
 	}
 	return attrValue{}, fmt.Errorf("unexpected attribute value at position %d", p.pos)
+}
+
+func (p *parser) parseTypeValue() (string, error) {
+	if p.eof() || p.peek() != '(' {
+		return "", fmt.Errorf("expected ( at position %d", p.pos)
+	}
+	p.pos++
+	p.skipSpaces()
+	start := p.pos
+	for !p.eof() && p.peek() != ')' && p.peek() != ' ' && p.peek() != '\t' && p.peek() != '\n' && p.peek() != '\r' {
+		p.pos++
+	}
+	if start == p.pos {
+		return "", fmt.Errorf("expected type name at position %d", p.pos)
+	}
+	typeName := p.src[start:p.pos]
+	p.skipSpaces()
+	if p.eof() || p.peek() != ')' {
+		return "", fmt.Errorf("expected ) at position %d", p.pos)
+	}
+	p.pos++
+	return typeName, nil
 }
 
 // anchoredLiteralPrefix extracts only the plainly literal ASCII prefix from a
@@ -384,7 +425,22 @@ func (p *parser) parseString(quote byte) (string, error) {
 		c := p.src[p.pos]
 		if c == '\\' && p.pos+1 < len(p.src) {
 			next := p.src[p.pos+1]
-			sb.WriteByte(next)
+			switch next {
+			case 'b':
+				sb.WriteByte('\b')
+			case 'f':
+				sb.WriteByte('\f')
+			case 'n':
+				sb.WriteByte('\n')
+			case 'r':
+				sb.WriteByte('\r')
+			case 't':
+				sb.WriteByte('\t')
+			case 'v':
+				sb.WriteByte('\v')
+			default:
+				sb.WriteByte(next)
+			}
 			p.pos += 2
 			continue
 		}
@@ -404,6 +460,7 @@ func (p *parser) parseRegex() (string, string, error) {
 	}
 	p.pos++ // opening /
 	var pat strings.Builder
+	inClass := false
 	for !p.eof() {
 		c := p.src[p.pos]
 		if c == '\\' && p.pos+1 < len(p.src) {
@@ -412,18 +469,43 @@ func (p *parser) parseRegex() (string, string, error) {
 			p.pos += 2
 			continue
 		}
-		if c == '/' {
+		if c == '[' {
+			inClass = true
+			pat.WriteByte(c)
+			p.pos++
+			continue
+		}
+		if c == ']' && inClass {
+			inClass = false
+			pat.WriteByte(c)
+			p.pos++
+			continue
+		}
+		if c == '/' && !inClass {
 			p.pos++ // closing /
 			flagsStart := p.pos
 			for !p.eof() {
 				fc := p.src[p.pos]
-				if fc >= 'a' && fc <= 'z' || fc >= 'A' && fc <= 'Z' {
+				if fc == 'i' || fc == 'm' || fc == 's' || fc == 'u' {
 					p.pos++
 					continue
 				}
 				break
 			}
-			return pat.String(), p.src[flagsStart:p.pos], nil
+			if p.pos < len(p.src) && (p.src[p.pos] >= 'a' && p.src[p.pos] <= 'z' || p.src[p.pos] >= 'A' && p.src[p.pos] <= 'Z') {
+				return "", "", fmt.Errorf("unsupported regular expression flag %q", p.src[p.pos])
+			}
+			pattern := pat.String()
+			if pattern == "" {
+				return "", "", errors.New("empty regular expression")
+			}
+			flags := p.src[flagsStart:p.pos]
+			for i := range len(flags) {
+				if strings.ContainsRune(flags[:i], rune(flags[i])) {
+					return "", "", fmt.Errorf("duplicate regular expression flag %q", flags[i])
+				}
+			}
+			return pattern, flags, nil
 		}
 		pat.WriteByte(c)
 		p.pos++
@@ -433,9 +515,6 @@ func (p *parser) parseRegex() (string, string, error) {
 
 func (p *parser) parseNumber() (float64, error) {
 	start := p.pos
-	if p.peek() == '-' {
-		p.pos++
-	}
 	for !p.eof() && p.src[p.pos] >= '0' && p.src[p.pos] <= '9' {
 		p.pos++
 	}
@@ -472,19 +551,72 @@ func (p *parser) parsePseudo(inner selector) (selector, error) {
 			return nil, err
 		}
 		return wrapPseudo(inner, pseudoSelector{Name: name, N: n}), nil
-	case "is", "matches", "not", "has":
+	case "is", "matches", "not":
 		args, err := p.parsePseudoSelectorArgs()
 		if err != nil {
 			return nil, err
 		}
 		return wrapPseudo(inner, pseudoSelector{Name: name, Args: args}), nil
+	case "has":
+		args, err := p.parseHasSelectorArgs()
+		if err != nil {
+			return nil, err
+		}
+		return wrapPseudo(inner, pseudoSelector{Name: name, Args: args}), nil
+	}
+	className := strings.ToLower(name)
+	switch className {
 	case "statement", "expression", "declaration", "function", "pattern":
-		// Treat known esquery class pseudos as a no-op match (we don't
-		// model these category sets). The combination with a head
-		// selector still narrows by the head, so this is conservative.
-		return inner, nil
+		return wrapPseudo(inner, pseudoSelector{Name: className}), nil
 	}
 	return nil, fmt.Errorf("unsupported pseudo class %q at position %d", name, p.pos)
+}
+
+func (p *parser) parseHasSelectorArgs() ([]selector, error) {
+	if p.eof() || p.peek() != '(' {
+		return nil, fmt.Errorf("expected ( at position %d", p.pos)
+	}
+	p.pos++
+	p.skipSpaces()
+
+	args := make([]selector, 0, 1)
+	for {
+		if p.eof() {
+			return nil, fmt.Errorf("expected selector at position %d", p.pos)
+		}
+		relative := false
+		relativeKind := combChild
+		if p.peek() == '>' || p.peek() == '+' || p.peek() == '~' {
+			relative = true
+			switch p.peek() {
+			case '+':
+				relativeKind = combAdjacent
+			case '~':
+				relativeKind = combSibling
+			}
+			p.pos++
+			p.skipSpaces()
+		}
+		arg, err := p.parseCompound()
+		if err != nil {
+			return nil, err
+		}
+		if relative {
+			arg = relativeSelector{Kind: relativeKind, Inner: arg}
+		}
+		args = append(args, arg)
+		p.skipSpaces()
+		if p.eof() || p.peek() != ',' {
+			break
+		}
+		p.pos++
+		p.skipSpaces()
+	}
+	if p.eof() || p.peek() != ')' {
+		return nil, fmt.Errorf("expected ) at position %d", p.pos)
+	}
+	p.pos++
+	return args, nil
 }
 
 func wrapPseudo(inner selector, p pseudoSelector) selector {

--- a/internal/rules/no_restricted_syntax/parser_test.go
+++ b/internal/rules/no_restricted_syntax/parser_test.go
@@ -8,6 +8,7 @@ import (
 func TestParseSelector_Wellformed(t *testing.T) {
 	cases := []string{
 		"Identifier",
+		"#identifier",
 		"*",
 		"FunctionExpression",
 		"BinaryExpression",
@@ -19,11 +20,15 @@ func TestParseSelector_Wellformed(t *testing.T) {
 		"FunctionDeclaration[params.length>=2]",
 		"FunctionDeclaration[params.length<=2]",
 		"FunctionDeclaration[params.length<2]",
+		"FunctionDeclaration[params.0.name=x]",
+		"Identifier[name=type(string)]",
+		"Literal[value=.5]",
 		"Literal[regex.flags=/./]",
 		"Literal[regex.flags=/i/]",
 		`ImportDeclaration[source.value=/^some\/path$/]`,
 		"ArrowFunctionExpression > BlockStatement",
 		"Property > Literal.key",
+		".body.declarations.init",
 		"FunctionDeclaration FunctionExpression",
 		"Literal + Literal",
 		"* ~ *",
@@ -31,6 +36,10 @@ func TestParseSelector_Wellformed(t *testing.T) {
 		":matches(Identifier, Literal)",
 		":not(VariableDeclaration)",
 		":has(Literal)",
+		":has(> Identifier)",
+		":has(+ Identifier)",
+		":has(~ Identifier)",
+		":Expression",
 		":nth-child(1)",
 		":nth-last-child(2)",
 		":first-child",
@@ -62,6 +71,11 @@ func TestParseSelector_Malformed(t *testing.T) {
 		"BinaryExpression[name=",             // missing value
 		"BinaryExpression[name=']",           // unterminated string
 		"BinaryExpression[name=/]",           // unterminated regex (no closing /)
+		"Identifier[name=//]",                // empty regex
+		"Identifier[name=/foo/g]",            // unsupported regex flag
+		"Identifier[name=/foo/ii]",           // duplicate regex flag
+		"Identifier[name=type()]",            // empty typeof operand
+		"Literal[value=-1]",                  // esquery numbers are unsigned
 		":nth-child",                         // missing arg
 		":nth-child(",                        // unterminated paren
 		":nth-child(abc)",                    // non-numeric arg
@@ -71,6 +85,7 @@ func TestParseSelector_Malformed(t *testing.T) {
 		"Identifier >",                       // dangling combinator
 		"Identifier >> Foo",                  // double combinator
 		":unknownPseudo",                     // unsupported pseudo
+		":HAS(Identifier)",                   // named pseudos are case-sensitive
 		"FunctionDeclaration[params.length>", // missing operand
 		"BinaryExpression[name=&&]",          // illegal operator value
 	}
@@ -117,7 +132,7 @@ func TestParseRuleOptions_Shapes(t *testing.T) {
 		if len(got) != 2 {
 			t.Fatalf("expected 2, got %d", len(got))
 		}
-		if got[0].selector != "WithStatement" || got[0].message != "" {
+		if got[0].selector != "WithStatement" || got[0].message != "Using 'WithStatement' is not allowed." {
 			t.Fatalf("entry 0 mismatch: %#v", got[0])
 		}
 		if got[1].selector != "VariableDeclaration" || got[1].message != "x" {
@@ -179,5 +194,43 @@ func TestParseRuleOptions_CustomMessage(t *testing.T) {
 	}
 	if msg := got[0].formatMessage(); msg != "no" {
 		t.Fatalf("custom message mismatch: %q", msg)
+	}
+}
+
+func TestSelectorSpecificityMatchesESLint(t *testing.T) {
+	tests := []struct {
+		selector    string
+		attributes  int
+		identifiers int
+	}{
+		{selector: "Identifier", identifiers: 1},
+		{selector: `[name='foo']`, attributes: 1},
+		{selector: `Identifier[name='foo']`, attributes: 1, identifiers: 1},
+		{selector: `FunctionDeclaration > Identifier.id`, attributes: 1, identifiers: 2},
+		{selector: `:nth-child(2)`, attributes: 1},
+		// ESLint deliberately excludes selectors nested inside :has().
+		{selector: `CallExpression:has(Identifier MemberExpression)`, identifiers: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.selector, func(t *testing.T) {
+			parsed, err := parseSelector(test.selector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := analyzeSelectorSpecificity(parsed)
+			if got.attributes != test.attributes || got.identifiers != test.identifiers {
+				t.Fatalf("specificity = (%d, %d), want (%d, %d)", got.attributes, got.identifiers, test.attributes, test.identifiers)
+			}
+		})
+	}
+}
+
+func TestCandidateKindsUniverseAbsorbsTypedBranches(t *testing.T) {
+	parsed, err := parseSelector(`:matches(*, Identifier)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kinds := candidateKinds(parsed); !kinds.universe {
+		t.Fatalf("candidate kinds = %#v, want universe", kinds)
 	}
 }

--- a/internal/rules/no_restricted_syntax/selector.go
+++ b/internal/rules/no_restricted_syntax/selector.go
@@ -28,7 +28,7 @@ func (identifierSelector) isSelector() {}
 // `Literal.key` requires the Literal to be the key of a Property).
 type classSelector struct {
 	Inner selector
-	Class string
+	Path  []string
 }
 
 func (classSelector) isSelector() {}
@@ -53,17 +53,15 @@ const (
 	attrValueNone   attrValueKind = iota // presence
 	attrValueString                      // "x" or 'x'
 	attrValueNumber                      // 42
-	attrValueBool                        // true / false
 	attrValueRegex                       // /pattern/flags
-	attrValueIdent                       // bareword (e.g. type(undefined))
-	attrValueNull                        // null literal
+	attrValueIdent                       // bareword literal (e.g. undefined)
+	attrValueType                        // type(string), type(number), ...
 )
 
 type attrValue struct {
 	Kind          attrValueKind
 	Str           string
 	Num           float64
-	Bool          bool
 	Regex         string
 	Flags         string
 	Ident         string
@@ -73,7 +71,7 @@ type attrValue struct {
 
 // attrSelector matches a node whose attribute (a dotted path inside the
 // node's logical fields) satisfies a comparison. With Op == attrPresent the
-// rule only checks that the value resolves to truthy / non-nil.
+// rule only checks that the path resolves to a non-null value.
 type attrSelector struct {
 	Inner selector
 	Path  []string
@@ -103,6 +101,16 @@ type combinatorSelector struct {
 }
 
 func (combinatorSelector) isSelector() {}
+
+// relativeSelector is the leading-combinator form accepted inside :has(),
+// for example `:has(> Identifier)`. esquery models its left side as the exact
+// node on which :has() is being evaluated.
+type relativeSelector struct {
+	Kind  combinatorKind
+	Inner selector
+}
+
+func (relativeSelector) isSelector() {}
 
 // pseudoSelector covers the `:is(...)`, `:matches(...)`, `:not(...)`,
 // `:has(...)`, `:nth-child(N)`, `:nth-last-child(N)`, `:first-child`,

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -562,6 +562,7 @@ tsgo
 tsgolint
 TSJSDoc
 tsoptions
+tsparser
 tspath
 tsutils
 typeparam


### PR DESCRIPTION
## Summary

- Fix `no-restricted-syntax` attribute paths so `parent.callee.name` sees the logical ESTree parent, including through parser-only parentheses.
- Align common esquery 1.7 semantics: numeric paths, `ImportExpression`/`ImportAttribute`, null vs. undefined, false-valued attribute presence, `type(...)`, relational/string/regex matching, nested fields, semantic classes, `:has()`, selector specificity, and duplicate-selector overwrite behavior.
- Optimize hot matching paths by indexing exact string attributes, removing an already-proven dispatch predicate, precomputing default messages, avoiding AST slice copies, and keeping the parent matcher allocation-free.
- Document the remaining structural gaps (`!` subjects, incomplete TS-ESTree/virtual-node facades, and config-time invalid-selector rejection).

### Package-local Go benchmark

Median of 6 runs, `-benchtime=500ms -benchmem`; no main checkout/build or repository-wide benchmark was run.

| Case | Before | After | Change |
|---|---:|---:|---:|
| RepresentativeListeners time | 162,230 ns/op | 114,602 ns/op | -29.4% |
| RepresentativeListeners allocs | 1,664 allocs/op | 320 allocs/op | -80.8% |
| DefaultMessageReports allocs | 3,648 allocs/op | 1,216 allocs/op | -66.7% |
| ParentSelector time | 43,874 ns/op | 18,560 ns/op | -57.7% |
| ParentSelector allocs | 256 allocs/op | 0 allocs/op | -100% |
| CachedRuleRun | 463.4 ns/op, 544 B/op, 11 allocs/op | 463.5 ns/op, 544 B/op, 11 allocs/op | unchanged |

### Correctness and adversarial review

- Added the reported wrapped/unwrapped `lazy` regression cases.
- Attacked dispatch with repeated and contradictory predicates, missing `undefined` paths, fallback regexes, and compared optimized results against the full matcher for every node in a mixed corpus.
- Covered typed-nil/null short-circuiting, dynamic imports, transparent AST wrappers, `:has()` scope escape, disable directives, regex flags/escapes, selector ordering, and duplicate selectors.
- Final targeted check: `go test ./internal/rules/no_restricted_syntax -count=1`.
- Temporary benchmark source was removed after measurement.

## Related Links

- https://github.com/eslint/eslint/releases/tag/v10.8.1
- https://github.com/estools/esquery/tree/444da2c9b1f973555102b0e3a2c62f5d607dc6fe

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
