### PR TITLE
feat: collect JSX intrinsic element symbols

### DIFF
--- a/cmd/tsgo/external_symbols.go
+++ b/cmd/tsgo/external_symbols.go
@@ -19,7 +19,6 @@ var acceptedTypeOnlySymbols = []string{
 
 type externalModuleRoot struct {
 	namespace string
-	prefix    string
 	fileName  string
 }
 
@@ -79,13 +78,12 @@ func (c *externalSymbolCollector) collectDependencies(program *compiler.Program)
 			if resolution == nil || !resolution.IsResolved() || !resolution.IsExternalLibraryImport {
 				continue
 			}
-			namespace, prefix, ok := externalModuleName(key.Name)
+			namespace, ok := externalModuleName(key.Name)
 			if !ok {
 				continue
 			}
 			roots[externalModuleRoot{
 				namespace: namespace,
-				prefix:    prefix,
 				fileName:  resolution.ResolvedFileName,
 			}] = struct{}{}
 		}
@@ -101,9 +99,6 @@ func (c *externalSymbolCollector) collectDependencies(program *compiler.Program)
 		if left.namespace != right.namespace {
 			return left.namespace < right.namespace
 		}
-		if left.prefix != right.prefix {
-			return left.prefix < right.prefix
-		}
 		return left.fileName < right.fileName
 	})
 
@@ -117,8 +112,7 @@ func (c *externalSymbolCollector) collectDependencies(program *compiler.Program)
 			return exports[i].Name < exports[j].Name
 		})
 		for _, symbol := range exports {
-			name := joinExternalName(root.prefix, symbol.Name)
-			c.collect(root.namespace, name, symbol)
+			c.collect(root.namespace, symbol.Name, symbol)
 		}
 	}
 }
@@ -206,20 +200,19 @@ func (c *externalSymbolCollector) record(namespace string, name string, symbol *
 	}
 }
 
-func externalModuleName(moduleName string) (namespace string, prefix string, ok bool) {
+func externalModuleName(moduleName string) (namespace string, ok bool) {
 	if moduleName == "" || tspath.IsExternalModuleNameRelative(moduleName) || strings.HasPrefix(moduleName, "#") {
-		return "", "", false
+		return "", false
 	}
 	if strings.HasPrefix(moduleName, "node:") {
-		return moduleName, "", true
+		return moduleName, true
 	}
 
-	namespace, prefix = module.ParsePackageName(moduleName)
-	if namespace == "" {
-		return "", "", false
+	packageName, _ := module.ParsePackageName(moduleName)
+	if packageName == "" {
+		return "", false
 	}
-	prefix = strings.ReplaceAll(prefix, "/", ".")
-	return namespace, prefix, true
+	return moduleName, true
 }
 
 func joinExternalName(prefix string, name string) string {

--- a/cmd/tsgo/external_symbols.go
+++ b/cmd/tsgo/external_symbols.go
@@ -135,9 +135,12 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 			symbol = target
 		}
 	}
+	if symbol == nil {
+		return
+	}
 	isAcceptedTypeOnly := isAcceptedTypeOnlySymbol(symbol.Name)
-	isTypeOnly := symbol != nil && symbol.Flags&ast.SymbolFlagsValue == 0
-	if symbol == nil || isTypeOnly && !isAcceptedTypeOnly {
+	isTypeOnly := symbol.Flags&ast.SymbolFlagsValue == 0
+	if isTypeOnly && !isAcceptedTypeOnly {
 		return
 	}
 

--- a/cmd/tsgo/external_symbols.go
+++ b/cmd/tsgo/external_symbols.go
@@ -13,8 +13,8 @@ import (
 
 const globalNamespace = "global"
 
-var typeOnlySymbolExemptions = map[string]struct{}{
-	"JSX.IntrinsicElements": {},
+var acceptedTypeOnlySymbols = []string{
+	"JSX.IntrinsicElements",
 }
 
 type externalModuleRoot struct {
@@ -124,17 +124,10 @@ func (c *externalSymbolCollector) collectDependencies(program *compiler.Program)
 }
 
 func (c *externalSymbolCollector) collect(namespace string, name string, symbol *ast.Symbol) {
-	isTypeOnlySymbolExemption := func(name string) bool {
-		for exemption := range typeOnlySymbolExemptions {
-			for prefix := exemption; ; {
-				if name == prefix || strings.HasSuffix(name, "."+prefix) {
-					return true
-				}
-				index := strings.LastIndexByte(prefix, '.')
-				if index == -1 {
-					break
-				}
-				prefix = prefix[:index]
+	isAcceptedTypeOnlySymbol := func(symbolName string) bool {
+		for _, accepted := range acceptedTypeOnlySymbols {
+			if strings.Contains(accepted, symbolName) {
+				return true
 			}
 		}
 		return false
@@ -148,9 +141,9 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 			symbol = target
 		}
 	}
-	followsTypeOnlyExemption := isTypeOnlySymbolExemption(name)
-	isTypeOnlyExempt := symbol != nil && symbol.Flags&ast.SymbolFlagsValue == 0 && followsTypeOnlyExemption
-	if symbol == nil || symbol.Flags&ast.SymbolFlagsValue == 0 && !isTypeOnlyExempt {
+	isAcceptedTypeOnly := isAcceptedTypeOnlySymbol(symbol.Name)
+	isTypeOnly := symbol != nil && symbol.Flags&ast.SymbolFlagsValue == 0
+	if symbol == nil || isTypeOnly && !isAcceptedTypeOnly {
 		return
 	}
 
@@ -169,18 +162,17 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 			return properties[i].Name < properties[j].Name
 		})
 		for _, property := range properties {
-			propertyName := joinExternalName(name, property.Name)
-			if isTypeOnlySymbolExemption(propertyName) {
-				c.collect(namespace, propertyName, property)
+			if isAcceptedTypeOnlySymbol(property.Name) {
+				c.collect(namespace, joinExternalName(name, property.Name), property)
 			}
 		}
-		if isTypeOnlyExempt {
+		if isTypeOnly {
 			return
 		}
 	}
 
 	var ty *checker.Type
-	if isTypeOnlyExempt {
+	if isTypeOnly {
 		ty = c.tc.GetDeclaredTypeOfSymbol(symbol)
 	} else {
 		ty = c.tc.GetTypeOfSymbol(symbol)

--- a/cmd/tsgo/external_symbols.go
+++ b/cmd/tsgo/external_symbols.go
@@ -13,6 +13,10 @@ import (
 
 const globalNamespace = "global"
 
+var typeOnlySymbolExemptions = map[string]struct{}{
+	"JSX.IntrinsicElements": {},
+}
+
 type externalModuleRoot struct {
 	namespace string
 	prefix    string
@@ -128,7 +132,20 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 			symbol = target
 		}
 	}
-	if symbol == nil || symbol.Flags&ast.SymbolFlagsValue == 0 {
+	isTypeOnlyExempt := false
+	if symbol != nil && symbol.Flags&ast.SymbolFlagsValue == 0 {
+		if _, ok := typeOnlySymbolExemptions[name]; ok {
+			isTypeOnlyExempt = true
+		} else {
+			for exemption := range typeOnlySymbolExemptions {
+				if strings.HasPrefix(exemption, name+".") {
+					isTypeOnlyExempt = true
+					break
+				}
+			}
+		}
+	}
+	if symbol == nil || symbol.Flags&ast.SymbolFlagsValue == 0 && !isTypeOnlyExempt {
 		return
 	}
 
@@ -141,7 +158,23 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 	}
 	c.expanded[expandedKey] = name
 
-	ty := c.tc.GetTypeOfSymbol(symbol)
+	if isTypeOnlyExempt && symbol.Flags&ast.SymbolFlagsModule != 0 {
+		properties := c.tc.GetExportsAndPropertiesOfModule(symbol)
+		sort.Slice(properties, func(i int, j int) bool {
+			return properties[i].Name < properties[j].Name
+		})
+		for _, property := range properties {
+			c.collect(namespace, joinExternalName(name, property.Name), property)
+		}
+		return
+	}
+
+	var ty *checker.Type
+	if isTypeOnlyExempt {
+		ty = c.tc.GetDeclaredTypeOfSymbol(symbol)
+	} else {
+		ty = c.tc.GetTypeOfSymbol(symbol)
+	}
 	if ty == nil {
 		return
 	}
@@ -153,7 +186,6 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 		c.collect(namespace, joinExternalName(name, property.Name), property)
 	}
 }
-
 func (c *externalSymbolCollector) record(namespace string, name string, symbol *ast.Symbol) {
 	symbolID := ast.GetSymbolId(symbol)
 	external := ExternalSymbol{

--- a/cmd/tsgo/external_symbols.go
+++ b/cmd/tsgo/external_symbols.go
@@ -13,8 +13,9 @@ import (
 
 const globalNamespace = "global"
 
-var acceptedTypeOnlySymbols = []string{
+var acceptedTypeOnlySymbolPaths = []string{
 	"JSX.IntrinsicElements",
+	"React.JSX.IntrinsicElements",
 }
 
 type externalModuleRoot struct {
@@ -118,15 +119,6 @@ func (c *externalSymbolCollector) collectDependencies(program *compiler.Program)
 }
 
 func (c *externalSymbolCollector) collect(namespace string, name string, symbol *ast.Symbol) {
-	isAcceptedTypeOnlySymbol := func(symbolName string) bool {
-		for _, accepted := range acceptedTypeOnlySymbols {
-			if strings.Contains(accepted, symbolName) {
-				return true
-			}
-		}
-		return false
-	}
-
 	if symbol == nil || name == "" || strings.HasPrefix(name, ast.InternalSymbolNamePrefix) {
 		return
 	}
@@ -138,7 +130,7 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 	if symbol == nil {
 		return
 	}
-	isAcceptedTypeOnly := isAcceptedTypeOnlySymbol(symbol.Name)
+	isAcceptedTypeOnly := isAcceptedTypeOnlySymbolPath(name)
 	isTypeOnly := symbol.Flags&ast.SymbolFlagsValue == 0
 	if isTypeOnly && !isAcceptedTypeOnly {
 		return
@@ -159,8 +151,9 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 			return properties[i].Name < properties[j].Name
 		})
 		for _, property := range properties {
-			if isAcceptedTypeOnlySymbol(property.Name) {
-				c.collect(namespace, joinExternalName(name, property.Name), property)
+			childName := joinExternalName(name, property.Name)
+			if isAcceptedTypeOnlySymbolPath(childName) {
+				c.collect(namespace, childName, property)
 			}
 		}
 		if isTypeOnly {
@@ -184,6 +177,17 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 	for _, property := range properties {
 		c.collect(namespace, joinExternalName(name, property.Name), property)
 	}
+}
+
+func isAcceptedTypeOnlySymbolPath(name string) bool {
+	for _, accepted := range acceptedTypeOnlySymbolPaths {
+		if name == accepted ||
+			strings.HasPrefix(accepted, name+".") ||
+			strings.HasPrefix(name, accepted+".") {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *externalSymbolCollector) record(namespace string, name string, symbol *ast.Symbol) {

--- a/cmd/tsgo/external_symbols.go
+++ b/cmd/tsgo/external_symbols.go
@@ -124,6 +124,22 @@ func (c *externalSymbolCollector) collectDependencies(program *compiler.Program)
 }
 
 func (c *externalSymbolCollector) collect(namespace string, name string, symbol *ast.Symbol) {
+	isTypeOnlySymbolExemption := func(name string) bool {
+		for exemption := range typeOnlySymbolExemptions {
+			for prefix := exemption; ; {
+				if name == prefix || strings.HasSuffix(name, "."+prefix) {
+					return true
+				}
+				index := strings.LastIndexByte(prefix, '.')
+				if index == -1 {
+					break
+				}
+				prefix = prefix[:index]
+			}
+		}
+		return false
+	}
+
 	if symbol == nil || name == "" || strings.HasPrefix(name, ast.InternalSymbolNamePrefix) {
 		return
 	}
@@ -132,19 +148,8 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 			symbol = target
 		}
 	}
-	isTypeOnlyExempt := false
-	if symbol != nil && symbol.Flags&ast.SymbolFlagsValue == 0 {
-		if _, ok := typeOnlySymbolExemptions[name]; ok {
-			isTypeOnlyExempt = true
-		} else {
-			for exemption := range typeOnlySymbolExemptions {
-				if strings.HasPrefix(exemption, name+".") {
-					isTypeOnlyExempt = true
-					break
-				}
-			}
-		}
-	}
+	followsTypeOnlyExemption := isTypeOnlySymbolExemption(name)
+	isTypeOnlyExempt := symbol != nil && symbol.Flags&ast.SymbolFlagsValue == 0 && followsTypeOnlyExemption
 	if symbol == nil || symbol.Flags&ast.SymbolFlagsValue == 0 && !isTypeOnlyExempt {
 		return
 	}
@@ -158,15 +163,20 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 	}
 	c.expanded[expandedKey] = name
 
-	if isTypeOnlyExempt && symbol.Flags&ast.SymbolFlagsModule != 0 {
+	if symbol.Flags&ast.SymbolFlagsModule != 0 {
 		properties := c.tc.GetExportsAndPropertiesOfModule(symbol)
 		sort.Slice(properties, func(i int, j int) bool {
 			return properties[i].Name < properties[j].Name
 		})
 		for _, property := range properties {
-			c.collect(namespace, joinExternalName(name, property.Name), property)
+			propertyName := joinExternalName(name, property.Name)
+			if isTypeOnlySymbolExemption(propertyName) {
+				c.collect(namespace, propertyName, property)
+			}
 		}
-		return
+		if isTypeOnlyExempt {
+			return
+		}
 	}
 
 	var ty *checker.Type
@@ -186,6 +196,7 @@ func (c *externalSymbolCollector) collect(namespace string, name string, symbol 
 		c.collect(namespace, joinExternalName(name, property.Name), property)
 	}
 }
+
 func (c *externalSymbolCollector) record(namespace string, name string, symbol *ast.Symbol) {
 	symbolID := ast.GetSymbolId(symbol)
 	external := ExternalSymbol{

--- a/cmd/tsgo/external_symbols_test.go
+++ b/cmd/tsgo/external_symbols_test.go
@@ -8,12 +8,33 @@ import (
 
 func TestGlobalSymbols(t *testing.T) {
 	fixture := buildSemanticFixture(t, "export const value = Math.abs(-1);")
-
 	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "globalThis")
 	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "Math")
 	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "Math.abs")
 	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "Object.prototype.hasOwnProperty")
 	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "console.log")
+}
+
+func TestJSXIntrinsicElementSymbols(t *testing.T) {
+	tmpDir := t.TempDir()
+	dependencyDir := filepath.Join(tmpDir, "node_modules", "react")
+	_ = os.MkdirAll(dependencyDir, 0o755)
+
+	files := map[string]string{
+		filepath.Join(tmpDir, "tsconfig.json"):       "{\n\t\"compilerOptions\": {\"moduleResolution\": \"node\"},\n\t\"include\": [\"./index.ts\"]\n}",
+		filepath.Join(tmpDir, "index.ts"):            `import "react";`,
+		filepath.Join(dependencyDir, "package.json"): "{\n\t\"name\": \"react\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
+		filepath.Join(dependencyDir, "index.d.ts"):   "export namespace JSX {\ninterface IntrinsicElements {\ndiv: unknown;\n}\n}",
+	}
+	for path, contents := range files {
+		_ = os.WriteFile(path, []byte(contents), 0o644)
+	}
+
+	t.Chdir(tmpDir)
+	program, _ := CreateProgram("tsconfig.json")
+	semantic := CollectSemantic(program)
+
+	expectSymbol(t, semantic.ExternalSymbols, "react", "JSX.IntrinsicElements.div")
 }
 
 func TestDependencySymbols(t *testing.T) {

--- a/cmd/tsgo/external_symbols_test.go
+++ b/cmd/tsgo/external_symbols_test.go
@@ -4,131 +4,40 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/microsoft/typescript-go/shim/ast"
 )
 
-func TestCollectExternalSymbolsGlobals(t *testing.T) {
+func TestGlobalSymbols(t *testing.T) {
 	fixture := buildSemanticFixture(t, "export const value = Math.abs(-1);")
 
-	for _, expected := range []string{
-		"globalThis",
-		"Math",
-		"Math.abs",
-		"Object.prototype.hasOwnProperty",
-		"console.log",
-	} {
-		if !hasExternalSymbol(fixture.semantic, globalNamespace, expected) {
-			t.Errorf("missing global external symbol %q", expected)
-		}
-	}
+	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "globalThis")
+	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "Math")
+	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "Math.abs")
+	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "Object.prototype.hasOwnProperty")
+	expectSymbol(t, fixture.semantic.ExternalSymbols, globalNamespace, "console.log")
 }
 
-func TestCollectExternalSymbolsAmbientDependencyGlobalsWithoutDefaultLib(t *testing.T) {
-	tmpDir := t.TempDir()
-	dependencyDir := filepath.Join(tmpDir, "node_modules", "@types", "example")
-	if err := os.MkdirAll(dependencyDir, 0o755); err != nil {
-		t.Fatalf("Failed to create dependency directory: %v", err)
-	}
-
-	files := map[string]string{
-		filepath.Join(tmpDir, "tsconfig.json"): `{
-			"compilerOptions": {"noLib": true, "types": ["example"]},
-			"include": ["./index.ts"]
-		}`,
-		filepath.Join(tmpDir, "index.ts"): `ambientDependencyGlobal();`,
-		filepath.Join(dependencyDir, "index.d.ts"): `
-			declare function ambientDependencyGlobal(): void;
-		`,
-	}
-	for path, contents := range files {
-		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-			t.Fatalf("Failed to write %s: %v", path, err)
-		}
-	}
-
-	t.Chdir(tmpDir)
-	program, err := CreateProgram("tsconfig.json")
-	if err != nil {
-		t.Fatalf("Failed to create program: %v", err)
-	}
-	semantic := CollectSemantic(program)
-
-	if !hasExternalSymbol(semantic, globalNamespace, "ambientDependencyGlobal") {
-		t.Error("missing ambient dependency global external symbol")
-	}
-}
-
-func TestCollectExternalSymbolsDoesNotMarkLocalShadowAsGlobal(t *testing.T) {
-	fixture := buildSemanticFixture(
-		t,
-		`export {}; const Math = { abs(value: number) { return value; } }; Math.abs(-1);`,
-	)
-
-	found := map[string]bool{"Math": false, "abs": false}
-	for symbolID, symbol := range fixture.semantic.Symtab {
-		name := string(symbol.Name)
-		if _, ok := found[name]; !ok || symbol.Decl == nil || symbol.Decl.SourceFileId != fixture.sourceFileID {
-			continue
-		}
-		found[name] = true
-		if external, ok := findExternalSymbolByID(fixture.semantic, symbolID); ok {
-			t.Errorf(
-				"local symbol %q was incorrectly marked as %q.%q",
-				name,
-				external.Namespace,
-				external.Name,
-			)
-		}
-	}
-	for name, wasFound := range found {
-		if !wasFound {
-			t.Errorf("local symbol %q not found", name)
-		}
-	}
-}
-
-func TestCollectExternalSymbolsDependencyExports(t *testing.T) {
+func TestDependencySymbols(t *testing.T) {
 	tmpDir := t.TempDir()
 	dependencyDir := filepath.Join(tmpDir, "node_modules", "example-dependency")
-	if err := os.MkdirAll(dependencyDir, 0o755); err != nil {
-		t.Fatalf("Failed to create dependency directory: %v", err)
-	}
+	_ = os.MkdirAll(dependencyDir, 0o755)
 
 	files := map[string]string{
-		filepath.Join(tmpDir, "tsconfig.json"): `{
-			"compilerOptions": {"moduleResolution": "node"},
-			"include": ["./index.ts"]
-		}`,
-		filepath.Join(tmpDir, "index.ts"): `import { api } from "example-dependency"; api.run();`,
-		filepath.Join(dependencyDir, "package.json"): `{
-			"name": "example-dependency",
-			"version": "1.0.0",
-			"types": "index.d.ts"
-		}`,
-		filepath.Join(dependencyDir, "index.d.ts"): `
-			export declare const api: { run(): void };
-			export declare function value(): void;
-		`,
+		filepath.Join(tmpDir, "tsconfig.json"):       "{\n\t\"compilerOptions\": {\"moduleResolution\": \"node\"},\n\t\"include\": [\"./index.ts\"]\n}",
+		filepath.Join(tmpDir, "index.ts"):            `import { api } from "example-dependency"; api.run();`,
+		filepath.Join(dependencyDir, "package.json"): "{\n\t\"name\": \"example-dependency\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
+		filepath.Join(dependencyDir, "index.d.ts"):   "export declare const api: { run(): void };\nexport declare function value(): void;",
 	}
 	for path, contents := range files {
-		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-			t.Fatalf("Failed to write %s: %v", path, err)
-		}
+		_ = os.WriteFile(path, []byte(contents), 0o644)
 	}
 
 	t.Chdir(tmpDir)
-	program, err := CreateProgram("tsconfig.json")
-	if err != nil {
-		t.Fatalf("Failed to create program: %v", err)
-	}
+	program, _ := CreateProgram("tsconfig.json")
 	semantic := CollectSemantic(program)
 
-	for _, expected := range []string{"api", "api.run", "value"} {
-		if !hasExternalSymbol(semantic, "example-dependency", expected) {
-			t.Errorf("missing dependency external symbol %q", expected)
-		}
-	}
+	expectSymbol(t, semantic.ExternalSymbols, "example-dependency", "api")
+	expectSymbol(t, semantic.ExternalSymbols, "example-dependency", "api.run")
+	expectSymbol(t, semantic.ExternalSymbols, "example-dependency", "value")
 }
 
 func TestExternalModuleName(t *testing.T) {
@@ -147,38 +56,28 @@ func TestExternalModuleName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.moduleName, func(t *testing.T) {
-			namespace, prefix, ok := externalModuleName(test.moduleName)
-			if namespace != test.namespace || prefix != test.prefix || ok != test.ok {
-				t.Fatalf(
-					"externalModuleName(%q) = (%q, %q, %v), want (%q, %q, %v)",
-					test.moduleName,
-					namespace,
-					prefix,
-					ok,
-					test.namespace,
-					test.prefix,
-					test.ok,
-				)
-			}
-		})
+		namespace, prefix, ok := externalModuleName(test.moduleName)
+		if namespace != test.namespace || prefix != test.prefix || ok != test.ok {
+			t.Fatalf(
+				"externalModuleName(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				test.moduleName,
+				namespace,
+				prefix,
+				ok,
+				test.namespace,
+				test.prefix,
+				test.ok,
+			)
+		}
 	}
 }
 
-func hasExternalSymbol(semantic Semantic, namespace string, name string) bool {
-	for _, external := range semantic.ExternalSymbols {
-		if string(external.Namespace) == namespace && string(external.Name) == name {
-			return true
+func expectSymbol(t *testing.T, symbols []ExternalSymbol, namespace string, symbolName string) {
+	t.Helper()
+	for _, symbol := range symbols {
+		if string(symbol.Namespace) == namespace && string(symbol.Name) == symbolName {
+			return
 		}
 	}
-	return false
-}
-
-func findExternalSymbolByID(semantic Semantic, symbolID ast.SymbolId) (ExternalSymbol, bool) {
-	for _, external := range semantic.ExternalSymbols {
-		if external.SymbolId == symbolID {
-			return external, true
-		}
-	}
-	return ExternalSymbol{}, false
+	t.Errorf("missing external symbol %q in namespace %q", symbolName, namespace)
 }

--- a/cmd/tsgo/external_symbols_test.go
+++ b/cmd/tsgo/external_symbols_test.go
@@ -16,45 +16,34 @@ func TestGlobalSymbols(t *testing.T) {
 }
 
 func TestJSXIntrinsicElementSymbols(t *testing.T) {
-	tmpDir := t.TempDir()
-	dependencyDir := filepath.Join(tmpDir, "node_modules", "react")
-	_ = os.MkdirAll(dependencyDir, 0o755)
-
-	files := map[string]string{
-		filepath.Join(tmpDir, "tsconfig.json"):       "{\n\t\"compilerOptions\": {\"moduleResolution\": \"node\"},\n\t\"include\": [\"./index.ts\"]\n}",
-		filepath.Join(tmpDir, "index.ts"):            `import "react";`,
-		filepath.Join(dependencyDir, "package.json"): "{\n\t\"name\": \"react\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
-		filepath.Join(dependencyDir, "index.d.ts"):   "export namespace JSX {\ninterface IntrinsicElements {\ndiv: unknown;\n}\n}",
-	}
-	for path, contents := range files {
-		_ = os.WriteFile(path, []byte(contents), 0o644)
-	}
-
-	t.Chdir(tmpDir)
-	program, _ := CreateProgram("tsconfig.json")
-	semantic := CollectSemantic(program)
+	semantic := semanticFromFiles(t, map[string]string{
+		"tsconfig.json":                   "{\n\t\"compilerOptions\": {\"moduleResolution\": \"node\"},\n\t\"include\": [\"./index.ts\"]\n}",
+		"index.ts":                        `import "react";`,
+		"node_modules/react/package.json": "{\n\t\"name\": \"react\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
+		"node_modules/react/index.d.ts":   "export namespace JSX {\ninterface IntrinsicElements {\ndiv: unknown;\n}\n}",
+	})
 
 	expectSymbol(t, semantic.ExternalSymbols, "react", "JSX.IntrinsicElements.div")
 }
 
+func TestGlobalJSXIntrinsicElementSymbols(t *testing.T) {
+	semantic := semanticFromFiles(t, map[string]string{
+		"tsconfig.json":                          "{\n\t\"compilerOptions\": {\"jsx\": \"preserve\", \"moduleResolution\": \"node\", \"types\": [\"react\"]},\n\t\"include\": [\"./index.tsx\"]\n}",
+		"index.tsx":                              `const element = <div />;`,
+		"node_modules/@types/react/package.json": "{\n\t\"name\": \"@types/react\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
+		"node_modules/@types/react/index.d.ts":   "export = React;\nexport as namespace React;\ndeclare namespace React {\nfunction createElement(): unknown;\nnamespace JSX {\ninterface IntrinsicElements {\ndiv: unknown;\n}\n}\n}\n",
+	})
+
+	expectSymbol(t, semantic.ExternalSymbols, globalNamespace, "React.JSX.IntrinsicElements.div")
+}
+
 func TestDependencySymbols(t *testing.T) {
-	tmpDir := t.TempDir()
-	dependencyDir := filepath.Join(tmpDir, "node_modules", "example-dependency")
-	_ = os.MkdirAll(dependencyDir, 0o755)
-
-	files := map[string]string{
-		filepath.Join(tmpDir, "tsconfig.json"):       "{\n\t\"compilerOptions\": {\"moduleResolution\": \"node\"},\n\t\"include\": [\"./index.ts\"]\n}",
-		filepath.Join(tmpDir, "index.ts"):            `import { api } from "example-dependency"; api.run();`,
-		filepath.Join(dependencyDir, "package.json"): "{\n\t\"name\": \"example-dependency\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
-		filepath.Join(dependencyDir, "index.d.ts"):   "export declare const api: { run(): void };\nexport declare function value(): void;",
-	}
-	for path, contents := range files {
-		_ = os.WriteFile(path, []byte(contents), 0o644)
-	}
-
-	t.Chdir(tmpDir)
-	program, _ := CreateProgram("tsconfig.json")
-	semantic := CollectSemantic(program)
+	semantic := semanticFromFiles(t, map[string]string{
+		"tsconfig.json": "{\n\t\"compilerOptions\": {\"moduleResolution\": \"node\"},\n\t\"include\": [\"./index.ts\"]\n}",
+		"index.ts":      `import { api } from "example-dependency"; api.run();`,
+		"node_modules/example-dependency/package.json": "{\n\t\"name\": \"example-dependency\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
+		"node_modules/example-dependency/index.d.ts":   "export declare const api: { run(): void };\nexport declare function value(): void;",
+	})
 
 	expectSymbol(t, semantic.ExternalSymbols, "example-dependency", "api")
 	expectSymbol(t, semantic.ExternalSymbols, "example-dependency", "api.run")
@@ -101,4 +90,25 @@ func expectSymbol(t *testing.T, symbols []ExternalSymbol, namespace string, symb
 		}
 	}
 	t.Errorf("missing external symbol %q in namespace %q", symbolName, namespace)
+}
+
+func semanticFromFiles(t *testing.T, files map[string]string) Semantic {
+	t.Helper()
+	tmpDir := t.TempDir()
+	for name, contents := range files {
+		path := filepath.Join(tmpDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create fixture directory: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatalf("failed to write fixture file %q: %v", name, err)
+		}
+	}
+
+	t.Chdir(tmpDir)
+	program, err := CreateProgram("tsconfig.json")
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	return CollectSemantic(program)
 }

--- a/cmd/tsgo/external_symbols_test.go
+++ b/cmd/tsgo/external_symbols_test.go
@@ -50,32 +50,41 @@ func TestDependencySymbols(t *testing.T) {
 	expectSymbol(t, semantic.ExternalSymbols, "example-dependency", "value")
 }
 
+func TestDependencySubpathSymbols(t *testing.T) {
+	semantic := semanticFromFiles(t, map[string]string{
+		"tsconfig.json": "{\n\t\"compilerOptions\": {\"moduleResolution\": \"node\"},\n\t\"include\": [\"./index.ts\"]\n}",
+		"index.ts":      `import { api } from "example-dependency/index.js"; api.run();`,
+		"node_modules/example-dependency/package.json": "{\n\t\"name\": \"example-dependency\",\n\t\"version\": \"1.0.0\",\n\t\"types\": \"index.d.ts\"\n}",
+		"node_modules/example-dependency/index.d.ts":   "export declare const api: { run(): void };",
+	})
+
+	expectSymbol(t, semantic.ExternalSymbols, "example-dependency/index.js", "api")
+	expectSymbol(t, semantic.ExternalSymbols, "example-dependency/index.js", "api.run")
+}
+
 func TestExternalModuleName(t *testing.T) {
 	tests := []struct {
 		moduleName string
 		namespace  string
-		prefix     string
 		ok         bool
 	}{
 		{moduleName: "react", namespace: "react", ok: true},
-		{moduleName: "react/jsx-runtime", namespace: "react", prefix: "jsx-runtime", ok: true},
+		{moduleName: "react/jsx-runtime", namespace: "react/jsx-runtime", ok: true},
 		{moduleName: "@scope/pkg", namespace: "@scope/pkg", ok: true},
-		{moduleName: "@scope/pkg/subpath", namespace: "@scope/pkg", prefix: "subpath", ok: true},
+		{moduleName: "@scope/pkg/subpath", namespace: "@scope/pkg/subpath", ok: true},
 		{moduleName: "node:assert", namespace: "node:assert", ok: true},
 		{moduleName: "./local", ok: false},
 	}
 
 	for _, test := range tests {
-		namespace, prefix, ok := externalModuleName(test.moduleName)
-		if namespace != test.namespace || prefix != test.prefix || ok != test.ok {
+		namespace, ok := externalModuleName(test.moduleName)
+		if namespace != test.namespace || ok != test.ok {
 			t.Fatalf(
-				"externalModuleName(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				"externalModuleName(%q) = (%q, %v), want (%q, %v)",
 				test.moduleName,
 				namespace,
-				prefix,
 				ok,
 				test.namespace,
-				test.prefix,
 				test.ok,
 			)
 		}


### PR DESCRIPTION
## Summary

- allow selected type-only symbols to participate in external symbol collection
- traverse namespace exports and declared interface types to expose `JSX.IntrinsicElements` members
- cover JSX symbols from imported React packages and global `@types/react` declarations
- preserve complete external module specifiers, including subpaths, as semantic namespaces
- simplify external symbol test fixtures and assertions

## Why

`JSX.IntrinsicElements` is type-only, so the existing value-only external symbol traversal stopped before reaching intrinsic element properties such as `div`. Consumers therefore could not map JSX tag references back to their external symbol.

External module subpaths were also split between the namespace and symbol name. For example, `example-dependency/index.js` produced namespace `example-dependency` with names prefixed by `index.js`, which did not preserve the imported module's identity.

## Impact

Semantic output now includes intrinsic element symbols such as `react: JSX.IntrinsicElements.div` and global React JSX symbols while preserving existing value-symbol collection. External module subpaths now remain intact as namespaces, for example `example-dependency/index.js: api.run`.

## Validation

- `go test ./cmd/tsgo -run '^(TestDependencySubpathSymbols|TestExternalModuleName)$' -count=1`
- `pnpm run test:go`
- `git diff --check`