### PR TITLE
perf(lsp): collect after a lint pass drops what it derived

### DIFF
--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -1687,4 +1688,7 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 	if !lintResult.HasSyntaxErrors {
 		s.dispatchPluginLintWithConfig(uri, generation, rslintConfig, configCwd, isJSConfig)
 	}
+
+	// The pacer cannot see that the lint just dropped what it derived.
+	go runtime.GC()
 }


### PR DESCRIPTION
## Summary

A lint derives whole-Program structures, hands back diagnostics, and drops them. The collector paces off heap growth relative to what is live, which has no way to know that happened, so the next edit's allocation stacks on the last one's garbage and the heap climbs well past what is actually reachable.

Asking for a collection once the lint has dropped what it derived keeps that from accumulating. It runs on its own goroutine — `runtime.GC` blocks its caller and relinting happens on the main goroutine, so collecting there would stall every editor interaction for as long as marking takes. No guard is needed: `runtime.GC` waits for the in-flight mark and then starts a new cycle, and `gcStart` re-checks `gcTriggerCycle` under `work.startSema`, so concurrent callers that observed the same cycle collapse into one.

Measured with a scripted LSP client over stdio, so every variant sees a byte-identical message sequence. VS Code 1.128.0 `src` (7464 `.ts`), all core rules plus all nine plugins, one document, ten edits, `GODEBUG=gctrace=1`:

| | peak RSS | total CPU | GC CPU | forced cycles |
| --- | --- | --- | --- | --- |
| main | 7011 MB | 81.1 s | 32.8 s | 1 |
| this PR | 4182 MB | 110.7 s | 62.9 s | 12 |

Peak RSS drops 40%. Total CPU rises 36%, and the rise is entirely GC CPU: one extra full mark per lint pass, about 2.7 s at this project's live heap. Live heap is the same for both variants, ~1.97 GB in every run measured, which is what says this is garbage rather than retention.

Forced cycles come out at exactly one per lint pass plus one from upstream's idle cache clean (`typescript-go/internal/project/session.go:566`), in every run.

A soft memory limit reaches a similar peak for more CPU, and its cost varies with typing rhythm — the collector is pinned to a fixed watermark and fires whenever the heap approaches it, rather than once per lint.

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
