### PR TITLE
fix: align no-shadow with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_shadow/no_shadow.go
+++ b/internal/plugins/typescript/rules/no_shadow/no_shadow.go
@@ -11,10 +11,9 @@ import (
 var schemaJSON []byte
 
 // NoShadowRule is the typescript-eslint wrapper around the core no-shadow
-// implementation. The rule shares the entire scope/shadow-detection pipeline
-// with the ESLint core rule (`internal/rules/no_shadow`); the only behavioral
-// difference is the default `hoist` option, which is `functions-and-types`
-// here versus `functions` in core ESLint.
+// implementation. The rule shares the scope/shadow-detection pipeline with
+// the ESLint core rule (`internal/rules/no_shadow`) while selecting
+// typescript-eslint's defaults and its default TypeScript type globals.
 var NoShadowRule = rule.CreateRule(rule.Rule{
 	Name:   "no-shadow",
 	Schema: rule.NewSchema(schemaJSON),

--- a/internal/plugins/typescript/rules/no_shadow/no_shadow_test.go
+++ b/internal/plugins/typescript/rules/no_shadow/no_shadow_test.go
@@ -60,22 +60,27 @@ function foo() {
   var Object = 0;
 }
 			`},
-			// parserOptions.lib / TypeScript's default libraries do not configure
-			// ESLint host globals, even for the typescript-eslint variant.
-			{Code: `function foo(window: number, top: number, console: number) {}`,
+			// Host-library names are not part of scope-manager's default esnext
+			// type globals.
+			{Code: `function foo(window: number, NodeListOf: number, HTMLElement: number) {}`,
 				Options: map[string]interface{}{"builtinGlobals": true}},
+			{Code: `function foo(Record: number) {}`,
+				Options: map[string]interface{}{"builtinGlobals": false}},
 
-			// ---- ctx.Globals: an explicit `off` setting (config
-			// `Array: "off"` / `/* global Array: off */`) un-declares the
-			// builtin, so shadowing it stays silent even under
-			// `builtinGlobals: true` ----
+			// Type-only declarations do not shadow implicit globals while
+			// ignoreTypeValueShadow is enabled (the default).
 			{Code: `
-function fn(Array: number) {}
-			`, Options: map[string]interface{}{"builtinGlobals": true}, Globals: map[string]any{"Array": "off"}},
-			{Code: `
-/* global Array: off */
-declare const Array: (environment: 'dev' | 'prod' | 'test') => boolean;
+function fn() {
+  type Record = string;
+}
 			`, Options: map[string]interface{}{"builtinGlobals": true}},
+			{Code: `
+function fn() {
+  type ConfiguredType = string;
+}
+			`, Options: map[string]interface{}{"builtinGlobals": true}, Globals: map[string]any{"ConfiguredType": "readonly"}},
+			{Code: `type Fn = (ConfiguredType: number) => void;`,
+				Options: map[string]interface{}{"builtinGlobals": true}, Globals: map[string]any{"ConfiguredType": "readonly"}},
 
 			// ---- this params ----
 			{Code: `
@@ -600,10 +605,6 @@ declare function doWork(): Promise<void>;
 const reducer = <S, A>(initial: S, fn: (s: S, a: A) => S) =>
   (state: S, action: A) => fn(state, action);
 			`},
-
-			// ---- Function-name initializer exception with TS wrappers ----
-			{Code: `(function() { var f = (function f() {} as any); f() }())`},
-			{Code: `(function() { var A = (class A {} satisfies object); })()`},
 
 			// ---- Destructuring with defaults — outer name reuse in default expr ----
 			{Code: `
@@ -1179,6 +1180,61 @@ function doThing(foo: number, bar: number) {}
 					},
 				},
 			},
+			// A type-only sibling specifier does not turn a value import into a
+			// type import in the typescript-eslint extension.
+			{
+				Code: `
+import { request, type Server } from 'node:http';
+function use(request: unknown) {}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadow",
+						Message:   "'request' is already declared in the upper scope on line 2 column 10.",
+						Line:      3,
+						Column:    14,
+					},
+				},
+			},
+			// TypeScript assertion wrappers are not transparent initializers.
+			{
+				Code: `(function() { var f = (function f() {} as any); f() }())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: `(function() { var A = (class A {} satisfies object); })()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// The typescript-eslint extension uses a dedicated enum diagnostic.
+			{
+				Code: `enum A { A }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noEnumShadow",
+						Message:   "Enum members are added to the enum scope, so references to 'A' in enum member initializers resolve to this member instead of the declaration in the upper scope on line 1 column 6.",
+						Line:      1,
+						Column:    10,
+					},
+				},
+			},
+			// Scope-manager merges the namespace and enum declarations; the enum
+			// definition still selects noEnumShadow while the first declaration
+			// supplies the reported upper-scope location.
+			{
+				Code: `namespace A {} enum A { A }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noEnumShadow",
+						Message:   "Enum members are added to the enum scope, so references to 'A' in enum member initializers resolve to this member instead of the declaration in the upper scope on line 1 column 11.",
+						Line:      1,
+						Column:    25,
+					},
+				},
+			},
 			// value interface shadowed by `declare module` interface
 			{
 				Code: `
@@ -1594,6 +1650,175 @@ declare const Array: (environment: 'dev' | 'prod' | 'test') => boolean;
 						Message:   "'Array' is already a global variable.",
 						Line:      2,
 						Column:    15,
+					},
+				},
+			},
+			// scope-manager's default TypeScript type globals participate in
+			// builtin shadow checks, including globals without runtime values.
+			{
+				Code: `
+function fn(Record: number) {}
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      2,
+						Column:    13,
+					},
+				},
+			},
+			{
+				Code: `
+function fn(ImportMeta: number) {}
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'ImportMeta' is already a global variable.",
+						Line:      2,
+						Column:    13,
+					},
+				},
+			},
+			{
+				Code:    `type Fn = (Record: number) => void;`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      1,
+						Column:    12,
+					},
+				},
+			},
+			// Type-only declarations are reported when the type/value exception
+			// is disabled.
+			{
+				Code: `
+function fn() {
+  type Record = string;
+}
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true, "ignoreTypeValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      3,
+						Column:    8,
+					},
+				},
+			},
+			// Import bindings are value variables in scope-manager, even for
+			// `import type`, so the default type/value exception does not hide it.
+			{
+				Code: `
+import type { Record } from 'pkg';
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      2,
+						Column:    15,
+					},
+				},
+			},
+			// Turning off a same-named value global does not remove the default
+			// TypeScript type variable from scope-manager.
+			{
+				Code: `
+function fn(Array: number) {}
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Globals: map[string]any{"Array": "off"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Array' is already a global variable.",
+						Line:      2,
+						Column:    13,
+					},
+				},
+			},
+			{
+				Code: `
+/* global Array: off */
+declare const Array: (environment: string) => boolean;
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Array' is already a global variable.",
+						Line:      3,
+						Column:    15,
+					},
+				},
+			},
+			{
+				Code: `
+import type { ConfiguredType } from 'pkg';
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Globals: map[string]any{"ConfiguredType": "readonly"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'ConfiguredType' is already a global variable.",
+						Line:      2,
+						Column:    15,
+					},
+				},
+			},
+			// scope-manager merges same-scope declarations into one variable,
+			// so an implicit global produces one report at the first identifier.
+			{
+				Code: `
+interface Record {}
+namespace Record { export const value = 1; }
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      2,
+						Column:    11,
+					},
+				},
+			},
+			{
+				Code: `
+class Record {}
+namespace Record { export const value = 1; }
+				`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      2,
+						Column:    7,
+					},
+				},
+			},
+			// The static-method generic exception only applies when the outer
+			// binding is the enclosing class's generic, not an implicit global.
+			{
+				Code:    `class C { static method<Record>() {} }`,
+				Options: map[string]interface{}{"builtinGlobals": true, "ignoreTypeValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      1,
+						Column:    25,
 					},
 				},
 			},
@@ -2255,6 +2480,31 @@ class A<T> extends Map<string, T> {}
 						Message:   "'T' is already declared in the upper scope on line 2 column 6.",
 						Line:      3,
 						Column:    9,
+					},
+				},
+			},
+		},
+	)
+}
+
+func TestNoShadowTSESLintJavaScriptGlobals(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.allow-js.json",
+		t,
+		&NoShadowRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `function fn(Record) {}`,
+				FileName: "plain.js",
+				Options:  map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noShadowGlobal",
+						Message:   "'Record' is already a global variable.",
+						Line:      1,
+						Column:    13,
 					},
 				},
 			},

--- a/internal/rules/no_shadow/no_shadow.go
+++ b/internal/rules/no_shadow/no_shadow.go
@@ -22,9 +22,9 @@ var schemaJSON []byte
 // declarations visible within the file plus, when `builtinGlobals` is on, the
 // effective ESLint global scope from `ctx.Globals`: ECMAScript builtins and
 // globals declared via config `languageOptions.globals` or `/* global */`
-// comments, where an explicit `off` setting un-declares the name. Concepts
-// rslint does not expose (for example `parserOptions.globalReturn`) remain
-// unmodeled.
+// comments. The typescript-eslint variant also includes scope-manager's
+// default TypeScript type globals. Concepts rslint does not expose (for
+// example `parserOptions.globalReturn`) remain unmodeled.
 
 type hoistMode int
 
@@ -43,6 +43,13 @@ type options struct {
 	ignoreOnInitialization                     bool
 	ignoreTypeValueShadow                      bool
 	ignoreFunctionTypeParameterNameValueShadow bool
+}
+
+type ruleVariant struct {
+	defaults                            options
+	includeDefaultTypeScriptTypeGlobals bool
+	typeImportUsesOwnSpecifier          bool
+	reportEnumShadow                    bool
 }
 
 func defaultOptions() options {
@@ -67,7 +74,7 @@ func defaultOptionsTSESLint() options {
 func parseOptionsWith(rawOptions []any, opts options) options {
 	// Always copy the allow map: the caller's `opts` may be a long-lived
 	// defaults instance shared across rule invocations (e.g. the closure
-	// captured by `runWithDefaults`). Mutating in-place would leak state
+	// captured by `runWithVariant`). Mutating in-place would leak state
 	// from one source file's lint run to the next.
 	src := opts.allow
 	opts.allow = make(map[string]bool, len(src)+4)
@@ -205,9 +212,12 @@ func (s *scope) variableScope() *scope {
 // ---------------------------------------------------------------------------
 
 type builder struct {
-	sourceFile     *ast.SourceFile
-	allScopes      []*scope
-	builtinGlobals map[string]bool
+	sourceFile                          *ast.SourceFile
+	allScopes                           []*scope
+	builtinGlobals                      map[string]bool
+	includeDefaultTypeScriptTypeGlobals bool
+	typeImportUsesOwnSpecifier          bool
+	reportEnumShadow                    bool
 }
 
 func (b *builder) push(kind scopeKind, block *ast.Node, parent *scope) *scope {
@@ -1232,28 +1242,40 @@ func (b *builder) visitSwitchCases(sw *ast.SwitchStatement, outer *scope) {
 var NoShadowRule = rule.Rule{
 	Name:   "no-shadow",
 	Schema: rule.NewSchema(schemaJSON),
-	Run:    runWithDefaults(defaultOptions()),
+	Run: runWithVariant(ruleVariant{
+		defaults: defaultOptions(),
+	}),
 }
 
 // RunTSESLint exposes the rule body with typescript-eslint's defaults so the
 // `@typescript-eslint/no-shadow` wrapper can reuse the implementation. The
 // underlying closure is built once at package init — `parseOptionsWith`
 // copies the captured `allow` map per invocation, so this is safe.
-var runTSESLint = runWithDefaults(defaultOptionsTSESLint())
+var runTSESLint = runWithVariant(ruleVariant{
+	defaults:                            defaultOptionsTSESLint(),
+	includeDefaultTypeScriptTypeGlobals: true,
+	typeImportUsesOwnSpecifier:          true,
+	reportEnumShadow:                    true,
+})
 
 func RunTSESLint(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	return runTSESLint(ctx, options)
 }
 
-func runWithDefaults(defaults options) func(rule.RuleContext, []any) rule.RuleListeners {
+func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.RuleListeners {
 	return func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
-		opts := parseOptionsWith(rawOptions, defaults)
+		opts := parseOptionsWith(rawOptions, variant.defaults)
 		if ctx.SourceFile == nil {
 			return rule.RuleListeners{}
 		}
 
-		b := &builder{sourceFile: ctx.SourceFile}
-		global := b.buildProgram(ctx.SourceFile)
+		b := &builder{
+			sourceFile:                          ctx.SourceFile,
+			includeDefaultTypeScriptTypeGlobals: variant.includeDefaultTypeScriptTypeGlobals,
+			typeImportUsesOwnSpecifier:          variant.typeImportUsesOwnSpecifier,
+			reportEnumShadow:                    variant.reportEnumShadow,
+		}
+		b.buildProgram(ctx.SourceFile)
 
 		filename := ""
 		if ctx.SourceFile.AsNode() != nil {
@@ -1263,10 +1285,10 @@ func runWithDefaults(defaults options) func(rule.RuleContext, []any) rule.RuleLi
 			strings.HasSuffix(filename, ".d.cts") ||
 			strings.HasSuffix(filename, ".d.mts")
 
-		// Build the set solely from ESLint's effective global scope. TypeScript
-		// default-library value symbols such as window/top/console describe the
-		// type-checking environment, not languageOptions.globals, and must not make
-		// this core scope rule depend on whether a TypeChecker is available.
+		// Build the configured and language-default globals from ESLint's
+		// effective global scope. The TypeScript variant checks scope-manager's
+		// default type globals separately; host-library value symbols such as
+		// window/top/console are intentionally not inferred from a TypeChecker.
 		builtinGlobals := map[string]bool{}
 		if opts.builtinGlobals {
 			ctx.Globals.ApplyTo(builtinGlobals)
@@ -1295,7 +1317,7 @@ func runWithDefaults(defaults options) func(rule.RuleContext, []any) rule.RuleLi
 				if isDeclFile && v.declareModifier {
 					continue
 				}
-				b.checkVariable(ctx, s, v, opts, global)
+				b.checkVariable(ctx, s, v, opts)
 			}
 		}
 
@@ -1310,11 +1332,21 @@ func isDuplicatedClassNameInClassScope(v *variable) bool {
 }
 
 // checkVariable tests whether `v` shadows a variable in some outer scope.
-func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opts options, global *scope) {
+func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opts options) {
 	shadowed := findShadowed(v, s.parent)
-	shadowedGlobal := shadowed == nil && opts.builtinGlobals && b.builtinGlobals[v.name]
+	shadowedDefaultTypeScriptGlobal := shadowed == nil && opts.builtinGlobals &&
+		b.includeDefaultTypeScriptTypeGlobals && rule.IsDefaultTypeScriptTypeGlobal(v.name)
+	shadowedGlobal := shadowed == nil && opts.builtinGlobals &&
+		(b.builtinGlobals[v.name] || shadowedDefaultTypeScriptGlobal)
 	if shadowed == nil && !shadowedGlobal {
 		return
+	}
+	if shadowedGlobal {
+		merged, first := mergeImplicitGlobalShadow(s, v)
+		if !first {
+			return
+		}
+		v = merged
 	}
 
 	// Ignore function-name-initializer exceptions:
@@ -1338,18 +1370,19 @@ func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opt
 	}
 
 	// TS: ignoreTypeValueShadow
-	if shadowed != nil && opts.ignoreTypeValueShadow && isTypeValueShadow(v, shadowed) {
+	if opts.ignoreTypeValueShadow && isTypeValueShadow(v, shadowed, b.typeImportUsesOwnSpecifier) {
 		return
 	}
 
 	// TS: ignoreFunctionTypeParameterNameValueShadow
-	if opts.ignoreFunctionTypeParameterNameValueShadow && isFunctionTypeParameterShadow(v) {
+	if opts.ignoreFunctionTypeParameterNameValueShadow &&
+		isFunctionTypeParameterNameValueShadow(v, shadowed, shadowedDefaultTypeScriptGlobal) {
 		return
 	}
 
-	// TS: type parameter of a static method shadowing the enclosing class's
-	// type parameter is a no-op at runtime and ESLint ignores it.
-	if isGenericOfStaticMethod(v) {
+	// TS: a static method's type parameter shadowing its enclosing class's
+	// type parameter is a special exception. Other outer bindings still count.
+	if isGenericOfAStaticMethodShadow(v, shadowed) {
 		return
 	}
 
@@ -1367,6 +1400,16 @@ func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opt
 	}
 	if shadowed != nil && shadowed.id != nil {
 		line, column := getLineColumn(b.sourceFile, shadowed.id)
+		if b.reportEnumShadow && hasDefinitionKind(shadowed, defEnumName) {
+			ctx.ReportNode(v.id, rule.RuleMessage{
+				Id: "noEnumShadow",
+				Description: fmt.Sprintf(
+					"Enum members are added to the enum scope, so references to '%s' in enum member initializers resolve to this member instead of the declaration in the upper scope on line %d column %d.",
+					v.name, line, column,
+				),
+			})
+			return
+		}
 		ctx.ReportNode(v.id, rule.RuleMessage{
 			Id: "noShadow",
 			Description: fmt.Sprintf(
@@ -1383,6 +1426,44 @@ func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opt
 	})
 }
 
+// hasDefinitionKind mirrors scope-manager's merged Variable definitions. The
+// local scope model stores each declaration separately, so inspect all
+// same-name declarations when upstream asks whether any definition is an enum.
+func hasDefinitionKind(v *variable, kind defKind) bool {
+	if v == nil || v.scope == nil {
+		return false
+	}
+	for _, definition := range v.scope.byName[v.name] {
+		if definition.kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeImplicitGlobalShadow models scope-manager's one-variable-per-name
+// representation. TypeScript declaration merging can add several definitions
+// to that variable; no-shadow still checks it once, reports its first
+// identifier, and treats it as a value if any definition is value-capable.
+func mergeImplicitGlobalShadow(s *scope, v *variable) (*variable, bool) {
+	definitions := s.byName[v.name]
+	if len(definitions) == 0 || definitions[0] != v {
+		return v, false
+	}
+	if len(definitions) == 1 {
+		return v, true
+	}
+
+	merged := *v
+	for _, definition := range definitions {
+		if isValueVariable(definition) {
+			merged.isValueBinding = true
+			break
+		}
+	}
+	return &merged, true
+}
+
 // findShadowed walks outward from `start` and returns the first outer
 // variable with the same name as `v`, or nil if none is found. Builtin
 // globals are handled separately by checkVariable.
@@ -1395,17 +1476,34 @@ func findShadowed(v *variable, start *scope) *variable {
 	return nil
 }
 
-// isTypeValueShadow mirrors the ESLint/typescript-eslint logic.
-// ESLint's check treats the shadowed binding as a "type import" if ANY
-// specifier in the same ImportDeclaration is type-only — this is a quirk
-// that bubbles the `type` marker across all specifiers of one declaration.
-func isTypeValueShadow(v *variable, shadowed *variable) bool {
-	isInnerValue := v.isValueBinding
+// isTypeValueShadow mirrors the typescript-eslint logic. A nil shadowed
+// variable represents an ESLint implicit global: scope-manager variables with
+// no definition are treated as values for this option, even when the global
+// itself is type-only. Import bindings are also value variables in
+// scope-manager, including `import type` bindings.
+// ESLint core treats the shadowed binding as a type import when any specifier
+// in its ImportDeclaration is type-only. The typescript-eslint extension only
+// checks the current binding's own specifier; the variant flag preserves both
+// upstream behaviors.
+func isTypeValueShadow(v *variable, shadowed *variable, typeImportUsesOwnSpecifier bool) bool {
+	isInnerValue := isValueVariable(v)
+	if shadowed == nil {
+		return !isInnerValue
+	}
 
-	isTypeImport := shadowed.kind == defImport && importHasAnyTypeOnlySpecifier(shadowed.defNode)
-	isShadowedValue := shadowed.isValueBinding && !isTypeImport
+	isTypeImport := shadowed.kind == defImport &&
+		((typeImportUsesOwnSpecifier && shadowed.isTypeOnlyImport) ||
+			(!typeImportUsesOwnSpecifier && importHasAnyTypeOnlySpecifier(shadowed.defNode)))
+	isShadowedValue := isValueVariable(shadowed) && !isTypeImport
 
 	return isInnerValue != isShadowedValue
+}
+
+// isValueVariable translates the builder's declaration metadata to
+// scope-manager's isValueVariable flag. Scope-manager considers every import
+// binding value-capable here, including `import type` bindings.
+func isValueVariable(v *variable) bool {
+	return v != nil && (v.isValueBinding || v.kind == defImport)
 }
 
 // importHasAnyTypeOnlySpecifier returns true when the ImportDeclaration
@@ -1445,9 +1543,9 @@ func importHasAnyTypeOnlySpecifier(node *ast.Node) bool {
 	return false
 }
 
-// isGenericOfStaticMethod returns true when `v` is a type parameter of a
-// method declaration carrying the `static` modifier. ESLint ignores these
-// shadows since the static method runs against a class-independent `this`.
+// isGenericOfStaticMethod reports whether `v` is a type parameter declared by
+// a static method. The caller still has to verify that the shadowed binding is
+// the enclosing class's type parameter.
 func isGenericOfStaticMethod(v *variable) bool {
 	if v.kind != defTypeParameter {
 		return false
@@ -1474,9 +1572,29 @@ func isGenericOfStaticMethod(v *variable) bool {
 	return false
 }
 
+func isGenericOfClass(v *variable) bool {
+	if v == nil || v.kind != defTypeParameter || v.defNode == nil {
+		return false
+	}
+	for cur := v.defNode.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			return true
+		case ast.KindMethodDeclaration, ast.KindFunctionDeclaration,
+			ast.KindFunctionExpression, ast.KindArrowFunction:
+			return false
+		}
+	}
+	return false
+}
+
+func isGenericOfAStaticMethodShadow(v *variable, shadowed *variable) bool {
+	return shadowed != nil && isGenericOfStaticMethod(v) && isGenericOfClass(shadowed)
+}
+
 // isFunctionTypeParameterShadow returns true when `v` is a parameter of a
-// TS function type / construct signature — its binding lives in a type-level
-// position and ESLint ignores these shadows by default.
+// TS function type / construct signature. Whether the option ignores it also
+// depends on the shadowed variable being value-capable.
 func isFunctionTypeParameterShadow(v *variable) bool {
 	if v.kind != defParameter {
 		return false
@@ -1500,6 +1618,19 @@ func isFunctionTypeParameterShadow(v *variable) bool {
 		return true
 	}
 	return false
+}
+
+func isFunctionTypeParameterNameValueShadow(v *variable, shadowed *variable, shadowedDefaultTypeScriptGlobal bool) bool {
+	if !isFunctionTypeParameterShadow(v) {
+		return false
+	}
+	if shadowed == nil {
+		// TypeScript default globals have an isValueVariable field set to
+		// false. Other ESLint implicit globals have no such field and are
+		// treated as values by the upstream rule.
+		return !shadowedDefaultTypeScriptGlobal
+	}
+	return isValueVariable(shadowed)
 }
 
 // isExternalDeclarationMerging covers the `import type Foo from 'bar'` +
@@ -1563,57 +1694,95 @@ func isInTdz(inner *variable, outer *variable, mode hoistMode) bool {
 	return false
 }
 
-// isFunctionNameInitializerException implements the `var a = function a() {}`
-// / `var A = class A {}` / default-destructuring variants that ESLint ignores.
-//
-// Mirrors ESLint's `isOnInitializer`: requires (a) the inner is a Function-
-// Expression name or ClassExpression inner-name, (b) the inner identifier
-// sits inside the outer binding's declarator/parameter range, and (c) the
-// inner's enclosing scope IS the scope owning the outer binding. Together,
-// (b)+(c) handle arbitrary call/decorator wrappers (`wrap(function x() {})`)
-// without an AST-walk whitelist, while still rejecting unrelated siblings
-// (`const a = 1; const b = function a() {}` — different declarator ranges,
-// so (b) fails and we report).
+// isFunctionNameInitializerException implements the direct initializer cases
+// that ESLint ignores: `var a = function a() {}`, `var A = class A {}`, and
+// their logical/conditional/default-value variants. Calls and TypeScript
+// assertion expressions are not transparent, so `wrap(function a() {})` and
+// `function a() {} as unknown` still report.
 func isFunctionNameInitializerException(inner *variable, outer *variable) bool {
-	if outer.defNode == nil || inner.defNode == nil {
+	if outer == nil || outer.id == nil || inner == nil || inner.defNode == nil {
 		return false
 	}
 	if inner.kind != defFnExprName && (inner.kind != defClassInnerName || inner.defNode.Kind != ast.KindClassExpression) {
 		return false
 	}
-	if inner.scope == nil || inner.scope.parent == nil || outer.scope == nil {
+	initializer := bindingInitializer(outer.id)
+	if initializer == nil {
 		return false
 	}
-	startPos, endPos, ok := outerInitializerLexicalRange(outer.defNode)
-	if !ok {
+	nodeToCheck := inner.defNode
+	if initializer.Pos() > nodeToCheck.Pos() || nodeToCheck.End() > initializer.End() {
 		return false
 	}
-	expr := inner.defNode
-	if startPos > expr.Pos() || expr.End() > endPos {
-		return false
-	}
-	return inner.scope.parent == outer.scope
+	return initializer == unwrapInitializerExpression(nodeToCheck)
 }
 
-// outerInitializerLexicalRange returns the range ESLint's scope manager would
-// expose as the binding's `Definition.parent.range`: the enclosing
-// VariableDeclaration for var/let/const + destructuring elements, and the
-// enclosing function-like node for parameters.
-func outerInitializerLexicalRange(defNode *ast.Node) (int, int, bool) {
-	for cur := defNode; cur != nil; cur = cur.Parent {
+// bindingInitializer returns the default/initializer attached to this exact
+// binding. Stopping at the nearest binding element is important for sibling
+// destructuring entries: the initializer of `b` is not the initializer of `a`.
+func bindingInitializer(identifier *ast.Node) *ast.Node {
+	for cur := identifier.Parent; cur != nil; cur = cur.Parent {
 		switch cur.Kind {
-		case ast.KindVariableDeclaration:
-			return cur.Pos(), cur.End(), true
-		case ast.KindParameter:
-			for p := cur.Parent; p != nil; p = p.Parent {
-				if ast.IsFunctionLike(p) {
-					return p.Pos(), p.End(), true
-				}
+		case ast.KindBindingElement:
+			binding := cur.AsBindingElement()
+			if binding == nil {
+				return nil
 			}
-			return cur.Pos(), cur.End(), true
+			return binding.Initializer
+		case ast.KindVariableDeclaration:
+			declaration := cur.AsVariableDeclaration()
+			if declaration == nil {
+				return nil
+			}
+			return declaration.Initializer
+		case ast.KindParameter:
+			parameter := cur.AsParameterDeclaration()
+			if parameter == nil {
+				return nil
+			}
+			return parameter.Initializer
 		}
 	}
-	return 0, 0, false
+	return nil
+}
+
+// unwrapInitializerExpression follows only the expression shapes that ESTree
+// treats as transparently capable of evaluating to the child: parentheses,
+// logical operands, and the two result branches of a conditional expression.
+func unwrapInitializerExpression(node *ast.Node) *ast.Node {
+	current := node
+	for current != nil && current.Parent != nil {
+		parent := current.Parent
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+			parenthesized := parent.AsParenthesizedExpression()
+			if parenthesized == nil || parenthesized.Expression != current {
+				return current
+			}
+			current = parent
+		case ast.KindBinaryExpression:
+			binary := parent.AsBinaryExpression()
+			if binary == nil || binary.OperatorToken == nil ||
+				(binary.Left != current && binary.Right != current) {
+				return current
+			}
+			switch binary.OperatorToken.Kind {
+			case ast.KindBarBarToken, ast.KindAmpersandAmpersandToken, ast.KindQuestionQuestionToken:
+				current = parent
+			default:
+				return current
+			}
+		case ast.KindConditionalExpression:
+			conditional := parent.AsConditionalExpression()
+			if conditional == nil || (conditional.WhenTrue != current && conditional.WhenFalse != current) {
+				return current
+			}
+			current = parent
+		default:
+			return current
+		}
+	}
+	return current
 }
 
 // isInInitPatternCall handles the `ignoreOnInitialization` option.

--- a/internal/rules/no_shadow/no_shadow_test.go
+++ b/internal/rules/no_shadow/no_shadow_test.go
@@ -145,31 +145,6 @@ func TestNoShadowRule(t *testing.T) {
 			// ---- allow list ----
 			{Code: `function foo(cb) { (function (cb) { cb(42); })(cb); }`, Options: map[string]interface{}{"allow": []interface{}{"cb"}}},
 
-			// ---- Function-name initializer exception with arbitrary CallExpression
-			// wrappers — ESLint's `outerScope === innerScope.upper` accepts any
-			// non-scope-introducing wrapper, not just a fixed list of operators.
-			{Code: `const a = wrap(function a() {});`},
-			{Code: `const a = foo || wrap(function a() {});`},
-			{Code: `const { a = wrap(function a() {}) } = obj;`},
-			{Code: `const { a = foo || wrap(function a() {}) } = obj;`},
-			{Code: `function foo(a = wrap(function a() {})) {}`},
-			{Code: `function foo(a = foo || wrap(function a() {})) {}`},
-			{Code: `const A = wrap(class A {});`},
-			{Code: `const A = foo || wrap(class A {});`},
-			{Code: `const { A = wrap(class A {}) } = obj;`},
-			{Code: `const { A = foo || wrap(class A {}) } = obj;`},
-			{Code: `function foo(A = wrap(class A {})) {}`},
-			{Code: `function foo(A = foo || wrap(class A {})) {}`},
-			// Sibling-init in same destructuring also exempted by the same rule.
-			{Code: `const { a = foo, b = function a() {} } = {}`},
-			{Code: `const { A = Foo, B = class A {} } = {}`},
-			// FunctionExpression / ClassExpression at the test position of a
-			// ternary in the initializer is also exempted (same scope/range).
-			{Code: `var a = function a() {} ? foo : bar`},
-			{Code: `var A = class A {} ? foo : bar`},
-			// Wrap with side-effecting top-level `let` — still exempted.
-			{Code: `let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });`, Options: map[string]interface{}{"hoist": "all"}},
-
 			// ---- Class fields / methods (not shadowing — different kinds) ----
 			{Code: `class C { foo; foo() { let foo; } }`},
 
@@ -606,6 +581,28 @@ function bar() { }`},
 			{Code: `(function() { var a = class { constructor() { class a {} } }; })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
 			{Code: `class A { constructor() { var A; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
 
+			// ---- Function/class names that are not direct initializers ----
+			// Calls are not transparent, even when a surrounding logical expression is.
+			{Code: `const a = wrap(function a() {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 25}}},
+			{Code: `const a = foo || wrap(function a() {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `const { a = wrap(function a() {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `const { a = foo || wrap(function a() {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(a = wrap(function a() {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(a = foo || wrap(function a() {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `const A = wrap(class A {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `const A = foo || wrap(class A {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `const { A = wrap(class A {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `const { A = foo || wrap(class A {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(A = wrap(class A {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(A = foo || wrap(class A {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			// A sibling destructuring default is not this binding's initializer.
+			{Code: `const { a = foo, b = function a() {} } = {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `const { A = Foo, B = class A {} } = {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			// The test position of a conditional expression is not a result branch.
+			{Code: `var a = function a() {} ? foo : bar`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `var A = class A {} ? foo : bar`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+
 			// ---- Nested shadowing chain (multiple errors) ----
 			{
 				Code: `(function a() { function a(){ function a(){} } })()`,
@@ -937,6 +934,14 @@ function bar() { }`},
 				Code: "\n\t\tconst A = 2;\n\t\tenum Test {\n\t\t\tA = 1,\n\t\t\tB = A,\n\t\t}\n\t",
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "noShadow"},
+				},
+			},
+			// Core ESLint keeps the generic noShadow diagnostic when the outer
+			// declaration is the enum itself.
+			{
+				Code: `enum A { A }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 10},
 				},
 			},
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-shadow.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-shadow.test.ts.snap
@@ -1057,6 +1057,448 @@ exports[`no-shadow > invalid 40`] = `
 
 exports[`no-shadow > invalid 41`] = `
 {
+  "code": "const a = wrap(function a() {});",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 42`] = `
+{
+  "code": "const a = foo || wrap(function a() {});",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 43`] = `
+{
+  "code": "const { a = wrap(function a() {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 44`] = `
+{
+  "code": "const { a = foo || wrap(function a() {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 45`] = `
+{
+  "code": "function foo(a = wrap(function a() {})) {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 46`] = `
+{
+  "code": "function foo(a = foo || wrap(function a() {})) {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 47`] = `
+{
+  "code": "const A = wrap(class A {});",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 48`] = `
+{
+  "code": "const A = foo || wrap(class A {});",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 49`] = `
+{
+  "code": "const { A = wrap(class A {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 50`] = `
+{
+  "code": "const { A = foo || wrap(class A {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 51`] = `
+{
+  "code": "function foo(A = wrap(class A {})) {}",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 52`] = `
+{
+  "code": "function foo(A = foo || wrap(class A {})) {}",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 53`] = `
+{
+  "code": "const { a = foo, b = function a() {} } = {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 54`] = `
+{
+  "code": "const { A = Foo, B = class A {} } = {}",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 55`] = `
+{
+  "code": "var a = function a() {} ? foo : bar",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 56`] = `
+{
+  "code": "var A = class A {} ? foo : bar",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 57`] = `
+{
+  "code": "let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 29.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 58`] = `
+{
   "code": "(function a() { function a(){ function a(){} } })()",
   "diagnostics": [
     {
@@ -1096,7 +1538,7 @@ exports[`no-shadow > invalid 41`] = `
 }
 `;
 
-exports[`no-shadow > invalid 42`] = `
+exports[`no-shadow > invalid 59`] = `
 {
   "code": "function foo() { var Object = 0; }",
   "diagnostics": [
@@ -1122,7 +1564,7 @@ exports[`no-shadow > invalid 42`] = `
 }
 `;
 
-exports[`no-shadow > invalid 43`] = `
+exports[`no-shadow > invalid 60`] = `
 {
   "code": "var Object = 0;",
   "diagnostics": [
@@ -1148,7 +1590,7 @@ exports[`no-shadow > invalid 43`] = `
 }
 `;
 
-exports[`no-shadow > invalid 44`] = `
+exports[`no-shadow > invalid 61`] = `
 {
   "code": "(function Array() {})",
   "diagnostics": [
@@ -1174,7 +1616,7 @@ exports[`no-shadow > invalid 44`] = `
 }
 `;
 
-exports[`no-shadow > invalid 45`] = `
+exports[`no-shadow > invalid 62`] = `
 {
   "code": "function foo(cb) { (function (cb) { cb(42); })(cb); }",
   "diagnostics": [
@@ -1200,7 +1642,7 @@ exports[`no-shadow > invalid 45`] = `
 }
 `;
 
-exports[`no-shadow > invalid 46`] = `
+exports[`no-shadow > invalid 63`] = `
 {
   "code": "class C { static { let a; { let a; } } }",
   "diagnostics": [
@@ -1226,7 +1668,7 @@ exports[`no-shadow > invalid 46`] = `
 }
 `;
 
-exports[`no-shadow > invalid 47`] = `
+exports[`no-shadow > invalid 64`] = `
 {
   "code": "class C { static { var C; } }",
   "diagnostics": [
@@ -1252,7 +1694,7 @@ exports[`no-shadow > invalid 47`] = `
 }
 `;
 
-exports[`no-shadow > invalid 48`] = `
+exports[`no-shadow > invalid 65`] = `
 {
   "code": "class C { static { let C; } }",
   "diagnostics": [
@@ -1278,7 +1720,7 @@ exports[`no-shadow > invalid 48`] = `
 }
 `;
 
-exports[`no-shadow > invalid 49`] = `
+exports[`no-shadow > invalid 66`] = `
 {
   "code": "var a; class C { static { var a; } }",
   "diagnostics": [
@@ -1304,7 +1746,7 @@ exports[`no-shadow > invalid 49`] = `
 }
 `;
 
-exports[`no-shadow > invalid 50`] = `
+exports[`no-shadow > invalid 67`] = `
 {
   "code": "class C { static { var a; } } var a;",
   "diagnostics": [
@@ -1330,7 +1772,7 @@ exports[`no-shadow > invalid 50`] = `
 }
 `;
 
-exports[`no-shadow > invalid 51`] = `
+exports[`no-shadow > invalid 68`] = `
 {
   "code": "class C { static { let a; } } let a;",
   "diagnostics": [
@@ -1356,7 +1798,7 @@ exports[`no-shadow > invalid 51`] = `
 }
 `;
 
-exports[`no-shadow > invalid 52`] = `
+exports[`no-shadow > invalid 69`] = `
 {
   "code": "class C { static { var a; } } let a;",
   "diagnostics": [
@@ -1382,7 +1824,7 @@ exports[`no-shadow > invalid 52`] = `
 }
 `;
 
-exports[`no-shadow > invalid 53`] = `
+exports[`no-shadow > invalid 70`] = `
 {
   "code": "class C { static { var a; class D { static { var a; } } } }",
   "diagnostics": [
@@ -1408,7 +1850,7 @@ exports[`no-shadow > invalid 53`] = `
 }
 `;
 
-exports[`no-shadow > invalid 54`] = `
+exports[`no-shadow > invalid 71`] = `
 {
   "code": "class C { static { let a; class D { static { let a; } } } }",
   "diagnostics": [
@@ -1434,7 +1876,7 @@ exports[`no-shadow > invalid 54`] = `
 }
 `;
 
-exports[`no-shadow > invalid 55`] = `
+exports[`no-shadow > invalid 72`] = `
 {
   "code": "let x = foo((x,y) => {});
 let y;",
@@ -1476,7 +1918,7 @@ let y;",
 }
 `;
 
-exports[`no-shadow > invalid 56`] = `
+exports[`no-shadow > invalid 73`] = `
 {
   "code": "let x = ((x,y) => {})();
 let y;",
@@ -1518,7 +1960,7 @@ let y;",
 }
 `;
 
-exports[`no-shadow > invalid 57`] = `
+exports[`no-shadow > invalid 74`] = `
 {
   "code": "const a = fn(()=>{ class C { fn () { const a = 42; return a } } return new C() })",
   "diagnostics": [
@@ -1544,7 +1986,7 @@ exports[`no-shadow > invalid 57`] = `
 }
 `;
 
-exports[`no-shadow > invalid 58`] = `
+exports[`no-shadow > invalid 75`] = `
 {
   "code": "function a() {}
 foo(a => {});",
@@ -1571,7 +2013,7 @@ foo(a => {});",
 }
 `;
 
-exports[`no-shadow > invalid 59`] = `
+exports[`no-shadow > invalid 76`] = `
 {
   "code": "const a = fn(()=>{ function C() { this.fn=function() { const a = 42; return a } } return new C() });",
   "diagnostics": [
@@ -1597,7 +2039,7 @@ exports[`no-shadow > invalid 59`] = `
 }
 `;
 
-exports[`no-shadow > invalid 60`] = `
+exports[`no-shadow > invalid 77`] = `
 {
   "code": "const x = foo(() => { const bar = () => { return x => {}; }; return bar; });",
   "diagnostics": [
@@ -1623,7 +2065,7 @@ exports[`no-shadow > invalid 60`] = `
 }
 `;
 
-exports[`no-shadow > invalid 61`] = `
+exports[`no-shadow > invalid 78`] = `
 {
   "code": "const x = foo(() => { return { bar(x) {} }; });",
   "diagnostics": [
@@ -1649,7 +2091,7 @@ exports[`no-shadow > invalid 61`] = `
 }
 `;
 
-exports[`no-shadow > invalid 62`] = `
+exports[`no-shadow > invalid 79`] = `
 {
   "code": "const x = () => { foo(x => x); }",
   "diagnostics": [
@@ -1675,7 +2117,7 @@ exports[`no-shadow > invalid 62`] = `
 }
 `;
 
-exports[`no-shadow > invalid 63`] = `
+exports[`no-shadow > invalid 80`] = `
 {
   "code": "const foo = () => { let x; bar(x => x); }",
   "diagnostics": [
@@ -1701,7 +2143,7 @@ exports[`no-shadow > invalid 63`] = `
 }
 `;
 
-exports[`no-shadow > invalid 64`] = `
+exports[`no-shadow > invalid 81`] = `
 {
   "code": "foo(() => { const x = x => x; });",
   "diagnostics": [
@@ -1727,7 +2169,7 @@ exports[`no-shadow > invalid 64`] = `
 }
 `;
 
-exports[`no-shadow > invalid 65`] = `
+exports[`no-shadow > invalid 82`] = `
 {
   "code": "const foo = (x) => { bar(x => {}) }",
   "diagnostics": [
@@ -1753,7 +2195,7 @@ exports[`no-shadow > invalid 65`] = `
 }
 `;
 
-exports[`no-shadow > invalid 66`] = `
+exports[`no-shadow > invalid 83`] = `
 {
   "code": "const a = (()=>{ class C { fn () { const a = 42; return a } } return new C() })()",
   "diagnostics": [
@@ -1779,7 +2221,7 @@ exports[`no-shadow > invalid 66`] = `
 }
 `;
 
-exports[`no-shadow > invalid 67`] = `
+exports[`no-shadow > invalid 84`] = `
 {
   "code": "const x = () => { (x => x)(); }",
   "diagnostics": [
@@ -1805,7 +2247,7 @@ exports[`no-shadow > invalid 67`] = `
 }
 `;
 
-exports[`no-shadow > invalid 68`] = `
+exports[`no-shadow > invalid 85`] = `
 {
   "code": "(function Array() {})",
   "diagnostics": [
@@ -1831,7 +2273,7 @@ exports[`no-shadow > invalid 68`] = `
 }
 `;
 
-exports[`no-shadow > invalid 69`] = `
+exports[`no-shadow > invalid 86`] = `
 {
   "code": "let a; { let b = (function a() {}) }",
   "diagnostics": [
@@ -1857,7 +2299,7 @@ exports[`no-shadow > invalid 69`] = `
 }
 `;
 
-exports[`no-shadow > invalid 70`] = `
+exports[`no-shadow > invalid 87`] = `
 {
   "code": "let a = foo; { let b = (function a() {}) }",
   "diagnostics": [
@@ -1883,7 +2325,7 @@ exports[`no-shadow > invalid 70`] = `
 }
 `;
 
-exports[`no-shadow > invalid 71`] = `
+exports[`no-shadow > invalid 88`] = `
 {
   "code": "
   type T = 1;
@@ -1914,7 +2356,7 @@ exports[`no-shadow > invalid 71`] = `
 }
 `;
 
-exports[`no-shadow > invalid 72`] = `
+exports[`no-shadow > invalid 89`] = `
 {
   "code": "
   type T = 1;
@@ -1943,7 +2385,7 @@ exports[`no-shadow > invalid 72`] = `
 }
 `;
 
-exports[`no-shadow > invalid 73`] = `
+exports[`no-shadow > invalid 90`] = `
 {
   "code": "
   function foo<T>() {
@@ -1973,7 +2415,7 @@ exports[`no-shadow > invalid 73`] = `
 }
 `;
 
-exports[`no-shadow > invalid 74`] = `
+exports[`no-shadow > invalid 91`] = `
 {
   "code": "
   type T = string;
@@ -2002,7 +2444,7 @@ exports[`no-shadow > invalid 74`] = `
 }
 `;
 
-exports[`no-shadow > invalid 75`] = `
+exports[`no-shadow > invalid 92`] = `
 {
   "code": "
   const x = 1;
@@ -2033,7 +2475,7 @@ exports[`no-shadow > invalid 75`] = `
 }
 `;
 
-exports[`no-shadow > invalid 76`] = `
+exports[`no-shadow > invalid 93`] = `
 {
   "code": "
   const test = 1;
@@ -2062,7 +2504,7 @@ exports[`no-shadow > invalid 76`] = `
 }
 `;
 
-exports[`no-shadow > invalid 77`] = `
+exports[`no-shadow > invalid 94`] = `
 {
   "code": "
   const arg = 0;
@@ -2093,7 +2535,7 @@ exports[`no-shadow > invalid 77`] = `
 }
 `;
 
-exports[`no-shadow > invalid 78`] = `
+exports[`no-shadow > invalid 95`] = `
 {
   "code": "
   const arg = 0;
@@ -2124,7 +2566,7 @@ exports[`no-shadow > invalid 78`] = `
 }
 `;
 
-exports[`no-shadow > invalid 79`] = `
+exports[`no-shadow > invalid 96`] = `
 {
   "code": "
   const arg = 0;
@@ -2153,7 +2595,7 @@ exports[`no-shadow > invalid 79`] = `
 }
 `;
 
-exports[`no-shadow > invalid 80`] = `
+exports[`no-shadow > invalid 97`] = `
 {
   "code": "
   const arg = 0;
@@ -2182,7 +2624,7 @@ exports[`no-shadow > invalid 80`] = `
 }
 `;
 
-exports[`no-shadow > invalid 81`] = `
+exports[`no-shadow > invalid 98`] = `
 {
   "code": "
   const arg = 0;
@@ -2213,7 +2655,7 @@ exports[`no-shadow > invalid 81`] = `
 }
 `;
 
-exports[`no-shadow > invalid 82`] = `
+exports[`no-shadow > invalid 99`] = `
 {
   "code": "
   const arg = 0;
@@ -2244,7 +2686,7 @@ exports[`no-shadow > invalid 82`] = `
 }
 `;
 
-exports[`no-shadow > invalid 83`] = `
+exports[`no-shadow > invalid 100`] = `
 {
   "code": "
   const arg = 0;
@@ -2273,7 +2715,7 @@ exports[`no-shadow > invalid 83`] = `
 }
 `;
 
-exports[`no-shadow > invalid 84`] = `
+exports[`no-shadow > invalid 101`] = `
 {
   "code": "
   const arg = 0;
@@ -2304,7 +2746,7 @@ exports[`no-shadow > invalid 84`] = `
 }
 `;
 
-exports[`no-shadow > invalid 85`] = `
+exports[`no-shadow > invalid 102`] = `
 {
   "code": "
 import type { foo } from './foo';
@@ -2333,7 +2775,7 @@ function doThing(foo: number) {}
 }
 `;
 
-exports[`no-shadow > invalid 86`] = `
+exports[`no-shadow > invalid 103`] = `
 {
   "code": "
 import { type foo } from './foo';
@@ -2362,7 +2804,7 @@ function doThing(foo: number) {}
 }
 `;
 
-exports[`no-shadow > invalid 87`] = `
+exports[`no-shadow > invalid 104`] = `
 {
   "code": "
 import { foo } from './foo';
@@ -2391,7 +2833,7 @@ function doThing(foo: number, bar: number) {}
 }
 `;
 
-exports[`no-shadow > invalid 88`] = `
+exports[`no-shadow > invalid 105`] = `
 {
   "code": "
 interface Foo {}
@@ -2420,7 +2862,7 @@ declare module 'bar' { export interface Foo { x: string } }
 }
 `;
 
-exports[`no-shadow > invalid 89`] = `
+exports[`no-shadow > invalid 106`] = `
 {
   "code": "
 import type { Foo } from 'bar';
@@ -2449,7 +2891,7 @@ declare module 'baz' { export interface Foo { x: string } }
 }
 `;
 
-exports[`no-shadow > invalid 90`] = `
+exports[`no-shadow > invalid 107`] = `
 {
   "code": "
 import { type Foo } from 'bar';
@@ -2478,7 +2920,7 @@ declare module 'baz' { export interface Foo { x: string } }
 }
 `;
 
-exports[`no-shadow > invalid 91`] = `
+exports[`no-shadow > invalid 108`] = `
 {
   "code": "
   let x = foo((x, y) => {});
@@ -2522,7 +2964,7 @@ exports[`no-shadow > invalid 91`] = `
 }
 `;
 
-exports[`no-shadow > invalid 92`] = `
+exports[`no-shadow > invalid 109`] = `
 {
   "code": "
   let x = foo((x, y) => {});
@@ -2551,7 +2993,7 @@ exports[`no-shadow > invalid 92`] = `
 }
 `;
 
-exports[`no-shadow > invalid 93`] = `
+exports[`no-shadow > invalid 110`] = `
 {
   "code": "
   type Foo<A> = 1;
@@ -2580,7 +3022,7 @@ exports[`no-shadow > invalid 93`] = `
 }
 `;
 
-exports[`no-shadow > invalid 94`] = `
+exports[`no-shadow > invalid 111`] = `
 {
   "code": "
   interface Foo<A> {}
@@ -2609,7 +3051,7 @@ exports[`no-shadow > invalid 94`] = `
 }
 `;
 
-exports[`no-shadow > invalid 95`] = `
+exports[`no-shadow > invalid 112`] = `
 {
   "code": "
   interface Foo<A> {}
@@ -2638,7 +3080,7 @@ exports[`no-shadow > invalid 95`] = `
 }
 `;
 
-exports[`no-shadow > invalid 96`] = `
+exports[`no-shadow > invalid 113`] = `
 {
   "code": "
   type Foo<A> = 1;
@@ -2667,7 +3109,7 @@ exports[`no-shadow > invalid 96`] = `
 }
 `;
 
-exports[`no-shadow > invalid 97`] = `
+exports[`no-shadow > invalid 114`] = `
 {
   "code": "
   {
@@ -2698,7 +3140,7 @@ exports[`no-shadow > invalid 97`] = `
 }
 `;
 
-exports[`no-shadow > invalid 98`] = `
+exports[`no-shadow > invalid 115`] = `
 {
   "code": "
   {
@@ -2729,7 +3171,7 @@ exports[`no-shadow > invalid 98`] = `
 }
 `;
 
-exports[`no-shadow > invalid 99`] = `
+exports[`no-shadow > invalid 116`] = `
 {
   "code": "
   type Foo<A> = 1;
@@ -2758,7 +3200,7 @@ exports[`no-shadow > invalid 99`] = `
 }
 `;
 
-exports[`no-shadow > invalid 100`] = `
+exports[`no-shadow > invalid 117`] = `
 {
   "code": "
   interface Foo<A> {}
@@ -2787,7 +3229,7 @@ exports[`no-shadow > invalid 100`] = `
 }
 `;
 
-exports[`no-shadow > invalid 101`] = `
+exports[`no-shadow > invalid 118`] = `
 {
   "code": "
   interface Foo<A> {}
@@ -2816,7 +3258,7 @@ exports[`no-shadow > invalid 101`] = `
 }
 `;
 
-exports[`no-shadow > invalid 102`] = `
+exports[`no-shadow > invalid 119`] = `
 {
   "code": "
   type Foo<A> = 1;
@@ -2845,7 +3287,7 @@ exports[`no-shadow > invalid 102`] = `
 }
 `;
 
-exports[`no-shadow > invalid 103`] = `
+exports[`no-shadow > invalid 120`] = `
 {
   "code": "
   {
@@ -2876,7 +3318,7 @@ exports[`no-shadow > invalid 103`] = `
 }
 `;
 
-exports[`no-shadow > invalid 104`] = `
+exports[`no-shadow > invalid 121`] = `
 {
   "code": "
   {
@@ -2907,7 +3349,7 @@ exports[`no-shadow > invalid 104`] = `
 }
 `;
 
-exports[`no-shadow > invalid 105`] = `
+exports[`no-shadow > invalid 122`] = `
 {
   "code": "
   type Foo<A> = 1;
@@ -2936,7 +3378,7 @@ exports[`no-shadow > invalid 105`] = `
 }
 `;
 
-exports[`no-shadow > invalid 106`] = `
+exports[`no-shadow > invalid 123`] = `
 {
   "code": "
 	if (true) {
@@ -2968,7 +3410,7 @@ exports[`no-shadow > invalid 106`] = `
 }
 `;
 
-exports[`no-shadow > invalid 107`] = `
+exports[`no-shadow > invalid 124`] = `
 {
   "code": "
 	// types
@@ -3020,7 +3462,7 @@ exports[`no-shadow > invalid 107`] = `
 }
 `;
 
-exports[`no-shadow > invalid 108`] = `
+exports[`no-shadow > invalid 125`] = `
 {
   "code": "
 	// types
@@ -3057,7 +3499,7 @@ exports[`no-shadow > invalid 108`] = `
 }
 `;
 
-exports[`no-shadow > invalid 109`] = `
+exports[`no-shadow > invalid 126`] = `
 {
   "code": "
   interface Foo<A> {}
@@ -3086,7 +3528,7 @@ exports[`no-shadow > invalid 109`] = `
 }
 `;
 
-exports[`no-shadow > invalid 110`] = `
+exports[`no-shadow > invalid 127`] = `
 {
   "code": "
   interface Foo<A> {}
@@ -3115,7 +3557,7 @@ exports[`no-shadow > invalid 110`] = `
 }
 `;
 
-exports[`no-shadow > invalid 111`] = `
+exports[`no-shadow > invalid 128`] = `
 {
   "code": "
   type Foo<A> = 1;
@@ -3144,7 +3586,7 @@ exports[`no-shadow > invalid 111`] = `
 }
 `;
 
-exports[`no-shadow > invalid 112`] = `
+exports[`no-shadow > invalid 129`] = `
 {
   "code": "
   {
@@ -3175,7 +3617,7 @@ exports[`no-shadow > invalid 112`] = `
 }
 `;
 
-exports[`no-shadow > invalid 113`] = `
+exports[`no-shadow > invalid 130`] = `
 {
   "code": "
   {
@@ -3206,7 +3648,7 @@ exports[`no-shadow > invalid 113`] = `
 }
 `;
 
-exports[`no-shadow > invalid 114`] = `
+exports[`no-shadow > invalid 131`] = `
 {
   "code": "
 		const A = 2;
@@ -3238,7 +3680,7 @@ exports[`no-shadow > invalid 114`] = `
 }
 `;
 
-exports[`no-shadow > invalid 115`] = `
+exports[`no-shadow > invalid 132`] = `
 {
   "code": "type X<T> = T extends (infer U) ? (U extends (infer U) ? U : never) : never;",
   "diagnostics": [
@@ -3264,7 +3706,7 @@ exports[`no-shadow > invalid 115`] = `
 }
 `;
 
-exports[`no-shadow > invalid 116`] = `
+exports[`no-shadow > invalid 133`] = `
 {
   "code": "const x = 1; const o = { foo(x: number) { return x; } };",
   "diagnostics": [
@@ -3290,7 +3732,7 @@ exports[`no-shadow > invalid 116`] = `
 }
 `;
 
-exports[`no-shadow > invalid 117`] = `
+exports[`no-shadow > invalid 134`] = `
 {
   "code": "const x = 1; const o = { get foo() { const x = 2; return x; } };",
   "diagnostics": [
@@ -3316,7 +3758,7 @@ exports[`no-shadow > invalid 117`] = `
 }
 `;
 
-exports[`no-shadow > invalid 118`] = `
+exports[`no-shadow > invalid 135`] = `
 {
   "code": "const x = 1; const o = { async foo(x: number) { return x; } };",
   "diagnostics": [
@@ -3342,7 +3784,7 @@ exports[`no-shadow > invalid 118`] = `
 }
 `;
 
-exports[`no-shadow > invalid 119`] = `
+exports[`no-shadow > invalid 136`] = `
 {
   "code": "const x = 1; const o = { *foo(x: number) { yield x; } };",
   "diagnostics": [
@@ -3368,7 +3810,7 @@ exports[`no-shadow > invalid 119`] = `
 }
 `;
 
-exports[`no-shadow > invalid 120`] = `
+exports[`no-shadow > invalid 137`] = `
 {
   "code": "using u = { [Symbol.dispose]() {} }; { using u = { [Symbol.dispose]() {} }; }",
   "diagnostics": [
@@ -3394,7 +3836,7 @@ exports[`no-shadow > invalid 120`] = `
 }
 `;
 
-exports[`no-shadow > invalid 121`] = `
+exports[`no-shadow > invalid 138`] = `
 {
   "code": "class C<T> { static s<T>(): T { return null as any; } i<T>(): T { return null as any; } }",
   "diagnostics": [
@@ -3420,7 +3862,7 @@ exports[`no-shadow > invalid 121`] = `
 }
 `;
 
-exports[`no-shadow > invalid 122`] = `
+exports[`no-shadow > invalid 139`] = `
 {
   "code": "const a = 1; function f({ x: a }: any) { return a; }",
   "diagnostics": [
@@ -3446,7 +3888,7 @@ exports[`no-shadow > invalid 122`] = `
 }
 `;
 
-exports[`no-shadow > invalid 123`] = `
+exports[`no-shadow > invalid 140`] = `
 {
   "code": "const fn = function f(f: number) { return f; };",
   "diagnostics": [
@@ -3472,7 +3914,7 @@ exports[`no-shadow > invalid 123`] = `
 }
 `;
 
-exports[`no-shadow > invalid 124`] = `
+exports[`no-shadow > invalid 141`] = `
 {
   "code": "function dec(x: any) { return x; }
 @dec class CD { method() { const dec = 1; return dec; } }",
@@ -3499,7 +3941,7 @@ exports[`no-shadow > invalid 124`] = `
 }
 `;
 
-exports[`no-shadow > invalid 125`] = `
+exports[`no-shadow > invalid 142`] = `
 {
   "code": "const k = 'x'; class C { foo() { const k = 1; return k; } }",
   "diagnostics": [
@@ -3525,7 +3967,7 @@ exports[`no-shadow > invalid 125`] = `
 }
 `;
 
-exports[`no-shadow > invalid 126`] = `
+exports[`no-shadow > invalid 143`] = `
 {
   "code": "const a = 1; function f({ a = a }: any) { return a; }",
   "diagnostics": [
@@ -3551,7 +3993,7 @@ exports[`no-shadow > invalid 126`] = `
 }
 `;
 
-exports[`no-shadow > invalid 127`] = `
+exports[`no-shadow > invalid 144`] = `
 {
   "code": "const e = 1; try {} catch ({ message: e }) { return e; }",
   "diagnostics": [
@@ -3577,7 +4019,7 @@ exports[`no-shadow > invalid 127`] = `
 }
 `;
 
-exports[`no-shadow > invalid 128`] = `
+exports[`no-shadow > invalid 145`] = `
 {
   "code": "async function* g() { const v = 1; for await (const v of [Promise.resolve(1)]) yield v; }",
   "diagnostics": [
@@ -3603,7 +4045,7 @@ exports[`no-shadow > invalid 128`] = `
 }
 `;
 
-exports[`no-shadow > invalid 129`] = `
+exports[`no-shadow > invalid 146`] = `
 {
   "code": "const a = 1, b = 2; function f() { const a = 3, b = 4; return a + b; }",
   "diagnostics": [
@@ -3644,7 +4086,7 @@ exports[`no-shadow > invalid 129`] = `
 }
 `;
 
-exports[`no-shadow > invalid 130`] = `
+exports[`no-shadow > invalid 147`] = `
 {
   "code": "function f() { const z = 1; switch (z) { case 1: { const z = 2; break; } case 2: { const z = 3; break; } } }",
   "diagnostics": [
@@ -3685,7 +4127,7 @@ exports[`no-shadow > invalid 130`] = `
 }
 `;
 
-exports[`no-shadow > invalid 131`] = `
+exports[`no-shadow > invalid 148`] = `
 {
   "code": "import * as Mods from 'fs'; function f(Mods: number) { return Mods; }",
   "diagnostics": [
@@ -3711,7 +4153,7 @@ exports[`no-shadow > invalid 131`] = `
 }
 `;
 
-exports[`no-shadow > invalid 132`] = `
+exports[`no-shadow > invalid 149`] = `
 {
   "code": "const Z = 1; const make = () => class Z {};",
   "diagnostics": [
@@ -3737,7 +4179,7 @@ exports[`no-shadow > invalid 132`] = `
 }
 `;
 
-exports[`no-shadow > invalid 133`] = `
+exports[`no-shadow > invalid 150`] = `
 {
   "code": "const t = 1; type T = typeof t; function f(t: number) { return t; }",
   "diagnostics": [
@@ -3763,7 +4205,7 @@ exports[`no-shadow > invalid 133`] = `
 }
 `;
 
-exports[`no-shadow > invalid 134`] = `
+exports[`no-shadow > invalid 151`] = `
 {
   "code": "const opts = { x: 1 }; function f(opts: typeof opts = opts) { return opts; }",
   "diagnostics": [
@@ -3789,7 +4231,7 @@ exports[`no-shadow > invalid 134`] = `
 }
 `;
 
-exports[`no-shadow > invalid 135`] = `
+exports[`no-shadow > invalid 152`] = `
 {
   "code": "const a = 1; const fn = function() { const a = 2; return a; };",
   "diagnostics": [
@@ -3815,7 +4257,7 @@ exports[`no-shadow > invalid 135`] = `
 }
 `;
 
-exports[`no-shadow > invalid 136`] = `
+exports[`no-shadow > invalid 153`] = `
 {
   "code": "const A = 1; class A_outer { x = class A {}; }",
   "diagnostics": [
@@ -3841,7 +4283,7 @@ exports[`no-shadow > invalid 136`] = `
 }
 `;
 
-exports[`no-shadow > invalid 137`] = `
+exports[`no-shadow > invalid 154`] = `
 {
   "code": "function f(...args: number[]) { function g({ args }: any) { return args; } }",
   "diagnostics": [
@@ -3867,7 +4309,7 @@ exports[`no-shadow > invalid 137`] = `
 }
 `;
 
-exports[`no-shadow > invalid 138`] = `
+exports[`no-shadow > invalid 155`] = `
 {
   "code": "function* g() { const v = 1; for (const v of [1,2,3]) { yield v; } }",
   "diagnostics": [
@@ -3893,7 +4335,7 @@ exports[`no-shadow > invalid 138`] = `
 }
 `;
 
-exports[`no-shadow > invalid 139`] = `
+exports[`no-shadow > invalid 156`] = `
 {
   "code": "function f<A>(fn: <A>(x: A) => A): A { return fn as any; }",
   "diagnostics": [
@@ -3919,7 +4361,7 @@ exports[`no-shadow > invalid 139`] = `
 }
 `;
 
-exports[`no-shadow > invalid 140`] = `
+exports[`no-shadow > invalid 157`] = `
 {
   "code": "function f<T>(): <T>(x: T) => T { return null as any; }",
   "diagnostics": [
@@ -3945,7 +4387,7 @@ exports[`no-shadow > invalid 140`] = `
 }
 `;
 
-exports[`no-shadow > invalid 141`] = `
+exports[`no-shadow > invalid 158`] = `
 {
   "code": "try {} catch (e) { try {} catch (e) {} }",
   "diagnostics": [
@@ -3971,7 +4413,7 @@ exports[`no-shadow > invalid 141`] = `
 }
 `;
 
-exports[`no-shadow > invalid 142`] = `
+exports[`no-shadow > invalid 159`] = `
 {
   "code": "class C<T> { m<T>(x: T): T { return x; } }",
   "diagnostics": [
@@ -3997,7 +4439,7 @@ exports[`no-shadow > invalid 142`] = `
 }
 `;
 
-exports[`no-shadow > invalid 143`] = `
+exports[`no-shadow > invalid 160`] = `
 {
   "code": "const x = 1; function f(x: number) { function g(x: number) { return x; } return g; }",
   "diagnostics": [
@@ -4038,7 +4480,7 @@ exports[`no-shadow > invalid 143`] = `
 }
 `;
 
-exports[`no-shadow > invalid 144`] = `
+exports[`no-shadow > invalid 161`] = `
 {
   "code": "const a = 1; function f([, a]: any[]) { return a; }",
   "diagnostics": [
@@ -4064,7 +4506,7 @@ exports[`no-shadow > invalid 144`] = `
 }
 `;
 
-exports[`no-shadow > invalid 145`] = `
+exports[`no-shadow > invalid 162`] = `
 {
   "code": "const a = 1; const fn = { call: (cb: any) => cb }; fn.call?.(a => a);",
   "diagnostics": [
@@ -4090,7 +4532,7 @@ exports[`no-shadow > invalid 145`] = `
 }
 `;
 
-exports[`no-shadow > invalid 146`] = `
+exports[`no-shadow > invalid 163`] = `
 {
   "code": "const x = 1; class C { constructor(public x: number) {} m() { const x = 1; return x; } }",
   "diagnostics": [
@@ -4131,7 +4573,7 @@ exports[`no-shadow > invalid 146`] = `
 }
 `;
 
-exports[`no-shadow > invalid 147`] = `
+exports[`no-shadow > invalid 164`] = `
 {
   "code": "const mod = 1; import('m').then((mod) => mod);",
   "diagnostics": [
@@ -4157,7 +4599,7 @@ exports[`no-shadow > invalid 147`] = `
 }
 `;
 
-exports[`no-shadow > invalid 148`] = `
+exports[`no-shadow > invalid 165`] = `
 {
   "code": "type X<T> = T extends Array<infer U> ? (U extends Array<infer U> ? U : never) : never;",
   "diagnostics": [
@@ -4183,7 +4625,7 @@ exports[`no-shadow > invalid 148`] = `
 }
 `;
 
-exports[`no-shadow > invalid 149`] = `
+exports[`no-shadow > invalid 166`] = `
 {
   "code": "const g = Array<number>; function f(Array: any) { return Array; }",
   "diagnostics": [
@@ -4209,7 +4651,7 @@ exports[`no-shadow > invalid 149`] = `
 }
 `;
 
-exports[`no-shadow > invalid 150`] = `
+exports[`no-shadow > invalid 167`] = `
 {
   "code": "const x = 1; class C { accessor x = 1; m() { const x = 2; return x; } }",
   "diagnostics": [
@@ -4235,7 +4677,7 @@ exports[`no-shadow > invalid 150`] = `
 }
 `;
 
-exports[`no-shadow > invalid 151`] = `
+exports[`no-shadow > invalid 168`] = `
 {
   "code": "async function f() { const x = 1; for await (const { v: x } of [Promise.resolve({ v: 1 })]) { return x; } }",
   "diagnostics": [
@@ -4261,7 +4703,7 @@ exports[`no-shadow > invalid 151`] = `
 }
 `;
 
-exports[`no-shadow > invalid 152`] = `
+exports[`no-shadow > invalid 169`] = `
 {
   "code": "async function f() { using u = { [Symbol.dispose]() {} }; for (const u of [] as any[]) { void u; } }",
   "diagnostics": [
@@ -4287,7 +4729,7 @@ exports[`no-shadow > invalid 152`] = `
 }
 `;
 
-exports[`no-shadow > invalid 153`] = `
+exports[`no-shadow > invalid 170`] = `
 {
   "code": "const k = 'a'; function f({ [k]: v }: any) { const k = 1; return [v, k]; }",
   "diagnostics": [
@@ -4313,7 +4755,7 @@ exports[`no-shadow > invalid 153`] = `
 }
 `;
 
-exports[`no-shadow > invalid 154`] = `
+exports[`no-shadow > invalid 171`] = `
 {
   "code": "function withTheme<P>(Component: any) { return function ThemedComponent(props: P) { const Component = 1; return Component; }; }",
   "diagnostics": [
@@ -4339,7 +4781,7 @@ exports[`no-shadow > invalid 154`] = `
 }
 `;
 
-exports[`no-shadow > invalid 155`] = `
+exports[`no-shadow > invalid 172`] = `
 {
   "code": "type A = { type: 'inc' } | { type: 'set'; value: number }; function reducer(state: number, action: A) { switch (action.type) { case 'inc': { const state = 1; return state + 1; } case 'set': return action.value; } }",
   "diagnostics": [
@@ -4365,7 +4807,7 @@ exports[`no-shadow > invalid 155`] = `
 }
 `;
 
-exports[`no-shadow > invalid 156`] = `
+exports[`no-shadow > invalid 173`] = `
 {
   "code": "function chain() { const item = { id: 1 }; [1, 2, 3].map(item => item + 1).filter(item => item > 1).forEach(item => void item); void item; }",
   "diagnostics": [
@@ -4421,7 +4863,7 @@ exports[`no-shadow > invalid 156`] = `
 }
 `;
 
-exports[`no-shadow > invalid 157`] = `
+exports[`no-shadow > invalid 174`] = `
 {
   "code": "const e = 1; try { try { throw new Error(); } catch (e) { try { throw e; } catch (e) {} } } catch (e) {} void e;",
   "diagnostics": [
@@ -4477,7 +4919,7 @@ exports[`no-shadow > invalid 157`] = `
 }
 `;
 
-exports[`no-shadow > invalid 158`] = `
+exports[`no-shadow > invalid 175`] = `
 {
   "code": "const methodName = 'foo'; const obj = { [methodName](methodName: string) { return methodName; } };",
   "diagnostics": [
@@ -4503,7 +4945,7 @@ exports[`no-shadow > invalid 158`] = `
 }
 `;
 
-exports[`no-shadow > invalid 159`] = `
+exports[`no-shadow > invalid 176`] = `
 {
   "code": "function f() { for (let i = 0; i < 1; i++) { for (let i = 0; i < 1; i++) {} } }",
   "diagnostics": [
@@ -4529,7 +4971,7 @@ exports[`no-shadow > invalid 159`] = `
 }
 `;
 
-exports[`no-shadow > invalid 160`] = `
+exports[`no-shadow > invalid 177`] = `
 {
   "code": "const a = 1; class C { m(x: string): void; m(x: number): void; m(a: any): void { void a; } }",
   "diagnostics": [
@@ -4555,7 +4997,7 @@ exports[`no-shadow > invalid 160`] = `
 }
 `;
 
-exports[`no-shadow > invalid 161`] = `
+exports[`no-shadow > invalid 178`] = `
 {
   "code": "function mk<T>(x: T) { return { get<T>(): T { return null as any; } }; }",
   "diagnostics": [
@@ -4581,7 +5023,7 @@ exports[`no-shadow > invalid 161`] = `
 }
 `;
 
-exports[`no-shadow > invalid 162`] = `
+exports[`no-shadow > invalid 179`] = `
 {
   "code": "const c = 1; { /* empty */ } { const c = 2; void c; }",
   "diagnostics": [
@@ -4607,7 +5049,7 @@ exports[`no-shadow > invalid 162`] = `
 }
 `;
 
-exports[`no-shadow > invalid 163`] = `
+exports[`no-shadow > invalid 180`] = `
 {
   "code": "const enum E { A, B } function f(E: number) { return E; }",
   "diagnostics": [
@@ -4633,7 +5075,7 @@ exports[`no-shadow > invalid 163`] = `
 }
 `;
 
-exports[`no-shadow > invalid 164`] = `
+exports[`no-shadow > invalid 181`] = `
 {
   "code": "abstract class C<T extends object> { abstract m<T>(): T; }",
   "diagnostics": [
@@ -4659,7 +5101,7 @@ exports[`no-shadow > invalid 164`] = `
 }
 `;
 
-exports[`no-shadow > invalid 165`] = `
+exports[`no-shadow > invalid 182`] = `
 {
   "code": "const iter = 1; class C { [Symbol.iterator](iter: number) { return iter; } }",
   "diagnostics": [
@@ -4685,7 +5127,7 @@ exports[`no-shadow > invalid 165`] = `
 }
 `;
 
-exports[`no-shadow > invalid 166`] = `
+exports[`no-shadow > invalid 183`] = `
 {
   "code": "const x = 1; class C { constructor(x?: number) { void x; } }",
   "diagnostics": [
@@ -4711,7 +5153,7 @@ exports[`no-shadow > invalid 166`] = `
 }
 `;
 
-exports[`no-shadow > invalid 167`] = `
+exports[`no-shadow > invalid 184`] = `
 {
   "code": "const val = { x: 1 }; function f(val: typeof val) { return val; }",
   "diagnostics": [
@@ -4737,7 +5179,7 @@ exports[`no-shadow > invalid 167`] = `
 }
 `;
 
-exports[`no-shadow > invalid 168`] = `
+exports[`no-shadow > invalid 185`] = `
 {
   "code": "const x = 1; class C { async m(x: number) { return x; } }",
   "diagnostics": [
@@ -4763,7 +5205,7 @@ exports[`no-shadow > invalid 168`] = `
 }
 `;
 
-exports[`no-shadow > invalid 169`] = `
+exports[`no-shadow > invalid 186`] = `
 {
   "code": "const x = 1; class C { *m(x: number) { yield x; } }",
   "diagnostics": [
@@ -4789,7 +5231,7 @@ exports[`no-shadow > invalid 169`] = `
 }
 `;
 
-exports[`no-shadow > invalid 170`] = `
+exports[`no-shadow > invalid 187`] = `
 {
   "code": "declare function foo(): void; function bar() { const foo = 1; return foo; }",
   "diagnostics": [
@@ -4815,7 +5257,7 @@ exports[`no-shadow > invalid 170`] = `
 }
 `;
 
-exports[`no-shadow > invalid 171`] = `
+exports[`no-shadow > invalid 188`] = `
 {
   "code": "const h = 1; class C extends (function() { const h = 2; return class {}; })() {}",
   "diagnostics": [
@@ -4841,7 +5283,7 @@ exports[`no-shadow > invalid 171`] = `
 }
 `;
 
-exports[`no-shadow > invalid 172`] = `
+exports[`no-shadow > invalid 189`] = `
 {
   "code": "const h = 1; class C extends ((h => h)(1), Object) {}",
   "diagnostics": [
@@ -4867,7 +5309,7 @@ exports[`no-shadow > invalid 172`] = `
 }
 `;
 
-exports[`no-shadow > invalid 173`] = `
+exports[`no-shadow > invalid 190`] = `
 {
   "code": "function dec(x: any) { return x; }
 @((target: any) => { const dec = 1; return dec && target; })
@@ -4895,7 +5337,7 @@ class D {}",
 }
 `;
 
-exports[`no-shadow > invalid 174`] = `
+exports[`no-shadow > invalid 191`] = `
 {
   "code": "const md = 1; class C { @((t: any, k: string) => { const md = 1; void md; }) method() {} }",
   "diagnostics": [
@@ -4921,7 +5363,7 @@ exports[`no-shadow > invalid 174`] = `
 }
 `;
 
-exports[`no-shadow > invalid 175`] = `
+exports[`no-shadow > invalid 192`] = `
 {
   "code": "const pd = 1; class C { method(@((t: any, k: any, i: number) => { const pd = 1; void pd; }) x: number) {} }",
   "diagnostics": [
@@ -4947,7 +5389,7 @@ exports[`no-shadow > invalid 175`] = `
 }
 `;
 
-exports[`no-shadow > invalid 176`] = `
+exports[`no-shadow > invalid 193`] = `
 {
   "code": "const k = 1; class C { [((k) => k)(2)]() {} }",
   "diagnostics": [
@@ -4973,7 +5415,7 @@ exports[`no-shadow > invalid 176`] = `
 }
 `;
 
-exports[`no-shadow > invalid 177`] = `
+exports[`no-shadow > invalid 194`] = `
 {
   "code": "const k = 1; class C { [((k) => k)(2)] = 1; }",
   "diagnostics": [
@@ -4999,7 +5441,7 @@ exports[`no-shadow > invalid 177`] = `
 }
 `;
 
-exports[`no-shadow > invalid 178`] = `
+exports[`no-shadow > invalid 195`] = `
 {
   "code": "const g = 1; class C { get [((g) => g)(1)]() { return 1; } }",
   "diagnostics": [
@@ -5025,7 +5467,7 @@ exports[`no-shadow > invalid 178`] = `
 }
 `;
 
-exports[`no-shadow > invalid 179`] = `
+exports[`no-shadow > invalid 196`] = `
 {
   "code": "const m = 1; class C { async *[((m) => m)(1)]() {} }",
   "diagnostics": [
@@ -5051,7 +5493,7 @@ exports[`no-shadow > invalid 179`] = `
 }
 `;
 
-exports[`no-shadow > invalid 180`] = `
+exports[`no-shadow > invalid 197`] = `
 {
   "code": "
   {
@@ -5082,7 +5524,7 @@ exports[`no-shadow > invalid 180`] = `
 }
 `;
 
-exports[`no-shadow > invalid 181`] = `
+exports[`no-shadow > invalid 198`] = `
 {
   "code": "
   {
@@ -5113,7 +5555,7 @@ exports[`no-shadow > invalid 181`] = `
 }
 `;
 
-exports[`no-shadow > invalid 182`] = `
+exports[`no-shadow > invalid 199`] = `
 {
   "code": "
 	if (true) {
@@ -5145,7 +5587,7 @@ exports[`no-shadow > invalid 182`] = `
 }
 `;
 
-exports[`no-shadow > invalid 183`] = `
+exports[`no-shadow > invalid 200`] = `
 {
   "code": "
 	// types
@@ -5197,7 +5639,7 @@ exports[`no-shadow > invalid 183`] = `
 }
 `;
 
-exports[`no-shadow > invalid 184`] = `
+exports[`no-shadow > invalid 201`] = `
 {
   "code": "
 	// types
@@ -5223,561 +5665,6 @@ exports[`no-shadow > invalid 184`] = `
         "start": {
           "column": 11,
           "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 185`] = `
-{
-  "code": "
-  {
-	interface A {}
-  }
-  type A = 1;
-		",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 5 column 8.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 13,
-          "line": 3,
-        },
-        "start": {
-          "column": 12,
-          "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 186`] = `
-{
-  "code": "let x = foo((x,y) => {});
-let y;",
-  "diagnostics": [
-    {
-      "message": "'x' is already declared in the upper scope on line 1 column 5.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 15,
-          "line": 1,
-        },
-        "start": {
-          "column": 14,
-          "line": 1,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-    {
-      "message": "'y' is already declared in the upper scope on line 2 column 5.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 17,
-          "line": 1,
-        },
-        "start": {
-          "column": 16,
-          "line": 1,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 2,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 187`] = `
-{
-  "code": "function a() {}
-foo(a => {});",
-  "diagnostics": [
-    {
-      "message": "'a' is already declared in the upper scope on line 1 column 10.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 6,
-          "line": 2,
-        },
-        "start": {
-          "column": 5,
-          "line": 2,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 188`] = `
-{
-  "code": "let x = ((x,y) => {})();
-let y;",
-  "diagnostics": [
-    {
-      "message": "'x' is already declared in the upper scope on line 1 column 5.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 12,
-          "line": 1,
-        },
-        "start": {
-          "column": 11,
-          "line": 1,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-    {
-      "message": "'y' is already declared in the upper scope on line 2 column 5.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 14,
-          "line": 1,
-        },
-        "start": {
-          "column": 13,
-          "line": 1,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 2,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 189`] = `
-{
-  "code": "
-  type T = 1;
-  {
-	type T = 2;
-  }
-		",
-  "diagnostics": [
-    {
-      "message": "'T' is already declared in the upper scope on line 2 column 8.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 8,
-          "line": 4,
-        },
-        "start": {
-          "column": 7,
-          "line": 4,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 190`] = `
-{
-  "code": "
-  type T = 1;
-  function foo<T>(arg: T) {}
-		",
-  "diagnostics": [
-    {
-      "message": "'T' is already declared in the upper scope on line 2 column 8.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 17,
-          "line": 3,
-        },
-        "start": {
-          "column": 16,
-          "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 191`] = `
-{
-  "code": "
-  function foo<T>() {
-	return function <T>() {};
-  }
-		",
-  "diagnostics": [
-    {
-      "message": "'T' is already declared in the upper scope on line 2 column 16.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 20,
-          "line": 3,
-        },
-        "start": {
-          "column": 19,
-          "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 192`] = `
-{
-  "code": "
-  type T = string;
-  function foo<T extends (arg: any) => void>(arg: T) {}
-		",
-  "diagnostics": [
-    {
-      "message": "'T' is already declared in the upper scope on line 2 column 8.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 17,
-          "line": 3,
-        },
-        "start": {
-          "column": 16,
-          "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 193`] = `
-{
-  "code": "
-  const arg = 0;
-  
-  declare const Test: {
-	new (arg: string): typeof arg;
-  };
-		",
-  "diagnostics": [
-    {
-      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 10,
-          "line": 5,
-        },
-        "start": {
-          "column": 7,
-          "line": 5,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 194`] = `
-{
-  "code": "
-  import type { foo } from './foo';
-  function doThing(foo: number) {}
-		",
-  "diagnostics": [
-    {
-      "message": "'foo' is already declared in the upper scope on line 2 column 17.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 23,
-          "line": 3,
-        },
-        "start": {
-          "column": 20,
-          "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 195`] = `
-{
-  "code": "
-  import { type foo } from './foo';
-  function doThing(foo: number) {}
-		",
-  "diagnostics": [
-    {
-      "message": "'foo' is already declared in the upper scope on line 2 column 17.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 23,
-          "line": 3,
-        },
-        "start": {
-          "column": 20,
-          "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 196`] = `
-{
-  "code": "
-  import { foo } from './foo';
-  function doThing(foo: number, bar: number) {}
-		",
-  "diagnostics": [
-    {
-      "message": "'foo' is already declared in the upper scope on line 2 column 12.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 23,
-          "line": 3,
-        },
-        "start": {
-          "column": 20,
-          "line": 3,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 197`] = `
-{
-  "code": "
-  interface Foo {}
-  
-  declare module 'bar' {
-	export interface Foo {
-	  x: string;
-	}
-  }
-		",
-  "diagnostics": [
-    {
-      "message": "'Foo' is already declared in the upper scope on line 2 column 13.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 22,
-          "line": 5,
-        },
-        "start": {
-          "column": 19,
-          "line": 5,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 198`] = `
-{
-  "code": "
-  import type { Foo } from 'bar';
-  
-  declare module 'baz' {
-	export interface Foo {
-	  x: string;
-	}
-  }
-		",
-  "diagnostics": [
-    {
-      "message": "'Foo' is already declared in the upper scope on line 2 column 17.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 22,
-          "line": 5,
-        },
-        "start": {
-          "column": 19,
-          "line": 5,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 199`] = `
-{
-  "code": "
-  import { type Foo } from 'bar';
-  
-  declare module 'baz' {
-	export interface Foo {
-	  x: string;
-	}
-  }
-		",
-  "diagnostics": [
-    {
-      "message": "'Foo' is already declared in the upper scope on line 2 column 17.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 22,
-          "line": 5,
-        },
-        "start": {
-          "column": 19,
-          "line": 5,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 200`] = `
-{
-  "code": "
-  let x = foo((x, y) => {});
-  let y;
-		",
-  "diagnostics": [
-    {
-      "message": "'x' is already declared in the upper scope on line 2 column 7.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 17,
-          "line": 2,
-        },
-        "start": {
-          "column": 16,
-          "line": 2,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-    {
-      "message": "'y' is already declared in the upper scope on line 3 column 7.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 20,
-          "line": 2,
-        },
-        "start": {
-          "column": 19,
-          "line": 2,
-        },
-      },
-      "ruleName": "no-shadow",
-    },
-  ],
-  "errorCount": 2,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 201`] = `
-{
-  "code": "
-  let x = foo((x, y) => {});
-  let y;
-		",
-  "diagnostics": [
-    {
-      "message": "'x' is already declared in the upper scope on line 2 column 7.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 17,
-          "line": 2,
-        },
-        "start": {
-          "column": 16,
-          "line": 2,
         },
       },
       "ruleName": "no-shadow",
@@ -5822,6 +5709,530 @@ exports[`no-shadow > invalid 202`] = `
 
 exports[`no-shadow > invalid 203`] = `
 {
+  "code": "let x = foo((x,y) => {});
+let y;",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 2 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 204`] = `
+{
+  "code": "function a() {}
+foo(a => {});",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 205`] = `
+{
+  "code": "let x = ((x,y) => {})();
+let y;",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 2 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 206`] = `
+{
+  "code": "
+  type T = 1;
+  {
+	type T = 2;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 207`] = `
+{
+  "code": "
+  type T = 1;
+  function foo<T>(arg: T) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 208`] = `
+{
+  "code": "
+  function foo<T>() {
+	return function <T>() {};
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 16.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 209`] = `
+{
+  "code": "
+  type T = string;
+  function foo<T extends (arg: any) => void>(arg: T) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 210`] = `
+{
+  "code": "
+  const arg = 0;
+  
+  declare const Test: {
+	new (arg: string): typeof arg;
+  };
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 211`] = `
+{
+  "code": "
+  import type { foo } from './foo';
+  function doThing(foo: number) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 212`] = `
+{
+  "code": "
+  import { type foo } from './foo';
+  function doThing(foo: number) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 213`] = `
+{
+  "code": "
+  import { foo } from './foo';
+  function doThing(foo: number, bar: number) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 12.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 214`] = `
+{
+  "code": "
+  interface Foo {}
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 215`] = `
+{
+  "code": "
+  import type { Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 216`] = `
+{
+  "code": "
+  import { type Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 217`] = `
+{
+  "code": "
+  let x = foo((x, y) => {});
+  let y;
+		",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 2 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 3 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 218`] = `
+{
+  "code": "
+  let x = foo((x, y) => {});
+  let y;
+		",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 2 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 219`] = `
+{
   "code": "
   {
 	interface A {}
@@ -5851,7 +6262,38 @@ exports[`no-shadow > invalid 203`] = `
 }
 `;
 
-exports[`no-shadow > invalid 204`] = `
+exports[`no-shadow > invalid 220`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 221`] = `
 {
   "code": "
 	if (true) {
@@ -5883,7 +6325,7 @@ exports[`no-shadow > invalid 204`] = `
 }
 `;
 
-exports[`no-shadow > invalid 205`] = `
+exports[`no-shadow > invalid 222`] = `
 {
   "code": "
 	// types
@@ -5935,7 +6377,7 @@ exports[`no-shadow > invalid 205`] = `
 }
 `;
 
-exports[`no-shadow > invalid 206`] = `
+exports[`no-shadow > invalid 223`] = `
 {
   "code": "
 	// types
@@ -5972,7 +6414,7 @@ exports[`no-shadow > invalid 206`] = `
 }
 `;
 
-exports[`no-shadow > invalid 207`] = `
+exports[`no-shadow > invalid 224`] = `
 {
   "code": "
   {
@@ -6003,7 +6445,7 @@ exports[`no-shadow > invalid 207`] = `
 }
 `;
 
-exports[`no-shadow > invalid 208`] = `
+exports[`no-shadow > invalid 225`] = `
 {
   "code": "
 			const A = 2;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-shadow.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-shadow.test.ts
@@ -718,29 +718,6 @@ function bar() { }`,
   }
 		`,
     },
-
-    // ---- Function-name initializer exception covers arbitrary wrappers
-    // (ESLint scope-based check: outerScope === innerScope.upper).
-    'const a = wrap(function a() {});',
-    'const a = foo || wrap(function a() {});',
-    'const { a = wrap(function a() {}) } = obj;',
-    'const { a = foo || wrap(function a() {}) } = obj;',
-    'const { a = foo, b = function a() {} } = {}',
-    'const { A = Foo, B = class A {} } = {}',
-    'function foo(a = wrap(function a() {})) {}',
-    'function foo(a = foo || wrap(function a() {})) {}',
-    'const A = wrap(class A {});',
-    'const A = foo || wrap(class A {});',
-    'const { A = wrap(class A {}) } = obj;',
-    'const { A = foo || wrap(class A {}) } = obj;',
-    'function foo(A = wrap(class A {})) {}',
-    'function foo(A = foo || wrap(class A {})) {}',
-    'var a = function a() {} ? foo : bar',
-    'var A = class A {} ? foo : bar',
-    {
-      code: 'let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });',
-      options: [{ hoist: 'all' }] as any,
-    },
   ],
   invalid: [
     // ---- Core JS shadow with line/column ----
@@ -918,6 +895,80 @@ function bar() { }`,
     },
     {
       code: 'class A { constructor() { var A; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Function/class names that are not direct initializers ----
+    // Calls are not transparent, even when a surrounding logical expression is.
+    {
+      code: 'const a = wrap(function a() {});',
+      errors: [{ messageId: 'noShadow', line: 1, column: 25 }],
+    },
+    {
+      code: 'const a = foo || wrap(function a() {});',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const { a = wrap(function a() {}) } = obj;',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const { a = foo || wrap(function a() {}) } = obj;',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(a = wrap(function a() {})) {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(a = foo || wrap(function a() {})) {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const A = wrap(class A {});',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const A = foo || wrap(class A {});',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const { A = wrap(class A {}) } = obj;',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const { A = foo || wrap(class A {}) } = obj;',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(A = wrap(class A {})) {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(A = foo || wrap(class A {})) {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // A sibling destructuring default is not this binding's initializer.
+    {
+      code: 'const { a = foo, b = function a() {} } = {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const { A = Foo, B = class A {} } = {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // The test position of a conditional expression is not a result branch.
+    {
+      code: 'var a = function a() {} ? foo : bar',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'var A = class A {} ? foo : bar',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });',
+      options: [{ hoist: 'all' }] as any,
       errors: [{ messageId: 'noShadow' }],
     },
 

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-shadow/__snapshots__/no-shadow.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-shadow/__snapshots__/no-shadow.test.ts.snap
@@ -2,6 +2,243 @@
 
 exports[`no-shadow > invalid 1`] = `
 {
+  "code": "const f = (function f() {} as unknown);",
+  "diagnostics": [
+    {
+      "message": "'f' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 2`] = `
+{
+  "code": "enum A { A }",
+  "diagnostics": [
+    {
+      "message": "Enum members are added to the enum scope, so references to 'A' in enum member initializers resolve to this member instead of the declaration in the upper scope on line 1 column 6.",
+      "messageId": "noEnumShadow",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 3`] = `
+{
+  "code": "function fn(Record: number) {}",
+  "diagnostics": [
+    {
+      "message": "'Record' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 4`] = `
+{
+  "code": "function fn() { type Record = string; }",
+  "diagnostics": [
+    {
+      "message": "'Record' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 5`] = `
+{
+  "code": "import type { Record } from 'pkg';",
+  "diagnostics": [
+    {
+      "message": "'Record' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 6`] = `
+{
+  "code": "type Fn = (Record: number) => void;",
+  "diagnostics": [
+    {
+      "message": "'Record' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 7`] = `
+{
+  "code": "interface Record {} namespace Record { export const value = 1; }",
+  "diagnostics": [
+    {
+      "message": "'Record' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 8`] = `
+{
+  "code": "class C { static method<Record>() {} }",
+  "diagnostics": [
+    {
+      "message": "'Record' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 9`] = `
+{
+  "code": "
+import { request, type Server } from 'node:http';
+function use(request: unknown) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'request' is already declared in the upper scope on line 2 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 10`] = `
+{
   "code": "
 type T = 1;
 {
@@ -31,7 +268,7 @@ type T = 1;
 }
 `;
 
-exports[`no-shadow > invalid 2`] = `
+exports[`no-shadow > invalid 11`] = `
 {
   "code": "
 type T = 1;
@@ -60,7 +297,7 @@ function foo<T>(arg: T) {}
 }
 `;
 
-exports[`no-shadow > invalid 3`] = `
+exports[`no-shadow > invalid 12`] = `
 {
   "code": "
 function foo<T>() {
@@ -90,7 +327,7 @@ function foo<T>() {
 }
 `;
 
-exports[`no-shadow > invalid 4`] = `
+exports[`no-shadow > invalid 13`] = `
 {
   "code": "
 type T = string;
@@ -119,7 +356,7 @@ function foo<T extends (arg: any) => void>(arg: T) {}
 }
 `;
 
-exports[`no-shadow > invalid 5`] = `
+exports[`no-shadow > invalid 14`] = `
 {
   "code": "
 const x = 1;
@@ -150,7 +387,7 @@ const x = 1;
 }
 `;
 
-exports[`no-shadow > invalid 6`] = `
+exports[`no-shadow > invalid 15`] = `
 {
   "code": "
 const test = 1;
@@ -179,7 +416,7 @@ type Fn = (test: string) => typeof test;
 }
 `;
 
-exports[`no-shadow > invalid 7`] = `
+exports[`no-shadow > invalid 16`] = `
 {
   "code": "
 const arg = 0;
@@ -211,7 +448,7 @@ interface Test {
 }
 `;
 
-exports[`no-shadow > invalid 8`] = `
+exports[`no-shadow > invalid 17`] = `
 {
   "code": "
 const arg = 0;
@@ -243,7 +480,7 @@ interface Test {
 }
 `;
 
-exports[`no-shadow > invalid 9`] = `
+exports[`no-shadow > invalid 18`] = `
 {
   "code": "
 const arg = 0;
@@ -273,7 +510,7 @@ declare function test(arg: string): typeof arg;
 }
 `;
 
-exports[`no-shadow > invalid 10`] = `
+exports[`no-shadow > invalid 19`] = `
 {
   "code": "
 const arg = 0;
@@ -303,7 +540,7 @@ declare const test: (arg: string) => typeof arg;
 }
 `;
 
-exports[`no-shadow > invalid 11`] = `
+exports[`no-shadow > invalid 20`] = `
 {
   "code": "
 const arg = 0;
@@ -335,7 +572,7 @@ declare class Test {
 }
 `;
 
-exports[`no-shadow > invalid 12`] = `
+exports[`no-shadow > invalid 21`] = `
 {
   "code": "
 const arg = 0;
@@ -367,7 +604,7 @@ declare const Test: {
 }
 `;
 
-exports[`no-shadow > invalid 13`] = `
+exports[`no-shadow > invalid 22`] = `
 {
   "code": "
 const arg = 0;
@@ -397,7 +634,7 @@ type Bar = new (arg: number) => typeof arg;
 }
 `;
 
-exports[`no-shadow > invalid 14`] = `
+exports[`no-shadow > invalid 23`] = `
 {
   "code": "
 const arg = 0;
@@ -429,7 +666,7 @@ declare namespace Lib {
 }
 `;
 
-exports[`no-shadow > invalid 15`] = `
+exports[`no-shadow > invalid 24`] = `
 {
   "code": "
 import type { foo } from './foo';
@@ -458,7 +695,7 @@ function doThing(foo: number) {}
 }
 `;
 
-exports[`no-shadow > invalid 16`] = `
+exports[`no-shadow > invalid 25`] = `
 {
   "code": "
 import { type foo } from './foo';
@@ -487,7 +724,7 @@ function doThing(foo: number) {}
 }
 `;
 
-exports[`no-shadow > invalid 17`] = `
+exports[`no-shadow > invalid 26`] = `
 {
   "code": "
 import { foo } from './foo';
@@ -516,7 +753,7 @@ function doThing(foo: number, bar: number) {}
 }
 `;
 
-exports[`no-shadow > invalid 18`] = `
+exports[`no-shadow > invalid 27`] = `
 {
   "code": "
 interface Foo {}
@@ -550,7 +787,7 @@ declare module 'bar' {
 }
 `;
 
-exports[`no-shadow > invalid 19`] = `
+exports[`no-shadow > invalid 28`] = `
 {
   "code": "
 import type { Foo } from 'bar';
@@ -584,7 +821,7 @@ declare module 'baz' {
 }
 `;
 
-exports[`no-shadow > invalid 20`] = `
+exports[`no-shadow > invalid 29`] = `
 {
   "code": "
 import { type Foo } from 'bar';
@@ -618,7 +855,7 @@ declare module 'baz' {
 }
 `;
 
-exports[`no-shadow > invalid 21`] = `
+exports[`no-shadow > invalid 30`] = `
 {
   "code": "
 let x = foo((x, y) => {});
@@ -662,7 +899,7 @@ let y;
 }
 `;
 
-exports[`no-shadow > invalid 22`] = `
+exports[`no-shadow > invalid 31`] = `
 {
   "code": "
 let x = foo((x, y) => {});
@@ -691,280 +928,15 @@ let y;
 }
 `;
 
-exports[`no-shadow > invalid 23`] = `
-{
-  "code": "
-type Foo<A> = 1;
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 11,
-          "line": 2,
-        },
-        "start": {
-          "column": 10,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 24`] = `
-{
-  "code": "
-interface Foo<A> {}
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 16,
-          "line": 2,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 25`] = `
-{
-  "code": "
-interface Foo<A> {}
-interface A {}
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 11.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 16,
-          "line": 2,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 26`] = `
-{
-  "code": "
-type Foo<A> = 1;
-interface A {}
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 11.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 11,
-          "line": 2,
-        },
-        "start": {
-          "column": 10,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 27`] = `
-{
-  "code": "
-{
-  type A = 1;
-}
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 5 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 9,
-          "line": 3,
-        },
-        "start": {
-          "column": 8,
-          "line": 3,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 28`] = `
-{
-  "code": "
-{
-  interface A {}
-}
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 5 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 14,
-          "line": 3,
-        },
-        "start": {
-          "column": 13,
-          "line": 3,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 29`] = `
-{
-  "code": "
-type Foo<A> = 1;
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 11,
-          "line": 2,
-        },
-        "start": {
-          "column": 10,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 30`] = `
-{
-  "code": "
-interface Foo<A> {}
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 16,
-          "line": 2,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 31`] = `
-{
-  "code": "
-interface Foo<A> {}
-interface A {}
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 11.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 16,
-          "line": 2,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
 exports[`no-shadow > invalid 32`] = `
 {
   "code": "
 type Foo<A> = 1;
-interface A {}
+type A = 1;
       ",
   "diagnostics": [
     {
-      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "message": "'A' is already declared in the upper scope on line 3 column 6.",
       "messageId": "noShadow",
       "range": {
         "end": {
@@ -988,6 +960,93 @@ interface A {}
 exports[`no-shadow > invalid 33`] = `
 {
   "code": "
+interface Foo<A> {}
+type A = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 6.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 34`] = `
+{
+  "code": "
+interface Foo<A> {}
+interface A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 35`] = `
+{
+  "code": "
+type Foo<A> = 1;
+interface A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 36`] = `
+{
+  "code": "
 {
   type A = 1;
 }
@@ -1016,7 +1075,7 @@ type A = 1;
 }
 `;
 
-exports[`no-shadow > invalid 34`] = `
+exports[`no-shadow > invalid 37`] = `
 {
   "code": "
 {
@@ -1047,102 +1106,15 @@ type A = 1;
 }
 `;
 
-exports[`no-shadow > invalid 35`] = `
-{
-  "code": "
-type Foo<A> = 1;
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 11,
-          "line": 2,
-        },
-        "start": {
-          "column": 10,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 36`] = `
-{
-  "code": "
-interface Foo<A> {}
-type A = 1;
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 6.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 16,
-          "line": 2,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-shadow > invalid 37`] = `
-{
-  "code": "
-interface Foo<A> {}
-interface A {}
-      ",
-  "diagnostics": [
-    {
-      "message": "'A' is already declared in the upper scope on line 3 column 11.",
-      "messageId": "noShadow",
-      "range": {
-        "end": {
-          "column": 16,
-          "line": 2,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-shadow",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
 exports[`no-shadow > invalid 38`] = `
 {
   "code": "
 type Foo<A> = 1;
-interface A {}
+type A = 1;
       ",
   "diagnostics": [
     {
-      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "message": "'A' is already declared in the upper scope on line 3 column 6.",
       "messageId": "noShadow",
       "range": {
         "end": {
@@ -1164,6 +1136,93 @@ interface A {}
 `;
 
 exports[`no-shadow > invalid 39`] = `
+{
+  "code": "
+interface Foo<A> {}
+type A = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 6.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 40`] = `
+{
+  "code": "
+interface Foo<A> {}
+interface A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 41`] = `
+{
+  "code": "
+type Foo<A> = 1;
+interface A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 42`] = `
 {
   "code": "
 {
@@ -1194,7 +1253,185 @@ type A = 1;
 }
 `;
 
-exports[`no-shadow > invalid 40`] = `
+exports[`no-shadow > invalid 43`] = `
+{
+  "code": "
+{
+  interface A {}
+}
+type A = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 6.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 44`] = `
+{
+  "code": "
+type Foo<A> = 1;
+type A = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 6.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 45`] = `
+{
+  "code": "
+interface Foo<A> {}
+type A = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 6.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 46`] = `
+{
+  "code": "
+interface Foo<A> {}
+interface A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 47`] = `
+{
+  "code": "
+type Foo<A> = 1;
+interface A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 48`] = `
+{
+  "code": "
+{
+  type A = 1;
+}
+type A = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 6.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 49`] = `
 {
   "code": "
 {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-shadow/no-shadow.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-shadow/no-shadow.test.ts
@@ -8,6 +8,118 @@ const ruleTester = new RuleTester();
 ruleTester.run('no-shadow', {
   invalid: [
     {
+      code: 'const f = (function f() {} as unknown);',
+      errors: [
+        {
+          data: {
+            name: 'f',
+            shadowedColumn: 7,
+            shadowedLine: 1,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
+    {
+      code: 'enum A { A }',
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 1,
+          },
+          messageId: 'noEnumShadow',
+        },
+      ],
+    },
+    {
+      code: 'function fn(Record: number) {}',
+      errors: [
+        {
+          data: { name: 'Record' },
+          messageId: 'noShadowGlobal',
+        },
+      ],
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: 'function fn() { type Record = string; }',
+      errors: [
+        {
+          data: { name: 'Record' },
+          messageId: 'noShadowGlobal',
+        },
+      ],
+      options: [
+        {
+          builtinGlobals: true,
+          ignoreTypeValueShadow: false,
+        },
+      ],
+    },
+    {
+      code: "import type { Record } from 'pkg';",
+      errors: [
+        {
+          data: { name: 'Record' },
+          messageId: 'noShadowGlobal',
+        },
+      ],
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: 'type Fn = (Record: number) => void;',
+      errors: [
+        {
+          data: { name: 'Record' },
+          messageId: 'noShadowGlobal',
+        },
+      ],
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: 'interface Record {} namespace Record { export const value = 1; }',
+      errors: [
+        {
+          data: { name: 'Record' },
+          messageId: 'noShadowGlobal',
+        },
+      ],
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: 'class C { static method<Record>() {} }',
+      errors: [
+        {
+          data: { name: 'Record' },
+          messageId: 'noShadowGlobal',
+        },
+      ],
+      options: [
+        {
+          builtinGlobals: true,
+          ignoreTypeValueShadow: false,
+        },
+      ],
+    },
+    {
+      code: `
+import { request, type Server } from 'node:http';
+function use(request: unknown) {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'request',
+            shadowedColumn: 10,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
+    {
       code: `
 type T = 1;
 {
@@ -901,6 +1013,18 @@ const fn = (has: string) => {};
     },
   ],
   valid: [
+    {
+      code: 'function fn() { type Record = string; }',
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: 'function fn(Record: number) {}',
+      options: [{ builtinGlobals: false }],
+    },
+    {
+      code: 'function fn(NodeListOf: number, HTMLElement: number) {}',
+      options: [{ builtinGlobals: true }],
+    },
     'function foo<T = (arg: any) => any>(arg: T) {}',
     'function foo<T = ([arg]: [any]) => any>(arg: T) {}',
     'function foo<T = ({ args }: { args: any }) => any>(arg: T) {}',


### PR DESCRIPTION
## Summary

- align `@typescript-eslint/no-shadow` with scope-manager's default TypeScript type globals when `builtinGlobals` is enabled
- align implicit-global, mixed type-import, declaration-merge, and static-method generic semantics
- align direct function/class initializer exceptions and TypeScript enum diagnostics found through adversarial upstream and real-repository comparisons

## Validation

- `go test ./internal/rules/no_shadow ./internal/plugins/typescript/rules/no_shadow`
- `go build -o /tmp/rslint-no-shadow-current ./cmd/rslint`
- exact comparison with `@typescript-eslint/eslint-plugin@8.65.0` by rule, message, and start location:
  - adversarial corpus: 218 / 218 diagnostics
  - rsbuild: 1,397 TS/TSX files, 70 / 70 diagnostics
  - rspack: 585 TS/TSX files, 233 / 233 diagnostics
