### PR TITLE
feat: port rule no-negated-condition

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -77,6 +77,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_misleading_character_class"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
+	"github.com/web-infra-dev/rslint/internal/rules/no_negated_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_nested_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
@@ -240,6 +241,7 @@ func GetAllRules() []rule.Rule {
 		no_restricted_syntax.NoRestrictedSyntaxRule,
 		no_multi_assign.NoMultiAssignRule,
 		no_multi_str.NoMultiStrRule,
+		no_negated_condition.NoNegatedConditionRule,
 		no_nested_ternary.NoNestedTernaryRule,
 		no_nonoctal_decimal_escape.NoNonoctalDecimalEscapeRule,
 		no_octal.NoOctalRule,

--- a/internal/rules/no_negated_condition/no_negated_condition.go
+++ b/internal/rules/no_negated_condition/no_negated_condition.go
@@ -1,0 +1,68 @@
+package no_negated_condition
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/no-negated-condition
+
+var unexpectedNegatedMsg = rule.RuleMessage{
+	Id:          "unexpectedNegated",
+	Description: "Unexpected negated condition.",
+}
+
+// isNegatedTest reports whether test (after peeling parens) is a negated
+// unary expression (`!x`) or a negated equality binary expression
+// (`x != y` / `x !== y`). Mirrors upstream's isNegatedUnaryExpression /
+// isNegatedBinaryExpression.
+func isNegatedTest(test *ast.Node) bool {
+	if test == nil {
+		return false
+	}
+	inner := ast.SkipParentheses(test)
+	switch inner.Kind {
+	case ast.KindPrefixUnaryExpression:
+		return inner.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken
+	case ast.KindBinaryExpression:
+		op := inner.AsBinaryExpression().OperatorToken
+		if op == nil {
+			return false
+		}
+		return op.Kind == ast.KindExclamationEqualsToken || op.Kind == ast.KindExclamationEqualsEqualsToken
+	}
+	return false
+}
+
+// hasElseWithoutCondition reports whether node has a plain `else` branch,
+// i.e. an ElseStatement that is not itself an `else if` IfStatement link.
+func hasElseWithoutCondition(ifStmt *ast.IfStatement) bool {
+	return ifStmt.ElseStatement != nil && ifStmt.ElseStatement.Kind != ast.KindIfStatement
+}
+
+var NoNegatedConditionRule = rule.Rule{
+	Name:   "no-negated-condition",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindIfStatement: func(node *ast.Node) {
+				ifStmt := node.AsIfStatement()
+				if ifStmt == nil || !hasElseWithoutCondition(ifStmt) {
+					return
+				}
+				if isNegatedTest(ifStmt.Expression) {
+					ctx.ReportNode(node, unexpectedNegatedMsg)
+				}
+			},
+			ast.KindConditionalExpression: func(node *ast.Node) {
+				cond := node.AsConditionalExpression()
+				if cond == nil {
+					return
+				}
+				if isNegatedTest(cond.Condition) {
+					ctx.ReportNode(node, unexpectedNegatedMsg)
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_negated_condition/no_negated_condition.md
+++ b/internal/rules/no_negated_condition/no_negated_condition.md
@@ -1,0 +1,59 @@
+# no-negated-condition
+
+## Rule Details
+
+Negated conditions are more difficult to understand. Code can be made more readable by inverting the condition instead.
+
+This rule disallows negated conditions in either of the following:
+
+- `if` statements which have an `else` branch
+- ternary expressions
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+if (!a) {
+  doSomething();
+} else {
+  doSomethingElse();
+}
+
+if (a != b) {
+  doSomething();
+} else {
+  doSomethingElse();
+}
+
+if (a !== b) {
+  doSomething();
+} else {
+  doSomethingElse();
+}
+
+!a ? c : b;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+if (!a) {
+  doSomething();
+}
+
+if (!a) {
+  doSomething();
+} else if (b) {
+  doSomething();
+}
+
+if (a != b) {
+  doSomething();
+}
+
+a ? b : c;
+```
+
+## Original Documentation
+
+- [ESLint: no-negated-condition](https://eslint.org/docs/latest/rules/no-negated-condition)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-negated-condition.js)

--- a/internal/rules/no_negated_condition/no_negated_condition_extras_test.go
+++ b/internal/rules/no_negated_condition/no_negated_condition_extras_test.go
@@ -1,0 +1,165 @@
+package no_negated_condition
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoNegatedConditionExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+func TestNoNegatedConditionExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoNegatedConditionRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: receiver / expression wrappers ----
+			// A TS type-expression wrapper on the *whole* test changes its
+			// top-level Kind away from Unary/Binary, so it no longer matches
+			// — mirrors how ESLint's own ESTree check (test.type === ...)
+			// would also miss these once the parser records the cast node.
+			{Code: `if ((a != b) as any) {} else {}`},
+			{Code: `if ((a != b) satisfies boolean) {} else {}`},
+
+			// Locks in isNegatedUnaryExpression() operator gate: any prefix
+			// unary operator other than `!` must not match.
+			{Code: `if (-a) {} else {}`},
+			{Code: `if (typeof a) {} else {}`},
+
+			// Locks in isNegatedBinaryExpression() operator gate: tsgo
+			// collapses ESTree's LogicalExpression (`&&`/`||`) into the same
+			// BinaryExpression kind as equality operators, unlike ESLint's
+			// ESTree where these never reach the isNegatedBinaryExpression
+			// check at all (different node type). Must still fall through.
+			{Code: `if (a && b) {} else {}`},
+			{Code: `if (a || b) {} else {}`},
+
+			// ---- Dimension 4: access / key forms ----
+			// N/A: the rule inspects only the shape of the test expression
+			// (unary/binary operator), never object/class property keys.
+
+			// ---- Dimension 4: declaration/container forms ----
+			// N/A: the rule matches IfStatement/ConditionalExpression nodes
+			// directly and does not special-case the enclosing function or
+			// class container.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: receiver / expression wrappers ----
+			// Single- and multi-level parenthesized test: tsgo preserves
+			// ParenthesizedExpression as an explicit node (ESTree flattens
+			// it away), so the top-level Kind check must SkipParentheses
+			// first or these silently stop matching.
+			{
+				Code: "if ((!a)) {} else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: "if (((!a))) {} else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code: "if ((a != b)) {} else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// TS non-null assertion on the unary operand: `!a!` parses as
+			// `!(a!)` — the outer PrefixUnaryExpression operator is still
+			// `!`, so this must match regardless of what the operand is.
+			{
+				Code: "if (!a!) {} else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 20},
+				},
+			},
+			// Optional chain as the unary operand: the `?.` flag lives on
+			// the inner PropertyAccessExpression, not the outer `!`.
+			{
+				Code: "if (!a?.b) {} else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 22},
+				},
+			},
+
+			// ---- Dimension 4: nesting / traversal boundaries ----
+			// Locks in upstream's per-IfStatement visitor semantics: an
+			// `else if` link is itself a distinct IfStatement node, visited
+			// independently of its parent. The outer if's alternate is an
+			// IfStatement (skipped by hasElseWithoutCondition), but the
+			// inner else-if link's own alternate is a plain `else`, so only
+			// the inner one reports.
+			{
+				Code: "if (a) {} else if (!b) {} else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 16, EndLine: 1, EndColumn: 34},
+				},
+			},
+			// Same lock-in with a longer else-if chain: only the last link
+			// (whose own alternate is the final plain `else`) reports.
+			{
+				Code: "if (a) {} else if (b) {} else if (!c) {} else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 31, EndLine: 1, EndColumn: 49},
+				},
+			},
+			// Nested (non-else-if) if inside a negated outer if: the rule
+			// evaluates each IfStatement independently, so the outer
+			// reports on its own test/alternate without being affected by
+			// the inner (non-negated, so non-matching) if-else.
+			{
+				Code: "if (!a) { if (b) {} else {} } else {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// Nested ConditionalExpression: only the inner ternary (whose
+			// own test is negated) reports, not the outer one.
+			{
+				Code: "a ? b : !c ? d : e",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 9, EndLine: 1, EndColumn: 19},
+				},
+			},
+
+			// ---- Dimension 1: AST node types — non-block statement bodies ----
+			// `if`/`else` without braces still produce IfStatement /
+			// ElseStatement nodes; the rule doesn't inspect body shape.
+			{
+				Code: "if (!a); else;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 15},
+				},
+			},
+
+			// ---- Real-user: negated optional-chain guard ----
+			// A common production pattern: guarding on a negated optional
+			// property access before an else branch.
+			{
+				Code: `if (!user?.isActive) { markInactive(); } else { markActive(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 64},
+				},
+			},
+			// ---- Real-user: negated member access off a parenthesized TS cast ----
+			// The `as` cast here wraps only a sub-expression (the receiver
+			// of `.isValid`), not the whole test, so it does not shield the
+			// outer negation the way wrapping the entire test does above.
+			{
+				Code: `if (!(value as MyType).isValid) { reject(); } else { accept(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 65},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_negated_condition/no_negated_condition_upstream_test.go
+++ b/internal/rules/no_negated_condition/no_negated_condition_upstream_test.go
@@ -1,0 +1,74 @@
+package no_negated_condition
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoNegatedConditionUpstream migrates the full valid/invalid suite from
+// upstream ESLint tests/lib/rules/no-negated-condition.js 1:1. Position
+// assertions cover line/column for every invalid case. rslint-specific
+// lock-in cases live in the no_negated_condition_extras_test.go file.
+func TestNoNegatedConditionUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoNegatedConditionRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "if (a) {}"},
+			{Code: "if (a) {} else {}"},
+			{Code: "if (!a) {}"},
+			{Code: "if (!a) {} else if (b) {}"},
+			{Code: "if (!a) {} else if (b) {} else {}"},
+			{Code: "if (a == b) {}"},
+			{Code: "if (a == b) {} else {}"},
+			{Code: "if (a != b) {}"},
+			{Code: "if (a != b) {} else if (b) {}"},
+			{Code: "if (a != b) {} else if (b) {} else {}"},
+			{Code: "if (a !== b) {}"},
+			{Code: "if (a === b) {} else {}"},
+			{Code: "a ? b : c"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "if (!a) {;} else {;}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: "if (a != b) {;} else {;}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code: "if (a !== b) {;} else {;}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code: "!a ? b : c",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code: "a != b ? c : d",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: "a !== b ? c : d",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegated", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -483,6 +483,7 @@ export default defineConfig({
     './tests/eslint/rules/no-loop-func.test.ts',
     './tests/eslint/rules/no-multi-assign.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
+    './tests/eslint/rules/no-negated-condition.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
     './tests/eslint/rules/no-ternary.test.ts',
     './tests/eslint/rules/no-nonoctal-decimal-escape.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-negated-condition.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-negated-condition.test.ts.snap
@@ -1,0 +1,157 @@
+// Rstest Snapshot v1
+
+exports[`no-negated-condition > invalid 1`] = `
+{
+  "code": "if (!a) {;} else {;}",
+  "diagnostics": [
+    {
+      "message": "Unexpected negated condition.",
+      "messageId": "unexpectedNegated",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-negated-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-negated-condition > invalid 2`] = `
+{
+  "code": "if (a != b) {;} else {;}",
+  "diagnostics": [
+    {
+      "message": "Unexpected negated condition.",
+      "messageId": "unexpectedNegated",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-negated-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-negated-condition > invalid 3`] = `
+{
+  "code": "if (a !== b) {;} else {;}",
+  "diagnostics": [
+    {
+      "message": "Unexpected negated condition.",
+      "messageId": "unexpectedNegated",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-negated-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-negated-condition > invalid 4`] = `
+{
+  "code": "!a ? b : c",
+  "diagnostics": [
+    {
+      "message": "Unexpected negated condition.",
+      "messageId": "unexpectedNegated",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-negated-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-negated-condition > invalid 5`] = `
+{
+  "code": "a != b ? c : d",
+  "diagnostics": [
+    {
+      "message": "Unexpected negated condition.",
+      "messageId": "unexpectedNegated",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-negated-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-negated-condition > invalid 6`] = `
+{
+  "code": "a !== b ? c : d",
+  "diagnostics": [
+    {
+      "message": "Unexpected negated condition.",
+      "messageId": "unexpectedNegated",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-negated-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-negated-condition.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-negated-condition.test.ts
@@ -1,0 +1,47 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-negated-condition', {
+  valid: [
+    'if (a) {}',
+    'if (a) {} else {}',
+    'if (!a) {}',
+    'if (!a) {} else if (b) {}',
+    'if (!a) {} else if (b) {} else {}',
+    'if (a == b) {}',
+    'if (a == b) {} else {}',
+    'if (a != b) {}',
+    'if (a != b) {} else if (b) {}',
+    'if (a != b) {} else if (b) {} else {}',
+    'if (a !== b) {}',
+    'if (a === b) {} else {}',
+    'a ? b : c',
+  ],
+  invalid: [
+    {
+      code: 'if (!a) {;} else {;}',
+      errors: [{ messageId: 'unexpectedNegated' }],
+    },
+    {
+      code: 'if (a != b) {;} else {;}',
+      errors: [{ messageId: 'unexpectedNegated' }],
+    },
+    {
+      code: 'if (a !== b) {;} else {;}',
+      errors: [{ messageId: 'unexpectedNegated' }],
+    },
+    {
+      code: '!a ? b : c',
+      errors: [{ messageId: 'unexpectedNegated' }],
+    },
+    {
+      code: 'a != b ? c : d',
+      errors: [{ messageId: 'unexpectedNegated' }],
+    },
+    {
+      code: 'a !== b ? c : d',
+      errors: [{ messageId: 'unexpectedNegated' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-negated-condition` rule from ESLint to rslint.

Disallows negated conditions in `if` statements that have a plain `else` branch, and in ternary expressions, since negated conditions are harder to read than their inverted equivalent.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-negated-condition
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-negated-condition.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).