### PR TITLE
docs(jsx-a11y): record each rule's aligned upstream version

### DIFF
--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text.md
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text.md
@@ -130,4 +130,5 @@ These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/alt-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md)
+- [eslint-plugin-jsx-a11y: alt-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/alt-text.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/alt-text.js)

--- a/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.md
+++ b/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.md
@@ -106,4 +106,5 @@ with the more concise and accessible:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/anchor-ambiguous-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-ambiguous-text.md)
+- [eslint-plugin-jsx-a11y: anchor-ambiguous-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/anchor-ambiguous-text.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/anchor-ambiguous-text.js)

--- a/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.md
+++ b/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.md
@@ -64,4 +64,5 @@ Examples of **correct** code for this rule with `{ "components": ["Anchor"] }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/anchor-has-content](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-has-content.md)
+- [eslint-plugin-jsx-a11y: anchor-has-content](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/anchor-has-content.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/anchor-has-content.js)

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.md
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.md
@@ -102,4 +102,5 @@ the `onClick` does not redirect the report.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/anchor-is-valid](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md)
+- [eslint-plugin-jsx-a11y: anchor-is-valid](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/anchor-is-valid.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/anchor-is-valid.js)

--- a/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.md
+++ b/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.md
@@ -54,4 +54,5 @@ This rule takes no options.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/aria-activedescendant-has-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md)
+- [eslint-plugin-jsx-a11y: aria-activedescendant-has-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/aria-activedescendant-has-tabindex.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/aria-activedescendant-has-tabindex.js)

--- a/internal/plugins/jsx_a11y/rules/aria_props/aria_props.md
+++ b/internal/plugins/jsx_a11y/rules/aria_props/aria_props.md
@@ -48,4 +48,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-props.md)
+- [eslint-plugin-jsx-a11y: aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/aria-props.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/aria-props.js)

--- a/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.md
+++ b/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.md
@@ -90,4 +90,5 @@ This rule takes no options.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/aria-proptypes](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md)
+- [eslint-plugin-jsx-a11y: aria-proptypes](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/aria-proptypes.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/aria-proptypes.js)

--- a/internal/plugins/jsx_a11y/rules/aria_role/aria_role.md
+++ b/internal/plugins/jsx_a11y/rules/aria_role/aria_role.md
@@ -96,4 +96,5 @@ Examples of **incorrect** code with `{ "ignoreNonDOM": true }` (a real DOM eleme
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/aria-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-role.md)
+- [eslint-plugin-jsx-a11y: aria-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/aria-role.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/aria-role.js)

--- a/internal/plugins/jsx_a11y/rules/aria_unsupported_elements/aria_unsupported_elements.md
+++ b/internal/plugins/jsx_a11y/rules/aria_unsupported_elements/aria_unsupported_elements.md
@@ -36,4 +36,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/aria-unsupported-elements](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-unsupported-elements.md)
+- [eslint-plugin-jsx-a11y: aria-unsupported-elements](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/aria-unsupported-elements.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/aria-unsupported-elements.js)

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.md
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.md
@@ -115,4 +115,5 @@ These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/autocomplete-valid](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md)
+- [eslint-plugin-jsx-a11y: autocomplete-valid](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/autocomplete-valid.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/autocomplete-valid.js)

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.md
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.md
@@ -57,4 +57,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/click-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md)
+- [eslint-plugin-jsx-a11y: click-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/click-events-have-key-events.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/click-events-have-key-events.js)

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.md
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.md
@@ -161,4 +161,5 @@ Examples of **correct** code for this rule with
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/control-has-associated-label](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/control-has-associated-label.md)
+- [eslint-plugin-jsx-a11y: control-has-associated-label](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/control-has-associated-label.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/control-has-associated-label.js)

--- a/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content.md
+++ b/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content.md
@@ -67,4 +67,5 @@ Examples of **correct** code for this rule with `{ "components": ["Heading"] }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/heading-has-content](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/heading-has-content.md)
+- [eslint-plugin-jsx-a11y: heading-has-content](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/heading-has-content.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/heading-has-content.js)

--- a/internal/plugins/jsx_a11y/rules/html_has_lang/html_has_lang.md
+++ b/internal/plugins/jsx_a11y/rules/html_has_lang/html_has_lang.md
@@ -47,4 +47,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/html-has-lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/html-has-lang.md)
+- [eslint-plugin-jsx-a11y: html-has-lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/html-has-lang.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/html-has-lang.js)

--- a/internal/plugins/jsx_a11y/rules/iframe_has_title/iframe_has_title.md
+++ b/internal/plugins/jsx_a11y/rules/iframe_has_title/iframe_has_title.md
@@ -57,4 +57,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/iframe-has-title](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/iframe-has-title.md)
+- [eslint-plugin-jsx-a11y: iframe-has-title](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/iframe-has-title.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/iframe-has-title.js)

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.md
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.md
@@ -90,4 +90,5 @@ Examples of **correct** code with `{ "words": ["Bild", "Foto"] }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/img-redundant-alt](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md)
+- [eslint-plugin-jsx-a11y: img-redundant-alt](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/img-redundant-alt.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/img-redundant-alt.js)

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.md
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.md
@@ -96,4 +96,5 @@ Examples of **correct** code with `{ "tabbable": ["button"] }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/interactive-supports-focus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/interactive-supports-focus.md)
+- [eslint-plugin-jsx-a11y: interactive-supports-focus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/interactive-supports-focus.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/interactive-supports-focus.js)

--- a/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.md
+++ b/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.md
@@ -208,4 +208,5 @@ These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/label-has-associated-control](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/label-has-associated-control.md)
+- [eslint-plugin-jsx-a11y: label-has-associated-control](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/label-has-associated-control.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/label-has-associated-control.js)

--- a/internal/plugins/jsx_a11y/rules/lang/lang.md
+++ b/internal/plugins/jsx_a11y/rules/lang/lang.md
@@ -58,4 +58,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/lang.md)
+- [eslint-plugin-jsx-a11y: lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/lang.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/lang.js)

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.md
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.md
@@ -122,4 +122,5 @@ These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/media-has-caption](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md)
+- [eslint-plugin-jsx-a11y: media-has-caption](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/media-has-caption.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/media-has-caption.js)

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.md
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.md
@@ -97,4 +97,5 @@ corresponding pairing entirely.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/mouse-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md)
+- [eslint-plugin-jsx-a11y: mouse-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/mouse-events-have-key-events.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/mouse-events-have-key-events.js)

--- a/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.md
+++ b/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.md
@@ -41,4 +41,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-access-key](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-access-key.md)
+- [eslint-plugin-jsx-a11y: no-access-key](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-access-key.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-access-key.js)

--- a/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.md
+++ b/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.md
@@ -55,4 +55,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-aria-hidden-on-focusable](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md)
+- [eslint-plugin-jsx-a11y: no-aria-hidden-on-focusable](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-aria-hidden-on-focusable.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-aria-hidden-on-focusable.js)

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.md
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.md
@@ -71,4 +71,5 @@ Examples of **incorrect** code with `{ "ignoreNonDOM": true }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-autofocus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md)
+- [eslint-plugin-jsx-a11y: no-autofocus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-autofocus.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-autofocus.js)

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.md
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.md
@@ -100,4 +100,5 @@ These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-distracting-elements](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md)
+- [eslint-plugin-jsx-a11y: no-distracting-elements](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-distracting-elements.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-distracting-elements.js)

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.md
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.md
@@ -91,4 +91,5 @@ Examples of **incorrect** code with `{ "tr": ["none", "presentation"] }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-interactive-element-to-noninteractive-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md)
+- [eslint-plugin-jsx-a11y: no-interactive-element-to-noninteractive-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-interactive-element-to-noninteractive-role.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-interactive-element-to-noninteractive-role.js)

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.md
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.md
@@ -141,4 +141,5 @@ Examples of **incorrect** code with `{ "iframe": ["onError", "onLoad"] }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-noninteractive-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md)
+- [eslint-plugin-jsx-a11y: no-noninteractive-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-noninteractive-element-interactions.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-noninteractive-element-interactions.js)

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role.md
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role.md
@@ -98,4 +98,5 @@ Examples of **incorrect** code with `{ "ul": ["menu", "menubar"] }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-noninteractive-element-to-interactive-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md)
+- [eslint-plugin-jsx-a11y: no-noninteractive-element-to-interactive-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-noninteractive-element-to-interactive-role.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-noninteractive-element-to-interactive-role.js)

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.md
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.md
@@ -112,4 +112,5 @@ Examples of **correct** code with `{ "allowExpressionValues": true }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-noninteractive-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-tabindex.md)
+- [eslint-plugin-jsx-a11y: no-noninteractive-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-noninteractive-tabindex.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-noninteractive-tabindex.js)

--- a/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles.md
+++ b/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles.md
@@ -71,4 +71,5 @@ Examples of **correct** code for this rule with `{ "ul": ["list"], "ol": ["list"
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-redundant-roles](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-redundant-roles.md)
+- [eslint-plugin-jsx-a11y: no-redundant-roles](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-redundant-roles.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-redundant-roles.js)

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.md
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.md
@@ -120,4 +120,5 @@ Examples of **incorrect** code with `{ "allowExpressionValues": false }`:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/no-static-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md)
+- [eslint-plugin-jsx-a11y: no-static-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/no-static-element-interactions.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/no-static-element-interactions.js)

--- a/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.md
+++ b/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.md
@@ -67,4 +67,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/prefer-tag-over-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md)
+- [eslint-plugin-jsx-a11y: prefer-tag-over-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/prefer-tag-over-role.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/prefer-tag-over-role.js)

--- a/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.md
+++ b/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.md
@@ -45,4 +45,5 @@ This rule takes no options.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/role-has-required-aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md)
+- [eslint-plugin-jsx-a11y: role-has-required-aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/role-has-required-aria-props.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/role-has-required-aria-props.js)

--- a/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props.md
+++ b/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props.md
@@ -79,4 +79,5 @@ This rule takes no options.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/role-supports-aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-supports-aria-props.md)
+- [eslint-plugin-jsx-a11y: role-supports-aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/role-supports-aria-props.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/role-supports-aria-props.js)

--- a/internal/plugins/jsx_a11y/rules/scope/scope.md
+++ b/internal/plugins/jsx_a11y/rules/scope/scope.md
@@ -61,4 +61,5 @@ These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/scope](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/scope.md)
+- [eslint-plugin-jsx-a11y: scope](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/scope.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/scope.js)

--- a/internal/plugins/jsx_a11y/rules/tabindex_no_positive/tabindex_no_positive.md
+++ b/internal/plugins/jsx_a11y/rules/tabindex_no_positive/tabindex_no_positive.md
@@ -66,4 +66,5 @@ This rule takes no options.
 
 ## Original Documentation
 
-- [eslint-plugin-jsx-a11y/tabindex-no-positive](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/tabindex-no-positive.md)
+- [eslint-plugin-jsx-a11y: tabindex-no-positive](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/docs/rules/tabindex-no-positive.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/tabindex-no-positive.js)


### PR DESCRIPTION
## Summary

- Every `jsx_a11y/` rule doc now pins its "Original Documentation" links to `eslint-plugin-jsx-a11y@v6.10.2` — the latest release, both when these rules were ported and still today. v6.10.2 shipped 2025-01-05 and no newer release has appeared since.
- All 36 rules were ported 2026-05-08 through 2026-05-15 — well after v6.10.2 shipped — so there's a single unambiguous version for the whole plugin, unlike unicorn/promise where the port window straddled a release.
- Added the previously-missing "Source code" link to every rule; the doc link text/format was already consistent, only the `main`/`HEAD` refs needed pinning.
- Verified every doc and source path exists at the pinned tag before writing the links.

## Related Links

#874, #880, #881, #882, #884, #885, #886, #887, #889, #890, #891, #892, #893, #894, #899, #900, #902, #906, #907, #909, #912, #914, #915, #917, #918, #919, #920, #921, #923, #927, #928, #929, #939, #940, #942, #943

## Checklist

- [x] Tests updated (or not required) — docs-only change.
- [x] Documentation updated (or not required).