### PR TITLE
feat: port rule no-lonely-if

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -77,6 +77,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_label_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_lone_blocks"
+	"github.com/web-infra-dev/rslint/internal/rules/no_lonely_if"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_misleading_character_class"
@@ -245,6 +246,7 @@ func GetAllRules() []rule.Rule {
 		no_inner_declarations.NoInnerDeclarationsRule,
 		no_irregular_whitespace.NoIrregularWhitespaceRule,
 		no_lone_blocks.NoLoneBlocksRule,
+		no_lonely_if.NoLonelyIfRule,
 		no_loop_func.NoLoopFuncRule,
 		no_loss_of_precision.NoLossOfPrecisionRule,
 		no_misleading_character_class.NoMisleadingCharacterClassRule,

--- a/internal/rules/curly/curly.go
+++ b/internal/rules/curly/curly.go
@@ -256,7 +256,7 @@ func (c *curlyChecker) prepareCheck(node, body *ast.Node, name string, condition
 	expected := expectDontCare
 
 	switch {
-	case hasBlock && (len(c.blockStatements(body)) != 1 || c.areBracesNecessary(body)):
+	case hasBlock && (len(c.blockStatements(body)) != 1 || utils.AreBracesNecessary(c.sf, body)):
 		expected = expectBraces
 	case c.opts.multiOnly:
 		expected = expectNoBraces
@@ -445,23 +445,6 @@ func (c *curlyChecker) lastTokenBefore(fromPos, beforePos int) (start, end int, 
 	return
 }
 
-// areBracesNecessary mirrors astUtils.areBracesNecessary: a single-statement
-// block still needs its braces when the statement is a lexical declaration, or
-// when it ends with an `if` that would capture a trailing `else`.
-func (c *curlyChecker) areBracesNecessary(block *ast.Node) bool {
-	statement := c.blockStatements(block)[0]
-	return isLexicalDeclaration(statement) ||
-		(hasUnsafeIf(statement) && c.isFollowedByElseKeyword(block))
-}
-
-func (c *curlyChecker) isFollowedByElseKeyword(block *ast.Node) bool {
-	nextStart := scanner.SkipTrivia(c.text, block.End())
-	if nextStart >= len(c.text) {
-		return false
-	}
-	return scanner.ScanTokenAtPosition(c.sf, nextStart) == ast.KindElseKeyword
-}
-
 // isCollapsedOneLiner reports whether the body sits on the same line as the
 // token that precedes it (its closing `)` / `do` / `else`).
 func (c *curlyChecker) isCollapsedOneLiner(node *ast.Node) bool {
@@ -511,53 +494,4 @@ func (c *curlyChecker) hasLeadingComments(block, statement *ast.Node) bool {
 
 func (c *curlyChecker) blockStatements(block *ast.Node) []*ast.Node {
 	return block.AsBlock().Statements.Nodes
-}
-
-// isLexicalDeclaration mirrors astUtils.isLexicalDeclaration: let/const/using/
-// await using variable declarations and function/class declarations.
-//
-// NOTE: Unlike ESLint (which only sees JavaScript), tsgo also parses TypeScript
-// declarations that are equally illegal as an unbraced control-statement body
-// (`if (a) enum E {}` is a syntax error). They are treated the same as lexical
-// declarations so the autofix never strips a required block.
-func isLexicalDeclaration(node *ast.Node) bool {
-	switch node.Kind {
-	case ast.KindVariableStatement:
-		declList := node.AsVariableStatement().DeclarationList
-		return declList.Flags&ast.NodeFlagsBlockScoped != 0
-	case ast.KindFunctionDeclaration,
-		ast.KindClassDeclaration,
-		ast.KindEnumDeclaration,
-		ast.KindModuleDeclaration,
-		ast.KindInterfaceDeclaration,
-		ast.KindTypeAliasDeclaration,
-		ast.KindImportEqualsDeclaration:
-		return true
-	}
-	return false
-}
-
-// hasUnsafeIf reports whether the code contains an `if` that would become
-// associated with an `else` appended directly after it.
-func hasUnsafeIf(node *ast.Node) bool {
-	switch node.Kind {
-	case ast.KindIfStatement:
-		ifStmt := node.AsIfStatement()
-		if ifStmt.ElseStatement == nil {
-			return true
-		}
-		return hasUnsafeIf(ifStmt.ElseStatement)
-	case ast.KindForStatement:
-		return hasUnsafeIf(node.AsForStatement().Statement)
-	case ast.KindForInStatement, ast.KindForOfStatement:
-		return hasUnsafeIf(node.AsForInOrOfStatement().Statement)
-	case ast.KindLabeledStatement:
-		return hasUnsafeIf(node.AsLabeledStatement().Statement)
-	case ast.KindWithStatement:
-		return hasUnsafeIf(node.AsWithStatement().Statement)
-	case ast.KindWhileStatement:
-		return hasUnsafeIf(node.AsWhileStatement().Statement)
-	default:
-		return false
-	}
 }

--- a/internal/rules/no_lonely_if/no_lonely_if.go
+++ b/internal/rules/no_lonely_if/no_lonely_if.go
@@ -68,6 +68,13 @@ func buildLonelyIfFix(sf *ast.SourceFile, elseBlock, ifNode *ast.Node) (rule.Rul
 	innerRange := utils.BracedNodeInnerRange(sf, elseBlock)
 	nodeRange := utils.TrimNodeTextRange(sf, ifNode)
 
+	// An unterminated `else {` recovers as a Block without a closing brace, so
+	// the inner if reaches past the brace pair's interior and there is no pair
+	// to unwrap.
+	if nodeRange.Pos() < innerRange.Pos() || nodeRange.End() > innerRange.End() {
+		return rule.RuleFix{}, false
+	}
+
 	// Don't fix if there are any non-whitespace characters interfering (e.g. comments).
 	if !ecmascript.IsBlank(text[innerRange.Pos():nodeRange.Pos()]) ||
 		!ecmascript.IsBlank(text[nodeRange.End():innerRange.End()]) {
@@ -80,11 +87,14 @@ func buildLonelyIfFix(sf *ast.SourceFile, elseBlock, ifNode *ast.Node) (rule.Rul
 		tokenAfterElseBlock, hasTokenAfter := utils.TokenAtOrAfter(sf, blockRange.End())
 
 		if hasLastIfToken && lastIfToken.Kind != ast.KindSemicolonToken && hasTokenAfter {
-			thenEnd := utils.TrimNodeTextRange(sf, thenStatement).End()
 			r, _ := utf8.DecodeRuneInString(tokenAfterElseBlock.Text)
 
-			if utils.IsSameLine(sf, thenEnd, tokenAfterElseBlock.Start) ||
-				strings.ContainsRune("([/+`-", r) ||
+			// `<` is absent from ESLint's set because no JavaScript statement can
+			// start with it. A TypeScript one can (`<T>x;`), and it continues the
+			// preceding expression across a line break, so an unbraced if body
+			// would swallow the statement that follows the else block.
+			if utils.IsSameLine(sf, thenStatement.End(), tokenAfterElseBlock.Start) ||
+				strings.ContainsRune("([/+`-<", r) ||
 				lastIfToken.Kind == ast.KindPlusPlusToken ||
 				lastIfToken.Kind == ast.KindMinusMinusToken {
 				// Fixing would change the semantics of the code due to ASI.
@@ -101,6 +111,6 @@ func buildLonelyIfFix(sf *ast.SourceFile, elseBlock, ifNode *ast.Node) (rule.Rul
 
 	return rule.RuleFixReplaceRange(
 		core.NewTextRange(blockRange.Pos(), blockRange.End()),
-		prefix+utils.TrimmedNodeText(sf, ifNode),
+		prefix+text[nodeRange.Pos():nodeRange.End()],
 	), true
 }

--- a/internal/rules/no_lonely_if/no_lonely_if.go
+++ b/internal/rules/no_lonely_if/no_lonely_if.go
@@ -1,0 +1,105 @@
+package no_lonely_if
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// NoLonelyIfRule disallows `if` statements as the only statement in `else`
+// blocks.
+// https://eslint.org/docs/latest/rules/no-lonely-if
+var NoLonelyIfRule = rule.Rule{
+	Name:   "no-lonely-if",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		sf := ctx.SourceFile
+
+		return rule.RuleListeners{
+			ast.KindIfStatement: func(node *ast.Node) {
+				parent := node.Parent
+				if parent == nil || parent.Kind != ast.KindBlock {
+					return
+				}
+				if len(parent.AsBlock().Statements.Nodes) != 1 {
+					return
+				}
+
+				grandparent := parent.Parent
+				if grandparent == nil || grandparent.Kind != ast.KindIfStatement {
+					return
+				}
+				if grandparent.AsIfStatement().ElseStatement != parent {
+					return
+				}
+
+				if utils.AreBracesNecessary(sf, parent) {
+					return
+				}
+
+				ctx.ReportNodeWithDeferredFixes(node, rule.RuleMessage{
+					Id:          "unexpectedLonelyIf",
+					Description: "Unexpected if as the only statement in an else block.",
+				}, func() []rule.RuleFix {
+					fix, ok := buildLonelyIfFix(sf, parent, node)
+					if !ok {
+						return nil
+					}
+					return []rule.RuleFix{fix}
+				})
+			},
+		}
+	},
+}
+
+// buildLonelyIfFix mirrors ESLint's fixer: it replaces the `else { if (...) {...} }`
+// block with `else if (...) {...}`. It refuses to fix (returns ok=false) when
+// comments sit between the else block's braces and the inner if statement, or
+// when removing the braces would change the code's meaning due to ASI.
+func buildLonelyIfFix(sf *ast.SourceFile, elseBlock, ifNode *ast.Node) (rule.RuleFix, bool) {
+	text := sf.Text()
+
+	blockRange := utils.TrimNodeTextRange(sf, elseBlock)
+	innerRange := utils.BracedNodeInnerRange(sf, elseBlock)
+	nodeRange := utils.TrimNodeTextRange(sf, ifNode)
+
+	// Don't fix if there are any non-whitespace characters interfering (e.g. comments).
+	if strings.TrimSpace(text[innerRange.Pos():nodeRange.Pos()]) != "" ||
+		strings.TrimSpace(text[nodeRange.End():innerRange.End()]) != "" {
+		return rule.RuleFix{}, false
+	}
+
+	thenStatement := ifNode.AsIfStatement().ThenStatement
+	if thenStatement.Kind != ast.KindBlock {
+		lastIfToken, hasLastIfToken := utils.PreviousTokenBefore(sf, thenStatement, thenStatement.End())
+		tokenAfterElseBlock, hasTokenAfter := utils.TokenAtOrAfter(sf, blockRange.End())
+
+		if hasLastIfToken && lastIfToken.Kind != ast.KindSemicolonToken && hasTokenAfter {
+			thenEnd := utils.TrimNodeTextRange(sf, thenStatement).End()
+			r, _ := utf8.DecodeRuneInString(tokenAfterElseBlock.Text)
+
+			if utils.IsSameLine(sf, thenEnd, tokenAfterElseBlock.Start) ||
+				strings.ContainsRune("([/+`-", r) ||
+				lastIfToken.Kind == ast.KindPlusPlusToken ||
+				lastIfToken.Kind == ast.KindMinusMinusToken {
+				// Fixing would change the semantics of the code due to ASI.
+				return rule.RuleFix{}, false
+			}
+		}
+	}
+
+	elseKeyword, hasElseKeyword := utils.TokenBeforePosition(sf, blockRange.Pos())
+	prefix := ""
+	if hasElseKeyword && elseKeyword.End == blockRange.Pos() {
+		prefix = " "
+	}
+
+	return rule.RuleFixReplaceRange(
+		core.NewTextRange(blockRange.Pos(), blockRange.End()),
+		prefix+utils.TrimmedNodeText(sf, ifNode),
+	), true
+}

--- a/internal/rules/no_lonely_if/no_lonely_if.go
+++ b/internal/rules/no_lonely_if/no_lonely_if.go
@@ -8,6 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 // NoLonelyIfRule disallows `if` statements as the only statement in `else`
@@ -68,8 +69,8 @@ func buildLonelyIfFix(sf *ast.SourceFile, elseBlock, ifNode *ast.Node) (rule.Rul
 	nodeRange := utils.TrimNodeTextRange(sf, ifNode)
 
 	// Don't fix if there are any non-whitespace characters interfering (e.g. comments).
-	if strings.TrimSpace(text[innerRange.Pos():nodeRange.Pos()]) != "" ||
-		strings.TrimSpace(text[nodeRange.End():innerRange.End()]) != "" {
+	if !ecmascript.IsBlank(text[innerRange.Pos():nodeRange.Pos()]) ||
+		!ecmascript.IsBlank(text[nodeRange.End():innerRange.End()]) {
 		return rule.RuleFix{}, false
 	}
 

--- a/internal/rules/no_lonely_if/no_lonely_if.md
+++ b/internal/rules/no_lonely_if/no_lonely_if.md
@@ -1,0 +1,85 @@
+# no-lonely-if
+
+## Rule Details
+
+If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.
+
+```js
+if (foo) {
+    // ...
+} else {
+    if (bar) {
+        // ...
+    }
+}
+```
+
+should be rewritten as
+
+```js
+if (foo) {
+    // ...
+} else if (bar) {
+    // ...
+}
+```
+
+This rule disallows `if` statements as the only statement in `else` blocks.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+if (condition) {
+    // ...
+} else {
+    if (anotherCondition) {
+        // ...
+    }
+}
+
+if (condition) {
+    // ...
+} else {
+    if (anotherCondition) {
+        // ...
+    } else {
+        // ...
+    }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+if (condition) {
+    // ...
+} else if (anotherCondition) {
+    // ...
+}
+
+if (condition) {
+    // ...
+} else if (anotherCondition) {
+    // ...
+} else {
+    // ...
+}
+
+if (condition) {
+    // ...
+} else {
+    if (anotherCondition) {
+        // ...
+    }
+    doSomething();
+}
+```
+
+## When Not To Use It
+
+Disable this rule if the code is clearer without requiring the `else if` form.
+
+## Original Documentation
+
+- [ESLint: no-lonely-if](https://eslint.org/docs/latest/rules/no-lonely-if)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-lonely-if.js)

--- a/internal/rules/no_lonely_if/no_lonely_if.md
+++ b/internal/rules/no_lonely_if/no_lonely_if.md
@@ -4,7 +4,7 @@
 
 If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.
 
-```js
+```javascript
 if (foo) {
     // ...
 } else {
@@ -16,7 +16,7 @@ if (foo) {
 
 should be rewritten as
 
-```js
+```javascript
 if (foo) {
     // ...
 } else if (bar) {

--- a/internal/rules/no_lonely_if/no_lonely_if_extras_test.go
+++ b/internal/rules/no_lonely_if/no_lonely_if_extras_test.go
@@ -1,0 +1,248 @@
+// TestNoLonelyIfExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension row / real-user issue it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Dimension 4 (universal edge shapes) note: no-lonely-if is purely
+// structural — it never reads a receiver expression, a property/key form, or
+// a declaration/container shape. The "Receiver / expression wrappers",
+// "Access / key forms", and "Declaration / container forms" rows are N/A for
+// this rule. The applicable rows are "Nesting / traversal boundaries" and
+// "Graceful degradation" (empty bodies), both covered below.
+package no_lonely_if
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLonelyIfExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLonelyIfRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream arm: `parent === grandparent.alternate` is false
+			// because parent is the grandparent's *consequent* block, not its
+			// alternate.
+			{Code: "if (a) { if (b) {} } else { baz(); }"},
+
+			// Locks in upstream arm: `grandparent.type === "IfStatement"` is
+			// false (grandparent is a WhileStatement).
+			{Code: "while (a) { if (b) {} }"},
+
+			// Locks in upstream arm: `parent.body.length === 1` is false (the
+			// else block has two statements).
+			{Code: "if (a) {} else { if (b) {} foo(); }"},
+
+			// Locks in upstream arm: `parent && parent.type === "BlockStatement"`
+			// is false — the if has no parent block at all (top-level statement).
+			{Code: "if (b) {}"},
+
+			// Locks in upstream arm: `parent && parent.type === "BlockStatement"`
+			// is false — parent is another IfStatement (an `else if` chain, no
+			// block wrapper).
+			{Code: "if (a) {} else if (b) {} else if (c) {}"},
+
+			// ---- Real-user: eslint/eslint#19033 ----
+			// "no-lonely-if has incorrect fix when nested inside parent if
+			// without BlockStatement". Reporting here would allow an unsafe
+			// autofix that makes the outer `else` unreachable, so
+			// areBracesNecessary's hasUnsafeIf/isFollowedByElseKeyword gate must
+			// suppress the report. (This is the exact scenario the upstream fix
+			// in eslint/eslint#19087 added regression coverage for.)
+			{Code: "if (true)\n" +
+				"\tif (false) {}\n" +
+				"\telse { if (false) {} }\n" +
+				"else throw Error('unreachable');"},
+
+			// Locks in HasUnsafeIf's ForStatement recursion arm: the dangling
+			// `if` is reached through a `for (;;)` loop in the else-chain.
+			{Code: "if (x)\n" +
+				"  if (a) {} else { if (b) {} else for (;;) if (c) foo(); }\n" +
+				"else\n" +
+				"  bar();"},
+
+			// Locks in HasUnsafeIf's WhileStatement recursion arm: same shape,
+			// through a `while` loop.
+			{Code: "if (x)\n" +
+				"  if (a) {} else { if (b) {} else while (c) if (d) foo(); }\n" +
+				"else\n" +
+				"  bar();"},
+
+			// Locks in HasUnsafeIf's LabeledStatement recursion arm: same
+			// shape, through a labeled statement.
+			{Code: "if (x)\n" +
+				"  if (a) {} else { if (b) {} else lbl: if (c) foo(); }\n" +
+				"else\n" +
+				"  bar();"},
+
+			// ---- Dimension 2: deeply nested (4-level) lonely-if chain, only the ----
+			// outermost is a lonely-if relative to its own immediate else block;
+			// each level reports independently (verified in the invalid chain
+			// below). This valid case checks a chain that bottoms out in an
+			// `else if` (no trailing lonely block), so nothing is reported.
+			{Code: "if (a) {} else if (b) {} else if (c) {} else if (d) {} else {}"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 2: multiple independent lonely-ifs must not bleed ----
+			// into each other's boundary — both the outer and the inner
+			// lonely-if are reported, each fixed independently.
+			{
+				Code: "if (a) {\n" +
+					"} else {\n" +
+					"  if (b) {\n" +
+					"  } else {\n" +
+					"    if (c) {}\n" +
+					"  }\n" +
+					"}",
+				Output: []string{
+					"if (a) {\n" +
+						"} else if (b) {\n" +
+						"  } else {\n" +
+						"    if (c) {}\n" +
+						"  }",
+					"if (a) {\n" +
+						"} else if (b) {\n" +
+						"  } else if (c) {}",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 3, Column: 3},
+					{MessageId: "unexpectedLonelyIf", Line: 5, Column: 5},
+				},
+			},
+
+			// ---- Dimension 3: consequent is an EmptyStatement; its own last ----
+			// token is the semicolon, so the ASI-hazard check's
+			// `lastIfToken.Kind != KindSemicolonToken` guard is false and the fix
+			// applies normally.
+			{
+				Code:   "if (a) {} else { if (b); }",
+				Output: []string{"if (a) {} else if (b);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 18},
+				},
+			},
+
+			// ---- Dimension 3: no token follows the else block at all (end of ----
+			// file); `hasTokenAfter` is false so the ASI-hazard check is skipped
+			// entirely and the fix applies.
+			{
+				Code:   "if (foo) {} else { if (bar) baz() }",
+				Output: []string{"if (foo) {} else if (bar) baz()"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- Dimension 3: token after the else block starts with `(` on a ----
+			// different line than the consequent (IIFE-call ASI hazard); not
+			// fixed.
+			{
+				Code: "if (foo) {\n" +
+					"} else {\n" +
+					"  if (bar) baz()\n" +
+					"}\n" +
+					"(qux)();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 3, Column: 3},
+				},
+			},
+
+			// ---- Dimension 3: token after the else block starts with `/` on a ----
+			// different line (regex-literal ASI hazard); not fixed.
+			{
+				Code: "if (foo) {\n" +
+					"} else {\n" +
+					"  if (bar) baz()\n" +
+					"}\n" +
+					"/regex/.test(qux);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 3, Column: 3},
+				},
+			},
+
+			// ---- Dimension 3: `else{` with no space before the opening brace; ----
+			// the fixer must insert a leading space so `else` and the replacement
+			// `if` text don't fuse into `elseif`.
+			{
+				Code:   "if (foo) {} else{ if (bar) baz(); }",
+				Output: []string{"if (foo) {} else if (bar) baz();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 19},
+				},
+			},
+		},
+	)
+}
+
+// TestNoLonelyIfEditDemand verifies that the diagnostic (range, message) is
+// identical across all four edit demands, that the autofix is only built
+// under EditDemandAutofix/EditDemandAll (no-lonely-if never emits
+// suggestions), and that EditDemandAll's fix matches EditDemandAutofix's.
+func TestNoLonelyIfEditDemand(t *testing.T) {
+	code := "if (a) {} else { if (b) baz(); }"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/no-lonely-if-edit-demand.ts",
+		Path:     tspath.Path("/no-lonely-if-edit-demand.ts"),
+	}, code, core.ScriptKindTS)
+
+	outerIf := sourceFile.Statements.Nodes[0]
+	elseBlock := outerIf.AsIfStatement().ElseStatement
+	innerIf := elseBlock.AsBlock().Statements.Nodes[0]
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(NoLonelyIfRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+
+		NoLonelyIfRule.Run(ctx, nil)[ast.KindIfStatement](innerIf)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	none := run(rule.EditDemandNone)
+	autofix := run(rule.EditDemandAutofix)
+	suggestion := run(rule.EditDemandSuggestion)
+	all := run(rule.EditDemandAll)
+
+	for name, d := range map[string]rule.RuleDiagnostic{"autofix": autofix, "suggestion": suggestion, "all": all} {
+		if d.Range != none.Range || !reflect.DeepEqual(d.Message, none.Message) {
+			t.Fatalf("%s: diagnostic changed with edit demand: none=%#v %s=%#v", name, none, name, d)
+		}
+	}
+
+	if none.FixesPtr != nil {
+		t.Fatalf("EditDemandNone consumer received fixes: %#v", none.Fixes())
+	}
+	if len(suggestion.Fixes()) != 0 {
+		t.Fatalf("EditDemandSuggestion consumer received fixes: %#v", suggestion.Fixes())
+	}
+	if len(autofix.Fixes()) != 1 {
+		t.Fatalf("EditDemandAutofix fix count = %d, want 1", len(autofix.Fixes()))
+	}
+	if !reflect.DeepEqual(autofix.Fixes(), all.Fixes()) {
+		t.Fatalf("EditDemandAll fixes = %#v, want %#v (same as EditDemandAutofix)", all.Fixes(), autofix.Fixes())
+	}
+}

--- a/internal/rules/no_lonely_if/no_lonely_if_extras_test.go
+++ b/internal/rules/no_lonely_if/no_lonely_if_extras_test.go
@@ -172,6 +172,21 @@ func TestNoLonelyIfExtras(t *testing.T) {
 				},
 			},
 
+			// ---- Dimension 3: `<` is a TypeScript-only ASI hazard. ESLint's ----
+			// character set omits it because no JavaScript statement can begin
+			// with `<`, but a TypeScript type assertion can, and it continues the
+			// unbraced consequent across the line break; not fixed.
+			{
+				Code: "if (foo) {\n" +
+					"} else {\n" +
+					"  if (bar) baz()\n" +
+					"}\n" +
+					"<any>qux;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 3, Column: 3},
+				},
+			},
+
 			// ---- Dimension 4 (graceful degradation): the whitespace the fixer ----
 			// scans for interference is ECMAScript's, not Go's. U+FEFF is
 			// whitespace to JavaScript, so the braces come off…
@@ -204,6 +219,55 @@ func TestNoLonelyIfExtras(t *testing.T) {
 			},
 		},
 	)
+}
+
+// TestNoLonelyIfUnterminatedElseBlock covers the graceful-degradation shape
+// the rule tester cannot express, because it rejects sources with syntactic
+// errors: an unterminated `else {` recovers as a Block with no closing brace,
+// so the inner if reaches past the brace pair's interior. The diagnostic still
+// lands, and since there is no brace pair to unwrap it carries no fix.
+func TestNoLonelyIfUnterminatedElseBlock(t *testing.T) {
+	for _, code := range []string{
+		"if (a) {} else { if (b) c();",
+		"if (a) {} else { if (b) c()",
+		"if (a) {} else { if (b) c(); ",
+		"if (a) {} else {",
+	} {
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/no-lonely-if-unterminated.ts",
+			Path:     tspath.Path("/no-lonely-if-unterminated.ts"),
+		}, code, core.ScriptKindTS)
+
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(NoLonelyIfRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: rule.EditDemandAutofix,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+
+		listener := NoLonelyIfRule.Run(ctx, nil)[ast.KindIfStatement]
+		var visit func(node *ast.Node) bool
+		visit = func(node *ast.Node) bool {
+			if node.Kind == ast.KindIfStatement {
+				listener(node)
+			}
+			node.ForEachChild(visit)
+			return false
+		}
+		sourceFile.AsNode().ForEachChild(visit)
+
+		for _, diagnostic := range diagnostics {
+			if fixes := diagnostic.Fixes(); len(fixes) != 0 {
+				t.Errorf("%q: fixes = %#v, want none", code, fixes)
+			}
+		}
+	}
 }
 
 // TestNoLonelyIfEditDemand verifies that the diagnostic (range, message) is

--- a/internal/rules/no_lonely_if/no_lonely_if_extras_test.go
+++ b/internal/rules/no_lonely_if/no_lonely_if_extras_test.go
@@ -172,6 +172,26 @@ func TestNoLonelyIfExtras(t *testing.T) {
 				},
 			},
 
+			// ---- Dimension 4 (graceful degradation): the whitespace the fixer ----
+			// scans for interference is ECMAScript's, not Go's. U+FEFF is
+			// whitespace to JavaScript, so the braces come off…
+			{
+				Code:   "if (a) {} else {\uFEFFif (b) c();\uFEFF}",
+				Output: []string{"if (a) {} else if (b) c();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 18},
+				},
+			},
+
+			// …and U+0085 is not, so the interference check sees a character
+			// between the brace and the `if` and the diagnostic carries no fix.
+			{
+				Code: "if (a) {} else {\u0085if (b) c();\u0085}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 18},
+				},
+			},
+
 			// ---- Dimension 3: `else{` with no space before the opening brace; ----
 			// the fixer must insert a leading space so `else` and the replacement
 			// `if` text don't fuse into `elseif`.

--- a/internal/rules/no_lonely_if/no_lonely_if_upstream_test.go
+++ b/internal/rules/no_lonely_if/no_lonely_if_upstream_test.go
@@ -1,0 +1,207 @@
+// TestNoLonelyIfUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/no-lonely-if.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the no_lonely_if_extras_test.go file.
+package no_lonely_if
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLonelyIfUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLonelyIfRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "if (a) {;} else if (b) {;}"},
+			{Code: "if (a) {;} else { if (b) {;} ; }"},
+			{Code: "if (a) if (a) {} else { if (b) {} } else {}"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   "if (a) {;} else { if (b) {;} }",
+				Output: []string{"if (a) {;} else if (b) {;}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: "if (a) {\n" +
+					"  foo();\n" +
+					"} else {\n" +
+					"  if (b) {\n" +
+					"    bar();\n" +
+					"  }\n" +
+					"}",
+				Output: []string{"if (a) {\n" +
+					"  foo();\n" +
+					"} else if (b) {\n" +
+					"    bar();\n" +
+					"  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code: "if (a) {\n" +
+					"  foo();\n" +
+					"} else /* comment */ {\n" +
+					"  if (b) {\n" +
+					"    bar();\n" +
+					"  }\n" +
+					"}",
+				Output: []string{"if (a) {\n" +
+					"  foo();\n" +
+					"} else /* comment */ if (b) {\n" +
+					"    bar();\n" +
+					"  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code: "if (a) {\n" +
+					"  foo();\n" +
+					"} else {\n" +
+					"  /* otherwise, do the other thing */ if (b) {\n" +
+					"    bar();\n" +
+					"  }\n" +
+					"}",
+				// Not fixed: a comment sits between the else block's brace and the inner if.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 4, Column: 39},
+				},
+			},
+			{
+				Code: "if (a) {\n" +
+					"  foo();\n" +
+					"} else {\n" +
+					"  if /* this comment is ok */ (b) {\n" +
+					"    bar();\n" +
+					"  }\n" +
+					"}",
+				Output: []string{"if (a) {\n" +
+					"  foo();\n" +
+					"} else if /* this comment is ok */ (b) {\n" +
+					"    bar();\n" +
+					"  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code: "if (a) {\n" +
+					"  foo();\n" +
+					"} else {\n" +
+					"  if (b) {\n" +
+					"    bar();\n" +
+					"  } /* this comment will prevent this test case from being autofixed. */\n" +
+					"}",
+				// Not fixed: a comment sits between the inner if and the else block's closing brace.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code:   "if (foo) {} else { if (bar) baz(); }",
+				Output: []string{"if (foo) {} else if (bar) baz();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 20},
+				},
+			},
+			{
+				// Not fixed; removing the braces would cause a SyntaxError.
+				Code: "if (foo) {} else { if (bar) baz() } qux();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 20},
+				},
+			},
+			{
+				// This is fixed because there is a semicolon after baz().
+				Code:   "if (foo) {} else { if (bar) baz(); } qux();",
+				Output: []string{"if (foo) {} else if (bar) baz(); qux();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 1, Column: 20},
+				},
+			},
+			{
+				// Not fixed; removing the braces would change the semantics due to ASI.
+				Code: "if (foo) {\n" +
+					"} else {\n" +
+					"  if (bar) baz()\n" +
+					"}\n" +
+					"[1, 2, 3].forEach(foo);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 3, Column: 3},
+				},
+			},
+			{
+				// Not fixed; removing the braces would change the semantics due to ASI.
+				Code: "if (foo) {\n" +
+					"} else {\n" +
+					"  if (bar) baz++\n" +
+					"}\n" +
+					"foo;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 3, Column: 3},
+				},
+			},
+			{
+				// This is fixed because there is a semicolon after baz++
+				Code: "if (foo) {\n" +
+					"} else {\n" +
+					"  if (bar) baz++;\n" +
+					"}\n" +
+					"foo;",
+				Output: []string{"if (foo) {\n" +
+					"} else if (bar) baz++;\n" +
+					"foo;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 3, Column: 3},
+				},
+			},
+			{
+				// Not fixed; bar() would be interpreted as a template literal tag.
+				Code: "if (a) {\n" +
+					"  foo();\n" +
+					"} else {\n" +
+					"  if (b) bar()\n" +
+					"}\n" +
+					"`template literal`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code: "if (a) {\n" +
+					"  foo();\n" +
+					"} else {\n" +
+					"  if (b) {\n" +
+					"    bar();\n" +
+					"  } else if (c) {\n" +
+					"    baz();\n" +
+					"  } else {\n" +
+					"    qux();\n" +
+					"  }\n" +
+					"}",
+				Output: []string{"if (a) {\n" +
+					"  foo();\n" +
+					"} else if (b) {\n" +
+					"    bar();\n" +
+					"  } else if (c) {\n" +
+					"    baz();\n" +
+					"  } else {\n" +
+					"    qux();\n" +
+					"  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLonelyIf", Line: 4, Column: 3},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/braces.go
+++ b/internal/utils/braces.go
@@ -1,0 +1,73 @@
+package utils
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// IsLexicalDeclaration mirrors ESLint astUtils.isLexicalDeclaration: true for
+// let/const/using/await-using variable declarations and function/class
+// declarations.
+//
+// NOTE: Unlike ESLint (which only sees JavaScript), tsgo also parses
+// TypeScript declarations that are equally illegal as an unbraced
+// control-statement body (`if (a) enum E {}` is a syntax error). They are
+// treated the same as lexical declarations so an autofix never strips a
+// required block.
+func IsLexicalDeclaration(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindVariableStatement:
+		declList := node.AsVariableStatement().DeclarationList
+		return declList.Flags&ast.NodeFlagsBlockScoped != 0
+	case ast.KindFunctionDeclaration,
+		ast.KindClassDeclaration,
+		ast.KindEnumDeclaration,
+		ast.KindModuleDeclaration,
+		ast.KindInterfaceDeclaration,
+		ast.KindTypeAliasDeclaration,
+		ast.KindImportEqualsDeclaration:
+		return true
+	}
+	return false
+}
+
+// HasUnsafeIf mirrors ESLint astUtils.areBracesNecessary's internal
+// hasUnsafeIf: reports whether node contains an `if` statement that would
+// become associated with an `else` keyword appended directly after node.
+func HasUnsafeIf(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindIfStatement:
+		ifStmt := node.AsIfStatement()
+		if ifStmt.ElseStatement == nil {
+			return true
+		}
+		return HasUnsafeIf(ifStmt.ElseStatement)
+	case ast.KindForStatement:
+		return HasUnsafeIf(node.AsForStatement().Statement)
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		return HasUnsafeIf(node.AsForInOrOfStatement().Statement)
+	case ast.KindLabeledStatement:
+		return HasUnsafeIf(node.AsLabeledStatement().Statement)
+	case ast.KindWithStatement:
+		return HasUnsafeIf(node.AsWithStatement().Statement)
+	case ast.KindWhileStatement:
+		return HasUnsafeIf(node.AsWhileStatement().Statement)
+	default:
+		return false
+	}
+}
+
+// IsFollowedByElseKeyword reports whether the next non-trivia token after
+// node is the `else` keyword.
+func IsFollowedByElseKeyword(sourceFile *ast.SourceFile, node *ast.Node) bool {
+	token, ok := TokenAtOrAfter(sourceFile, node.End())
+	return ok && token.Kind == ast.KindElseKeyword
+}
+
+// AreBracesNecessary mirrors ESLint astUtils.areBracesNecessary: reports
+// whether the existing curly braces around a single-statement BlockStatement
+// body are necessary to preserve the semantics of the code — either because
+// the statement is a lexical declaration, or because it ends in an `if` that
+// would capture a trailing `else` once the braces are removed.
+func AreBracesNecessary(sourceFile *ast.SourceFile, block *ast.Node) bool {
+	statement := block.AsBlock().Statements.Nodes[0]
+	return IsLexicalDeclaration(statement) ||
+		(HasUnsafeIf(statement) && IsFollowedByElseKeyword(sourceFile, block))
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -491,6 +491,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unused-expressions.test.ts',
     './tests/eslint/rules/no-unused-labels.test.ts',
     './tests/eslint/rules/no-lone-blocks.test.ts',
+    './tests/eslint/rules/no-lonely-if.test.ts',
     './tests/eslint/rules/no-loop-func.test.ts',
     './tests/eslint/rules/no-multi-assign.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-lonely-if.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-lonely-if.test.ts.snap
@@ -1,0 +1,422 @@
+// Rstest Snapshot v1
+
+exports[`no-lonely-if > invalid 1`] = `
+{
+  "code": "if (a) {;} else { if (b) {;} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 2`] = `
+{
+  "code": "if (a) {
+  foo();
+} else {
+  if (b) {
+    bar();
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 3`] = `
+{
+  "code": "if (a) {
+  foo();
+} else /* comment */ {
+  if (b) {
+    bar();
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 4`] = `
+{
+  "code": "if (a) {
+  foo();
+} else {
+  /* otherwise, do the other thing */ if (b) {
+    bar();
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 39,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 5`] = `
+{
+  "code": "if (a) {
+  foo();
+} else {
+  if /* this comment is ok */ (b) {
+    bar();
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 6`] = `
+{
+  "code": "if (a) {
+  foo();
+} else {
+  if (b) {
+    bar();
+  } /* this comment will prevent this test case from being autofixed. */
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 7`] = `
+{
+  "code": "if (foo) {} else { if (bar) baz(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 8`] = `
+{
+  "code": "if (foo) {} else { if (bar) baz() } qux();",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 9`] = `
+{
+  "code": "if (foo) {} else { if (bar) baz(); } qux();",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 10`] = `
+{
+  "code": "if (foo) {
+} else {
+  if (bar) baz()
+}
+[1, 2, 3].forEach(foo);",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 11`] = `
+{
+  "code": "if (foo) {
+} else {
+  if (bar) baz++
+}
+foo;",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 12`] = `
+{
+  "code": "if (foo) {
+} else {
+  if (bar) baz++;
+}
+foo;",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 13`] = `
+{
+  "code": "if (a) {
+  foo();
+} else {
+  if (b) bar()
+}
+\`template literal\`;",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lonely-if > invalid 14`] = `
+{
+  "code": "if (a) {
+  foo();
+} else {
+  if (b) {
+    bar();
+  } else if (c) {
+    baz();
+  } else {
+    qux();
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected if as the only statement in an else block.",
+      "messageId": "unexpectedLonelyIf",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 10,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lonely-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-lonely-if.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-lonely-if.test.ts
@@ -1,0 +1,73 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors the upstream no-lonely-if valid/invalid semantic set (Layer 1). It
+// verifies rule registration + wire protocol + ESLint-compatible diagnostic
+// shape; the exhaustive edge-shape / branch lock-in coverage lives in the Go
+// suite.
+ruleTester.run('no-lonely-if', {
+  valid: [
+    'if (a) {;} else if (b) {;}',
+    'if (a) {;} else { if (b) {;} ; }',
+    'if (a) if (a) {} else { if (b) {} } else {}',
+  ],
+  invalid: [
+    {
+      code: 'if (a) {;} else { if (b) {;} }',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (a) {\n  foo();\n} else {\n  if (b) {\n    bar();\n  }\n}',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (a) {\n  foo();\n} else /* comment */ {\n  if (b) {\n    bar();\n  }\n}',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (a) {\n  foo();\n} else {\n  /* otherwise, do the other thing */ if (b) {\n    bar();\n  }\n}',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (a) {\n  foo();\n} else {\n  if /* this comment is ok */ (b) {\n    bar();\n  }\n}',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (a) {\n  foo();\n} else {\n  if (b) {\n    bar();\n  } /* this comment will prevent this test case from being autofixed. */\n}',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (foo) {} else { if (bar) baz(); }',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (foo) {} else { if (bar) baz() } qux();',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (foo) {} else { if (bar) baz(); } qux();',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (foo) {\n} else {\n  if (bar) baz()\n}\n[1, 2, 3].forEach(foo);',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (foo) {\n} else {\n  if (bar) baz++\n}\nfoo;',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (foo) {\n} else {\n  if (bar) baz++;\n}\nfoo;',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (a) {\n  foo();\n} else {\n  if (b) bar()\n}\n`template literal`;',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+    {
+      code: 'if (a) {\n  foo();\n} else {\n  if (b) {\n    bar();\n  } else if (c) {\n    baz();\n  } else {\n    qux();\n  }\n}',
+      errors: [{ messageId: 'unexpectedLonelyIf' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-lonely-if` rule from ESLint to rslint.

Disallows `if` statements as the only statement in `else` blocks, suggesting the `else if` form instead. Includes autofix.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-lonely-if
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-lonely-if.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).