### PR TITLE
docs(typescript): record each rule's aligned upstream version

### DIFF
--- a/internal/plugins/typescript/rules/adjacent_overload_signatures/adjacent_overload_signatures.md
+++ b/internal/plugins/typescript/rules/adjacent_overload_signatures/adjacent_overload_signatures.md
@@ -34,4 +34,5 @@ class MyClass {
 
 ## Original Documentation
 
-- [typescript-eslint adjacent-overload-signatures](https://typescript-eslint.io/rules/adjacent-overload-signatures)
+- [typescript-eslint: adjacent-overload-signatures](https://typescript-eslint.io/rules/adjacent-overload-signatures)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts)

--- a/internal/plugins/typescript/rules/array_type/array_type.md
+++ b/internal/plugins/typescript/rules/array_type/array_type.md
@@ -24,4 +24,5 @@ const c: (string | number)[] = [];
 
 ## Original Documentation
 
-- [typescript-eslint array-type](https://typescript-eslint.io/rules/array-type)
+- [typescript-eslint: array-type](https://typescript-eslint.io/rules/array-type)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.39.0/packages/eslint-plugin/src/rules/array-type.ts)

--- a/internal/plugins/typescript/rules/await_thenable/await_thenable.md
+++ b/internal/plugins/typescript/rules/await_thenable/await_thenable.md
@@ -42,4 +42,5 @@ async function baz(iter: AsyncIterable<number>) {
 
 ## Original Documentation
 
-- [typescript-eslint await-thenable](https://typescript-eslint.io/rules/await-thenable)
+- [typescript-eslint: await-thenable](https://typescript-eslint.io/rules/await-thenable)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/await-thenable.ts)

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.md
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.md
@@ -31,4 +31,5 @@ const x: number = 'hello';
 
 ## Original Documentation
 
-- [typescript-eslint ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment)
+- [typescript-eslint: ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.46.3/packages/eslint-plugin/src/rules/ban-ts-comment.ts)

--- a/internal/plugins/typescript/rules/ban_tslint_comment/ban_tslint_comment.md
+++ b/internal/plugins/typescript/rules/ban_tslint_comment/ban_tslint_comment.md
@@ -24,4 +24,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [typescript-eslint ban-tslint-comment](https://typescript-eslint.io/rules/ban-tslint-comment)
+- [typescript-eslint: ban-tslint-comment](https://typescript-eslint.io/rules/ban-tslint-comment)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/ban-tslint-comment.ts)

--- a/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.md
+++ b/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.md
@@ -36,4 +36,5 @@ class Bar {
 
 ## Original Documentation
 
-- [typescript-eslint class-literal-property-style](https://typescript-eslint.io/rules/class-literal-property-style)
+- [typescript-eslint: class-literal-property-style](https://typescript-eslint.io/rules/class-literal-property-style)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.39.0/packages/eslint-plugin/src/rules/class-literal-property-style.ts)

--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.md
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.md
@@ -159,5 +159,4 @@ class Foo implements Bar {
 ## Original Documentation
 
 - [typescript-eslint: class-methods-use-this](https://typescript-eslint.io/rules/class-methods-use-this)
-- [ESLint: class-methods-use-this](https://eslint.org/docs/latest/rules/class-methods-use-this)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/class-methods-use-this.ts)

--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.md
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.md
@@ -158,5 +158,6 @@ class Foo implements Bar {
 
 ## Original Documentation
 
-- [typescript-eslint class-methods-use-this](https://typescript-eslint.io/rules/class-methods-use-this)
-- [ESLint class-methods-use-this](https://eslint.org/docs/latest/rules/class-methods-use-this)
+- [typescript-eslint: class-methods-use-this](https://typescript-eslint.io/rules/class-methods-use-this)
+- [ESLint: class-methods-use-this](https://eslint.org/docs/latest/rules/class-methods-use-this)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/class-methods-use-this.ts)

--- a/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.md
+++ b/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.md
@@ -23,4 +23,5 @@ const map2: Map<string, number> = new Map<string, number>();
 
 ## Original Documentation
 
-- [typescript-eslint consistent-generic-constructors](https://typescript-eslint.io/rules/consistent-generic-constructors)
+- [typescript-eslint: consistent-generic-constructors](https://typescript-eslint.io/rules/consistent-generic-constructors)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.46.3/packages/eslint-plugin/src/rules/consistent-generic-constructors.ts)

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.md
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.md
@@ -32,4 +32,5 @@ interface Baz {
 
 ## Original Documentation
 
-- [typescript-eslint consistent-indexed-object-style](https://typescript-eslint.io/rules/consistent-indexed-object-style)
+- [typescript-eslint: consistent-indexed-object-style](https://typescript-eslint.io/rules/consistent-indexed-object-style)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts)

--- a/internal/plugins/typescript/rules/consistent_return/consistent_return.md
+++ b/internal/plugins/typescript/rules/consistent_return/consistent_return.md
@@ -44,4 +44,5 @@ function bar(): void {
 
 ## Original Documentation
 
-- [typescript-eslint consistent-return](https://typescript-eslint.io/rules/consistent-return)
+- [typescript-eslint: consistent-return](https://typescript-eslint.io/rules/consistent-return)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-return.ts)

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.md
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.md
@@ -23,4 +23,5 @@ const z = value as const;
 
 ## Original Documentation
 
-- [typescript-eslint consistent-type-assertions](https://typescript-eslint.io/rules/consistent-type-assertions)
+- [typescript-eslint: consistent-type-assertions](https://typescript-eslint.io/rules/consistent-type-assertions)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-type-assertions.ts)

--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.md
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.md
@@ -71,4 +71,5 @@ Note: Interfaces inside `declare global` blocks report an error but are not auto
 
 ## Original Documentation
 
-- [typescript-eslint consistent-type-definitions](https://typescript-eslint.io/rules/consistent-type-definitions)
+- [typescript-eslint: consistent-type-definitions](https://typescript-eslint.io/rules/consistent-type-definitions)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-type-definitions.ts)

--- a/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.md
+++ b/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.md
@@ -32,4 +32,5 @@ export { value, type MyType } from './mixed';
 
 ## Original Documentation
 
-- [typescript-eslint consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports)
+- [typescript-eslint: consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.46.3/packages/eslint-plugin/src/rules/consistent-type-exports.ts)

--- a/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.md
+++ b/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.md
@@ -26,4 +26,5 @@ import { value, type MyType } from './mixed';
 
 ## Original Documentation
 
-- [typescript-eslint consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports)
+- [typescript-eslint: consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-type-imports.ts)

--- a/internal/plugins/typescript/rules/default_param_last/default_param_last.md
+++ b/internal/plugins/typescript/rules/default_param_last/default_param_last.md
@@ -30,4 +30,5 @@ function baz(a: number, b = 1, ...rest: number[]) {}
 
 ## Original Documentation
 
-- [typescript-eslint default-param-last](https://typescript-eslint.io/rules/default-param-last)
+- [typescript-eslint: default-param-last](https://typescript-eslint.io/rules/default-param-last)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/default-param-last.ts)

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.md
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.md
@@ -24,4 +24,5 @@ const w = obj[dynamicKey]; // computed access
 
 ## Original Documentation
 
-- [typescript-eslint dot-notation](https://typescript-eslint.io/rules/dot-notation)
+- [typescript-eslint: dot-notation](https://typescript-eslint.io/rules/dot-notation)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/dot-notation.ts)

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.md
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.md
@@ -48,4 +48,5 @@ class Test {
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/explicit-function-return-type
+- [typescript-eslint: explicit-function-return-type](https://typescript-eslint.io/rules/explicit-function-return-type)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/explicit-function-return-type.ts)

--- a/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.md
+++ b/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.md
@@ -129,4 +129,5 @@ class Test {
 
 ## Original Documentation
 
-- [typescript-eslint explicit-member-accessibility](https://typescript-eslint.io/rules/explicit-member-accessibility)
+- [typescript-eslint: explicit-member-accessibility](https://typescript-eslint.io/rules/explicit-member-accessibility)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts)

--- a/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.md
+++ b/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.md
@@ -136,4 +136,5 @@ const x = (() => {}) as Foo;
 
 ## Original Documentation
 
-- [typescript-eslint explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types)
+- [typescript-eslint: explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts)

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations.md
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations.md
@@ -89,5 +89,6 @@ for (var item of items) {
 
 ## Original Documentation
 
-- [typescript-eslint init-declarations](https://typescript-eslint.io/rules/init-declarations)
-- [ESLint init-declarations](https://eslint.org/docs/latest/rules/init-declarations)
+- [typescript-eslint: init-declarations](https://typescript-eslint.io/rules/init-declarations)
+- [ESLint: init-declarations](https://eslint.org/docs/latest/rules/init-declarations)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/init-declarations.ts)

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations.md
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations.md
@@ -90,5 +90,4 @@ for (var item of items) {
 ## Original Documentation
 
 - [typescript-eslint: init-declarations](https://typescript-eslint.io/rules/init-declarations)
-- [ESLint: init-declarations](https://eslint.org/docs/latest/rules/init-declarations)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/init-declarations.ts)

--- a/internal/plugins/typescript/rules/max_params/max_params.md
+++ b/internal/plugins/typescript/rules/max_params/max_params.md
@@ -84,5 +84,4 @@ class Foo {
 ## Original Documentation
 
 - [typescript-eslint: max-params](https://typescript-eslint.io/rules/max-params)
-- [ESLint: max-params](https://eslint.org/docs/latest/rules/max-params)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/max-params.ts)

--- a/internal/plugins/typescript/rules/max_params/max_params.md
+++ b/internal/plugins/typescript/rules/max_params/max_params.md
@@ -83,5 +83,6 @@ class Foo {
 
 ## Original Documentation
 
-- [`@typescript-eslint/max-params`](https://typescript-eslint.io/rules/max-params)
-- [`max-params` (ESLint core)](https://eslint.org/docs/latest/rules/max-params)
+- [typescript-eslint: max-params](https://typescript-eslint.io/rules/max-params)
+- [ESLint: max-params](https://eslint.org/docs/latest/rules/max-params)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/max-params.ts)

--- a/internal/plugins/typescript/rules/member_ordering/member_ordering.md
+++ b/internal/plugins/typescript/rules/member_ordering/member_ordering.md
@@ -38,4 +38,5 @@ interface Foo {
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/member-ordering
+- [typescript-eslint: member-ordering](https://typescript-eslint.io/rules/member-ordering)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/member-ordering.ts)

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.md
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.md
@@ -54,4 +54,5 @@ interface T1 {
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/method-signature-style
+- [typescript-eslint: method-signature-style](https://typescript-eslint.io/rules/method-signature-style)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.58.2/packages/eslint-plugin/src/rules/method-signature-style.ts)

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.md
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.md
@@ -188,4 +188,5 @@ When no options are provided, the rule uses the following defaults:
 
 ## Original Documentation
 
-- [typescript-eslint naming-convention](https://typescript-eslint.io/rules/naming-convention)
+- [typescript-eslint: naming-convention](https://typescript-eslint.io/rules/naming-convention)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/naming-convention.ts)

--- a/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.md
+++ b/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.md
@@ -33,5 +33,5 @@ new Array<Foo>(1, 2, 3);
 
 ## Original Documentation
 
-- [typescript-eslint no-array-constructor](https://typescript-eslint.io/rules/no-array-constructor)
-- [ESLint no-array-constructor](https://eslint.org/docs/rules/no-array-constructor)
+- [typescript-eslint: no-array-constructor](https://typescript-eslint.io/rules/no-array-constructor)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-array-constructor.ts)

--- a/internal/plugins/typescript/rules/no_array_delete/no_array_delete.md
+++ b/internal/plugins/typescript/rules/no_array_delete/no_array_delete.md
@@ -28,4 +28,5 @@ delete obj['a']; // objects are fine
 
 ## Original Documentation
 
-- [typescript-eslint no-array-delete](https://typescript-eslint.io/rules/no-array-delete)
+- [typescript-eslint: no-array-delete](https://typescript-eslint.io/rules/no-array-delete)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-array-delete.ts)

--- a/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.md
+++ b/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.md
@@ -34,4 +34,5 @@ class MyClass {
 
 ## Original Documentation
 
-- [typescript-eslint no-base-to-string](https://typescript-eslint.io/rules/no-base-to-string)
+- [typescript-eslint: no-base-to-string](https://typescript-eslint.io/rules/no-base-to-string)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/no-base-to-string.ts)

--- a/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.md
+++ b/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.md
@@ -26,4 +26,5 @@ foo.bar == 'hello';
 
 ## Original Documentation
 
-- [typescript-eslint no-confusing-non-null-assertion](https://typescript-eslint.io/rules/no-confusing-non-null-assertion)
+- [typescript-eslint: no-confusing-non-null-assertion](https://typescript-eslint.io/rules/no-confusing-non-null-assertion)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts)

--- a/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.md
+++ b/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.md
@@ -36,4 +36,5 @@ const fn = () => void console.log('hello');
 
 ## Original Documentation
 
-- [typescript-eslint no-confusing-void-expression](https://typescript-eslint.io/rules/no-confusing-void-expression)
+- [typescript-eslint: no-confusing-void-expression](https://typescript-eslint.io/rules/no-confusing-void-expression)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts)

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.md
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.md
@@ -6,4 +6,5 @@ Disallow usage of declarations marked with `@deprecated`.
 
 ## Original Documentation
 
-- https://typescript-eslint.io/rules/no-deprecated
+- [typescript-eslint: no-deprecated](https://typescript-eslint.io/rules/no-deprecated)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-deprecated.ts)

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.md
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.md
@@ -56,5 +56,4 @@ class D {
 ## Original Documentation
 
 - [typescript-eslint: no-dupe-class-members](https://typescript-eslint.io/rules/no-dupe-class-members)
-- [ESLint: no-dupe-class-members](https://eslint.org/docs/latest/rules/no-dupe-class-members)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-dupe-class-members.ts)

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.md
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.md
@@ -55,5 +55,6 @@ class D {
 
 ## Original Documentation
 
-- [ESLint `no-dupe-class-members`](https://eslint.org/docs/latest/rules/no-dupe-class-members)
-- [TypeScript-ESLint `no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/)
+- [typescript-eslint: no-dupe-class-members](https://typescript-eslint.io/rules/no-dupe-class-members)
+- [ESLint: no-dupe-class-members](https://eslint.org/docs/latest/rules/no-dupe-class-members)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-dupe-class-members.ts)

--- a/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values.md
+++ b/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values.md
@@ -43,4 +43,5 @@ enum Color {
 
 ## Original Documentation
 
-- [typescript-eslint no-duplicate-enum-values](https://typescript-eslint.io/rules/no-duplicate-enum-values)
+- [typescript-eslint: no-duplicate-enum-values](https://typescript-eslint.io/rules/no-duplicate-enum-values)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-duplicate-enum-values.ts)

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.md
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.md
@@ -30,4 +30,5 @@ function fn(x?: string) {}
 
 ## Original Documentation
 
-- [typescript-eslint no-duplicate-type-constituents](https://typescript-eslint.io/rules/no-duplicate-type-constituents)
+- [typescript-eslint: no-duplicate-type-constituents](https://typescript-eslint.io/rules/no-duplicate-type-constituents)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts)

--- a/internal/plugins/typescript/rules/no_dynamic_delete/no_dynamic_delete.md
+++ b/internal/plugins/typescript/rules/no_dynamic_delete/no_dynamic_delete.md
@@ -23,4 +23,5 @@ delete container[7];
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/no-dynamic-delete
+- [typescript-eslint: no-dynamic-delete](https://typescript-eslint.io/rules/no-dynamic-delete)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-dynamic-delete.ts)

--- a/internal/plugins/typescript/rules/no_empty_function/no_empty_function.md
+++ b/internal/plugins/typescript/rules/no_empty_function/no_empty_function.md
@@ -35,4 +35,5 @@ class MyClass {
 
 ## Original Documentation
 
-- [typescript-eslint no-empty-function](https://typescript-eslint.io/rules/no-empty-function)
+- [typescript-eslint: no-empty-function](https://typescript-eslint.io/rules/no-empty-function)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-empty-function.ts)

--- a/internal/plugins/typescript/rules/no_empty_interface/no_empty_interface.md
+++ b/internal/plugins/typescript/rules/no_empty_interface/no_empty_interface.md
@@ -31,4 +31,5 @@ type Bar = Baz;
 
 ## Original Documentation
 
-- [typescript-eslint no-empty-interface](https://typescript-eslint.io/rules/no-empty-interface)
+- [typescript-eslint: no-empty-interface](https://typescript-eslint.io/rules/no-empty-interface)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-empty-interface.ts)

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.md
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.md
@@ -86,4 +86,5 @@ type DialogProps = {};
 
 ## Original Documentation
 
-- [typescript-eslint no-empty-object-type](https://typescript-eslint.io/rules/no-empty-object-type)
+- [typescript-eslint: no-empty-object-type](https://typescript-eslint.io/rules/no-empty-object-type)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-empty-object-type.ts)

--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.md
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.md
@@ -32,4 +32,5 @@ const key: PropertyKey = 'name';
 
 ## Original Documentation
 
-- [typescript-eslint no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any)
+- [typescript-eslint: no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-explicit-any.ts)

--- a/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion.md
+++ b/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion.md
@@ -26,4 +26,5 @@ function foo(bar?: { n: number }) {
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/no-extra-non-null-assertion
+- [typescript-eslint: no-extra-non-null-assertion](https://typescript-eslint.io/rules/no-extra-non-null-assertion)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts)

--- a/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.md
+++ b/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.md
@@ -41,4 +41,5 @@ export function helper() {}
 
 ## Original Documentation
 
-- [typescript-eslint no-extraneous-class](https://typescript-eslint.io/rules/no-extraneous-class)
+- [typescript-eslint: no-extraneous-class](https://typescript-eslint.io/rules/no-extraneous-class)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.46.3/packages/eslint-plugin/src/rules/no-extraneous-class.ts)

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.md
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.md
@@ -36,4 +36,5 @@ void promise;
 
 ## Original Documentation
 
-- [typescript-eslint no-floating-promises](https://typescript-eslint.io/rules/no-floating-promises)
+- [typescript-eslint: no-floating-promises](https://typescript-eslint.io/rules/no-floating-promises)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-floating-promises.ts)

--- a/internal/plugins/typescript/rules/no_for_in_array/no_for_in_array.md
+++ b/internal/plugins/typescript/rules/no_for_in_array/no_for_in_array.md
@@ -36,4 +36,5 @@ for (let i = 0; i < arr.length; i++) {
 
 ## Original Documentation
 
-- [typescript-eslint no-for-in-array](https://typescript-eslint.io/rules/no-for-in-array)
+- [typescript-eslint: no-for-in-array](https://typescript-eslint.io/rules/no-for-in-array)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-for-in-array.ts)

--- a/internal/plugins/typescript/rules/no_implied_eval/no_implied_eval.md
+++ b/internal/plugins/typescript/rules/no_implied_eval/no_implied_eval.md
@@ -30,4 +30,5 @@ window.setTimeout(() => doSomething(), 100);
 
 ## Original Documentation
 
-- [typescript-eslint no-implied-eval](https://typescript-eslint.io/rules/no-implied-eval)
+- [typescript-eslint: no-implied-eval](https://typescript-eslint.io/rules/no-implied-eval)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-implied-eval.ts)

--- a/internal/plugins/typescript/rules/no_import_type_side_effects/no_import_type_side_effects.md
+++ b/internal/plugins/typescript/rules/no_import_type_side_effects/no_import_type_side_effects.md
@@ -31,4 +31,5 @@ import 'mod';
 
 ## Original Documentation
 
-- [typescript-eslint no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects)
+- [typescript-eslint: no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-import-type-side-effects.ts)

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.md
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.md
@@ -95,4 +95,5 @@ When set to `true`, ignores explicit type annotations on class properties with i
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/no-inferrable-types
+- [typescript-eslint: no-inferrable-types](https://typescript-eslint.io/rules/no-inferrable-types)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-inferrable-types.ts)

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.md
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.md
@@ -197,5 +197,4 @@ If you do not want to be notified about usage of the `this` keyword outside of c
 ## Original Documentation
 
 - [typescript-eslint: no-invalid-this](https://typescript-eslint.io/rules/no-invalid-this)
-- [ESLint: no-invalid-this](https://eslint.org/docs/latest/rules/no-invalid-this)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-invalid-this.ts)

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.md
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.md
@@ -196,5 +196,6 @@ If you do not want to be notified about usage of the `this` keyword outside of c
 
 ## Original Documentation
 
-- [typescript-eslint no-invalid-this](https://typescript-eslint.io/rules/no-invalid-this)
-- [ESLint no-invalid-this](https://eslint.org/docs/latest/rules/no-invalid-this)
+- [typescript-eslint: no-invalid-this](https://typescript-eslint.io/rules/no-invalid-this)
+- [ESLint: no-invalid-this](https://eslint.org/docs/latest/rules/no-invalid-this)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-invalid-this.ts)

--- a/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.md
+++ b/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.md
@@ -80,4 +80,5 @@ class Test {
 
 ## Original Documentation
 
-- [typescript-eslint no-invalid-void-type](https://typescript-eslint.io/rules/no-invalid-void-type)
+- [typescript-eslint: no-invalid-void-type](https://typescript-eslint.io/rules/no-invalid-void-type)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-invalid-void-type.ts)

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func.md
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func.md
@@ -57,5 +57,6 @@ If you do not want to be notified about functions defined inside loops, you can 
 
 ## Original Documentation
 
-- [typescript-eslint/no-loop-func](https://typescript-eslint.io/rules/no-loop-func/)
-- [ESLint no-loop-func](https://eslint.org/docs/latest/rules/no-loop-func)
+- [typescript-eslint: no-loop-func](https://typescript-eslint.io/rules/no-loop-func)
+- [ESLint: no-loop-func](https://eslint.org/docs/latest/rules/no-loop-func)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.59.1/packages/eslint-plugin/src/rules/no-loop-func.ts)

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func.md
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func.md
@@ -58,5 +58,4 @@ If you do not want to be notified about functions defined inside loops, you can 
 ## Original Documentation
 
 - [typescript-eslint: no-loop-func](https://typescript-eslint.io/rules/no-loop-func)
-- [ESLint: no-loop-func](https://eslint.org/docs/latest/rules/no-loop-func)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.59.1/packages/eslint-plugin/src/rules/no-loop-func.ts)

--- a/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.md
+++ b/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.md
@@ -77,5 +77,4 @@ type Foo = Parameters<Bar>[2];
 ## Original Documentation
 
 - [typescript-eslint: no-magic-numbers](https://typescript-eslint.io/rules/no-magic-numbers)
-- [ESLint: no-magic-numbers](https://eslint.org/docs/latest/rules/no-magic-numbers)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-magic-numbers.ts)

--- a/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.md
+++ b/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.md
@@ -76,5 +76,6 @@ type Foo = Parameters<Bar>[2];
 
 ## Original Documentation
 
-[ESLint - no-magic-numbers](https://eslint.org/docs/latest/rules/no-magic-numbers)
-[typescript-eslint - no-magic-numbers](https://typescript-eslint.io/rules/no-magic-numbers)
+- [typescript-eslint: no-magic-numbers](https://typescript-eslint.io/rules/no-magic-numbers)
+- [ESLint: no-magic-numbers](https://eslint.org/docs/latest/rules/no-magic-numbers)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-magic-numbers.ts)

--- a/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.md
+++ b/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.md
@@ -29,4 +29,5 @@ foo();
 
 ## Original Documentation
 
-- [typescript-eslint no-meaningless-void-operator](https://typescript-eslint.io/rules/no-meaningless-void-operator)
+- [typescript-eslint: no-meaningless-void-operator](https://typescript-eslint.io/rules/no-meaningless-void-operator)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts)

--- a/internal/plugins/typescript/rules/no_misused_new/no_misused_new.md
+++ b/internal/plugins/typescript/rules/no_misused_new/no_misused_new.md
@@ -38,4 +38,5 @@ interface Baz {
 
 ## Original Documentation
 
-- [typescript-eslint no-misused-new](https://typescript-eslint.io/rules/no-misused-new)
+- [typescript-eslint: no-misused-new](https://typescript-eslint.io/rules/no-misused-new)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-misused-new.ts)

--- a/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.md
+++ b/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.md
@@ -47,4 +47,5 @@ const listeners = {
 
 ## Original Documentation
 
-- [typescript-eslint no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises)
+- [typescript-eslint: no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/no-misused-promises.ts)

--- a/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.md
+++ b/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.md
@@ -41,4 +41,5 @@ const chars = Array.from(new Intl.Segmenter().segment('hello'));
 
 ## Original Documentation
 
-- [typescript-eslint no-misused-spread](https://typescript-eslint.io/rules/no-misused-spread)
+- [typescript-eslint: no-misused-spread](https://typescript-eslint.io/rules/no-misused-spread)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-misused-spread.ts)

--- a/internal/plugins/typescript/rules/no_mixed_enums/no_mixed_enums.md
+++ b/internal/plugins/typescript/rules/no_mixed_enums/no_mixed_enums.md
@@ -43,4 +43,5 @@ enum Direction {
 
 ## Original Documentation
 
-- [typescript-eslint no-mixed-enums](https://typescript-eslint.io/rules/no-mixed-enums)
+- [typescript-eslint: no-mixed-enums](https://typescript-eslint.io/rules/no-mixed-enums)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-mixed-enums.ts)

--- a/internal/plugins/typescript/rules/no_namespace/no_namespace.md
+++ b/internal/plugins/typescript/rules/no_namespace/no_namespace.md
@@ -38,4 +38,5 @@ declare namespace MyLib {
 
 ## Original Documentation
 
-- [typescript-eslint no-namespace](https://typescript-eslint.io/rules/no-namespace)
+- [typescript-eslint: no-namespace](https://typescript-eslint.io/rules/no-namespace)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-namespace.ts)

--- a/internal/plugins/typescript/rules/no_non_null_asserted_nullish_coalescing/no_non_null_asserted_nullish_coalescing.md
+++ b/internal/plugins/typescript/rules/no_non_null_asserted_nullish_coalescing/no_non_null_asserted_nullish_coalescing.md
@@ -24,4 +24,5 @@ foo.bazz ?? bar;
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing
+- [typescript-eslint: no-non-null-asserted-nullish-coalescing](https://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-non-null-asserted-nullish-coalescing.ts)

--- a/internal/plugins/typescript/rules/no_non_null_asserted_optional_chain/no_non_null_asserted_optional_chain.md
+++ b/internal/plugins/typescript/rules/no_non_null_asserted_optional_chain/no_non_null_asserted_optional_chain.md
@@ -22,4 +22,5 @@ foo?.bar();
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain
+- [typescript-eslint: no-non-null-asserted-optional-chain](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts)

--- a/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion.md
+++ b/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion.md
@@ -28,4 +28,5 @@ const includesBaz = example.property?.includes('baz') ?? false;
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/no-non-null-assertion
+- [typescript-eslint: no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-non-null-assertion.ts)

--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare.md
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare.md
@@ -84,5 +84,6 @@ namespace A {}
 
 ## Original Documentation
 
-- [https://typescript-eslint.io/rules/no-redeclare](https://typescript-eslint.io/rules/no-redeclare)
-- [https://eslint.org/docs/latest/rules/no-redeclare](https://eslint.org/docs/latest/rules/no-redeclare)
+- [typescript-eslint: no-redeclare](https://typescript-eslint.io/rules/no-redeclare)
+- [ESLint: no-redeclare](https://eslint.org/docs/latest/rules/no-redeclare)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-redeclare.ts)

--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare.md
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare.md
@@ -85,5 +85,4 @@ namespace A {}
 ## Original Documentation
 
 - [typescript-eslint: no-redeclare](https://typescript-eslint.io/rules/no-redeclare)
-- [ESLint: no-redeclare](https://eslint.org/docs/latest/rules/no-redeclare)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-redeclare.ts)

--- a/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents.md
+++ b/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents.md
@@ -26,4 +26,5 @@ type ReturnType = string | never; // allowed in return type position
 
 ## Original Documentation
 
-- [typescript-eslint no-redundant-type-constituents](https://typescript-eslint.io/rules/no-redundant-type-constituents)
+- [typescript-eslint: no-redundant-type-constituents](https://typescript-eslint.io/rules/no-redundant-type-constituents)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts)

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports.md
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports.md
@@ -24,4 +24,5 @@ import { readFile } from 'fs';
 
 ## Original Documentation
 
-- [typescript-eslint no-require-imports](https://typescript-eslint.io/rules/no-require-imports)
+- [typescript-eslint: no-require-imports](https://typescript-eslint.io/rules/no-require-imports)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-require-imports.ts)

--- a/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.md
+++ b/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.md
@@ -88,5 +88,4 @@ If you do not need to restrict imports of any modules, do not enable this rule.
 ## Original Documentation
 
 - [typescript-eslint: no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports)
-- [ESLint: no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-restricted-imports.ts)

--- a/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.md
+++ b/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.md
@@ -87,5 +87,6 @@ If you do not need to restrict imports of any modules, do not enable this rule.
 
 ## Original Documentation
 
-- [typescript-eslint rule documentation](https://typescript-eslint.io/rules/no-restricted-imports)
-- [Base ESLint rule documentation](https://eslint.org/docs/latest/rules/no-restricted-imports)
+- [typescript-eslint: no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports)
+- [ESLint: no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-restricted-imports.ts)

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.md
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.md
@@ -63,4 +63,5 @@ let value: [];
 
 ## Original Documentation
 
-- [typescript-eslint no-restricted-types](https://typescript-eslint.io/rules/no-restricted-types)
+- [typescript-eslint: no-restricted-types](https://typescript-eslint.io/rules/no-restricted-types)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-restricted-types.ts)

--- a/internal/plugins/typescript/rules/no_shadow/no_shadow.md
+++ b/internal/plugins/typescript/rules/no_shadow/no_shadow.md
@@ -77,4 +77,5 @@ Same semantics and defaults as the ESLint core rule.
 
 ## Original Documentation
 
-[https://typescript-eslint.io/rules/no-shadow](https://typescript-eslint.io/rules/no-shadow)
+- [typescript-eslint: no-shadow](https://typescript-eslint.io/rules/no-shadow)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.59.1/packages/eslint-plugin/src/rules/no-shadow.ts)

--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias.md
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias.md
@@ -25,4 +25,5 @@ setTimeout(() => {
 
 ## Original Documentation
 
-- [typescript-eslint no-this-alias](https://typescript-eslint.io/rules/no-this-alias)
+- [typescript-eslint: no-this-alias](https://typescript-eslint.io/rules/no-this-alias)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-this-alias.ts)

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.md
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.md
@@ -20,4 +20,5 @@ interface Name {
 
 ## Original Documentation
 
-- https://typescript-eslint.io/rules/no-type-alias
+- [typescript-eslint: no-type-alias](https://typescript-eslint.io/rules/no-type-alias)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-type-alias.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.md
@@ -56,4 +56,5 @@ if (nullableFlag === true) {
 
 ## Original Documentation
 
-- [typescript-eslint no-unnecessary-boolean-literal-compare](https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare)
+- [typescript-eslint: no-unnecessary-boolean-literal-compare](https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.29.0/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.md
@@ -42,4 +42,5 @@ function foo(arg: string) {
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/no-unnecessary-condition
+- [typescript-eslint: no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.58.1/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.md
@@ -98,4 +98,5 @@ class Foo {
 
 ## Original Documentation
 
-- [typescript-eslint no-unnecessary-parameter-property-assignment](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment)
+- [typescript-eslint: no-unnecessary-parameter-property-assignment](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.59.3/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_qualifier/no_unnecessary_qualifier.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_qualifier/no_unnecessary_qualifier.md
@@ -49,4 +49,5 @@ namespace Y {
 
 ## Original Documentation
 
-- [typescript-eslint no-unnecessary-qualifier](https://typescript-eslint.io/rules/no-unnecessary-qualifier)
+- [typescript-eslint: no-unnecessary-qualifier](https://typescript-eslint.io/rules/no-unnecessary-qualifier)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_template_expression/no_unnecessary_template_expression.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_template_expression/no_unnecessary_template_expression.md
@@ -26,4 +26,5 @@ const tagged = tag`${value}`;
 
 ## Original Documentation
 
-- [typescript-eslint no-unnecessary-template-expression](https://typescript-eslint.io/rules/no-unnecessary-template-expression)
+- [typescript-eslint: no-unnecessary-template-expression](https://typescript-eslint.io/rules/no-unnecessary-template-expression)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.29.1/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.md
@@ -33,4 +33,5 @@ const y: Foo<number> = [];
 
 ## Original Documentation
 
-- [typescript-eslint no-unnecessary-type-arguments](https://typescript-eslint.io/rules/no-unnecessary-type-arguments)
+- [typescript-eslint: no-unnecessary-type-arguments](https://typescript-eslint.io/rules/no-unnecessary-type-arguments)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.29.0/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.md
@@ -31,4 +31,5 @@ const x = 3 as const; // const assertions are allowed
 
 ## Original Documentation
 
-- [typescript-eslint no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion)
+- [typescript-eslint: no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.md
@@ -38,4 +38,5 @@ const Quux = <T>() => {};
 
 ## Original Documentation
 
-- [typescript-eslint rule: no-unnecessary-type-constraint](https://typescript-eslint.io/rules/no-unnecessary-type-constraint)
+- [typescript-eslint: no-unnecessary-type-constraint](https://typescript-eslint.io/rules/no-unnecessary-type-constraint)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.md
@@ -55,4 +55,5 @@ new Boolean(true);
 
 ## Original Documentation
 
-- [typescript-eslint no-unnecessary-type-conversion](https://typescript-eslint.io/rules/no-unnecessary-type-conversion)
+- [typescript-eslint: no-unnecessary-type-conversion](https://typescript-eslint.io/rules/no-unnecessary-type-conversion)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.59.3/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.md
@@ -51,4 +51,5 @@ The `replaceUsagesWithConstraint` suggestion parenthesizes the constraint wherev
 
 ## Original Documentation
 
-[typescript-eslint: no-unnecessary-type-parameters](https://typescript-eslint.io/rules/no-unnecessary-type-parameters)
+- [typescript-eslint: no-unnecessary-type-parameters](https://typescript-eslint.io/rules/no-unnecessary-type-parameters)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument.md
+++ b/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument.md
@@ -34,4 +34,5 @@ baz(...strArray);
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-argument](https://typescript-eslint.io/rules/no-unsafe-argument)
+- [typescript-eslint: no-unsafe-argument](https://typescript-eslint.io/rules/no-unsafe-argument)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unsafe-argument.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_assignment/no_unsafe_assignment.md
+++ b/internal/plugins/typescript/rules/no_unsafe_assignment/no_unsafe_assignment.md
@@ -32,4 +32,5 @@ function fn(arg: string) {
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment)
+- [typescript-eslint: no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_call/no_unsafe_call.md
+++ b/internal/plugins/typescript/rules/no_unsafe_call/no_unsafe_call.md
@@ -33,4 +33,5 @@ tag`hello`;
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-call](https://typescript-eslint.io/rules/no-unsafe-call)
+- [typescript-eslint: no-unsafe-call](https://typescript-eslint.io/rules/no-unsafe-call)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/no-unsafe-call.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.md
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.md
@@ -69,4 +69,5 @@ class Foo {}
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-declaration-merging](https://typescript-eslint.io/rules/no-unsafe-declaration-merging)
+- [typescript-eslint: no-unsafe-declaration-merging](https://typescript-eslint.io/rules/no-unsafe-declaration-merging)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unsafe-declaration-merging.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison.md
+++ b/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison.md
@@ -39,4 +39,5 @@ fruit === Fruit.Banana;
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-enum-comparison](https://typescript-eslint.io/rules/no-unsafe-enum-comparison)
+- [typescript-eslint: no-unsafe-enum-comparison](https://typescript-eslint.io/rules/no-unsafe-enum-comparison)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/no-unsafe-enum-comparison.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.md
+++ b/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.md
@@ -39,4 +39,5 @@ let value: <T>(t: T) => T;
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-function-type](https://typescript-eslint.io/rules/no-unsafe-function-type)
+- [typescript-eslint: no-unsafe-function-type](https://typescript-eslint.io/rules/no-unsafe-function-type)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unsafe-function-type.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_member_access/no_unsafe_member_access.md
+++ b/internal/plugins/typescript/rules/no_unsafe_member_access/no_unsafe_member_access.md
@@ -35,4 +35,5 @@ map[key];
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-member-access](https://typescript-eslint.io/rules/no-unsafe-member-access)
+- [typescript-eslint: no-unsafe-member-access](https://typescript-eslint.io/rules/no-unsafe-member-access)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.md
+++ b/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.md
@@ -38,4 +38,5 @@ function baz(): any {
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-return](https://typescript-eslint.io/rules/no-unsafe-return)
+- [typescript-eslint: no-unsafe-return](https://typescript-eslint.io/rules/no-unsafe-return)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unsafe-return.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.md
+++ b/internal/plugins/typescript/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.md
@@ -33,4 +33,5 @@ function fn(x: string | number) {
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-type-assertion](https://typescript-eslint.io/rules/no-unsafe-type-assertion)
+- [typescript-eslint: no-unsafe-type-assertion](https://typescript-eslint.io/rules/no-unsafe-type-assertion)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.29.0/packages/eslint-plugin/src/rules/no-unsafe-type-assertion.ts)

--- a/internal/plugins/typescript/rules/no_unsafe_unary_minus/no_unsafe_unary_minus.md
+++ b/internal/plugins/typescript/rules/no_unsafe_unary_minus/no_unsafe_unary_minus.md
@@ -34,4 +34,5 @@ declare const val: number | bigint;
 
 ## Original Documentation
 
-- [typescript-eslint no-unsafe-unary-minus](https://typescript-eslint.io/rules/no-unsafe-unary-minus)
+- [typescript-eslint: no-unsafe-unary-minus](https://typescript-eslint.io/rules/no-unsafe-unary-minus)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unsafe-unary-minus.ts)

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.md
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.md
@@ -43,3 +43,4 @@ foo?.();
 
 - [typescript-eslint: no-unused-expressions](https://typescript-eslint.io/rules/no-unused-expressions)
 - [ESLint: no-unused-expressions](https://eslint.org/docs/latest/rules/no-unused-expressions)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unused-expressions.ts)

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.md
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.md
@@ -42,5 +42,4 @@ foo?.();
 ## Original Documentation
 
 - [typescript-eslint: no-unused-expressions](https://typescript-eslint.io/rules/no-unused-expressions)
-- [ESLint: no-unused-expressions](https://eslint.org/docs/latest/rules/no-unused-expressions)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unused-expressions.ts)

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.md
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.md
@@ -92,5 +92,4 @@ Detection is shape-based, so the rule cannot see uses that reach the member thro
 ## Original Documentation
 
 - [typescript-eslint: no-unused-private-class-members](https://typescript-eslint.io/rules/no-unused-private-class-members)
-- [ESLint: no-unused-private-class-members](https://eslint.org/docs/latest/rules/no-unused-private-class-members)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unused-private-class-members.ts)

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.md
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.md
@@ -91,5 +91,6 @@ Detection is shape-based, so the rule cannot see uses that reach the member thro
 
 ## Original Documentation
 
-- [typescript-eslint no-unused-private-class-members](https://typescript-eslint.io/rules/no-unused-private-class-members)
-- [ESLint no-unused-private-class-members](https://eslint.org/docs/latest/rules/no-unused-private-class-members)
+- [typescript-eslint: no-unused-private-class-members](https://typescript-eslint.io/rules/no-unused-private-class-members)
+- [ESLint: no-unused-private-class-members](https://eslint.org/docs/latest/rules/no-unused-private-class-members)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unused-private-class-members.ts)

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.md
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.md
@@ -70,4 +70,5 @@ function baz(_unused: string) {}
 
 ## Original Documentation
 
-- [typescript-eslint no-unused-vars](https://typescript-eslint.io/rules/no-unused-vars)
+- [typescript-eslint: no-unused-vars](https://typescript-eslint.io/rules/no-unused-vars)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unused-vars.ts)

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
@@ -50,5 +50,4 @@ Also accepts `"nofunc"` as a shorthand for `{ functions: false }`.
 ## Original Documentation
 
 - [typescript-eslint: no-use-before-define](https://typescript-eslint.io/rules/no-use-before-define)
-- [ESLint: no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-use-before-define.ts)

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
@@ -49,5 +49,6 @@ Also accepts `"nofunc"` as a shorthand for `{ functions: false }`.
 
 ## Original Documentation
 
-- https://typescript-eslint.io/rules/no-use-before-define
-- https://eslint.org/docs/latest/rules/no-use-before-define
+- [typescript-eslint: no-use-before-define](https://typescript-eslint.io/rules/no-use-before-define)
+- [ESLint: no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-use-before-define.ts)

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.md
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.md
@@ -49,5 +49,6 @@ class C extends D {
 
 ## Original Documentation
 
-- [typescript-eslint no-useless-constructor](https://typescript-eslint.io/rules/no-useless-constructor)
-- [ESLint no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor)
+- [typescript-eslint: no-useless-constructor](https://typescript-eslint.io/rules/no-useless-constructor)
+- [ESLint: no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-useless-constructor.ts)

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.md
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.md
@@ -50,5 +50,4 @@ class C extends D {
 ## Original Documentation
 
 - [typescript-eslint: no-useless-constructor](https://typescript-eslint.io/rules/no-useless-constructor)
-- [ESLint: no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-useless-constructor.ts)

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.md
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.md
@@ -71,4 +71,5 @@ If you only want to match upstream's behavior exactly, ignore these additional r
 
 ## Original Documentation
 
-- [typescript-eslint no-useless-default-assignment](https://typescript-eslint.io/rules/no-useless-default-assignment)
+- [typescript-eslint: no-useless-default-assignment](https://typescript-eslint.io/rules/no-useless-default-assignment)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.59.4/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts)

--- a/internal/plugins/typescript/rules/no_useless_empty_export/no_useless_empty_export.md
+++ b/internal/plugins/typescript/rules/no_useless_empty_export/no_useless_empty_export.md
@@ -27,4 +27,5 @@ export {};
 
 ## Original Documentation
 
-- [typescript-eslint no-useless-empty-export](https://typescript-eslint.io/rules/no-useless-empty-export)
+- [typescript-eslint: no-useless-empty-export](https://typescript-eslint.io/rules/no-useless-empty-export)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-useless-empty-export.ts)

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.md
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.md
@@ -26,4 +26,5 @@ import { foo } from 'foo';
 
 ## Original Documentation
 
-- [typescript-eslint no-var-requires](https://typescript-eslint.io/rules/no-var-requires)
+- [typescript-eslint: no-var-requires](https://typescript-eslint.io/rules/no-var-requires)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-var-requires.ts)

--- a/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.md
+++ b/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.md
@@ -37,4 +37,5 @@ let value: Number;
 
 ## Original Documentation
 
-- [typescript-eslint no-wrapper-object-types](https://typescript-eslint.io/rules/no-wrapper-object-types)
+- [typescript-eslint: no-wrapper-object-types](https://typescript-eslint.io/rules/no-wrapper-object-types)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-wrapper-object-types.ts)

--- a/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.md
+++ b/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.md
@@ -22,4 +22,5 @@ const qux = bar as SomeDifferentType;
 
 ## Original Documentation
 
-- [typescript-eslint non-nullable-type-assertion-style](https://typescript-eslint.io/rules/non-nullable-type-assertion-style)
+- [typescript-eslint: non-nullable-type-assertion-style](https://typescript-eslint.io/rules/non-nullable-type-assertion-style)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts)

--- a/internal/plugins/typescript/rules/only_throw_error/only_throw_error.md
+++ b/internal/plugins/typescript/rules/only_throw_error/only_throw_error.md
@@ -25,4 +25,5 @@ throw new CustomError('error');
 
 ## Original Documentation
 
-- [typescript-eslint only-throw-error](https://typescript-eslint.io/rules/only-throw-error)
+- [typescript-eslint: only-throw-error](https://typescript-eslint.io/rules/only-throw-error)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/only-throw-error.ts)

--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties.md
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties.md
@@ -56,4 +56,5 @@ class Foo {
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/parameter-properties
+- [typescript-eslint: parameter-properties](https://typescript-eslint.io/rules/parameter-properties)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/parameter-properties.ts)

--- a/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const.md
+++ b/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const.md
@@ -25,4 +25,5 @@ let arr = [1, 2, 3] as const;
 
 ## Original Documentation
 
-- [typescript-eslint prefer-as-const](https://typescript-eslint.io/rules/prefer-as-const)
+- [typescript-eslint: prefer-as-const](https://typescript-eslint.io/rules/prefer-as-const)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-as-const.ts)

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.md
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.md
@@ -73,5 +73,4 @@ const { x }: { x: string } = obj;
 ## Original Documentation
 
 - [typescript-eslint: prefer-destructuring](https://typescript-eslint.io/rules/prefer-destructuring)
-- [ESLint: prefer-destructuring](https://eslint.org/docs/latest/rules/prefer-destructuring)
 - [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-destructuring.ts)

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.md
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.md
@@ -72,5 +72,6 @@ const { x }: { x: string } = obj;
 
 ## Original Documentation
 
-- [ESLint core rule](https://eslint.org/docs/latest/rules/prefer-destructuring)
-- [TypeScript-ESLint rule](https://typescript-eslint.io/rules/prefer-destructuring)
+- [typescript-eslint: prefer-destructuring](https://typescript-eslint.io/rules/prefer-destructuring)
+- [ESLint: prefer-destructuring](https://eslint.org/docs/latest/rules/prefer-destructuring)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-destructuring.ts)

--- a/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers.md
+++ b/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers.md
@@ -38,4 +38,5 @@ enum Empty {}
 
 ## Original Documentation
 
-- [typescript-eslint prefer-enum-initializers](https://typescript-eslint.io/rules/prefer-enum-initializers)
+- [typescript-eslint: prefer-enum-initializers](https://typescript-eslint.io/rules/prefer-enum-initializers)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts)

--- a/internal/plugins/typescript/rules/prefer_find/prefer_find.md
+++ b/internal/plugins/typescript/rules/prefer_find/prefer_find.md
@@ -93,4 +93,5 @@ If you intentionally use patterns like `.filter(callback)[0]` to execute side ef
 
 ## Original Documentation
 
-- [typescript-eslint prefer-find](https://typescript-eslint.io/rules/prefer-find)
+- [typescript-eslint: prefer-find](https://typescript-eslint.io/rules/prefer-find)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-find.ts)

--- a/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.md
+++ b/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.md
@@ -39,4 +39,5 @@ for (let i = 0; i < array.length; i++) {
 
 ## Original Documentation
 
-[typescript-eslint: prefer-for-of](https://typescript-eslint.io/rules/prefer-for-of)
+- [typescript-eslint: prefer-for-of](https://typescript-eslint.io/rules/prefer-for-of)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-for-of.ts)

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.md
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.md
@@ -66,4 +66,5 @@ Disable this rule if you prefer interfaces or object type literals for stylistic
 
 ## Original Documentation
 
-- [typescript-eslint prefer-function-type](https://typescript-eslint.io/rules/prefer-function-type)
+- [typescript-eslint: prefer-function-type](https://typescript-eslint.io/rules/prefer-function-type)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-function-type.ts)

--- a/internal/plugins/typescript/rules/prefer_includes/prefer_includes.md
+++ b/internal/plugins/typescript/rules/prefer_includes/prefer_includes.md
@@ -23,4 +23,5 @@ if (arr.includes(value)) {
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/prefer-includes
+- [typescript-eslint: prefer-includes](https://typescript-eslint.io/rules/prefer-includes)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-includes.ts)

--- a/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.md
+++ b/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.md
@@ -48,4 +48,5 @@ When set to `true`, allows using bitwise expressions in enum initializers, which
 
 ## Original Documentation
 
-- [typescript-eslint prefer-literal-enum-member](https://typescript-eslint.io/rules/prefer-literal-enum-member)
+- [typescript-eslint: prefer-literal-enum-member](https://typescript-eslint.io/rules/prefer-literal-enum-member)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts)

--- a/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword.md
+++ b/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword.md
@@ -26,4 +26,5 @@ declare module 'foo' {}
 
 ## Original Documentation
 
-- [typescript-eslint prefer-namespace-keyword](https://typescript-eslint.io/rules/prefer-namespace-keyword)
+- [typescript-eslint: prefer-namespace-keyword](https://typescript-eslint.io/rules/prefer-namespace-keyword)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-namespace-keyword.ts)

--- a/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.md
+++ b/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.md
@@ -85,4 +85,5 @@ Default: `false`. By default the rule errors on every file when `strictNullCheck
 
 ## Original Documentation
 
-[`@typescript-eslint/prefer-nullish-coalescing`](https://typescript-eslint.io/rules/prefer-nullish-coalescing)
+- [typescript-eslint: prefer-nullish-coalescing](https://typescript-eslint.io/rules/prefer-nullish-coalescing)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts)

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.md
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.md
@@ -88,5 +88,5 @@ When set to `true`, the rule will only report on expressions where at least one 
 
 ## Original Documentation
 
-- [typescript-eslint prefer-optional-chain](https://typescript-eslint.io/rules/prefer-optional-chain)
-- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.65.0/packages/eslint-plugin/src/rules/prefer-optional-chain.ts)
+- [typescript-eslint: prefer-optional-chain](https://typescript-eslint.io/rules/prefer-optional-chain)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-optional-chain.ts)

--- a/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.md
+++ b/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.md
@@ -22,4 +22,5 @@ Promise.reject(unknownVariable);
 
 ## Original Documentation
 
-- [typescript-eslint prefer-promise-reject-errors](https://typescript-eslint.io/rules/prefer-promise-reject-errors)
+- [typescript-eslint: prefer-promise-reject-errors](https://typescript-eslint.io/rules/prefer-promise-reject-errors)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/prefer-promise-reject-errors.ts)

--- a/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.md
+++ b/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.md
@@ -60,4 +60,5 @@ When set to `true`, only checks members that are assigned an arrow function expr
 
 ## Original Documentation
 
-- [typescript-eslint prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly)
+- [typescript-eslint: prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.54.0/packages/eslint-plugin/src/rules/prefer-readonly.ts)

--- a/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.md
+++ b/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.md
@@ -23,4 +23,5 @@ function qux(value: string) {} // primitives are always readonly
 
 ## Original Documentation
 
-- [typescript-eslint prefer-readonly-parameter-types](https://typescript-eslint.io/rules/prefer-readonly-parameter-types)
+- [typescript-eslint: prefer-readonly-parameter-types](https://typescript-eslint.io/rules/prefer-readonly-parameter-types)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.46.3/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts)

--- a/internal/plugins/typescript/rules/prefer_reduce_type_parameter/prefer_reduce_type_parameter.md
+++ b/internal/plugins/typescript/rules/prefer_reduce_type_parameter/prefer_reduce_type_parameter.md
@@ -26,4 +26,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-- [typescript-eslint prefer-reduce-type-parameter](https://typescript-eslint.io/rules/prefer-reduce-type-parameter)
+- [typescript-eslint: prefer-reduce-type-parameter](https://typescript-eslint.io/rules/prefer-reduce-type-parameter)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts)

--- a/internal/plugins/typescript/rules/prefer_regexp_exec/prefer_regexp_exec.md
+++ b/internal/plugins/typescript/rules/prefer_regexp_exec/prefer_regexp_exec.md
@@ -22,4 +22,5 @@ value.match(/foo/g);
 
 ## Original Documentation
 
-- https://typescript-eslint.io/rules/prefer-regexp-exec
+- [typescript-eslint: prefer-regexp-exec](https://typescript-eslint.io/rules/prefer-regexp-exec)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts)

--- a/internal/plugins/typescript/rules/prefer_return_this_type/prefer_return_this_type.md
+++ b/internal/plugins/typescript/rules/prefer_return_this_type/prefer_return_this_type.md
@@ -32,4 +32,5 @@ class Foo {
 
 ## Original Documentation
 
-- [typescript-eslint prefer-return-this-type](https://typescript-eslint.io/rules/prefer-return-this-type)
+- [typescript-eslint: prefer-return-this-type](https://typescript-eslint.io/rules/prefer-return-this-type)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.29.0/packages/eslint-plugin/src/rules/prefer-return-this-type.ts)

--- a/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.md
+++ b/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.md
@@ -57,4 +57,5 @@ When set to `"always"`, allows equality checks for a single character (e.g. `foo
 
 ## Original Documentation
 
-- [typescript-eslint prefer-string-starts-ends-with](https://typescript-eslint.io/rules/prefer-string-starts-ends-with)
+- [typescript-eslint: prefer-string-starts-ends-with](https://typescript-eslint.io/rules/prefer-string-starts-ends-with)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.55.0/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts)

--- a/internal/plugins/typescript/rules/prefer_ts_expect_error/prefer_ts_expect_error.md
+++ b/internal/plugins/typescript/rules/prefer_ts_expect_error/prefer_ts_expect_error.md
@@ -18,4 +18,5 @@ Examples of **correct** code for this rule:
 
 ## Original Documentation
 
-https://typescript-eslint.io/rules/prefer-ts-expect-error
+- [typescript-eslint: prefer-ts-expect-error](https://typescript-eslint.io/rules/prefer-ts-expect-error)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.57.0/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts)

--- a/internal/plugins/typescript/rules/promise_function_async/promise_function_async.md
+++ b/internal/plugins/typescript/rules/promise_function_async/promise_function_async.md
@@ -32,4 +32,5 @@ class Baz {
 
 ## Original Documentation
 
-- [typescript-eslint promise-function-async](https://typescript-eslint.io/rules/promise-function-async)
+- [typescript-eslint: promise-function-async](https://typescript-eslint.io/rules/promise-function-async)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.29.1/packages/eslint-plugin/src/rules/promise-function-async.ts)

--- a/internal/plugins/typescript/rules/related_getter_setter_pairs/related_getter_setter_pairs.md
+++ b/internal/plugins/typescript/rules/related_getter_setter_pairs/related_getter_setter_pairs.md
@@ -42,4 +42,5 @@ class Bar {
 
 ## Original Documentation
 
-- [typescript-eslint related-getter-setter-pairs](https://typescript-eslint.io/rules/related-getter-setter-pairs)
+- [typescript-eslint: related-getter-setter-pairs](https://typescript-eslint.io/rules/related-getter-setter-pairs)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/related-getter-setter-pairs.ts)

--- a/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.md
+++ b/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.md
@@ -28,4 +28,5 @@ strings.sort(); // OK, string arrays are ignored by default
 
 ## Original Documentation
 
-- [typescript-eslint require-array-sort-compare](https://typescript-eslint.io/rules/require-array-sort-compare)
+- [typescript-eslint: require-array-sort-compare](https://typescript-eslint.io/rules/require-array-sort-compare)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/require-array-sort-compare.ts)

--- a/internal/plugins/typescript/rules/require_await/require_await.md
+++ b/internal/plugins/typescript/rules/require_await/require_await.md
@@ -33,4 +33,5 @@ function baz() {
 
 ## Original Documentation
 
-- [typescript-eslint require-await](https://typescript-eslint.io/rules/require-await)
+- [typescript-eslint: require-await](https://typescript-eslint.io/rules/require-await)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/require-await.ts)

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.md
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.md
@@ -23,4 +23,5 @@ const explicit = String(1) + '2';
 
 ## Original Documentation
 
-- [typescript-eslint restrict-plus-operands](https://typescript-eslint.io/rules/restrict-plus-operands)
+- [typescript-eslint: restrict-plus-operands](https://typescript-eslint.io/rules/restrict-plus-operands)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/restrict-plus-operands.ts)

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.md
@@ -66,4 +66,5 @@ To require every interpolated value to be a `string`, empty the `allow` list and
 
 ## Original Documentation
 
-- [typescript-eslint restrict-template-expressions](https://typescript-eslint.io/rules/restrict-template-expressions)
+- [typescript-eslint: restrict-template-expressions](https://typescript-eslint.io/rules/restrict-template-expressions)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/restrict-template-expressions.ts)

--- a/internal/plugins/typescript/rules/return_await/return_await.md
+++ b/internal/plugins/typescript/rules/return_await/return_await.md
@@ -45,4 +45,5 @@ async function baz() {
 
 ## Original Documentation
 
-- [typescript-eslint return-await](https://typescript-eslint.io/rules/return-await)
+- [typescript-eslint: return-await](https://typescript-eslint.io/rules/return-await)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/return-await.ts)

--- a/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.md
+++ b/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.md
@@ -139,4 +139,5 @@ If your codebase does not rely on JavaScript truthiness coercion in boolean posi
 
 ## Original Documentation
 
-- [typescript-eslint strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions)
+- [typescript-eslint: strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts)

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.md
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.md
@@ -121,4 +121,5 @@ fn(() => {
 
 ## Original Documentation
 
-- [typescript-eslint strict-void-return](https://typescript-eslint.io/rules/strict-void-return)
+- [typescript-eslint: strict-void-return](https://typescript-eslint.io/rules/strict-void-return)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/strict-void-return.ts)

--- a/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.md
+++ b/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.md
@@ -41,4 +41,5 @@ function move(dir: Direction) {
 
 ## Original Documentation
 
-- [typescript-eslint switch-exhaustiveness-check](https://typescript-eslint.io/rules/switch-exhaustiveness-check)
+- [typescript-eslint: switch-exhaustiveness-check](https://typescript-eslint.io/rules/switch-exhaustiveness-check)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts)

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.md
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.md
@@ -29,4 +29,5 @@ import { foo } from 'bar';
 
 ## Original Documentation
 
-- [typescript-eslint triple-slash-reference](https://typescript-eslint.io/rules/triple-slash-reference)
+- [typescript-eslint: triple-slash-reference](https://typescript-eslint.io/rules/triple-slash-reference)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/triple-slash-reference.ts)

--- a/internal/plugins/typescript/rules/unbound_method/unbound_method.md
+++ b/internal/plugins/typescript/rules/unbound_method/unbound_method.md
@@ -37,4 +37,5 @@ typeof instance.method;
 
 ## Original Documentation
 
-- [typescript-eslint unbound-method](https://typescript-eslint.io/rules/unbound-method)
+- [typescript-eslint: unbound-method](https://typescript-eslint.io/rules/unbound-method)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.28.0/packages/eslint-plugin/src/rules/unbound-method.ts)

--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures.md
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures.md
@@ -32,4 +32,5 @@ function baz(x: string): string;
 
 ## Original Documentation
 
-- [typescript-eslint unified-signatures](https://typescript-eslint.io/rules/unified-signatures)
+- [typescript-eslint: unified-signatures](https://typescript-eslint.io/rules/unified-signatures)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/unified-signatures.ts)

--- a/internal/plugins/typescript/rules/use_unknown_in_catch_callback_variable/use_unknown_in_catch_callback_variable.md
+++ b/internal/plugins/typescript/rules/use_unknown_in_catch_callback_variable/use_unknown_in_catch_callback_variable.md
@@ -25,4 +25,5 @@ promise.catch((...args: [unknown]) => {});
 
 ## Original Documentation
 
-- [typescript-eslint use-unknown-in-catch-callback-variable](https://typescript-eslint.io/rules/use-unknown-in-catch-callback-variable)
+- [typescript-eslint: use-unknown-in-catch-callback-variable](https://typescript-eslint.io/rules/use-unknown-in-catch-callback-variable)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts)


### PR DESCRIPTION
## Summary

- Every `typescript/` rule doc's "Original Documentation" section now pins a "Source code" link to the newest typescript-eslint release the rule's Go port is verified against, alongside the existing (unpinnable) typescript-eslint.io doc link.
- All 131 rules audited: 98 bump to the latest release, v8.67.0 (56 had zero upstream commits since port; 42 more had only cosmetic drift, or behavioral drift rslint's Go port already independently implements, confirmed against existing Go tests).
- The remaining 33 rules stay pinned at the tag they were last actually verified against, because upstream has real behavioral changes rslint hasn't ported yet:
  - `array-type` (v8.39.0): bare `Array`/`ReadonlyArray` no longer autofixed to `any[]`, and shadowed `Array`/`ReadonlyArray` no longer flagged.
  - `await-thenable` (v8.28.0): new check for non-awaitable values passed to `Promise.all`/`race`/`allSettled`/`any`.
  - `ban-ts-comment` (v8.46.3): multi-line directive matching now handles `\r`-only and Unicode line terminators.
  - `class-literal-property-style` (v8.39.0): field-style suggestion now preserves type annotations and is withheld on decorated getters.
  - `consistent-generic-constructors` (v8.46.3): typed-array constructors (`Float32Array`, etc.) referencing the global builtin are now exempt.
  - `consistent-type-exports` (v8.46.3): alias-chain resolution now checks the value flag before continuing, fixing misclassified re-exports.
  - `method-signature-style` (v8.58.2): readonly function-typed properties now get a suggestion instead of an autofix that emitted invalid syntax.
  - `no-base-to-string` (v8.28.0): `checkUnknown` option, `@@toPrimitive`/`valueOf` detection, base-type traversal and generic-name matching for `ignoredTypeNames`, and a multi-declaration overload fix are all unported.
  - `no-extraneous-class` (v8.46.3): `TSIndexSignature` handling — likely already correct via the Go port's default-case fallback, but no test demonstrates it, so it isn't claimed as verified.
  - `no-loop-func` (v8.59.1): deliberately does not treat `using`/`await using` as constant bindings (rslint's own test suite locks in the old behavior).
  - `no-misused-promises` (v8.28.0): async-dispose detection for `using`/`await using` declarations is unported (other behavioral fixes in this window are already ported and tested).
  - `no-shadow` (v8.59.1): new `noEnumShadow` messageId for enum-member shadowing, and a stricter direct-initializer check, are both unported (rslint's own test suite locks in the old behavior).
  - `no-unnecessary-boolean-literal-compare` (v8.29.0): autofix still uses the pre-fix algorithm with known precedence bugs.
  - `no-unnecessary-condition` (v8.58.1): `isPossiblyNullish` still excludes `void` by explicit design comment.
  - `no-unnecessary-parameter-property-assignment` (v8.59.3): deliberately mirrors the upstream bug where `this[ident] = ident` was misclassified (explicit comment in the Go source).
  - `no-unnecessary-template-expression` (v8.29.1): newline detection still only checks `\n`/`\r\n`, not the fuller upstream line-break matcher.
  - `no-unnecessary-type-arguments` (v8.29.0): skipping `TSInstantiationExpression` parents is unported.
  - `no-unnecessary-type-assertion` (v8.28.0): still uses the old equality-based check; the assignability-based rewrite (723-line upstream change) is unported, marked by the Go source's own TODO.
  - `no-unnecessary-type-conversion` (v8.59.3): shadow detection still uses the old non-scope-chain-walking check (rslint's own test suite locks in the old behavior).
  - `no-unsafe-assignment` / `no-unsafe-call` / `no-unsafe-member-access` (all v8.28.0): upstream's error-vs-any messageId split and new `unsafeObjectPattern`/`allowOptionalChaining` cases are unported.
  - `no-unsafe-enum-comparison` (v8.28.0): union-of-literals support is unported.
  - `no-unsafe-type-assertion` (v8.29.0): missing the try/catch guard upstream added around a TS-compiler crash on recursive template literal types; rslint's rule pipeline has no panic recovery either.
  - `no-useless-default-assignment` (v8.59.4): overload check still only inspects the first signature instead of scanning all contextual overloads.
  - `prefer-promise-reject-errors` (v8.28.0): `allow` option is declared in the schema but never read.
  - `prefer-readonly` (v8.54.0): computed keys are still unconditionally ignored instead of analyzing statically-known ones.
  - `prefer-readonly-parameter-types` (v8.46.3): type resolution still uses `getTypeAtLocation` instead of the alias-preserving fix, and `allow` only supports bare strings.
  - `prefer-return-this-type` (v8.29.0): still uses strict type equality instead of checking union membership.
  - `prefer-string-starts-ends-with` (v8.55.0): end-anchor detection still a naive suffix check, not the unescaped-`$` fix.
  - `prefer-ts-expect-error` (v8.57.0): same line-terminator gap as `ban-ts-comment`/`no-unnecessary-template-expression`.
  - `promise-function-async` (v8.29.1): missing messageId for hybrid promise/non-promise union return types.
  - `unbound-method` (v8.28.0): union-typed member-expression access isn't checked, and the message text predates a wording fix.

## Checklist

- [x] Tests updated (or not required) — docs-only change.
- [x] Documentation updated (or not required).