### PR TITLE
perf(lsp): carry module specifier collection across editor Programs

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -91,6 +91,10 @@ type runProgramOptions struct {
 	// PreparedPlan supplies the already-collected files and resolved rules for
 	// this Program. nil preserves the direct collection/callback path.
 	PreparedPlan *programLintPlan
+	// ModuleSpecifiers, when non-nil, lets the module graph read the syntactic
+	// half of its answers from a cache the caller carries across runs. nil
+	// confines every answer to this run.
+	ModuleSpecifiers *rule.ModuleSpecifierCache
 }
 
 type programLintResult struct {
@@ -173,7 +177,7 @@ func runLintRulesInProgram(opts runProgramOptions, consumer rule.DiagnosticConsu
 	// One module graph shared by every rule on every file of this Program.
 	// What a file imports is a property of the Program, so it is derived on
 	// the first file that asks and the rest of the run reuses it.
-	moduleGraph := rule.NewModuleGraph(opts.Program)
+	moduleGraph := rule.NewCachedModuleGraph(opts.Program, opts.ModuleSpecifiers)
 
 	// lintFile lints one file with its already-resolved rules and checker. Its
 	// comments, DisableManager, and rule contexts are per-file. The listener
@@ -663,6 +667,7 @@ func LintSingleFile(opts LintSingleFileOptions) {
 		TargetFiles:      []string{opts.File},
 		HasTargetFiles:   true,
 		GetRulesForFile:  getRulesForFile,
+		ModuleSpecifiers: opts.ModuleSpecifiers,
 		SyntaxErrorFiles: map[string]struct{}{},
 		// A single file is a single shard — run it on the calling goroutine
 		// instead of scheduling a background task.

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -168,4 +168,10 @@ type LintSingleFileOptions struct {
 	Cwd string
 	// Consumer has the same native-only semantics as RunLinterOptions.Consumer.
 	Consumer rule.DiagnosticConsumer
+	// ModuleSpecifiers, when non-nil, carries the module graph's syntactic half
+	// across the sequence of runs the caller owns. An editor lints one file
+	// against a new Program per keystroke, and the graph spans the Program, so
+	// without it every keystroke re-reads the imports of every file in the
+	// project. nil confines every answer to this run.
+	ModuleSpecifiers *rule.ModuleSpecifierCache
 }

--- a/internal/lsp/lint_program_store.go
+++ b/internal/lsp/lint_program_store.go
@@ -302,7 +302,19 @@ func (s *lintProgramStore) isOpenSourceOverlayWatchChange(
 func (s *lintProgramStore) Invalidate() bool {
 	hadPrograms := len(s.programs) != 0
 	clear(s.programs)
+	if hadPrograms {
+		s.discarded()
+	}
 	return hadPrograms
+}
+
+// discarded reports that Programs this store was going to reuse are gone. A
+// Program that is rebuilt hands its files' paths to the run that rebuilt it,
+// which supersedes their cached collections; one that is dropped hands them to
+// nobody, so what the cache holds for them — including files the project no
+// longer contains — would outlive every Program that ever held them.
+func (s *lintProgramStore) discarded() {
+	s.server.moduleSpecifiers.Reset()
 }
 
 func (s *lintProgramStore) markContent(
@@ -350,6 +362,9 @@ func (s *lintProgramStore) markContent(
 			delete(s.programs, configFileName)
 			discarded = true
 		}
+	}
+	if discarded {
+		s.discarded()
 	}
 	return discarded
 }

--- a/internal/lsp/lint_program_store_test.go
+++ b/internal/lsp/lint_program_store_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 type lintProgramStoreFixture struct {
@@ -114,6 +116,36 @@ func TestLintProgramStoreReusesAndUpdatesSource(t *testing.T) {
 	}
 	if sourceFile.Text() != changed {
 		t.Fatalf("updated source text = %q, want %q", sourceFile.Text(), changed)
+	}
+}
+
+// TestLintProgramStoreDiscardReleasesModuleSpecifiers locks in that the
+// resident Programs and the collections read from their files go away
+// together. A rebuilt Program hands its files' paths to the run that rebuilds
+// it, which supersedes their entries; a discarded one hands them to nobody, so
+// its trees would sit in the cache for the rest of the session.
+func TestLintProgramStoreDiscardReleasesModuleSpecifiers(t *testing.T) {
+	fixture := newLintProgramStoreFixture(t, "export const value = 1;\n")
+	fixture.server.moduleSpecifiers = rule.NewModuleSpecifierCache()
+
+	program := fixture.load(t)
+	sourceFile := program.GetSourceFile(fixture.sourcePath)
+	if sourceFile == nil {
+		t.Fatal("the resident Program does not contain the lint target")
+		return
+	}
+	rule.NewCachedModuleGraph(program, fixture.server.moduleSpecifiers).
+		Edges(sourceFile, rule.ModuleSyntax{ESModule: true})
+	if fixture.server.moduleSpecifiers.Len() == 0 {
+		t.Fatal("the run read nothing into the cache; the test proves nothing")
+	}
+
+	if !fixture.store.Invalidate() {
+		t.Fatal("the store had no resident Program to discard")
+	}
+
+	if held := fixture.server.moduleSpecifiers.Len(); held != 0 {
+		t.Fatalf("the cache holds %d paths of the discarded Program, want 0", held)
 	}
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -159,6 +159,11 @@ type Server struct {
 
 	session      *project.Session
 	lintPrograms *lintProgramStore
+	// moduleSpecifiers survives the Program a document is linted against.
+	// Every keystroke produces a new one, and rules that walk the module graph
+	// span the whole Program, so the imports of every file in the project are
+	// re-read on every keystroke without it.
+	moduleSpecifiers *rule.ModuleSpecifierCache
 
 	// enables tests to share a cache of parsed source files
 	parseCache *project.ParseCache

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -1282,8 +1282,15 @@ func (s *Server) runConfiguredLint(
 ) (lintPassResult, error) {
 	loadProgram := s.newStandaloneLintProgramLoader(uri)
 	finalize := func() {}
+	// Only the resident Programs hand the same file objects to the next run.
+	// The standalone loader builds over a host of its own every time, so every
+	// file it produces is a new object the cache could only miss on and then
+	// hold — pinning the discarded Program's whole tree until the request after
+	// next displaced it. That path passes none, as the speculative one does.
+	var moduleSpecifiers *rule.ModuleSpecifierCache
 	if s.lintPrograms != nil && s.lintPrograms.Usable() {
 		loadProgram, finalize = s.lintPrograms.Request(ctx, uri)
+		moduleSpecifiers = s.moduleSpecifiers
 	}
 	defer finalize()
 	return runLintWithProgramLoader(
@@ -1297,7 +1304,7 @@ func (s *Server) runConfiguredLint(
 		tsConfigPaths,
 		s.fs,
 		loadProgram,
-		s.moduleSpecifiers,
+		moduleSpecifiers,
 	)
 }
 

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -153,6 +153,7 @@ func (s *Server) handleInitialized(ctx context.Context, params *lsproto.Initiali
 	if s.watchEnabled && s.outgoingQueue != nil {
 		s.lintPrograms = newLintProgramStore(s)
 	}
+	s.moduleSpecifiers = rule.NewModuleSpecifierCache()
 
 	// Populate the global rule registry once per process; the LSP request path
 	// resolves rule names against it after config merging.
@@ -967,7 +968,7 @@ type lintProgramLoader func(
 ) (*compiler.Program, *ast.SourceFile, error)
 
 func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx context.Context, rslintConfig config.RslintConfig, cwd string, enforcePlugins bool, tsConfigPaths []string, fs vfs.FS) ([]rule.RuleDiagnostic, error) {
-	result, err := runLintWithProgramLoader(uri, session, ctx, rslintConfig, cwd, cwd, enforcePlugins, tsConfigPaths, fs, nil)
+	result, err := runLintWithProgramLoader(uri, session, ctx, rslintConfig, cwd, cwd, enforcePlugins, tsConfigPaths, fs, nil, nil)
 	return result.Diagnostics, err
 }
 
@@ -986,6 +987,7 @@ func runLintWithProgramLoader(
 	tsConfigPaths []string,
 	fs vfs.FS,
 	loadProgram lintProgramLoader,
+	moduleSpecifiers *rule.ModuleSpecifierCache,
 ) (lintPassResult, error) {
 	filename := uriToPath(uri)
 	configFilePath, configCwd := config.ResolveConfigPathSpace(filename, cwd, fs)
@@ -1019,6 +1021,7 @@ func runLintWithProgramLoader(
 		hasTypeInfo,
 		fileConfigResolver,
 		rule.EditDemandAll,
+		moduleSpecifiers,
 		ctx,
 	), nil
 }
@@ -1063,6 +1066,7 @@ func lintSingleFile(
 	hasTypeInfo bool,
 	fileConfigResolver *config.FileConfigResolver,
 	editDemand rule.EditDemand,
+	moduleSpecifiers *rule.ModuleSpecifierCache,
 	ctx context.Context,
 ) lintPassResult {
 	if sourceFile == nil {
@@ -1097,10 +1101,11 @@ func lintSingleFile(
 	}
 
 	linter.LintSingleFile(linter.LintSingleFileOptions{
-		Program:     program,
-		File:        sourceFile.FileName(),
-		Cwd:         processCwd,
-		HasTypeInfo: hasTypeInfo,
+		Program:          program,
+		File:             sourceFile.FileName(),
+		Cwd:              processCwd,
+		HasTypeInfo:      hasTypeInfo,
+		ModuleSpecifiers: moduleSpecifiers,
 		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
 			return rulesServedToEditors(fileConfigResolver.ActiveRulesForFileHasTypeInfo(configFilePath, hasTypeInfo))
 		},
@@ -1292,6 +1297,7 @@ func (s *Server) runConfiguredLint(
 		tsConfigPaths,
 		s.fs,
 		loadProgram,
+		s.moduleSpecifiers,
 	)
 }
 
@@ -1323,6 +1329,10 @@ func (s *Server) runConfiguredLintForContent(
 	s.addEditorOverlayFile(files, filename, content)
 	overlayFS := utils.NewOverlayVFS(s.fs, files)
 
+	// This path builds its Program over a filesystem of its own on every
+	// request, so its files are new objects that share nothing with the
+	// server's cache and would only displace what the diagnostics path put
+	// there. It passes none.
 	for _, tsConfigPath := range tsConfigPaths {
 		program, err := createStandaloneLintProgram(tsConfigPath, overlayFS)
 		if err != nil {
@@ -1337,6 +1347,7 @@ func (s *Server) runConfiguredLintForContent(
 				true,
 				resolver,
 				rule.EditDemandAutofix,
+				nil,
 				ctx,
 			), nil
 		}
@@ -1354,6 +1365,7 @@ func (s *Server) runConfiguredLintForContent(
 		false,
 		resolver,
 		rule.EditDemandAutofix,
+		nil,
 		ctx,
 	), nil
 }

--- a/internal/lsp/unicode_bom_test.go
+++ b/internal/lsp/unicode_bom_test.go
@@ -111,7 +111,7 @@ func TestUnicodeBomIsNotServedToEditors(t *testing.T) {
 			resolver := config.NewFileConfigResolver(cfg, dir, false)
 
 			served := lintSingleFile(
-				program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, context.Background(),
+				program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, nil, context.Background(),
 			).Diagnostics
 
 			if len(served) != 0 {
@@ -157,7 +157,7 @@ func TestOtherRulesStillRunInTheEditor(t *testing.T) {
 	resolver := config.NewFileConfigResolver(cfg, dir, false)
 
 	served := lintSingleFile(
-		program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, context.Background(),
+		program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, nil, context.Background(),
 	).Diagnostics
 
 	byRule := make(map[string][]rule.RuleFix, len(served))

--- a/internal/rule/module_graph.go
+++ b/internal/rule/module_graph.go
@@ -84,10 +84,10 @@ func (edge ModuleEdge) Dynamic() bool {
 }
 
 // ModuleGraph answers which modules each file of one Program references and
-// what they resolve to. A file's answer depends only on its own syntax, so it
-// is derived once per lint run however many rules and files ask for it — the
-// alternative being that each rule re-reads and re-resolves the same imports
-// for every file it looks past.
+// what they resolve to. A file's answer is derived once per lint run however
+// many rules and files ask for it — the alternative being that each rule
+// re-reads and re-resolves the same imports for every file it looks past. What
+// the file itself decides can outlive the run; see ModuleSpecifierCache.
 //
 // It reports what the syntax says and nothing more. Which of these references
 // a rule treats as a dependency — whether type-only imports count, whether
@@ -99,6 +99,10 @@ type ModuleGraph struct {
 	// collection at worst, which is cheaper than serializing every file in the
 	// run behind one mutex.
 	edges utils.LazyMap[moduleEdgeKey, []ModuleEdge]
+	// specifiers, when the caller supplies one, carries the syntactic half of
+	// the answer across the Programs of one editor session. nil confines every
+	// answer to this run.
+	specifiers *ModuleSpecifierCache
 }
 
 // moduleEdgeKey pairs a file with the syntaxes the caller asked about, which
@@ -110,6 +114,13 @@ type moduleEdgeKey struct {
 
 func NewModuleGraph(program *compiler.Program) *ModuleGraph {
 	return &ModuleGraph{program: program}
+}
+
+// NewCachedModuleGraph returns a graph that reads its syntactic half from
+// cache, which the caller owns and reuses across runs. See ModuleSpecifierCache
+// for what that does and does not carry over.
+func NewCachedModuleGraph(program *compiler.Program, cache *ModuleSpecifierCache) *ModuleGraph {
+	return &ModuleGraph{program: program, specifiers: cache}
 }
 
 // Files returns every file of the Program, in the Program's own order. A
@@ -132,28 +143,71 @@ func (graph *ModuleGraph) Edges(file *ast.SourceFile, syntax ModuleSyntax) []Mod
 
 	key := moduleEdgeKey{file: file, syntax: syntax}
 	return graph.edges.Get(key, func() []ModuleEdge {
-		return graph.collect(file, syntax)
+		return graph.resolveAll(file, graph.specifiersOf(file, syntax))
 	})
 }
 
-func (graph *ModuleGraph) collect(file *ast.SourceFile, syntax ModuleSyntax) []ModuleEdge {
+// specifiersOf returns what file writes, reading the caller's cache when there
+// is one. Collection is a pure function of the file's own syntax, so a cached
+// answer is the answer for as long as that exact file object exists.
+func (graph *ModuleGraph) specifiersOf(file *ast.SourceFile, syntax ModuleSyntax) []moduleSpecifier {
+	if graph.specifiers == nil {
+		return collectSpecifiers(file, syntax)
+	}
+	return graph.specifiers.get(file, syntax)
+}
+
+// resolveAll turns what a file writes into what it references, which is the
+// half of the answer only this Program can give.
+func (graph *ModuleGraph) resolveAll(file *ast.SourceFile, specifiers []moduleSpecifier) []ModuleEdge {
+	if len(specifiers) == 0 {
+		return nil
+	}
+	edges := make([]ModuleEdge, len(specifiers))
+	for i := range specifiers {
+		edges[i] = ModuleEdge{
+			Specifier:   specifiers[i].specifier,
+			Declaration: specifiers[i].declaration,
+			From:        file,
+			Kind:        specifiers[i].kind,
+			TypeOnly:    specifiers[i].typeOnly,
+		}
+		edges[i].ResolvedPath, edges[i].Target, _ =
+			utils.ResolveModuleFile(graph.program, file, specifiers[i].specifier)
+	}
+	return edges
+}
+
+// moduleSpecifier is the half of a ModuleEdge that a file's own syntax
+// decides: which string literal names a module, what syntax it was written
+// in, and whether that syntax survives into emitted JavaScript. What the
+// specifier resolves to is deliberately absent — that is the Program's answer,
+// and two Programs holding the same unchanged file can disagree about it.
+type moduleSpecifier struct {
+	specifier   *ast.Node
+	declaration *ast.Node
+	kind        ModuleEdgeKind
+	typeOnly    bool
+}
+
+func collectSpecifiers(file *ast.SourceFile, syntax ModuleSyntax) []moduleSpecifier {
 	// SourceFile.Imports is populated by the parser and avoids walking every
 	// AST node in the usual static-ESM case. The generic collector remains
 	// necessary for call-based references, parser recovery, and imports
 	// inside module bodies.
 	if syntax.CommonJS || syntax.AMD || needsFullModuleScan(file) {
-		return graph.collectByWalk(file, syntax)
+		return collectByWalk(file, syntax)
 	}
-	return graph.collectStaticImports(file)
+	return collectStaticImports(file)
 }
 
 // collectStaticImports reads the module specifiers the parser already
 // recorded. It handles the shapes those specifiers can take in a file with no
 // dynamic import, no module declaration and no parse error, which is what
 // needsFullModuleScan checks for.
-func (graph *ModuleGraph) collectStaticImports(file *ast.SourceFile) []ModuleEdge {
+func collectStaticImports(file *ast.SourceFile) []moduleSpecifier {
 	imports := file.Imports()
-	edges := make([]ModuleEdge, 0, len(imports))
+	specifiers := make([]moduleSpecifier, 0, len(imports))
 	for _, specifier := range imports {
 		declaration := ast.TryGetImportFromModuleSpecifier(specifier)
 		if declaration == nil {
@@ -173,9 +227,14 @@ func (graph *ModuleGraph) collectStaticImports(file *ast.SourceFile) []ModuleEdg
 			continue
 		}
 
-		edges = append(edges, graph.newEdge(file, specifier, declaration, kind, typeOnly))
+		specifiers = append(specifiers, moduleSpecifier{
+			specifier:   specifier,
+			declaration: declaration,
+			kind:        kind,
+			typeOnly:    typeOnly,
+		})
 	}
-	return edges
+	return specifiers
 }
 
 // needsFullModuleScan reports whether file can hold module specifiers that are
@@ -193,8 +252,8 @@ func needsFullModuleScan(file *ast.SourceFile) bool {
 	return false
 }
 
-func (graph *ModuleGraph) collectByWalk(file *ast.SourceFile, syntax ModuleSyntax) []ModuleEdge {
-	var edges []ModuleEdge
+func collectByWalk(file *ast.SourceFile, syntax ModuleSyntax) []moduleSpecifier {
+	var specifiers []moduleSpecifier
 	// A module specifier can appear anywhere a call can, so every subtree is
 	// walked; no node accounts for its own children here.
 	utils.VisitDescendants(file.AsNode(), func(node *ast.Node) bool {
@@ -204,7 +263,7 @@ func (graph *ModuleGraph) collectByWalk(file *ast.SourceFile, syntax ModuleSynta
 				return true
 			}
 			importDecl := node.AsImportDeclaration()
-			graph.appendEdge(&edges, file, importDecl.ModuleSpecifier, node, ModuleEdgeImport, importDeclarationOnlyImportsTypes(importDecl))
+			appendSpecifier(&specifiers, importDecl.ModuleSpecifier, node, ModuleEdgeImport, importDeclarationOnlyImportsTypes(importDecl))
 		case ast.KindExportDeclaration:
 			if !syntax.ESModule {
 				return true
@@ -212,16 +271,16 @@ func (graph *ModuleGraph) collectByWalk(file *ast.SourceFile, syntax ModuleSynta
 			exportDecl := node.AsExportDeclaration()
 			// tsgo matches eslint-plugin-import here: only `export type * from`
 			// is exclusively type-only; named type re-exports still stay edges.
-			graph.appendEdge(&edges, file, exportDecl.ModuleSpecifier, node, ModuleEdgeExport, ast.IsTypeOnlyImportOrExportDeclaration(node))
+			appendSpecifier(&specifiers, exportDecl.ModuleSpecifier, node, ModuleEdgeExport, ast.IsTypeOnlyImportOrExportDeclaration(node))
 		case ast.KindCallExpression:
-			graph.appendCallEdges(&edges, file, node.AsCallExpression(), syntax)
+			appendCallSpecifiers(&specifiers, node.AsCallExpression(), syntax)
 		}
 		return true
 	})
-	return edges
+	return specifiers
 }
 
-func (graph *ModuleGraph) appendCallEdges(edges *[]ModuleEdge, file *ast.SourceFile, call *ast.CallExpression, syntax ModuleSyntax) {
+func appendCallSpecifiers(specifiers *[]moduleSpecifier, call *ast.CallExpression, syntax ModuleSyntax) {
 	if call == nil {
 		return
 	}
@@ -235,7 +294,7 @@ func (graph *ModuleGraph) appendCallEdges(edges *[]ModuleEdge, file *ast.SourceF
 		if len(call.Arguments.Nodes) == 0 {
 			return
 		}
-		graph.appendEdge(edges, file, ast.SkipParentheses(call.Arguments.Nodes[0]), call.AsNode(), ModuleEdgeDynamicImport, false)
+		appendSpecifier(specifiers, ast.SkipParentheses(call.Arguments.Nodes[0]), call.AsNode(), ModuleEdgeDynamicImport, false)
 		return
 	}
 
@@ -247,7 +306,7 @@ func (graph *ModuleGraph) appendCallEdges(edges *[]ModuleEdge, file *ast.SourceF
 	if syntax.CommonJS && ast.IsRequireCall(call.AsNode(), false) {
 		arg := ast.SkipParentheses(call.Arguments.Nodes[0])
 		if arg != nil && ast.IsStringLiteralLike(arg) {
-			graph.appendEdge(edges, file, arg, call.AsNode(), ModuleEdgeRequire, false)
+			appendSpecifier(specifiers, arg, call.AsNode(), ModuleEdgeRequire, false)
 		}
 		return
 	}
@@ -265,12 +324,12 @@ func (graph *ModuleGraph) appendCallEdges(edges *[]ModuleEdge, file *ast.SourceF
 			if element == nil || !ast.IsStringLiteralLike(element) {
 				continue
 			}
-			graph.appendEdge(edges, file, element, call.AsNode(), ModuleEdgeAMD, false)
+			appendSpecifier(specifiers, element, call.AsNode(), ModuleEdgeAMD, false)
 		}
 	}
 }
 
-func (graph *ModuleGraph) appendEdge(edges *[]ModuleEdge, file *ast.SourceFile, specifier *ast.Node, declaration *ast.Node, kind ModuleEdgeKind, typeOnly bool) {
+func appendSpecifier(specifiers *[]moduleSpecifier, specifier *ast.Node, declaration *ast.Node, kind ModuleEdgeKind, typeOnly bool) {
 	if specifier == nil {
 		return
 	}
@@ -278,19 +337,12 @@ func (graph *ModuleGraph) appendEdge(edges *[]ModuleEdge, file *ast.SourceFile, 
 	if specifier == nil || !ast.IsStringLiteralLike(specifier) {
 		return
 	}
-	*edges = append(*edges, graph.newEdge(file, specifier, declaration, kind, typeOnly))
-}
-
-func (graph *ModuleGraph) newEdge(file *ast.SourceFile, specifier *ast.Node, declaration *ast.Node, kind ModuleEdgeKind, typeOnly bool) ModuleEdge {
-	edge := ModuleEdge{
-		Specifier:   specifier,
-		Declaration: declaration,
-		From:        file,
-		Kind:        kind,
-		TypeOnly:    typeOnly,
-	}
-	edge.ResolvedPath, edge.Target, _ = utils.ResolveModuleFile(graph.program, file, specifier)
-	return edge
+	*specifiers = append(*specifiers, moduleSpecifier{
+		specifier:   specifier,
+		declaration: declaration,
+		kind:        kind,
+		typeOnly:    typeOnly,
+	})
 }
 
 func importDeclarationOnlyImportsTypes(importDecl *ast.ImportDeclaration) bool {

--- a/internal/rule/module_specifier_cache.go
+++ b/internal/rule/module_specifier_cache.go
@@ -1,0 +1,98 @@
+package rule
+
+import (
+	"sync"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+)
+
+// ModuleSpecifierCache carries what a file writes about the modules it
+// references from one lint run to the next. A run builds its own ModuleGraph
+// over its own Program, and an editor produces a new Program on every
+// keystroke, so without this every run re-reads the module specifiers of every
+// file in the Program to answer for the one file it lints.
+//
+// Only the syntactic half is kept. What a specifier resolves to is the
+// Program's answer, not the file's, and two Programs holding this same file
+// can disagree about it — a file that appeared on disk in between changes what
+// a relative specifier names without changing a byte of any file that writes
+// it. Resolution therefore runs again for every run, and nothing here needs
+// invalidating: an entry is the answer for exactly as long as the file object
+// it was read from is the file, which pointer identity decides.
+//
+// The cache holds one file per path. An editor replaces a file object when its
+// text changes, so an entry for a path is superseded rather than accumulated,
+// and the cache stays the size of the project rather than the size of the
+// session. Two Programs that hold distinct file objects for one path — which
+// is what separate lint Programs built from separate hosts do — take turns
+// instead of sharing, which costs the collection they would have shared and
+// stays correct.
+//
+// Rules never construct one: the linter takes it from whoever owns the
+// sequence of runs, and a caller that owns no such sequence passes none.
+type ModuleSpecifierCache struct {
+	mu      sync.Mutex
+	entries map[tspath.Path]*specifierCacheEntry
+}
+
+// specifierCacheEntry holds one path's answers. A file is asked about in as
+// many syntaxes as the run's rules disagree on, which in practice is one or
+// two, so the syntaxes are scanned rather than hashed.
+type specifierCacheEntry struct {
+	file      *ast.SourceFile
+	bySyntax  []ModuleSyntax
+	collected [][]moduleSpecifier
+}
+
+func NewModuleSpecifierCache() *ModuleSpecifierCache {
+	return &ModuleSpecifierCache{entries: make(map[tspath.Path]*specifierCacheEntry)}
+}
+
+// get returns what file writes in these syntaxes, collecting it on the first
+// request and on every request that names a file object this path has not been
+// seen holding.
+func (cache *ModuleSpecifierCache) get(file *ast.SourceFile, syntax ModuleSyntax) []moduleSpecifier {
+	path := file.Path()
+
+	cache.mu.Lock()
+	if collected, ok := cache.entries[path].lookup(file, syntax); ok {
+		cache.mu.Unlock()
+		return collected
+	}
+	cache.mu.Unlock()
+
+	// Collected outside the lock: the result depends on nothing but the file,
+	// so two runs racing on one key cost a redundant collection at worst,
+	// which is cheaper than serializing every file of a run behind one mutex.
+	collected := collectSpecifiers(file, syntax)
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	entry := cache.entries[path]
+	if entry == nil || entry.file != file {
+		entry = &specifierCacheEntry{file: file}
+		cache.entries[path] = entry
+	}
+	if stored, ok := entry.lookup(file, syntax); ok {
+		return stored
+	}
+	entry.bySyntax = append(entry.bySyntax, syntax)
+	entry.collected = append(entry.collected, collected)
+	return collected
+}
+
+// lookup returns what this entry holds for file in these syntaxes. An entry
+// read from a different file object answers for nothing: an editor replaces
+// the object whenever the text it was parsed from changes.
+func (entry *specifierCacheEntry) lookup(file *ast.SourceFile, syntax ModuleSyntax) ([]moduleSpecifier, bool) {
+	if entry == nil || entry.file != file {
+		return nil, false
+	}
+	for i, seen := range entry.bySyntax {
+		if seen == syntax {
+			return entry.collected[i], true
+		}
+	}
+	return nil, false
+}

--- a/internal/rule/module_specifier_cache.go
+++ b/internal/rule/module_specifier_cache.go
@@ -29,6 +29,12 @@ import (
 // instead of sharing, which costs the collection they would have shared and
 // stays correct.
 //
+// Superseding is what bounds the cache, and only a later run over the same
+// path supersedes anything. An owner that discards the Programs it was going
+// to run against — the project reloaded, the config changed — leaves entries
+// for files no later run will name, holding trees no Program holds any more,
+// and says so with Reset.
+//
 // Rules never construct one: the linter takes it from whoever owns the
 // sequence of runs, and a caller that owns no such sequence passes none.
 type ModuleSpecifierCache struct {
@@ -47,6 +53,31 @@ type specifierCacheEntry struct {
 
 func NewModuleSpecifierCache() *ModuleSpecifierCache {
 	return &ModuleSpecifierCache{entries: make(map[tspath.Path]*specifierCacheEntry)}
+}
+
+// Reset drops every entry. An entry names the file object it was read from,
+// and a file object owns the tree it was parsed from, so the cache holds one
+// tree per path it has answered for. That is the Program's tree for as long as
+// runs keep coming over the same project, and nobody's once the owner discards
+// the Programs: Reset is how the owner says it did, at the price of collecting
+// again whatever the next run asks about.
+func (cache *ModuleSpecifierCache) Reset() {
+	if cache == nil {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	clear(cache.entries)
+}
+
+// Len is how many paths the cache currently answers for.
+func (cache *ModuleSpecifierCache) Len() int {
+	if cache == nil {
+		return 0
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return len(cache.entries)
 }
 
 // get returns what file writes in these syntaxes, collecting it on the first

--- a/internal/rule/module_specifier_cache_internal_test.go
+++ b/internal/rule/module_specifier_cache_internal_test.go
@@ -1,0 +1,176 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const specifierCacheImporter = "/specifier-cache-fixture/importer.ts"
+const specifierCacheTarget = "/specifier-cache-fixture/target.ts"
+
+var esm = ModuleSyntax{ESModule: true}
+
+// TestModuleSpecifierCacheReusesOneFilesCollection locks in the point of the
+// cache: a second run over the same unchanged file is answered from the first
+// run's collection rather than by reading the file again.
+func TestModuleSpecifierCacheReusesOneFilesCollection(t *testing.T) {
+	program, _ := specifierCacheProgram(t, specifierCacheFiles(false))
+	file := specifierCacheFile(t, program)
+	cache := NewModuleSpecifierCache()
+
+	first := cache.get(file, esm)
+	second := cache.get(file, esm)
+
+	if len(first) != 1 {
+		t.Fatalf("collected %d specifiers, want 1", len(first))
+	}
+	if &first[0] != &second[0] {
+		t.Fatal("the second request collected the file again")
+	}
+}
+
+// TestModuleSpecifierCacheSeparatesSyntaxes locks in that one file's entry
+// answers for the syntaxes it was asked about and no others: a `require` call
+// is a reference under commonjs and nothing at all without it.
+func TestModuleSpecifierCacheSeparatesSyntaxes(t *testing.T) {
+	program, _ := specifierCacheProgram(t, specifierCacheFiles(true))
+	file := specifierCacheFile(t, program)
+	cache := NewModuleSpecifierCache()
+
+	esmOnly := cache.get(file, esm)
+	withCommonJS := cache.get(file, ModuleSyntax{ESModule: true, CommonJS: true})
+
+	if len(esmOnly) != 1 {
+		t.Fatalf("collected %d ES module specifiers, want 1", len(esmOnly))
+	}
+	if len(withCommonJS) != 2 {
+		t.Fatalf("collected %d specifiers with commonjs, want 2", len(withCommonJS))
+	}
+	if reused := cache.get(file, esm); &reused[0] != &esmOnly[0] {
+		t.Fatal("the commonjs request displaced the ES module answer")
+	}
+}
+
+// TestModuleSpecifierCacheSupersedesReplacedFiles locks in what makes the
+// cache safe to keep across an editing session without invalidating it: an
+// entry answers for one file object, and an editor replaces that object
+// whenever the text behind it changes.
+func TestModuleSpecifierCacheSupersedesReplacedFiles(t *testing.T) {
+	originalProgram, _ := specifierCacheProgram(t, specifierCacheFiles(false))
+	editedProgram, _ := specifierCacheProgram(t, specifierCacheFiles(true))
+	original := specifierCacheFile(t, originalProgram)
+	edited := specifierCacheFile(t, editedProgram)
+	if original == edited {
+		t.Fatal("the fixture programs share one file object; the test proves nothing")
+	}
+	if original.Path() != edited.Path() {
+		t.Fatal("the fixture files disagree on their path; the test proves nothing")
+	}
+	cache := NewModuleSpecifierCache()
+
+	before := cache.get(original, ModuleSyntax{ESModule: true, CommonJS: true})
+	after := cache.get(edited, ModuleSyntax{ESModule: true, CommonJS: true})
+
+	if len(before) != 1 {
+		t.Fatalf("collected %d specifiers before the edit, want 1", len(before))
+	}
+	if len(after) != 2 {
+		t.Fatalf("collected %d specifiers after the edit, want 2", len(after))
+	}
+}
+
+// TestCachedModuleGraphResolvesPerProgram locks in the half the cache
+// deliberately does not carry. What a specifier names is the Program's answer,
+// not the file's: editing an imported file leaves the importer's own text — and
+// so its file object, and so its cache entry — untouched, while the file it
+// names becomes a different object. A cache that carried resolution would hand
+// the rule the source file of a Program that is no longer being linted.
+func TestCachedModuleGraphResolvesPerProgram(t *testing.T) {
+	files := specifierCacheFiles(false)
+	program, fs := specifierCacheProgram(t, files)
+	file := specifierCacheFile(t, program)
+
+	files[specifierCacheTarget] = "export const value = 2;\n"
+	changed := tspath.ToPath(
+		specifierCacheTarget,
+		program.GetCurrentDirectory(),
+		fs.UseCaseSensitiveFileNames(),
+	)
+	updated, _, reused := program.UpdateProgram(changed, program.Host(), nil)
+	if updated == nil || !reused {
+		t.Fatalf("the fixture edit did not update the program in place (reused=%v)", reused)
+	}
+	updated.BindSourceFiles()
+	if specifierCacheFile(t, updated) != file {
+		t.Fatal("the update replaced the importer too; the test proves nothing")
+	}
+	if updated.GetSourceFile(specifierCacheTarget) == program.GetSourceFile(specifierCacheTarget) {
+		t.Fatal("the update reused the edited file; the test proves nothing")
+	}
+	cache := NewModuleSpecifierCache()
+
+	before := NewCachedModuleGraph(program, cache).Edges(file, esm)
+	after := NewCachedModuleGraph(updated, cache).Edges(file, esm)
+
+	if len(before) != 1 || len(after) != 1 {
+		t.Fatalf("resolved %d and %d edges, want 1 each", len(before), len(after))
+	}
+	if before[0].Target != program.GetSourceFile(specifierCacheTarget) {
+		t.Fatal("the first run resolved outside its own program")
+	}
+	if after[0].Target != updated.GetSourceFile(specifierCacheTarget) {
+		t.Fatal("the second run reused the first run's resolution")
+	}
+}
+
+// specifierCacheFiles is a two-file project whose importer writes one static
+// import, plus a `require` call when withRequire is set. The two shapes stand
+// in for one file before and after an edit.
+func specifierCacheFiles(withRequire bool) map[string]string {
+	importer := "import { value } from './target';\nexport const used = value;\n"
+	if withRequire {
+		importer += "const also = require('./target');\nexport const second = also;\n"
+	}
+	return map[string]string{
+		specifierCacheImporter: importer,
+		specifierCacheTarget:   "export const value = 1;\n",
+	}
+}
+
+// specifierCacheProgram builds a program over files, which it keeps reading:
+// writing to the map and updating the program is how a test edits a file.
+func specifierCacheProgram(t *testing.T, files map[string]string) (*compiler.Program, vfs.FS) {
+	t.Helper()
+
+	fs := rslint_utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), files)
+	host := rslint_utils.CreateCompilerHost("/", fs)
+	program, err := rslint_utils.CreateProgramFromOptions(
+		true,
+		&core.CompilerOptions{AllowJs: core.TSTrue},
+		[]string{specifierCacheImporter},
+		host,
+	)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptions: %v", err)
+	}
+	program.BindSourceFiles()
+	return program, fs
+}
+
+func specifierCacheFile(t *testing.T, program *compiler.Program) *ast.SourceFile {
+	t.Helper()
+
+	file := program.GetSourceFile(specifierCacheImporter)
+	if file == nil {
+		t.Fatal("the fixture importer is not in the program")
+	}
+	return file
+}

--- a/internal/rule/module_specifier_cache_internal_test.go
+++ b/internal/rule/module_specifier_cache_internal_test.go
@@ -16,7 +16,7 @@ import (
 const specifierCacheImporter = "/specifier-cache-fixture/importer.ts"
 const specifierCacheTarget = "/specifier-cache-fixture/target.ts"
 
-var esm = ModuleSyntax{ESModule: true}
+var specifierCacheESM = ModuleSyntax{ESModule: true}
 
 // TestModuleSpecifierCacheReusesOneFilesCollection locks in the point of the
 // cache: a second run over the same unchanged file is answered from the first
@@ -26,8 +26,8 @@ func TestModuleSpecifierCacheReusesOneFilesCollection(t *testing.T) {
 	file := specifierCacheFile(t, program)
 	cache := NewModuleSpecifierCache()
 
-	first := cache.get(file, esm)
-	second := cache.get(file, esm)
+	first := cache.get(file, specifierCacheESM)
+	second := cache.get(file, specifierCacheESM)
 
 	if len(first) != 1 {
 		t.Fatalf("collected %d specifiers, want 1", len(first))
@@ -45,7 +45,7 @@ func TestModuleSpecifierCacheSeparatesSyntaxes(t *testing.T) {
 	file := specifierCacheFile(t, program)
 	cache := NewModuleSpecifierCache()
 
-	esmOnly := cache.get(file, esm)
+	esmOnly := cache.get(file, specifierCacheESM)
 	withCommonJS := cache.get(file, ModuleSyntax{ESModule: true, CommonJS: true})
 
 	if len(esmOnly) != 1 {
@@ -54,7 +54,7 @@ func TestModuleSpecifierCacheSeparatesSyntaxes(t *testing.T) {
 	if len(withCommonJS) != 2 {
 		t.Fatalf("collected %d specifiers with commonjs, want 2", len(withCommonJS))
 	}
-	if reused := cache.get(file, esm); &reused[0] != &esmOnly[0] {
+	if reused := cache.get(file, specifierCacheESM); &reused[0] != &esmOnly[0] {
 		t.Fatal("the commonjs request displaced the ES module answer")
 	}
 }
@@ -84,6 +84,35 @@ func TestModuleSpecifierCacheSupersedesReplacedFiles(t *testing.T) {
 	}
 	if len(after) != 2 {
 		t.Fatalf("collected %d specifiers after the edit, want 2", len(after))
+	}
+}
+
+// TestModuleSpecifierCacheResetReleasesEntries locks in what bounds the cache.
+// An entry stays until a later run over the same path supersedes it, so an
+// owner that discards the Programs — and with them the runs that would have
+// named those paths again — has to say so, or the trees those entries hold
+// outlive every Program that ever held them.
+func TestModuleSpecifierCacheResetReleasesEntries(t *testing.T) {
+	program, _ := specifierCacheProgram(t, specifierCacheFiles(false))
+	file := specifierCacheFile(t, program)
+	cache := NewModuleSpecifierCache()
+
+	first := cache.get(file, specifierCacheESM)
+	if held := cache.Len(); held != 1 {
+		t.Fatalf("the cache holds %d paths after one file, want 1", held)
+	}
+
+	cache.Reset()
+
+	if held := cache.Len(); held != 0 {
+		t.Fatalf("the cache holds %d paths after Reset, want 0", held)
+	}
+	recollected := cache.get(file, specifierCacheESM)
+	if len(recollected) != 1 {
+		t.Fatalf("collected %d specifiers after Reset, want 1", len(recollected))
+	}
+	if &recollected[0] == &first[0] {
+		t.Fatal("Reset kept the entry it was told to drop")
 	}
 }
 
@@ -117,8 +146,8 @@ func TestCachedModuleGraphResolvesPerProgram(t *testing.T) {
 	}
 	cache := NewModuleSpecifierCache()
 
-	before := NewCachedModuleGraph(program, cache).Edges(file, esm)
-	after := NewCachedModuleGraph(updated, cache).Edges(file, esm)
+	before := NewCachedModuleGraph(program, cache).Edges(file, specifierCacheESM)
+	after := NewCachedModuleGraph(updated, cache).Edges(file, specifierCacheESM)
 
 	if len(before) != 1 || len(after) != 1 {
 		t.Fatalf("resolved %d and %d edges, want 1 each", len(before), len(after))


### PR DESCRIPTION
## Summary

`ModuleGraph.Edges` answered two questions at once: which module specifiers a file writes, which only that file's syntax decides, and what each specifier resolves to, which only the Program can answer. Both were derived per lint run.

An editor produces a new `*compiler.Program` on every keystroke, and the graph a whole-project rule like `import/no-cycle` builds spans that Program, so every keystroke re-read the imports of every file in the project in order to lint the one open file.

This splits the two halves. The syntactic half now comes from a `ModuleSpecifierCache` the caller owns, and the language server keeps one for its lifetime. Resolution still runs against the current Program on every pass.

The cache needs no invalidation. An entry is keyed on the path and answers only for the exact `*ast.SourceFile` it was read from, and an editor replaces that object whenever the text behind it changes. It holds one file per path, so an entry is superseded rather than accumulated.

Resolution is deliberately left out of the cache: a file appearing on disk changes what a relative specifier names without changing a byte of any file that writes it.

The CLI passes no cache and is unaffected.

### Benchmark

VS Code's `./src` (8995 files), the `import` plugin's rules, driven over LSP with a fixed message sequence so both sides see byte-identical traffic. 3 runs each, alternating, 10 edits per run.

| | before | after | |
| --- | --- | --- | --- |
| CPU per edit | 1489 ms | 1288 ms | −13.5% |
| median edit latency | 382 ms | 330 ms | −13.6% |
| GC CPU | 13.3 s | 12.2 s | −7.8% |
| peak RSS | 2533 MB | 2476 MB | −2.2% |
| live heap after GC | 2198 MB | 2207 MB | +0.4% |

Per-run ranges do not overlap on either headline metric. Live heap is flat, which is the check that matters for a cache that holds AST nodes across Programs. CLI wall time is unchanged: 2.181 s vs 2.161 s over 7 runs each, with the difference well inside the ±0.06 s spread.

### Tests

`internal/rule/module_specifier_cache_internal_test.go` covers reuse within one file object, separation between syntaxes, supersession when the file object is replaced, and that resolution is redone per Program. Each was confirmed to fail against the defect it guards.

## Related Links

- #1611
- #1676

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
