### PR TITLE
fix: align no-redeclare TypeScript globals

### DIFF
--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare_test.go
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare_test.go
@@ -82,6 +82,11 @@ func TestNoRedeclareRule(t *testing.T) {
 			{Code: "var self = 0;"},
 			{Code: "var console = 0;"},
 			{Code: "var document = 0;"},
+			// Host-library declarations are not part of scope-manager's default
+			// esnext globals. Supporting parserOptions.lib is a separate feature.
+			{Code: "var AbortController = 0;"},
+			{Code: "type NodeListOf = 1;"},
+			{Code: "type HTMLElement = 1;"},
 			// In a module the directive remains in the outer global scope while
 			// the syntax declaration is module-local; neither declaration repeats.
 			{Code: "export {};\n/*globals top */ var top = 0;"},
@@ -597,25 +602,18 @@ func TestNoRedeclareRule(t *testing.T) {
 					{MessageId: "redeclaredBySyntax", Message: "'document' is already defined by a variable declaration.", Line: 1, Column: 28, EndLine: 1, EndColumn: 36},
 				},
 			},
-			// DOM TYPE_VALUE names do remain implicit lib variables.
+			// Name-level parity includes scope-manager's default esnext type
+			// globals and legal interface augmentations.
 			{
-				Code: "var AbortController = 0;",
+				Code: "type Record = 1;",
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "redeclaredAsBuiltin", Message: "'AbortController' is already defined as a built-in global variable.", Line: 1, Column: 5, EndLine: 1, EndColumn: 20},
-				},
-			},
-			// Name-level parity includes pure type globals and legal interface
-			// augmentations, just as typescript-eslint's scope manager does.
-			{
-				Code: "type NodeListOf = 1;",
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "redeclaredAsBuiltin", Line: 1, Column: 6, EndLine: 1, EndColumn: 16},
+					{MessageId: "redeclaredAsBuiltin", Line: 1, Column: 6, EndLine: 1, EndColumn: 12},
 				},
 			},
 			{
-				Code: "type HTMLElement = 1;",
+				Code: "type IteratorObjectConstructor = 1;",
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "redeclaredAsBuiltin", Line: 1, Column: 6, EndLine: 1, EndColumn: 17},
+					{MessageId: "redeclaredAsBuiltin", Line: 1, Column: 6, EndLine: 1, EndColumn: 31},
 				},
 			},
 			{

--- a/internal/rules/no_redeclare/no_redeclare.go
+++ b/internal/rules/no_redeclare/no_redeclare.go
@@ -388,13 +388,11 @@ func filterByKind(decls []declInfo, kind ast.Kind) []declInfo {
 }
 
 type programGlobalDeclarations struct {
-	ctx                             rule.RuleContext
-	builtinMode                     builtinGlobalsMode
-	builtinGlobals                  bool
-	defaultLibraryTypeGlobals       map[string]bool
-	defaultLibraryTypeGlobalsLoaded bool
-	inlineByName                    map[string]rule.InlineGlobal
-	inlineOrder                     []string
+	ctx            rule.RuleContext
+	builtinMode    builtinGlobalsMode
+	builtinGlobals bool
+	inlineByName   map[string]rule.InlineGlobal
+	inlineOrder    []string
 }
 
 func newProgramGlobalDeclarations(ctx rule.RuleContext, o options, mode builtinGlobalsMode) *programGlobalDeclarations {
@@ -428,14 +426,7 @@ func (declarations *programGlobalDeclarations) isImplicitBuiltin(name string) bo
 	}
 
 	if declarations.builtinMode == builtinGlobalsTypeScriptLibs {
-		if declarations.ctx.Program != nil && declarations.ctx.TypeChecker != nil {
-			if !declarations.defaultLibraryTypeGlobalsLoaded {
-				declarations.defaultLibraryTypeGlobals = make(map[string]bool)
-				utils.AddDefaultLibraryTypeGlobalNames(declarations.defaultLibraryTypeGlobals, declarations.ctx.Program, declarations.ctx.TypeChecker)
-				declarations.defaultLibraryTypeGlobalsLoaded = true
-			}
-		}
-		isTypeScriptTypeGlobal := declarations.defaultLibraryTypeGlobals[name]
+		isTypeScriptTypeGlobal := rule.IsDefaultTypeScriptTypeGlobal(name)
 		if declarations.ctx.Globals.LanguageAccess(name).IsDeclared() || isTypeScriptTypeGlobal {
 			if declarations.ctx.Globals.ConfigOverride(name) == utils.GlobalAccessOff {
 				if _, hasActiveDirective := declarations.inlineByName[name]; hasActiveDirective {

--- a/internal/rules/no_redeclare/no_redeclare_extras_test.go
+++ b/internal/rules/no_redeclare/no_redeclare_extras_test.go
@@ -22,6 +22,25 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+func TestTypeScriptImplicitBuiltinsDoNotRequireProgram(t *testing.T) {
+	declarations := newProgramGlobalDeclarations(
+		rule.RuleContext{},
+		typescriptDefaults(),
+		builtinGlobalsTypeScriptLibs,
+	)
+
+	for _, name := range []string{"Record", "ImportMeta", "IteratorObjectConstructor"} {
+		if !declarations.isImplicitBuiltin(name) {
+			t.Errorf("expected default TypeScript type global %q to be an implicit builtin", name)
+		}
+	}
+	for _, name := range []string{"NodeListOf", "HTMLElement", "AbortController"} {
+		if declarations.isImplicitBuiltin(name) {
+			t.Errorf("did not expect host-library name %q to be an implicit builtin", name)
+		}
+	}
+}
+
 func TestNoRedeclareExtras(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-redeclare.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-redeclare.test.ts
@@ -494,8 +494,9 @@ type T = 2;
       ],
     },
     {
-      // SKIP: rslint's builtin list does not include the TS DOM lib's
-      // `NodeListOf`; `builtinGlobals` covers ES core names only.
+      // SKIP: rslint does not support parserOptions.lib yet. Without that
+      // explicit option, NodeListOf is correctly absent from the default
+      // esnext scope-manager globals.
       code: `
 type NodeListOf = 1;
       `,


### PR DESCRIPTION
## Summary

- use the shared scope-manager default TypeScript type-global set for @typescript-eslint/no-redeclare
- stop deriving implicit globals from the active tsconfig libraries
- keep host-library globals out of the default scope while preserving configuration and directive behavior

## Validation

- targeted Go tests for core and TypeScript no-redeclare packages
- production CLI build
- exact differential against ESLint 10.8.0, @typescript-eslint/parser 8.65.0, and @typescript-eslint/eslint-plugin 8.65.0
- 196 diagnostics matched exactly across all default type globals, host globals, modules, builtinGlobals false, and global override/directive cases