### PR TITLE
fix: align no-unsafe-return with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.go
+++ b/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.go
@@ -1,32 +1,76 @@
 package no_unsafe_return
 
 import (
-	"fmt"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+const unsafeReturnThisHelp = "\nYou can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function."
+
 func buildUnsafeReturnMessage(t string) rule.RuleMessage {
+	var description string
+	switch t {
+	case "error":
+		description = "Unsafe return of a value of type error."
+	case "`any`":
+		description = "Unsafe return of a value of type `any`."
+	case "`Promise<any>`":
+		description = "Unsafe return of a value of type `Promise<any>`."
+	case "`any[]`":
+		description = "Unsafe return of a value of type `any[]`."
+	default:
+		description = "Unsafe return of a value of type " + t + "."
+	}
 	return rule.RuleMessage{
 		Id:          "unsafeReturn",
-		Description: fmt.Sprintf("Unsafe return of a value of type %v.", t),
+		Description: description,
 	}
 }
 func buildUnsafeReturnAssignmentMessage(sender, receiver string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeReturnAssignment",
-		Description: fmt.Sprintf("Unsafe return of type `%v` from function with return type `%v`.", sender, receiver),
+		Description: "Unsafe return of type `" + sender + "` from function with return type `" + receiver + "`.",
 	}
 }
 func buildUnsafeReturnThisMessage(t string) rule.RuleMessage {
-	return rule.RuleMessage{
-		Id: "unsafeReturnThis",
-		Description: fmt.Sprintf("Unsafe return of a value of type `%v`. `this` is typed as `any`.", t) +
-			"You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
+	var description string
+	switch t {
+	case "error":
+		description = "Unsafe return of a value of type `error`. `this` is typed as `any`." + unsafeReturnThisHelp
+	case "`any`":
+		description = "Unsafe return of a value of type ``any``. `this` is typed as `any`." + unsafeReturnThisHelp
+	case "`Promise<any>`":
+		description = "Unsafe return of a value of type ``Promise<any>``. `this` is typed as `any`." + unsafeReturnThisHelp
+	case "`any[]`":
+		description = "Unsafe return of a value of type ``any[]``. `this` is typed as `any`." + unsafeReturnThisHelp
+	default:
+		description = "Unsafe return of a value of type `" + t + "`. `this` is typed as `any`." + unsafeReturnThisHelp
 	}
+	return rule.RuleMessage{
+		Id:          "unsafeReturnThis",
+		Description: description,
+	}
+}
+
+func discriminateReturnType(
+	t *checker.Type,
+	typeChecker *checker.Checker,
+	program *compiler.Program,
+	node *ast.Node,
+) utils.DiscriminatedAnyType {
+	if utils.IsTypeAnyType(t) {
+		return utils.DiscriminatedAnyTypeAny
+	}
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsPrimitive|checker.TypeFlagsUnknown|checker.TypeFlagsNever) {
+		return utils.DiscriminatedAnyTypeSafe
+	}
+	if utils.IsTypeAnyArrayType(t, typeChecker) {
+		return utils.DiscriminatedAnyTypeAnyArray
+	}
+	return utils.DiscriminateAnyType(t, typeChecker, program, node)
 }
 
 var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
@@ -44,20 +88,22 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 			returnNode *ast.Node,
 			reportingNode *ast.Node,
 		) {
-			returnNodeType := ctx.TypeChecker.GetTypeAtLocation(returnNode)
-
-			anyType := utils.DiscriminateAnyType(
-				returnNodeType,
-				ctx.TypeChecker,
-				ctx.Program,
-				returnNode,
-			)
 			functionNode := utils.GetParentFunctionNode(returnNode)
 			if functionNode == nil {
 				return
 			}
 
-			constrainedReturnNodeType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, returnNode)
+			returnNodeType := ctx.TypeChecker.GetTypeAtLocation(returnNode)
+			anyType := discriminateReturnType(
+				returnNodeType,
+				ctx.TypeChecker,
+				ctx.Program,
+				returnNode,
+			)
+			if anyType == utils.DiscriminatedAnyTypeSafe &&
+				utils.IsTypeFlagSet(returnNodeType, checker.TypeFlagsPrimitive|checker.TypeFlagsUnknown|checker.TypeFlagsNever) {
+				return
+			}
 
 			// function expressions will not have their return type modified based on receiver typing
 			// so we have to use the contextual typing in these cases, i.e.
@@ -70,10 +116,13 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 			if functionType == nil {
 				functionType = ctx.TypeChecker.GetTypeAtLocation(functionNode)
 			}
-			callSignatures := utils.CollectAllCallSignatures(ctx.TypeChecker, functionType)
+			var callSignatures []*checker.Signature
+			callSignaturesLoaded := false
 			// If there is an explicit type annotation *and* that type matches the actual
 			// function return type, we shouldn't complain (it's intentional, even if unsafe)
 			if functionNode.Type() != nil {
+				callSignatures = utils.CollectAllCallSignatures(ctx.TypeChecker, functionType)
+				callSignaturesLoaded = true
 				for _, signature := range callSignatures {
 					signatureReturnType := checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, signature)
 
@@ -96,6 +145,9 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 			}
 
 			if anyType != utils.DiscriminatedAnyTypeSafe {
+				if !callSignaturesLoaded {
+					callSignatures = utils.CollectAllCallSignatures(ctx.TypeChecker, functionType)
+				}
 				// Allow cases when the declared return type of the function is either unknown or unknown[]
 				// and the function is returning any or any[].
 				for _, signature := range callSignatures {
@@ -107,11 +159,11 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 					if anyType == utils.DiscriminatedAnyTypeAnyArray && utils.IsTypeUnknownArrayType(functionReturnType, ctx.TypeChecker) {
 						return
 					}
-					awaitedType := checker.Checker_getAwaitedType(ctx.TypeChecker, functionReturnType)
-					if awaitedType != nil &&
-						anyType == utils.DiscriminatedAnyTypePromiseAny &&
-						utils.IsTypeUnknownType(awaitedType) {
-						return
+					if anyType == utils.DiscriminatedAnyTypePromiseAny {
+						awaitedType := checker.Checker_getAwaitedType(ctx.TypeChecker, functionReturnType)
+						if awaitedType != nil && utils.IsTypeUnknownType(awaitedType) {
+							return
+						}
 					}
 				}
 
@@ -120,7 +172,8 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 				}
 
 				var typeString string
-				if utils.IsIntrinsicErrorType(constrainedReturnNodeType) {
+				if anyType == utils.DiscriminatedAnyTypeAny &&
+					utils.IsIntrinsicErrorType(utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, returnNode)) {
 					typeString = "error"
 				} else if anyType == utils.DiscriminatedAnyTypeAny {
 					typeString = "`any`"
@@ -146,6 +199,9 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
+			if !callSignaturesLoaded || utils.IsUnionType(functionType) || utils.IsIntersectionType(functionType) {
+				callSignatures = utils.GetCallSignatures(ctx.TypeChecker, functionType)
+			}
 			if len(callSignatures) < 1 {
 				return
 			}

--- a/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return_test.go
@@ -833,3 +833,77 @@ function overload(x: any): any {
 		},
 	})
 }
+
+func TestNoUnsafeReturnContextualSignatureEdges(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeReturnRule, []rule_tester.ValidTestCase{
+		{Code: `
+type UnionSet = (() => Set<string>) | (() => Set<number>);
+const unionSets: UnionSet = () => new Set<any>();
+`},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `
+type IntersectionSet = (() => Set<string>) & (() => Set<number>);
+const intersectionSets: IntersectionSet = () => new Set<any>();
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unsafeReturnAssignment"}},
+		},
+	})
+}
+
+func TestNoUnsafeReturnThisMessage(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.noImplicitThis.json", t, &NoUnsafeReturnRule, nil, []rule_tester.InvalidTestCase{
+		{
+			Code: `
+function implicitThis() {
+  return this;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unsafeReturnThis",
+				Message: "Unsafe return of a value of type ``any``. `this` is typed as `any`.\n" +
+					"You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
+			}},
+		},
+	})
+}
+
+func TestNoUnsafeReturnExplicitStrictnessMatrix(t *testing.T) {
+	const code = `
+declare const value: any;
+declare const bool: boolean;
+function identifierAny() {
+  return value && bool;
+}
+function callAny() {
+  return value.method() && bool;
+}
+`
+
+	tests := []struct {
+		name      string
+		tsconfig  string
+		isInvalid bool
+	}{
+		{name: "strict false", tsconfig: "tsconfig.unstrict.json"},
+		{name: "strict true", tsconfig: "tsconfig.json", isInvalid: true},
+		{name: "strict true with strictNullChecks false", tsconfig: "tsconfig.strict-with-null-checks-off.json"},
+		{name: "strict false with strictNullChecks true", tsconfig: "tsconfig.strict-null-checks-only.json", isInvalid: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !test.isInvalid {
+				rule_tester.RunRuleTester(fixtures.GetRootDir(), test.tsconfig, t, &NoUnsafeReturnRule, []rule_tester.ValidTestCase{{Code: code}}, nil)
+				return
+			}
+			rule_tester.RunRuleTester(fixtures.GetRootDir(), test.tsconfig, t, &NoUnsafeReturnRule, nil, []rule_tester.InvalidTestCase{{
+				Code: code,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeReturn", Line: 5, Column: 3},
+					{MessageId: "unsafeReturn", Line: 8, Column: 3},
+				},
+			}})
+		})
+	}
+}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-return.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-return.test.ts.snap
@@ -520,7 +520,8 @@ function bar() {
       ",
   "diagnostics": [
     {
-      "message": "Unsafe return of a value of type \`\`any\`\`. \`this\` is typed as \`any\`.You can try to fix this by turning on the \`noImplicitThis\` compiler option, or adding a \`this\` parameter to the function.",
+      "message": "Unsafe return of a value of type \`\`any\`\`. \`this\` is typed as \`any\`.
+You can try to fix this by turning on the \`noImplicitThis\` compiler option, or adding a \`this\` parameter to the function.",
       "messageId": "unsafeReturnThis",
       "range": {
         "end": {
@@ -535,7 +536,8 @@ function bar() {
       "ruleName": "@typescript-eslint/no-unsafe-return",
     },
     {
-      "message": "Unsafe return of a value of type \`\`any\`\`. \`this\` is typed as \`any\`.You can try to fix this by turning on the \`noImplicitThis\` compiler option, or adding a \`this\` parameter to the function.",
+      "message": "Unsafe return of a value of type \`\`any\`\`. \`this\` is typed as \`any\`.
+You can try to fix this by turning on the \`noImplicitThis\` compiler option, or adding a \`this\` parameter to the function.",
       "messageId": "unsafeReturnThis",
       "range": {
         "end": {
@@ -1495,7 +1497,8 @@ const obj = {
       ",
   "diagnostics": [
     {
-      "message": "Unsafe return of a value of type \`\`any\`\`. \`this\` is typed as \`any\`.You can try to fix this by turning on the \`noImplicitThis\` compiler option, or adding a \`this\` parameter to the function.",
+      "message": "Unsafe return of a value of type \`\`any\`\`. \`this\` is typed as \`any\`.
+You can try to fix this by turning on the \`noImplicitThis\` compiler option, or adding a \`this\` parameter to the function.",
       "messageId": "unsafeReturnThis",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Match typescript-eslint v8.67.0 when choosing the first contextual call signature for union/intersection function types. The previous helper flattened union signatures and discarded multi-signature intersections, causing one false positive and one false negative in the focused corpus.
- Match the exact `unsafeReturnThis` diagnostic text, including the newline before its remediation sentence.
- Reduce rule-local work with direct type fast paths, lazy call-signature/awaited/constrained-type checks, and allocation-free common diagnostic messages.
- Keep TypeScript configuration and checker semantics outside the rule: production code contains no TypeScript-version check, `strictNullChecks` branch, logical-expression rewrite, or other compatibility normalization.

### Correctness

- The explicit compiler-option matrix is covered with the current rslint TypeScript-Go checker:
  - `strict: false`, `strictNullChecks: false`: `any && boolean` is safe and is not reported.
  - `strict: true`, `strictNullChecks: true`: it is `any` and is reported.
  - `strict: true`, `strictNullChecks: false`: it is not reported.
  - `strict: false`, `strictNullChecks: true`: it is reported.
- TypeScript 5.9.3 and 6.0.3 produce the same type strings for that explicitly configured matrix. Omitted defaults are not used as the rule-semantic oracle.
- The contextual-signature corpus matches upstream: a union callback returning `Set<any>` is accepted, while the corresponding intersection reports `unsafeReturnAssignment`.
- Targeted Go tests pass for three consecutive runs, and the migrated Rstest file passes both tests without snapshot drift.
- `check-spell`, `format:check`, changed-code Go lint for this rule package, and `git diff --check` pass.

### Real-repository differential

This is an integration observation, not a TypeScript-version compatibility target for the rule.

- With rsbuild's current config and typescript-eslint 8.67.0 + TypeScript 6.0.3, diagnostics match exactly: 111/111, including ranges, message IDs, and text.
- On rspack, 225/226 diagnostics match. The only upstream-only location is `packages/rspack-test-tools/src/helper/read-config-file.ts:30`: both checkers resolve the conditional branches as `RspackOptions[]` and `any[]`, but TypeScript 6 merges the expression to `any[]` while TypeScript-Go merges it to `RspackOptions[]`. No rule workaround was added for this checker-level difference.

### Go benchmark

Command:

```sh
go test -run '^$' -bench '^BenchmarkNoUnsafeReturn$' -benchmem -count=6 -benchtime=300ms ./internal/plugins/typescript/rules/no_unsafe_return
```

Apple M5 Max; six-run medians. CPU idle was 75.48% immediately before the baseline and 90.99% immediately before the final run.

| Case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Unsafe any / diagnostics | 11609.5 → 7743.5 (-33.3%) | 16514 → 8320 (-49.6%) | 199 → 71 (-64.3%) |
| Unsafe any / autofix demand | 11771.5 → 7874.5 (-33.1%) | 16514 → 8320 (-49.6%) | 199 → 71 (-64.3%) |
| Unsafe any / suggestion demand | 11981 → 7838.5 (-34.6%) | 16514 → 8320 (-49.6%) | 199 → 71 (-64.3%) |
| Safe/no match | 10474.5 → 3833 (-63.4%) | 16000 → 3200 (-80.0%) | 231 → 39 (-83.1%) |
| Logical AND / non-strict fixture | 14691.5 → 10814 (-26.4%) | 16514 → 8320 (-49.6%) | 199 → 71 (-64.3%) |
| Logical AND / strict fixture | 14556 → 10613.5 (-27.1%) | 16514 → 8320 (-49.6%) | 199 → 71 (-64.3%) |

In the fixed 10,500-file, one-rule workload, listener time decreased from 88.8 ms to 74.4 ms (-16.2%).

## Related Links

- [typescript-eslint v8.67.0 implementation](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unsafe-return.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
