### PR TITLE
feat: port rule no-void

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -131,6 +131,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
+	"github.com/web-infra-dev/rslint/internal/rules/no_void"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
 	"github.com/web-infra-dev/rslint/internal/rules/object_shorthand"
 	"github.com/web-infra-dev/rslint/internal/rules/one_var"
@@ -268,6 +269,7 @@ func GetAllRules() []rule.Rule {
 		prefer_template.PreferTemplateRule,
 		no_this_before_super.NoThisBeforeSuperRule,
 		no_var.NoVarRule,
+		no_void.NoVoidRule,
 		no_with.NoWithRule,
 		prefer_rest_params.PreferRestParamsRule,
 		prefer_spread.PreferSpreadRule,

--- a/internal/rules/no_void/no_void.go
+++ b/internal/rules/no_void/no_void.go
@@ -1,0 +1,55 @@
+package no_void
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+//go:embed no_void.schema.json
+var schemaJSON []byte
+
+// https://eslint.org/docs/latest/rules/no-void
+var NoVoidRule = rule.Rule{
+	Name:   "no-void",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		return rule.RuleListeners{
+			ast.KindVoidExpression: func(node *ast.Node) {
+				if opts.allowAsStatement {
+					// ESTree has no ParenthesizedExpression node, so a
+					// void expression wrapped only in parentheses still has
+					// the surrounding ExpressionStatement as its parent.
+					parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+					if parent != nil && parent.Kind == ast.KindExpressionStatement {
+						return
+					}
+				}
+
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "noVoid",
+					Description: "Expected 'undefined' and instead saw 'void'.",
+				})
+			},
+		}
+	},
+}
+
+type noVoidOptions struct {
+	allowAsStatement bool
+}
+
+func parseOptions(options []any) noVoidOptions {
+	opts := noVoidOptions{allowAsStatement: false}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]any)
+	if value, ok := optsMap["allowAsStatement"].(bool); ok {
+		opts.allowAsStatement = value
+	}
+	return opts
+}

--- a/internal/rules/no_void/no_void.md
+++ b/internal/rules/no_void/no_void.md
@@ -1,0 +1,54 @@
+# no-void
+
+## Rule Details
+
+Disallow use of the `void` operator.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+void foo;
+void someFunction();
+
+const foo = void bar();
+function baz() {
+  return void 0;
+}
+```
+
+## Options
+
+### `allowAsStatement`
+
+When `true`, permits `void` as a standalone statement but still prohibits its
+use in expression contexts such as variable assignments or return statements.
+Default: `false`.
+
+Examples of **incorrect** code for this rule with `{ "allowAsStatement": true }`:
+
+```json
+{ "no-void": ["error", { "allowAsStatement": true }] }
+```
+
+```javascript
+const foo = void bar();
+function baz() {
+  return void 0;
+}
+```
+
+Examples of **correct** code for this rule with `{ "allowAsStatement": true }`:
+
+```json
+{ "no-void": ["error", { "allowAsStatement": true }] }
+```
+
+```javascript
+void foo;
+void someFunction();
+```
+
+## Original Documentation
+
+- [ESLint: no-void](https://eslint.org/docs/latest/rules/no-void)
+- [Source code](https://github.com/eslint/eslint/blob/main/lib/rules/no-void.js)

--- a/internal/rules/no_void/no_void.md
+++ b/internal/rules/no_void/no_void.md
@@ -51,4 +51,4 @@ void someFunction();
 ## Original Documentation
 
 - [ESLint: no-void](https://eslint.org/docs/latest/rules/no-void)
-- [Source code](https://github.com/eslint/eslint/blob/main/lib/rules/no-void.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-void.js)

--- a/internal/rules/no_void/no_void.schema.json
+++ b/internal/rules/no_void/no_void.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowAsStatement": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/no_void/no_void_extras_test.go
+++ b/internal/rules/no_void/no_void_extras_test.go
@@ -1,0 +1,174 @@
+// TestNoVoidExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+//
+// Dimension 4 walk (rows that don't apply to no-void, with reasons):
+//   - N/A access / key forms (identifier, string, numeric, private, computed,
+//     element access): the rule inspects a UnaryExpression's own parent, not a
+//     property key.
+//   - N/A optional chain (X?.y, X?.()): void has no member-access receiver.
+//   - N/A declaration/container forms (class/function declaration vs
+//     expression, async/generator variants): the rule fires the same way in
+//     every enclosing container; no listener targets a declaration.
+//   - N/A autofix boundaries: the rule has neither an autofix nor a
+//     suggestion.
+//   - N/A graceful degradation around SpreadAssignment / RestElement / empty
+//     bodies / overload signatures: the rule never inspects object, array, or
+//     class-member shapes.
+package no_void
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+var allowAsStatement = []any{map[string]any{"allowAsStatement": true}}
+
+func TestNoVoidExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoVoidRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: parenthesized wrapper transparent to the statement check ----
+			// ESTree has no ParenthesizedExpression node, so `(void 0);` sees
+			// ExpressionStatement as the UnaryExpression's direct parent.
+			// tsgo interposes a ParenthesizedExpression node here instead; the
+			// rule must walk past it to match upstream.
+			{Code: `(void 0);`, Options: allowAsStatement},
+			{Code: `((void 0));`, Options: allowAsStatement},
+
+			// ---- Dimension 2: scoping & nesting — void statement stays allowed across every enclosing container ----
+			{Code: `if (a) void 0; else void 1;`, Options: allowAsStatement},
+			{Code: `while (a) void 0;`, Options: allowAsStatement},
+			{Code: `do void 0; while (a);`, Options: allowAsStatement},
+			{Code: `for (let i = 0; i < 1; i++) void 0;`, Options: allowAsStatement},
+			{Code: `switch (a) { case 1: void 0; }`, Options: allowAsStatement},
+			{Code: `label: void 0;`, Options: allowAsStatement},
+			{Code: `{ void 0; }`, Options: allowAsStatement},
+			{Code: `class Foo { m() { void 0; } }`, Options: allowAsStatement},
+			{Code: `const f = async () => { void 0; };`, Options: allowAsStatement},
+
+			// ---- Dimension 4: void 0! is still a bare statement — the `!` binds to the argument, not the void expression ----
+			{Code: `void 0!;`, Options: allowAsStatement, FileName: "file.ts"},
+
+			// ---- Real-user: eslint/eslint#19876 — void used to explicitly discard a floating promise ----
+			{Code: `void fetchData();`, Options: allowAsStatement},
+			{Code: `elements.forEach(el => { void process(el); });`, Options: allowAsStatement},
+
+			// ---- Real-user: eslint/eslint#12688 — void async IIFE used as a top-level statement ----
+			{Code: `void (async () => { await doStuff(); })();`, Options: allowAsStatement},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: nesting where only the outer void counts as the statement ----
+			// Locks in upstream UnaryExpression listener: allowAsStatement is
+			// irrelevant once the void expression is nested inside another
+			// expression, even another void expression. The outer void's
+			// direct parent is the ExpressionStatement (allowed); the inner
+			// void's direct parent is the outer UnaryExpression (reported).
+			{
+				Code:    `void void 0;`,
+				Options: allowAsStatement,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 6, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// Locks in upstream UnaryExpression listener arm: node.parent.type
+			// must be exactly "ExpressionStatement" — a ConditionalExpression,
+			// SequenceExpression, or ForStatement init clause does not count,
+			// even though the surrounding statement is expression-only.
+			{
+				Code:    `a ? void 0 : void 1;`,
+				Options: allowAsStatement,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 5, EndLine: 1, EndColumn: 11},
+					{MessageId: "noVoid", Line: 1, Column: 14, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code:    `void 0, void 1;`,
+				Options: allowAsStatement,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+					{MessageId: "noVoid", Line: 1, Column: 9, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    `for (void 0; ; ) {}`,
+				Options: allowAsStatement,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 6, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// ---- Dimension 3-adjacent: multi-line report range ----
+			// The reported range spans from the `void` keyword through the end
+			// of its argument even when they sit on different lines.
+			{
+				Code: "var foo =\n  void\n  0;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 2, Column: 3, EndLine: 3, EndColumn: 4},
+				},
+			},
+
+			// ---- Real-user: eslint/eslint#12688 — void used to make an arrow function's non-value-returning body explicit ----
+			// Locks in upstream UnaryExpression listener arm: an arrow
+			// function's concise (expression) body is not an ExpressionStatement,
+			// so allowAsStatement does not cover it even though the intent is
+			// statement-like.
+			{
+				Code:    `const log = x => void console.log(x);`,
+				Options: allowAsStatement,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 18, EndLine: 1, EndColumn: 37},
+				},
+			},
+
+			// Locks in upstream UnaryExpression listener arm: await unwraps to
+			// an AwaitExpression parent, not ExpressionStatement.
+			{
+				Code:    `async function f() { await void 0; }`,
+				Options: allowAsStatement,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 28, EndLine: 1, EndColumn: 34},
+				},
+			},
+
+			// ---- Dimension 4: TS-only wrappers around the void expression itself keep reporting ----
+			// A NonNullExpression, AsExpression, or SatisfiesExpression that
+			// wraps the void expression (through parentheses or, for `as`/
+			// `satisfies`, directly by TS precedence) is a genuine expression
+			// use, not a bare statement; ESLint has no equivalent syntax to
+			// compare against, so this locks in rslint's own behavior.
+			{
+				Code:     `(void 0)!;`,
+				Options:  allowAsStatement,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 2, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code:     `void 0 as any;`,
+				Options:  allowAsStatement,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code:     `void 0 satisfies unknown;`,
+				Options:  allowAsStatement,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_void/no_void_upstream_test.go
+++ b/internal/rules/no_void/no_void_upstream_test.go
@@ -1,0 +1,78 @@
+// TestNoVoidUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/no-void.js 1:1. Position assertions cover
+// line/column/endLine/endColumn for every invalid case. rslint-specific
+// lock-in cases live in the no_void_extras_test.go file.
+package no_void
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoVoidUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoVoidRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid ----
+			{Code: `var foo = bar()`},
+			{Code: `foo.void()`},
+			{Code: `foo.void = bar`},
+			{Code: `delete foo;`},
+			{
+				Code:    `void 0`,
+				Options: []any{map[string]any{"allowAsStatement": true}},
+			},
+			{
+				Code:    `void(0)`,
+				Options: []any{map[string]any{"allowAsStatement": true}},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid ----
+			{
+				Code: `void 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Message: "Expected 'undefined' and instead saw 'void'.", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code:    `void 0`,
+				Options: []any{map[string]any{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code:    `void 0`,
+				Options: []any{map[string]any{"allowAsStatement": false}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code: `void(0)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code: `var foo = void 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    `var foo = void 0`,
+				Options: []any{map[string]any{"allowAsStatement": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noVoid", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -88,6 +88,7 @@ export default defineConfig({
     './tests/eslint/rules/no-eval.test.ts',
     './tests/eslint/rules/no-implicit-coercion.test.ts',
     './tests/eslint/rules/no-implied-eval.test.ts',
+    './tests/eslint/rules/no-void.test.ts',
     './tests/eslint/rules/no-iterator.test.ts',
     './tests/eslint/rules/getter-return.test.ts',
     './tests/eslint/rules/guard-for-in.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-void.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-void.test.ts.snap
@@ -1,0 +1,157 @@
+// Rstest Snapshot v1
+
+exports[`no-void > invalid 1`] = `
+{
+  "code": "void 0",
+  "diagnostics": [
+    {
+      "message": "Expected 'undefined' and instead saw 'void'.",
+      "messageId": "noVoid",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-void",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-void > invalid 2`] = `
+{
+  "code": "void 0",
+  "diagnostics": [
+    {
+      "message": "Expected 'undefined' and instead saw 'void'.",
+      "messageId": "noVoid",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-void",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-void > invalid 3`] = `
+{
+  "code": "void 0",
+  "diagnostics": [
+    {
+      "message": "Expected 'undefined' and instead saw 'void'.",
+      "messageId": "noVoid",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-void",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-void > invalid 4`] = `
+{
+  "code": "void(0)",
+  "diagnostics": [
+    {
+      "message": "Expected 'undefined' and instead saw 'void'.",
+      "messageId": "noVoid",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-void",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-void > invalid 5`] = `
+{
+  "code": "var foo = void 0",
+  "diagnostics": [
+    {
+      "message": "Expected 'undefined' and instead saw 'void'.",
+      "messageId": "noVoid",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-void",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-void > invalid 6`] = `
+{
+  "code": "var foo = void 0",
+  "diagnostics": [
+    {
+      "message": "Expected 'undefined' and instead saw 'void'.",
+      "messageId": "noVoid",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-void",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-void.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-void.test.ts
@@ -1,0 +1,97 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-void', {
+  valid: [
+    'var foo = bar()',
+    'foo.void()',
+    'foo.void = bar',
+    'delete foo;',
+    {
+      code: 'void 0',
+      options: { allowAsStatement: true },
+    },
+    {
+      code: 'void(0)',
+      options: { allowAsStatement: true },
+    },
+  ],
+  invalid: [
+    {
+      code: 'void 0',
+      errors: [
+        {
+          messageId: 'noVoid',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 7,
+        },
+      ],
+    },
+    {
+      code: 'void 0',
+      options: {},
+      errors: [
+        {
+          messageId: 'noVoid',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 7,
+        },
+      ],
+    },
+    {
+      code: 'void 0',
+      options: { allowAsStatement: false },
+      errors: [
+        {
+          messageId: 'noVoid',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 7,
+        },
+      ],
+    },
+    {
+      code: 'void(0)',
+      errors: [
+        {
+          messageId: 'noVoid',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 8,
+        },
+      ],
+    },
+    {
+      code: 'var foo = void 0',
+      errors: [
+        {
+          messageId: 'noVoid',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      code: 'var foo = void 0',
+      options: { allowAsStatement: true },
+      errors: [
+        {
+          messageId: 'noVoid',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-void` rule from ESLint to rslint.

Disallows use of the `void` operator, with an `allowAsStatement` option to permit `void` as a standalone statement while still prohibiting its use in expression contexts such as assignments and return statements.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-void
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-void.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).