### PR TITLE
feat: port rule no-div-regex

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -41,6 +41,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_control_regex"
 	"github.com/web-infra-dev/rslint/internal/rules/no_debugger"
 	"github.com/web-infra-dev/rslint/internal/rules/no_delete_var"
+	"github.com/web-infra-dev/rslint/internal/rules/no_div_regex"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_args"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_class_members"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_else_if"
@@ -203,6 +204,7 @@ func GetAllRules() []rule.Rule {
 		no_control_regex.NoControlRegexRule,
 		no_debugger.NoDebuggerRule,
 		no_delete_var.NoDeleteVarRule,
+		no_div_regex.NoDivRegexRule,
 		no_dupe_args.NoDupeArgsRule,
 		no_dupe_class_members.NoDupeClassMembersRule,
 		no_dupe_keys.NoDupeKeysRule,

--- a/internal/rules/no_div_regex/no_div_regex.go
+++ b/internal/rules/no_div_regex/no_div_regex.go
@@ -1,0 +1,34 @@
+package no_div_regex
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-div-regex
+var NoDivRegexRule = rule.Rule{
+	Name:   "no-div-regex",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
+				text := node.Text()
+				if len(text) < 2 || text[1] != '=' {
+					return
+				}
+
+				ctx.ReportNodeWithDeferredFixes(node, rule.RuleMessage{
+					Id:          "unexpected",
+					Description: "A regular expression literal can be confused with '/='.",
+				}, func() []rule.RuleFix {
+					eqPos := utils.TrimNodeTextRange(ctx.SourceFile, node).Pos() + 1
+					return []rule.RuleFix{
+						rule.RuleFixReplaceRange(core.NewTextRange(eqPos, eqPos+1), "[=]"),
+					}
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_div_regex/no_div_regex.md
+++ b/internal/rules/no_div_regex/no_div_regex.md
@@ -1,0 +1,26 @@
+# no-div-regex
+
+## Rule Details
+
+Disallows equal signs explicitly at the beginning of regular expression literals, since `/=` at the start of a regular expression can be visually confused with a division-assignment operator.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function bar() {
+  return /=foo/;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function bar() {
+  return /[=]foo/;
+}
+```
+
+## Original Documentation
+
+- [ESLint: no-div-regex](https://eslint.org/docs/latest/rules/no-div-regex)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-div-regex.js)

--- a/internal/rules/no_div_regex/no_div_regex_extras_test.go
+++ b/internal/rules/no_div_regex/no_div_regex_extras_test.go
@@ -1,0 +1,220 @@
+// TestNoDivRegexExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Dimension walk notes for no-div-regex:
+//   - Dimension 2 (scoping & nesting): N/A — the rule inspects only a
+//     RegularExpressionLiteral's own token text; it performs no scope lookup
+//     or ancestor walk, so function/class/block nesting cannot affect
+//     detection.
+//   - Dimension 4 (access/key forms): N/A — the rule never inspects a
+//     property or key; it fires directly on the RegularExpressionLiteral
+//     node.
+//   - Dimension 4 (declaration/container forms): N/A — the rule does not
+//     target function or class declarations.
+//   - Dimension 4 (graceful degradation: SpreadAssignment/RestElement,
+//     overload signatures/abstract/declare members): N/A — none of these
+//     shapes can contain or affect a regular expression literal's own token
+//     text.
+package no_div_regex
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDivRegexExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoDivRegexRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 1: flags don't affect the leading-character check ----
+			{Code: `var re = /foo=bar/gimsuy;`},
+			// ---- Dimension 4: receiver wrapper — parenthesized, non-`=` pattern stays valid ----
+			{Code: `var re = (/foo/);`},
+			// ---- Dimension 1: other literal kinds coexisting with a valid regex must not
+			// be mistaken for regex literals or otherwise trigger the rule ----
+			{Code: `var s = "=foo"; var n = 0; var b = true; var re = /foo/;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: graceful degradation — minimal one-character pattern ("=") ----
+			{
+				Code:   `var re = /=/;`,
+				Output: []string{`var re = /[=]/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10, EndLine: 1, EndColumn: 13},
+				},
+			},
+			// ---- Dimension 1: flags after an offending pattern don't suppress the fix ----
+			{
+				Code:   `var re = /=foo/gi;`,
+				Output: []string{`var re = /[=]foo/gi;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10, EndLine: 1, EndColumn: 18},
+				},
+			},
+			// ---- Dimension 4: receiver wrapper — parenthesized regex literal is still detected ----
+			{
+				Code:   `var re = (/=foo/);`,
+				Output: []string{`var re = (/[=]foo/);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- Dimension 4: TS non-null assertion suffix on the literal itself is still detected ----
+			{
+				Code:   `var ok = /=foo/!.test("x");`,
+				Output: []string{`var ok = /[=]foo/!.test("x");`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10, EndLine: 1, EndColumn: 16},
+				},
+			},
+			// ---- Dimension 4: TS `as` type-expression wrapper is still detected ----
+			{
+				Code:   `var ok = (/=foo/ as RegExp).test("x");`,
+				Output: []string{`var ok = (/[=]foo/ as RegExp).test("x");`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// ---- Position assertion: multi-line source, literal on its own line ----
+			{
+				Code:   "var re =\n  /=foo/;",
+				Output: []string{"var re =\n  /[=]foo/;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 3, EndLine: 2, EndColumn: 9},
+				},
+			},
+			// ---- Real-user: default-parameter validator pattern ----
+			{
+				Code:   `function validate(input, pattern = /=x/) { return pattern.test(input); }`,
+				Output: []string{`function validate(input, pattern = /[=]x/) { return pattern.test(input); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36, EndLine: 1, EndColumn: 40},
+				},
+			},
+			// ---- Real-user: class static field validator pattern ----
+			{
+				Code:   `class Validator { static pattern = /=email/; }`,
+				Output: []string{`class Validator { static pattern = /[=]email/; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36, EndLine: 1, EndColumn: 44},
+				},
+			},
+			// ---- Locks in upstream Literal() sole branch: the listener reports
+			// unconditionally per-node, so multiple offending literals in the same file
+			// are each reported independently (no dedupe / early-exit after the first) ----
+			{
+				Code:   `var a = /=foo/; var b = /=bar/;`,
+				Output: []string{`var a = /[=]foo/; var b = /[=]bar/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpected", Line: 1, Column: 25, EndLine: 1, EndColumn: 31},
+				},
+			},
+		},
+	)
+}
+
+// TestNoDivRegexEditDemand exercises Dimension 3 (autofix boundaries):
+// diagnostic count, message, and range must stay identical across every edit
+// demand, and the fix must materialize only when autofix is requested.
+func TestNoDivRegexEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"var a = /=foo/;\nvar b = /=bar/;",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      lintprogram.NewFromCompiler(program),
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoDivRegexRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoDivRegexRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got, want := withoutEdits(diagnostics[index]), withoutEdits(allEdits[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if fixes := *allEdits[index].FixesPtr; len(fixes) == 0 {
+			t.Fatalf("diagnostic %d: all-edits demand produced no fixes", index)
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{
+		diagnosticsOnly,
+		autofixOnly,
+		suggestionOnly,
+		allEdits,
+	} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+	}
+}

--- a/internal/rules/no_div_regex/no_div_regex_upstream_test.go
+++ b/internal/rules/no_div_regex/no_div_regex_upstream_test.go
@@ -1,0 +1,47 @@
+// TestNoDivRegexUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/no-div-regex.js 1:1, plus the incorrect/correct
+// examples shown on the rule's documentation page. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the no_div_regex_extras_test.go file.
+package no_div_regex
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDivRegexUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoDivRegexRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid ----
+			{Code: `var f = function() { return /foo/ig.test('bar'); };`},
+			{Code: `var f = function() { return /\=foo/; };`},
+			// ---- Doc examples: correct ----
+			{Code: `function bar() { return /[=]foo/; }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid ----
+			{
+				Code:   `var f = function() { return /=foo/; };`,
+				Output: []string{`var f = function() { return /[=]foo/; };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "A regular expression literal can be confused with '/='.", Line: 1, Column: 29, EndLine: 1, EndColumn: 35},
+				},
+			},
+			// ---- Doc examples: incorrect ----
+			{
+				Code:   `function bar() { return /=foo/; }`,
+				Output: []string{`function bar() { return /[=]foo/; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25, EndLine: 1, EndColumn: 31},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -77,6 +77,7 @@ export default defineConfig({
     './tests/eslint/rules/no-case-declarations.test.ts',
     './tests/eslint/rules/no-console.test.ts',
     './tests/eslint/rules/no-continue.test.ts',
+    './tests/eslint/rules/no-div-regex.test.ts',
     './tests/eslint/rules/no-dupe-args.test.ts',
     './tests/eslint/rules/no-dupe-class-members.test.ts',
     './tests/eslint/rules/no-dupe-keys.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-div-regex.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-div-regex.test.ts.snap
@@ -1,0 +1,27 @@
+// Rstest Snapshot v1
+
+exports[`no-div-regex > invalid 1`] = `
+{
+  "code": "var f = function() { return /=foo/; };",
+  "diagnostics": [
+    {
+      "message": "A regular expression literal can be confused with '/='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-div-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-div-regex.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-div-regex.test.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-div-regex', {
+  valid: [
+    "var f = function() { return /foo/ig.test('bar'); };",
+    'var f = function() { return /\\=foo/; };',
+  ],
+  invalid: [
+    {
+      code: 'var f = function() { return /=foo/; };',
+      errors: [{ messageId: 'unexpected', line: 1, column: 29 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-div-regex` rule from ESLint to rslint.

Disallows equal signs explicitly at the beginning of regular expression literals, since `/=` at the start of a regex can be visually confused with a division-assignment operator. The rule is autofixable, wrapping the leading `=` in a character class (e.g. `/=foo/` → `/[=]foo/`).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-div-regex
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-div-regex.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).