### PR TITLE
fix: align no-label-var TypeScript scopes

### DIFF
--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -256,17 +256,23 @@ func (s *RefStore) IsDefinedInFile(node *ast.Node) bool {
 
 // IsNameDefinedInFile reports whether name is visible in the value scope at
 // location through a declaration in this file or a binding supplied by the
-// resolved file wrapper. Unlike IsDefinedInFile, location need
-// not itself be a reference-position identifier. The TypeChecker is never
-// consulted.
+// resolved file wrapper. Unlike IsDefinedInFile, location need not itself be a
+// reference-position identifier. The TypeChecker is never consulted.
 func (s *RefStore) IsNameDefinedInFile(location *ast.Node, name string) bool {
+	return s.IsNameDefinedInFileWithMeaning(location, name, ast.SymbolFlagsValue)
+}
+
+// IsNameDefinedInFileWithMeaning is IsNameDefinedInFile for an explicit set of
+// declaration spaces. Implicit wrapper bindings participate only in value
+// lookups.
+func (s *RefStore) IsNameDefinedInFileWithMeaning(location *ast.Node, name string, meaning ast.SymbolFlags) bool {
 	if s == nil || location == nil || name == "" {
 		return false
 	}
-	if s.resolver.Resolve(location, name, ast.SymbolFlagsValue, nil, true /*isUse*/, false /*excludeGlobals*/) != nil {
+	if s.resolver.Resolve(location, name, meaning, nil, true /*isUse*/, false /*excludeGlobals*/) != nil {
 		return true
 	}
-	return s.HasImplicitWrapperBinding(name)
+	return meaning&ast.SymbolFlagsValue != 0 && s.HasImplicitWrapperBinding(name)
 }
 
 // HasNonGlobalTopLevelScope reports whether the resolved language defaults

--- a/internal/rules/no_label_var/no_label_var.go
+++ b/internal/rules/no_label_var/no_label_var.go
@@ -6,20 +6,36 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+func hasEnclosingTypeParameter(node *ast.Node, name string) bool {
+	for current := node.Parent; current != nil; current = current.Parent {
+		if !ast.IsFunctionLikeDeclaration(current) &&
+			current.Kind != ast.KindClassDeclaration && current.Kind != ast.KindClassExpression {
+			continue
+		}
+		for _, typeParameter := range current.TypeParameters() {
+			if typeParameter != nil && typeParameter.Name() != nil && typeParameter.Name().Text() == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // https://eslint.org/docs/latest/rules/no-label-var
 //
 // ESLint's `getVariableByName` walks the scope chain all the way to the global
 // scope. The same-file binding checks and framework globals view cover those
-// layers without allowing TypeScript libraries to change the result:
+// layers without allowing the active TypeScript program to change the result:
 //
 //  1. utils.IsShadowed — fast, works without type info; covers every binding
 //     declared inside the current source file (var/let/const, function, class,
 //     enum, namespace, import, parameter, catch, for-init, function-expression
 //     name, hoisted vars).
-//  2. ctx.Refs — resolves binder-owned and implicit names at the label's
-//     location, including function `arguments` and a CommonJS wrapper's
-//     declaration-less `arguments`.
-//  3. ctx.Globals — catches the selected ECMAScript edition, resolved language
+//  2. ctx.Refs — resolves binder-owned names in every declaration space at the
+//     label's location, plus value bindings supplied by a file wrapper.
+//  3. The shared default TypeScript type-global set mirrors scope-manager for
+//     TypeScript files without consulting tsconfig libraries.
+//  4. ctx.Globals — catches the selected ECMAScript edition, resolved language
 //     globals, config and inline globals, including explicit `off` overrides.
 var NoLabelVarRule = rule.Rule{
 	Name:   "no-label-var",
@@ -44,7 +60,23 @@ var NoLabelVarRule = rule.Rule{
 					report(node)
 					return
 				}
-				if ctx.Refs != nil && ctx.Refs.IsNameDefinedInFile(node, name) {
+				// scope-manager leaves class type parameters in the lexical scope
+				// chain of static members, while TypeScript's resolver deliberately
+				// hides them there. Preserve the scope-manager answer.
+				if hasEnclosingTypeParameter(node, name) {
+					report(node)
+					return
+				}
+				if ctx.Refs != nil && ctx.Refs.IsNameDefinedInFileWithMeaning(
+					node,
+					name,
+					ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+				) {
+					report(node)
+					return
+				}
+
+				if !ast.IsInJSFile(node) && rule.IsDefaultTypeScriptTypeGlobal(name) {
 					report(node)
 					return
 				}

--- a/internal/rules/no_label_var/no_label_var_test.go
+++ b/internal/rules/no_label_var/no_label_var_test.go
@@ -28,12 +28,9 @@ func TestNoLabelVarRule(t *testing.T) {
 			{Code: `for (const k in obj) { q: for(;;) { break q; } }`},
 			{Code: `for (const v of arr) { q: for(;;) { break q; } }`},
 
-			// ---- TS type-only declarations should NOT clash (only values count) ----
-			{Code: `interface X {} X: for(;;) { break X; }`},
-			{Code: `type X = number; X: for(;;) { break X; }`},
-			// NOTE: `import type` is intentionally NOT in the valid list — utils.IsShadowed
-			// does not distinguish type-only imports from value imports, so it triggers.
-			// See the matching invalid case below.
+			// ---- Type-only names in sibling scopes are not visible ----
+			{Code: `function f<T>() {} T: for(;;) { break T; }`},
+			{Code: `function f() { type X = number; } X: for(;;) { break X; }`},
 
 			// ---- Nested label inside iteration; outer var has different name ----
 			{Code: `var x = 1; function f() { y: for(;;) { break y; } }`},
@@ -49,9 +46,14 @@ func TestNoLabelVarRule(t *testing.T) {
 			// ---- Declared global that does not clash with the label name ----
 			{Code: `q: for(;;) { break q; }`, Globals: map[string]any{"myConfiguredGlobal": "readonly"}},
 
-			// TypeScript libraries do not implicitly populate ESLint's global scope.
+			// Host libraries are not part of scope-manager's default esnext scope.
 			{Code: `window: for (;;) { break window; }`},
 			{Code: `console: for (;;) { break console; }`},
+			{Code: `NodeListOf: for (;;) { break NodeListOf; }`},
+			{Code: `AbortController: for (;;) { break AbortController; }`},
+
+			// Global augmentations are not visible as module-local variables.
+			{Code: `export {}; declare global { interface X {} } X: for(;;) { break X; }`},
 		},
 
 		[]rule_tester.InvalidTestCase{
@@ -72,6 +74,81 @@ func TestNoLabelVarRule(t *testing.T) {
 				Code: `function bar(x) { x: for(;;) { break x; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "identifierClashWithLabel", Line: 1, Column: 19},
+				},
+			},
+
+			// ---- TypeScript type-space bindings ----
+			{
+				Code: `interface X {} X: for(;;) { break X; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `type X = number; X: for(;;) { break X; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `{ type X = number; X: for(;;) { break X; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `function f<T>() { T: for(;;) { break T; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `class C<T> { m() { T: for(;;) { break T; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `class C<T> { static m() { T: for(;;) { break T; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `class C<T> { static { T: for(;;) { break T; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `function outer<T>() { function inner() { T: for(;;) { break T; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code: `Record: for(;;) { break Record; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `ImportMeta: for(;;) { break ImportMeta; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `export {}; Record: for(;;) { break Record; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code:    `Record: for(;;) { break Record; }`,
+				Globals: map[string]any{"Record": "off"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
 				},
 			},
 
@@ -194,8 +271,7 @@ func TestNoLabelVarRule(t *testing.T) {
 					{MessageId: "identifierClashWithLabel", Line: 1, Column: 31},
 				},
 			},
-			// Type-only import: utils.IsShadowed does not differentiate type-only
-			// from value imports, so this is reported. Lock current behavior.
+			// Type-only imports are scope variables too.
 			{
 				Code: `import type { X } from 'mod'; X: for(;;) { break X; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
@@ -274,18 +350,27 @@ func TestNoLabelVarRule(t *testing.T) {
 func TestNoLabelVarECMAVersion(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),
-		"tsconfig.json",
+		"tsconfig.allow-js.json",
 		t,
 		&NoLabelVarRule,
 		[]rule_tester.ValidTestCase{
 			{
 				Code:            `Promise: for (;;) { break Promise; }`,
+				FileName:        "promise.js",
 				LanguageOptions: rule.LanguageOptions{ECMAVersion: 5},
 			},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
 				Code:            `Promise: for (;;) { break Promise; }`,
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 5},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:            `Promise: for (;;) { break Promise; }`,
+				FileName:        "promise.js",
 				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2015},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
@@ -304,6 +389,8 @@ func TestNoLabelVarLanguageDefaults(t *testing.T) {
 		[]rule_tester.ValidTestCase{
 			{Code: `arguments: while (false) { break arguments; }`, FileName: "plain-label.js"},
 			{Code: `require: while (false) { break require; }`, FileName: "plain-require.js"},
+			// TypeScript scope-manager globals are not part of ordinary JS scope.
+			{Code: `Record: for (;;) { break Record; }`, FileName: "record.js"},
 			{
 				Code:     `require: while (false) { break require; }`,
 				FileName: "require-off.cjs",

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-label-var.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-label-var.test.ts.snap
@@ -80,6 +80,162 @@ exports[`no-label-var > invalid 3`] = `
 
 exports[`no-label-var > invalid 4`] = `
 {
+  "code": "interface X {} X: for(;;) { break X; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 5`] = `
+{
+  "code": "type X = number; X: for(;;) { break X; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 6`] = `
+{
+  "code": "function f<T>() { T: for(;;) { break T; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 7`] = `
+{
+  "code": "class C<T> { static m() { T: for(;;) { break T; } } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 8`] = `
+{
+  "code": "Record: for(;;) { break Record; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 9`] = `
+{
+  "code": "export {}; Record: for(;;) { break Record; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 10`] = `
+{
   "code": "function bar() { let x = 1; x: for(;;) { break x; } }",
   "diagnostics": [
     {
@@ -104,7 +260,7 @@ exports[`no-label-var > invalid 4`] = `
 }
 `;
 
-exports[`no-label-var > invalid 5`] = `
+exports[`no-label-var > invalid 11`] = `
 {
   "code": "function bar() { const x = 1; x: for(;;) { break x; } }",
   "diagnostics": [
@@ -130,7 +286,7 @@ exports[`no-label-var > invalid 5`] = `
 }
 `;
 
-exports[`no-label-var > invalid 6`] = `
+exports[`no-label-var > invalid 12`] = `
 {
   "code": "function bar() { function x() {} x: for(;;) { break x; } }",
   "diagnostics": [
@@ -156,7 +312,7 @@ exports[`no-label-var > invalid 6`] = `
 }
 `;
 
-exports[`no-label-var > invalid 7`] = `
+exports[`no-label-var > invalid 13`] = `
 {
   "code": "class X {}
 X: for(;;) { break X; }",
@@ -183,7 +339,7 @@ X: for(;;) { break X; }",
 }
 `;
 
-exports[`no-label-var > invalid 8`] = `
+exports[`no-label-var > invalid 14`] = `
 {
   "code": "function bar({ x }) { x: for(;;) { break x; } }",
   "diagnostics": [
@@ -209,7 +365,7 @@ exports[`no-label-var > invalid 8`] = `
 }
 `;
 
-exports[`no-label-var > invalid 9`] = `
+exports[`no-label-var > invalid 15`] = `
 {
   "code": "try {} catch (e) { e: for(;;) { break e; } }",
   "diagnostics": [
@@ -235,7 +391,7 @@ exports[`no-label-var > invalid 9`] = `
 }
 `;
 
-exports[`no-label-var > invalid 10`] = `
+exports[`no-label-var > invalid 16`] = `
 {
   "code": "try {} catch ({ a }) { a: for(;;) { break a; } }",
   "diagnostics": [
@@ -261,7 +417,7 @@ exports[`no-label-var > invalid 10`] = `
 }
 `;
 
-exports[`no-label-var > invalid 11`] = `
+exports[`no-label-var > invalid 17`] = `
 {
   "code": "for (let i = 0; i < 1; i++) { i: for(;;) { break i; } }",
   "diagnostics": [
@@ -287,7 +443,7 @@ exports[`no-label-var > invalid 11`] = `
 }
 `;
 
-exports[`no-label-var > invalid 12`] = `
+exports[`no-label-var > invalid 18`] = `
 {
   "code": "for (let v of arr) { v: for(;;) { break v; } }",
   "diagnostics": [
@@ -313,7 +469,7 @@ exports[`no-label-var > invalid 12`] = `
 }
 `;
 
-exports[`no-label-var > invalid 13`] = `
+exports[`no-label-var > invalid 19`] = `
 {
   "code": "for (const k in obj) { k: for(;;) { break k; } }",
   "diagnostics": [
@@ -339,7 +495,7 @@ exports[`no-label-var > invalid 13`] = `
 }
 `;
 
-exports[`no-label-var > invalid 14`] = `
+exports[`no-label-var > invalid 20`] = `
 {
   "code": "function f() { x: for(;;) { break x; } { var x = 1; } }",
   "diagnostics": [
@@ -365,7 +521,7 @@ exports[`no-label-var > invalid 14`] = `
 }
 `;
 
-exports[`no-label-var > invalid 15`] = `
+exports[`no-label-var > invalid 21`] = `
 {
   "code": "function foo() { foo: for(;;) { break foo; } }",
   "diagnostics": [
@@ -391,7 +547,7 @@ exports[`no-label-var > invalid 15`] = `
 }
 `;
 
-exports[`no-label-var > invalid 16`] = `
+exports[`no-label-var > invalid 22`] = `
 {
   "code": "(function fee() { fee: for(;;) { break fee; } })()",
   "diagnostics": [
@@ -417,7 +573,7 @@ exports[`no-label-var > invalid 16`] = `
 }
 `;
 
-exports[`no-label-var > invalid 17`] = `
+exports[`no-label-var > invalid 23`] = `
 {
   "code": "import x from 'mod'; x: for(;;) { break x; }",
   "diagnostics": [
@@ -443,7 +599,7 @@ exports[`no-label-var > invalid 17`] = `
 }
 `;
 
-exports[`no-label-var > invalid 18`] = `
+exports[`no-label-var > invalid 24`] = `
 {
   "code": "import { x } from 'mod'; x: for(;;) { break x; }",
   "diagnostics": [
@@ -469,7 +625,7 @@ exports[`no-label-var > invalid 18`] = `
 }
 `;
 
-exports[`no-label-var > invalid 19`] = `
+exports[`no-label-var > invalid 25`] = `
 {
   "code": "import * as x from 'mod'; x: for(;;) { break x; }",
   "diagnostics": [
@@ -495,7 +651,7 @@ exports[`no-label-var > invalid 19`] = `
 }
 `;
 
-exports[`no-label-var > invalid 20`] = `
+exports[`no-label-var > invalid 26`] = `
 {
   "code": "import { y as x } from 'mod'; x: for(;;) { break x; }",
   "diagnostics": [
@@ -521,7 +677,7 @@ exports[`no-label-var > invalid 20`] = `
 }
 `;
 
-exports[`no-label-var > invalid 21`] = `
+exports[`no-label-var > invalid 27`] = `
 {
   "code": "import type { X } from 'mod'; X: for(;;) { break X; }",
   "diagnostics": [
@@ -547,7 +703,7 @@ exports[`no-label-var > invalid 21`] = `
 }
 `;
 
-exports[`no-label-var > invalid 22`] = `
+exports[`no-label-var > invalid 28`] = `
 {
   "code": "enum X { A } X: for(;;) { break X; }",
   "diagnostics": [
@@ -573,7 +729,7 @@ exports[`no-label-var > invalid 22`] = `
 }
 `;
 
-exports[`no-label-var > invalid 23`] = `
+exports[`no-label-var > invalid 29`] = `
 {
   "code": "namespace N { export const x = 1; } N: for(;;) { break N; }",
   "diagnostics": [
@@ -599,7 +755,7 @@ exports[`no-label-var > invalid 23`] = `
 }
 `;
 
-exports[`no-label-var > invalid 24`] = `
+exports[`no-label-var > invalid 30`] = `
 {
   "code": "var a = 1; function f() { a: for(;;) { b: for(;;) { break b; } } }",
   "diagnostics": [
@@ -625,7 +781,7 @@ exports[`no-label-var > invalid 24`] = `
 }
 `;
 
-exports[`no-label-var > invalid 25`] = `
+exports[`no-label-var > invalid 31`] = `
 {
   "code": "Promise: for (;;) { break Promise; }",
   "diagnostics": [
@@ -651,7 +807,7 @@ exports[`no-label-var > invalid 25`] = `
 }
 `;
 
-exports[`no-label-var > invalid 26`] = `
+exports[`no-label-var > invalid 32`] = `
 {
   "code": "Array: for (;;) { break Array; }",
   "diagnostics": [
@@ -677,7 +833,7 @@ exports[`no-label-var > invalid 26`] = `
 }
 `;
 
-exports[`no-label-var > invalid 27`] = `
+exports[`no-label-var > invalid 33`] = `
 {
   "code": "Math: for (;;) { break Math; }",
   "diagnostics": [
@@ -703,7 +859,7 @@ exports[`no-label-var > invalid 27`] = `
 }
 `;
 
-exports[`no-label-var > invalid 28`] = `
+exports[`no-label-var > invalid 34`] = `
 {
   "code": "Symbol: for (;;) { break Symbol; }",
   "diagnostics": [

--- a/packages/rslint-test-tools/tests/eslint/rules/no-label-var.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-label-var.test.ts
@@ -16,9 +16,10 @@ ruleTester.run('no-label-var', {
     'for (const k in obj) { q: for(;;) { break q; } }',
     'for (const v of arr) { q: for(;;) { break q; } }',
 
-    // ---- TS type-only declarations should NOT clash (only values count) ----
-    'interface X {} X: for(;;) { break X; }',
-    'type X = number; X: for(;;) { break X; }',
+    // ---- Type-only names in sibling scopes are not visible ----
+    'function f<T>() {} T: for(;;) { break T; }',
+    'function f() { type X = number; } X: for(;;) { break X; }',
+    'export {}; declare global { interface X {} } X: for(;;) { break X; }',
 
     // ---- Nested label inside iteration; outer var has different name ----
     'var x = 1; function f() { y: for(;;) { break y; } }',
@@ -44,6 +45,32 @@ ruleTester.run('no-label-var', {
     {
       code: 'function bar(x) { x: for(;;) { break x; } }',
       errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 19 }],
+    },
+
+    // ---- TypeScript type-space bindings ----
+    {
+      code: 'interface X {} X: for(;;) { break X; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 16 }],
+    },
+    {
+      code: 'type X = number; X: for(;;) { break X; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 18 }],
+    },
+    {
+      code: 'function f<T>() { T: for(;;) { break T; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 19 }],
+    },
+    {
+      code: 'class C<T> { static m() { T: for(;;) { break T; } } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 27 }],
+    },
+    {
+      code: 'Record: for(;;) { break Record; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 1 }],
+    },
+    {
+      code: 'export {}; Record: for(;;) { break Record; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 12 }],
     },
 
     // ---- Local-binding clashes (strategy A path) ----
@@ -132,8 +159,7 @@ ruleTester.run('no-label-var', {
       errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 27 }],
     },
 
-    // ---- Globals from tsgo lib (strategy B path; requires TypeChecker) ----
-    // Use ES standard built-ins so the assertion holds without `lib: ["dom"]`.
+    // ---- ECMAScript globals ----
     {
       code: 'Promise: for (;;) { break Promise; }',
       errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 1 }],


### PR DESCRIPTION
## Summary

- resolve same-file bindings across TypeScript value, type, namespace, and alias spaces
- include scope-manager default TypeScript type globals without reading active tsconfig libraries
- preserve ordinary JavaScript, host-library, module augmentation, wrapper-binding, and globals override behavior
- match scope-manager lexical handling of class type parameters in static members

## Validation

- targeted Go tests for RefStore and no-label-var
- production CLI build
- exact differential against ESLint 10.8.0 and @typescript-eslint/parser 8.65.0
- 205 diagnostics matched exactly across all default type globals, local type scopes, static members, modules, host and ambient globals, JavaScript ECMAScript versions, and globals overrides