### PR TITLE
fix: align minimatch with ECMAScript semantics

### DIFF
--- a/internal/utils/ecmascript/regexp.go
+++ b/internal/utils/ecmascript/regexp.go
@@ -1,0 +1,54 @@
+// Package ecmascript provides small helpers for ECMAScript syntax.
+package ecmascript
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/diagnostics"
+	"github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// IsValidRegexLiteral reports whether literal is a complete ECMAScript RegExp
+// literal, including leading/trailing slashes and flags, under tsgo's latest
+// regular expression grammar.
+func IsValidRegexLiteral(literal string) bool {
+	flags := literalFlags(literal)
+	s := scanner.NewScanner()
+	hasError := false
+	s.SetScriptTarget(core.ScriptTargetLatest)
+	s.SetOnError(func(message *diagnostics.Message, _ int, _ int, _ ...any) {
+		if !isIgnorableRegexLiteralDiagnostic(message, flags) {
+			hasError = true
+		}
+	})
+	s.SetText(literal)
+	s.ResetTokenState(0)
+	if s.Scan() != ast.KindSlashToken {
+		return false
+	}
+	if s.ReScanSlashToken(true) != ast.KindRegularExpressionLiteral {
+		return false
+	}
+	return !hasError && s.TokenFlags()&ast.TokenFlagsUnterminated == 0 && s.TokenEnd() == len(literal)
+}
+
+func literalFlags(literal string) string {
+	if len(literal) < 2 || literal[0] != '/' {
+		return ""
+	}
+	lastSlash := strings.LastIndex(literal[1:], "/")
+	if lastSlash < 0 {
+		return ""
+	}
+	return literal[lastSlash+2:]
+}
+
+func isIgnorableRegexLiteralDiagnostic(message *diagnostics.Message, flags string) bool {
+	if strings.ContainsAny(flags, "uv") {
+		return false
+	}
+	return message == diagnostics.This_backreference_refers_to_a_group_that_does_not_exist_There_are_only_0_capturing_groups_in_this_regular_expression ||
+		message == diagnostics.This_backreference_refers_to_a_group_that_does_not_exist_There_are_no_capturing_groups_in_this_regular_expression
+}

--- a/internal/utils/minimatch/casefold.go
+++ b/internal/utils/minimatch/casefold.go
@@ -19,16 +19,50 @@ import (
 // Rather than ask regexp2 to ignore case, a pattern is widened to name every
 // character it should compare equal to and then matched exactly.
 
+// unicode17CasePairs are the simple uppercase mappings Node 26 has from
+// Unicode 16 and 17 that Go 1.26's Unicode 15 tables do not. Keeping this small
+// delta here makes the compatibility target explicit without depending on a
+// Node installation or a generated Unicode table.
+var unicode17CasePairs = [...][2]rune{
+	{0x019B, 0xA7DC},
+	{0x0264, 0xA7CB},
+	{0x1C8A, 0x1C89},
+	{0xA7CD, 0xA7CC},
+	{0xA7CF, 0xA7CE},
+	{0xA7D3, 0xA7D2},
+	{0xA7D5, 0xA7D4},
+	{0xA7DB, 0xA7DA},
+}
+
 // canonicalize maps a character to the one JavaScript compares it as. Go's
-// simple uppercase stands in for String.prototype.toUpperCase, which they only
-// differ over where the uppercase spans more than one character — `ß` is the
-// familiar one — and JavaScript keeps the original character there too.
+// simple uppercase stands in for String.prototype.toUpperCase after accounting
+// for the characters where the full uppercase spans multiple UTF-16 code units.
 func canonicalize(r rune) rune {
+	// A regexp without the `u` flag canonicalizes one UTF-16 code unit at a
+	// time, so it cannot case-fold a supplementary-plane character.
+	if r > 0xFFFF || expandsOnUppercase(r) {
+		return r
+	}
+	for _, pair := range unicode17CasePairs {
+		if r == pair[0] {
+			return pair[1]
+		}
+	}
 	upper := unicode.ToUpper(r)
 	if r >= utf8.RuneSelf && upper < utf8.RuneSelf {
 		return r
 	}
 	return upper
+}
+
+// expandsOnUppercase reports the characters for which Go's simple uppercase
+// is one character but Node 26's Unicode 17 full uppercase is multiple
+// characters. ECMAScript keeps the original character in that case.
+func expandsOnUppercase(r rune) bool {
+	return r >= 0x1F80 && r <= 0x1F87 ||
+		r >= 0x1F90 && r <= 0x1F97 ||
+		r >= 0x1FA0 && r <= 0x1FA7 ||
+		r == 0x1FB3 || r == 0x1FC3 || r == 0x1FF3
 }
 
 // caseTables groups the characters that canonicalize alike. A group of one has
@@ -49,6 +83,10 @@ var caseTables = sync.OnceValues(func() (map[rune][]rune, [][]rune) {
 			record(r)
 			record(canonicalize(r))
 		}
+	}
+	for _, pair := range unicode17CasePairs {
+		record(pair[0])
+		record(pair[1])
 	}
 
 	byMember := map[rune][]rune{}

--- a/internal/utils/minimatch/class_internal_test.go
+++ b/internal/utils/minimatch/class_internal_test.go
@@ -1,0 +1,33 @@
+package minimatch
+
+import "testing"
+
+func TestIsValidJSClass(t *testing.T) {
+	tests := []struct {
+		name  string
+		class string
+		want  bool
+	}{
+		{name: "ordinary", class: "[a-z]", want: true},
+		{name: "nested opening bracket", class: "[[]", want: true},
+		{name: "descending range", class: "[z-a]", want: false},
+		{name: "ambiguous closing bracket", class: "[]^?]", want: false},
+		{name: "descending range to line feed", class: "[!-\n]", want: false},
+		{name: "line feed", class: "[a\n]", want: true},
+		{name: "escaped line feed starts range", class: "[\\\n-a]", want: true},
+		{name: "two backslashes before line feed", class: "[\\\\\n-a]", want: true},
+		{name: "descending carriage return range", class: "[\r-\n]", want: false},
+		{name: "escaped line separator starts descending range", class: "[\\\u2028-a]", want: false},
+		{name: "slash", class: "[/]", want: true},
+		{name: "escaped slash", class: "[\\/]", want: true},
+		{name: "slash after two backslashes", class: "[\\\\/]", want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isValidJSClass(test.class); got != test.want {
+				t.Errorf("isValidJSClass(%q) = %v, want %v", test.class, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/utils/minimatch/minimatch.go
+++ b/internal/utils/minimatch/minimatch.go
@@ -40,6 +40,7 @@ import (
 	"unicode"
 
 	"github.com/dlclark/regexp2"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 // Options mirrors the minimatch options a caller can pass. The zero value is
@@ -528,11 +529,10 @@ func (m *Matcher) parseSource(pattern string, isSub bool) (string, bool, bool) {
 			// the contents so any character that was passed through as-is gets
 			// translated.
 			//
-			// What decides that is whether the class compiles, so ask about the
-			// translated source rather than the pattern text it came from: a
-			// character such as `[` or `\` that a glob passes straight through
-			// carries a meaning of its own in a regexp character class.
-			if _, err := regexp2.Compile(re[reClassStart:]+"]", regexp2.None); err != nil {
+			// What decides that is whether the original class compiles as an
+			// ECMAScript regexp. regexp2 follows .NET character-class syntax,
+			// which accepts and rejects a different set of classes.
+			if !isValidJSClass(pattern[classStart : i+1]) {
 				class := pattern[classStart+1 : i]
 				source, sourceMagic, _ := m.parseSource(class, true)
 				re = re[:reClassStart] + `\[` + source + `\]`
@@ -653,6 +653,55 @@ func (m *Matcher) parseSource(pattern string, isSub bool) (string, bool, bool) {
 	}
 
 	return re, hasMagic, true
+}
+
+// isValidJSClass asks the ECMAScript scanner whether class is a complete
+// character class. minimatch uses the RegExp constructor for this check; the
+// scanner accepts a literal instead, so delimiters and raw line terminators
+// are escaped without changing the pattern the regexp parser sees.
+func isValidJSClass(class string) bool {
+	var literal strings.Builder
+	literal.Grow(len(class) + 2)
+	literal.WriteByte('/')
+	backslashes := 0
+	for _, r := range class {
+		switch r {
+		case '\\':
+			literal.WriteRune(r)
+			backslashes++
+			continue
+		case '/':
+			if backslashes%2 == 0 {
+				literal.WriteByte('\\')
+			}
+			literal.WriteRune(r)
+		case '\n':
+			if backslashes%2 == 0 {
+				literal.WriteByte('\\')
+			}
+			literal.WriteByte('n')
+		case '\r':
+			if backslashes%2 == 0 {
+				literal.WriteByte('\\')
+			}
+			literal.WriteByte('r')
+		case '\u2028':
+			if backslashes%2 == 0 {
+				literal.WriteByte('\\')
+			}
+			literal.WriteString("u2028")
+		case '\u2029':
+			if backslashes%2 == 0 {
+				literal.WriteByte('\\')
+			}
+			literal.WriteString("u2029")
+		default:
+			literal.WriteRune(r)
+		}
+		backslashes = 0
+	}
+	literal.WriteByte('/')
+	return ecmascript.IsValidRegexLiteral(literal.String())
 }
 
 // Match reports whether path matches the compiled pattern.

--- a/internal/utils/minimatch/minimatch_test.go
+++ b/internal/utils/minimatch/minimatch_test.go
@@ -114,6 +114,10 @@ func TestMatch(t *testing.T) {
 		// An invalid or unterminated class matches itself.
 		{"/src/[z-a]/x", "/src/[z-a]/x", true},
 		{"/src/[z-a]/x", "/src/a/x", false},
+		{"[!-\n]", "[!-\n]", true},
+		{"[!-\n]", "a", false},
+		{"[]^?]", "[]^?]", true},
+		{"[]^?]", "]", false},
 		{"/src/[abc/x", "/src/[abc/x", true},
 		{"/src/[abc/x", "/src/a/x", false},
 
@@ -308,11 +312,12 @@ func TestMatchOptions(t *testing.T) {
 // and U+03C2 ς are one character to it, while U+212A K and `k` are two, and
 // neither answer is the one Unicode case folding gives.
 func TestMatchNoCase(t *testing.T) {
-	tests := []struct {
+	type testCase struct {
 		pattern string
 		path    string
 		want    bool
-	}{
+	}
+	tests := []testCase{
 		{"/src/Server/*.ts", "/src/server/a.ts", true},
 		{"caf\u00e9", "CAF\u00c9", true},
 		{"@(a|b)", "B", true},
@@ -335,6 +340,10 @@ func TestMatchNoCase(t *testing.T) {
 		// a capital eszett does not uppercase onto the small one
 		{"\u00df", "\u1e9e", false},
 
+		// a regexp without `u` does not fold a supplementary-plane letter
+		{"\U00010428", "\U00010400", false},
+		{"\U00010400", "\U00010428", false},
+
 		// a negated class turns down whatever the widened class covers
 		{"[!a]", "A", false},
 		{"[!a-z]", "K", false},
@@ -343,6 +352,44 @@ func TestMatchNoCase(t *testing.T) {
 		{"[a-]", "a", true},
 		{"[a-]", "A", true},
 		{"[a-]", "-", true},
+	}
+
+	// These mappings were added in Unicode 16 and 17 after the Unicode 15
+	// tables in Go 1.26. Node 26 uses Unicode 17 for regexp canonicalization.
+	unicode17Pairs := [][2]rune{
+		{0x019B, 0xA7DC},
+		{0x0264, 0xA7CB},
+		{0x1C8A, 0x1C89},
+		{0xA7CD, 0xA7CC},
+		{0xA7CF, 0xA7CE},
+		{0xA7D3, 0xA7D2},
+		{0xA7D5, 0xA7D4},
+		{0xA7DB, 0xA7DA},
+	}
+	for _, pair := range unicode17Pairs {
+		tests = append(tests,
+			testCase{pattern: string(pair[0]), path: string(pair[1]), want: true},
+			testCase{pattern: string(pair[1]), path: string(pair[0]), want: true},
+			testCase{pattern: "[" + string(pair[0]) + "]", path: string(pair[1]), want: true},
+			testCase{pattern: "[" + string(pair[1]) + "]", path: string(pair[0]), want: true},
+		)
+	}
+
+	// Full uppercase expands each of these into multiple UTF-16 code units,
+	// so ECMAScript keeps it distinct from Go's simple uppercase character.
+	multiUnitUppercase := [][2]rune{{0x1FB3, 0x1FBC}, {0x1FC3, 0x1FCC}, {0x1FF3, 0x1FFC}}
+	for _, bounds := range [][2]rune{{0x1F80, 0x1F87}, {0x1F90, 0x1F97}, {0x1FA0, 0x1FA7}} {
+		for r := bounds[0]; r <= bounds[1]; r++ {
+			multiUnitUppercase = append(multiUnitUppercase, [2]rune{r, r + 8})
+		}
+	}
+	for _, pair := range multiUnitUppercase {
+		tests = append(tests,
+			testCase{pattern: string(pair[0]), path: string(pair[1]), want: false},
+			testCase{pattern: string(pair[1]), path: string(pair[0]), want: false},
+			testCase{pattern: "[" + string(pair[0]) + "]", path: string(pair[1]), want: false},
+			testCase{pattern: "[" + string(pair[1]) + "]", path: string(pair[0]), want: false},
+		)
 	}
 
 	for _, test := range tests {

--- a/internal/utils/regex_literal.go
+++ b/internal/utils/regex_literal.go
@@ -1,42 +1,10 @@
 package utils
 
-import (
-	"strings"
-
-	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/diagnostics"
-	"github.com/microsoft/typescript-go/shim/scanner"
-)
+import "github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 
 // IsValidRegexLiteral reports whether literal is a complete ECMAScript RegExp
 // literal, including leading/trailing slashes and flags, under tsgo's latest
 // regex grammar. Use this before offering a fix that emits a regex literal.
 func IsValidRegexLiteral(literal string) bool {
-	_, flags := ExtractRegexPatternAndFlags(literal)
-	s := scanner.NewScanner()
-	hasError := false
-	s.SetScriptTarget(core.ScriptTargetLatest)
-	s.SetOnError(func(message *diagnostics.Message, _ int, _ int, _ ...any) {
-		if !isIgnorableRegexLiteralDiagnostic(message, flags) {
-			hasError = true
-		}
-	})
-	s.SetText(literal)
-	s.ResetTokenState(0)
-	if s.Scan() != ast.KindSlashToken {
-		return false
-	}
-	if s.ReScanSlashToken(true) != ast.KindRegularExpressionLiteral {
-		return false
-	}
-	return !hasError && s.TokenFlags()&ast.TokenFlagsUnterminated == 0 && s.TokenEnd() == len(literal)
-}
-
-func isIgnorableRegexLiteralDiagnostic(message *diagnostics.Message, flags string) bool {
-	if strings.ContainsAny(flags, "uv") {
-		return false
-	}
-	return message == diagnostics.This_backreference_refers_to_a_group_that_does_not_exist_There_are_only_0_capturing_groups_in_this_regular_expression ||
-		message == diagnostics.This_backreference_refers_to_a_group_that_does_not_exist_There_are_no_capturing_groups_in_this_regular_expression
+	return ecmascript.IsValidRegexLiteral(literal)
 }


### PR DESCRIPTION
## Summary

- validate glob character classes with the ECMAScript scanner before treating invalid classes as literals
- match Node 26 and Unicode 17 legacy case-insensitive regular expression semantics without a Node runtime or generated Unicode table
- cover JavaScript-only class syntax, Unicode 17 mappings, multi-unit uppercase mappings, and supplementary-plane behavior

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).