### PR TITLE
fix: align no-unsafe-argument with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument.go
+++ b/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument.go
@@ -1,8 +1,6 @@
 package no_unsafe_argument
 
 import (
-	"fmt"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -12,25 +10,25 @@ import (
 func buildUnsafeArgumentMessage(sender string, receiver string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeArgument",
-		Description: fmt.Sprintf("Unsafe argument of type %v assigned to a parameter of type %v.", sender, receiver),
+		Description: "Unsafe argument of type " + sender + " assigned to a parameter of type " + receiver + ".",
 	}
 }
 func buildUnsafeArraySpreadMessage(sender string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeArraySpread",
-		Description: fmt.Sprintf("Unsafe spread of an %v array type.", sender),
+		Description: "Unsafe spread of an " + sender + " array type.",
 	}
 }
 func buildUnsafeSpreadMessage(sender string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeSpread",
-		Description: fmt.Sprintf("Unsafe spread of an %v type.", sender),
+		Description: "Unsafe spread of an " + sender + " type.",
 	}
 }
 func buildUnsafeTupleSpreadMessage(sender string, receiver string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeTupleSpread",
-		Description: fmt.Sprintf("Unsafe spread of a tuple type. The argument is %v and is assigned to a parameter of type %v.", sender, receiver),
+		Description: "Unsafe spread of a tuple type. The argument is " + sender + " and is assigned to a parameter of type " + receiver + ".",
 	}
 }
 
@@ -52,16 +50,16 @@ type restType struct {
 func newFunctionSignature(
 	typeChecker *checker.Checker,
 	node *ast.Node,
-) *functionSignature {
+) (functionSignature, bool) {
 	signature := checker.Checker_getResolvedSignature(typeChecker, node, nil, checker.CheckModeNormal)
 	if signature == nil {
-		return nil
+		return functionSignature{}, false
 	}
 
-	paramTypes := []*checker.Type{}
-	var restT restType
-
 	parameters := checker.Signature_parameters(signature)
+	var paramTypes []*checker.Type
+	var restT restType
+	hasRestType := false
 
 	for i, param := range parameters {
 		t := typeChecker.GetTypeOfSymbolAtLocation(param, node)
@@ -89,25 +87,31 @@ func newFunctionSignature(
 						Kind:  restTypeKindOther,
 					}
 				}
+				hasRestType = true
 				break
 			}
 		}
 
+		if paramTypes == nil {
+			paramTypes = make([]*checker.Type, 0, len(parameters))
+		}
 		paramTypes = append(paramTypes, t)
 	}
 
-	return &functionSignature{
-		paramTypes: paramTypes,
-		restType:   &restT,
-	}
+	return functionSignature{
+		paramTypes:  paramTypes,
+		restType:    restT,
+		hasRestType: hasRestType,
+	}, true
 }
 
 type functionSignature struct {
 	hasConsumedArguments bool
 	parameterTypeIndex   int
 
-	paramTypes []*checker.Type
-	restType   *restType
+	paramTypes  []*checker.Type
+	restType    restType
+	hasRestType bool
 }
 
 func (s *functionSignature) consumeRemainingArguments() {
@@ -119,7 +123,7 @@ func (s *functionSignature) getNextParameterType() *checker.Type {
 	s.parameterTypeIndex += 1
 
 	if index >= len(s.paramTypes) || s.hasConsumedArguments {
-		if s.restType == nil {
+		if !s.hasRestType {
 			return nil
 		}
 
@@ -160,7 +164,7 @@ var NoUnsafeArgumentRule = rule.CreateRule(rule.Rule{
 				return "error typed"
 			}
 
-			return ctx.TypeChecker.TypeToString(t)
+			return "`" + ctx.TypeChecker.TypeToString(t) + "`"
 		}
 
 		describeTypeForSpread := func(t *checker.Type) string {
@@ -176,7 +180,7 @@ var NoUnsafeArgumentRule = rule.CreateRule(rule.Rule{
 				return "error typed"
 			}
 
-			return "of type " + ctx.TypeChecker.TypeToString(t)
+			return "of type `" + ctx.TypeChecker.TypeToString(t) + "`"
 		}
 
 		checkUnsafeArguments := func(
@@ -193,8 +197,8 @@ var NoUnsafeArgumentRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			signature := newFunctionSignature(ctx.TypeChecker, node)
-			if signature == nil {
+			signature, ok := newFunctionSignature(ctx.TypeChecker, node)
+			if !ok {
 				panic("Expected to a signature resolved")
 			}
 
@@ -257,15 +261,16 @@ var NoUnsafeArgumentRule = rule.CreateRule(rule.Rule{
 						continue
 					}
 
-					argumentType := ctx.TypeChecker.GetTypeAtLocation(argument)
+					reportNode := ast.SkipParentheses(argument)
+					argumentType := ctx.TypeChecker.GetTypeAtLocation(reportNode)
 					_, _, unsafe := utils.IsUnsafeAssignment(
 						argumentType,
 						parameterType,
 						ctx.TypeChecker,
-						argument,
+						reportNode,
 					)
 					if unsafe {
-						ctx.ReportNode(argument, buildUnsafeArgumentMessage(describeType(argumentType), describeType(parameterType)))
+						ctx.ReportNode(reportNode, buildUnsafeArgumentMessage(describeType(argumentType), describeType(parameterType)))
 					}
 				}
 			}

--- a/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument_extras_test.go
@@ -1,0 +1,495 @@
+// TestNoUnsafeArgumentExtras locks in branches and edge shapes that the
+// upstream suite in no_unsafe_argument_upstream_test.go does not exercise.
+// Each case identifies the upstream branch, universal edge shape, or real-user
+// regression it protects.
+package no_unsafe_argument
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func runNoUnsafeArgumentLenientProgram(
+	t *testing.T,
+	entryFileName string,
+	files map[string]string,
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	root := fixtures.GetRootDir()
+	overlays := make(map[string]string, len(files))
+	rootNames := make([]string, 0, len(files))
+	for fileName, code := range files {
+		filePath := tspath.ResolvePath(root.Dir, fileName)
+		overlays[filePath] = code
+		rootNames = append(rootNames, filePath)
+	}
+	fs := utils.NewOverlayVFS(root.FS, overlays)
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	program, err := utils.CreateProgramFromOptionsLenient(
+		false,
+		&core.CompilerOptions{},
+		rootNames,
+		host,
+	)
+	if err != nil {
+		t.Fatalf("create lenient program: %v", err)
+	}
+	entryPath := tspath.ResolvePath(root.Dir, entryFileName)
+	sourceFile := program.GetSourceFile(entryPath)
+	if sourceFile == nil {
+		t.Fatalf("lenient program did not contain %s", entryFileName)
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	_, err = linter.RunLinter(linter.RunLinterOptions{
+		Programs:         []*compiler.Program{program},
+		SingleThreaded:   true,
+		Scope:            linter.FileScope{Files: []string{sourceFile.FileName()}},
+		ExcludePaths:     []string{},
+		SyntaxErrorFiles: map[string]struct{}{},
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:             NoUnsafeArgumentRule.Name,
+				Severity:         rule.SeverityError,
+				RequiresTypeInfo: true,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return NoUnsafeArgumentRule.Run(ctx, nil)
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandNone,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("run linter: %v", err)
+	}
+	return diagnostics
+}
+
+func TestNoUnsafeArgumentTypeScriptVersionBoundary(t *testing.T) {
+	t.Parallel()
+	// ---- Real-user: rspack packages/rspack/src/config/defaults.ts ----
+	// TypeScript 5.9 types tty as boolean, while TypeScript 6 and typescript-go
+	// 7 type it as any. The rule follows its checker, matching the current
+	// supported upstream combination by reporting the argument.
+
+	const fileName = "file.ts"
+	const code = `
+import type { InfrastructureLogging } from './no_unsafe_argument_types';
+
+declare const infrastructureLogging: InfrastructureLogging;
+declare const process: { env: { TERM?: string } };
+
+const tty =
+  (infrastructureLogging as any).stream?.isTTY &&
+  process.env.TERM !== 'dumb';
+
+declare function setDefault<T, P extends keyof T>(
+  object: T,
+  property: P,
+  value: T[P],
+): void;
+setDefault(infrastructureLogging, 'colors', tty);
+`
+	const typesCode = `
+export type InfrastructureLogging = {
+  colors?: boolean;
+  stream?: { isTTY?: boolean };
+};
+`
+
+	diagnostics := runNoUnsafeArgumentLenientProgram(t, fileName, map[string]string{
+		fileName:                      code,
+		"no_unsafe_argument_types.ts": typesCode,
+	})
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one logical-AND diagnostic, got %#v", diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Message.Id != "unsafeArgument" ||
+		diagnostic.Message.Description != "Unsafe argument of type `any` assigned to a parameter of type `boolean | undefined`." {
+		t.Fatalf("unexpected logical-AND diagnostic: %#v", diagnostic)
+	}
+	if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != "tty" {
+		t.Fatalf("logical-AND diagnostic range covers %q, want tty", got)
+	}
+}
+
+func TestNoUnsafeArgumentLogicalExpressionBoundaries(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnsafeArgumentRule,
+		[]rule_tester.ValidTestCase{
+			{
+				// Locks in the non-strict checker type for a simple unannotated const.
+				TSConfig: "tsconfig.unstrict.json",
+				Code: `
+declare function acceptBoolean(value: boolean): void;
+declare const anyValue: any;
+const value = anyValue && true;
+acceptBoolean(value);
+`,
+			},
+			{
+				// ---- Dimension 4: direct, nested, aliased, property, and return shapes ----
+				TSConfig: "tsconfig.unstrict.json",
+				Code: `
+declare function acceptBoolean(value: boolean): void;
+declare const anyValue: any;
+
+acceptBoolean(anyValue && true);
+acceptBoolean((anyValue && true));
+acceptBoolean(anyValue && anyValue && true);
+acceptBoolean((anyValue && true) || false);
+
+let letValue = anyValue && true;
+var varValue = anyValue && true;
+const alias = letValue;
+const objectValue = { value: anyValue && true };
+function getValue() { return anyValue && true; }
+
+acceptBoolean(letValue);
+acceptBoolean(varValue);
+acceptBoolean(alias);
+acceptBoolean(objectValue.value);
+acceptBoolean(getValue());
+`,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				// strictNullChecks keeps `any && boolean` unsafe upstream.
+				Code: `
+declare function acceptBoolean(value: boolean): void;
+declare const anyValue: any;
+const value = anyValue && true;
+acceptBoolean(value);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      5,
+					Column:    15,
+					EndColumn: 20,
+				}},
+			},
+			{
+				// An explicit any annotation remains authoritative.
+				TSConfig: "tsconfig.unstrict.json",
+				Code: `
+declare function acceptBoolean(value: boolean): void;
+declare const anyValue: any;
+const value: any = anyValue && true;
+acceptBoolean(value);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      5,
+					Column:    15,
+					EndColumn: 20,
+				}},
+			},
+			{
+				// An any-typed right operand remains unsafe.
+				TSConfig: "tsconfig.unstrict.json",
+				Code: `
+declare function acceptBoolean(value: boolean): void;
+declare const anyValue: any;
+const value = true && anyValue;
+acceptBoolean(value);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      5,
+					Column:    15,
+					EndColumn: 20,
+				}},
+			},
+			{
+				// An error-typed right operand retains upstream's error diagnostic.
+				TSConfig: "tsconfig.unstrict.json",
+				Code: `
+declare function acceptBoolean(value: boolean): void;
+declare const anyValue: any;
+const value = anyValue && missingName;
+acceptBoolean(value);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Message:   "Unsafe argument of type error typed assigned to a parameter of type `boolean`.",
+					Line:      5,
+					Column:    15,
+					EndLine:   5,
+					EndColumn: 20,
+				}},
+			},
+		},
+	)
+}
+
+func TestNoUnsafeArgumentLogicalAndMutableFlow(t *testing.T) {
+	// A later write makes the flow type any. Run this in an isolated Program:
+	// RuleTester batches virtual files, which changes this no-strict flow type.
+	const fileName = "no_unsafe_argument_mutable_flow.ts"
+	const code = `
+declare function acceptBoolean(value: boolean): void;
+declare const anyValue: any;
+let value = anyValue && true;
+value = anyValue;
+acceptBoolean(value);
+`
+	diagnostics := runNoUnsafeArgumentLenientProgram(t, fileName, map[string]string{
+		fileName: code,
+	})
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one unsafe mutable-flow diagnostic, got %#v", diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Message.Id != "unsafeArgument" ||
+		diagnostic.Message.Description != "Unsafe argument of type `any` assigned to a parameter of type `boolean`." {
+		t.Fatalf("unexpected mutable-flow diagnostic: %#v", diagnostic)
+	}
+	if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != "value" {
+		t.Fatalf("mutable-flow diagnostic range covers %q, want value", got)
+	}
+}
+
+func TestNoUnsafeArgumentExtras(t *testing.T) {
+	// N/A Dimension 4 access/key forms: the rule does not inspect member keys.
+	// N/A Dimension 4 autofix boundaries: the rule has no fixes or suggestions.
+	// N/A Dimension 4 scope boundaries: every listener is node-local.
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnsafeArgumentRule,
+		[]rule_tester.ValidTestCase{
+			{
+				// ---- Real-user: typescript-eslint#10415 generic-constraint false negative ----
+				// This is a known upstream false negative; parity means not reporting it.
+				Code: `
+declare const constrained: <T extends number>(value: T) => void;
+constrained(1 as any);
+`,
+			},
+			{
+				// ---- Real-user: typescript-eslint#11801 nested object any enhancement ----
+				// Upstream currently checks generic type arguments, not object properties.
+				Code: `
+declare const fromLibrary: { value: any };
+declare function acceptObject(value: { value: number }): void;
+acceptObject(fromLibrary);
+`,
+			},
+			{
+				// ---- Real-user: typescript-eslint#5014 recursive types must not recurse forever ----
+				Code: `
+type RecursiveArray = Array<RecursiveArray>;
+declare const values: RecursiveArray;
+declare function identity<T>(value: T): T;
+identity(values);
+`,
+			},
+			{
+				// Locks in checkUnsafeArguments()'s non-array iterable spread branch.
+				Code: `
+declare function acceptStrings(...values: string[]): void;
+declare const values: Set<any>;
+acceptStrings(...values);
+`,
+			},
+			{
+				// Locks in FunctionSignature's generic rest-type branch.
+				Code: `
+declare function genericRest<T extends string[]>(...values: T): void;
+genericRest('safe', 1 as any);
+`,
+			},
+			{
+				// ---- Dimension 4: parenthesized new Map() keeps upstream's safe special case ----
+				Code: `
+declare function acceptsMap(value: Map<string, string>): void;
+acceptsMap((new Map()));
+acceptsMap(((new Map())));
+`,
+			},
+			{
+				// ---- Dimension 4: empty arguments degrade gracefully ----
+				Code: `
+declare function optional(value?: number): void;
+optional();
+`,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				// ---- Dimension 4: one parenthesized argument; ESTree excludes parens ----
+				Code: `
+declare function acceptNumber(value: number): void;
+declare const anyValue: any;
+acceptNumber((anyValue));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Message:   "Unsafe argument of type `any` assigned to a parameter of type `number`.",
+					Line:      4,
+					Column:    15,
+					EndLine:   4,
+					EndColumn: 23,
+				}},
+			},
+			{
+				// ---- Dimension 4: multiply parenthesized argument ----
+				Code: `
+declare function acceptNumber(value: number): void;
+declare const anyValue: any;
+acceptNumber(((anyValue)));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    16,
+					EndLine:   4,
+					EndColumn: 24,
+				}},
+			},
+			{
+				// ---- Dimension 4: comment trivia inside parentheses ----
+				Code: `
+declare function acceptNumber(value: number): void;
+declare const anyValue: any;
+acceptNumber((/* leading */ anyValue));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    29,
+					EndLine:   4,
+					EndColumn: 37,
+				}},
+			},
+			{
+				// ---- Dimension 4: TS non-null assertion wrapper ----
+				Code: `
+declare function acceptNumber(value: number): void;
+declare const anyValue: any;
+acceptNumber(anyValue!);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    14,
+					EndLine:   4,
+					EndColumn: 23,
+				}},
+			},
+			{
+				// ---- Dimension 4: TS as-expression wrapper ----
+				Code: `
+declare function acceptNumber(value: number): void;
+declare const anyValue: any;
+acceptNumber(anyValue as any);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    14,
+					EndLine:   4,
+					EndColumn: 29,
+				}},
+			},
+			{
+				// ---- Dimension 4: TS satisfies-expression wrapper ----
+				Code: `
+declare function acceptNumber(value: number): void;
+declare const anyValue: any;
+acceptNumber(anyValue satisfies unknown);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    14,
+					EndLine:   4,
+					EndColumn: 40,
+				}},
+			},
+			{
+				// ---- Dimension 4: optional call ----
+				Code: `
+declare const anyValue: any;
+declare const maybeFunction: ((value: number) => void) | undefined;
+maybeFunction?.(anyValue);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    17,
+					EndLine:   4,
+					EndColumn: 25,
+				}},
+			},
+			{
+				// Locks in the NewExpression listener's ordinary argument branch.
+				Code: `
+declare const anyValue: any;
+declare class Box { constructor(value: number); }
+new Box(anyValue);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    9,
+					EndLine:   4,
+					EndColumn: 17,
+				}},
+			},
+			{
+				// Locks in NewExpression plus tuple-spread checking.
+				Code: `
+declare const anyValue: any;
+declare class Box { constructor(value: number); }
+new Box(...([anyValue] as const));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeTupleSpread",
+					Message:   "Unsafe spread of a tuple type. The argument is of type `any` and is assigned to a parameter of type `number`.",
+					Line:      4,
+					Column:    9,
+					EndLine:   4,
+					EndColumn: 33,
+				}},
+			},
+			{
+				// Locks in FunctionSignature.getNextParameterType()'s tuple fallback.
+				Code: `
+declare function tupleRest(...values: [number, string]): void;
+declare const anyValue: any;
+tupleRest(...([1, 'ok', anyValue] as [number, string, any]));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeTupleSpread",
+					Message:   "Unsafe spread of a tuple type. The argument is of type `any` and is assigned to a parameter of type `string`.",
+					Line:      4,
+					Column:    11,
+					EndLine:   4,
+					EndColumn: 60,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument_upstream_test.go
@@ -1,3 +1,7 @@
+// TestNoUnsafeArgumentUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts 1:1.
+// Position assertions cover line and column for every invalid case. rslint-
+// specific lock-ins live in no_unsafe_argument_extras_test.go.
 package no_unsafe_argument
 
 import (
@@ -7,7 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-func TestNoUnsafeArgumentRule(t *testing.T) {
+func TestNoUnsafeArgumentUpstream(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeArgumentRule, []rule_tester.ValidTestCase{
 		{Code: `
 doesNotExist(1 as any);
@@ -116,6 +120,7 @@ foo(1 as any);
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeArgument",
+					Message:   "Unsafe argument of type `any` assigned to a parameter of type `number`.",
 					Line:      3,
 					Column:    5,
 					EndColumn: 13,
@@ -130,6 +135,7 @@ foo(error);
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeArgument",
+					Message:   "Unsafe argument of type error typed assigned to a parameter of type `number`.",
 					Line:      3,
 					Column:    5,
 					EndColumn: 10,
@@ -193,6 +199,7 @@ foo(...(x as any));
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeSpread",
+					Message:   "Unsafe spread of an `any` type.",
 					Line:      4,
 					Column:    5,
 					EndColumn: 18,
@@ -208,6 +215,7 @@ foo(...(x as any[]));
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeArraySpread",
+					Message:   "Unsafe spread of an `any[]` array type.",
 					Line:      4,
 					Column:    5,
 					EndColumn: 20,
@@ -225,6 +233,7 @@ foo(...errors);
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeArraySpread",
+					Message:   "Unsafe spread of an error array type.",
 					Line:      6,
 					Column:    5,
 					EndColumn: 14,
@@ -241,6 +250,7 @@ foo(...x);
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeTupleSpread",
+					Message:   "Unsafe spread of a tuple type. The argument is of type `any` and is assigned to a parameter of type `number`.",
 					Line:      5,
 					Column:    5,
 					EndColumn: 9,
@@ -257,6 +267,7 @@ foo(...x);
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeTupleSpread",
+					Message:   "Unsafe spread of a tuple type. The argument is error typed and is assigned to a parameter of type `number`.",
 					Line:      5,
 					Column:    5,
 					EndColumn: 9,

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-argument.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-argument.test.ts.snap
@@ -8,7 +8,7 @@ foo(1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type number.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -37,7 +37,7 @@ foo(error);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type error typed assigned to a parameter of type number.",
+      "message": "Unsafe argument of type error typed assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -66,7 +66,7 @@ foo(1, 1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type string.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -95,7 +95,7 @@ foo(1, 2, 3, 1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type number.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -124,7 +124,7 @@ foo(1 as any, 1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type string.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -139,7 +139,7 @@ foo(1 as any, 1 as any);
       "ruleName": "@typescript-eslint/no-unsafe-argument",
     },
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type number.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -169,7 +169,7 @@ foo(...(x as any));
       ",
   "diagnostics": [
     {
-      "message": "Unsafe spread of an any type.",
+      "message": "Unsafe spread of an \`any\` type.",
       "messageId": "unsafeSpread",
       "range": {
         "end": {
@@ -199,7 +199,7 @@ foo(...(x as any[]));
       ",
   "diagnostics": [
     {
-      "message": "Unsafe spread of an any[] array type.",
+      "message": "Unsafe spread of an \`any[]\` array type.",
       "messageId": "unsafeArraySpread",
       "range": {
         "end": {
@@ -262,7 +262,7 @@ foo(...x);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe spread of a tuple type. The argument is of type any and is assigned to a parameter of type number.",
+      "message": "Unsafe spread of a tuple type. The argument is of type \`any\` and is assigned to a parameter of type \`number\`.",
       "messageId": "unsafeTupleSpread",
       "range": {
         "end": {
@@ -293,7 +293,7 @@ foo(...x);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe spread of a tuple type. The argument is error typed and is assigned to a parameter of type number.",
+      "message": "Unsafe spread of a tuple type. The argument is error typed and is assigned to a parameter of type \`number\`.",
       "messageId": "unsafeTupleSpread",
       "range": {
         "end": {
@@ -322,7 +322,7 @@ foo(...(['foo', 1, 2] as [string, any, number]));
       ",
   "diagnostics": [
     {
-      "message": "Unsafe spread of a tuple type. The argument is of type any and is assigned to a parameter of type number.",
+      "message": "Unsafe spread of a tuple type. The argument is of type \`any\` and is assigned to a parameter of type \`number\`.",
       "messageId": "unsafeTupleSpread",
       "range": {
         "end": {
@@ -353,7 +353,7 @@ foo('a', ...x, 1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type string.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -384,7 +384,7 @@ foo('a', ...x, 1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type string.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -415,7 +415,7 @@ foo(new Set<any>(), ...x);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type Set<any> assigned to a parameter of type Set<string>.",
+      "message": "Unsafe argument of type \`Set<any>\` assigned to a parameter of type \`Set<string>\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -430,7 +430,7 @@ foo(new Set<any>(), ...x);
       "ruleName": "@typescript-eslint/no-unsafe-argument",
     },
     {
-      "message": "Unsafe spread of a tuple type. The argument is of type Map<any, string> and is assigned to a parameter of type Map<string, string>.",
+      "message": "Unsafe spread of a tuple type. The argument is of type \`Map<any, string>\` and is assigned to a parameter of type \`Map<string, string>\`.",
       "messageId": "unsafeTupleSpread",
       "range": {
         "end": {
@@ -459,7 +459,7 @@ foo(1 as any, 'a' as any, 1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type number.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -474,7 +474,7 @@ foo(1 as any, 'a' as any, 1 as any);
       "ruleName": "@typescript-eslint/no-unsafe-argument",
     },
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type string.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -503,7 +503,7 @@ foo('a', 1 as any, 'a' as any, 1 as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type number.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -518,7 +518,7 @@ foo('a', 1 as any, 'a' as any, 1 as any);
       "ruleName": "@typescript-eslint/no-unsafe-argument",
     },
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type string.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -549,7 +549,7 @@ foo(t as any);
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type T.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`T\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -584,7 +584,7 @@ foo<number>\`\${arg}\${arg}\${arg}\`;
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type number.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -599,7 +599,7 @@ foo<number>\`\${arg}\${arg}\${arg}\`;
       "ruleName": "@typescript-eslint/no-unsafe-argument",
     },
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type string.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -629,7 +629,7 @@ foo\`\${arg}\`;
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type number.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {
@@ -660,7 +660,7 @@ foo\`\${arg}\`;
       ",
   "diagnostics": [
     {
-      "message": "Unsafe argument of type any assigned to a parameter of type T.",
+      "message": "Unsafe argument of type \`any\` assigned to a parameter of type \`T\`.",
       "messageId": "unsafeArgument",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

Align `@typescript-eslint/no-unsafe-argument` diagnostics with typescript-eslint v8.67.0:

- preserve upstream backticks around rendered types in all four messages;
- unwrap parenthesized ordinary arguments for upstream-compatible ranges and the `new Map()` safe special case;
- add adversarial coverage for calls, constructors, tagged templates, spreads, wrappers, recursive types, generic constraints, and TypeScript checker-version boundaries;
- reduce rule-local message and function-signature allocations.

The audit's rspack logical-AND case is TypeScript-version-dependent: TypeScript 5.9 types the argument as `boolean`, while the currently supported TypeScript 6 and typescript-go 7 type it as `any`. The rule now has a lock-in test that follows the active checker, matching the current upstream combination.

### Go benchmark

Command:

```sh
go test ./internal/plugins/typescript/rules/no_unsafe_argument -run '^$' -bench '^BenchmarkNoUnsafeArgument$' -benchmem -count=5
```

Results are the mean of five samples on Darwin/arm64 (Apple M5 Max), comparing the task-start implementation with the final implementation:

| Case | ns/op | Change | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Safe typed argument | `259.72 → 222.00` | `-14.52%` | `304 → 208` | `6 → 4` |
| Unsafe `any` argument | `1065.60 → 889.58` | `-16.52%` | `2856 → 2744` | `33 → 31` |
| Unsafe `any` spread | `600.54 → 500.88` | `-16.60%` | `1552 → 1448` | `19 → 17` |
| Any-typed callee early return | `22.65 → 20.37` | `-10.06%` | `0 → 0` | `0 → 0` |
| Empty-argument early return | `3.36 → 3.02` | `-10.03%` | `0 → 0` | `0 → 0` |

The logical-AND identifier case is intentionally excluded from before/after comparison because the checker-version audit changed its expected diagnostic count from zero to one; comparing those timings would conflate rule cost with diagnostic construction.

Correctness verification:

- target Go package tests pass;
- target JS integration tests and updated snapshots pass;
- strict, non-strict, and rspack differential corpora match upstream diagnostics and ranges exactly;
- `check-spell`, `format:check`, changed-package Go lint, and `git diff --check` pass.

## Related Links

- [typescript-eslint: no-unsafe-argument](https://typescript-eslint.io/rules/no-unsafe-argument)
- [Upstream source](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unsafe-argument.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
