### PR TITLE
feat: port rule block-scoped-var

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/accessor_pairs"
 	"github.com/web-infra-dev/rslint/internal/rules/array_callback_return"
 	"github.com/web-infra-dev/rslint/internal/rules/arrow_body_style"
+	"github.com/web-infra-dev/rslint/internal/rules/block_scoped_var"
 	"github.com/web-infra-dev/rslint/internal/rules/complexity"
 	"github.com/web-infra-dev/rslint/internal/rules/consistent_return"
 	"github.com/web-infra-dev/rslint/internal/rules/constructor_super"
@@ -162,6 +163,7 @@ func GetAllRules() []rule.Rule {
 		accessor_pairs.AccessorPairsRule,
 		array_callback_return.ArrayCallbackReturnRule,
 		arrow_body_style.ArrowBodyStyleRule,
+		block_scoped_var.BlockScopedVarRule,
 		complexity.ComplexityRule,
 		consistent_return.ConsistentReturnRule,
 		constructor_super.ConstructorSuperRule,

--- a/internal/rules/block_scoped_var/block_scoped_var.go
+++ b/internal/rules/block_scoped_var/block_scoped_var.go
@@ -1,0 +1,148 @@
+package block_scoped_var
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/block-scoped-var
+var BlockScopedVarRule = rule.Rule{
+	Name:   "block-scoped-var",
+	Schema: rule.EmptyArraySchema,
+	Run:    run,
+}
+
+// varOccurrence is one `var`-declared binding identifier, paired with the
+// block-scope range that was active around its declaration.
+type varOccurrence struct {
+	identifier *ast.Node
+	symbol     *ast.Symbol
+	scopeRange core.TextRange
+}
+
+func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+	if ctx.SourceFile == nil {
+		return nil
+	}
+
+	var occurrences []varOccurrence
+	declsBySymbol := make(map[*ast.Symbol][]*ast.Node)
+
+	var visit func(node *ast.Node)
+	visit = func(node *ast.Node) {
+		if node.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(node) {
+			scopeRange := blockScopeRange(ctx.SourceFile, node)
+			utils.ForEachVariableDeclarationBinding(node, func(_ *ast.Node, identifier *ast.Node, _ string) {
+				symbol := identifier.Parent.Symbol()
+				if symbol == nil {
+					return
+				}
+				occurrences = append(occurrences, varOccurrence{
+					identifier: identifier,
+					symbol:     symbol,
+					scopeRange: scopeRange,
+				})
+				declsBySymbol[symbol] = append(declsBySymbol[symbol], identifier)
+			})
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return false
+		})
+	}
+	visit(ctx.SourceFile.AsNode())
+
+	var diagnostics []diagnostic
+	for _, occurrence := range occurrences {
+		diagnostics = append(diagnostics, checkOccurrence(ctx, occurrence, declsBySymbol[occurrence.symbol])...)
+	}
+
+	// ESLint sorts all of a rule's reports by position before emitting them,
+	// so two sibling `var` declarations that flag each other interleave by
+	// report location rather than by declaration-processing order.
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		return diagnostics[i].textRange.Pos() < diagnostics[j].textRange.Pos()
+	})
+	for _, d := range diagnostics {
+		ctx.ReportRange(d.textRange, d.message)
+	}
+
+	return nil
+}
+
+type diagnostic struct {
+	textRange core.TextRange
+	message   rule.RuleMessage
+}
+
+// checkOccurrence collects a diagnostic for every use of occurrence's
+// declared variable that falls outside the block scope that was active when
+// it was declared. "Uses" include both ordinary reads/writes and the binding
+// identifiers of any sibling `var` declarations of the same variable
+// elsewhere in the file — ESLint's scope analysis treats every declarator's
+// own identifier as a reference too, which is what lets two sibling `var`
+// declarations of the same name flag each other.
+func checkOccurrence(ctx rule.RuleContext, occurrence varOccurrence, siblingDeclarations []*ast.Node) []diagnostic {
+	uses := append([]*ast.Node{}, ctx.Refs.References(occurrence.symbol)...)
+	uses = append(uses, siblingDeclarations...)
+	sort.Slice(uses, func(i, j int) bool {
+		return uses[i].Pos() < uses[j].Pos()
+	})
+
+	name := occurrence.identifier.Text()
+	defRange := utils.TrimNodeTextRange(ctx.SourceFile, occurrence.identifier)
+	defLineIndex, defCharIndex := scanner.GetECMALineAndUTF16CharacterOfPosition(ctx.SourceFile, defRange.Pos())
+	defLine, defColumn := defLineIndex+1, int(defCharIndex)+1
+
+	var diagnostics []diagnostic
+	for _, use := range uses {
+		useRange := utils.TrimNodeTextRange(ctx.SourceFile, use)
+		if useRange.Pos() < occurrence.scopeRange.Pos() || useRange.End() > occurrence.scopeRange.End() {
+			diagnostics = append(diagnostics, diagnostic{
+				textRange: useRange,
+				message: rule.RuleMessage{
+					Id: "outOfScope",
+					Description: fmt.Sprintf(
+						"'%s' declared on line %d column %d is used outside of binding context.",
+						name, defLine, defColumn,
+					),
+				},
+			})
+		}
+	}
+	return diagnostics
+}
+
+// blockScopeRange returns the range of the nearest enclosing block scope for
+// a `var` declaration list: the innermost Block, for-loop, or switch
+// statement containing it, or the whole source file when there is none.
+//
+// This mirrors ESLint's stack of BlockStatement/ForStatement/ForInStatement/
+// ForOfStatement/SwitchStatement/CatchClause/StaticBlock ranges without
+// maintaining an explicit traversal stack: the range active at any given
+// `var` declaration is always exactly its nearest enclosing node of one of
+// those kinds, since scope entry/exit is properly nested. CatchClause and
+// StaticBlock are omitted because a `var` inside either is always nested
+// inside that construct's own Block first, which this function reaches
+// first and which spans the same effective set of positions.
+func blockScopeRange(sourceFile *ast.SourceFile, declarationList *ast.Node) core.TextRange {
+	for current := declarationList.Parent; current != nil; current = current.Parent {
+		switch current.Kind {
+		case ast.KindBlock,
+			ast.KindForStatement,
+			ast.KindForInStatement,
+			ast.KindForOfStatement,
+			ast.KindSwitchStatement:
+			return utils.TrimNodeTextRange(sourceFile, current)
+		case ast.KindSourceFile:
+			return core.NewTextRange(0, current.End())
+		}
+	}
+	return core.NewTextRange(0, sourceFile.AsNode().End())
+}

--- a/internal/rules/block_scoped_var/block_scoped_var.go
+++ b/internal/rules/block_scoped_var/block_scoped_var.go
@@ -38,7 +38,13 @@ func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 	visit = func(node *ast.Node) {
 		if node.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(node) {
 			scopeRange := blockScopeRange(ctx.SourceFile, node)
-			utils.ForEachVariableDeclarationBinding(node, func(_ *ast.Node, identifier *ast.Node, _ string) {
+			// A for-in/for-of head has no `=` of its own, but the loop
+			// implicitly assigns into the binding on every iteration, which
+			// ESLint's scope analysis treats the same as an explicit
+			// initializer for this rule's purposes.
+			isForInOrForOf := node.Parent != nil &&
+				(node.Parent.Kind == ast.KindForInStatement || node.Parent.Kind == ast.KindForOfStatement)
+			utils.ForEachVariableDeclarationBinding(node, func(declaration *ast.Node, identifier *ast.Node, _ string) {
 				symbol := identifier.Parent.Symbol()
 				if symbol == nil {
 					return
@@ -48,7 +54,13 @@ func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 					symbol:     symbol,
 					scopeRange: scopeRange,
 				})
-				declsBySymbol[symbol] = append(declsBySymbol[symbol], identifier)
+				// ESLint's eslint-scope only creates a self-reference for a
+				// declarator that is assigned a value — a bare `var a;` never
+				// becomes a "reference," so it can never flag (or be flagged
+				// by) a sibling `var` declaration of the same name.
+				if isForInOrForOf || hasInitializer(declaration) {
+					declsBySymbol[symbol] = append(declsBySymbol[symbol], identifier)
+				}
 			})
 		}
 		node.ForEachChild(func(child *ast.Node) bool {
@@ -84,8 +96,9 @@ type diagnostic struct {
 // checkOccurrence collects a diagnostic for every use of occurrence's
 // declared variable that falls outside the block scope that was active when
 // it was declared. "Uses" include both ordinary reads/writes and the binding
-// identifiers of any sibling `var` declarations of the same variable
-// elsewhere in the file — ESLint's scope analysis treats every declarator's
+// identifiers of any sibling `var` declarations of the same variable that
+// have their own initializer (or are a for-in/for-of loop's binding)
+// elsewhere in the file — ESLint's scope analysis treats such a declarator's
 // own identifier as a reference too, which is what lets two sibling `var`
 // declarations of the same name flag each other.
 func checkOccurrence(ctx rule.RuleContext, occurrence varOccurrence, siblingDeclarations []*ast.Node) []diagnostic {
@@ -117,6 +130,13 @@ func checkOccurrence(ctx rule.RuleContext, occurrence varOccurrence, siblingDecl
 		}
 	}
 	return diagnostics
+}
+
+// hasInitializer reports whether a VariableDeclaration node has an `=`
+// initializer.
+func hasInitializer(declaration *ast.Node) bool {
+	variableDeclaration := declaration.AsVariableDeclaration()
+	return variableDeclaration != nil && variableDeclaration.Initializer != nil
 }
 
 // blockScopeRange returns the range of the nearest enclosing block scope for

--- a/internal/rules/block_scoped_var/block_scoped_var.go
+++ b/internal/rules/block_scoped_var/block_scoped_var.go
@@ -59,6 +59,15 @@ func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 				// becomes a "reference," so it can never flag (or be flagged
 				// by) a sibling `var` declaration of the same name.
 				if isForInOrForOf || hasInitializer(declaration) {
+					// NOTE: Unlike ESLint, a binding-pattern element with its
+					// own default value (`var { a = 1 } = x`) is only added
+					// once here, not twice. eslint-scope creates two
+					// self-references for such an element instead of one,
+					// which (only when that element is later cross-checked
+					// against a sibling `var` of the same name) makes ESLint
+					// emit the exact same diagnostic twice. This is an
+					// eslint-scope implementation quirk, not a deliberate
+					// part of the rule; see "Differences from ESLint" below.
 					declsBySymbol[symbol] = append(declsBySymbol[symbol], identifier)
 				}
 			})

--- a/internal/rules/block_scoped_var/block_scoped_var.md
+++ b/internal/rules/block_scoped_var/block_scoped_var.md
@@ -103,6 +103,14 @@ class C {
 
 This rule has no options.
 
+## Differences from ESLint
+
+- When a destructuring binding element with its own default value (e.g. the
+  `a` in `var { a = 1 } = x;`) is flagged for being used outside the block
+  where a sibling `var` of the same name is declared, it is reported once.
+  ESLint's scope analysis creates two internal references for such an
+  element, so it reports the identical diagnostic twice in that situation.
+
 ## Original Documentation
 
 - [ESLint: block-scoped-var](https://eslint.org/docs/latest/rules/block-scoped-var)

--- a/internal/rules/block_scoped_var/block_scoped_var.md
+++ b/internal/rules/block_scoped_var/block_scoped_var.md
@@ -1,0 +1,109 @@
+# block-scoped-var
+
+## Rule Details
+
+The `block-scoped-var` rule generates warnings when variables are used outside of the block in which they were defined. This emulates C-style block scope.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function doIf() {
+  if (true) {
+    var build = true;
+  }
+
+  console.log(build);
+}
+
+function doIfElse() {
+  if (true) {
+    var build = true;
+  } else {
+    var build = false;
+  }
+}
+
+function doTryCatch() {
+  try {
+    var build = 1;
+  } catch (e) {
+    var f = build;
+  }
+}
+
+function doFor() {
+  for (var x = 1; x < 10; x++) {
+    var y = f(x);
+  }
+  console.log(y);
+}
+
+class C {
+  static {
+    if (something) {
+      var build = true;
+    }
+    build = false;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function doIf() {
+  var build;
+
+  if (true) {
+    build = true;
+  }
+
+  console.log(build);
+}
+
+function doIfElse() {
+  var build;
+
+  if (true) {
+    build = true;
+  } else {
+    build = false;
+  }
+}
+
+function doTryCatch() {
+  var build;
+  var f;
+
+  try {
+    build = 1;
+  } catch (e) {
+    f = build;
+  }
+}
+
+function doFor() {
+  for (var x = 1; x < 10; x++) {
+    var y = f(x);
+    console.log(y);
+  }
+}
+
+class C {
+  static {
+    var build = false;
+    if (something) {
+      build = true;
+    }
+  }
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [ESLint: block-scoped-var](https://eslint.org/docs/latest/rules/block-scoped-var)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/block-scoped-var.js)

--- a/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
+++ b/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
@@ -1,0 +1,92 @@
+// Edge-shape augmentation (Dimensions 1-4) and upstream-branch lock-ins for
+// block-scoped-var, beyond what tests/lib/rules/block-scoped-var.js covers.
+// See block_scoped_var_upstream_test.go for the migrated upstream suite.
+package block_scoped_var
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestBlockScopedVarExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&BlockScopedVarRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 1: TS-specific wrappers on an in-scope read ----
+			{Code: "function f() { if (true) { var a = 1; (a).toString(); } }"},
+			{Code: "function f() { if (true) { var a = 1; a!.toString(); } }"},
+			{Code: "function f() { if (true) { var a: any = 1; (a as string).length; } }"},
+			{Code: "function f() { if (true) { var a = 1; a?.toString(); } }"},
+
+			// ---- Dimension 2: 3+ levels of nesting, only the boundary that matters flags ----
+			{Code: "function f() { if (true) { if (true) { if (true) { var a = 1; a; } } } }"},
+			{Code: "function f() { var a = 1; if (true) { if (true) { if (true) { a; } } } }"},
+
+			// ---- Dimension 4: graceful degradation on binding-pattern shapes ----
+			{Code: "function f() { if (true) { var { a, ...rest } = { a: 1 }; a; rest; } }"},
+			{Code: "function f() { if (true) { var [a, ...rest] = [1]; a; rest; } }"},
+			{Code: "function f() { if (true) { var {} = {}; } }"},
+			{Code: "function f() { if (true) { var [] = []; } }"},
+
+			// ---- Dimension 4: TS type annotation on an in-scope var ----
+			{Code: "function f() { if (true) { var a: number = 1; a; } }"},
+
+			// ---- Dimension 4: ambient `declare var` does not crash or false-positive ----
+			{Code: "declare var a: number; a;"},
+			{Code: "function f() { declare var a: number; a; }"},
+
+			// ---- Real-user: catch-clause param shadows an unrelated same-named outer var ----
+			{Code: "function f() { var e = 1; try {} catch (e) { e; } e; }"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: TS wrappers around an out-of-scope read still flag the identifier ----
+			outOfScope("function f() { if (true) { var a = 1; } (a).toString(); }",
+				scopeErr("a", 1, 32, 1, 42)),
+			outOfScope("function f() { if (true) { var a = 1; } ((a)).toString(); }",
+				scopeErr("a", 1, 32, 1, 43)),
+			outOfScope("function f() { if (true) { var a = 1; } a!.toString(); }",
+				scopeErr("a", 1, 32, 1, 41)),
+			outOfScope("function f() { if (true) { var a: any = 1; } (a as string).length; }",
+				scopeErr("a", 1, 32, 1, 47)),
+			outOfScope("function f() { if (true) { var a = 1; } a?.toString(); }",
+				scopeErr("a", 1, 32, 1, 41)),
+			outOfScope("function f() { if (true) { var a = function(){}; } a?.(); }",
+				scopeErr("a", 1, 32, 1, 52)),
+
+			// ---- Dimension 4: computed key and template-literal reads of an out-of-scope var ----
+			outOfScope("function f() { if (true) { var a = 1; } var o = { [a]: 1 }; }",
+				scopeErr("a", 1, 32, 1, 52)),
+			outOfScope("function f() { if (true) { var a = 1; } `${a}`; }",
+				scopeErr("a", 1, 32, 1, 44)),
+
+			// ---- Dimension 4: destructured rest binding used outside its block ----
+			outOfScope("function f() { if (true) { var { a, ...rest } = { a: 1 }; } rest; }",
+				scopeErr("rest", 1, 40, 1, 61)),
+			outOfScope("function f() { if (true) { var [a, ...rest] = [1]; } rest; }",
+				scopeErr("rest", 1, 39, 1, 54)),
+
+			// ---- Dimension 2: 3-level nesting, innermost declaration leaks past its own block only ----
+			outOfScope("function f() { if (true) { if (true) { if (true) { var a = 1; } a; } } }",
+				scopeErr("a", 1, 56, 1, 65)),
+
+			// ---- Real-user: `var` assigned only inside a conditional branch, read after the block ----
+			outOfScope("function connect(cb) { if (cb) { var onDone = function() { cb(); }; } return onDone; }",
+				scopeErr("onDone", 1, 38, 1, 78)),
+
+			// ---- Real-user: try/catch fallback assignment read after both blocks (classic gotcha) ----
+			// Locks in that sibling `var` declarations of the same name cross-flag
+			// each other's own identifier, not just later reads (see the if/else
+			// and duplicate-for-loop cases in the upstream suite).
+			outOfScope("function parse(input) { try { var result = input.a; } catch (e) { var result = null; } return result; }",
+				scopeErr("result", 1, 71, 1, 35),
+				scopeErr("result", 1, 35, 1, 71),
+				scopeErr("result", 1, 35, 1, 95),
+				scopeErr("result", 1, 71, 1, 95)),
+		},
+	)
+}

--- a/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
+++ b/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
@@ -42,6 +42,12 @@ func TestBlockScopedVarExtras(t *testing.T) {
 
 			// ---- Real-user: catch-clause param shadows an unrelated same-named outer var ----
 			{Code: "function f() { var e = 1; try {} catch (e) { e; } e; }"},
+
+			// ---- Locks in: a bare `var` declarator (no initializer) never
+			// ---- creates a self-reference, so two sibling bare declarations
+			// ---- of the same name never cross-flag each other. ----
+			{Code: "if (true) { var a; } else { var a; }"},
+			{Code: "function f() { for (var a;;) {} for (var a;;) {} }"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: TS wrappers around an out-of-scope read still flag the identifier ----
@@ -87,6 +93,18 @@ func TestBlockScopedVarExtras(t *testing.T) {
 				scopeErr("result", 1, 35, 1, 71),
 				scopeErr("result", 1, 35, 1, 95),
 				scopeErr("result", 1, 71, 1, 95)),
+
+			// ---- Locks in: an initialized `var` declarator's self-reference
+			// ---- only fires against a sibling declarator that itself has an
+			// ---- initializer (or is a for-in/for-of binding) — a bare
+			// ---- sibling declarator is never flagged and never flags back.
+			outOfScope("function f() { try { var a = compute(); } catch (e) { var a; } return a; }",
+				scopeErr("a", 1, 59, 1, 26),
+				scopeErr("a", 1, 26, 1, 71),
+				scopeErr("a", 1, 59, 1, 71)),
+			outOfScope("function f() { for (var a in {}) {} for (var a in {}) {} }",
+				scopeErr("a", 1, 46, 1, 25),
+				scopeErr("a", 1, 25, 1, 46)),
 		},
 	)
 }

--- a/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
+++ b/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
@@ -48,6 +48,25 @@ func TestBlockScopedVarExtras(t *testing.T) {
 			// ---- of the same name never cross-flag each other. ----
 			{Code: "if (true) { var a; } else { var a; }"},
 			{Code: "function f() { for (var a;;) {} for (var a;;) {} }"},
+
+			// ---- Locks in: a for-of/for-in binding's implicit self-reference
+			// ---- does not extend to an unrelated later bare `var` of the
+			// ---- same name — it is still gated on that later declarator
+			// ---- having its own initializer.
+			{Code: "function f() { for (var a of []) {} var a; }"},
+
+			// ---- Real-user: class static blocks are independent var scopes,
+			// ---- so the same name declared in two different static blocks
+			// ---- of one class never cross-flags, with or without an
+			// ---- initializer.
+			{Code: "class C { static { var a; a; } static { var a; a; } }"},
+			{Code: "class C { static { var a = 1; } static { var a = 2; } }"},
+
+			// ---- Real-user: a nested function's `var` never cross-flags an
+			// ---- outer function's same-named `var` — they are different
+			// ---- symbols in different var scopes, even with matching
+			// ---- initializer shapes.
+			{Code: "function outer() { if (true) { var a = 1; } function inner() { if (true) { var a = 2; } } }"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: TS wrappers around an out-of-scope read still flag the identifier ----
@@ -105,6 +124,38 @@ func TestBlockScopedVarExtras(t *testing.T) {
 			outOfScope("function f() { for (var a in {}) {} for (var a in {}) {} }",
 				scopeErr("a", 1, 46, 1, 25),
 				scopeErr("a", 1, 25, 1, 46)),
+
+			// ---- Locks in: `hasInitializer` is checked per declarator, not
+			// ---- per declaration list — a bare declarator sitting next to an
+			// ---- initialized one in the same `var` statement keeps its own
+			// ---- gating.
+			outOfScope("if (true) { var a, b = 1; } else { var a = 2, b; }",
+				scopeErr("b", 1, 47, 1, 20),
+				scopeErr("a", 1, 17, 1, 40)),
+
+			// ---- Locks in: a for-of binding's implicit self-reference does
+			// ---- cross-flag against a *later* declarator that has its own
+			// ---- initializer.
+			outOfScope("function f() { for (var a of []) {} var a = 1; }",
+				scopeErr("a", 1, 25, 1, 41)),
+
+			// ---- Real-user: a fully bare branch among initialized ones is
+			// ---- still checked as an occurrence (against reads and against
+			// ---- initialized siblings) even though it never joins the
+			// ---- sibling list itself.
+			outOfScope("if (x) { var a = 1; } else if (y) { var a; } else { var a = 3; }",
+				scopeErr("a", 1, 41, 1, 14),
+				scopeErr("a", 1, 57, 1, 14),
+				scopeErr("a", 1, 14, 1, 57),
+				scopeErr("a", 1, 41, 1, 57)),
+
+			// ---- Dimension 4: eslint-scope double-references a defaulted
+			// ---- binding-pattern element, so ESLint would report this exact
+			// ---- diagnostic twice; this port reports it once (see
+			// ---- "Differences from ESLint" in block_scoped_var.md).
+			outOfScope("if (true) { var { a = 1 } = {}; } else { var { a = 1 } = {}; }",
+				scopeErr("a", 1, 48, 1, 19),
+				scopeErr("a", 1, 19, 1, 48)),
 		},
 	)
 }

--- a/internal/rules/block_scoped_var/block_scoped_var_upstream_test.go
+++ b/internal/rules/block_scoped_var/block_scoped_var_upstream_test.go
@@ -1,0 +1,199 @@
+// TestBlockScopedVarUpstream migrates the full valid/invalid suite from
+// ESLint v10.8.1 tests/lib/rules/block-scoped-var.js 1:1. rslint's parser
+// does not gate syntax on languageOptions.ecmaVersion the way espree does, so
+// that option is dropped from ported cases unless it also selects globals
+// this rule cares about (it does not, so it never appears below).
+// languageOptions.sourceType is dropped too: rslint infers module-ness from
+// actual import/export syntax rather than an explicit flag, and every
+// upstream case that sets it either has no such syntax (module-ness makes no
+// observable difference here) or already has real import/export (module-ness
+// is inferred anyway). rslint-specific lock-ins live in
+// block_scoped_var_extras_test.go.
+package block_scoped_var
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// scopeErr builds the expected outOfScope error for a use reported at
+// line/column, whose declaration data.name/definitionLine/definitionColumn
+// point back at defLine/defColumn.
+func scopeErr(name string, defLine, defColumn, line, column int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "outOfScope",
+		Message:   fmt.Sprintf("'%s' declared on line %d column %d is used outside of binding context.", name, defLine, defColumn),
+		Line:      line,
+		Column:    column,
+		EndLine:   line,
+		EndColumn: column + len(name),
+	}
+}
+
+func outOfScope(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{Code: code, Errors: errors}
+}
+
+func TestBlockScopedVarUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&BlockScopedVarRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid: https://github.com/eslint/eslint/issues/2242 ----
+			{Code: "function f() { } f(); var exports = { f: f };"},
+			{Code: "var f = () => {}; f(); var exports = { f: f };"},
+
+			// ---- upstream valid: basic function/var scoping ----
+			{Code: "!function f(){ f; }"},
+			{Code: "function f() { } f(); var exports = { f: f };"},
+			{Code: "function f() { var a, b; { a = true; } b = a; }"},
+			{Code: "var a; function f() { var b = a; }"},
+			{Code: "function f(a) { }"},
+			{Code: "!function(a) { };"},
+			{Code: "!function f(a) { };"},
+			{Code: "function f(a) { var b = a; }"},
+			{Code: "!function f(a) { var b = a; };"},
+			{Code: "function f() { var g = f; }"},
+			{Code: "function f() { } function g() { var f = g; }"},
+			{Code: "function f() { var hasOwnProperty; { hasOwnProperty; } }"},
+			{Code: "function f(){ a; b; var a, b; }"},
+			{Code: "function f(){ g(); function g(){} }"},
+			{Code: "if (true) { var a = 1; a; }"},
+			{Code: "var a; if (true) { a; }"},
+			{Code: "for (var i = 0; i < 10; i++) { i; }"},
+			{Code: "var i; for(i; i; i) { i; }"},
+			{Code: `function myFunc(foo) {  "use strict";  var { bar } = foo;  bar.hello();}`},
+			{Code: `function myFunc(foo) {  "use strict";  var [ bar ]  = foo;  bar.hello();}`},
+			{Code: "function myFunc(...foo) {  return foo;}"},
+			{Code: "var f = () => { var g = f; }"},
+			{Code: "class Foo {}\nexport default Foo;"},
+			{Code: "new Date"},
+			{Code: "var eslint = require('eslint');"},
+			{Code: "var fun = function({x}) {return x;};"},
+			{Code: "var fun = function([,x]) {return x;};"},
+			{Code: "function f(a) { return a.b; }"},
+			{Code: `var a = { "foo": 3 };`},
+			{Code: "var a = { foo: 3 };"},
+			{Code: "var a = { foo: 3, bar: 5 };"},
+			{Code: "var a = { set foo(a){}, get bar(){} };"},
+			{Code: "function f(a) { return arguments[0]; }"},
+			{Code: "function f() { }; var a = f;"},
+			{Code: "var a = f; function f() { };"},
+			{Code: "function f(){ for(var i; i; i) i; }"},
+			{Code: "function f(){ for(var a=0, b=1; a; b) a, b; }"},
+			{Code: "function f(){ for(var a in {}) a; }"},
+			{Code: "function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} }"},
+			{Code: "a:;"},
+			{Code: "foo: while (true) { bar: for (var i = 0; i < 13; ++i) {if (i === 7) break foo; } }"},
+			{Code: "foo: while (true) { bar: for (var i = 0; i < 13; ++i) {if (i === 7) continue foo; } }"},
+			{Code: `const React = require("react/addons");const cx = React.addons.classSet;`},
+			{Code: "var v = 1;  function x() { return v; };"},
+			{Code: `import * as y from "./other.js"; y();`},
+			{Code: `import y from "./other.js"; y();`},
+			{Code: `import {x as y} from "./other.js"; y();`},
+			{Code: "var x; export {x};"},
+			{Code: "var x; export {x as v};"},
+			{Code: `export {x} from "./other.js";`},
+			{Code: `export {x as v} from "./other.js";`},
+			{Code: "class Test { myFunction() { return true; }}"},
+			{Code: "class Test { get flag() { return true; }}"},
+			{Code: "var Test = class { myFunction() { return true; }}"},
+			{Code: "var doStuff; let {x: y} = {x: 1}; doStuff(y);"},
+			{Code: "function foo({x: y}) { return y; }"},
+
+			// ---- upstream valid: same coverage as no-undef ----
+			{Code: "!function f(){}; f"},
+			{Code: "var f = function foo() { }; foo(); var exports = { f: foo };"},
+			{Code: "var f = () => { x; }"},
+			{Code: "function f(){ x; }"},
+			{Code: "var eslint = require('eslint');"},
+			{Code: "function f(a) { return a[b]; }"},
+			{Code: "function f() { return b.a; }"},
+			{Code: "var a = { foo: bar };"},
+			{Code: "var a = { foo: foo };"},
+			{Code: "var a = { bar: 7, foo: bar };"},
+			{Code: "var a = arguments;"},
+			{Code: "function x(){}; var a = arguments;"},
+			{Code: "function z(b){}; var a = b;"},
+			{Code: "function z(){var b;}; var a = b;"},
+			{Code: "function f(){ try{}catch(e){} e }"},
+			{Code: "a:b;"},
+
+			// ---- upstream valid: https://github.com/eslint/eslint/issues/2253 ----
+			{Code: "/*global React*/ let {PropTypes, addons: {PureRenderMixin}} = React; let Test = React.createClass({mixins: [PureRenderMixin]});"},
+			{Code: "/*global prevState*/ const { virtualSize: prevVirtualSize = 0 } = prevState;"},
+			{Code: "const { dummy: { data, isLoading }, auth: { isLoggedIn } } = this.props;"},
+
+			// ---- upstream valid: https://github.com/eslint/eslint/issues/2747 ----
+			{Code: `function a(n) { return n > 0 ? b(n - 1) : "a"; } function b(n) { return n > 0 ? a(n - 1) : "b"; }`},
+
+			// ---- upstream valid: https://github.com/eslint/eslint/issues/2967 ----
+			{Code: "(function () { foo(); })(); function foo() {}"},
+
+			// ---- upstream valid: class static blocks ----
+			{Code: "class C { static { var foo; foo; } }"},
+			{Code: "class C { static { foo; var foo; } }"},
+			{Code: "class C { static { if (bar) { foo; } var foo; } }"},
+			{Code: "var foo; class C { static { foo; } } "},
+			{Code: "class C { static { foo; } } var foo;"},
+			{Code: "var foo; class C { static {} [foo]; } "},
+			{Code: "foo; class C { static {} } var foo; "},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream invalid: basic out-of-block reads ----
+			outOfScope("function f(){ x; { var x; } }",
+				scopeErr("x", 1, 24, 1, 15)),
+			outOfScope("function f(){ { var x; } x; }",
+				scopeErr("x", 1, 21, 1, 26)),
+			outOfScope("function f() { var a; { var b = 0; } a = b; }",
+				scopeErr("b", 1, 29, 1, 42)),
+			outOfScope("function f() { try { var a = 0; } catch (e) { var b = a; } }",
+				scopeErr("a", 1, 26, 1, 55)),
+			outOfScope("function a() { for(var b in {}) { var c = b; } c; }",
+				scopeErr("c", 1, 39, 1, 48)),
+			outOfScope("function a() { for(var b of {}) { var c = b; } c; }",
+				scopeErr("c", 1, 39, 1, 48)),
+			outOfScope("function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} b; }",
+				scopeErr("b", 1, 39, 1, 76)),
+			outOfScope("for (var a = 0;;) {} a;",
+				scopeErr("a", 1, 10, 1, 22)),
+			outOfScope("for (var a in []) {} a;",
+				scopeErr("a", 1, 10, 1, 22)),
+			outOfScope("for (var a of []) {} a;",
+				scopeErr("a", 1, 10, 1, 22)),
+			outOfScope("{ var a = 0; } a;",
+				scopeErr("a", 1, 7, 1, 16)),
+			outOfScope("if (true) { var a; } a;",
+				scopeErr("a", 1, 17, 1, 22)),
+
+			// ---- upstream invalid: sibling `var` declarations flag each other ----
+			outOfScope("if (true) { var a = 1; } else { var a = 2; }",
+				scopeErr("a", 1, 37, 1, 17),
+				scopeErr("a", 1, 17, 1, 37)),
+			outOfScope("for (var i = 0;;) {} for(var i = 0;;) {}",
+				scopeErr("i", 1, 30, 1, 10),
+				scopeErr("i", 1, 10, 1, 30)),
+
+			outOfScope("class C { static { if (bar) { var foo; } foo; } }",
+				scopeErr("foo", 1, 35, 1, 42)),
+
+			outOfScope("{ var foo,\n  bar; } bar;",
+				scopeErr("bar", 2, 3, 2, 10)),
+			outOfScope("{ var { foo,\n  bar } = baz; } bar;",
+				scopeErr("bar", 2, 3, 2, 18)),
+
+			outOfScope("if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }",
+				scopeErr("a", 1, 45, 1, 16),
+				scopeErr("a", 1, 65, 1, 16),
+				scopeErr("a", 1, 16, 1, 45),
+				scopeErr("a", 1, 65, 1, 45),
+				scopeErr("a", 1, 16, 1, 65),
+				scopeErr("a", 1, 45, 1, 65)),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -70,6 +70,7 @@ export default defineConfig({
     // eslint
     './tests/eslint/rules/accessor-pairs.test.ts',
     './tests/eslint/rules/arrow-body-style.test.ts',
+    './tests/eslint/rules/block-scoped-var.test.ts',
     './tests/eslint/rules/curly.test.ts',
     './tests/eslint/rules/default-case.test.ts',
     './tests/eslint/rules/dot-notation.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/block-scoped-var.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/block-scoped-var.test.ts.snap
@@ -1,0 +1,576 @@
+// Rstest Snapshot v1
+
+exports[`block-scoped-var > invalid 1`] = `
+{
+  "code": "function f(){ x; { var x; } }",
+  "diagnostics": [
+    {
+      "message": "'x' declared on line 1 column 24 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 2`] = `
+{
+  "code": "function f(){ { var x; } x; }",
+  "diagnostics": [
+    {
+      "message": "'x' declared on line 1 column 21 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 3`] = `
+{
+  "code": "function f() { var a; { var b = 0; } a = b; }",
+  "diagnostics": [
+    {
+      "message": "'b' declared on line 1 column 29 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 4`] = `
+{
+  "code": "function f() { try { var a = 0; } catch (e) { var b = a; } }",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 26 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 5`] = `
+{
+  "code": "function a() { for(var b in {}) { var c = b; } c; }",
+  "diagnostics": [
+    {
+      "message": "'c' declared on line 1 column 39 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 6`] = `
+{
+  "code": "function a() { for(var b of {}) { var c = b; } c; }",
+  "diagnostics": [
+    {
+      "message": "'c' declared on line 1 column 39 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 7`] = `
+{
+  "code": "function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} b; }",
+  "diagnostics": [
+    {
+      "message": "'b' declared on line 1 column 39 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 1,
+        },
+        "start": {
+          "column": 76,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 8`] = `
+{
+  "code": "for (var a = 0;;) {} a;",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 10 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 9`] = `
+{
+  "code": "for (var a in []) {} a;",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 10 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 10`] = `
+{
+  "code": "for (var a of []) {} a;",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 10 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 11`] = `
+{
+  "code": "{ var a = 0; } a;",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 7 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 12`] = `
+{
+  "code": "if (true) { var a; } a;",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 17 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 13`] = `
+{
+  "code": "if (true) { var a = 1; } else { var a = 2; }",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 37 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+    {
+      "message": "'a' declared on line 1 column 17 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 14`] = `
+{
+  "code": "for (var i = 0;;) {} for(var i = 0;;) {}",
+  "diagnostics": [
+    {
+      "message": "'i' declared on line 1 column 30 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+    {
+      "message": "'i' declared on line 1 column 10 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 15`] = `
+{
+  "code": "class C { static { if (bar) { var foo; } foo; } }",
+  "diagnostics": [
+    {
+      "message": "'foo' declared on line 1 column 35 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 16`] = `
+{
+  "code": "{ var foo,
+  bar; } bar;",
+  "diagnostics": [
+    {
+      "message": "'bar' declared on line 2 column 3 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 17`] = `
+{
+  "code": "{ var { foo,
+  bar } = baz; } bar;",
+  "diagnostics": [
+    {
+      "message": "'bar' declared on line 2 column 3 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 2,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`block-scoped-var > invalid 18`] = `
+{
+  "code": "if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }",
+  "diagnostics": [
+    {
+      "message": "'a' declared on line 1 column 45 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+    {
+      "message": "'a' declared on line 1 column 65 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+    {
+      "message": "'a' declared on line 1 column 16 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+    {
+      "message": "'a' declared on line 1 column 65 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+    {
+      "message": "'a' declared on line 1 column 16 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 65,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+    {
+      "message": "'a' declared on line 1 column 45 is used outside of binding context.",
+      "messageId": "outOfScope",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 65,
+          "line": 1,
+        },
+      },
+      "ruleName": "block-scoped-var",
+    },
+  ],
+  "errorCount": 6,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/block-scoped-var.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/block-scoped-var.test.ts
@@ -1,0 +1,193 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('block-scoped-var', {
+  valid: [
+    // https://github.com/eslint/eslint/issues/2242
+    'function f() { } f(); var exports = { f: f };',
+    'var f = () => {}; f(); var exports = { f: f };',
+
+    '!function f(){ f; }',
+    'function f() { } f(); var exports = { f: f };',
+    'function f() { var a, b; { a = true; } b = a; }',
+    'var a; function f() { var b = a; }',
+    'function f(a) { }',
+    '!function(a) { };',
+    '!function f(a) { };',
+    'function f(a) { var b = a; }',
+    '!function f(a) { var b = a; };',
+    'function f() { var g = f; }',
+    'function f() { } function g() { var f = g; }',
+    'function f() { var hasOwnProperty; { hasOwnProperty; } }',
+    'function f(){ a; b; var a, b; }',
+    'function f(){ g(); function g(){} }',
+    'if (true) { var a = 1; a; }',
+    'var a; if (true) { a; }',
+    'for (var i = 0; i < 10; i++) { i; }',
+    'var i; for(i; i; i) { i; }',
+    'function myFunc(foo) {  "use strict";  var { bar } = foo;  bar.hello();}',
+    'function myFunc(foo) {  "use strict";  var [ bar ]  = foo;  bar.hello();}',
+    'function myFunc(...foo) {  return foo;}',
+    'var f = () => { var g = f; }',
+    'class Foo {}\nexport default Foo;',
+    'new Date',
+    "var eslint = require('eslint');",
+    'var fun = function({x}) {return x;};',
+    'var fun = function([,x]) {return x;};',
+    'function f(a) { return a.b; }',
+    'var a = { "foo": 3 };',
+    'var a = { foo: 3 };',
+    'var a = { foo: 3, bar: 5 };',
+    'var a = { set foo(a){}, get bar(){} };',
+    'function f(a) { return arguments[0]; }',
+    'function f() { }; var a = f;',
+    'var a = f; function f() { };',
+    'function f(){ for(var i; i; i) i; }',
+    'function f(){ for(var a=0, b=1; a; b) a, b; }',
+    'function f(){ for(var a in {}) a; }',
+    'function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} }',
+    'a:;',
+    'foo: while (true) { bar: for (var i = 0; i < 13; ++i) {if (i === 7) break foo; } }',
+    'foo: while (true) { bar: for (var i = 0; i < 13; ++i) {if (i === 7) continue foo; } }',
+    'const React = require("react/addons");const cx = React.addons.classSet;',
+    'var v = 1;  function x() { return v; };',
+    'import * as y from "./other.js"; y();',
+    'import y from "./other.js"; y();',
+    'import {x as y} from "./other.js"; y();',
+    'var x; export {x};',
+    'var x; export {x as v};',
+    'export {x} from "./other.js";',
+    'export {x as v} from "./other.js";',
+    'class Test { myFunction() { return true; }}',
+    'class Test { get flag() { return true; }}',
+    'var Test = class { myFunction() { return true; }}',
+    'var doStuff; let {x: y} = {x: 1}; doStuff(y);',
+    'function foo({x: y}) { return y; }',
+
+    // same coverage as no-undef
+    '!function f(){}; f',
+    'var f = function foo() { }; foo(); var exports = { f: foo };',
+    'var f = () => { x; }',
+    'function f(){ x; }',
+    "var eslint = require('eslint');",
+    'function f(a) { return a[b]; }',
+    'function f() { return b.a; }',
+    'var a = { foo: bar };',
+    'var a = { foo: foo };',
+    'var a = { bar: 7, foo: bar };',
+    'var a = arguments;',
+    'function x(){}; var a = arguments;',
+    'function z(b){}; var a = b;',
+    'function z(){var b;}; var a = b;',
+    'function f(){ try{}catch(e){} e }',
+    'a:b;',
+
+    // https://github.com/eslint/eslint/issues/2253
+    '/*global React*/ let {PropTypes, addons: {PureRenderMixin}} = React; let Test = React.createClass({mixins: [PureRenderMixin]});',
+    '/*global prevState*/ const { virtualSize: prevVirtualSize = 0 } = prevState;',
+    'const { dummy: { data, isLoading }, auth: { isLoggedIn } } = this.props;',
+
+    // https://github.com/eslint/eslint/issues/2747
+    'function a(n) { return n > 0 ? b(n - 1) : "a"; } function b(n) { return n > 0 ? a(n - 1) : "b"; }',
+
+    // https://github.com/eslint/eslint/issues/2967
+    '(function () { foo(); })(); function foo() {}',
+
+    // class static blocks
+    'class C { static { var foo; foo; } }',
+    'class C { static { foo; var foo; } }',
+    'class C { static { if (bar) { foo; } var foo; } }',
+    'var foo; class C { static { foo; } } ',
+    'class C { static { foo; } } var foo;',
+    'var foo; class C { static {} [foo]; } ',
+    'foo; class C { static {} } var foo; ',
+  ],
+  invalid: [
+    {
+      code: 'function f(){ x; { var x; } }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 15 }],
+    },
+    {
+      code: 'function f(){ { var x; } x; }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 26 }],
+    },
+    {
+      code: 'function f() { var a; { var b = 0; } a = b; }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 42 }],
+    },
+    {
+      code: 'function f() { try { var a = 0; } catch (e) { var b = a; } }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 55 }],
+    },
+    {
+      code: 'function a() { for(var b in {}) { var c = b; } c; }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 48 }],
+    },
+    {
+      code: 'function a() { for(var b of {}) { var c = b; } c; }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 48 }],
+    },
+    {
+      code: 'function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} b; }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 76 }],
+    },
+    {
+      code: 'for (var a = 0;;) {} a;',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 22 }],
+    },
+    {
+      code: 'for (var a in []) {} a;',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 22 }],
+    },
+    {
+      code: 'for (var a of []) {} a;',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 22 }],
+    },
+    {
+      code: '{ var a = 0; } a;',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 16 }],
+    },
+    {
+      code: 'if (true) { var a; } a;',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 22 }],
+    },
+    {
+      code: 'if (true) { var a = 1; } else { var a = 2; }',
+      errors: [
+        { messageId: 'outOfScope', line: 1, column: 17 },
+        { messageId: 'outOfScope', line: 1, column: 37 },
+      ],
+    },
+    {
+      code: 'for (var i = 0;;) {} for(var i = 0;;) {}',
+      errors: [
+        { messageId: 'outOfScope', line: 1, column: 10 },
+        { messageId: 'outOfScope', line: 1, column: 30 },
+      ],
+    },
+    {
+      code: 'class C { static { if (bar) { var foo; } foo; } }',
+      errors: [{ messageId: 'outOfScope', line: 1, column: 42 }],
+    },
+    {
+      code: '{ var foo,\n  bar; } bar;',
+      errors: [{ messageId: 'outOfScope', line: 2, column: 10 }],
+    },
+    {
+      code: '{ var { foo,\n  bar } = baz; } bar;',
+      errors: [{ messageId: 'outOfScope', line: 2, column: 18 }],
+    },
+    {
+      code: 'if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }',
+      errors: [
+        { messageId: 'outOfScope', line: 1, column: 16 },
+        { messageId: 'outOfScope', line: 1, column: 16 },
+        { messageId: 'outOfScope', line: 1, column: 45 },
+        { messageId: 'outOfScope', line: 1, column: 45 },
+        { messageId: 'outOfScope', line: 1, column: 65 },
+        { messageId: 'outOfScope', line: 1, column: 65 },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `block-scoped-var` rule from ESLint to rslint.

Generates warnings when `var`-declared variables are used outside of the block in which they were defined, emulating C-style block scope.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/block-scoped-var
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/block-scoped-var.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).