### PR TITLE
fix: align non-nullable type assertion style

### DIFF
--- a/internal/plugins/typescript/rules/fixtures/tsconfig.no-explicit-strict.json
+++ b/internal/plugins/typescript/rules/fixtures/tsconfig.no-explicit-strict.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "experimentalDecorators": true,
+    "types": []
+  }
+}

--- a/internal/plugins/typescript/rules/fixtures/tsconfig.strict-null-checks-only.json
+++ b/internal/plugins/typescript/rules/fixtures/tsconfig.strict-null-checks-only.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "strict": false,
+    "strictNullChecks": true,
+    "target": "ES2020"
+  }
+}

--- a/internal/plugins/typescript/rules/fixtures/tsconfig.strict-with-null-checks-off.json
+++ b/internal/plugins/typescript/rules/fixtures/tsconfig.strict-with-null-checks-off.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "strict": true,
+    "strictNullChecks": false,
+    "target": "ES2020"
+  }
+}

--- a/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.go
+++ b/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.go
@@ -196,11 +196,10 @@ func (s *nonNullableTypeAssertionStyleState) checkAssertion(node *ast.Node) {
 
 func runNonNullableTypeAssertionStyle(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 	compilerOptions := ctx.Program.Options()
-	if !utils.IsStrictCompilerOptionEnabled(compilerOptions, compilerOptions.StrictNullChecks) {
-		// With the TypeScript versions supported by the upstream rule, null and
-		// undefined are erased when strictNullChecks is not enabled, so the rule
-		// cannot find an assertion that only removes those constituents. Keep that
-		// behavior even though newer typescript-go versions default strictness on.
+	if !compilerOptions.GetStrictOptionValue(compilerOptions.StrictNullChecks) {
+		// Use the compiler's effective value: TypeScript 6 enables strictness by
+		// default when neither strict nor strictNullChecks is specified, while an
+		// explicit false still erases null and undefined from the relevant types.
 		return nil
 	}
 

--- a/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.go
+++ b/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.go
@@ -3,7 +3,6 @@ package non_nullable_type_assertion_style
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -15,100 +14,207 @@ func buildPreferNonNullAssertionMessage() rule.RuleMessage {
 	}
 }
 
+type nonNullableTypeParts struct {
+	union  []*checker.Type
+	single *checker.Type
+}
+
+func (p nonNullableTypeParts) len() int {
+	if p.single != nil {
+		return 1
+	}
+	return len(p.union)
+}
+
+func (p nonNullableTypeParts) at(index int) *checker.Type {
+	if p.single != nil {
+		return p.single
+	}
+	return p.union[index]
+}
+
+func isNullableType(t *checker.Type) bool {
+	return t != nil && checker.Type_flags(t)&checker.TypeFlagsNullable != 0
+}
+
+func splitTypeParts(t *checker.Type, flags checker.TypeFlags) nonNullableTypeParts {
+	if flags&checker.TypeFlagsUnion != 0 {
+		return nonNullableTypeParts{union: t.Types()}
+	}
+	return nonNullableTypeParts{single: t}
+}
+
+func splitOriginalTypeParts(t *checker.Type, flags checker.TypeFlags) (nonNullableTypeParts, int, bool) {
+	types := splitTypeParts(t, flags)
+	if types.single != nil {
+		if flags&checker.TypeFlagsNullable != 0 {
+			return types, 0, true
+		}
+		return types, 1, false
+	}
+
+	nonNullableCount := 0
+	for _, part := range types.union {
+		if !isNullableType(part) {
+			nonNullableCount++
+		}
+	}
+	return types, nonNullableCount, nonNullableCount != len(types.union)
+}
+
+// couldBeNullable recursively checks if a type could be null or undefined.
+// No explicit cycle detection is needed because TypeScript prevents circular
+// type parameter constraints. This matches the upstream implementation.
+func couldBeNullable(typeChecker *checker.Checker, t *checker.Type) bool {
+	if t == nil {
+		return false
+	}
+	flags := checker.Type_flags(t)
+	if flags&checker.TypeFlagsTypeParameter != 0 {
+		constraint := checker.Checker_getBaseConstraintOfType(typeChecker, t)
+		if constraint == nil {
+			return true
+		}
+		return couldBeNullable(typeChecker, constraint)
+	}
+	if flags&checker.TypeFlagsUnion != 0 {
+		for _, part := range t.Types() {
+			if couldBeNullable(typeChecker, part) {
+				return true
+			}
+		}
+		return false
+	}
+	return flags&checker.TypeFlagsNullable != 0
+}
+
+func sameTypesWithoutNullable(
+	typeChecker *checker.Checker,
+	assertedTypes nonNullableTypeParts,
+	originalTypes nonNullableTypeParts,
+	originalNonNullableTypeCount int,
+) bool {
+	assertedTypeCount := assertedTypes.len()
+	if assertedTypeCount != originalNonNullableTypeCount {
+		return false
+	}
+	for i := range assertedTypeCount {
+		if couldBeNullable(typeChecker, assertedTypes.at(i)) {
+			return false
+		}
+	}
+
+	// Small unions dominate in practice, so compare their constituent pointers
+	// directly and avoid allocating a map. TypeScript union constituents are
+	// unique, so equal counts plus one-way membership proves set equality. Fall
+	// back to one set for wide unions to keep adversarial inputs linear.
+	const linearTypeComparisonLimit = 8
+	originalTypeCount := originalTypes.len()
+	if originalTypeCount > linearTypeComparisonLimit || assertedTypeCount > linearTypeComparisonLimit {
+		nonNullableOriginalTypes := make(map[*checker.Type]struct{}, originalNonNullableTypeCount)
+		for i := range originalTypeCount {
+			originalType := originalTypes.at(i)
+			if !isNullableType(originalType) {
+				nonNullableOriginalTypes[originalType] = struct{}{}
+			}
+		}
+
+		for i := range assertedTypeCount {
+			assertedType := assertedTypes.at(i)
+			if _, ok := nonNullableOriginalTypes[assertedType]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+
+	for i := range assertedTypeCount {
+		assertedType := assertedTypes.at(i)
+		found := false
+		for j := range originalTypeCount {
+			if originalTypes.at(j) == assertedType {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func checkAssertion(ctx *rule.RuleContext, node *ast.Node) {
+	if ast.IsConstAssertion(node) {
+		return
+	}
+
+	expression := node.Expression()
+	originalType := ctx.TypeChecker.GetTypeAtLocation(expression)
+	if originalType == nil {
+		return
+	}
+	originalFlags := checker.Type_flags(originalType)
+	if originalFlags&(checker.TypeFlagsAny|checker.TypeFlagsUnknown) != 0 {
+		return
+	}
+	originalTypes, originalNonNullableTypeCount, hasNullableType := splitOriginalTypeParts(originalType, originalFlags)
+	if !hasNullableType {
+		return
+	}
+
+	assertedType := ctx.TypeChecker.GetTypeAtLocation(node.Type())
+	if assertedType == nil {
+		return
+	}
+	assertedFlags := checker.Type_flags(assertedType)
+	if assertedFlags&(checker.TypeFlagsAny|checker.TypeFlagsUnknown) != 0 {
+		return
+	}
+	assertedTypes := splitTypeParts(assertedType, assertedFlags)
+	if !sameTypesWithoutNullable(ctx.TypeChecker, assertedTypes, originalTypes, originalNonNullableTypeCount) {
+		return
+	}
+
+	ctx.ReportNodeWithDeferredFixes(node, buildPreferNonNullAssertionMessage(), func() []rule.RuleFix {
+		unwrappedExpression := ast.SkipParentheses(expression)
+		expressionText := utils.TrimmedNodeText(ctx.SourceFile, unwrappedExpression)
+		if ast.GetExpressionPrecedence(unwrappedExpression) <= ast.OperatorPrecedenceUnary {
+			expressionText = "(" + expressionText + ")"
+		}
+		return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, expressionText+"!")}
+	})
+}
+
+type nonNullableTypeAssertionStyleState struct {
+	ctx rule.RuleContext
+}
+
+func (s *nonNullableTypeAssertionStyleState) checkAssertion(node *ast.Node) {
+	checkAssertion(&s.ctx, node)
+}
+
+func runNonNullableTypeAssertionStyle(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+	compilerOptions := ctx.Program.Options()
+	if !utils.IsStrictCompilerOptionEnabled(compilerOptions, compilerOptions.StrictNullChecks) {
+		// With the TypeScript versions supported by the upstream rule, null and
+		// undefined are erased when strictNullChecks is not enabled, so the rule
+		// cannot find an assertion that only removes those constituents. Keep that
+		// behavior even though newer typescript-go versions default strictness on.
+		return nil
+	}
+
+	state := &nonNullableTypeAssertionStyleState{ctx: ctx}
+	listener := state.checkAssertion
+	return rule.RuleListeners{
+		ast.KindAsExpression:            listener,
+		ast.KindTypeAssertionExpression: listener,
+	}
+}
+
 var NonNullableTypeAssertionStyleRule = rule.CreateRule(rule.Rule{
 	Name:             "non-nullable-type-assertion-style",
 	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		getTypesIfNotLoose := func(node *ast.Node) []*checker.Type {
-			t := ctx.TypeChecker.GetTypeAtLocation(node)
-			if utils.IsTypeFlagSet(t, checker.TypeFlagsAny|checker.TypeFlagsUnknown) {
-				return nil
-			}
-			return utils.UnionTypeParts(t)
-		}
-
-		// couldBeNullable recursively checks if a type could be null or undefined.
-		// Note: No explicit cycle detection is needed here, as TypeScript's type system
-		// prevents circular type parameter constraints. This matches the upstream
-		// typescript-eslint implementation which also relies on this guarantee.
-		// See: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
-		var couldBeNullable func(t *checker.Type) bool
-		couldBeNullable = func(t *checker.Type) bool {
-			if utils.IsTypeParameter(t) {
-				constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t)
-				if constraint == nil {
-					return true
-				}
-				return couldBeNullable(constraint)
-			}
-			for _, p := range utils.UnionTypeParts(t) {
-				if utils.IsTypeFlagSet(p, checker.TypeFlagsNullable) {
-					return true
-				}
-			}
-			return false
-		}
-
-		checkAssertion := func(node *ast.Node) {
-			if ast.IsConstAssertion(node) {
-				return
-			}
-
-			expression := node.Expression()
-			originalTypes := getTypesIfNotLoose(expression)
-			if originalTypes == nil {
-				return
-			}
-
-			typeAnnotation := node.Type()
-			assertedTypes := getTypesIfNotLoose(typeAnnotation)
-			if assertedTypes == nil {
-				return
-			}
-
-			nonNullableOriginalType := utils.NewSetWithSizeHint[*checker.Type](len(originalTypes))
-			for _, t := range originalTypes {
-				if !utils.IsTypeFlagSet(t, checker.TypeFlagsNullable) {
-					nonNullableOriginalType.Add(t)
-				}
-			}
-			if nonNullableOriginalType.Len() == len(originalTypes) {
-				return
-			}
-
-			assertedTypesSet := utils.NewSetWithSizeHint[*checker.Type](len(assertedTypes))
-			for _, t := range assertedTypes {
-				if couldBeNullable(t) || !nonNullableOriginalType.Has(t) {
-					return
-				}
-				assertedTypesSet.Add(t)
-			}
-
-			for originalType := range nonNullableOriginalType.Keys() {
-				if !assertedTypesSet.Has(originalType) {
-					return
-				}
-			}
-
-			higherPrecedenceThanUnary := ast.GetExpressionPrecedence(expression) > ast.OperatorPrecedenceUnary
-
-			var removeRange core.TextRange
-			if ast.IsAssertionExpression(node) {
-				removeRange = node.Loc.WithPos(expression.End())
-			} else {
-				removeRange = node.Loc.WithEnd(expression.Pos())
-			}
-			if higherPrecedenceThanUnary {
-				ctx.ReportNodeWithFixes(node, buildPreferNonNullAssertionMessage(), rule.RuleFixRemoveRange(removeRange), rule.RuleFixInsertAfter(expression, "!"))
-			} else {
-				ctx.ReportNodeWithFixes(node, buildPreferNonNullAssertionMessage(), rule.RuleFixRemoveRange(removeRange), rule.RuleFixInsertBefore(ctx.SourceFile, expression, "("), rule.RuleFixInsertAfter(expression, ")!"))
-			}
-		}
-
-		return rule.RuleListeners{
-			ast.KindAsExpression:            checkAssertion,
-			ast.KindTypeAssertionExpression: checkAssertion,
-		}
-	},
+	Run:              runNonNullableTypeAssertionStyle,
 })

--- a/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
+++ b/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
@@ -1,9 +1,14 @@
 package non_nullable_type_assertion_style
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -24,6 +29,33 @@ const cast = original as string | number | undefined;
 		{Code: `
 declare const original: number | undefined;
 const cast = original as any;
+    `},
+		{Code: `
+declare const original: string | undefined;
+const cast = original as number;
+    `},
+		{Code: `
+declare const original:
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | undefined;
+const cast = original as
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'j';
     `},
 		{Code: `
 declare const original: number | null | undefined;
@@ -56,6 +88,16 @@ const x = 1 as 1;
 declare function foo<T = any>(): T;
 const bar = foo() as number;
     `},
+		{Code: `
+function getValue<U, T extends U | string>(value: T | undefined): T {
+  return value as T;
+}
+    `},
+		{Code: `
+function getValue<U, T extends U>(value: T | undefined): T {
+  return value as T;
+}
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `
@@ -70,8 +112,51 @@ const bar = maybe!;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "preferNonNullAssertion",
+					Message:   "Use a ! assertion to more succinctly remove null and undefined from the type.",
 					Line:      3,
 					Column:    13,
+					EndLine:   3,
+					EndColumn: 28,
+				},
+			},
+		},
+		{
+			Code: `
+declare const maybe: string | undefined;
+const bar = <string>maybe;
+      `,
+			Output: []string{`
+declare const maybe: string | undefined;
+const bar = maybe!;
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNonNullAssertion",
+					Line:      3,
+					Column:    13,
+					EndLine:   3,
+					EndColumn: 26,
+				},
+			},
+		},
+		{
+			Code: `
+declare const maybe: string | undefined;
+const bar = ((maybe)) as string;
+      `,
+			Output: []string{`
+declare const maybe: string | undefined;
+const bar = maybe!;
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNonNullAssertion",
+					Line:      3,
+					Column:    13,
+					EndLine:   3,
+					EndColumn: 32,
 				},
 			},
 		},
@@ -243,6 +328,51 @@ const b = (a || undefined)!;
 				},
 			},
 		},
+		{
+			Code: `
+declare const value:
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | undefined;
+const cast = value as
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i';
+      `,
+			Output: []string{`
+declare const value:
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | undefined;
+const cast = value!;
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNonNullAssertion",
+				Line:      13,
+				Column:    14,
+			}},
+		},
 	})
 }
 
@@ -299,4 +429,181 @@ function first<T extends string | number>(array: ArrayLike<T>): T | null {
 			},
 		},
 	})
+}
+
+func TestNonNullableTypeAssertionStyleRule_withoutExplicitStrictNullChecks(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.no-explicit-strict.json", t, &NonNullableTypeAssertionStyleRule, []rule_tester.ValidTestCase{
+		{Code: `
+declare function normalize(value?: string): string | undefined;
+const value = normalize() as string;
+      `},
+		{Code: `
+declare const key: unique symbol;
+function read(adm: { [key]?: string[] }): string[] {
+  if (key in adm) {
+    return adm[key] as string[];
+  }
+  return [];
+}
+      `},
+		{Code: `
+declare function getOptions(): { output: { hash?: string } };
+if (getOptions().output.hash) {
+  const hash = getOptions().output.hash as string;
+}
+      `},
+		{Code: `
+declare const values: string[];
+if (values.length > 0) {
+  const value = values.pop() as string;
+}
+      `},
+	}, nil)
+}
+
+func TestNonNullableTypeAssertionStyleRule_strictNullChecksOverrides(t *testing.T) {
+	t.Run("enabled without strict", func(t *testing.T) {
+		rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.strict-null-checks-only.json", t, &NonNullableTypeAssertionStyleRule, nil, []rule_tester.InvalidTestCase{
+			{
+				Code: `
+declare const maybe: string | undefined;
+const value = maybe as string;
+        `,
+				Output: []string{`
+declare const maybe: string | undefined;
+const value = maybe!;
+        `,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferNonNullAssertion",
+					Line:      3,
+					Column:    15,
+				}},
+			},
+		})
+	})
+
+	t.Run("disabled with strict", func(t *testing.T) {
+		rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.strict-with-null-checks-off.json", t, &NonNullableTypeAssertionStyleRule, []rule_tester.ValidTestCase{
+			{Code: `
+declare const maybe: string | undefined;
+const value = maybe as string;
+        `},
+		}, nil)
+	})
+}
+
+func TestNonNullableTypeAssertionStyleRule_editDemandAndSuppression(t *testing.T) {
+	t.Parallel()
+
+	const source = `declare const maybe: string | undefined;
+const asAssertion = maybe as string;
+const angleAssertion = <string>maybe;
+const redundantParens = ((maybe)) as string;
+// eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+const suppressed = maybe as string;
+`
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		source,
+		"non-nullable-type-assertion-style-edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		_, err := linter.RunLinter(linter.RunLinterOptions{
+			Programs:       []*compiler.Program{program},
+			SingleThreaded: true,
+			TargetFiles:    [][]string{{sourceFile.FileName()}},
+			ExcludePaths:   []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:             NonNullableTypeAssertionStyleRule.Name,
+					Severity:         rule.SeverityError,
+					RequiresTypeInfo: NonNullableTypeAssertionStyleRule.RequiresTypeInfo,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NonNullableTypeAssertionStyleRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(diagnostics) != 3 {
+			t.Fatalf("demand %d: diagnostics = %d, want 3: %#v", demand, len(diagnostics), diagnostics)
+		}
+		return diagnostics
+	}
+
+	diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+		rule.EditDemandAll:        run(rule.EditDemandAll),
+	}
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	expectedRanges := []string{
+		"maybe as string",
+		"<string>maybe",
+		"((maybe)) as string",
+	}
+
+	for index, allEdits := range diagnostics[rule.EditDemandAll] {
+		want := withoutEdits(allEdits)
+		for demand, demandDiagnostics := range diagnostics {
+			if got := withoutEdits(demandDiagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("diagnostic %d changed for demand %d:\ngot:  %#v\nwant: %#v", index, demand, got, want)
+			}
+			if demandDiagnostics[index].Suggestions != nil {
+				t.Errorf("diagnostic %d demand %d unexpectedly has suggestions", index, demand)
+			}
+		}
+
+		if got := source[allEdits.Range.Pos():allEdits.Range.End()]; got != expectedRanges[index] {
+			t.Errorf("diagnostic %d reports %q, want %q", index, got, expectedRanges[index])
+		}
+		autofix := diagnostics[rule.EditDemandAutofix][index].FixesPtr
+		if autofix == nil || !reflect.DeepEqual(autofix, allEdits.FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if fixes := allEdits.Fixes(); len(fixes) != 1 || fixes[0].Text != "maybe!" || fixes[0].Range != allEdits.Range {
+			t.Errorf("diagnostic %d fixes = %#v, want full-node replacement with maybe!", index, fixes)
+		}
+		if diagnostics[rule.EditDemandNone][index].FixesPtr != nil ||
+			diagnostics[rule.EditDemandSuggestion][index].FixesPtr != nil {
+			t.Errorf("diagnostic %d attached fixes without autofix demand", index)
+		}
+	}
+
+	fixed, unapplied, changed := linter.ApplyRuleFixes(source, diagnostics[rule.EditDemandAll])
+	if !changed || len(unapplied) != 0 {
+		t.Fatalf("ApplyRuleFixes changed=%v unapplied=%d", changed, len(unapplied))
+	}
+	const expected = `declare const maybe: string | undefined;
+const asAssertion = maybe!;
+const angleAssertion = maybe!;
+const redundantParens = maybe!;
+// eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+const suppressed = maybe as string;
+`
+	if fixed != expected {
+		t.Fatalf("fixed source = %q, want %q", fixed, expected)
+	}
 }

--- a/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
+++ b/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
@@ -432,12 +432,24 @@ function first<T extends string | number>(array: ArrayLike<T>): T | null {
 }
 
 func TestNonNullableTypeAssertionStyleRule_withoutExplicitStrictNullChecks(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.no-explicit-strict.json", t, &NonNullableTypeAssertionStyleRule, []rule_tester.ValidTestCase{
-		{Code: `
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.no-explicit-strict.json", t, &NonNullableTypeAssertionStyleRule, nil, []rule_tester.InvalidTestCase{
+		{
+			Code: `
 declare function normalize(value?: string): string | undefined;
 const value = normalize() as string;
+      `,
+			Output: []string{`
+declare function normalize(value?: string): string | undefined;
+const value = normalize()!;
       `},
-		{Code: `
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNonNullAssertion",
+				Line:      3,
+				Column:    15,
+			}},
+		},
+		{
+			Code: `
 declare const key: unique symbol;
 function read(adm: { [key]?: string[] }): string[] {
   if (key in adm) {
@@ -445,23 +457,73 @@ function read(adm: { [key]?: string[] }): string[] {
   }
   return [];
 }
+      `,
+			Output: []string{`
+declare const key: unique symbol;
+function read(adm: { [key]?: string[] }): string[] {
+  if (key in adm) {
+    return adm[key]!;
+  }
+  return [];
+}
       `},
-		{Code: `
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNonNullAssertion",
+				Line:      5,
+				Column:    12,
+			}},
+		},
+		{
+			Code: `
 declare function getOptions(): { output: { hash?: string } };
 if (getOptions().output.hash) {
   const hash = getOptions().output.hash as string;
 }
+      `,
+			Output: []string{`
+declare function getOptions(): { output: { hash?: string } };
+if (getOptions().output.hash) {
+  const hash = getOptions().output.hash!;
+}
       `},
-		{Code: `
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNonNullAssertion",
+				Line:      4,
+				Column:    16,
+			}},
+		},
+		{
+			Code: `
 declare const values: string[];
 if (values.length > 0) {
   const value = values.pop() as string;
 }
+      `,
+			Output: []string{`
+declare const values: string[];
+if (values.length > 0) {
+  const value = values.pop()!;
+}
       `},
-	}, nil)
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNonNullAssertion",
+				Line:      4,
+				Column:    17,
+			}},
+		},
+	})
 }
 
 func TestNonNullableTypeAssertionStyleRule_strictNullChecksOverrides(t *testing.T) {
+	t.Run("disabled explicitly", func(t *testing.T) {
+		rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.unstrict.json", t, &NonNullableTypeAssertionStyleRule, []rule_tester.ValidTestCase{
+			{Code: `
+declare const maybe: string | undefined;
+const value = maybe as string;
+        `},
+		}, nil)
+	})
+
 	t.Run("enabled without strict", func(t *testing.T) {
 		rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.strict-null-checks-only.json", t, &NonNullableTypeAssertionStyleRule, nil, []rule_tester.InvalidTestCase{
 			{


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/non-nullable-type-assertion-style` diagnostics and full-node autofixes with upstream for angle-bracket assertions, redundant parentheses, comments, low-precedence expressions, generic constraints, and small/wide unions.
- Use the compiler's effective `strictNullChecks` value. TypeScript 6 enables strictness when neither `strict` nor `strictNullChecks` is specified; explicit `false` still disables the rule's nullable-type matches.
- Defer fix construction and reduce rule-local allocations with cached type flags, allocation-free small-union comparison, and a one-map wide-union fallback.
- Add strictness-matrix, edit-demand, suppression, exact-range, generic-constraint, and adversarial union coverage.

The audit's five rspack diagnostics were version-sensitive: TypeScript 5.9 treats an unspecified `strict` option as disabled, while rspack's TypeScript 6.0.3 treats it as enabled. With the repository's actual TypeScript version, current upstream reports all five; rslint now does too.

### Real-project correctness

Compared the exact same tracked/type-aware files with `@typescript-eslint/eslint-plugin@8.67.0`, ESLint 10.8.0, and TypeScript 6.0.3. Comparison keys were file, rule, message, start position, and end position.

| Project scope | Files | Upstream | rslint | Only upstream | Only rslint |
| --- | ---: | ---: | ---: | ---: | ---: |
| VS Code type-aware extension set | 279 | 1 | 1 | 0 | 0 |
| rspack `packages/rspack/src` | 263 | 5 | 5 | 0 | 0 |
| rsbuild `packages/core/src` | 128 | 0 | 0 | 0 | 0 |
| **Total** | **670** | **6** | **6** | **0** | **0** |

Synthetic differential checks also matched diagnostic counts, messages, exact ranges, and byte-for-byte fixed output. Explicit `strict: false`, explicit `strictNullChecks: true`, and `strict: true` plus `strictNullChecks: false` are covered separately.

### Performance

On the fixed VS Code workload (10,500 discovered files, one enabled rule), median listener time improved from `33.6 ms` to `19.6 ms` (`-41.7%`); 301 files reached the typed listener.

Go benchmark command (8 samples per case; table reports medians):

```sh
go test -run '^$' -bench '^BenchmarkNonNullableTypeAssertionStyleSecondPass$' -benchmem -count=8 ./internal/plugins/typescript/rules/non_nullable_type_assertion_style
```

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Run, strict enabled | `127.30 → 100.70` (`-20.9%`) | `480 → 416` | `7 → 4` |
| Run, strict disabled | `46.02 → 3.97` (`-91.4%`) | `256 → 0` | `2 → 0` |
| Matched diagnostic | `93.65 → 81.92` (`-12.5%`) | `168 → 160` | `2 → 1` |
| Matched autofix | `223.05 → 186.65` (`-16.3%`) | `544 → 536` | `7 → 6` |
| Angle-bracket autofix | `205.65 → 174.85` (`-15.0%`) | `544 → 536` | `7 → 6` |
| Low-precedence autofix | `215.60 → 184.30` (`-14.5%`) | `560 → 552` | `7 → 6` |
| Redundant-parentheses autofix | `212.05 → 188.50` (`-11.1%`) | `544 → 536` | `7 → 6` |
| No match | `29.30 → 21.42` (`-26.9%`) | `8 → 0` | `1 → 0` |

### Validation

- `go test ./internal/plugins/typescript/rules/non_nullable_type_assertion_style -count=3`
- Targeted `non-nullable-type-assertion-style` Rstest: 4/4 passed
- Real-project upstream differential: 670 files, exact diagnostic-set match
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/non_nullable_type_assertion_style/...`
- `git diff --check`

## Related Links

- Upstream rule: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
