### PR TITLE
fix: align no-unnecessary-type-parameters with upstream

### DIFF
--- a/internal/plugins/typescript/rules/fixtures/tsconfig.default-strictness.json
+++ b/internal/plugins/typescript/rules/fixtures/tsconfig.default-strictness.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "experimentalDecorators": true,
+    "types": []
+  }
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -2,7 +2,10 @@ package no_unnecessary_type_parameters
 
 import (
 	"math"
+	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -87,7 +90,11 @@ func checkNode(ctx rule.RuleContext, node *ast.Node, descriptor string) {
 		}
 
 		if counts == nil {
-			counts = countTypeParameterUsage(ctx.TypeChecker, node)
+			counts = countTypeParameterUsage(
+				ctx.TypeChecker,
+				node,
+				ctx.Program != nil && needsLegacyObjectSpreadRecovery(ctx.Program.Options()),
+			)
 		}
 		useCount := counts[nameNode]
 		if useCount == 0 || useCount > 2 {
@@ -108,6 +115,1541 @@ func checkNode(ctx rule.RuleContext, node *ast.Node, descriptor string) {
 			}}
 		})
 	}
+}
+
+func collectSignatureReturnTypeParameterUsages(tc *checker.Checker, sig *checker.Signature) map[*ast.Node]int {
+	if sig == nil {
+		return nil
+	}
+	normalizeMultiplicity := func(usages map[*ast.Node]int) map[*ast.Node]int {
+		if returnTypeAssumesMultipleUses(tc, sig) {
+			for name, count := range usages {
+				if count == 1 {
+					usages[name] = 2
+				}
+			}
+		}
+		return usages
+	}
+	declaration := sig.Declaration()
+	if declaration == nil {
+		return nil
+	}
+	if returnType := declaration.Type(); returnType != nil {
+		usages := make(map[*ast.Node]int)
+		collectTypeParameterUsageCounts(tc, returnType, usages, false)
+		return normalizeMultiplicity(usages)
+	}
+
+	allUsages := make(map[*ast.Node]int)
+	collectTypeParameterUsageCounts(tc, declaration, allUsages, false)
+	nonReturnUsages := make(map[*ast.Node]int)
+	if this := sig.ThisParameter(); this != nil && this.ValueDeclaration != nil {
+		collectTypeParameterUsageCounts(tc, this.ValueDeclaration, nonReturnUsages, false)
+	}
+	for _, parameter := range sig.Parameters() {
+		if parameter.ValueDeclaration != nil {
+			collectTypeParameterUsageCounts(tc, parameter.ValueDeclaration, nonReturnUsages, false)
+		}
+	}
+	for _, typeParameter := range sig.TypeParameters() {
+		if symbol := typeParameter.Symbol(); symbol != nil && len(symbol.Declarations) != 0 {
+			collectTypeParameterUsageCounts(tc, symbol.Declarations[0], nonReturnUsages, false)
+		}
+	}
+
+	returnUsages := make(map[*ast.Node]int)
+	for name, count := range allUsages {
+		if returnCount := count - nonReturnUsages[name]; returnCount > 0 {
+			returnUsages[name] = returnCount
+		}
+	}
+	return normalizeMultiplicity(returnUsages)
+}
+
+type genericReturnUsage struct {
+	count int
+	group *ast.Node
+}
+
+// genericCallArgumentReturnUsages returns the target type parameters that an
+// argument can infer and that also occur in the target's return type. Counts
+// preserve repeated return positions, allowing arguments for the same target
+// parameter to be merged as alternatives while distinct parameters add.
+func genericCallArgumentReturnUsages(tc *checker.Checker, callNode *ast.Node, argumentIndex int) map[*ast.Node]genericReturnUsage {
+	// An explicit type argument fixes the generic result independently of the
+	// value argument. If it mentions the enclosing type parameter, the normal
+	// return-type walk already sees that occurrence; otherwise the spread is
+	// intentionally erased from the signature.
+	if len(callNode.TypeArguments()) != 0 {
+		return nil
+	}
+	// These ubiquitous library helpers preserve the argument (or its awaited
+	// value) in their result. Recognizing them before asking the checker to
+	// instantiate their large declaration graphs keeps the compatibility path
+	// cheap on real code and avoids repeatedly materializing Promise/Array APIs.
+	callee := callExpressionTarget(callNode)
+	if callee != nil {
+		callee = ast.SkipParentheses(callee)
+	}
+	if callee != nil && callee.Kind == ast.KindPropertyAccessExpression {
+		propertyAccess := callee.AsPropertyAccessExpression()
+		if propertyAccess.Name() != nil && ast.IsIdentifier(propertyAccess.Name()) {
+			switch propertyAccess.Name().AsIdentifier().Text {
+			case "resolve":
+				if argumentIndex == 0 && isTypeScriptLibValueNamed(tc, propertyAccess.Expression, "Promise") {
+					return map[*ast.Node]genericReturnUsage{propertyAccess.Name(): {count: 2}}
+				}
+				return nil
+			case "map":
+				if argumentIndex == 0 && tc.IsArrayType(tc.GetTypeAtLocation(propertyAccess.Expression)) &&
+					isTypeScriptLibSymbol(tc, tc.GetSymbolAtLocation(propertyAccess.Name())) {
+					return map[*ast.Node]genericReturnUsage{propertyAccess.Name(): {count: 2}}
+				}
+				return nil
+			}
+		}
+	}
+	// For ordinary local generic helpers, walking the declaration is both more
+	// precise and much cheaper than resolving the instantiated parameter type.
+	if callee != nil && callee.Kind == ast.KindIdentifier {
+		if symbol := tc.GetSymbolAtLocation(callee); symbol != nil {
+			var declaration *ast.Node
+			if len(symbol.Declarations) == 1 && ast.IsFunctionLike(symbol.Declarations[0]) {
+				declaration = symbol.Declarations[0]
+			}
+			if declaration == nil {
+				goto resolveSignature
+			}
+			parameters := declaration.Parameters()
+			parameterIndex := argumentIndex
+			if parameterIndex >= len(parameters) {
+				if len(parameters) == 0 || parameters[len(parameters)-1].AsParameterDeclaration().DotDotDotToken == nil {
+					return nil
+				}
+				parameterIndex = len(parameters) - 1
+			}
+			if parameterType := parameters[parameterIndex].Type(); parameterType != nil {
+				parameterName := directDeclaredTypeParameter(declaration, parameterType)
+				if parameterName == nil {
+					goto resolveSignature
+				}
+				returnUsages := collectSignatureReturnTypeParameterUsages(tc, tc.GetSignatureFromDeclaration(declaration))
+				if count := returnUsages[parameterName]; count != 0 {
+					return map[*ast.Node]genericReturnUsage{parameterName: {
+						count: count,
+						group: genericReturnSurfaceGroup(declaration, parameterName),
+					}}
+				}
+				return nil
+			}
+		}
+	}
+
+resolveSignature:
+	sig := checker.Checker_getResolvedSignature(tc, callNode, nil, checker.CheckModeNormal)
+	if sig == nil {
+		return nil
+	}
+	for sig.Target() != nil {
+		sig = sig.Target()
+	}
+	if sig.Declaration() == nil {
+		return nil
+	}
+
+	parameters := sig.Parameters()
+	if len(parameters) == 0 {
+		return nil
+	}
+	parameterIndex := argumentIndex
+	if parameterIndex >= len(parameters) {
+		if !sig.HasRestParameter() {
+			return nil
+		}
+		parameterIndex = len(parameters) - 1
+	}
+	parameterDeclaration := parameters[parameterIndex].ValueDeclaration
+	if parameterDeclaration == nil {
+		return nil
+	}
+
+	returnUsages := collectSignatureReturnTypeParameterUsages(tc, sig)
+	if len(returnUsages) == 0 {
+		return nil
+	}
+	parameterUsages := make(map[*ast.Node]bool)
+	collectInferableTypeParameterUsages(tc, tc.GetTypeOfSymbol(parameters[parameterIndex]), returnUsages, parameterUsages)
+	result := make(map[*ast.Node]genericReturnUsage)
+	for name := range parameterUsages {
+		if count := returnUsages[name]; count != 0 {
+			result[name] = genericReturnUsage{
+				count: count,
+				group: genericReturnSurfaceGroup(sig.Declaration(), name),
+			}
+		}
+	}
+	return result
+}
+
+func directDeclaredTypeParameter(declaration *ast.Node, typeNode *ast.Node) *ast.Node {
+	if declaration == nil || typeNode == nil {
+		return nil
+	}
+	typeNode = ast.SkipTypeParentheses(typeNode)
+	switch typeNode.Kind {
+	case ast.KindArrayType:
+		return directDeclaredTypeParameter(declaration, typeNode.AsArrayTypeNode().ElementType)
+	case ast.KindTupleType:
+		elements := typeNode.AsTupleTypeNode().Elements.Nodes
+		if len(elements) == 1 {
+			return directDeclaredTypeParameter(declaration, elements[0])
+		}
+		return nil
+	case ast.KindRestType, ast.KindOptionalType, ast.KindNamedTupleMember:
+		return directDeclaredTypeParameter(declaration, typeNode.Type())
+	case ast.KindTypeReference:
+	default:
+		return nil
+	}
+	typeName := typeNode.AsTypeReferenceNode().TypeName
+	if typeName == nil || !ast.IsIdentifier(typeName) {
+		return nil
+	}
+	name := typeName.AsIdentifier().Text
+	for _, typeParameter := range declaration.TypeParameters() {
+		if typeParameter.Name() != nil && ast.IsIdentifier(typeParameter.Name()) && typeParameter.Name().AsIdentifier().Text == name {
+			return typeParameter.Name()
+		}
+	}
+	return nil
+}
+
+// Type parameters that occur as sibling constituents of a naked union or
+// intersection share one result surface. If two call arguments infer the same
+// enclosing generic into those constituents, TypeScript collapses (T & T) or
+// (T | T) to one occurrence instead of counting both target parameters.
+func genericReturnSurfaceGroup(declaration *ast.Node, name *ast.Node) *ast.Node {
+	if declaration == nil || name == nil {
+		return name
+	}
+	returnType := declaration.Type()
+	if returnType == nil {
+		return name
+	}
+	returnType = ast.SkipTypeParentheses(returnType)
+	if returnType.Kind != ast.KindUnionType && returnType.Kind != ast.KindIntersectionType {
+		return name
+	}
+	var constituents []*ast.Node
+	if returnType.Kind == ast.KindUnionType {
+		constituents = returnType.AsUnionTypeNode().Types.Nodes
+	} else {
+		constituents = returnType.AsIntersectionTypeNode().Types.Nodes
+	}
+	for _, constituent := range constituents {
+		if directDeclaredTypeParameter(declaration, constituent) == name {
+			return returnType
+		}
+	}
+	return name
+}
+
+func callExpressionTarget(node *ast.Node) *ast.Node {
+	switch node.Kind {
+	case ast.KindCallExpression:
+		return node.AsCallExpression().Expression
+	case ast.KindNewExpression:
+		return node.AsNewExpression().Expression
+	case ast.KindTaggedTemplateExpression:
+		return node.AsTaggedTemplateExpression().Tag
+	}
+	return nil
+}
+
+func isTypeScriptLibValueNamed(tc *checker.Checker, node *ast.Node, name string) bool {
+	if node == nil || node.Kind != ast.KindIdentifier || node.AsIdentifier().Text != name {
+		return false
+	}
+	symbol := tc.GetSymbolAtLocation(node)
+	if symbol == nil {
+		return false
+	}
+	if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+		symbol = tc.GetAliasedSymbol(symbol)
+	}
+	return symbol != nil && symbol.Name == name && isTypeScriptLibSymbol(tc, symbol)
+}
+
+func isTypeScriptLibSymbol(tc *checker.Checker, symbol *ast.Symbol) bool {
+	if symbol == nil {
+		return false
+	}
+	if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+		symbol = tc.GetAliasedSymbol(symbol)
+	}
+	for _, declaration := range symbol.Declarations {
+		if sourceFile := ast.GetSourceFileOfNode(declaration); sourceFile != nil && sourceFile.IsDeclarationFile {
+			base := filepath.Base(sourceFile.FileName())
+			if strings.HasPrefix(base, "lib.") && strings.HasSuffix(base, ".d.ts") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func returnTypeAssumesMultipleUses(tc *checker.Checker, sig *checker.Signature) bool {
+	if sig == nil {
+		return false
+	}
+	t := tc.GetReturnTypeOfSignature(sig)
+	if predicate := tc.GetTypePredicateOfSignature(sig); predicate != nil && predicate.Type() != nil {
+		t = predicate.Type()
+	}
+	if t == nil {
+		return false
+	}
+	if alias := t.Alias(); alias != nil && alias.TypeArguments() != nil {
+		return true
+	}
+	if !utils.IsTypeReference(t) {
+		return false
+	}
+	target := t.Target()
+	if checker.IsTupleType(target) {
+		return !target.AsTupleType().IsReadonly()
+	}
+	if tc.IsArrayType(target) {
+		symbol := t.Symbol()
+		return symbol != nil && symbol.Name == "Array"
+	}
+	return true
+}
+
+// collectInferableTypeParameterUsages records the generic parameters whose
+// values may be inferred from an argument at a given parameter position.
+// NoInfer<T> is deliberately opaque: T can occur in the target's return type
+// without the argument having any influence on the inferred result.
+func collectInferableTypeParameterUsages(tc *checker.Checker, root *checker.Type, wanted map[*ast.Node]int, usages map[*ast.Node]bool) {
+	visited := make(map[*checker.Type]bool)
+	// The caller only needs to know whether this parameter and the return type
+	// share at least one inferable generic; stop at the first match instead of
+	// materializing an entire standard-library type graph.
+	remaining := len(wanted)
+	var visit func(*checker.Type)
+
+	visitSignature := func(sig *checker.Signature) {
+		if sig == nil || remaining == 0 {
+			return
+		}
+		if this := sig.ThisParameter(); this != nil {
+			visit(tc.GetTypeOfSymbol(this))
+		}
+		for _, parameter := range sig.Parameters() {
+			visit(tc.GetTypeOfSymbol(parameter))
+		}
+		visit(tc.GetReturnTypeOfSignature(sig))
+	}
+
+	visit = func(t *checker.Type) {
+		if t == nil || visited[t] || remaining == 0 {
+			return
+		}
+		visited[t] = true
+
+		if utils.IsTypeFlagSet(t, checker.TypeFlagsSubstitution) {
+			substitution := t.AsSubstitutionType()
+			if constraint := substitution.SubstConstraint(); constraint != nil && utils.IsTypeFlagSet(constraint, checker.TypeFlagsUnknown) {
+				return
+			}
+			visit(substitution.BaseType())
+			return
+		}
+		if utils.IsTypeParameter(t) {
+			if symbol := t.Symbol(); symbol != nil && len(symbol.Declarations) != 0 {
+				declaration := symbol.Declarations[0]
+				if ast.IsTypeParameterDeclaration(declaration) && declaration.Name() != nil && wanted[declaration.Name()] != 0 && !usages[declaration.Name()] {
+					usages[declaration.Name()] = true
+					remaining--
+				}
+			}
+			return
+		}
+		switch {
+		case utils.IsUnionType(t) || utils.IsIntersectionType(t):
+			for _, constituent := range t.Types() {
+				visit(constituent)
+			}
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsIndexedAccess):
+			indexed := t.AsIndexedAccessType()
+			visit(indexed.ObjectType())
+			visit(indexed.IndexType())
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsTemplateLiteral):
+			for _, part := range t.AsTemplateLiteralType().Types() {
+				visit(part)
+			}
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsConditional):
+			conditional := t.AsConditionalType()
+			visit(conditional.CheckType())
+			visit(conditional.ExtendsType())
+		case utils.IsObjectType(t):
+			properties := checker.Checker_getPropertiesOfType(tc, t)
+			for _, property := range properties {
+				visit(tc.GetTypeOfSymbol(property))
+			}
+			for _, info := range checker.Checker_getIndexInfosOfType(tc, t) {
+				visit(info.ValueType())
+			}
+			if len(properties) == 0 && checker.Type_objectFlags(t)&checker.ObjectFlagsMapped != 0 {
+				constraint := checker.Checker_getConstraintTypeFromMappedType(tc, t)
+				nameType := checker.Checker_getNameTypeFromMappedType(tc, t)
+				if constraint != nil && !utils.IsTypeFlagSet(constraint, checker.TypeFlagsNever) &&
+					(nameType == nil || !utils.IsTypeFlagSet(nameType, checker.TypeFlagsNever)) {
+					visit(constraint)
+					visit(checker.Checker_getTemplateTypeFromMappedType(tc, t))
+				}
+			}
+			for _, sig := range utils.GetCallSignatures(tc, t) {
+				visitSignature(sig)
+			}
+			for _, sig := range utils.GetConstructSignatures(tc, t) {
+				visitSignature(sig)
+			}
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsIndex):
+			visit(t.AsIndexType().Target())
+		case utils.IsTypeFlagSet(t, checker.TypeFlagsStringMapping):
+			visit(t.AsStringMappingType().Target())
+		}
+	}
+
+	visit(root)
+}
+
+// collectLegacyNullableSpreadUsages identifies the narrow inference delta
+// between TypeScript 5.9 and tsgo: with omitted strictness options, spreading
+// an optional T preserves object-like constituents (including an implicitly
+// unconstrained T); tsgo's strict default erases them. Primitive/unknown
+// constraints and non-nullable operands agree already and are not recovered.
+func collectLegacyNullableSpreadUsages(tc *checker.Checker, expression *ast.Node) map[*ast.Node]int {
+	if expression == nil {
+		return nil
+	}
+	expression = ast.SkipParentheses(expression)
+	if expression.Kind == ast.KindBinaryExpression && expression.AsBinaryExpression().OperatorToken.Kind == ast.KindAmpersandAmpersandToken {
+		binary := expression.AsBinaryExpression()
+		leftUsages := collectLegacyNullableSpreadUsages(tc, binary.Left)
+		if len(leftUsages) == 0 {
+			return nil
+		}
+		rightType := tc.GetTypeAtLocation(binary.Right)
+		for name := range leftUsages {
+			if !typeContainsTypeParameterDeclaration(rightType, name, make(map[*checker.Type]bool)) {
+				delete(leftUsages, name)
+			}
+		}
+		return leftUsages
+	}
+	t := tc.GetTypeAtLocation(expression)
+	if t == nil || !utils.IsUnionType(t) {
+		return nil
+	}
+	hasNullish := false
+	for _, constituent := range t.Types() {
+		if utils.IsTypeFlagSet(constituent, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+			hasNullish = true
+			break
+		}
+	}
+	if !hasNullish {
+		return nil
+	}
+
+	var usages map[*ast.Node]int
+	for _, constituent := range t.Types() {
+		collectLegacySpreadTypeParameterUsages(tc, constituent, false, false, &usages)
+	}
+	return usages
+}
+
+func collectLegacySpreadTypeParameterUsages(tc *checker.Checker, t *checker.Type, objectGuaranteed bool, requireObjectGuarantee bool, usages *map[*ast.Node]int) {
+	if t == nil || utils.IsTypeFlagSet(t, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+		return
+	}
+	if utils.IsTypeParameter(t) {
+		symbol := t.Symbol()
+		if symbol == nil || len(symbol.Declarations) == 0 || !ast.IsTypeParameterDeclaration(symbol.Declarations[0]) {
+			return
+		}
+		declaration := symbol.Declarations[0].AsTypeParameterDeclaration()
+		if declaration.Name() == nil {
+			return
+		}
+		if requireObjectGuarantee && !objectGuaranteed {
+			return
+		}
+		if declaration.Constraint != nil && !isLegacyObjectLikeConstraint(tc.GetConstraintOfTypeParameter(t)) && !objectGuaranteed {
+			return
+		}
+		if *usages == nil {
+			*usages = make(map[*ast.Node]int)
+		}
+		(*usages)[declaration.Name()]++
+		return
+	}
+	if !utils.IsIntersectionType(t) {
+		return
+	}
+	intersectionGuaranteesObject := objectGuaranteed
+	if !intersectionGuaranteesObject {
+		for _, constituent := range t.Types() {
+			if !utils.IsTypeParameter(constituent) && isLegacyObjectLikeConstraint(constituent) {
+				intersectionGuaranteesObject = true
+				break
+			}
+		}
+	}
+	for _, constituent := range t.Types() {
+		collectLegacySpreadTypeParameterUsages(tc, constituent, intersectionGuaranteesObject, true, usages)
+	}
+}
+
+func isLegacyObjectLikeConstraint(t *checker.Type) bool {
+	if t == nil {
+		return false
+	}
+	if utils.IsObjectType(t) || utils.IsTypeFlagSet(t, checker.TypeFlagsNonPrimitive) {
+		return true
+	}
+	// `T extends U` is retained by legacy object-spread inference even when U
+	// is itself unconstrained. This differs from explicit `unknown`/`any` and
+	// primitive constraints, which erase T from the spread result.
+	if utils.IsTypeParameter(t) {
+		return true
+	}
+	if utils.IsIntersectionType(t) {
+		foundObjectLike := false
+		for _, constituent := range t.Types() {
+			if !isLegacyObjectLikeConstraint(constituent) {
+				return false
+			}
+			foundObjectLike = true
+		}
+		return foundObjectLike
+	}
+	if !utils.IsUnionType(t) {
+		return false
+	}
+	foundObjectLike := false
+	for _, constituent := range t.Types() {
+		if utils.IsTypeFlagSet(constituent, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+			continue
+		}
+		if !isLegacyObjectLikeConstraint(constituent) {
+			return false
+		}
+		foundObjectLike = true
+	}
+	return foundObjectLike
+}
+
+func typeContainsTypeParameterDeclaration(t *checker.Type, name *ast.Node, visited map[*checker.Type]bool) bool {
+	if t == nil || visited[t] {
+		return false
+	}
+	visited[t] = true
+	if utils.IsTypeParameter(t) {
+		symbol := t.Symbol()
+		return symbol != nil && len(symbol.Declarations) != 0 && ast.IsTypeParameterDeclaration(symbol.Declarations[0]) && symbol.Declarations[0].Name() == name
+	}
+	if utils.IsUnionType(t) || utils.IsIntersectionType(t) {
+		for _, constituent := range t.Types() {
+			if typeContainsTypeParameterDeclaration(constituent, name, visited) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isObjectSpreadProperty(property *ast.Symbol) bool {
+	if checker.GetDeclarationModifierFlagsFromSymbol(property)&(ast.ModifierFlagsPrivate|ast.ModifierFlagsProtected) != 0 {
+		return false
+	}
+	isClassElement := false
+	for _, declaration := range property.Declarations {
+		if ast.IsPrivateIdentifierClassElementDeclaration(declaration) {
+			return false
+		}
+		if declaration.Parent != nil && ast.IsClassLike(declaration.Parent) {
+			isClassElement = true
+		}
+	}
+	return property.Flags&(ast.SymbolFlagsMethod|ast.SymbolFlagsGetAccessor|ast.SymbolFlagsSetAccessor) == 0 || !isClassElement
+}
+
+func computedPropertyAssumesMultipleUses(tc *checker.Checker, property *ast.Node) bool {
+	name := property.Name()
+	if name == nil || name.Kind != ast.KindComputedPropertyName || property.Parent == nil {
+		return false
+	}
+	for _, info := range checker.Checker_getIndexInfosOfType(tc, tc.GetTypeAtLocation(property.Parent)) {
+		if keyType := info.KeyType(); keyType != nil && utils.IsTypeFlagSet(keyType, checker.TypeFlagsString|checker.TypeFlagsNumber) {
+			return true
+		}
+	}
+	return false
+}
+
+// collectInferredObjectSpreadUsages follows only expression positions that
+// contribute to an inferred return (including yielded values and generic
+// identity-like calls), then records type parameters carried by object-spread
+// operands. It deliberately does not traverse arbitrary subexpressions: an
+// object spread passed to a consumer or hidden behind an explicit annotation
+// does not become part of the function signature.
+func collectInferredObjectSpreadUsages(tc *checker.Checker, node *ast.Node) map[*ast.Node]int {
+	if node != nil && ast.IsFunctionLike(node) && node.Type() == nil {
+		if body := node.Body(); body != nil && body.Kind != ast.KindBlock {
+			if usages, handled := collectSimpleLegacyObjectSpreadUsages(tc, body); handled {
+				return usages
+			}
+		}
+	}
+	return collectInferredObjectSpreadUsagesWorker(tc, node, nil)
+}
+
+func collectInferredObjectSpreadExpressionUsages(tc *checker.Checker, expression *ast.Node) map[*ast.Node]int {
+	if usages, handled := collectSimpleLegacyObjectSpreadUsages(tc, expression); handled {
+		return usages
+	}
+	return collectInferredObjectSpreadUsagesWorker(tc, nil, expression)
+}
+
+// collectSimpleLegacyObjectSpreadUsages handles the dominant compatibility
+// shape without constructing the general return-flow walker: an inferred
+// expression-bodied function (or default initializer) whose result is one
+// object literal with one direct spread. The general path remains responsible
+// for nested spreads, branches, calls, selections, and destructuring.
+func collectSimpleLegacyObjectSpreadUsages(tc *checker.Checker, expression *ast.Node) (map[*ast.Node]int, bool) {
+	for expression != nil {
+		expression = ast.SkipParentheses(expression)
+		switch expression.Kind {
+		case ast.KindNonNullExpression, ast.KindSatisfiesExpression,
+			ast.KindAwaitExpression, ast.KindPartiallyEmittedExpression:
+			expression = expression.Expression()
+			continue
+		case ast.KindAsExpression, ast.KindTypeAssertionExpression:
+			if ast.IsConstTypeReference(expression.Type()) {
+				expression = expression.Expression()
+				continue
+			}
+			return nil, true
+		}
+		break
+	}
+	if expression == nil || expression.Kind != ast.KindObjectLiteralExpression {
+		return nil, false
+	}
+
+	var spreadExpression *ast.Node
+	for _, property := range expression.AsObjectLiteralExpression().Properties.Nodes {
+		if property.Kind == ast.KindSpreadAssignment {
+			if spreadExpression != nil {
+				return nil, false
+			}
+			spreadExpression = property.AsSpreadAssignment().Expression
+			continue
+		}
+		if containsObjectSpreadSyntax(property) {
+			return nil, false
+		}
+	}
+	if spreadExpression == nil {
+		return nil, true
+	}
+	if usages := collectLegacyNullableSpreadUsages(tc, spreadExpression); len(usages) != 0 {
+		return usages, true
+	}
+	if !containsObjectSpreadSyntax(spreadExpression) {
+		return nil, true
+	}
+	return nil, false
+}
+
+func containsObjectSpreadSyntax(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindSpreadAssignment {
+		return true
+	}
+	found := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		if containsObjectSpreadSyntax(child) {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func objectRestSelectionKey(excluded map[string]bool) string {
+	names := make([]string, 0, len(excluded))
+	for name := range excluded {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return "\x00object-rest:" + strings.Join(names, "\x00")
+}
+
+func collectInferredObjectSpreadUsagesWorker(tc *checker.Checker, node *ast.Node, rootExpression *ast.Node) map[*ast.Node]int {
+	if rootExpression == nil {
+		if node == nil || node.Type() != nil || !ast.IsFunctionLike(node) || node.Body() == nil {
+			return nil
+		}
+		if node.SubtreeFacts()&ast.SubtreeContainsESObjectRestOrSpread == 0 {
+			return nil
+		}
+	}
+
+	var usages map[*ast.Node]int
+	var activeDeclarations map[*ast.Node]bool
+	var collectExpression func(*ast.Node)
+	var collectFunction func(*ast.Node)
+	var collectProperty func(*ast.Node)
+	var collectDeclaration func(*ast.Node)
+	var collectSelectedProperty func(*ast.Node, string)
+	var collectObjectRest func(*ast.Node, map[string]bool)
+	var collectArrayRest func(*ast.Node, int)
+	var collectNestedBindingSource func(*ast.Node)
+	var collectResolvedFunction func(*ast.Node)
+	var activeSelections map[*ast.Node]map[string]bool
+	activeFunctions := make(map[*ast.Node]bool)
+	cloneUsages := func(source map[*ast.Node]int) map[*ast.Node]int {
+		if len(source) == 0 {
+			return nil
+		}
+		cloned := make(map[*ast.Node]int, len(source))
+		for name, count := range source {
+			cloned[name] = count
+		}
+		return cloned
+	}
+	collectAlternativeActions := func(actions []func(), alternativesRemainDistinct bool) {
+		if alternativesRemainDistinct {
+			for _, action := range actions {
+				action()
+			}
+			return
+		}
+		before := cloneUsages(usages)
+		maxDeltas := make(map[*ast.Node]int)
+		for _, action := range actions {
+			usages = cloneUsages(before)
+			action()
+			for name, count := range usages {
+				if delta := count - before[name]; delta > maxDeltas[name] {
+					maxDeltas[name] = delta
+				}
+			}
+		}
+		usages = cloneUsages(before)
+		for name, delta := range maxDeltas {
+			if usages == nil {
+				usages = make(map[*ast.Node]int)
+			}
+			usages[name] += delta
+		}
+	}
+	collectAlternatives := func(expressions []*ast.Node, alternativesRemainDistinct bool) {
+		actions := make([]func(), 0, len(expressions))
+		for _, expression := range expressions {
+			actions = append(actions, func() { collectExpression(expression) })
+		}
+		collectAlternativeActions(actions, alternativesRemainDistinct)
+	}
+	type callArgumentGroup struct {
+		returnCount int
+		arguments   []*ast.Node
+	}
+	collectCallArguments := func(callNode *ast.Node, arguments []*ast.Node, parameterOffset int) {
+		groups := make(map[*ast.Node]*callArgumentGroup)
+		for index, argument := range arguments {
+			for name, returnUsage := range genericCallArgumentReturnUsages(tc, callNode, index+parameterOffset) {
+				groupKey := returnUsage.group
+				if groupKey == nil {
+					groupKey = name
+				}
+				group := groups[groupKey]
+				if group == nil {
+					group = &callArgumentGroup{returnCount: returnUsage.count}
+					groups[groupKey] = group
+				} else if returnUsage.count > group.returnCount {
+					group.returnCount = returnUsage.count
+				}
+				group.arguments = append(group.arguments, argument)
+			}
+		}
+		for _, group := range groups {
+			before := cloneUsages(usages)
+			collectAlternatives(group.arguments, false)
+			if group.returnCount <= 1 {
+				continue
+			}
+			for name, count := range usages {
+				if count-before[name] == 1 {
+					usages[name]++
+				}
+			}
+		}
+	}
+
+	recordSpreadUsages := func(expression *ast.Node, spreadUsages map[*ast.Node]int) {
+		var before map[*ast.Node]int
+		if len(spreadUsages) != 0 {
+			before = make(map[*ast.Node]int, len(spreadUsages))
+		}
+		for name, count := range spreadUsages {
+			before[name] = usages[name]
+			if usages == nil {
+				usages = make(map[*ast.Node]int)
+			}
+			usages[name] += count
+		}
+		// A spread operand can itself be an object assembled from another
+		// generic spread, or a local initialized from one. For parameters whose
+		// resolved surface already exposes a generic, retain only the outer
+		// occurrence so a nested construction isn't counted twice.
+		if len(spreadUsages) == 0 || expression.SubtreeFacts()&ast.SubtreeContainsESObjectRestOrSpread != 0 {
+			collectExpression(expression)
+			for name, count := range spreadUsages {
+				usages[name] = before[name] + count
+			}
+		}
+	}
+	recordSpread := func(expression *ast.Node) {
+		recordSpreadUsages(expression, collectLegacyNullableSpreadUsages(tc, expression))
+	}
+
+	collectProperty = func(property *ast.Node) {
+		if property == nil {
+			return
+		}
+		switch property.Kind {
+		case ast.KindSpreadAssignment:
+			recordSpread(property.AsSpreadAssignment().Expression)
+		case ast.KindPropertyAssignment:
+			initializer := property.AsPropertyAssignment().Initializer
+			if !computedPropertyAssumesMultipleUses(tc, property) {
+				collectExpression(initializer)
+				return
+			}
+			before := cloneUsages(usages)
+			collectExpression(initializer)
+			for name, count := range usages {
+				if count-before[name] == 1 {
+					usages[name]++
+				}
+			}
+		case ast.KindShorthandPropertyAssignment:
+			if symbol := tc.GetShorthandAssignmentValueSymbol(property); symbol != nil {
+				collectDeclaration(symbol.ValueDeclaration)
+			}
+			collectExpression(property.AsShorthandPropertyAssignment().ObjectAssignmentInitializer)
+		case ast.KindMethodDeclaration, ast.KindGetAccessor:
+			collectFunction(property)
+		case ast.KindPropertyDeclaration:
+			collectExpression(property.Initializer())
+		}
+	}
+
+	collectObjectRest = func(base *ast.Node, excluded map[string]bool) {
+		if base == nil {
+			return
+		}
+		base = ast.SkipParentheses(base)
+		switch base.Kind {
+		case ast.KindNonNullExpression, ast.KindSatisfiesExpression:
+			collectObjectRest(base.Expression(), excluded)
+			return
+		case ast.KindAsExpression, ast.KindTypeAssertionExpression:
+			if ast.IsConstTypeReference(base.Type()) {
+				collectObjectRest(base.Expression(), excluded)
+			} else {
+				recordSpread(base)
+			}
+			return
+		case ast.KindIdentifier:
+			if directUsages := collectLegacyNullableSpreadUsages(tc, base); len(directUsages) != 0 {
+				recordSpreadUsages(base, directUsages)
+				return
+			}
+			if symbol := tc.GetSymbolAtLocation(base); symbol != nil && symbol.ValueDeclaration != nil {
+				declaration := symbol.ValueDeclaration
+				selectionKey := objectRestSelectionKey(excluded)
+				seenNames := activeSelections[declaration]
+				if seenNames == nil {
+					seenNames = make(map[string]bool)
+					if activeSelections == nil {
+						activeSelections = make(map[*ast.Node]map[string]bool)
+					}
+					activeSelections[declaration] = seenNames
+				}
+				if seenNames[selectionKey] {
+					return
+				}
+				seenNames[selectionKey] = true
+				collectObjectRest(declaration.Initializer(), excluded)
+				delete(seenNames, selectionKey)
+				return
+			}
+		case ast.KindObjectLiteralExpression:
+			seen := excluded
+			var surfaceSpreadUsages map[*ast.Node]int
+			properties := base.AsObjectLiteralExpression().Properties.Nodes
+			for index := len(properties) - 1; index >= 0; index-- {
+				property := properties[index]
+				if property.Kind == ast.KindSpreadAssignment {
+					spread := ast.SkipParentheses(property.AsSpreadAssignment().Expression)
+					directUsages := collectLegacyNullableSpreadUsages(tc, spread)
+					var before map[*ast.Node]int
+					if len(directUsages) != 0 {
+						before = make(map[*ast.Node]int, len(directUsages))
+						for name := range directUsages {
+							before[name] = usages[name]
+						}
+					}
+					if len(directUsages) != 0 {
+						recordSpreadUsages(spread, directUsages)
+					} else {
+						if seen == nil {
+							seen = make(map[string]bool)
+						}
+						collectObjectRest(spread, seen)
+					}
+					for name, count := range directUsages {
+						previous := surfaceSpreadUsages[name]
+						allowed := count - previous
+						if allowed < 0 {
+							allowed = 0
+						}
+						if usages[name]-before[name] > allowed {
+							usages[name] = before[name] + allowed
+						}
+						if count > previous {
+							if surfaceSpreadUsages == nil {
+								surfaceSpreadUsages = make(map[*ast.Node]int)
+							}
+							surfaceSpreadUsages[name] = count
+						}
+					}
+					continue
+				}
+				nameNode := property.Name()
+				if nameNode == nil {
+					continue
+				}
+				name := ast.GetPropertyNameForPropertyNameNode(nameNode)
+				if name == "" {
+					collectProperty(property)
+					continue
+				}
+				if seen[name] {
+					continue
+				}
+				if seen == nil {
+					seen = make(map[string]bool)
+				}
+				seen[name] = true
+				collectProperty(property)
+			}
+			return
+		}
+
+		// A non-literal spread source can still carry the enclosing generic
+		// through its residual surface after named properties are removed. Its
+		// known own properties also overwrite earlier literal properties.
+		if spreadType := tc.GetTypeAtLocation(base); spreadType != nil {
+			if excluded == nil {
+				excluded = make(map[string]bool)
+			}
+			for _, spreadProperty := range checker.Checker_getPropertiesOfType(tc, spreadType) {
+				if isObjectSpreadProperty(spreadProperty) {
+					excluded[spreadProperty.Name] = true
+				}
+			}
+		}
+		recordSpread(base)
+	}
+
+	collectArrayRest = func(base *ast.Node, start int) {
+		if base == nil {
+			return
+		}
+		base = ast.SkipParentheses(base)
+		if base.Kind == ast.KindIdentifier {
+			if symbol := tc.GetSymbolAtLocation(base); symbol != nil && symbol.ValueDeclaration != nil {
+				declaration := symbol.ValueDeclaration
+				selectionKey := "\x00array-rest:" + strconv.Itoa(start)
+				seenNames := activeSelections[declaration]
+				if seenNames == nil {
+					seenNames = make(map[string]bool)
+					if activeSelections == nil {
+						activeSelections = make(map[*ast.Node]map[string]bool)
+					}
+					activeSelections[declaration] = seenNames
+				}
+				if seenNames[selectionKey] {
+					return
+				}
+				seenNames[selectionKey] = true
+				collectArrayRest(declaration.Initializer(), start)
+				delete(seenNames, selectionKey)
+			}
+			return
+		}
+		if base.Kind != ast.KindArrayLiteralExpression {
+			collectExpression(base)
+			return
+		}
+		for index, element := range base.AsArrayLiteralExpression().Elements.Nodes {
+			if index < start || element == nil || element.Kind == ast.KindOmittedExpression {
+				continue
+			}
+			if element.Kind == ast.KindSpreadElement {
+				collectExpression(element.AsSpreadElement().Expression)
+			} else {
+				collectExpression(element)
+			}
+		}
+	}
+
+	collectNestedBindingSource = func(bindingNode *ast.Node) {
+		var selectors []string
+		current := bindingNode
+		var base *ast.Node
+		for current != nil && current.Kind == ast.KindBindingElement {
+			binding := current.AsBindingElement()
+			if binding.DotDotDotToken != nil || current.Parent == nil {
+				return
+			}
+			switch current.Parent.Kind {
+			case ast.KindObjectBindingPattern:
+				name := binding.PropertyName
+				if name == nil {
+					name = binding.Name()
+				}
+				if name == nil {
+					return
+				}
+				selectors = append(selectors, ast.GetPropertyNameForPropertyNameNode(name))
+			case ast.KindArrayBindingPattern:
+				index := slices.Index(current.Parent.AsBindingPattern().Elements.Nodes, current)
+				if index < 0 {
+					return
+				}
+				selectors = append(selectors, strconv.Itoa(index))
+			default:
+				return
+			}
+
+			owner := current.Parent.Parent
+			if owner == nil {
+				return
+			}
+			if owner.Kind == ast.KindVariableDeclaration {
+				if owner.Type() != nil {
+					return
+				}
+				base = owner.Initializer()
+				break
+			}
+			current = owner
+		}
+		if base == nil {
+			return
+		}
+
+		var resolveSelectedInitializer func(*ast.Node, string) *ast.Node
+		resolving := make(map[*ast.Node]bool)
+		resolveSelectedInitializer = func(expression *ast.Node, name string) *ast.Node {
+			if expression == nil {
+				return nil
+			}
+			expression = ast.SkipParentheses(expression)
+			switch expression.Kind {
+			case ast.KindNonNullExpression, ast.KindSatisfiesExpression:
+				return resolveSelectedInitializer(expression.Expression(), name)
+			case ast.KindAsExpression, ast.KindTypeAssertionExpression:
+				if ast.IsConstTypeReference(expression.Type()) {
+					return resolveSelectedInitializer(expression.Expression(), name)
+				}
+				return nil
+			case ast.KindIdentifier:
+				if symbol := tc.GetSymbolAtLocation(expression); symbol != nil && symbol.ValueDeclaration != nil {
+					declaration := symbol.ValueDeclaration
+					if resolving[declaration] {
+						return nil
+					}
+					resolving[declaration] = true
+					return resolveSelectedInitializer(declaration.Initializer(), name)
+				}
+			case ast.KindObjectLiteralExpression:
+				properties := expression.AsObjectLiteralExpression().Properties.Nodes
+				for index := len(properties) - 1; index >= 0; index-- {
+					property := properties[index]
+					if property.Kind == ast.KindSpreadAssignment {
+						spread := property.AsSpreadAssignment().Expression
+						spreadType := tc.GetTypeAtLocation(spread)
+						if spreadType != nil && checker.Checker_getPropertyOfType(tc, spreadType, name) != nil {
+							return resolveSelectedInitializer(spread, name)
+						}
+						continue
+					}
+					propertyName := property.Name()
+					if propertyName == nil || ast.GetPropertyNameForPropertyNameNode(propertyName) != name {
+						continue
+					}
+					switch property.Kind {
+					case ast.KindPropertyAssignment:
+						return property.AsPropertyAssignment().Initializer
+					case ast.KindShorthandPropertyAssignment:
+						return property.Name()
+					}
+					return nil
+				}
+			case ast.KindArrayLiteralExpression:
+				index, err := strconv.Atoi(name)
+				if err == nil && index >= 0 {
+					elements := expression.AsArrayLiteralExpression().Elements.Nodes
+					if index < len(elements) && elements[index] != nil && elements[index].Kind != ast.KindOmittedExpression && elements[index].Kind != ast.KindSpreadElement {
+						return elements[index]
+					}
+				}
+			}
+			return nil
+		}
+
+		for index := len(selectors) - 1; index >= 0; index-- {
+			base = resolveSelectedInitializer(base, selectors[index])
+			if base == nil {
+				return
+			}
+		}
+		collectExpression(base)
+	}
+
+	collectDeclaration = func(declaration *ast.Node) {
+		if declaration == nil || activeDeclarations[declaration] {
+			return
+		}
+		if activeDeclarations == nil {
+			activeDeclarations = make(map[*ast.Node]bool)
+		}
+		activeDeclarations[declaration] = true
+		defer delete(activeDeclarations, declaration)
+		if ast.IsFunctionLike(declaration) {
+			collectFunction(declaration)
+			return
+		}
+		switch declaration.Kind {
+		case ast.KindVariableDeclaration, ast.KindParameter,
+			ast.KindPropertyDeclaration, ast.KindPropertySignature:
+			if declaration.Type() != nil {
+				return
+			}
+			collectExpression(declaration.Initializer())
+		case ast.KindPropertyAssignment, ast.KindEnumMember:
+			collectExpression(declaration.Initializer())
+		case ast.KindBindingElement:
+			binding := declaration.AsBindingElement()
+			if root := ast.GetRootDeclaration(declaration); root != nil &&
+				(root.Kind == ast.KindVariableDeclaration || root.Kind == ast.KindParameter) && root.Type() != nil {
+				return
+			}
+			if declaration.Parent != nil && declaration.Parent.Kind == ast.KindObjectBindingPattern {
+				root := declaration.Parent.Parent
+				if binding.DotDotDotToken != nil && root != nil && root.Kind == ast.KindVariableDeclaration {
+					excluded := make(map[string]bool)
+					for _, sibling := range declaration.Parent.AsBindingPattern().Elements.Nodes {
+						if sibling == declaration || sibling == nil || sibling.Kind != ast.KindBindingElement {
+							continue
+						}
+						siblingBinding := sibling.AsBindingElement()
+						name := siblingBinding.PropertyName
+						if name == nil {
+							name = siblingBinding.Name()
+						}
+						if name != nil {
+							excluded[ast.GetPropertyNameForPropertyNameNode(name)] = true
+						}
+					}
+					collectObjectRest(root.Initializer(), excluded)
+					collectExpression(binding.Initializer)
+					return
+				}
+				name := binding.PropertyName
+				if name == nil {
+					name = binding.Name()
+				}
+				if name != nil && root != nil && root.Kind == ast.KindVariableDeclaration {
+					collectSelectedProperty(root.Initializer(), ast.GetPropertyNameForPropertyNameNode(name))
+				} else if root != nil && root.Kind == ast.KindBindingElement {
+					collectNestedBindingSource(declaration)
+				}
+				collectExpression(binding.Initializer)
+			} else if declaration.Parent != nil && declaration.Parent.Kind == ast.KindArrayBindingPattern {
+				root := declaration.Parent.Parent
+				if root != nil && root.Kind == ast.KindVariableDeclaration {
+					index := slices.Index(declaration.Parent.AsBindingPattern().Elements.Nodes, declaration)
+					if binding.DotDotDotToken != nil {
+						collectArrayRest(root.Initializer(), index)
+					} else if index >= 0 {
+						collectSelectedProperty(root.Initializer(), strconv.Itoa(index))
+					}
+				} else if root != nil && root.Kind == ast.KindBindingElement {
+					collectNestedBindingSource(declaration)
+				}
+				collectExpression(binding.Initializer)
+			} else {
+				collectExpression(binding.Initializer)
+			}
+		case ast.KindShorthandPropertyAssignment:
+			collectProperty(declaration)
+		}
+	}
+
+	collectSelectedProperty = func(base *ast.Node, name string) {
+		if base == nil || name == "" {
+			return
+		}
+		base = ast.SkipParentheses(base)
+		switch base.Kind {
+		case ast.KindNonNullExpression, ast.KindSatisfiesExpression:
+			collectSelectedProperty(base.Expression(), name)
+			return
+		case ast.KindAsExpression, ast.KindTypeAssertionExpression:
+			if ast.IsConstTypeReference(base.Type()) {
+				collectSelectedProperty(base.Expression(), name)
+			}
+			return
+		case ast.KindConditionalExpression:
+			conditional := base.AsConditionalExpression()
+			collectAlternativeActions([]func(){
+				func() { collectSelectedProperty(conditional.WhenTrue, name) },
+				func() { collectSelectedProperty(conditional.WhenFalse, name) },
+			}, utils.IsUnionType(tc.GetTypeAtLocation(base)))
+			return
+		case ast.KindBinaryExpression:
+			binary := base.AsBinaryExpression()
+			switch binary.OperatorToken.Kind {
+			case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+				collectAlternativeActions([]func(){
+					func() { collectSelectedProperty(binary.Left, name) },
+					func() { collectSelectedProperty(binary.Right, name) },
+				}, utils.IsUnionType(tc.GetTypeAtLocation(base)))
+			case ast.KindCommaToken, ast.KindEqualsToken:
+				collectSelectedProperty(binary.Right, name)
+			}
+			return
+		case ast.KindIdentifier:
+			symbol := tc.GetSymbolAtLocation(base)
+			if symbol != nil && symbol.ValueDeclaration != nil {
+				declaration := symbol.ValueDeclaration
+				seenNames := activeSelections[declaration]
+				if seenNames == nil {
+					seenNames = make(map[string]bool)
+					if activeSelections == nil {
+						activeSelections = make(map[*ast.Node]map[string]bool)
+					}
+					activeSelections[declaration] = seenNames
+				}
+				if seenNames[name] {
+					return
+				}
+				seenNames[name] = true
+				switch declaration.Kind {
+				case ast.KindVariableDeclaration, ast.KindParameter, ast.KindBindingElement,
+					ast.KindPropertyDeclaration, ast.KindPropertyAssignment:
+					collectSelectedProperty(declaration.Initializer(), name)
+				}
+				delete(seenNames, name)
+			}
+			return
+		case ast.KindObjectLiteralExpression:
+			properties := base.AsObjectLiteralExpression().Properties.Nodes
+			for index := len(properties) - 1; index >= 0; index-- {
+				property := properties[index]
+				if property.Kind == ast.KindSpreadAssignment {
+					spread := property.AsSpreadAssignment().Expression
+					spreadType := tc.GetTypeAtLocation(spread)
+					if spreadType != nil && checker.Checker_getPropertyOfType(tc, spreadType, name) != nil {
+						collectSelectedProperty(spread, name)
+						return
+					}
+					continue
+				}
+				propertyName := property.Name()
+				if propertyName != nil && ast.GetPropertyNameForPropertyNameNode(propertyName) == name {
+					collectProperty(property)
+					return
+				}
+			}
+			return
+		case ast.KindArrayLiteralExpression:
+			index, err := strconv.Atoi(name)
+			if err != nil || index < 0 {
+				return
+			}
+			position := 0
+			elements := base.AsArrayLiteralExpression().Elements.Nodes
+			for elementIndex, element := range elements {
+				if element == nil || element.Kind == ast.KindOmittedExpression {
+					if position == index {
+						return
+					}
+					position++
+					continue
+				}
+				if element.Kind == ast.KindSpreadElement {
+					// Without evaluating tuple length, the selected slot may come
+					// from either side of this spread. Follow the remaining return
+					// candidates conservatively.
+					collectExpression(element.AsSpreadElement().Expression)
+					for _, remaining := range elements[elementIndex+1:] {
+						collectExpression(remaining)
+					}
+					return
+				}
+				if position == index {
+					collectExpression(element)
+					return
+				}
+				position++
+			}
+			return
+		}
+
+		if objectType := tc.GetTypeAtLocation(base); objectType != nil {
+			if property := checker.Checker_getPropertyOfType(tc, objectType, name); property != nil {
+				collectProperty(property.ValueDeclaration)
+			}
+		}
+	}
+
+	collectFunction = func(function *ast.Node) {
+		if function == nil || !ast.IsFunctionLike(function) || function.Type() != nil || activeFunctions[function] {
+			return
+		}
+		activeFunctions[function] = true
+		defer delete(activeFunctions, function)
+		assumeMultipleReturnUses := returnTypeAssumesMultipleUses(tc, tc.GetSignatureFromDeclaration(function))
+		collectReturnedExpressions := func(expressions []*ast.Node) {
+			before := cloneUsages(usages)
+			returnType := tc.GetReturnTypeOfSignature(tc.GetSignatureFromDeclaration(function))
+			collectAlternatives(expressions, utils.IsUnionType(returnType))
+			if !assumeMultipleReturnUses {
+				return
+			}
+			for name, count := range usages {
+				if count-before[name] == 1 {
+					usages[name]++
+				}
+			}
+		}
+		if function != node {
+			for _, parameter := range function.Parameters() {
+				if parameter.Type() == nil {
+					collectExpression(parameter.Initializer())
+				}
+			}
+		}
+		functionBody := function.Body()
+		if functionBody == nil {
+			return
+		}
+		if functionBody.Kind != ast.KindBlock {
+			collectReturnedExpressions([]*ast.Node{functionBody})
+			return
+		}
+		var returnExpressions []*ast.Node
+		ast.ForEachReturnStatement(functionBody, func(statement *ast.Node) bool {
+			returnExpressions = append(returnExpressions, statement.Expression())
+			return false
+		})
+		collectReturnedExpressions(returnExpressions)
+		if ast.GetFunctionFlags(function)&ast.FunctionFlagsGenerator != 0 {
+			var yieldExpressions []*ast.Node
+			var visitYield func(*ast.Node) bool
+			visitYield = func(current *ast.Node) bool {
+				if current != functionBody && ast.IsFunctionLike(current) {
+					return false
+				}
+				if current.Kind == ast.KindYieldExpression {
+					yieldExpressions = append(yieldExpressions, current.AsYieldExpression().Expression)
+					return false
+				}
+				return current.ForEachChild(visitYield)
+			}
+			functionBody.ForEachChild(visitYield)
+			collectReturnedExpressions(yieldExpressions)
+		}
+	}
+
+	collectResolvedFunction = func(callNode *ast.Node) {
+		sig := checker.Checker_getResolvedSignature(tc, callNode, nil, checker.CheckModeNormal)
+		if sig != nil {
+			collectFunction(sig.Declaration())
+		}
+	}
+
+	collectExpression = func(expression *ast.Node) {
+		if expression == nil {
+			return
+		}
+		switch expression.Kind {
+		case ast.KindParenthesizedExpression, ast.KindNonNullExpression,
+			ast.KindSatisfiesExpression, ast.KindAwaitExpression,
+			ast.KindPartiallyEmittedExpression:
+			collectExpression(expression.Expression())
+
+		case ast.KindAsExpression, ast.KindTypeAssertionExpression:
+			if ast.IsConstTypeReference(expression.Type()) {
+				collectExpression(expression.Expression())
+			}
+
+		case ast.KindConditionalExpression:
+			conditional := expression.AsConditionalExpression()
+			collectAlternatives([]*ast.Node{conditional.WhenTrue, conditional.WhenFalse}, utils.IsUnionType(tc.GetTypeAtLocation(expression)))
+
+		case ast.KindBinaryExpression:
+			binary := expression.AsBinaryExpression()
+			switch binary.OperatorToken.Kind {
+			case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+				collectAlternatives([]*ast.Node{binary.Left, binary.Right}, utils.IsUnionType(tc.GetTypeAtLocation(expression)))
+			case ast.KindCommaToken, ast.KindEqualsToken:
+				collectExpression(binary.Right)
+			}
+
+		case ast.KindObjectLiteralExpression:
+			collectObjectRest(expression, nil)
+
+		case ast.KindArrayLiteralExpression:
+			for _, element := range expression.AsArrayLiteralExpression().Elements.Nodes {
+				if element.Kind == ast.KindSpreadElement {
+					collectExpression(element.AsSpreadElement().Expression)
+				} else {
+					collectExpression(element)
+				}
+			}
+
+		case ast.KindArrowFunction, ast.KindFunctionExpression:
+			collectFunction(expression)
+
+		case ast.KindClassExpression:
+			if members := expression.MemberList(); members != nil {
+				for _, member := range members.Nodes {
+					collectProperty(member)
+				}
+			}
+
+		case ast.KindCallExpression:
+			collectCallArguments(expression, expression.AsCallExpression().Arguments.Nodes, 0)
+			collectResolvedFunction(expression)
+
+		case ast.KindNewExpression:
+			collectCallArguments(expression, expression.AsNewExpression().Arguments.Nodes, 0)
+
+		case ast.KindTaggedTemplateExpression:
+			tagged := expression.AsTaggedTemplateExpression()
+			if tagged.Template.Kind == ast.KindTemplateExpression {
+				spans := tagged.Template.AsTemplateExpression().TemplateSpans.Nodes
+				arguments := make([]*ast.Node, 0, len(spans))
+				for _, span := range spans {
+					arguments = append(arguments, span.AsTemplateSpan().Expression)
+				}
+				collectCallArguments(expression, arguments, 1)
+			}
+			collectResolvedFunction(expression)
+
+		case ast.KindSpreadElement:
+			collectExpression(expression.AsSpreadElement().Expression)
+
+		case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+			name := ast.GetElementOrPropertyAccessName(expression)
+			if name != nil {
+				collectSelectedProperty(expression.Expression(), ast.GetPropertyNameForPropertyNameNode(name))
+			} else {
+				collectExpression(expression.Expression())
+			}
+
+		case ast.KindIdentifier:
+			symbol := tc.GetSymbolAtLocation(expression)
+			if symbol == nil {
+				return
+			}
+			collectDeclaration(symbol.ValueDeclaration)
+		}
+	}
+
+	if rootExpression != nil {
+		collectExpression(rootExpression)
+	} else {
+		collectFunction(node)
+	}
+	return usages
+}
+
+// needsLegacyObjectSpreadRecovery identifies the one default mismatch behind
+// this compatibility path: TypeScript 5.9 defaults omitted `strict` and
+// `strictNullChecks` to false, while current tsgo defaults them to true.
+func needsLegacyObjectSpreadRecovery(options *core.CompilerOptions) bool {
+	return options != nil &&
+		options.Strict == core.TSUnknown &&
+		options.StrictNullChecks == core.TSUnknown
+}
+
+// collectLegacyObjectSpreadSignatureUsages is kept separate from the normal
+// checker walk so projects with explicit strictness retain the rule's cheap
+// allocation profile. The compatibility analysis is only needed when both
+// strictness settings were omitted.
+func collectLegacyObjectSpreadSignatureUsages(tc *checker.Checker, node *ast.Node, usages map[*ast.Node]int) {
+	collectDeclaration := func(declaration *ast.Node) {
+		if !ast.IsFunctionLike(declaration) {
+			return
+		}
+		sig := tc.GetSignatureFromDeclaration(declaration)
+		if sig == nil {
+			return
+		}
+		for _, parameter := range sig.Parameters() {
+			if parameter.ValueDeclaration == nil || parameter.ValueDeclaration.Type() != nil {
+				continue
+			}
+			for name, count := range collectInferredObjectSpreadExpressionUsages(tc, parameter.ValueDeclaration.Initializer()) {
+				usages[name] += count
+			}
+		}
+		for name, count := range collectInferredObjectSpreadUsages(tc, sig.Declaration()) {
+			usages[name] += count
+		}
+	}
+
+	if ast.IsClassLike(node) {
+		if members := node.MemberList(); members != nil {
+			for _, member := range members.Nodes {
+				collectDeclaration(member)
+				if member.Kind == ast.KindPropertyDeclaration || member.Kind == ast.KindPropertySignature {
+					if initializer := member.Initializer(); ast.IsFunctionLike(initializer) {
+						collectDeclaration(initializer)
+					}
+				}
+			}
+		}
+		return
+	}
+	collectDeclaration(node)
 }
 
 // isTypeParameterRepeatedInAST is the cheap syntactic shortcut: if the type
@@ -227,7 +1769,7 @@ func skipUnionIntersectionUpward(node *ast.Node) *ast.Node {
 // (including inferred return types). For a class, every member contributes
 // (with generic type-argument usages always treated as "multiple"); for a
 // function-like node, only its own signature contributes.
-func countTypeParameterUsage(tc *checker.Checker, node *ast.Node) map[*ast.Node]int {
+func countTypeParameterUsage(tc *checker.Checker, node *ast.Node, recoverLegacyObjectSpreads bool) map[*ast.Node]int {
 	counts := make(map[*ast.Node]int)
 
 	if ast.IsClassLike(node) {
@@ -241,6 +1783,9 @@ func countTypeParameterUsage(tc *checker.Checker, node *ast.Node) map[*ast.Node]
 		}
 	} else {
 		collectTypeParameterUsageCounts(tc, node, counts, false)
+	}
+	if recoverLegacyObjectSpreads {
+		collectLegacyObjectSpreadSignatureUsages(tc, node, counts)
 	}
 
 	return counts
@@ -261,6 +1806,10 @@ func countTypeParameterUsage(tc *checker.Checker, node *ast.Node) map[*ast.Node]
 // arguments always count as multiple use there, since a class's type
 // parameters are shared across every member.
 func collectTypeParameterUsageCounts(tc *checker.Checker, node *ast.Node, foundIdentifierUsages map[*ast.Node]int, fromClass bool) {
+	collectTypeParameterUsageCountsWorker(tc, node, foundIdentifierUsages, fromClass)
+}
+
+func collectTypeParameterUsageCountsWorker(tc *checker.Checker, node *ast.Node, foundIdentifierUsages map[*ast.Node]int, fromClass bool) {
 	visitedProperties := make(map[*checker.Type]bool)
 	visitedConstraints := make(map[*ast.Node]bool)
 	visitedDefault := false

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
@@ -83,6 +83,282 @@ const extractErrorData = <TData,>(error?: unknown): IError<TData> | null => {
 };
 `},
 
+		// ---- Real-user: rspack normalization.ts inferred object-spread return ----
+		// Spreading an optional generic value preserves T in the inferred return
+		// type, so the parameter occurrence and inferred return occurrence relate
+		// two signature positions. Upstream typescript-eslint 8.65.0 does not
+		// report this shape.
+		{
+			Code:     `const cloneObject = <T>(value?: T) => ({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+function cloneObject<T>(value?: T) {
+  return { ...value };
+}
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code:     `const cloneObject = <T>(value?: T) => ({ tag: 1, ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code:     `const cloneObject = <T>(value?: T) => ({ ...value, tag: 1 });`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		// The legacy inference also flows through containers, branches, wrappers,
+		// and generic return positions. These all resolve to types containing T in
+		// TypeScript 5.9 with omitted strictness options.
+		{
+			Code: `
+declare const flag: boolean;
+const nested = <T>(value?: T) => ({ nested: { ...value } });
+const array = <T>(value?: T) => [{ ...value }];
+const tuple = <T>(value?: T) => [{ ...value }] as const;
+const conditional = <T>(value?: T) => flag ? { ...value } : { ...value };
+const logical = <T>(value?: T) => flag && { ...value };
+const satisfied = <T>(value?: T) => ({ ...value }) satisfies object;
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+declare function identityObject<X>(value: X): X;
+const promised = <T>(value?: T) => Promise.resolve({ ...value });
+const identity = <T>(value?: T) => identityObject({ ...value });
+const getter = <T>(value?: T) => ({ get clone() { return { ...value }; } });
+function* generated<T>(value?: T) { yield { ...value }; }
+const pair = <T, U>(left?: T, right?: U) => ({
+  left: { ...left },
+  right: [{ ...right }],
+});
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+const local = <T>(value?: T) => {
+  const clone = { ...value };
+  return clone;
+};
+const shorthand = <T>(value?: T) => {
+  const clone = { ...value };
+  return { clone };
+};
+const spreadLocal = <T>(value?: T) => {
+  const clone = { ...value };
+  return { ...clone };
+};
+const asynchronous = async <T>(value?: T) => {
+  const clone = { ...value };
+  return clone;
+};
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+declare function chooseRight<A, B>(left: A, right: B, echo: A): B;
+class Box<X> { constructor(readonly value: X) {} }
+const called = <T>(value?: T) => chooseRight({}, { ...value }, {});
+const constructed = <T>(value?: T) => new Box({ ...value });
+const returnedClass = <T>(value?: T) => class {
+  clone() { return { ...value }; }
+};
+const returnedMethod = <T>(value?: T) => ({
+  clone() { return { ...value }; },
+});
+function* generated<T>(value?: T) { yield* [{ ...value }]; }
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+declare const key: 'nested' | 'fixed';
+const dynamic = <T>(value?: T) => ({ nested: { ...value }, fixed: 0 })[key];
+const selected = <T>(value?: T) => {
+  const result = { nested: { ...value }, fixed: 0 };
+  return result.nested;
+};
+const destructured = <T>(value?: T) => {
+  const { nested } = { nested: { ...value }, fixed: 0 };
+  return nested;
+};
+function inferredIdentity<X>(input: X) { return input; }
+const inferred = <T>(value?: T) => inferredIdentity({ ...value });
+const mapped = <T>(value?: T) => [value].map(item => ({ ...item }));
+declare function identityTag<X>(strings: TemplateStringsArray, value: X): X;
+const tagged = <T>(value?: T) => identityTag` + "`" + `${{ ...value }}` + "`" + `;
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+declare function identityObject<X>(value: X): X;
+declare function tupleIdentity<X>(...values: [X]): X;
+const explicit = <T>(value?: T) => identityObject<T>({ ...value });
+const spreadArgument = <T>(value?: T) => tupleIdentity(...[{ ...value }]);
+const arrayDestructured = <T>(value?: T) => {
+  const [clone] = [{ ...value }];
+  return clone;
+};
+const arraySelected = <T>(value?: T) => [{ ...value }][0];
+const spreadOverwrites = <T>(value?: T) =>
+  ({ clone: 0, ...{ clone: { ...value } } }).clone;
+const objectRest = <T>(value?: T) => {
+  const { fixed, ...rest } = { fixed: 0, clone: { ...value } };
+  return rest;
+};
+const localCall = <T>(value?: T) => {
+  const getClone = () => ({ ...value });
+  return getClone();
+};
+const immediateCall = <T>(value?: T) => (() => ({ ...value }))();
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+declare const flag: boolean;
+const arrayRest = <T>(value?: T) => {
+  const [, ...rest] = [0, { ...value }];
+  return rest;
+};
+const objectRestSpreadWins = <T>(value?: T) => {
+  const { ...rest } = { clone: 0, ...{ clone: { ...value } } };
+  return rest;
+};
+const defaultBinding = <T>(value?: T) => {
+  const { clone = { ...value } } = {};
+  return clone;
+};
+const selectedConditional = <T>(value?: T) =>
+  (flag ? { clone: { ...value } } : { clone: 0 }).clone;
+const nestedObjectBinding = <T>(value?: T) => {
+  const { outer: { clone } } = { outer: { clone: { ...value } } };
+  return clone;
+};
+const nestedArrayBinding = <T>(value?: T) => {
+  const [[clone]] = [[{ ...value }]];
+  return clone;
+};
+interface StructuralInput<X> { value: X }
+type StructuralAlias<X> = { value: X };
+declare function structuralResult<X>(value: StructuralInput<X>): X;
+declare function structuralAliasResult<X>(value: StructuralAlias<X>): X;
+const structuralInference = <T>(value?: T) =>
+  structuralResult({ value: { ...value } });
+const structuralAliasInference = <T>(value?: T) =>
+  structuralAliasResult({ value: { ...value } });
+const inferredDefaultParameter = <T>(value?: T, clone = { ...value }) => 0;
+const returnedFunctionDefault = <T>(value?: T) =>
+  (clone = { ...value }) => 0;
+const returnedMethodDefault = <T>(value?: T) => ({
+  clone(input = { ...value }) { return input; },
+});
+const defaultOnlyAndReturned = <T>(clone = { ...({} as T) }) => clone;
+const doubleReturnOnly = <T>() => ({
+  first: { ...({} as T) },
+  second: { ...({} as T) },
+});
+declare function mappedResult<X>(value: { [K in keyof X]: X[K] }): X;
+declare function partialResult<X>(value: Partial<X>): X;
+declare function fixedMappedResult<X>(value: { [K in 'value']: X }): X;
+const mappedInference = <T>(value?: T) =>
+  mappedResult({ clone: { ...value } });
+const partialInference = <T>(value?: T) =>
+  partialResult({ clone: { ...value } });
+const fixedMappedInference = <T>(value?: T) =>
+  fixedMappedResult({ value: { ...value } });
+const constrainedObject = <T extends object>(value?: T) => ({ ...value });
+const constrainedRecord = <T extends Record<string, unknown>>(value?: T) => ({ ...value });
+const mixedLostReturn = <T>() => ({ direct: null as T, ...({} as T | undefined) });
+const nestedDoubleReturnOnly = <T>() => {
+  const inner = { first: { ...({} as T) }, second: { ...({} as T) } };
+  return { ...inner };
+};
+const duplicateLocalReturnOnly = <T>() => {
+  const clone = { ...({} as T | undefined) };
+  return { first: clone, second: clone };
+};
+const duplicateSelectionReturnOnly = <T>() => {
+  const result = { clone: { ...({} as T | undefined) } };
+  return { first: result.clone, second: result.clone };
+};
+const wholeObjectSpreadWins = <T>(value?: T) =>
+  ({ clone: 0, ...{ clone: { ...value } } });
+class CloneMethod { clone() {} }
+const classMethodDoesNotOverwrite = <T>(value?: T) =>
+  ({ clone: { ...value }, ...new CloneMethod() });
+const returnOnlyArray = <T>() => [{ ...({} as T | undefined) }];
+const promisedReturnOnlyArray = <T>() => Promise.resolve([{ ...({} as T | undefined) }]);
+declare function pairResult<A, B>(left: A, right: B): { left: A; right: B };
+const pairCallReturnOnly = <T>() => pairResult(
+  { ...({} as T | undefined) },
+  { ...({} as T | undefined) },
+);
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+const method = <T>(value?: T) => ({ ...({} as { method(): T }) });
+const promise = <T>(value?: T) => ({ ...({} as Promise<T>) });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		// Adversarial differential cases: legacy inference also preserves T
+		// through nullable object constraints, object intersections, &&, distinct
+		// union branches, and computed string index signatures.
+		{
+			Code: `
+declare const flag: boolean;
+declare const key: 'clone' | 'fixed';
+const nullableConstraint = <T extends object | undefined>(value?: T) => ({ ...value });
+const objectIntersection = <T>(value: (T & object) | undefined) => ({ ...value });
+const logicalAnd = <T>(value?: T) => ({ ...(value && value) });
+const transitiveConstraint = <U, T extends U>(value?: T, echo?: U) => ({ ...value });
+const distinctBranches = <T>() => flag
+  ? { left: { ...({} as T | undefined) } }
+  : { right: { ...({} as T | undefined) } };
+function distinctBlockReturns<T>() {
+  if (flag) return { left: { ...({} as T | undefined) } };
+  return { right: { ...({} as T | undefined) } };
+}
+const computedIndex = <T>() => ({ [key]: { ...({} as T | undefined) } });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		{
+			Code: `
+type Mapped<X> = { [K in keyof X]: X[K] };
+type StringMap<X> = { [key: string]: X };
+const mapped = <T>(value?: T) => ({ ...({} as Mapped<T>) });
+const indexed = <T>(value?: T) => ({ ...({} as StringMap<T>) });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		// Object spread copies public class fields, so their value types remain
+		// part of the inferred return surface.
+		{
+			Code: `
+class PublicFields<X> {
+  first!: X;
+  second?: X;
+}
+const clone = <T>(value?: T) => ({ ...({} as PublicFields<T>) });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+		},
+		// Explicitly disabling strictness already gives tsgo the legacy inference;
+		// the recovery path is only for the omitted-option default mismatch.
+		{
+			Code:     `const cloneObject = <T>(value?: T) => ({ nested: { ...value } });`,
+			TSConfig: "tsconfig.unstrict.json",
+		},
+
 		// ---- Branch lock-in: isTypeParameterRepeatedInAST self-reference exclusion ----
 		// Locks in upstream isTypeParameterRepeatedInAST() arm: a reference to
 		// T inside T's own constraint clause doesn't count toward repetition,
@@ -173,11 +449,9 @@ interface Holder<A> {
 declare function hold<T>(x: Holder<((T))>): void;
 `},
 
-		// ---- Deliberate divergence: mapped-type `as` clause counts as a use ----
-		// A key remapped through `as` is a real signature position, so T relating
-		// the parameter to the remapped key is not a lone use. ESLint misses this
-		// because its type walk never descends into a mapped type's name type,
-		// and reports T here.
+		// ---- Upstream v8.67: mapped-type `as` clause counts as a use ----
+		// Upstream now visits MappedType.nameType, so a key remapped through T is
+		// correctly recognized as a second signature position.
 		{Code: `<T extends string>(t: T) => t as { [K in 'a' as T]: 0 };`},
 
 		// ---- Deliberate divergence: every index signature counts, not just
@@ -190,6 +464,756 @@ declare function hold<T>(x: Holder<((T))>): void;
 		{Code: "declare function patternKeyed<T>(x: number): { [k: `a${string}`]: T };"},
 		{Code: `declare function symbolKeyedParam<T>(x: { [k: symbol]: T }): void;`},
 	}, []rule_tester.InvalidTestCase{
+		// ---- Real-user: inferred object-spread return strictness boundaries ----
+		// With strict null checks enabled, TypeScript 5.9 infers `{}` here and
+		// upstream reports T. The compatibility path must not suppress it.
+		{
+			Code: `const cloneObject = <T>(value?: T) => ({ ...value });`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the function signature.",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const cloneObject = (value?: unknown) => ({ ...value });`,
+				}},
+			}},
+		},
+		// An assertion on the spread operand erases T before return inference,
+		// so upstream reports this even when strict null checks are disabled.
+		{
+			Code:     `const cloneObject = <T>(value?: T) => ({ ...(value as object) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the function signature.",
+				Line:      1,
+				Column:    22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const cloneObject = (value?: unknown) => ({ ...(value as object) });`,
+				}},
+			}},
+		},
+		// A generic used only by the inferred return still occupies just one
+		// signature position and therefore remains reportable.
+		{
+			Code:     `const createObject = <T>() => ({ ...({} as T) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Message:   "Type parameter T is used only once in the function signature.",
+				Line:      1,
+				Column:    23,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const createObject = () => ({ ...({} as unknown) });`,
+				}},
+			}},
+		},
+		// A reachable spread is not enough on its own: if a call, sequence, or
+		// property selection erases the spread result from the return type, T is
+		// still used in only one signature position and must be reported.
+		{
+			Code: `declare function discardObject(value: object): number;
+const discarded = <T>(value?: T) => discardObject({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare function discardObject(value: object): number;
+const discarded = (value?: unknown) => discardObject({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function returnEmptyObject(value: object): {};
+const discarded = <T>(value?: T) => returnEmptyObject({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare function returnEmptyObject(value: object): {};
+const discarded = (value?: unknown) => returnEmptyObject({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const discarded = <T>(value?: T) => ({ nested: { ...value }, fixed: 0 }).fixed;`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const discarded = (value?: unknown) => ({ nested: { ...value }, fixed: 0 }).fixed;`,
+				}},
+			}},
+		},
+		{
+			Code:     `const explicit = <T>(value?: T): object => ({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    19,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const explicit = (value?: unknown): object => ({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code: `const discarded = <T>(value?: T) => {
+  const clone = { ...value };
+  return 0;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const discarded = (value?: unknown) => {
+  const clone = { ...value };
+  return 0;
+};`,
+				}},
+			}},
+		},
+		{
+			Code: `type EmptyPick<X> = Pick<X, never>;
+const clone = <T>(value?: T) => ({ ...({} as EmptyPick<T>) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    16,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `type EmptyPick<X> = Pick<X, never>;
+const clone = (value?: unknown) => ({ ...({} as EmptyPick<unknown>) });`,
+				}},
+			}},
+		},
+		{
+			Code: `type PhantomMapped<X> = { [K in never]: X };
+const clone = <T>(value?: T) => ({ ...({} as PhantomMapped<T>) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    16,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `type PhantomMapped<X> = { [K in never]: X };
+const clone = (value?: unknown) => ({ ...({} as PhantomMapped<unknown>) });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T>(value?: T) => ({ ...({} as () => T) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    16,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = (value?: unknown) => ({ ...({} as () => unknown) });`,
+				}},
+			}},
+		},
+		// Explicit type arguments and NoInfer disconnect a spread argument from
+		// the generic return, and a later property overwrite removes it from the
+		// selected return surface.
+		{
+			Code: `declare function identityObject<X>(value: X): X;
+const clone = <T>(value?: T) => identityObject<object>({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare function identityObject<X>(value: X): X;
+const clone = (value?: unknown) => identityObject<object>({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function noInferIdentity<X = object>(value: NoInfer<X>): X;
+const clone = <T>(value?: T) => noInferIdentity({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare function noInferIdentity<X = object>(value: NoInfer<X>): X;
+const clone = (value?: unknown) => noInferIdentity({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) =>
+  ({ clone: { ...value }, ...{ clone: 0 } }).clone;`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) =>
+  ({ clone: { ...value }, ...{ clone: 0 } }).clone;`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) =>
+  ({ clone: { ...value }, ...{ clone: 0 } });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) =>
+  ({ clone: { ...value }, ...{ clone: 0 } });`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) => {
+  const fixed = { clone: 0 };
+  return { clone: { ...value }, ...fixed };
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) => {
+  const fixed = { clone: 0 };
+  return { clone: { ...value }, ...fixed };
+};`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) => {
+  const { generic, ...rest } = { generic: { ...value }, fixed: 0 };
+  return rest;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) => {
+  const { generic, ...rest } = { generic: { ...value }, fixed: 0 };
+  return rest;
+};`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) => {
+  const { ...rest } = { generic: { ...value }, ...{ generic: 0 } };
+  return rest;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) => {
+  const { ...rest } = { generic: { ...value }, ...{ generic: 0 } };
+  return rest;
+};`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) => {
+  const { generic = { ...value } }: { generic?: object } = {};
+  return generic;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) => {
+  const { generic = { ...value } }: { generic?: object } = {};
+  return generic;
+};`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) => {
+  const [fixed] = [0, { ...value }];
+  return fixed;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) => {
+  const [fixed] = [0, { ...value }];
+  return fixed;
+};`,
+				}},
+			}},
+		},
+		{
+			Code: `interface PhantomInput<X> { fixed: number }
+declare function phantomResult<X>(value: PhantomInput<X>): X;
+const clone = <T>(value?: T) => phantomResult({ fixed: 0, ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `interface PhantomInput<X> { fixed: number }
+declare function phantomResult<X>(value: PhantomInput<X>): X;
+const clone = (value?: unknown) => phantomResult({ fixed: 0, ...value });`,
+				}},
+			}},
+		},
+		{
+			Code: `type PhantomInput<X> = { fixed: number };
+declare function phantomResult<X>(value: PhantomInput<X>): X;
+const clone = <T>(value?: T) => phantomResult({ fixed: 0, ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      3,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `type PhantomInput<X> = { fixed: number };
+declare function phantomResult<X>(value: PhantomInput<X>): X;
+const clone = (value?: unknown) => phantomResult({ fixed: 0, ...value });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T>(value?: T, copy: object = { ...value }) => 0;`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = (value?: unknown, copy: object = { ...value }) => 0;`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>() => {
+  const inner = { ...({} as T) };
+  return { ...inner };
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = () => {
+  const inner = { ...({} as unknown) };
+  return { ...inner };
+};`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function erasedMappedResult<X>(value: { [K in keyof X as never]: X[K] }): X;
+const clone = <T>(value?: T) => erasedMappedResult({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare function erasedMappedResult<X>(value: { [K in keyof X as never]: X[K] }): X;
+const clone = (value?: unknown) => erasedMappedResult({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T extends string>(value?: T) => ({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = (value?: string) => ({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T extends unknown>(value?: T) => ({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = (value?: unknown) => ({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T extends object>() => ({ ...({} as T | undefined) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = () => ({ ...({} as object | undefined) });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T>() => [{ ...({} as T | undefined) }] as const;`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = () => [{ ...({} as unknown | undefined) }] as const;`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T>() => ({ list: [{ ...({} as T | undefined) }] });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = () => ({ list: [{ ...({} as unknown | undefined) }] });`,
+				}},
+			}},
+		},
+		{
+			Code: `declare const flag: boolean;
+const clone = <T>() => flag
+  ? { kind: 'a', ...({} as T | undefined) }
+  : { kind: 'b', ...({} as T | undefined) };`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare const flag: boolean;
+const clone = () => flag
+  ? { kind: 'a', ...({} as unknown | undefined) }
+  : { kind: 'b', ...({} as unknown | undefined) };`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function sameResult<X>(left: X, right: X): X;
+const clone = <T>() => sameResult(
+  { ...({} as T | undefined) },
+  { ...({} as T | undefined) },
+);`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare function sameResult<X>(left: X, right: X): X;
+const clone = () => sameResult(
+  { ...({} as unknown | undefined) },
+  { ...({} as unknown | undefined) },
+);`,
+				}},
+			}},
+		},
+		// Repeating the same generic spread on one object surface collapses to a
+		// single T in TypeScript's inferred intersection, so it remains sole.
+		{
+			Code:     `const clone = <T>() => ({ ...({} as T | undefined), ...({} as T | undefined) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = () => ({ ...({} as unknown | undefined), ...({} as unknown | undefined) });`,
+				}},
+			}},
+		},
+		// Distinct callee type parameters that are returned as a naked
+		// intersection collapse when both arguments infer the same outer T.
+		{
+			Code:     `const clone = <T>() => Object.assign({ ...({} as T | undefined) }, { ...({} as T | undefined) });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = () => Object.assign({ ...({} as unknown | undefined) }, { ...({} as unknown | undefined) });`,
+				}},
+			}},
+		},
+		// Explicit annotations on locals and default parameters erase the spread
+		// from the inferred signature even when that annotated value is returned.
+		{
+			Code: `const clone = <T>(value?: T) => {
+  const copy: object = { ...value };
+  return copy;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) => {
+  const copy: object = { ...value };
+  return copy;
+};`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <T>(value?: T, copy: object = { ...value }) => copy;`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = (value?: unknown, copy: object = { ...value }) => copy;`,
+				}},
+			}},
+		},
+		// Primitive intersections and single computed properties do not preserve
+		// multiple generic positions in the inferred return type.
+		{
+			Code:     `const clone = <T>(value: (T & string) | undefined) => ({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = (value: (unknown & string) | undefined) => ({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const clone = <U, T extends U & string>(value?: T, echo?: U) => ({ ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    19,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const clone = <U>(value?: U & string, echo?: U) => ({ ...value });`,
+				}},
+			}},
+		},
+		{
+			Code: `declare const key: 'clone';
+const clone = <T>() => ({ [key]: { ...({} as T | undefined) } });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare const key: 'clone';
+const clone = () => ({ [key]: { ...({} as unknown | undefined) } });`,
+				}},
+			}},
+		},
+		{
+			Code: `const clone = <T>(value?: T) => {
+  const { item }: { item: object } = { item: { ...value } };
+  return item;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const clone = (value?: unknown) => {
+  const { item }: { item: object } = { item: { ...value } };
+  return item;
+};`,
+				}},
+			}},
+		},
+		// Class methods, accessors, and private/protected fields are absent from
+		// the enumerable surface copied by object spread. Each class uses X twice
+		// so the diagnostic isolates the enclosing function.
+		{
+			Code: `
+class MethodSurface<X> {
+  read(input: X): X { return input; }
+}
+const clone = <T>(value?: T) => ({ ...({} as MethodSurface<T>) });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      5,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class MethodSurface<X> {
+  read(input: X): X { return input; }
+}
+const clone = (value?: unknown) => ({ ...({} as MethodSurface<unknown>) });
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+class AccessorSurface<X> {
+  get value(): X { throw new Error(); }
+  set value(input: X) {}
+}
+const clone = <T>(value?: T) => ({ ...({} as AccessorSurface<T>) });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      6,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class AccessorSurface<X> {
+  get value(): X { throw new Error(); }
+  set value(input: X) {}
+}
+const clone = (value?: unknown) => ({ ...({} as AccessorSurface<unknown>) });
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+class PrivateSurface<X> {
+  private first!: X;
+  private second!: X;
+}
+const clone = <T>(value?: T) => ({ ...({} as PrivateSurface<T>) });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      6,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class PrivateSurface<X> {
+  private first!: X;
+  private second!: X;
+}
+const clone = (value?: unknown) => ({ ...({} as PrivateSurface<unknown>) });
+`,
+				}},
+			}},
+		},
+		{
+			Code: `
+class ProtectedSurface<X> {
+  protected first!: X;
+  protected second!: X;
+}
+const clone = <T>(value?: T) => ({ ...({} as ProtectedSurface<T>) });
+`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      6,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `
+class ProtectedSurface<X> {
+  protected first!: X;
+  protected second!: X;
+}
+const clone = (value?: unknown) => ({ ...({} as ProtectedSurface<unknown>) });
+`,
+				}},
+			}},
+		},
+		{
+			Code: `declare function chooseRight<A, B>(left: A, right: B, echo: A): B;
+const discarded = <T>(value?: T) => chooseRight({ ...value }, {}, { ...value });`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      2,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `declare function chooseRight<A, B>(left: A, right: B, echo: A): B;
+const discarded = (value?: unknown) => chooseRight({ ...value }, {}, { ...value });`,
+				}},
+			}},
+		},
+		{
+			Code:     `const asserted = <T>(value?: T) => ({ ...value }) as object;`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    19,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output:    `const asserted = (value?: unknown) => ({ ...value }) as object;`,
+				}},
+			}},
+		},
+		{
+			Code: `const discarded = <T>(value?: T) => {
+  const result = { nested: { ...value }, fixed: 0 };
+  return result.fixed;
+};`,
+			TSConfig: "tsconfig.default-strictness.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "sole",
+				Line:      1,
+				Column:    20,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "replaceUsagesWithConstraint",
+					Output: `const discarded = (value?: unknown) => {
+  const result = { nested: { ...value }, fixed: 0 };
+  return result.fixed;
+};`,
+				}},
+			}},
+		},
+
 		// A comment after the separator belongs to the following type parameter.
 		// Removing the first parameter must preserve it, matching upstream.
 		{


### PR DESCRIPTION
## Summary

- align `@typescript-eslint/no-unnecessary-type-parameters` with upstream when `strict` and `strictNullChecks` are omitted, including the rspack `value?: T => ({ ...value })` false positive
- recover inferred signature usage through object-spread return flows, generic calls, branches, destructuring, classes, defaults, and related aggregate surfaces without changing explicit-strictness behavior
- cover suggestion precedence and adversarial constraint boundaries, including primitive intersections such as `T extends U & string`

### Verification

- matched `@typescript-eslint` 8.67 exactly on a 322-line deep corpus (43 diagnostics) and a 144-case adversarial corpus (53 diagnostics)
- `go test ./internal/plugins/typescript/rules/no_unnecessary_type_parameters -count=3`
- scoped `golangci-lint` on the changed Go files
- `pnpm run check-spell`
- `pnpm run format:check`

### Go benchmark

Apple M5 Max, `-benchmem -count=5`; values are medians:

| Case | Before ns/op | After ns/op | Before B/op | After B/op | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| no match / repeated | 14,855 | 16,159 | 10,083 | 10,084 | 130 | 130 |
| diagnostics only | 143,552 | 155,616 | 168,845 | 168,847 | 737 | 737 |
| wrong autofix demand | 143,342 | 155,609 | 168,844 | 168,852 | 737 | 737 |
| suggestions | 149,197 | 166,667 | 183,439 | 183,442 | 897 | 897 |
| omitted-strictness object-spread recovery | 37,529 | 36,464 | 22,629 | 21,860 | 263 | 231 |

The unchanged no-match control shifted by 8.8% between runs, showing host timing drift. Allocation counts for all existing paths are unchanged. The new compatibility path improved despite that drift: 2.8% lower time, 3.4% lower bytes, and 12.2% fewer allocations.

## Related Links

- Upstream rule: https://typescript-eslint.io/rules/no-unnecessary-type-parameters/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
