### PR TITLE
feat: port rule no-ternary

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -104,6 +104,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_shadow_restricted_names"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
+	"github.com/web-infra-dev/rslint/internal/rules/no_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_throw_literal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unassigned_vars"
@@ -252,6 +253,7 @@ func GetAllRules() []rule.Rule {
 		no_shadow_restricted_names.NoShadowRestrictedNamesRule,
 		strict.StrictRule,
 		no_template_curly_in_string.NoTemplateCurlyInStringRule,
+		no_ternary.NoTernaryRule,
 		no_useless_computed_key.NoUselessComputedKeyRule,
 		no_useless_concat.NoUselessConcatRule,
 		no_sparse_arrays.NoSparseArraysRule,

--- a/internal/rules/no_ternary/no_ternary.go
+++ b/internal/rules/no_ternary/no_ternary.go
@@ -1,0 +1,22 @@
+package no_ternary
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/no-ternary
+var NoTernaryRule = rule.Rule{
+	Name:   "no-ternary",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindConditionalExpression: func(node *ast.Node) {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "noTernaryOperator",
+					Description: "Ternary operator used.",
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_ternary/no_ternary.md
+++ b/internal/rules/no_ternary/no_ternary.md
@@ -1,0 +1,40 @@
+# no-ternary
+
+## Rule Details
+
+This rule disallows ternary operators.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const foo = isBar ? baz : qux;
+
+function quux() {
+  return foo ? bar() : baz();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+let foo;
+
+if (isBar) {
+    foo = baz;
+} else {
+    foo = qux;
+}
+
+function quux() {
+    if (foo) {
+        return bar();
+    } else {
+        return baz();
+    }
+}
+```
+
+## Original Documentation
+
+- [ESLint: no-ternary](https://eslint.org/docs/latest/rules/no-ternary)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-ternary.js)

--- a/internal/rules/no_ternary/no_ternary_extras_test.go
+++ b/internal/rules/no_ternary/no_ternary_extras_test.go
@@ -1,0 +1,162 @@
+// TestNoTernaryExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in. See no_ternary_upstream_test.go for the migrated upstream suite.
+//
+// no-ternary's upstream create() has a single unconditional report call with
+// no internal branches, so Layer 3 (branch lock-ins) reduces to the one true
+// decision the rule makes: which AST kind its listener is scoped to. That is
+// locked in below alongside the Layer 2 (Dimension 4 + real-user) cases.
+package no_ternary
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoTernaryExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoTernaryRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: Access/key forms — N/A: the rule matches
+			// ---- unconditionally on ast.KindConditionalExpression and never
+			// ---- inspects property access or key identity, so there is no
+			// ---- per-key-form behavior to diverge. ----
+
+			// ---- Dimension 4: Graceful degradation — N/A: every
+			// ---- ConditionalExpression syntactically requires all three
+			// ---- operands (condition, WhenTrue, WhenFalse), so there is no
+			// ---- empty/partial-operand shape to degrade on. ----
+
+			// ---- Locks in: the listener is scoped to
+			// ---- ast.KindConditionalExpression and never fires for
+			// ---- ast.KindConditionalType — a TS conditional type shares the
+			// ---- `?:`-like reading but is a distinct AST kind. ----
+			{Code: `type X<T> = T extends string ? "yes" : "no";`},
+			{Code: `type Y<T> = T extends string ? (T extends "a" ? 1 : 2) : 3;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver — single-level wrap;
+			// ---- reported range excludes the outer parentheses ----
+			{
+				Code: "var x = (a ? b : c);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+				},
+			},
+			// ---- Dimension 4: `(X) as T` type-expression wrapper on the
+			// ---- whole ternary ----
+			{
+				Code: "(a ? b : c) as any;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 2, EndLine: 1, EndColumn: 11},
+				},
+			},
+			// ---- Dimension 4: `X!` non-null assertion wrapper on the whole
+			// ---- ternary ----
+			{
+				Code: "(a ? b : c)!;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 2, EndLine: 1, EndColumn: 11},
+				},
+			},
+			// ---- Dimension 4: `X?.y` optional chaining inside the condition
+			// ---- operand does not change the reported range of the
+			// ---- enclosing ConditionalExpression ----
+			{
+				Code: "a?.b ? c : d;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+				},
+			},
+			// ---- Dimension 4: ternary as a computed property key ----
+			{
+				Code: "var o = { [a ? b : c]: 1 };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 12, EndLine: 1, EndColumn: 21},
+				},
+			},
+			// ---- Dimension 4: ternary as an object property value ----
+			{
+				Code: "var o = { key: a ? b : c };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// ---- Dimension 4: ternary as a class-field initializer ----
+			{
+				Code: "class C { x = a ? b : c; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 15, EndLine: 1, EndColumn: 24},
+				},
+			},
+			// ---- Dimension 4: ternary as a default parameter value ----
+			{
+				Code: "function f(a = b ? c : d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// ---- Dimension 4: ternary as an unbraced arrow-function body ----
+			{
+				Code: "const f = () => a ? b : c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 17, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundary — a nested ternary
+			// ---- in the WhenFalse position reports independently of the
+			// ---- outer one; there is no dedup / boundary suppression ----
+			{
+				Code: "a ? b : c ? d : e;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 1, EndLine: 1, EndColumn: 18},
+					{MessageId: "noTernaryOperator", Line: 1, Column: 9, EndLine: 1, EndColumn: 18},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundary — a ternary inside
+			// ---- a nested function body still reports; function boundaries
+			// ---- carry no special meaning for this rule ----
+			{
+				Code: "function f() { function g() { return a ? b : c; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 38, EndLine: 1, EndColumn: 47},
+				},
+			},
+			// ---- Position contract: multi-line ternary — Line/Column mark
+			// ---- the start ('a'), EndLine/EndColumn mark the end ('c') on a
+			// ---- different line ----
+			{
+				Code: "var x = a\n  ? b\n  : c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 9, EndLine: 3, EndColumn: 6},
+				},
+			},
+			// ---- Real-user: JSX conditional rendering — the most common
+			// ---- real-world shape a `no-ternary` config encounters; the
+			// ---- reported range is just the ternary, not the surrounding
+			// ---- JSXExpressionContainer or its JSX-element branches ----
+			{
+				Code: "const el = <div>{cond ? <A /> : <B />}</div>;",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 18, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// ---- Real-user: ternary directly in a default-export
+			// ---- declaration ----
+			{
+				Code: "export default cond ? a : b;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noTernaryOperator", Line: 1, Column: 16, EndLine: 1, EndColumn: 28},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_ternary/no_ternary_upstream_test.go
+++ b/internal/rules/no_ternary/no_ternary_upstream_test.go
@@ -1,0 +1,65 @@
+// TestNoTernaryUpstream migrates the full valid/invalid suite from ESLint
+// v10.8.1 tests/lib/rules/no-ternary.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// no_ternary_extras_test.go.
+package no_ternary
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoTernaryUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoTernaryRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid ----
+			{Code: `"x ? y";`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream invalid ----
+			{
+				Code: "var foo = true ? thing : stuff;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noTernaryOperator",
+						Message:   "Ternary operator used.",
+						Line:      1,
+						Column:    11,
+						EndLine:   1,
+						EndColumn: 31,
+					},
+				},
+			},
+			{
+				Code: "true ? thing() : stuff();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noTernaryOperator",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code: "function foo(bar) { return bar ? baz : qux; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noTernaryOperator",
+						Line:      1,
+						Column:    28,
+						EndLine:   1,
+						EndColumn: 43,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -481,6 +481,7 @@ export default defineConfig({
     './tests/eslint/rules/no-multi-assign.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
+    './tests/eslint/rules/no-ternary.test.ts',
     './tests/eslint/rules/no-nonoctal-decimal-escape.test.ts',
     './tests/eslint/rules/no-unexpected-multiline.test.ts',
     './tests/eslint/rules/object-shorthand.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-ternary.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-ternary.test.ts.snap
@@ -1,0 +1,79 @@
+// Rstest Snapshot v1
+
+exports[`no-ternary > invalid 1`] = `
+{
+  "code": "var foo = true ? thing : stuff;",
+  "diagnostics": [
+    {
+      "message": "Ternary operator used.",
+      "messageId": "noTernaryOperator",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-ternary > invalid 2`] = `
+{
+  "code": "true ? thing() : stuff();",
+  "diagnostics": [
+    {
+      "message": "Ternary operator used.",
+      "messageId": "noTernaryOperator",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-ternary > invalid 3`] = `
+{
+  "code": "function foo(bar) { return bar ? baz : qux; }",
+  "diagnostics": [
+    {
+      "message": "Ternary operator used.",
+      "messageId": "noTernaryOperator",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-ternary.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-ternary.test.ts
@@ -1,0 +1,21 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-ternary', {
+  valid: ['"x ? y";'],
+  invalid: [
+    {
+      code: 'var foo = true ? thing : stuff;',
+      errors: [{ messageId: 'noTernaryOperator', line: 1, column: 11 }],
+    },
+    {
+      code: 'true ? thing() : stuff();',
+      errors: [{ messageId: 'noTernaryOperator', line: 1, column: 1 }],
+    },
+    {
+      code: 'function foo(bar) { return bar ? baz : qux; }',
+      errors: [{ messageId: 'noTernaryOperator', line: 1, column: 28 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-ternary` rule from ESLint to rslint.

This rule disallows ternary operators.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-ternary
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-ternary.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).