### PR TITLE
feat: port rule no-plusplus

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -86,6 +86,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_octal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_octal_escape"
 	"github.com/web-infra-dev/rslint/internal/rules/no_param_reassign"
+	"github.com/web-infra-dev/rslint/internal/rules/no_plusplus"
 	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
 	"github.com/web-infra-dev/rslint/internal/rules/no_prototype_builtins"
 	"github.com/web-infra-dev/rslint/internal/rules/no_redeclare"
@@ -237,6 +238,7 @@ func GetAllRules() []rule.Rule {
 		no_octal.NoOctalRule,
 		no_octal_escape.NoOctalEscapeRule,
 		no_param_reassign.NoParamReassignRule,
+		no_plusplus.NoPlusplusRule,
 		no_proto.NoProtoRule,
 		no_redeclare.NoRedeclareRule,
 		radix.RadixRule,

--- a/internal/rules/no_plusplus/no_plusplus.go
+++ b/internal/rules/no_plusplus/no_plusplus.go
@@ -1,0 +1,97 @@
+package no_plusplus
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed no_plusplus.schema.json
+var schemaJSON []byte
+
+type options struct {
+	allowForLoopAfterthoughts bool
+}
+
+func parseOptions(raw []any) options {
+	opts := options{allowForLoopAfterthoughts: false}
+	if len(raw) == 0 {
+		return opts
+	}
+	m, _ := raw[0].(map[string]any)
+	if v, ok := m["allowForLoopAfterthoughts"].(bool); ok {
+		opts.allowForLoopAfterthoughts = v
+	}
+	return opts
+}
+
+func buildUnexpectedUnaryOpMessage(operator string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedUnaryOp",
+		Description: fmt.Sprintf("Unary operator '%s' used.", operator),
+		Data: map[string]string{
+			"operator": operator,
+		},
+	}
+}
+
+// isForLoopAfterthought mirrors upstream's isForLoopAfterthought(node), which
+// walks up through SequenceExpression ancestors before checking
+// isForStatementUpdate. tsgo has no SequenceExpression node — the comma
+// operator collapses into a BinaryExpression (see AST_PATTERNS.md), and
+// parentheses are explicit ParenthesizedExpression wrappers instead of being
+// stripped from the tree — so the walk skips both.
+func isForLoopAfterthought(node *ast.Node) bool {
+	current := utils.OutermostParenthesizedExpression(node)
+	parent := current.Parent
+	if utils.IsCommaOperator(parent) {
+		return isForLoopAfterthought(parent)
+	}
+	return parent != nil && parent.Kind == ast.KindForStatement &&
+		parent.AsForStatement().Incrementor == current
+}
+
+func operatorText(kind ast.Kind) (string, bool) {
+	switch kind {
+	case ast.KindPlusPlusToken:
+		return "++", true
+	case ast.KindMinusMinusToken:
+		return "--", true
+	default:
+		return "", false
+	}
+}
+
+// NoPlusplusRule disallows the unary operators ++ and --.
+//
+// https://eslint.org/docs/latest/rules/no-plusplus
+var NoPlusplusRule = rule.Rule{
+	Name:   "no-plusplus",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		check := func(node *ast.Node, operatorKind ast.Kind) {
+			operator, ok := operatorText(operatorKind)
+			if !ok {
+				return
+			}
+			if opts.allowForLoopAfterthoughts && isForLoopAfterthought(node) {
+				return
+			}
+			ctx.ReportNode(node, buildUnexpectedUnaryOpMessage(operator))
+		}
+
+		return rule.RuleListeners{
+			ast.KindPrefixUnaryExpression: func(node *ast.Node) {
+				check(node, node.AsPrefixUnaryExpression().Operator)
+			},
+			ast.KindPostfixUnaryExpression: func(node *ast.Node) {
+				check(node, node.AsPostfixUnaryExpression().Operator)
+			},
+		}
+	},
+}

--- a/internal/rules/no_plusplus/no_plusplus.md
+++ b/internal/rules/no_plusplus/no_plusplus.md
@@ -1,0 +1,82 @@
+# no-plusplus
+
+## Rule Details
+
+Because the unary `++` and `--` operators are subject to automatic semicolon insertion, differences in whitespace can change the semantics of source code.
+
+This rule disallows the unary operators `++` and `--`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+let foo = 0;
+foo++;
+
+let bar = 42;
+bar--;
+
+for (let i = 0; i < l; i++) {
+  doSomething(i);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+let foo = 0;
+foo += 1;
+
+let bar = 42;
+bar -= 1;
+
+for (let i = 0; i < l; i += 1) {
+  doSomething(i);
+}
+```
+
+## Options
+
+This rule has an object option.
+
+- `"allowForLoopAfterthoughts": true` allows unary operators `++` and `--` in the afterthought (final expression) of a `for` loop.
+
+### allowForLoopAfterthoughts
+
+Examples of **correct** code for this rule with the `{ "allowForLoopAfterthoughts": true }` option:
+
+```json
+{ "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }] }
+```
+
+```javascript
+for (let i = 0; i < l; i++) {
+  doSomething(i);
+}
+
+for (let i = l; i >= 0; i--) {
+  doSomething(i);
+}
+
+for (let i = 0, j = l; i < l; i++, j--) {
+  doSomething(i, j);
+}
+```
+
+Examples of **incorrect** code for this rule with the `{ "allowForLoopAfterthoughts": true }` option:
+
+```javascript
+for (let i = 0; i < l; j = i++) {
+  doSomething(i, j);
+}
+
+for (let i = l; i--; ) {
+  doSomething(i);
+}
+
+for (let i = 0; i < l; ) i++;
+```
+
+## Original Documentation
+
+- [ESLint: no-plusplus](https://eslint.org/docs/latest/rules/no-plusplus)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-plusplus.js)

--- a/internal/rules/no_plusplus/no_plusplus.schema.json
+++ b/internal/rules/no_plusplus/no_plusplus.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowForLoopAfterthoughts": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/no_plusplus/no_plusplus_extras_test.go
+++ b/internal/rules/no_plusplus/no_plusplus_extras_test.go
@@ -1,0 +1,124 @@
+// TestNoPlusplusExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Dimension 4 walk (rows that don't apply to no-plusplus, with reasons):
+//   - N/A access / key forms (identifier, string, numeric, private,
+//     computed, element access): the rule inspects only the operator of a
+//     Prefix/PostfixUnaryExpression, never a property key.
+//   - N/A optional chain (X?.y, X?.()): `++`/`--` require a simple
+//     assignment target; an optional-chain expression is never a valid
+//     UpdateExpression operand.
+//   - N/A TS type-expression wrappers on the operand (`(X as any).y`,
+//     `X satisfies T`): the rule never inspects the operand's shape, only
+//     the enclosing UpdateExpression's own operator and ancestor chain.
+//   - N/A declaration/container forms (class/function declaration vs
+//     expression, async/generator variants): the rule fires the same way in
+//     every enclosing container; no listener targets a declaration.
+//   - N/A autofix boundaries: the rule has neither an autofix nor a
+//     suggestion.
+//   - N/A graceful degradation around SpreadAssignment / RestElement / empty
+//     bodies / overload signatures: the rule never inspects object, array,
+//     or class-member shapes.
+package no_plusplus
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoPlusplusExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoPlusplusRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: parenthesized wrapper directly around the update expression ----
+			// ESTree has no ParenthesizedExpression node, so `(i++)` as a for
+			// loop's afterthought sees ForStatement as i++'s direct parent. tsgo
+			// interposes a ParenthesizedExpression node instead; the rule must
+			// walk past it (and past multiple nested wrappers) to match upstream.
+			{Code: `for (;; (i++));`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; ((i++)));`, Options: allowForLoopAfterthoughts},
+
+			// ---- Dimension 4: parens around one member of the comma chain ----
+			// A ParenthesizedExpression can wrap either operand of the comma
+			// BinaryExpression without changing which chain the operand belongs
+			// to; the walk must skip parens found *between* comma levels too.
+			{Code: `for (;; foo(), (i++));`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; (i++), foo());`, Options: allowForLoopAfterthoughts},
+
+			// ---- Dimension 4: parens around the whole comma chain ----
+			{Code: `for (;; (foo(), i++));`, Options: allowForLoopAfterthoughts},
+
+			// ---- Real-user: eslint/eslint#13005 (two-pointer variant, mixed ++/--) ----
+			// The comma-chain climb must treat ++ and -- identically — this is
+			// the common two-pointer-swap idiom that motivated upstream to widen
+			// allowForLoopAfterthoughts to arbitrary comma-operand position.
+			{Code: `for (let i = 0, j = arr.length - 1; i < j; i++, j--) { swap(arr, i, j); }`, Options: allowForLoopAfterthoughts},
+
+			// ---- Dimension 2: nested for loops — each loop's own incrementor is independently allowed ----
+			// Locks in that the Incrementor identity check (parent.AsForStatement().Incrementor == current)
+			// is scoped per-ForStatement and doesn't bleed across nesting: the
+			// outer loop's `i++` and the inner loop's `j++` are each their own
+			// loop's afterthought.
+			{Code: `for (let i = 0;; i++) { for (let j = 0;; j++) { doSomething(i, j); } }`, Options: allowForLoopAfterthoughts},
+
+			// ---- Options contract: explicit {} uses the schema default (false is a no-op distinction here since these are valid regardless) ----
+			{Code: `var foo = 0; foo=+1;`, Options: []any{map[string]any{}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Real-user: eslint/eslint#11343 — ++ nested inside a LogicalExpression, not a for-loop context ----
+			{
+				Code: `let c = b || a++;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 14, EndLine: 1, EndColumn: 17},
+				},
+			},
+
+			// ---- Dimension 2: nesting boundary — a statement inside the loop body that merely looks like an afterthought is still reported ----
+			// Locks in that only the exact node stored in ForStatement.Incrementor
+			// is exempted; an `i++` statement in the loop body (even one that
+			// mirrors the loop variable) is not.
+			{
+				Code:    `for (let i = 0; i < 5;) { i++; }`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 27, EndLine: 1, EndColumn: 30},
+				},
+			},
+
+			// Locks in the same nesting-boundary guarantee from the invalid side:
+			// a bare `i++;` statement inside the inner loop's body is reported
+			// even though both enclosing loops have their own allowed afterthoughts.
+			{
+				Code:    `outer: for (let i = 0;; i++) { for (let j = 0;; j++) { i++; break outer; } }`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 56, EndLine: 1, EndColumn: 59},
+				},
+			},
+
+			// ---- Options contract: schema default is false; explicit false is not a no-op difference from omitting the option ----
+			{
+				Code:    `for (;; i++);`,
+				Options: []any{map[string]any{"allowForLoopAfterthoughts": false}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 9, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:    `for (;; i++);`,
+				Options: []any{map[string]any{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 9, EndLine: 1, EndColumn: 12},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_plusplus/no_plusplus_upstream_test.go
+++ b/internal/rules/no_plusplus/no_plusplus_upstream_test.go
@@ -1,0 +1,136 @@
+// TestNoPlusplusUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/no-plusplus.js 1:1. Position assertions cover
+// line/column/endLine/endColumn for every invalid case. rslint-specific
+// lock-in cases live in the no_plusplus_extras_test.go file.
+package no_plusplus
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+var allowForLoopAfterthoughts = []any{map[string]any{"allowForLoopAfterthoughts": true}}
+
+func TestNoPlusplusUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoPlusplusRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid ----
+			{Code: `var foo = 0; foo=+1;`},
+
+			// With "allowForLoopAfterthoughts" allowed
+			{Code: `var foo = 0; foo=+1;`, Options: allowForLoopAfterthoughts},
+			{Code: `for (i = 0; i < l; i++) { console.log(i); }`, Options: allowForLoopAfterthoughts},
+			{Code: `for (var i = 0, j = i + 1; j < example.length; i++, j++) {}`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; i--, foo());`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; foo(), --i);`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; foo(), ++i, bar);`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; i++, (++j, k--));`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; foo(), (bar(), i++), baz());`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; (--i, j += 2), bar = j + 1);`, Options: allowForLoopAfterthoughts},
+			{Code: `for (;; a, (i--, (b, ++j, c)), d);`, Options: allowForLoopAfterthoughts},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid ----
+			{
+				Code: `var foo = 0; foo++;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 14, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code: `var foo = 0; foo--;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '--' used.", Line: 1, Column: 14, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code: `for (i = 0; i < l; i++) { console.log(i); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 20, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code: `for (i = 0; i < l; foo, i++) { console.log(i); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 25, EndLine: 1, EndColumn: 28},
+				},
+			},
+
+			// With "allowForLoopAfterthoughts" allowed
+			{
+				Code:    `var foo = 0; foo++;`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 14, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:    `for (i = 0; i < l; i++) { v++; }`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 27, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				// Locks in upstream isForStatementUpdate: node.parent.type must be
+				// "ForStatement" AND parent.update === node — this i++ sits in the
+				// init slot, not the update slot.
+				Code:    `for (i++;;);`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 6, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				// Same as above, but the condition slot.
+				Code:    `for (;--i;);`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '--' used.", Line: 1, Column: 7, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				// The update is in the loop body, not the afterthought slot.
+				Code:    `for (;;) ++i;`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 10, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				// Locks in upstream isForLoopAfterthought base case: the update's
+				// parent is an AssignmentExpression, not the ForStatement directly.
+				Code:    `for (;; i = j++);`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 13, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				// The outer comma expression is the afterthought, but --j sits
+				// inside a CallExpression argument, not directly in the comma chain.
+				Code:    `for (;; i++, f(--j));`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '--' used.", Line: 1, Column: 16, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				// i++ sits inside a parenthesised comma expression that is itself
+				// the right operand of a BinaryExpression (`+`), not the
+				// afterthought slot.
+				Code:    `for (;; foo + (i++, bar));`,
+				Options: allowForLoopAfterthoughts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedUnaryOp", Message: "Unary operator '++' used.", Line: 1, Column: 16, EndLine: 1, EndColumn: 19},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_sequences/no_sequences.go
+++ b/internal/rules/no_sequences/no_sequences.go
@@ -27,16 +27,6 @@ func parseOptions(raw []any) options {
 	return opts
 }
 
-// isCommaBinary reports whether node is a BinaryExpression whose operator is
-// the comma token — tsgo's collapsed form of ESLint's SequenceExpression.
-func isCommaBinary(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindBinaryExpression {
-		return false
-	}
-	bin := node.AsBinaryExpression()
-	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken
-}
-
 // walkUpSkippingParens returns the first ancestor of node that is not a
 // ParenthesizedExpression, along with the count of ParenthesizedExpression
 // wrappers traversed. The returned child is the direct descendant of that
@@ -91,7 +81,7 @@ func firstCommaToken(node *ast.Node) *ast.Node {
 	for {
 		bin := current.AsBinaryExpression()
 		left := ast.SkipParentheses(bin.Left)
-		if !isCommaBinary(left) {
+		if !utils.IsCommaOperator(left) {
 			return bin.OperatorToken
 		}
 		current = left
@@ -107,7 +97,7 @@ var NoSequencesRule = rule.Rule{
 
 		return rule.RuleListeners{
 			ast.KindBinaryExpression: func(node *ast.Node) {
-				if !isCommaBinary(node) {
+				if !utils.IsCommaOperator(node) {
 					return
 				}
 				// Single walk-up; all downstream checks read from these.
@@ -115,7 +105,7 @@ var NoSequencesRule = rule.Rule{
 
 				// Only report once per comma chain — skip inner nodes of
 				// `(a, b), c` / `a, b, c`.
-				if isCommaBinary(parent) {
+				if utils.IsCommaOperator(parent) {
 					return
 				}
 				// `for (init; cond; update)` — ESLint unconditionally allows

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -35,6 +35,16 @@ func OutermostParenthesizedExpression(node *ast.Node) *ast.Node {
 	return current
 }
 
+// IsCommaOperator reports whether node is a BinaryExpression whose operator is
+// the comma token — tsgo's collapsed form of ESLint's SequenceExpression.
+func IsCommaOperator(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := node.AsBinaryExpression()
+	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken
+}
+
 // IsCallee checks if a node is the callee of a CallExpression or NewExpression,
 // skipping parentheses and TS type assertions between the node and the call.
 func IsCallee(node *ast.Node) bool {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
     './tests/eslint/rules/no-new-object.test.ts',
     './tests/eslint/rules/no-new-wrappers.test.ts',
     './tests/eslint/rules/no-param-reassign.test.ts',
+    './tests/eslint/rules/no-plusplus.test.ts',
     './tests/eslint/rules/no-self-assign.test.ts',
     './tests/eslint/rules/no-undef.test.ts',
     './tests/eslint/rules/no-undef-init.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-plusplus.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-plusplus.test.ts.snap
@@ -1,0 +1,313 @@
+// Rstest Snapshot v1
+
+exports[`no-plusplus > invalid 1`] = `
+{
+  "code": "var foo = 0; foo++;",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 2`] = `
+{
+  "code": "var foo = 0; foo--;",
+  "diagnostics": [
+    {
+      "message": "Unary operator '--' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 3`] = `
+{
+  "code": "for (i = 0; i < l; i++) { console.log(i); }",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 4`] = `
+{
+  "code": "for (i = 0; i < l; foo, i++) { console.log(i); }",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 5`] = `
+{
+  "code": "var foo = 0; foo++;",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 6`] = `
+{
+  "code": "for (i = 0; i < l; i++) { v++; }",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 7`] = `
+{
+  "code": "for (i++;;);",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 8`] = `
+{
+  "code": "for (;--i;);",
+  "diagnostics": [
+    {
+      "message": "Unary operator '--' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 9`] = `
+{
+  "code": "for (;;) ++i;",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 10`] = `
+{
+  "code": "for (;; i = j++);",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 11`] = `
+{
+  "code": "for (;; i++, f(--j));",
+  "diagnostics": [
+    {
+      "message": "Unary operator '--' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-plusplus > invalid 12`] = `
+{
+  "code": "for (;; foo + (i++, bar));",
+  "diagnostics": [
+    {
+      "message": "Unary operator '++' used.",
+      "messageId": "unexpectedUnaryOp",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-plusplus",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-plusplus.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-plusplus.test.ts
@@ -1,0 +1,207 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-plusplus', {
+  valid: [
+    'var foo = 0; foo=+1;',
+
+    // With "allowForLoopAfterthoughts" allowed
+    {
+      code: 'var foo = 0; foo=+1;',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (i = 0; i < l; i++) { console.log(i); }',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (var i = 0, j = i + 1; j < example.length; i++, j++) {}',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (;; i--, foo());',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (;; foo(), --i);',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (;; foo(), ++i, bar);',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (;; i++, (++j, k--));',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (;; foo(), (bar(), i++), baz());',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (;; (--i, j += 2), bar = j + 1);',
+      options: { allowForLoopAfterthoughts: true },
+    },
+    {
+      code: 'for (;; a, (i--, (b, ++j, c)), d);',
+      options: { allowForLoopAfterthoughts: true },
+    },
+  ],
+  invalid: [
+    {
+      code: 'var foo = 0; foo++;',
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+    },
+    {
+      code: 'var foo = 0; foo--;',
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+    },
+    {
+      code: 'for (i = 0; i < l; i++) { console.log(i); }',
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 20,
+          endLine: 1,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: 'for (i = 0; i < l; foo, i++) { console.log(i); }',
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 28,
+        },
+      ],
+    },
+
+    // With "allowForLoopAfterthoughts" allowed
+    {
+      code: 'var foo = 0; foo++;',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+    },
+    {
+      code: 'for (i = 0; i < l; i++) { v++; }',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 27,
+          endLine: 1,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: 'for (i++;;);',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 6,
+          endLine: 1,
+          endColumn: 9,
+        },
+      ],
+    },
+    {
+      code: 'for (;--i;);',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 10,
+        },
+      ],
+    },
+    {
+      code: 'for (;;) ++i;',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: 'for (;; i = j++);',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: 'for (;; i++, f(--j));',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+    },
+    {
+      code: 'for (;; foo + (i++, bar));',
+      options: { allowForLoopAfterthoughts: true },
+      errors: [
+        {
+          messageId: 'unexpectedUnaryOp',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-plusplus` rule from ESLint to rslint.

Disallows the unary operators `++` and `--`. Supports the `allowForLoopAfterthoughts` option to permit them in the afterthought (final expression) of a `for` loop.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-plusplus
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-plusplus.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).