### PR TITLE
fix: align restrict-plus-operands with upstream

### DIFF
--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
@@ -2,7 +2,6 @@ package restrict_plus_operands
 
 import (
 	_ "embed"
-	"fmt"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -17,19 +16,19 @@ var schemaJSON []byte
 func buildBigintAndNumberMessage(left, right string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "bigintAndNumber",
-		Description: fmt.Sprintf("Numeric '+' operations must either be both bigints or both numbers. Got `%v` + `%v`.", left, right),
+		Description: "Numeric '+' operations must either be both bigints or both numbers. Got `" + left + "` + `" + right + "`.",
 	}
 }
 func buildInvalidMessage(stringLike, t string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "invalid",
-		Description: fmt.Sprintf("Invalid operand for a '+' operation. Operands must each be a number or %v. Got `%v`.", stringLike, t),
+		Description: "Invalid operand for a '+' operation. Operands must each be a number or " + stringLike + ". Got `" + t + "`.",
 	}
 }
 func buildMismatchedMessage(stringLike, left, right string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "mismatched",
-		Description: fmt.Sprintf("Operands of '+' operations must be a number or %v. Got `%v` + `%v`.", stringLike, left, right),
+		Description: "Operands of '+' operations must be a number or " + stringLike + ". Got `" + left + "` + `" + right + "`.",
 	}
 }
 
@@ -40,6 +39,44 @@ type RestrictPlusOperandsOptions struct {
 	AllowNumberAndString    bool
 	AllowRegExp             bool
 	SkipCompoundAssignments bool
+}
+
+func isDeeplyObjectType(t *checker.Type) bool {
+	if utils.IsIntersectionType(t) {
+		return utils.Every(t.Types(), utils.IsObjectType)
+	}
+	return utils.IsObjectType(t)
+}
+
+func invalidObjectOperandType(
+	typeChecker *checker.Checker,
+	part *checker.Type,
+	otherType *checker.Type,
+	allowAny bool,
+	allowRegExp bool,
+) (string, bool) {
+	isAny := utils.IsTypeAnyType(part)
+	isTypeParameter := utils.IsTypeParameter(part)
+	deeplyObject := isDeeplyObjectType(part)
+	if !isTypeParameter && !deeplyObject && (allowAny || !isAny) {
+		return "", false
+	}
+
+	typeName := utils.GetTypeName(typeChecker, part)
+	renderedType := typeName
+	if isTypeParameter {
+		renderedType = typeChecker.TypeToString(part)
+	}
+	if typeName == "RegExp" {
+		if allowRegExp && !utils.IsTypeFlagSet(otherType, checker.TypeFlagsNumberLike) {
+			return "", false
+		}
+		return renderedType, true
+	}
+	if (!allowAny && isAny) || deeplyObject {
+		return renderedType, true
+	}
+	return "", false
 }
 
 func parseOptions(options []any) RestrictPlusOperandsOptions {
@@ -82,37 +119,41 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
-		stringLikes := make([]string, 0, 5)
+		var stringLikes [5]string
+		stringLikeCount := 0
 		if opts.AllowAny {
-			stringLikes = append(stringLikes, "`any`")
+			stringLikes[stringLikeCount] = "`any`"
+			stringLikeCount++
 		}
 		if opts.AllowBoolean {
-			stringLikes = append(stringLikes, "`boolean`")
+			stringLikes[stringLikeCount] = "`boolean`"
+			stringLikeCount++
 		}
 		if opts.AllowNullish {
-			stringLikes = append(stringLikes, "`null`")
+			stringLikes[stringLikeCount] = "`null`"
+			stringLikeCount++
 		}
 		if opts.AllowRegExp {
-			stringLikes = append(stringLikes, "`RegExp`")
+			stringLikes[stringLikeCount] = "`RegExp`"
+			stringLikeCount++
 		}
 		if opts.AllowNullish {
-			stringLikes = append(stringLikes, "`undefined`")
+			stringLikes[stringLikeCount] = "`undefined`"
+			stringLikeCount++
 		}
 		var stringLike string
-		switch len(stringLikes) {
+		switch stringLikeCount {
 		case 0:
 			stringLike = "string"
 		case 1:
 			stringLike = "string, allowing a string + " + stringLikes[0]
 		default:
-			stringLike = "string, allowing a string + any of: " + strings.Join(stringLikes, ", ")
+			stringLike = "string, allowing a string + any of: " + strings.Join(stringLikes[:stringLikeCount], ", ")
 		}
 
 		getTypeConstrained := func(node *ast.Node) *checker.Type {
 			return checker.Checker_getBaseTypeOfLiteralType(ctx.TypeChecker, utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node))
 		}
-
-		globalRegexpType := checker.Checker_globalRegExpType(ctx.TypeChecker)
 
 		invalidFlags := checker.TypeFlagsESSymbolLike |
 			checker.TypeFlagsNever |
@@ -128,38 +169,48 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 		}
 
 		checkInvalidPlusOperand := func(baseNode *ast.Node, baseType, otherType *checker.Type) (checker.TypeFlags, bool) {
-			foundRegexp := false
-
-			var flags checker.TypeFlags
-
-			reported := false
-			for _, part := range utils.UnionTypeParts(baseType) {
-				flags |= checker.Type_flags(part)
-				if reported {
-					continue
-				}
-				if utils.IsTypeFlagSet(part, invalidFlags) {
+			if !utils.IsUnionType(baseType) {
+				flags := checker.Type_flags(baseType)
+				if flags&invalidFlags != 0 {
 					ctx.ReportNode(baseNode, buildInvalidMessage(stringLike, ctx.TypeChecker.TypeToString(baseType)))
-					reported = true
-					continue
+					return flags, true
 				}
-
-				// RegExps also contain checker.TypeFlagsAny & checker.TypeFlagsObject
-				if part == globalRegexpType {
-					if opts.AllowRegExp && !utils.IsTypeFlagSet(otherType, checker.TypeFlagsNumberLike) {
-						continue
-					}
-				} else if (opts.AllowAny || !utils.IsTypeAnyType(part)) && !utils.Every(utils.IntersectionTypeParts(part), utils.IsObjectType) {
-					continue
+				if typeName, invalid := invalidObjectOperandType(
+					ctx.TypeChecker,
+					baseType,
+					otherType,
+					opts.AllowAny,
+					opts.AllowRegExp,
+				); invalid {
+					ctx.ReportNode(baseNode, buildInvalidMessage(stringLike, typeName))
+					return flags, true
 				}
-				foundRegexp = true
+				return flags, false
 			}
 
-			if !reported && foundRegexp {
-				ctx.ReportNode(baseNode, buildInvalidMessage(stringLike, ctx.TypeChecker.TypeToString(globalRegexpType)))
+			parts := baseType.Types()
+			var flags checker.TypeFlags
+			for _, part := range parts {
+				flags |= checker.Type_flags(part)
+			}
+			if flags&invalidFlags != 0 {
+				ctx.ReportNode(baseNode, buildInvalidMessage(stringLike, ctx.TypeChecker.TypeToString(baseType)))
 				return flags, true
 			}
 
+			reported := false
+			for _, part := range parts {
+				if typeName, invalid := invalidObjectOperandType(
+					ctx.TypeChecker,
+					part,
+					otherType,
+					opts.AllowAny,
+					opts.AllowRegExp,
+				); invalid {
+					ctx.ReportNode(baseNode, buildInvalidMessage(stringLike, typeName))
+					reported = true
+				}
+			}
 			return flags, reported
 		}
 
@@ -179,32 +230,33 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			leftTypeFlags, leftInvalid := checkInvalidPlusOperand(node.Left, leftType, rightType)
-			rightTypeFlags, rightInvalid := checkInvalidPlusOperand(node.Right, rightType, leftType)
+			leftNode := node.Left
+			if leftNode.Kind == ast.KindParenthesizedExpression {
+				leftNode = ast.SkipParentheses(leftNode)
+			}
+			rightNode := node.Right
+			if rightNode.Kind == ast.KindParenthesizedExpression {
+				rightNode = ast.SkipParentheses(rightNode)
+			}
+			leftTypeFlags, leftInvalid := checkInvalidPlusOperand(leftNode, leftType, rightType)
+			rightTypeFlags, rightInvalid := checkInvalidPlusOperand(rightNode, rightType, leftType)
 			if leftInvalid || rightInvalid {
 				return
 			}
 
-			checkMismatchedPlusOperands := func(baseTypeFlags, otherTypeFlags checker.TypeFlags) bool {
-				if !opts.AllowNumberAndString &&
-					baseTypeFlags&checker.TypeFlagsStringLike != 0 &&
-					otherTypeFlags&(checker.TypeFlagsNumberLike|checker.TypeFlagsBigIntLike) != 0 {
-					ctx.ReportNode(&node.Node, buildMismatchedMessage(stringLike, ctx.TypeChecker.TypeToString(leftType), ctx.TypeChecker.TypeToString(rightType)))
-					return true
-				}
-
-				if baseTypeFlags&checker.TypeFlagsNumberLike != 0 && otherTypeFlags&checker.TypeFlagsBigIntLike != 0 {
-					ctx.ReportNode(&node.Node, buildBigintAndNumberMessage(ctx.TypeChecker.TypeToString(leftType), ctx.TypeChecker.TypeToString(rightType)))
-					return true
-				}
-
-				return false
-			}
-
-			if checkMismatchedPlusOperands(leftTypeFlags, rightTypeFlags) {
+			if !opts.AllowNumberAndString &&
+				(leftTypeFlags&checker.TypeFlagsStringLike != 0 &&
+					rightTypeFlags&(checker.TypeFlagsNumberLike|checker.TypeFlagsBigIntLike) != 0 ||
+					rightTypeFlags&checker.TypeFlagsStringLike != 0 &&
+						leftTypeFlags&(checker.TypeFlagsNumberLike|checker.TypeFlagsBigIntLike) != 0) {
+				ctx.ReportNode(&node.Node, buildMismatchedMessage(stringLike, ctx.TypeChecker.TypeToString(leftType), ctx.TypeChecker.TypeToString(rightType)))
 				return
 			}
-			checkMismatchedPlusOperands(rightTypeFlags, leftTypeFlags)
+
+			if leftTypeFlags&checker.TypeFlagsNumberLike != 0 && rightTypeFlags&checker.TypeFlagsBigIntLike != 0 ||
+				rightTypeFlags&checker.TypeFlagsNumberLike != 0 && leftTypeFlags&checker.TypeFlagsBigIntLike != 0 {
+				ctx.ReportNode(&node.Node, buildBigintAndNumberMessage(ctx.TypeChecker.TypeToString(leftType), ctx.TypeChecker.TypeToString(rightType)))
+			}
 		}
 
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
@@ -1473,3 +1473,275 @@ func TestRestrictPlusOperandsSerializedOptions(t *testing.T) {
 		},
 	)
 }
+
+// TestRestrictPlusOperandsExtras locks in object-operand diagnostics that are
+// not message-checked by the migrated suite in restrict_plus_operands_test.go.
+func TestRestrictPlusOperandsExtras(t *testing.T) {
+	const invalidMessagePrefix = "Invalid operand for a '+' operation. Operands must each be a number or string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`. Got `"
+	strictOptions := map[string]any{
+		"allowAny":             false,
+		"allowBoolean":         false,
+		"allowNullish":         false,
+		"allowNumberAndString": false,
+		"allowRegExp":          false,
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RestrictPlusOperandsRule, []rule_tester.ValidTestCase{
+		{
+			// Locks in upstream getTypeName() behavior for a shadowed RegExp.
+			Code: `function convert() {
+  class RegExp {}
+  const value = new RegExp();
+  return '' + value;
+}`,
+		},
+		{
+			// Locks in upstream getTypeName() behavior for a qualified RegExp.
+			Code: `namespace Custom {
+  export class RegExp {}
+}
+declare const value: Custom.RegExp;
+const result = '' + value;`,
+		},
+		{
+			// Type-parameter constraints participate in allowRegExp by type name.
+			Code: "function convert<T extends RegExp>(value: T) { return '' + value; }",
+		},
+		{
+			// Reporting through an unwrapped operand must still honor directives.
+			Code: "// eslint-disable-next-line test\nconst result = '' + ({});",
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			// Real-user regression: rspack's ModuleError.ts narrows err to Error.
+			Code: `function createMessage(err: Error): string {
+  let message = '';
+
+  if (err && typeof err === 'object' && err.message) {
+    message += err.message;
+  } else if (err) {
+    message += err;
+  }
+
+  return message;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   invalidMessagePrefix + "Error`.",
+				Line:      7,
+				Column:    16,
+				EndLine:   7,
+				EndColumn: 19,
+			}},
+		},
+		{
+			// Locks in upstream's per-union-constituent object reports.
+			Code: "declare const value: Date | Error;\nconst result = '' + value;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalid",
+					Message:   invalidMessagePrefix + "Date`.",
+					Line:      2,
+					Column:    21,
+					EndLine:   2,
+					EndColumn: 26,
+				},
+				{
+					MessageId: "invalid",
+					Message:   invalidMessagePrefix + "Error`.",
+					Line:      2,
+					Column:    21,
+					EndLine:   2,
+					EndColumn: 26,
+				},
+			},
+		},
+		{
+			// Parentheses and leading comments are not part of the ESTree operand.
+			Code: "declare const value: Error;\nconst result = '' + ((/* keep */ value));",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   invalidMessagePrefix + "Error`.",
+				Line:      2,
+				Column:    34,
+				EndLine:   2,
+				EndColumn: 39,
+			}},
+		},
+		{
+			// Parentheses around a TS assertion are omitted, but the assertion stays.
+			Code: "declare const value: Error;\nconst result = '' + (value as Error);",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   invalidMessagePrefix + "Error`.",
+				Line:      2,
+				Column:    22,
+				EndLine:   2,
+				EndColumn: 36,
+			}},
+		},
+		{
+			// Parentheses around a satisfies expression are omitted from its range.
+			Code: "declare const value: Error;\nconst result = '' + (value satisfies Error);",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   invalidMessagePrefix + "Error`.",
+				Line:      2,
+				Column:    22,
+				EndLine:   2,
+				EndColumn: 43,
+			}},
+		},
+		{
+			// The same unwrapping applies when the invalid operand is on the left.
+			Code: "declare const value: Error;\nconst result = ((value)) + '';",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   invalidMessagePrefix + "Error`.",
+				Line:      2,
+				Column:    18,
+				EndLine:   2,
+				EndColumn: 23,
+			}},
+		},
+		{
+			// A RegExp-named local type is rejected when paired with a number.
+			Code: `function convert() {
+  class RegExp {}
+  const value = new RegExp();
+  return 1 + value;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   invalidMessagePrefix + "RegExp`.",
+				Line:      4,
+				Column:    14,
+				EndLine:   4,
+				EndColumn: 19,
+			}},
+		},
+		{
+			// Disabling allowRegExp rejects shadowed types named RegExp too.
+			Code: `function convert() {
+  class RegExp {}
+  const value = new RegExp();
+  return '' + value;
+}`,
+			Options: strictOptions,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   "Invalid operand for a '+' operation. Operands must each be a number or string. Got `RegExp`.",
+				Line:      4,
+				Column:    15,
+				EndLine:   4,
+				EndColumn: 20,
+			}},
+		},
+		{
+			// Disabling allowRegExp also rejects a RegExp-constrained parameter.
+			Code:    "function convert<T extends RegExp>(value: T) { return '' + value; }",
+			Options: strictOptions,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   "Invalid operand for a '+' operation. Operands must each be a number or string. Got `RegExp`.",
+				Line:      1,
+				Column:    60,
+				EndLine:   1,
+				EndColumn: 65,
+			}},
+		},
+		{
+			// The zero-stringLikes branch retains the exact strict message.
+			Code:    "declare const value: { value: number };\nconst result = '' + value;",
+			Options: strictOptions,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   "Invalid operand for a '+' operation. Operands must each be a number or string. Got `{ value: number; }`.",
+				Line:      2,
+				Column:    21,
+				EndLine:   2,
+				EndColumn: 26,
+			}},
+		},
+		{
+			// The one-stringLike branch retains the exact message.
+			Code: "declare const value: Error;\nconst result = '' + value;",
+			Options: map[string]any{
+				"allowAny":     false,
+				"allowBoolean": false,
+				"allowNullish": false,
+				"allowRegExp":  true,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   "Invalid operand for a '+' operation. Operands must each be a number or string, allowing a string + `RegExp`. Got `Error`.",
+				Line:      2,
+				Column:    21,
+				EndLine:   2,
+				EndColumn: 26,
+			}},
+		},
+		{
+			// Locks in the exact mismatched diagnostic after message construction changes.
+			Code:    "const result = 1 + '';",
+			Options: strictOptions,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatched",
+				Message:   "Operands of '+' operations must be a number or string. Got `number` + `string`.",
+				Line:      1,
+				Column:    16,
+				EndLine:   1,
+				EndColumn: 22,
+			}},
+		},
+		{
+			// Locks in the exact bigint/number diagnostic after message construction changes.
+			Code: "const result = 1 + 1n;",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bigintAndNumber",
+				Message:   "Numeric '+' operations must either be both bigints or both numbers. Got `number` + `bigint`.",
+				Line:      1,
+				Column:    16,
+				EndLine:   1,
+				EndColumn: 22,
+			}},
+		},
+		{
+			// An invalid primitive union is one base-type complaint, not object reports.
+			Code: "declare const value: symbol | Error;\nconst result = '' + value;",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Line:      2,
+				Column:    21,
+				EndLine:   2,
+				EndColumn: 26,
+			}},
+		},
+		{
+			// A valid string constituent does not mask an invalid object constituent.
+			Code: "declare const value: Error | string;\nconst result = '' + value;",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Message:   invalidMessagePrefix + "Error`.",
+				Line:      2,
+				Column:    21,
+				EndLine:   2,
+				EndColumn: 26,
+			}},
+		},
+		{
+			// Re-enabling the rule after a scoped directive reports normally.
+			Code: `/* eslint-disable test */
+const suppressed = '' + ({});
+/* eslint-enable test */
+const reported = '' + ({});`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "invalid",
+				Line:      4,
+				Column:    24,
+				EndLine:   4,
+				EndColumn: 26,
+			}},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- report the actual invalid object operand type instead of rendering every object as the global `RegExp` type
- match upstream behavior for object-union diagnostics, `RegExp`-named types, and parenthesized operand ranges
- add adversarial regression coverage and reduce allocations on the common rule paths

## Related Links

- [Upstream `@typescript-eslint/restrict-plus-operands` implementation](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/restrict-plus-operands.ts#L187-L203)

## Validation

- normalized differential corpus against `typescript-eslint@8.67.0`: no differences
- verified the real Rspack `ModuleError.ts` reproduction now reports `Got \`Error\`.`
- `go test ./internal/plugins/typescript/rules/restrict_plus_operands -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/restrict_plus_operands/...`

## Go benchmark

Command: `go test ./internal/plugins/typescript/rules/restrict_plus_operands -run '^$' -bench '^BenchmarkRestrictPlusOperands$' -benchmem -count=6`

Apple M5 Max, with the same prebuilt typed fixtures and listener-only invocation before and after. The temporary benchmark source is not included in the commit.

| Case | Before | After | Time delta | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| NoMatchMinus | 1.212 ns | 1.038 ns | -14.36% | 0 → 0 |
| PrimitiveFastPath | 39.39 ns | 40.64 ns | no significant change | 0 → 0 |
| DefaultStringNumberAllowed | 77.12 ns | 47.11 ns | -38.92% | 4 → 0 |
| StrictStringNumberDiagnostic | 839.7 ns | 751.0 ns | -10.56% | 35 → 28 |
| ObjectDiagnostic | 1.015 µs | 0.898 µs | -11.44% | 25 → 19 |
| ObjectUnionDiagnostics | 1.022 µs | 1.818 µs | +77.75% | 25 → 38 |
| SkippedCompoundAssignment | 1.302 ns | 1.096 ns | no significant change | 0 → 0 |
| CompoundObjectDiagnostic | 1.236 µs | 0.885 µs | -28.39% | 25 → 19 |
| geomean | 92.05 ns | 83.49 ns | **-9.30%** | — |

`ObjectUnionDiagnostics` now emits the two upstream-compatible diagnostics (`Date` and `Error`) instead of one incorrect `RegExp` diagnostic, so its additional work is the expected correctness cost.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
