### PR TITLE
ci: prepare wasm artifacts for npm release

### DIFF
--- a/.github/actions/move-artifacts/move-artifacts.js
+++ b/.github/actions/move-artifacts/move-artifacts.js
@@ -75,7 +75,9 @@ async function moveArtifacts() {
     // subpackages (flat, alongside the Go binary). Artifacts are named
     // `rslint.{tuple}.node`; target is `npm/rslint/{tuple}/` (libc suffix kept
     // so gnu/musl stay separate). Not chmod'd — a `.node` is dlopen'd.
-    const nodeFiles = findBinaries('binaries', 'rslint.');
+    const nodeFiles = findBinaries('binaries', 'rslint.').filter((file) =>
+      file.endsWith('.node'),
+    );
     console.log(`Found ${nodeFiles.length} napi .node files`);
 
     for (const file of nodeFiles) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
   publish-npm:
     if: ${{ inputs.to_release == 'all' || inputs.to_release == 'npm' }}
     name: ${{ inputs.dry_run == true && 'Dry Run - NPM Packages' || 'Publish NPM Packages' }}
-    needs: [build, napi-build]
+    needs: [build, build-wasm, napi-build]
     runs-on: ubuntu-22.04
     environment: release
     permissions:
@@ -77,6 +77,7 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
+
       # Update npm to the latest version to enable OIDC
       - name: Update npm
         run: |
@@ -94,14 +95,19 @@ jobs:
         with:
           path: binaries
 
+      - name: Copy rslint WASM artifact
+        run: cp binaries/rslint-wasm/rslint.wasm packages/rslint-wasm/rslint.wasm
+
       - name: Move binaries
         uses: ./.github/actions/move-artifacts
-      # The per-platform .node parser binaries ship in the @rslint/native-{tuple}
-      # subpackages, populated from the napi-build artifacts by move-artifacts
-      # above. core's loader resolves them at runtime, so no napi build / Rust is
-      # needed here — build:js just bundles the worker (loader + types live in core).
-      - name: Build @rslint/core dist
-        run: pnpm --filter @rslint/core build:js
+
+      # The native binaries and WASM are downloaded above. The JavaScript
+      # package outputs are fast to build and remain part of the publish job.
+      - name: Build npm package JavaScript
+        run: |
+          pnpm --filter @rslint/core build:js
+          pnpm --filter @rslint/wasm build:js
+
       - name: Publish npm packages
         if: ${{ inputs.dry_run == false }}
         run: |
@@ -185,6 +191,33 @@ jobs:
               pnpm publish:ovsx
             fi
           fi
+
+  build-wasm:
+    name: Build WASM
+    runs-on: rspack-ubuntu-22.04-large
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.inputs.branch }}
+          submodules: true
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: 1.26.0
+          cache-name: release-wasm
+
+      - name: Build rslint WASM
+        run: GOOS=js GOARCH=wasm go build -o packages/rslint-wasm/rslint.wasm -ldflags="-s -w" ./cmd/rslint
+
+      - name: Upload rslint WASM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rslint-wasm
+          path: packages/rslint-wasm/rslint.wasm
+          if-no-files-found: error
 
   build:
     env:

--- a/packages/rslint-wasm/package.json
+++ b/packages/rslint-wasm/package.json
@@ -13,8 +13,7 @@
   "files": [
     "dist/index.mjs",
     "dist/**.d.ts",
-    "rslint.wasm",
-    "rslint.wasm.gz"
+    "rslint.wasm"
   ],
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary

- Build `rslint.wasm` in a dedicated `build-wasm` job and upload only that binary as a release artifact.
- Download and copy the WASM artifact into `packages/rslint-wasm` before publishing, while keeping the fast core and WASM JavaScript builds in `publish-npm` as before.
- Restrict N-API artifact discovery to `.node` files so the downloaded `rslint.wasm` is not misclassified.
- Exclude the redundant `rslint.wasm.gz` from the npm package while retaining local generation for the website.
- Verified with WASM artifact assembly simulation, JavaScript package builds, `pnpm publish --dry-run`, `pnpm run check-spell`, and `pnpm run format:check`; no Go files changed, so targeted Go lint had no inputs.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).