### PR TITLE
docs(promise): record each rule's aligned upstream version

### DIFF
--- a/internal/plugins/promise/rules/always_return/always_return.md
+++ b/internal/plugins/promise/rules/always_return/always_return.md
@@ -94,4 +94,5 @@ None known.
 
 ## Original Documentation
 
-- [eslint-plugin-promise: always-return](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/always-return.md)
+- [eslint-plugin-promise: always-return](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/always-return.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/always-return.js)

--- a/internal/plugins/promise/rules/avoid_new/avoid_new.md
+++ b/internal/plugins/promise/rules/avoid_new/avoid_new.md
@@ -27,4 +27,5 @@ new Promise.resolve();
 
 ## Original Documentation
 
-- [eslint-plugin-promise: avoid-new](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/avoid-new.md)
+- [eslint-plugin-promise: avoid-new](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/avoid-new.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/avoid-new.js)

--- a/internal/plugins/promise/rules/catch_or_return/catch_or_return.md
+++ b/internal/plugins/promise/rules/catch_or_return/catch_or_return.md
@@ -103,4 +103,5 @@ None known.
 
 ## Original Documentation
 
-- [eslint-plugin-promise: catch-or-return](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/catch-or-return.md)
+- [eslint-plugin-promise: catch-or-return](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/catch-or-return.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/catch-or-return.js)

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.md
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.md
@@ -63,3 +63,8 @@ whatever.then(() => process.nextTick(cb))              // error
 ## Differences from ESLint
 
 None. The rule behaves identically to the upstream `eslint-plugin-promise` implementation.
+
+## Original Documentation
+
+- [eslint-plugin-promise: no-callback-in-promise](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-callback-in-promise.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-callback-in-promise.js)

--- a/internal/plugins/promise/rules/no_multiple_resolved/no_multiple_resolved.md
+++ b/internal/plugins/promise/rules/no_multiple_resolved/no_multiple_resolved.md
@@ -83,4 +83,5 @@ new Promise(async (resolve, reject) => {
 
 ## Original Documentation
 
-- [eslint-plugin-promise: no-multiple-resolved](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-multiple-resolved.md)
+- [eslint-plugin-promise: no-multiple-resolved](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-multiple-resolved.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-multiple-resolved.js)

--- a/internal/plugins/promise/rules/no_nesting/no_nesting.md
+++ b/internal/plugins/promise/rules/no_nesting/no_nesting.md
@@ -45,4 +45,5 @@ doThing().then(function () {
 
 ## Original Documentation
 
-https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-nesting.md
+- [eslint-plugin-promise: no-nesting](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-nesting.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-nesting.js)

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics.md
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics.md
@@ -38,4 +38,5 @@ This rule provides an autofix that removes the `new` keyword.
 
 ## Original Documentation
 
-- [eslint-plugin-promise: no-new-statics](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-new-statics.md)
+- [eslint-plugin-promise: no-new-statics](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-new-statics.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-new-statics.js)

--- a/internal/plugins/promise/rules/no_promise_in_callback/no_promise_in_callback.md
+++ b/internal/plugins/promise/rules/no_promise_in_callback/no_promise_in_callback.md
@@ -76,4 +76,5 @@ None known.
 
 ## Original Documentation
 
-- [eslint-plugin-promise: no-promise-in-callback](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-promise-in-callback.md)
+- [eslint-plugin-promise: no-promise-in-callback](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-promise-in-callback.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-promise-in-callback.js)

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
@@ -28,7 +28,8 @@ myPromise.finally(() => {})
 
 ## Original Documentation
 
-https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-return-in-finally.md
+- [eslint-plugin-promise: no-return-in-finally](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-return-in-finally.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-return-in-finally.js)
 
 ## ESLint Parity and Compatibility
 

--- a/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.md
+++ b/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.md
@@ -60,4 +60,5 @@ None known.
 
 ## Original Documentation
 
-- [eslint-plugin-promise: no-return-wrap](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-return-wrap.md)
+- [eslint-plugin-promise: no-return-wrap](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-return-wrap.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-return-wrap.js)

--- a/internal/plugins/promise/rules/param_names/param_names.md
+++ b/internal/plugins/promise/rules/param_names/param_names.md
@@ -57,5 +57,5 @@ new Promise(function (resolve, no) {});
 
 ## Original Documentation
 
-- [eslint-plugin-promise: param-names](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.2.1/docs/rules/param-names.md)
-- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.2.1/rules/param-names.js)
+- [eslint-plugin-promise: param-names](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/param-names.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/param-names.js)

--- a/internal/plugins/promise/rules/param_names/param_names.md
+++ b/internal/plugins/promise/rules/param_names/param_names.md
@@ -57,4 +57,5 @@ new Promise(function (resolve, no) {});
 
 ## Original Documentation
 
-- [eslint-plugin-promise: param-names](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/param-names.md)
+- [eslint-plugin-promise: param-names](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.2.1/docs/rules/param-names.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.2.1/rules/param-names.js)

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.md
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.md
@@ -78,4 +78,5 @@ async function foo() {
 
 ## Original Documentation
 
-https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-await-to-then.md
+- [eslint-plugin-promise: prefer-await-to-then](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/prefer-await-to-then.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/prefer-await-to-then.js)

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
@@ -30,4 +30,5 @@ Fixed an upstream autofix bug: `x.then(a, b, c)` now fixes to `x.catch(b).then(a
 
 ## Original Documentation
 
-- [eslint-plugin-promise: prefer-catch](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-catch.md)
+- [eslint-plugin-promise: prefer-catch](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/prefer-catch.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/prefer-catch.js)

--- a/internal/plugins/promise/rules/valid_params/valid_params.md
+++ b/internal/plugins/promise/rules/valid_params/valid_params.md
@@ -57,4 +57,5 @@ None known.
 
 ## Original Documentation
 
-- [eslint-plugin-promise: valid-params](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/valid-params.md)
+- [eslint-plugin-promise: valid-params](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/valid-params.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/valid-params.js)


### PR DESCRIPTION
## Summary

- Every `promise/` rule doc now pins its "Original Documentation" links to `eslint-plugin-promise@v7.3.0` — the latest release, and current for all 14 rules since 13 of them were ported after it shipped (2026-04-27) and no newer release has appeared since. The 14th, `param-names`, was ported 8 days before v7.3.0 shipped, but its rule source and doc are byte-identical between v7.2.1 and v7.3.0 (confirmed via the GitHub compare API), so it's pinned to v7.3.0 too for consistency.
- Added the previously-missing "Source code" link to every rule and unified the doc link text.
- Filled in a wholly missing "Original Documentation" section on `no-callback-in-promise`, and preserved `no-return-in-finally`'s trailing "ESLint Parity and Compatibility" section unchanged.
- Verified every doc and source path exists at its pinned tag before writing the links.

## Related Links

- `always-return`: #938
- `avoid-new`: #1053
- `catch-or-return`: #1051
- `no-callback-in-promise`: #1057
- `no-multiple-resolved`: #1055
- `no-nesting`: #1056
- `no-new-statics`: #1052
- `no-promise-in-callback`: #1065
- `no-return-in-finally`: #1058
- `no-return-wrap`: #937
- `param-names`: #717
- `prefer-await-to-then`: #1059
- `prefer-catch`: #1060
- `valid-params`: #1067

## Checklist

- [x] Tests updated (or not required) — docs-only change.
- [x] Documentation updated (or not required).