### PR TITLE
chore: remove cspell directive breaking website build

### DIFF
--- a/cspell.config.cjs
+++ b/cspell.config.cjs
@@ -15,6 +15,7 @@ module.exports = {
     'packages/vscode-extension/out',
     'packages/rslint-test-tools/tests',
     'packages/rslint/pkg/mod',
+    'packages/rslint/rule-schemas.json',
     'cmd/tsgo',
     './agents',
     'crates/rslint-native/index.js',

--- a/internal/plugins/rstest/rules/valid_title/valid_title.md
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.md
@@ -119,13 +119,11 @@ test('foo', () => {});
 it('foo', () => {});
 ```
 
-<!-- cspell:ignore sdjifo -->
-
 ### Differences from `jest/valid-title`
 
 The rule is otherwise a port of `jest/valid-title`, with three differences that follow from how Rstest itself behaves.
 
-**The set of valid `printf` specifiers is Rstest's, not Jest's.** Rstest formats parameterized titles with Node's `util.format` semantics (`formatRegExp` is `/%[sdjifoOc%]/`), while Jest uses its own `pretty-format` placeholder set. So:
+**The set of valid `printf` specifiers is Rstest's, not Jest's.** Rstest formats parameterized titles with Node's `util.format` semantics, accepting `s`, `d`, `j`, `i`, `f`, `o`, `O`, `c`, and `%` after a `%`, while Jest uses its own `pretty-format` placeholder set. So:
 
 | Title | `jest/valid-title` | `rstest/valid-title` |
 | --- | :---: | :---: |


### PR DESCRIPTION
## Summary

- remove the HTML cspell directive that breaks the generated MDX page
- spell out the supported printf specifiers so the source documentation needs no ignore directive
- exclude the ignored generated `packages/rslint/rule-schemas.json` artifact from spell checking

## Testing

- `pnpm build:website`
- `pnpm run check-spell`
- `pnpm run format:check`