### PR TITLE
fix: harden restrict-template-expressions

### DIFF
--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
@@ -2,10 +2,11 @@ package restrict_template_expressions
 
 import (
 	_ "embed"
-	"fmt"
+	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -24,12 +25,14 @@ type RestrictTemplateExpressionsOptions struct {
 	AllowRegExp  bool
 }
 
+var defaultAllowedTypes = []utils.TypeOrValueSpecifier{{
+	From: utils.TypeOrValueSpecifierFromLib,
+	Name: utils.NameList{"Error", "URL", "URLSearchParams"},
+}}
+
 func parseOptions(options []any) RestrictTemplateExpressionsOptions {
 	opts := RestrictTemplateExpressionsOptions{
-		Allow: []utils.TypeOrValueSpecifier{{
-			From: utils.TypeOrValueSpecifierFromLib,
-			Name: utils.NameList{"Error", "URL", "URLSearchParams"},
-		}},
+		Allow:        defaultAllowedTypes,
 		AllowAny:     true,
 		AllowBoolean: true,
 		AllowNullish: true,
@@ -70,7 +73,7 @@ func parseOptions(options []any) RestrictTemplateExpressionsOptions {
 func buildInvalidTypeMessage(t string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "invalidType",
-		Description: fmt.Sprintf("Invalid type \"%v\" of template literal expression.", t),
+		Description: "Invalid type \"" + t + "\" of template literal expression.",
 	}
 }
 
@@ -90,29 +93,128 @@ func getBaseTypesForType(typeChecker *checker.Checker, t *checker.Type) []*check
 	return checker.Checker_getBaseTypes(typeChecker, target)
 }
 
-// matchesTypeOrBaseType reports whether the type or any of its base types
-// satisfies the matcher.
-func matchesTypeOrBaseType(
+// matchesAllowedTypeOrBaseType reports whether the type or any of its base
+// types satisfies one of the configured allow specifiers. It only allocates a
+// visited set when there are base types to traverse.
+func matchesAllowedTypeOrBaseType(
 	typeChecker *checker.Checker,
-	matcher func(t *checker.Type) bool,
 	t *checker.Type,
+	allow []utils.TypeOrValueSpecifier,
+	program *compiler.Program,
+) bool {
+	if utils.TypeMatchesSomeSpecifier(t, allow, nil, program) {
+		return true
+	}
+
+	baseTypes := getBaseTypesForType(typeChecker, t)
+	if len(baseTypes) == 0 {
+		return false
+	}
+
+	seen := make(map[*checker.Type]struct{}, len(baseTypes)+1)
+	seen[t] = struct{}{}
+	for _, base := range baseTypes {
+		if matchesAllowedBaseType(typeChecker, base, allow, program, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAllowedBaseType(
+	typeChecker *checker.Checker,
+	t *checker.Type,
+	allow []utils.TypeOrValueSpecifier,
+	program *compiler.Program,
 	seen map[*checker.Type]struct{},
 ) bool {
 	if _, ok := seen[t]; ok {
 		return false
 	}
 	seen[t] = struct{}{}
-
-	if matcher(t) {
+	if utils.TypeMatchesSomeSpecifier(t, allow, nil, program) {
 		return true
 	}
-
 	for _, base := range getBaseTypesForType(typeChecker, t) {
-		if matchesTypeOrBaseType(typeChecker, matcher, base, seen) {
+		if matchesAllowedBaseType(typeChecker, base, allow, program, seen) {
 			return true
 		}
 	}
 	return false
+}
+
+type templateExpressionTypeChecker struct {
+	typeChecker *checker.Checker
+	program     *compiler.Program
+	options     RestrictTemplateExpressionsOptions
+}
+
+func (c *templateExpressionTypeChecker) isAllowed(innerType *checker.Type, arrayPath []*checker.Type) bool {
+	if innerType == nil {
+		return false
+	}
+	if utils.IsUnionType(innerType) {
+		for _, part := range innerType.Types() {
+			if !c.isAllowed(part, arrayPath) {
+				return false
+			}
+		}
+		return true
+	}
+	if utils.IsIntersectionType(innerType) {
+		for _, part := range innerType.Types() {
+			if c.isAllowed(part, arrayPath) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if utils.IsTypeFlagSet(innerType, checker.TypeFlagsStringLike) {
+		return true
+	}
+
+	// These checks are pure alternatives to the allow list. Checking them first
+	// avoids symbol and declaration work for the common primitive paths.
+	if c.options.AllowAny && utils.IsTypeAnyType(innerType) {
+		return true
+	}
+	if c.options.AllowArray &&
+		(checker.Checker_isArrayType(c.typeChecker, innerType) || checker.IsTupleType(innerType)) {
+		if !slices.Contains(arrayPath, innerType) {
+			if arrayPath == nil {
+				arrayPath = make([]*checker.Type, 0, 4)
+			}
+			if c.isAllowed(
+				utils.GetNumberIndexType(c.typeChecker, innerType),
+				append(arrayPath, innerType),
+			) {
+				return true
+			}
+		}
+	}
+	if c.options.AllowBoolean && utils.IsTypeFlagSet(innerType, checker.TypeFlagsBooleanLike) {
+		return true
+	}
+	if c.options.AllowNullish && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+		return true
+	}
+	if c.options.AllowNumber && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNumberLike|checker.TypeFlagsBigIntLike) {
+		return true
+	}
+	if c.options.AllowNever && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNever) {
+		return true
+	}
+
+	if len(c.options.Allow) > 0 && matchesAllowedTypeOrBaseType(
+		c.typeChecker,
+		innerType,
+		c.options.Allow,
+		c.program,
+	) {
+		return true
+	}
+	return c.options.AllowRegExp && utils.GetTypeName(c.typeChecker, innerType) == "RegExp"
 }
 
 var RestrictTemplateExpressionsRule = rule.CreateRule(rule.Rule{
@@ -120,55 +222,10 @@ var RestrictTemplateExpressionsRule = rule.CreateRule(rule.Rule{
 	RequiresTypeInfo: true,
 	Schema:           rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := parseOptions(options)
-
-		var recursivelyCheckType func(innerType *checker.Type) bool
-		recursivelyCheckType = func(innerType *checker.Type) bool {
-			if innerType == nil {
-				return false
-			}
-			if utils.IsUnionType(innerType) {
-				return utils.Every(innerType.Types(), recursivelyCheckType)
-			}
-			if utils.IsIntersectionType(innerType) {
-				return utils.Some(innerType.Types(), recursivelyCheckType)
-			}
-
-			if utils.IsTypeFlagSet(innerType, checker.TypeFlagsStringLike) {
-				return true
-			}
-
-			if len(opts.Allow) > 0 && matchesTypeOrBaseType(ctx.TypeChecker, func(t *checker.Type) bool {
-				return utils.TypeMatchesSomeSpecifier(t, opts.Allow, nil, ctx.Program)
-			}, innerType, map[*checker.Type]struct{}{}) {
-				return true
-			}
-
-			if opts.AllowAny && utils.IsTypeAnyType(innerType) {
-				return true
-			}
-			if opts.AllowArray &&
-				(checker.Checker_isArrayType(ctx.TypeChecker, innerType) || checker.IsTupleType(innerType)) &&
-				recursivelyCheckType(utils.GetNumberIndexType(ctx.TypeChecker, innerType)) {
-				return true
-			}
-			if opts.AllowBoolean && utils.IsTypeFlagSet(innerType, checker.TypeFlagsBooleanLike) {
-				return true
-			}
-			if opts.AllowNullish && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
-				return true
-			}
-			if opts.AllowNumber && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNumberLike|checker.TypeFlagsBigIntLike) {
-				return true
-			}
-			if opts.AllowRegExp && utils.GetTypeName(ctx.TypeChecker, innerType) == "RegExp" {
-				return true
-			}
-			if opts.AllowNever && utils.IsTypeFlagSet(innerType, checker.TypeFlagsNever) {
-				return true
-			}
-
-			return false
+		typeChecker := templateExpressionTypeChecker{
+			typeChecker: ctx.TypeChecker,
+			program:     ctx.Program,
+			options:     parseOptions(options),
 		}
 
 		return rule.RuleListeners{
@@ -181,7 +238,12 @@ var RestrictTemplateExpressionsRule = rule.CreateRule(rule.Rule{
 				for _, span := range node.AsTemplateExpression().TemplateSpans.Nodes {
 					expression := span.AsTemplateSpan().Expression
 					expressionType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, expression)
-					if !recursivelyCheckType(expressionType) {
+					// Keep the overwhelmingly common direct-string path out of the
+					// recursive checker.
+					if expressionType != nil && utils.IsTypeFlagSet(expressionType, checker.TypeFlagsStringLike) {
+						continue
+					}
+					if !typeChecker.isAllowed(expressionType, nil) {
 						ctx.ReportNode(expression, buildInvalidTypeMessage(ctx.TypeChecker.TypeToString(expressionType)))
 					}
 				}

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions_test.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions_test.go
@@ -495,3 +495,154 @@ func TestRestrictTemplateExpressionsRule(t *testing.T) {
 		},
 	)
 }
+
+func TestRestrictTemplateExpressionsEdgeCases(t *testing.T) {
+	invalidType := func(message string) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{{
+			MessageId: "invalidType",
+			Message:   message,
+		}}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RestrictTemplateExpressionsRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code:    "declare const arg: readonly string[];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "const arg = ['foo', 1] as const;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "declare const arg: [string, number?];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "declare const arg: [string, ...number[]];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "const msg = `arg = ${[, 2]}`;\n",
+				Options: map[string]any{"allowArray": true},
+			},
+			{
+				Code:    "declare const arg: never[];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true, "allowNever": true},
+			},
+			{
+				Code: "type Recursive = Recursive[];\ndeclare const arg: Recursive;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{
+					"allowArray": true,
+					"allow":      []any{"Recursive"},
+				},
+			},
+			{
+				Code: "class Base {}\nclass Middle extends Base {}\nclass Leaf extends Middle {}\ndeclare const arg: Leaf;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{
+					map[string]any{"from": "file", "name": "Base"},
+				}},
+			},
+			{
+				Code: "interface A { a: 1 }\ninterface B { b: 1 }\ninterface C extends A, B { c: 1 }\ndeclare const arg: C;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{
+					map[string]any{"from": "file", "name": "B"},
+				}},
+			},
+			{
+				Code: "class Base<T> { value!: T }\nclass Leaf extends Base<string> {}\ndeclare const arg: Leaf;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{
+					map[string]any{"from": "file", "name": "Base"},
+				}},
+			},
+			{
+				Code: "type Custom = { value: string };\ndeclare const arg: Custom;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allow": []any{
+					map[string]any{"from": "file", "name": "Custom"},
+				}},
+			},
+			{
+				Code: "class Child extends URL {}\ndeclare const arg: Child;\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: number & { readonly brand: unique symbol };\nconst msg = `arg = ${arg}`;\n",
+			},
+			{
+				Code: "declare const arg: object;\ndeclare function tag(strings: TemplateStringsArray, ...values: unknown[]): string;\nconst msg = tag`arg = ${arg}`;\n",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    "declare const arg: [string, number?];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true, "allowNullish": false},
+				Errors:  invalidType("Invalid type \"[string, (number | undefined)?]\" of template literal expression."),
+			},
+			{
+				Code:    "declare const arg: (string | object)[][];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+				Errors:  invalidType("Invalid type \"(string | object)[][]\" of template literal expression."),
+			},
+			{
+				Code:    "const msg = `arg = ${[, 2]}`;\n",
+				Options: map[string]any{"allowArray": true, "allowNullish": false},
+				Errors:  invalidType("Invalid type \"(number | undefined)[]\" of template literal expression."),
+			},
+			{
+				Code:    "declare const arg: never[];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+				Errors:  invalidType("Invalid type \"never[]\" of template literal expression."),
+			},
+			{
+				Code:    "declare const arg: any[];\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true, "allowAny": false},
+				Errors:  invalidType("Invalid type \"any[]\" of template literal expression."),
+			},
+			{
+				Code:    "type Recursive = Recursive[];\ndeclare const arg: Recursive;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+				Errors:  invalidType("Invalid type \"Recursive\" of template literal expression."),
+			},
+			{
+				Code:    "type Left = Right[];\ntype Right = Left[];\ndeclare const arg: Left;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+				Errors:  invalidType("Invalid type \"Left\" of template literal expression."),
+			},
+			{
+				Code:    "class CustomArray extends Array<string> {}\ndeclare const arg: CustomArray;\nconst msg = `arg = ${arg}`;\n",
+				Options: map[string]any{"allowArray": true},
+				Errors:  invalidType("Invalid type \"CustomArray\" of template literal expression."),
+			},
+			{
+				Code:   "class Child extends RegExp {}\ndeclare const arg: Child;\nconst msg = `arg = ${arg}`;\n",
+				Errors: invalidType("Invalid type \"Child\" of template literal expression."),
+			},
+			{
+				Code:   "const arg = new String('value');\nconst msg = `arg = ${arg}`;\n",
+				Errors: invalidType("Invalid type \"String\" of template literal expression."),
+			},
+			{
+				Code:   "declare const arg: unknown;\nconst msg = `arg = ${arg as object}`;\n",
+				Errors: invalidType("Invalid type \"object\" of template literal expression."),
+			},
+			{
+				Code:   "declare const arg: { a: 1 };\nconst msg = `arg = ${arg satisfies object}`;\n",
+				Errors: invalidType("Invalid type \"{ a: 1; }\" of template literal expression."),
+			},
+			{
+				Code:   "declare const arg: object;\nconst msg = `arg = ${(arg)}`;\n",
+				Errors: invalidType("Invalid type \"object\" of template literal expression."),
+			},
+			{
+				Code: "declare const a: object;\ndeclare const b: string;\ndeclare const c: symbol;\nconst msg = `${a} ${b} ${c}`;\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidType", Message: "Invalid type \"object\" of template literal expression."},
+					{MessageId: "invalidType", Message: "Invalid type \"symbol\" of template literal expression."},
+				},
+			},
+		},
+	)
+}


### PR DESCRIPTION
## Summary

- Keep `restrict-template-expressions` aligned with the current upstream behavior across readonly/optional/rest tuples, recursive arrays, inherited allow-list types, wrapper objects, assertions, and multi-expression templates.
- Stop cyclic and mutually cyclic array aliases from recursing indefinitely while still honoring an explicit `allow` entry for the recursive type.
- Avoid eager default-option, allow-list traversal, visited-set, and diagnostic-message allocations on common paths.

### Go benchmark

Apple M5 Max, CPU idle at least 70% before each run, median of five 500ms samples:

```sh
go test ./internal/plugins/typescript/rules/restrict_template_expressions \
  -run '^$' \
  -bench '^BenchmarkRestrictTemplateExpressions$' \
  -benchmem \
  -benchtime=500ms \
  -count=5
```

| Case | Before ns/op | After ns/op | Delta | Before B/op | After B/op | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| SetupDefault | 145.9 | 111.2 | -23.8% | 624 | 472 | 8 | 5 |
| AllowedString | 20.39 | 19.59 | -3.9% | 0 | 0 | 0 | 0 |
| AllowedNumber | 71.87 | 20.96 | -70.8% | 32 | 0 | 4 | 0 |
| AllowedUnion | 77.27 | 25.20 | -67.4% | 32 | 0 | 4 | 0 |
| AllowedNestedArray | 152.0 | 41.30 | -72.8% | 64 | 0 | 8 | 0 |
| AllowedDerivedError | 111.3 | 109.4 | -1.7% | 40 | 40 | 5 | 5 |
| InvalidObject | 802.0 | 750.0 | -6.5% | 2752 | 2736 | 33 | 32 |
| TaggedTemplate | 1.686 | 1.680 | -0.4% | 0 | 0 | 0 | 0 |

Correctness and checks:

- Target Go package tests, repeated three times
- Target `restrict-template-expressions` Rstest file
- Current upstream v8.67 + TypeScript 6 differential checks and the five rsbuild/rspack audit reproductions
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/restrict_template_expressions/...`
- `git diff --check`

## Related Links

- [Upstream `restrict-template-expressions` implementation](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/restrict-template-expressions.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
