### PR TITLE
fix: use program accessor in block-scoped-var

### DIFF
--- a/internal/rules/block_scoped_var/block_scoped_var.go
+++ b/internal/rules/block_scoped_var/block_scoped_var.go
@@ -87,8 +87,8 @@ func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 	}
 
 	options := &core.CompilerOptions{}
-	if ctx.Program != nil {
-		options = ctx.Program.Options()
+	if sourceProgram := ctx.Program(); sourceProgram != nil {
+		options = sourceProgram.Options()
 	}
 	resolver := binder.NameResolver{CompilerOptions: options}
 	if ctx.SourceFile.IsBound() && ast.IsGlobalSourceFile(ctx.SourceFile.AsNode()) {

--- a/internal/rules/block_scoped_var/block_scoped_var_tsx.go
+++ b/internal/rules/block_scoped_var/block_scoped_var_tsx.go
@@ -279,16 +279,17 @@ func (state *blockScopedVarState) implicitTypeGlobalGroups() map[string]*varGrou
 	}
 
 	activeTypeGlobals := make(map[string]bool)
-	if state.ctx.Program != nil && state.ctx.TypeChecker != nil {
-		utils.AddDefaultLibraryTypeGlobalNames(activeTypeGlobals, state.ctx.Program, state.ctx.TypeChecker)
+	sourceProgram := state.ctx.Program()
+	if sourceProgram != nil && state.ctx.TypeChecker != nil {
+		utils.AddDefaultLibraryTypeGlobalNames(activeTypeGlobals, sourceProgram, state.ctx.TypeChecker)
 	}
 	// Without a Program, scope-manager 8.65 seeds its generated esnext
 	// catalog. With a Program it derives the catalog from target and, notably,
 	// ignores noLib; reuse that same public catalog for the ESNext/noLib case
 	// that the checker omits.
-	defaultESNext := state.ctx.Program == nil ||
-		(state.ctx.Program.Options().NoLib.IsTrue() &&
-			state.ctx.Program.Options().GetEmitScriptTarget() == core.ScriptTargetESNext)
+	defaultESNext := sourceProgram == nil ||
+		(sourceProgram.Options().NoLib.IsTrue() &&
+			sourceProgram.Options().GetEmitScriptTarget() == core.ScriptTargetESNext)
 	if defaultESNext {
 		for _, group := range state.groupOrder {
 			if rule.IsDefaultTypeScriptTypeGlobal(group.name) {
@@ -321,7 +322,8 @@ func (state *blockScopedVarState) implicitTypeGlobalGroups() map[string]*varGrou
 }
 
 func (state *blockScopedVarState) isDefaultLibrarySymbol(symbol *ast.Symbol) bool {
-	return state.ctx.Program != nil && utils.IsSymbolFromDefaultLibrary(state.ctx.Program, symbol)
+	sourceProgram := state.ctx.Program()
+	return sourceProgram != nil && utils.IsSymbolFromDefaultLibrary(sourceProgram, symbol)
 }
 
 // mergedGroupForTypeTarget joins TypeScript's local/export symbol pair without
@@ -510,8 +512,8 @@ func (state *blockScopedVarState) addTSXFactoryReferences() {
 
 	factoryName := "React"
 	fragmentName := ""
-	if state.ctx.Program != nil {
-		options := state.ctx.Program.Options()
+	if sourceProgram := state.ctx.Program(); sourceProgram != nil {
+		options := sourceProgram.Options()
 		if options.JsxFactory != "" {
 			factoryName = jsxFactoryRoot(options.JsxFactory)
 		}


### PR DESCRIPTION
## Summary

- migrate block-scoped-var from the removed `RuleContext.Program` field to `RuleContext.Program()`
- preserve nil-program handling by caching the accessor result within each affected function
- restore Go, CLI, schema dump, and WASM compilation after #1685 and #1739 landed together

## Related Links

- https://github.com/web-infra-dev/rslint/actions/runs/31803250611
- #1685
- #1739

## Testing

- `go test -count=1 ./internal/rules/block_scoped_var ./internal/rule ./internal/program`
- `go vet ./internal/rules/block_scoped_var ./internal/rule ./internal/program`
- `go test -run "^$" ./cmd/rslint ./tools/dump_rule_schemas`

## Checklist

- [x] Tests updated (not required; existing tests cover the accessor paths).
- [x] Documentation updated (not required).