### PR TITLE
refactor: parse rule options by type assertion instead of JSON round-trips

### DIFF
--- a/.agents/skills/port-rule/references/UTILS_REFERENCE.md
+++ b/.agents/skills/port-rule/references/UTILS_REFERENCE.md
@@ -121,9 +121,6 @@ result := utils.NaturalCompare("item2", "item10") // -1
 ### Other Utilities
 
 ```go
-// Create a pointer (useful for optional fields)
-ptr := utils.Ref(value) // *T
-
 // Check if a character is a JS whitespace character
 isWhite := utils.IsStrWhiteSpace(r)
 ```

--- a/internal/plugins/import/rules/no_cycle/no_cycle.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.go
@@ -2,6 +2,7 @@ package no_cycle
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -101,6 +102,13 @@ func parseMaxDepth(raw any) (int, bool) {
 			return 0, false
 		}
 		return normalizeDepth(int(value))
+	case json.Number:
+		if i, err := value.Int64(); err == nil {
+			return normalizeDepth(int(i))
+		}
+		if f, err := value.Float64(); err == nil {
+			return normalizeDepth(int(f))
+		}
 	case string:
 		if value == "∞" {
 			return unlimitedDepth, true

--- a/internal/plugins/import/rules/no_cycle/no_cycle.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.go
@@ -2,7 +2,6 @@ package no_cycle
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -102,13 +101,6 @@ func parseMaxDepth(raw any) (int, bool) {
 			return 0, false
 		}
 		return normalizeDepth(int(value))
-	case json.Number:
-		if i, err := value.Int64(); err == nil {
-			return normalizeDepth(int(i))
-		}
-		if f, err := value.Float64(); err == nil {
-			return normalizeDepth(int(f))
-		}
 	case string:
 		if value == "∞" {
 			return unlimitedDepth, true

--- a/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
@@ -1,6 +1,7 @@
 package no_cycle_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
@@ -54,6 +55,9 @@ func TestNoCycleExtras(t *testing.T) {
 
 			// Locks in upstream detectCycle() maxDepth branch: depth-three is beyond maxDepth 2.
 			{Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"maxDepth": 2}}},
+
+			// A json.Number maxDepth is schema-valid and must limit traversal like a plain number.
+			{Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"maxDepth": json.Number("2")}}},
 		},
 		[]rule_tester.InvalidTestCase{
 			// Module-augmentation bodies are not present in SourceFile.Imports and must use the full collector.

--- a/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
+++ b/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
@@ -51,11 +51,8 @@ func parseOptions(options []any) NoBaseToStringOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
-	if raw, ok := optsMap["ignoredTypeNames"].([]interface{}); ok {
+	optsMap, _ := options[0].(map[string]any)
+	if raw, ok := optsMap["ignoredTypeNames"].([]any); ok {
 		opts.IgnoredTypeNames = utils.ToStringSlice(raw)
 	}
 	return opts

--- a/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
+++ b/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
@@ -2,7 +2,6 @@ package no_base_to_string
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -42,7 +41,7 @@ func buildBaseToStringMessage(name string, certainty usefulness) rule.RuleMessag
 }
 
 type NoBaseToStringOptions struct {
-	IgnoredTypeNames []string `json:"ignoredTypeNames"`
+	IgnoredTypeNames []string
 }
 
 func parseOptions(options []any) NoBaseToStringOptions {
@@ -52,10 +51,12 @@ func parseOptions(options []any) NoBaseToStringOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	if optsMap, ok := options[0].(map[string]interface{}); ok {
-		if optsJSON, err := json.Marshal(optsMap); err == nil {
-			_ = json.Unmarshal(optsJSON, &opts)
-		}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if raw, ok := optsMap["ignoredTypeNames"].([]interface{}); ok {
+		opts.IgnoredTypeNames = utils.ToStringSlice(raw)
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
+++ b/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
@@ -72,10 +72,7 @@ func parseOptions(options []any) NoConfusingVoidExpressionOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["ignoreArrowShorthand"].(bool); ok {
 		opts.IgnoreArrowShorthand = value
 	}

--- a/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
+++ b/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
@@ -2,7 +2,6 @@ package no_confusing_void_expression
 
 import (
 	_ "embed"
-	"encoding/json"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -63,9 +62,9 @@ func buildVoidExprWrapVoidMessage() rule.RuleMessage {
 }
 
 type NoConfusingVoidExpressionOptions struct {
-	IgnoreArrowShorthand         bool `json:"ignoreArrowShorthand,omitempty"`
-	IgnoreVoidOperator           bool `json:"ignoreVoidOperator,omitempty"`
-	IgnoreVoidReturningFunctions bool `json:"ignoreVoidReturningFunctions,omitempty"`
+	IgnoreArrowShorthand         bool
+	IgnoreVoidOperator           bool
+	IgnoreVoidReturningFunctions bool
 }
 
 func parseOptions(options []any) NoConfusingVoidExpressionOptions {
@@ -73,9 +72,18 @@ func parseOptions(options []any) NoConfusingVoidExpressionOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	// Convert the configured option object to JSON and back into the struct.
-	if optsJSON, err := json.Marshal(options[0]); err == nil {
-		_ = json.Unmarshal(optsJSON, &opts)
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if value, ok := optsMap["ignoreArrowShorthand"].(bool); ok {
+		opts.IgnoreArrowShorthand = value
+	}
+	if value, ok := optsMap["ignoreVoidOperator"].(bool); ok {
+		opts.IgnoreVoidOperator = value
+	}
+	if value, ok := optsMap["ignoreVoidReturningFunctions"].(bool); ok {
+		opts.IgnoreVoidReturningFunctions = value
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
@@ -455,7 +455,7 @@ func parseAllowSpecifiers(options []any) []utils.TypeOrValueSpecifier {
 	if len(options) == 0 {
 		return nil
 	}
-	optsMap, _ := options[0].(map[string]interface{})
+	optsMap, _ := options[0].(map[string]any)
 	return utils.ParseTypeOrValueSpecifiers(optsMap["allow"])
 }
 

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
@@ -3,7 +3,6 @@ package no_deprecated
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
@@ -451,27 +450,13 @@ func deprecatedReasonFromDeclaration(declaration *ast.Node) string {
 }
 
 // parseAllowSpecifiers decodes the `allow` option — type specifiers written
-// either in the string shorthand or in object form — through
-// TypeOrValueSpecifier's own UnmarshalJSON rather than re-deriving both shapes
-// by hand.
+// either in the string shorthand or in object form.
 func parseAllowSpecifiers(options []any) []utils.TypeOrValueSpecifier {
 	if len(options) == 0 {
 		return nil
 	}
 	optsMap, _ := options[0].(map[string]interface{})
-	raw, ok := optsMap["allow"]
-	if !ok {
-		return nil
-	}
-	rawJSON, err := json.Marshal(raw)
-	if err != nil {
-		return nil
-	}
-	var allow []utils.TypeOrValueSpecifier
-	if err := json.Unmarshal(rawJSON, &allow); err != nil {
-		return nil
-	}
-	return allow
+	return utils.ParseTypeOrValueSpecifiers(optsMap["allow"])
 }
 
 func mostSpecificNodeContainingRange(node *ast.Node, position int, end int) *ast.Node {

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
@@ -54,10 +54,7 @@ func parseOptions(options []any) NoDuplicateTypeConstituentsOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["ignoreIntersections"].(bool); ok {
 		opts.IgnoreIntersections = value
 	}

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
@@ -2,7 +2,6 @@ package no_duplicate_type_constituents
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -43,8 +42,8 @@ const (
 )
 
 type NoDuplicateTypeConstituentsOptions struct {
-	IgnoreIntersections bool `json:"ignoreIntersections"`
-	IgnoreUnions        bool `json:"ignoreUnions"`
+	IgnoreIntersections bool
+	IgnoreUnions        bool
 }
 
 func parseOptions(options []any) NoDuplicateTypeConstituentsOptions {
@@ -55,10 +54,15 @@ func parseOptions(options []any) NoDuplicateTypeConstituentsOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	if optsMap, ok := options[0].(map[string]interface{}); ok {
-		if optsJSON, err := json.Marshal(optsMap); err == nil {
-			_ = json.Unmarshal(optsJSON, &opts)
-		}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if value, ok := optsMap["ignoreIntersections"].(bool); ok {
+		opts.IgnoreIntersections = value
+	}
+	if value, ok := optsMap["ignoreUnions"].(bool); ok {
+		opts.IgnoreUnions = value
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
@@ -2,7 +2,6 @@ package no_floating_promises
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -15,33 +14,40 @@ import (
 var schemaJSON []byte
 
 type NoFloatingPromisesOptions struct {
-	AllowForKnownSafeCalls    []utils.TypeOrValueSpecifier `json:"allowForKnownSafeCalls"`
-	AllowForKnownSafePromises []utils.TypeOrValueSpecifier `json:"allowForKnownSafePromises"`
-	CheckThenables            *bool                        `json:"checkThenables"`
-	IgnoreIIFE                *bool                        `json:"ignoreIIFE"`
-	IgnoreVoid                *bool                        `json:"ignoreVoid"`
+	AllowForKnownSafeCalls    []utils.TypeOrValueSpecifier
+	AllowForKnownSafePromises []utils.TypeOrValueSpecifier
+	CheckThenables            bool
+	IgnoreIIFE                bool
+	IgnoreVoid                bool
 }
 
 func parseOptions(options []any) NoFloatingPromisesOptions {
 	opts := NoFloatingPromisesOptions{
 		AllowForKnownSafeCalls:    []utils.TypeOrValueSpecifier{},
 		AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{},
+		IgnoreVoid:                true,
 	}
-	if len(options) > 0 {
-		if optsMap, ok := options[0].(map[string]interface{}); ok {
-			if optsJSON, err := json.Marshal(optsMap); err == nil {
-				_ = json.Unmarshal(optsJSON, &opts)
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
-	if opts.CheckThenables == nil {
-		opts.CheckThenables = utils.Ref(false)
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
 	}
-	if opts.IgnoreIIFE == nil {
-		opts.IgnoreIIFE = utils.Ref(false)
+	if specifiers := utils.ParseTypeOrValueSpecifiers(optsMap["allowForKnownSafeCalls"]); specifiers != nil {
+		opts.AllowForKnownSafeCalls = specifiers
 	}
-	if opts.IgnoreVoid == nil {
-		opts.IgnoreVoid = utils.Ref(true)
+	if specifiers := utils.ParseTypeOrValueSpecifiers(optsMap["allowForKnownSafePromises"]); specifiers != nil {
+		opts.AllowForKnownSafePromises = specifiers
+	}
+	if value, ok := optsMap["checkThenables"].(bool); ok {
+		opts.CheckThenables = value
+	}
+	if value, ok := optsMap["ignoreIIFE"].(bool); ok {
+		opts.IgnoreIIFE = value
+	}
+	if value, ok := optsMap["ignoreVoid"].(bool); ok {
+		opts.IgnoreVoid = value
 	}
 	return opts
 }
@@ -184,7 +190,7 @@ var NoFloatingPromisesRule = rule.CreateRule(rule.Rule{
 			}
 
 			// ...and only check all Thenables if explicitly told to
-			if !*opts.CheckThenables {
+			if !opts.CheckThenables {
 				return false
 			}
 
@@ -305,7 +311,7 @@ var NoFloatingPromisesRule = rule.CreateRule(rule.Rule{
 				return isUnhandledPromise(expr.Right)
 			}
 
-			if !*opts.IgnoreVoid && ast.IsVoidExpression(node) {
+			if !opts.IgnoreVoid && ast.IsVoidExpression(node) {
 				// Similarly, a `void` expression always returns undefined, so we need to
 				// see what's inside it without checking the type of the overall expression.
 				return isUnhandledPromise(node.Expression())
@@ -394,7 +400,7 @@ var NoFloatingPromisesRule = rule.CreateRule(rule.Rule{
 			ast.KindExpressionStatement: func(node *ast.Node) {
 				exprStatement := node.AsExpressionStatement()
 
-				if *opts.IgnoreIIFE && isAsyncIife(exprStatement) {
+				if opts.IgnoreIIFE && isAsyncIife(exprStatement) {
 					return
 				}
 
@@ -411,13 +417,13 @@ var NoFloatingPromisesRule = rule.CreateRule(rule.Rule{
 				}
 				if promiseArray {
 					var msg rule.RuleMessage
-					if *opts.IgnoreVoid {
+					if opts.IgnoreVoid {
 						msg = buildFloatingPromiseArrayVoidMessage()
 					} else {
 						msg = buildFloatingPromiseArrayMessage()
 					}
 					ctx.ReportNode(node, msg)
-				} else if *opts.IgnoreVoid {
+				} else if opts.IgnoreVoid {
 					var msg rule.RuleMessage
 					if nonFunctionHandler {
 						msg = buildFloatingUselessRejectionHandlerVoidMessage()

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
@@ -30,10 +30,7 @@ func parseOptions(options []any) NoFloatingPromisesOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if specifiers := utils.ParseTypeOrValueSpecifiers(optsMap["allowForKnownSafeCalls"]); specifiers != nil {
 		opts.AllowForKnownSafeCalls = specifiers
 	}

--- a/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
+++ b/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
@@ -2,7 +2,6 @@ package no_meaningless_void_operator
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -28,20 +27,20 @@ func buildRemoveVoidMessage() rule.RuleMessage {
 }
 
 type NoMeaninglessVoidOperatorOptions struct {
-	CheckNever *bool `json:"checkNever"`
+	CheckNever bool
 }
 
 func parseOptions(options []any) NoMeaninglessVoidOperatorOptions {
 	opts := NoMeaninglessVoidOperatorOptions{}
-	if len(options) > 0 {
-		if optsMap, ok := options[0].(map[string]interface{}); ok {
-			if optsJSON, err := json.Marshal(optsMap); err == nil {
-				_ = json.Unmarshal(optsJSON, &opts)
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
-	if opts.CheckNever == nil {
-		opts.CheckNever = utils.Ref(false)
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if value, ok := optsMap["checkNever"].(bool); ok {
+		opts.CheckNever = value
 	}
 	return opts
 }
@@ -70,7 +69,7 @@ var NoMeaninglessVoidOperatorRule = rule.CreateRule(rule.Rule{
 
 				if mask&checker.TypeFlagsVoidLike != 0 {
 					ctx.ReportNodeWithFixes(node, buildMeaninglessVoidOperatorMessage(ctx.TypeChecker.TypeToString(argType)), fixRemoveVoidKeyword())
-				} else if *opts.CheckNever && mask&checker.TypeFlagsNever != 0 {
+				} else if opts.CheckNever && mask&checker.TypeFlagsNever != 0 {
 					ctx.ReportNodeWithSuggestions(node, buildMeaninglessVoidOperatorMessage(ctx.TypeChecker.TypeToString(argType)), rule.RuleSuggestion{
 						Message:  buildRemoveVoidMessage(),
 						FixesArr: []rule.RuleFix{fixRemoveVoidKeyword()},

--- a/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
+++ b/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
@@ -35,10 +35,7 @@ func parseOptions(options []any) NoMeaninglessVoidOperatorOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["checkNever"].(bool); ok {
 		opts.CheckNever = value
 	}

--- a/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
@@ -2,7 +2,6 @@ package no_misused_promises
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -71,99 +70,72 @@ func buildVoidReturnVariableMessage() rule.RuleMessage {
 }
 
 type NoMisusedPromisesChecksVoidReturnOptions struct {
-	Arguments        *bool `json:"arguments,omitempty"`
-	Attributes       *bool `json:"attributes,omitempty"`
-	InheritedMethods *bool `json:"inheritedMethods,omitempty"`
-	Properties       *bool `json:"properties,omitempty"`
-	Returns          *bool `json:"returns,omitempty"`
-	Variables        *bool `json:"variables,omitempty"`
+	Arguments        bool
+	Attributes       bool
+	InheritedMethods bool
+	Properties       bool
+	Returns          bool
+	Variables        bool
 }
+
 type NoMisusedPromisesOptions struct {
-	ChecksConditionals   *bool                                     `json:"checksConditionals,omitempty"`
-	ChecksSpreads        *bool                                     `json:"checksSpreads,omitempty"`
-	ChecksVoidReturn     *bool                                     `json:"-"`
-	ChecksVoidReturnOpts *NoMisusedPromisesChecksVoidReturnOptions `json:"-"`
-}
-
-// rawNoMisusedPromisesOptions mirrors the JSON shape (where checksVoidReturn
-// can be `boolean | object`) so we can unmarshal it without needing a custom
-// schema in TypeScript.
-type rawNoMisusedPromisesOptions struct {
-	ChecksConditionals *bool           `json:"checksConditionals,omitempty"`
-	ChecksSpreads      *bool           `json:"checksSpreads,omitempty"`
-	ChecksVoidReturn   json.RawMessage `json:"checksVoidReturn,omitempty"`
-}
-
-func (o *NoMisusedPromisesOptions) UnmarshalJSON(data []byte) error {
-	var raw rawNoMisusedPromisesOptions
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	o.ChecksConditionals = raw.ChecksConditionals
-	o.ChecksSpreads = raw.ChecksSpreads
-
-	if len(raw.ChecksVoidReturn) == 0 {
-		return nil
-	}
-
-	// `checksVoidReturn` may be either a boolean (enable/disable all sub-checks)
-	// or an object overriding individual sub-checks.
-	var asBool bool
-	if err := json.Unmarshal(raw.ChecksVoidReturn, &asBool); err == nil {
-		o.ChecksVoidReturn = utils.Ref(asBool)
-		return nil
-	}
-
-	var sub NoMisusedPromisesChecksVoidReturnOptions
-	if err := json.Unmarshal(raw.ChecksVoidReturn, &sub); err != nil {
-		return err
-	}
-	o.ChecksVoidReturn = utils.Ref(true)
-	o.ChecksVoidReturnOpts = &sub
-	return nil
+	ChecksConditionals   bool
+	ChecksSpreads        bool
+	ChecksVoidReturn     bool
+	ChecksVoidReturnOpts NoMisusedPromisesChecksVoidReturnOptions
 }
 
 func parseOptions(options []any) NoMisusedPromisesOptions {
-	opts := NoMisusedPromisesOptions{}
-	if len(options) > 0 {
-		if optsMap, ok := options[0].(map[string]interface{}); ok {
-			// Round-trip through JSON to populate the typed struct (malformed
-			// input falls back to defaults — config-shape validation is a
-			// project-level concern).
-			if optsJSON, err := json.Marshal(optsMap); err == nil {
-				_ = json.Unmarshal(optsJSON, &opts)
-			}
+	opts := NoMisusedPromisesOptions{
+		ChecksConditionals: true,
+		ChecksSpreads:      true,
+		ChecksVoidReturn:   true,
+		ChecksVoidReturnOpts: NoMisusedPromisesChecksVoidReturnOptions{
+			Arguments:        true,
+			Attributes:       true,
+			InheritedMethods: true,
+			Properties:       true,
+			Returns:          true,
+			Variables:        true,
+		},
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if value, ok := optsMap["checksConditionals"].(bool); ok {
+		opts.ChecksConditionals = value
+	}
+	if value, ok := optsMap["checksSpreads"].(bool); ok {
+		opts.ChecksSpreads = value
+	}
+	// `checksVoidReturn` is either a boolean enabling or disabling every
+	// sub-check, or an object overriding them individually.
+	switch value := optsMap["checksVoidReturn"].(type) {
+	case bool:
+		opts.ChecksVoidReturn = value
+	case map[string]interface{}:
+		if v, ok := value["arguments"].(bool); ok {
+			opts.ChecksVoidReturnOpts.Arguments = v
 		}
-	}
-	if opts.ChecksConditionals == nil {
-		opts.ChecksConditionals = utils.Ref(true)
-	}
-	if opts.ChecksSpreads == nil {
-		opts.ChecksSpreads = utils.Ref(true)
-	}
-	if opts.ChecksVoidReturn == nil {
-		opts.ChecksVoidReturn = utils.Ref(true)
-	}
-	if opts.ChecksVoidReturnOpts == nil {
-		opts.ChecksVoidReturnOpts = utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{})
-	}
-	if opts.ChecksVoidReturnOpts.Arguments == nil {
-		opts.ChecksVoidReturnOpts.Arguments = utils.Ref(true)
-	}
-	if opts.ChecksVoidReturnOpts.Attributes == nil {
-		opts.ChecksVoidReturnOpts.Attributes = utils.Ref(true)
-	}
-	if opts.ChecksVoidReturnOpts.InheritedMethods == nil {
-		opts.ChecksVoidReturnOpts.InheritedMethods = utils.Ref(true)
-	}
-	if opts.ChecksVoidReturnOpts.Properties == nil {
-		opts.ChecksVoidReturnOpts.Properties = utils.Ref(true)
-	}
-	if opts.ChecksVoidReturnOpts.Returns == nil {
-		opts.ChecksVoidReturnOpts.Returns = utils.Ref(true)
-	}
-	if opts.ChecksVoidReturnOpts.Variables == nil {
-		opts.ChecksVoidReturnOpts.Variables = utils.Ref(true)
+		if v, ok := value["attributes"].(bool); ok {
+			opts.ChecksVoidReturnOpts.Attributes = v
+		}
+		if v, ok := value["inheritedMethods"].(bool); ok {
+			opts.ChecksVoidReturnOpts.InheritedMethods = v
+		}
+		if v, ok := value["properties"].(bool); ok {
+			opts.ChecksVoidReturnOpts.Properties = v
+		}
+		if v, ok := value["returns"].(bool); ok {
+			opts.ChecksVoidReturnOpts.Returns = v
+		}
+		if v, ok := value["variables"].(bool); ok {
+			opts.ChecksVoidReturnOpts.Variables = v
+		}
 	}
 	return opts
 }
@@ -832,16 +804,16 @@ var NoMisusedPromisesRule = rule.CreateRule(rule.Rule{
 
 		listeners := rule.RuleListeners{
 			ast.KindBinaryExpression: func(node *ast.Node) {
-				if *opts.ChecksConditionals {
+				if opts.ChecksConditionals {
 					checkConditional(node, false)
 				}
 
-				if *opts.ChecksVoidReturn && *opts.ChecksVoidReturnOpts.Variables && ast.IsAssignmentExpression(node, false) {
+				if opts.ChecksVoidReturn && opts.ChecksVoidReturnOpts.Variables && ast.IsAssignmentExpression(node, false) {
 					checkAssignment(node.AsBinaryExpression())
 				}
 			},
 		}
-		if *opts.ChecksConditionals {
+		if opts.ChecksConditionals {
 			listeners[ast.KindPropertyAccessExpression] = checkArrayPredicates
 			listeners[ast.KindElementAccessExpression] = checkArrayPredicates
 
@@ -859,33 +831,33 @@ var NoMisusedPromisesRule = rule.CreateRule(rule.Rule{
 			listeners[ast.KindIfStatement] = func(node *ast.Node) { checkConditional(node.Expression(), true) }
 		}
 
-		if *opts.ChecksVoidReturn {
-			if *opts.ChecksVoidReturnOpts.Arguments {
+		if opts.ChecksVoidReturn {
+			if opts.ChecksVoidReturnOpts.Arguments {
 				listeners[ast.KindCallExpression] = checkArguments
 				listeners[ast.KindNewExpression] = checkArguments
 			}
-			if *opts.ChecksVoidReturnOpts.Attributes {
+			if opts.ChecksVoidReturnOpts.Attributes {
 				listeners[ast.KindJsxAttribute] = func(node *ast.Node) { checkJSXAttribute(node.AsJsxAttribute()) }
 			}
-			if *opts.ChecksVoidReturnOpts.InheritedMethods {
+			if opts.ChecksVoidReturnOpts.InheritedMethods {
 				listeners[ast.KindClassDeclaration] = checkClassLikeOrInterfaceNode
 				listeners[ast.KindClassExpression] = checkClassLikeOrInterfaceNode
 				listeners[ast.KindInterfaceDeclaration] = checkClassLikeOrInterfaceNode
 			}
-			if *opts.ChecksVoidReturnOpts.Properties {
+			if opts.ChecksVoidReturnOpts.Properties {
 				listeners[ast.KindPropertyAssignment] = checkProperty
 				listeners[ast.KindMethodDeclaration] = checkProperty
 				listeners[ast.KindShorthandPropertyAssignment] = checkProperty
 			}
-			if *opts.ChecksVoidReturnOpts.Returns {
+			if opts.ChecksVoidReturnOpts.Returns {
 				listeners[ast.KindReturnStatement] = func(node *ast.Node) { checkReturnStatement(node.AsReturnStatement()) }
 			}
-			if *opts.ChecksVoidReturnOpts.Variables {
+			if opts.ChecksVoidReturnOpts.Variables {
 				listeners[ast.KindVariableDeclaration] = func(node *ast.Node) { checkVariableDeclaration(node.AsVariableDeclaration()) }
 			}
 
 		}
-		if *opts.ChecksSpreads {
+		if opts.ChecksSpreads {
 			listeners[ast.KindSpreadElement] = checkSpread
 			listeners[ast.KindSpreadAssignment] = checkSpread
 		}

--- a/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
@@ -102,10 +102,7 @@ func parseOptions(options []any) NoMisusedPromisesOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["checksConditionals"].(bool); ok {
 		opts.ChecksConditionals = value
 	}
@@ -117,7 +114,7 @@ func parseOptions(options []any) NoMisusedPromisesOptions {
 	switch value := optsMap["checksVoidReturn"].(type) {
 	case bool:
 		opts.ChecksVoidReturn = value
-	case map[string]interface{}:
+	case map[string]any:
 		if v, ok := value["arguments"].(bool); ok {
 			opts.ChecksVoidReturnOpts.Arguments = v
 		}

--- a/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
+++ b/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
@@ -2,7 +2,6 @@ package no_misused_spread
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -81,21 +80,22 @@ func buildReplaceMapSpreadInObjectMessage() rule.RuleMessage {
 }
 
 type NoMisusedSpreadOptions struct {
-	Allow []utils.TypeOrValueSpecifier `json:"allow"`
+	Allow []utils.TypeOrValueSpecifier
 }
 
 func parseOptions(options []any) NoMisusedSpreadOptions {
-	opts := NoMisusedSpreadOptions{}
-	if len(options) > 0 {
-		if optsMap, ok := options[0].(map[string]interface{}); ok {
-			// Convert the configured option object to JSON and back into the struct.
-			if optsJSON, err := json.Marshal(optsMap); err == nil {
-				_ = json.Unmarshal(optsJSON, &opts)
-			}
-		}
+	opts := NoMisusedSpreadOptions{
+		Allow: []utils.TypeOrValueSpecifier{},
 	}
-	if opts.Allow == nil {
-		opts.Allow = []utils.TypeOrValueSpecifier{}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if specifiers := utils.ParseTypeOrValueSpecifiers(optsMap["allow"]); specifiers != nil {
+		opts.Allow = specifiers
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
+++ b/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
@@ -90,10 +90,7 @@ func parseOptions(options []any) NoMisusedSpreadOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if specifiers := utils.ParseTypeOrValueSpecifiers(optsMap["allow"]); specifiers != nil {
 		opts.Allow = specifiers
 	}

--- a/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
@@ -2,7 +2,6 @@ package no_unnecessary_boolean_literal_compare
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -52,27 +51,31 @@ func buildNoStrictNullCheckMessage() rule.RuleMessage {
 }
 
 type NoUnnecessaryBooleanLiteralCompareOptions struct {
-	AllowComparingNullableBooleansToFalse                  *bool `json:"allowComparingNullableBooleansToFalse,omitempty"`
-	AllowComparingNullableBooleansToTrue                   *bool `json:"allowComparingNullableBooleansToTrue,omitempty"`
-	AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing *bool `json:"allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing,omitempty"`
+	AllowComparingNullableBooleansToFalse                  bool
+	AllowComparingNullableBooleansToTrue                   bool
+	AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing bool
 }
 
 func parseOptions(options []any) NoUnnecessaryBooleanLiteralCompareOptions {
-	opts := NoUnnecessaryBooleanLiteralCompareOptions{}
-	if len(options) > 0 {
-		if optsJSON, err := json.Marshal(options[0]); err == nil {
-			// Convert the configured option object to JSON and back into the struct.
-			_ = json.Unmarshal(optsJSON, &opts)
-		}
+	opts := NoUnnecessaryBooleanLiteralCompareOptions{
+		AllowComparingNullableBooleansToFalse: true,
+		AllowComparingNullableBooleansToTrue:  true,
 	}
-	if opts.AllowComparingNullableBooleansToFalse == nil {
-		opts.AllowComparingNullableBooleansToFalse = utils.Ref(true)
+	if len(options) == 0 {
+		return opts
 	}
-	if opts.AllowComparingNullableBooleansToTrue == nil {
-		opts.AllowComparingNullableBooleansToTrue = utils.Ref(true)
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
 	}
-	if opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing == nil {
-		opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = utils.Ref(false)
+	if value, ok := optsMap["allowComparingNullableBooleansToFalse"].(bool); ok {
+		opts.AllowComparingNullableBooleansToFalse = value
+	}
+	if value, ok := optsMap["allowComparingNullableBooleansToTrue"].(bool); ok {
+		opts.AllowComparingNullableBooleansToTrue = value
+	}
+	if value, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
+		opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = value
 	}
 	return opts
 }
@@ -101,7 +104,7 @@ var NoUnnecessaryBooleanLiteralCompareRule = rule.CreateRule(rule.Rule{
 			compilerOptions.StrictNullChecks,
 		)
 
-		if !isStrictNullChecks && !*opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing {
+		if !isStrictNullChecks && !opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing {
 			ctx.ReportRange(core.NewTextRange(0, 0), buildNoStrictNullCheckMessage())
 		}
 
@@ -178,7 +181,7 @@ var NoUnnecessaryBooleanLiteralCompareRule = rule.CreateRule(rule.Rule{
 					return
 				}
 
-				if comparison.expressionIsNullableBoolean && ((comparison.literalBooleanInComparison && *opts.AllowComparingNullableBooleansToTrue) || (!comparison.literalBooleanInComparison && *opts.AllowComparingNullableBooleansToFalse)) {
+				if comparison.expressionIsNullableBoolean && ((comparison.literalBooleanInComparison && opts.AllowComparingNullableBooleansToTrue) || (!comparison.literalBooleanInComparison && opts.AllowComparingNullableBooleansToFalse)) {
 					return
 				}
 

--- a/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
@@ -64,10 +64,7 @@ func parseOptions(options []any) NoUnnecessaryBooleanLiteralCompareOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["allowComparingNullableBooleansToFalse"].(bool); ok {
 		opts.AllowComparingNullableBooleansToFalse = value
 	}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -2,7 +2,6 @@ package no_unnecessary_type_assertion
 
 import (
 	_ "embed"
-	"encoding/json"
 	"slices"
 	"strings"
 
@@ -46,10 +45,10 @@ func buildUnnecessaryAssertionMessage() rule.RuleMessage {
 
 type NoUnnecessaryTypeAssertionOptions struct {
 	// TODO(port): maybe typeOrValueSpecifier?
-	TypesToIgnore []string `json:"typesToIgnore"`
+	TypesToIgnore []string
 	// Whether to check const assertions on literal values
 	// When true, reports cases like `const foo = 'bar' as const` where the assertion is unnecessary
-	CheckLiteralConstAssertions bool `json:"checkLiteralConstAssertions"`
+	CheckLiteralConstAssertions bool
 }
 
 func parseOptions(options []any) NoUnnecessaryTypeAssertionOptions {
@@ -59,10 +58,15 @@ func parseOptions(options []any) NoUnnecessaryTypeAssertionOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	if optsMap, ok := options[0].(map[string]interface{}); ok {
-		if optsJSON, err := json.Marshal(optsMap); err == nil {
-			_ = json.Unmarshal(optsJSON, &opts)
-		}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if raw, ok := optsMap["typesToIgnore"].([]interface{}); ok {
+		opts.TypesToIgnore = utils.ToStringSlice(raw)
+	}
+	if value, ok := optsMap["checkLiteralConstAssertions"].(bool); ok {
+		opts.CheckLiteralConstAssertions = value
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -58,11 +58,8 @@ func parseOptions(options []any) NoUnnecessaryTypeAssertionOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
-	if raw, ok := optsMap["typesToIgnore"].([]interface{}); ok {
+	optsMap, _ := options[0].(map[string]any)
+	if raw, ok := optsMap["typesToIgnore"].([]any); ok {
 		opts.TypesToIgnore = utils.ToStringSlice(raw)
 	}
 	if value, ok := optsMap["checkLiteralConstAssertions"].(bool); ok {

--- a/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
+++ b/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
@@ -29,10 +29,7 @@ func parseOptions(options []any) OnlyThrowErrorOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if specifiers := utils.ParseTypeOrValueSpecifiers(optsMap["allow"]); specifiers != nil {
 		opts.Allow = specifiers
 	}

--- a/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
+++ b/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
@@ -2,7 +2,6 @@ package only_throw_error
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -14,32 +13,37 @@ import (
 var schemaJSON []byte
 
 type OnlyThrowErrorOptions struct {
-	Allow                []utils.TypeOrValueSpecifier `json:"allow"`
-	AllowRethrowing      *bool                        `json:"allowRethrowing"`
-	AllowThrowingAny     *bool                        `json:"allowThrowingAny"`
-	AllowThrowingUnknown *bool                        `json:"allowThrowingUnknown"`
+	Allow                []utils.TypeOrValueSpecifier
+	AllowRethrowing      bool
+	AllowThrowingAny     bool
+	AllowThrowingUnknown bool
 }
 
 func parseOptions(options []any) OnlyThrowErrorOptions {
-	opts := OnlyThrowErrorOptions{}
-	if len(options) > 0 {
-		if optsMap, ok := options[0].(map[string]interface{}); ok {
-			if optsJSON, err := json.Marshal(optsMap); err == nil {
-				_ = json.Unmarshal(optsJSON, &opts)
-			}
-		}
+	opts := OnlyThrowErrorOptions{
+		Allow:                []utils.TypeOrValueSpecifier{},
+		AllowRethrowing:      true,
+		AllowThrowingAny:     true,
+		AllowThrowingUnknown: true,
 	}
-	if opts.Allow == nil {
-		opts.Allow = []utils.TypeOrValueSpecifier{}
+	if len(options) == 0 {
+		return opts
 	}
-	if opts.AllowRethrowing == nil {
-		opts.AllowRethrowing = utils.Ref(true)
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
 	}
-	if opts.AllowThrowingAny == nil {
-		opts.AllowThrowingAny = utils.Ref(true)
+	if specifiers := utils.ParseTypeOrValueSpecifiers(optsMap["allow"]); specifiers != nil {
+		opts.Allow = specifiers
 	}
-	if opts.AllowThrowingUnknown == nil {
-		opts.AllowThrowingUnknown = utils.Ref(true)
+	if value, ok := optsMap["allowRethrowing"].(bool); ok {
+		opts.AllowRethrowing = value
+	}
+	if value, ok := optsMap["allowThrowingAny"].(bool); ok {
+		opts.AllowThrowingAny = value
+	}
+	if value, ok := optsMap["allowThrowingUnknown"].(bool); ok {
+		opts.AllowThrowingUnknown = value
 	}
 	return opts
 }
@@ -170,7 +174,7 @@ var OnlyThrowErrorRule = rule.CreateRule(rule.Rule{
 			ast.KindThrowStatement: func(node *ast.Node) {
 				expr := node.Expression()
 
-				if *opts.AllowRethrowing && isRethrownError(ctx, expr) {
+				if opts.AllowRethrowing && isRethrownError(ctx, expr) {
 					return
 				}
 
@@ -185,11 +189,11 @@ var OnlyThrowErrorRule = rule.CreateRule(rule.Rule{
 					return
 				}
 
-				if *opts.AllowThrowingAny && utils.IsTypeAnyType(t) {
+				if opts.AllowThrowingAny && utils.IsTypeAnyType(t) {
 					return
 				}
 
-				if *opts.AllowThrowingUnknown && utils.IsTypeUnknownType(t) {
+				if opts.AllowThrowingUnknown && utils.IsTypeUnknownType(t) {
 					return
 				}
 

--- a/internal/plugins/typescript/rules/prefer_optional_chain/analyze_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/analyze_chain.go
@@ -501,7 +501,7 @@ func (ca *ChainAnalyzer) reportChainWithTail(
 }
 
 func (ca *ChainAnalyzer) shouldUseFix(operands []Operand) bool {
-	if derefBoolDefault(ca.opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing, false) {
+	if ca.opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing {
 		return true
 	}
 
@@ -574,7 +574,7 @@ func (ca *ChainAnalyzer) shouldUseFix(operands []Operand) bool {
 }
 
 func (ca *ChainAnalyzer) shouldSkipForRequireNullish(operands []Operand) bool {
-	if !derefBoolDefault(ca.opts.RequireNullish, false) {
+	if !ca.opts.RequireNullish {
 		return false
 	}
 	if ca.ctx.TypeChecker == nil {
@@ -1192,7 +1192,7 @@ func (ca *ChainAnalyzer) getNodeTextWithTrivia(node *ast.Node) string {
 }
 
 func (ca *ChainAnalyzer) CheckNullishAndReport(node *ast.Node) bool {
-	if !derefBoolDefault(ca.opts.RequireNullish, false) {
+	if !ca.opts.RequireNullish {
 		return false
 	}
 

--- a/internal/plugins/typescript/rules/prefer_optional_chain/gather_logical_operands.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/gather_logical_operands.go
@@ -328,7 +328,7 @@ func invertComparisonType(ct NullishComparisonType) NullishComparisonType {
 
 // isValidBooleanCheckType checks if a node's type is valid for boolean
 // truthiness in optional chain detection. disallowFalsyLiteral controls
-// whether falsy literal types (false, 0, '', 0n) cause rejection — set to
+// whether falsy literal types (false, 0, ”, 0n) cause rejection — set to
 // true for guard operands, false for the last operand in a chain.
 // Matches upstream's `isValidFalseBooleanCheckType(node, disallowFalsyLiteral, ...)`.
 func (a *OperandAnalyzer) isValidBooleanCheckType(node *ast.Node) bool {
@@ -372,22 +372,22 @@ func (a *OperandAnalyzer) isValidBooleanCheckTypeImpl(node *ast.Node, disallowFa
 			continue
 		}
 
-		if derefBoolDefault(opts.CheckAny, true) && flags&checker.TypeFlagsAny != 0 {
+		if opts.CheckAny && flags&checker.TypeFlagsAny != 0 {
 			continue
 		}
-		if derefBoolDefault(opts.CheckUnknown, true) && flags&checker.TypeFlagsUnknown != 0 {
+		if opts.CheckUnknown && flags&checker.TypeFlagsUnknown != 0 {
 			continue
 		}
-		if derefBoolDefault(opts.CheckString, true) && flags&checker.TypeFlagsStringLike != 0 {
+		if opts.CheckString && flags&checker.TypeFlagsStringLike != 0 {
 			continue
 		}
-		if derefBoolDefault(opts.CheckNumber, true) && flags&checker.TypeFlagsNumberLike != 0 {
+		if opts.CheckNumber && flags&checker.TypeFlagsNumberLike != 0 {
 			continue
 		}
-		if derefBoolDefault(opts.CheckBoolean, true) && flags&checker.TypeFlagsBooleanLike != 0 {
+		if opts.CheckBoolean && flags&checker.TypeFlagsBooleanLike != 0 {
 			continue
 		}
-		if derefBoolDefault(opts.CheckBigInt, true) && flags&checker.TypeFlagsBigIntLike != 0 {
+		if opts.CheckBigInt && flags&checker.TypeFlagsBigIntLike != 0 {
 			continue
 		}
 		if flags&checker.TypeFlagsTypeParameter != 0 {
@@ -431,22 +431,22 @@ func (a *OperandAnalyzer) isValidBooleanCheckTypeImpl(node *ast.Node, disallowFa
 
 func (a *OperandAnalyzer) isTypePartValidForBoolean(flags checker.TypeFlags) bool {
 	opts := a.opts
-	if derefBoolDefault(opts.CheckAny, true) && flags&checker.TypeFlagsAny != 0 {
+	if opts.CheckAny && flags&checker.TypeFlagsAny != 0 {
 		return true
 	}
-	if derefBoolDefault(opts.CheckUnknown, true) && flags&checker.TypeFlagsUnknown != 0 {
+	if opts.CheckUnknown && flags&checker.TypeFlagsUnknown != 0 {
 		return true
 	}
-	if derefBoolDefault(opts.CheckString, true) && flags&checker.TypeFlagsStringLike != 0 {
+	if opts.CheckString && flags&checker.TypeFlagsStringLike != 0 {
 		return true
 	}
-	if derefBoolDefault(opts.CheckNumber, true) && flags&checker.TypeFlagsNumberLike != 0 {
+	if opts.CheckNumber && flags&checker.TypeFlagsNumberLike != 0 {
 		return true
 	}
-	if derefBoolDefault(opts.CheckBoolean, true) && flags&checker.TypeFlagsBooleanLike != 0 {
+	if opts.CheckBoolean && flags&checker.TypeFlagsBooleanLike != 0 {
 		return true
 	}
-	if derefBoolDefault(opts.CheckBigInt, true) && flags&checker.TypeFlagsBigIntLike != 0 {
+	if opts.CheckBigInt && flags&checker.TypeFlagsBigIntLike != 0 {
 		return true
 	}
 	if flags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid|checker.TypeFlagsNever) != 0 {
@@ -482,7 +482,7 @@ func isValidChainTarget(node *ast.Node, allowIdentifier bool) bool {
 }
 
 // isFalsyLiteralType checks if a type is a specific falsy literal value:
-// false, 0, '', or 0n. These appear in discriminated unions like `false | { a: string }`
+// false, 0, ”, or 0n. These appear in discriminated unions like `false | { a: string }`
 // where truthiness is used as a type discriminator rather than a null guard.
 func isFalsyLiteralType(t *checker.Type) bool {
 	flags := checker.Type_flags(t)

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -2,25 +2,66 @@ package prefer_optional_chain
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 //go:embed prefer_optional_chain.schema.json
 var schemaJSON []byte
 
 type PreferOptionalChainOptions struct {
-	AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing *bool `json:"allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing"`
-	CheckAny                                                           *bool `json:"checkAny"`
-	CheckUnknown                                                       *bool `json:"checkUnknown"`
-	CheckString                                                        *bool `json:"checkString"`
-	CheckNumber                                                        *bool `json:"checkNumber"`
-	CheckBoolean                                                       *bool `json:"checkBoolean"`
-	CheckBigInt                                                        *bool `json:"checkBigInt"`
-	RequireNullish                                                     *bool `json:"requireNullish"`
+	AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing bool
+	CheckAny                                                           bool
+	CheckUnknown                                                       bool
+	CheckString                                                        bool
+	CheckNumber                                                        bool
+	CheckBoolean                                                       bool
+	CheckBigInt                                                        bool
+	RequireNullish                                                     bool
+}
+
+func parseOptions(options []any) PreferOptionalChainOptions {
+	opts := PreferOptionalChainOptions{
+		CheckAny:     true,
+		CheckUnknown: true,
+		CheckString:  true,
+		CheckNumber:  true,
+		CheckBoolean: true,
+		CheckBigInt:  true,
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if value, ok := optsMap["allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing"].(bool); ok {
+		opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing = value
+	}
+	if value, ok := optsMap["checkAny"].(bool); ok {
+		opts.CheckAny = value
+	}
+	if value, ok := optsMap["checkUnknown"].(bool); ok {
+		opts.CheckUnknown = value
+	}
+	if value, ok := optsMap["checkString"].(bool); ok {
+		opts.CheckString = value
+	}
+	if value, ok := optsMap["checkNumber"].(bool); ok {
+		opts.CheckNumber = value
+	}
+	if value, ok := optsMap["checkBoolean"].(bool); ok {
+		opts.CheckBoolean = value
+	}
+	if value, ok := optsMap["checkBigInt"].(bool); ok {
+		opts.CheckBigInt = value
+	}
+	if value, ok := optsMap["requireNullish"].(bool); ok {
+		opts.RequireNullish = value
+	}
+	return opts
 }
 
 func buildPreferOptionalChainMessage() rule.RuleMessage {
@@ -42,40 +83,7 @@ var PreferOptionalChainRule = rule.CreateRule(rule.Rule{
 	RequiresTypeInfo: true,
 	Schema:           rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := PreferOptionalChainOptions{}
-		if len(options) > 0 {
-			if optsMap, ok := options[0].(map[string]interface{}); ok {
-				if optsJSON, err := json.Marshal(optsMap); err == nil {
-					_ = json.Unmarshal(optsJSON, &opts)
-				}
-			}
-		}
-
-		// Set defaults
-		if opts.CheckAny == nil {
-			opts.CheckAny = utils.Ref(true)
-		}
-		if opts.CheckUnknown == nil {
-			opts.CheckUnknown = utils.Ref(true)
-		}
-		if opts.CheckString == nil {
-			opts.CheckString = utils.Ref(true)
-		}
-		if opts.CheckNumber == nil {
-			opts.CheckNumber = utils.Ref(true)
-		}
-		if opts.CheckBoolean == nil {
-			opts.CheckBoolean = utils.Ref(true)
-		}
-		if opts.CheckBigInt == nil {
-			opts.CheckBigInt = utils.Ref(true)
-		}
-		if opts.RequireNullish == nil {
-			opts.RequireNullish = utils.Ref(false)
-		}
-		if opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing == nil {
-			opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing = utils.Ref(false)
-		}
+		opts := parseOptions(options)
 
 		analyzer := NewOperandAnalyzer(ctx, opts)
 		chainAnalyzer := NewChainAnalyzer(ctx, opts)
@@ -126,10 +134,3 @@ var PreferOptionalChainRule = rule.CreateRule(rule.Rule{
 		}
 	},
 })
-
-func derefBoolDefault(b *bool, defaultVal bool) bool {
-	if b == nil {
-		return defaultVal
-	}
-	return *b
-}

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -33,10 +33,7 @@ func parseOptions(options []any) PreferOptionalChainOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing"].(bool); ok {
 		opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing = value
 	}

--- a/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
+++ b/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
@@ -2,7 +2,6 @@ package prefer_promise_reject_errors
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -21,33 +20,28 @@ func buildRejectAnErrorMessage() rule.RuleMessage {
 }
 
 type PreferPromiseRejectErrorsOptions struct {
-	AllowEmptyReject     *bool `json:"allowEmptyReject"`
-	AllowThrowingAny     *bool `json:"allowThrowingAny"`
-	AllowThrowingUnknown *bool `json:"allowThrowingUnknown"`
+	AllowEmptyReject     bool
+	AllowThrowingAny     bool
+	AllowThrowingUnknown bool
 }
 
 func parseOptions(options []any) PreferPromiseRejectErrorsOptions {
-	opts := PreferPromiseRejectErrorsOptions{
-		AllowEmptyReject:     utils.Ref(false),
-		AllowThrowingAny:     utils.Ref(false),
-		AllowThrowingUnknown: utils.Ref(false),
-	}
+	opts := PreferPromiseRejectErrorsOptions{}
 	if len(options) == 0 {
 		return opts
 	}
-	if optsMap, ok := options[0].(map[string]interface{}); ok {
-		if optsJSON, err := json.Marshal(optsMap); err == nil {
-			_ = json.Unmarshal(optsJSON, &opts)
-		}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
 	}
-	if opts.AllowEmptyReject == nil {
-		opts.AllowEmptyReject = utils.Ref(false)
+	if value, ok := optsMap["allowEmptyReject"].(bool); ok {
+		opts.AllowEmptyReject = value
 	}
-	if opts.AllowThrowingAny == nil {
-		opts.AllowThrowingAny = utils.Ref(false)
+	if value, ok := optsMap["allowThrowingAny"].(bool); ok {
+		opts.AllowThrowingAny = value
 	}
-	if opts.AllowThrowingUnknown == nil {
-		opts.AllowThrowingUnknown = utils.Ref(false)
+	if value, ok := optsMap["allowThrowingUnknown"].(bool); ok {
+		opts.AllowThrowingUnknown = value
 	}
 	return opts
 }
@@ -64,17 +58,17 @@ var PreferPromiseRejectErrorsRule = rule.CreateRule(rule.Rule{
 				argument := callExpression.Arguments.Nodes[0]
 				t := ctx.TypeChecker.GetTypeAtLocation(argument)
 
-				if *opts.AllowThrowingAny && utils.IsTypeAnyType(t) {
+				if opts.AllowThrowingAny && utils.IsTypeAnyType(t) {
 					return
 				}
-				if *opts.AllowThrowingUnknown && utils.IsTypeUnknownType(t) {
+				if opts.AllowThrowingUnknown && utils.IsTypeUnknownType(t) {
 					return
 				}
 
 				if utils.IsErrorLike(ctx.Program, ctx.TypeChecker, t) || utils.IsReadonlyErrorLike(ctx.Program, ctx.TypeChecker, t) {
 					return
 				}
-			} else if *opts.AllowEmptyReject {
+			} else if opts.AllowEmptyReject {
 				return
 			}
 			ctx.ReportNode(&callExpression.Node, buildRejectAnErrorMessage())

--- a/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
+++ b/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
@@ -30,10 +30,7 @@ func parseOptions(options []any) PreferPromiseRejectErrorsOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["allowEmptyReject"].(bool); ok {
 		opts.AllowEmptyReject = value
 	}

--- a/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.go
+++ b/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.go
@@ -29,11 +29,21 @@ func buildPreferEndsWithMessage() rule.RuleMessage {
 }
 
 type Options struct {
-	AllowSingleElementEquality *string `json:"allowSingleElementEquality"`
+	AllowSingleElementEquality string
 }
 
-var defaultOpts = Options{
-	AllowSingleElementEquality: utils.Ref("never"),
+func parseOptions(options []any) Options {
+	opts := Options{
+		AllowSingleElementEquality: "never",
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]any)
+	if value, ok := optsMap["allowSingleElementEquality"].(string); ok {
+		opts.AllowSingleElementEquality = value
+	}
+	return opts
 }
 
 // callInfo holds parsed call expression info
@@ -417,18 +427,11 @@ var PreferStringStartsEndsWithRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := defaultOpts
-
-		if len(options) > 0 {
-			optsMap, _ := options[0].(map[string]interface{})
-			if allowSingleElementEquality, ok := optsMap["allowSingleElementEquality"].(string); ok {
-				opts.AllowSingleElementEquality = utils.Ref(allowSingleElementEquality)
-			}
-		}
+		opts := parseOptions(options)
 
 		h := &ruleHelper{
 			ctx:                        ctx,
-			allowSingleElementEquality: opts.AllowSingleElementEquality != nil && *opts.AllowSingleElementEquality == "always",
+			allowSingleElementEquality: opts.AllowSingleElementEquality == "always",
 		}
 
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
+++ b/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
@@ -2,7 +2,6 @@ package promise_function_async
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -21,42 +20,48 @@ func buildMissingAsyncMessage() rule.RuleMessage {
 }
 
 type PromiseFunctionAsyncOptions struct {
-	AllowAny *bool `json:"allowAny,omitempty"`
+	AllowAny bool
 	// TODO(port): TypeOrValueSpecifier
-	AllowedPromiseNames       []string `json:"allowedPromiseNames,omitempty"`
-	CheckArrowFunctions       *bool    `json:"checkArrowFunctions,omitempty"`
-	CheckFunctionDeclarations *bool    `json:"checkFunctionDeclarations,omitempty"`
-	CheckFunctionExpressions  *bool    `json:"checkFunctionExpressions,omitempty"`
-	CheckMethodDeclarations   *bool    `json:"checkMethodDeclarations,omitempty"`
+	AllowedPromiseNames       []string
+	CheckArrowFunctions       bool
+	CheckFunctionDeclarations bool
+	CheckFunctionExpressions  bool
+	CheckMethodDeclarations   bool
 }
 
 func parseOptions(options []any) PromiseFunctionAsyncOptions {
-	opts := PromiseFunctionAsyncOptions{}
-	if len(options) > 0 {
-		if optsMap, ok := options[0].(map[string]interface{}); ok {
-			// Convert the configured option object to JSON and back into the struct.
-			if optsJSON, err := json.Marshal(optsMap); err == nil {
-				_ = json.Unmarshal(optsJSON, &opts)
-			}
-		}
+	opts := PromiseFunctionAsyncOptions{
+		AllowAny:                  true,
+		AllowedPromiseNames:       []string{},
+		CheckArrowFunctions:       true,
+		CheckFunctionDeclarations: true,
+		CheckFunctionExpressions:  true,
+		CheckMethodDeclarations:   true,
 	}
-	if opts.AllowAny == nil {
-		opts.AllowAny = utils.Ref(true)
+	if len(options) == 0 {
+		return opts
 	}
-	if opts.AllowedPromiseNames == nil {
-		opts.AllowedPromiseNames = []string{}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
 	}
-	if opts.CheckArrowFunctions == nil {
-		opts.CheckArrowFunctions = utils.Ref(true)
+	if value, ok := optsMap["allowAny"].(bool); ok {
+		opts.AllowAny = value
 	}
-	if opts.CheckFunctionDeclarations == nil {
-		opts.CheckFunctionDeclarations = utils.Ref(true)
+	if raw, ok := optsMap["allowedPromiseNames"].([]interface{}); ok {
+		opts.AllowedPromiseNames = utils.ToStringSlice(raw)
 	}
-	if opts.CheckFunctionExpressions == nil {
-		opts.CheckFunctionExpressions = utils.Ref(true)
+	if value, ok := optsMap["checkArrowFunctions"].(bool); ok {
+		opts.CheckArrowFunctions = value
 	}
-	if opts.CheckMethodDeclarations == nil {
-		opts.CheckMethodDeclarations = utils.Ref(true)
+	if value, ok := optsMap["checkFunctionDeclarations"].(bool); ok {
+		opts.CheckFunctionDeclarations = value
+	}
+	if value, ok := optsMap["checkFunctionExpressions"].(bool); ok {
+		opts.CheckFunctionExpressions = value
+	}
+	if value, ok := optsMap["checkMethodDeclarations"].(bool); ok {
+		opts.CheckMethodDeclarations = value
 	}
 	return opts
 }
@@ -127,7 +132,7 @@ var PromiseFunctionAsyncRule = rule.CreateRule(rule.Rule{
 			everySignatureReturnsPromise := true
 			for _, signature := range signatures {
 				returnType := checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, signature)
-				if !*opts.AllowAny && utils.IsTypeFlagSet(returnType, checker.TypeFlagsAnyOrUnknown) {
+				if !opts.AllowAny && utils.IsTypeFlagSet(returnType, checker.TypeFlagsAnyOrUnknown) {
 					// Report without auto fixer because the return type is unknown
 					// TODO(port): getFunctionHeadLoc
 					ctx.ReportNode(node, buildMissingAsyncMessage())
@@ -154,19 +159,19 @@ var PromiseFunctionAsyncRule = rule.CreateRule(rule.Rule{
 			ctx.ReportNodeWithFixes(node, buildMissingAsyncMessage(), rule.RuleFixInsertBefore(ctx.SourceFile, insertAsyncBeforeNode, " async "))
 		}
 
-		if *opts.CheckArrowFunctions {
+		if opts.CheckArrowFunctions {
 			listeners[ast.KindArrowFunction] = validateNode
 		}
 
-		if *opts.CheckFunctionDeclarations {
+		if opts.CheckFunctionDeclarations {
 			listeners[ast.KindFunctionDeclaration] = validateNode
 		}
 
-		if *opts.CheckFunctionExpressions {
+		if opts.CheckFunctionExpressions {
 			listeners[ast.KindFunctionExpression] = validateNode
 		}
 
-		if *opts.CheckMethodDeclarations {
+		if opts.CheckMethodDeclarations {
 			listeners[ast.KindMethodDeclaration] = func(node *ast.Node) {
 				if utils.IncludesModifier(node, ast.KindAbstractKeyword) {
 					// Abstract method can't be async

--- a/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
+++ b/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
@@ -41,14 +41,11 @@ func parseOptions(options []any) PromiseFunctionAsyncOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["allowAny"].(bool); ok {
 		opts.AllowAny = value
 	}
-	if raw, ok := optsMap["allowedPromiseNames"].([]interface{}); ok {
+	if raw, ok := optsMap["allowedPromiseNames"].([]any); ok {
 		opts.AllowedPromiseNames = utils.ToStringSlice(raw)
 	}
 	if value, ok := optsMap["checkArrowFunctions"].(bool); ok {

--- a/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
+++ b/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
@@ -30,10 +30,7 @@ func parseOptions(options []any) RequireArraySortCompareOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["ignoreStringArrays"].(bool); ok {
 		opts.IgnoreStringArrays = value
 	}

--- a/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
+++ b/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
@@ -2,7 +2,6 @@ package require_array_sort_compare
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -21,23 +20,22 @@ func buildRequireCompareMessage() rule.RuleMessage {
 }
 
 type RequireArraySortCompareOptions struct {
-	IgnoreStringArrays *bool `json:"ignoreStringArrays"`
+	IgnoreStringArrays bool
 }
 
 func parseOptions(options []any) RequireArraySortCompareOptions {
 	opts := RequireArraySortCompareOptions{
-		IgnoreStringArrays: utils.Ref(true),
+		IgnoreStringArrays: true,
 	}
 	if len(options) == 0 {
 		return opts
 	}
-	if optsMap, ok := options[0].(map[string]interface{}); ok {
-		if optsJSON, err := json.Marshal(optsMap); err == nil {
-			_ = json.Unmarshal(optsJSON, &opts)
-		}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
 	}
-	if opts.IgnoreStringArrays == nil {
-		opts.IgnoreStringArrays = utils.Ref(true)
+	if value, ok := optsMap["ignoreStringArrays"].(bool); ok {
+		opts.IgnoreStringArrays = value
 	}
 	return opts
 }
@@ -67,7 +65,7 @@ var RequireArraySortCompareRule = rule.CreateRule(rule.Rule{
 
 				calleeObjType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, callee.Expression())
 
-				if *opts.IgnoreStringArrays && checker.Checker_isArrayOrTupleType(ctx.TypeChecker, calleeObjType) {
+				if opts.IgnoreStringArrays && checker.Checker_isArrayOrTupleType(ctx.TypeChecker, calleeObjType) {
 					if utils.Every(checker.Checker_getTypeArguments(ctx.TypeChecker, calleeObjType), func(t *checker.Type) bool {
 						return utils.IsTypeFlagSet(t, checker.TypeFlagsString)
 					}) {

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
@@ -34,58 +34,44 @@ func buildMismatchedMessage(stringLike, left, right string) rule.RuleMessage {
 }
 
 type RestrictPlusOperandsOptions struct {
-	AllowAny                *bool `json:"allowAny"`
-	AllowBoolean            *bool `json:"allowBoolean"`
-	AllowNullish            *bool `json:"allowNullish"`
-	AllowNumberAndString    *bool `json:"allowNumberAndString"`
-	AllowRegExp             *bool `json:"allowRegExp"`
-	SkipCompoundAssignments *bool `json:"skipCompoundAssignments"`
+	AllowAny                bool
+	AllowBoolean            bool
+	AllowNullish            bool
+	AllowNumberAndString    bool
+	AllowRegExp             bool
+	SkipCompoundAssignments bool
 }
 
 func parseOptions(options []any) RestrictPlusOperandsOptions {
-	opts := RestrictPlusOperandsOptions{}
-	if len(options) > 0 {
-		if optsMap, ok := options[0].(map[string]any); ok {
-			if value, ok := optsMap["allowAny"].(bool); ok {
-				opts.AllowAny = utils.Ref(value)
-			}
-			if value, ok := optsMap["allowBoolean"].(bool); ok {
-				opts.AllowBoolean = utils.Ref(value)
-			}
-			if value, ok := optsMap["allowNullish"].(bool); ok {
-				opts.AllowNullish = utils.Ref(value)
-			}
-			if value, ok := optsMap["allowNumberAndString"].(bool); ok {
-				opts.AllowNumberAndString = utils.Ref(value)
-			}
-			if value, ok := optsMap["allowRegExp"].(bool); ok {
-				opts.AllowRegExp = utils.Ref(value)
-			}
-			if value, ok := optsMap["skipCompoundAssignments"].(bool); ok {
-				opts.SkipCompoundAssignments = utils.Ref(value)
-			}
-		}
+	opts := RestrictPlusOperandsOptions{
+		AllowAny:             true,
+		AllowBoolean:         true,
+		AllowNullish:         true,
+		AllowNumberAndString: true,
+		AllowRegExp:          true,
 	}
-
-	if opts.AllowAny == nil {
-		opts.AllowAny = utils.Ref(true)
+	if len(options) == 0 {
+		return opts
 	}
-	if opts.AllowBoolean == nil {
-		opts.AllowBoolean = utils.Ref(true)
+	optsMap, _ := options[0].(map[string]any)
+	if value, ok := optsMap["allowAny"].(bool); ok {
+		opts.AllowAny = value
 	}
-	if opts.AllowNullish == nil {
-		opts.AllowNullish = utils.Ref(true)
+	if value, ok := optsMap["allowBoolean"].(bool); ok {
+		opts.AllowBoolean = value
 	}
-	if opts.AllowNumberAndString == nil {
-		opts.AllowNumberAndString = utils.Ref(true)
+	if value, ok := optsMap["allowNullish"].(bool); ok {
+		opts.AllowNullish = value
 	}
-	if opts.AllowRegExp == nil {
-		opts.AllowRegExp = utils.Ref(true)
+	if value, ok := optsMap["allowNumberAndString"].(bool); ok {
+		opts.AllowNumberAndString = value
 	}
-	if opts.SkipCompoundAssignments == nil {
-		opts.SkipCompoundAssignments = utils.Ref(false)
+	if value, ok := optsMap["allowRegExp"].(bool); ok {
+		opts.AllowRegExp = value
 	}
-
+	if value, ok := optsMap["skipCompoundAssignments"].(bool); ok {
+		opts.SkipCompoundAssignments = value
+	}
 	return opts
 }
 
@@ -97,19 +83,19 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 		opts := parseOptions(options)
 
 		stringLikes := make([]string, 0, 5)
-		if *opts.AllowAny {
+		if opts.AllowAny {
 			stringLikes = append(stringLikes, "`any`")
 		}
-		if *opts.AllowBoolean {
+		if opts.AllowBoolean {
 			stringLikes = append(stringLikes, "`boolean`")
 		}
-		if *opts.AllowNullish {
+		if opts.AllowNullish {
 			stringLikes = append(stringLikes, "`null`")
 		}
-		if *opts.AllowRegExp {
+		if opts.AllowRegExp {
 			stringLikes = append(stringLikes, "`RegExp`")
 		}
-		if *opts.AllowNullish {
+		if opts.AllowNullish {
 			stringLikes = append(stringLikes, "`undefined`")
 		}
 		var stringLike string
@@ -131,13 +117,13 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 		invalidFlags := checker.TypeFlagsESSymbolLike |
 			checker.TypeFlagsNever |
 			checker.TypeFlagsUnknown
-		if !*opts.AllowAny {
+		if !opts.AllowAny {
 			invalidFlags |= checker.TypeFlagsAny
 		}
-		if !*opts.AllowBoolean {
+		if !opts.AllowBoolean {
 			invalidFlags |= checker.TypeFlagsBooleanLike
 		}
-		if !*opts.AllowNullish {
+		if !opts.AllowNullish {
 			invalidFlags |= checker.TypeFlagsNullable
 		}
 
@@ -160,10 +146,10 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 
 				// RegExps also contain checker.TypeFlagsAny & checker.TypeFlagsObject
 				if part == globalRegexpType {
-					if *opts.AllowRegExp && !utils.IsTypeFlagSet(otherType, checker.TypeFlagsNumberLike) {
+					if opts.AllowRegExp && !utils.IsTypeFlagSet(otherType, checker.TypeFlagsNumberLike) {
 						continue
 					}
-				} else if (*opts.AllowAny || !utils.IsTypeAnyType(part)) && !utils.Every(utils.IntersectionTypeParts(part), utils.IsObjectType) {
+				} else if (opts.AllowAny || !utils.IsTypeAnyType(part)) && !utils.Every(utils.IntersectionTypeParts(part), utils.IsObjectType) {
 					continue
 				}
 				foundRegexp = true
@@ -200,7 +186,7 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 			}
 
 			checkMismatchedPlusOperands := func(baseTypeFlags, otherTypeFlags checker.TypeFlags) bool {
-				if !*opts.AllowNumberAndString &&
+				if !opts.AllowNumberAndString &&
 					baseTypeFlags&checker.TypeFlagsStringLike != 0 &&
 					otherTypeFlags&(checker.TypeFlagsNumberLike|checker.TypeFlagsBigIntLike) != 0 {
 					ctx.ReportNode(&node.Node, buildMismatchedMessage(stringLike, ctx.TypeChecker.TypeToString(leftType), ctx.TypeChecker.TypeToString(rightType)))
@@ -224,7 +210,7 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 		return rule.RuleListeners{
 			ast.KindBinaryExpression: func(node *ast.Node) {
 				expr := node.AsBinaryExpression()
-				if expr.OperatorToken.Kind == ast.KindPlusToken || (!*opts.SkipCompoundAssignments && expr.OperatorToken.Kind == ast.KindPlusEqualsToken) {
+				if expr.OperatorToken.Kind == ast.KindPlusToken || (!opts.SkipCompoundAssignments && expr.OperatorToken.Kind == ast.KindPlusEqualsToken) {
 					checkPlusOperands(expr)
 				}
 			},

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
@@ -8,68 +8,40 @@ import (
 )
 
 func TestParseOptions(t *testing.T) {
-	type optionValues struct {
-		allowAny                bool
-		allowBoolean            bool
-		allowNullish            bool
-		allowNumberAndString    bool
-		allowRegExp             bool
-		skipCompoundAssignments bool
-	}
-	resolve := func(t *testing.T, options []any) optionValues {
-		t.Helper()
-		got := parseOptions(options)
-		value := func(name string, pointer *bool) bool {
-			t.Helper()
-			if pointer == nil {
-				t.Fatalf("resolved option %s is nil", name)
-				return false
-			}
-			return *pointer
-		}
-		return optionValues{
-			allowAny:                value("allowAny", got.AllowAny),
-			allowBoolean:            value("allowBoolean", got.AllowBoolean),
-			allowNullish:            value("allowNullish", got.AllowNullish),
-			allowNumberAndString:    value("allowNumberAndString", got.AllowNumberAndString),
-			allowRegExp:             value("allowRegExp", got.AllowRegExp),
-			skipCompoundAssignments: value("skipCompoundAssignments", got.SkipCompoundAssignments),
-		}
-	}
 	tests := []struct {
 		name    string
 		options []any
-		want    optionValues
+		want    RestrictPlusOperandsOptions
 	}{
 		{
 			name: "defaults",
-			want: optionValues{
-				allowAny:             true,
-				allowBoolean:         true,
-				allowNullish:         true,
-				allowNumberAndString: true,
-				allowRegExp:          true,
+			want: RestrictPlusOperandsOptions{
+				AllowAny:             true,
+				AllowBoolean:         true,
+				AllowNullish:         true,
+				AllowNumberAndString: true,
+				AllowRegExp:          true,
 			},
 		},
 		{
 			name: "serialized partial overrides",
-			options: []any{map[string]interface{}{
+			options: []any{map[string]any{
 				"allowAny":                false,
 				"allowNullish":            false,
 				"skipCompoundAssignments": true,
 			}},
-			want: optionValues{
-				allowBoolean:            true,
-				allowNumberAndString:    true,
-				allowRegExp:             true,
-				skipCompoundAssignments: true,
+			want: RestrictPlusOperandsOptions{
+				AllowBoolean:            true,
+				AllowNumberAndString:    true,
+				AllowRegExp:             true,
+				SkipCompoundAssignments: true,
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := resolve(t, test.options); got != test.want {
+			if got := parseOptions(test.options); got != test.want {
 				t.Fatalf("resolved options = %+v, want %+v", got, test.want)
 			}
 		})

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
@@ -2,7 +2,6 @@ package restrict_template_expressions
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -25,21 +24,6 @@ type RestrictTemplateExpressionsOptions struct {
 	AllowRegExp  bool
 }
 
-// parseAllow decodes the `allow` option — type specifiers written either in
-// the string shorthand or in object form — through TypeOrValueSpecifier's own
-// UnmarshalJSON rather than re-deriving both shapes by hand.
-func parseAllow(raw any) []utils.TypeOrValueSpecifier {
-	rawJSON, err := json.Marshal(raw)
-	if err != nil {
-		return nil
-	}
-	var allow []utils.TypeOrValueSpecifier
-	if err := json.Unmarshal(rawJSON, &allow); err != nil {
-		return nil
-	}
-	return allow
-}
-
 func parseOptions(options []any) RestrictTemplateExpressionsOptions {
 	opts := RestrictTemplateExpressionsOptions{
 		Allow: []utils.TypeOrValueSpecifier{{
@@ -60,7 +44,7 @@ func parseOptions(options []any) RestrictTemplateExpressionsOptions {
 		return opts
 	}
 	if raw, ok := optsMap["allow"]; ok {
-		opts.Allow = parseAllow(raw)
+		opts.Allow = utils.ParseTypeOrValueSpecifiers(raw)
 	}
 	if v, ok := optsMap["allowAny"].(bool); ok {
 		opts.AllowAny = v

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
@@ -39,10 +39,7 @@ func parseOptions(options []any) RestrictTemplateExpressionsOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if raw, ok := optsMap["allow"]; ok {
 		opts.Allow = utils.ParseTypeOrValueSpecifiers(raw)
 	}

--- a/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.go
+++ b/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.go
@@ -11,7 +11,6 @@ package strict_boolean_expressions
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -25,23 +24,6 @@ import (
 
 //go:embed strict_boolean_expressions.schema.json
 var schemaJSON []byte
-
-// Options mirrors typescript-eslint's option shape. Pointer-typed booleans
-// distinguish "user explicitly set false" from "user did not set, fall back to
-// upstream default" — important because upstream defaults are split: string /
-// number / nullable-object default to `true`, everything else defaults to
-// `false`.
-type Options struct {
-	AllowAny                                               *bool `json:"allowAny"`
-	AllowNullableBoolean                                   *bool `json:"allowNullableBoolean"`
-	AllowNullableEnum                                      *bool `json:"allowNullableEnum"`
-	AllowNullableNumber                                    *bool `json:"allowNullableNumber"`
-	AllowNullableObject                                    *bool `json:"allowNullableObject"`
-	AllowNullableString                                    *bool `json:"allowNullableString"`
-	AllowNumber                                            *bool `json:"allowNumber"`
-	AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing *bool `json:"allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"`
-	AllowString                                            *bool `json:"allowString"`
-}
 
 type resolvedOptions struct {
 	allowAny                                               bool
@@ -68,48 +50,37 @@ func parseOptions(options []any) resolvedOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, _ := options[0].(map[string]interface{})
-	if optsMap == nil {
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
 		return opts
 	}
 
-	// Round-trip via JSON to fill the pointer-typed Options struct, which keeps
-	// "explicitly set to false" distinguishable from "not set at all".
-	jsonBytes, err := json.Marshal(optsMap)
-	if err != nil {
-		return opts
+	if value, ok := optsMap["allowAny"].(bool); ok {
+		opts.allowAny = value
 	}
-	var parsed Options
-	if err := json.Unmarshal(jsonBytes, &parsed); err != nil {
-		return opts
+	if value, ok := optsMap["allowNullableBoolean"].(bool); ok {
+		opts.allowNullableBoolean = value
 	}
-
-	if parsed.AllowAny != nil {
-		opts.allowAny = *parsed.AllowAny
+	if value, ok := optsMap["allowNullableEnum"].(bool); ok {
+		opts.allowNullableEnum = value
 	}
-	if parsed.AllowNullableBoolean != nil {
-		opts.allowNullableBoolean = *parsed.AllowNullableBoolean
+	if value, ok := optsMap["allowNullableNumber"].(bool); ok {
+		opts.allowNullableNumber = value
 	}
-	if parsed.AllowNullableEnum != nil {
-		opts.allowNullableEnum = *parsed.AllowNullableEnum
+	if value, ok := optsMap["allowNullableObject"].(bool); ok {
+		opts.allowNullableObject = value
 	}
-	if parsed.AllowNullableNumber != nil {
-		opts.allowNullableNumber = *parsed.AllowNullableNumber
+	if value, ok := optsMap["allowNullableString"].(bool); ok {
+		opts.allowNullableString = value
 	}
-	if parsed.AllowNullableObject != nil {
-		opts.allowNullableObject = *parsed.AllowNullableObject
+	if value, ok := optsMap["allowNumber"].(bool); ok {
+		opts.allowNumber = value
 	}
-	if parsed.AllowNullableString != nil {
-		opts.allowNullableString = *parsed.AllowNullableString
+	if value, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
+		opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = value
 	}
-	if parsed.AllowNumber != nil {
-		opts.allowNumber = *parsed.AllowNumber
-	}
-	if parsed.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing != nil {
-		opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = *parsed.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing
-	}
-	if parsed.AllowString != nil {
-		opts.allowString = *parsed.AllowString
+	if value, ok := optsMap["allowString"].(bool); ok {
+		opts.allowString = value
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.go
+++ b/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.go
@@ -50,10 +50,7 @@ func parseOptions(options []any) resolvedOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 
 	if value, ok := optsMap["allowAny"].(bool); ok {
 		opts.allowAny = value

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
@@ -2,7 +2,6 @@ package strict_void_return
 
 import (
 	_ "embed"
-	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -36,7 +35,22 @@ func buildNonVoidReturnMessage() rule.RuleMessage {
 }
 
 type StrictVoidReturnOptions struct {
-	AllowReturnAny *bool `json:"allowReturnAny,omitempty"`
+	AllowReturnAny bool
+}
+
+func parseOptions(options []any) StrictVoidReturnOptions {
+	opts := StrictVoidReturnOptions{}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if value, ok := optsMap["allowReturnAny"].(bool); ok {
+		opts.AllowReturnAny = value
+	}
+	return opts
 }
 
 var StrictVoidReturnRule = rule.CreateRule(rule.Rule{
@@ -44,20 +58,10 @@ var StrictVoidReturnRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := StrictVoidReturnOptions{}
-		if len(options) > 0 {
-			if optsMap, ok := options[0].(map[string]interface{}); ok {
-				if optsJSON, err := json.Marshal(optsMap); err == nil {
-					_ = json.Unmarshal(optsJSON, &opts)
-				}
-			}
-		}
-		if opts.AllowReturnAny == nil {
-			opts.AllowReturnAny = utils.Ref(false)
-		}
+		opts := parseOptions(options)
 
 		allowedReturnTypeFlags := checker.TypeFlagsVoid | checker.TypeFlagsNever | checker.TypeFlagsUndefined
-		if *opts.AllowReturnAny {
+		if opts.AllowReturnAny {
 			allowedReturnTypeFlags |= checker.TypeFlagsAny
 		}
 

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
@@ -43,10 +43,7 @@ func parseOptions(options []any) StrictVoidReturnOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	optsMap, ok := options[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]any)
 	if value, ok := optsMap["allowReturnAny"].(bool); ok {
 		opts.AllowReturnAny = value
 	}

--- a/internal/plugins/typescript/rules/unbound_method/unbound_method.go
+++ b/internal/plugins/typescript/rules/unbound_method/unbound_method.go
@@ -30,7 +30,19 @@ func buildUnboundWithoutThisAnnotationMessage() rule.RuleMessage {
 }
 
 type UnboundMethodOptions struct {
-	IgnoreStatic *bool
+	IgnoreStatic bool
+}
+
+func parseOptions(options []any) UnboundMethodOptions {
+	opts := UnboundMethodOptions{}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]any)
+	if value, ok := optsMap["ignoreStatic"].(bool); ok {
+		opts.IgnoreStatic = value
+	}
+	return opts
 }
 
 func isNodeInsideTypeDeclaration(node *ast.Node) bool {
@@ -199,16 +211,7 @@ var UnboundMethodRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := UnboundMethodOptions{}
-		if len(options) > 0 {
-			optsMap, _ := options[0].(map[string]interface{})
-			if ignoreStatic, ok := optsMap["ignoreStatic"].(bool); ok {
-				opts.IgnoreStatic = utils.Ref(ignoreStatic)
-			}
-		}
-		if opts.IgnoreStatic == nil {
-			opts.IgnoreStatic = utils.Ref(false)
-		}
+		opts := parseOptions(options)
 
 		isNativelyBound := func(object *ast.Node, property *ast.Node) bool {
 			// We can't rely entirely on the type-level checks made at the end of this
@@ -241,7 +244,7 @@ var UnboundMethodRule = rule.CreateRule(rule.Rule{
 				return false
 			}
 
-			dangerous, firstParamIsThis := checkIfMethod(symbol, *opts.IgnoreStatic)
+			dangerous, firstParamIsThis := checkIfMethod(symbol, opts.IgnoreStatic)
 
 			if !dangerous {
 				return false

--- a/internal/utils/type_matches_specifier.go
+++ b/internal/utils/type_matches_specifier.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -18,25 +17,6 @@ import (
 
 type TypeOrValueSpecifierFrom uint8
 
-// unmarshal TypeOrValueSpecifierFrom from JSON string
-func (s *TypeOrValueSpecifierFrom) UnmarshalJSON(data []byte) error {
-	var str string
-	if err := json.Unmarshal(data, &str); err != nil {
-		return fmt.Errorf("failed to unmarshal TypeOrValueSpecifierFrom: %w", err)
-	}
-	switch str {
-	case "file":
-		*s = TypeOrValueSpecifierFromFile
-	case "lib":
-		*s = TypeOrValueSpecifierFromLib
-	case "package":
-		*s = TypeOrValueSpecifierFromPackage
-	default:
-		return fmt.Errorf("unknown TypeOrValueSpecifierFrom value: %s", str)
-	}
-	return nil
-}
-
 const (
 	TypeOrValueSpecifierFromFile TypeOrValueSpecifierFrom = iota
 	TypeOrValueSpecifierFromLib
@@ -48,59 +28,117 @@ const (
 
 type NameList []string
 
-// unmarshal a string or a list of strings to NameList
-func (s *NameList) UnmarshalJSON(data []byte) error {
-	var singleName string
-	if err := json.Unmarshal(data, &singleName); err == nil {
-		*s = NameList{singleName}
-		return nil
-	}
-
-	var names []string
-	if err := json.Unmarshal(data, &names); err != nil {
-		return fmt.Errorf("failed to unmarshal NameList: %w", err)
-	}
-	*s = names
-	return nil
-}
-
 type TypeOrValueSpecifier struct {
-	From TypeOrValueSpecifierFrom `json:"from"`
-	Name NameList                 `json:"name"`
+	From TypeOrValueSpecifierFrom
+	Name NameList
 	// Can be used when From == TypeOrValueSpecifierFromFile
-	Path string `json:"path"`
+	Path string
 	// Can be used when From == TypeOrValueSpecifierFromPackage
-	Package string `json:"package"`
+	Package string
 	// pathProvided distinguishes an omitted path from an explicitly empty one.
 	// Both decode to Path == "", but upstream treats only the omitted form as
 	// matching declarations anywhere in the current project.
 	pathProvided bool
 }
 
-// UnmarshalJSON handles both string shorthand ("Promise") and object form
-// ({"from": "lib", "name": "Promise"}) for TypeOrValueSpecifier, matching
-// the original TypeScript-ESLint TypeOrValueSpecifier union type.
-func (s *TypeOrValueSpecifier) UnmarshalJSON(data []byte) error {
-	var str string
-	if err := json.Unmarshal(data, &str); err == nil {
-		*s = TypeOrValueSpecifier{
+// ParseTypeOrValueSpecifier decodes one entry of a type specifier option from
+// its configured value, handling both the string shorthand ("Promise") and the
+// object form ({"from": "lib", "name": "Promise"}), matching the original
+// TypeScript-ESLint TypeOrValueSpecifier union type. It reports false for a
+// value that matches neither shape.
+func ParseTypeOrValueSpecifier(raw any) (TypeOrValueSpecifier, bool) {
+	if str, ok := raw.(string); ok {
+		return TypeOrValueSpecifier{
 			From: TypeOrValueSpecifierFromString,
 			Name: NameList{str},
+		}, true
+	}
+
+	fields, ok := raw.(map[string]interface{})
+	if !ok {
+		return TypeOrValueSpecifier{}, false
+	}
+
+	var specifier TypeOrValueSpecifier
+	if raw, ok := fields["from"]; ok {
+		str, ok := raw.(string)
+		if !ok {
+			return TypeOrValueSpecifier{}, false
 		}
+		switch str {
+		case "file":
+			specifier.From = TypeOrValueSpecifierFromFile
+		case "lib":
+			specifier.From = TypeOrValueSpecifierFromLib
+		case "package":
+			specifier.From = TypeOrValueSpecifierFromPackage
+		default:
+			return TypeOrValueSpecifier{}, false
+		}
+	}
+	if raw, ok := fields["name"]; ok {
+		names, ok := parseNameList(raw)
+		if !ok {
+			return TypeOrValueSpecifier{}, false
+		}
+		specifier.Name = names
+	}
+	if raw, ok := fields["path"]; ok {
+		str, ok := raw.(string)
+		if !ok {
+			return TypeOrValueSpecifier{}, false
+		}
+		specifier.Path = str
+		specifier.pathProvided = true
+	}
+	if raw, ok := fields["package"]; ok {
+		str, ok := raw.(string)
+		if !ok {
+			return TypeOrValueSpecifier{}, false
+		}
+		specifier.Package = str
+	}
+	return specifier, true
+}
+
+// ParseTypeOrValueSpecifiers decodes a list of type specifiers. It returns nil
+// when the value is not a list or when any entry matches neither specifier
+// shape, so a malformed option falls back to the rule's default.
+func ParseTypeOrValueSpecifiers(raw any) []TypeOrValueSpecifier {
+	items, ok := raw.([]interface{})
+	if !ok {
 		return nil
 	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(data, &fields); err != nil {
-		return err
+	specifiers := make([]TypeOrValueSpecifier, 0, len(items))
+	for _, item := range items {
+		specifier, ok := ParseTypeOrValueSpecifier(item)
+		if !ok {
+			return nil
+		}
+		specifiers = append(specifiers, specifier)
 	}
-	type Alias TypeOrValueSpecifier
-	var alias Alias
-	if err := json.Unmarshal(data, &alias); err != nil {
-		return err
+	return specifiers
+}
+
+// parseNameList decodes a specifier's `name`, written either as a single name
+// or as a list of them.
+func parseNameList(raw any) (NameList, bool) {
+	if str, ok := raw.(string); ok {
+		return NameList{str}, true
 	}
-	*s = TypeOrValueSpecifier(alias)
-	_, s.pathProvided = fields["path"]
-	return nil
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	names := make(NameList, 0, len(items))
+	for _, item := range items {
+		str, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		names = append(names, str)
+	}
+	return names, true
 }
 
 func specifierNameMatchesWithCalleeNames(

--- a/internal/utils/type_matches_specifier.go
+++ b/internal/utils/type_matches_specifier.go
@@ -54,7 +54,7 @@ func ParseTypeOrValueSpecifier(raw any) (TypeOrValueSpecifier, bool) {
 		}, true
 	}
 
-	fields, ok := raw.(map[string]interface{})
+	fields, ok := raw.(map[string]any)
 	if !ok {
 		return TypeOrValueSpecifier{}, false
 	}
@@ -105,7 +105,7 @@ func ParseTypeOrValueSpecifier(raw any) (TypeOrValueSpecifier, bool) {
 // when the value is not a list or when any entry matches neither specifier
 // shape, so a malformed option falls back to the rule's default.
 func ParseTypeOrValueSpecifiers(raw any) []TypeOrValueSpecifier {
-	items, ok := raw.([]interface{})
+	items, ok := raw.([]any)
 	if !ok {
 		return nil
 	}
@@ -126,7 +126,7 @@ func parseNameList(raw any) (NameList, bool) {
 	if str, ok := raw.(string); ok {
 		return NameList{str}, true
 	}
-	items, ok := raw.([]interface{})
+	items, ok := raw.([]any)
 	if !ok {
 		return nil, false
 	}

--- a/internal/utils/type_matches_specifier_test.go
+++ b/internal/utils/type_matches_specifier_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -384,17 +383,17 @@ func TestTypeMatchesSomeSpecifierDistinguishesOmittedAndEmptyFilePath(t *testing
 	defer done()
 
 	demo := typeOfTestAlias(t, program, c, filePath)
-	decode := func(raw string) TypeOrValueSpecifier {
+	decode := func(raw map[string]interface{}) TypeOrValueSpecifier {
 		t.Helper()
-		var specifier TypeOrValueSpecifier
-		assert.NilError(t, json.Unmarshal([]byte(raw), &specifier))
+		specifier, ok := ParseTypeOrValueSpecifier(raw)
+		assert.Assert(t, ok)
 		return specifier
 	}
 
 	assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{
-		decode(`{"from":"file","name":"Demo"}`),
+		decode(map[string]interface{}{"from": "file", "name": "Demo"}),
 	}, nil, program), true)
 	assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{
-		decode(`{"from":"file","name":"Demo","path":""}`),
+		decode(map[string]interface{}{"from": "file", "name": "Demo", "path": ""}),
 	}, nil, program), false)
 }

--- a/internal/utils/type_matches_specifier_test.go
+++ b/internal/utils/type_matches_specifier_test.go
@@ -383,7 +383,7 @@ func TestTypeMatchesSomeSpecifierDistinguishesOmittedAndEmptyFilePath(t *testing
 	defer done()
 
 	demo := typeOfTestAlias(t, program, c, filePath)
-	decode := func(raw map[string]interface{}) TypeOrValueSpecifier {
+	decode := func(raw map[string]any) TypeOrValueSpecifier {
 		t.Helper()
 		specifier, ok := ParseTypeOrValueSpecifier(raw)
 		assert.Assert(t, ok)
@@ -391,9 +391,9 @@ func TestTypeMatchesSomeSpecifierDistinguishesOmittedAndEmptyFilePath(t *testing
 	}
 
 	assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{
-		decode(map[string]interface{}{"from": "file", "name": "Demo"}),
+		decode(map[string]any{"from": "file", "name": "Demo"}),
 	}, nil, program), true)
 	assert.Equal(t, TypeMatchesSomeSpecifier(demo, []TypeOrValueSpecifier{
-		decode(map[string]interface{}{"from": "file", "name": "Demo", "path": ""}),
+		decode(map[string]any{"from": "file", "name": "Demo", "path": ""}),
 	}, nil, program), false)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -214,11 +214,6 @@ func TypeRecurser(t *checker.Type, predicate func(t *checker.Type) /* should sto
 	}
 }
 
-// SUPER DIRTY HACK FOR OPTIONAL FIELDS :(
-func Ref[T any](a T) *T {
-	return &a
-}
-
 func GetNumberIndexType(typeChecker *checker.Checker, t *checker.Type) *checker.Type {
 	return checker.Checker_getIndexTypeOfType(typeChecker, t, checker.Checker_numberType(typeChecker))
 }


### PR DESCRIPTION
## Summary

Replaces the `json.Marshal` / `json.Unmarshal` round-trip used to decode rule options with direct type assertions on `options[0]`, matching the option-parsing style documented in the port-rule skill.

Rules converted: `no-base-to-string`, `no-confusing-void-expression`, `no-deprecated`, `no-duplicate-type-constituents`, `no-floating-promises`, `no-meaningless-void-operator`, `no-misused-promises`, `no-misused-spread`, `no-unnecessary-boolean-literal-compare`, `no-unnecessary-type-assertion`, `only-throw-error`, `prefer-optional-chain`, `prefer-promise-reject-errors`, `promise-function-async`, `require-array-sort-compare`, `restrict-template-expressions`, `strict-boolean-expressions`, `strict-void-return`.

Along with it:

- Option structs no longer use pointer-typed fields: defaults live in the struct initializer, so `*bool` / `*string` become plain `bool` / `string`. This also covers `restrict-plus-operands`, `unbound-method` and `prefer-string-starts-ends-with`, and removes the now-unused `utils.Ref` helper and `prefer-optional-chain`'s `derefBoolDefault`.
- `json:"..."` tags are dropped from the touched option structs, since nothing decodes them anymore.
- New `utils.ParseTypeOrValueSpecifier` / `utils.ParseTypeOrValueSpecifiers` decode type specifiers (string shorthand and object form) straight from config values; the `UnmarshalJSON` implementations on `TypeOrValueSpecifier`, `NameList` and `TypeOrValueSpecifierFrom` are removed.
- `no-misused-promises` parses `checksVoidReturn`'s `boolean | object` shape with a type switch instead of a custom `UnmarshalJSON`.
- `strict-boolean-expressions` drops its intermediate pointer-typed `Options` struct and parses straight into `resolvedOptions`.

## Related Links

- #1673 — the option-parsing guidance this PR follows
- #1667 — removed the legacy options compatibility layer this builds on

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

