### PR TITLE
feat: port rule no-array-constructor

### DIFF
--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -424,6 +424,14 @@ func jsdocOnlyScope(symbol *ast.Symbol, name string) *ast.Node {
 			return node
 		}
 	}
+	// JSDoc template parameters on classes are resolved from the class's type
+	// parameter environment rather than a Locals table. A reparsed clone is
+	// attached directly to the class, so leave the class before looking for an
+	// authored outer declaration.
+	declaration := symbol.Declarations[0]
+	if declaration.Kind == ast.KindTypeParameter && declaration.Parent != nil && ast.IsClassLike(declaration.Parent) {
+		return declaration.Parent
+	}
 	return nil
 }
 

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -44,6 +44,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/max_statements"
 	"github.com/web-infra-dev/rslint/internal/rules/new_cap"
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
+	"github.com/web-infra-dev/rslint/internal/rules/no_array_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
 	"github.com/web-infra-dev/rslint/internal/rules/no_bitwise"
@@ -260,6 +261,7 @@ func coreRules() []rule.Rule {
 		max_statements.MaxStatementsRule,
 		new_cap.NewCapRule,
 		no_alert.NoAlertRule,
+		no_array_constructor.NoArrayConstructorRule,
 		no_async_promise_executor.NoAsyncPromiseExecutorRule,
 		no_await_in_loop.NoAwaitInLoopRule,
 		no_bitwise.NoBitwiseRule,

--- a/internal/rules/no_array_constructor/no_array_constructor.go
+++ b/internal/rules/no_array_constructor/no_array_constructor.go
@@ -82,6 +82,7 @@ var NoArrayConstructorRule = rule.Rule{
 	Name:   "no-array-constructor",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		var shadowCache utils.ScopeManagerShadowCache
 		check := func(node *ast.Node) {
 			callee, args, typeArgs := calleeArgsAndTypeArgs(node)
 			if callee == nil {
@@ -133,16 +134,19 @@ var NoArrayConstructorRule = rule.Rule{
 			// keeps a function's parameter initializers in the same scope as its
 			// body declarations, where both TypeScript's resolver and IsShadowed
 			// follow runtime lexical semantics instead.
-			if utils.HasEnclosingParameter(callee, "Array") ||
-				utils.HasEnclosingTypeParameter(callee, "Array") ||
+			if shadowCache.HasEnclosingParameter(callee, "Array") ||
+				shadowCache.HasEnclosingTypeParameter(callee, "Array") ||
 				utils.HasEnclosingClassExpressionName(callee, "Array") ||
-				utils.IsShadowedFromParameterInitializer(callee, "Array") {
+				shadowCache.IsShadowedFromParameterInitializer(callee, "Array") {
 				return
 			}
 			// A config `/* global Array: off */` / `languageOptions.globals`
 			// entry un-declares Espree's builtin. typescript-eslint/parser also
 			// installs its library `Array` variable, which remains visible after
-			// the override, so TypeScript-flavoured files still report.
+			// the override, so TypeScript-flavoured files still report. rslint does
+			// not currently project parserOptions.lib into native rule contexts;
+			// the documented divergence for an explicitly empty lib follows from
+			// preserving that existing API boundary.
 			if ast.IsInJSFile(callee) && !ctx.Globals.Access("Array").IsDeclared() {
 				return
 			}

--- a/internal/rules/no_array_constructor/no_array_constructor.go
+++ b/internal/rules/no_array_constructor/no_array_constructor.go
@@ -101,7 +101,7 @@ var NoArrayConstructorRule = rule.Rule{
 			}
 			// `Array<Foo>()` — explicit type arguments mean this isn't the
 			// bare-constructor call the rule targets.
-			if typeArgs != nil && len(typeArgs.Nodes) > 0 {
+			if typeArgs != nil {
 				return
 			}
 			// A single non-spread argument (`Array(9)`, `Array(x)`) may be
@@ -112,8 +112,19 @@ var NoArrayConstructorRule = rule.Rule{
 				return
 			}
 
-			// A local declaration shadows the global constructor.
-			if utils.IsShadowed(callee, "Array") {
+			// A local declaration shadows the global constructor. The binder
+			// lookup resolves the declaration once without rescanning every
+			// enclosing body for each matching call. Keep the AST fallback for
+			// manually assembled rule contexts that do not provide a RefStore.
+			if ctx.Refs == nil {
+				if utils.IsShadowed(callee, "Array") {
+					return
+				}
+			} else if ctx.Refs.IsNameDefinedInFileWithMeaning(
+				callee,
+				"Array",
+				ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+			) {
 				return
 			}
 			// scope-manager keeps class type parameters visible inside static
@@ -122,26 +133,15 @@ var NoArrayConstructorRule = rule.Rule{
 			// declarations, where both TypeScript's resolver and IsShadowed
 			// follow runtime lexical semantics instead.
 			if utils.HasEnclosingTypeParameter(callee, "Array") ||
+				utils.HasEnclosingClassExpressionName(callee, "Array") ||
 				utils.IsShadowedFromParameterInitializer(callee, "Array") {
 				return
 			}
-			// scope-manager also creates an `Array` variable for TypeScript
-			// type-space declarations — type aliases, interfaces, type
-			// parameters, type-only imports — which utils.IsShadowed doesn't
-			// model. Resolving the name in every declaration space at the call
-			// site covers them.
-			if ctx.Refs != nil && ctx.Refs.IsNameDefinedInFileWithMeaning(
-				callee,
-				"Array",
-				ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
-			) {
-				return
-			}
 			// A config `/* global Array: off */` / `languageOptions.globals`
-			// entry un-declares the builtin, so `Array` no longer resolves to
-			// a known global — ESLint's `getVariableByName` would return
-			// undefined and the rule stays silent.
-			if !ctx.Globals.Access("Array").IsDeclared() {
+			// entry un-declares Espree's builtin. typescript-eslint/parser also
+			// installs its library `Array` variable, which remains visible after
+			// the override, so TypeScript-flavoured files still report.
+			if ast.IsInJSFile(callee) && !ctx.Globals.Access("Array").IsDeclared() {
 				return
 			}
 

--- a/internal/rules/no_array_constructor/no_array_constructor.go
+++ b/internal/rules/no_array_constructor/no_array_constructor.go
@@ -1,0 +1,216 @@
+package no_array_constructor
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func preferLiteralMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferLiteral",
+		Description: "The array literal notation [] is preferable.",
+	}
+}
+
+func useLiteralMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useLiteral",
+		Description: "Replace with an array literal.",
+	}
+}
+
+func useLiteralAfterSemicolonMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useLiteralAfterSemicolon",
+		Description: "Replace with an array literal, add preceding semicolon.",
+	}
+}
+
+// calleeArgsAndTypeArgs extracts the callee, argument list, and type-argument
+// list shared by CallExpression and NewExpression, the two forms this rule
+// inspects.
+func calleeArgsAndTypeArgs(node *ast.Node) (callee *ast.Node, args *ast.NodeList, typeArgs *ast.NodeList) {
+	switch node.Kind {
+	case ast.KindCallExpression:
+		callExpr := node.AsCallExpression()
+		return callExpr.Expression, callExpr.Arguments, callExpr.TypeArguments
+	case ast.KindNewExpression:
+		newExpr := node.AsNewExpression()
+		return newExpr.Expression, newExpr.Arguments, newExpr.TypeArguments
+	}
+	return nil, nil, nil
+}
+
+// findOpenParen scans forward from calleeEnd (the position right after the
+// possibly-parenthesized callee) for the call's own opening paren, stopping
+// at nodeEnd. Only `?.` punctuation and trivia can appear before it, since
+// type arguments were already excluded by the caller. found is false when the
+// node has no parentheses at all, e.g. a bare `new Array`.
+func findOpenParen(sourceFile *ast.SourceFile, calleeEnd int, nodeEnd int) (pos int, found bool) {
+	text := sourceFile.Text()
+	p := calleeEnd
+	for p < nodeEnd {
+		p = scanner.SkipTrivia(text, p)
+		if p >= nodeEnd {
+			break
+		}
+		if text[p] == '(' {
+			return p, true
+		}
+		p++
+	}
+	return 0, false
+}
+
+func countNonSpread(args *ast.NodeList) int {
+	if args == nil {
+		return 0
+	}
+	count := 0
+	for _, arg := range args.Nodes {
+		if arg.Kind != ast.KindSpreadElement {
+			count++
+		}
+	}
+	return count
+}
+
+// https://eslint.org/docs/latest/rules/no-array-constructor
+var NoArrayConstructorRule = rule.Rule{
+	Name:   "no-array-constructor",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			callee, args, typeArgs := calleeArgsAndTypeArgs(node)
+			if callee == nil {
+				return
+			}
+			// ESTree flattens grouping parentheses around the callee, so
+			// `(Array)()` still has an Identifier callee; TS-only wrappers
+			// (non-null assertion, `as`/`satisfies`) are deliberately left
+			// alone since ESTree never collapses those back to a bare
+			// Identifier either.
+			callee = ast.SkipParentheses(callee)
+			if callee == nil || callee.Kind != ast.KindIdentifier {
+				return
+			}
+			if callee.AsIdentifier().Text != "Array" {
+				return
+			}
+			// `Array<Foo>()` — explicit type arguments mean this isn't the
+			// bare-constructor call the rule targets.
+			if typeArgs != nil && len(typeArgs.Nodes) > 0 {
+				return
+			}
+			// A single non-spread argument (`Array(9)`, `Array(x)`) may be
+			// intentionally creating a sparse array of that length — leave
+			// it alone, since the argument's runtime type can't be known
+			// statically.
+			if args != nil && len(args.Nodes) == 1 && args.Nodes[0].Kind != ast.KindSpreadElement {
+				return
+			}
+
+			// A local declaration shadows the global constructor.
+			if utils.IsShadowed(callee, "Array") {
+				return
+			}
+			// scope-manager keeps class type parameters visible inside static
+			// members, where TypeScript's resolver hides them, and keeps a
+			// function's parameter initializers in the same scope as its body
+			// declarations, where both TypeScript's resolver and IsShadowed
+			// follow runtime lexical semantics instead.
+			if utils.HasEnclosingTypeParameter(callee, "Array") ||
+				utils.IsShadowedFromParameterInitializer(callee, "Array") {
+				return
+			}
+			// scope-manager also creates an `Array` variable for TypeScript
+			// type-space declarations — type aliases, interfaces, type
+			// parameters, type-only imports — which utils.IsShadowed doesn't
+			// model. Resolving the name in every declaration space at the call
+			// site covers them.
+			if ctx.Refs != nil && ctx.Refs.IsNameDefinedInFileWithMeaning(
+				callee,
+				"Array",
+				ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+			) {
+				return
+			}
+			// A config `/* global Array: off */` / `languageOptions.globals`
+			// entry un-declares the builtin, so `Array` no longer resolves to
+			// a known global — ESLint's `getVariableByName` would return
+			// undefined and the rule stays silent.
+			if !ctx.Globals.Access("Array").IsDeclared() {
+				return
+			}
+
+			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			openParen, hasParens := findOpenParen(ctx.SourceFile, callee.End(), nodeRange.End())
+			argsText := ""
+			commentBound := nodeRange.End()
+			if hasParens {
+				argsText = ctx.SourceFile.Text()[openParen+1 : nodeRange.End()-1]
+				commentBound = openParen
+			}
+			fixText := "[" + argsText + "]"
+
+			// NOTE: Unlike ESLint, utils.NeedsPrecedingSemicolon doesn't model
+			// TypeScript-only node kinds (type positions, ambient/overload
+			// function declarations, import-equals declarations), so it falls
+			// back to the conservative "needs a semicolon" answer there —
+			// e.g. after `type T = Foo` or `import Foo = Bar`. The extra `;`
+			// never changes behavior, only adds a redundant character; see
+			// the rule doc's "Differences from ESLint" section.
+			addSemicolon := utils.IsStartOfExpressionStatement(ctx.SourceFile, node) &&
+				utils.NeedsPrecedingSemicolon(ctx.SourceFile, node)
+			if addSemicolon {
+				fixText = ";" + fixText
+			}
+
+			// Replacing the call with an array literal directly (rather than
+			// as an opt-in suggestion) is only safe when doing so can't
+			// change runtime behavior or silently drop source text:
+			//   - `Array?.(...)` short-circuits to `undefined` when `Array`
+			//     is nullish; `[...]` always evaluates.
+			//   - A single spread plus at most one more argument
+			//     (`Array(5, ...args)`) is equivalent to the sparse-array
+			//     single-argument form when the spread happens to be empty
+			//     at runtime — an outcome an autofix must not risk.
+			//   - A comment between the node's start and the call's own
+			//     opening paren (`Array/*a*/()`) would be silently discarded
+			//     by the fix. Comments inside the argument list itself don't
+			//     count: the fix copies that text through verbatim.
+			shouldSuggest := ast.IsOptionalChainRoot(node) ||
+				(args != nil && len(args.Nodes) > 0 && countNonSpread(args) < 2) ||
+				utils.HasCommentInSpan(ctx.Comments.All(), nodeRange.Pos(), commentBound)
+
+			buildFixes := func() []rule.RuleFix {
+				if shouldSuggest {
+					return nil
+				}
+				return []rule.RuleFix{rule.RuleFixReplaceRange(nodeRange, fixText)}
+			}
+			buildSuggestions := func() []rule.RuleSuggestion {
+				if !shouldSuggest {
+					return nil
+				}
+				msg := useLiteralMessage()
+				if addSemicolon {
+					msg = useLiteralAfterSemicolonMessage()
+				}
+				return []rule.RuleSuggestion{{
+					Message:  msg,
+					FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(nodeRange, fixText)},
+				}}
+			}
+
+			ctx.ReportNodeWithDeferredFixesAndSuggestions(node, preferLiteralMessage(), buildFixes, buildSuggestions)
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: check,
+			ast.KindNewExpression:  check,
+		}
+	},
+}

--- a/internal/rules/no_array_constructor/no_array_constructor.go
+++ b/internal/rules/no_array_constructor/no_array_constructor.go
@@ -127,12 +127,14 @@ var NoArrayConstructorRule = rule.Rule{
 			) {
 				return
 			}
-			// scope-manager keeps class type parameters visible inside static
-			// members, where TypeScript's resolver hides them, and keeps a
-			// function's parameter initializers in the same scope as its body
-			// declarations, where both TypeScript's resolver and IsShadowed
+			// scope-manager keeps function parameters visible directly inside
+			// parameter decorators and class type parameters visible inside
+			// static members, where TypeScript's resolver hides them. It also
+			// keeps a function's parameter initializers in the same scope as its
+			// body declarations, where both TypeScript's resolver and IsShadowed
 			// follow runtime lexical semantics instead.
-			if utils.HasEnclosingTypeParameter(callee, "Array") ||
+			if utils.HasEnclosingParameter(callee, "Array") ||
+				utils.HasEnclosingTypeParameter(callee, "Array") ||
 				utils.HasEnclosingClassExpressionName(callee, "Array") ||
 				utils.IsShadowedFromParameterInitializer(callee, "Array") {
 				return

--- a/internal/rules/no_array_constructor/no_array_constructor.md
+++ b/internal/rules/no_array_constructor/no_array_constructor.md
@@ -61,6 +61,7 @@ Array?.(0, 1, 2);
 ## Differences from ESLint
 
 - When the array constructor call is fixed onto a new line right after certain TypeScript-only constructs — a type alias (`type T = Foo`), an ambient or overload function declaration (`declare function foo()`), an import-equals declaration (`import Foo = Bar`), or an `as`/`satisfies` type cast — rslint's autofix inserts a leading `;` that ESLint omits (e.g. `type T = Foo\n;[0, 1]` instead of `type T = Foo\n[0, 1]`). The extra semicolon never changes the resulting code's behavior.
+- In TypeScript files, rslint treats `Array` as a predefined library variable even when `parserOptions.lib` is explicitly empty. For example, with `parserOptions.lib: []` and `globals: { Array: "off" }`, rslint still reports and fixes `Array()`, while typescript-eslint does not. Native rule contexts do not currently expose parser-specific library selection.
 
 ## Original Documentation
 

--- a/internal/rules/no_array_constructor/no_array_constructor.md
+++ b/internal/rules/no_array_constructor/no_array_constructor.md
@@ -1,0 +1,68 @@
+# no-array-constructor
+
+## Rule Details
+
+Use of the `Array` constructor to construct a new array is generally discouraged in favor of array literal notation because of the single-argument pitfall and because the `Array` global may be redefined. The exception is when the `Array` constructor is used to intentionally create sparse arrays of a specified size by giving the constructor a single numeric argument.
+
+This rule disallows `Array` constructors.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Array();
+
+Array(0, 1, 2);
+
+new Array(0, 1, 2);
+
+Array(...args);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Array(500);
+
+new Array(someOtherArray.length);
+
+[0, 1, 2];
+
+const createArray = Array => new Array();
+```
+
+This rule additionally supports TypeScript type syntax.
+
+Examples of **correct** code for this rule:
+
+```typescript
+new Array<number>(1, 2, 3);
+
+new Array<Foo>();
+
+Array<number>(1, 2, 3);
+
+Array<Foo>();
+
+Array?.foo();
+```
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+new Array();
+
+new Array(0, 1, 2);
+
+Array?.(x, y);
+
+Array?.(0, 1, 2);
+```
+
+## Differences from ESLint
+
+- When the array constructor call is fixed onto a new line right after certain TypeScript-only constructs — a type alias (`type T = Foo`), an ambient or overload function declaration (`declare function foo()`), an import-equals declaration (`import Foo = Bar`), or an `as`/`satisfies` type cast — rslint's autofix inserts a leading `;` that ESLint omits (e.g. `type T = Foo\n;[0, 1]` instead of `type T = Foo\n[0, 1]`). The extra semicolon never changes the resulting code's behavior.
+
+## Original Documentation
+
+- [ESLint: no-array-constructor](https://eslint.org/docs/latest/rules/no-array-constructor)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-array-constructor.js)

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -20,6 +20,8 @@ package no_array_constructor
 
 import (
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -47,6 +49,11 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 		t,
 		&NoArrayConstructorRule,
 		[]rule_tester.ValidTestCase{
+			// A recoverable empty TypeScript type-argument list still means the
+			// call carried explicit type arguments. typescript-eslint stops at its
+			// parser diagnostic and never runs this rule or offers an autofix.
+			{Code: `Array<>(1, 2);`},
+
 			// ---- Dimension 4: TS non-null assertion callee ----
 			// `Array!` is a TSNonNullExpression, never collapsed back to a
 			// bare Identifier by ESTree either, so upstream's
@@ -174,6 +181,22 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			{Code: `new (0, Array)();`},
 		},
 		[]rule_tester.InvalidTestCase{
+			// TypeScript's parser installs its library `Array` variable even when
+			// an authored global override is `off`, so getVariableByName still
+			// finds the constructor. Espree's corresponding behavior remains in
+			// the upstream suite under file.js.
+			{
+				Code:    `Array();`,
+				Globals: map[string]any{"Array": "off"},
+				Output:  []string{`[];`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1, EndLine: 1, EndColumn: 8}},
+			},
+			directFixCase(
+				`/* global Array:off */ Array();`,
+				`Array()`,
+				`/* global Array:off */ [];`,
+			),
+
 			// ---- Dimension 2: scoping — JSDoc @template tags remain comments
 			// to ESTree and scope-manager even though tsgo creates synthetic type
 			// parameters from them and attaches those to the host declaration. ----
@@ -579,4 +602,30 @@ func createNoArrayConstructorProgram(t testing.TB, fileName string, code string)
 		t.Fatalf("source file %q not found", fileName)
 	}
 	return program, sourceFile
+}
+
+// BenchmarkNoArrayConstructorRepeatedCalls protects the scope-scan hot path
+// called out in PR #1753. Program construction is excluded so the result
+// measures repeated rule checks in one unshadowed function scope.
+func BenchmarkNoArrayConstructorRepeatedCalls(b *testing.B) {
+	for _, count := range []int{1_000, 2_000, 4_000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			var source strings.Builder
+			source.WriteString("function f() {")
+			for range count {
+				source.WriteString("void Array(1, 2);")
+			}
+			source.WriteByte('}')
+
+			program, sourceFile := createNoArrayConstructorProgram(b, "repeated-calls.ts", source.String())
+			var options []any
+			b.ResetTimer()
+			for range b.N {
+				diagnostics := lintNoArrayConstructorWithDemand(program, sourceFile, options, rule.EditDemandNone)
+				if len(diagnostics) != count {
+					b.Fatalf("diagnostics = %d, want %d", len(diagnostics), count)
+				}
+			}
+		})
+	}
 }

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -119,6 +119,10 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			{Code: `class C { m(@dec(Array()) x: number) { var Array; } }`},
 			{Code: `class C { m(@dec(Array()) x: number) { let Array; } }`},
 			{Code: `class C { m(@dec(Array()) x: number, Array: any) { } }`},
+			// Evaluating an object member's computed name does not enter that
+			// member's function scope, so the decorated method stays visible.
+			{Code: `class C { m(@dec({ [Array()]() {} }) x: number, Array: any) { } }`},
+			{Code: `class C { m(@dec({ get [Array()]() { return 1 } }) x: number, Array: any) { } }`},
 			// The enclosing class stays in the chain, so its name and type
 			// parameters shadow a call nested inside a parameter decorator.
 			{Code: "class Array { m(@dec(() => Array()) x: number) { } }"},
@@ -619,6 +623,39 @@ func BenchmarkNoArrayConstructorRepeatedCalls(b *testing.B) {
 			source.WriteByte('}')
 
 			program, sourceFile := createNoArrayConstructorProgram(b, "repeated-calls.ts", source.String())
+			var options []any
+			b.ResetTimer()
+			for range b.N {
+				diagnostics := lintNoArrayConstructorWithDemand(program, sourceFile, options, rule.EditDemandNone)
+				if len(diagnostics) != count {
+					b.Fatalf("diagnostics = %d, want %d", len(diagnostics), count)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkNoArrayConstructorRepeatedCallsWithParameters protects parameter
+// lookup from becoming O(parameters * calls) in an ordinary function body.
+func BenchmarkNoArrayConstructorRepeatedCallsWithParameters(b *testing.B) {
+	for _, count := range []int{500, 1_000, 2_000, 4_000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			var source strings.Builder
+			source.WriteString("function f(")
+			for i := range count {
+				if i > 0 {
+					source.WriteByte(',')
+				}
+				source.WriteString("p")
+				source.WriteString(strconv.Itoa(i))
+			}
+			source.WriteString(") {")
+			for range count {
+				source.WriteString("void Array(1, 2);")
+			}
+			source.WriteByte('}')
+
+			program, sourceFile := createNoArrayConstructorProgram(b, "repeated-calls-with-parameters.ts", source.String())
 			var options []any
 			b.ResetTimer()
 			for range b.N {

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -101,6 +101,14 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			// parameters shadow a call nested inside a parameter decorator.
 			{Code: "class Array { m(@dec(() => Array()) x: number) { } }"},
 			{Code: "class C<Array> { m(@dec(() => Array()) x: number) { } }"},
+			// A class's own decorator is evaluated in the scope holding the
+			// class, but a reference sitting directly in one, with no scope in
+			// between, still resolves against the class scope.
+			{Code: `@dec(Array()) class C<Array> { }`},
+			{Code: `const C = @dec(Array()) class Array { };`},
+			// A class declaration's name is declared in the scope holding the
+			// class, so it shadows the call wherever the decorator resolves.
+			{Code: `@dec(() => Array()) class Array { }`},
 
 			// ---- Dimension 2: scoping — a member's decorators and computed
 			// name are evaluated in the enclosing class or object literal, so
@@ -128,6 +136,10 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			// The shadow reaches into nested namespaces, which are ordinary
 			// lexical children of the outer module block.
 			{Code: `namespace N { const Array = () => 1; namespace M { Array(); } }`},
+			// A dotted namespace name declares nothing itself, but the body
+			// it opens is still a scope of its own.
+			{Code: `namespace N.Array { const Array = () => 1; Array(); }`},
+			{Code: `namespace N { const Array = () => 1; namespace M.Array { Array(); } }`},
 
 			// Real-user: eslint/eslint#12273 (closed as intentional — a
 			// single non-spread argument is left alone even when it's
@@ -228,6 +240,55 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 				"class C { m<Array>(@dec(() => Array()) x: number) { } }",
 				`Array()`,
 				"class C { m<Array>(@dec(() => []) x: number) { } }",
+			),
+
+			// ---- Dimension 2: scoping — the same holds for a class's own
+			// decorator: a scope created inside one is attached to the scope
+			// holding the class, so neither the class's type parameters nor a
+			// class expression's own name reach the call ----
+			directFixCase(
+				`@dec(() => Array()) class C<Array> { }`,
+				`Array()`,
+				`@dec(() => []) class C<Array> { }`,
+			),
+			directFixCase(
+				`@dec(function () { return Array(); }) class C<Array> { }`,
+				`Array()`,
+				`@dec(function () { return []; }) class C<Array> { }`,
+			),
+			directFixCase(
+				`@dec(class { p = Array(); }) class C<Array> { }`,
+				`Array()`,
+				`@dec(class { p = []; }) class C<Array> { }`,
+			),
+			directFixCase(
+				`const C = @dec(() => Array()) class Array { };`,
+				`Array()`,
+				`const C = @dec(() => []) class Array { };`,
+			),
+			directFixCase(
+				`const C = @dec(class { p = Array(); }) class Array { };`,
+				`Array()`,
+				`const C = @dec(class { p = []; }) class Array { };`,
+			),
+
+			// ---- Dimension 2: scoping — only a namespace whose name is a
+			// plain identifier declares a variable, so neither segment of a
+			// dotted name shadows the call ----
+			directFixCase(
+				`namespace N.Array { Array(); }`,
+				`Array()`,
+				`namespace N.Array { []; }`,
+			),
+			directFixCase(
+				`namespace Array.M { Array(); }`,
+				`Array()`,
+				`namespace Array.M { []; }`,
+			),
+			directFixCase(
+				`namespace N { namespace M.Array { } Array(); }`,
+				`Array()`,
+				`namespace N { namespace M.Array { } []; }`,
 			),
 
 			// ---- Dimension 2: scoping — a decorator or computed name belongs

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -33,6 +33,13 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+func jsdocDirectFixCase(code, marker, output, fileName string) rule_tester.InvalidTestCase {
+	testCase := directFixCase(code, marker, output)
+	testCase.FileName = fileName
+	testCase.TSConfig = "tsconfig.allow-js.json"
+	return testCase
+}
+
 func TestNoArrayConstructorExtras(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),
@@ -75,6 +82,13 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			{Code: `import type { Array } from "my-array"; Array();`},
 			{Code: `function f<Array>() { Array(); }`},
 			{Code: `class C<Array> { m() { Array(); } }`},
+			// A real outer binding still shadows the call when a JSDoc template
+			// with the same name is attached to the intervening class.
+			{
+				Code:     `function outer(Array) { /** @template Array */ class C { m(){ Array() } } }`,
+				FileName: "no-array-constructor-jsdoc-authored-outer.js",
+				TSConfig: "tsconfig.allow-js.json",
+			},
 			// ---- Dimension 2: scoping — class type parameter inside a static
 			// member, which scope-manager keeps in the lexical scope chain while
 			// TypeScript's resolver hides it ----
@@ -160,6 +174,28 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			{Code: `new (0, Array)();`},
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 2: scoping — JSDoc @template tags remain comments
+			// to ESTree and scope-manager even though tsgo creates synthetic type
+			// parameters from them and attaches those to the host declaration. ----
+			jsdocDirectFixCase(
+				`/** @template Array */ function f(){ Array() }`,
+				`Array()`,
+				`/** @template Array */ function f(){ [] }`,
+				"no-array-constructor-jsdoc-function.js",
+			),
+			jsdocDirectFixCase(
+				`/** @template Array */ const f = () => Array();`,
+				`Array()`,
+				`/** @template Array */ const f = () => [];`,
+				"no-array-constructor-jsdoc-arrow.js",
+			),
+			jsdocDirectFixCase(
+				`/** @template Array */ class C { m(){ Array() } }`,
+				`Array()`,
+				`/** @template Array */ class C { m(){ [] } }`,
+				"no-array-constructor-jsdoc-class.js",
+			),
+
 			// ---- Dimension 4: parenthesized callee, multi-level ----
 			// Upstream's own test only covers single-level `(Array)()`.
 			directFixCase(`((Array))();`, `((Array))()`, `[];`),

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
@@ -455,6 +456,53 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 	)
 }
 
+func TestNoArrayConstructorEmptyParserLibDivergence(t *testing.T) {
+	program, sourceFile := createNoArrayConstructorProgram(t, "empty-parser-lib.ts", "Array();\n")
+	root := fixtures.GetRootDir()
+	config := rslintconfig.RslintConfig{{
+		Files: []string{"**/*.ts"},
+		LanguageOptions: &rslintconfig.LanguageOptions{Raw: map[string]any{
+			"globals": map[string]any{"Array": "off"},
+			"parserOptions": map[string]any{
+				"lib": []any{},
+			},
+		}},
+		Rules: rslintconfig.Rules{"no-array-constructor": "error"},
+	}}
+	configuredRules, merged := rslintconfig.ResolveEnabledRules(
+		rule.NewCatalog(NoArrayConstructorRule),
+		config,
+		sourceFile.FileName(),
+		root.Dir,
+		false,
+	)
+	if merged == nil || len(configuredRules) != 1 {
+		t.Fatalf("resolved rules = %d, merged config = %v; want one configured rule", len(configuredRules), merged != nil)
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:         lintprogram.NewFromCompiler(program),
+		File:            sourceFile.FileName(),
+		HasTypeInfo:     true,
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule { return configuredRules },
+		ExcludePaths:    []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandAutofix,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	fixes := diagnostics[0].Fixes()
+	if len(fixes) != 1 || fixes[0].Text != "[]" {
+		t.Fatalf("fixes = %#v, want one [] replacement", fixes)
+	}
+}
+
 // TestNoArrayConstructorEditDemand verifies that the fix/suggestion builders
 // don't change what the rule reports: diagnostic count, message, and range
 // stay identical across every edit demand, and fixes/suggestions are
@@ -656,6 +704,101 @@ func BenchmarkNoArrayConstructorRepeatedCallsWithParameters(b *testing.B) {
 			source.WriteByte('}')
 
 			program, sourceFile := createNoArrayConstructorProgram(b, "repeated-calls-with-parameters.ts", source.String())
+			var options []any
+			b.ResetTimer()
+			for range b.N {
+				diagnostics := lintNoArrayConstructorWithDemand(program, sourceFile, options, rule.EditDemandNone)
+				if len(diagnostics) != count {
+					b.Fatalf("diagnostics = %d, want %d", len(diagnostics), count)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkNoArrayConstructorRepeatedCallsWithTypeParameters(b *testing.B) {
+	for _, count := range []int{500, 1_000, 2_000, 4_000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			var source strings.Builder
+			source.WriteString("function f<")
+			for i := range count {
+				if i > 0 {
+					source.WriteByte(',')
+				}
+				source.WriteString("T")
+				source.WriteString(strconv.Itoa(i))
+			}
+			source.WriteString(">() {")
+			for range count {
+				source.WriteString("void Array(1, 2);")
+			}
+			source.WriteByte('}')
+
+			program, sourceFile := createNoArrayConstructorProgram(b, "repeated-calls-with-type-parameters.ts", source.String())
+			var options []any
+			b.ResetTimer()
+			for range b.N {
+				diagnostics := lintNoArrayConstructorWithDemand(program, sourceFile, options, rule.EditDemandNone)
+				if len(diagnostics) != count {
+					b.Fatalf("diagnostics = %d, want %d", len(diagnostics), count)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkNoArrayConstructorRepeatedCallsInParameterDecorator(b *testing.B) {
+	for _, count := range []int{500, 1_000, 2_000, 4_000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			var source strings.Builder
+			source.WriteString("class C { m(@dec([")
+			for i := range count {
+				if i > 0 {
+					source.WriteByte(',')
+				}
+				source.WriteString("Array(1, 2)")
+			}
+			source.WriteString("]) x: number")
+			for i := range count {
+				source.WriteString(", p")
+				source.WriteString(strconv.Itoa(i))
+				source.WriteString(": number")
+			}
+			source.WriteString(") {} }")
+
+			program, sourceFile := createNoArrayConstructorProgram(b, "repeated-calls-in-parameter-decorator.ts", source.String())
+			var options []any
+			b.ResetTimer()
+			for range b.N {
+				diagnostics := lintNoArrayConstructorWithDemand(program, sourceFile, options, rule.EditDemandNone)
+				if len(diagnostics) != count {
+					b.Fatalf("diagnostics = %d, want %d", len(diagnostics), count)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkNoArrayConstructorRepeatedCallsInParameterInitializer(b *testing.B) {
+	for _, count := range []int{500, 1_000, 2_000, 4_000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			var source strings.Builder
+			source.WriteString("function f(x = [")
+			for i := range count {
+				if i > 0 {
+					source.WriteByte(',')
+				}
+				source.WriteString("Array(1, 2)")
+			}
+			source.WriteString("]) {")
+			for i := range count {
+				source.WriteString("let p")
+				source.WriteString(strconv.Itoa(i))
+				source.WriteByte(';')
+			}
+			source.WriteByte('}')
+
+			program, sourceFile := createNoArrayConstructorProgram(b, "repeated-calls-in-parameter-initializer.ts", source.String())
 			var options []any
 			b.ResetTimer()
 			for range b.N {

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -309,6 +309,11 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 				`export {}; declare global { const Array: any; } [];`,
 			),
 			directFixCase(
+				`export {}; declare global { type Array = any; } Array();`,
+				`Array()`,
+				`export {}; declare global { type Array = any; } [];`,
+			),
+			directFixCase(
 				`export {}; declare global { namespace Array {} } Array();`,
 				`Array()`,
 				`export {}; declare global { namespace Array {} } [];`,

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -102,6 +102,21 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			{Code: "class Array { m(@dec(() => Array()) x: number) { } }"},
 			{Code: "class C<Array> { m(@dec(() => Array()) x: number) { } }"},
 
+			// ---- Dimension 2: scoping — a member's decorators and computed
+			// name are evaluated in the enclosing class or object literal, so
+			// only that outer scope shadows a call there ----
+			{Code: `class C<Array> { @dec(Array()) m() { } }`},
+			{Code: `class C<Array> { [Array()]() { } }`},
+			{Code: `class Array { [Array()]() { } }`},
+
+			// ---- Dimension 2: scoping — a function declaration with no block
+			// to hold it is defined in the innermost scope that already exists
+			// at its position, which is the function scope the parameter
+			// initializer resolves against ----
+			{Code: `function f(x = Array()) { if (a) function Array() {} }`},
+			{Code: `function f(x = Array()) { lbl: function Array() {} }`},
+			{Code: `function f(x = Array()) { while (a) function Array() {} }`},
+
 			// ---- Dimension 2: scoping — a TypeScript namespace body is a
 			// scope of its own, so a declaration inside it shadows the global
 			// constructor for the whole module block ----
@@ -213,6 +228,60 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 				"class C { m<Array>(@dec(() => Array()) x: number) { } }",
 				`Array()`,
 				"class C { m<Array>(@dec(() => []) x: number) { } }",
+			),
+
+			// ---- Dimension 2: scoping — a decorator or computed name belongs
+			// to the enclosing class or object literal, not to the member that
+			// carries it, so the member's own type parameters, parameters, and
+			// body bindings never reach the call ----
+			directFixCase(
+				`class C { @dec(Array()) m() { var Array; } }`,
+				`Array()`,
+				`class C { @dec([]) m() { var Array; } }`,
+			),
+			directFixCase(
+				`class C { @dec(Array()) m(Array: any) { } }`,
+				`Array()`,
+				`class C { @dec([]) m(Array: any) { } }`,
+			),
+			directFixCase(
+				`class C { @dec(Array()) m<Array>() { } }`,
+				`Array()`,
+				`class C { @dec([]) m<Array>() { } }`,
+			),
+			directFixCase(
+				`class C { [Array()]() { var Array; } }`,
+				`Array()`,
+				`class C { [[]]() { var Array; } }`,
+			),
+			directFixCase(
+				`class C { [Array()](Array: any) { } }`,
+				`Array()`,
+				`class C { [[]](Array: any) { } }`,
+			),
+			directFixCase(
+				`class C { [Array()]<Array>() { } }`,
+				`Array()`,
+				`class C { [[]]<Array>() { } }`,
+			),
+			directFixCase(
+				`const o = { [Array()]() { var Array; } };`,
+				`Array()`,
+				`const o = { [[]]() { var Array; } };`,
+			),
+
+			// ---- Dimension 2: scoping — a block or a `let`-scoped loop does
+			// hold the function declaration, keeping it out of the function
+			// scope the parameter initializer resolves against ----
+			directFixCase(
+				`function f(x = Array()) { { function Array() {} } }`,
+				`Array()`,
+				`function f(x = []) { { function Array() {} } }`,
+			),
+			directFixCase(
+				`function f(x = Array()) { for (let i; ;) function Array() {} }`,
+				`Array()`,
+				`function f(x = []) { for (let i; ;) function Array() {} }`,
 			),
 
 			// A type parameter is only in scope inside its own declaration.

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -1,0 +1,388 @@
+package no_array_constructor
+
+// TestNoArrayConstructorExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+//
+// N/A Dimension 4 rows:
+//   - Access/key forms: the rule never inspects a property or key, only the
+//     callee identifier, its type arguments, and the argument list.
+//   - Declaration/container forms (class/function declaration vs expression):
+//     the rule targets Call/New expressions, not declarations.
+//   - SpreadAssignment in an object literal / RestElement in a binding
+//     pattern: the rule never inspects object literals or binding patterns.
+//   - Overload signatures / `abstract` / `declare` members, empty class/
+//     function bodies: already exercised by the upstream-migrated
+//     "no semicolon required after TypeScript syntax" block
+//     (`declare function foo()`, `function foo(): []`, ...).
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestNoArrayConstructorExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoArrayConstructorRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TS non-null assertion callee ----
+			// `Array!` is a TSNonNullExpression, never collapsed back to a
+			// bare Identifier by ESTree either, so upstream's
+			// `node.callee.type !== "Identifier"` check also stays silent.
+			{Code: `Array!();`},
+			{Code: `new Array!();`},
+
+			// ---- Dimension 4: TS type-expression wrapper callee ----
+			{Code: `(Array as any)();`},
+			{Code: `(Array satisfies Function)();`},
+
+			// ---- Dimension 2: scoping — shadowed by function declaration ----
+			{Code: `function Array() {} new Array();`},
+			// ---- Dimension 2: scoping — shadowed by class declaration ----
+			{Code: `class Array {} new Array();`},
+			// ---- Dimension 2: scoping — shadowed by nested block `let` ----
+			{Code: `{ let Array = class {}; new Array(); }`},
+			// ---- Dimension 2: scoping — shadowed by catch parameter ----
+			{Code: `try {} catch (Array) { new Array(); }`},
+			// ---- Dimension 2: scoping — shadowed by a default import ----
+			{Code: `import Array from "my-array"; new Array();`},
+			// ---- Dimension 2: scoping — outer parameter shadow reaches
+			// deeply nested arrows ----
+			{Code: `function f(Array) { return () => () => new Array(); }`},
+
+			// ---- Dimension 2: scoping — TypeScript type-space declarations.
+			// scope-manager gives a type alias, interface, type parameter, or
+			// type-only import an `Array` variable with identifiers, so upstream
+			// stays silent even though TypeScript itself still resolves the call
+			// to the global. ----
+			{Code: `type Array = {}; Array();`},
+			{Code: `interface Array {} Array();`},
+			{Code: `import type { Array } from "my-array"; Array();`},
+			{Code: `function f<Array>() { Array(); }`},
+			{Code: `class C<Array> { m() { Array(); } }`},
+			// ---- Dimension 2: scoping — class type parameter inside a static
+			// member, which scope-manager keeps in the lexical scope chain while
+			// TypeScript's resolver hides it ----
+			{Code: `class C<Array> { static m() { Array(); } }`},
+
+			// ---- Dimension 2: scoping — scope-manager puts a function's
+			// parameter initializers in the same scope as its body declarations,
+			// so a body binding shadows the call in a default value ----
+			{Code: `function f(x = Array()) { var Array; }`},
+			{Code: `function f(x = Array()) { let Array; }`},
+			{Code: `function f(x = Array()) { function Array() {} }`},
+			{Code: `function f(x = Array()) { class Array {} }`},
+			// A `var` reaches the function scope from any depth.
+			{Code: `function f(x = Array()) { if (a) { var Array; } }`},
+			// The shadow also reaches a call nested inside the default value.
+			{Code: `function f(x = () => Array()) { var Array; }`},
+			{Code: `const g = (x = Array()) => { var Array; };`},
+			// A parameter decorator is not an initializer, but scope-manager
+			// still resolves a reference directly inside one against the
+			// decorated function's own scope.
+			{Code: `class C { m(@dec(Array()) x: number) { var Array; } }`},
+			{Code: `class C { m(@dec(Array()) x: number) { let Array; } }`},
+			// The enclosing class stays in the chain, so its name and type
+			// parameters shadow a call nested inside a parameter decorator.
+			{Code: "class Array { m(@dec(() => Array()) x: number) { } }"},
+			{Code: "class C<Array> { m(@dec(() => Array()) x: number) { } }"},
+
+			// ---- Dimension 2: scoping — a TypeScript namespace body is a
+			// scope of its own, so a declaration inside it shadows the global
+			// constructor for the whole module block ----
+			{Code: `namespace N { const Array = () => 123; Array(); }`},
+			{Code: `namespace N { function Array() {} new Array(); }`},
+			{Code: `namespace N { import Array = globalThis.Array; Array(); }`},
+			// A `var` in a namespace hoists to the module block, not out of it.
+			{Code: `namespace N { var Array = 1; { new Array(); } }`},
+			// The shadow reaches into nested namespaces, which are ordinary
+			// lexical children of the outer module block.
+			{Code: `namespace N { const Array = () => 1; namespace M { Array(); } }`},
+
+			// Real-user: eslint/eslint#12273 (closed as intentional — a
+			// single non-spread argument is left alone even when it's
+			// obviously not a length, since the rule has no type
+			// information to tell `Array('3')` apart from `Array(3)`).
+			{Code: `Array('3');`},
+
+			// Real-user: eslint/eslint#19494 (open at the time of porting —
+			// a known upstream false negative). `new (0, Array)()` calls the
+			// global Array constructor via a comma-operator callee, but the
+			// callee is a BinaryExpression, not an Identifier, so neither
+			// upstream nor this port detects it. Locked in to match
+			// upstream's current (imperfect) behavior rather than silently
+			// diverging from it.
+			{Code: `new (0, Array)();`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized callee, multi-level ----
+			// Upstream's own test only covers single-level `(Array)()`.
+			directFixCase(`((Array))();`, `((Array))()`, `[];`),
+
+			// ---- Dimension 2 / nesting boundary: only the inner, zero-
+			// argument call is reported; the outer call has exactly one
+			// non-spread argument (the inner CallExpression), so upstream's
+			// own single-argument exception naturally excludes it — this
+			// also proves the CallExpression listener doesn't misfire on
+			// the outer node just because the inner one matched. ----
+			directFixCase(`Array(Array());`, `Array()`, `Array([]);`),
+			// Same boundary, NewExpression form on both sides — proves the
+			// NewExpression listener is independent of the CallExpression
+			// one and doesn't cross-report.
+			directFixCase(`new Array(new Array());`, `new Array()`, `new Array([]);`),
+
+			// Locks in the `nonSpreadCount` reduce (not just a length check):
+			// three arguments where two are non-spread is still safe to
+			// autofix directly, matching upstream's `Array(5, 6, ...args)`
+			// case but with the spread positioned first instead of last.
+			directFixCase(`Array(1, ...a, 2, ...b);`, `Array(1, ...a, 2, ...b)`, `[1, ...a, 2, ...b];`),
+			// Inverse: only one non-spread argument among three — stays
+			// suggestion-only, matching upstream's `Array(5, ...args)` case
+			// but with the non-spread argument last instead of first.
+			suggestCase(`Array(...a, 1, ...b);`, `Array(...a, 1, ...b)`, "useLiteral", `[...a, 1, ...b];`),
+
+			// ---- Contract: exact diagnostic message text ----
+			// The rule only ever emits one top-level messageId
+			// ("preferLiteral"); asserted with an exact string match here.
+			{
+				Code:   `new Array();`,
+				Output: []string{`[];`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferLiteral",
+					Message:   "The array literal notation [] is preferable.",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 12,
+				}},
+			},
+
+			// ---- Dimension 2: scoping — a `let` in a nested block stays in
+			// that block's scope, so it never reaches the parameter initializer ----
+			directFixCase(
+				`function f(x = Array()) { { let Array; } }`,
+				`Array()`,
+				`function f(x = []) { { let Array; } }`,
+			),
+			// A body that declares nothing leaves the default value bound to
+			// the global.
+			directFixCase(
+				`function f(x = Array()) { }`,
+				`Array()`,
+				`function f(x = []) { }`,
+			),
+			// ---- Dimension 2: scoping — scope-manager attaches a scope
+			// created inside a parameter decorator to the enclosing class,
+			// not to the decorated function, so the function's own body
+			// bindings never reach the call ----
+			directFixCase(
+				"class C { m(@dec(() => Array()) x: number) { var Array; } }",
+				`Array()`,
+				"class C { m(@dec(() => []) x: number) { var Array; } }",
+			),
+			directFixCase(
+				"class C { m(@dec(function () { return Array(); }) x: number) { var Array; } }",
+				`Array()`,
+				"class C { m(@dec(function () { return []; }) x: number) { var Array; } }",
+			),
+			directFixCase(
+				"class C { m(@dec(class { p = Array(); }) x: number) { var Array; } }",
+				`Array()`,
+				"class C { m(@dec(class { p = []; }) x: number) { var Array; } }",
+			),
+			// The decorated function's parameters and type parameters are out
+			// of the chain for the same reason.
+			directFixCase(
+				"class C { m(@dec(() => Array()) x: number, Array: any) { } }",
+				`Array()`,
+				"class C { m(@dec(() => []) x: number, Array: any) { } }",
+			),
+			directFixCase(
+				"class C { m<Array>(@dec(() => Array()) x: number) { } }",
+				`Array()`,
+				"class C { m<Array>(@dec(() => []) x: number) { } }",
+			),
+
+			// A type parameter is only in scope inside its own declaration.
+			directFixCase(
+				`declare function f<Array>(): void; Array();`,
+				`Array()`,
+				`declare function f<Array>(): void; [];`,
+			),
+
+			// ---- Dimension 2: scoping — unshadowed reference reachable
+			// through nested arrows still reports ----
+			directFixCase(
+				`function f() { return () => () => Array(); }`,
+				`Array()`,
+				`function f() { return () => () => []; }`,
+			),
+		},
+	)
+}
+
+// TestNoArrayConstructorEditDemand verifies that the fix/suggestion builders
+// don't change what the rule reports: diagnostic count, message, and range
+// stay identical across every edit demand, and fixes/suggestions are
+// materialized only when requested — for both branches of the rule's
+// fix-vs-suggestion split.
+func TestNoArrayConstructorEditDemand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct fix", func(t *testing.T) {
+		t.Parallel()
+		testNoArrayConstructorEditDemand(t, "() => Array();\n", false)
+	})
+	t.Run("suggestion only", func(t *testing.T) {
+		t.Parallel()
+		testNoArrayConstructorEditDemand(t, "() => Array?.();\n", true)
+	})
+}
+
+func testNoArrayConstructorEditDemand(t *testing.T, source string, wantSuggestion bool) {
+	t.Helper()
+
+	program, sourceFile := createNoArrayConstructorProgram(t, "edit-demand.ts", source)
+	options := rule_tester.ResolveTestCaseOptions(t, &NoArrayConstructorRule, nil)
+
+	diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		got := lintNoArrayConstructorWithDemand(program, sourceFile, options, demand)
+		if len(got) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+		}
+		if got[0].Message.Id != "preferLiteral" {
+			t.Errorf("demand %d: unexpected message id %q", demand, got[0].Message.Id)
+		}
+		if got[0].Message.Description != "The array literal notation [] is preferable." {
+			t.Errorf("demand %d: unexpected message %q", demand, got[0].Message.Description)
+		}
+		diagnostics[demand] = got[0]
+	}
+
+	diagnosticsOnly := diagnostics[rule.EditDemandNone]
+	for demand, diagnostic := range diagnostics {
+		want, got := diagnosticsOnly, diagnostic
+		want.FixesPtr, want.Suggestions = nil, nil
+		got.FixesPtr, got.Suggestions = nil, nil
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, got, want)
+		}
+	}
+
+	// EditDemandNone never materializes fixes or suggestions regardless of
+	// which branch the rule took.
+	if d := diagnostics[rule.EditDemandNone]; d.FixesPtr != nil || d.Suggestions != nil {
+		t.Errorf("EditDemandNone unexpectedly materialized edits: fixes=%#v suggestions=%#v", d.FixesPtr, d.Suggestions)
+	}
+
+	if wantSuggestion {
+		for _, demand := range []rule.EditDemand{rule.EditDemandAutofix} {
+			if d := diagnostics[demand]; d.FixesPtr != nil || d.Suggestions != nil {
+				t.Errorf("demand %d unexpectedly materialized edits: fixes=%#v suggestions=%#v", demand, d.FixesPtr, d.Suggestions)
+			}
+		}
+		for _, demand := range []rule.EditDemand{rule.EditDemandSuggestion, rule.EditDemandAll} {
+			d := diagnostics[demand]
+			if d.FixesPtr != nil {
+				t.Errorf("demand %d unexpectedly materialized autofixes: %#v", demand, d.FixesPtr)
+			}
+			if d.Suggestions == nil || len(*d.Suggestions) != 1 {
+				t.Fatalf("demand %d: suggestions = %#v, want exactly one", demand, d.Suggestions)
+			}
+			suggestion := (*d.Suggestions)[0]
+			if suggestion.Message.Id != "useLiteral" {
+				t.Errorf("demand %d: unexpected suggestion id %q", demand, suggestion.Message.Id)
+			}
+			fixes := suggestion.Fixes()
+			if len(fixes) != 1 || fixes[0].Text != "[]" {
+				t.Errorf("demand %d: unexpected suggestion fixes %#v", demand, fixes)
+			}
+		}
+		return
+	}
+
+	for _, demand := range []rule.EditDemand{rule.EditDemandSuggestion} {
+		if d := diagnostics[demand]; d.FixesPtr != nil || d.Suggestions != nil {
+			t.Errorf("demand %d unexpectedly materialized edits: fixes=%#v suggestions=%#v", demand, d.FixesPtr, d.Suggestions)
+		}
+	}
+	for _, demand := range []rule.EditDemand{rule.EditDemandAutofix, rule.EditDemandAll} {
+		d := diagnostics[demand]
+		if d.Suggestions != nil {
+			t.Errorf("demand %d unexpectedly materialized suggestions: %#v", demand, d.Suggestions)
+		}
+		if d.FixesPtr == nil || len(*d.FixesPtr) != 1 || (*d.FixesPtr)[0].Text != "[]" {
+			t.Errorf("demand %d: unexpected autofix %#v", demand, d.FixesPtr)
+		}
+	}
+}
+
+func lintNoArrayConstructorWithDemand(
+	program *compiler.Program,
+	sourceFile *ast.SourceFile,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:         lintprogram.NewFromCompiler(program),
+		File:            sourceFile.FileName(),
+		HasTypeInfo:     true,
+		GetRulesForFile: noArrayConstructorConfiguredRules(options),
+		ExcludePaths:    []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}
+
+func noArrayConstructorConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
+	return func(*ast.SourceFile) []linter.ConfiguredRule {
+		return []linter.ConfiguredRule{{
+			Name:     NoArrayConstructorRule.Name,
+			Severity: rule.SeverityError,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return NoArrayConstructorRule.Run(ctx, options)
+			},
+		}}
+	}
+}
+
+func createNoArrayConstructorProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+
+	root := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{tspath.ResolvePath(root.Dir, fileName): code})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	program, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -485,8 +485,7 @@ func TestNoArrayConstructorEmptyParserLibDivergence(t *testing.T) {
 		Program:         lintprogram.NewFromCompiler(program),
 		File:            sourceFile.FileName(),
 		HasTypeInfo:     true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule { return configuredRules },
-		ExcludePaths:    []string{},
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule { return configuredRules },
 		Consumer: rule.DiagnosticConsumer{
 			Demand: rule.EditDemandAutofix,
 			Report: func(diagnostic rule.RuleDiagnostic) {
@@ -617,7 +616,6 @@ func lintNoArrayConstructorWithDemand(
 		File:            sourceFile.FileName(),
 		HasTypeInfo:     true,
 		GetRulesForFile: noArrayConstructorConfiguredRules(options),
-		ExcludePaths:    []string{},
 		Consumer: rule.DiagnosticConsumer{
 			Demand: demand,
 			Report: func(diagnostic rule.RuleDiagnostic) {
@@ -628,9 +626,9 @@ func lintNoArrayConstructorWithDemand(
 	return diagnostics
 }
 
-func noArrayConstructorConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
-	return func(*ast.SourceFile) []linter.ConfiguredRule {
-		return []linter.ConfiguredRule{{
+func noArrayConstructorConfiguredRules(options []any) func(*ast.SourceFile) []rule.ConfiguredRule {
+	return func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:     NoArrayConstructorRule.Name,
 			Severity: rule.SeverityError,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -140,6 +140,9 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			// it opens is still a scope of its own.
 			{Code: `namespace N.Array { const Array = () => 1; Array(); }`},
 			{Code: `namespace N { const Array = () => 1; namespace M.Array { Array(); } }`},
+			// The body of a `declare global` augmentation is a scope of its
+			// own, so its declarations do shadow a call written inside it.
+			{Code: `export {}; declare global { interface Array {} const a: any; Array(); }`},
 
 			// Real-user: eslint/eslint#12273 (closed as intentional — a
 			// single non-spread argument is left alone even when it's
@@ -289,6 +292,26 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 				`namespace N { namespace M.Array { } Array(); }`,
 				`Array()`,
 				`namespace N { namespace M.Array { } []; }`,
+			),
+
+			// ---- Dimension 2: scoping — a `declare global` augmentation is a
+			// scope of its own, in every declaration space, so what it adds to
+			// the global scope never shadows the call in the module carrying
+			// it ----
+			directFixCase(
+				`export {}; declare global { interface Array {} } Array();`,
+				`Array()`,
+				`export {}; declare global { interface Array {} } [];`,
+			),
+			directFixCase(
+				`export {}; declare global { const Array: any; } Array();`,
+				`Array()`,
+				`export {}; declare global { const Array: any; } [];`,
+			),
+			directFixCase(
+				`export {}; declare global { namespace Array {} } Array();`,
+				`Array()`,
+				`export {}; declare global { namespace Array {} } [];`,
 			),
 
 			// ---- Dimension 2: scoping — a decorator or computed name belongs

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -118,6 +118,7 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			// decorated function's own scope.
 			{Code: `class C { m(@dec(Array()) x: number) { var Array; } }`},
 			{Code: `class C { m(@dec(Array()) x: number) { let Array; } }`},
+			{Code: `class C { m(@dec(Array()) x: number, Array: any) { } }`},
 			// The enclosing class stays in the chain, so its name and type
 			// parameters shadow a call nested inside a parameter decorator.
 			{Code: "class Array { m(@dec(() => Array()) x: number) { } }"},

--- a/internal/rules/no_array_constructor/no_array_constructor_upstream_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_upstream_test.go
@@ -1,0 +1,359 @@
+package no_array_constructor
+
+// TestNoArrayConstructorUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/no-array-constructor.js 1:1 — both the plain
+// RuleTester (Espree) and the ruleTesterTypeScript (@typescript-eslint/parser)
+// blocks, since rslint parses every file with a single TS-aware parser and
+// has no equivalent split. Position assertions cover line/column for every
+// invalid case. rslint-specific lock-in cases live in the
+// no_array_constructor_extras_test.go file.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func lineColAt(code string, idx int) (line, col int) {
+	before := code[:idx]
+	line = 1 + strings.Count(before, "\n")
+	lastNL := strings.LastIndex(before, "\n")
+	col = idx - lastNL
+	return
+}
+
+// rangeOf locates the first occurrence of marker in code and returns its
+// 1-based line/column span (EndColumn is exclusive), matching the
+// diagnostic's reported node range.
+func rangeOf(code, marker string) (startLine, startCol, endLine, endCol int) {
+	idx := strings.Index(code, marker)
+	if idx < 0 {
+		panic("rangeOf: marker not found: " + marker)
+	}
+	startLine, startCol = lineColAt(code, idx)
+	endLine, endCol = lineColAt(code, idx+len(marker))
+	return
+}
+
+// directFixCase builds an InvalidTestCase for a report that upstream applies
+// as a direct autofix (shouldSuggest is false: no optional chain, no leading
+// comment, and either zero arguments or ≥2 non-spread arguments).
+func directFixCase(code, marker, output string) rule_tester.InvalidTestCase {
+	l1, c1, l2, c2 := rangeOf(code, marker)
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Output: []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferLiteral",
+			Line:      l1, Column: c1, EndLine: l2, EndColumn: c2,
+		}},
+	}
+}
+
+// suggestCase builds an InvalidTestCase for a report upstream only offers as
+// a suggestion (shouldSuggest is true).
+func suggestCase(code, marker, messageId, output string) rule_tester.InvalidTestCase {
+	l1, c1, l2, c2 := rangeOf(code, marker)
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferLiteral",
+			Line:      l1, Column: c1, EndLine: l2, EndColumn: c2,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+				MessageId: messageId,
+				Output:    output,
+			}},
+		}},
+	}
+}
+
+// asiCase builds a directFixCase for one of upstream's ASI-safety fixtures:
+// code containing exactly one occurrence of pattern (either "Array(...)" or
+// "new Array(...)"). All of upstream's ASI fixtures are argument-free or have
+// ≥2 non-spread arguments, so the fix is always a direct autofix, never a
+// suggestion.
+func asiCase(code, pattern string, needsSemicolon bool) rule_tester.InvalidTestCase {
+	idx := strings.Index(code, pattern)
+	if idx < 0 {
+		panic("asiCase: pattern not found in code: " + pattern)
+	}
+	open := strings.Index(pattern, "(")
+	argsText := pattern[open+1 : len(pattern)-1]
+	fixText := "[" + argsText + "]"
+	if needsSemicolon {
+		fixText = ";" + fixText
+	}
+	output := code[:idx] + fixText + code[idx+len(pattern):]
+	return directFixCase(code, pattern, output)
+}
+
+// tsAsiCase builds a directFixCase for the "no semicolon required after
+// TypeScript syntax" block: prefix is a TS declaration/statement that never
+// leaves an ASI hazard behind it, followed by `Array(0, 1)` on the next line.
+//
+// weAddSemicolon locks in a documented, safe divergence from upstream: our
+// utils.NeedsPrecedingSemicolon (see its doc comment) omits ESLint's
+// TypeScript-only exemptions for type positions, ambient/overload function
+// declarations, and import-equals declarations, so it falls back to the
+// conservative "needs a semicolon" answer for the token kinds these prefixes
+// end with — upstream needs none. The extra `;` never changes behavior, only
+// adds a redundant character, so it's a documented difference (see the rule's
+// "Differences from ESLint" section) rather than a bug.
+func tsAsiCase(prefix string, weAddSemicolon bool) rule_tester.InvalidTestCase {
+	code := prefix + "\nArray(0, 1)"
+	fix := "[0, 1]"
+	if weAddSemicolon {
+		fix = ";" + fix
+	}
+	output := prefix + "\n" + fix
+	return directFixCase(code, "Array(0, 1)", output)
+}
+
+func TestNoArrayConstructorUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoArrayConstructorRule,
+		[]rule_tester.ValidTestCase{
+			// ---- plain RuleTester valid ----
+			{Code: `new Array(x)`},
+			{Code: `Array(x)`},
+			{Code: `new Array(9)`},
+			{Code: `Array(9)`},
+			{Code: `new foo.Array()`},
+			{Code: `foo.Array()`},
+			{Code: `new Array.foo`},
+			{Code: `Array.foo()`},
+			{Code: `new globalThis.Array`},
+			{Code: `const createArray = Array => new Array()`},
+			{Code: `var Array; new Array;`},
+			{Code: `new Array()`, Globals: map[string]any{"Array": "off"}},
+
+			// ---- ruleTesterTypeScript valid ----
+			{Code: `new Array(x);`},
+			{Code: `Array(x);`},
+			{Code: `new Array(9);`},
+			{Code: `Array(9);`},
+			{Code: `new foo.Array();`},
+			{Code: `foo.Array();`},
+			{Code: `new Array.foo();`},
+			{Code: `Array.foo();`},
+			// TypeScript: explicit type arguments mean this isn't the bare
+			// constructor call the rule targets.
+			{Code: `new Array<Foo>(1, 2, 3);`},
+			{Code: `new Array<Foo>();`},
+			{Code: `Array<Foo>(1, 2, 3);`},
+			{Code: `Array<Foo>();`},
+			{Code: `Array<Foo>(3);`},
+			// optional chain — still a single non-spread argument or a
+			// member/type-argument form the rule doesn't target.
+			{Code: `Array?.(x);`},
+			{Code: `Array?.(9);`},
+			{Code: `foo?.Array();`},
+			{Code: `Array?.foo();`},
+			{Code: `foo.Array?.();`},
+			{Code: `Array.foo?.();`},
+			{Code: `Array?.<Foo>(1, 2, 3);`},
+			{Code: `Array?.<Foo>();`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- plain RuleTester: explicit cases ----
+			directFixCase(`new Array()`, `new Array()`, `[]`),
+			directFixCase(`new Array`, `new Array`, `[]`),
+			directFixCase(`new Array(x, y)`, `new Array(x, y)`, `[x, y]`),
+			directFixCase(`new Array(0, 1, 2)`, `new Array(0, 1, 2)`, `[0, 1, 2]`),
+			suggestCase(`const array = Array?.();`, `Array?.()`, "useLiteral", `const array = [];`),
+			directFixCase(
+				"const array = (Array)(\n    /* foo */ a,\n    b = c() // bar\n);",
+				"(Array)(\n    /* foo */ a,\n    b = c() // bar\n)",
+				"const array = [\n    /* foo */ a,\n    b = c() // bar\n];",
+			),
+			suggestCase(`const array = Array(...args);`, `Array(...args)`, "useLiteral", `const array = [...args];`),
+			suggestCase(`const array = Array(...foo, ...bar);`, `Array(...foo, ...bar)`, "useLiteral", `const array = [...foo, ...bar];`),
+			suggestCase(`const array = new Array(...args);`, `new Array(...args)`, "useLiteral", `const array = [...args];`),
+			suggestCase(`const array = Array(5, ...args);`, `Array(5, ...args)`, "useLiteral", `const array = [5, ...args];`),
+			directFixCase(`const array = Array(5, 6, ...args);`, `Array(5, 6, ...args)`, `const array = [5, 6, ...args];`),
+			directFixCase(`a = new (Array);`, `new (Array)`, `a = [];`),
+			directFixCase(`a = new (Array) && (foo);`, `new (Array)`, `a = [] && (foo);`),
+
+			// ---- Semicolon required before array literal to compensate for ASI ----
+			asiCase("foo\nArray()", "Array()", true),
+			asiCase("foo()\nArray(bar, baz)", "Array(bar, baz)", true),
+			asiCase("new foo\nArray()", "Array()", true),
+			asiCase("(a++)\nArray()", "Array()", true),
+			asiCase("++a\nArray()", "Array()", true),
+			asiCase("const foo = function() {}\nArray()", "Array()", true),
+			asiCase(`const foo = class {}
+Array("a", "b", "c")`, `Array("a", "b", "c")`, true),
+			asiCase("foo = this.return\nArray()", "Array()", true),
+			asiCase("var yield = bar.yield\nArray()", "Array()", true),
+			asiCase("var foo = { bar: baz }\nArray()", "Array()", true),
+
+			// ---- No semicolon required before array literal because ASI does not occur ----
+			asiCase("Array()", "Array()", false),
+			asiCase("{}\nArray()", "Array()", false),
+			asiCase("function foo() {}\nArray()", "Array()", false),
+			asiCase("class Foo {}\nArray()", "Array()", false),
+			asiCase("foo: Array();", "Array()", false),
+			asiCase("foo();Array();", "Array()", false),
+			asiCase("{ Array(); }", "Array()", false),
+			asiCase("if (a) Array();", "Array()", false),
+			asiCase("if (a); else Array();", "Array()", false),
+			asiCase("while (a) Array();", "Array()", false),
+			asiCase("do Array();\nwhile (a);", "Array()", false),
+			asiCase("for (let i = 0; i < 10; i++) Array();", "Array()", false),
+			asiCase("for (const prop in obj) Array();", "Array()", false),
+			asiCase("for (const element of iterable) Array();", "Array()", false),
+			asiCase("with (obj) Array();", "Array()", false),
+
+			// ---- No semicolon required before array literal because ASI still occurs ----
+			asiCase("const foo = () => {}\nArray()", "Array()", false),
+			asiCase("a++\nArray()", "Array()", false),
+			asiCase("a--\nArray()", "Array()", false),
+			asiCase("function foo() {\n    return\n    Array();\n}", "Array()", false),
+			asiCase("function * foo() {\n    yield\n    Array();\n}", "Array()", false),
+			asiCase("do {}\nwhile (a)\nArray()", "Array()", false),
+			asiCase("debugger\nArray()", "Array()", false),
+			asiCase("for (;;) {\n    break\n    Array()\n}", "Array()", false),
+			asiCase("for (;;) {\n    continue\n    Array()\n}", "Array()", false),
+			asiCase("foo: break foo\nArray()", "Array()", false),
+			asiCase("foo: while (true) continue foo\nArray()", "Array()", false),
+			asiCase("const foo = bar\nexport { foo }\nArray()", "Array()", false),
+			asiCase("export { foo } from 'bar'\nArray()", "Array()", false),
+			asiCase(`export { foo } from 'bar' with { type: "json" }
+Array()`, "Array()", false),
+			asiCase("export * as foo from 'bar'\nArray()", "Array()", false),
+			asiCase(`export * as foo from 'bar' with { type: "json" }
+Array()`, "Array()", false),
+			asiCase("import foo from 'bar'\nArray()", "Array()", false),
+			asiCase(`import foo from 'bar' with { type: "json" }
+Array()`, "Array()", false),
+			asiCase("var yield = 5;\n\nyield: while (foo) {\n    if (bar)\n        break yield\n    new Array();\n}", "new Array()", false),
+			asiCase("var foo\nArray()", "Array()", false),
+			asiCase("let bar\nArray()", "Array()", false),
+
+			// ---- Comment preservation around the callee / parentheses ----
+			directFixCase("/*a*/Array()", "Array()", "/*a*/[]"),
+			directFixCase("/*a*/Array()/*b*/", "Array()", "/*a*/[]/*b*/"),
+			suggestCase("Array/*a*/()", "Array/*a*/()", "useLiteral", "[]"),
+			suggestCase(
+				"/*a*//*b*/Array/*c*//*d*/()/*e*//*f*/;/*g*//*h*/",
+				"Array/*c*//*d*/()",
+				"useLiteral",
+				"/*a*//*b*/[]/*e*//*f*/;/*g*//*h*/",
+			),
+			directFixCase("Array(/*a*/ /*b*/)", "Array(/*a*/ /*b*/)", "[/*a*/ /*b*/]"),
+			directFixCase(
+				"Array(/*a*/ x /*b*/, /*c*/ y /*d*/)",
+				"Array(/*a*/ x /*b*/, /*c*/ y /*d*/)",
+				"[/*a*/ x /*b*/, /*c*/ y /*d*/]",
+			),
+			directFixCase(
+				"/*a*/Array(/*b*/ x /*c*/, /*d*/ y /*e*/)/*f*/;/*g*/",
+				"Array(/*b*/ x /*c*/, /*d*/ y /*e*/)",
+				"/*a*/[/*b*/ x /*c*/, /*d*/ y /*e*/]/*f*/;/*g*/",
+			),
+			directFixCase("/*a*/new Array", "new Array", "/*a*/[]"),
+			directFixCase("/*a*/new Array/*b*/", "new Array", "/*a*/[]/*b*/"),
+			suggestCase("new/*a*/Array", "new/*a*/Array", "useLiteral", "[]"),
+			suggestCase(
+				"new/*a*//*b*/Array/*c*//*d*/()/*e*//*f*/;/*g*//*h*/",
+				"new/*a*//*b*/Array/*c*//*d*/()",
+				"useLiteral",
+				"[]/*e*//*f*/;/*g*//*h*/",
+			),
+			directFixCase("new Array(/*a*/ /*b*/)", "new Array(/*a*/ /*b*/)", "[/*a*/ /*b*/]"),
+			directFixCase(
+				"new Array(/*a*/ x /*b*/, /*c*/ y /*d*/)",
+				"new Array(/*a*/ x /*b*/, /*c*/ y /*d*/)",
+				"[/*a*/ x /*b*/, /*c*/ y /*d*/]",
+			),
+			suggestCase(
+				"new/*a*/Array(/*b*/ x /*c*/, /*d*/ y /*e*/)/*f*/;/*g*/",
+				"new/*a*/Array(/*b*/ x /*c*/, /*d*/ y /*e*/)",
+				"useLiteral",
+				"[/*b*/ x /*c*/, /*d*/ y /*e*/]/*f*/;/*g*/",
+			),
+			suggestCase("// a\nArray // b\n()", "Array // b\n()", "useLiteral", "// a\n[]"),
+			suggestCase("// a\nArray // b\n() // c", "Array // b\n()", "useLiteral", "// a\n[] // c"),
+			suggestCase("new // a\nArray // b\n()", "new // a\nArray // b\n()", "useLiteral", "[]"),
+			suggestCase("new (Array /* a */);", "new (Array /* a */)", "useLiteral", "[];"),
+			suggestCase("(/* a */ Array)(1, 2, 3);", "(/* a */ Array)(1, 2, 3)", "useLiteral", "[1, 2, 3];"),
+			suggestCase("(Array /* a */)(1, 2, 3);", "(Array /* a */)(1, 2, 3)", "useLiteral", "[1, 2, 3];"),
+			suggestCase("(Array) /* a */ (1, 2, 3);", "(Array) /* a */ (1, 2, 3)", "useLiteral", "[1, 2, 3];"),
+			suggestCase("(/* a */(Array))();", "(/* a */(Array))()", "useLiteral", "[];"),
+			suggestCase(
+				"Array?.(0, 1, 2).forEach(doSomething);",
+				"Array?.(0, 1, 2)",
+				"useLiteral",
+				"[0, 1, 2].forEach(doSomething);",
+			),
+
+			// ---- ruleTesterTypeScript: explicit cases ----
+			directFixCase(`new Array();`, `new Array()`, `[];`),
+			directFixCase(`Array();`, `Array()`, `[];`),
+			directFixCase(`new Array(x, y);`, `new Array(x, y)`, `[x, y];`),
+			directFixCase(`Array(x, y);`, `Array(x, y)`, `[x, y];`),
+			directFixCase(`new Array(0, 1, 2);`, `new Array(0, 1, 2)`, `[0, 1, 2];`),
+			directFixCase(`Array(0, 1, 2);`, `Array(0, 1, 2)`, `[0, 1, 2];`),
+			suggestCase(`Array?.(0, 1, 2);`, `Array?.(0, 1, 2)`, "useLiteral", `[0, 1, 2];`),
+			suggestCase(`Array?.(x, y);`, `Array?.(x, y)`, "useLiteral", `[x, y];`),
+			suggestCase(`Array /*a*/ ?.();`, `Array /*a*/ ?.()`, "useLiteral", `[];`),
+			suggestCase(`Array?./*a*/();`, `Array?./*a*/()`, "useLiteral", `[];`),
+
+			// ---- No semicolon required after TypeScript syntax ----
+			// The five `type T = ...` cases, the six function-overload/ambient
+			// cases, and the three `import ... =` cases each lock in the
+			// documented divergence described on tsAsiCase: rslint adds a
+			// redundant `;` that upstream omits. The uninitialized-declarator
+			// cases (`const foo`, `declare const foo`, `let foo: bar`) match
+			// upstream exactly since that path is fully implemented.
+			tsAsiCase("type T = Foo", true),
+			tsAsiCase("type T = Foo<Bar>", true),
+			tsAsiCase("type T = (A | B)", true),
+			tsAsiCase("type T = -1", true),
+			tsAsiCase("type T = 'foo'", true),
+			tsAsiCase("const foo", false),
+			tsAsiCase("declare const foo", false),
+			tsAsiCase("function foo()", true),
+			tsAsiCase("declare function foo()", true),
+			tsAsiCase("function foo(): []", true),
+			tsAsiCase("declare function foo(): []", true),
+			tsAsiCase("function foo(): (Foo)", true),
+			tsAsiCase("declare function foo(): (Foo)", true),
+			tsAsiCase("let foo: bar", false),
+			tsAsiCase("import Foo = require('foo')", true),
+			tsAsiCase("import Foo = Bar", true),
+			tsAsiCase("import Foo = Bar.Baz.Qux", true),
+
+			// ---- Multiple reports in one file, mixed semicolon requirement ----
+			// The second report in each case (`Array() // ";" not required`)
+			// follows an `as Fn` / `as Object` type-cast identifier — the same
+			// documented divergence as the tsAsiCase block above, so rslint's
+			// fix adds a `;` there too.
+			{
+				Code: "(function () {\n\tFn\n\tArray() // \";\" required\n}) as Fn\nArray() // \";\" not required",
+				Output: []string{
+					"(function () {\n\tFn\n\t;[] // \";\" required\n}) as Fn\n;[] // \";\" not required",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 3, Column: 2, EndLine: 3, EndColumn: 9},
+					{MessageId: "preferLiteral", Line: 5, Column: 1, EndLine: 5, EndColumn: 8},
+				},
+			},
+			{
+				Code: "({\n\tfoo() {\n\t\tObject\n\t\tArray() // \";\" required\n\t}\n}) as Object\nArray() // \";\" not required",
+				Output: []string{
+					"({\n\tfoo() {\n\t\tObject\n\t\t;[] // \";\" required\n\t}\n}) as Object\n;[] // \";\" not required",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 4, Column: 3, EndLine: 4, EndColumn: 10},
+					{MessageId: "preferLiteral", Line: 7, Column: 1, EndLine: 7, EndColumn: 8},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_array_constructor/no_array_constructor_upstream_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_upstream_test.go
@@ -130,7 +130,10 @@ func TestNoArrayConstructorUpstream(t *testing.T) {
 			{Code: `new globalThis.Array`},
 			{Code: `const createArray = Array => new Array()`},
 			{Code: `var Array; new Array;`},
-			{Code: `new Array()`, Globals: map[string]any{"Array": "off"}},
+			{
+				Code: `new Array()`, FileName: "no-array-constructor-espree.js", TSConfig: "tsconfig.allow-js.json",
+				Globals: map[string]any{"Array": "off"},
+			},
 
 			// ---- ruleTesterTypeScript valid ----
 			{Code: `new Array(x);`},

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -219,6 +219,27 @@ func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 	return false
 }
 
+// HasEnclosingClassExpressionName reports whether scope-manager exposes an
+// enclosing class expression's own name at node. A reference sitting directly
+// in the class's decorator acquires the class scope, while a scope created
+// inside that decorator is parented outside the class and cannot see the name.
+func HasEnclosingClassExpressionName(node *ast.Node, name string) bool {
+	prevChild := node
+	crossedScope := false
+	for current := node.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindClassExpression && !escapesClassScope(prevChild, crossedScope) {
+			if className := current.Name(); className != nil && className.Kind == ast.KindIdentifier && className.Text() == name {
+				return true
+			}
+		}
+		if ast.IsFunctionLikeDeclaration(current) || ast.IsClassLike(current) {
+			crossedScope = true
+		}
+		prevChild = current
+	}
+	return false
+}
+
 // escapesFunctionScope reports whether a reference that reached fn through
 // prevChild is out of fn's own scope, so none of fn's bindings — parameters,
 // type parameters, function name, body declarations — reach it.

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -184,12 +184,75 @@ func isDirectParameterOf(fn *ast.Node, child *ast.Node) bool {
 	return false
 }
 
+type scopeManagerShadowKey struct {
+	node *ast.Node
+	name string
+}
+
+// ScopeManagerShadowCache reuses declaration-set answers while a rule models
+// typescript-eslint scope-manager boundaries for many references in one file.
+// The zero value is ready to use.
+type ScopeManagerShadowCache struct {
+	typeParameters   map[scopeManagerShadowKey]bool
+	parameters       map[scopeManagerShadowKey]bool
+	bodyDeclarations map[scopeManagerShadowKey]bool
+}
+
+func cachedScopeManagerAnswer(cache *map[scopeManagerShadowKey]bool, key scopeManagerShadowKey, compute func() bool) bool {
+	if *cache == nil {
+		*cache = make(map[scopeManagerShadowKey]bool)
+	} else if result, ok := (*cache)[key]; ok {
+		return result
+	}
+	result := compute()
+	(*cache)[key] = result
+	return result
+}
+
+func (cache *ScopeManagerShadowCache) hasTypeParameter(scope *ast.Node, name string) bool {
+	return cachedScopeManagerAnswer(&cache.typeParameters, scopeManagerShadowKey{node: scope, name: name}, func() bool {
+		for _, typeParameter := range scope.TypeParameters() {
+			// TypeScript creates synthetic type parameters from JSDoc @template
+			// tags and attaches them to the host declaration. They remain comments
+			// rather than scope variables in ESTree and scope-manager.
+			if typeParameter != nil && typeParameter.Flags&ast.NodeFlagsReparsed == 0 &&
+				typeParameter.Name() != nil && typeParameter.Name().Text() == name {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (cache *ScopeManagerShadowCache) hasParameter(fn *ast.Node, name string) bool {
+	return cachedScopeManagerAnswer(&cache.parameters, scopeManagerShadowKey{node: fn, name: name}, func() bool {
+		for _, parameter := range fn.Parameters() {
+			if parameter != nil && parameter.Name() != nil && HasNameInBindingPattern(parameter.Name(), name) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (cache *ScopeManagerShadowCache) hasBodyDeclaration(body *ast.Node, name string) bool {
+	return cachedScopeManagerAnswer(&cache.bodyDeclarations, scopeManagerShadowKey{node: body, name: name}, func() bool {
+		return hasFunctionScopeDeclaration(body, name) || HasHoistedVarDeclaration(body, name)
+	})
+}
+
 // HasEnclosingTypeParameter reports whether any enclosing function-like or
 // class declaration declares a type parameter called name. scope-manager keeps
 // class type parameters in the lexical scope chain of static members, while
 // TypeScript's own resolver deliberately hides them there, so rules that model
 // scope-manager variables need this on top of a resolver-based lookup.
 func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
+	var cache ScopeManagerShadowCache
+	return cache.HasEnclosingTypeParameter(node, name)
+}
+
+// HasEnclosingTypeParameter is the cached form of the package-level helper.
+func (cache *ScopeManagerShadowCache) HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 	prevChild := node
 	inParameterDecorator := false
 	crossedScope := false
@@ -202,16 +265,8 @@ func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 		entersFunctionScope := isFunctionLike &&
 			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)
 		entersClassScope := isClassLike && !escapesClassScope(prevChild, crossedScope)
-		if entersFunctionScope || entersClassScope {
-			for _, typeParameter := range current.TypeParameters() {
-				// TypeScript creates synthetic type parameters from JSDoc @template
-				// tags and attaches them to the host declaration. They remain comments
-				// rather than scope variables in ESTree and scope-manager.
-				if typeParameter != nil && typeParameter.Flags&ast.NodeFlagsReparsed == 0 &&
-					typeParameter.Name() != nil && typeParameter.Name().Text() == name {
-					return true
-				}
-			}
+		if (entersFunctionScope || entersClassScope) && cache.hasTypeParameter(current, name) {
+			return true
 		}
 		if entersFunctionScope || entersClassScope {
 			crossedScope = true
@@ -229,6 +284,12 @@ func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 // class scope. A scope created inside the decorator drops the function scope
 // from the chain, just as it does for type parameters and body declarations.
 func HasEnclosingParameter(node *ast.Node, name string) bool {
+	var cache ScopeManagerShadowCache
+	return cache.HasEnclosingParameter(node, name)
+}
+
+// HasEnclosingParameter is the cached form of the package-level helper.
+func (cache *ScopeManagerShadowCache) HasEnclosingParameter(node *ast.Node, name string) bool {
 	prevChild := node
 	inParameterDecorator := false
 	crossedScope := false
@@ -241,12 +302,8 @@ func HasEnclosingParameter(node *ast.Node, name string) bool {
 		entersFunctionScope := isFunctionLike &&
 			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)
 		entersClassScope := isClassLike && !escapesClassScope(prevChild, crossedScope)
-		if entersFunctionScope && inParameterDecorator && isDirectParameterOf(current, prevChild) {
-			for _, parameter := range current.Parameters() {
-				if parameter != nil && parameter.Name() != nil && HasNameInBindingPattern(parameter.Name(), name) {
-					return true
-				}
-			}
+		if entersFunctionScope && inParameterDecorator && isDirectParameterOf(current, prevChild) && cache.hasParameter(current, name) {
+			return true
 		}
 		if entersFunctionScope || entersClassScope {
 			crossedScope = true
@@ -338,6 +395,13 @@ func escapesClassScope(prevChild *ast.Node, crossedScope bool) bool {
 // once an arrow, function, or class body intervenes the decorated function's
 // scope is out of the chain entirely.
 func IsShadowedFromParameterInitializer(node *ast.Node, name string) bool {
+	var cache ScopeManagerShadowCache
+	return cache.IsShadowedFromParameterInitializer(node, name)
+}
+
+// IsShadowedFromParameterInitializer is the cached form of the package-level
+// helper.
+func (cache *ScopeManagerShadowCache) IsShadowedFromParameterInitializer(node *ast.Node, name string) bool {
 	prevChild := node
 	inParameterDecorator := false
 	crossedScope := false
@@ -351,8 +415,7 @@ func IsShadowedFromParameterInitializer(node *ast.Node, name string) bool {
 			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)
 		entersClassScope := isClassLike && !escapesClassScope(prevChild, crossedScope)
 		if entersFunctionScope && isDirectParameterOf(current, prevChild) {
-			if body := current.Body(); body != nil &&
-				(hasFunctionScopeDeclaration(body, name) || HasHoistedVarDeclaration(body, name)) {
+			if body := current.Body(); body != nil && cache.hasBodyDeclaration(body, name) {
 				return true
 			}
 		}

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -199,8 +199,10 @@ func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 		}
 		isFunctionLike := ast.IsFunctionLikeDeclaration(current)
 		isClassLike := ast.IsClassLike(current)
-		if (isFunctionLike && !escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)) ||
-			(isClassLike && !escapesClassScope(prevChild, crossedScope)) {
+		entersFunctionScope := isFunctionLike &&
+			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)
+		entersClassScope := isClassLike && !escapesClassScope(prevChild, crossedScope)
+		if entersFunctionScope || entersClassScope {
 			for _, typeParameter := range current.TypeParameters() {
 				// TypeScript creates synthetic type parameters from JSDoc @template
 				// tags and attaches them to the host declaration. They remain comments
@@ -211,7 +213,7 @@ func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 				}
 			}
 		}
-		if isFunctionLike || isClassLike {
+		if entersFunctionScope || entersClassScope {
 			crossedScope = true
 		}
 		prevChild = current
@@ -234,15 +236,19 @@ func HasEnclosingParameter(node *ast.Node, name string) bool {
 		if current.Kind == ast.KindParameter {
 			inParameterDecorator = prevChild.Kind == ast.KindDecorator
 		}
-		if ast.IsFunctionLikeDeclaration(current) &&
-			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope) {
+		isFunctionLike := ast.IsFunctionLikeDeclaration(current)
+		isClassLike := ast.IsClassLike(current)
+		entersFunctionScope := isFunctionLike &&
+			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)
+		entersClassScope := isClassLike && !escapesClassScope(prevChild, crossedScope)
+		if entersFunctionScope && inParameterDecorator && isDirectParameterOf(current, prevChild) {
 			for _, parameter := range current.Parameters() {
 				if parameter != nil && parameter.Name() != nil && HasNameInBindingPattern(parameter.Name(), name) {
 					return true
 				}
 			}
 		}
-		if ast.IsFunctionLikeDeclaration(current) || ast.IsClassLike(current) {
+		if entersFunctionScope || entersClassScope {
 			crossedScope = true
 		}
 		prevChild = current
@@ -258,12 +264,17 @@ func HasEnclosingClassExpressionName(node *ast.Node, name string) bool {
 	prevChild := node
 	crossedScope := false
 	for current := node.Parent; current != nil; current = current.Parent {
-		if current.Kind == ast.KindClassExpression && !escapesClassScope(prevChild, crossedScope) {
+		isFunctionLike := ast.IsFunctionLikeDeclaration(current)
+		isClassLike := ast.IsClassLike(current)
+		entersFunctionScope := isFunctionLike &&
+			!escapesFunctionScope(current, prevChild, false, crossedScope)
+		entersClassScope := isClassLike && !escapesClassScope(prevChild, crossedScope)
+		if current.Kind == ast.KindClassExpression && entersClassScope {
 			if className := current.Name(); className != nil && className.Kind == ast.KindIdentifier && className.Text() == name {
 				return true
 			}
 		}
-		if ast.IsFunctionLikeDeclaration(current) || ast.IsClassLike(current) {
+		if entersFunctionScope || entersClassScope {
 			crossedScope = true
 		}
 		prevChild = current
@@ -334,14 +345,18 @@ func IsShadowedFromParameterInitializer(node *ast.Node, name string) bool {
 		if current.Kind == ast.KindParameter {
 			inParameterDecorator = prevChild.Kind == ast.KindDecorator
 		}
-		if ast.IsFunctionLikeDeclaration(current) && isDirectParameterOf(current, prevChild) &&
-			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope) {
+		isFunctionLike := ast.IsFunctionLikeDeclaration(current)
+		isClassLike := ast.IsClassLike(current)
+		entersFunctionScope := isFunctionLike &&
+			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)
+		entersClassScope := isClassLike && !escapesClassScope(prevChild, crossedScope)
+		if entersFunctionScope && isDirectParameterOf(current, prevChild) {
 			if body := current.Body(); body != nil &&
 				(hasFunctionScopeDeclaration(body, name) || HasHoistedVarDeclaration(body, name)) {
 				return true
 			}
 		}
-		if ast.IsFunctionLikeDeclaration(current) || ast.IsClassLike(current) {
+		if entersFunctionScope || entersClassScope {
 			crossedScope = true
 		}
 		prevChild = current

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -202,7 +202,11 @@ func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 		if (isFunctionLike && !escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope)) ||
 			(isClassLike && !escapesClassScope(prevChild, crossedScope)) {
 			for _, typeParameter := range current.TypeParameters() {
-				if typeParameter != nil && typeParameter.Name() != nil && typeParameter.Name().Text() == name {
+				// TypeScript creates synthetic type parameters from JSDoc @template
+				// tags and attaches them to the host declaration. They remain comments
+				// rather than scope variables in ESTree and scope-manager.
+				if typeParameter != nil && typeParameter.Flags&ast.NodeFlagsReparsed == 0 &&
+					typeParameter.Name() != nil && typeParameter.Name().Text() == name {
 					return true
 				}
 			}

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -219,6 +219,37 @@ func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
 	return false
 }
 
+// HasEnclosingParameter reports whether scope-manager exposes an enclosing
+// function-like declaration's parameter called name at node. This is needed
+// in addition to binder-backed resolution for references directly inside a
+// parameter decorator: scope-manager gives the decorator the decorated
+// function's scope, while TypeScript resolves the decorator in the enclosing
+// class scope. A scope created inside the decorator drops the function scope
+// from the chain, just as it does for type parameters and body declarations.
+func HasEnclosingParameter(node *ast.Node, name string) bool {
+	prevChild := node
+	inParameterDecorator := false
+	crossedScope := false
+	for current := node.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindParameter {
+			inParameterDecorator = prevChild.Kind == ast.KindDecorator
+		}
+		if ast.IsFunctionLikeDeclaration(current) &&
+			!escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope) {
+			for _, parameter := range current.Parameters() {
+				if parameter != nil && parameter.Name() != nil && HasNameInBindingPattern(parameter.Name(), name) {
+					return true
+				}
+			}
+		}
+		if ast.IsFunctionLikeDeclaration(current) || ast.IsClassLike(current) {
+			crossedScope = true
+		}
+		prevChild = current
+	}
+	return false
+}
+
 // HasEnclosingClassExpressionName reports whether scope-manager exposes an
 // enclosing class expression's own name at node. A reference sitting directly
 // in the class's decorator acquires the class scope, while a scope created

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -210,32 +210,49 @@ func cachedScopeManagerAnswer(cache *map[scopeManagerShadowKey]bool, key scopeMa
 }
 
 func (cache *ScopeManagerShadowCache) hasTypeParameter(scope *ast.Node, name string) bool {
+	if cache == nil {
+		return hasScopeManagerTypeParameter(scope, name)
+	}
 	return cachedScopeManagerAnswer(&cache.typeParameters, scopeManagerShadowKey{node: scope, name: name}, func() bool {
-		for _, typeParameter := range scope.TypeParameters() {
-			// TypeScript creates synthetic type parameters from JSDoc @template
-			// tags and attaches them to the host declaration. They remain comments
-			// rather than scope variables in ESTree and scope-manager.
-			if typeParameter != nil && typeParameter.Flags&ast.NodeFlagsReparsed == 0 &&
-				typeParameter.Name() != nil && typeParameter.Name().Text() == name {
-				return true
-			}
-		}
-		return false
+		return hasScopeManagerTypeParameter(scope, name)
 	})
+}
+
+func hasScopeManagerTypeParameter(scope *ast.Node, name string) bool {
+	for _, typeParameter := range scope.TypeParameters() {
+		// TypeScript creates synthetic type parameters from JSDoc @template
+		// tags and attaches them to the host declaration. They remain comments
+		// rather than scope variables in ESTree and scope-manager.
+		if typeParameter != nil && typeParameter.Flags&ast.NodeFlagsReparsed == 0 &&
+			typeParameter.Name() != nil && typeParameter.Name().Text() == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (cache *ScopeManagerShadowCache) hasParameter(fn *ast.Node, name string) bool {
+	if cache == nil {
+		return hasScopeManagerParameter(fn, name)
+	}
 	return cachedScopeManagerAnswer(&cache.parameters, scopeManagerShadowKey{node: fn, name: name}, func() bool {
-		for _, parameter := range fn.Parameters() {
-			if parameter != nil && parameter.Name() != nil && HasNameInBindingPattern(parameter.Name(), name) {
-				return true
-			}
-		}
-		return false
+		return hasScopeManagerParameter(fn, name)
 	})
 }
 
+func hasScopeManagerParameter(fn *ast.Node, name string) bool {
+	for _, parameter := range fn.Parameters() {
+		if parameter != nil && parameter.Name() != nil && HasNameInBindingPattern(parameter.Name(), name) {
+			return true
+		}
+	}
+	return false
+}
+
 func (cache *ScopeManagerShadowCache) hasBodyDeclaration(body *ast.Node, name string) bool {
+	if cache == nil {
+		return hasFunctionScopeDeclaration(body, name) || HasHoistedVarDeclaration(body, name)
+	}
 	return cachedScopeManagerAnswer(&cache.bodyDeclarations, scopeManagerShadowKey{node: body, name: name}, func() bool {
 		return hasFunctionScopeDeclaration(body, name) || HasHoistedVarDeclaration(body, name)
 	})
@@ -247,8 +264,9 @@ func (cache *ScopeManagerShadowCache) hasBodyDeclaration(body *ast.Node, name st
 // TypeScript's own resolver deliberately hides them there, so rules that model
 // scope-manager variables need this on top of a resolver-based lookup.
 func HasEnclosingTypeParameter(node *ast.Node, name string) bool {
-	var cache ScopeManagerShadowCache
-	return cache.HasEnclosingTypeParameter(node, name)
+	// A one-shot package lookup cannot reuse a cache, so keep this path free of
+	// cache-map allocations. Rules with repeated queries should own a cache.
+	return (*ScopeManagerShadowCache)(nil).HasEnclosingTypeParameter(node, name)
 }
 
 // HasEnclosingTypeParameter is the cached form of the package-level helper.
@@ -284,8 +302,9 @@ func (cache *ScopeManagerShadowCache) HasEnclosingTypeParameter(node *ast.Node, 
 // class scope. A scope created inside the decorator drops the function scope
 // from the chain, just as it does for type parameters and body declarations.
 func HasEnclosingParameter(node *ast.Node, name string) bool {
-	var cache ScopeManagerShadowCache
-	return cache.HasEnclosingParameter(node, name)
+	// A one-shot package lookup cannot reuse a cache, so keep this path free of
+	// cache-map allocations. Rules with repeated queries should own a cache.
+	return (*ScopeManagerShadowCache)(nil).HasEnclosingParameter(node, name)
 }
 
 // HasEnclosingParameter is the cached form of the package-level helper.
@@ -395,8 +414,9 @@ func escapesClassScope(prevChild *ast.Node, crossedScope bool) bool {
 // once an arrow, function, or class body intervenes the decorated function's
 // scope is out of the chain entirely.
 func IsShadowedFromParameterInitializer(node *ast.Node, name string) bool {
-	var cache ScopeManagerShadowCache
-	return cache.IsShadowedFromParameterInitializer(node, name)
+	// A one-shot package lookup cannot reuse a cache, so keep this path free of
+	// cache-map allocations. Rules with repeated queries should own a cache.
+	return (*ScopeManagerShadowCache)(nil).IsShadowedFromParameterInitializer(node, name)
 }
 
 // IsShadowedFromParameterInitializer is the cached form of the package-level

--- a/internal/utils/shadowing_test.go
+++ b/internal/utils/shadowing_test.go
@@ -171,10 +171,11 @@ try {} catch (caught) {
 // decorated function drops out of the chain entirely.
 func TestShadowingScopeModels(t *testing.T) {
 	tests := []struct {
-		name                 string
-		code                 string
-		shadowed             bool
-		fromParameterInit    bool
+		name                   string
+		code                   string
+		shadowed               bool
+		fromParameterInit      bool
+		enclosingParameter     bool
 		enclosingTypeParameter bool
 	}{
 		// A namespace body is a scope of its own.
@@ -248,13 +249,14 @@ func TestShadowingScopeModels(t *testing.T) {
 			fromParameterInit: true,
 		},
 		{
-			name:     "parameter decorator, sibling parameter",
-			code:     `class C { m(@dec(Target()) x: number, Target: any) { } }`,
-			shadowed: true,
+			name:               "parameter decorator, sibling parameter",
+			code:               `class C { m(@dec(Target()) x: number, Target: any) { } }`,
+			shadowed:           true,
+			enclosingParameter: true,
 		},
 		{
-			name:                 "parameter decorator, method type parameter",
-			code:                 `class C { m<Target>(@dec(Target()) x: number) { } }`,
+			name:                   "parameter decorator, method type parameter",
+			code:                   `class C { m<Target>(@dec(Target()) x: number) { } }`,
 			enclosingTypeParameter: true,
 		},
 
@@ -278,8 +280,8 @@ func TestShadowingScopeModels(t *testing.T) {
 			shadowed: true,
 		},
 		{
-			name:                 "nested scope in a parameter decorator, class type parameter",
-			code:                 `class C<Target> { m(@dec(() => Target()) x: number) { } }`,
+			name:                   "nested scope in a parameter decorator, class type parameter",
+			code:                   `class C<Target> { m(@dec(() => Target()) x: number) { } }`,
 			enclosingTypeParameter: true,
 		},
 
@@ -298,8 +300,8 @@ func TestShadowingScopeModels(t *testing.T) {
 			code: `class C { @dec(Target()) m<Target>() { } }`,
 		},
 		{
-			name:                 "method decorator, class type parameter",
-			code:                 `class C<Target> { @dec(Target()) m() { } }`,
+			name:                   "method decorator, class type parameter",
+			code:                   `class C<Target> { @dec(Target()) m() { } }`,
 			enclosingTypeParameter: true,
 		},
 		{
@@ -319,8 +321,8 @@ func TestShadowingScopeModels(t *testing.T) {
 			code: `class C { [Target()]<Target>() { } }`,
 		},
 		{
-			name:                 "computed method name, class type parameter",
-			code:                 `class C<Target> { [Target()]() { } }`,
+			name:                   "computed method name, class type parameter",
+			code:                   `class C<Target> { [Target()]() { } }`,
 			enclosingTypeParameter: true,
 		},
 		{
@@ -402,6 +404,9 @@ func TestShadowingScopeModels(t *testing.T) {
 			}
 			if got := IsShadowedFromParameterInitializer(callee, "Target"); got != test.fromParameterInit {
 				t.Errorf("IsShadowedFromParameterInitializer() = %v, want %v", got, test.fromParameterInit)
+			}
+			if got := HasEnclosingParameter(callee, "Target"); got != test.enclosingParameter {
+				t.Errorf("HasEnclosingParameter() = %v, want %v", got, test.enclosingParameter)
 			}
 			if got := HasEnclosingTypeParameter(callee, "Target"); got != test.enclosingTypeParameter {
 				t.Errorf("HasEnclosingTypeParameter() = %v, want %v", got, test.enclosingTypeParameter)

--- a/internal/utils/shadowing_test.go
+++ b/internal/utils/shadowing_test.go
@@ -259,6 +259,11 @@ func TestShadowingScopeModels(t *testing.T) {
 			code:                   `class C { m<Target>(@dec(Target()) x: number) { } }`,
 			enclosingTypeParameter: true,
 		},
+		{
+			name:               "parameter decorator, object method computed name, sibling parameter",
+			code:               `class C { m(@dec({ [Target()]() {} }) x: number, Target: any) { } }`,
+			enclosingParameter: true,
+		},
 
 		// A scope created inside a parameter decorator belongs to the enclosing
 		// class, so the decorated function drops out of the chain.

--- a/internal/utils/shadowing_test.go
+++ b/internal/utils/shadowing_test.go
@@ -419,3 +419,27 @@ func TestShadowingScopeModels(t *testing.T) {
 		})
 	}
 }
+
+func TestScopeManagerShadowPackageHelpersDoNotAllocateCaches(t *testing.T) {
+	code := `class C<Target> { m<Target>(@dec(Target()) x: number, Target: any) { var Target; } }`
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, code, core.ScriptKindTS)
+	callee := findNodeWithText(t, sourceFile, "Target()").Expression()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if !HasEnclosingTypeParameter(callee, "Target") {
+			panic("type parameter should be visible")
+		}
+		if !HasEnclosingParameter(callee, "Target") {
+			panic("parameter should be visible")
+		}
+		if !IsShadowedFromParameterInitializer(callee, "Target") {
+			panic("body declaration should be visible")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("package-level shadow helpers allocated %.2f objects per run, want 0", allocs)
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -487,6 +487,7 @@ export default defineConfig({
     './tests/eslint/rules/vars-on-top.test.ts',
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
+    './tests/eslint/rules/no-array-constructor.test.ts',
     './tests/eslint/rules/no-bitwise.test.ts',
     './tests/eslint/rules/complexity.test.ts',
     './tests/eslint/rules/consistent-return.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-array-constructor.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-array-constructor.test.ts.snap
@@ -1,0 +1,628 @@
+// Rstest Snapshot v1
+
+exports[`no-array-constructor > invalid 1`] = `
+{
+  "code": "new Array()",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 2`] = `
+{
+  "code": "new Array",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 3`] = `
+{
+  "code": "new Array(x, y)",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 4`] = `
+{
+  "code": "new Array(0, 1, 2)",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 5`] = `
+{
+  "code": "const array = Array?.();",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 6`] = `
+{
+  "code": "const array = Array(...args);",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 7`] = `
+{
+  "code": "const array = Array(5, 6, ...args);",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 8`] = `
+{
+  "code": "a = new (Array);",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 9`] = `
+{
+  "code": "
+foo
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 10`] = `
+{
+  "code": "
+new foo
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 11`] = `
+{
+  "code": "
+const foo = function() {}
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 12`] = `
+{
+  "code": "
+{}
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 13`] = `
+{
+  "code": "foo: Array();",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 14`] = `
+{
+  "code": "while (a) Array();",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 15`] = `
+{
+  "code": "with (obj) Array();",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 16`] = `
+{
+  "code": "
+a++
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 17`] = `
+{
+  "code": "
+function foo() {
+    return
+    Array();
+}
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 18`] = `
+{
+  "code": "
+debugger
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 19`] = `
+{
+  "code": "
+export { foo } from 'bar'
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 20`] = `
+{
+  "code": "
+var foo
+Array()
+",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 21`] = `
+{
+  "code": "new Array();",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 22`] = `
+{
+  "code": "Array(0, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-array-constructor > invalid 23`] = `
+{
+  "code": "Array?.(0, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "The array literal notation [] is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-array-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-array-constructor.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-array-constructor.test.ts
@@ -17,6 +17,7 @@ ruleTester.run('no-array-constructor', {
     'var Array; new Array;',
     {
       code: 'new Array()',
+      filename: 'src/virtual.js',
       languageOptions: {
         globals: { Array: 'off' },
       },

--- a/packages/rslint-test-tools/tests/eslint/rules/no-array-constructor.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-array-constructor.test.ts
@@ -1,0 +1,135 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-array-constructor', {
+  valid: [
+    'new Array(x)',
+    'Array(x)',
+    'new Array(9)',
+    'Array(9)',
+    'new foo.Array()',
+    'foo.Array()',
+    'new Array.foo',
+    'Array.foo()',
+    'new globalThis.Array',
+    'const createArray = Array => new Array()',
+    'var Array; new Array;',
+    {
+      code: 'new Array()',
+      languageOptions: {
+        globals: { Array: 'off' },
+      },
+    },
+    // TypeScript
+    'new Array<Foo>(1, 2, 3);',
+    'new Array<Foo>();',
+    'Array<Foo>(1, 2, 3);',
+    'Array<Foo>();',
+    'Array<Foo>(3);',
+    'Array?.(x);',
+    'Array?.(9);',
+  ],
+  invalid: [
+    {
+      code: 'new Array()',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'new Array',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'new Array(x, y)',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'new Array(0, 1, 2)',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'const array = Array?.();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'const array = Array(...args);',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'const array = Array(5, 6, ...args);',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'a = new (Array);',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // Semicolon required before array literal to compensate for ASI
+    {
+      code: '\nfoo\nArray()\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '\nnew foo\nArray()\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '\nconst foo = function() {}\nArray()\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // No semicolon required before array literal because ASI does not occur
+    {
+      code: '\n{}\nArray()\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'foo: Array();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'while (a) Array();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'with (obj) Array();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // No semicolon required before array literal because ASI still occurs
+    {
+      code: '\na++\nArray()\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '\nfunction foo() {\n    return\n    Array();\n}\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '\ndebugger\nArray()\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: "\nexport { foo } from 'bar'\nArray()\n",
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '\nvar foo\nArray()\n',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // TypeScript
+    {
+      code: 'new Array();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'Array(0, 1, 2);',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'Array?.(0, 1, 2);',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-array-constructor` rule from ESLint core to rslint.

Disallows using `Array()` / `new Array()` in favor of array literal notation, except when a single non-spread argument is given (the sparse-array-length case, which can't be distinguished from a regular value without type information). Supports TypeScript type-argument and optional-chain forms.

Stacked on #1751 (`no-object-constructor`), which this rule reuses `utils.NeedsPrecedingSemicolon`'s full ASI-safety logic from — this PR's diff is just the `no-array-constructor` rule itself.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-array-constructor
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-array-constructor.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).