### PR TITLE
docs(react): record each rule's aligned upstream version

### DIFF
--- a/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming.md
+++ b/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming.md
@@ -134,5 +134,5 @@ inspect inside them. Examples:
 
 ## Original Documentation
 
-- [eslint-plugin-react / boolean-prop-naming](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/boolean-prop-naming.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/boolean-prop-naming.js)
+- [eslint-plugin-react: boolean-prop-naming](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/boolean-prop-naming.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/boolean-prop-naming.js)

--- a/internal/plugins/react/rules/button_has_type/button_has_type.md
+++ b/internal/plugins/react/rules/button_has_type/button_has_type.md
@@ -71,4 +71,5 @@ Examples of **correct** code with this configuration:
 
 ## Original Documentation
 
-- [react/button-has-type](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md)
+- [eslint-plugin-react: button-has-type](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/button-has-type.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/button-has-type.js)

--- a/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly.md
+++ b/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly.md
@@ -72,4 +72,5 @@ Examples of **correct** code for this rule with `{ "ignoreExclusiveCheckedAttrib
 
 ## Original Documentation
 
-- [react/checked-requires-onchange-or-readonly](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/checked-requires-onchange-or-readonly.md)
+- [eslint-plugin-react: checked-requires-onchange-or-readonly](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/checked-requires-onchange-or-readonly.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/checked-requires-onchange-or-readonly.js)

--- a/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.md
+++ b/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.md
@@ -130,4 +130,5 @@ function Foo(props) {
 
 ## Original Documentation
 
-- [eslint-plugin-react `destructuring-assignment`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md)
+- [eslint-plugin-react: destructuring-assignment](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/destructuring-assignment.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/destructuring-assignment.js)

--- a/internal/plugins/react/rules/display_name/display_name.md
+++ b/internal/plugins/react/rules/display_name/display_name.md
@@ -157,5 +157,5 @@ If you are not interested in giving every component a `displayName` and rely on 
 
 ## Original Documentation
 
-- [eslint-plugin-react / display-name](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/display-name.js)
+- [eslint-plugin-react: display-name](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/display-name.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/display-name.js)

--- a/internal/plugins/react/rules/forbid_component_props/forbid_component_props.md
+++ b/internal/plugins/react/rules/forbid_component_props/forbid_component_props.md
@@ -80,4 +80,5 @@ Combine several properties to cover more cases:
 
 ## Original Documentation
 
-- [eslint-plugin-react/forbid-component-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md)
+- [eslint-plugin-react: forbid-component-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/forbid-component-props.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/forbid-component-props.js)

--- a/internal/plugins/react/rules/forbid_dom_props/forbid_dom_props.md
+++ b/internal/plugins/react/rules/forbid_dom_props/forbid_dom_props.md
@@ -102,4 +102,5 @@ particular value on a particular DOM Node:
 
 ## Original Documentation
 
-- [eslint-plugin-react/forbid-dom-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md)
+- [eslint-plugin-react: forbid-dom-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/forbid-dom-props.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/forbid-dom-props.js)

--- a/internal/plugins/react/rules/forbid_elements/forbid_elements.md
+++ b/internal/plugins/react/rules/forbid_elements/forbid_elements.md
@@ -100,4 +100,5 @@ If you don't want to forbid any elements.
 
 ## Original Documentation
 
-- [eslint-plugin-react / forbid-elements](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md)
+- [eslint-plugin-react: forbid-elements](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/forbid-elements.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/forbid-elements.js)

--- a/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types.md
+++ b/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types.md
@@ -68,5 +68,5 @@ this rule disabled.
 
 ## Original Documentation
 
-- [eslint-plugin-react / forbid-foreign-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forbid-foreign-prop-types.js)
+- [eslint-plugin-react: forbid-foreign-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/forbid-foreign-prop-types.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/forbid-foreign-prop-types.js)

--- a/internal/plugins/react/rules/forbid_prop_types/forbid_prop_types.md
+++ b/internal/plugins/react/rules/forbid_prop_types/forbid_prop_types.md
@@ -131,5 +131,5 @@ This rule is a formatting/documenting preference and not following it won't nega
 
 ## Original Documentation
 
-- [eslint-plugin-react / forbid-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forbid-prop-types.js)
+- [eslint-plugin-react: forbid-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/forbid-prop-types.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/forbid-prop-types.js)

--- a/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref.md
+++ b/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref.md
@@ -36,5 +36,5 @@ This rule has no options.
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forward-ref-uses-ref.md
-- https://react.dev/reference/react/forwardRef
+- [eslint-plugin-react: forward-ref-uses-ref](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/forward-ref-uses-ref.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/forward-ref-uses-ref.js)

--- a/internal/plugins/react/rules/jsx_boolean_value/jsx_boolean_value.md
+++ b/internal/plugins/react/rules/jsx_boolean_value/jsx_boolean_value.md
@@ -28,4 +28,5 @@ Examples of **correct** code with the default `"never"` option:
 
 ## Original Documentation
 
-- [react/jsx-boolean-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
+- [eslint-plugin-react: jsx-boolean-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-boolean-value.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-boolean-value.js)

--- a/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing.md
+++ b/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing.md
@@ -62,4 +62,5 @@ Block-level elements (e.g. `<p>`, `<div>`) and custom components (e.g.
 
 ## Original Documentation
 
-- [react/jsx-child-element-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-child-element-spacing.md)
+- [eslint-plugin-react: jsx-child-element-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-child-element-spacing.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-child-element-spacing.js)

--- a/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.md
+++ b/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.md
@@ -172,4 +172,5 @@ If you are not using JSX, you can disable this rule.
 
 ## Original Documentation
 
-- [react/jsx-closing-bracket-location](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
+- [eslint-plugin-react: jsx-closing-bracket-location](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-closing-bracket-location.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-closing-bracket-location.js)

--- a/internal/plugins/react/rules/jsx_closing_tag_location/jsx_closing_tag_location.md
+++ b/internal/plugins/react/rules/jsx_closing_tag_location/jsx_closing_tag_location.md
@@ -28,4 +28,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [react/jsx-closing-tag-location](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md)
+- [eslint-plugin-react: jsx-closing-tag-location](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-closing-tag-location.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-closing-tag-location.js)

--- a/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.md
+++ b/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.md
@@ -74,4 +74,5 @@ The string shorthand sets `props` and `children` to the given value;
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md
+- [eslint-plugin-react: jsx-curly-brace-presence](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-curly-brace-presence.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-curly-brace-presence.js)

--- a/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing.md
+++ b/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing.md
@@ -150,4 +150,5 @@ Examples of **correct** code for this rule with `{ "children": true }`:
 
 ## Original Documentation
 
-- [eslint-plugin-react/jsx-curly-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md)
+- [eslint-plugin-react: jsx-curly-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-curly-spacing.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-curly-spacing.js)

--- a/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing.md
+++ b/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing.md
@@ -25,4 +25,5 @@ Examples of **correct** code with the default `"never"` option:
 
 ## Original Documentation
 
-- [react/jsx-equals-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md)
+- [eslint-plugin-react: jsx-equals-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-equals-spacing.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-equals-spacing.js)

--- a/internal/plugins/react/rules/jsx_filename_extension/jsx_filename_extension.md
+++ b/internal/plugins/react/rules/jsx_filename_extension/jsx_filename_extension.md
@@ -28,4 +28,5 @@ var Hello = <div>Hello</div>;
 
 ## Original Documentation
 
-- [react/jsx-filename-extension](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md)
+- [eslint-plugin-react: jsx-filename-extension](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-filename-extension.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-filename-extension.js)

--- a/internal/plugins/react/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.md
+++ b/internal/plugins/react/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.md
@@ -32,4 +32,5 @@ Examples of **correct** code with `"multiline-multiprop"` (default):
 
 ## Original Documentation
 
-- [react/jsx-first-prop-new-line](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md)
+- [eslint-plugin-react: jsx-first-prop-new-line](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-first-prop-new-line.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-first-prop-new-line.js)

--- a/internal/plugins/react/rules/jsx_fragments/jsx_fragments.md
+++ b/internal/plugins/react/rules/jsx_fragments/jsx_fragments.md
@@ -58,4 +58,5 @@ when an older React version is specified in shared settings.
 
 ## Original Documentation
 
-- [react/jsx-fragments](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md)
+- [eslint-plugin-react: jsx-fragments](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-fragments.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-fragments.js)

--- a/internal/plugins/react/rules/jsx_handler_names/jsx_handler_names.md
+++ b/internal/plugins/react/rules/jsx_handler_names/jsx_handler_names.md
@@ -110,4 +110,5 @@ If you are not using JSX, or if you don't want to enforce specific naming conven
 
 ## Original Documentation
 
-- [react/jsx-handler-names](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md)
+- [eslint-plugin-react: jsx-handler-names](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-handler-names.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-handler-names.js)

--- a/internal/plugins/react/rules/jsx_indent/jsx_indent.md
+++ b/internal/plugins/react/rules/jsx_indent/jsx_indent.md
@@ -111,4 +111,5 @@ If you are not using JSX, you can disable this rule. If you use a code formatter
 
 ## Original Documentation
 
-- [react/jsx-indent](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md)
+- [eslint-plugin-react: jsx-indent](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-indent.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-indent.js)

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.md
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.md
@@ -137,4 +137,5 @@ If you are not using JSX, you can disable this rule. If you use a code formatter
 
 ## Original Documentation
 
-- [react/jsx-indent-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md)
+- [eslint-plugin-react: jsx-indent-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-indent-props.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-indent-props.js)

--- a/internal/plugins/react/rules/jsx_key/jsx_key.md
+++ b/internal/plugins/react/rules/jsx_key/jsx_key.md
@@ -122,4 +122,5 @@ the JSX inside an iterable, you may want to disable this rule.
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
+- [eslint-plugin-react: jsx-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-key.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-key.js)

--- a/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth.md
+++ b/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth.md
@@ -117,4 +117,5 @@ If you are not using JSX then you can disable this rule.
 
 ## Original Documentation
 
-- [eslint-plugin-react/docs/rules/jsx-max-depth.md](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-depth.md)
+- [eslint-plugin-react: jsx-max-depth](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-max-depth.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-max-depth.js)

--- a/internal/plugins/react/rules/jsx_max_props_per_line/jsx_max_props_per_line.md
+++ b/internal/plugins/react/rules/jsx_max_props_per_line/jsx_max_props_per_line.md
@@ -27,4 +27,5 @@ Examples of **correct** code with the default `{ "maximum": 1, "when": "always" 
 
 ## Original Documentation
 
-- [react/jsx-max-props-per-line](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md)
+- [eslint-plugin-react: jsx-max-props-per-line](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-max-props-per-line.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-max-props-per-line.js)

--- a/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.md
+++ b/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.md
@@ -61,4 +61,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [eslint-plugin-react/jsx-no-bind](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md)
+- [eslint-plugin-react: jsx-no-bind](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-bind.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-bind.js)

--- a/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes.md
+++ b/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes.md
@@ -70,4 +70,5 @@ var Hello = createReactClass({
 
 ## Original Documentation
 
-- [eslint-plugin-react / jsx-no-comment-textnodes](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md)
+- [eslint-plugin-react: jsx-no-comment-textnodes](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-comment-textnodes.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-comment-textnodes.js)

--- a/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props.md
+++ b/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props.md
@@ -40,4 +40,5 @@ Examples of **incorrect** code for this rule with `{ "ignoreCase": true }`:
 
 ## Original Documentation
 
-- [eslint-plugin-react docs](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md)
+- [eslint-plugin-react: jsx-no-duplicate-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-duplicate-props.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-duplicate-props.js)

--- a/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.md
+++ b/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.md
@@ -90,4 +90,5 @@ const Component = ({ enabled, checked }) => {
 
 ## Original Documentation
 
-- ESLint plugin: [`react/jsx-no-leaked-render`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md)
+- [eslint-plugin-react: jsx-no-leaked-render](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-leaked-render.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-leaked-render.js)

--- a/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.md
+++ b/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.md
@@ -129,4 +129,5 @@ If your project does not need to enforce wrapping JSX text in expressions or has
 
 ## Original Documentation
 
-- [react/jsx-no-literals](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md)
+- [eslint-plugin-react: jsx-no-literals](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-literals.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-literals.js)

--- a/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.md
+++ b/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.md
@@ -64,4 +64,5 @@ If only settings should be used, the array option can be omitted:
 
 ## Original Documentation
 
-- [eslint-plugin-react/jsx-no-script-url](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-script-url.md)
+- [eslint-plugin-react: jsx-no-script-url](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-script-url.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-script-url.js)

--- a/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.md
+++ b/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.md
@@ -99,4 +99,5 @@ A few upstream implementation details deserve a note:
 
 ## Original Documentation
 
-- [eslint-plugin-react docs](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)
+- [eslint-plugin-react: jsx-no-target-blank](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-target-blank.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-target-blank.js)

--- a/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef.md
+++ b/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef.md
@@ -39,4 +39,5 @@ When `false` (default), a JSX tag identifier in a module (a file with `import`/`
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
+- [eslint-plugin-react: jsx-no-undef](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-undef.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-undef.js)

--- a/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
+++ b/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
@@ -113,5 +113,5 @@ Examples of **correct** code for this rule, when `allowLeadingUnderscore` is
 
 ## Original Documentation
 
-- ESLint-plugin-react rule: [https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)
-- Source: [https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-pascal-case.js](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-pascal-case.js)
+- [eslint-plugin-react: jsx-pascal-case](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-pascal-case.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-pascal-case.js)

--- a/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.md
+++ b/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.md
@@ -24,4 +24,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [react/jsx-props-no-multi-spaces](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-multi-spaces.md)
+- [eslint-plugin-react: jsx-props-no-multi-spaces](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-props-no-multi-spaces.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-props-no-multi-spaces.js)

--- a/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi.md
+++ b/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi.md
@@ -23,4 +23,5 @@ This rule has no options.
 
 ## Original Documentation
 
-- [react/jsx-props-no-spread-multi](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spread-multi.md)
+- [eslint-plugin-react: jsx-props-no-spread-multi](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-props-no-spread-multi.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-props-no-spread-multi.js)

--- a/internal/plugins/react/rules/jsx_uses_react/jsx_uses_react.md
+++ b/internal/plugins/react/rules/jsx_uses_react/jsx_uses_react.md
@@ -6,4 +6,5 @@ Prevent React from being incorrectly marked as unused when JSX is used. This rul
 
 ## Original Documentation
 
-- [react/jsx-uses-react](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md)
+- [eslint-plugin-react: jsx-uses-react](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-uses-react.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-uses-react.js)

--- a/internal/plugins/react/rules/jsx_uses_vars/jsx_uses_vars.md
+++ b/internal/plugins/react/rules/jsx_uses_vars/jsx_uses_vars.md
@@ -6,4 +6,5 @@ Prevent variables used in JSX from being incorrectly marked as unused. This rule
 
 ## Original Documentation
 
-- [react/jsx-uses-vars](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md)
+- [eslint-plugin-react: jsx-uses-vars](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-uses-vars.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-uses-vars.js)

--- a/internal/plugins/react/rules/jsx_wrap_multilines/jsx_wrap_multilines.md
+++ b/internal/plugins/react/rules/jsx_wrap_multilines/jsx_wrap_multilines.md
@@ -47,4 +47,5 @@ Properties:
 
 ## Original Documentation
 
-- [react/jsx-wrap-multilines](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)
+- [eslint-plugin-react: jsx-wrap-multilines](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-wrap-multilines.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-wrap-multilines.js)

--- a/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.md
+++ b/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.md
@@ -70,4 +70,5 @@ class Hello extends React.Component {
 
 ## Original Documentation
 
-- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md
+- [eslint-plugin-react: no-access-state-in-setstate](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-access-state-in-setstate.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-access-state-in-setstate.js)

--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key.md
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key.md
@@ -67,5 +67,5 @@ If you have a stable list of items that will never be reordered, inserted into, 
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-array-index-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-array-index-key.js)
+- [eslint-plugin-react: no-array-index-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-array-index-key.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-array-index-key.js)

--- a/internal/plugins/react/rules/no_children_prop/no_children_prop.md
+++ b/internal/plugins/react/rules/no_children_prop/no_children_prop.md
@@ -69,4 +69,5 @@ React.createElement(MyComponent, {}, () => <div />)
 
 ## Original Documentation
 
-- [eslint-plugin-react/no-children-prop](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md)
+- [eslint-plugin-react: no-children-prop](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-children-prop.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-children-prop.js)

--- a/internal/plugins/react/rules/no_danger/no_danger.md
+++ b/internal/plugins/react/rules/no_danger/no_danger.md
@@ -67,4 +67,5 @@ has already been sanitized.
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md
+- [eslint-plugin-react: no-danger](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-danger.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-danger.js)

--- a/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.md
+++ b/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.md
@@ -43,4 +43,5 @@ React.createElement("div", {}, "Children");
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md
+- [eslint-plugin-react: no-danger-with-children](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-danger-with-children.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-danger-with-children.js)

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated.md
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated.md
@@ -94,4 +94,5 @@ rslint flags these forms; ESLint does not:
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md
+- [eslint-plugin-react: no-deprecated](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-deprecated.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-deprecated.js)

--- a/internal/plugins/react/rules/no_did_mount_set_state/no_did_mount_set_state.md
+++ b/internal/plugins/react/rules/no_did_mount_set_state/no_did_mount_set_state.md
@@ -95,4 +95,5 @@ The rule is a no-op when `settings.react.version` is explicitly set to
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-did-mount-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md)
+- [eslint-plugin-react: no-did-mount-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-did-mount-set-state.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-did-mount-set-state.js)

--- a/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state.md
+++ b/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state.md
@@ -86,4 +86,5 @@ The rule is a no-op when `settings.react.version` is explicitly set to
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-did-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md)
+- [eslint-plugin-react: no-did-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-did-update-set-state.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-did-update-set-state.js)

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.md
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.md
@@ -68,4 +68,5 @@ class Hello {
 
 ## Original Documentation
 
-- [eslint-plugin-react `no-direct-mutation-state`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md)
+- [eslint-plugin-react: no-direct-mutation-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-direct-mutation-state.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-direct-mutation-state.js)

--- a/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node.md
+++ b/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node.md
@@ -53,4 +53,5 @@ class MyComponent extends Component {
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-find-dom-node](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md)
+- [eslint-plugin-react: no-find-dom-node](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-find-dom-node.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-find-dom-node.js)

--- a/internal/plugins/react/rules/no_is_mounted/no_is_mounted.md
+++ b/internal/plugins/react/rules/no_is_mounted/no_is_mounted.md
@@ -74,4 +74,5 @@ class Hello extends React.Component {
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-is-mounted](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md)
+- [eslint-plugin-react: no-is-mounted](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-is-mounted.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-is-mounted.js)

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp.md
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp.md
@@ -87,5 +87,5 @@ If you prefer to declare multiple components per file you can disable this rule.
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-multi-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-multi-comp.js)
+- [eslint-plugin-react: no-multi-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-multi-comp.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-multi-comp.js)

--- a/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.md
+++ b/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.md
@@ -69,4 +69,5 @@ class Qux extends React.PureComponent {
 
 ## Original Documentation
 
-- [eslint-plugin-react: no-redundant-should-component-update](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md)
+- [eslint-plugin-react: no-redundant-should-component-update](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-redundant-should-component-update.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-redundant-should-component-update.js)

--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value.md
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value.md
@@ -53,4 +53,5 @@ upstream's default branch.
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-render-return-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md)
+- [eslint-plugin-react: no-render-return-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-render-return-value.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-render-return-value.js)

--- a/internal/plugins/react/rules/no_set_state/no_set_state.md
+++ b/internal/plugins/react/rules/no_set_state/no_set_state.md
@@ -78,4 +78,5 @@ class Hello extends React.Component {
 
 ## Original Documentation
 
-- [eslint-plugin-react `no-set-state`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-set-state.md)
+- [eslint-plugin-react: no-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-set-state.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-set-state.js)

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs.md
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs.md
@@ -77,4 +77,5 @@ var Hello = createReactClass({
 
 ## Original Documentation
 
-- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
+- [eslint-plugin-react: no-string-refs](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-string-refs.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-string-refs.js)

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.md
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.md
@@ -82,4 +82,5 @@ const Foo = createReactClass({
 
 ## Original Documentation
 
-- [eslint-plugin-react `no-this-in-sfc`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md)
+- [eslint-plugin-react: no-this-in-sfc](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-this-in-sfc.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-this-in-sfc.js)

--- a/internal/plugins/react/rules/no_typos/no_typos.md
+++ b/internal/plugins/react/rules/no_typos/no_typos.md
@@ -117,4 +117,5 @@ MyComponent.propTypes = {
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-typos](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-typos.md)
+- [eslint-plugin-react: no-typos](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-typos.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-typos.js)

--- a/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.md
+++ b/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.md
@@ -51,4 +51,5 @@ TypeScript's JSX parser rejects unescaped `>` and `}` in JSX text with a syntax 
 
 ## Original Documentation
 
-- [react/no-unescaped-entities](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md)
+- [eslint-plugin-react: no-unescaped-entities](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-unescaped-entities.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-unescaped-entities.js)

--- a/internal/plugins/react/rules/no_unknown_property/no_unknown_property.md
+++ b/internal/plugins/react/rules/no_unknown_property/no_unknown_property.md
@@ -102,4 +102,5 @@ When the version is not set, the rule assumes the latest React.
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-unknown-property](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md)
+- [eslint-plugin-react: no-unknown-property](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-unknown-property.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-unknown-property.js)

--- a/internal/plugins/react/rules/no_unsafe/no_unsafe.md
+++ b/internal/plugins/react/rules/no_unsafe/no_unsafe.md
@@ -83,5 +83,5 @@ This rule is influenced by the shared React settings:
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-unsafe](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unsafe.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unsafe.js)
+- [eslint-plugin-react: no-unsafe](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-unsafe.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-unsafe.js)

--- a/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.md
+++ b/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.md
@@ -101,4 +101,5 @@ function ParentComponent() {
 
 ## Original Documentation
 
-- [eslint-plugin-react no-unstable-nested-components](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md)
+- [eslint-plugin-react: no-unstable-nested-components](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-unstable-nested-components.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-unstable-nested-components.js)

--- a/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.md
+++ b/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.md
@@ -64,4 +64,5 @@ always ignored, even when unused.
 
 ## Original Documentation
 
-- [react/no-unused-class-component-methods](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-class-component-methods.md)
+- [eslint-plugin-react: no-unused-class-component-methods](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-unused-class-component-methods.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-unused-class-component-methods.js)

--- a/internal/plugins/react/rules/no_unused_state/no_unused_state.md
+++ b/internal/plugins/react/rules/no_unused_state/no_unused_state.md
@@ -49,5 +49,5 @@ class MyComponent extends React.Component {
 
 ## Original Documentation
 
-- [eslint-plugin-react/no-unused-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-state.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unused-state.js)
+- [eslint-plugin-react: no-unused-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-unused-state.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-unused-state.js)

--- a/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state.md
+++ b/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state.md
@@ -93,4 +93,5 @@ renamed alias) is also flagged, matching `eslint-plugin-react`'s
 
 ## Original Documentation
 
-- [eslint-plugin-react / no-will-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md)
+- [eslint-plugin-react: no-will-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/no-will-update-set-state.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/no-will-update-set-state.js)

--- a/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class.md
+++ b/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class.md
@@ -80,4 +80,5 @@ The rule honors the shared React settings:
 
 ## Original Documentation
 
-- [eslint-plugin-react `prefer-es6-class`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md)
+- [eslint-plugin-react: prefer-es6-class](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/prefer-es6-class.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/prefer-es6-class.js)

--- a/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.md
+++ b/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.md
@@ -73,4 +73,5 @@ class Foo extends React.PureComponent {
 
 ## Original Documentation
 
-- [react/prefer-stateless-function](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md)
+- [eslint-plugin-react: prefer-stateless-function](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/prefer-stateless-function.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/prefer-stateless-function.js)

--- a/internal/plugins/react/rules/react_in_jsx_scope/react_in_jsx_scope.md
+++ b/internal/plugins/react/rules/react_in_jsx_scope/react_in_jsx_scope.md
@@ -6,4 +6,5 @@ Prevent missing React import when using JSX. This rule is implemented as a no-op
 
 ## Original Documentation
 
-- [react/react-in-jsx-scope](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md)
+- [eslint-plugin-react: react-in-jsx-scope](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/react-in-jsx-scope.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/react-in-jsx-scope.js)

--- a/internal/plugins/react/rules/require_optimization/require_optimization.md
+++ b/internal/plugins/react/rules/require_optimization/require_optimization.md
@@ -79,5 +79,5 @@ The decorator name must appear as a bare identifier in the class's decorator lis
 
 ## Original Documentation
 
-- [eslint-plugin-react: require-optimization](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-optimization.md)
-- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/require-optimization.js)
+- [eslint-plugin-react: require-optimization](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/require-optimization.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/require-optimization.js)

--- a/internal/plugins/react/rules/require_render_return/require_render_return.md
+++ b/internal/plugins/react/rules/require_render_return/require_render_return.md
@@ -89,4 +89,5 @@ class Hello extends React.Component {
 
 ## Original Documentation
 
-- [eslint-plugin-react / require-render-return](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-render-return.md)
+- [eslint-plugin-react: require-render-return](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/require-render-return.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/require-render-return.js)

--- a/internal/plugins/react/rules/self_closing_comp/self_closing_comp.md
+++ b/internal/plugins/react/rules/self_closing_comp/self_closing_comp.md
@@ -26,4 +26,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [react/self-closing-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md)
+- [eslint-plugin-react: self-closing-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/self-closing-comp.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/self-closing-comp.js)

--- a/internal/plugins/react/rules/style_prop_object/style_prop_object.md
+++ b/internal/plugins/react/rules/style_prop_object/style_prop_object.md
@@ -28,4 +28,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [react/style-prop-object](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/style-prop-object.md)
+- [eslint-plugin-react: style-prop-object](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/style-prop-object.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/style-prop-object.js)

--- a/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.md
+++ b/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.md
@@ -28,4 +28,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [react/void-dom-elements-no-children](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md)
+- [eslint-plugin-react: void-dom-elements-no-children](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/void-dom-elements-no-children.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/void-dom-elements-no-children.js)


### PR DESCRIPTION
## Summary

- Every `react/` rule doc now pins its "Original Documentation" links to `eslint-plugin-react@v7.37.5` — the latest release, both when these rules were ported and still today. v7.37.5 shipped 2025-04-03 and no newer release has appeared since.
- All 74 rules were ported 2026-03-12 through 2026-07-06 — well after v7.37.5 shipped — so there's a single unambiguous version for the whole plugin.
- Added the previously-missing "Source code" link to 66 rules and unified the link text, which was a mix of 4 different styles including a malformed doubly-bracketed link on `jsx-pascal-case`.
- Fixed `jsx-no-target-blank`, whose doc link pointed at the plugin's `README.md#configuration` instead of its actual rule doc, which exists upstream.
- Verified every doc and source path exists at the pinned tag before writing the links.

## Related Links

#494, #689, #691, #718, #719, #738, #739, #740, #741, #742, #743, #744, #745, #746, #747, #749, #750, #751, #752, #754, #755, #756, #757, #759, #760, #761, #769, #770, #794, #796, #797, #798, #799, #800, #801, #846, #847, #848, #849, #850, #851, #852, #853, #854, #857, #858, #859, #861, #862, #863, #865, #866, #867, #868, #869, #871, #872, #1030, #1198, #1200, #1205

## Checklist

- [x] Tests updated (or not required) — docs-only change.
- [x] Documentation updated (or not required).