### PR TITLE
feat: port rule init-declarations

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/for_direction"
 	"github.com/web-infra-dev/rslint/internal/rules/getter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/guard_for_in"
+	"github.com/web-infra-dev/rslint/internal/rules/init_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/max_depth"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines_per_function"
@@ -172,6 +173,7 @@ func GetAllRules() []rule.Rule {
 		for_direction.ForDirectionRule,
 		getter_return.GetterReturnRule,
 		guard_for_in.GuardForInRule,
+		init_declarations.InitDeclarationsRule,
 		max_depth.MaxDepthRule,
 		max_lines.MaxLinesRule,
 		max_lines_per_function.MaxLinesPerFunctionRule,

--- a/internal/rules/init_declarations/init_declarations.go
+++ b/internal/rules/init_declarations/init_declarations.go
@@ -86,6 +86,23 @@ func checkVariableDeclarationList(ctx rule.RuleContext, node *ast.Node, opts ini
 	kind := utils.GetVarDeclListKind(node)
 	isConstantBinding := kind == "const" || kind == "using" || kind == "await using"
 
+	// Upstream's isInitialized() walks straight from the declarator to its
+	// enclosing VariableDeclaration to THAT node's parent, and treats a
+	// for-loop parent as init/left-slot identity — true only when the
+	// declaration literally IS the loop's init/left slot, false otherwise
+	// (never falling back to checking the initializer). An unbraced for-loop
+	// body that is itself a var declaration (`for (...) var x = 1;`) hits
+	// this false branch: ESTree represents the body as the VariableDeclaration
+	// node directly (no wrapper), so its parent is the for-loop, but it isn't
+	// the init/left slot. tsgo instead always wraps a declaration statement —
+	// including a for-loop's unbraced body — in a VariableStatement, so the
+	// equivalent structural check here is one level up: a
+	// VariableDeclarationList whose parent is a VariableStatement whose own
+	// parent is a for-loop is unambiguously that body (init/left slots are
+	// bare VariableDeclarationLists in tsgo, never VariableStatement-wrapped).
+	isUnbracedForLoopBody := !inForLoop && parent != nil && parent.Kind == ast.KindVariableStatement &&
+		parent.Parent != nil && isForLoopKind(parent.Parent.Kind)
+
 	for _, decl := range declList.Declarations.Nodes {
 		varDecl := decl.AsVariableDeclaration()
 		if varDecl == nil {
@@ -99,14 +116,13 @@ func checkVariableDeclarationList(ctx rule.RuleContext, node *ast.Node, opts ini
 			continue
 		}
 
-		// Upstream's isInitialized(): a for-loop binding (`for (var i ...)`,
-		// `for (var k in x)`, `for (var v of x)`) is always considered
-		// initialized, even without an explicit initializer — the loop's
-		// init/left slot IS the declaration by AST construction, so upstream's
-		// `block.init === declaration` / `block.left === declaration` checks
-		// are trivially true whenever a VariableDeclarationList's parent is a
-		// for-loop. Otherwise, initialized means an explicit initializer.
-		initialized := inForLoop || varDecl.Initializer != nil
+		// Upstream's isInitialized(): a for-loop's own init/left binding
+		// (`for (var i ...)`, `for (var k in x)`, `for (var v of x)`) is
+		// always considered initialized, even without an explicit
+		// initializer — see isUnbracedForLoopBody's comment above for why an
+		// unbraced for-loop body is a distinct, always-uninitialized case
+		// instead. Otherwise, initialized means an explicit initializer.
+		initialized := inForLoop || (!isUnbracedForLoopBody && varDecl.Initializer != nil)
 
 		var messageId string
 		switch {

--- a/internal/rules/init_declarations/init_declarations.go
+++ b/internal/rules/init_declarations/init_declarations.go
@@ -1,0 +1,156 @@
+package init_declarations
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed init_declarations.schema.json
+var schemaJSON []byte
+
+// https://eslint.org/docs/latest/rules/init-declarations
+//
+// Upstream listens on VariableDeclaration/TSModuleDeclaration ESTree nodes and
+// tracks ambient-namespace nesting with a manually toggled boolean. rslint
+// listens on the tsgo-equivalent VariableDeclarationList instead — a
+// VariableDeclarationList sits directly under ForStatement / ForInStatement /
+// ForOfStatement for loop initializers (no enclosing VariableStatement), which
+// is why the loop-shape checks below inspect its parent rather than a
+// grandparent — and uses utils.IsInAmbientContext, which the binder derives
+// from `declare` modifiers and .d.ts files, instead of a hand-rolled
+// enter/exit toggle over TSModuleDeclaration.
+var InitDeclarationsRule = rule.Rule{
+	Name:   "init-declarations",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		return rule.RuleListeners{
+			ast.KindVariableDeclarationList: func(node *ast.Node) {
+				checkVariableDeclarationList(ctx, node, opts)
+			},
+		}
+	},
+}
+
+type initDeclarationsOptions struct {
+	mode              string // "always" or "never"
+	ignoreForLoopInit bool
+}
+
+// parseOptions reads ESLint's `["<mode>", { ...sub-options }]` options array:
+// the mode string in slot 0 (defaulting to "always", matching upstream's
+// `meta.defaultOptions`), and the sub-option object — only meaningful for
+// "never" — in slot 1.
+func parseOptions(options []any) initDeclarationsOptions {
+	opts := initDeclarationsOptions{mode: "always"}
+
+	if len(options) == 0 {
+		return opts
+	}
+
+	if modeStr, _ := options[0].(string); modeStr == "always" || modeStr == "never" {
+		opts.mode = modeStr
+	}
+	if len(options) > 1 {
+		if subOpts, ok := options[1].(map[string]any); ok {
+			if b, ok := subOpts["ignoreForLoopInit"].(bool); ok {
+				opts.ignoreForLoopInit = b
+			}
+		}
+	}
+
+	return opts
+}
+
+func checkVariableDeclarationList(ctx rule.RuleContext, node *ast.Node, opts initDeclarationsOptions) {
+	declList := node.AsVariableDeclarationList()
+	if declList == nil || declList.Declarations == nil {
+		return
+	}
+
+	// Upstream: `if (node.declare || insideDeclaredNamespace) return;` — an
+	// ambient declaration list (either `declare var/let/const ...` itself, or
+	// any declaration nested inside a `declare namespace`/`declare module`/
+	// ambient `.d.ts` context) is exempt in both modes.
+	if utils.IsInAmbientContext(node) {
+		return
+	}
+
+	parent := node.Parent
+	inForLoop := parent != nil && isForLoopKind(parent.Kind)
+	isIgnoredForLoop := opts.ignoreForLoopInit && inForLoop
+	kind := utils.GetVarDeclListKind(node)
+	isConstantBinding := kind == "const" || kind == "using" || kind == "await using"
+
+	for _, decl := range declList.Declarations.Nodes {
+		varDecl := decl.AsVariableDeclaration()
+		if varDecl == nil {
+			continue
+		}
+
+		// Upstream only reports for `id.type === "Identifier"`; destructuring
+		// patterns (`var {a} = x`, `var [a] = x`) are silently skipped.
+		nameNode := varDecl.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			continue
+		}
+
+		// Upstream's isInitialized(): a for-loop binding (`for (var i ...)`,
+		// `for (var k in x)`, `for (var v of x)`) is always considered
+		// initialized, even without an explicit initializer — the loop's
+		// init/left slot IS the declaration by AST construction, so upstream's
+		// `block.init === declaration` / `block.left === declaration` checks
+		// are trivially true whenever a VariableDeclarationList's parent is a
+		// for-loop. Otherwise, initialized means an explicit initializer.
+		initialized := inForLoop || varDecl.Initializer != nil
+
+		var messageId string
+		switch {
+		case opts.mode == "always" && !initialized:
+			// Note: "always" applies uniformly to every kind, including
+			// const/using/await using — those require initializers to parse
+			// at all, and an explicit `declare`-only exemption is handled
+			// above, so this branch is unreachable for them in practice.
+			messageId = "initialized"
+		case opts.mode == "never" && !isConstantBinding && initialized && !isIgnoredForLoop:
+			messageId = "notInitialized"
+		}
+
+		if messageId == "" {
+			continue
+		}
+
+		idName := nameNode.AsIdentifier().Text
+		ctx.ReportNode(decl, buildMessage(messageId, idName))
+	}
+}
+
+func buildMessage(messageId, idName string) rule.RuleMessage {
+	var desc string
+	if messageId == "initialized" {
+		desc = "Variable '" + idName + "' should be initialized on declaration."
+	} else {
+		desc = "Variable '" + idName + "' should not be initialized on declaration."
+	}
+	return rule.RuleMessage{
+		Id:          messageId,
+		Description: desc,
+		Data:        map[string]string{"idName": idName},
+	}
+}
+
+// isForLoopKind reports whether kind is a for-loop statement kind. A
+// VariableDeclarationList can only sit in the initializer / left slot of
+// these three kinds, so a parent of one of these kinds already implies the
+// declaration list IS the loop binding.
+func isForLoopKind(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
+		return true
+	}
+	return false
+}

--- a/internal/rules/init_declarations/init_declarations.md
+++ b/internal/rules/init_declarations/init_declarations.md
@@ -1,0 +1,79 @@
+# init-declarations
+
+## Rule Details
+
+Require or disallow initialization in variable declarations.
+
+This rule applies to `var`, `let`, `const`, `using`, and `await using` declarations. It reports each declarator whose initialization does or does not match the configured mode.
+
+Examples of **incorrect** code for this rule with `"always"` (the default):
+
+```javascript
+function foo() {
+  var bar;
+  let baz;
+}
+```
+
+Examples of **correct** code for this rule with `"always"`:
+
+```javascript
+function foo() {
+  var bar = 1;
+  let baz = 2;
+  const qux = 3;
+}
+```
+
+Examples of **incorrect** code for this rule with `"never"`:
+
+```json
+{ "init-declarations": ["error", "never"] }
+```
+
+```javascript
+function foo() {
+  var bar = 1;
+  let baz = 2;
+  for (let i = 0; i < 1; i++) {}
+}
+```
+
+Examples of **correct** code for this rule with `"never"`:
+
+```javascript
+function foo() {
+  var bar;
+  let baz;
+  const buzz = 1;
+}
+```
+
+`const`, `using`, and `await using` declarations always require an initializer, so `"never"` never flags them.
+
+Examples of **correct** code for this rule with `{ "ignoreForLoopInit": true }`:
+
+```json
+{ "init-declarations": ["error", "never", { "ignoreForLoopInit": true }] }
+```
+
+```javascript
+for (let i = 0; i < 1; i++) {}
+```
+
+A destructuring declarator (`var { a } = obj;`, `var [a] = arr;`) is never reported, in either mode.
+
+`declare var`/`declare let`/`declare const`, and any declaration nested inside a `declare namespace`/`declare module`/ambient `.d.ts` context, is exempt in both modes.
+
+## Options
+
+This rule takes up to two options:
+
+1. A string, either `"always"` (default) or `"never"`.
+2. When the first option is `"never"`, an object with:
+   - `ignoreForLoopInit`: when `true`, allows initialization in a `for` loop's declaration even under `"never"`. Default `false`.
+
+## Original Documentation
+
+- [ESLint: init-declarations](https://eslint.org/docs/latest/rules/init-declarations)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/init-declarations.js)

--- a/internal/rules/init_declarations/init_declarations.schema.json
+++ b/internal/rules/init_declarations/init_declarations.schema.json
@@ -1,0 +1,33 @@
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "items": [
+        {
+          "enum": ["always"]
+        }
+      ],
+      "minItems": 0,
+      "maxItems": 1
+    },
+    {
+      "type": "array",
+      "items": [
+        {
+          "enum": ["never"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ignoreForLoopInit": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "minItems": 0,
+      "maxItems": 2
+    }
+  ]
+}

--- a/internal/rules/init_declarations/init_declarations_extras_test.go
+++ b/internal/rules/init_declarations/init_declarations_extras_test.go
@@ -39,6 +39,13 @@ func TestInitDeclarationsExtras(t *testing.T) {
 			// ---- Dimension 4: nesting/traversal boundary — `declare global` ----
 			{Code: `declare global { var x: number; }`, Options: []any{"always"}},
 
+			// ---- Locks in upstream isInitialized(): unbraced for-loop body ----
+			// A braced for-loop body is an ordinary nested VariableStatement,
+			// not the loop's own init/left slot and not the unbraced-body
+			// special case either — it must fall through to the plain
+			// explicit-initializer check.
+			{Code: `for (var a in []) { var foo = 1; }`, Options: []any{"always"}},
+
 			// ---- Real-user: typescript-eslint#4392 eg.2 ----
 			// A `declare const` sibling inside a declared namespace must not
 			// disturb ambient status for a later, non-declared nested
@@ -131,6 +138,26 @@ declare namespace A {
 					Message:   "Variable 'count' should not be initialized on declaration.",
 					Line:      1, Column: 5, EndLine: 1, EndColumn: 14,
 				}},
+			},
+
+			// ---- Locks in upstream isInitialized(): unbraced for-loop body ----
+			// tsgo wraps a for-loop's unbraced body in a VariableStatement
+			// (unlike ESTree, which uses the VariableDeclaration directly as
+			// the body), so `foo` is NOT the loop's init/left slot — it must
+			// be treated as always-uninitialized, the same as upstream,
+			// regardless of its own explicit initializer.
+			{
+				Code:    `for (var a in []) var foo = 1;`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 23, EndLine: 1, EndColumn: 30}},
+			},
+			// Under "never", only `a` (the loop's own binding, unconditionally
+			// "initialized") is reportable — `foo` must NOT also be reported
+			// even though it has an explicit initializer.
+			{
+				Code:    `for (var a in []) var foo = 1;`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 10, EndLine: 1, EndColumn: 11}},
 			},
 		},
 	)

--- a/internal/rules/init_declarations/init_declarations_extras_test.go
+++ b/internal/rules/init_declarations/init_declarations_extras_test.go
@@ -1,0 +1,137 @@
+package init_declarations
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestInitDeclarationsExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension row / real-user scenario it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+func TestInitDeclarationsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&InitDeclarationsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Locks in upstream: `id.type === "Identifier"` gate ----
+			// Destructuring declarators are silently skipped regardless of
+			// mode/kind; none of these upstream-migrated cases exercise a
+			// destructuring pattern at all.
+			{Code: `var {a} = obj;`, Options: []any{"never"}},
+			{Code: `let [a] = arr;`, Options: []any{"never"}},
+			{Code: `var {} = obj;`, Options: []any{"never"}}, // N/A: Dimension 4 graceful degradation — empty binding pattern
+			{Code: `for (let [a] of items) {}`, Options: []any{"never"}},
+			{Code: `for (const {a} of items) {}`},
+
+			// ---- Locks in upstream: `node.declare` on a non-const kind ----
+			// Only "declare const" is migrated from upstream; a bare
+			// `declare` on let/var must exempt them too, even though they
+			// aren't otherwise exempt via CONSTANT_BINDINGS.
+			{Code: `declare let x: number;`, Options: []any{"always"}},
+			{Code: `declare var y: number = 1;`, Options: []any{"never"}},
+
+			// ---- Dimension 4: nesting/traversal boundary — `declare global` ----
+			{Code: `declare global { var x: number; }`, Options: []any{"always"}},
+
+			// ---- Real-user: typescript-eslint#4392 eg.2 ----
+			// A `declare const` sibling inside a declared namespace must not
+			// disturb ambient status for a later, non-declared nested
+			// namespace. The pre-ESLint-core-dialect typescript-eslint wrapper
+			// tracked ambient nesting with a boolean toggled by
+			// TSModuleDeclaration enter/exit; this port instead derives
+			// ambient status from the binder's NodeFlagsAmbient
+			// (utils.IsInAmbientContext), which propagates structurally and
+			// isn't sensitive to sibling declare statements.
+			{
+				Code: `
+declare namespace obj1 {
+  declare const a: number;
+  namespace obj1_1 {
+    const b: string;
+  }
+}
+`,
+				Options: []any{"always"},
+			},
+
+			// ---- Dimension 4: nesting boundary — redundant nested "declare namespace" ----
+			// A `declare namespace` nested inside another `declare namespace`
+			// must not prematurely end ambient status for its later siblings.
+			{
+				Code: `
+declare namespace A {
+  declare namespace B {
+    let x: number;
+  }
+  let y: number;
+}
+`,
+				Options: []any{"always"},
+			},
+
+			// ---- Dimension 2: scoping — options JSON-shape coverage for ignoreForLoopInit ----
+			{Code: `for (var foo in []) {}`, Options: []any{"never", map[string]any{"ignoreForLoopInit": true}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in parseOptions' `mode` default fallback (upstream `meta.defaultOptions: ["always"]`) ----
+			{
+				Code:   `var foo;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 8}},
+			},
+
+			// ---- Dimension 4: options JSON-shape coverage — ignoreForLoopInit: false still reports ----
+			{
+				Code:    `for (var foo in []) {}`,
+				Options: []any{"never", map[string]any{"ignoreForLoopInit": false}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 10, EndLine: 1, EndColumn: 13}},
+			},
+
+			// ---- Dimension 2: scoping — arrow function body ----
+			{
+				Code:    `const f = () => { var a; };`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 23, EndLine: 1, EndColumn: 24}},
+			},
+
+			// ---- Dimension 2: scoping — getter body ----
+			{
+				Code:    `class C { get x() { var a; } }`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 25, EndLine: 1, EndColumn: 26}},
+			},
+
+			// ---- Dimension 2: scoping — class static block (explicit Dimension-4 checklist row) ----
+			{
+				Code:    `class C { static { var a; } }`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 24, EndLine: 1, EndColumn: 25}},
+			},
+
+			// ---- Diagnostic contract: exact message text per messageId ----
+			{
+				Code:    `var count;`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "initialized",
+					Message:   "Variable 'count' should be initialized on declaration.",
+					Line:      1, Column: 5, EndLine: 1, EndColumn: 10,
+				}},
+			},
+			{
+				Code:    `var count = 1;`,
+				Options: []any{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "notInitialized",
+					Message:   "Variable 'count' should not be initialized on declaration.",
+					Line:      1, Column: 5, EndLine: 1, EndColumn: 14,
+				}},
+			},
+		},
+	)
+}

--- a/internal/rules/init_declarations/init_declarations_upstream_test.go
+++ b/internal/rules/init_declarations/init_declarations_upstream_test.go
@@ -1,0 +1,357 @@
+package init_declarations
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestInitDeclarationsUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/init-declarations.js (eslint v10.8.1) 1:1 — both
+// the default-parser suite (ruleTester) and the @typescript-eslint/parser
+// suite (ruleTesterTypeScript). rslint parses every file with tsgo, so both
+// suites run as one flat Go suite; TS-syntax cases from the second upstream
+// suite are marked accordingly. Position assertions cover line/column for
+// every invalid case. rslint-specific lock-in cases live in
+// init_declarations_extras_test.go.
+func TestInitDeclarationsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&InitDeclarationsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ruleTester (default parser) ----
+			{Code: `var foo = null;`},
+			{Code: `foo = true;`},
+			{Code: `var foo = 1, bar = false, baz = {};`},
+			{Code: `function foo() { var foo = 0; var bar = []; }`},
+			{Code: `var fn = function() {};`},
+			{Code: `var foo = bar = 2;`},
+			{Code: `for (var i = 0; i < 1; i++) {}`},
+			{Code: `for (var foo in []) {}`},
+			{Code: `for (var foo of []) {}`},
+			{Code: `let a = true;`, Options: []any{"always"}},
+			{Code: `const a = {};`, Options: []any{"always"}},
+			{Code: `using a = foo();`, Options: []any{"always"}},
+			{Code: `await using a = foo();`, Options: []any{"always"}},
+			{Code: `function foo() { let a = 1, b = false; if (a) { let c = 3, d = null; } }`, Options: []any{"always"}},
+			{Code: `function foo() { const a = 1, b = true; if (a) { const c = 3, d = null; } }`, Options: []any{"always"}},
+			{Code: `function foo() { let a = 1; const b = false; var c = true; }`, Options: []any{"always"}},
+			{Code: `var foo;`, Options: []any{"never"}},
+			{Code: `var foo, bar, baz;`, Options: []any{"never"}},
+			{Code: `function foo() { var foo; var bar; }`, Options: []any{"never"}},
+			{Code: `let a;`, Options: []any{"never"}},
+			{Code: `const a = 1;`, Options: []any{"never"}},
+			{Code: `using a = foo();`, Options: []any{"never"}},
+			{Code: `await using a = foo();`, Options: []any{"never"}},
+			{Code: `function foo() { let a, b; if (a) { let c, d; } }`, Options: []any{"never"}},
+			{Code: `function foo() { const a = 1, b = true; if (a) { const c = 3, d = null; } }`, Options: []any{"never"}},
+			{Code: `function foo() { let a; const b = false; var c; }`, Options: []any{"never"}},
+			{Code: `for(var i = 0; i < 1; i++){}`, Options: []any{"never", map[string]any{"ignoreForLoopInit": true}}},
+			{Code: `for (var foo in []) {}`, Options: []any{"never", map[string]any{"ignoreForLoopInit": true}}},
+			{Code: `for (var foo of []) {}`, Options: []any{"never", map[string]any{"ignoreForLoopInit": true}}},
+
+			// ---- ruleTesterTypeScript (@typescript-eslint/parser) ----
+			{Code: `declare const foo: number;`, Options: []any{"always"}},
+			{Code: `declare const foo: number;`, Options: []any{"never"}},
+			{Code: `
+	  declare namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`, Options: []any{"always"}},
+			{Code: `
+	  declare namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`, Options: []any{"never"}},
+			{Code: `
+	  declare namespace myLib {
+		let valueInside: number;
+	  }
+		let valueOutside: number;
+			`, Options: []any{"never"}},
+			{Code: `
+	  interface GreetingSettings {
+		greeting: string;
+		duration?: number;
+		color?: string;
+	  }
+			`},
+			{Code: `
+	  interface GreetingSettings {
+		greeting: string;
+		duration?: number;
+		color?: string;
+	  }
+			`, Options: []any{"never"}},
+			{Code: `type GreetingLike = string | (() => string) | Greeter;`},
+			{Code: `type GreetingLike = string | (() => string) | Greeter;`, Options: []any{"never"}},
+			{Code: `
+	  function foo() {
+		var bar: string;
+	  }
+			`, Options: []any{"never"}},
+			{Code: `var bar: string;`, Options: []any{"never"}},
+			{Code: `
+	  var bar: string = function (): string {
+		return 'string';
+	  };
+			`, Options: []any{"always"}},
+			{Code: `
+	  var bar: string = function (arg1: string): string {
+		return 'string';
+	  };
+			`, Options: []any{"always"}},
+			{Code: `function foo(arg1: string = 'string'): void {}`, Options: []any{"never"}},
+			{Code: `const foo: string = 'hello';`, Options: []any{"never"}},
+			{Code: `
+	  const class1 = class NAME {
+		constructor() {
+		  var name1: string = 'hello';
+		}
+	  };
+			`},
+			{Code: `
+	  const class1 = class NAME {
+		static pi: number = 3.14;
+	  };
+			`},
+			{Code: `
+	  const class1 = class NAME {
+		static pi: number = 3.14;
+	  };
+			`, Options: []any{"never"}},
+			{Code: `
+	  interface IEmployee {
+		empCode: number;
+		empName: string;
+		getSalary: (number) => number; // arrow function
+		getManagerName(number): string;
+	  }
+			`},
+			{Code: `
+	  interface IEmployee {
+		empCode: number;
+		empName: string;
+		getSalary: (number) => number; // arrow function
+		getManagerName(number): string;
+	  }
+			`, Options: []any{"never"}},
+			{Code: `const foo: number = 'asd';`, Options: []any{"always"}},
+			{Code: `const foo: number;`, Options: []any{"never"}},
+			{Code: `
+	  namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`, Options: []any{"never"}},
+			{Code: `
+	  namespace myLib {
+		let numberOfGreetings: number = 2;
+	  }
+			`, Options: []any{"always"}},
+			{Code: `
+	  declare namespace myLib1 {
+		const foo: number;
+		namespace myLib2 {
+		  let bar: string;
+		  namespace myLib3 {
+			let baz: object;
+		  }
+		}
+	  }
+			`, Options: []any{"always"}},
+			{Code: `
+	  declare namespace myLib1 {
+		const foo: number;
+		namespace myLib2 {
+		  let bar: string;
+		  namespace myLib3 {
+			let baz: object;
+		  }
+		}
+	  }
+			`, Options: []any{"never"}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- ruleTester (default parser) ----
+			{
+				Code:    `var foo;`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 8}},
+			},
+			{
+				Code:    `for (var a in []) var foo;`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 23, EndLine: 1, EndColumn: 26}},
+			},
+			{
+				Code:    `var foo, bar = false, baz;`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "initialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 8},
+					{MessageId: "initialized", Line: 1, Column: 23, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code:    `function foo() { var foo = 0; var bar; }`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 35, EndLine: 1, EndColumn: 38}},
+			},
+			{
+				Code:    `function foo() { var foo; var bar = foo; }`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 22, EndLine: 1, EndColumn: 25}},
+			},
+			{
+				Code:    `let a;`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 6}},
+			},
+			{
+				Code:    `function foo() { let a = 1, b; if (a) { let c = 3, d = null; } }`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 29, EndLine: 1, EndColumn: 30}},
+			},
+			{
+				Code:    `function foo() { let a; const b = false; var c; }`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "initialized", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+					{MessageId: "initialized", Line: 1, Column: 46, EndLine: 1, EndColumn: 47},
+				},
+			},
+			{
+				Code:    `var foo = bar = 2;`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 18}},
+			},
+			{
+				Code:    `var foo = true;`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 15}},
+			},
+			{
+				Code:    `var foo, bar = 5, baz = 3;`,
+				Options: []any{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notInitialized", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+					{MessageId: "notInitialized", Line: 1, Column: 19, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code:    `function foo() { var foo; var bar = foo; }`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 31, EndLine: 1, EndColumn: 40}},
+			},
+			{
+				Code:    `let a = 1;`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 10}},
+			},
+			{
+				Code:    `function foo() { let a = 'foo', b; if (a) { let c, d; } }`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 22, EndLine: 1, EndColumn: 31}},
+			},
+			{
+				Code:    `function foo() { let a; const b = false; var c = 1; }`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 46, EndLine: 1, EndColumn: 51}},
+			},
+			{
+				Code:    `for(var i = 0; i < 1; i++){}`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 9, EndLine: 1, EndColumn: 14}},
+			},
+			{
+				Code:    `for (var foo in []) {}`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 10, EndLine: 1, EndColumn: 13}},
+			},
+			{
+				Code:    `for (var foo of []) {}`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 10, EndLine: 1, EndColumn: 13}},
+			},
+
+			// ---- ruleTesterTypeScript (@typescript-eslint/parser) ----
+			{
+				Code:    `let arr: string[] = ['arr', 'ar'];`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 34}},
+			},
+			{
+				Code:    `let arr: string = function () {};`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 33}},
+			},
+			{
+				Code: `
+	  const class1 = class NAME {
+		constructor() {
+		  var name1: string = 'hello';
+		}
+	  };
+			`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 4, Column: 9, EndLine: 4, EndColumn: 32}},
+			},
+			{
+				Code:    `let arr: string;`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 16}},
+			},
+			{
+				Code: `
+	  namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 3, Column: 7, EndLine: 3, EndColumn: 32}},
+			},
+			{
+				Code: `
+	  namespace myLib {
+		let numberOfGreetings: number = 2;
+	  }
+			`,
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "notInitialized", Line: 3, Column: 7, EndLine: 3, EndColumn: 36}},
+			},
+			{
+				// Not "declare namespace" (unlike the valid case above) — a plain
+				// namespace does not exempt its members.
+				Code: `
+		namespace myLib1 {
+		  const foo: number;
+			namespace myLib2 {
+			  let bar: string;
+			  namespace myLib3 {
+				let baz: object;
+			  }
+		  }
+		}
+			`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "initialized", Line: 3, Column: 11, EndLine: 3, EndColumn: 22},
+					{MessageId: "initialized", Line: 5, Column: 10, EndLine: 5, EndColumn: 21},
+					{MessageId: "initialized", Line: 7, Column: 9, EndLine: 7, EndColumn: 20},
+				},
+			},
+			{
+				Code: `
+	  declare namespace myLib {
+		let valueInside: number;
+	  }
+		let valueOutside: number;
+			`,
+				Options: []any{"always"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "initialized", Line: 5, Column: 7, EndLine: 5, EndColumn: 27}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -91,6 +91,7 @@ export default defineConfig({
     './tests/eslint/rules/no-iterator.test.ts',
     './tests/eslint/rules/getter-return.test.ts',
     './tests/eslint/rules/guard-for-in.test.ts',
+    './tests/eslint/rules/init-declarations.test.ts',
     './tests/eslint/rules/no-loss-of-precision.test.ts',
     './tests/eslint/rules/no-ex-assign.test.ts',
     './tests/eslint/rules/no-constant-binary-expression.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/init-declarations.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/init-declarations.test.ts.snap
@@ -1,0 +1,781 @@
+// Rstest Snapshot v1
+
+exports[`init-declarations > invalid 1`] = `
+{
+  "code": "var foo;",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 2`] = `
+{
+  "code": "for (var a in []) var foo;",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 3`] = `
+{
+  "code": "var foo, bar = false, baz;",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+    {
+      "message": "Variable 'baz' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 4`] = `
+{
+  "code": "function foo() { var foo = 0; var bar; }",
+  "diagnostics": [
+    {
+      "message": "Variable 'bar' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 5`] = `
+{
+  "code": "function foo() { var foo; var bar = foo; }",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 6`] = `
+{
+  "code": "let a;",
+  "diagnostics": [
+    {
+      "message": "Variable 'a' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 7`] = `
+{
+  "code": "function foo() { let a = 1, b; if (a) { let c = 3, d = null; } }",
+  "diagnostics": [
+    {
+      "message": "Variable 'b' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 8`] = `
+{
+  "code": "function foo() { let a; const b = false; var c; }",
+  "diagnostics": [
+    {
+      "message": "Variable 'a' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+    {
+      "message": "Variable 'c' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 9`] = `
+{
+  "code": "var foo = bar = 2;",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 10`] = `
+{
+  "code": "var foo = true;",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 11`] = `
+{
+  "code": "var foo, bar = 5, baz = 3;",
+  "diagnostics": [
+    {
+      "message": "Variable 'bar' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+    {
+      "message": "Variable 'baz' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 12`] = `
+{
+  "code": "function foo() { var foo; var bar = foo; }",
+  "diagnostics": [
+    {
+      "message": "Variable 'bar' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 13`] = `
+{
+  "code": "let a = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable 'a' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 14`] = `
+{
+  "code": "function foo() { let a = 'foo', b; if (a) { let c, d; } }",
+  "diagnostics": [
+    {
+      "message": "Variable 'a' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 15`] = `
+{
+  "code": "function foo() { let a; const b = false; var c = 1; }",
+  "diagnostics": [
+    {
+      "message": "Variable 'c' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 16`] = `
+{
+  "code": "for(var i = 0; i < 1; i++){}",
+  "diagnostics": [
+    {
+      "message": "Variable 'i' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 17`] = `
+{
+  "code": "for (var foo in []) {}",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 18`] = `
+{
+  "code": "for (var foo of []) {}",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 19`] = `
+{
+  "code": "let arr: string[] = ['arr', 'ar'];",
+  "diagnostics": [
+    {
+      "message": "Variable 'arr' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 20`] = `
+{
+  "code": "let arr: string = function () {};",
+  "diagnostics": [
+    {
+      "message": "Variable 'arr' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 21`] = `
+{
+  "code": "
+	  const class1 = class NAME {
+		constructor() {
+		  var name1: string = 'hello';
+		}
+	  };
+			",
+  "diagnostics": [
+    {
+      "message": "Variable 'name1' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 22`] = `
+{
+  "code": "let arr: string;",
+  "diagnostics": [
+    {
+      "message": "Variable 'arr' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 23`] = `
+{
+  "code": "
+	  namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			",
+  "diagnostics": [
+    {
+      "message": "Variable 'numberOfGreetings' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 24`] = `
+{
+  "code": "
+	  namespace myLib {
+		let numberOfGreetings: number = 2;
+	  }
+			",
+  "diagnostics": [
+    {
+      "message": "Variable 'numberOfGreetings' should not be initialized on declaration.",
+      "messageId": "notInitialized",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 25`] = `
+{
+  "code": "
+		namespace myLib1 {
+		  const foo: number;
+			namespace myLib2 {
+			  let bar: string;
+			  namespace myLib3 {
+				let baz: object;
+			  }
+		  }
+		}
+			",
+  "diagnostics": [
+    {
+      "message": "Variable 'foo' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+    {
+      "message": "Variable 'bar' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 5,
+        },
+        "start": {
+          "column": 10,
+          "line": 5,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+    {
+      "message": "Variable 'baz' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 7,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`init-declarations > invalid 26`] = `
+{
+  "code": "
+	  declare namespace myLib {
+		let valueInside: number;
+	  }
+		let valueOutside: number;
+			",
+  "diagnostics": [
+    {
+      "message": "Variable 'valueOutside' should be initialized on declaration.",
+      "messageId": "initialized",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "init-declarations",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/init-declarations.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/init-declarations.test.ts
@@ -1,0 +1,400 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('init-declarations', {
+  valid: [
+    'var foo = null;',
+    'foo = true;',
+    'var foo = 1, bar = false, baz = {};',
+    'function foo() { var foo = 0; var bar = []; }',
+    'var fn = function() {};',
+    'var foo = bar = 2;',
+    'for (var i = 0; i < 1; i++) {}',
+    'for (var foo in []) {}',
+    'for (var foo of []) {}',
+    { code: 'let a = true;', options: ['always'] as any },
+    { code: 'const a = {};', options: ['always'] as any },
+    { code: 'using a = foo();', options: ['always'] as any },
+    { code: 'await using a = foo();', options: ['always'] as any },
+    {
+      code: 'function foo() { let a = 1, b = false; if (a) { let c = 3, d = null; } }',
+      options: ['always'] as any,
+    },
+    {
+      code: 'function foo() { const a = 1, b = true; if (a) { const c = 3, d = null; } }',
+      options: ['always'] as any,
+    },
+    {
+      code: 'function foo() { let a = 1; const b = false; var c = true; }',
+      options: ['always'] as any,
+    },
+    { code: 'var foo;', options: ['never'] as any },
+    { code: 'var foo, bar, baz;', options: ['never'] as any },
+    { code: 'function foo() { var foo; var bar; }', options: ['never'] as any },
+    { code: 'let a;', options: ['never'] as any },
+    { code: 'const a = 1;', options: ['never'] as any },
+    { code: 'using a = foo();', options: ['never'] as any },
+    { code: 'await using a = foo();', options: ['never'] as any },
+    {
+      code: 'function foo() { let a, b; if (a) { let c, d; } }',
+      options: ['never'] as any,
+    },
+    {
+      code: 'function foo() { const a = 1, b = true; if (a) { const c = 3, d = null; } }',
+      options: ['never'] as any,
+    },
+    {
+      code: 'function foo() { let a; const b = false; var c; }',
+      options: ['never'] as any,
+    },
+    {
+      code: 'for(var i = 0; i < 1; i++){}',
+      options: ['never', { ignoreForLoopInit: true }] as any,
+    },
+    {
+      code: 'for (var foo in []) {}',
+      options: ['never', { ignoreForLoopInit: true }] as any,
+    },
+    {
+      code: 'for (var foo of []) {}',
+      options: ['never', { ignoreForLoopInit: true }] as any,
+    },
+
+    // ---- ruleTesterTypeScript (@typescript-eslint/parser) suite ----
+    { code: 'declare const foo: number;', options: ['always'] as any },
+    { code: 'declare const foo: number;', options: ['never'] as any },
+    {
+      code: `
+	  declare namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`,
+      options: ['always'] as any,
+    },
+    {
+      code: `
+	  declare namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`,
+      options: ['never'] as any,
+    },
+    {
+      code: `
+	  declare namespace myLib {
+		let valueInside: number;
+	  }
+		let valueOutside: number;
+			`,
+      options: ['never'] as any,
+    },
+    `
+	  interface GreetingSettings {
+		greeting: string;
+		duration?: number;
+		color?: string;
+	  }
+			`,
+    {
+      code: `
+	  interface GreetingSettings {
+		greeting: string;
+		duration?: number;
+		color?: string;
+	  }
+			`,
+      options: ['never'] as any,
+    },
+    'type GreetingLike = string | (() => string) | Greeter;',
+    {
+      code: 'type GreetingLike = string | (() => string) | Greeter;',
+      options: ['never'] as any,
+    },
+    {
+      code: `
+	  function foo() {
+		var bar: string;
+	  }
+			`,
+      options: ['never'] as any,
+    },
+    { code: 'var bar: string;', options: ['never'] as any },
+    {
+      code: `
+	  var bar: string = function (): string {
+		return 'string';
+	  };
+			`,
+      options: ['always'] as any,
+    },
+    {
+      code: `
+	  var bar: string = function (arg1: string): string {
+		return 'string';
+	  };
+			`,
+      options: ['always'] as any,
+    },
+    {
+      code: "function foo(arg1: string = 'string'): void {}",
+      options: ['never'] as any,
+    },
+    { code: "const foo: string = 'hello';", options: ['never'] as any },
+    `
+	  const class1 = class NAME {
+		constructor() {
+		  var name1: string = 'hello';
+		}
+	  };
+			`,
+    `
+	  const class1 = class NAME {
+		static pi: number = 3.14;
+	  };
+			`,
+    {
+      code: `
+	  const class1 = class NAME {
+		static pi: number = 3.14;
+	  };
+			`,
+      options: ['never'] as any,
+    },
+    `
+	  interface IEmployee {
+		empCode: number;
+		empName: string;
+		getSalary: (number) => number; // arrow function
+		getManagerName(number): string;
+	  }
+			`,
+    {
+      code: `
+	  interface IEmployee {
+		empCode: number;
+		empName: string;
+		getSalary: (number) => number; // arrow function
+		getManagerName(number): string;
+	  }
+			`,
+      options: ['never'] as any,
+    },
+    { code: "const foo: number = 'asd';", options: ['always'] as any },
+    { code: 'const foo: number;', options: ['never'] as any },
+    {
+      code: `
+	  namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`,
+      options: ['never'] as any,
+    },
+    {
+      code: `
+	  namespace myLib {
+		let numberOfGreetings: number = 2;
+	  }
+			`,
+      options: ['always'] as any,
+    },
+    {
+      code: `
+	  declare namespace myLib1 {
+		const foo: number;
+		namespace myLib2 {
+		  let bar: string;
+		  namespace myLib3 {
+			let baz: object;
+		  }
+		}
+	  }
+			`,
+      options: ['always'] as any,
+    },
+    {
+      code: `
+	  declare namespace myLib1 {
+		const foo: number;
+		namespace myLib2 {
+		  let bar: string;
+		  namespace myLib3 {
+			let baz: object;
+		  }
+		}
+	  }
+			`,
+      options: ['never'] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'var foo;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: 'for (var a in []) var foo;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: 'var foo, bar = false, baz;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }, { messageId: 'initialized' }],
+    },
+    {
+      code: 'function foo() { var foo = 0; var bar; }',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: 'function foo() { var foo; var bar = foo; }',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: 'let a;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: 'function foo() { let a = 1, b; if (a) { let c = 3, d = null; } }',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: 'function foo() { let a; const b = false; var c; }',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }, { messageId: 'initialized' }],
+    },
+    {
+      code: 'var foo = bar = 2;',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'var foo = true;',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'var foo, bar = 5, baz = 3;',
+      options: ['never'] as any,
+      errors: [
+        { messageId: 'notInitialized' },
+        { messageId: 'notInitialized' },
+      ],
+    },
+    {
+      code: 'function foo() { var foo; var bar = foo; }',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'let a = 1;',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: "function foo() { let a = 'foo', b; if (a) { let c, d; } }",
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'function foo() { let a; const b = false; var c = 1; }',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'for(var i = 0; i < 1; i++){}',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'for (var foo in []) {}',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'for (var foo of []) {}',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+
+    // ---- ruleTesterTypeScript (@typescript-eslint/parser) suite ----
+    {
+      code: "let arr: string[] = ['arr', 'ar'];",
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'let arr: string = function () {};',
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: `
+	  const class1 = class NAME {
+		constructor() {
+		  var name1: string = 'hello';
+		}
+	  };
+			`,
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: 'let arr: string;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: `
+	  namespace myLib {
+		let numberOfGreetings: number;
+	  }
+			`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+    {
+      code: `
+	  namespace myLib {
+		let numberOfGreetings: number = 2;
+	  }
+			`,
+      options: ['never'] as any,
+      errors: [{ messageId: 'notInitialized' }],
+    },
+    {
+      code: `
+		namespace myLib1 {
+		  const foo: number;
+			namespace myLib2 {
+			  let bar: string;
+			  namespace myLib3 {
+				let baz: object;
+			  }
+		  }
+		}
+			`,
+      options: ['always'] as any,
+      errors: [
+        { messageId: 'initialized' },
+        { messageId: 'initialized' },
+        { messageId: 'initialized' },
+      ],
+    },
+    {
+      code: `
+	  declare namespace myLib {
+		let valueInside: number;
+	  }
+		let valueOutside: number;
+			`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'initialized' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `init-declarations` rule from ESLint to rslint.

Requires or disallows initialization in variable declarations (`var`, `let`, `const`, `using`, `await using`), with an `ignoreForLoopInit` option.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/init-declarations
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/init-declarations.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).