### PR TITLE
docs(react-hooks): record each rule's aligned upstream version

### DIFF
--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
@@ -143,4 +143,4 @@ The rule accepts a single options object:
 ## Original Documentation
 
 - [react.dev — Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
-- [Source code](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts)
+- [Source code](https://github.com/facebook/react/blob/eslint-plugin-react-hooks@7.1.1/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts)

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
@@ -120,4 +120,4 @@ callbacks. Defaults to none.
 ## Original Documentation
 
 - [react.dev — Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
-- [Source code](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts)
+- [Source code](https://github.com/facebook/react/blob/eslint-plugin-react-hooks@7.1.1/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts)


### PR DESCRIPTION
## Summary

- Both `react_hooks/` rules now pin their "Source code" link to `eslint-plugin-react-hooks@7.1.1` — the release current when both were ported (2026-04-26, 9 days after 7.1.1 shipped). Only three tags have ever been cut for this package (`5.0.0`, `7.1.0`, `7.1.1`), and no new stable release has appeared since despite ~20 `7.1.1-canary-*` prereleases published in the meantime — the `latest` dist-tag on npm is still `7.1.1` as of today.
- The doc link stays on `react.dev`, unpinned — it's a custom site with no per-release versioning, same treatment as `eslint.org` and `typescript-eslint.io`.
- Verified both source paths exist at the pinned tag before writing the links.

## Related Links

#806, #808

## Checklist

- [x] Tests updated (or not required) — docs-only change.
- [x] Documentation updated (or not required).