### PR TITLE
fix: align consistent-indexed-object-style with upstream

### DIFF
--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
@@ -2,9 +2,13 @@ package consistent_indexed_object_style
 
 import (
 	_ "embed"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 //go:embed consistent_indexed_object_style.schema.json
@@ -14,7 +18,26 @@ type ConsistentIndexedObjectStyleOptions struct {
 	Style string `json:"style"`
 }
 
-// ConsistentIndexedObjectStyleRule enforces consistent usage of type imports
+var (
+	preferRecordMessage = rule.RuleMessage{
+		Id:          "preferRecord",
+		Description: "A record is preferred over an index signature.",
+	}
+	preferRecordSuggestionMessage = rule.RuleMessage{
+		Id:          "preferRecordSuggestion",
+		Description: "Change into a record instead of an index signature.",
+	}
+	preferIndexSignatureMessage = rule.RuleMessage{
+		Id:          "preferIndexSignature",
+		Description: "An index signature is preferred over a record.",
+	}
+	preferIndexSignatureSuggestionMessage = rule.RuleMessage{
+		Id:          "preferIndexSignatureSuggestion",
+		Description: "Change into an index signature instead of a record.",
+	}
+)
+
+// ConsistentIndexedObjectStyleRule requires a consistent indexed-object syntax.
 var ConsistentIndexedObjectStyleRule = rule.CreateRule(rule.Rule{
 	Name:   "consistent-indexed-object-style",
 	Schema: rule.NewSchema(schemaJSON),
@@ -22,434 +45,751 @@ var ConsistentIndexedObjectStyleRule = rule.CreateRule(rule.Rule{
 })
 
 func parseOptions(options []any) ConsistentIndexedObjectStyleOptions {
-	opts := ConsistentIndexedObjectStyleOptions{
-		Style: "record", // default
-	}
-	if len(options) == 0 {
-		return opts
-	}
-	if style, ok := options[0].(string); ok {
-		opts.Style = style
+	opts := ConsistentIndexedObjectStyleOptions{Style: "record"}
+	if len(options) > 0 {
+		if style, ok := options[0].(string); ok {
+			opts.Style = style
+		}
 	}
 	return opts
 }
 
 func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
-	opts := parseOptions(options)
+	if parseOptions(options).Style == "index-signature" {
+		return rule.RuleListeners{
+			ast.KindTypeReference: func(node *ast.Node) {
+				reportRecordAsIndexSignature(&ctx, node)
+			},
+		}
+	}
 
+	circularReferences := circularReferenceAnalyzer{refs: ctx.Refs}
 	return rule.RuleListeners{
-		// Check interfaces with index signatures
 		ast.KindInterfaceDeclaration: func(node *ast.Node) {
-			if opts.Style != "record" {
+			declaration := node.AsInterfaceDeclaration()
+			if declaration == nil || !hasSingleIndexSignatureMember(declaration.Members) {
 				return
 			}
-
-			if node.Kind != ast.KindInterfaceDeclaration {
-				return
+			indexSignature := declaration.Members.Nodes[0]
+			keyType, valueType, ok := indexSignatureTypes(indexSignature)
+			if ok {
+				reportInterfaceAsRecord(&ctx, &circularReferences, node, declaration, indexSignature, keyType, valueType)
 			}
-
-			interfaceDecl := node.AsInterfaceDeclaration()
-			if interfaceDecl == nil {
-				return
-			}
-
-			// Skip if interface extends other types
-			if interfaceDecl.HeritageClauses != nil && len(interfaceDecl.HeritageClauses.Nodes) > 0 {
-				return
-			}
-
-			// Check if interface has exactly one member and it's an index signature
-			if interfaceDecl.Members == nil || len(interfaceDecl.Members.Nodes) != 1 {
-				return
-			}
-
-			member := interfaceDecl.Members.Nodes[0]
-			if member.Kind != ast.KindIndexSignature {
-				return
-			}
-
-			indexSig := member.AsIndexSignatureDeclaration()
-			if indexSig == nil {
-				return
-			}
-
-			// Check for circular references
-			if isDeeplyReferencingType(interfaceDecl.Name(), indexSig.Type) {
-				return
-			}
-
-			// Report violation
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "preferRecord",
-				Description: "A record is preferred over an index signature.",
-			})
 		},
-
-		// Check type literals with index signatures
-		ast.KindTypeLiteral: func(node *ast.Node) {
-			if opts.Style != "record" {
-				return
-			}
-
-			if node.Kind != ast.KindTypeLiteral {
-				return
-			}
-
-			typeLiteral := node.AsTypeLiteralNode()
-			if typeLiteral == nil {
-				return
-			}
-
-			// Check if type literal has exactly one member and it's an index signature
-			if typeLiteral.Members == nil || len(typeLiteral.Members.Nodes) != 1 {
-				return
-			}
-
-			member := typeLiteral.Members.Nodes[0]
-			if member.Kind != ast.KindIndexSignature {
-				return
-			}
-
-			indexSig := member.AsIndexSignatureDeclaration()
-			if indexSig == nil {
-				return
-			}
-
-			// Check for circular references - need to find the type alias name
-			if isCircularTypeReference(node, indexSig.Type) {
-				return
-			}
-
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "preferRecord",
-				Description: "A record is preferred over an index signature.",
-			})
-		},
-
-		// Check mapped types
 		ast.KindMappedType: func(node *ast.Node) {
-			if opts.Style != "record" {
-				return
-			}
-
-			if node.Kind != ast.KindMappedType {
-				return
-			}
-
 			mappedType := node.AsMappedTypeNode()
-			if mappedType == nil {
+			if mappedType == nil || mappedType.TypeParameter == nil {
 				return
 			}
-
-			// Check if mapped type can be converted to Record
-			if !canConvertMappedTypeToRecord(mappedType) {
+			typeParameter := mappedType.TypeParameter.AsTypeParameterDeclaration()
+			if typeParameter == nil || typeParameter.Name() == nil || typeParameter.Name().Kind != ast.KindIdentifier ||
+				typeParameter.Constraint == nil {
 				return
 			}
-
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "preferRecord",
-				Description: "A record is preferred over an index signature.",
-			})
+			constraint := typeParameter.Constraint
+			if constraint.Kind == ast.KindTypeOperator {
+				typeOperator := constraint.AsTypeOperatorNode()
+				if typeOperator != nil && typeOperator.Operator == ast.KindKeyOfKeyword {
+					return
+				}
+			}
+			reportMappedTypeAsRecord(&ctx, &circularReferences, node, mappedType, typeParameter, constraint)
 		},
-
-		// Check Record types when in index-signature mode
-		ast.KindTypeReference: func(node *ast.Node) {
-			if opts.Style != "index-signature" {
+		ast.KindTypeLiteral: func(node *ast.Node) {
+			typeLiteral := node.AsTypeLiteralNode()
+			if typeLiteral == nil || !hasSingleIndexSignatureMember(typeLiteral.Members) {
 				return
 			}
-
-			if node.Kind != ast.KindTypeReference {
-				return
+			indexSignature := typeLiteral.Members.Nodes[0]
+			keyType, valueType, ok := indexSignatureTypes(indexSignature)
+			if ok {
+				reportTypeLiteralAsRecord(&ctx, &circularReferences, node, indexSignature, keyType, valueType)
 			}
-
-			typeRef := node.AsTypeReferenceNode()
-			if typeRef == nil {
-				return
-			}
-
-			// Check if this is a Record type reference
-			if !isRecordType(typeRef) {
-				return
-			}
-
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "preferIndexSignature",
-				Description: "An index signature is preferred over a record.",
-			})
 		},
 	}
 }
 
-// isRecordType checks if a type reference is a Record type
-func isRecordType(typeRef *ast.TypeReferenceNode) bool {
-	if typeRef.TypeName == nil {
-		return false
-	}
-
-	if typeRef.TypeName.Kind != ast.KindIdentifier {
-		return false
-	}
-
-	ident := typeRef.TypeName.AsIdentifier()
-	if ident == nil {
-		return false
-	}
-
-	// Check if it's "Record"
-	if ident.Text != "Record" {
-		return false
-	}
-
-	// Must have type arguments
-	if typeRef.TypeArguments == nil || len(typeRef.TypeArguments.Nodes) < 2 {
-		return false
-	}
-
-	// First type argument should be string, number, or symbol
-	firstArg := typeRef.TypeArguments.Nodes[0]
-	return isValidRecordKeyType(firstArg)
+func hasSingleIndexSignatureMember(members *ast.NodeList) bool {
+	return members != nil && len(members.Nodes) == 1 && members.Nodes[0] != nil &&
+		members.Nodes[0].Kind == ast.KindIndexSignature
 }
 
-// isValidRecordKeyType checks if a type is a valid key type for Record
-func isValidRecordKeyType(typeNode *ast.Node) bool {
-	switch typeNode.Kind {
-	case ast.KindStringKeyword, ast.KindNumberKeyword, ast.KindSymbolKeyword:
-		return true
-	case ast.KindLiteralType:
-		return true
-	case ast.KindUnionType:
-		unionType := typeNode.AsUnionTypeNode()
-		if unionType == nil || unionType.Types == nil {
-			return false
+func reportInterfaceAsRecord(
+	ctx *rule.RuleContext,
+	circularReferences *circularReferenceAnalyzer,
+	node *ast.Node,
+	declaration *ast.InterfaceDeclaration,
+	indexSignature *ast.Node,
+	keyType *ast.Node,
+	valueType *ast.Node,
+) {
+	if circularReferences.referencesDeclaration(node, valueType) {
+		return
+	}
+
+	reportRange := interfaceDeclarationRange(ctx.SourceFile, node)
+	safeFix := (declaration.HeritageClauses == nil || len(declaration.HeritageClauses.Nodes) == 0) &&
+		!ast.HasSyntacticModifier(node, ast.ModifierFlagsDefault)
+	reportIndexSignatureAsRecord(
+		ctx,
+		reportRange,
+		indexSignature,
+		keyType,
+		valueType,
+		declaration,
+		";",
+		safeFix,
+	)
+}
+
+func reportTypeLiteralAsRecord(
+	ctx *rule.RuleContext,
+	circularReferences *circularReferenceAnalyzer,
+	node *ast.Node,
+	indexSignature *ast.Node,
+	keyType *ast.Node,
+	valueType *ast.Node,
+) {
+	if canDeeplyReferenceType(valueType.Kind) {
+		if parentDeclaration := findParentTypeAlias(node); parentDeclaration != nil &&
+			circularReferences.referencesDeclaration(parentDeclaration, valueType) {
+			return
 		}
-		// All union members should be valid key types
-		for _, t := range unionType.Types.Nodes {
-			if !isValidRecordKeyType(t) {
-				return false
+	}
+
+	reportIndexSignatureAsRecord(
+		ctx,
+		bracedTypeRange(ctx.SourceFile, node),
+		indexSignature,
+		keyType,
+		valueType,
+		nil,
+		"",
+		true,
+	)
+}
+
+func indexSignatureTypes(indexSignature *ast.Node) (
+	keyType *ast.Node,
+	valueType *ast.Node,
+	ok bool,
+) {
+	declaration := indexSignature.AsIndexSignatureDeclaration()
+	if declaration == nil || declaration.Parameters == nil || len(declaration.Parameters.Nodes) == 0 || declaration.Type == nil {
+		return nil, nil, false
+	}
+	parameter := declaration.Parameters.Nodes[0].AsParameterDeclaration()
+	if parameter == nil || parameter.DotDotDotToken != nil || parameter.Name() == nil ||
+		parameter.Name().Kind != ast.KindIdentifier || parameter.Type == nil {
+		return nil, nil, false
+	}
+	return parameter.Type, declaration.Type, true
+}
+
+func reportIndexSignatureAsRecord(
+	ctx *rule.RuleContext,
+	reportRange core.TextRange,
+	indexSignature *ast.Node,
+	keyType *ast.Node,
+	valueType *ast.Node,
+	interfaceDeclaration *ast.InterfaceDeclaration,
+	postfix string,
+	safeFix bool,
+) {
+	if !safeFix {
+		ctx.ReportRange(reportRange, preferRecordMessage)
+		return
+	}
+
+	keyType = skipParenthesizedType(keyType)
+	valueType = skipParenthesizedType(valueType)
+	ctx.ReportRangeWithDeferredFixesAndSuggestions(
+		reportRange,
+		preferRecordMessage,
+		func() []rule.RuleFix {
+			if hasUnpreservedComments(ctx, reportRange, keyType, valueType) {
+				return nil
 			}
-		}
-		return true
-	}
-	return false
+			return []rule.RuleFix{rule.RuleFixReplaceRange(
+				reportRange,
+				indexSignatureRecordReplacement(ctx, interfaceDeclaration, indexSignature, keyType, valueType, postfix),
+			)}
+		},
+		func() []rule.RuleSuggestion {
+			if !hasUnpreservedComments(ctx, reportRange, keyType, valueType) {
+				return nil
+			}
+			return []rule.RuleSuggestion{{
+				Message: preferRecordSuggestionMessage,
+				FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(
+					reportRange,
+					indexSignatureRecordReplacement(ctx, interfaceDeclaration, indexSignature, keyType, valueType, postfix),
+				)},
+			}}
+		},
+	)
 }
 
-// canConvertMappedTypeToRecord checks if a mapped type can be converted to Record
-func canConvertMappedTypeToRecord(mappedType *ast.MappedTypeNode) bool {
-	// Check if the type parameter constraint is string, number, or symbol
-	if mappedType.TypeParameter == nil {
-		return false
+func indexSignatureRecordReplacement(
+	ctx *rule.RuleContext,
+	interfaceDeclaration *ast.InterfaceDeclaration,
+	indexSignature *ast.Node,
+	keyType *ast.Node,
+	valueType *ast.Node,
+	postfix string,
+) string {
+	key := utils.TrimmedNodeText(ctx.SourceFile, keyType)
+	value := utils.TrimmedNodeText(ctx.SourceFile, valueType)
+	record := "Record<" + key + ", " + value + ">"
+	if ast.HasSyntacticModifier(indexSignature, ast.ModifierFlagsReadonly) {
+		record = "Readonly<" + record + ">"
+	}
+	if interfaceDeclaration == nil {
+		return record + postfix
+	}
+	return interfaceTypeAliasPrefix(ctx.SourceFile, interfaceDeclaration) + record + postfix
+}
+
+func interfaceTypeAliasPrefix(sourceFile *ast.SourceFile, declaration *ast.InterfaceDeclaration) string {
+	var text strings.Builder
+	text.WriteString("type ")
+	text.WriteString(declaration.Name().Text())
+	if declaration.TypeParameters != nil && len(declaration.TypeParameters.Nodes) > 0 {
+		text.WriteByte('<')
+		for index, typeParameter := range declaration.TypeParameters.Nodes {
+			if index > 0 {
+				text.WriteString(", ")
+			}
+			text.WriteString(utils.TrimmedNodeText(sourceFile, typeParameter))
+		}
+		text.WriteByte('>')
+	}
+	text.WriteString(" = ")
+	return text.String()
+}
+
+func interfaceDeclarationRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	nodeRange := utils.TrimNodeTextRange(sourceFile, node)
+	modifiers := node.Modifiers()
+	if modifiers == nil || len(modifiers.Nodes) == 0 {
+		return nodeRange
+	}
+	for _, modifier := range modifiers.Nodes {
+		if modifier.Kind != ast.KindExportKeyword && modifier.Kind != ast.KindDefaultKeyword {
+			return core.NewTextRange(utils.TrimNodeTextRange(sourceFile, modifier).Pos(), node.End())
+		}
+	}
+	if !ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) {
+		return nodeRange
 	}
 
-	// TypeParameter is already a *Node, check if it's a valid type parameter
-	if mappedType.TypeParameter.Kind != ast.KindTypeParameter {
-		return false
+	s := scanner.GetScannerForSourceFile(sourceFile, nodeRange.Pos())
+	for s.TokenStart() < node.End() {
+		if s.Token() == ast.KindInterfaceKeyword {
+			return core.NewTextRange(s.TokenStart(), node.End())
+		}
+		s.Scan()
 	}
+	return nodeRange
+}
 
-	typeParam := mappedType.TypeParameter.AsTypeParameterDeclaration()
-	if typeParam == nil {
-		return false
+func bracedTypeRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	sourceText := sourceFile.Text()
+	start := node.Pos()
+	end := node.End()
+	if start >= 0 && end <= len(sourceText) && start < end {
+		if sourceText[start] == '{' {
+			return core.NewTextRange(start, end)
+		}
+		if start+1 < end && isASCIIWhitespace(sourceText[start]) && sourceText[start+1] == '{' {
+			return core.NewTextRange(start+1, end)
+		}
+		for start < end && isASCIIWhitespace(sourceText[start]) {
+			start++
+		}
+		if start < end && sourceText[start] == '{' {
+			return core.NewTextRange(start, end)
+		}
 	}
+	return utils.TrimNodeTextRange(sourceFile, node)
+}
 
-	// Check constraint
-	if typeParam.Constraint == nil {
-		return false
-	}
-
-	constraint := typeParam.Constraint
-	switch constraint.Kind {
-	case ast.KindStringKeyword, ast.KindNumberKeyword, ast.KindSymbolKeyword:
-		// Valid key types
+func isASCIIWhitespace(character byte) bool {
+	switch character {
+	case ' ', '\t', '\n', '\r', '\f', '\v':
+		return true
 	default:
 		return false
 	}
+}
 
-	// Check if the mapped type references the type parameter in a way that prevents conversion
-	if mappedType.Type != nil && isDeeplyReferencingTypeParam(typeParam.Name(), mappedType.Type) {
-		return false
+func reportMappedTypeAsRecord(
+	ctx *rule.RuleContext,
+	circularReferences *circularReferenceAnalyzer,
+	node *ast.Node,
+	mappedType *ast.MappedTypeNode,
+	typeParameter *ast.TypeParameterDeclaration,
+	constraint *ast.Node,
+) {
+	if mappedTypeReferencesKey(ctx, mappedType, typeParameter) {
+		return
+	}
+	if node.Parent != nil {
+		circularStart := node.Parent
+		if circularStart.Kind == ast.KindTypeAliasDeclaration {
+			circularStart = mappedType.Type
+		}
+		if circularStart != nil && canDeeplyReferenceType(circularStart.Kind) {
+			if parentDeclaration := findParentTypeAlias(node); parentDeclaration != nil &&
+				circularReferences.referencesDeclaration(parentDeclaration, circularStart) {
+				return
+			}
+		}
 	}
 
+	reportRange := bracedTypeRange(ctx.SourceFile, node)
+	if mappedType.ReadonlyToken != nil && mappedType.ReadonlyToken.Kind == ast.KindMinusToken {
+		ctx.ReportRange(reportRange, preferRecordMessage)
+		return
+	}
+
+	constraint = skipParenthesizedType(constraint)
+	valueType := skipParenthesizedType(mappedType.Type)
+	ctx.ReportRangeWithDeferredFixesAndSuggestions(
+		reportRange,
+		preferRecordMessage,
+		func() []rule.RuleFix {
+			if hasUnpreservedComments(ctx, reportRange, constraint, valueType) {
+				return nil
+			}
+			return []rule.RuleFix{rule.RuleFixReplaceRange(
+				reportRange,
+				mappedTypeRecordReplacement(ctx, mappedType, constraint, valueType),
+			)}
+		},
+		func() []rule.RuleSuggestion {
+			if !hasUnpreservedComments(ctx, reportRange, constraint, valueType) {
+				return nil
+			}
+			return []rule.RuleSuggestion{{
+				Message: preferRecordSuggestionMessage,
+				FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(
+					reportRange,
+					mappedTypeRecordReplacement(ctx, mappedType, constraint, valueType),
+				)},
+			}}
+		},
+	)
+}
+
+func mappedTypeRecordReplacement(
+	ctx *rule.RuleContext,
+	mappedType *ast.MappedTypeNode,
+	constraint *ast.Node,
+	valueType *ast.Node,
+) string {
+	key := utils.TrimmedNodeText(ctx.SourceFile, constraint)
+	value := "any"
+	if valueType != nil {
+		value = utils.TrimmedNodeText(ctx.SourceFile, valueType)
+	}
+	record := "Record<" + key + ", " + value + ">"
+	if mappedType.QuestionToken != nil {
+		switch mappedType.QuestionToken.Kind {
+		case ast.KindQuestionToken, ast.KindPlusToken:
+			record = "Partial<" + record + ">"
+		case ast.KindMinusToken:
+			record = "Required<" + record + ">"
+		}
+	}
+	if mappedType.ReadonlyToken != nil {
+		switch mappedType.ReadonlyToken.Kind {
+		case ast.KindReadonlyKeyword, ast.KindPlusToken:
+			record = "Readonly<" + record + ">"
+		}
+	}
+	return record
+}
+
+func mappedTypeReferencesKey(ctx *rule.RuleContext, mappedType *ast.MappedTypeNode, typeParameter *ast.TypeParameterDeclaration) bool {
+	target := mappedType.TypeParameter.Symbol()
+	name := typeParameter.Name().Text()
+	return subtreeReferencesSymbol(ctx, mappedType.NameType, target, name) ||
+		subtreeReferencesSymbol(ctx, mappedType.Type, target, name)
+}
+
+func subtreeReferencesSymbol(ctx *rule.RuleContext, node *ast.Node, target *ast.Symbol, fallbackName string) bool {
+	if node == nil || isIdentifierFreeType(node.Kind) {
+		return false
+	}
+	sourceText := ctx.SourceFile.Text()
+	if node.Pos() >= 0 && node.End() <= len(sourceText) && node.Pos() <= node.End() {
+		nodeText := sourceText[node.Pos():node.End()]
+		if !strings.Contains(nodeText, "\\") && !strings.Contains(nodeText, fallbackName) {
+			return false
+		}
+	}
+	return subtreeReferencesSymbolWorker(ctx.Refs, node, target, fallbackName)
+}
+
+func isIdentifierFreeType(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindAnyKeyword,
+		ast.KindBigIntKeyword,
+		ast.KindBooleanKeyword,
+		ast.KindNeverKeyword,
+		ast.KindNumberKeyword,
+		ast.KindObjectKeyword,
+		ast.KindStringKeyword,
+		ast.KindSymbolKeyword,
+		ast.KindUndefinedKeyword,
+		ast.KindUnknownKeyword,
+		ast.KindVoidKeyword:
+		return true
+	default:
+		return false
+	}
+}
+
+func subtreeReferencesSymbolWorker(refs *rule.RefStore, node *ast.Node, target *ast.Symbol, fallbackName string) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindIdentifier && node.Text() == fallbackName {
+		if refs == nil {
+			return true
+		}
+		if symbol := refs.ResolveInFile(node); symbol != nil && symbol == target {
+			return true
+		}
+	}
+	found := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		if subtreeReferencesSymbolWorker(refs, child, target, fallbackName) {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func reportRecordAsIndexSignature(ctx *rule.RuleContext, node *ast.Node) {
+	typeReference := node.AsTypeReferenceNode()
+	if typeReference == nil || typeReference.TypeName == nil || typeReference.TypeName.Kind != ast.KindIdentifier ||
+		typeReference.TypeName.Text() != "Record" || typeReference.TypeArguments == nil || len(typeReference.TypeArguments.Nodes) != 2 {
+		return
+	}
+
+	keyType := skipParenthesizedType(typeReference.TypeArguments.Nodes[0])
+	valueType := skipParenthesizedType(typeReference.TypeArguments.Nodes[1])
+	reportRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	ctx.ReportRangeWithDeferredFixesAndSuggestions(
+		reportRange,
+		preferIndexSignatureMessage,
+		func() []rule.RuleFix {
+			if !isAutofixableRecordKey(keyType.Kind) || hasUnpreservedComments(ctx, reportRange, keyType, valueType) {
+				return nil
+			}
+			return []rule.RuleFix{rule.RuleFixReplaceRange(
+				reportRange,
+				recordIndexSignatureReplacement(ctx, keyType, valueType),
+			)}
+		},
+		func() []rule.RuleSuggestion {
+			if isAutofixableRecordKey(keyType.Kind) && !hasUnpreservedComments(ctx, reportRange, keyType, valueType) {
+				return nil
+			}
+			return []rule.RuleSuggestion{{
+				Message: preferIndexSignatureSuggestionMessage,
+				FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(
+					reportRange,
+					recordIndexSignatureReplacement(ctx, keyType, valueType),
+				)},
+			}}
+		},
+	)
+}
+
+func isAutofixableRecordKey(kind ast.Kind) bool {
+	return kind == ast.KindStringKeyword || kind == ast.KindNumberKeyword || kind == ast.KindSymbolKeyword
+}
+
+func recordIndexSignatureReplacement(ctx *rule.RuleContext, keyType *ast.Node, valueType *ast.Node) string {
+	key := utils.TrimmedNodeText(ctx.SourceFile, keyType)
+	value := utils.TrimmedNodeText(ctx.SourceFile, valueType)
+	return "{ [key: " + key + "]: " + value + " }"
+}
+
+func hasUnpreservedComments(ctx *rule.RuleContext, nodeRange core.TextRange, preserved ...*ast.Node) bool {
+	if ctx.Comments == nil {
+		return false
+	}
+	for _, comment := range ctx.Comments.All() {
+		if comment.End() <= nodeRange.Pos() {
+			continue
+		}
+		if comment.Pos() >= nodeRange.End() {
+			break
+		}
+		if comment.Pos() < nodeRange.Pos() || comment.End() > nodeRange.End() {
+			continue
+		}
+		isPreserved := false
+		for _, target := range preserved {
+			if target == nil {
+				continue
+			}
+			targetRange := utils.TrimNodeTextRange(ctx.SourceFile, target)
+			if comment.Pos() >= targetRange.Pos() && comment.End() <= targetRange.End() {
+				isPreserved = true
+				break
+			}
+		}
+		if !isPreserved {
+			return true
+		}
+	}
+	return false
+}
+
+func skipParenthesizedType(node *ast.Node) *ast.Node {
+	for node != nil && node.Kind == ast.KindParenthesizedType {
+		parenthesizedType := node.AsParenthesizedTypeNode()
+		if parenthesizedType == nil || parenthesizedType.Type == nil {
+			break
+		}
+		node = parenthesizedType.Type
+	}
+	return node
+}
+
+func findParentTypeAlias(node *ast.Node) *ast.Node {
+	for current := node; current != nil && current.Parent != nil; {
+		parent := current.Parent
+		if parent.Kind == ast.KindTypeAliasDeclaration {
+			return parent
+		}
+		if isTypeAnnotationBoundary(parent) {
+			return nil
+		}
+		current = parent
+	}
+	return nil
+}
+
+func isTypeAnnotationBoundary(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindCallSignature,
+		ast.KindConstructSignature,
+		ast.KindConstructorType,
+		ast.KindFunctionType,
+		ast.KindIndexSignature,
+		ast.KindMethodSignature,
+		ast.KindParameter,
+		ast.KindPropertySignature:
+		return true
+	default:
+		return false
+	}
+}
+
+type circularReferenceAnalyzer struct {
+	refs *rule.RefStore
+}
+
+func (a *circularReferenceAnalyzer) referencesDeclaration(targetDeclaration *ast.Node, start *ast.Node) bool {
+	if start == nil || !canDeeplyReferenceType(start.Kind) || targetDeclaration == nil || targetDeclaration.Name() == nil ||
+		targetDeclaration.Name().Kind != ast.KindIdentifier {
+		return false
+	}
+	checker := circularReferenceChecker{
+		refs:              a.refs,
+		targetDeclaration: targetDeclaration,
+		targetSymbol:      circularTargetSymbol(targetDeclaration),
+		targetName:        targetDeclaration.Name().Text(),
+	}
+	return checker.check(start)
+}
+
+func circularTargetSymbol(declaration *ast.Node) *ast.Symbol {
+	var typeParameters *ast.NodeList
+	switch declaration.Kind {
+	case ast.KindTypeAliasDeclaration:
+		if typed := declaration.AsTypeAliasDeclaration(); typed != nil {
+			typeParameters = typed.TypeParameters
+		}
+	case ast.KindInterfaceDeclaration:
+		if typed := declaration.AsInterfaceDeclaration(); typed != nil {
+			typeParameters = typed.TypeParameters
+		}
+	}
+	if typeParameters != nil {
+		declarationName := declaration.Name().Text()
+		for _, parameter := range typeParameters.Nodes {
+			if name := parameter.Name(); name != nil && name.Kind == ast.KindIdentifier && name.Text() == declarationName {
+				return parameter.Symbol()
+			}
+		}
+	}
+	return declaration.Symbol()
+}
+
+func canDeeplyReferenceType(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindIdentifier,
+		ast.KindTypeLiteral,
+		ast.KindTypeAliasDeclaration,
+		ast.KindIndexedAccessType,
+		ast.KindMappedType,
+		ast.KindConditionalType,
+		ast.KindUnionType,
+		ast.KindIntersectionType,
+		ast.KindInterfaceDeclaration,
+		ast.KindIndexSignature,
+		ast.KindTypeReference,
+		ast.KindParenthesizedType:
+		return true
+	default:
+		return false
+	}
+}
+
+type circularReferenceChecker struct {
+	refs              *rule.RefStore
+	targetDeclaration *ast.Node
+	targetSymbol      *ast.Symbol
+	targetName        string
+	visitedSmall      [8]*ast.Node
+	visitedCount      int
+	visitedLarge      map[*ast.Node]struct{}
+}
+
+func (c *circularReferenceChecker) check(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return c.checkIdentifier(node)
+	case ast.KindTypeLiteral:
+		typeLiteral := node.AsTypeLiteralNode()
+		return typeLiteral != nil && c.checkNodes(typeLiteral.Members)
+	case ast.KindTypeAliasDeclaration:
+		declaration := node.AsTypeAliasDeclaration()
+		return declaration != nil && c.check(declaration.Type)
+	case ast.KindIndexedAccessType:
+		indexedAccessType := node.AsIndexedAccessTypeNode()
+		return indexedAccessType != nil && (c.check(indexedAccessType.IndexType) || c.check(indexedAccessType.ObjectType))
+	case ast.KindMappedType:
+		mappedType := node.AsMappedTypeNode()
+		return mappedType != nil && c.check(mappedType.Type)
+	case ast.KindConditionalType:
+		conditionalType := node.AsConditionalTypeNode()
+		return conditionalType != nil &&
+			(c.check(conditionalType.CheckType) ||
+				c.check(conditionalType.ExtendsType) ||
+				c.check(conditionalType.FalseType) ||
+				c.check(conditionalType.TrueType))
+	case ast.KindUnionType:
+		unionType := node.AsUnionTypeNode()
+		return unionType != nil && c.checkNodes(unionType.Types)
+	case ast.KindIntersectionType:
+		intersectionType := node.AsIntersectionTypeNode()
+		return intersectionType != nil && c.checkNodes(intersectionType.Types)
+	case ast.KindInterfaceDeclaration:
+		declaration := node.AsInterfaceDeclaration()
+		return declaration != nil && c.checkNodes(declaration.Members)
+	case ast.KindIndexSignature:
+		indexSignature := node.AsIndexSignatureDeclaration()
+		return indexSignature != nil && c.check(indexSignature.Type)
+	case ast.KindTypeReference:
+		typeReference := node.AsTypeReferenceNode()
+		return typeReference != nil &&
+			(c.check(typeReference.TypeName) || c.checkNodes(typeReference.TypeArguments))
+	case ast.KindParenthesizedType:
+		parenthesizedType := node.AsParenthesizedTypeNode()
+		return parenthesizedType != nil && c.check(parenthesizedType.Type)
+	default:
+		return false
+	}
+}
+
+func (c *circularReferenceChecker) checkNodes(nodes *ast.NodeList) bool {
+	if nodes == nil {
+		return false
+	}
+	for _, node := range nodes.Nodes {
+		if c.check(node) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *circularReferenceChecker) checkIdentifier(identifier *ast.Node) bool {
+	var symbol *ast.Symbol
+	if c.refs != nil {
+		symbol = c.refs.ResolveInFile(identifier)
+	}
+	if symbol == nil {
+		return identifier.Text() == c.targetName
+	}
+	if symbol == c.targetSymbol || symbolDeclaresNode(symbol, c.targetDeclaration) {
+		return true
+	}
+
+	for _, declaration := range symbol.Declarations {
+		if declaration.Kind != ast.KindTypeAliasDeclaration && declaration.Kind != ast.KindInterfaceDeclaration {
+			continue
+		}
+		if !c.markDeclarationVisited(declaration) {
+			continue
+		}
+		if c.check(declaration) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *circularReferenceChecker) markDeclarationVisited(declaration *ast.Node) bool {
+	for index := 0; index < c.visitedCount && index < len(c.visitedSmall); index++ {
+		if c.visitedSmall[index] == declaration {
+			return false
+		}
+	}
+	if c.visitedLarge != nil {
+		if _, seen := c.visitedLarge[declaration]; seen {
+			return false
+		}
+		c.visitedLarge[declaration] = struct{}{}
+		c.visitedCount++
+		return true
+	}
+	if c.visitedCount < len(c.visitedSmall) {
+		c.visitedSmall[c.visitedCount] = declaration
+		c.visitedCount++
+		return true
+	}
+
+	c.visitedLarge = make(map[*ast.Node]struct{}, len(c.visitedSmall)*2)
+	for _, visited := range c.visitedSmall {
+		c.visitedLarge[visited] = struct{}{}
+	}
+	c.visitedLarge[declaration] = struct{}{}
+	c.visitedCount++
 	return true
 }
 
-// isDeeplyReferencingType checks if a type deeply references another type (circular reference)
-func isDeeplyReferencingType(name *ast.Node, typeNode *ast.Node) bool {
-	if name == nil || typeNode == nil {
+func symbolDeclaresNode(symbol *ast.Symbol, declaration *ast.Node) bool {
+	if symbol == nil || declaration == nil {
 		return false
 	}
-
-	nameIdent := name.AsIdentifier()
-	if nameIdent == nil {
-		return false
-	}
-
-	return checkTypeReference(nameIdent.Text, typeNode)
-}
-
-// isDeeplyReferencingTypeParam checks if a type references a type parameter
-func isDeeplyReferencingTypeParam(name *ast.Node, typeNode *ast.Node) bool {
-	if name == nil || typeNode == nil {
-		return false
-	}
-
-	nameIdent := name.AsIdentifier()
-	if nameIdent == nil {
-		return false
-	}
-
-	return checkTypeReference(nameIdent.Text, typeNode)
-}
-
-// checkTypeReference recursively checks if a type references a given identifier
-func checkTypeReference(targetName string, typeNode *ast.Node) bool {
-	if typeNode == nil {
-		return false
-	}
-
-	switch typeNode.Kind {
-	case ast.KindTypeReference:
-		typeRef := typeNode.AsTypeReferenceNode()
-		if typeRef != nil && typeRef.TypeName != nil {
-			if typeRef.TypeName.Kind == ast.KindIdentifier {
-				ident := typeRef.TypeName.AsIdentifier()
-				if ident != nil && ident.Text == targetName {
-					return true
-				}
-			}
-			// Check type arguments
-			if typeRef.TypeArguments != nil {
-				for _, arg := range typeRef.TypeArguments.Nodes {
-					if checkTypeReference(targetName, arg) {
-						return true
-					}
-				}
-			}
-		}
-
-	case ast.KindArrayType:
-		arrayType := typeNode.AsArrayTypeNode()
-		if arrayType != nil && arrayType.ElementType != nil {
-			return checkTypeReference(targetName, arrayType.ElementType)
-		}
-
-	case ast.KindUnionType:
-		unionType := typeNode.AsUnionTypeNode()
-		if unionType != nil && unionType.Types != nil {
-			for _, t := range unionType.Types.Nodes {
-				if checkTypeReference(targetName, t) {
-					return true
-				}
-			}
-		}
-
-	case ast.KindIntersectionType:
-		intersectionType := typeNode.AsIntersectionTypeNode()
-		if intersectionType != nil && intersectionType.Types != nil {
-			for _, t := range intersectionType.Types.Nodes {
-				if checkTypeReference(targetName, t) {
-					return true
-				}
-			}
-		}
-
-	case ast.KindParenthesizedType:
-		parenType := typeNode.AsParenthesizedTypeNode()
-		if parenType != nil && parenType.Type != nil {
-			return checkTypeReference(targetName, parenType.Type)
-		}
-
-	case ast.KindTupleType:
-		tupleType := typeNode.AsTupleTypeNode()
-		if tupleType != nil && tupleType.Elements != nil {
-			for _, elem := range tupleType.Elements.Nodes {
-				if checkTypeReference(targetName, elem) {
-					return true
-				}
-			}
-		}
-
-	case ast.KindTypeLiteral:
-		typeLiteral := typeNode.AsTypeLiteralNode()
-		if typeLiteral != nil && typeLiteral.Members != nil {
-			for _, member := range typeLiteral.Members.Nodes {
-				if checkMemberReference(targetName, member) {
-					return true
-				}
-			}
-		}
-
-	case ast.KindFunctionType, ast.KindConstructorType:
-		// For function/constructor types, check parameters and return type
-		if typeNode.Kind == ast.KindFunctionType {
-			funcType := typeNode.AsFunctionTypeNode()
-			if funcType != nil {
-				if funcType.Type != nil && checkTypeReference(targetName, funcType.Type) {
-					return true
-				}
-				if funcType.Parameters != nil {
-					for _, param := range funcType.Parameters.Nodes {
-						paramDecl := param.AsParameterDeclaration()
-						if paramDecl != nil && paramDecl.Type != nil {
-							if checkTypeReference(targetName, paramDecl.Type) {
-								return true
-							}
-						}
-					}
-				}
-			}
+	for _, candidate := range symbol.Declarations {
+		if candidate == declaration {
+			return true
 		}
 	}
-
-	return false
-}
-
-// checkMemberReference checks if a type member references a given identifier
-func checkMemberReference(targetName string, member *ast.Node) bool {
-	if member == nil {
-		return false
-	}
-
-	switch member.Kind {
-	case ast.KindPropertySignature:
-		propSig := member.AsPropertySignatureDeclaration()
-		if propSig != nil && propSig.Type != nil {
-			return checkTypeReference(targetName, propSig.Type)
-		}
-
-	case ast.KindMethodSignature:
-		methodSig := member.AsMethodSignatureDeclaration()
-		if methodSig != nil && methodSig.Type != nil {
-			return checkTypeReference(targetName, methodSig.Type)
-		}
-
-	case ast.KindIndexSignature:
-		indexSig := member.AsIndexSignatureDeclaration()
-		if indexSig != nil && indexSig.Type != nil {
-			return checkTypeReference(targetName, indexSig.Type)
-		}
-	}
-
-	return false
-}
-
-// isCircularTypeReference checks if a type literal in a type alias has a circular reference
-func isCircularTypeReference(typeLiteralNode *ast.Node, valueType *ast.Node) bool {
-	if typeLiteralNode == nil || valueType == nil {
-		return false
-	}
-
-	// Walk up the AST to find the type alias declaration
-	parent := typeLiteralNode.Parent
-	for parent != nil {
-		if parent.Kind == ast.KindTypeAliasDeclaration {
-			typeAlias := parent.AsTypeAliasDeclaration()
-			if typeAlias != nil && typeAlias.Name() != nil {
-				// Check if the value type references the type alias name
-				return isDeeplyReferencingType(typeAlias.Name(), valueType)
-			}
-			break
-		}
-		parent = parent.Parent
-	}
-
 	return false
 }

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style_test.go
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style_test.go
@@ -1,274 +1,538 @@
 package consistent_indexed_object_style
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
 func TestConsistentIndexedObjectStyleRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ConsistentIndexedObjectStyleRule, []rule_tester.ValidTestCase{
-		// Default mode (record style)
-		{Code: "type Foo = Record<string, any>;"},
+		// Ordinary non-matches.
 		{Code: "type Foo = Record<string, unknown>;"},
-		{Code: "type Foo = Record<number, any>;"},
-		{Code: "type Foo = Record<symbol, any>;"},
-		{Code: "type Foo = Readonly<Record<string, any>>;"},
-		{Code: "type Foo = Partial<Record<string, any>>;"},
-		{Code: "type Foo = { [key: string]: any; bar: string };"},
-		{Code: "type Foo = { bar: string; [key: string]: any };"},
-		{Code: "type Foo = {};"},
-		{Code: "interface Foo {}"},
-		{Code: "interface Foo { bar: string; }"},
-		{Code: "interface Foo { [key: string]: any; bar: string; }"},
-		{Code: "interface Foo { bar: string; [key: string]: any; }"},
-		{Code: "interface Foo extends Bar { [key: string]: any; }"},
+		{Code: "type Foo = { [key: string]: unknown; value: unknown };"},
+		{Code: "interface Foo { [key: string]: unknown; value: unknown }"},
+		{Code: "interface Foo { [key: string] }"},
+		{Code: "interface Foo { [...key: string]: unknown }"},
 
-		// Empty interfaces and types
-		{Code: "type Empty = {};"},
-		{Code: "interface Empty {}"},
+		// Direct circular references through every upstream-recursed type shape.
+		{Code: "type Foo = { [key: string]: Foo };"},
+		{Code: "type Foo = { [key: string]: string | Foo };"},
+		{Code: "interface Foo { [key: string]: Foo & {} }"},
+		{Code: "interface Foo<T> { [key: string]: Foo<T> extends T ? string : number }"},
+		{Code: "interface Foo { [key: string]: Foo[number] }"},
+		{Code: "interface Foo { [key: string]: Array<Foo> }"},
+		{Code: "type Foo = { [K in string]: Foo };"},
+		// Upstream resolves a same-named declaration type parameter as the circular target.
+		{Code: "type Foo<Foo> = { [key: string]: Foo };"},
+		{Code: "interface Foo<Foo> { [key: string]: Foo }"},
 
-		// Mixed properties with index signatures (valid in record mode)
-		{Code: "type Foo = { a: string; [key: string]: any };"},
-		{Code: "interface Foo { a: string; [key: string]: any; }"},
+		// Real-user circular graphs from upstream #7148/#7863 and the rspack audit.
+		{Code: `
+type Tree1 = { [key: string]: number | Tree2 };
+type Tree2 = { [key: string]: number | Tree1 };
+`},
+		{Code: `
+type JsonPrimitive = string | number | boolean | null;
+type JsonArray = JsonValue[];
+type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+type JsonObject = { [key: string]: JsonValue };
+`},
+		{Code: `
+type Link0 = Link1;
+type Link1 = Link2;
+type Link2 = Link3;
+type Link3 = Link4;
+type Link4 = Link5;
+type Link5 = Link6;
+type Link6 = Link7;
+type Link7 = Link8;
+type Link8 = Foo;
+type Foo = { [key: string]: Link0 };
+`},
+		{Code: `
+type ExampleUnion = boolean | number;
+type ExampleRoot = ExampleUnion | ExampleObject;
+interface ExampleObject { [key: string]: ExampleRoot }
+`},
+		{Code: `
+type JsonValueTypes = null | string | number | boolean | JsonObjectTypes | JsonValueTypes[];
+type JsonObjectTypes = { [index: string]: JsonValueTypes } & {
+  [index: string]: undefined | null | string | number | boolean | JsonObjectTypes | JsonValueTypes[];
+};
+`},
+		{Code: `
+type JsonPrimitive = string | number | boolean | null;
+type JsonArray = JsonValue[];
+type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+type JsonObject = { [Key in string]: JsonValue } & {
+  [Key in string]?: JsonValue | undefined;
+};
+`},
 
-		// Function signatures with index signature parameters
-		{Code: "function foo(arg: { [key: string]: any; bar: string }) {}"},
-		{Code: "const foo = (arg: { [key: string]: any; bar: string }) => {};"},
-
-		// Generic interfaces with index signatures and other properties
-		{Code: "interface Foo<T> { [key: string]: T; bar: T; }"},
-
-		// Circular type references (should not convert)
-		{Code: "interface Foo { [key: string]: Foo; }"},
-		{Code: "interface Foo { [key: string]: Foo | string; }"},
-		{Code: "interface Foo { [key: string]: Foo[] | string; }"},
-		{Code: "type Foo = { [key: string]: Foo; }"},
-
-		// Mapped types that reference the key
-		{Code: "type Foo<T extends string> = { [K in T]: K };"},
-
-		// Index-signature mode
-		{Code: "type Foo = { [key: string]: any };", Options: "index-signature"},
-		{Code: "type Foo = { [key: number]: any };", Options: "index-signature"},
-		{Code: "interface Foo { [key: string]: any; }", Options: "index-signature"},
-		{Code: "type Foo = { readonly [key: string]: any };", Options: "index-signature"},
-		{Code: "type Foo<T> = { [K in string]: T };", Options: "index-signature"},
-		{Code: "type Foo = {};", Options: "index-signature"},
-		{Code: "interface Foo {}", Options: "index-signature"},
-
-		// Non-Record types in index-signature mode
-		{Code: "type Foo = Map<string, any>;", Options: "index-signature"},
-		{Code: "type Foo = Array<string>;", Options: "index-signature"},
-
-		// Generic types other than Record
-		{Code: "type Foo = Partial<Bar>;"},
-		{Code: "type Foo = Required<Bar>;"},
-		{Code: "type Foo = Pick<Bar, 'a' | 'b'>;"},
+		// Mapped-type exclusions.
+		{Code: "type KeyValue = { [K in string]: K };"},
+		{Code: `type EscapedKey = { [\u004b in string]: \u004b };`},
+		{Code: "type KeyArray = { [K in string]: K[] };"},
+		{Code: "type KeyRemap = { [K in string as K]: unknown };"},
+		{Code: "type Keyof = { [K in keyof Base]: unknown };"},
+		{Code: "type OuterCycle = { [K in string]: unknown } | OuterCycle;"},
+		{Code: `
+type MappedValue = string | MappedObject;
+type MappedObject = { [K in string]: MappedValue };
+`},
+		// Index-signature mode requires an unqualified Record with exactly two arguments.
+		{Code: "type Foo = Record;", Options: "index-signature"},
+		{Code: "type Foo = Record<string>;", Options: "index-signature"},
+		{Code: "type Foo = Record<string, unknown, never>;", Options: "index-signature"},
+		{Code: "type Foo = Namespace.Record<string, unknown>;", Options: "index-signature"},
+		{Code: "type Foo = { [key: string]: unknown };", Options: "index-signature"},
 	}, []rule_tester.InvalidTestCase{
-		// Default mode (prefer record) - interface with only index signature
 		{
-			Code: "interface Foo { [key: string]: any; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "interface Foo { [key: string]: unknown; }",
+			Output: []string{"type Foo = Record<string, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Message:   "A record is preferred over an index signature.",
+				Line:      1,
+				Column:    1,
+			}},
 		},
 		{
-			Code: "interface Foo { [key: string]: unknown; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "interface Foo<A = unknown> { readonly [key: string]: A; }",
+			Output: []string{"type Foo<A = unknown> = Readonly<Record<string, A>>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 		{
-			Code: "interface Foo { [key: number]: any; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			// Heritage makes the conversion unsafe, but upstream still reports.
+			Code:   "interface Foo extends Base { [key: string]: unknown }",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 		{
-			Code: "interface Foo { readonly [key: string]: any; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-
-		// Type literals with only index signature
-		{
-			Code: "type Foo = { [key: string]: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code: "export default interface Foo { [key: string]: unknown }",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Column:    16,
+			}},
 		},
 		{
-			Code: "type Foo = { [key: string]: unknown };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "export interface Foo { [key: string]: unknown }",
+			Output: []string{"export type Foo = Record<string, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Column:    8,
+			}},
 		},
 		{
-			Code: "type Foo = { [key: number]: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-		{
-			Code: "type Foo = { readonly [key: string]: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "type Foo = { [key: string]: unknown };",
+			Output: []string{"type Foo = Record<string, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Line:      1,
+				Column:    12,
+				EndLine:   1,
+				EndColumn: 38,
+			}},
 		},
 
-		// Mapped types that can be converted
+		// Upstream intentionally does not treat these wrappers as circular.
 		{
-			Code: "type Foo = { [K in string]: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "interface Foo { [key: string]: Foo[] }",
+			Output: []string{"type Foo = Record<string, Foo[]>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 		{
-			Code: "type Foo = { [K in number]: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "interface Foo { [key: string]: [Foo] }",
+			Output: []string{"type Foo = Record<string, [Foo]>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 		{
-			Code: "type Foo = { readonly [K in string]: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "interface Foo { [key: string]: () => Foo }",
+			Output: []string{"type Foo = Record<string, () => Foo>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 		{
-			Code: "type Foo = { [K in string]?: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "interface Foo { [key: string]: { value: Foo } }",
+			Output: []string{"type Foo = Record<string, { value: Foo }>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			// The outer declaration is circular; only the nested type literal is reported.
+			Code:   "interface Foo { [key: string]: { [inner: string]: Foo } }",
+			Output: []string{"interface Foo { [key: string]: Record<string, Foo> }"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Column:    32,
+			}},
+		},
+		{
+			Code:   "type Foo = { [key: string]: { [inner: string]: Foo } };",
+			Output: []string{"type Foo = { [key: string]: Record<string, Foo> };"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Column:    29,
+			}},
+		},
+		{
+			Code:   "type Foo = (value: { [key: string]: Foo }) => void;",
+			Output: []string{"type Foo = (value: Record<string, Foo>) => void;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			Code: `
+type CycleA = CycleB;
+type CycleB = CycleA;
+type Foo = { [key: string]: CycleA };
+`,
+			Output: []string{`
+type CycleA = CycleB;
+type CycleB = CycleA;
+type Foo = Record<string, CycleA>;
+`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			// A nested mapped key named like the alias shadows it and is not a circular reference.
+			Code:   "type Foo = { [key: string]: { [Foo in string]: Foo } };",
+			Output: []string{"type Foo = Record<string, { [Foo in string]: Foo }>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			// An inferred type parameter with the alias's name is likewise a distinct binding.
+			Code:   "type Foo = { [key: string]: unknown extends infer Foo ? Foo : never };",
+			Output: []string{"type Foo = Record<string, unknown extends infer Foo ? Foo : never>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			// More than eight declarations exercises the allocation-free visited set's overflow path.
+			Code: `
+type Cycle0 = Cycle1;
+type Cycle1 = Cycle2;
+type Cycle2 = Cycle3;
+type Cycle3 = Cycle4;
+type Cycle4 = Cycle5;
+type Cycle5 = Cycle6;
+type Cycle6 = Cycle7;
+type Cycle7 = Cycle8;
+type Cycle8 = Cycle0;
+type Foo = { [key: string]: Cycle0 };
+`,
+			Output: []string{`
+type Cycle0 = Cycle1;
+type Cycle1 = Cycle2;
+type Cycle2 = Cycle3;
+type Cycle3 = Cycle4;
+type Cycle4 = Cycle5;
+type Cycle5 = Cycle6;
+type Cycle6 = Cycle7;
+type Cycle7 = Cycle8;
+type Cycle8 = Cycle0;
+type Foo = Record<string, Cycle0>;
+`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			Code:   "declare interface Foo { [key: string]: unknown }",
+			Output: []string{"type Foo = Record<string, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Column:    1,
+			}},
+		},
+		{
+			Code:   "export declare interface Foo { [key: string]: unknown }",
+			Output: []string{"export type Foo = Record<string, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Column:    8,
+			}},
 		},
 
-		// Generic interfaces with only index signature
+		// Mapped types accept arbitrary constraints unless an upstream exclusion applies.
 		{
-			Code: "interface Foo<T> { [key: string]: T; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "type Foo = { [K in PropertyKey]: unknown };",
+			Output: []string{"type Foo = Record<PropertyKey, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 		{
-			Code: "interface Foo<T, K> { [key: string]: T | K; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code:   "type Foo<Key extends PropertyKey> = { [K in Key]: unknown };",
+			Output: []string{"type Foo<Key extends PropertyKey> = Record<Key, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			Code:   "type Foo = { [K in 'a' | 'b']: unknown };",
+			Output: []string{"type Foo = Record<'a' | 'b', unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			Code:   "type Foo = { [K in (keyof Base)]: unknown };",
+			Output: []string{"type Foo = Record<keyof Base, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			Code:   "type Foo = { readonly [K in PropertyKey]-?: string };",
+			Output: []string{"type Foo = Readonly<Required<Record<PropertyKey, string>>>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			Code:   "type Foo = { [K in string]?: unknown };",
+			Output: []string{"type Foo = Partial<Record<string, unknown>>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			Code:   "type Foo = { -readonly [K in string]: unknown };",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			// Upstream #11179: a missing mapped value converts to any.
+			Code:   "type Foo = { [K in string] };",
+			Output: []string{"type Foo = Record<string, any>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
+		},
+		{
+			// The inner K shadows the mapped key, so it does not block conversion.
+			Code:   "type Foo = { [K in string]: <K>() => K };",
+			Output: []string{"type Foo = Record<string, <K>() => K>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 
-		// Index-signature mode (prefer index-signature)
-		{
-			Code:    "type Foo = Record<string, any>;",
-			Options: "index-signature",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferIndexSignature"},
-			},
-		},
+		// Index-signature mode reports every unqualified two-argument Record.
 		{
 			Code:    "type Foo = Record<string, unknown>;",
 			Options: "index-signature",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferIndexSignature"},
-			},
+			Output:  []string{"type Foo = { [key: string]: unknown };"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferIndexSignature",
+				Message:   "An index signature is preferred over a record.",
+				Column:    12,
+			}},
 		},
 		{
-			Code:    "type Foo = Record<number, any>;",
+			Code:    "type Foo = Record<Key, unknown>;",
 			Options: "index-signature",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferIndexSignature"},
-			},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferIndexSignature",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "preferIndexSignatureSuggestion",
+					Output:    "type Foo = { [key: Key]: unknown };",
+				}},
+			}},
 		},
 		{
-			Code:    "type Foo = Record<symbol, any>;",
+			Code:    "type Foo = Record<string | number, unknown>;",
 			Options: "index-signature",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferIndexSignature"},
-			},
-		},
-		{
-			Code:    "type Foo = Record<'a' | 'b', any>;",
-			Options: "index-signature",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferIndexSignature"},
-			},
-		},
-		{
-			Code:    "type Foo<T> = Record<string, T>;",
-			Options: "index-signature",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferIndexSignature"},
-			},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferIndexSignature",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "preferIndexSignatureSuggestion",
+					Output:    "type Foo = { [key: string | number]: unknown };",
+				}},
+			}},
 		},
 
-		// Nested in other types
+		// Comments outside preserved key/value nodes downgrade fixes to suggestions.
 		{
-			Code: "type Foo = Array<{ [key: string]: any }>;",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code: "type Foo = { /* keep */ [key: string]: unknown };",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "preferRecordSuggestion",
+					Output:    "type Foo = Record<string, unknown>;",
+				}},
+			}},
 		},
 		{
-			Code: "type Foo = { prop: { [key: string]: any } };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-
-		// In function signatures
-		{
-			Code: "function foo(arg: { [key: string]: any }) {}",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			// A comment before the opening brace is outside the reported node and must survive the range fast path.
+			Code:   "type Foo = /* keep */ { [key: string]: unknown };",
+			Output: []string{"type Foo = /* keep */ Record<string, unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 		{
-			Code: "const foo = (arg: { [key: string]: any }) => {};",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			Code: "type Foo = { [K in /* keep */ 'a' | 'b']: unknown };",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferRecord",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "preferRecordSuggestion",
+					Output:    "type Foo = Record<'a' | 'b', unknown>;",
+				}},
+			}},
 		},
 		{
-			Code: "function foo(): { [key: string]: any } { return {}; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-
-		// With comments
-		{
-			Code: "interface Foo { /* comment */ [key: string]: any; }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-		{
-			Code: "type Foo = { /* comment */ [key: string]: any };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-
-		// Complex value types
-		{
-			Code: "type Foo = { [key: string]: string | number };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-		{
-			Code: "type Foo = { [key: string]: { nested: string } };",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
-		},
-		{
-			Code: "interface Foo { [key: string]: Array<string> }",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferRecord"},
-			},
+			// A comment inside the preserved key type remains in an autofix.
+			Code:   "type Foo = { [K in 'a' /* keep */ | 'b']: unknown };",
+			Output: []string{"type Foo = Record<'a' /* keep */ | 'b', unknown>;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferRecord"}},
 		},
 	})
 }
+
+func TestConsistentIndexedObjectStyleDisableDirectives(t *testing.T) {
+	t.Parallel()
+
+	const code = `// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+type NextLine = { [key: string]: unknown };
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style */
+type Scoped = { [key: string]: unknown };
+/* eslint-enable @typescript-eslint/consistent-indexed-object-style */
+type Reported = { [key: string]: unknown };`
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(code, "disable-directives.ts", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:      program,
+		File:         sourceFile.FileName(),
+		ExcludePaths: []string{},
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     "@typescript-eslint/consistent-indexed-object-style",
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return ConsistentIndexedObjectStyleRule.Run(ctx, nil)
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandNone,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want only the enabled type", len(diagnostics))
+	}
+	if got := code[diagnostics[0].Range.Pos():diagnostics[0].Range.End()]; got != "{ [key: string]: unknown }" {
+		t.Fatalf("reported range text = %q", got)
+	}
+}
+
+func TestConsistentIndexedObjectStyleEditDemand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		options     []any
+		disposition []editDemandExpectation
+	}{
+		{
+			name: "record mode",
+			code: `
+type Fix = { [key: string]: unknown };
+type Suggest = { /* keep */ [key: string]: unknown };
+interface None extends Base { [key: string]: unknown }
+`,
+			disposition: []editDemandExpectation{expectAutofix, expectSuggestion, expectNoEdit},
+		},
+		{
+			name: "index-signature mode",
+			code: `
+type Fix = Record<string, unknown>;
+type Suggest = Record<Key, unknown>;
+`,
+			options:     []any{"index-signature"},
+			disposition: []editDemandExpectation{expectAutofix, expectSuggestion},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+			program, sourceFile, err := helper.CreateTestProgram(test.code, "edit-demand.ts", "tsconfig.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+				t.Helper()
+				var diagnostics []rule.RuleDiagnostic
+				linter.LintSingleFile(linter.LintSingleFileOptions{
+					Program:      program,
+					File:         sourceFile.FileName(),
+					ExcludePaths: []string{},
+					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+						return []linter.ConfiguredRule{{
+							Name:     ConsistentIndexedObjectStyleRule.Name,
+							Severity: rule.SeverityError,
+							Run: func(ctx rule.RuleContext) rule.RuleListeners {
+								return ConsistentIndexedObjectStyleRule.Run(ctx, test.options)
+							},
+						}}
+					},
+					Consumer: rule.DiagnosticConsumer{
+						Demand: demand,
+						Report: func(diagnostic rule.RuleDiagnostic) {
+							diagnostics = append(diagnostics, diagnostic)
+						},
+					},
+				})
+				if len(diagnostics) != len(test.disposition) {
+					t.Fatalf("demand %d: diagnostics = %d, want %d", demand, len(diagnostics), len(test.disposition))
+				}
+				return diagnostics
+			}
+
+			diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{
+				rule.EditDemandNone:       run(rule.EditDemandNone),
+				rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+				rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+				rule.EditDemandAll:        run(rule.EditDemandAll),
+			}
+			withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+				diagnostic.FixesPtr = nil
+				diagnostic.Suggestions = nil
+				return diagnostic
+			}
+
+			for index, expectation := range test.disposition {
+				identity := withoutEdits(diagnostics[rule.EditDemandAll][index])
+				for demand, demandDiagnostics := range diagnostics {
+					if got := withoutEdits(demandDiagnostics[index]); !reflect.DeepEqual(got, identity) {
+						t.Errorf("diagnostic %d demand %d changed identity:\ngot  %#v\nwant %#v", index, demand, got, identity)
+					}
+				}
+
+				none := diagnostics[rule.EditDemandNone][index]
+				autofix := diagnostics[rule.EditDemandAutofix][index]
+				suggestion := diagnostics[rule.EditDemandSuggestion][index]
+				all := diagnostics[rule.EditDemandAll][index]
+				if none.FixesPtr != nil || none.Suggestions != nil || autofix.Suggestions != nil || suggestion.FixesPtr != nil {
+					t.Errorf("diagnostic %d leaked an edit into the wrong demand", index)
+				}
+				switch expectation {
+				case expectAutofix:
+					if autofix.FixesPtr == nil || all.FixesPtr == nil || suggestion.Suggestions != nil || all.Suggestions != nil {
+						t.Errorf("diagnostic %d did not remain autofix-only", index)
+					}
+				case expectSuggestion:
+					if suggestion.Suggestions == nil || all.Suggestions == nil || autofix.FixesPtr != nil || all.FixesPtr != nil {
+						t.Errorf("diagnostic %d did not remain suggestion-only", index)
+					}
+				case expectNoEdit:
+					if autofix.FixesPtr != nil || suggestion.Suggestions != nil || all.FixesPtr != nil || all.Suggestions != nil {
+						t.Errorf("diagnostic %d unexpectedly materialized an edit", index)
+					}
+				}
+			}
+		})
+	}
+}
+
+type editDemandExpectation uint8
+
+const (
+	expectAutofix editDemandExpectation = iota
+	expectSuggestion
+	expectNoEdit
+)

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -270,7 +270,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/class-methods-use-this/class-methods-use-this-core.test.ts',
     './tests/typescript-eslint/rules/class-methods-use-this/class-methods-use-this.test.ts',
     // './tests/typescript-eslint/rules/consistent-generic-constructors.test.ts',
-    // './tests/typescript-eslint/rules/consistent-indexed-object-style.test.ts',
+    './tests/typescript-eslint/rules/consistent-indexed-object-style.test.ts',
     // './tests/typescript-eslint/rules/consistent-return.test.ts',
     './tests/typescript-eslint/rules/consistent-type-assertions.test.ts',
     './tests/typescript-eslint/rules/consistent-type-definitions.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-indexed-object-style.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-indexed-object-style.test.ts.snap
@@ -1,0 +1,1722 @@
+// Rstest Snapshot v1
+
+exports[`consistent-indexed-object-style > invalid 1`] = `
+{
+  "code": "
+interface Foo {
+  [key: string]: any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, any>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 2`] = `
+{
+  "code": "
+interface Foo {
+  readonly [key: string]: any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Readonly<Record<string, any>>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 3`] = `
+{
+  "code": "
+interface Foo<A> {
+  [key: string]: A;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<A> = Record<string, A>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 4`] = `
+{
+  "code": "
+interface Foo<A = any> {
+  [key: string]: A;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<A = any> = Record<string, A>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 5`] = `
+{
+  "code": "
+interface B extends A {
+  [index: number]: unknown;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 6`] = `
+{
+  "code": "
+interface Foo<A> {
+  readonly [key: string]: A;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<A> = Readonly<Record<string, A>>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 7`] = `
+{
+  "code": "
+interface Foo<A, B> {
+  [key: A]: B;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<A, B> = Record<A, B>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 8`] = `
+{
+  "code": "
+interface Foo<A, B> {
+  readonly [key: A]: B;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<A, B> = Readonly<Record<A, B>>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 9`] = `
+{
+  "code": "type Foo = { [key: string]: any };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Record<string, any>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 10`] = `
+{
+  "code": "type Foo = { readonly [key: string]: any };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Readonly<Record<string, any>>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 11`] = `
+{
+  "code": "type Foo = Generic<{ [key: string]: any }>;",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Generic<Record<string, any>>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 12`] = `
+{
+  "code": "type Foo = Generic<{ readonly [key: string]: any }>;",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Generic<Readonly<Record<string, any>>>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 13`] = `
+{
+  "code": "function foo(arg: { [key: string]: any }) {}",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "function foo(arg: Record<string, any>) {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 14`] = `
+{
+  "code": "function foo(): { [key: string]: any } {}",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "function foo(): Record<string, any> {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 15`] = `
+{
+  "code": "function foo(arg: { readonly [key: string]: any }) {}",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "function foo(arg: Readonly<Record<string, any>>) {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 16`] = `
+{
+  "code": "function foo(): { readonly [key: string]: any } {}",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "function foo(): Readonly<Record<string, any>> {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 17`] = `
+{
+  "code": "type Foo = Record<string, any>;",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = { [key: string]: any };",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 18`] = `
+{
+  "code": "type Foo<T> = Record<string, T>;",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo<T> = { [key: string]: T };",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 19`] = `
+{
+  "code": "type Foo = { [k: string]: A.Foo };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Record<string, A.Foo>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 20`] = `
+{
+  "code": "type Foo = { [key: string]: AnotherFoo };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Record<string, AnotherFoo>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 21`] = `
+{
+  "code": "type Foo = { [key: string]: { [key: string]: Foo } };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = { [key: string]: Record<string, Foo> };",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 22`] = `
+{
+  "code": "type Foo = { [key: string]: string } | Foo;",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Record<string, string> | Foo;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 23`] = `
+{
+  "code": "
+interface Foo<T> {
+  [k: string]: T;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<T> = Record<string, T>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 24`] = `
+{
+  "code": "
+interface Foo {
+  [k: string]: A.Foo;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, A.Foo>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 25`] = `
+{
+  "code": "
+interface Foo {
+  [k: string]: { [key: string]: Foo };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  [k: string]: Record<string, Foo>;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 26`] = `
+{
+  "code": "
+interface Foo {
+  [key: string]: { foo: Foo };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, { foo: Foo }>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 27`] = `
+{
+  "code": "
+interface Foo {
+  [key: string]: Foo[];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, Foo[]>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 28`] = `
+{
+  "code": "
+interface Foo {
+  [key: string]: () => Foo;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, () => Foo>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 29`] = `
+{
+  "code": "
+interface Foo {
+  [s: string]: [Foo];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, [Foo]>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 30`] = `
+{
+  "code": "
+interface Foo1 {
+  [key: string]: Foo2;
+}
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo1 = Record<string, Foo2>;
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 31`] = `
+{
+  "code": "
+interface Foo1 {
+  [key: string]: Record<string, Foo2>;
+}
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo1 = Record<string, Record<string, Foo2>>;
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 32`] = `
+{
+  "code": "
+type Foo1 = {
+  [key: string]: { foo2: Foo2 };
+};
+
+type Foo2 = {
+  [key: string]: Foo3;
+};
+
+type Foo3 = {
+  [key: string]: Record<string, Foo1>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 8,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 12,
+        },
+        "start": {
+          "column": 13,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+type Foo1 = Record<string, { foo2: Foo2 }>;
+
+type Foo2 = Record<string, Foo3>;
+
+type Foo3 = Record<string, Record<string, Foo1>>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 33`] = `
+{
+  "code": "
+type Foos<K extends string = never> = {
+  [k in K]: { foo: Foo };
+};
+
+type Foo = Foos;
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 39,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foos<K extends string = never> = Record<K, { foo: Foo }>;
+
+type Foo = Foos;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 34`] = `
+{
+  "code": "
+type Foos<K extends string = never> = {
+  [k in K]: Foo[];
+};
+
+type Foo = Foos;
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 39,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foos<K extends string = never> = Record<K, Foo[]>;
+
+type Foo = Foos;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 35`] = `
+{
+  "code": "type Foo = Generic<Record<string, any>>;",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = Generic<{ [key: string]: any }>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 36`] = `
+{
+  "code": "type Foo = Record<string | number, any>;",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 37`] = `
+{
+  "code": "type Foo = Record<Exclude<'a' | 'b' | 'c', 'a'>, any>;",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 38`] = `
+{
+  "code": "type Foo = Record<number, any>;",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = { [key: number]: any };",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 39`] = `
+{
+  "code": "type Foo = Record<symbol, any>;",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Foo = { [key: symbol]: any };",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 40`] = `
+{
+  "code": "function foo(arg: Record<string, any>) {}",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "function foo(arg: { [key: string]: any }) {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 41`] = `
+{
+  "code": "function foo(): Record<string, any> {}",
+  "diagnostics": [
+    {
+      "message": "An index signature is preferred over a record.",
+      "messageId": "preferIndexSignature",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "function foo(): { [key: string]: any } {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 42`] = `
+{
+  "code": "type T = { readonly [key in string]: number };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type T = Readonly<Record<string, number>>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 43`] = `
+{
+  "code": "type T = { +readonly [key in string]: number };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type T = Readonly<Record<string, number>>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 44`] = `
+{
+  "code": "type T = { -readonly [key in string]: number };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 45`] = `
+{
+  "code": "type T = { [key in string]: number };",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type T = Record<string, number>;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 46`] = `
+{
+  "code": "
+function foo(e: { [key in PropertyKey]?: string }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(e: Partial<Record<PropertyKey, string>>) {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 47`] = `
+{
+  "code": "
+function foo(e: { [key in PropertyKey]+?: string }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(e: Partial<Record<PropertyKey, string>>) {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 48`] = `
+{
+  "code": "
+function foo(e: { [key in PropertyKey]-?: string }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(e: Required<Record<PropertyKey, string>>) {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 49`] = `
+{
+  "code": "
+function foo(e: { readonly [key in PropertyKey]-?: string }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(e: Readonly<Required<Record<PropertyKey, string>>>) {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 50`] = `
+{
+  "code": "
+type Options = [
+  { [Type in (typeof optionTesters)[number]['option']]?: boolean } & {
+    allow?: TypeOrValueSpecifier[];
+  },
+];
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Options = [
+  Partial<Record<(typeof optionTesters)[number]['option'], boolean>> & {
+    allow?: TypeOrValueSpecifier[];
+  },
+];
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 51`] = `
+{
+  "code": "
+export type MakeRequired<Base, Key extends keyof Base> = {
+  [K in Key]-?: NonNullable<Base[Key]>;
+} & Omit<Base, Key>;
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 58,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+export type MakeRequired<Base, Key extends keyof Base> = Required<Record<Key, NonNullable<Base[Key]>>> & Omit<Base, Key>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 52`] = `
+{
+  "code": "
+function f(): {
+  [k in (keyof ParseResult)]: unknown;
+} {
+  return {};
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function f(): Record<keyof ParseResult, unknown> {
+  return {};
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 53`] = `
+{
+  "code": "
+interface Foo {
+  [key: string]: Bar;
+}
+
+interface Bar {
+  [key: string];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, Bar>;
+
+interface Bar {
+  [key: string];
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-indexed-object-style > invalid 54`] = `
+{
+  "code": "
+type Foo = {
+  [k in string];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "A record is preferred over an index signature.",
+      "messageId": "preferRecord",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-indexed-object-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = Record<string, any>;
+      ",
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

- align `@typescript-eslint/consistent-indexed-object-style` with the current upstream rule, including binder-resolved indirect circular aliases and interfaces
- match upstream diagnostics, ranges, autofixes, suggestions, comment preservation, mapped modifiers, shadowing, and both style options
- enable the upstream Rstest suite and add focused adversarial coverage for real rspack cycles, deep alias graphs, annotation boundaries, and edit demand
- keep diagnostic-only execution lazy, share the rule context per file, and use a source-validated range fast path

### Go benchmark

Command (Apple M5 Max, darwin/arm64; five samples, table uses medians):

```sh
go test -run '^$' -bench '^BenchmarkConsistentIndexedObjectStyle$' -benchmem -count=5 ./internal/plugins/typescript/rules/consistent_indexed_object_style
```

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Diagnostics only, matched | `53,202 → 61,899` | `44,349 → 34,048` | `419 → 352` |
| Autofix, matched | `51,136 → 70,365` | `44,349 → 59,138` | `419 → 672` |
| Suggestion, matched | `46,741 → 73,689` | `34,107 → 73,827` | `355 → 795` |
| Indirect circular, no diagnostic | `53,626 → 67,409` | `34,109 → 34,049` | `355 → 352` |
| No match | `44,486 → 55,500` | `34,107 → 34,046` | `355 → 352` |
| Ignored option | `47,654 → 61,286` | `34,108 → 33,967` | `355 → 347` |

The after batch was slower across both control paths (`No match` +24.8%, `Ignored option` +28.6%), so the raw time changes include run-level noise. The diagnostic path nevertheless reduced memory by 23.2% and allocations by 16.0%. The autofix case now materializes fixes that the previous implementation omitted, while the suggestion case now emits an upstream-compatible diagnostic and suggestion where the previous implementation emitted nothing, so those two time/allocation rows are not behavior-equivalent comparisons.

### Testing

- `go test -count=3 ./internal/plugins/typescript/rules/consistent_indexed_object_style`
- `npx rstest run --testTimeout=10000 consistent-indexed-object-style`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/plugins/typescript/rules/consistent_indexed_object_style`
- differential fixtures against `@typescript-eslint/eslint-plugin@8.67.0`
- rspack `Resolver.ts` and `util/fs.ts` false-positive reproductions

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/issues/7148
- https://github.com/typescript-eslint/typescript-eslint/issues/7863

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
