### PR TITLE
feat(rstest): add valid-expect rule

### DIFF
--- a/internal/plugins/jest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect.go
@@ -8,7 +8,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
-	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	sharedValidExpect "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/valid_expect"
 	"slices"
 	"strconv"
 )
@@ -217,92 +217,6 @@ func shouldBeAwaited(parsed *utils.ParsedJestFnCall, asyncMatchers []string) boo
 	return slices.Contains(asyncMatchers, parsed.Matcher)
 }
 
-func isPromiseMethodCall(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindCallExpression {
-		return false
-	}
-
-	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
-	if !utils.IsMemberAccessNode(callee) {
-		return false
-	}
-
-	return testFramework.CalleeChainName(internalUtils.AccessExpressionObject(callee)) == "Promise"
-}
-
-func getPromiseCallExpressionNode(node *ast.Node) *ast.Node {
-	if node == nil {
-		return nil
-	}
-
-	if node.Kind == ast.KindArrayLiteralExpression && node.Parent != nil && node.Parent.Kind == ast.KindCallExpression {
-		node = node.Parent
-	}
-
-	if isPromiseMethodCall(node) {
-		return node
-	}
-
-	return nil
-}
-
-func findPromiseCallExpressionNode(node *ast.Node) *ast.Node {
-	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
-		return nil
-	}
-	if node.Parent.Kind != ast.KindCallExpression && node.Parent.Kind != ast.KindArrayLiteralExpression {
-		return nil
-	}
-	return getPromiseCallExpressionNode(node.Parent)
-}
-
-func getParentIfPromiseChained(node *ast.Node) *ast.Node {
-	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
-		return node
-	}
-
-	grandParent := node.Parent.Parent
-	if grandParent.Kind != ast.KindCallExpression || !utils.IsMemberAccessNode(grandParent.AsCallExpression().Expression) {
-		return node
-	}
-
-	member := grandParent.AsCallExpression().Expression
-	entries := utils.GetJestFnMemberEntries(member)
-	if len(entries) == 0 {
-		return node
-	}
-
-	last := entries[len(entries)-1].Name
-	if last == "then" || last == "catch" {
-		return getParentIfPromiseChained(grandParent)
-	}
-
-	return node
-}
-
-func isAcceptableReturnNode(node *ast.Node, allowReturn bool) bool {
-	if node == nil {
-		return false
-	}
-
-	if allowReturn && node.Kind == ast.KindReturnStatement {
-		return true
-	}
-	if node.Kind == ast.KindConditionalExpression {
-		return isAcceptableReturnNode(node.Parent, allowReturn)
-	}
-
-	return node.Kind == ast.KindArrowFunction || node.Kind == ast.KindAwaitExpression
-}
-
-func promiseArrayExceptionKey(sourceFile *ast.SourceFile, node *ast.Node) string {
-	if sourceFile == nil || node == nil {
-		return ""
-	}
-	r := internalUtils.TrimNodeTextRange(sourceFile, node)
-	return fmt.Sprintf("%d:%d", r.Pos(), r.End())
-}
-
 func expectOpenParenRange(sourceFile *ast.SourceFile, call *ast.Node) core.TextRange {
 	if sourceFile == nil || call == nil || call.Kind != ast.KindCallExpression {
 		return internalUtils.TrimNodeTextRange(sourceFile, call)
@@ -329,26 +243,9 @@ func tooManyArgsRange(sourceFile *ast.SourceFile, args []*ast.Node, maxArgs int)
 	return core.NewTextRange(start, end)
 }
 
-func asyncInsertFix(sourceFile *ast.SourceFile, fn *ast.Node) rule.RuleFix {
-	switch fn.Kind {
-	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
-		head := internalUtils.GetFunctionHeadLoc(sourceFile, fn)
-		return rule.RuleFixReplaceRange(core.NewTextRange(head.Pos(), head.Pos()), "async ")
-	default:
-		return rule.RuleFixInsertBefore(sourceFile, fn, "async ")
-	}
-}
-
-func awaitFix(sourceFile *ast.SourceFile, node *ast.Node, alwaysAwait bool) rule.RuleFix {
-	if alwaysAwait && node.Parent != nil && node.Parent.Kind == ast.KindReturnStatement {
-		ret := node.Parent
-		retRange := internalUtils.TrimNodeTextRange(sourceFile, ret)
-		nodeRange := internalUtils.TrimNodeTextRange(sourceFile, node)
-		return rule.RuleFixReplaceRange(core.NewTextRange(retRange.Pos(), nodeRange.Pos()), "await ")
-	}
-	return rule.RuleFixInsertBefore(sourceFile, node, "await ")
-}
-
+// resolveAsyncAssertionReportNode locates the assertion expression a matcher
+// belongs to — jest matchers are always called, so it is the call wrapping the
+// matcher's member access — and hands it to the shared resolver.
 func resolveAsyncAssertionReportNode(
 	matcherEntry *utils.ParsedJestFnMemberEntry,
 	alwaysAwait bool,
@@ -362,19 +259,7 @@ func resolveAsyncAssertionReportNode(
 		return nil, false, false, false
 	}
 
-	promiseChainedAssertionNode := getParentIfPromiseChained(matcherMemberNode.Parent)
-	insideAssertionArray = promiseChainedAssertionNode.Parent != nil && promiseChainedAssertionNode.Parent.Kind == ast.KindArrayLiteralExpression
-	reportNode = promiseChainedAssertionNode
-	if promiseCallNode := findPromiseCallExpressionNode(promiseChainedAssertionNode); promiseCallNode != nil {
-		reportNode = promiseCallNode
-		promiseWrapped = true
-	}
-
-	if reportNode.Parent == nil || isAcceptableReturnNode(reportNode.Parent, !alwaysAwait) {
-		return reportNode, promiseWrapped, insideAssertionArray, false
-	}
-
-	return reportNode, promiseWrapped, insideAssertionArray, true
+	return sharedValidExpect.ResolveAsyncAssertionReportNode(matcherMemberNode.Parent, alwaysAwait)
 }
 
 func reportAsyncDescriptor(
@@ -388,10 +273,10 @@ func reportAsyncDescriptor(
 	var fixes []rule.RuleFix
 	if fn := ast.GetContainingFunction(descriptor.node); fn != nil {
 		if !ast.IsAsyncFunction(fn) && !asyncInserted[fn] {
-			fixes = append(fixes, asyncInsertFix(ctx.SourceFile, fn))
+			fixes = append(fixes, sharedValidExpect.AsyncInsertFix(ctx.SourceFile, fn))
 			asyncInserted[fn] = true
 		}
-		fixes = append(fixes, awaitFix(ctx.SourceFile, descriptor.node, alwaysAwait))
+		fixes = append(fixes, sharedValidExpect.AwaitFix(ctx.SourceFile, descriptor.node, alwaysAwait))
 	}
 
 	if len(fixes) > 0 {
@@ -485,7 +370,7 @@ var ValidExpectRule = rule.Rule{
 					return
 				}
 
-				reportNodeKey := promiseArrayExceptionKey(ctx.SourceFile, reportNode)
+				reportNodeKey := sharedValidExpect.PromiseArrayExceptionKey(ctx.SourceFile, reportNode)
 				if shouldReport && !arrayExceptions[reportNodeKey] {
 					descriptors = append(descriptors, asyncDescriptor{
 						node:           reportNode,

--- a/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
@@ -28,6 +28,10 @@ func TestValidExpectRule(t *testing.T) {
 			{Code: "test(\"valid-expect\", () => { return expect(Promise.resolve(2)).resolves.toBeDefined(); });"},
 			{Code: "test(\"valid-expect\", () => { return expect(Promise.reject(2)).rejects.toBeDefined(); });"},
 			{Code: "test(\"valid-expect\", () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });"},
+			// Parentheses are nodes in the TypeScript AST but not in ESTree, so
+			// the await/return check must look past them to match upstream.
+			{Code: "test(\"valid-expect\", async () => { await (expect(Promise.resolve(2)).resolves.toBeDefined()); });"},
+			{Code: "test(\"valid-expect\", () => { return (expect(Promise.resolve(2)).resolves.toBeDefined()); });"},
 			{Code: "test(\"valid-expect\", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });"},
 			{Code: "test(\"valid-expect\", function () { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });"},
 			{Code: "test(\"valid-expect\", function () { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });"},

--- a/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
@@ -32,6 +32,8 @@ func TestValidExpectRule(t *testing.T) {
 			// the await/return check must look past them to match upstream.
 			{Code: "test(\"valid-expect\", async () => { await (expect(Promise.resolve(2)).resolves.toBeDefined()); });"},
 			{Code: "test(\"valid-expect\", () => { return (expect(Promise.resolve(2)).resolves.toBeDefined()); });"},
+			{Code: "test(\"valid-expect\", async () => { await Promise.all([(expect(Promise.resolve(2)).resolves.toBeDefined()), expect(Promise.resolve(3)).resolves.toBeDefined()]); });"},
+			{Code: "test(\"valid-expect\", async () => { await (expect(Promise.resolve(2)).resolves.toBeDefined()).then(() => {}); });"},
 			{Code: "test(\"valid-expect\", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });"},
 			{Code: "test(\"valid-expect\", function () { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });"},
 			{Code: "test(\"valid-expect\", function () { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });"},
@@ -264,6 +266,14 @@ func TestValidExpectRule(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "asyncMustBeAwaited", Column: 1, EndColumn: 50},
 				},
+			},
+			{
+				Code:    "test(\"valid-expect\", () => { return (expect(Promise.resolve(2)).resolves.toBeDefined()); });",
+				Options: map[string]interface{}{"alwaysAwait": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{"test(\"valid-expect\", async () => { await (expect(Promise.resolve(2)).resolves.toBeDefined()); });"},
 			},
 			{
 				Code: `expect.extend({
@@ -596,6 +606,13 @@ func TestValidExpectRule(t *testing.T) {
       `},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited", Line: 2, Column: 3, EndLine: 5, EndColumn: 5},
+				},
+			},
+			{
+				Code:   `test("valid-expect", () => { Promise.all([(expect(Promise.resolve(2)).resolves.toBeDefined()), expect(Promise.resolve(3)).resolves.toBeDefined()]); });`,
+				Output: []string{`test("valid-expect", async () => { await Promise.all([(expect(Promise.resolve(2)).resolves.toBeDefined()), expect(Promise.resolve(3)).resolves.toBeDefined()]); });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited"},
 				},
 			},
 			{

--- a/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
@@ -616,6 +616,13 @@ func TestValidExpectRule(t *testing.T) {
 				},
 			},
 			{
+				Code:   `test("valid-expect", () => { Promise.all(([expect(Promise.resolve(2)).resolves.toBeDefined(), expect(Promise.resolve(3)).resolves.toBeDefined()])); });`,
+				Output: []string{`test("valid-expect", async () => { await Promise.all(([expect(Promise.resolve(2)).resolves.toBeDefined(), expect(Promise.resolve(3)).resolves.toBeDefined()])); });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited"},
+				},
+			},
+			{
 				Code: `test("valid-expect", () => {
   Promise.x([
     expect(Promise.resolve(2)).resolves.not.toBeDefined(),

--- a/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect_test.go
@@ -32,6 +32,7 @@ func TestValidExpectRule(t *testing.T) {
 			// the await/return check must look past them to match upstream.
 			{Code: "test(\"valid-expect\", async () => { await (expect(Promise.resolve(2)).resolves.toBeDefined()); });"},
 			{Code: "test(\"valid-expect\", () => { return (expect(Promise.resolve(2)).resolves.toBeDefined()); });"},
+			{Code: "test(\"valid-expect\", () => { return (condition ? expect(Promise.resolve(2)).resolves.toBeDefined() : expect(2).toBeDefined()); });"},
 			{Code: "test(\"valid-expect\", async () => { await Promise.all([(expect(Promise.resolve(2)).resolves.toBeDefined()), expect(Promise.resolve(3)).resolves.toBeDefined()]); });"},
 			{Code: "test(\"valid-expect\", async () => { await (expect(Promise.resolve(2)).resolves.toBeDefined()).then(() => {}); });"},
 			{Code: "test(\"valid-expect\", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });"},

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_interpolation_in_snapshots"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_title"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -19,6 +20,7 @@ func GetAllRules() []rule.Rule {
 		no_identical_title.NoIdenticalTitleRule,
 		no_interpolation_in_snapshots.NoInterpolationInSnapshotsRule,
 		no_mocks_import.NoMocksImportRule,
+		valid_expect.ValidExpectRule,
 		valid_title.ValidTitleRule,
 	}
 }

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -294,23 +294,25 @@ var ValidExpectRule = rule.Rule{
 
 				// Static members (expect.assertions(1), expect.any(...)) carry no
 				// assertion factory, so argument and await checks do not apply.
-				if parsed.Head != nil && parsed.Head.Kind == ast.KindCallExpression {
-					args := parsed.Head.AsCallExpression().Arguments.Nodes
-					if len(args) < opts.MinArgs {
+				if parsed.Head == nil || parsed.Head.Kind != ast.KindCallExpression {
+					return
+				}
+
+				args := parsed.Head.AsCallExpression().Arguments.Nodes
+				if len(args) < opts.MinArgs {
+					ctx.ReportRange(
+						expectFactoryOpenParenRange(ctx.SourceFile, parsed.Head),
+						buildErrorNotEnoughArgsMessage(opts.MinArgs),
+					)
+				}
+				if len(args) > opts.MaxArgs {
+					// vitest allowance: a lone message string/template, or the
+					// options object of poll/element, is not an excess argument.
+					if len(args) != opts.MaxArgs+1 || !isAllowedExtraExpectArg(args[opts.MaxArgs], parsed.Entry) {
 						ctx.ReportRange(
-							expectFactoryOpenParenRange(ctx.SourceFile, parsed.Head),
-							buildErrorNotEnoughArgsMessage(opts.MinArgs),
+							tooManyArgsRange(ctx.SourceFile, args, opts.MaxArgs),
+							buildErrorTooManyArgsMessage(opts.MaxArgs),
 						)
-					}
-					if len(args) > opts.MaxArgs {
-						// vitest allowance: a lone message string/template, or the
-						// options object of poll/element, is not an excess argument.
-						if len(args) != opts.MaxArgs+1 || !isAllowedExtraExpectArg(args[opts.MaxArgs], parsed.Entry) {
-							ctx.ReportRange(
-								tooManyArgsRange(ctx.SourceFile, args, opts.MaxArgs),
-								buildErrorTooManyArgsMessage(opts.MaxArgs),
-							)
-						}
 					}
 				}
 

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -176,7 +176,7 @@ func isPromiseMethodCall(node *ast.Node) bool {
 	}
 
 	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
-	if !isMemberAccessNode(callee) {
+	if !rstestUtils.IsMemberAccessNode(callee) {
 		return false
 	}
 
@@ -215,7 +215,7 @@ func getParentIfPromiseChained(node *ast.Node) *ast.Node {
 	}
 
 	grandParent := node.Parent.Parent
-	if grandParent.Kind != ast.KindCallExpression || !isMemberAccessNode(grandParent.AsCallExpression().Expression) {
+	if grandParent.Kind != ast.KindCallExpression || !rstestUtils.IsMemberAccessNode(grandParent.AsCallExpression().Expression) {
 		return node
 	}
 
@@ -298,20 +298,6 @@ func reportAsyncDescriptor(
 		return
 	}
 	ctx.ReportNode(descriptor.node, msg)
-}
-
-// --- Rstest-specific helpers ---
-
-func isMemberAccessNode(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
-		return true
-	default:
-		return false
-	}
 }
 
 // expectFactoryOpenParenRange locates the `(` of the assertion factory call so

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -10,7 +10,7 @@ import (
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
-	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	sharedValidExpect "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/valid_expect"
 )
 
 //go:embed valid_expect.schema.json
@@ -164,117 +164,9 @@ func readIntOption(options map[string]interface{}, key string, defaultValue int)
 // --- Async assertion machinery ---
 //
 // The Promise-chain walking, acceptable-return detection, array de-duplication
-// and async/await fixers below are ported verbatim from
-// internal/plugins/jest/rules/valid_expect/valid_expect.go, which is itself
-// aligned with eslint-plugin-vitest. Kept as a local copy rather than shared:
-// sharing them would require touching the jest rule and re-running its
-// regression, and there is no third consumer yet.
-
-func isPromiseMethodCall(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindCallExpression {
-		return false
-	}
-
-	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
-	if !rstestUtils.IsMemberAccessNode(callee) {
-		return false
-	}
-
-	return testFramework.CalleeChainName(internalUtils.AccessExpressionObject(callee)) == "Promise"
-}
-
-func getPromiseCallExpressionNode(node *ast.Node) *ast.Node {
-	if node == nil {
-		return nil
-	}
-
-	if node.Kind == ast.KindArrayLiteralExpression && node.Parent != nil && node.Parent.Kind == ast.KindCallExpression {
-		node = node.Parent
-	}
-
-	if isPromiseMethodCall(node) {
-		return node
-	}
-
-	return nil
-}
-
-func findPromiseCallExpressionNode(node *ast.Node) *ast.Node {
-	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
-		return nil
-	}
-	if node.Parent.Kind != ast.KindCallExpression && node.Parent.Kind != ast.KindArrayLiteralExpression {
-		return nil
-	}
-	return getPromiseCallExpressionNode(node.Parent)
-}
-
-func getParentIfPromiseChained(node *ast.Node) *ast.Node {
-	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
-		return node
-	}
-
-	grandParent := node.Parent.Parent
-	if grandParent.Kind != ast.KindCallExpression || !rstestUtils.IsMemberAccessNode(grandParent.AsCallExpression().Expression) {
-		return node
-	}
-
-	member := grandParent.AsCallExpression().Expression
-	entries := testFramework.GetMemberEntries(member)
-	if len(entries) == 0 {
-		return node
-	}
-
-	last := entries[len(entries)-1].Name
-	if last == "then" || last == "catch" {
-		return getParentIfPromiseChained(grandParent)
-	}
-
-	return node
-}
-
-func isAcceptableReturnNode(node *ast.Node, allowReturn bool) bool {
-	if node == nil {
-		return false
-	}
-
-	if allowReturn && node.Kind == ast.KindReturnStatement {
-		return true
-	}
-	if node.Kind == ast.KindConditionalExpression {
-		return isAcceptableReturnNode(node.Parent, allowReturn)
-	}
-
-	return node.Kind == ast.KindArrowFunction || node.Kind == ast.KindAwaitExpression
-}
-
-func promiseArrayExceptionKey(sourceFile *ast.SourceFile, node *ast.Node) string {
-	if sourceFile == nil || node == nil {
-		return ""
-	}
-	r := internalUtils.TrimNodeTextRange(sourceFile, node)
-	return fmt.Sprintf("%d:%d", r.Pos(), r.End())
-}
-
-func asyncInsertFix(sourceFile *ast.SourceFile, fn *ast.Node) rule.RuleFix {
-	switch fn.Kind {
-	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
-		head := internalUtils.GetFunctionHeadLoc(sourceFile, fn)
-		return rule.RuleFixReplaceRange(core.NewTextRange(head.Pos(), head.Pos()), "async ")
-	default:
-		return rule.RuleFixInsertBefore(sourceFile, fn, "async ")
-	}
-}
-
-func awaitFix(sourceFile *ast.SourceFile, node *ast.Node, alwaysAwait bool) rule.RuleFix {
-	if alwaysAwait && node.Parent != nil && node.Parent.Kind == ast.KindReturnStatement {
-		ret := node.Parent
-		retRange := internalUtils.TrimNodeTextRange(sourceFile, ret)
-		nodeRange := internalUtils.TrimNodeTextRange(sourceFile, node)
-		return rule.RuleFixReplaceRange(core.NewTextRange(retRange.Pos(), nodeRange.Pos()), "await ")
-	}
-	return rule.RuleFixInsertBefore(sourceFile, node, "await ")
-}
+// and async/await fixers live in the shared package: they are pure syntax, with
+// no jest or rstest semantics, and keeping two copies is what let the same
+// parenthesized-assertion false positive exist twice.
 
 func reportAsyncDescriptor(
 	ctx rule.RuleContext,
@@ -287,10 +179,10 @@ func reportAsyncDescriptor(
 	var fixes []rule.RuleFix
 	if fn := ast.GetContainingFunction(descriptor.node); fn != nil {
 		if !ast.IsAsyncFunction(fn) && !asyncInserted[fn] {
-			fixes = append(fixes, asyncInsertFix(ctx.SourceFile, fn))
+			fixes = append(fixes, sharedValidExpect.AsyncInsertFix(ctx.SourceFile, fn))
 			asyncInserted[fn] = true
 		}
-		fixes = append(fixes, awaitFix(ctx.SourceFile, descriptor.node, alwaysAwait))
+		fixes = append(fixes, sharedValidExpect.AwaitFix(ctx.SourceFile, descriptor.node, alwaysAwait))
 	}
 
 	if len(fixes) > 0 {
@@ -350,37 +242,6 @@ func isAllowedExtraExpectArg(arg *ast.Node, entry rstestUtils.RstestExpectEntry)
 
 func shouldBeAwaited(parsed *rstestUtils.ParsedRstestExpectCall, asyncMatchers []string) bool {
 	return rstestUtils.ShouldRstestExpectBeAwaited(parsed, asyncMatchers)
-}
-
-// resolveAsyncAssertionReportNode mirrors the jest rule: from the complete
-// assertion expression it walks out through chained .then/.catch, notes whether
-// the assertion sits inside a Promise.all([...]) array, and decides whether the
-// resulting node must be awaited or returned. assertionNode must be the
-// outermost expression of the chain — ParsedRstestExpectCall.Expression — so
-// that a Chai chain carrying several matchers, such as
-// expect(p).resolves.to.be.a("string").that.contains("x"), is inspected as a
-// whole rather than at its first matcher.
-func resolveAsyncAssertionReportNode(
-	assertionNode *ast.Node,
-	alwaysAwait bool,
-) (reportNode *ast.Node, promiseWrapped bool, insideAssertionArray bool, shouldReport bool) {
-	if assertionNode == nil {
-		return nil, false, false, false
-	}
-
-	promiseChainedAssertionNode := getParentIfPromiseChained(assertionNode)
-	insideAssertionArray = promiseChainedAssertionNode.Parent != nil && promiseChainedAssertionNode.Parent.Kind == ast.KindArrayLiteralExpression
-	reportNode = promiseChainedAssertionNode
-	if promiseCallNode := findPromiseCallExpressionNode(promiseChainedAssertionNode); promiseCallNode != nil {
-		reportNode = promiseCallNode
-		promiseWrapped = true
-	}
-
-	if reportNode.Parent == nil || isAcceptableReturnNode(reportNode.Parent, !alwaysAwait) {
-		return reportNode, promiseWrapped, insideAssertionArray, false
-	}
-
-	return reportNode, promiseWrapped, insideAssertionArray, true
 }
 
 // reportBrokenChain reports a chain that the parser resolved without a matcher.
@@ -457,7 +318,7 @@ var ValidExpectRule = rule.Rule{
 					return
 				}
 
-				reportNode, promiseWrapped, insideAssertionArray, shouldReport := resolveAsyncAssertionReportNode(
+				reportNode, promiseWrapped, insideAssertionArray, shouldReport := sharedValidExpect.ResolveAsyncAssertionReportNode(
 					parsed.Expression,
 					opts.AlwaysAwait,
 				)
@@ -465,7 +326,7 @@ var ValidExpectRule = rule.Rule{
 					return
 				}
 
-				reportNodeKey := promiseArrayExceptionKey(ctx.SourceFile, reportNode)
+				reportNodeKey := sharedValidExpect.PromiseArrayExceptionKey(ctx.SourceFile, reportNode)
 				if shouldReport && !arrayExceptions[reportNodeKey] {
 					descriptors = append(descriptors, asyncDescriptor{
 						node:           reportNode,

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -353,30 +353,18 @@ func shouldBeAwaited(parsed *rstestUtils.ParsedRstestExpectCall, asyncMatchers [
 }
 
 // resolveAsyncAssertionReportNode mirrors the jest rule: from the complete
-// matcher expression it walks out through chained .then/.catch, notes whether
+// assertion expression it walks out through chained .then/.catch, notes whether
 // the assertion sits inside a Promise.all([...]) array, and decides whether the
-// resulting node must be awaited or returned. A call-style matcher's complete
-// expression is its parent CallExpression, while a Chai property matcher is
-// already complete at the member-access expression.
+// resulting node must be awaited or returned. assertionNode must be the
+// outermost expression of the chain — ParsedRstestExpectCall.Expression — so
+// that a Chai chain carrying several matchers, such as
+// expect(p).resolves.to.be.a("string").that.contains("x"), is inspected as a
+// whole rather than at its first matcher.
 func resolveAsyncAssertionReportNode(
-	matcher rstestUtils.ParsedRstestExpectMatcher,
+	assertionNode *ast.Node,
 	alwaysAwait bool,
 ) (reportNode *ast.Node, promiseWrapped bool, insideAssertionArray bool, shouldReport bool) {
-	if matcher.Entry.Node == nil || matcher.Entry.Node.Parent == nil {
-		return nil, false, false, false
-	}
-
-	matcherMemberNode := matcher.Entry.Node.Parent
-	assertionNode := matcherMemberNode
-	switch matcher.Kind {
-	case rstestUtils.RstestExpectMatcherCall:
-		if matcherMemberNode.Parent == nil {
-			return nil, false, false, false
-		}
-		assertionNode = matcherMemberNode.Parent
-	case rstestUtils.RstestExpectMatcherProperty:
-		// The member access itself executes a Chai property matcher.
-	default:
+	if assertionNode == nil {
 		return nil, false, false, false
 	}
 
@@ -470,7 +458,7 @@ var ValidExpectRule = rule.Rule{
 				}
 
 				reportNode, promiseWrapped, insideAssertionArray, shouldReport := resolveAsyncAssertionReportNode(
-					parsed.Matchers[0],
+					parsed.Expression,
 					opts.AlwaysAwait,
 				)
 				if reportNode == nil {

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -292,8 +292,8 @@ var ValidExpectRule = rule.Rule{
 					return
 				}
 
-				// Static members (expect.assertions(1), expect.any(...)) carry no
-				// assertion factory, so argument and await checks do not apply.
+				// Forms with no assertion factory carry no assertion, so argument
+				// and await checks do not apply.
 				if parsed.Head == nil || parsed.Head.Kind != ast.KindCallExpression {
 					return
 				}

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -366,24 +366,35 @@ func shouldBeAwaited(parsed *rstestUtils.ParsedRstestExpectCall, asyncMatchers [
 	return rstestUtils.ShouldRstestExpectBeAwaited(parsed, asyncMatchers)
 }
 
-// resolveAsyncAssertionReportNode mirrors the jest rule: from the matcher
-// member it walks out through chained .then/.catch, notes whether the assertion
-// sits inside a Promise.all([...]) array, and decides whether the resulting node
-// must be awaited or returned.
+// resolveAsyncAssertionReportNode mirrors the jest rule: from the complete
+// matcher expression it walks out through chained .then/.catch, notes whether
+// the assertion sits inside a Promise.all([...]) array, and decides whether the
+// resulting node must be awaited or returned. A call-style matcher's complete
+// expression is its parent CallExpression, while a Chai property matcher is
+// already complete at the member-access expression.
 func resolveAsyncAssertionReportNode(
-	matcherEntry *rstestUtils.ParsedRstestFnMemberEntry,
+	matcher rstestUtils.ParsedRstestExpectMatcher,
 	alwaysAwait bool,
 ) (reportNode *ast.Node, promiseWrapped bool, insideAssertionArray bool, shouldReport bool) {
-	if matcherEntry == nil || matcherEntry.Node == nil || matcherEntry.Node.Parent == nil {
+	if matcher.Entry.Node == nil || matcher.Entry.Node.Parent == nil {
 		return nil, false, false, false
 	}
 
-	matcherMemberNode := matcherEntry.Node.Parent
-	if matcherMemberNode.Parent == nil {
+	matcherMemberNode := matcher.Entry.Node.Parent
+	assertionNode := matcherMemberNode
+	switch matcher.Kind {
+	case rstestUtils.RstestExpectMatcherCall:
+		if matcherMemberNode.Parent == nil {
+			return nil, false, false, false
+		}
+		assertionNode = matcherMemberNode.Parent
+	case rstestUtils.RstestExpectMatcherProperty:
+		// The member access itself executes a Chai property matcher.
+	default:
 		return nil, false, false, false
 	}
 
-	promiseChainedAssertionNode := getParentIfPromiseChained(matcherMemberNode.Parent)
+	promiseChainedAssertionNode := getParentIfPromiseChained(assertionNode)
 	insideAssertionArray = promiseChainedAssertionNode.Parent != nil && promiseChainedAssertionNode.Parent.Kind == ast.KindArrayLiteralExpression
 	reportNode = promiseChainedAssertionNode
 	if promiseCallNode := findPromiseCallExpressionNode(promiseChainedAssertionNode); promiseCallNode != nil {
@@ -468,12 +479,12 @@ var ValidExpectRule = rule.Rule{
 					}
 				}
 
-				if parsed.MatcherEntry == nil || !shouldBeAwaited(parsed, opts.AsyncMatchers) {
+				if len(parsed.Matchers) == 0 || !shouldBeAwaited(parsed, opts.AsyncMatchers) {
 					return
 				}
 
 				reportNode, promiseWrapped, insideAssertionArray, shouldReport := resolveAsyncAssertionReportNode(
-					parsed.MatcherEntry,
+					parsed.Matchers[0],
 					opts.AlwaysAwait,
 				)
 				if reportNode == nil {

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -1,0 +1,503 @@
+package valid_expect
+
+import (
+	_ "embed"
+	"fmt"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+//go:embed valid_expect.schema.json
+var schemaJSON []byte
+
+type validExpectOptions struct {
+	AlwaysAwait   bool
+	AsyncMatchers []string
+	MinArgs       int
+	MaxArgs       int
+}
+
+type asyncDescriptor struct {
+	node           *ast.Node
+	promiseWrapped bool
+}
+
+func pluralSuffix(amount int) string {
+	if amount == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// Message builders. Ids and text match jest/valid-expect exactly.
+
+func buildErrorTooManyArgsMessage(amount int) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "tooManyArgs",
+		Description: fmt.Sprintf("Expect takes at most %d argument%s", amount, pluralSuffix(amount)),
+		Data: map[string]string{
+			"amount": strconv.Itoa(amount),
+			"s":      pluralSuffix(amount),
+		},
+	}
+}
+
+func buildErrorNotEnoughArgsMessage(amount int) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "notEnoughArgs",
+		Description: fmt.Sprintf("Expect requires at least %d argument%s", amount, pluralSuffix(amount)),
+		Data: map[string]string{
+			"amount": strconv.Itoa(amount),
+			"s":      pluralSuffix(amount),
+		},
+	}
+}
+
+func buildErrorModifierUnknownMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "modifierUnknown",
+		Description: "Expect has an unknown modifier",
+	}
+}
+
+func buildErrorMatcherNotFoundMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "matcherNotFound",
+		Description: "Expect must have a corresponding matcher call",
+	}
+}
+
+func buildErrorMatcherNotCalledMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "matcherNotCalled",
+		Description: "Matchers must be called to assert",
+	}
+}
+
+func buildErrorAsyncMustBeAwaitedMessage(alwaysAwait bool) rule.RuleMessage {
+	orReturned := " or returned"
+	if alwaysAwait {
+		orReturned = ""
+	}
+	return rule.RuleMessage{
+		Id:          "asyncMustBeAwaited",
+		Description: "Async assertions must be awaited" + orReturned,
+		Data:        map[string]string{"orReturned": orReturned},
+	}
+}
+
+func buildErrorPromisesWithAsyncAssertionsMustBeAwaitedMessage(alwaysAwait bool) rule.RuleMessage {
+	orReturned := " or returned"
+	if alwaysAwait {
+		orReturned = ""
+	}
+	return rule.RuleMessage{
+		Id:          "promisesWithAsyncAssertionsMustBeAwaited",
+		Description: "Promises which return async assertions must be awaited" + orReturned,
+		Data:        map[string]string{"orReturned": orReturned},
+	}
+}
+
+func buildAsyncDescriptorMessage(descriptor asyncDescriptor, alwaysAwait bool) rule.RuleMessage {
+	if descriptor.promiseWrapped {
+		return buildErrorPromisesWithAsyncAssertionsMustBeAwaitedMessage(alwaysAwait)
+	}
+	return buildErrorAsyncMustBeAwaitedMessage(alwaysAwait)
+}
+
+func parseOptions(options []any) validExpectOptions {
+	out := validExpectOptions{
+		AlwaysAwait:   false,
+		AsyncMatchers: []string{"toReject", "toResolve"},
+		MinArgs:       1,
+		MaxArgs:       1,
+	}
+
+	if len(options) == 0 {
+		return out
+	}
+	m, _ := options[0].(map[string]interface{})
+
+	if raw, ok := m["alwaysAwait"].(bool); ok {
+		out.AlwaysAwait = raw
+	}
+	out.MinArgs = readIntOption(m, "minArgs", out.MinArgs)
+	out.MaxArgs = readIntOption(m, "maxArgs", out.MaxArgs)
+	if raw, ok := m["asyncMatchers"].([]interface{}); ok {
+		out.AsyncMatchers = out.AsyncMatchers[:0]
+		for _, value := range raw {
+			if s, ok := value.(string); ok {
+				out.AsyncMatchers = append(out.AsyncMatchers, s)
+			}
+		}
+	}
+
+	return out
+}
+
+func readIntOption(options map[string]interface{}, key string, defaultValue int) int {
+	raw, ok := options[key]
+	if !ok {
+		return defaultValue
+	}
+
+	switch value := raw.(type) {
+	case float64:
+		return int(value)
+	case int:
+		return value
+	case int32:
+		return int(value)
+	case int64:
+		return int(value)
+	default:
+		return defaultValue
+	}
+}
+
+// --- Async assertion machinery ---
+//
+// The Promise-chain walking, acceptable-return detection, array de-duplication
+// and async/await fixers below are ported verbatim from
+// internal/plugins/jest/rules/valid_expect/valid_expect.go, which is itself
+// aligned with eslint-plugin-vitest. Kept as a local copy rather than shared:
+// sharing them would require touching the jest rule and re-running its
+// regression, and there is no third consumer yet.
+
+func isPromiseMethodCall(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+
+	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+	if !isMemberAccessNode(callee) {
+		return false
+	}
+
+	return testFramework.CalleeChainName(internalUtils.AccessExpressionObject(callee)) == "Promise"
+}
+
+func getPromiseCallExpressionNode(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+
+	if node.Kind == ast.KindArrayLiteralExpression && node.Parent != nil && node.Parent.Kind == ast.KindCallExpression {
+		node = node.Parent
+	}
+
+	if isPromiseMethodCall(node) {
+		return node
+	}
+
+	return nil
+}
+
+func findPromiseCallExpressionNode(node *ast.Node) *ast.Node {
+	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
+		return nil
+	}
+	if node.Parent.Kind != ast.KindCallExpression && node.Parent.Kind != ast.KindArrayLiteralExpression {
+		return nil
+	}
+	return getPromiseCallExpressionNode(node.Parent)
+}
+
+func getParentIfPromiseChained(node *ast.Node) *ast.Node {
+	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
+		return node
+	}
+
+	grandParent := node.Parent.Parent
+	if grandParent.Kind != ast.KindCallExpression || !isMemberAccessNode(grandParent.AsCallExpression().Expression) {
+		return node
+	}
+
+	member := grandParent.AsCallExpression().Expression
+	entries := testFramework.GetMemberEntries(member)
+	if len(entries) == 0 {
+		return node
+	}
+
+	last := entries[len(entries)-1].Name
+	if last == "then" || last == "catch" {
+		return getParentIfPromiseChained(grandParent)
+	}
+
+	return node
+}
+
+func isAcceptableReturnNode(node *ast.Node, allowReturn bool) bool {
+	if node == nil {
+		return false
+	}
+
+	if allowReturn && node.Kind == ast.KindReturnStatement {
+		return true
+	}
+	if node.Kind == ast.KindConditionalExpression {
+		return isAcceptableReturnNode(node.Parent, allowReturn)
+	}
+
+	return node.Kind == ast.KindArrowFunction || node.Kind == ast.KindAwaitExpression
+}
+
+func promiseArrayExceptionKey(sourceFile *ast.SourceFile, node *ast.Node) string {
+	if sourceFile == nil || node == nil {
+		return ""
+	}
+	r := internalUtils.TrimNodeTextRange(sourceFile, node)
+	return fmt.Sprintf("%d:%d", r.Pos(), r.End())
+}
+
+func asyncInsertFix(sourceFile *ast.SourceFile, fn *ast.Node) rule.RuleFix {
+	switch fn.Kind {
+	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
+		head := internalUtils.GetFunctionHeadLoc(sourceFile, fn)
+		return rule.RuleFixReplaceRange(core.NewTextRange(head.Pos(), head.Pos()), "async ")
+	default:
+		return rule.RuleFixInsertBefore(sourceFile, fn, "async ")
+	}
+}
+
+func awaitFix(sourceFile *ast.SourceFile, node *ast.Node, alwaysAwait bool) rule.RuleFix {
+	if alwaysAwait && node.Parent != nil && node.Parent.Kind == ast.KindReturnStatement {
+		ret := node.Parent
+		retRange := internalUtils.TrimNodeTextRange(sourceFile, ret)
+		nodeRange := internalUtils.TrimNodeTextRange(sourceFile, node)
+		return rule.RuleFixReplaceRange(core.NewTextRange(retRange.Pos(), nodeRange.Pos()), "await ")
+	}
+	return rule.RuleFixInsertBefore(sourceFile, node, "await ")
+}
+
+func reportAsyncDescriptor(
+	ctx rule.RuleContext,
+	descriptor asyncDescriptor,
+	alwaysAwait bool,
+	asyncInserted map[*ast.Node]bool,
+) {
+	msg := buildAsyncDescriptorMessage(descriptor, alwaysAwait)
+
+	var fixes []rule.RuleFix
+	if fn := ast.GetContainingFunction(descriptor.node); fn != nil {
+		if !ast.IsAsyncFunction(fn) && !asyncInserted[fn] {
+			fixes = append(fixes, asyncInsertFix(ctx.SourceFile, fn))
+			asyncInserted[fn] = true
+		}
+		fixes = append(fixes, awaitFix(ctx.SourceFile, descriptor.node, alwaysAwait))
+	}
+
+	if len(fixes) > 0 {
+		ctx.ReportNodeWithFixes(descriptor.node, msg, fixes...)
+		return
+	}
+	ctx.ReportNode(descriptor.node, msg)
+}
+
+// --- Rstest-specific helpers ---
+
+func isMemberAccessNode(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+// expectFactoryOpenParenRange locates the `(` of the assertion factory call so
+// notEnoughArgs points at the empty argument list, mirroring jest's
+// expectOpenParenRange. head is the factory call (expect(x) / expect.soft(x)).
+func expectFactoryOpenParenRange(sourceFile *ast.SourceFile, head *ast.Node) core.TextRange {
+	if sourceFile == nil || head == nil || head.Kind != ast.KindCallExpression {
+		return internalUtils.TrimNodeTextRange(sourceFile, head)
+	}
+
+	callExpr := head.AsCallExpression()
+	start := internalUtils.TrimNodeTextRange(sourceFile, callExpr.Expression).End()
+	text := sourceFile.Text()
+	for i := start; i < len(text) && i < head.End(); i++ {
+		if text[i] == '(' {
+			return core.NewTextRange(i, i+1)
+		}
+	}
+
+	return internalUtils.TrimNodeTextRange(sourceFile, head).WithEnd(start)
+}
+
+func tooManyArgsRange(sourceFile *ast.SourceFile, args []*ast.Node, maxArgs int) core.TextRange {
+	start := internalUtils.TrimNodeTextRange(sourceFile, args[maxArgs]).Pos()
+	end := internalUtils.TrimNodeTextRange(sourceFile, args[len(args)-1]).End()
+	if end > start {
+		end--
+	}
+	return core.NewTextRange(start, end)
+}
+
+// isAllowedExtraExpectArg reports whether a second expect argument is a valid
+// message overload, matching eslint-plugin-vitest: expect(actual, message) and
+// expect(actual, `template`) are legal, and expect.poll / expect.element take
+// an options object as their second argument.
+func isAllowedExtraExpectArg(arg *ast.Node, entry rstestUtils.RstestExpectEntry) bool {
+	if entry == rstestUtils.RstestExpectEntryPoll || entry == rstestUtils.RstestExpectEntryElement {
+		return true
+	}
+	if arg == nil {
+		return false
+	}
+	switch ast.SkipParentheses(arg).Kind {
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldBeAwaited(parsed *rstestUtils.ParsedRstestExpectCall, asyncMatchers []string) bool {
+	return rstestUtils.ShouldRstestExpectBeAwaited(parsed, asyncMatchers)
+}
+
+// resolveAsyncAssertionReportNode mirrors the jest rule: from the matcher
+// member it walks out through chained .then/.catch, notes whether the assertion
+// sits inside a Promise.all([...]) array, and decides whether the resulting node
+// must be awaited or returned.
+func resolveAsyncAssertionReportNode(
+	matcherEntry *rstestUtils.ParsedRstestFnMemberEntry,
+	alwaysAwait bool,
+) (reportNode *ast.Node, promiseWrapped bool, insideAssertionArray bool, shouldReport bool) {
+	if matcherEntry == nil || matcherEntry.Node == nil || matcherEntry.Node.Parent == nil {
+		return nil, false, false, false
+	}
+
+	matcherMemberNode := matcherEntry.Node.Parent
+	if matcherMemberNode.Parent == nil {
+		return nil, false, false, false
+	}
+
+	promiseChainedAssertionNode := getParentIfPromiseChained(matcherMemberNode.Parent)
+	insideAssertionArray = promiseChainedAssertionNode.Parent != nil && promiseChainedAssertionNode.Parent.Kind == ast.KindArrayLiteralExpression
+	reportNode = promiseChainedAssertionNode
+	if promiseCallNode := findPromiseCallExpressionNode(promiseChainedAssertionNode); promiseCallNode != nil {
+		reportNode = promiseCallNode
+		promiseWrapped = true
+	}
+
+	if reportNode.Parent == nil || isAcceptableReturnNode(reportNode.Parent, !alwaysAwait) {
+		return reportNode, promiseWrapped, insideAssertionArray, false
+	}
+
+	return reportNode, promiseWrapped, insideAssertionArray, true
+}
+
+// reportBrokenChain reports a chain that the parser resolved without a matcher.
+// The reason comes directly from the shared analysis, so unlike jest this rule
+// does not re-derive it. matcher-not-called points at the trailing member; the
+// other reasons point at the outermost expression.
+func reportBrokenChain(ctx rule.RuleContext, parsed *rstestUtils.ParsedRstestExpectCall) {
+	switch parsed.Reason {
+	case rstestUtils.RstestExpectParseReasonMatcherNotFound:
+		ctx.ReportNode(parsed.Expression, buildErrorMatcherNotFoundMessage())
+	case rstestUtils.RstestExpectParseReasonMatcherNotCalled:
+		if len(parsed.MemberEntries) == 0 {
+			ctx.ReportNode(parsed.Expression, buildErrorMatcherNotCalledMessage())
+			return
+		}
+		last := parsed.MemberEntries[len(parsed.MemberEntries)-1]
+		// A trailing modifier that was never followed by a matcher is a missing
+		// matcher, not an uncalled one, matching jest/vitest.
+		if rstestUtils.RSTEST_EXPECT_MODIFIER_NAMES[last.Name] {
+			ctx.ReportNode(last.Node, buildErrorMatcherNotFoundMessage())
+			return
+		}
+		ctx.ReportNode(last.Node, buildErrorMatcherNotCalledMessage())
+	case rstestUtils.RstestExpectParseReasonModifierUnknown:
+		ctx.ReportNode(parsed.Expression, buildErrorModifierUnknownMessage())
+	}
+}
+
+var ValidExpectRule = rule.Rule{
+	Name:   "rstest/valid-expect",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		arrayExceptions := map[string]bool{}
+		asyncInserted := map[*ast.Node]bool{}
+		var descriptors []asyncDescriptor
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := analysis.ParseExpectCall(node)
+				if parsed == nil {
+					return
+				}
+
+				if parsed.Reason != rstestUtils.RstestExpectParseReasonNone {
+					reportBrokenChain(ctx, parsed)
+					return
+				}
+
+				// Static members (expect.assertions(1), expect.any(...)) carry no
+				// assertion factory, so argument and await checks do not apply.
+				if parsed.Head != nil && parsed.Head.Kind == ast.KindCallExpression {
+					args := parsed.Head.AsCallExpression().Arguments.Nodes
+					if len(args) < opts.MinArgs {
+						ctx.ReportRange(
+							expectFactoryOpenParenRange(ctx.SourceFile, parsed.Head),
+							buildErrorNotEnoughArgsMessage(opts.MinArgs),
+						)
+					}
+					if len(args) > opts.MaxArgs {
+						// vitest allowance: a lone message string/template, or the
+						// options object of poll/element, is not an excess argument.
+						if len(args) != opts.MaxArgs+1 || !isAllowedExtraExpectArg(args[opts.MaxArgs], parsed.Entry) {
+							ctx.ReportRange(
+								tooManyArgsRange(ctx.SourceFile, args, opts.MaxArgs),
+								buildErrorTooManyArgsMessage(opts.MaxArgs),
+							)
+						}
+					}
+				}
+
+				if parsed.MatcherEntry == nil || !shouldBeAwaited(parsed, opts.AsyncMatchers) {
+					return
+				}
+
+				reportNode, promiseWrapped, insideAssertionArray, shouldReport := resolveAsyncAssertionReportNode(
+					parsed.MatcherEntry,
+					opts.AlwaysAwait,
+				)
+				if reportNode == nil {
+					return
+				}
+
+				reportNodeKey := promiseArrayExceptionKey(ctx.SourceFile, reportNode)
+				if shouldReport && !arrayExceptions[reportNodeKey] {
+					descriptors = append(descriptors, asyncDescriptor{
+						node:           reportNode,
+						promiseWrapped: promiseWrapped,
+					})
+				}
+
+				if insideAssertionArray {
+					arrayExceptions[reportNodeKey] = true
+				}
+			},
+			rule.ListenerOnExit(ast.KindEndOfFile): func(node *ast.Node) {
+				_ = node
+				for _, descriptor := range descriptors {
+					reportAsyncDescriptor(ctx, descriptor, opts.AlwaysAwait, asyncInserted)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.md
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.md
@@ -1,0 +1,76 @@
+# valid-expect
+
+## Rule Details
+
+Enforce valid `expect()` usage in Rstest. `expect` must be called with the
+right number of arguments, must be followed by a matcher, and asynchronous
+assertions must be awaited or returned so their failures are not lost.
+
+Examples of incorrect code:
+
+```ts
+expect();                       // notEnoughArgs
+expect(value);                  // matcherNotFound
+expect(value).toBe;             // matcherNotCalled
+expect(value).notAModifier();   // modifierUnknown
+
+test("async", async () => {
+  expect(promise).resolves.toBe(1); // asyncMustBeAwaited
+});
+```
+
+Examples of correct code:
+
+```ts
+expect(value).toBe(1);
+expect(value).not.toBe(2);
+expect(value, "message").toBe(1);   // second message argument is allowed
+
+test("async", async () => {
+  await expect(promise).resolves.toBe(1);
+  await expect(promise).rejects.toThrow();
+});
+```
+
+## Rstest specifics
+
+rstest's `expect` comes from `@vitest/expect` + chai, so this rule follows the
+vitest behavior where it differs from jest:
+
+- **A second argument to `expect` is allowed** when it is a message string or
+  template literal (`expect(value, "msg")`), and `expect.poll(fn, options)` /
+  `expect.element(el, options)` accept an options object. These do not trigger
+  `tooManyArgs`.
+- **Chai property matchers are valid** without a call: `expect(value).to.be.ok`,
+  `expect(spy).to.have.been.called`. They are not reported as `matcherNotCalled`.
+- **Static members carry no assertion**: `expect.assertions(1)`,
+  `expect.hasAssertions()` and asymmetric matchers such as `expect.any(Number)`
+  are not subject to argument or await checks.
+
+`expect` is recognized from globals, `@rstest/core` imports and aliases,
+`require`, namespace access, `import.meta.rstest`, test-context `expect`
+(`test('x', ({ expect }) => ...)`), and `@rstest/playwright`.
+
+## Options
+
+```json
+{
+  "rstest/valid-expect": [
+    "error",
+    {
+      "alwaysAwait": false,
+      "asyncMatchers": ["toReject", "toResolve"],
+      "minArgs": 1,
+      "maxArgs": 1
+    }
+  ]
+}
+```
+
+- **`alwaysAwait`** — require every async assertion to be awaited, disallowing
+  `return`.
+- **`asyncMatchers`** — matcher names treated as asynchronous (must be awaited).
+- **`minArgs`** / **`maxArgs`** — the required argument count for `expect`.
+
+The rule provides an automatic fix that inserts `await` (and `async` on the
+enclosing function) for async assertions that are not awaited.

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.md
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.md
@@ -43,9 +43,10 @@ vitest behavior where it differs from jest:
   `tooManyArgs`.
 - **Chai property matchers are valid** without a call: `expect(value).to.be.ok`,
   `expect(spy).to.have.been.called`. They are not reported as `matcherNotCalled`.
-- **Static members carry no assertion**: `expect.assertions(1)`,
-  `expect.hasAssertions()` and asymmetric matchers such as `expect.any(Number)`
-  are not subject to argument or await checks.
+- **Forms with no assertion factory carry no assertion**: `expect.assertions(1)`,
+  `expect.hasAssertions()`, asymmetric matchers such as `expect.any(Number)` and
+  bare chains such as `expect.resolves.toBe(1)` or `expect.toResolve()` are not
+  subject to argument or await checks.
 
 `expect` is recognized from globals, `@rstest/core` imports and aliases,
 `require`, namespace access, `import.meta.rstest`, test-context `expect`

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.schema.json
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.schema.json
@@ -1,0 +1,31 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "alwaysAwait": {
+          "type": "boolean",
+          "default": false
+        },
+        "asyncMatchers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "minArgs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "maxArgs": {
+          "type": "number",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -46,6 +46,11 @@ func TestValidExpectRule(t *testing.T) {
 			{Code: `test("t", () => expect(p).resolves.to.be.true);`},
 			// A Chai chain may carry several matchers; the await/return check
 			// looks at the outermost expression, not the first matcher.
+			// Parentheses are nodes in the TypeScript AST but not in ESTree, so
+			// the await/return check must look past them to match upstream.
+			{Code: `test("t", async () => { await (expect(p).resolves.toBe(1)); });`},
+			{Code: `test("t", () => { return (expect(p).resolves.toBe(1)); });`},
+			{Code: `test("t", async () => { await ((expect(p).resolves.to.be.true)); });`},
 			{Code: `test("t", async () => { await expect(p).resolves.to.be.a("string").that.contains("x"); });`},
 			{Code: `test("t", async () => { await expect(p).resolves.to.be.an("object").that.is.ok; });`},
 			{Code: `test("t", () => { return expect(p).resolves.to.be.a("string").that.contains("x"); });`},
@@ -131,6 +136,15 @@ func TestValidExpectRule(t *testing.T) {
 					{MessageId: "asyncMustBeAwaited"},
 				},
 				Output: []string{`test("t", async () => { await expect(p).resolves.to.be.true; });`},
+			},
+			{
+				// A parenthesized assertion that nothing awaits still reports,
+				// and the fix goes inside the parentheses.
+				Code: `test("t", async () => { (expect(p).resolves.toBe(1)); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { (await expect(p).resolves.toBe(1)); });`},
 			},
 			{
 				// A multi-matcher chain still reports when it is not awaited,

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -44,6 +44,11 @@ func TestValidExpectRule(t *testing.T) {
 			{Code: `test("t", async () => { await expect(p).resolves.to.be.true; });`},
 			{Code: `test("t", () => { return expect(p).resolves.to.be.true; });`},
 			{Code: `test("t", () => expect(p).resolves.to.be.true);`},
+			// A Chai chain may carry several matchers; the await/return check
+			// looks at the outermost expression, not the first matcher.
+			{Code: `test("t", async () => { await expect(p).resolves.to.be.a("string").that.contains("x"); });`},
+			{Code: `test("t", async () => { await expect(p).resolves.to.be.an("object").that.is.ok; });`},
+			{Code: `test("t", () => { return expect(p).resolves.to.be.a("string").that.contains("x"); });`},
 			{Code: `expect(value).not.toBe(1);`},
 			{Code: `test("t", async () => { await expect.poll(() => value).toBe(1); });`},
 			// poll/element are not treated as async by valid-expect (matching
@@ -126,6 +131,15 @@ func TestValidExpectRule(t *testing.T) {
 					{MessageId: "asyncMustBeAwaited"},
 				},
 				Output: []string{`test("t", async () => { await expect(p).resolves.to.be.true; });`},
+			},
+			{
+				// A multi-matcher chain still reports when it is not awaited,
+				// and the fix covers the whole chain.
+				Code: `test("t", async () => { expect(p).resolves.to.be.a("string").that.contains("x"); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await expect(p).resolves.to.be.a("string").that.contains("x"); });`},
 			},
 			{
 				Code: `test("t", async () => { const all = Promise.all([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]); });`,

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -1,0 +1,143 @@
+package valid_expect_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_expect"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestValidExpectRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&valid_expect.ValidExpectRule,
+		[]rule_tester.ValidTestCase{
+			// Basic well-formed assertions.
+			{Code: `expect(value).toBe(1);`},
+			{Code: `expect(value).not.toBe(1);`},
+			{Code: `expect("something").toEqual("else");`},
+
+			// Static members carry no assertion factory: no arg/await checks.
+			{Code: `expect.hasAssertions();`},
+			{Code: `expect.assertions(1);`},
+			{Code: `expect.any(Number);`},
+			{Code: `expect.stringContaining("x");`},
+
+			// vitest maxArgs allowance: message second argument and poll/element
+			// options are not excess arguments.
+			{Code: `expect(value, "message").toBe(1);`},
+			{Code: "expect(value, `msg ${x}`).toBe(1);"},
+			{Code: `test("t", async () => { await expect.poll(() => value, { timeout: 1 }).toBe(1); });`},
+			{Code: `test("t", async () => { await expect.element(locator, { timeout: 1 }).toBeVisible(); });`},
+
+			// Chai property matchers are valid without a call.
+			{Code: `expect(value).to.be.ok;`},
+			{Code: `expect(value).to.be.a("string");`},
+			{Code: `expect(spy).to.have.been.called;`},
+
+			// Async assertions awaited or returned.
+			{Code: `test("t", async () => { await expect(p).resolves.toBe(1); });`},
+			{Code: `test("t", () => { return expect(p).rejects.toThrow(); });`},
+			{Code: `expect(value).not.toBe(1);`},
+			{Code: `test("t", async () => { await expect.poll(() => value).toBe(1); });`},
+			// poll/element are not treated as async by valid-expect (matching
+			// vitest: only resolves/rejects modifiers and asyncMatchers require
+			// await), so a poll chain without await is not reported here.
+			{Code: `test("t", () => { expect.poll(() => value).toBe(1); });`},
+
+			// Provenance: non-Rstest expect and local shadow are ignored.
+			{Code: `import { expect } from "vitest"; expect(1);`},
+			{Code: `const expect = () => {}; expect(1);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// --- arg count ---
+			{
+				Code: `expect().toBe(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notEnoughArgs"},
+				},
+			},
+			{
+				Code: `expect(1, 2, 3).toBe(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "tooManyArgs"},
+				},
+			},
+			{
+				Code: `expect(value, 123).toBe(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "tooManyArgs"},
+				},
+			},
+			// jest would report tooManyArgs here; rstest allows the message arg,
+			// so this appears ONLY in the valid list above. A three-arg call still
+			// reports because the allowance is a single trailing message.
+
+			// --- broken chains (reason from the expect parser) ---
+			{
+				Code: `expect(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "matcherNotFound"},
+				},
+			},
+			{
+				Code: `expect(value).toBe;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "matcherNotCalled"},
+				},
+			},
+			{
+				Code: `expect(value).resolves;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "matcherNotFound"},
+				},
+			},
+			{
+				Code: `expect(value).foo.toBe(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "modifierUnknown"},
+				},
+			},
+
+			// --- async must be awaited ---
+			{
+				Code: `test("t", async () => { expect(p).resolves.toBe(1); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await expect(p).resolves.toBe(1); });`},
+			},
+			{
+				Code: `test("t", async () => { expect(p).rejects.toThrow(); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await expect(p).rejects.toThrow(); });`},
+			},
+			{
+				Code: `test("t", async () => { const all = Promise.all([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { const all = await Promise.all([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]); });`},
+			},
+
+			// --- provenance (resolved by the expect parser) ---
+			{
+				Code: `import { expect as check } from "@rstest/core"; check(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "matcherNotFound"},
+				},
+			},
+			{
+				Code: `test("t", ({ expect }) => { expect(1); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "matcherNotFound"},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -80,13 +80,13 @@ func TestValidExpectRule(t *testing.T) {
 			{
 				Code: `expect().toBe(1);`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "notEnoughArgs"},
+					{MessageId: "notEnoughArgs", Column: 7, EndColumn: 8},
 				},
 			},
 			{
 				Code: `expect(1, 2, 3).toBe(1);`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "tooManyArgs"},
+					{MessageId: "tooManyArgs", Column: 11, EndColumn: 14},
 				},
 			},
 			{

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -52,6 +52,7 @@ func TestValidExpectRule(t *testing.T) {
 			// the await/return check must look past them to match upstream.
 			{Code: `test("t", async () => { await (expect(p).resolves.toBe(1)); });`},
 			{Code: `test("t", () => { return (expect(p).resolves.toBe(1)); });`},
+			{Code: `test("t", () => { return (condition ? expect(p).resolves.toBe(1) : expect(q).toBe(1)); });`},
 			{Code: `test("t", async () => { await ((expect(p).resolves.to.be.true)); });`},
 			{Code: `test("t", async () => { await Promise.all([(expect(p).resolves.toBe(1)), expect(q).resolves.toBe(2)]); });`},
 			{Code: `test("t", async () => { await (expect(p).resolves.toBe(1)).then(() => {}); });`},

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -51,6 +51,8 @@ func TestValidExpectRule(t *testing.T) {
 			{Code: `test("t", async () => { await (expect(p).resolves.toBe(1)); });`},
 			{Code: `test("t", () => { return (expect(p).resolves.toBe(1)); });`},
 			{Code: `test("t", async () => { await ((expect(p).resolves.to.be.true)); });`},
+			{Code: `test("t", async () => { await Promise.all([(expect(p).resolves.toBe(1)), expect(q).resolves.toBe(2)]); });`},
+			{Code: `test("t", async () => { await (expect(p).resolves.toBe(1)).then(() => {}); });`},
 			{Code: `test("t", async () => { await expect(p).resolves.to.be.a("string").that.contains("x"); });`},
 			{Code: `test("t", async () => { await expect(p).resolves.to.be.an("object").that.is.ok; });`},
 			{Code: `test("t", () => { return expect(p).resolves.to.be.a("string").that.contains("x"); });`},
@@ -152,6 +154,14 @@ func TestValidExpectRule(t *testing.T) {
 				Output: []string{`test("t", async () => { (await expect(p).resolves.toBe(1)); });`},
 			},
 			{
+				Code:    `test("t", () => { return (expect(p).resolves.toBe(1)); });`,
+				Options: []any{map[string]any{"alwaysAwait": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await (expect(p).resolves.toBe(1)); });`},
+			},
+			{
 				// A multi-matcher chain still reports when it is not awaited,
 				// and the fix covers the whole chain.
 				Code: `test("t", async () => { expect(p).resolves.to.be.a("string").that.contains("x"); });`,
@@ -166,6 +176,13 @@ func TestValidExpectRule(t *testing.T) {
 					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited"},
 				},
 				Output: []string{`test("t", async () => { const all = await Promise.all([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]); });`},
+			},
+			{
+				Code: `test("t", async () => { Promise.all([(expect(p).resolves.toBe(1)), expect(q).resolves.toBe(2)]); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await Promise.all([(expect(p).resolves.toBe(1)), expect(q).resolves.toBe(2)]); });`},
 			},
 			{
 				Code:    `test("t", () => { return expect(p).resolves.toBe(1); });`,

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -60,6 +60,11 @@ func TestValidExpectRule(t *testing.T) {
 			// vitest: only resolves/rejects modifiers and asyncMatchers require
 			// await), so a poll chain without await is not reported here.
 			{Code: `test("t", () => { expect.poll(() => value).toBe(1); });`},
+			{Code: `expect(1, 2).toBe(1);`, Options: []any{map[string]any{"maxArgs": 2}}},
+			{
+				Code:    `test("t", async () => { await expect(p).toResolveEventually(); });`,
+				Options: []any{map[string]any{"asyncMatchers": []any{"toResolveEventually"}}},
+			},
 
 			// Provenance: non-Rstest expect and local shadow are ignored.
 			{Code: `import { expect } from "vitest"; expect(1);`},
@@ -161,6 +166,29 @@ func TestValidExpectRule(t *testing.T) {
 					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited"},
 				},
 				Output: []string{`test("t", async () => { const all = await Promise.all([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]); });`},
+			},
+			{
+				Code:    `test("t", () => { return expect(p).resolves.toBe(1); });`,
+				Options: []any{map[string]any{"alwaysAwait": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await expect(p).resolves.toBe(1); });`},
+			},
+			{
+				Code:    `expect(value).toBe(1);`,
+				Options: []any{map[string]any{"minArgs": 2}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notEnoughArgs"},
+				},
+			},
+			{
+				Code:    `test("t", () => { expect(p).toResolveEventually(); });`,
+				Options: []any{map[string]any{"asyncMatchers": []any{"toResolveEventually"}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await expect(p).toResolveEventually(); });`},
 			},
 
 			// --- provenance (resolved by the expect parser) ---

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -41,6 +41,9 @@ func TestValidExpectRule(t *testing.T) {
 			// Async assertions awaited or returned.
 			{Code: `test("t", async () => { await expect(p).resolves.toBe(1); });`},
 			{Code: `test("t", () => { return expect(p).rejects.toThrow(); });`},
+			{Code: `test("t", async () => { await expect(p).resolves.to.be.true; });`},
+			{Code: `test("t", () => { return expect(p).resolves.to.be.true; });`},
+			{Code: `test("t", () => expect(p).resolves.to.be.true);`},
 			{Code: `expect(value).not.toBe(1);`},
 			{Code: `test("t", async () => { await expect.poll(() => value).toBe(1); });`},
 			// poll/element are not treated as async by valid-expect (matching
@@ -116,6 +119,13 @@ func TestValidExpectRule(t *testing.T) {
 					{MessageId: "asyncMustBeAwaited"},
 				},
 				Output: []string{`test("t", async () => { await expect(p).rejects.toThrow(); });`},
+			},
+			{
+				Code: `test("t", async () => { expect(p).resolves.to.be.true; });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await expect(p).resolves.to.be.true; });`},
 			},
 			{
 				Code: `test("t", async () => { const all = Promise.all([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]); });`,

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -25,6 +25,8 @@ func TestValidExpectRule(t *testing.T) {
 			{Code: `expect.assertions(1);`},
 			{Code: `expect.any(Number);`},
 			{Code: `expect.stringContaining("x");`},
+			{Code: `expect.resolves.toBe(1);`},
+			{Code: `test("t", () => { expect.toResolve(); });`},
 
 			// vitest maxArgs allowance: message second argument and poll/element
 			// options are not excess arguments.

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect_test.go
@@ -185,6 +185,13 @@ func TestValidExpectRule(t *testing.T) {
 				Output: []string{`test("t", async () => { await Promise.all([(expect(p).resolves.toBe(1)), expect(q).resolves.toBe(2)]); });`},
 			},
 			{
+				Code: `test("t", async () => { Promise.all(([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)])); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "promisesWithAsyncAssertionsMustBeAwaited"},
+				},
+				Output: []string{`test("t", async () => { await Promise.all(([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)])); });`},
+			},
+			{
 				Code:    `test("t", () => { return expect(p).resolves.toBe(1); });`,
 				Options: []any{map[string]any{"alwaysAwait": true}},
 				Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -457,7 +457,7 @@ func classifyRstestExpectCall(
 	parsed.Reason = reason
 	if reason == RstestExpectParseReasonMatcherNotFound &&
 		len(chain) > 0 &&
-		IsMemberAccessNode(expression) &&
+		isMemberAccessNode(expression) &&
 		!hasComputedDynamicRstestExpectMember(chain) {
 		parsed.Reason = RstestExpectParseReasonMatcherNotCalled
 	}
@@ -676,8 +676,7 @@ func isComputedDynamicMemberName(node *ast.Node) bool {
 		parent.AsElementAccessExpression().Expression != node
 }
 
-// IsMemberAccessNode reports whether node is a property or element access.
-func IsMemberAccessNode(node *ast.Node) bool {
+func isMemberAccessNode(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -457,7 +457,7 @@ func classifyRstestExpectCall(
 	parsed.Reason = reason
 	if reason == RstestExpectParseReasonMatcherNotFound &&
 		len(chain) > 0 &&
-		isMemberAccessNode(expression) &&
+		IsMemberAccessNode(expression) &&
 		!hasComputedDynamicRstestExpectMember(chain) {
 		parsed.Reason = RstestExpectParseReasonMatcherNotCalled
 	}
@@ -676,7 +676,8 @@ func isComputedDynamicMemberName(node *ast.Node) bool {
 		parent.AsElementAccessExpression().Expression != node
 }
 
-func isMemberAccessNode(node *ast.Node) bool {
+// IsMemberAccessNode reports whether node is a property or element access.
+func IsMemberAccessNode(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}

--- a/internal/utils/test_framework/rules/valid_expect/async_assertion.go
+++ b/internal/utils/test_framework/rules/valid_expect/async_assertion.go
@@ -94,7 +94,8 @@ func isAcceptableReturnNode(node *ast.Node, allowReturn bool) bool {
 		return true
 	}
 	if node.Kind == ast.KindConditionalExpression {
-		return isAcceptableReturnNode(node.Parent, allowReturn)
+		outer := internalUtils.OutermostParenthesizedExpression(node)
+		return isAcceptableReturnNode(outer.Parent, allowReturn)
 	}
 
 	return node.Kind == ast.KindArrowFunction || node.Kind == ast.KindAwaitExpression

--- a/internal/utils/test_framework/rules/valid_expect/async_assertion.go
+++ b/internal/utils/test_framework/rules/valid_expect/async_assertion.go
@@ -50,6 +50,7 @@ func getPromiseCallExpressionNode(node *ast.Node) *ast.Node {
 }
 
 func findPromiseCallExpressionNode(node *ast.Node) *ast.Node {
+	node = internalUtils.OutermostParenthesizedExpression(node)
 	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
 		return nil
 	}
@@ -60,11 +61,12 @@ func findPromiseCallExpressionNode(node *ast.Node) *ast.Node {
 }
 
 func getParentIfPromiseChained(node *ast.Node) *ast.Node {
-	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
+	outer := internalUtils.OutermostParenthesizedExpression(node)
+	if outer == nil || outer.Parent == nil || outer.Parent.Parent == nil {
 		return node
 	}
 
-	grandParent := node.Parent.Parent
+	grandParent := outer.Parent.Parent
 	if grandParent.Kind != ast.KindCallExpression || !ast.IsAccessExpression(grandParent.AsCallExpression().Expression) {
 		return node
 	}
@@ -122,10 +124,11 @@ func AsyncInsertFix(sourceFile *ast.SourceFile, fn *ast.Node) rule.RuleFix {
 // AwaitFix awaits an async assertion, replacing a `return` with `await` when
 // returning it is not accepted.
 func AwaitFix(sourceFile *ast.SourceFile, node *ast.Node, alwaysAwait bool) rule.RuleFix {
-	if alwaysAwait && node.Parent != nil && node.Parent.Kind == ast.KindReturnStatement {
-		ret := node.Parent
+	outer := internalUtils.OutermostParenthesizedExpression(node)
+	if alwaysAwait && outer.Parent != nil && outer.Parent.Kind == ast.KindReturnStatement {
+		ret := outer.Parent
 		retRange := internalUtils.TrimNodeTextRange(sourceFile, ret)
-		nodeRange := internalUtils.TrimNodeTextRange(sourceFile, node)
+		nodeRange := internalUtils.TrimNodeTextRange(sourceFile, outer)
 		return rule.RuleFixReplaceRange(core.NewTextRange(retRange.Pos(), nodeRange.Pos()), "await ")
 	}
 	return rule.RuleFixInsertBefore(sourceFile, node, "await ")
@@ -149,7 +152,8 @@ func ResolveAsyncAssertionReportNode(
 	}
 
 	promiseChainedAssertionNode := getParentIfPromiseChained(assertionNode)
-	insideAssertionArray = promiseChainedAssertionNode.Parent != nil && promiseChainedAssertionNode.Parent.Kind == ast.KindArrayLiteralExpression
+	outerChained := internalUtils.OutermostParenthesizedExpression(promiseChainedAssertionNode)
+	insideAssertionArray = outerChained.Parent != nil && outerChained.Parent.Kind == ast.KindArrayLiteralExpression
 	reportNode = promiseChainedAssertionNode
 	if promiseCallNode := findPromiseCallExpressionNode(promiseChainedAssertionNode); promiseCallNode != nil {
 		reportNode = promiseCallNode

--- a/internal/utils/test_framework/rules/valid_expect/async_assertion.go
+++ b/internal/utils/test_framework/rules/valid_expect/async_assertion.go
@@ -1,0 +1,181 @@
+// Package valid_expect holds the framework-neutral async-assertion machinery
+// shared by jest/valid-expect and rstest/valid-expect: walking out of a chained
+// .then/.catch, spotting a Promise.all([...]) wrapper, deciding whether the
+// result is awaited or returned, and the async/await fixes.
+//
+// Only the parts whose correctness does not depend on the framework live here.
+// The rules keep their own bodies: how a broken chain's reason is derived, what
+// counts as an excess expect argument and which matcher shapes exist all differ
+// between jest and rstest, and merging those would mean framework branches
+// inside a shared body.
+package valid_expect
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+func isPromiseMethodCall(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+
+	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+	if !isMemberAccessNode(callee) {
+		return false
+	}
+
+	return testFramework.CalleeChainName(internalUtils.AccessExpressionObject(callee)) == "Promise"
+}
+
+func isMemberAccessNode(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+func getPromiseCallExpressionNode(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+
+	if node.Kind == ast.KindArrayLiteralExpression && node.Parent != nil && node.Parent.Kind == ast.KindCallExpression {
+		node = node.Parent
+	}
+
+	if isPromiseMethodCall(node) {
+		return node
+	}
+
+	return nil
+}
+
+func findPromiseCallExpressionNode(node *ast.Node) *ast.Node {
+	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
+		return nil
+	}
+	if node.Parent.Kind != ast.KindCallExpression && node.Parent.Kind != ast.KindArrayLiteralExpression {
+		return nil
+	}
+	return getPromiseCallExpressionNode(node.Parent)
+}
+
+func getParentIfPromiseChained(node *ast.Node) *ast.Node {
+	if node == nil || node.Parent == nil || node.Parent.Parent == nil {
+		return node
+	}
+
+	grandParent := node.Parent.Parent
+	if grandParent.Kind != ast.KindCallExpression || !isMemberAccessNode(grandParent.AsCallExpression().Expression) {
+		return node
+	}
+
+	member := grandParent.AsCallExpression().Expression
+	entries := testFramework.GetMemberEntries(member)
+	if len(entries) == 0 {
+		return node
+	}
+
+	last := entries[len(entries)-1].Name
+	if last == "then" || last == "catch" {
+		return getParentIfPromiseChained(grandParent)
+	}
+
+	return node
+}
+
+func isAcceptableReturnNode(node *ast.Node, allowReturn bool) bool {
+	if node == nil {
+		return false
+	}
+
+	if allowReturn && node.Kind == ast.KindReturnStatement {
+		return true
+	}
+	if node.Kind == ast.KindConditionalExpression {
+		return isAcceptableReturnNode(node.Parent, allowReturn)
+	}
+
+	return node.Kind == ast.KindArrowFunction || node.Kind == ast.KindAwaitExpression
+}
+
+// PromiseArrayExceptionKey identifies a Promise.all([...]) call by source range,
+// so the assertions inside its array report once between them.
+func PromiseArrayExceptionKey(sourceFile *ast.SourceFile, node *ast.Node) string {
+	if sourceFile == nil || node == nil {
+		return ""
+	}
+	r := internalUtils.TrimNodeTextRange(sourceFile, node)
+	return fmt.Sprintf("%d:%d", r.Pos(), r.End())
+}
+
+// AsyncInsertFix marks the function containing an async assertion as async.
+func AsyncInsertFix(sourceFile *ast.SourceFile, fn *ast.Node) rule.RuleFix {
+	switch fn.Kind {
+	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
+		head := internalUtils.GetFunctionHeadLoc(sourceFile, fn)
+		return rule.RuleFixReplaceRange(core.NewTextRange(head.Pos(), head.Pos()), "async ")
+	default:
+		return rule.RuleFixInsertBefore(sourceFile, fn, "async ")
+	}
+}
+
+// AwaitFix awaits an async assertion, replacing a `return` with `await` when
+// returning it is not accepted.
+func AwaitFix(sourceFile *ast.SourceFile, node *ast.Node, alwaysAwait bool) rule.RuleFix {
+	if alwaysAwait && node.Parent != nil && node.Parent.Kind == ast.KindReturnStatement {
+		ret := node.Parent
+		retRange := internalUtils.TrimNodeTextRange(sourceFile, ret)
+		nodeRange := internalUtils.TrimNodeTextRange(sourceFile, node)
+		return rule.RuleFixReplaceRange(core.NewTextRange(retRange.Pos(), nodeRange.Pos()), "await ")
+	}
+	return rule.RuleFixInsertBefore(sourceFile, node, "await ")
+}
+
+// ResolveAsyncAssertionReportNode decides where an async assertion is reported
+// and whether it has to be reported at all. assertionNode must be the outermost
+// expression of the assertion chain: for a Chai chain carrying several matchers,
+// such as expect(p).resolves.to.be.a("string").that.contains("x"), an inner
+// matcher's call would be inspected against the wrong parent.
+//
+// reportNode is the node the report and the await fix apply to. promiseWrapped
+// tells the caller to use the Promise-specific message, and insideAssertionArray
+// marks a Promise.all([...]) array whose assertions report only once.
+func ResolveAsyncAssertionReportNode(
+	assertionNode *ast.Node,
+	alwaysAwait bool,
+) (reportNode *ast.Node, promiseWrapped bool, insideAssertionArray bool, shouldReport bool) {
+	if assertionNode == nil {
+		return nil, false, false, false
+	}
+
+	promiseChainedAssertionNode := getParentIfPromiseChained(assertionNode)
+	insideAssertionArray = promiseChainedAssertionNode.Parent != nil && promiseChainedAssertionNode.Parent.Kind == ast.KindArrayLiteralExpression
+	reportNode = promiseChainedAssertionNode
+	if promiseCallNode := findPromiseCallExpressionNode(promiseChainedAssertionNode); promiseCallNode != nil {
+		reportNode = promiseCallNode
+		promiseWrapped = true
+	}
+
+	// Parentheses around the assertion are nodes in the TypeScript AST but not
+	// in ESTree, so the await or return upstream sees as the direct parent sits
+	// one or more wrappers up here. reportNode itself stays the report range and
+	// the insertion point for the fix.
+	outermost := internalUtils.OutermostParenthesizedExpression(reportNode)
+	if outermost.Parent == nil || isAcceptableReturnNode(outermost.Parent, !alwaysAwait) {
+		return reportNode, promiseWrapped, insideAssertionArray, false
+	}
+
+	return reportNode, promiseWrapped, insideAssertionArray, true
+}

--- a/internal/utils/test_framework/rules/valid_expect/async_assertion.go
+++ b/internal/utils/test_framework/rules/valid_expect/async_assertion.go
@@ -26,23 +26,11 @@ func isPromiseMethodCall(node *ast.Node) bool {
 	}
 
 	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
-	if !isMemberAccessNode(callee) {
+	if !ast.IsAccessExpression(callee) {
 		return false
 	}
 
 	return testFramework.CalleeChainName(internalUtils.AccessExpressionObject(callee)) == "Promise"
-}
-
-func isMemberAccessNode(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
-		return true
-	default:
-		return false
-	}
 }
 
 func getPromiseCallExpressionNode(node *ast.Node) *ast.Node {
@@ -77,7 +65,7 @@ func getParentIfPromiseChained(node *ast.Node) *ast.Node {
 	}
 
 	grandParent := node.Parent.Parent
-	if grandParent.Kind != ast.KindCallExpression || !isMemberAccessNode(grandParent.AsCallExpression().Expression) {
+	if grandParent.Kind != ast.KindCallExpression || !ast.IsAccessExpression(grandParent.AsCallExpression().Expression) {
 		return node
 	}
 

--- a/internal/utils/test_framework/rules/valid_expect/async_assertion.go
+++ b/internal/utils/test_framework/rules/valid_expect/async_assertion.go
@@ -38,8 +38,8 @@ func getPromiseCallExpressionNode(node *ast.Node) *ast.Node {
 		return nil
 	}
 
-	if node.Kind == ast.KindArrayLiteralExpression && node.Parent != nil && node.Parent.Kind == ast.KindCallExpression {
-		node = node.Parent
+	if outer := internalUtils.OutermostParenthesizedExpression(node); node.Kind == ast.KindArrayLiteralExpression && outer.Parent != nil && outer.Parent.Kind == ast.KindCallExpression {
+		node = outer.Parent
 	}
 
 	if isPromiseMethodCall(node) {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -556,6 +556,7 @@ export default defineConfig({
     './tests/rstest/rules/no-identical-title.test.ts',
     './tests/rstest/rules/no-interpolation-in-snapshots.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
+    './tests/rstest/rules/valid-expect.test.ts',
     './tests/rstest/rules/valid-title.test.ts',
 
     // eslint-plugin-promise

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -142,6 +142,7 @@ describe('defineConfig and config presets', () => {
       'rstest/no-identical-title': 'error',
       'rstest/no-interpolation-in-snapshots': 'error',
       'rstest/no-mocks-import': 'error',
+      'rstest/valid-expect': 'error',
       'rstest/valid-title': 'error',
     });
   });

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/valid-expect.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/valid-expect.test.ts
@@ -1035,6 +1035,29 @@ ruleTester.run('valid-expect', {} as never, {
         },
       ],
     },
+    // Parentheses around the array argument are transparent when finding the
+    // Promise wrapper, so the call reports once instead of each assertion.
+    {
+      code: `
+        test("valid-expect", () => {
+          Promise.all(([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]));
+        });
+      `,
+      output: `
+        test("valid-expect", async () => {
+          await Promise.all(([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]));
+        });
+      `,
+      errors: [
+        {
+          line: 2,
+          column: 3,
+          endColumn: 78,
+          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
     // Promise.any([expect1, expect2]) returns one error
     {
       code: `

--- a/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
@@ -54,6 +54,14 @@ ruleTester.run('valid-expect', {} as never, {
         });
       `,
     },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          await Promise.all(([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]));
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -84,6 +92,21 @@ ruleTester.run('valid-expect', {} as never, {
         import { expect, test } from '@rstest/core';
         test('t', async () => {
           await expect(promise).resolves.to.be.true;
+        });
+      `,
+    },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', () => {
+          Promise.all(([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]));
+        });
+      `,
+      errors: [{ messageId: 'promisesWithAsyncAssertionsMustBeAwaited' }],
+      output: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          await Promise.all(([expect(p).resolves.toBe(1), expect(q).resolves.toBe(2)]));
         });
       `,
     },

--- a/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
@@ -46,6 +46,14 @@ ruleTester.run('valid-expect', {} as never, {
         test('t', () => expect(promise).resolves.to.be.true);
       `,
     },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          await expect(promise).resolves.to.be.a('string').that.contains('x');
+        });
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
@@ -1,0 +1,46 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('valid-expect', {} as never, {
+  valid: [
+    {
+      code: `
+        import { expect } from '@rstest/core';
+        expect(value).toBe(1);
+      `,
+    },
+    {
+      code: `
+        import { expect } from '@rstest/core';
+        expect(value, 'message').toBe(1);
+      `,
+    },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          await expect(promise).resolves.toBe(1);
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { expect } from '@rstest/core';
+        expect(value);
+      `,
+      errors: [{ messageId: 'matcherNotFound' }],
+    },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          expect(promise).resolves.toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/valid-expect.test.ts
@@ -24,6 +24,28 @@ ruleTester.run('valid-expect', {} as never, {
         });
       `,
     },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          await expect(promise).resolves.to.be.true;
+        });
+      `,
+    },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', () => {
+          return expect(promise).resolves.to.be.true;
+        });
+      `,
+    },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', () => expect(promise).resolves.to.be.true);
+      `,
+    },
   ],
   invalid: [
     {
@@ -41,6 +63,21 @@ ruleTester.run('valid-expect', {} as never, {
         });
       `,
       errors: [{ messageId: 'asyncMustBeAwaited' }],
+    },
+    {
+      code: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          expect(promise).resolves.to.be.true;
+        });
+      `,
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
+      output: `
+        import { expect, test } from '@rstest/core';
+        test('t', async () => {
+          await expect(promise).resolves.to.be.true;
+        });
+      `,
     },
   ],
 });

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -9,6 +9,7 @@ const recommended: RslintConfigEntry = {
     'rstest/no-identical-title': 'error',
     'rstest/no-interpolation-in-snapshots': 'error',
     'rstest/no-mocks-import': 'error',
+    'rstest/valid-expect': 'error',
     'rstest/valid-title': 'error',
   },
 };


### PR DESCRIPTION
## Summary

Port `eslint-plugin-jest`'s `valid-expect` to rstest: validate the shape of `expect(...)` assertions — argument count, that a matcher is present and actually called, and that async assertions (`resolves` / `rejects` and configured async matchers) are awaited or returned. It consumes the shared rstest call analysis (`GetRstestCallAnalysis` / `ParseExpectCall`) and reads broken-chain reasons from the parser rather than re-deriving them; added to the rstest `recommended` preset at `error`.

## Behavior change in `jest/valid-expect`

An assertion wrapped in parentheses is no longer reported. Parentheses are nodes in the TypeScript AST but not in ESTree, so the `await` or `return` that upstream sees as the assertion's direct parent sat one wrapper away here:

```js
test('t', async () => { await (expect(Promise.resolve(2)).resolves.toBeDefined()); });
test('t', () => { return (expect(Promise.resolve(2)).resolves.toBeDefined()); });
```

Both are valid under `eslint-plugin-jest`, while this rule reported `asyncMustBeAwaited` and its fix rewrote working code. An assertion nothing awaits, `(expect(p).resolves.toBe(1));`, still reports, and the fix goes inside the parentheses.

Parenthesized conditional expressions are handled consistently as well, so `return (condition ? expect(p).resolves.toBe(1) : expect(q).toBe(1))` is accepted just like the unparenthesized form.

The machinery both rules share — Promise-chain walking, the await/return check, the `Promise.all([...])` de-duplication and the async/await fixes — now lives in `internal/utils/test_framework/rules/valid_expect` rather than being copied into each rule, which is how the same false positive came to exist twice. The rule bodies stay separate: broken-chain reasons, argument allowances and matcher shapes genuinely differ between the two frameworks.

## Differences from jest

rstest's `expect` is vitest/chai lineage, so the rule follows vitest rather than jest where the framework differs:

- **a second `expect` argument is allowed** when it is a message string or template literal (`expect(actual, "msg")`), and `expect.poll(fn, options)` / `expect.element(el, options)` accept an options object. Other second arguments still report `tooManyArgs`. jest's strict `maxArgs = 1` would false-positive here.
- **Chai property matchers are valid without a call** (`expect(x).to.be.ok`); these are not treated as `matcherNotCalled`.
- **forms without an assertion factory are not subjected to argument or await checks**. This includes static members (`expect.assertions(1)`, `expect.hasAssertions()`, asymmetric matchers) and bare modifier or static chains such as `expect.resolves.toBe(1)` and `expect.toResolve()`; the rule does not insert `await` into code whose assertion factory it cannot validate.
- expect provenance covers the full rstest surface (globals, `@rstest/core` imports/aliases, `require`, namespace, `import.meta.rstest`, TestContext `expect`, `@rstest/playwright`).

No `expectTypeOf` / type-assertion handling, since that is out of scope for this rule.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
