### PR TITLE
fix: align no-deprecated with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
@@ -22,7 +22,7 @@ var deprecatedReasonPattern = regexp.MustCompile(`(?s)@deprecated\s*([\s\S]*?)\*
 const (
 	diagnosticCodeSecondEntityName     = 6387
 	declarationReasonSearchWindowBytes = 512
-	maxConstantPropertyResolveDepth    = 8
+	maxAliasDeprecationDepth           = 64
 )
 
 type sourceDeprecationLookupKind uint8
@@ -46,6 +46,14 @@ type sourceDeprecationLookupKey struct {
 type sourceDeprecationInfo struct {
 	isDeprecated bool
 	reason       string
+}
+
+type callLikeDeprecationInfo struct {
+	checked                        bool
+	callLikeNode                   *ast.Node
+	isDeprecated                   bool
+	reason                         string
+	resolvedNonDeprecatedSignature bool
 }
 
 func buildDeprecatedMessage(name string) rule.RuleMessage {
@@ -308,17 +316,33 @@ func searchForDeprecationInAliasesChain(
 		}
 		return false, ""
 	}
-	if isDeprecated, reason := getJsDocDeprecation(typeChecker, symbol); isDeprecated {
-		return true, reason
+	targetSymbol := typeChecker.GetAliasedSymbol(symbol)
+	for depth := 0; symbol != nil && symbol.Flags&ast.SymbolFlagsAlias != 0 && depth < maxAliasDeprecationDepth; depth++ {
+		if symbol == targetSymbol {
+			if checkDeprecationsOfAliasedSymbol {
+				return getJsDocDeprecation(typeChecker, symbol)
+			}
+			break
+		}
+		if isDeprecated, reason := getJsDocDeprecation(typeChecker, symbol); isDeprecated {
+			return true, reason
+		}
+		if len(symbol.Declarations) == 0 {
+			break
+		}
+		immediateAliasedSymbol := typeChecker.GetImmediateAliasedSymbol(symbol)
+		if immediateAliasedSymbol == nil {
+			break
+		}
+		if immediateAliasedSymbol == symbol {
+			break
+		}
+		symbol = immediateAliasedSymbol
+		if checkDeprecationsOfAliasedSymbol && symbol == targetSymbol {
+			return getJsDocDeprecation(typeChecker, symbol)
+		}
 	}
-	if !checkDeprecationsOfAliasedSymbol {
-		return false, ""
-	}
-	aliasedSymbol := typeChecker.GetAliasedSymbol(symbol)
-	if aliasedSymbol == nil {
-		return false, ""
-	}
-	return getJsDocDeprecation(typeChecker, aliasedSymbol)
+	return false, ""
 }
 
 func stripQuotes(text string) string {
@@ -646,22 +670,28 @@ func symbolAtLocation(typeChecker *checker.Checker, node *ast.Node) *ast.Symbol 
 	return nil
 }
 
-func getCallLikeDeprecation(ctx rule.RuleContext, node *ast.Node) (bool, string) {
+func getCallLikeDeprecation(ctx rule.RuleContext, node *ast.Node) (bool, string, bool) {
 	if ctx.TypeChecker == nil || node == nil || node.Parent == nil {
-		return false, ""
+		return false, "", false
 	}
 	signature := checker.Checker_getResolvedSignature(ctx.TypeChecker, node.Parent, nil, checker.CheckModeNormal)
 	if signature == nil {
-		return false, ""
+		return false, "", false
 	}
 	signatureDecl := signature.Declaration()
-	if signatureDecl != nil && (isDeclarationDeprecated(ctx.TypeChecker, signatureDecl) || hasDeprecatedTag(signatureDecl)) {
+	signatureDeprecated := signatureDecl != nil && isDeclarationDeprecated(ctx.TypeChecker, signatureDecl)
+	resolvedNonDeprecatedSignature := signatureDecl != nil &&
+		(signatureDecl.Kind == ast.KindFunctionDeclaration ||
+			signatureDecl.Kind == ast.KindMethodDeclaration ||
+			signatureDecl.Kind == ast.KindMethodSignature) &&
+		!signatureDeprecated
+	if signatureDeprecated {
 		reason := getJsDocDeprecationFromNode(signatureDecl)
-		return true, reason
+		return true, reason, false
 	}
 	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
 	if symbol == nil {
-		return false, ""
+		return false, "", resolvedNonDeprecatedSignature
 	}
 	aliasedSymbol := symbol
 	if symbol.Flags&ast.SymbolFlagsAlias != 0 {
@@ -674,16 +704,33 @@ func getCallLikeDeprecation(ctx rule.RuleContext, node *ast.Node) (bool, string)
 	if symbolDeclarationKind != ast.KindMethodDeclaration &&
 		symbolDeclarationKind != ast.KindFunctionDeclaration &&
 		symbolDeclarationKind != ast.KindMethodSignature {
-		return searchForDeprecationInAliasesChain(ctx.TypeChecker, symbol, true)
+		isDeprecated, reason := searchForDeprecationInAliasesChain(ctx.TypeChecker, symbol, true)
+		return isDeprecated, reason, resolvedNonDeprecatedSignature
 	}
 	isDeprecated, reason := searchForDeprecationInAliasesChain(ctx.TypeChecker, symbol, false)
 	if isDeprecated {
-		return true, reason
+		return true, reason, false
 	}
 	if signatureDecl == nil && aliasedSymbol != nil {
-		return getJsDocDeprecation(ctx.TypeChecker, aliasedSymbol)
+		isDeprecated, reason := getJsDocDeprecation(ctx.TypeChecker, aliasedSymbol)
+		return isDeprecated, reason, false
 	}
-	return false, ""
+	return false, "", resolvedNonDeprecatedSignature
+}
+
+func getCallLikeDeprecationInfo(ctx rule.RuleContext, node *ast.Node) callLikeDeprecationInfo {
+	callLikeNode := getCallLikeNode(node)
+	if callLikeNode == nil {
+		return callLikeDeprecationInfo{checked: true}
+	}
+	isDeprecated, reason, resolvedNonDeprecatedSignature := getCallLikeDeprecation(ctx, callLikeNode)
+	return callLikeDeprecationInfo{
+		checked:                        true,
+		callLikeNode:                   callLikeNode,
+		isDeprecated:                   isDeprecated,
+		reason:                         reason,
+		resolvedNonDeprecatedSignature: resolvedNonDeprecatedSignature,
+	}
 }
 
 func getJsxAttributeDeprecation(ctx rule.RuleContext, elementNode *ast.Node, propertyName string) (bool, string) {
@@ -787,13 +834,19 @@ func getBindingPatternSourceType(ctx rule.RuleContext, bindingPattern *ast.Node,
 	return nil
 }
 
-func getDeprecationReason(ctx rule.RuleContext, node *ast.Node) (bool, string) {
+func getDeprecationReason(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	callLikeDeprecation callLikeDeprecationInfo,
+) (bool, string) {
 	if ctx.TypeChecker == nil || node == nil {
 		return false, ""
 	}
-	callLikeNode := getCallLikeNode(node)
-	if callLikeNode != nil {
-		return getCallLikeDeprecation(ctx, callLikeNode)
+	if !callLikeDeprecation.checked {
+		callLikeDeprecation = getCallLikeDeprecationInfo(ctx, node)
+	}
+	if callLikeDeprecation.callLikeNode != nil {
+		return callLikeDeprecation.isDeprecated, callLikeDeprecation.reason
 	}
 	if node.Parent != nil && node.Parent.Kind == ast.KindJsxAttribute && node.Kind != ast.KindSuperKeyword {
 		if node.Parent.Parent != nil && node.Parent.Parent.Parent != nil {
@@ -832,7 +885,7 @@ func getDeprecationReason(ctx rule.RuleContext, node *ast.Node) (bool, string) {
 									propertyName = bindingName
 								}
 								if propertyName == "" && bindingElement.PropertyName != nil {
-									if resolvedName, ok := resolveConstantPropertyName(ctx, bindingElement.PropertyName, 0, map[*ast.Symbol]bool{}); ok {
+									if resolvedName, ok := elementAccessPropertyName(ctx, bindingElement.PropertyName); ok {
 										propertyName = resolvedName
 									}
 								}
@@ -1177,18 +1230,13 @@ func symbolIsDeprecated(typeChecker *checker.Checker, symbol *ast.Symbol) bool {
 	if typeChecker == nil || symbol == nil {
 		return false
 	}
-	if symbol.ValueDeclaration != nil && isDeclarationDeprecated(typeChecker, symbol.ValueDeclaration) {
-		return true
-	}
-	if len(symbol.Declarations) == 0 {
-		return false
-	}
-	for _, declaration := range symbol.Declarations {
-		if declaration == nil || !isDeclarationDeprecated(typeChecker, declaration) {
-			return false
-		}
-	}
-	return true
+	isDeprecated, _ := getJsDocDeprecation(typeChecker, symbol)
+	return isDeprecated
+}
+
+func resolvedSymbolIsDeprecated(typeChecker *checker.Checker, symbol *ast.Symbol) bool {
+	isDeprecated, _ := searchForDeprecationInAliasesChain(typeChecker, symbol, true)
+	return isDeprecated
 }
 
 func bindingElementPropertyName(bindingElement *ast.BindingElement) string {
@@ -1230,94 +1278,34 @@ func bindingElementIndex(bindingElement *ast.BindingElement) (int, bool) {
 	return 0, false
 }
 
-func resolveConstantPropertyName(ctx rule.RuleContext, node *ast.Node, depth int, seen map[*ast.Symbol]bool) (string, bool) {
-	if ctx.TypeChecker == nil || node == nil || depth > maxConstantPropertyResolveDepth {
+func elementAccessPropertyName(ctx rule.RuleContext, argument *ast.Node) (string, bool) {
+	if ctx.TypeChecker == nil || argument == nil {
 		return "", false
 	}
-	node = ast.SkipParentheses(node)
-	if node == nil {
+	propertyType := ctx.TypeChecker.GetTypeAtLocation(argument)
+	if propertyType == nil {
 		return "", false
 	}
-	switch node.Kind {
-	case ast.KindStringLiteral:
-		stringLiteral := node.AsStringLiteral()
-		if stringLiteral == nil {
-			return "", false
-		}
-		return stringLiteral.Text, true
-	case ast.KindNoSubstitutionTemplateLiteral:
-		templateLiteral := node.AsNoSubstitutionTemplateLiteral()
-		if templateLiteral == nil {
-			return "", false
-		}
-		return templateLiteral.Text, true
-	case ast.KindNumericLiteral:
-		numericLiteral := node.AsNumericLiteral()
-		if numericLiteral == nil {
-			return "", false
-		}
-		return numericLiteral.Text, true
-	case ast.KindAsExpression:
-		asExpression := node.AsAsExpression()
-		if asExpression == nil {
-			return "", false
-		}
-		return resolveConstantPropertyName(ctx, asExpression.Expression, depth+1, seen)
-	case ast.KindTypeAssertionExpression:
-		typeAssertion := node.AsTypeAssertion()
-		if typeAssertion == nil {
-			return "", false
-		}
-		return resolveConstantPropertyName(ctx, typeAssertion.Expression, depth+1, seen)
-	case ast.KindPropertyAccessExpression:
-		propertyAccess := node.AsPropertyAccessExpression()
-		if propertyAccess == nil || propertyAccess.Name() == nil {
-			return "", false
-		}
-		symbol := ctx.TypeChecker.GetSymbolAtLocation(propertyAccess.Name())
-		if symbol != nil && symbol.ValueDeclaration != nil && symbol.ValueDeclaration.Kind == ast.KindEnumMember {
-			enumMember := symbol.ValueDeclaration.AsEnumMember()
-			if enumMember != nil {
-				return resolveConstantPropertyName(ctx, enumMember.Initializer, depth+1, seen)
-			}
-		}
-	case ast.KindIdentifier:
-		symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-		if symbol == nil || symbol.ValueDeclaration == nil || symbol.ValueDeclaration.Kind != ast.KindVariableDeclaration {
-			return "", false
-		}
-		if seen[symbol] {
-			return "", false
-		}
-		seen[symbol] = true
-		defer delete(seen, symbol)
-
-		variableDeclaration := symbol.ValueDeclaration.AsVariableDeclaration()
-		if variableDeclaration == nil || variableDeclaration.Initializer == nil {
-			return "", false
-		}
-		return resolveConstantPropertyName(ctx, variableDeclaration.Initializer, depth+1, seen)
+	flags := checker.Type_flags(propertyType)
+	if flags&(checker.TypeFlagsStringLiteral|checker.TypeFlagsNumberLiteral|checker.TypeFlagsBigIntLiteral) == 0 {
+		return "", false
 	}
-	if constantValue := ctx.TypeChecker.GetConstantValue(node); constantValue != nil {
-		if text, ok := constantValue.(string); ok {
-			return text, true
-		}
-		switch value := constantValue.(type) {
-		case float64:
-			return strconv.FormatFloat(value, 'f', -1, 64), true
-		case int:
-			return strconv.Itoa(value), true
-		case int32:
-			return strconv.Itoa(int(value)), true
-		case int64:
-			return strconv.FormatInt(value, 10), true
-		}
+	literalType := propertyType.AsLiteralType()
+	if literalType == nil {
+		return "", false
+	}
+	if flags&checker.TypeFlagsStringLiteral != 0 {
+		value, ok := literalType.Value().(string)
+		return value, ok
+	}
+	if flags&checker.TypeFlagsNumberLiteral != 0 {
+		return checker.ValueToString(literalType.Value()), true
+	}
+	if flags&checker.TypeFlagsBigIntLiteral != 0 {
+		// Upstream applies String() to TypeScript's PseudoBigInt object.
+		return "[object Object]", true
 	}
 	return "", false
-}
-
-func elementAccessPropertyName(ctx rule.RuleContext, argument *ast.Node) (string, bool) {
-	return resolveConstantPropertyName(ctx, argument, 0, map[*ast.Symbol]bool{})
 }
 
 func isPropertyLikeDeclaration(node *ast.Node) bool {
@@ -1590,27 +1578,155 @@ func shouldUseDeprecatedVariableSourceFallback(node *ast.Node) bool {
 	}
 }
 
-// isLocalNonDeprecatedSymbol returns true when the identifier at node resolves
-// to a local (same-file) declaration that is NOT deprecated. In that case we
-// skip the name-only fallback to avoid false positives when a local variable
-// shadows a deprecated declaration of the same name.
-func isLocalNonDeprecatedSymbol(ctx rule.RuleContext, node *ast.Node) bool {
+func bindingElementHasResolvedNonDeprecatedProperty(ctx rule.RuleContext, declaration *ast.Node) bool {
+	if ctx.TypeChecker == nil || declaration == nil || declaration.Kind != ast.KindBindingElement || declaration.Parent == nil {
+		return false
+	}
+	bindingElement := declaration.AsBindingElement()
+	if bindingElement == nil {
+		return false
+	}
+	bindingPattern := declaration.Parent
+	if bindingPattern.Kind != ast.KindObjectBindingPattern && bindingPattern.Kind != ast.KindArrayBindingPattern {
+		return false
+	}
+	sourceType := getBindingPatternSourceType(ctx, bindingPattern, map[*ast.Node]bool{})
+	if sourceType == nil {
+		return false
+	}
+	propertyName := bindingElementPropertyName(bindingElement)
+	if bindingPattern.Kind == ast.KindArrayBindingPattern {
+		index, ok := bindingElementIndex(bindingElement)
+		if !ok {
+			return false
+		}
+		propertyName = strconv.Itoa(index)
+	}
+	if propertyName == "" {
+		return false
+	}
+	property := checker.Checker_getPropertyOfType(ctx.TypeChecker, sourceType, propertyName)
+	if property == nil {
+		return false
+	}
+	// Module namespace properties can be export aliases. Upstream checks the
+	// export alias's own JSDoc here rather than merging tags from the aliased
+	// function's overload declarations. A deprecated re-export still reports,
+	// while an unannotated re-export of mixed overloads does not.
+	if property.Flags&ast.SymbolFlagsAlias != 0 {
+		return !symbolIsDeprecated(ctx.TypeChecker, property)
+	}
+	return !resolvedSymbolIsDeprecated(ctx.TypeChecker, property)
+}
+
+func propertyAccessHasResolvedNonDeprecatedProperty(ctx rule.RuleContext, node *ast.Node) bool {
+	if ctx.TypeChecker == nil || node == nil {
+		return false
+	}
+	var access *ast.PropertyAccessExpression
+	if node.Kind == ast.KindPropertyAccessExpression {
+		access = node.AsPropertyAccessExpression()
+	} else if isPropertyAccessName(node) {
+		access = node.Parent.AsPropertyAccessExpression()
+	}
+	if access == nil || access.Expression == nil || access.Name() == nil {
+		return false
+	}
+	objectType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, access.Expression)
+	if objectType == nil {
+		return false
+	}
+	property := checker.Checker_getPropertyOfType(ctx.TypeChecker, objectType, access.Name().Text())
+	if property == nil {
+		return false
+	}
+	return !resolvedSymbolIsDeprecated(ctx.TypeChecker, property)
+}
+
+func hasResolvedNonDeprecatedAccessTarget(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	callLikeDeprecation callLikeDeprecationInfo,
+) bool {
 	if ctx.TypeChecker == nil || ctx.SourceFile == nil || node == nil {
 		return false
+	}
+	if !callLikeDeprecation.checked {
+		callLikeDeprecation = getCallLikeDeprecationInfo(ctx, node)
+	}
+	if callLikeDeprecation.callLikeNode != nil {
+		if callLikeDeprecation.isDeprecated {
+			return false
+		}
+		if callLikeDeprecation.resolvedNonDeprecatedSignature {
+			return true
+		}
+	}
+	if propertyAccessHasResolvedNonDeprecatedProperty(ctx, node) {
+		return true
+	}
+	bindingDeclaration := node
+	if bindingDeclaration.Kind != ast.KindBindingElement && bindingDeclaration.Parent != nil && bindingDeclaration.Parent.Kind == ast.KindBindingElement {
+		bindingDeclaration = bindingDeclaration.Parent
+	}
+	if bindingElementHasResolvedNonDeprecatedProperty(ctx, bindingDeclaration) {
+		return true
+	}
+	// References to a destructured variable resolve to the local binding symbol,
+	// not to the source object's property. Follow that symbol back to its binding
+	// element so an unrelated deprecated property with the same name cannot win
+	// through the source-wide fallback.
+	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
+	if symbol != nil {
+		for _, declaration := range symbol.Declarations {
+			if declaration != nil && declaration.Kind == ast.KindBindingElement &&
+				bindingElementHasResolvedNonDeprecatedProperty(ctx, declaration) {
+				return true
+			}
+		}
+		if symbol.ValueDeclaration != nil && symbol.ValueDeclaration.Kind == ast.KindBindingElement &&
+			bindingElementHasResolvedNonDeprecatedProperty(ctx, symbol.ValueDeclaration) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasResolvedNonDeprecatedTarget returns true when the checker has resolved the
+// identifier to a concrete non-deprecated declaration. A source-wide lookup by
+// name is only safe when resolution failed: otherwise an unrelated type with a
+// deprecated member of the same name can be mistaken for the resolved target.
+func hasResolvedNonDeprecatedTarget(ctx rule.RuleContext, node *ast.Node) bool {
+	if propertyAccessHasResolvedNonDeprecatedProperty(ctx, node) {
+		return true
 	}
 	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
 	if symbol == nil {
 		return false
 	}
+	allowCrossFileDeclaration := isPropertyAccessName(node)
 	checkDecl := func(decl *ast.Node) bool {
-		if decl == nil || decl.Kind == ast.KindBindingElement || decl.Kind == ast.KindShorthandPropertyAssignment {
+		if decl == nil || decl.Kind == ast.KindShorthandPropertyAssignment {
 			return false
+		}
+		if decl.Kind == ast.KindBindingElement {
+			return bindingElementHasResolvedNonDeprecatedProperty(ctx, decl)
 		}
 		declSourceFile := ast.GetSourceFileOfNode(decl)
-		if declSourceFile == nil || declSourceFile != ctx.SourceFile {
+		if declSourceFile == nil {
 			return false
 		}
-		// If the declaration is deprecated, allow the fallback to find it.
+		if declSourceFile != ctx.SourceFile {
+			// Virtual-file programs can expose a second SourceFile instance for
+			// a declaration in the current logical file. Preserve the existing
+			// source fallback for that case; only a property access resolved to a
+			// genuinely different file is conclusive cross-file evidence.
+			if !allowCrossFileDeclaration || declSourceFile.FileName() == ctx.SourceFile.FileName() {
+				return false
+			}
+		}
+		// If the resolved declaration is deprecated, let the normal detection
+		// path (or, if necessary, its source fallback) report it.
 		if isDeclarationDeprecated(ctx.TypeChecker, decl) {
 			return false
 		}
@@ -1738,6 +1854,15 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 			}
 			sourceDeprecationCache[key] = info
 			return info.isDeprecated, info.reason
+		}
+		lastCallLikeDeprecation := callLikeDeprecationInfo{}
+		callLikeDeprecationForNode := func(node *ast.Node) callLikeDeprecationInfo {
+			callLikeNode := getCallLikeNode(node)
+			if lastCallLikeDeprecation.checked && lastCallLikeDeprecation.callLikeNode == callLikeNode {
+				return lastCallLikeDeprecation
+			}
+			lastCallLikeDeprecation = getCallLikeDeprecationInfo(ctx, node)
+			return lastCallLikeDeprecation
 		}
 		// A reference is allowed when the type at that location matches a
 		// specifier, or when the referenced value itself does — an export whose
@@ -1888,6 +2013,22 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if shouldIgnoreDynamicImportDefault(node, diagnostic.Pos(), diagnostic.End(), name, ctx.TypeChecker) {
 					continue
 				}
+				elementAccess := elementAccessForDiagnosticRange(node, diagnostic.Pos(), diagnostic.End())
+				if elementAccess != nil {
+					if isObjectTypeAllowed(elementAccess.Expression) {
+						continue
+					}
+				} else if isAllowed(node) {
+					continue
+				}
+				resolvedNode := node
+				if access := propertyAccessForDiagnosticRange(node, diagnostic.Pos(), diagnostic.End()); access != nil && access.Name() != nil {
+					resolvedNode = access.Name()
+				}
+				callDeprecation := callLikeDeprecationForNode(resolvedNode)
+				if hasResolvedNonDeprecatedAccessTarget(ctx, resolvedNode, callDeprecation) {
+					continue
+				}
 				symbol := symbolAtLocation(ctx.TypeChecker, node)
 				if symbol != nil && declarationInCurrentFile(symbol, ctx.SourceFile) {
 					if isDeprecatedLocal, _ := getJsDocDeprecation(ctx.TypeChecker, symbol); !isDeprecatedLocal {
@@ -1903,7 +2044,6 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if isInImportStatementRange(sourceFile, diagnostic.Pos()) {
 					continue
 				}
-				elementAccess := elementAccessForDiagnosticRange(node, diagnostic.Pos(), diagnostic.End())
 				if elementAccess != nil && elementAccess.Expression != nil {
 					rawObjectType := ctx.TypeChecker.GetTypeAtLocation(elementAccess.Expression)
 					if rawObjectType != nil && (utils.IsTypeAnyType(rawObjectType) || utils.IsTypeUnknownType(rawObjectType)) {
@@ -1913,13 +2053,6 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				diagnosticRange := core.NewTextRange(diagnostic.Pos(), diagnostic.End())
 				if promotedRange := promotedDynamicImportDefaultRange(node, diagnostic.Pos(), diagnostic.End(), name, ctx.TypeChecker); promotedRange != nil {
 					diagnosticRange = *promotedRange
-				}
-				if elementAccess != nil {
-					if isObjectTypeAllowed(elementAccess.Expression) {
-						continue
-					}
-				} else if isAllowed(node) {
-					continue
 				}
 				if !claimRange(diagnosticRange) {
 					continue
@@ -1946,7 +2079,8 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 					}
 				}
 				if message.Id != "deprecatedWithReason" {
-					if _, reason := getDeprecationReason(ctx, deprecationNode); reason != "" {
+					callDeprecation := callLikeDeprecationForNode(deprecationNode)
+					if _, reason := getDeprecationReason(ctx, deprecationNode, callDeprecation); reason != "" {
 						message = buildDeprecatedWithReasonMessage(name, reason)
 					}
 				}
@@ -1975,15 +2109,27 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				return
 			}
 			reportName := name
-			isDeprecated, reason := getDeprecationReason(ctx, node)
-			localNonDeprecated := false
-			if !isDeprecated {
-				localNonDeprecated = isLocalNonDeprecatedSymbol(ctx, node)
+			callDeprecation := callLikeDeprecationForNode(node)
+			isDeprecated, reason := getDeprecationReason(ctx, node, callDeprecation)
+			allowanceChecked := isDeprecated
+			if allowanceChecked && isAllowed(node) {
+				return
 			}
-			if !isDeprecated && shouldUseDeprecatedVariableSourceFallback(node) && !localNonDeprecated {
+			resolvedNonDeprecated := !isDeprecated && callDeprecation.resolvedNonDeprecatedSignature
+			if isDeprecated && isBindingElementNameOrProperty(node) {
+				resolvedNonDeprecated = hasResolvedNonDeprecatedAccessTarget(ctx, node, callDeprecation)
+				if resolvedNonDeprecated {
+					isDeprecated = false
+					reason = ""
+				}
+			}
+			if !isDeprecated && !resolvedNonDeprecated {
+				resolvedNonDeprecated = hasResolvedNonDeprecatedTarget(ctx, node)
+			}
+			if !isDeprecated && shouldUseDeprecatedVariableSourceFallback(node) && !resolvedNonDeprecated {
 				isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationVariable, name, 0, false)
 			}
-			if !isDeprecated && isPropertyAccessName(node) && !localNonDeprecated {
+			if !isDeprecated && isPropertyAccessName(node) && !resolvedNonDeprecated {
 				isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationStructuralProperty, name, 0, false)
 				if !isDeprecated {
 					argCount, matchArgCount := propertyAccessCallArgCount(node)
@@ -1993,10 +2139,10 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 					}
 				}
 			}
-			if !isDeprecated && isBindingElementNameOrProperty(node) && !localNonDeprecated {
+			if !isDeprecated && isBindingElementNameOrProperty(node) && !resolvedNonDeprecated {
 				isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationProperty, name, 0, false)
 			}
-			if !isDeprecated && !localNonDeprecated {
+			if !isDeprecated && !resolvedNonDeprecated {
 				argCount, matchArgCount := callArgCountForIdentifierCallee(node)
 				if matchArgCount {
 					isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationFunction, name, argCount, true)
@@ -2007,7 +2153,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 			if !isDeprecated {
 				return
 			}
-			if isAllowed(node) {
+			if !allowanceChecked && isAllowed(node) {
 				return
 			}
 			trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
@@ -2190,11 +2336,18 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if shouldIgnoreDynamicImportDefault(nameNode, nameNode.Pos(), nameNode.End(), name, ctx.TypeChecker) {
 					return
 				}
+				if isAllowed(nameNode) {
+					return
+				}
+				callDeprecation := callLikeDeprecationForNode(nameNode)
+				if !callDeprecation.isDeprecated && callDeprecation.resolvedNonDeprecatedSignature {
+					return
+				}
 				propertySymbol := ctx.TypeChecker.GetSymbolAtLocation(nameNode)
 				if !symbolIsDeprecated(ctx.TypeChecker, propertySymbol) {
 					return
 				}
-				if isAllowed(nameNode) {
+				if hasResolvedNonDeprecatedAccessTarget(ctx, nameNode, callDeprecation) {
 					return
 				}
 				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
@@ -2202,7 +2355,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if !claimRange(diagnosticRange) {
 					return
 				}
-				_, reason := getDeprecationReason(ctx, nameNode)
+				_, reason := getDeprecationReason(ctx, nameNode, callDeprecation)
 				message := buildDeprecatedMessage(name)
 				if reason != "" {
 					message = buildDeprecatedWithReasonMessage(name, reason)

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
@@ -10,6 +10,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -126,7 +127,19 @@ func getReportedNodeName(node *ast.Node) string {
 	return node.Text()
 }
 
-func getJsDocDeprecationFromNode(node *ast.Node) string {
+func reportedIdentifierName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindIdentifier, ast.KindPrivateIdentifier, ast.KindSuperKeyword:
+		return getReportedNodeName(node)
+	default:
+		return ""
+	}
+}
+
+func getJsDocDeprecationFromNode(typeChecker *checker.Checker, node *ast.Node) string {
 	if node == nil {
 		return ""
 	}
@@ -141,17 +154,126 @@ func getJsDocDeprecationFromNode(node *ast.Node) string {
 				continue
 			}
 			deprecatedTag := tagNode.AsJSDocDeprecatedTag()
-			if deprecatedTag != nil && deprecatedTag.Comment != nil && len(deprecatedTag.Comment.Nodes) > 0 {
-				var text strings.Builder
-				for _, commentNode := range deprecatedTag.Comment.Nodes {
-					text.WriteString(commentNode.Text())
-				}
-				return strings.TrimSpace(text.String())
+			if deprecatedTag != nil {
+				return strings.TrimSpace(jsDocCommentText(typeChecker, deprecatedTag.Comment))
 			}
 			return ""
 		}
 	}
 	return ""
+}
+
+func jsDocCommentText(typeChecker *checker.Checker, comment *ast.NodeList) string {
+	if comment == nil {
+		return ""
+	}
+	if len(comment.Nodes) == 1 && comment.Nodes[0].Kind == ast.KindJSDocText {
+		return comment.Nodes[0].Text()
+	}
+	var text strings.Builder
+	for _, commentNode := range comment.Nodes {
+		switch commentNode.Kind {
+		case ast.KindJSDocText:
+			text.WriteString(commentNode.Text())
+		case ast.KindJSDocLink, ast.KindJSDocLinkCode, ast.KindJSDocLinkPlain:
+			text.WriteString(formatJSDocLink(typeChecker, commentNode))
+		}
+	}
+	return text.String()
+}
+
+// formatJSDocLink mirrors TypeScript's buildLinkParts followed by
+// displayPartsToString, including its intentionally observable spacing.
+func formatJSDocLink(typeChecker *checker.Checker, link *ast.Node) string {
+	if link == nil {
+		return ""
+	}
+	linkKind := "link"
+	switch link.Kind {
+	case ast.KindJSDocLinkCode:
+		linkKind = "linkcode"
+	case ast.KindJSDocLinkPlain:
+		linkKind = "linkplain"
+	}
+	prefix := "{@" + linkKind + " "
+
+	linkText := link.Text()
+	nameNode := link.Name()
+	if nameNode == nil {
+		return prefix + linkText + "}"
+	}
+
+	suffix := jsDocLinkNameEnd(linkText)
+	name := scanner.GetTextOfNode(nameNode) + linkText[:suffix]
+	remainingText := skipJSDocLinkSeparator(linkText[suffix:])
+	if jsDocLinkTargetExists(typeChecker, nameNode) {
+		return prefix + name + remainingText + "}"
+	}
+
+	separator := ""
+	if suffix == 0 || (suffix < len(linkText) && linkText[suffix] == '|' && !strings.HasSuffix(name, " ")) {
+		separator = " "
+	}
+	return prefix + name + separator + remainingText + "}"
+}
+
+func jsDocLinkTargetExists(typeChecker *checker.Checker, name *ast.Node) bool {
+	if typeChecker == nil || name == nil {
+		return false
+	}
+	symbol := typeChecker.GetSymbolAtLocation(name)
+	if symbol == nil {
+		return false
+	}
+	symbol = typeChecker.SkipAlias(symbol)
+	if symbol == nil {
+		return false
+	}
+	for _, target := range typeChecker.GetRootSymbols(symbol) {
+		if target != nil && (target.ValueDeclaration != nil || len(target.Declarations) > 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func jsDocLinkNameEnd(text string) int {
+	if strings.HasPrefix(text, "://") {
+		if separator := strings.IndexByte(text, '|'); separator >= 0 {
+			return separator
+		}
+		return len(text)
+	}
+	if strings.HasPrefix(text, "()") {
+		return 2
+	}
+	if len(text) == 0 || text[0] != '<' {
+		return 0
+	}
+	depth := 0
+	for index, character := range text {
+		switch character {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		}
+		if depth == 0 {
+			return index + 1
+		}
+	}
+	return 0
+}
+
+func skipJSDocLinkSeparator(text string) string {
+	if len(text) == 0 || text[0] != '|' {
+		return text
+	}
+	index := 1
+	for index < len(text) && text[index] == ' ' {
+		index++
+	}
+	return text[index:]
 }
 
 func hasDeprecatedTag(node *ast.Node) bool {
@@ -282,20 +404,14 @@ func getJsDocDeprecation(typeChecker *checker.Checker, symbol *ast.Symbol) (bool
 			continue
 		}
 		if isDeclarationDeprecated(typeChecker, decl) {
-			reason := getJsDocDeprecationFromNode(decl)
-			if reason == "" {
-				reason = deprecatedReasonFromDeclaration(decl)
-			}
+			reason := deprecatedReasonFromDeclaration(typeChecker, decl)
 			return true, reason
 		}
 	}
 	if symbol.ValueDeclaration != nil {
 		if symbol.ValueDeclaration.Kind != ast.KindBindingElement &&
 			isDeclarationDeprecated(typeChecker, symbol.ValueDeclaration) {
-			reason := getJsDocDeprecationFromNode(symbol.ValueDeclaration)
-			if reason == "" {
-				reason = deprecatedReasonFromDeclaration(symbol.ValueDeclaration)
-			}
+			reason := deprecatedReasonFromDeclaration(typeChecker, symbol.ValueDeclaration)
 			return true, reason
 		}
 	}
@@ -406,7 +522,7 @@ func cleanupDeprecatedReason(text string) string {
 			parts = append(parts, trimmed)
 		}
 	}
-	return strings.TrimSpace(strings.Join(parts, " "))
+	return strings.TrimSpace(strings.Join(parts, "\n"))
 }
 
 func deprecatedReasonFromDiagnostic(diagnostic *ast.Diagnostic) string {
@@ -433,9 +549,12 @@ func deprecatedReasonFromDiagnostic(diagnostic *ast.Diagnostic) string {
 	return ""
 }
 
-func deprecatedReasonFromDeclaration(declaration *ast.Node) string {
+func deprecatedReasonFromDeclaration(typeChecker *checker.Checker, declaration *ast.Node) string {
 	if declaration == nil {
 		return ""
+	}
+	if reason := getJsDocDeprecationFromNode(typeChecker, declaration); reason != "" {
+		return reason
 	}
 	sourceFile := ast.GetSourceFileOfNode(declaration)
 	if sourceFile == nil {
@@ -686,7 +805,7 @@ func getCallLikeDeprecation(ctx rule.RuleContext, node *ast.Node) (bool, string,
 			signatureDecl.Kind == ast.KindMethodSignature) &&
 		!signatureDeprecated
 	if signatureDeprecated {
-		reason := getJsDocDeprecationFromNode(signatureDecl)
+		reason := getJsDocDeprecationFromNode(ctx.TypeChecker, signatureDecl)
 		return true, reason, false
 	}
 	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
@@ -1365,7 +1484,7 @@ func deprecatedInfoByNameInSource(ctx rule.RuleContext, name string, propertyOnl
 		}
 		found = true
 		if reason == "" {
-			reason = deprecatedReasonFromDeclaration(node)
+			reason = deprecatedReasonFromDeclaration(ctx.TypeChecker, node)
 		}
 		return reason != ""
 	})
@@ -1395,7 +1514,7 @@ func deprecatedVariableInfoByNameInSource(ctx rule.RuleContext, name string) (bo
 		}
 		found = true
 		if reason == "" {
-			reason = deprecatedReasonFromDeclaration(node)
+			reason = deprecatedReasonFromDeclaration(ctx.TypeChecker, node)
 		}
 		return reason != ""
 	})
@@ -1432,7 +1551,7 @@ func deprecatedStructuralPropertyInfoByNameInSource(ctx rule.RuleContext, name s
 			return false
 		}
 		if reason == "" {
-			reason = deprecatedReasonFromDeclaration(node)
+			reason = deprecatedReasonFromDeclaration(ctx.TypeChecker, node)
 		}
 		return reason != ""
 	})
@@ -1479,7 +1598,7 @@ func deprecatedMethodInfoByNameInSource(ctx rule.RuleContext, name string, argCo
 			continue
 		}
 		if reason == "" {
-			reason = deprecatedReasonFromDeclaration(node)
+			reason = deprecatedReasonFromDeclaration(ctx.TypeChecker, node)
 		}
 	}
 	return found && allDeprecated, reason
@@ -1525,7 +1644,7 @@ func deprecatedFunctionInfoByNameInSource(ctx rule.RuleContext, name string, arg
 			continue
 		}
 		if reason == "" {
-			reason = deprecatedReasonFromDeclaration(node)
+			reason = deprecatedReasonFromDeclaration(ctx.TypeChecker, node)
 		}
 	}
 	return found && allDeprecated, reason
@@ -1556,7 +1675,7 @@ func deprecatedPropertyInfoByNameInSource(ctx rule.RuleContext, name string) (bo
 			return false
 		}
 		if reason == "" {
-			reason = deprecatedReasonFromDeclaration(node)
+			reason = deprecatedReasonFromDeclaration(ctx.TypeChecker, node)
 		}
 		return reason != ""
 	})
@@ -1768,17 +1887,6 @@ func isPropertyAccessCalleeName(node *ast.Node) bool {
 	}
 	callExpression := node.Parent.Parent.AsCallExpression()
 	return callExpression != nil && callExpression.Expression == node.Parent
-}
-
-func propertyAccessDisplayName(sourceFile *ast.SourceFile, node *ast.Node) string {
-	if !isPropertyAccessName(node) {
-		return getReportedNodeName(node)
-	}
-	text := strings.TrimSpace(sourceSpanText(sourceFile, node.Parent.Pos(), node.Parent.End()))
-	if text == "" {
-		return getReportedNodeName(node)
-	}
-	return text
 }
 
 func propertyAccessCallArgCount(node *ast.Node) (int, bool) {
@@ -2022,8 +2130,15 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 					continue
 				}
 				resolvedNode := node
+				reportName := name
+				if identifierName := reportedIdentifierName(resolvedNode); identifierName != "" {
+					reportName = identifierName
+				}
 				if access := propertyAccessForDiagnosticRange(node, diagnostic.Pos(), diagnostic.End()); access != nil && access.Name() != nil {
 					resolvedNode = access.Name()
+					if identifierName := reportedIdentifierName(resolvedNode); identifierName != "" {
+						reportName = identifierName
+					}
 				}
 				callDeprecation := callLikeDeprecationForNode(resolvedNode)
 				if hasResolvedNonDeprecatedAccessTarget(ctx, resolvedNode, callDeprecation) {
@@ -2057,19 +2172,27 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if !claimRange(diagnosticRange) {
 					continue
 				}
-				message := buildDeprecatedMessage(name)
-				if reason := deprecatedReasonFromDiagnostic(diagnostic); reason != "" {
-					message = buildDeprecatedWithReasonMessage(name, reason)
-				} else if symbol != nil {
+				message := buildDeprecatedMessage(reportName)
+				reason := ""
+				if symbol != nil {
+					_, reason = searchForDeprecationInAliasesChain(ctx.TypeChecker, symbol, true)
+				}
+				if reason == "" {
+					reason = deprecatedReasonFromDiagnostic(diagnostic)
+				}
+				if reason == "" && symbol != nil {
 					for _, declaration := range symbol.Declarations {
 						if declaration == nil {
 							continue
 						}
-						if reason := deprecatedReasonFromDeclaration(declaration); reason != "" {
-							message = buildDeprecatedWithReasonMessage(name, reason)
+						if reasonFromDeclaration := deprecatedReasonFromDeclaration(ctx.TypeChecker, declaration); reasonFromDeclaration != "" {
+							reason = reasonFromDeclaration
 							break
 						}
 					}
+				}
+				if reason != "" {
+					message = buildDeprecatedWithReasonMessage(reportName, reason)
 				}
 				deprecationNode := node
 				if node != nil && node.Kind == ast.KindVariableDeclaration {
@@ -2081,12 +2204,12 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if message.Id != "deprecatedWithReason" {
 					callDeprecation := callLikeDeprecationForNode(deprecationNode)
 					if _, reason := getDeprecationReason(ctx, deprecationNode, callDeprecation); reason != "" {
-						message = buildDeprecatedWithReasonMessage(name, reason)
+						message = buildDeprecatedWithReasonMessage(reportName, reason)
 					}
 				}
 				if message.Id != "deprecatedWithReason" {
-					if _, reason := lookupSourceDeprecation(sourceDeprecationAny, name, 0, false); reason != "" {
-						message = buildDeprecatedWithReasonMessage(name, reason)
+					if _, reason := lookupSourceDeprecation(sourceDeprecationAny, reportName, 0, false); reason != "" {
+						message = buildDeprecatedWithReasonMessage(reportName, reason)
 					}
 				}
 				ctx.ReportRange(diagnosticRange, message)
@@ -2134,9 +2257,6 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				if !isDeprecated {
 					argCount, matchArgCount := propertyAccessCallArgCount(node)
 					isDeprecated, reason = lookupSourceDeprecation(sourceDeprecationMethod, name, argCount, matchArgCount)
-					if isDeprecated && isPropertyAccessCalleeName(node) {
-						reportName = propertyAccessDisplayName(ctx.SourceFile, node)
-					}
 				}
 			}
 			if !isDeprecated && isBindingElementNameOrProperty(node) && !resolvedNonDeprecated {
@@ -2176,7 +2296,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 					if declaration == nil {
 						continue
 					}
-					if reasonFromDecl := deprecatedReasonFromDeclaration(declaration); reasonFromDecl != "" {
+					if reasonFromDecl := deprecatedReasonFromDeclaration(ctx.TypeChecker, declaration); reasonFromDecl != "" {
 						message = buildDeprecatedWithReasonMessage(reportName, reasonFromDecl)
 						break
 					}
@@ -2266,7 +2386,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				message := buildDeprecatedMessage(nameText)
 				if propertySymbol != nil {
 					for _, declaration := range propertySymbol.Declarations {
-						if reason := deprecatedReasonFromDeclaration(declaration); reason != "" {
+						if reason := deprecatedReasonFromDeclaration(ctx.TypeChecker, declaration); reason != "" {
 							message = buildDeprecatedWithReasonMessage(nameText, reason)
 							break
 						}
@@ -2311,7 +2431,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 				message := buildDeprecatedMessage(propertyName)
 				if propertySymbol != nil {
 					for _, declaration := range propertySymbol.Declarations {
-						if reason := deprecatedReasonFromDeclaration(declaration); reason != "" {
+						if reason := deprecatedReasonFromDeclaration(ctx.TypeChecker, declaration); reason != "" {
 							message = buildDeprecatedWithReasonMessage(propertyName, reason)
 							break
 						}
@@ -2361,7 +2481,7 @@ var NoDeprecatedRule = rule.CreateRule(rule.Rule{
 					message = buildDeprecatedWithReasonMessage(name, reason)
 				} else if propertySymbol != nil {
 					for _, declaration := range propertySymbol.Declarations {
-						if reasonFromDecl := deprecatedReasonFromDeclaration(declaration); reasonFromDecl != "" {
+						if reasonFromDecl := deprecatedReasonFromDeclaration(ctx.TypeChecker, declaration); reasonFromDecl != "" {
 							message = buildDeprecatedWithReasonMessage(name, reasonFromDecl)
 							break
 						}

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
@@ -460,6 +460,295 @@ const x = <Comp foo={1} />;
 	})
 }
 
+func TestNoDeprecatedIgnoresNameOnlyFallbackForResolvedTargets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dynamic-import-binding-cross-symbol-collision", func(t *testing.T) {
+		t.Parallel()
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"implementation.ts": `
+export function glob(patterns: string[]): Promise<string[]> {
+  return Promise.resolve(patterns);
+}
+export function globSync(patterns: string[]): string[] {
+  return patterns;
+}
+			`,
+			"current.ts": `
+export { glob, globSync } from './implementation';
+			`,
+			"main.ts": `
+interface LegacyFinder {
+  /** @deprecated Provide patterns as the first argument instead. */
+  glob(pattern: string): Promise<string[]>;
+  /** @deprecated Provide patterns as the first argument instead. */
+  globSync(pattern: string): string[];
+}
+
+async function run() {
+  const { glob, globSync } = await import('./current');
+  await glob(['*.ts']);
+  globSync(['*.ts']);
+}
+
+run();
+			`,
+		}, "main.ts", nil)
+		if len(diagnostics) != 0 {
+			t.Fatalf("expected 0 diagnostics, got %#v", diagnostics)
+		}
+	})
+
+	t.Run("resolved-method-signature-cross-type-collision", func(t *testing.T) {
+		t.Parallel()
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"current.ts": `
+export interface CurrentEmitter {
+  on(event: string, listener: () => void): CurrentEmitter;
+}
+			`,
+			"main.ts": `
+import type { CurrentEmitter } from './current';
+
+interface LegacyEmitter {
+  /** @deprecated Use addListener instead. */
+  on(event: string, listener: () => void): LegacyEmitter;
+}
+
+declare const current: CurrentEmitter;
+current.on('error', () => {});
+			`,
+		}, "main.ts", nil)
+		if len(diagnostics) != 0 {
+			t.Fatalf("expected 0 diagnostics, got %#v", diagnostics)
+		}
+	})
+
+	t.Run("selected-non-deprecated-overload", func(t *testing.T) {
+		t.Parallel()
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"main.ts": `
+interface Emitter {
+  /** @deprecated Use destroy instead. */
+  on(event: 'abort', listener: () => void): Emitter;
+  on(event: 'error', listener: (error: Error) => void): Emitter;
+}
+
+declare const emitter: Emitter;
+emitter.on('error', () => {});
+			`,
+		}, "main.ts", nil)
+		if len(diagnostics) != 0 {
+			t.Fatalf("expected 0 diagnostics, got %#v", diagnostics)
+		}
+	})
+}
+
+func TestNoDeprecatedMatchesUpstreamResolutionBoundaries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("computed-key-literal-types", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+declare const Keys: { numeric: 1 };
+declare const keySource: { property: 'old' };
+declare const annotatedKey: 'old';
+
+const target = {
+  /** @deprecated Use currentNumeric instead. */
+  [1]: 'numeric',
+  /** @deprecated Use current instead. */
+  old: 'string',
+};
+const bigintTarget = {
+  /** @deprecated Mirrors upstream's String(PseudoBigInt) key. */
+  ['[object Object]']: 'bigint',
+};
+declare const bigintKey: 1n;
+
+target[Keys.numeric];
+target[keySource.property];
+target[annotatedKey];
+function read(key: 'old') {
+  return target[key];
+}
+target['anything' as 'old'];
+bigintTarget[bigintKey];
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"main.ts": code,
+		}, "main.ts", nil)
+		if len(diagnostics) != 6 {
+			t.Fatalf("expected 6 diagnostics, got %#v", diagnostics)
+		}
+		gotRanges := map[string]int{}
+		for _, diagnostic := range diagnostics {
+			gotRanges[code[diagnostic.Range.Pos():diagnostic.Range.End()]]++
+		}
+		for _, want := range []string{"Keys.numeric", "keySource.property", "annotatedKey", "key", "'anything' as 'old'", "bigintKey"} {
+			if gotRanges[want] != 1 {
+				t.Fatalf("diagnostic ranges = %#v, want one %q", gotRanges, want)
+			}
+		}
+	})
+
+	t.Run("computed-key-widened-types", func(t *testing.T) {
+		t.Parallel()
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"main.ts": `
+const target = {
+  /** @deprecated Use current instead. */
+  old: 'string',
+};
+let mutableKey = 'old';
+const assertedKey = 'old' as string;
+target[mutableKey];
+target[assertedKey];
+`,
+		}, "main.ts", nil)
+		if len(diagnostics) != 0 {
+			t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+		}
+	})
+
+	t.Run("mixed-overload-reference-and-calls", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+interface Emitter {
+  /** @deprecated Use destroy instead. */
+  on(event: 'abort', listener: () => void): Emitter;
+  on(event: 'error', listener: (error: Error) => void): Emitter;
+}
+
+declare const emitter: Emitter;
+const methodReference = emitter.on;
+emitter.on('error', () => {});
+emitter.on('abort', () => {});
+
+interface Props {
+  /** @deprecated Use current instead. */
+  callback: () => void;
+}
+declare const props: Props;
+props.callback();
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"main.ts": code,
+		}, "main.ts", nil)
+		if len(diagnostics) != 3 {
+			t.Fatalf("expected 3 diagnostics, got %#v", diagnostics)
+		}
+		gotRanges := map[string]int{}
+		for _, diagnostic := range diagnostics {
+			gotRanges[code[diagnostic.Range.Pos():diagnostic.Range.End()]]++
+		}
+		if gotRanges["on"] != 2 || gotRanges["callback"] != 1 {
+			t.Fatalf("diagnostic ranges = %#v, want two on and one callback", gotRanges)
+		}
+	})
+
+	t.Run("mixed-declarations-remain-deprecated-when-destructured", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+interface Emitter {
+  /** @deprecated Use destroy instead. */
+  on(event: 'abort', listener: () => void): Emitter;
+  on(event: 'error', listener: (error: Error) => void): Emitter;
+}
+declare const emitter: Emitter;
+const { on } = emitter;
+on('error', () => {});
+on('abort', () => {});
+
+interface Merged {
+  /** @deprecated Use current instead. */
+  item: string;
+}
+interface Merged {
+  item: string;
+}
+declare const merged: Merged;
+const { item } = merged;
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"main.ts": code,
+		}, "main.ts", nil)
+		if len(diagnostics) != 3 {
+			t.Fatalf("expected 3 diagnostics, got %#v", diagnostics)
+		}
+		gotRanges := map[string]int{}
+		for _, diagnostic := range diagnostics {
+			gotRanges[code[diagnostic.Range.Pos():diagnostic.Range.End()]]++
+		}
+		if gotRanges["on"] != 2 || gotRanges["item"] != 1 {
+			t.Fatalf("diagnostic ranges = %#v, want two on and one item", gotRanges)
+		}
+	})
+
+	t.Run("directly-exported-mixed-overload-binding", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+async function run() {
+  const { glob } = await import('./dependency');
+  await glob(['*.ts']);
+}
+void run();
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"dependency.ts": `
+export function glob(patterns: string[]): Promise<string[]>;
+/** @deprecated Provide patterns as the first argument instead. */
+export function glob(options: { patterns: string[] }): Promise<string[]>;
+export function glob(input: string[] | { patterns: string[] }): Promise<string[]> {
+  return Promise.resolve(Array.isArray(input) ? input : input.patterns);
+}
+`,
+			"main.ts": code,
+		}, "main.ts", nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("expected one diagnostic, got %#v", diagnostics)
+		}
+		if got := code[diagnostics[0].Range.Pos():diagnostics[0].Range.End()]; got != "glob" {
+			t.Fatalf("diagnostic range = %q, want glob", got)
+		}
+	})
+
+	t.Run("deprecated-reexport-binding", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+import * as imported from './dependency';
+import { normalFunction } from './dependency';
+const { normalVariable } = imported;
+normalFunction();
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{
+			"dependency.ts": `
+const normalVariable = 1;
+function normalFunction(): void {}
+export {
+  /** @deprecated */
+  normalVariable,
+  /** @deprecated */
+  normalFunction,
+};
+`,
+			"main.ts": code,
+		}, "main.ts", nil)
+		if len(diagnostics) != 2 {
+			t.Fatalf("expected two diagnostics, got %#v", diagnostics)
+		}
+		gotRanges := map[string]int{}
+		for _, diagnostic := range diagnostics {
+			gotRanges[code[diagnostic.Range.Pos():diagnostic.Range.End()]]++
+		}
+		for _, want := range []string{"normalVariable", "normalFunction"} {
+			if gotRanges[want] != 1 {
+				t.Fatalf("diagnostic ranges = %#v, want one %q", gotRanges, want)
+			}
+		}
+	})
+}
+
 func TestNoDeprecatedMultilineImportsAndMultiDeclarators(t *testing.T) {
 	t.Parallel()
 

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
@@ -372,7 +372,7 @@ legacy.old();
 	}
 	for index, diagnostic := range diagnostics {
 		if diagnostic.Message.Id != "deprecatedWithReason" ||
-			diagnostic.Message.Description != "`legacy.old` is deprecated. Use current instead." {
+			diagnostic.Message.Description != "`old` is deprecated. Use current instead." {
 			t.Fatalf("diagnostic %d message = %#v", index, diagnostic.Message)
 		}
 		if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != "old" {
@@ -382,6 +382,181 @@ legacy.old();
 			t.Fatalf("diagnostic %d unexpectedly included edits: %#v", index, diagnostic)
 		}
 	}
+}
+
+func TestNoDeprecatedMatchesUpstreamMessageFormatting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("jsdoc-links", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+/**
+ * @deprecated This only works with the legacy {@link render} and {@link
+ * renderSync} APIs. Use {@link Options} with {@link compile}, {@link
+ * compileString}, {@link compileAsync}, and {@link compileStringAsync} instead.
+ */
+type LegacyOptions = string;
+const legacyValue: LegacyOptions = '';
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{"main.ts": code}, "main.ts", nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
+		}
+		want := "`LegacyOptions` is deprecated. This only works with the legacy {@link render } and {@link * renderSync} APIs. Use {@link Options } with {@link compile }, {@link * compileString}, {@link compileAsync }, and {@link compileStringAsync } instead."
+		if got := diagnostics[0].Message.Description; got != want {
+			t.Fatalf("message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("import-alias-with-jsdoc-links", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]string{
+			"deprecated.ts": `
+/**
+ * @deprecated This only works with the legacy {@link render} and {@link
+ * renderSync} APIs. Use {@link Options} instead.
+ */
+export type LegacyOptions = string;
+`,
+			"main.ts": `
+import type { LegacyOptions as LegacySassOptions } from './deprecated';
+declare const options: LegacySassOptions;
+`,
+		}
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, files, "main.ts", nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
+		}
+		want := "`LegacySassOptions` is deprecated. This only works with the legacy {@link render } and {@link * renderSync} APIs. Use {@link Options } instead."
+		if got := diagnostics[0].Message.Description; got != want {
+			t.Fatalf("message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("multiline-reason", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+interface Cache {
+  /**
+   * @deprecated This option has no effect. Rspack keeps only one persistent
+   * cache per compiler path.
+   */
+  maxVersions?: number;
+}
+declare const cache: Cache;
+cache.maxVersions;
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{"main.ts": code}, "main.ts", nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
+		}
+		want := "`maxVersions` is deprecated. This option has no effect. Rspack keeps only one persistent\ncache per compiler path."
+		if got := diagnostics[0].Message.Description; got != want {
+			t.Fatalf("message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("blank-line-in-reason", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+/**
+ * @deprecated First line.
+ *
+ * Third line.
+ */
+type BlankLine = string;
+const value: BlankLine = '';
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{"main.ts": code}, "main.ts", nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
+		}
+		want := "`BlankLine` is deprecated. First line.\n\nThird line."
+		if got := diagnostics[0].Message.Description; got != want {
+			t.Fatalf("message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("crlf-reason", func(t *testing.T) {
+		t.Parallel()
+		code := strings.ReplaceAll(`/**
+ * @deprecated First line.
+ * Second line.
+ */
+type CRLF = string;
+const value: CRLF = '';
+`, "\n", "\r\n")
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{"main.ts": code}, "main.ts", nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
+		}
+		want := "`CRLF` is deprecated. First line.\r\nSecond line."
+		if got := diagnostics[0].Message.Description; got != want {
+			t.Fatalf("message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("jsdoc-link-display-parts", func(t *testing.T) {
+		t.Parallel()
+		const code = `
+class NewThing {}
+/** @deprecated Use {@link NewThing}. */ class OldResolved {}
+/** @deprecated Use {@link MissingThing}. */ class OldMissing {}
+/** @deprecated Use {@link NewThing | replacement}. */ class OldLabel {}
+/** @deprecated Use {@linkcode NewThing}. */ class OldCode {}
+/** @deprecated Use {@linkplain NewThing label}. */ class OldPlain {}
+/** @deprecated See {@link https://example.com | docs}. */ class OldURL {}
+/**
+ * @deprecated Use {@link
+ * NewThing}.
+ */
+class OldMultiline {}
+/** @deprecated A {@link NewThing<T>} B. */ class GenericResolved {}
+/** @deprecated A {@link Missing<T>} B. */ class GenericMissing {}
+/** @deprecated A {@link NewThing() | call label} B. */ class CallResolved {}
+/** @deprecated A {@link Missing() | call label} B. */ class CallMissing {}
+/**
+ * @deprecated A {@link NewThing |
+ * label} B.
+ */
+class WrappedLabel {}
+new OldResolved();
+new OldMissing();
+new OldLabel();
+new OldCode();
+new OldPlain();
+new OldURL();
+new OldMultiline();
+new GenericResolved();
+new GenericMissing();
+new CallResolved();
+new CallMissing();
+new WrappedLabel();
+`
+		diagnostics := runNoDeprecatedDiagnosticsForFiles(t, map[string]string{"main.ts": code}, "main.ts", nil)
+		if len(diagnostics) != 12 {
+			t.Fatalf("expected 12 diagnostics, got %#v", diagnostics)
+		}
+		want := []string{
+			"`OldResolved` is deprecated. Use {@link NewThing}.",
+			"`OldMissing` is deprecated. Use {@link MissingThing }.",
+			"`OldLabel` is deprecated. Use {@link NewThing" + "replacement}.",
+			"`OldCode` is deprecated. Use {@linkcode NewThing}.",
+			"`OldPlain` is deprecated. Use {@linkplain NewThing" + "label}.",
+			"`OldURL` is deprecated. See {@link https://example.com docs}.",
+			"`OldMultiline` is deprecated. Use {@link * NewThing}.",
+			"`GenericResolved` is deprecated. A {@link NewThing<T>} B.",
+			"`GenericMissing` is deprecated. A {@link Missing<T>} B.",
+			"`CallResolved` is deprecated. A {@link NewThing() | call label} B.",
+			"`CallMissing` is deprecated. A {@link Missing() | call label} B.",
+			"`WrappedLabel` is deprecated. A {@link NewThing} * label} B.",
+		}
+		for index, diagnostic := range diagnostics {
+			if got := diagnostic.Message.Description; got != want[index] {
+				t.Fatalf("diagnostic %d message = %q, want %q", index, got, want[index])
+			}
+		}
+	})
 }
 
 func TestNoDeprecatedRespectsScopedLineDisables(t *testing.T) {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-deprecated.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-deprecated.test.ts.snap
@@ -1165,7 +1165,7 @@ exports[`no-deprecated > invalid 38`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`a.b\` is deprecated.",
+      "message": "\`b\` is deprecated.",
       "messageId": "deprecated",
       "range": {
         "end": {
@@ -1307,7 +1307,7 @@ exports[`no-deprecated > invalid 42`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`a.b\` is deprecated.",
+      "message": "\`b\` is deprecated.",
       "messageId": "deprecated",
       "range": {
         "end": {
@@ -1343,7 +1343,7 @@ exports[`no-deprecated > invalid 43`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`a.b\` is deprecated. Use b(value).",
+      "message": "\`b\` is deprecated. Use b(value).",
       "messageId": "deprecatedWithReason",
       "range": {
         "end": {
@@ -1751,7 +1751,7 @@ exports[`no-deprecated > invalid 55`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`A.b\` is deprecated.",
+      "message": "\`b\` is deprecated.",
       "messageId": "deprecated",
       "range": {
         "end": {
@@ -1785,7 +1785,7 @@ exports[`no-deprecated > invalid 56`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`assert.fail\` is deprecated. since v10.0.0 - use fail([message]) or other assert functions instead.",
+      "message": "\`fail\` is deprecated. since v10.0.0 - use fail([message]) or other assert functions instead.",
       "messageId": "deprecatedWithReason",
       "range": {
         "end": {
@@ -3069,7 +3069,7 @@ exports[`no-deprecated > invalid 96`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`imported.deprecatedFunctionWithOverloads\` is deprecated.",
+      "message": "\`deprecatedFunctionWithOverloads\` is deprecated.",
       "messageId": "deprecated",
       "range": {
         "end": {
@@ -3339,7 +3339,7 @@ exports[`no-deprecated > invalid 105`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`imported.ClassWithDeprecatedConstructor\` is deprecated.",
+      "message": "\`ClassWithDeprecatedConstructor\` is deprecated.",
       "messageId": "deprecated",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/no-deprecated` symbol and call-signature resolution with upstream before using source-wide fallbacks, removing the audited false positives around same-named symbols, overloads, re-exports, dynamic imports, function-valued properties, and computed keys.
- Match upstream diagnostic text exactly: report the referenced identifier instead of a qualified member path, preserve JSDoc line endings, and serialize `{@link}`, `{@linkcode}`, and `{@linkplain}` display parts with TypeScript's observable spacing.
- Reuse resolved deprecation results, prefer parsed JSDoc over source rescans, and keep a single-text-node fast path to reduce rule-local work and allocations.

### Exact upstream comparison

Pinned upstream: ESLint 10.8.0, `@typescript-eslint/parser` / `eslint-plugin` 8.65.0, and TypeScript 5.9.3.

| Project | Revision | Files | Upstream | rslint | Missing | Extra | Field/message mismatches |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| rsbuild | `93ff4e72` | 1,112 | 17 | 17 | 0 | 0 | 0 |
| rspack | `513f5af6` | 372 | 30 | 30 | 0 | 0 | 0 |

The comparison covers rule name, severity, file, start/end location, and the complete message. Both rslint runs were repeated and produced identical diagnostics. Within these audited repositories there are no remaining false positives, false negatives, or message differences.

The three previously remaining differences were:

- rsbuild's `LegacySassOptions`: JSDoc links were omitted from the reason.
- rspack's `buffer.slice`: rslint reported `` `buffer.slice` `` instead of upstream's `` `slice` ``.
- rspack's `maxVersions`: rslint flattened `persistent\ncache` to a space.

All three now match upstream exactly.

### Validation

- Official typescript-eslint `no-deprecated` valid/invalid corpus: 2/2 groups passed, including message IDs and snapshots.
- Added adversarial coverage for aliases, qualified members, LF/CRLF/blank-line reasons, resolved and unresolved JSDoc links, URLs, labels, generics, call suffixes, and wrapped links.
- `go test ./internal/plugins/typescript/rules/no_deprecated -count=3`
- `pnpm --dir packages/rslint-test-tools exec rstest run --testTimeout=10000 tests/typescript-eslint/rules/no-deprecated.test.ts`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/plugins/typescript/rules/no_deprecated`
- `git diff --check`
- VS Code one-rule smoke: 10,501 discovered files, 301 rule-eligible files, 16 warnings, 395.2 ms native listener time; no crash, hang, or residual process.

### Go benchmark

Apple M5 Max, five samples per case, `-benchtime=500ms`; CPU idle was 87.32% before and 73.80% after.

Command: `go test -run '^$' -bench '^BenchmarkNoDeprecated$' -benchmem -benchtime=500ms -count=5 ./internal/plugins/typescript/rules/no_deprecated`

| Case | Before ns/op | After ns/op | Time | Before → after B/op | Before → after allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| deprecated member | 85,366.0 | 75,106.6 | -12.0% | 53,824 → 46,216 | 1,067 → 749 |
| no match | 57,796.0 | 44,856.4 | -22.4% | 7,720 → 7,792 | 95 → 97 |
| selected nondeprecated overload | 66,477.6 | 64,960.4 | -2.3% | 8,344 → 8,416 | 97 → 99 |
| dynamic import binding | 63,457.8 | 42,074.4 | -33.7% | 9,240 → 9,336 | 168 → 115 |
| allowed deprecated member | 78,465.4 | 73,908.6 | -5.8% | 25,224 → 11,472 | 930 → 356 |

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; no public API or configuration changed).
