### PR TITLE
fix: align block-scoped-var with ESLint

### DIFF
--- a/internal/plugins/typescript/rules/fixtures/tsconfig.block-scoped-var-jsx.json
+++ b/internal/plugins/typescript/rules/fixtures/tsconfig.block-scoped-var-jsx.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxFactory": "preact.h",
+    "jsxFragmentFactory": "preact.Fragment",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "types": []
+  }
+}

--- a/internal/rules/block_scoped_var/block_scoped_var.go
+++ b/internal/rules/block_scoped_var/block_scoped_var.go
@@ -2,13 +2,18 @@ package block_scoped_var
 
 import (
 	"fmt"
-	"sort"
+	"slices"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/binder"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // https://eslint.org/docs/latest/rules/block-scoped-var
@@ -18,83 +23,1051 @@ var BlockScopedVarRule = rule.Rule{
 	Run:    run,
 }
 
-// varOccurrence is one `var`-declared binding identifier, paired with the
-// block-scope range that was active around its declaration.
+// A varOccurrence is the one definition ESLint associates with a variable for
+// one VariableDeclaration node, paired with the binding context active there.
+// A declaration list can bind the same variable more than once, but
+// sourceCode.getDeclaredVariables returns that variable only once.
 type varOccurrence struct {
 	identifier *ast.Node
-	symbol     *ast.Symbol
 	scopeRange core.TextRange
 }
 
+type referenceEvent struct {
+	identifier   *ast.Node
+	multiplicity int
+	bindingRange bool
+	textRange    core.TextRange
+}
+
+type varGroup struct {
+	symbol            *ast.Symbol
+	name              string
+	host              *ast.Node
+	functionBodyStart int
+	mayHaveClassSelf  bool
+	occurrences       []varOccurrence
+	references        []referenceEvent
+}
+
+type pendingSyntheticReference struct {
+	target *ast.Symbol
+	event  referenceEvent
+}
+
+type canonicalKey struct {
+	host *ast.Node
+	name string
+}
+
+type blockScopedVarState struct {
+	ctx                        rule.RuleContext
+	resolver                   binder.NameResolver
+	canonical                  map[canonicalKey]*ast.Symbol
+	groups                     map[*ast.Symbol]*varGroup
+	groupOrder                 []*varGroup
+	ordinarySeen               map[*ast.Node]*varGroup
+	pendingSynthetic           []pendingSyntheticReference
+	nonVarDeclarations         []*ast.Node
+	classExpressions           []*ast.Node
+	namespaceExports           []*ast.Node
+	exportSpecifiers           []*ast.Node
+	indexSignatures            []*ast.Node
+	jsxNamespacedNames         []*ast.Node
+	functions                  []*ast.Node
+	parameterTypeScopes        []*ast.Node
+	hasTypeSignatureParameters bool
+	hasConditionalInfer        bool
+	classNames                 map[string]struct{}
+	hasJSX                     bool
+}
+
 func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {
-	if ctx.SourceFile == nil {
+	if ctx.SourceFile == nil || !containsVarKeywordCandidate(ctx.SourceFile.Text()) {
 		return nil
 	}
 
-	var occurrences []varOccurrence
-	declsBySymbol := make(map[*ast.Symbol][]*ast.Node)
+	options := &core.CompilerOptions{}
+	if ctx.Program != nil {
+		options = ctx.Program.Options()
+	}
+	resolver := binder.NameResolver{CompilerOptions: options}
+	if ctx.SourceFile.IsBound() && ast.IsGlobalSourceFile(ctx.SourceFile.AsNode()) {
+		resolver.Globals = ctx.SourceFile.Locals
+	}
 
-	var visit func(node *ast.Node)
-	visit = func(node *ast.Node) {
-		if node.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(node) {
-			scopeRange := blockScopeRange(ctx.SourceFile, node)
-			// A for-in/for-of head has no `=` of its own, but the loop
-			// implicitly assigns into the binding on every iteration, which
-			// ESLint's scope analysis treats the same as an explicit
-			// initializer for this rule's purposes.
-			isForInOrForOf := node.Parent != nil &&
-				(node.Parent.Kind == ast.KindForInStatement || node.Parent.Kind == ast.KindForOfStatement)
-			utils.ForEachVariableDeclarationBinding(node, func(declaration *ast.Node, identifier *ast.Node, _ string) {
-				symbol := identifier.Parent.Symbol()
-				if symbol == nil {
-					return
-				}
-				occurrences = append(occurrences, varOccurrence{
+	state := &blockScopedVarState{
+		ctx:      ctx,
+		resolver: resolver,
+	}
+	listeners := rule.RuleListeners{
+		ast.KindVariableDeclarationList:        state.collectVariableDeclarationList,
+		rule.ListenerOnExit(ast.KindEndOfFile): state.finish,
+	}
+	if strings.Contains(ctx.SourceFile.Text(), "class") {
+		listeners[ast.KindClassDeclaration] = state.collectClassDeclaration
+	}
+
+	// TypeScript's resolver has one known scope-manager mismatch for a named
+	// class expression's class-level decorator. Collect only those uncommon
+	// nodes, and repair references lazily at EOF.
+	if (ctx.SourceFile.ScriptKind == core.ScriptKindTS || ctx.SourceFile.ScriptKind == core.ScriptKindTSX) &&
+		strings.Contains(ctx.SourceFile.Text(), "@") {
+		listeners[ast.KindClassExpression] = state.collectDecoratedClassExpression
+	}
+	if ctx.SourceFile.ScriptKind == core.ScriptKindTS || ctx.SourceFile.ScriptKind == core.ScriptKindTSX {
+		listeners[ast.KindNamespaceExportDeclaration] = state.collectNamespaceExportDeclaration
+		listeners[ast.KindExportSpecifier] = state.collectExportSpecifier
+		listeners[ast.KindIndexSignature] = state.collectIndexSignature
+	}
+
+	// TSESTree treats both pieces of a namespaced TSX tag as value references;
+	// Espree does not. RefStore deliberately follows Espree, so collect the TSX
+	// nodes here for rule-local TSESTree parity.
+	if ctx.SourceFile.ScriptKind == core.ScriptKindTSX {
+		listeners[ast.KindJsxOpeningElement] = state.collectJSX
+		listeners[ast.KindJsxSelfClosingElement] = state.collectJSX
+		listeners[ast.KindJsxFragment] = state.collectJSX
+		listeners[ast.KindJsxNamespacedName] = state.collectJsxNamespacedName
+	}
+
+	return listeners
+}
+
+func (state *blockScopedVarState) collectJSX(_ *ast.Node) {
+	state.hasJSX = true
+}
+
+func (state *blockScopedVarState) collectClassDeclaration(node *ast.Node) {
+	if node.Name() == nil {
+		return
+	}
+	if state.classNames == nil {
+		state.classNames = make(map[string]struct{})
+	}
+	state.classNames[node.Name().Text()] = struct{}{}
+}
+
+func containsVarKeywordCandidate(text string) bool {
+	for offset := 0; offset < len(text); {
+		index := strings.Index(text[offset:], "var")
+		if index == -1 {
+			return false
+		}
+		index += offset
+		beforeBoundary := index == 0 || !isASCIIIdentifierPart(text[index-1])
+		after := index + len("var")
+		afterBoundary := after == len(text) || !isASCIIIdentifierPart(text[after])
+		if beforeBoundary && afterBoundary {
+			return true
+		}
+		offset = index + len("var")
+	}
+	return false
+}
+
+func isASCIIIdentifierPart(character byte) bool {
+	return character >= 'a' && character <= 'z' ||
+		character >= 'A' && character <= 'Z' ||
+		character >= '0' && character <= '9' ||
+		character == '_' || character == '$'
+}
+
+func (state *blockScopedVarState) collectVariableDeclarationList(node *ast.Node) {
+	if !utils.IsVarKeyword(node) {
+		state.nonVarDeclarations = append(state.nonVarDeclarations, node)
+		return
+	}
+
+	scopeRange := blockScopeRange(state.ctx.SourceFile, node)
+	reportable := scopeRange.Pos() != 0 || scopeRange.End() < state.ctx.SourceFile.AsNode().End()
+	isForInOrOf := node.Parent != nil &&
+		(node.Parent.Kind == ast.KindForInStatement || node.Parent.Kind == ast.KindForOfStatement)
+	host := utils.FindEnclosingScope(node)
+	var firstOccurrence *varGroup
+	var seenOccurrences map[*varGroup]struct{}
+
+	utils.ForEachVariableDeclarationBinding(node, func(declaration *ast.Node, identifier *ast.Node, name string) {
+		symbol := state.canonicalSymbol(identifier, name, host)
+		if symbol == nil {
+			return
+		}
+
+		group := state.group(symbol, host, name)
+
+		newOccurrence := firstOccurrence == nil
+		if firstOccurrence == nil {
+			firstOccurrence = group
+		} else if group != firstOccurrence {
+			if seenOccurrences == nil {
+				seenOccurrences = map[*varGroup]struct{}{firstOccurrence: {}}
+			}
+			if _, seen := seenOccurrences[group]; !seen {
+				seenOccurrences[group] = struct{}{}
+				newOccurrence = true
+			}
+		}
+		if newOccurrence {
+			if reportable {
+				group.occurrences = append(group.occurrences, varOccurrence{
 					identifier: identifier,
-					symbol:     symbol,
 					scopeRange: scopeRange,
 				})
-				// ESLint's eslint-scope only creates a self-reference for a
-				// declarator that is assigned a value — a bare `var a;` never
-				// becomes a "reference," so it can never flag (or be flagged
-				// by) a sibling `var` declaration of the same name.
-				if isForInOrForOf || hasInitializer(declaration) {
-					// NOTE: Unlike ESLint, a binding-pattern element with its
-					// own default value (`var { a = 1 } = x`) is only added
-					// once here, not twice. eslint-scope creates two
-					// self-references for such an element instead of one,
-					// which (only when that element is later cross-checked
-					// against a sibling `var` of the same name) makes ESLint
-					// emit the exact same diagnostic twice. This is an
-					// eslint-scope implementation quirk, not a deliberate
-					// part of the rule; see "Differences from ESLint" below.
-					declsBySymbol[symbol] = append(declsBySymbol[symbol], identifier)
+			}
+		}
+
+		multiplicity := variableDeclarationWriteMultiplicity(declaration, identifier, isForInOrOf)
+		if multiplicity == 0 {
+			return
+		}
+		if target := state.resolve(identifier, name, ast.SymbolFlagsValue|ast.SymbolFlagsAlias); target != nil {
+			state.addSyntheticReference(
+				target,
+				referenceEvent{
+					identifier:   identifier,
+					multiplicity: multiplicity,
+					bindingRange: true,
+				},
+			)
+		}
+	})
+}
+
+func (state *blockScopedVarState) collectNonVarDeclarationWrites(node *ast.Node, relevantNames map[string]struct{}) {
+	isForInOrOf := node.Parent != nil &&
+		(node.Parent.Kind == ast.KindForInStatement || node.Parent.Kind == ast.KindForOfStatement)
+	utils.ForEachVariableDeclarationBinding(node, func(declaration *ast.Node, identifier *ast.Node, name string) {
+		if _, relevant := relevantNames[name]; !relevant {
+			return
+		}
+		multiplicity := variableDeclarationWriteMultiplicity(declaration, identifier, isForInOrOf)
+		if multiplicity == 0 {
+			return
+		}
+		if target := state.resolve(identifier, name, ast.SymbolFlagsValue|ast.SymbolFlagsAlias); target != nil {
+			state.addSyntheticReference(
+				target,
+				referenceEvent{
+					identifier:   identifier,
+					multiplicity: multiplicity,
+					bindingRange: true,
+				},
+			)
+		}
+	})
+}
+
+func (state *blockScopedVarState) addSyntheticReference(target *ast.Symbol, event referenceEvent) {
+	if group := state.groups[target]; group != nil {
+		group.references = append(group.references, event)
+		return
+	}
+	state.pendingSynthetic = append(state.pendingSynthetic, pendingSyntheticReference{
+		target: target,
+		event:  event,
+	})
+}
+
+func (state *blockScopedVarState) canonicalSymbol(identifier *ast.Node, name string, host *ast.Node) *ast.Symbol {
+	if host == nil {
+		return utils.BindingNameSymbol(identifier)
+	}
+	if state.canonical == nil {
+		state.canonical = make(map[canonicalKey]*ast.Symbol)
+	}
+	key := canonicalKey{host: host, name: name}
+	if symbol, ok := state.canonical[key]; ok {
+		return symbol
+	}
+
+	symbol := state.resolve(host, name, ast.SymbolFlagsValue|ast.SymbolFlagsAlias)
+	if symbol == nil {
+		symbol = utils.BindingNameSymbol(identifier)
+	}
+	state.canonical[key] = symbol
+	return symbol
+}
+
+func (state *blockScopedVarState) resolve(location *ast.Node, name string, meaning ast.SymbolFlags) *ast.Symbol {
+	if location == nil || name == "" {
+		return nil
+	}
+	return state.resolver.Resolve(location, name, meaning, nil, false, false)
+}
+
+func (state *blockScopedVarState) group(symbol *ast.Symbol, host *ast.Node, name string) *varGroup {
+	if state.groups == nil {
+		state.groups = make(map[*ast.Symbol]*varGroup)
+	}
+	if group := state.groups[symbol]; group != nil {
+		return group
+	}
+	group := &varGroup{symbol: symbol, name: name, host: host}
+	if host != nil && ast.IsFunctionLike(host) && host.Body() != nil {
+		group.functionBodyStart = utils.TrimNodeTextRange(state.ctx.SourceFile, host.Body()).Pos()
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration != nil &&
+			(declaration.Kind == ast.KindClassDeclaration || declaration.Kind == ast.KindClassExpression) {
+			group.mayHaveClassSelf = true
+			break
+		}
+	}
+	state.groups[symbol] = group
+	state.groupOrder = append(state.groupOrder, group)
+	return group
+}
+
+func (state *blockScopedVarState) collectDecoratedClassExpression(node *ast.Node) {
+	if node.Name() != nil && len(node.Decorators()) != 0 {
+		state.classExpressions = append(state.classExpressions, node)
+	}
+}
+
+func (state *blockScopedVarState) collectNamespaceExportDeclaration(node *ast.Node) {
+	if node.Name() != nil {
+		state.namespaceExports = append(state.namespaceExports, node.Name())
+	}
+}
+
+func (state *blockScopedVarState) collectExportSpecifier(node *ast.Node) {
+	if utils.IsReExportSpecifier(node) {
+		return
+	}
+	specifier := node.AsExportSpecifier()
+	localName := specifier.Name()
+	if specifier.PropertyName != nil {
+		localName = specifier.PropertyName
+	}
+	if localName != nil && localName.Kind == ast.KindIdentifier {
+		state.exportSpecifiers = append(state.exportSpecifiers, localName)
+	}
+}
+
+func (state *blockScopedVarState) collectIndexSignature(node *ast.Node) {
+	state.indexSignatures = append(state.indexSignatures, node)
+}
+
+func (state *blockScopedVarState) collectJsxNamespacedName(node *ast.Node) {
+	if node.Parent == nil || node.Parent.Kind == ast.KindJsxAttribute {
+		return
+	}
+	switch node.Parent.Kind {
+	case ast.KindJsxOpeningElement, ast.KindJsxClosingElement, ast.KindJsxSelfClosingElement:
+		state.jsxNamespacedNames = append(state.jsxNamespacedNames, node)
+	}
+}
+
+func (state *blockScopedVarState) finish(_ *ast.Node) {
+	if len(state.groupOrder) == 0 {
+		return
+	}
+	relevantNames := make(map[string]struct{})
+	for _, group := range state.groupOrder {
+		if _, hasClass := state.classNames[group.name]; hasClass {
+			group.mayHaveClassSelf = true
+		}
+		if len(group.occurrences) != 0 {
+			relevantNames[group.name] = struct{}{}
+		}
+	}
+	if len(relevantNames) == 0 {
+		return
+	}
+	state.hasConditionalInfer = strings.Contains(state.ctx.SourceFile.Text(), "infer")
+	state.collectRelevantFunctions(relevantNames)
+	for _, declaration := range state.nonVarDeclarations {
+		state.collectNonVarDeclarationWrites(declaration, relevantNames)
+	}
+
+	for _, pending := range state.pendingSynthetic {
+		if group := state.groups[pending.target]; group != nil && len(group.occurrences) != 0 {
+			group.references = append(group.references, pending.event)
+		}
+	}
+	state.addParameterReferences()
+	state.addMergedTypeReferences()
+	state.addTypeParameterParameterReferences(relevantNames)
+	state.addPreBodyReferences(relevantNames)
+	state.addDecoratedClassExpressionReferences()
+	state.addNamespaceExportReferences()
+	state.addExportSpecifierReferences(relevantNames)
+	state.addIndexSignatureReferences(relevantNames)
+	state.addJsxNamespacedReferences()
+	state.addTSXFactoryReferences()
+
+	// Query the shared reference index exactly once per canonical variable.
+	// Reassign the rare pre-body resolution mismatch to the true upper target.
+	if state.ctx.Refs != nil {
+		for _, group := range state.groupOrder {
+			if len(group.occurrences) == 0 {
+				continue
+			}
+			for _, identifier := range state.ctx.Refs.References(group.symbol) {
+				target := group
+				if isTypeOnlyHeritageReference(identifier) {
+					// RefStore follows TypeScript's value treatment for a
+					// qualified heritage root. TSESTree visits it in type space;
+					// addMergedTypeReferences already restored real type targets.
+					target = nil
+				} else if group.mayHaveClassSelf && state.classScopeShadowsGroup(identifier, group) {
+					target = nil
+				} else if group.functionBodyStart != 0 &&
+					utils.TrimNodeTextRange(state.ctx.SourceFile, identifier).Pos() < group.functionBodyStart {
+					target = state.validReferenceTarget(
+						group.symbol,
+						identifier,
+						blockScopedVarReferenceMeaning(identifier),
+					)
+				}
+				state.addIndexedReference(target, identifier)
+			}
+		}
+	}
+
+	var diagnostics []diagnostic
+	for _, group := range state.groupOrder {
+		if len(group.occurrences) == 0 {
+			continue
+		}
+		slices.SortStableFunc(group.references, func(left, right referenceEvent) int {
+			return left.identifier.Pos() - right.identifier.Pos()
+		})
+		for index := range group.references {
+			event := &group.references[index]
+			if event.bindingRange {
+				event.textRange = utils.GetESTreeBindingIdentifierRange(state.ctx.SourceFile, event.identifier)
+			} else {
+				event.textRange = utils.TrimNodeTextRange(state.ctx.SourceFile, event.identifier)
+			}
+		}
+		for _, occurrence := range group.occurrences {
+			state.appendOccurrenceDiagnostics(&diagnostics, group, occurrence)
+		}
+	}
+
+	slices.SortStableFunc(diagnostics, func(left, right diagnostic) int {
+		return left.textRange.Pos() - right.textRange.Pos()
+	})
+	for _, item := range diagnostics {
+		state.ctx.ReportRange(item.textRange, item.message)
+	}
+}
+
+// collectRelevantFunctions reuses the binder's source-ordered lexical
+// container chain. This avoids a listener callback on every function and
+// still includes functions whose header was incorrectly bound to a body-only
+// declaration rather than to an outer reportable group.
+func (state *blockScopedVarState) collectRelevantFunctions(relevantNames map[string]struct{}) {
+	for container := state.ctx.SourceFile.AsNode(); container != nil; {
+		functionLike := ast.IsFunctionLike(container)
+		typeSignature := isTypeSignatureContainer(container)
+		hasParameters := false
+		hasTypeParameters := false
+		if functionLike || typeSignature {
+			hasParameters = len(container.Parameters()) != 0
+			hasTypeParameters = len(container.TypeParameters()) != 0
+		}
+		needsFunction := functionLike && container.Body() != nil &&
+			(hasParameters || container.Type() != nil || hasTypeParameters)
+		needsParameterTypeScope := hasParameters && hasTypeParameters && isParameterBeforeTypeParameterScope(container)
+		hasRelevantLocal := false
+		if needsFunction || needsParameterTypeScope {
+			hasRelevantLocal = symbolTableContainsAny(container.Locals(), relevantNames)
+		}
+		if typeSignature && hasParameters {
+			state.hasTypeSignatureParameters = true
+		}
+		if hasRelevantLocal && needsParameterTypeScope {
+			state.parameterTypeScopes = append(state.parameterTypeScopes, container)
+		}
+		if hasRelevantLocal && needsFunction {
+			state.functions = append(state.functions, container)
+		}
+		data := container.LocalsContainerData()
+		if data == nil {
+			break
+		}
+		container = data.NextContainer
+	}
+}
+
+func isTypeSignatureContainer(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionType,
+		ast.KindConstructorType,
+		ast.KindCallSignature,
+		ast.KindConstructSignature,
+		ast.KindMethodSignature,
+		ast.KindIndexSignature:
+		return true
+	}
+	return false
+}
+
+func isParameterBeforeTypeParameterScope(node *ast.Node) bool {
+	return node != nil && (ast.IsFunctionLike(node) || isTypeSignatureContainer(node)) &&
+		node.Kind != ast.KindIndexSignature
+}
+
+func symbolTableContainsAny(symbols ast.SymbolTable, names map[string]struct{}) bool {
+	if len(symbols) < len(names) {
+		for name := range symbols {
+			if _, exists := names[name]; exists {
+				return true
+			}
+		}
+		return false
+	}
+	for name := range names {
+		if symbols[name] != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *blockScopedVarState) addParameterReferences() {
+	for _, function := range state.functions {
+		for _, parameter := range function.Parameters() {
+			utils.CollectBindingNames(parameter.Name(), func(identifier *ast.Node, name string) {
+				canonical := state.canonical[canonicalKey{host: function, name: name}]
+				group := state.groups[canonical]
+				if group == nil {
+					return
+				}
+				multiplicity := parameterWriteMultiplicity(identifier, parameter)
+				if multiplicity != 0 {
+					group.references = append(group.references, referenceEvent{
+						identifier:   identifier,
+						multiplicity: multiplicity,
+						bindingRange: true,
+					})
 				}
 			})
 		}
-		node.ForEachChild(func(child *ast.Node) bool {
-			visit(child)
-			return false
-		})
 	}
-	visit(ctx.SourceFile.AsNode())
+}
 
-	var diagnostics []diagnostic
-	for _, occurrence := range occurrences {
-		diagnostics = append(diagnostics, checkOccurrence(ctx, occurrence, declsBySymbol[occurrence.symbol])...)
+// addPreBodyReferences repairs a tsgo resolver edge case without putting a
+// Parameter listener on every file. NameResolver can expose a function-body
+// declaration to an identifier in that function's header when another header
+// expression requires a scope change. TSESTree rejects such a target unless
+// the merged variable has at least one definition before the body.
+func (state *blockScopedVarState) addPreBodyReferences(relevantNames map[string]struct{}) {
+	if state.ctx.Refs == nil || len(state.functions) == 0 {
+		return
 	}
 
-	// ESLint sorts all of a rule's reports by position before emitting them,
-	// so two sibling `var` declarations that flag each other interleave by
-	// report location rather than by declaration-processing order.
-	sort.SliceStable(diagnostics, func(i, j int) bool {
-		return diagnostics[i].textRange.Pos() < diagnostics[j].textRange.Pos()
+	for _, host := range state.functions {
+		visit := func(root *ast.Node) {
+			utils.VisitDescendants(root, func(identifier *ast.Node) bool {
+				if identifier.Kind != ast.KindIdentifier || utils.IsNonReferenceIdentifier(identifier) {
+					return true
+				}
+				if _, relevant := relevantNames[identifier.Text()]; !relevant {
+					return true
+				}
+				symbol := state.ctx.Refs.ResolveInFile(identifier)
+				meaning := blockScopedVarReferenceMeaning(identifier)
+				if symbol != nil {
+					symbol = state.repairClassExpressionDecoratorTarget(identifier, symbol, meaning)
+				}
+				symbol = state.preBodyMergedSymbol(identifier, symbol, meaning)
+				state.addOrdinaryReference(state.validReferenceTarget(symbol, identifier, meaning), identifier)
+				return true
+			})
+		}
+		for _, parameter := range host.Parameters() {
+			visit(parameter)
+		}
+		visit(host.Type())
+		for _, typeParameter := range host.TypeParameters() {
+			visit(typeParameter)
+		}
+	}
+}
+
+// The TSESTree referencer defines every parameter before it visits a
+// function's type parameters, even though type parameters appear first in
+// source. Redirect value references in constraints/defaults to that parameter
+// variable (and its canonical var group, when one exists).
+func (state *blockScopedVarState) addTypeParameterParameterReferences(relevantNames map[string]struct{}) {
+	for _, scope := range state.parameterTypeScopes {
+		parameterNames := make(map[string]struct{})
+		for _, parameter := range scope.Parameters() {
+			utils.CollectBindingNames(parameter.Name(), func(_ *ast.Node, name string) {
+				if _, relevant := relevantNames[name]; relevant {
+					parameterNames[name] = struct{}{}
+				}
+			})
+		}
+		if len(parameterNames) == 0 {
+			continue
+		}
+		shadowed := make(map[string]int)
+		for _, typeParameter := range scope.TypeParameters() {
+			state.visitTypeParameterParameterReferences(typeParameter, scope, parameterNames, shadowed)
+		}
+	}
+}
+
+func (state *blockScopedVarState) visitTypeParameterParameterReferences(
+	node *ast.Node,
+	host *ast.Node,
+	parameterNames map[string]struct{},
+	shadowed map[string]int,
+) {
+	if node == nil {
+		return
+	}
+
+	if isFunctionTypeScope(node) {
+		// A method signature's computed key is evaluated outside its function
+		// type scope. Its parameters, type parameters, and return type are
+		// evaluated after all value parameters have been defined.
+		if node.Kind == ast.KindMethodSignature {
+			if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+				state.visitTypeParameterParameterReferences(
+					name.AsComputedPropertyName().Expression,
+					host,
+					parameterNames,
+					shadowed,
+				)
+			}
+		}
+
+		var added []string
+		for _, parameter := range node.Parameters() {
+			utils.CollectBindingNames(parameter.Name(), func(_ *ast.Node, name string) {
+				if _, relevant := parameterNames[name]; !relevant {
+					return
+				}
+				shadowed[name]++
+				added = append(added, name)
+			})
+		}
+		for _, parameter := range node.Parameters() {
+			state.visitTypeParameterParameterReferences(parameter.Type(), host, parameterNames, shadowed)
+		}
+		for _, typeParameter := range node.TypeParameters() {
+			state.visitTypeParameterParameterReferences(typeParameter, host, parameterNames, shadowed)
+		}
+		state.visitTypeParameterParameterReferences(node.Type(), host, parameterNames, shadowed)
+		for _, name := range added {
+			shadowed[name]--
+		}
+		return
+	}
+
+	if node.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(node) {
+		name := node.Text()
+		if _, parameter := parameterNames[name]; parameter && referenceMeaningIncludesValue(blockScopedVarReferenceMeaning(node)) {
+			if shadowed[name] != 0 {
+				state.suppressOrdinaryReference(node)
+				return
+			}
+			canonical := state.canonical[canonicalKey{host: host, name: name}]
+			if group := state.groups[canonical]; group != nil {
+				state.addOrdinaryReference(group, node)
+			} else {
+				state.suppressOrdinaryReference(node)
+			}
+		}
+		return
+	}
+
+	node.ForEachChild(func(child *ast.Node) bool {
+		state.visitTypeParameterParameterReferences(child, host, parameterNames, shadowed)
+		return false
 	})
-	for _, d := range diagnostics {
-		ctx.ReportRange(d.textRange, d.message)
-	}
+}
 
+func isFunctionTypeScope(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionType,
+		ast.KindConstructorType,
+		ast.KindCallSignature,
+		ast.KindConstructSignature,
+		ast.KindMethodSignature:
+		return true
+	}
+	return false
+}
+
+func referenceMeaningIncludesValue(meaning ast.SymbolFlags) bool {
+	requested := meaning &^ ast.SymbolFlagsAlias
+	return requested&ast.SymbolFlagsValue == ast.SymbolFlagsValue ||
+		requested == ast.SymbolFlagsFunctionScopedVariable
+}
+
+func (state *blockScopedVarState) preBodyMergedSymbol(identifier *ast.Node, symbol *ast.Symbol, meaning ast.SymbolFlags) *ast.Symbol {
+	if identifier == nil {
+		return symbol
+	}
+	referenceStart := utils.TrimNodeTextRange(state.ctx.SourceFile, identifier).Pos()
+	for current := identifier.Parent; current != nil; current = current.Parent {
+		if !ast.IsFunctionLike(current) || current.Body() == nil ||
+			referenceStart >= utils.TrimNodeTextRange(state.ctx.SourceFile, current.Body()).Pos() {
+			continue
+		}
+		if methodParameterDecoratorForReference(identifier, current) != nil {
+			continue
+		}
+		canonical := state.canonical[canonicalKey{host: current, name: identifier.Text()}]
+		group := state.groups[canonical]
+		if group == nil || !groupSupportsMeaning(group, meaning) {
+			continue
+		}
+		if symbol == group.symbol || !symbolHasDefinitionInsideNode(symbol, current) {
+			return group.symbol
+		}
+		return symbol
+	}
+	return symbol
+}
+
+func groupSupportsMeaning(group *varGroup, meaning ast.SymbolFlags) bool {
+	if group == nil {
+		return false
+	}
+	requested := meaning &^ ast.SymbolFlagsAlias
+	return group.symbol.Flags&requested != 0 ||
+		requested&ast.SymbolFlagsType == ast.SymbolFlagsType &&
+			group.symbol.Flags&ast.SymbolFlagsNamespace != 0
+}
+
+func symbolHasDefinitionInsideNode(symbol *ast.Symbol, node *ast.Node) bool {
+	if symbol == nil || node == nil {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration != nil && declaration.Pos() >= node.Pos() && declaration.End() <= node.End() {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *blockScopedVarState) addOrdinaryReference(group *varGroup, identifier *ast.Node) {
+	if group == nil || identifier == nil || state.isIgnoredOrdinaryReference(identifier) {
+		return
+	}
+	if state.ordinarySeen == nil {
+		state.ordinarySeen = make(map[*ast.Node]*varGroup)
+	}
+	if _, seen := state.ordinarySeen[identifier]; seen {
+		return
+	}
+	state.ordinarySeen[identifier] = group
+	state.appendOrdinaryReference(group, identifier)
+}
+
+func (state *blockScopedVarState) addIndexedReference(group *varGroup, identifier *ast.Node) {
+	if _, handled := state.ordinarySeen[identifier]; handled {
+		return
+	}
+	if group == nil || identifier == nil || state.isIgnoredOrdinaryReference(identifier) {
+		return
+	}
+	state.appendOrdinaryReference(group, identifier)
+}
+
+func (state *blockScopedVarState) suppressOrdinaryReference(identifier *ast.Node) {
+	if identifier == nil {
+		return
+	}
+	if state.ordinarySeen == nil {
+		state.ordinarySeen = make(map[*ast.Node]*varGroup)
+	}
+	if _, handled := state.ordinarySeen[identifier]; !handled {
+		state.ordinarySeen[identifier] = nil
+	}
+}
+
+func (state *blockScopedVarState) isIgnoredOrdinaryReference(identifier *ast.Node) bool {
+	return isESLintIntrinsicJsxTag(identifier) ||
+		isIgnoredImportTypeQualifier(identifier) ||
+		isIgnoredCompoundPatternReference(identifier) ||
+		state.hasConditionalInfer && isConditionalInferShadowed(identifier) ||
+		state.hasTypeSignatureParameters && isIgnoredFunctionTypeParameterReference(identifier) ||
+		state.isIgnoredEspreeClosingJsxTag(identifier)
+}
+
+// ESTree exposes a direct array/object left-hand side as a Pattern only for a
+// simple `=` assignment. For a parser-accepted compound assignment, the TSE
+// referencer intentionally skips that malformed pattern subtree altogether.
+func isIgnoredCompoundPatternReference(identifier *ast.Node) bool {
+	for current := identifier; current != nil && current.Parent != nil; current = current.Parent {
+		parent := current.Parent
+		if parent.Kind != ast.KindBinaryExpression {
+			continue
+		}
+		binary := parent.AsBinaryExpression()
+		if binary.Left != current || binary.OperatorToken == nil ||
+			!ast.IsCompoundAssignmentOperator(binary.OperatorToken.Kind) {
+			continue
+		}
+		return current.Kind == ast.KindArrayLiteralExpression ||
+			current.Kind == ast.KindObjectLiteralExpression
+	}
+	return false
+}
+
+// TSESTree keeps infer bindings in the surrounding conditional-type scope.
+// Resolution happens when that scope closes, so an infer appearing later in
+// the check/extends/true region shadows same-named outer variables throughout
+// that whole region. The false branch is visited after the scope closes.
+func isConditionalInferShadowed(identifier *ast.Node) bool {
+	if identifier == nil {
+		return false
+	}
+	if referenceMeaningIncludesValue(blockScopedVarReferenceMeaning(identifier)) {
+		return false
+	}
+	for current := identifier; current != nil && current.Parent != nil; current = current.Parent {
+		parent := current.Parent
+		if parent.Kind != ast.KindConditionalType {
+			continue
+		}
+		conditional := parent.AsConditionalTypeNode()
+		if conditional.FalseType == current {
+			continue
+		}
+		shadowed := false
+		utils.VisitDescendants(parent, func(node *ast.Node) bool {
+			if shadowed || node.Kind != ast.KindInferType {
+				return true
+			}
+			declaration := node.AsInferTypeNode().TypeParameter.AsTypeParameterDeclaration()
+			if declaration.Name().Text() == identifier.Text() && inferTargetsConditional(node, parent) {
+				shadowed = true
+			}
+			return true
+		})
+		if shadowed {
+			return true
+		}
+	}
+	return false
+}
+
+func inferTargetsConditional(inferType *ast.Node, target *ast.Node) bool {
+	for current := inferType; current != nil && current.Parent != nil; current = current.Parent {
+		parent := current.Parent
+		if parent.Kind != ast.KindConditionalType {
+			continue
+		}
+		conditional := parent.AsConditionalTypeNode()
+		if conditional.FalseType == current {
+			continue
+		}
+		return parent == target
+	}
+	return false
+}
+
+func (state *blockScopedVarState) isIgnoredEspreeClosingJsxTag(identifier *ast.Node) bool {
+	if state.ctx.SourceFile.ScriptKind != core.ScriptKindJS &&
+		state.ctx.SourceFile.ScriptKind != core.ScriptKindJSX {
+		return false
+	}
+	tagName := identifier
+	for tagName.Parent != nil && tagName.Parent.Kind == ast.KindPropertyAccessExpression &&
+		tagName.Parent.AsPropertyAccessExpression().Expression == tagName {
+		tagName = tagName.Parent
+	}
+	return tagName.Parent != nil && tagName.Parent.Kind == ast.KindJsxClosingElement
+}
+
+func (state *blockScopedVarState) appendOrdinaryReference(group *varGroup, identifier *ast.Node) {
+	group.references = append(group.references, referenceEvent{
+		identifier:   identifier,
+		multiplicity: ordinaryReferenceMultiplicity(identifier),
+	})
+}
+
+func isESLintIntrinsicJsxTag(identifier *ast.Node) bool {
+	if identifier == nil || !ast.IsJsxTagName(identifier) {
+		return false
+	}
+	name := identifier.Text()
+	if name == "" || name == "this" {
+		return false
+	}
+	if name[0] < utf8.RuneSelf {
+		return name[0] >= 'a' && name[0] <= 'z'
+	}
+	first, size := utf8.DecodeRuneInString(name)
+	if first > 0xffff {
+		// JavaScript indexes strings by UTF-16 code unit. An astral tag starts
+		// with an uncased high surrogate and is therefore component-like.
+		return false
+	}
+	// ESLint's Node runtime follows Unicode 16.0, while the Go/x-text tables
+	// used by this build predate the two new uppercase mappings below.
+	if first == '\u019b' || first == '\u0264' {
+		return true
+	}
+	firstText := name[:size]
+	return cases.Upper(language.Und).String(firstText) != firstText
+}
+
+func (state *blockScopedVarState) validReferenceTarget(symbol *ast.Symbol, identifier *ast.Node, meaning ast.SymbolFlags) *varGroup {
+	for symbol != nil {
+		host := invalidFunctionBodyResolution(state.ctx.SourceFile, identifier, symbol)
+		if host == nil {
+			group := state.groups[symbol]
+			if state.classScopeShadowsGroup(identifier, group) {
+				return nil
+			}
+			return group
+		}
+		if host.Kind == ast.KindFunctionExpression && host.Name() != nil && host.Name().Text() == identifier.Text() {
+			// FunctionExpressionNameScope sits between the function and its
+			// lexical parent; it is never a var group owned by this rule.
+			return nil
+		}
+		symbol = state.resolve(host.Parent, identifier.Text(), meaning)
+	}
 	return nil
+}
+
+// A named class has a second, class-local scope-manager variable for its
+// self-reference. TypeScript can merge that name with an outer var symbol, so
+// separate references in the class scope from the outer reportable group.
+// Class-level decorators are visited before the class scope exists.
+func (state *blockScopedVarState) classScopeShadowsGroup(identifier *ast.Node, group *varGroup) bool {
+	if identifier == nil || group == nil {
+		return false
+	}
+	for current := identifier.Parent; current != nil; current = current.Parent {
+		if current.Kind != ast.KindClassDeclaration && current.Kind != ast.KindClassExpression {
+			continue
+		}
+		if current.Name() == nil || current.Name().Text() != group.name ||
+			isInsideClassLevelDecorator(identifier, current) {
+			continue
+		}
+		if !nodeIsInside(group.host, current) {
+			return true
+		}
+	}
+	return false
+}
+
+func isInsideClassLevelDecorator(node *ast.Node, class *ast.Node) bool {
+	for current := node.Parent; current != nil && current != class; current = current.Parent {
+		if current.Kind == ast.KindDecorator && current.Parent == class {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeIsInside(node *ast.Node, ancestor *ast.Node) bool {
+	for current := node; current != nil; current = current.Parent {
+		if current == ancestor {
+			return true
+		}
+	}
+	return false
+}
+
+func invalidFunctionBodyResolution(sourceFile *ast.SourceFile, identifier *ast.Node, symbol *ast.Symbol) *ast.Node {
+	if identifier == nil || symbol == nil {
+		return nil
+	}
+	referenceStart := utils.TrimNodeTextRange(sourceFile, identifier).Pos()
+	for current := identifier.Parent; current != nil; current = current.Parent {
+		if !ast.IsFunctionLike(current) || current.Body() == nil {
+			continue
+		}
+		if decorator := methodParameterDecoratorForReference(identifier, current); decorator != nil {
+			if !symbolHasDefinitionInsideNode(symbol, decorator) && symbolHasDefinitionInsideNode(symbol, current) {
+				return current
+			}
+		}
+		bodyRange := utils.TrimNodeTextRange(sourceFile, current.Body())
+		if referenceStart >= bodyRange.Pos() {
+			continue
+		}
+		if symbolDefinitionsAreInsideRange(sourceFile, symbol, bodyRange) {
+			return current
+		}
+	}
+	return nil
+}
+
+func methodParameterDecoratorForReference(identifier *ast.Node, function *ast.Node) *ast.Node {
+	if identifier == nil || function == nil {
+		return nil
+	}
+	switch function.Kind {
+	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
+	default:
+		return nil
+	}
+	for current := identifier.Parent; current != nil && current != function; current = current.Parent {
+		if current.Kind == ast.KindDecorator && current.Parent != nil &&
+			current.Parent.Kind == ast.KindParameter && current.Parent.Parent == function {
+			return current
+		}
+	}
+	return nil
+}
+
+func symbolDefinitionsAreInsideRange(sourceFile *ast.SourceFile, symbol *ast.Symbol, textRange core.TextRange) bool {
+	if len(symbol.Declarations) == 0 {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil {
+			return false
+		}
+		definition := declaration.Name()
+		if definition == nil {
+			definition = declaration
+		}
+		definitionRange := utils.TrimNodeTextRange(sourceFile, definition)
+		if definitionRange.Pos() < textRange.Pos() || definitionRange.End() > textRange.End() {
+			return false
+		}
+	}
+	return true
+}
+
+func (state *blockScopedVarState) appendOccurrenceDiagnostics(diagnostics *[]diagnostic, group *varGroup, occurrence varOccurrence) {
+	var message rule.RuleMessage
+	messageReady := false
+
+	for _, event := range group.references {
+		if event.textRange.Pos() >= occurrence.scopeRange.Pos() && event.textRange.End() <= occurrence.scopeRange.End() {
+			continue
+		}
+		if !messageReady {
+			definitionRange := utils.TrimNodeTextRange(state.ctx.SourceFile, occurrence.identifier)
+			lineIndex, characterIndex := scanner.GetECMALineAndUTF16CharacterOfPosition(state.ctx.SourceFile, definitionRange.Pos())
+			message = rule.RuleMessage{
+				Id: "outOfScope",
+				Description: fmt.Sprintf(
+					"'%s' declared on line %d column %d is used outside of binding context.",
+					group.name,
+					lineIndex+1,
+					int(characterIndex)+1,
+				),
+			}
+			messageReady = true
+		}
+		for range event.multiplicity {
+			*diagnostics = append(*diagnostics, diagnostic{textRange: event.textRange, message: message})
+		}
+	}
 }
 
 type diagnostic struct {
@@ -102,64 +1075,77 @@ type diagnostic struct {
 	message   rule.RuleMessage
 }
 
-// checkOccurrence collects a diagnostic for every use of occurrence's
-// declared variable that falls outside the block scope that was active when
-// it was declared. "Uses" include both ordinary reads/writes and the binding
-// identifiers of any sibling `var` declarations of the same variable that
-// have their own initializer (or are a for-in/for-of loop's binding)
-// elsewhere in the file — ESLint's scope analysis treats such a declarator's
-// own identifier as a reference too, which is what lets two sibling `var`
-// declarations of the same name flag each other.
-func checkOccurrence(ctx rule.RuleContext, occurrence varOccurrence, siblingDeclarations []*ast.Node) []diagnostic {
-	uses := append([]*ast.Node{}, ctx.Refs.References(occurrence.symbol)...)
-	uses = append(uses, siblingDeclarations...)
-	sort.Slice(uses, func(i, j int) bool {
-		return uses[i].Pos() < uses[j].Pos()
-	})
-
-	name := occurrence.identifier.Text()
-	defRange := utils.TrimNodeTextRange(ctx.SourceFile, occurrence.identifier)
-	defLineIndex, defCharIndex := scanner.GetECMALineAndUTF16CharacterOfPosition(ctx.SourceFile, defRange.Pos())
-	defLine, defColumn := defLineIndex+1, int(defCharIndex)+1
-
-	var diagnostics []diagnostic
-	for _, use := range uses {
-		useRange := utils.TrimNodeTextRange(ctx.SourceFile, use)
-		if useRange.Pos() < occurrence.scopeRange.Pos() || useRange.End() > occurrence.scopeRange.End() {
-			diagnostics = append(diagnostics, diagnostic{
-				textRange: useRange,
-				message: rule.RuleMessage{
-					Id: "outOfScope",
-					Description: fmt.Sprintf(
-						"'%s' declared on line %d column %d is used outside of binding context.",
-						name, defLine, defColumn,
-					),
-				},
-			})
+func variableDeclarationWriteMultiplicity(declaration *ast.Node, identifier *ast.Node, isForInOrOf bool) int {
+	multiplicity := 0
+	if declaration.AsVariableDeclaration().Initializer != nil {
+		multiplicity++
+	}
+	if isForInOrOf {
+		multiplicity++
+	}
+	for current := identifier.Parent; current != nil && current != declaration; current = current.Parent {
+		if current.Kind == ast.KindBindingElement && current.AsBindingElement().Initializer != nil {
+			multiplicity++
 		}
 	}
-	return diagnostics
+	return multiplicity
 }
 
-// hasInitializer reports whether a VariableDeclaration node has an `=`
-// initializer.
-func hasInitializer(declaration *ast.Node) bool {
-	variableDeclaration := declaration.AsVariableDeclaration()
-	return variableDeclaration != nil && variableDeclaration.Initializer != nil
+func parameterWriteMultiplicity(identifier *ast.Node, parameter *ast.Node) int {
+	multiplicity := 0
+	if parameter.AsParameterDeclaration().Initializer != nil {
+		multiplicity++
+	}
+	for current := identifier.Parent; current != nil && current != parameter; current = current.Parent {
+		if current.Kind == ast.KindBindingElement && current.AsBindingElement().Initializer != nil {
+			multiplicity++
+		}
+	}
+	return multiplicity
 }
 
-// blockScopeRange returns the range of the nearest enclosing block scope for
-// a `var` declaration list: the innermost Block, for-loop, or switch
-// statement containing it, or the whole source file when there is none.
-//
-// This mirrors ESLint's stack of BlockStatement/ForStatement/ForInStatement/
-// ForOfStatement/SwitchStatement/CatchClause/StaticBlock ranges without
-// maintaining an explicit traversal stack: the range active at any given
-// `var` declaration is always exactly its nearest enclosing node of one of
-// those kinds, since scope entry/exit is properly nested. CatchClause and
-// StaticBlock are omitted because a `var` inside either is always nested
-// inside that construct's own Block first, which this function reaches
-// first and which spans the same effective set of positions.
+func ordinaryReferenceMultiplicity(identifier *ast.Node) int {
+	if !utils.IsWriteReference(identifier) {
+		return 1
+	}
+
+	multiplicity := 1
+	for current := identifier; current != nil && current.Parent != nil; current = current.Parent {
+		parent := current.Parent
+		if parent.Kind == ast.KindComputedPropertyName {
+			break
+		}
+
+		if parent.Kind == ast.KindShorthandPropertyAssignment {
+			assignment := parent.AsShorthandPropertyAssignment()
+			if assignment.ObjectAssignmentInitializer == current {
+				break
+			}
+			if assignment.Name() == current && assignment.ObjectAssignmentInitializer != nil &&
+				utils.IsInDestructuringAssignment(parent) {
+				multiplicity++
+			}
+			continue
+		}
+
+		if parent.Kind == ast.KindBinaryExpression {
+			binary := parent.AsBinaryExpression()
+			if binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken {
+				continue
+			}
+			if binary.Right == current {
+				break
+			}
+			if binary.Left == current && utils.IsDefaultValueInDestructuringAssignment(parent) {
+				multiplicity++
+			}
+		}
+	}
+	return multiplicity
+}
+
+// blockScopeRange returns the nearest binding context ESLint puts on the
+// rule's scope stack for a var declaration.
 func blockScopeRange(sourceFile *ast.SourceFile, declarationList *ast.Node) core.TextRange {
 	for current := declarationList.Parent; current != nil; current = current.Parent {
 		switch current.Kind {

--- a/internal/rules/block_scoped_var/block_scoped_var.md
+++ b/internal/rules/block_scoped_var/block_scoped_var.md
@@ -103,14 +103,6 @@ class C {
 
 This rule has no options.
 
-## Differences from ESLint
-
-- When a destructuring binding element with its own default value (e.g. the
-  `a` in `var { a = 1 } = x;`) is flagged for being used outside the block
-  where a sibling `var` of the same name is declared, it is reported once.
-  ESLint's scope analysis creates two internal references for such an
-  element, so it reports the identical diagnostic twice in that situation.
-
 ## Original Documentation
 
 - [ESLint: block-scoped-var](https://eslint.org/docs/latest/rules/block-scoped-var)

--- a/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
+++ b/internal/rules/block_scoped_var/block_scoped_var_extras_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+func outOfScopeTSX(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	testCase := outOfScope(code, errors...)
+	testCase.Tsx = true
+	return testCase
+}
+
+func outOfScopeJSX(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	testCase := outOfScope(code, errors...)
+	testCase.FileName = "block-scoped-var-invalid.jsx"
+	testCase.TSConfig = "tsconfig.allowJs.json"
+	return testCase
+}
+
+func scopeErrWithEnd(name string, defLine, defColumn, line, column, endColumn int) rule_tester.InvalidTestCaseError {
+	testError := scopeErr(name, defLine, defColumn, line, column)
+	testError.EndColumn = endColumn
+	return testError
+}
+
 func TestBlockScopedVarExtras(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),
@@ -67,6 +86,54 @@ func TestBlockScopedVarExtras(t *testing.T) {
 			// ---- symbols in different var scopes, even with matching
 			// ---- initializer shapes.
 			{Code: "function outer() { if (true) { var a = 1; } function inner() { if (true) { var a = 2; } } }"},
+
+			// ---- Scope-manager parity: declaration writes resolve in their
+			// ---- lexical scope, independently from the hoisted `var` symbol.
+			{Code: "function f(){try{}catch(e){if(x){var e=1;}else{var e=2;}}}"},
+			{Code: "export{};function f(){if(x){var A;}export type {A};}"},
+			{Code: "if(q){var A;}else{var A;}([x=A] += rhs)"},
+			{Code: "if(x){var A;}interface A{}type X<T>=A extends infer A?A:never"},
+			{Code: "export{};if(x){var Map;}type X=Map<string,string>"},
+			{Code: "if(q){var undefined}else{var undefined}type X=undefined"},
+			{Code: "if(q){var A,B}else{var A,B}class C implements A.B{}"},
+
+			// ---- A function header cannot resolve to a body-only declaration,
+			// ---- even when tsgo lowers another parameter through the body.
+			{Code: "const a=9;function f(x=(a=1),y=z?.q){if(q){var a;}}"},
+
+			// ---- Reopened TypeScript namespaces have distinct scope-manager
+			// ---- variables even though TypeScript merges their exported symbols.
+			{Code: "namespace N{export var a;if(q){var a=1;}}namespace N{export var a;if(r){var a=2;}}"},
+
+			// ---- Method parameter decorators run outside the method function
+			// ---- scope, but keep scopes nested inside the decorator expression.
+			{Code: "if(q){var a;}else{var a;}class C{m(@(()=>{let a=1;return a})() x:any){}}"},
+
+			// ---- TSX pragma lookup is definition-order-sensitive for parameters.
+			{Code: "function f(x=<div/>,React){if(q){var React;}}", Tsx: true},
+			{Code: "if(q){var React;}else{var React;}class C{m(@dec React:any=<div/>){}}", Tsx: true},
+
+			// ---- Function-type defaults are parser-accepted but ignored by the
+			// ---- TypeScript scope manager's type visitor.
+			{Code: "if(q){var React;}else{var React;}type F=(x=<div/>)=>void", Tsx: true},
+			{Code: "if(q){var A;}else{var A;}type F=(x=A)=>void"},
+
+			// ---- Named class self-references belong to the class-local variable,
+			// ---- not an outer var merged by TypeScript's binder.
+			{Code: "if(x){var A;}class A{m(){return A}}"},
+
+			// ---- Import-type qualifiers are not visited by TypeVisitor; type
+			// ---- arguments remain references and are covered by invalid cases.
+			{Code: "export{};if(x){var A;}interface A{}type X=import(\"m\").A"},
+			{Code: "export{};if(x){var A;}interface A{}type X=typeof import(\"m\").A"},
+
+			// ---- JSX in JS/JSX follows Espree: no React pseudo-reference and
+			// ---- no references for namespaced tag pieces or lowercase Unicode.
+			{Code: "if(x){var React;}else{var React;}<div/>", FileName: "block-scoped-var-valid.jsx", TSConfig: "tsconfig.allowJs.json"},
+			{Code: "if(x){var foo;}else{var foo;}<foo:bar/>", FileName: "block-scoped-var-valid.jsx", TSConfig: "tsconfig.allowJs.json"},
+			{Code: "if(x){var é;}else{var é;}<é/>", Tsx: true},
+			{Code: "function f(){if(x){var ƛ;}else{var ƛ;}<ƛ></ƛ>}", Tsx: true},
+			{Code: "function f(){if(x){var ɤ;}else{var ɤ;}<ɤ></ɤ>}", Tsx: true},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: TS wrappers around an out-of-scope read still flag the identifier ----
@@ -149,13 +216,176 @@ func TestBlockScopedVarExtras(t *testing.T) {
 				scopeErr("a", 1, 14, 1, 57),
 				scopeErr("a", 1, 41, 1, 57)),
 
-			// ---- Dimension 4: eslint-scope double-references a defaulted
-			// ---- binding-pattern element, so ESLint would report this exact
-			// ---- diagnostic twice; this port reports it once (see
-			// ---- "Differences from ESLint" in block_scoped_var.md).
+			// ---- eslint-scope records both the declaration initialization and
+			// ---- the binding default as writes to each destructured name.
 			outOfScope("if (true) { var { a = 1 } = {}; } else { var { a = 1 } = {}; }",
 				scopeErr("a", 1, 48, 1, 19),
+				scopeErr("a", 1, 48, 1, 19),
+				scopeErr("a", 1, 19, 1, 48),
 				scopeErr("a", 1, 19, 1, 48)),
+
+			// ---- Canonical var-scope identity is shared with function
+			// ---- declarations, while each declaration write keeps its own
+			// ---- lexical resolution.
+			outOfScope("function f(){function a(){}if(x){var a=1;}else{var a=2;}}",
+				scopeErr("a", 1, 52, 1, 38),
+				scopeErr("a", 1, 38, 1, 52)),
+
+			// ---- A duplicate declarator contributes one definition occurrence,
+			// ---- so the trailing reference is reported exactly once.
+			outOfScope("function f(){if(x){var a,a;}a;}",
+				scopeErr("a", 1, 24, 1, 29)),
+
+			// ---- Catch parameters intercept declaration writes, but references
+			// ---- to the function-scoped variable still use the canonical group.
+			outOfScope("function f(){try{}catch(e){if(x){var e=1;}}if(y){var e=2;}e;}",
+				scopeErr("e", 1, 38, 1, 54),
+				scopeErr("e", 1, 38, 1, 59),
+				scopeErr("e", 1, 54, 1, 59)),
+
+			// ---- Parameter defaults are declaration writes on the merged
+			// ---- function variable, including detached duplicate bindings.
+			outOfScope("function f(a:number=1){if(x){var a;}}",
+				scopeErrWithEnd("a", 1, 34, 1, 12, 20)),
+			outOfScope("function f([a,a=1]=[]){if(x){var a;}}",
+				scopeErr("a", 1, 34, 1, 13),
+				scopeErr("a", 1, 34, 1, 15),
+				scopeErr("a", 1, 34, 1, 15)),
+			outOfScope("function f(a=0){function a(){}if(q){var a;}}",
+				scopeErr("a", 1, 41, 1, 12)),
+
+			// ---- TSESTree declaration identifiers retain their type annotation
+			// ---- in the reported range.
+			outOfScope("if(x){var a:number=1}else{var a:string=2}",
+				scopeErrWithEnd("a", 1, 31, 1, 11, 19),
+				scopeErrWithEnd("a", 1, 11, 1, 31, 39)),
+
+			// ---- Parser-accepted non-var writes and namespace type references
+			// ---- participate in the same TSESTree scope variable.
+			outOfScope("function f(){if(x){var a;}const a=1;}",
+				scopeErr("a", 1, 24, 1, 33)),
+			outOfScope("export{};if(x){var A;}namespace A{}type X=A",
+				scopeErr("A", 1, 20, 1, 43)),
+			outOfScope("export namespace N{if(x){var A;}export namespace A{}type X=A}",
+				scopeErr("A", 1, 30, 1, 60)),
+			outOfScope("export{};if(x){var A;}export interface A{}type X=A",
+				scopeErr("A", 1, 20, 1, 50)),
+			outOfScope("export{};if(x){var A;}export class A{}type X=A",
+				scopeErr("A", 1, 20, 1, 46)),
+			outOfScope("export{};if(x){var A;}interface A{}type X=import(\"m\").X<A>",
+				scopeErr("A", 1, 20, 1, 57)),
+			outOfScope("export{};if(q){var A;}else{var A;}export as namespace A;",
+				scopeErr("A", 1, 20, 1, 55),
+				scopeErr("A", 1, 32, 1, 55)),
+			outOfScope("if(q){var x;}else{var x;}interface F{[x:string]:typeof x}",
+				scopeErr("x", 1, 11, 1, 56),
+				scopeErr("x", 1, 23, 1, 56)),
+			outOfScope("if(x){var PropertyKey;}type X=PropertyKey",
+				scopeErr("PropertyKey", 1, 11, 1, 31)),
+			outOfScope("if(q){var Infinity}else{var Infinity}type X=Infinity",
+				scopeErr("Infinity", 1, 11, 1, 45),
+				scopeErr("Infinity", 1, 29, 1, 45)),
+			outOfScope("/*global Custom*/if(q){var Custom}else{var Custom}type X=Custom",
+				scopeErr("Custom", 1, 28, 1, 58),
+				scopeErr("Custom", 1, 44, 1, 58)),
+			{
+				Code:     "if(x){var PropertyKey;}type X=PropertyKey",
+				TSConfig: "tsconfig.noLib.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					scopeErr("PropertyKey", 1, 11, 1, 31),
+				},
+			},
+			outOfScope("if(x){var A;}type X<T>=typeof A extends infer A?typeof A:typeof A",
+				scopeErr("A", 1, 11, 1, 31),
+				scopeErr("A", 1, 11, 1, 56),
+				scopeErr("A", 1, 11, 1, 65)),
+			outOfScope("function f<T extends ((a:any)=>typeof a)>(a=1){if(q){var a;}}",
+				scopeErr("a", 1, 58, 1, 43)),
+
+			// ---- Function headers reject body-only targets, but allow an early
+			// ---- type definition merged with the body var.
+			outOfScope("if(q){var A;}else{var A;}function f(x=(()=>A)){function A(){}}",
+				scopeErr("A", 1, 11, 1, 44),
+				scopeErr("A", 1, 23, 1, 44)),
+			outOfScope("const A=0;function f<A>(x:typeof A){if(q){var A;}}",
+				scopeErr("A", 1, 47, 1, 34)),
+			outOfScope("export{};if(x){var A;}interface A{}function f(){let A=0;class C implements A{}}",
+				scopeErr("A", 1, 20, 1, 76)),
+
+			// ---- A named class expression is not in scope in its class-level
+			// ---- decorator; method parameter decorators are outside the method
+			// ---- function scope but preserve scopes nested in the decorator.
+			outOfScope("function f(){if(x){var A;}else{var A;}const X=@dec(A) class A{}}",
+				scopeErr("A", 1, 24, 1, 52),
+				scopeErr("A", 1, 36, 1, 52)),
+			outOfScope("if(q){var a;}else{var a;}class C{m(@a a:any){if(z){var a;}}}",
+				scopeErr("a", 1, 11, 1, 37),
+				scopeErr("a", 1, 23, 1, 37)),
+			outOfScope("if(q){var a;}else{var a;}class C{m(@(()=>{if(z){var a=1;}return a})() x:any){}}",
+				scopeErr("a", 1, 53, 1, 65)),
+
+			// ---- TypeScript's JSX scope manager emits one definition-based
+			// ---- React pseudo-reference, with definition-order-sensitive scopes.
+			outOfScopeTSX("if(x){var React;}else{var React;}<div/>",
+				scopeErr("React", 1, 27, 1, 11)),
+			{
+				Code:     "if(x){var preact;}else{var preact;}<></>",
+				Tsx:      true,
+				TSConfig: "tsconfig.block-scoped-var-jsx.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					scopeErr("preact", 1, 28, 1, 11),
+					scopeErr("preact", 1, 28, 1, 11),
+				},
+			},
+			outOfScopeTSX("<div/>;if(a){var React;}<span/>;if(b){var React;}",
+				scopeErr("React", 1, 43, 1, 18)),
+			outOfScopeTSX("function f({x=<div/>,React}){if(q){var React;}}",
+				scopeErr("React", 1, 40, 1, 22)),
+			outOfScopeTSX("function f<React>(){<div/>;if(q){var React;}else{var React;}}",
+				scopeErr("React", 1, 38, 1, 12),
+				scopeErr("React", 1, 54, 1, 12)),
+			outOfScopeTSX("if(x){var React;}else{var React;}interface I<React>{[<div/>]:string}",
+				scopeErr("React", 1, 11, 1, 46),
+				scopeErr("React", 1, 27, 1, 46)),
+			outOfScopeTSX("if(x){var React;}else{var React;}class C{static{<div/>;let React;}}",
+				scopeErr("React", 1, 27, 1, 11)),
+
+			// ---- JSX inside a named class-expression decorator resolves outside
+			// ---- the class self-name for both pseudo and physical references.
+			outOfScopeTSX("function f(){if(x){var React;}const C=@dec(<React/>) class React{}}",
+				scopeErr("React", 1, 24, 1, 45)),
+
+			// ---- TSESTree treats both pieces of opening and closing namespaced
+			// ---- tags as physical value references.
+			outOfScopeTSX("function f(){if(x){var foo;var bar;}else{var foo;var bar;}<foo:bar></foo:bar>;}",
+				scopeErr("foo", 1, 24, 1, 60),
+				scopeErr("foo", 1, 46, 1, 60),
+				scopeErr("bar", 1, 32, 1, 64),
+				scopeErr("bar", 1, 54, 1, 64),
+				scopeErr("foo", 1, 24, 1, 70),
+				scopeErr("foo", 1, 46, 1, 70),
+				scopeErr("bar", 1, 32, 1, 74),
+				scopeErr("bar", 1, 54, 1, 74)),
+
+			// ---- JSX visitor ordering follows typescript-eslint rather than
+			// ---- tsgo's generic child order.
+			outOfScopeTSX("if(x){var React;}else{var React;}declare function call<T>(x:any):any;call<{[<div/>]:1}>(()=>{interface React{};return <div/>})",
+				scopeErr("React", 1, 11, 1, 104),
+				scopeErr("React", 1, 27, 1, 104)),
+			outOfScopeTSX("if(x){var React;}else{var React;}((({[(()=>{interface React{};return <div/>})()]:a} as {[<div/>]:1}) as any)=o)",
+				scopeErr("React", 1, 11, 1, 55),
+				scopeErr("React", 1, 27, 1, 55)),
+			outOfScopeTSX("if(x){var React;}else{var React;}for((()=>{interface React{};<span/>;return o})()[<div/>] in xs){}",
+				scopeErr("React", 1, 27, 1, 11)),
+
+			// ---- JS/JSX follows Espree physical component references without
+			// ---- adding the TypeScript React pseudo-reference.
+			outOfScopeJSX("if(x){var Foo;}else{var Foo;}<Foo/>",
+				scopeErr("Foo", 1, 11, 1, 31),
+				scopeErr("Foo", 1, 25, 1, 31)),
+			outOfScopeJSX("if(x){var Foo;}else{var Foo;}<Foo></Foo>",
+				scopeErr("Foo", 1, 11, 1, 31),
+				scopeErr("Foo", 1, 25, 1, 31)),
 		},
 	)
 }

--- a/internal/rules/block_scoped_var/block_scoped_var_tsx.go
+++ b/internal/rules/block_scoped_var/block_scoped_var_tsx.go
@@ -1,0 +1,1449 @@
+package block_scoped_var
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// blockScopedVarReferenceMeaning mirrors RefStore's declaration-space model.
+// It stays rule-local because block-scoped-var's performance guardrail limits
+// production changes to this package.
+func blockScopedVarReferenceMeaning(identifier *ast.Node) ast.SymbolFlags {
+	if identifier == nil {
+		return 0
+	}
+	parent := identifier.Parent
+	if parent != nil && parent.Kind == ast.KindTypePredicate {
+		return ast.SymbolFlagsFunctionScopedVariable
+	}
+	if parent != nil && parent.Kind == ast.KindExportAssignment {
+		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+	}
+	if parent != nil && parent.Kind == ast.KindExportSpecifier {
+		if ast.IsTypeOnlyImportOrExportDeclaration(parent) {
+			return ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+		}
+		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+	}
+	entity := identifier
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindQualifiedName {
+		entity = entity.Parent
+	}
+	if entity.Parent != nil && entity.Parent.Kind == ast.KindImportEqualsDeclaration &&
+		entity.Parent.AsImportEqualsDeclaration().ModuleReference == entity {
+		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+	}
+	if ast.IsPartOfTypeQuery(identifier) {
+		return ast.SymbolFlagsValue | ast.SymbolFlagsAlias
+	}
+	if isTypeOnlyDecoratorQualifier(identifier) {
+		return ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+	}
+	if ast.IsExpressionNode(identifier) {
+		return ast.SymbolFlagsValue | ast.SymbolFlagsAlias
+	}
+	if identifier.Parent != nil && identifier.Parent.Kind == ast.KindQualifiedName &&
+		identifier.Parent.AsQualifiedName().Left == identifier {
+		return ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+	}
+	if ast.IsPartOfTypeNode(identifier) {
+		return ast.SymbolFlagsType | ast.SymbolFlagsAlias
+	}
+	return ast.SymbolFlagsValue | ast.SymbolFlagsAlias
+}
+
+func isTypeOnlyDecoratorQualifier(identifier *ast.Node) bool {
+	entity := identifier
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindPropertyAccessExpression {
+		access := entity.Parent.AsPropertyAccessExpression()
+		if access.Expression != entity {
+			break
+		}
+		entity = entity.Parent
+	}
+	return entity != identifier && ast.IsPartOfTypeNode(entity)
+}
+
+// TypeVisitor intentionally ignores an import type's qualifier. Its type
+// arguments are visited separately and therefore remain ordinary references.
+func isIgnoredImportTypeQualifier(identifier *ast.Node) bool {
+	qualifier := identifier
+	for qualifier != nil && qualifier.Parent != nil && qualifier.Parent.Kind == ast.KindQualifiedName {
+		qualifier = qualifier.Parent
+	}
+	if qualifier == nil || qualifier.Parent == nil || qualifier.Parent.Kind != ast.KindImportType {
+		return false
+	}
+	return qualifier.Parent.AsImportTypeNode().Qualifier == qualifier
+}
+
+// TypeVisitor defines function-type parameter bindings and visits their type
+// annotations, but intentionally skips decorators, binding-pattern right-hand
+// nodes, and initializers. Index signatures use a different visitor.
+func isIgnoredFunctionTypeParameterReference(identifier *ast.Node) bool {
+	for current := identifier.Parent; current != nil; current = current.Parent {
+		if current.Kind != ast.KindParameter || current.Parent == nil {
+			continue
+		}
+		switch current.Parent.Kind {
+		case ast.KindFunctionType,
+			ast.KindConstructorType,
+			ast.KindCallSignature,
+			ast.KindConstructSignature,
+			ast.KindMethodSignature,
+			ast.KindIndexSignature:
+			return !nodeIsInside(identifier, current.Type())
+		}
+	}
+	return false
+}
+
+func (state *blockScopedVarState) addDecoratedClassExpressionReferences() {
+	for _, classExpression := range state.classExpressions {
+		classSymbol := classExpression.Symbol()
+		if classSymbol == nil || classExpression.Parent == nil {
+			continue
+		}
+		for _, decorator := range classExpression.Decorators() {
+			utils.VisitDescendants(decorator, func(identifier *ast.Node) bool {
+				if identifier.Kind != ast.KindIdentifier || state.ctx.Refs == nil ||
+					state.ctx.Refs.ResolveInFile(identifier) != classSymbol {
+					return true
+				}
+				meaning := blockScopedVarReferenceMeaning(identifier)
+				targetSymbol := state.resolve(classExpression.Parent, identifier.Text(), meaning)
+				state.addOrdinaryReference(state.validReferenceTarget(targetSymbol, identifier, meaning), identifier)
+				return true
+			})
+		}
+	}
+}
+
+func (state *blockScopedVarState) addNamespaceExportReferences() {
+	meaning := ast.SymbolFlagsValue | ast.SymbolFlagsAlias
+	for _, identifier := range state.namespaceExports {
+		target := state.resolve(identifier, identifier.Text(), meaning)
+		state.addOrdinaryReference(state.validReferenceTarget(target, identifier, meaning), identifier)
+	}
+}
+
+func (state *blockScopedVarState) addExportSpecifierReferences(relevantNames map[string]struct{}) {
+	for _, identifier := range state.exportSpecifiers {
+		if _, relevant := relevantNames[identifier.Text()]; !relevant {
+			continue
+		}
+		specifier := identifier.Parent
+		if specifier == nil || specifier.Kind != ast.KindExportSpecifier ||
+			specifier.Parent == nil || specifier.Parent.Parent == nil {
+			continue
+		}
+		exportDeclaration := specifier.Parent.Parent
+		meaning := blockScopedVarReferenceMeaning(identifier)
+		target := state.resolve(exportDeclaration.Parent, identifier.Text(), meaning)
+		group := state.validReferenceTarget(target, identifier, meaning)
+		if !groupSupportsMeaning(group, meaning) {
+			group = nil
+		}
+		if group == nil && meaning&(ast.SymbolFlagsType|ast.SymbolFlagsNamespace) != 0 {
+			group = state.mergedGroupForTypeTarget(identifier, target)
+		}
+		state.addOrdinaryReference(group, identifier)
+	}
+}
+
+// TypeVisitor visits an index signature's parameter and return types without
+// defining the index parameter as a scope variable. TypeScript's binder does
+// define it, so resolve those visited identifiers from outside the signature.
+func (state *blockScopedVarState) addIndexSignatureReferences(relevantNames map[string]struct{}) {
+	if state.ctx.Refs == nil {
+		return
+	}
+	for _, signature := range state.indexSignatures {
+		parameterSymbols := make(map[*ast.Symbol]struct{})
+		for _, parameter := range signature.Parameters() {
+			utils.CollectBindingNames(parameter.Name(), func(identifier *ast.Node, _ string) {
+				if symbol := utils.BindingNameSymbol(identifier); symbol != nil {
+					parameterSymbols[symbol] = struct{}{}
+				}
+			})
+		}
+		visitType := func(typeNode *ast.Node) {
+			utils.VisitDescendants(typeNode, func(identifier *ast.Node) bool {
+				if identifier.Kind != ast.KindIdentifier || utils.IsNonReferenceIdentifier(identifier) {
+					return true
+				}
+				if _, relevant := relevantNames[identifier.Text()]; !relevant {
+					return true
+				}
+				if _, boundToIndexParameter := parameterSymbols[state.ctx.Refs.ResolveInFile(identifier)]; !boundToIndexParameter {
+					return true
+				}
+				meaning := blockScopedVarReferenceMeaning(identifier)
+				target := state.resolve(signature.Parent, identifier.Text(), meaning)
+				group := state.validReferenceTarget(target, identifier, meaning)
+				if group == nil && meaning&(ast.SymbolFlagsType|ast.SymbolFlagsNamespace) != 0 {
+					group = state.mergedGroupForTypeTarget(identifier, target)
+				}
+				state.addOrdinaryReference(group, identifier)
+				return true
+			})
+		}
+		for _, parameter := range signature.Parameters() {
+			visitType(parameter.Type())
+		}
+		visitType(signature.Type())
+	}
+}
+
+// addMergedTypeReferences fills one scope-model gap in RefStore. TSESTree
+// keeps value and type definitions in one scope variable, while TypeScript can
+// represent an exported declaration with separate local/export symbols.
+func (state *blockScopedVarState) addMergedTypeReferences() {
+	if state.ctx.Refs == nil {
+		return
+	}
+	implicitTypeGroups := state.implicitTypeGlobalGroups()
+	var names map[string]struct{}
+	for _, group := range state.groupOrder {
+		if len(group.occurrences) == 0 {
+			continue
+		}
+		typeTarget := state.resolve(
+			group.host,
+			group.name,
+			ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+		)
+		if symbolHasTSETypeDefinitionInHost(typeTarget, group.host) || implicitTypeGroups[group.name] == group {
+			if names == nil {
+				names = make(map[string]struct{})
+			}
+			names[group.name] = struct{}{}
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+
+	utils.VisitDescendants(state.ctx.SourceFile.AsNode(), func(identifier *ast.Node) bool {
+		if identifier.Kind != ast.KindIdentifier || utils.IsNonReferenceIdentifier(identifier) {
+			return true
+		}
+		if _, relevant := names[identifier.Text()]; !relevant {
+			return true
+		}
+		resolved := state.ctx.Refs.ResolveInFile(identifier)
+		meaning := blockScopedVarReferenceMeaning(identifier)
+		typeOnlyHeritage := isTypeOnlyHeritageReference(identifier)
+		if typeOnlyHeritage {
+			meaning = ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+		} else if meaning&(ast.SymbolFlagsType|ast.SymbolFlagsNamespace) == 0 {
+			return true
+		}
+		target := resolved
+		if typeOnlyHeritage {
+			target = state.resolve(identifier, identifier.Text(), meaning)
+		} else if target == nil {
+			target = state.ctx.Refs.ResolveInFileWithMeaning(
+				identifier,
+				ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+			)
+		}
+		if implicitGroup := implicitTypeGroups[identifier.Text()]; implicitGroup != nil &&
+			(target == nil || target == implicitGroup.symbol || state.isDefaultLibrarySymbol(target)) {
+			state.addOrdinaryReference(implicitGroup, identifier)
+			return true
+		}
+		if state.groups[resolved] != nil && !typeOnlyHeritage {
+			return true
+		}
+		target = state.repairClassExpressionDecoratorTarget(identifier, target, meaning)
+		target = state.preBodyMergedSymbol(identifier, target, meaning)
+		group := state.validReferenceTarget(target, identifier, meaning)
+		if group == nil {
+			group = state.mergedGroupForTypeTarget(identifier, target)
+		}
+		state.addOrdinaryReference(group, identifier)
+		return true
+	})
+}
+
+func (state *blockScopedVarState) implicitTypeGlobalGroups() map[string]*varGroup {
+	if state.ctx.SourceFile == nil ||
+		(state.ctx.SourceFile.ScriptKind != core.ScriptKindTS && state.ctx.SourceFile.ScriptKind != core.ScriptKindTSX) ||
+		!ast.IsGlobalSourceFile(state.ctx.SourceFile.AsNode()) {
+		return nil
+	}
+
+	activeTypeGlobals := make(map[string]bool)
+	if state.ctx.Program != nil && state.ctx.TypeChecker != nil {
+		utils.AddDefaultLibraryTypeGlobalNames(activeTypeGlobals, state.ctx.Program, state.ctx.TypeChecker)
+	}
+	// Without a Program, scope-manager 8.65 seeds its generated esnext
+	// catalog. With a Program it derives the catalog from target and, notably,
+	// ignores noLib; reuse that same public catalog for the ESNext/noLib case
+	// that the checker omits.
+	defaultESNext := state.ctx.Program == nil ||
+		(state.ctx.Program.Options().NoLib.IsTrue() &&
+			state.ctx.Program.Options().GetEmitScriptTarget() == core.ScriptTargetESNext)
+	if defaultESNext {
+		for _, group := range state.groupOrder {
+			if rule.IsDefaultTypeScriptTypeGlobal(group.name) {
+				activeTypeGlobals[group.name] = true
+			}
+		}
+	}
+	// ESLint finalizes the parser scope with ECMAScript, configured, and
+	// inline globals without a declaration-space distinction. These injected
+	// names are additive: an authored `off` prevents injection, but cannot
+	// remove a type variable the TypeScript parser already supplied.
+	injectedGlobals := make(map[string]bool)
+	state.ctx.Globals.ApplyTo(injectedGlobals)
+	for name := range injectedGlobals {
+		activeTypeGlobals[name] = true
+	}
+
+	var result map[string]*varGroup
+	for _, group := range state.groupOrder {
+		if len(group.occurrences) == 0 || group.host != state.ctx.SourceFile.AsNode() ||
+			!activeTypeGlobals[group.name] {
+			continue
+		}
+		if result == nil {
+			result = make(map[string]*varGroup)
+		}
+		result[group.name] = group
+	}
+	return result
+}
+
+func (state *blockScopedVarState) isDefaultLibrarySymbol(symbol *ast.Symbol) bool {
+	return state.ctx.Program != nil && utils.IsSymbolFromDefaultLibrary(state.ctx.Program, symbol)
+}
+
+// mergedGroupForTypeTarget joins TypeScript's local/export symbol pair without
+// conflating identically named variables from reopened TSModule scopes. Both
+// symbols retain the same declaration; the lexical host selects the matching
+// scope-manager variable.
+func (state *blockScopedVarState) mergedGroupForTypeTarget(identifier *ast.Node, target *ast.Symbol) *varGroup {
+	if identifier == nil || target == nil {
+		return nil
+	}
+	for host := utils.FindEnclosingScope(identifier); host != nil; host = utils.FindEnclosingScope(host) {
+		canonical := state.canonical[canonicalKey{host: host, name: identifier.Text()}]
+		group := state.groups[canonical]
+		if group != nil && symbolHasTSETypeDefinitionInHost(target, host) {
+			if state.classScopeShadowsGroup(identifier, group) {
+				return nil
+			}
+			return group
+		}
+	}
+	return nil
+}
+
+func symbolHasTSETypeDefinitionInHost(symbol *ast.Symbol, host *ast.Node) bool {
+	if symbol == nil || host == nil {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration != nil && isTSETypeDefinitionKind(declaration.Kind) &&
+			tseDefinitionScopeHost(declaration) == host {
+			return true
+		}
+	}
+	return false
+}
+
+func tseDefinitionScopeHost(declaration *ast.Node) *ast.Node {
+	for current := declaration.Parent; current != nil; current = current.Parent {
+		switch current.Kind {
+		case ast.KindBlock:
+			parent := current.Parent
+			if parent != nil && ast.IsFunctionLike(parent) && parent.Body() == current {
+				return parent
+			}
+			if parent != nil && parent.Kind == ast.KindClassStaticBlockDeclaration {
+				return parent
+			}
+			return current
+		case ast.KindSourceFile,
+			ast.KindModuleBlock,
+			ast.KindClassDeclaration,
+			ast.KindClassExpression,
+			ast.KindClassStaticBlockDeclaration,
+			ast.KindForStatement,
+			ast.KindForInStatement,
+			ast.KindForOfStatement,
+			ast.KindSwitchStatement,
+			ast.KindCatchClause,
+			ast.KindTypeAliasDeclaration,
+			ast.KindInterfaceDeclaration,
+			ast.KindMappedType,
+			ast.KindConditionalType,
+			ast.KindFunctionType,
+			ast.KindConstructorType,
+			ast.KindCallSignature,
+			ast.KindConstructSignature,
+			ast.KindMethodSignature:
+			return current
+		}
+		if ast.IsFunctionLike(current) {
+			return current
+		}
+	}
+	return nil
+}
+
+func isTSETypeDefinitionKind(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindModuleDeclaration,
+		ast.KindInterfaceDeclaration,
+		ast.KindTypeAliasDeclaration,
+		ast.KindTypeParameter,
+		ast.KindClassDeclaration,
+		ast.KindEnumDeclaration,
+		ast.KindImportClause,
+		ast.KindImportSpecifier,
+		ast.KindNamespaceImport,
+		ast.KindImportEqualsDeclaration:
+		return true
+	}
+	return false
+}
+
+func isTypeOnlyHeritageReference(identifier *ast.Node) bool {
+	entity := identifier
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindPropertyAccessExpression &&
+		entity.Parent.AsPropertyAccessExpression().Expression == entity {
+		entity = entity.Parent
+	}
+	if entity.Parent == nil || entity.Parent.Kind != ast.KindExpressionWithTypeArguments ||
+		entity.Parent.AsExpressionWithTypeArguments().Expression != entity {
+		return false
+	}
+	heritage := entity.Parent.Parent
+	if heritage == nil || heritage.Kind != ast.KindHeritageClause {
+		return false
+	}
+	return heritage.AsHeritageClause().Token == ast.KindImplementsKeyword ||
+		(heritage.Parent != nil && heritage.Parent.Kind == ast.KindInterfaceDeclaration)
+}
+
+func (state *blockScopedVarState) addJsxNamespacedReferences() {
+	for _, node := range state.jsxNamespacedNames {
+		name := node.AsJsxNamespacedName()
+		for _, identifier := range []*ast.Node{name.Namespace, name.Name()} {
+			targetSymbol := state.resolve(identifier, identifier.Text(), ast.SymbolFlagsValue|ast.SymbolFlagsAlias)
+			targetSymbol = state.repairClassExpressionDecoratorTarget(identifier, targetSymbol, ast.SymbolFlagsValue|ast.SymbolFlagsAlias)
+			targetSymbol = state.preBodyMergedSymbol(identifier, targetSymbol, ast.SymbolFlagsValue|ast.SymbolFlagsAlias)
+			state.addOrdinaryReference(
+				state.validReferenceTarget(targetSymbol, identifier, ast.SymbolFlagsValue|ast.SymbolFlagsAlias),
+				identifier,
+			)
+		}
+	}
+}
+
+func (state *blockScopedVarState) repairClassExpressionDecoratorTarget(identifier *ast.Node, target *ast.Symbol, meaning ast.SymbolFlags) *ast.Symbol {
+	for current := identifier.Parent; current != nil; current = current.Parent {
+		if current.Kind != ast.KindDecorator || current.Parent == nil || current.Parent.Kind != ast.KindClassExpression {
+			continue
+		}
+		classExpression := current.Parent
+		if target == classExpression.Symbol() && classExpression.Parent != nil {
+			return state.resolve(classExpression.Parent, identifier.Text(), meaning)
+		}
+		return target
+	}
+	return target
+}
+
+type jsxTimelineScopeKind uint8
+
+const (
+	jsxScopeOther jsxTimelineScopeKind = iota
+	jsxScopeFunctionType
+	jsxScopeMappedType
+	jsxScopeConditionalType
+)
+
+type jsxTimelineVariable struct {
+	defined         bool
+	value           bool
+	firstIdentifier *ast.Node
+	group           *varGroup
+}
+
+type jsxTimelineScope struct {
+	upper             *jsxTimelineScope
+	variableScope     *jsxTimelineScope
+	functionBodyStart int
+	kind              jsxTimelineScopeKind
+	variables         [2]jsxTimelineVariable
+}
+
+type jsxTimelineChannel struct {
+	active     bool
+	nameIndex  int
+	done       bool
+	resolved   bool
+	pending    *jsxTimelineScope
+	identifier *ast.Node
+}
+
+type jsxTimeline struct {
+	state     *blockScopedVarState
+	names     [2]string
+	nameCount int
+	current   *jsxTimelineScope
+	channels  [2]jsxTimelineChannel
+}
+
+func (state *blockScopedVarState) addTSXFactoryReferences() {
+	if state.ctx.SourceFile.ScriptKind != core.ScriptKindTSX || !state.hasJSX {
+		return
+	}
+
+	factoryName := "React"
+	fragmentName := ""
+	if state.ctx.Program != nil {
+		options := state.ctx.Program.Options()
+		if options.JsxFactory != "" {
+			factoryName = jsxFactoryRoot(options.JsxFactory)
+		}
+		if options.JsxFragmentFactory != "" {
+			fragmentName = jsxFactoryRoot(options.JsxFragmentFactory)
+		}
+	}
+
+	timeline := jsxTimeline{state: state}
+	timeline.activateChannel(0, factoryName)
+	timeline.activateChannel(1, fragmentName)
+	if !timeline.channels[0].active && !timeline.channels[1].active {
+		return
+	}
+
+	timeline.pushScope(jsxScopeOther, true) // global
+	if ast.IsExternalOrCommonJSModule(state.ctx.SourceFile) {
+		timeline.pushScope(jsxScopeOther, true) // module
+	}
+	timeline.visitStatements(state.ctx.SourceFile.AsNode())
+	if ast.IsExternalOrCommonJSModule(state.ctx.SourceFile) {
+		timeline.popScope()
+	}
+	timeline.popScope()
+}
+
+func jsxFactoryRoot(factory string) string {
+	root, _, _ := strings.Cut(factory, ".")
+	return strings.TrimSpace(root)
+}
+
+func (timeline *jsxTimeline) activateChannel(channelIndex int, name string) {
+	if name == "" || !timeline.state.hasReportableGroup(name) {
+		return
+	}
+	nameIndex := -1
+	for index := range timeline.nameCount {
+		if timeline.names[index] == name {
+			nameIndex = index
+			break
+		}
+	}
+	if nameIndex == -1 {
+		nameIndex = timeline.nameCount
+		timeline.names[nameIndex] = name
+		timeline.nameCount++
+	}
+	timeline.channels[channelIndex] = jsxTimelineChannel{
+		active:    true,
+		nameIndex: nameIndex,
+	}
+}
+
+func (state *blockScopedVarState) hasReportableGroup(name string) bool {
+	for _, group := range state.groupOrder {
+		if group.name == name && len(group.occurrences) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (timeline *jsxTimeline) pushScope(kind jsxTimelineScopeKind, variableScope bool) {
+	scope := &jsxTimelineScope{upper: timeline.current, kind: kind}
+	if variableScope || timeline.current == nil {
+		scope.variableScope = scope
+	} else {
+		scope.variableScope = timeline.current.variableScope
+	}
+	timeline.current = scope
+}
+
+func (timeline *jsxTimeline) popScope() {
+	scope := timeline.current
+	if scope == nil {
+		return
+	}
+	for index := range timeline.channels {
+		channel := &timeline.channels[index]
+		if !channel.active || channel.resolved || channel.pending != scope {
+			continue
+		}
+		variable := &scope.variables[channel.nameIndex]
+		if variable.defined && variable.value {
+			if timelineReferenceCannotResolveToFunctionBodyVariable(
+				timeline.state.ctx.SourceFile,
+				channel.identifier,
+				scope,
+				variable,
+			) {
+				channel.pending = scope.upper
+				if channel.pending == nil {
+					channel.resolved = true
+				}
+			} else {
+				if variable.group != nil {
+					variable.group.references = append(variable.group.references, referenceEvent{
+						identifier:   channel.identifier,
+						multiplicity: 1,
+						bindingRange: true,
+					})
+				}
+				channel.resolved = true
+				channel.pending = nil
+			}
+		} else {
+			channel.pending = scope.upper
+			if channel.pending == nil {
+				channel.resolved = true
+			}
+		}
+	}
+	timeline.current = scope.upper
+}
+
+func timelineReferenceCannotResolveToFunctionBodyVariable(
+	sourceFile *ast.SourceFile,
+	identifier *ast.Node,
+	scope *jsxTimelineScope,
+	variable *jsxTimelineVariable,
+) bool {
+	if scope == nil || scope.functionBodyStart == 0 || identifier == nil ||
+		utils.TrimNodeTextRange(sourceFile, identifier).Pos() >= scope.functionBodyStart {
+		return false
+	}
+	return variable.firstIdentifier == nil ||
+		utils.TrimNodeTextRange(sourceFile, variable.firstIdentifier).Pos() >= scope.functionBodyStart
+}
+
+func (timeline *jsxTimeline) define(identifier *ast.Node, value bool, group *varGroup, target *jsxTimelineScope) {
+	if identifier == nil || target == nil {
+		return
+	}
+	nameIndex := timeline.indexOfName(identifier.Text())
+	if nameIndex == -1 {
+		return
+	}
+	variable := &target.variables[nameIndex]
+	if !variable.defined {
+		variable.defined = true
+		variable.firstIdentifier = identifier
+	}
+	variable.value = variable.value || value
+	if group != nil {
+		variable.group = group
+	}
+}
+
+func (timeline *jsxTimeline) indexOfName(name string) int {
+	for index := range timeline.nameCount {
+		if timeline.names[index] == name {
+			return index
+		}
+	}
+	return -1
+}
+
+func (timeline *jsxTimeline) referenceChannel(channelIndex int) {
+	channel := &timeline.channels[channelIndex]
+	if !channel.active || channel.done {
+		return
+	}
+	for scope := timeline.current; scope != nil; scope = scope.upper {
+		variable := &scope.variables[channel.nameIndex]
+		if !variable.defined {
+			continue
+		}
+		channel.done = true
+		channel.pending = scope
+		channel.identifier = variable.firstIdentifier
+		return
+	}
+}
+
+func (timeline *jsxTimeline) resolvedAllActiveChannels() bool {
+	hasActive := false
+	for index := range timeline.channels {
+		channel := &timeline.channels[index]
+		if !channel.active {
+			continue
+		}
+		hasActive = true
+		if !channel.resolved {
+			return false
+		}
+	}
+	return hasActive
+}
+
+func (timeline *jsxTimeline) visit(node *ast.Node) {
+	if node == nil || timeline.resolvedAllActiveChannels() {
+		return
+	}
+	switch node.Kind {
+	case ast.KindBlock:
+		timeline.pushScope(jsxScopeOther, false)
+		timeline.visitStatements(node)
+		timeline.popScope()
+
+	case ast.KindVariableDeclarationList:
+		timeline.visitVariableDeclarationList(node)
+
+	case ast.KindFunctionDeclaration:
+		if node.Name() != nil {
+			timeline.define(node.Name(), true, nil, timeline.current)
+		}
+		timeline.visitFunction(node, false, false)
+
+	case ast.KindFunctionExpression:
+		if node.Name() != nil {
+			timeline.pushScope(jsxScopeOther, false)
+			timeline.define(node.Name(), true, nil, timeline.current)
+			timeline.visitFunction(node, false, false)
+			timeline.popScope()
+		} else {
+			timeline.visitFunction(node, false, false)
+		}
+
+	case ast.KindArrowFunction:
+		timeline.visitFunction(node, false, false)
+
+	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
+		timeline.visitMethod(node)
+
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		timeline.visitClass(node)
+
+	case ast.KindPropertyDeclaration:
+		timeline.visitClassProperty(node)
+
+	case ast.KindClassStaticBlockDeclaration:
+		timeline.pushScope(jsxScopeOther, true)
+		if body := node.AsClassStaticBlockDeclaration().Body; body != nil {
+			timeline.visitStatements(body)
+		}
+		timeline.popScope()
+
+	case ast.KindCatchClause:
+		timeline.visitCatchClause(node)
+
+	case ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
+		timeline.visitFor(node)
+
+	case ast.KindSwitchStatement:
+		timeline.visitSwitch(node)
+
+	case ast.KindWithStatement:
+		withStatement := node.AsWithStatement()
+		timeline.visit(withStatement.Expression)
+		timeline.pushScope(jsxScopeOther, false)
+		timeline.visit(withStatement.Statement)
+		timeline.popScope()
+
+	case ast.KindModuleDeclaration:
+		if !ast.IsGlobalScopeAugmentation(node) && node.Name() != nil && node.Name().Kind == ast.KindIdentifier {
+			timeline.define(node.Name(), true, nil, timeline.current)
+		}
+		timeline.pushScope(jsxScopeOther, true)
+		timeline.visit(node.AsModuleDeclaration().Body)
+		timeline.popScope()
+
+	case ast.KindModuleBlock:
+		timeline.visitStatements(node)
+
+	case ast.KindInterfaceDeclaration:
+		timeline.visitInterface(node)
+
+	case ast.KindTypeAliasDeclaration:
+		timeline.visitTypeAlias(node)
+
+	case ast.KindTypeParameter:
+		timeline.visitTypeParameter(node, timeline.current)
+
+	case ast.KindFunctionType, ast.KindConstructorType, ast.KindCallSignature, ast.KindConstructSignature:
+		timeline.visitFunctionType(node)
+
+	case ast.KindMethodSignature:
+		timeline.visitMethodSignature(node)
+
+	case ast.KindIndexSignature:
+		timeline.visitIndexSignature(node)
+
+	case ast.KindConditionalType:
+		timeline.visitConditionalType(node)
+
+	case ast.KindMappedType:
+		timeline.visitMappedType(node)
+
+	case ast.KindInferType:
+		timeline.visitInferType(node)
+
+	case ast.KindEnumDeclaration:
+		timeline.visitEnum(node)
+
+	case ast.KindImportDeclaration, ast.KindImportEqualsDeclaration:
+		timeline.visitImport(node)
+
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		timeline.visit(call.Expression)
+		for _, argument := range node.Arguments() {
+			timeline.visit(argument)
+		}
+		for _, typeArgument := range node.TypeArguments() {
+			timeline.visit(typeArgument)
+		}
+
+	case ast.KindNewExpression:
+		call := node.AsNewExpression()
+		timeline.visit(call.Expression)
+		for _, argument := range node.Arguments() {
+			timeline.visit(argument)
+		}
+		for _, typeArgument := range node.TypeArguments() {
+			timeline.visit(typeArgument)
+		}
+
+	case ast.KindTaggedTemplateExpression:
+		tagged := node.AsTaggedTemplateExpression()
+		timeline.visit(tagged.Tag)
+		timeline.visit(tagged.Template)
+		for _, typeArgument := range node.TypeArguments() {
+			timeline.visit(typeArgument)
+		}
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary.OperatorToken != nil && ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
+			if binary.OperatorToken.Kind == ast.KindEqualsToken {
+				left := timeline.visitExpressionTarget(binary.Left)
+				if isTimelinePattern(left) {
+					timeline.visitPatternRightHandNodes(left)
+				} else {
+					timeline.visit(left)
+				}
+			} else {
+				// A direct array/object pattern is not a valid compound target.
+				// TSESTree still parses it, but Referencer skips its entire left
+				// subtree. Wrapped expressions remain ordinary expressions.
+				switch binary.Left.Kind {
+				case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
+				default:
+					timeline.visit(binary.Left)
+				}
+			}
+			timeline.visit(binary.Right)
+		} else {
+			timeline.visitChildren(node)
+		}
+
+	case ast.KindPrefixUnaryExpression:
+		prefix := node.AsPrefixUnaryExpression()
+		if prefix.Operator == ast.KindPlusPlusToken || prefix.Operator == ast.KindMinusMinusToken {
+			argument := timeline.visitExpressionTarget(prefix.Operand)
+			if isTimelinePattern(argument) {
+				timeline.visitPatternRightHandNodes(argument)
+			} else {
+				timeline.visitChildren(node)
+			}
+		} else {
+			timeline.visitChildren(node)
+		}
+
+	case ast.KindPostfixUnaryExpression:
+		argument := timeline.visitExpressionTarget(node.AsPostfixUnaryExpression().Operand)
+		if isTimelinePattern(argument) {
+			timeline.visitPatternRightHandNodes(argument)
+		} else {
+			timeline.visitChildren(node)
+		}
+
+	case ast.KindImportType:
+		for _, typeArgument := range node.TypeArguments() {
+			timeline.visit(typeArgument)
+		}
+
+	case ast.KindAsExpression:
+		expression := node.AsAsExpression()
+		timeline.visit(expression.Expression)
+		timeline.visit(expression.Type)
+
+	case ast.KindSatisfiesExpression:
+		expression := node.AsSatisfiesExpression()
+		timeline.visit(expression.Expression)
+		timeline.visit(expression.Type)
+
+	case ast.KindTypeAssertionExpression:
+		expression := node.AsTypeAssertion()
+		timeline.visit(expression.Expression)
+		timeline.visit(expression.Type)
+
+	case ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement:
+		timeline.referenceChannel(0)
+		timeline.visitChildren(node)
+
+	case ast.KindJsxFragment:
+		timeline.referenceChannel(0)
+		timeline.referenceChannel(1)
+		timeline.visitChildren(node)
+
+	default:
+		timeline.visitChildren(node)
+	}
+}
+
+func (timeline *jsxTimeline) visitExpressionTarget(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	for node.Kind == ast.KindParenthesizedExpression {
+		node = node.Expression()
+	}
+	switch node.Kind {
+	case ast.KindNonNullExpression:
+		node = node.Expression()
+	case ast.KindAsExpression:
+		expression := node.AsAsExpression()
+		timeline.visit(expression.Type)
+		node = expression.Expression
+	case ast.KindTypeAssertionExpression:
+		expression := node.AsTypeAssertion()
+		timeline.visit(expression.Type)
+		node = expression.Expression
+	}
+	for node != nil && node.Kind == ast.KindParenthesizedExpression {
+		node = node.Expression()
+	}
+	return node
+}
+
+func isTimelinePattern(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier,
+		ast.KindObjectLiteralExpression,
+		ast.KindArrayLiteralExpression,
+		ast.KindSpreadElement,
+		ast.KindSpreadAssignment:
+		return true
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		return binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken
+	}
+	return false
+}
+
+func (timeline *jsxTimeline) visitPatternRightHandNodes(node *ast.Node) {
+	var rightHandNodes []*ast.Node
+	collectTimelinePatternRightHandNodes(node, &rightHandNodes)
+	for _, rightHand := range rightHandNodes {
+		timeline.visit(rightHand)
+	}
+}
+
+func collectTimelinePatternRightHandNodes(node *ast.Node, result *[]*ast.Node) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindParenthesizedExpression,
+		ast.KindNonNullExpression:
+		collectTimelinePatternRightHandNodes(node.Expression(), result)
+
+	case ast.KindDecorator:
+		return
+
+	case ast.KindAsExpression:
+		expression := node.AsAsExpression()
+		collectTimelinePatternRightHandNodes(expression.Expression, result)
+		collectTimelinePatternRightHandNodes(expression.Type, result)
+
+	case ast.KindSatisfiesExpression:
+		expression := node.AsSatisfiesExpression()
+		collectTimelinePatternRightHandNodes(expression.Expression, result)
+		collectTimelinePatternRightHandNodes(expression.Type, result)
+
+	case ast.KindTypeAssertionExpression:
+		expression := node.AsTypeAssertion()
+		collectTimelinePatternRightHandNodes(expression.Type, result)
+		collectTimelinePatternRightHandNodes(expression.Expression, result)
+
+	case ast.KindObjectLiteralExpression:
+		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
+			collectTimelinePatternRightHandNodes(property, result)
+		}
+
+	case ast.KindArrayLiteralExpression:
+		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
+			collectTimelinePatternRightHandNodes(element, result)
+		}
+
+	case ast.KindPropertyAssignment:
+		property := node.AsPropertyAssignment()
+		if property.Name() != nil && property.Name().Kind == ast.KindComputedPropertyName {
+			*result = append(*result, property.Name().AsComputedPropertyName().Expression)
+		}
+		collectTimelinePatternRightHandNodes(property.Initializer, result)
+
+	case ast.KindShorthandPropertyAssignment:
+		property := node.AsShorthandPropertyAssignment()
+		if property.ObjectAssignmentInitializer != nil {
+			*result = append(*result, property.ObjectAssignmentInitializer)
+		}
+
+	case ast.KindSpreadAssignment:
+		collectTimelinePatternRightHandNodes(node.AsSpreadAssignment().Expression, result)
+
+	case ast.KindSpreadElement:
+		collectTimelinePatternRightHandNodes(node.AsSpreadElement().Expression, result)
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary.OperatorToken != nil && ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
+			collectTimelinePatternRightHandNodes(binary.Left, result)
+			*result = append(*result, binary.Right)
+		} else {
+			node.ForEachChild(func(child *ast.Node) bool {
+				collectTimelinePatternRightHandNodes(child, result)
+				return false
+			})
+		}
+
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		*result = append(*result, access.ArgumentExpression, access.Expression)
+
+	case ast.KindPropertyAccessExpression:
+		*result = append(*result, node.AsPropertyAccessExpression().Expression)
+
+	case ast.KindCallExpression:
+		*result = append(*result, node.Arguments()...)
+		collectTimelinePatternRightHandNodes(node.AsCallExpression().Expression, result)
+
+	default:
+		node.ForEachChild(func(child *ast.Node) bool {
+			collectTimelinePatternRightHandNodes(child, result)
+			return false
+		})
+	}
+}
+
+func (timeline *jsxTimeline) visitChildren(node *ast.Node) {
+	node.ForEachChild(func(child *ast.Node) bool {
+		timeline.visit(child)
+		return timeline.resolvedAllActiveChannels()
+	})
+}
+
+func (timeline *jsxTimeline) visitStatements(node *ast.Node) {
+	for _, statement := range node.Statements() {
+		timeline.visit(statement)
+		if timeline.resolvedAllActiveChannels() {
+			break
+		}
+	}
+}
+
+func (timeline *jsxTimeline) visitVariableDeclarationList(node *ast.Node) {
+	list := node.AsVariableDeclarationList()
+	target := timeline.current
+	host := utils.FindEnclosingScope(node)
+	if utils.IsVarKeyword(node) {
+		target = timeline.current.variableScope
+	}
+	for _, declaration := range list.Declarations.Nodes {
+		variable := declaration.AsVariableDeclaration()
+		timeline.visitBindingPattern(variable.Name(), target, func(identifier *ast.Node) *varGroup {
+			if utils.IsVarKeyword(node) && timeline.indexOfName(identifier.Text()) != -1 {
+				canonical := timeline.state.canonical[canonicalKey{host: host, name: identifier.Text()}]
+				return timeline.state.groups[canonical]
+			}
+			return nil
+		})
+		timeline.visit(variable.Initializer)
+		timeline.visit(variable.Type)
+	}
+}
+
+func (timeline *jsxTimeline) visitBindingPattern(name *ast.Node, target *jsxTimelineScope, groupFor func(*ast.Node) *varGroup) {
+	utils.CollectBindingNames(name, func(identifier *ast.Node, _ string) {
+		var group *varGroup
+		if groupFor != nil {
+			group = groupFor(identifier)
+		}
+		timeline.define(identifier, true, group, target)
+	})
+	for _, rightHand := range bindingPatternRightHandNodes(name) {
+		timeline.visit(rightHand)
+	}
+}
+
+func bindingPatternRightHandNodes(name *ast.Node) []*ast.Node {
+	var result []*ast.Node
+	var collect func(*ast.Node)
+	collect = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		switch node.Kind {
+		case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
+			node.ForEachChild(func(child *ast.Node) bool {
+				if child.Kind == ast.KindBindingElement {
+					collect(child)
+				}
+				return false
+			})
+		case ast.KindBindingElement:
+			element := node.AsBindingElement()
+			if element.PropertyName != nil && element.PropertyName.Kind == ast.KindComputedPropertyName {
+				result = append(result, element.PropertyName.AsComputedPropertyName().Expression)
+			}
+			collect(element.Name())
+			if element.Initializer != nil {
+				result = append(result, element.Initializer)
+			}
+		}
+	}
+	collect(name)
+	return result
+}
+
+func (timeline *jsxTimeline) visitFunction(node *ast.Node, method, decoratorsVisited bool) {
+	if method && !decoratorsVisited {
+		for _, parameter := range node.Parameters() {
+			for _, decorator := range parameter.Decorators() {
+				timeline.visit(decorator)
+			}
+		}
+	}
+	timeline.pushScope(jsxScopeOther, true)
+	if body := node.Body(); body != nil {
+		timeline.current.functionBodyStart = utils.TrimNodeTextRange(timeline.state.ctx.SourceFile, body).Pos()
+	}
+	for _, parameter := range node.Parameters() {
+		timeline.visitParameter(parameter, method)
+	}
+	timeline.visit(node.Type())
+	for _, typeParameter := range node.TypeParameters() {
+		timeline.visitTypeParameter(typeParameter, timeline.current)
+	}
+	body := node.Body()
+	if body != nil && body.Kind == ast.KindBlock {
+		timeline.visitStatements(body)
+	} else {
+		timeline.visit(body)
+	}
+	timeline.popScope()
+}
+
+func (timeline *jsxTimeline) visitParameter(node *ast.Node, method bool) {
+	parameter := node.AsParameterDeclaration()
+	timeline.visitBindingPattern(parameter.Name(), timeline.current, nil)
+	timeline.visit(parameter.Initializer)
+	timeline.visit(parameter.Type)
+	if !method {
+		for _, decorator := range node.Decorators() {
+			timeline.visit(decorator)
+		}
+	}
+}
+
+func (timeline *jsxTimeline) visitMethod(node *ast.Node) {
+	if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+		timeline.visit(name.AsComputedPropertyName().Expression)
+	}
+	for _, parameter := range node.Parameters() {
+		for _, decorator := range parameter.Decorators() {
+			timeline.visit(decorator)
+		}
+	}
+	timeline.visitFunction(node, true, true)
+	for _, decorator := range node.Decorators() {
+		timeline.visit(decorator)
+	}
+}
+
+func (timeline *jsxTimeline) visitClass(node *ast.Node) {
+	if node.Kind == ast.KindClassDeclaration && node.Name() != nil {
+		timeline.define(node.Name(), true, nil, timeline.current)
+	}
+	for _, decorator := range node.Decorators() {
+		timeline.visit(decorator)
+	}
+	timeline.pushScope(jsxScopeOther, false)
+	if node.Name() != nil {
+		timeline.define(node.Name(), true, nil, timeline.current)
+	}
+	classData := node.ClassLikeData()
+	if classData.HeritageClauses != nil {
+		for _, clause := range classData.HeritageClauses.Nodes {
+			heritage := clause.AsHeritageClause()
+			if heritage.Token == ast.KindExtendsKeyword {
+				for _, item := range heritage.Types.Nodes {
+					timeline.visit(item.AsExpressionWithTypeArguments().Expression)
+				}
+			}
+		}
+	}
+	for _, typeParameter := range node.TypeParameters() {
+		timeline.visitTypeParameter(typeParameter, timeline.current)
+	}
+	if classData.HeritageClauses != nil {
+		for _, clause := range classData.HeritageClauses.Nodes {
+			for _, item := range clause.AsHeritageClause().Types.Nodes {
+				typeArguments := item.AsExpressionWithTypeArguments().TypeArguments
+				if typeArguments != nil {
+					for _, typeArgument := range typeArguments.Nodes {
+						timeline.visit(typeArgument)
+					}
+				}
+			}
+		}
+	}
+	for _, member := range node.Members() {
+		timeline.visit(member)
+	}
+	timeline.popScope()
+}
+
+func (timeline *jsxTimeline) visitClassProperty(node *ast.Node) {
+	property := node.AsPropertyDeclaration()
+	if name := property.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+		timeline.visit(name.AsComputedPropertyName().Expression)
+	}
+	if property.Initializer != nil {
+		timeline.pushScope(jsxScopeOther, true)
+		timeline.visit(property.Initializer)
+		timeline.popScope()
+	}
+	for _, decorator := range node.Decorators() {
+		timeline.visit(decorator)
+	}
+	timeline.visit(property.Type)
+}
+
+func (timeline *jsxTimeline) visitCatchClause(node *ast.Node) {
+	clause := node.AsCatchClause()
+	timeline.pushScope(jsxScopeOther, false)
+	if clause.VariableDeclaration != nil {
+		timeline.visitBindingPattern(clause.VariableDeclaration.Name(), timeline.current, nil)
+	}
+	timeline.visit(clause.Block)
+	timeline.popScope()
+}
+
+func (timeline *jsxTimeline) visitFor(node *ast.Node) {
+	switch node.Kind {
+	case ast.KindForStatement:
+		statement := node.AsForStatement()
+		needsScope := statement.Initializer != nil &&
+			statement.Initializer.Kind == ast.KindVariableDeclarationList &&
+			!utils.IsVarKeyword(statement.Initializer)
+		if needsScope {
+			timeline.pushScope(jsxScopeOther, false)
+		}
+		timeline.visit(statement.Initializer)
+		timeline.visit(statement.Condition)
+		timeline.visit(statement.Incrementor)
+		timeline.visit(statement.Statement)
+		if needsScope {
+			timeline.popScope()
+		}
+
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		statement := node.AsForInOrOfStatement()
+		needsScope := statement.Initializer.Kind == ast.KindVariableDeclarationList &&
+			!utils.IsVarKeyword(statement.Initializer)
+		if needsScope {
+			timeline.pushScope(jsxScopeOther, false)
+		}
+		if statement.Initializer.Kind == ast.KindVariableDeclarationList {
+			timeline.visit(statement.Initializer)
+		} else {
+			timeline.visitPatternRightHandNodes(statement.Initializer)
+		}
+		timeline.visit(statement.Expression)
+		timeline.visit(statement.Statement)
+		if needsScope {
+			timeline.popScope()
+		}
+	}
+}
+
+func (timeline *jsxTimeline) visitSwitch(node *ast.Node) {
+	statement := node.AsSwitchStatement()
+	timeline.visit(statement.Expression)
+	timeline.pushScope(jsxScopeOther, false)
+	timeline.visit(statement.CaseBlock)
+	timeline.popScope()
+}
+
+func (timeline *jsxTimeline) visitInterface(node *ast.Node) {
+	declaration := node.AsInterfaceDeclaration()
+	timeline.define(declaration.Name(), false, nil, timeline.current)
+	if declaration.TypeParameters != nil {
+		timeline.pushScope(jsxScopeOther, false)
+	}
+	for _, typeParameter := range node.TypeParameters() {
+		timeline.visitTypeParameter(typeParameter, timeline.current)
+	}
+	if declaration.HeritageClauses != nil {
+		for _, heritage := range declaration.HeritageClauses.Nodes {
+			timeline.visit(heritage)
+		}
+	}
+	for _, member := range declaration.Members.Nodes {
+		timeline.visit(member)
+	}
+	if declaration.TypeParameters != nil {
+		timeline.popScope()
+	}
+}
+
+func (timeline *jsxTimeline) visitTypeAlias(node *ast.Node) {
+	declaration := node.AsTypeAliasDeclaration()
+	timeline.define(declaration.Name(), false, nil, timeline.current)
+	if declaration.TypeParameters != nil {
+		timeline.pushScope(jsxScopeOther, false)
+	}
+	for _, typeParameter := range node.TypeParameters() {
+		timeline.visitTypeParameter(typeParameter, timeline.current)
+	}
+	timeline.visit(declaration.Type)
+	if declaration.TypeParameters != nil {
+		timeline.popScope()
+	}
+}
+
+func (timeline *jsxTimeline) visitTypeParameter(node *ast.Node, target *jsxTimelineScope) {
+	declaration := node.AsTypeParameterDeclaration()
+	timeline.define(declaration.Name(), false, nil, target)
+	timeline.visit(declaration.Constraint)
+	timeline.visit(declaration.DefaultType)
+}
+
+func (timeline *jsxTimeline) visitFunctionType(node *ast.Node) {
+	timeline.pushScope(jsxScopeFunctionType, false)
+	for _, typeParameter := range node.TypeParameters() {
+		timeline.visitTypeParameter(typeParameter, timeline.current)
+	}
+	for _, parameter := range node.Parameters() {
+		utils.CollectBindingNames(parameter.Name(), func(identifier *ast.Node, _ string) {
+			timeline.define(identifier, true, nil, timeline.current)
+		})
+		timeline.visit(parameter.Type())
+	}
+	timeline.visit(node.Type())
+	timeline.popScope()
+}
+
+func (timeline *jsxTimeline) visitMethodSignature(node *ast.Node) {
+	if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+		timeline.visit(name.AsComputedPropertyName().Expression)
+	}
+	timeline.visitFunctionType(node)
+}
+
+func (timeline *jsxTimeline) visitIndexSignature(node *ast.Node) {
+	for _, parameter := range node.Parameters() {
+		if parameter.Name() != nil && parameter.Name().Kind == ast.KindIdentifier {
+			timeline.visit(parameter.Type())
+		}
+	}
+	timeline.visit(node.Type())
+}
+
+func (timeline *jsxTimeline) visitConditionalType(node *ast.Node) {
+	conditional := node.AsConditionalTypeNode()
+	timeline.pushScope(jsxScopeConditionalType, false)
+	timeline.visit(conditional.CheckType)
+	timeline.visit(conditional.ExtendsType)
+	timeline.visit(conditional.TrueType)
+	timeline.popScope()
+	timeline.visit(conditional.FalseType)
+}
+
+func (timeline *jsxTimeline) visitMappedType(node *ast.Node) {
+	mapped := node.AsMappedTypeNode()
+	timeline.pushScope(jsxScopeMappedType, false)
+	typeParameter := mapped.TypeParameter.AsTypeParameterDeclaration()
+	timeline.define(typeParameter.Name(), false, nil, timeline.current)
+	timeline.visit(typeParameter.Constraint)
+	timeline.visit(mapped.NameType)
+	timeline.visit(mapped.Type)
+	timeline.popScope()
+}
+
+func (timeline *jsxTimeline) visitInferType(node *ast.Node) {
+	target := timeline.current
+	for scope := timeline.current; scope != nil; scope = scope.upper {
+		if scope.kind == jsxScopeConditionalType {
+			target = scope
+			break
+		}
+		if scope.kind != jsxScopeFunctionType && scope.kind != jsxScopeMappedType {
+			break
+		}
+	}
+	typeParameter := node.AsInferTypeNode().TypeParameter.AsTypeParameterDeclaration()
+	timeline.define(typeParameter.Name(), false, nil, target)
+	timeline.visit(typeParameter.Constraint)
+}
+
+func (timeline *jsxTimeline) visitEnum(node *ast.Node) {
+	declaration := node.AsEnumDeclaration()
+	timeline.define(declaration.Name(), true, nil, timeline.current)
+	timeline.pushScope(jsxScopeOther, false)
+	for _, member := range declaration.Members.Nodes {
+		if member.Name() != nil && member.Name().Kind == ast.KindIdentifier {
+			timeline.define(member.Name(), true, nil, timeline.current)
+		}
+		timeline.visit(member.AsEnumMember().Initializer)
+	}
+	timeline.popScope()
+}
+
+func (timeline *jsxTimeline) visitImport(node *ast.Node) {
+	if node.Kind == ast.KindImportEqualsDeclaration {
+		if node.Name() != nil {
+			timeline.define(node.Name(), true, nil, timeline.current)
+		}
+		return
+	}
+	utils.VisitDescendants(node, func(candidate *ast.Node) bool {
+		switch candidate.Kind {
+		case ast.KindImportClause, ast.KindNamespaceImport, ast.KindImportSpecifier:
+			if candidate.Name() != nil {
+				timeline.define(candidate.Name(), true, nil, timeline.current)
+			}
+		}
+		return true
+	})
+}


### PR DESCRIPTION
## Summary

- Normalize merged `var` identities and declaration occurrences so diagnostics, counts, and definition locations match ESLint 10.8.
- Model declaration, parameter, destructuring, TypeScript, and TSX reference events with exact TSESTree ranges while reusing binder, RefStore, and shared traversal helpers.
- Add adversarial regression coverage for the original review cases and the discovered JavaScript, TypeScript, and TSX boundaries.

### Go benchmark

Command: `go test ./internal/rules/block_scoped_var -run "^$" -bench "^BenchmarkBlockScopedVar$" -benchmem -benchtime=100x -count=5`

Median of five samples:

| Case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| NoVar | 5,052 → 3,499 | 0 → 0 | 0 → 0 |
| InScopeUnique | 62,547 → 63,408 | 80,161 → 109,025 | 742 → 773 |
| OutOfScopeUnique | 75,393 → 91,005 | 97,604 → 133,561 | 999 → 1,027 |
| MergedAndDuplicate | 112,007 → 117,619 | 89,901 → 128,495 | 881 → 1,012 |
| DestructuringAndCatch | 228,487 → 158,620 | 147,190 → 118,215 | 1,577 → 851 |
| JSXAndParameterDefaults | 41,964 → 69,643 | 26,400 → 62,482 | 208 → 578 |

The slower matched cases perform reference and diagnostic work that the prior implementation omitted. The zero-allocation no-match path is 30.7% faster, and the destructuring/catch path is 30.6% faster.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).