### PR TITLE
fix: skip JSDoc type constraints

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
@@ -47,6 +47,15 @@ var NoUnnecessaryTypeConstraintRule = rule.CreateRule(rule.Rule{
 				// In tsgo, `infer U`, mapped-type `[P in K]`, and JSDoc `@template` also
 				// surface as KindTypeParameter but have no TSTypeParameterDeclaration
 				// analog, so upstream doesn't report them.
+				//
+				// JSDoc type parameters can appear twice: once under the template tag and
+				// once as a reparsed clone attached to the host declaration. The clone no
+				// longer has a JSDoc parent, so its Reparsed flag is the distinguishing
+				// signal.
+				if node.Flags&ast.NodeFlagsReparsed != 0 {
+					return
+				}
+
 				parent := node.Parent
 				if parent == nil {
 					return

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
@@ -64,18 +64,44 @@ function data<T extends TODO>() {}
 		// tsgo may or may not parse these into KindTypeParameter nodes depending on file
 		// extension / allowJs. The guard ensures that if it does, the rule stays silent (matching
 		// ESLint, which never sees JSDoc templates as TSTypeParameterDeclaration).
-		{Code: `
+		{
+			Code: `
 /** @template T */
 function data() {}
-    `},
-		{Code: `
+    `,
+			FileName: "repro.js",
+			TSConfig: "tsconfig.allowJs.json",
+		},
+		{
+			Code: `
 /** @template {any} T */
 function data() {}
-    `},
-		{Code: `
+    `,
+			FileName: "repro.js",
+			TSConfig: "tsconfig.allowJs.json",
+		},
+		{
+			Code: `
 /** @template {unknown} T, U */
 function data() {}
-    `},
+    `,
+			FileName: "repro.js",
+			TSConfig: "tsconfig.allowJs.json",
+		},
+		{
+			Code: `/** @template {unknown} T */
+class Box {}`,
+			FileName: "repro.js",
+			TSConfig: "tsconfig.allowJs.json",
+		},
+		{
+			Code: `/** @template {unknown} T */
+export function identity(value) {
+  return value;
+}`,
+			FileName: "repro.js",
+			TSConfig: "tsconfig.allowJs.json",
+		},
 		// ---- Mapped-type guard under modifiers / name remap ----
 		// Make sure the `KindMappedType` guard survives readonly / negative modifiers and
 		// `as` name-remap clauses — those wrap the type parameter differently but parent is


### PR DESCRIPTION
## Summary

- Skip reparsed JSDoc `@template` type parameters in `no-unnecessary-type-constraint` to match upstream typescript-eslint behavior.
- Add JavaScript regression coverage with `allowJs` and `checkJs`, including constrained functions and classes.
- Verify the focused rule test, spell check, format check, changed-code Go lint, and the real reproduction repository.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).