### PR TITLE
fix(rstest): widen registration parsing for `no-disabled-tests` and `no-identical-title`

### DIFF
--- a/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.go
@@ -53,21 +53,25 @@ func isPendingCall(node *ast.Node, ctx rule.RuleContext) bool {
 	return true
 }
 
-func parseJestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
-	parsed := utils.ParseJestFnCall(node, ctx)
-	if parsed == nil {
-		return nil
-	}
-	return &shared.ParsedCall{
-		Call: &parsed.ParsedCall,
-		HasSkip: strings.HasPrefix(parsed.Name, "x") ||
-			slices.Contains(parsed.Members, "skip"),
-		HasTodo: slices.Contains(parsed.Members, "todo"),
-	}
-}
-
 var NoDisabledTestsRule = shared.NewRule(shared.Config{
-	Name:                    "jest/no-disabled-tests",
-	Parse:                   parseJestCall,
-	IsStandaloneSkippedCall: isPendingCall,
+	Name: "jest/no-disabled-tests",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		return shared.Runtime{
+			Parse: func(node *ast.Node) *shared.ParsedCall {
+				parsed := utils.ParseJestFnCall(node, ctx)
+				if parsed == nil {
+					return nil
+				}
+				return &shared.ParsedCall{
+					Call: &parsed.ParsedCall,
+					HasSkip: strings.HasPrefix(parsed.Name, "x") ||
+						slices.Contains(parsed.Members, "skip"),
+					HasTodo: slices.Contains(parsed.Members, "todo"),
+				}
+			},
+			IsStandaloneSkippedCall: func(node *ast.Node) bool {
+				return isPendingCall(node, ctx)
+			},
+		}
+	},
 })

--- a/internal/plugins/jest/rules/no_identical_title/no_identical_title.go
+++ b/internal/plugins/jest/rules/no_identical_title/no_identical_title.go
@@ -9,18 +9,20 @@ import (
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_identical_title"
 )
 
-func parseJestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
-	parsed := jestUtils.ParseJestFnCall(node, ctx)
-	if parsed == nil {
-		return nil
-	}
-	return &shared.ParsedCall{
-		Call:          &parsed.ParsedCall,
-		Parameterized: slices.Contains(parsed.Members, "each"),
-	}
-}
-
 var NoIdenticalTitleRule = shared.NewRule(shared.Config{
-	Name:  "jest/no-identical-title",
-	Parse: parseJestCall,
+	Name: "jest/no-identical-title",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		return shared.Runtime{
+			Parse: func(node *ast.Node) *shared.ParsedCall {
+				parsed := jestUtils.ParseJestFnCall(node, ctx)
+				if parsed == nil {
+					return nil
+				}
+				return &shared.ParsedCall{
+					Call:          &parsed.ParsedCall,
+					Parameterized: slices.Contains(parsed.Members, "each"),
+				}
+			},
+		}
+	},
 })

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
@@ -7,23 +7,26 @@ import (
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_disabled_tests"
 )
 
-func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
-	parsed := rstestUtils.ParseRstestFnCall(node, ctx)
-	if parsed == nil {
-		return nil
-	}
-	return &shared.ParsedCall{
-		Call: &parsed.ParsedCall,
-		// Semantic fields rather than Members, so `const skipped = test.skip`
-		// followed by `skipped('case', fn)` is still recognized.
-		HasSkip: parsed.Skipped,
-		HasTodo: parsed.Todo,
-	}
-}
-
 var NoDisabledTestsRule = shared.NewRule(shared.Config{
-	Name:  "rstest/no-disabled-tests",
-	Parse: parseRstestCall,
+	Name: "rstest/no-disabled-tests",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
+		return shared.Runtime{
+			Parse: func(node *ast.Node) *shared.ParsedCall {
+				parsed := analysis.ParseFnCall(node)
+				if parsed == nil {
+					return nil
+				}
+				return &shared.ParsedCall{
+					Call: &parsed.ParsedCall,
+					// Semantic fields rather than Members, so aliases retain
+					// modifiers consumed while resolving their declarations.
+					HasSkip: parsed.Skipped,
+					HasTodo: parsed.Todo,
+				}
+			},
+		}
+	},
 	// `TestCall` accepts `(description, options, fn?)`.
 	HasOptionsOverload: true,
 })

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
@@ -44,8 +44,38 @@ func TestNoDisabledTestsRule(t *testing.T) {
 			{Code: `declare const pending: any; pending();`},
 			{Code: `import { customTest } from "./test-utils"; customTest.skip("case", () => {});`},
 			{Code: `test.for([1]).skip("case", () => {}); describe.each([1]).skip("suite", () => {});`},
+			{Code: `import.meta.rstest.test.todo("case"); import.meta.rstest.test("case", () => {});`},
+			{Code: `import { test } from "@rstest/playwright"; test("case", () => {});`},
+			// @rstest/playwright does not export `it` as a registration API.
+			{Code: `import { it } from "@rstest/playwright"; it.skip("case", () => {});`},
 		},
 		[]rule_tester.InvalidTestCase{
+			{
+				Code: `import.meta.rstest.test.skip("case", () => {});
+import.meta.rstest.describe.skip("suite", () => {});
+const api = import.meta.rstest;
+api.test.skip("alias", () => {});
+import.meta.rstest.test("missing");
+import.meta.rstest.test("options", { timeout: 1 });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "skippedTest", Line: 2, Column: 1},
+					{MessageId: "skippedTest", Line: 4, Column: 1},
+					{MessageId: "missingFunction", Line: 5, Column: 1},
+					{MessageId: "missingFunction", Line: 6, Column: 1},
+				},
+			},
+			{
+				Code: `import { test, describe } from "@rstest/playwright";
+test.skip("case", () => {});
+describe.skip("suite", () => {});
+test("missing");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 2, Column: 1},
+					{MessageId: "skippedTest", Line: 3, Column: 1},
+					{MessageId: "missingFunction", Line: 4, Column: 1},
+				},
+			},
 			{
 				Code: `test.skip("case", () => {});`,
 				Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/plugins/rstest/rules/no_identical_title/no_identical_title.go
+++ b/internal/plugins/rstest/rules/no_identical_title/no_identical_title.go
@@ -7,18 +7,21 @@ import (
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_identical_title"
 )
 
-func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
-	parsed := rstestUtils.ParseRstestFnCall(node, ctx)
-	if parsed == nil {
-		return nil
-	}
-	return &shared.ParsedCall{
-		Call:          &parsed.ParsedCall,
-		Parameterized: parsed.IsParameterized(),
-	}
-}
-
 var NoIdenticalTitleRule = shared.NewRule(shared.Config{
-	Name:  "rstest/no-identical-title",
-	Parse: parseRstestCall,
+	Name: "rstest/no-identical-title",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
+		return shared.Runtime{
+			Parse: func(node *ast.Node) *shared.ParsedCall {
+				parsed := analysis.ParseFnCall(node)
+				if parsed == nil {
+					return nil
+				}
+				return &shared.ParsedCall{
+					Call:          &parsed.ParsedCall,
+					Parameterized: parsed.IsParameterized(),
+				}
+			},
+		}
+	},
 })

--- a/internal/plugins/rstest/rules/no_identical_title/no_identical_title_test.go
+++ b/internal/plugins/rstest/rules/no_identical_title/no_identical_title_test.go
@@ -55,8 +55,40 @@ customTest("same", () => {});`},
 describe.fails("same", () => {});`},
 			{Code: `test.only.extend({})("same", () => {});
 test.only.extend({})("same", () => {});`},
+			{Code: `import.meta.rstest.test.each([1, 2])("same", () => {});
+import.meta.rstest.test.each([3])("same", () => {});`},
+			{Code: `import { test } from "@rstest/playwright";
+test.describe("a", () => { test("same", () => {}); });
+test.describe("b", () => { test("same", () => {}); });`},
 		},
 		[]rule_tester.InvalidTestCase{
+			{
+				Code: `import.meta.rstest.describe("suite", () => {
+  import.meta.rstest.test("same", () => {});
+  import.meta.rstest.test("same", () => {});
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 3, Column: 27},
+				},
+			},
+			{
+				Code: `import { test, describe } from "@rstest/playwright";
+describe("suite", () => {
+  test("same", () => {});
+  test("same", () => {});
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 4, Column: 8},
+				},
+			},
+			{
+				Code: `import { test } from "@rstest/playwright";
+test.describe("same", () => {});
+test.describe("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleDescribeTitle", Line: 3, Column: 15},
+				},
+			},
 			{
 				Code: `test("same", () => {});
 test("same", () => {});`,

--- a/internal/plugins/rstest/rules/valid_title/valid_title.go
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.go
@@ -427,12 +427,8 @@ var ValidTitleRule = rule.Rule{
 
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				// The wider entry point: import.meta.rstest.test(...) and
-				// @rstest/playwright are official registration shapes, and a
-				// title rule holds for them just as it does for @rstest/core.
-				// The two older rules in this plugin use the narrow
-				// ParseRstestFnCall, which is a historical choice rather than a
-				// contract.
+				// import.meta.rstest.test(...) and @rstest/playwright are official
+				// registration shapes, so title validation applies to them too.
 				parsed := analysis.ParseFnCall(node)
 				if parsed == nil {
 					return

--- a/internal/plugins/rstest/utils/call_analysis.go
+++ b/internal/plugins/rstest/utils/call_analysis.go
@@ -54,7 +54,7 @@ func (analysis *RstestCallAnalysis) parseFnCallCandidate(
 	if parsed, ok := analysis.fnCalls[node]; ok {
 		return parsed
 	}
-	parsed := ParseRstestFnCallWithOfficialExtensions(node, analysis.ctx)
+	parsed := parseRstestFnCall(node, analysis.ctx)
 	analysis.fnCalls[node] = parsed
 	return parsed
 }

--- a/internal/plugins/rstest/utils/members_contract_test.go
+++ b/internal/plugins/rstest/utils/members_contract_test.go
@@ -21,9 +21,10 @@ var misalignedMembersProbe = rule.Rule{
 	Name:             "rstest/members-alignment-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestFnCall(node, ctx)
+				parsed := analysis.ParseFnCall(node)
 				if parsed == nil {
 					return
 				}
@@ -77,9 +78,10 @@ var semanticFlagProbe = rule.Rule{
 	Name:             "rstest/semantic-flag-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestFnCall(node, ctx)
+				parsed := analysis.ParseFnCall(node)
 				if parsed == nil {
 					return
 				}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -57,28 +57,12 @@ const (
 	rstestProfilePlaywright
 )
 
-// ParseRstestFnCall parses a final Rstest test/describe/hook registration
-// call; callers distinguish the three through Kind. Factory calls such as
-// test.each(cases), test.runIf(condition), and test.extend(fixtures) are
-// intentionally not returned.
-func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall {
-	return parseRstestFnCall(node, ctx, false, false)
-}
-
-func ParseRstestFnCallWithOfficialExtensions(
-	node *ast.Node,
-	ctx rule.RuleContext,
-) *ParsedRstestFnCall {
-	return parseRstestFnCall(node, ctx, true, true)
-}
-
 // IsTypeOfRstestFnCall reports whether node parses as a Rstest registration
 // call of one of the given kinds. What this plugin owns is the entry point:
-// parsing runs with official extensions enabled (import.meta + playwright),
-// the same choice RstestTestCallbacks.ParseFnCall makes. The kind matching
-// itself is shared with jest through testFramework.IsCallOfKind.
+// parsing includes import.meta and playwright, while kind matching is shared
+// with jest through testFramework.IsCallOfKind.
 func IsTypeOfRstestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...RstestFnType) bool {
-	parsed := ParseRstestFnCallWithOfficialExtensions(node, ctx)
+	parsed := parseRstestFnCall(node, ctx)
 	if parsed == nil {
 		return false
 	}
@@ -88,8 +72,6 @@ func IsTypeOfRstestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...RstestF
 func parseRstestFnCall(
 	node *ast.Node,
 	ctx rule.RuleContext,
-	includeImportMeta bool,
-	includePlaywright bool,
 ) *ParsedRstestFnCall {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return nil
@@ -106,10 +88,8 @@ func parseRstestFnCall(
 			ctx,
 			nil,
 			0,
-			includeImportMeta,
-			includePlaywright,
 		)
-	} else if includeImportMeta {
+	} else {
 		var importMetaRoot *ast.Node
 		importMetaRoot, parts, rootInvoked, ok = parseImportMetaRstestChain(call.Expression)
 		if ok && !rootInvoked && importMetaRoot != nil && len(parts) > 0 {
@@ -341,8 +321,6 @@ func resolveRstestRoot(
 	ctx rule.RuleContext,
 	visited map[*ast.Symbol]bool,
 	depth int,
-	includeImportMeta bool,
-	includePlaywright bool,
 ) (rstestResolvedAPI, int, bool) {
 	if root == nil || root.Kind != ast.KindIdentifier || depth > 16 {
 		return rstestResolvedAPI{}, 0, false
@@ -353,7 +331,7 @@ func resolveRstestRoot(
 	if ctx.TypeChecker != nil {
 		symbol = ctx.TypeChecker.GetSymbolAtLocation(root)
 	}
-	for _, profile := range rstestProfiles(includePlaywright) {
+	for _, profile := range rstestAllProfiles {
 		module := profileImportModule(profile)
 		name, originalNode, mode := testFramework.ResolveFunctionIdentifierReferenceFromSymbol(
 			localName,
@@ -373,21 +351,19 @@ func resolveRstestRoot(
 		}
 	}
 
-	if includeImportMeta {
-		if name, originalNode, ok := resolveImportMetaRstestBinding(symbol); ok {
-			if state := directRstestAPIState(rstestProfileCore, name); state != rstestAPIInvalid {
-				return rstestResolvedAPI{
-					name:         name,
-					state:        state,
-					originalNode: originalNode,
-					mode:         RSTEST_IMPORT_MODE,
-					profile:      rstestProfileCore,
-				}, 0, true
-			}
+	if name, originalNode, ok := resolveImportMetaRstestBinding(symbol); ok {
+		if state := directRstestAPIState(rstestProfileCore, name); state != rstestAPIInvalid {
+			return rstestResolvedAPI{
+				name:         name,
+				state:        state,
+				originalNode: originalNode,
+				mode:         RSTEST_IMPORT_MODE,
+				profile:      rstestProfileCore,
+			}, 0, true
 		}
 	}
 
-	for _, profile := range rstestProfiles(includePlaywright) {
+	for _, profile := range rstestAllProfiles {
 		if testFramework.IsModuleNamespaceSymbol(symbol, profileImportModule(profile)) {
 			if len(parts) == 0 || parts[0].invocation != rstestNotInvoked {
 				return rstestResolvedAPI{}, 0, false
@@ -417,7 +393,7 @@ func resolveRstestRoot(
 		}
 		initializer := declaration.AsVariableDeclaration().Initializer
 		aliasRoot, aliasParts, aliasRootInvoked, ok := parseRstestChain(initializer)
-		if includeImportMeta && !ok && isImportMetaRstest(initializer) {
+		if !ok && isImportMetaRstest(initializer) {
 			if len(parts) == 0 || parts[0].invocation != rstestNotInvoked {
 				continue
 			}
@@ -450,8 +426,6 @@ func resolveRstestRoot(
 			ctx,
 			visited,
 			depth+1,
-			includeImportMeta,
-			includePlaywright,
 		)
 		if !ok {
 			continue
@@ -655,12 +629,7 @@ func profileImportModule(profile rstestAPIProfile) string {
 	return RstestImportModule
 }
 
-func rstestProfiles(includePlaywright bool) []rstestAPIProfile {
-	if includePlaywright {
-		return []rstestAPIProfile{rstestProfileCore, rstestProfilePlaywright}
-	}
-	return []rstestAPIProfile{rstestProfileCore}
-}
+var rstestAllProfiles = [...]rstestAPIProfile{rstestProfileCore, rstestProfilePlaywright}
 
 func isImportMetaRstest(node *ast.Node) bool {
 	// SkipParentheses dereferences its argument, so the nil check has to come

--- a/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
@@ -18,9 +18,10 @@ var hookParseProbe = rule.Rule{
 	Name:             "rstest/hook-parse-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				parsed := rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx)
+				parsed := analysis.ParseFnCall(node)
 				if parsed == nil {
 					return
 				}
@@ -134,9 +135,10 @@ var hookKindProbe = rule.Rule{
 	Name:             "rstest/hook-kind-probe",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		analysis := rstestUtils.NewRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				if rstestUtils.ParseRstestFnCallWithOfficialExtensions(node, ctx) == nil {
+				if analysis.ParseFnCall(node) == nil {
 					return
 				}
 				ctx.ReportNode(node, probeMessage("kinds", fmt.Sprintf(

--- a/internal/utils/test_framework/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/utils/test_framework/rules/no_disabled_tests/no_disabled_tests.go
@@ -12,10 +12,15 @@ type ParsedCall struct {
 	HasTodo bool
 }
 
+type Runtime struct {
+	Parse                   func(*ast.Node) *ParsedCall
+	IsStandaloneSkippedCall func(*ast.Node) bool
+	Skip                    bool
+}
+
 type Config struct {
-	Name                    string
-	Parse                   func(*ast.Node, rule.RuleContext) *ParsedCall
-	IsStandaloneSkippedCall func(*ast.Node, rule.RuleContext) bool
+	Name    string
+	Prepare func(rule.RuleContext) Runtime
 	// HasOptionsOverload marks frameworks whose test API accepts a
 	// `(description, options, fn?)` overload. For those, a two-argument call
 	// passing an options object registers a test without a body.
@@ -56,15 +61,19 @@ func NewRule(config Config) rule.Rule {
 		Name:   config.Name,
 		Schema: rule.EmptyArraySchema,
 		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+			runtime := config.Prepare(ctx)
+			if runtime.Skip {
+				return rule.RuleListeners{}
+			}
 			return rule.RuleListeners{
 				ast.KindCallExpression: func(node *ast.Node) {
-					if config.IsStandaloneSkippedCall != nil &&
-						config.IsStandaloneSkippedCall(node, ctx) {
+					if runtime.IsStandaloneSkippedCall != nil &&
+						runtime.IsStandaloneSkippedCall(node) {
 						ctx.ReportNode(node, buildErrorSkippedTestMessage())
 						return
 					}
 
-					parsed := config.Parse(node, ctx)
+					parsed := runtime.Parse(node)
 					if parsed == nil || parsed.Call == nil ||
 						parsed.Call.Kind != testFramework.FnKindDescribe &&
 							parsed.Call.Kind != testFramework.FnKindTest {

--- a/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
+++ b/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
@@ -12,9 +12,14 @@ type ParsedCall struct {
 	Parameterized bool
 }
 
+type Runtime struct {
+	Parse func(*ast.Node) *ParsedCall
+	Skip  bool
+}
+
 type Config struct {
-	Name  string
-	Parse func(*ast.Node, rule.RuleContext) *ParsedCall
+	Name    string
+	Prepare func(rule.RuleContext) Runtime
 }
 
 func buildMultipleTestTitleMessage() rule.RuleMessage {
@@ -49,12 +54,16 @@ func NewRule(config Config) rule.Rule {
 		Name:   config.Name,
 		Schema: rule.EmptyArraySchema,
 		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+			runtime := config.Prepare(ctx)
+			if runtime.Skip {
+				return rule.RuleListeners{}
+			}
 			contexts := []*titleLayer{newTitleLayer()}
 			var describeCalls []*ast.Node
 
 			return rule.RuleListeners{
 				ast.KindCallExpression: func(node *ast.Node) {
-					parsed := config.Parse(node, ctx)
+					parsed := runtime.Parse(node)
 					if parsed == nil || parsed.Call == nil {
 						return
 					}

--- a/internal/utils/test_framework/rules/no_identical_title/no_identical_title_test.go
+++ b/internal/utils/test_framework/rules/no_identical_title/no_identical_title_test.go
@@ -31,12 +31,16 @@ func TestNewRuleParsesEachCallOnce(t *testing.T) {
 	describeCall, nestedCall := calls[0], calls[1]
 	r := NewRule(Config{
 		Name: "test/no-identical-title",
-		Parse: func(node *ast.Node, ctx rule.RuleContext) *ParsedCall {
-			parseCount++
-			if node != describeCall {
-				return nil
+		Prepare: func(ctx rule.RuleContext) Runtime {
+			return Runtime{
+				Parse: func(node *ast.Node) *ParsedCall {
+					parseCount++
+					if node != describeCall {
+						return nil
+					}
+					return &ParsedCall{Call: &testFramework.ParsedCall{Kind: testFramework.FnKindDescribe}}
+				},
 			}
-			return &ParsedCall{Call: &testFramework.ParsedCall{Kind: testFramework.FnKindDescribe}}
 		},
 	})
 

--- a/packages/rslint-test-tools/tests/rstest/rules/no-disabled-tests.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-disabled-tests.test.ts
@@ -47,8 +47,26 @@ ruleTester.run('no-disabled-tests', {} as never, {
     {
       code: 'test.for([1]).skip("case", () => {}); describe.each([1]).skip("suite", () => {});',
     },
+    { code: 'import.meta.rstest.test.todo("case");' },
+    {
+      code: 'import { test } from "@rstest/playwright"; test("case", () => {});',
+    },
+    {
+      code: 'import { it } from "@rstest/playwright"; it.skip("case", () => {});',
+    },
   ],
   invalid: [
+    {
+      code: 'import.meta.rstest.test.skip("case", () => {});',
+      errors: [{ line: 1, column: 1, messageId: 'skippedTest' }],
+    },
+    {
+      code: [
+        'import { test } from "@rstest/playwright";',
+        'test.skip("case", () => {});',
+      ].join('\n'),
+      errors: [{ line: 2, column: 1, messageId: 'skippedTest' }],
+    },
     {
       code: 'test.skip("case", () => {});',
       errors: [

--- a/packages/rslint-test-tools/tests/rstest/rules/no-identical-title.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-identical-title.test.ts
@@ -26,8 +26,30 @@ ruleTester.run('no-identical-title', {} as never, {
         test.each([3, 4])("case %i", () => {});
       `,
     },
+    {
+      code: `
+        import { test } from "@rstest/playwright";
+        test.describe("a", () => { test("same", () => {}); });
+        test.describe("b", () => { test("same", () => {}); });
+      `,
+    },
   ],
   invalid: [
+    {
+      code: `
+        import.meta.rstest.test("same", () => {});
+        import.meta.rstest.test("same", () => {});
+      `,
+      errors: [{ messageId: 'multipleTestTitle', line: 3, column: 33 }],
+    },
+    {
+      code: `
+        import { test } from "@rstest/playwright";
+        test.describe("same", () => {});
+        test.describe("same", () => {});
+      `,
+      errors: [{ messageId: 'multipleDescribeTitle', line: 4, column: 23 }],
+    },
     {
       code: `
         test("same", () => {});


### PR DESCRIPTION
## Summary

- Widen `rstest/no-disabled-tests` and `rstest/no-identical-title` registration parsing to cover `import.meta.rstest`, its aliases, and `@rstest/playwright`.
- Move both shared Jest/Rstest rule bodies to per-file `Prepare` / `Runtime`; Rstest now uses `RstestCallAnalysis`, while Jest behavior remains unchanged.
- Consolidate Rstest registration parsing and remove the narrow parser and its feature flags.
- Benchmark the latest rspack, rsbuild, rslib, rspress, rsdoctor, and rstest repositories (1,922 files; 1 warmup + 7 measured runs). The improvement comes from `RstestCallAnalysis` filtering unrelated call expressions through its candidate index before performing full semantic parsing.

| Rule | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| `rstest/no-disabled-tests` | 32.3 ms | 15.3 ms | -52.6% |
| `rstest/no-identical-title` | 15.6 ms | 14.2 ms | -9.0% |

- Diagnostic comparison found no removals or unrelated changes. The only addition is the expected `no-disabled-tests` warning for an existing skipped `@rstest/playwright` test.