### PR TITLE
docs(import): record each rule's aligned upstream version

### DIFF
--- a/internal/plugins/import/rules/default/default.md
+++ b/internal/plugins/import/rules/default/default.md
@@ -28,4 +28,5 @@ Modules that cannot be resolved, are ignored, or are not ES modules are not repo
 
 ## Original Documentation
 
-- [eslint-plugin-import/default](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md)
+- [eslint-plugin-import: default](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/default.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/default.js)

--- a/internal/plugins/import/rules/first/first.md
+++ b/internal/plugins/import/rules/first/first.md
@@ -47,4 +47,5 @@ import { x } from './foo';
 
 ## Original Documentation
 
-https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md
+- [eslint-plugin-import: first](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/first.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/first.js)

--- a/internal/plugins/import/rules/namespace/namespace.md
+++ b/internal/plugins/import/rules/namespace/namespace.md
@@ -56,4 +56,5 @@ Modules that cannot be resolved, are ignored, or are not ES modules are not repo
 
 ## Original Documentation
 
-- [eslint-plugin-import/namespace](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md)
+- [eslint-plugin-import: namespace](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/namespace.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/namespace.js)

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import.md
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import.md
@@ -39,4 +39,5 @@ const BAZ = 1;
 
 ## Original Documentation
 
-- [eslint-plugin-import/newline-after-import](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md)
+- [eslint-plugin-import: newline-after-import](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/newline-after-import.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/newline-after-import.js)

--- a/internal/plugins/import/rules/no_cycle/no_cycle.md
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.md
@@ -99,4 +99,5 @@ observable effect here.
 
 ## Original Documentation
 
-- [eslint-plugin-import/no-cycle](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md)
+- [eslint-plugin-import: no-cycle](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-cycle.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/no-cycle.js)

--- a/internal/plugins/import/rules/no_default_export/no_default_export.md
+++ b/internal/plugins/import/rules/no_default_export/no_default_export.md
@@ -26,4 +26,5 @@ export { foo };
 
 ## Original Documentation
 
-https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
+- [eslint-plugin-import: no-default-export](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-default-export.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/no-default-export.js)

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.md
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.md
@@ -54,4 +54,5 @@ When set to `true`, supports TypeScript inline type imports, allowing `import ty
 
 ## Original Documentation
 
-- [eslint-plugin-import/no-duplicates](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md)
+- [eslint-plugin-import: no-duplicates](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-duplicates.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/no-duplicates.js)

--- a/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.md
+++ b/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.md
@@ -29,4 +29,5 @@ export { count };
 
 ## Original Documentation
 
-https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-mutable-exports.md
+- [eslint-plugin-import: no-mutable-exports](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-mutable-exports.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/no-mutable-exports.js)

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths.md
@@ -140,4 +140,5 @@ reports `Unexpected path "../server/bar" imported in restricted zone. Use the AP
 
 ## Original Documentation
 
-- [import/no-restricted-paths](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md)
+- [eslint-plugin-import: no-restricted-paths](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-restricted-paths.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/no-restricted-paths.js)

--- a/internal/plugins/import/rules/no_self_import/no_self_import.md
+++ b/internal/plugins/import/rules/no_self_import/no_self_import.md
@@ -26,4 +26,5 @@ const utils = require('./utils');
 
 ## Original Documentation
 
-- [import/no-self-import](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md)
+- [eslint-plugin-import: no-self-import](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-self-import.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/no-self-import.js)

--- a/internal/plugins/import/rules/no_webpack_loader_syntax/no_webpack_loader_syntax.md
+++ b/internal/plugins/import/rules/no_webpack_loader_syntax/no_webpack_loader_syntax.md
@@ -26,4 +26,5 @@ const styles = require('./styles.css');
 
 ## Original Documentation
 
-- [import/no-webpack-loader-syntax](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-webpack-loader-syntax.md)
+- [eslint-plugin-import: no-webpack-loader-syntax](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-webpack-loader-syntax.md)
+- [Source code](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/src/rules/no-webpack-loader-syntax.js)


### PR DESCRIPTION
## Summary

- Every `import/` rule doc now pins its "Original Documentation" links to `eslint-plugin-import@v2.32.0` — the latest release, and correct for all 11 rules since every one was ported after it shipped (2025-06-20) and no newer release has appeared since (confirmed against both GitHub releases/tags and npm).
- Added the previously-missing "Source code" link to every rule (none had one) and unified the doc link text — previously a mix of bulleted/bare links and `eslint-plugin-import/x` vs `import/x` naming.
- Verified every doc and source path exists at the pinned tag before writing the links.

## Related Links

#1680

## Checklist

- [x] Tests updated (or not required) — docs-only change.
- [x] Documentation updated (or not required).