### PR TITLE
feat: port rule no-eq-null

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -53,6 +53,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_function"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_static_block"
+	"github.com/web-infra-dev/rslint/internal/rules/no_eq_null"
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extend_native"
@@ -213,6 +214,7 @@ func GetAllRules() []rule.Rule {
 		no_empty_function.NoEmptyFunctionRule,
 		no_empty_pattern.NoEmptyPatternRule,
 		no_empty_static_block.NoEmptyStaticBlockRule,
+		no_eq_null.NoEqNullRule,
 		no_eval.NoEvalRule,
 		no_ex_assign.NoExAssignRule,
 		no_extend_native.NoExtendNativeRule,

--- a/internal/rules/eqeqeq/eqeqeq.go
+++ b/internal/rules/eqeqeq/eqeqeq.go
@@ -37,11 +37,6 @@ func looseEquivalent(kind ast.Kind) string {
 	}
 }
 
-// isLooseEquality checks if the operator is == or !=.
-func isLooseEquality(kind ast.Kind) bool {
-	return kind == ast.KindEqualsEqualsToken || kind == ast.KindExclamationEqualsToken
-}
-
 // isStrictEquality checks if the operator is === or !==.
 func isStrictEquality(kind ast.Kind) bool {
 	return kind == ast.KindEqualsEqualsEqualsToken || kind == ast.KindExclamationEqualsEqualsToken
@@ -186,7 +181,7 @@ var EqeqeqRule = rule.Rule{
 func handleAlwaysMode(ctx rule.RuleContext, binary *ast.BinaryExpression, opKind ast.Kind, left, right *ast.Node, nullOption string) {
 	isNullCheck := utils.IsNullLiteral(left) || utils.IsNullLiteral(right)
 
-	if isLooseEquality(opKind) {
+	if utils.IsLooseEqualityOperator(opKind) {
 		if nullOption == "always" || !isNullCheck {
 			reportEqeqeq(ctx, binary.OperatorToken, left, right, strictEquivalent(opKind))
 		}
@@ -201,7 +196,7 @@ func handleAlwaysMode(ctx rule.RuleContext, binary *ast.BinaryExpression, opKind
 // 2. Comparing two literals of the same type
 // 3. Comparing against null
 func handleSmartMode(ctx rule.RuleContext, binary *ast.BinaryExpression, opKind ast.Kind, left, right *ast.Node) {
-	if !isLooseEquality(opKind) {
+	if !utils.IsLooseEqualityOperator(opKind) {
 		return
 	}
 

--- a/internal/rules/no_eq_null/no_eq_null.go
+++ b/internal/rules/no_eq_null/no_eq_null.go
@@ -1,0 +1,35 @@
+package no_eq_null
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// NoEqNullRule disallows null comparisons without type-checking operators.
+// https://eslint.org/docs/latest/rules/no-eq-null
+var NoEqNullRule = rule.Rule{
+	Name:   "no-eq-null",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				binary := node.AsBinaryExpression()
+				if binary == nil || binary.OperatorToken == nil {
+					return
+				}
+
+				if !utils.IsLooseEqualityOperator(binary.OperatorToken.Kind) {
+					return
+				}
+
+				if utils.IsNullLiteral(binary.Left) || utils.IsNullLiteral(binary.Right) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "unexpected",
+						Description: "Use '===' to compare with null.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_eq_null/no_eq_null.md
+++ b/internal/rules/no_eq_null/no_eq_null.md
@@ -1,0 +1,36 @@
+# no-eq-null
+
+## Rule Details
+
+Comparing to `null` without a type-checking operator (`==` or `!=`) can have unintended results as the comparison will evaluate to `true` when comparing not just to `null`, but also to `undefined`.
+
+The `no-eq-null` rule aims to reduce potential bugs and unwanted behavior by ensuring that comparisons to `null` only match `null`, and not also `undefined`. As such, it will flag comparisons to `null` when using `==` and `!=`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+if (foo == null) {
+  bar();
+}
+
+while (qux != null) {
+  baz();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+if (foo === null) {
+  bar();
+}
+
+while (qux !== null) {
+  baz();
+}
+```
+
+## Original Documentation
+
+- [ESLint: no-eq-null](https://eslint.org/docs/latest/rules/no-eq-null)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-eq-null.js)

--- a/internal/rules/no_eq_null/no_eq_null_extras_test.go
+++ b/internal/rules/no_eq_null/no_eq_null_extras_test.go
@@ -1,0 +1,147 @@
+// TestNoEqNullExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 shape / tsgo AST quirk it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+package no_eq_null
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEqNullExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEqNullRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TS non-null assertion wraps the null operand ----
+			// `null!` is a TSNonNullExpression around the null keyword, not the
+			// null keyword itself — matches typescript-eslint's parser, whose
+			// `.type` for the wrapped node is TSNonNullExpression, not Literal,
+			// so upstream's own `.type === "Literal"` check would also miss it.
+			{Code: `x == null!`},
+
+			// ---- Dimension 4: TS type-expression wrappers around the null
+			//      operand (`as`, `satisfies`) ----
+			// Same rationale as above: the wrapping AsExpression/SatisfiesExpression
+			// means the operand's node kind is no longer NullKeyword, mirroring
+			// typescript-eslint's own `.type !== "Literal"` outcome.
+			{Code: `x == (null as any)`},
+			{Code: `x == (null satisfies unknown)`},
+
+			// ---- Dimension 4: neither operand is a null literal ----
+			// Locks in the "no null operand" arm — a loose-equality comparison
+			// between two non-null operands must not report.
+			{Code: `1 == 2`},
+			{Code: `a == b`},
+
+			// ---- Locks in upstream badOperator arm: === / !== never report,
+			//      even with a null operand on either side ----
+			{Code: `x !== null`},
+			{Code: `null !== x`},
+			{Code: `null === null`},
+
+			// ---- Locks in the operator-kind gate: non-equality BinaryExpression
+			//      operators (&&, <) with a null operand must not report. tsgo
+			//      represents &&/|| as BinaryExpression (no separate
+			//      LogicalExpression kind), so this exercises the same listener. ----
+			{Code: `x && null`},
+			{Code: `null < x`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver, single and multi-level ----
+			// tsgo keeps ParenthesizedExpression as an explicit wrapper node;
+			// ESLint's ESTree has no such node at all, so `(null)` is
+			// indistinguishable from `null` there. utils.IsNullLiteral unwraps
+			// parentheses to stay aligned with that ESLint behavior.
+			{
+				Code: `x == (null)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: `x == ((null))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ---- Dimension 4: optional chain on the non-null operand is inert
+			//      to the null-literal check on the other operand ----
+			{
+				Code: `a?.b == null`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- Dimension 4: same-kind nesting — only the inner
+			//      BinaryExpression (a == null) matches; the outer
+			//      (BinaryExpression == b) does not, since its left operand is
+			//      itself a BinaryExpression, not a null literal. Exactly one
+			//      diagnostic, proving the listener doesn't bleed to the outer
+			//      node or double-report. ----
+			{
+				Code: `a == null == b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// ---- Locks in upstream OR-branch: left-side null with != (upstream
+			//      only exercises left-side null with ==, via `null == x`) ----
+			{
+				Code: `null != x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// ---- Locks in: both operands are null literals — exactly one
+			//      diagnostic, not two (the left-null and right-null arms are
+			//      combined with ||, not evaluated as separate reports). ----
+			{
+				Code: `null == null`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- Dimension 4: multi-line report range — Line/Column/EndLine/
+			//      EndColumn must track the BinaryExpression's actual span, not
+			//      collapse to a single line. ----
+			{
+				Code: "if (\n  x\n  ==\n  null\n) { }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 3, EndLine: 4, EndColumn: 7},
+				},
+			},
+
+			// ---- Real-user: defensive `typeof` + loose-null-check idiom, common
+			//      in pre-optional-chaining codebases guarding against both
+			//      undeclared and null/undefined values in the same condition. ----
+			{
+				Code: `if (typeof value !== "undefined" && value != null) { doSomething(value); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 37, EndLine: 1, EndColumn: 50},
+				},
+			},
+
+			// ---- Real-user: array-filter idiom that strips null/undefined
+			//      entries via a loose comparison, a very common pattern in
+			//      codebases predating `.filter(Boolean)` conventions. ----
+			{
+				Code: `items.filter(function (item) { return item != null; });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 39, EndLine: 1, EndColumn: 51},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_eq_null/no_eq_null_upstream_test.go
+++ b/internal/rules/no_eq_null/no_eq_null_upstream_test.go
@@ -1,0 +1,46 @@
+// TestNoEqNullUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/no-eq-null.js 1:1. Position assertions cover
+// line/column/endLine/endColumn for every invalid case, mirroring upstream's
+// own test file. rslint-specific lock-in cases live in
+// no_eq_null_extras_test.go.
+package no_eq_null
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEqNullUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEqNullRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `if (x === null) { }`},
+			{Code: `if (null === f()) { }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `if (x == null) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `if (x != null) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `do {} while (null == x)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14, EndLine: 1, EndColumn: 23},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -45,6 +45,12 @@ func IsCommaOperator(node *ast.Node) bool {
 	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken
 }
 
+// IsLooseEqualityOperator reports whether kind is the == or != token, as
+// opposed to their strict (===, !==) counterparts.
+func IsLooseEqualityOperator(kind ast.Kind) bool {
+	return kind == ast.KindEqualsEqualsToken || kind == ast.KindExclamationEqualsToken
+}
+
 // IsCallee checks if a node is the callee of a CallExpression or NewExpression,
 // skipping parentheses and TS type assertions between the node and the call.
 func IsCallee(node *ast.Node) bool {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -87,6 +87,7 @@ export default defineConfig({
     './tests/eslint/rules/no-empty-function.test.ts',
     './tests/eslint/rules/no-empty-pattern.test.ts',
     './tests/eslint/rules/no-empty-static-block.test.ts',
+    './tests/eslint/rules/no-eq-null.test.ts',
     './tests/eslint/rules/no-eval.test.ts',
     './tests/eslint/rules/no-implicit-coercion.test.ts',
     './tests/eslint/rules/no-implied-eval.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-eq-null.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-eq-null.test.ts.snap
@@ -1,0 +1,79 @@
+// Rstest Snapshot v1
+
+exports[`no-eq-null > invalid 1`] = `
+{
+  "code": "if (x == null) { }",
+  "diagnostics": [
+    {
+      "message": "Use '===' to compare with null.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eq-null",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eq-null > invalid 2`] = `
+{
+  "code": "if (x != null) { }",
+  "diagnostics": [
+    {
+      "message": "Use '===' to compare with null.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eq-null",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eq-null > invalid 3`] = `
+{
+  "code": "do {} while (null == x)",
+  "diagnostics": [
+    {
+      "message": "Use '===' to compare with null.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eq-null",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-eq-null.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-eq-null.test.ts
@@ -1,0 +1,21 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-eq-null', {
+  valid: ['if (x === null) { }', 'if (null === f()) { }'],
+  invalid: [
+    {
+      code: 'if (x == null) { }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'if (x != null) { }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'do {} while (null == x)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-eq-null` rule from ESLint to rslint.

Disallows `null` comparisons using `==`/`!=` (which also match `undefined`), requiring `===`/`!==` instead.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-eq-null
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-eq-null.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).