### PR TITLE
docs(jest): record each rule's aligned upstream version

### DIFF
--- a/internal/plugins/jest/rules/expect_expect/expect_expect.md
+++ b/internal/plugins/jest/rules/expect_expect/expect_expect.md
@@ -42,5 +42,5 @@ For more option examples and edge cases, see the upstream rule documentation lin
 
 ## Original Documentation
 
-- [eslint-plugin-jest: expect-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/expect-expect.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/expect-expect.ts)
+- [eslint-plugin-jest: expect-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/expect-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/expect-expect.ts)

--- a/internal/plugins/jest/rules/expect_expect/expect_expect.md
+++ b/internal/plugins/jest/rules/expect_expect/expect_expect.md
@@ -42,4 +42,5 @@ For more option examples and edge cases, see the upstream rule documentation lin
 
 ## Original Documentation
 
-- [jest/expect-expect](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/expect-expect.md)
+- [eslint-plugin-jest: expect-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/expect-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/expect-expect.ts)

--- a/internal/plugins/jest/rules/max_expects/max_expects.md
+++ b/internal/plugins/jest/rules/max_expects/max_expects.md
@@ -113,5 +113,5 @@ test('should not pass', () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: max-expects](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/max-expects.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/max-expects.ts)
+- [eslint-plugin-jest: max-expects](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/max-expects.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/max-expects.ts)

--- a/internal/plugins/jest/rules/max_expects/max_expects.md
+++ b/internal/plugins/jest/rules/max_expects/max_expects.md
@@ -113,4 +113,5 @@ test('should not pass', () => {
 
 ## Original Documentation
 
-- [jest/max-expects](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/max-expects.md)
+- [eslint-plugin-jest: max-expects](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/max-expects.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/max-expects.ts)

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.md
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.md
@@ -113,4 +113,5 @@ fdescribe('foo', () => {
 
 ## Original Documentation
 
-- [jest/max-nested-describe](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/max-nested-describe.md)
+- [eslint-plugin-jest: max-nested-describe](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/max-nested-describe.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/max-nested-describe.ts)

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.md
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.md
@@ -113,5 +113,5 @@ fdescribe('foo', () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: max-nested-describe](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/max-nested-describe.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/max-nested-describe.ts)
+- [eslint-plugin-jest: max-nested-describe](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/max-nested-describe.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/max-nested-describe.ts)

--- a/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.md
+++ b/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.md
@@ -38,4 +38,5 @@ expect(a).toThrow();
 
 ## Original Documentation
 
-- [jest/no-alias-methods](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-alias-methods.md)
+- [eslint-plugin-jest: no-alias-methods](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-alias-methods.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-alias-methods.ts)

--- a/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.md
+++ b/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.md
@@ -38,5 +38,5 @@ expect(a).toThrow();
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-alias-methods](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-alias-methods.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-alias-methods.ts)
+- [eslint-plugin-jest: no-alias-methods](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-alias-methods.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-alias-methods.ts)

--- a/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.md
+++ b/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.md
@@ -66,4 +66,5 @@ Because the heuristic treats any `test` / `it` / `describe`-like call opening in
 
 ## Original Documentation
 
-- [jest/no-commented-out-tests](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-commented-out-tests.md)
+- [eslint-plugin-jest: no-commented-out-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-commented-out-tests.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-commented-out-tests.ts)

--- a/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.md
+++ b/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.md
@@ -66,5 +66,5 @@ Because the heuristic treats any `test` / `it` / `describe`-like call opening in
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-commented-out-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-commented-out-tests.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-commented-out-tests.ts)
+- [eslint-plugin-jest: no-commented-out-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-commented-out-tests.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-commented-out-tests.ts)

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.md
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.md
@@ -132,4 +132,5 @@ it('includes the status code in the error', async () => {
 
 ## Original Documentation
 
-- [jest/no-conditional-expect](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md)
+- [eslint-plugin-jest: no-conditional-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-conditional-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-conditional-expect.ts)

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.md
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.md
@@ -132,5 +132,5 @@ it('includes the status code in the error', async () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-conditional-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-conditional-expect.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-conditional-expect.ts)
+- [eslint-plugin-jest: no-conditional-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-conditional-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-conditional-expect.ts)

--- a/internal/plugins/jest/rules/no_conditional_in_test/no_conditional_in_test.md
+++ b/internal/plugins/jest/rules/no_conditional_in_test/no_conditional_in_test.md
@@ -119,4 +119,5 @@ it('foo', () => {
 
 ## Original Documentation
 
-- [jest/no-conditional-in-test](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-in-test.md)
+- [eslint-plugin-jest: no-conditional-in-test](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.5/docs/rules/no-conditional-in-test.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.5/src/rules/no-conditional-in-test.ts)

--- a/internal/plugins/jest/rules/no_conditional_in_test/no_conditional_in_test.md
+++ b/internal/plugins/jest/rules/no_conditional_in_test/no_conditional_in_test.md
@@ -119,5 +119,5 @@ it('foo', () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-conditional-in-test](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.5/docs/rules/no-conditional-in-test.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.5/src/rules/no-conditional-in-test.ts)
+- [eslint-plugin-jest: no-conditional-in-test](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-conditional-in-test.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-conditional-in-test.ts)

--- a/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.md
+++ b/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.md
@@ -80,5 +80,5 @@ setTimeout(1000);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-confusing-set-timeout](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-confusing-set-timeout.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-confusing-set-timeout.ts)
+- [eslint-plugin-jest: no-confusing-set-timeout](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-confusing-set-timeout.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-confusing-set-timeout.ts)

--- a/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.md
+++ b/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.md
@@ -80,4 +80,5 @@ setTimeout(1000);
 
 ## Original Documentation
 
-- [jest/no-confusing-set-timeout](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-confusing-set-timeout.md)
+- [eslint-plugin-jest: no-confusing-set-timeout](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-confusing-set-timeout.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-confusing-set-timeout.ts)

--- a/internal/plugins/jest/rules/no_deprecated_functions/no_deprecated_functions.md
+++ b/internal/plugins/jest/rules/no_deprecated_functions/no_deprecated_functions.md
@@ -41,5 +41,5 @@ jest.createMockFromModule('m');
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-deprecated-functions](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-deprecated-functions.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-deprecated-functions.ts)
+- [eslint-plugin-jest: no-deprecated-functions](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-deprecated-functions.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-deprecated-functions.ts)

--- a/internal/plugins/jest/rules/no_deprecated_functions/no_deprecated_functions.md
+++ b/internal/plugins/jest/rules/no_deprecated_functions/no_deprecated_functions.md
@@ -41,4 +41,5 @@ jest.createMockFromModule('m');
 
 ## Original Documentation
 
-- [jest/no-deprecated-functions](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md)
+- [eslint-plugin-jest: no-deprecated-functions](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-deprecated-functions.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-deprecated-functions.ts)

--- a/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.md
+++ b/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.md
@@ -53,4 +53,5 @@ myTest('does not have function body');
 
 ## Original Documentation
 
-- [jest/no-disabled-tests](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-disabled-tests.md)
+- [eslint-plugin-jest: no-disabled-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-disabled-tests.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-disabled-tests.ts)

--- a/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.md
+++ b/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.md
@@ -53,5 +53,5 @@ myTest('does not have function body');
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-disabled-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-disabled-tests.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-disabled-tests.ts)
+- [eslint-plugin-jest: no-disabled-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-disabled-tests.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-disabled-tests.ts)

--- a/internal/plugins/jest/rules/no_done_callback/no_done_callback.md
+++ b/internal/plugins/jest/rules/no_done_callback/no_done_callback.md
@@ -42,5 +42,5 @@ test('myFunction()', async () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-done-callback](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-done-callback.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-done-callback.ts)
+- [eslint-plugin-jest: no-done-callback](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-done-callback.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-done-callback.ts)

--- a/internal/plugins/jest/rules/no_done_callback/no_done_callback.md
+++ b/internal/plugins/jest/rules/no_done_callback/no_done_callback.md
@@ -42,4 +42,5 @@ test('myFunction()', async () => {
 
 ## Original Documentation
 
-- [jest/no-done-callback](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-done-callback.md)
+- [eslint-plugin-jest: no-done-callback](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-done-callback.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-done-callback.ts)

--- a/internal/plugins/jest/rules/no_duplicate_hooks/no_duplicate_hooks.md
+++ b/internal/plugins/jest/rules/no_duplicate_hooks/no_duplicate_hooks.md
@@ -77,4 +77,5 @@ describe('foo', () => {
 
 ## Original Documentation
 
-- [jest/no-duplicate-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-duplicate-hooks.md)
+- [eslint-plugin-jest: no-duplicate-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-duplicate-hooks.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-duplicate-hooks.ts)

--- a/internal/plugins/jest/rules/no_duplicate_hooks/no_duplicate_hooks.md
+++ b/internal/plugins/jest/rules/no_duplicate_hooks/no_duplicate_hooks.md
@@ -77,5 +77,5 @@ describe('foo', () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-duplicate-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-duplicate-hooks.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-duplicate-hooks.ts)
+- [eslint-plugin-jest: no-duplicate-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-duplicate-hooks.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-duplicate-hooks.ts)

--- a/internal/plugins/jest/rules/no_export/no_export.md
+++ b/internal/plugins/jest/rules/no_export/no_export.md
@@ -49,4 +49,5 @@ Do not enable this rule on files that are not Jest test files. For shared test u
 
 ## Original Documentation
 
-- [jest/no-export](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md)
+- [eslint-plugin-jest: no-export](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-export.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-export.ts)

--- a/internal/plugins/jest/rules/no_export/no_export.md
+++ b/internal/plugins/jest/rules/no_export/no_export.md
@@ -49,5 +49,5 @@ Do not enable this rule on files that are not Jest test files. For shared test u
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-export](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-export.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-export.ts)
+- [eslint-plugin-jest: no-export](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-export.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-export.ts)

--- a/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.md
+++ b/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.md
@@ -41,5 +41,5 @@ test.each`
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-focused-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-focused-tests.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-focused-tests.ts)
+- [eslint-plugin-jest: no-focused-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-focused-tests.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-focused-tests.ts)

--- a/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.md
+++ b/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.md
@@ -41,4 +41,5 @@ test.each`
 
 ## Original Documentation
 
-- [jest/no-focused-tests](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md)
+- [eslint-plugin-jest: no-focused-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-focused-tests.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-focused-tests.ts)

--- a/internal/plugins/jest/rules/no_hooks/no_hooks.md
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks.md
@@ -38,5 +38,5 @@ describe("suite", () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-hooks.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-hooks.ts)
+- [eslint-plugin-jest: no-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-hooks.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-hooks.ts)

--- a/internal/plugins/jest/rules/no_hooks/no_hooks.md
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks.md
@@ -38,4 +38,5 @@ describe("suite", () => {
 
 ## Original Documentation
 
-- [jest/no-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-hooks.md)
+- [eslint-plugin-jest: no-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-hooks.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-hooks.ts)

--- a/internal/plugins/jest/rules/no_identical_title/no_identical_title.md
+++ b/internal/plugins/jest/rules/no_identical_title/no_identical_title.md
@@ -29,5 +29,5 @@ test("x" + n, () => {}); // not static — skipped
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-identical-title](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-identical-title.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-identical-title.ts)
+- [eslint-plugin-jest: no-identical-title](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-identical-title.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-identical-title.ts)

--- a/internal/plugins/jest/rules/no_identical_title/no_identical_title.md
+++ b/internal/plugins/jest/rules/no_identical_title/no_identical_title.md
@@ -29,4 +29,5 @@ test("x" + n, () => {}); // not static — skipped
 
 ## Original Documentation
 
-- [jest/no-identical-title](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md)
+- [eslint-plugin-jest: no-identical-title](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-identical-title.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-identical-title.ts)

--- a/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
+++ b/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
@@ -53,5 +53,5 @@ expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-interpolation-in-snapshots](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-interpolation-in-snapshots.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-interpolation-in-snapshots.ts)
+- [eslint-plugin-jest: no-interpolation-in-snapshots](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-interpolation-in-snapshots.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-interpolation-in-snapshots.ts)

--- a/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
+++ b/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
@@ -53,4 +53,5 @@ expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
 
 ## Original Documentation
 
-- [jest/no-interpolation-in-snapshots](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md)
+- [eslint-plugin-jest: no-interpolation-in-snapshots](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-interpolation-in-snapshots.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-interpolation-in-snapshots.ts)

--- a/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.md
+++ b/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.md
@@ -30,4 +30,5 @@ jest.setTimeout(5000);
 
 ## Original Documentation
 
-- [jest/no-jasmine-globals](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md)
+- [eslint-plugin-jest: no-jasmine-globals](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-jasmine-globals.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-jasmine-globals.ts)

--- a/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.md
+++ b/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.md
@@ -30,5 +30,5 @@ jest.setTimeout(5000);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-jasmine-globals](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-jasmine-globals.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-jasmine-globals.ts)
+- [eslint-plugin-jest: no-jasmine-globals](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-jasmine-globals.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-jasmine-globals.ts)

--- a/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.md
+++ b/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.md
@@ -22,5 +22,5 @@ require('thing');
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-mocks-import](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-mocks-import.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-mocks-import.ts)
+- [eslint-plugin-jest: no-mocks-import](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-mocks-import.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-mocks-import.ts)

--- a/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.md
+++ b/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.md
@@ -22,4 +22,5 @@ require('thing');
 
 ## Original Documentation
 
-- [jest/no-mocks-import](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md)
+- [eslint-plugin-jest: no-mocks-import](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-mocks-import.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-mocks-import.ts)

--- a/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.md
+++ b/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.md
@@ -69,5 +69,5 @@ jest.advanceTimersByTime(1000);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-restricted-jest-methods](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-restricted-jest-methods.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-restricted-jest-methods.ts)
+- [eslint-plugin-jest: no-restricted-jest-methods](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-restricted-jest-methods.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-restricted-jest-methods.ts)

--- a/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.md
+++ b/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.md
@@ -69,4 +69,5 @@ jest.advanceTimersByTime(1000);
 
 ## Original Documentation
 
-- [jest/no-restricted-jest-methods](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-restricted-jest-methods.md)
+- [eslint-plugin-jest: no-restricted-jest-methods](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-restricted-jest-methods.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-restricted-jest-methods.ts)

--- a/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.md
+++ b/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.md
@@ -75,5 +75,5 @@ expect(a).resolves.not.toBe(b);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-restricted-matchers](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-restricted-matchers.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-restricted-matchers.ts)
+- [eslint-plugin-jest: no-restricted-matchers](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-restricted-matchers.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-restricted-matchers.ts)

--- a/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.md
+++ b/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.md
@@ -75,4 +75,5 @@ expect(a).resolves.not.toBe(b);
 
 ## Original Documentation
 
-- [jest/no-restricted-matchers](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-restricted-matchers.md)
+- [eslint-plugin-jest: no-restricted-matchers](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-restricted-matchers.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-restricted-matchers.ts)

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.md
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.md
@@ -56,5 +56,5 @@ expect.extend({});
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-standalone-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-standalone-expect.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-standalone-expect.ts)
+- [eslint-plugin-jest: no-standalone-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-standalone-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-standalone-expect.ts)

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.md
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.md
@@ -56,4 +56,5 @@ expect.extend({});
 
 ## Original Documentation
 
-- [jest/no-standalone-expect](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md)
+- [eslint-plugin-jest: no-standalone-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/no-standalone-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/no-standalone-expect.ts)

--- a/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.md
+++ b/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.md
@@ -29,4 +29,5 @@ describe.skip('foo');
 
 ## Original Documentation
 
-- [jest/no-test-prefixes](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-test-prefixes.md)
+- [eslint-plugin-jest: no-test-prefixes](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-test-prefixes.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-test-prefixes.ts)

--- a/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.md
+++ b/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.md
@@ -29,5 +29,5 @@ describe.skip('foo');
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-test-prefixes](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/no-test-prefixes.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/no-test-prefixes.ts)
+- [eslint-plugin-jest: no-test-prefixes](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-test-prefixes.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-test-prefixes.ts)

--- a/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.md
+++ b/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.md
@@ -49,5 +49,5 @@ as the same safe unwrap because tsgo preserves them explicitly in the AST.
 
 ## Original Documentation
 
-- [eslint-plugin-jest: no-unneeded-async-expect-function](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-unneeded-async-expect-function.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-unneeded-async-expect-function.ts)
+- [eslint-plugin-jest: no-unneeded-async-expect-function](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/no-unneeded-async-expect-function.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/no-unneeded-async-expect-function.ts)

--- a/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.md
+++ b/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.md
@@ -49,4 +49,5 @@ as the same safe unwrap because tsgo preserves them explicitly in the AST.
 
 ## Original Documentation
 
-- [jest/no-unneeded-async-expect-function](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-unneeded-async-expect-function.md)
+- [eslint-plugin-jest: no-unneeded-async-expect-function](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/no-unneeded-async-expect-function.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/no-unneeded-async-expect-function.ts)

--- a/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.md
+++ b/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.md
@@ -34,5 +34,5 @@ expect(uncalledFunction).not.toHaveBeenCalled();
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-called-with](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-called-with.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-called-with.ts)
+- [eslint-plugin-jest: prefer-called-with](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-called-with.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-called-with.ts)

--- a/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.md
+++ b/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.md
@@ -34,4 +34,5 @@ expect(uncalledFunction).not.toHaveBeenCalled();
 
 ## Original Documentation
 
-- [jest/prefer-called-with](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-called-with.md)
+- [eslint-plugin-jest: prefer-called-with](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-called-with.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-called-with.ts)

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
@@ -50,4 +50,5 @@ expect(myName > theirName).toBe(true);
 
 ## Original Documentation
 
-- [jest/prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-comparison-matcher.md)
+- [eslint-plugin-jest: prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/prefer-comparison-matcher.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/prefer-comparison-matcher.ts)

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
@@ -50,5 +50,5 @@ expect(myName > theirName).toBe(true);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/docs/rules/prefer-comparison-matcher.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.4/src/rules/prefer-comparison-matcher.ts)
+- [eslint-plugin-jest: prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-comparison-matcher.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-comparison-matcher.ts)

--- a/internal/plugins/jest/rules/prefer_each/prefer_each.md
+++ b/internal/plugins/jest/rules/prefer_each/prefer_each.md
@@ -52,4 +52,5 @@ it('returns numbers that are greater than five', () => {
 
 ## Original Documentation
 
-- [jest/prefer-each](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-each.md)
+- [eslint-plugin-jest: prefer-each](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-each.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-each.ts)

--- a/internal/plugins/jest/rules/prefer_each/prefer_each.md
+++ b/internal/plugins/jest/rules/prefer_each/prefer_each.md
@@ -52,5 +52,5 @@ it('returns numbers that are greater than five', () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-each](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-each.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-each.ts)
+- [eslint-plugin-jest: prefer-each](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-each.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-each.ts)

--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.md
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.md
@@ -36,4 +36,5 @@ expect(myObj).not.toStrictEqual(thatObj);
 
 ## Original Documentation
 
-- [jest/prefer-equality-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-equality-matcher.md)
+- [eslint-plugin-jest: prefer-equality-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-equality-matcher.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-equality-matcher.ts)

--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.md
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.md
@@ -36,5 +36,5 @@ expect(myObj).not.toStrictEqual(thatObj);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-equality-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-equality-matcher.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-equality-matcher.ts)
+- [eslint-plugin-jest: prefer-equality-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-equality-matcher.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-equality-matcher.ts)

--- a/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.md
+++ b/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.md
@@ -55,4 +55,5 @@ it('errors', async () => {
 
 ## Original Documentation
 
-- [jest/prefer-expect-resolves](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-expect-resolves.md)
+- [eslint-plugin-jest: prefer-expect-resolves](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-expect-resolves.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-expect-resolves.ts)

--- a/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.md
+++ b/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.md
@@ -55,5 +55,5 @@ it('errors', async () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-expect-resolves](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-expect-resolves.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-expect-resolves.ts)
+- [eslint-plugin-jest: prefer-expect-resolves](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-expect-resolves.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-expect-resolves.ts)

--- a/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.md
+++ b/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.md
@@ -128,4 +128,5 @@ describe('foo', () => {
 
 ## Original Documentation
 
-- [jest/prefer-hooks-in-order](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-hooks-in-order.md)
+- [eslint-plugin-jest: prefer-hooks-in-order](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-hooks-in-order.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-hooks-in-order.ts)

--- a/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.md
+++ b/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.md
@@ -128,5 +128,5 @@ describe('foo', () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-hooks-in-order](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-hooks-in-order.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-hooks-in-order.ts)
+- [eslint-plugin-jest: prefer-hooks-in-order](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-hooks-in-order.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-hooks-in-order.ts)

--- a/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.md
+++ b/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.md
@@ -119,5 +119,5 @@ describe('foo', () => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-hooks-on-top](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-hooks-on-top.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-hooks-on-top.ts)
+- [eslint-plugin-jest: prefer-hooks-on-top](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-hooks-on-top.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-hooks-on-top.ts)

--- a/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.md
+++ b/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.md
@@ -119,4 +119,5 @@ describe('foo', () => {
 
 ## Original Documentation
 
-- [jest/prefer-hooks-on-top](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-hooks-on-top.md)
+- [eslint-plugin-jest: prefer-hooks-on-top](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-hooks-on-top.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-hooks-on-top.ts)

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.md
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.md
@@ -38,5 +38,5 @@ jest.mocked([].foo).mockReturnValue(1);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-jest-mocked](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/docs/rules/prefer-jest-mocked.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/src/rules/prefer-jest-mocked.ts)
+- [eslint-plugin-jest: prefer-jest-mocked](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-jest-mocked.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-jest-mocked.ts)

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.md
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.md
@@ -38,4 +38,5 @@ jest.mocked([].foo).mockReturnValue(1);
 
 ## Original Documentation
 
-- [jest/prefer-jest-mocked](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-jest-mocked.md)
+- [eslint-plugin-jest: prefer-jest-mocked](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/docs/rules/prefer-jest-mocked.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/src/rules/prefer-jest-mocked.ts)

--- a/internal/plugins/jest/rules/prefer_spy_on/prefer_spy_on.md
+++ b/internal/plugins/jest/rules/prefer_spy_on/prefer_spy_on.md
@@ -31,4 +31,5 @@ jest.spyOn(window, 'fetch').mockReturnValue('ok');
 
 ## Original Documentation
 
-- [jest/prefer-spy-on](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-spy-on.md)
+- [eslint-plugin-jest: prefer-spy-on](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/docs/rules/prefer-spy-on.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/src/rules/prefer-spy-on.ts)

--- a/internal/plugins/jest/rules/prefer_spy_on/prefer_spy_on.md
+++ b/internal/plugins/jest/rules/prefer_spy_on/prefer_spy_on.md
@@ -31,5 +31,5 @@ jest.spyOn(window, 'fetch').mockReturnValue('ok');
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-spy-on](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/docs/rules/prefer-spy-on.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.3/src/rules/prefer-spy-on.ts)
+- [eslint-plugin-jest: prefer-spy-on](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-spy-on.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-spy-on.ts)

--- a/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.md
+++ b/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.md
@@ -18,4 +18,5 @@ expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' });
 
 ## Original Documentation
 
-- [jest/prefer-strict-equal](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-strict-equal.md)
+- [eslint-plugin-jest: prefer-strict-equal](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-strict-equal.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-strict-equal.ts)

--- a/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.md
+++ b/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.md
@@ -18,5 +18,5 @@ expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' });
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-strict-equal](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-strict-equal.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-strict-equal.ts)
+- [eslint-plugin-jest: prefer-strict-equal](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-strict-equal.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-strict-equal.ts)

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.md
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.md
@@ -56,5 +56,5 @@ expect(catchError()).toStrictEqual({ message: undefined });
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-be.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-be.ts)
+- [eslint-plugin-jest: prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-to-be.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-to-be.ts)

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.md
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.md
@@ -56,4 +56,5 @@ expect(catchError()).toStrictEqual({ message: undefined });
 
 ## Original Documentation
 
-- [jest/prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-be.md)
+- [eslint-plugin-jest: prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-be.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-be.ts)

--- a/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.md
+++ b/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.md
@@ -25,5 +25,5 @@ expect(a).not.toContain(b);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-to-contain](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-contain.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-contain.ts)
+- [eslint-plugin-jest: prefer-to-contain](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-to-contain.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-to-contain.ts)

--- a/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.md
+++ b/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.md
@@ -25,4 +25,5 @@ expect(a).not.toContain(b);
 
 ## Original Documentation
 
-- [jest/prefer-to-contain](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-contain.md)
+- [eslint-plugin-jest: prefer-to-contain](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-contain.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-contain.ts)

--- a/internal/plugins/jest/rules/prefer_to_have_been_called/prefer_to_have_been_called.md
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called/prefer_to_have_been_called.md
@@ -27,4 +27,5 @@ expect(method).toHaveBeenCalled();
 
 ## Original Documentation
 
-- [jest/prefer-to-have-been-called](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-have-been-called.md)
+- [eslint-plugin-jest: prefer-to-have-been-called](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-have-been-called.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-have-been-called.ts)

--- a/internal/plugins/jest/rules/prefer_to_have_been_called/prefer_to_have_been_called.md
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called/prefer_to_have_been_called.md
@@ -27,5 +27,5 @@ expect(method).toHaveBeenCalled();
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-to-have-been-called](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-have-been-called.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-have-been-called.ts)
+- [eslint-plugin-jest: prefer-to-have-been-called](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-to-have-been-called.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-to-have-been-called.ts)

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
@@ -35,4 +35,5 @@ expect(method.mock.calls[0][0]).toStrictEqual(value);
 
 ## Original Documentation
 
-- [jest/prefer-to-have-been-called-times](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-have-been-called-times.md)
+- [eslint-plugin-jest: prefer-to-have-been-called-times](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-have-been-called-times.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-have-been-called-times.ts)

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
@@ -35,5 +35,5 @@ expect(method.mock.calls[0][0]).toStrictEqual(value);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-to-have-been-called-times](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-have-been-called-times.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-have-been-called-times.ts)
+- [eslint-plugin-jest: prefer-to-have-been-called-times](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-to-have-been-called-times.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-to-have-been-called-times.ts)

--- a/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.md
+++ b/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.md
@@ -24,4 +24,5 @@ expect(files).toHaveLength(1);
 
 ## Original Documentation
 
-- [jest/prefer-to-have-length](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-have-length.md)
+- [eslint-plugin-jest: prefer-to-have-length](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-have-length.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-have-length.ts)

--- a/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.md
+++ b/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.md
@@ -24,5 +24,5 @@ expect(files).toHaveLength(1);
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-to-have-length](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-to-have-length.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-to-have-length.ts)
+- [eslint-plugin-jest: prefer-to-have-length](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-to-have-length.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-to-have-length.ts)

--- a/internal/plugins/jest/rules/prefer_todo/prefer_todo.md
+++ b/internal/plugins/jest/rules/prefer_todo/prefer_todo.md
@@ -20,4 +20,5 @@ test.todo('i need to write this test');
 
 ## Original Documentation
 
-- [jest/prefer-todo](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-todo.md)
+- [eslint-plugin-jest: prefer-todo](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-todo.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-todo.ts)

--- a/internal/plugins/jest/rules/prefer_todo/prefer_todo.md
+++ b/internal/plugins/jest/rules/prefer_todo/prefer_todo.md
@@ -20,5 +20,5 @@ test.todo('i need to write this test');
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-todo](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/prefer-todo.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/prefer-todo.ts)
+- [eslint-plugin-jest: prefer-todo](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-todo.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-todo.ts)

--- a/internal/plugins/jest/rules/require_hook/require_hook.md
+++ b/internal/plugins/jest/rules/require_hook/require_hook.md
@@ -171,4 +171,5 @@ describe('Foo', () => {
 
 ## Original Documentation
 
-- [jest/require-hook](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-hook.md)
+- [eslint-plugin-jest: require-hook](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/require-hook.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/require-hook.ts)

--- a/internal/plugins/jest/rules/require_to_throw_message/require_to_throw_message.md
+++ b/internal/plugins/jest/rules/require_to_throw_message/require_to_throw_message.md
@@ -40,4 +40,5 @@ test('all the things', async () => {
 
 ## Original Documentation
 
-- [jest/require-to-throw-message](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-to-throw-message.md)
+- [eslint-plugin-jest: require-to-throw-message](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/require-to-throw-message.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/require-to-throw-message.ts)

--- a/internal/plugins/jest/rules/require_top_level_describe/require_top_level_describe.md
+++ b/internal/plugins/jest/rules/require_top_level_describe/require_top_level_describe.md
@@ -44,4 +44,5 @@ describe('one', () => {
 
 ## Original Documentation
 
-- [jest/require-top-level-describe](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-top-level-describe.md)
+- [eslint-plugin-jest: require-top-level-describe](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/require-top-level-describe.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/require-top-level-describe.ts)

--- a/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.md
+++ b/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.md
@@ -40,5 +40,5 @@ describe.each([1, 2, 3])("value %s", (value) => {
 
 ## Original Documentation
 
-- [eslint-plugin-jest: valid-describe-callback](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/valid-describe-callback.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/valid-describe-callback.ts)
+- [eslint-plugin-jest: valid-describe-callback](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/valid-describe-callback.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/valid-describe-callback.ts)

--- a/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.md
+++ b/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.md
@@ -40,4 +40,5 @@ describe.each([1, 2, 3])("value %s", (value) => {
 
 ## Original Documentation
 
-- [jest/valid-describe-callback](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-describe-callback.md)
+- [eslint-plugin-jest: valid-describe-callback](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/valid-describe-callback.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/valid-describe-callback.ts)

--- a/internal/plugins/jest/rules/valid_expect/valid_expect.md
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect.md
@@ -113,4 +113,5 @@ expect().pass();
 
 ## Original Documentation
 
-- [jest/valid-expect](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-expect.md)
+- [eslint-plugin-jest: valid-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/valid-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/valid-expect.ts)

--- a/internal/plugins/jest/rules/valid_expect/valid_expect.md
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect.md
@@ -113,5 +113,5 @@ expect().pass();
 
 ## Original Documentation
 
-- [eslint-plugin-jest: valid-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/valid-expect.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/valid-expect.ts)
+- [eslint-plugin-jest: valid-expect](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/valid-expect.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/valid-expect.ts)

--- a/internal/plugins/jest/rules/valid_title/valid_title.md
+++ b/internal/plugins/jest/rules/valid_title/valid_title.md
@@ -132,5 +132,5 @@ For full option examples and edge cases, see the upstream rule documentation bel
 
 ## Original Documentation
 
-- [eslint-plugin-jest: valid-title](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/valid-title.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/valid-title.ts)
+- [eslint-plugin-jest: valid-title](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/valid-title.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/valid-title.ts)

--- a/internal/plugins/jest/rules/valid_title/valid_title.md
+++ b/internal/plugins/jest/rules/valid_title/valid_title.md
@@ -132,4 +132,5 @@ For full option examples and edge cases, see the upstream rule documentation bel
 
 ## Original Documentation
 
-- [jest/valid-title](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-title.md)
+- [eslint-plugin-jest: valid-title](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/docs/rules/valid-title.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/valid-title.ts)


### PR DESCRIPTION
## Summary

- Every `jest/` rule doc now pins its "Original Documentation" links to `eslint-plugin-jest@v29.16.0` — the latest release.
- Initially resolved per rule from its introducing PR's merge time against the release timeline (the 46 rules were ported across a 4-month window spanning six releases, v29.15.1 through v29.16.0), then re-verified: audited every file — including shared `src/rules/utils/*.ts` helpers, not just each rule's own file — that changed between each rule's initially-resolved version and `v29.16.0`.
- Findings: 4 shared utils files changed only via a prettier reformatting commit (cosmetic); a new `isThenableType()` helper was added for `valid-expect-with-promise`, a rule rslint hasn't ported; every other changed rule file belongs to an unported rule. Only two rules had a relevant change:
  - `no-export.ts` gained two real fixes (`jest-community/eslint-plugin-jest#1976` don't report on assignment to locals named `module`, `jest-community/eslint-plugin-jest#1978` treat `describe` blocks as test files). Confirmed via the rule's own already-passing Go tests that rslint's `no_export` already implements both.
  - `no-restricted-matchers.md` changed by a one-word doc typo; its `.ts` source never changed.
- Result: all 46 rules verified aligned with `v29.16.0`, not just the version current at their individual port dates.
- Added the previously-missing "Source code" link to every rule; the doc link text/format was already consistent.

## Related Links

#572, #574, #577, #591, #592, #593, #614, #623, #776, #777, #779, #821, #870, #875, #931, #948, #950, #969, #984, #1017, #1019, #1025, #1026, #1032, #1048, #1061, #1062, #1063, #1076, #1107, #1110, #1118, #1124, #1147, #1148, #1160, #1167, #1169, #1224, #1236, #1284, #1293, #1338, #1455, #1456

## Checklist

- [x] Tests updated (or not required) — docs-only change.
- [x] Documentation updated (or not required).