### PR TITLE
feat: port rule max-classes-per-file

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -18,6 +18,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/getter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/guard_for_in"
 	"github.com/web-infra-dev/rslint/internal/rules/init_declarations"
+	"github.com/web-infra-dev/rslint/internal/rules/max_classes_per_file"
 	"github.com/web-infra-dev/rslint/internal/rules/max_depth"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines_per_function"
@@ -180,6 +181,7 @@ func GetAllRules() []rule.Rule {
 		getter_return.GetterReturnRule,
 		guard_for_in.GuardForInRule,
 		init_declarations.InitDeclarationsRule,
+		max_classes_per_file.MaxClassesPerFileRule,
 		max_depth.MaxDepthRule,
 		max_lines.MaxLinesRule,
 		max_lines_per_function.MaxLinesPerFunctionRule,

--- a/internal/rules/max_classes_per_file/max_classes_per_file.go
+++ b/internal/rules/max_classes_per_file/max_classes_per_file.go
@@ -1,0 +1,94 @@
+package max_classes_per_file
+
+import (
+	_ "embed"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed max_classes_per_file.schema.json
+var schemaJSON []byte
+
+const defaultMax = 1
+
+// MaxClassesPerFileRule enforces a maximum number of classes per file.
+// https://eslint.org/docs/latest/rules/max-classes-per-file
+var MaxClassesPerFileRule = rule.Rule{
+	Name:   "max-classes-per-file",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+		classCount := 0
+
+		listeners := rule.RuleListeners{
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				classCount++
+			},
+		}
+		if !opts.ignoreExpressions {
+			listeners[ast.KindClassExpression] = func(node *ast.Node) {
+				classCount++
+			}
+		}
+
+		// ESLint reports on "Program:exit" using the source range of the
+		// Program's own body (first statement start to last statement end),
+		// not the range of any particular class. The end-of-file token is
+		// always the last node the linter visits, so it stands in for
+		// "Program:exit" here.
+		statements := ctx.SourceFile.Statements
+		if statements == nil || len(statements.Nodes) == 0 {
+			return listeners
+		}
+		firstStatement := statements.Nodes[0]
+		lastStatement := statements.Nodes[len(statements.Nodes)-1]
+
+		listeners[rule.ListenerOnExit(ast.KindEndOfFile)] = func(node *ast.Node) {
+			if classCount <= opts.max {
+				return
+			}
+			textRange := core.NewTextRange(
+				utils.TrimNodeTextRange(ctx.SourceFile, firstStatement).Pos(),
+				lastStatement.End(),
+			)
+			ctx.ReportRange(textRange, rule.RuleMessage{
+				Id: "maximumExceeded",
+				Description: "File has too many classes (" +
+					strconv.Itoa(classCount) + "). Maximum allowed is " +
+					strconv.Itoa(opts.max) + ".",
+				Data: map[string]string{
+					"classCount": strconv.Itoa(classCount),
+					"max":        strconv.Itoa(opts.max),
+				},
+			})
+		}
+
+		return listeners
+	},
+}
+
+type ruleOptions struct {
+	max               int
+	ignoreExpressions bool
+}
+
+// parseOptions mirrors ESLint's destructuring of a bare max or an
+// { ignoreExpressions, max } object: a bare number never carries
+// ignoreExpressions, and an object without max falls back to the default.
+func parseOptions(options []any) ruleOptions {
+	opts := ruleOptions{max: defaultMax}
+	if len(options) == 0 {
+		return opts
+	}
+	opts.max = utils.ResolveLegacyMaxOption(options[0], defaultMax)
+	if m, ok := options[0].(map[string]any); ok {
+		if v, ok := m["ignoreExpressions"].(bool); ok {
+			opts.ignoreExpressions = v
+		}
+	}
+	return opts
+}

--- a/internal/rules/max_classes_per_file/max_classes_per_file.md
+++ b/internal/rules/max_classes_per_file/max_classes_per_file.md
@@ -1,0 +1,61 @@
+# max-classes-per-file
+
+## Rule Details
+
+This rule enforces that each file may contain only a particular number of classes and no more.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class Foo {}
+class Bar {}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class Foo {}
+```
+
+## Options
+
+This rule may be configured with either an object or a number.
+
+If the option is an object, it may contain one or both of:
+
+- `ignoreExpressions`: a boolean option (defaulted to `false`) to ignore class expressions.
+- `max`: a numeric option (defaulted to 1) to specify the maximum number of classes.
+
+Examples of **correct** code for this rule with `{ "max-classes-per-file": ["error", 2] }`:
+
+```json
+{ "max-classes-per-file": ["error", 2] }
+```
+
+```javascript
+class Foo {}
+class Bar {}
+```
+
+Examples of **correct** code for this rule with `{ "max-classes-per-file": ["error", { "ignoreExpressions": true }] }`:
+
+```json
+{ "max-classes-per-file": ["error", { "ignoreExpressions": true }] }
+```
+
+```javascript
+class VisitorFactory {
+  forDescriptor(descriptor) {
+    return class {
+      visit(node) {
+        return `Visiting ${descriptor}.`;
+      }
+    };
+  }
+}
+```
+
+## Original Documentation
+
+- [ESLint: max-classes-per-file](https://eslint.org/docs/latest/rules/max-classes-per-file)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/max-classes-per-file.js)

--- a/internal/rules/max_classes_per_file/max_classes_per_file.schema.json
+++ b/internal/rules/max_classes_per_file/max_classes_per_file.schema.json
@@ -1,0 +1,28 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ignoreExpressions": {
+              "type": "boolean"
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/max_classes_per_file/max_classes_per_file_extras_test.go
+++ b/internal/rules/max_classes_per_file/max_classes_per_file_extras_test.go
@@ -1,0 +1,208 @@
+package max_classes_per_file
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMaxClassesPerFileExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+func TestMaxClassesPerFileExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxClassesPerFileRule,
+		[]rule_tester.ValidTestCase{
+			// N/A: rule counts ClassDeclaration/ClassExpression node kinds
+			// directly; it never reads a property key or walks a member/
+			// element-access chain, so the "Access / key forms" and
+			// "Optional chain" Dimension 4 rows do not apply.
+
+			// N/A: the rule never inspects function bodies, destructuring
+			// patterns, spreads, or class members, so "Graceful degradation"
+			// (SpreadAssignment / RestElement / empty bodies / overload
+			// signatures) does not apply.
+
+			// ---- Dimension 4: empty Program body ----
+			{Code: ""},
+
+			// ---- Dimension 4: receiver wrappers around a class expression ----
+			// A single wrapped class expression still counts as exactly one
+			// class, so it stays under the default max of 1.
+			{Code: "var x = (class {});"},
+			{Code: "var x = (class {})!;"},
+			{Code: "var x = (class {}) satisfies object;"},
+
+			// ---- Branch: classCount == max is not > max (boundary), object
+			// option form with both `max` and `ignoreExpressions` set ----
+			{Code: "class Foo {}\nclass Bar {}", Options: option(map[string]interface{}{"ignoreExpressions": true, "max": 2})},
+
+			// ---- Options contract: explicit `ignoreExpressions: false` behaves
+			// the same as the (implicit-default) unset case -- expressions
+			// still count towards max. ----
+			{Code: "var x = class {};\nvar y = class {};", Options: option(map[string]interface{}{"ignoreExpressions": false, "max": 2})},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: `as`-wrapped class expressions still count ----
+			{
+				Code: "var x = (class {}) as any;\nvar y = (class {}) as any;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 27,
+				}},
+			},
+
+			// ---- Dimension 4: declaration/container forms ----
+			// `export default class {}` parses as an (anonymous)
+			// ClassDeclaration, not a ClassExpression, so it counts the same
+			// as a named declaration.
+			{
+				Code: "export default class {}\nclass Named {}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 15,
+				}},
+			},
+			// A named class expression (`class Named {}` as an expression)
+			// still counts as a ClassExpression, not a ClassDeclaration.
+			{
+				Code: "var x = class Named {};\nvar y = class Named2 {};",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 25,
+				}},
+			},
+
+			// ---- Dimension 1: TypeScript-specific class syntax ----
+			{
+				Code: "abstract class Foo {}\nabstract class Bar {}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 22,
+				}},
+			},
+			{
+				Code: "declare class Foo {}\ndeclare class Bar {}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 21,
+				}},
+			},
+			{
+				Code: "class Foo<T> {}\nclass Bar<T> {}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 16,
+				}},
+			},
+
+			// ---- Dimension 2: nesting boundaries ----
+			// A class declared inside a method body of another class still
+			// counts; the rule does not stop at the enclosing class boundary.
+			{
+				Code: "class Outer {\n  method() {\n    class Inner {}\n  }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 5, EndColumn: 2,
+				}},
+			},
+			// A class declared inside a function body counts too, and the
+			// reported range still spans the Program's own top-level
+			// statements, not the classes themselves.
+			{
+				Code: "function factory() {\n  class Local {}\n  return Local;\n}\nclass Top {}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 5, EndColumn: 13,
+				}},
+			},
+			// Deeply nested (3+ levels): a ClassExpression returned from a
+			// function, whose own method contains a nested function
+			// declaring a further ClassDeclaration. Both are still counted
+			// even though there is a single top-level statement.
+			{
+				Code: "function outer() {\n  return class Level1 {\n    method() {\n      function inner() {\n        class Level2 {}\n        return Level2;\n      }\n      return inner;\n    }\n  };\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 11, EndColumn: 2,
+				}},
+			},
+
+			// ---- Locks in upstream parseOptions() arm: object option with
+			// only `max` (no `ignoreExpressions` key) leaves ignoreExpressions
+			// undefined, which is falsy -- class expressions still count. ----
+			{
+				Code:    "var x = class {};\nvar y = class {};",
+				Options: option(map[string]interface{}{"max": 1}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 18,
+				}},
+			},
+			// ---- Locks in upstream parseOptions() arm: object option with
+			// only `ignoreExpressions` (no `max` key) falls back to the
+			// `option.max || 1` default. ----
+			{
+				Code:    "class Foo {}\nclass Bar {}",
+				Options: option(map[string]interface{}{"ignoreExpressions": true}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 13,
+				}},
+			},
+
+			// ---- Options contract: an empty options object `{}` behaves
+			// identically to omitting options entirely -- both fall back to
+			// the same defaults (max: 1, ignoreExpressions: false). ----
+			{
+				Code:    "class Foo {}\nclass Bar {}",
+				Options: option(map[string]interface{}{}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 13,
+				}},
+			},
+
+			// ---- Real-user: barrel-style module exporting several model
+			// classes from one file (a common source of real violations). ----
+			{
+				Code:    "export class UserModel {}\nexport class PostModel {}\nexport class CommentModel {}",
+				Options: option(2),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(3, 2),
+					Line:      1, Column: 1, EndLine: 3, EndColumn: 29,
+				}},
+			},
+			// ---- Real-user: TypeScript mixin factories, each returning an
+			// anonymous class expression -- a common false-positive
+			// complaint against this rule with default options. ----
+			{
+				Code: "function Serializable(Base) {\n  return class extends Base {\n    serialize() {}\n  };\n}\nfunction Comparable(Base) {\n  return class extends Base {\n    compare() {}\n  };\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 10, EndColumn: 2,
+				}},
+			},
+		},
+	)
+}

--- a/internal/rules/max_classes_per_file/max_classes_per_file_upstream_test.go
+++ b/internal/rules/max_classes_per_file/max_classes_per_file_upstream_test.go
@@ -1,0 +1,151 @@
+package max_classes_per_file
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMaxClassesPerFileUpstream migrates the full valid/invalid suite from
+// upstream eslint/tests/lib/rules/max-classes-per-file.js 1:1 (v10.8.1).
+// Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in the max_classes_per_file_extras_test.go file.
+func TestMaxClassesPerFileUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxClassesPerFileRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid ----
+			{Code: "class Foo {}"},
+			{Code: "var x = class {};"},
+			{Code: "var x = 5;"},
+			// SKIP: rule_tester exercises rule logic directly and does not
+			// evaluate eslint-disable directive comments, which is a
+			// framework-level (linter-pipeline) concern, not rule logic.
+			{
+				Code: "/* comment */\n/* eslint-disable rule-to-test/max-classes-per-file */\nclass A {}\nclass B {}",
+				Skip: true,
+			},
+			{Code: "class Foo {}", Options: option(1)},
+			{Code: "class Foo {}\nclass Bar {}", Options: option(2)},
+			{Code: "class Foo {}", Options: option(map[string]interface{}{"max": 1})},
+			{Code: "class Foo {}\nclass Bar {}", Options: option(map[string]interface{}{"max": 2})},
+			{
+				Code: `
+                class Foo {}
+                const myExpression = class {}
+            `,
+				Options: option(map[string]interface{}{"ignoreExpressions": true, "max": 1}),
+			},
+			{
+				Code: `
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}
+            `,
+				Options: option(map[string]interface{}{"ignoreExpressions": true, "max": 2}),
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid ----
+			{
+				Code: "class Foo {}\nclass Bar {}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 13,
+				}},
+			},
+			{
+				Code: "class Foo {}\nconst myExpression = class {}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 30,
+				}},
+			},
+			{
+				Code: "var x = class {};\nvar y = class {};",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 18,
+				}},
+			},
+			{
+				Code: "class Foo {}\nvar x = class {};",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 2, EndColumn: 18,
+				}},
+			},
+			{
+				Code:    "class Foo {} class Bar {}",
+				Options: option(1),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 26,
+				}},
+			},
+			{
+				Code:    "class Foo {} class Bar {} class Baz {}",
+				Options: option(2),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(3, 2),
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 39,
+				}},
+			},
+			{
+				Code: `
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}
+            `,
+				Options: option(map[string]interface{}{"ignoreExpressions": true, "max": 1}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      2, Column: 17, EndLine: 4, EndColumn: 46,
+				}},
+			},
+			{
+				Code: `
+                class Foo {}
+                class Bar {}
+                class Baz {}
+                const myExpression = class {}
+            `,
+				Options: option(map[string]interface{}{"ignoreExpressions": true, "max": 2}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(3, 2),
+					Line:      2, Column: 17, EndLine: 5, EndColumn: 46,
+				}},
+			},
+			{
+				Code: "/* comment */\nclass A {}\nclass B {}\n/* comment */",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "maximumExceeded",
+					Message:   maximumExceededMessage(2, 1),
+					Line:      2, Column: 1, EndLine: 3, EndColumn: 11,
+				}},
+			},
+		},
+	)
+}
+
+func option(v any) []interface{} {
+	return []interface{}{v}
+}
+
+func maximumExceededMessage(count, maxAllowed int) string {
+	return "File has too many classes (" + strconv.Itoa(count) +
+		"). Maximum allowed is " + strconv.Itoa(maxAllowed) + "."
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -469,6 +469,7 @@ export default defineConfig({
     './tests/eslint/rules/no-bitwise.test.ts',
     './tests/eslint/rules/complexity.test.ts',
     './tests/eslint/rules/consistent-return.test.ts',
+    './tests/eslint/rules/max-classes-per-file.test.ts',
     './tests/eslint/rules/max-depth.test.ts',
     './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/max-lines-per-function.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-classes-per-file.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-classes-per-file.test.ts.snap
@@ -1,0 +1,251 @@
+// Rstest Snapshot v1
+
+exports[`max-classes-per-file > invalid 1`] = `
+{
+  "code": "class Foo {}
+class Bar {}",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (2). Maximum allowed is 1.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 2`] = `
+{
+  "code": "class Foo {}
+const myExpression = class {}",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (2). Maximum allowed is 1.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 3`] = `
+{
+  "code": "var x = class {};
+var y = class {};",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (2). Maximum allowed is 1.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 4`] = `
+{
+  "code": "class Foo {}
+var x = class {};",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (2). Maximum allowed is 1.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 5`] = `
+{
+  "code": "class Foo {} class Bar {}",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (2). Maximum allowed is 1.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 6`] = `
+{
+  "code": "class Foo {} class Bar {} class Baz {}",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (3). Maximum allowed is 2.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 7`] = `
+{
+  "code": "
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}
+            ",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (2). Maximum allowed is 1.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 8`] = `
+{
+  "code": "
+                class Foo {}
+                class Bar {}
+                class Baz {}
+                const myExpression = class {}
+            ",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (3). Maximum allowed is 2.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 5,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-classes-per-file > invalid 9`] = `
+{
+  "code": "/* comment */
+class A {}
+class B {}
+/* comment */",
+  "diagnostics": [
+    {
+      "message": "File has too many classes (2). Maximum allowed is 1.",
+      "messageId": "maximumExceeded",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-classes-per-file",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/max-classes-per-file.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/max-classes-per-file.test.ts
@@ -1,0 +1,153 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('max-classes-per-file', {
+  valid: [
+    'class Foo {}',
+    'var x = class {};',
+    'var x = 5;',
+    { code: 'class Foo {}', options: [1] as any },
+    { code: 'class Foo {}\nclass Bar {}', options: [2] as any },
+    { code: 'class Foo {}', options: [{ max: 1 }] as any },
+    { code: 'class Foo {}\nclass Bar {}', options: [{ max: 2 }] as any },
+    {
+      code: `
+                class Foo {}
+                const myExpression = class {}
+            `,
+      options: [{ ignoreExpressions: true, max: 1 }] as any,
+    },
+    {
+      code: `
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}
+            `,
+      options: [{ ignoreExpressions: true, max: 2 }] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'class Foo {}\nclass Bar {}',
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {}\nconst myExpression = class {}',
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: 'var x = class {};\nvar y = class {};',
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {}\nvar x = class {};',
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {} class Bar {}',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 26,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {} class Bar {} class Baz {}',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 39,
+        },
+      ],
+    },
+    {
+      code: `
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}
+            `,
+      options: [{ ignoreExpressions: true, max: 1 }] as any,
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 2,
+          column: 17,
+          endLine: 4,
+          endColumn: 46,
+        },
+      ],
+    },
+    {
+      code: `
+                class Foo {}
+                class Bar {}
+                class Baz {}
+                const myExpression = class {}
+            `,
+      options: [{ ignoreExpressions: true, max: 2 }] as any,
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 2,
+          column: 17,
+          endLine: 5,
+          endColumn: 46,
+        },
+      ],
+    },
+    {
+      code: '/* comment */\nclass A {}\nclass B {}\n/* comment */',
+      errors: [
+        {
+          messageId: 'maximumExceeded',
+          line: 2,
+          column: 1,
+          endLine: 3,
+          endColumn: 11,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `max-classes-per-file` rule from ESLint to rslint.

Enforces that each file may contain only a particular number of classes and no more.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/max-classes-per-file
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/max-classes-per-file.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).