### PR TITLE
refactor: extract no-shadow's scope manager into internal/utils/scope

### DIFF
--- a/.agents/skills/port-rule/references/UTILS_REFERENCE.md
+++ b/.agents/skills/port-rule/references/UTILS_REFERENCE.md
@@ -431,6 +431,36 @@ See [AST_PATTERNS.md — Resolving Identifiers and Collecting References](./AST_
 
 ---
 
+## `internal/utils/scope/` - ESLint Scope Model
+
+An AST-derived reconstruction of ESLint's lexical scope tree — rslint's stand-in for `sourceCode.getScope()` / eslint-scope. Use it only when a rule's semantics are stated in terms of **scopes** (which scope owns a binding, what an inner scope shadows, whether two positions share a variable scope). For "which symbol is this identifier" and "where else is this symbol used", reach for `ctx.Refs` above instead — it is backed by the binder and understands globals, ambient, and cross-file declarations, which this package deliberately does not.
+
+```go
+manager := scope.Build(ctx.SourceFile)
+
+for _, s := range manager.Scopes { // creation order == pre-order walk of the tree
+    for _, v := range s.Vars {     // declaration order within the scope
+        // v.Name, v.ID (identifier node), v.DefNode, v.Kind (scope.Def*)
+    }
+}
+
+// Resolve a name outward, the way ESLint's scope chain does.
+for s := start; s != nil; s = s.Parent {
+    if declarations := s.Declarations(name); len(declarations) > 0 { /* ... */ }
+}
+```
+
+- Scope kinds (`scope.Kind*`): `Global`, `Function`, `FunctionExprName`, `Block`, `Catch`, `Class`, `Module`, `Type`. ESLint's module scope is collapsed into `Global`.
+- `Scope.VariableScope()` is eslint-scope's `Scope#variableScope`: the nearest enclosing function / namespace / global scope, i.e. the `var` hoist target.
+- Definition kinds (`scope.Def*`) map to eslint-scope's `Definition#type`, including the TypeScript ones (`DefType`, `DefEnumName`, `DefNamespaceName`, `DefTypeParameter`, `DefImport`).
+- eslint-scope merges all same-name declarations in a scope into one `Variable` with several `defs`; here each declaration is its own `scope.Variable` and `Scope.Declarations(name)` is the merged view, in source order — so `Declarations(name)[0]` is `defs[0]`.
+- `Scope.GlobalAugmentation` marks scopes inside `declare global { ... }`; bindings there are conceptually global.
+- Concepts rslint does not expose (`parserOptions.globalReturn`, `ecmaVersion`-dependent function-in-block hoisting) are unmodeled.
+
+`internal/rules/no_shadow` is the reference consumer.
+
+---
+
 ## `internal/utils/builtin_symbol_likes.go` - Builtin Symbol Checking
 
 ### Builtin Type Checking

--- a/internal/rules/no_shadow/no_shadow.go
+++ b/internal/rules/no_shadow/no_shadow.go
@@ -8,7 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 //go:embed no_shadow.schema.json
@@ -16,8 +16,9 @@ var schemaJSON []byte
 
 // https://eslint.org/docs/latest/rules/no-shadow
 //
-// Scope semantics are reconstructed by walking the AST and tracking scopes
-// directly (rslint has no eslint-scope-equivalent). This covers the common
+// Scope semantics come from the shared scope model in
+// `internal/utils/scope`, which reconstructs ESLint's scope tree by walking
+// the AST (rslint has no eslint-scope equivalent). This covers the common
 // cases exercised by the ESLint test suite. The rule reports shadowing against
 // declarations visible within the file plus, when `builtinGlobals` is on, the
 // effective ESLint global scope from `ctx.Globals`: ECMAScript builtins and
@@ -122,1120 +123,6 @@ func parseOptionsWith(rawOptions []any, opts options) options {
 }
 
 // ---------------------------------------------------------------------------
-// Scope model
-// ---------------------------------------------------------------------------
-
-type defKind int
-
-const (
-	defVariable       defKind = iota // var/let/const binding, binding element
-	defParameter                     // function parameter
-	defFunctionName                  // FunctionDeclaration name (outer scope)
-	defFnExprName                    // FunctionExpression name (inner scope only)
-	defClassName                     // ClassDeclaration name (outer scope)
-	defClassInnerName                // Class name visible inside class scope
-	defImport                        // Import specifier / default / namespace
-	defCatch                         // Catch parameter
-	defType                          // Interface, type alias
-	defEnumName                      // Enum declaration
-	defNamespaceName                 // Module/namespace declaration
-	defTypeParameter                 // Generic type parameter
-)
-
-type variable struct {
-	name    string
-	id      *ast.Node // identifier node of this declaration
-	defNode *ast.Node // declaration node (VariableDeclaration, FunctionDeclaration, ...)
-	parent  *ast.Node // parent of defNode (for parsed import detection, parameter typing, etc.)
-	kind    defKind
-
-	isValueBinding   bool // runtime value vs. type-only
-	isTypeOnlyImport bool // ImportSpecifier with `type` modifier
-	declareModifier  bool // `declare` modifier (.d.ts handling)
-
-	scope *scope
-}
-
-type scopeKind int
-
-const (
-	scopeGlobal           scopeKind = iota
-	scopeFunction                   // function-like bodies & their parameters
-	scopeFunctionExprName           // FunctionExpression's name binding
-	scopeBlock                      // { ... } / for-init / switch case
-	scopeCatch                      // catch clause
-	scopeClass                      // class body: type parameters & inner class name
-	scopeModule                     // TS namespace
-	scopeType                       // TS type alias / interface / function type: type parameters
-)
-
-type scope struct {
-	kind               scopeKind
-	block              *ast.Node
-	parent             *scope
-	vars               []*variable
-	byName             map[string][]*variable
-	globalAugmentation bool // true inside `declare global { ... }` chain
-}
-
-func newScope(kind scopeKind, block *ast.Node, parent *scope) *scope {
-	return &scope{
-		kind:   kind,
-		block:  block,
-		parent: parent,
-		byName: map[string][]*variable{},
-	}
-}
-
-func (s *scope) add(v *variable) {
-	v.scope = s
-	s.vars = append(s.vars, v)
-	s.byName[v.name] = append(s.byName[v.name], v)
-}
-
-// variableScope returns the nearest ancestor (or self) that acts as a var
-// hoist target: function-like scopes, module scopes, and the global scope.
-func (s *scope) variableScope() *scope {
-	current := s
-	for current != nil {
-		switch current.kind {
-		case scopeFunction, scopeModule, scopeGlobal:
-			return current
-		}
-		current = current.parent
-	}
-	return nil
-}
-
-// ---------------------------------------------------------------------------
-// Scope builder
-// ---------------------------------------------------------------------------
-
-type builder struct {
-	sourceFile                          *ast.SourceFile
-	allScopes                           []*scope
-	builtinGlobals                      map[string]bool
-	includeDefaultTypeScriptTypeGlobals bool
-	typeImportUsesOwnSpecifier          bool
-	reportEnumShadow                    bool
-}
-
-func (b *builder) push(kind scopeKind, block *ast.Node, parent *scope) *scope {
-	s := newScope(kind, block, parent)
-	if parent != nil && parent.globalAugmentation {
-		s.globalAugmentation = true
-	}
-	b.allScopes = append(b.allScopes, s)
-	return s
-}
-
-func (b *builder) buildProgram(sf *ast.SourceFile) *scope {
-	global := b.push(scopeGlobal, sf.AsNode(), nil)
-	if sf.Statements == nil {
-		return global
-	}
-	// First pass: hoist var / function / class / import names into the global scope.
-	b.hoistStatements(sf.Statements.Nodes, global)
-	// Second pass: walk children that introduce nested scopes.
-	for _, stmt := range sf.Statements.Nodes {
-		b.visitStatement(stmt, global)
-	}
-	return global
-}
-
-// hoistStatements collects declarations that belong to the enclosing
-// variable scope (var / function / class / enum / interface / type /
-// namespace / import). Block-scoped declarations (let/const/class inside
-// a nested block) are collected in visitBlock.
-func (b *builder) hoistStatements(statements []*ast.Node, s *scope) {
-	for _, stmt := range statements {
-		b.hoistStatement(stmt, s, false)
-	}
-}
-
-// addNamedDecl records a declaration whose binding name is the Name() child
-// of `stmt` (covers function, class, interface, type alias, enum, namespace,
-// import-equals). Returns without adding when the statement has no identifier
-// name (for example anonymous default exports and ambient-module strings).
-func (b *builder) addNamedDecl(stmt *ast.Node, s *scope, kind defKind, isValue bool) {
-	n := stmt.Name()
-	if n == nil || n.Kind != ast.KindIdentifier {
-		return
-	}
-	isAmbient := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient)
-	// Body-less FunctionDeclarations come in two flavors: overload signatures
-	// (no `declare`, there will be a later implementation) and ambient
-	// declarations (`declare function foo(): void`). typescript-eslint's scope
-	// manager merges all signatures under one Variable, so we only need to
-	// register a single binding: skip overload signatures, but keep ambient
-	// declarations so that inner scopes detect them as shadowed.
-	if kind == defFunctionName && stmt.Body() == nil && !isAmbient {
-		return
-	}
-	s.add(&variable{
-		name:            n.Text(),
-		id:              n,
-		defNode:         stmt,
-		parent:          stmt.Parent,
-		kind:            kind,
-		isValueBinding:  isValue,
-		declareModifier: isAmbient,
-	})
-}
-
-// hoistStatement records the declarations introduced by `stmt` into scope
-// `s`. When `blockScope` is true, only block-scoped bindings (let/const/
-// class/function/type/enum/namespace) are added — var is assumed to have
-// been hoisted to an outer variable scope. Otherwise, every binding kind
-// (including var) is added and the function's child statements are scanned
-// for nested `var` declarations that also hoist to this scope.
-func (b *builder) hoistStatement(stmt *ast.Node, s *scope, blockScope bool) {
-	if stmt == nil {
-		return
-	}
-	switch stmt.Kind {
-	case ast.KindVariableStatement:
-		vs := stmt.AsVariableStatement()
-		if vs == nil || vs.DeclarationList == nil {
-			return
-		}
-		isVar := utils.IsVarKeyword(vs.DeclarationList)
-		if blockScope && isVar {
-			return
-		}
-		declareMod := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient)
-		b.collectVariableDeclarations(vs.DeclarationList, s, declareMod)
-	case ast.KindFunctionDeclaration:
-		b.addNamedDecl(stmt, s, defFunctionName, true)
-	case ast.KindClassDeclaration:
-		b.addNamedDecl(stmt, s, defClassName, true)
-	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
-		b.addNamedDecl(stmt, s, defType, false)
-	case ast.KindEnumDeclaration:
-		b.addNamedDecl(stmt, s, defEnumName, true)
-	case ast.KindModuleDeclaration:
-		// Ambient `declare module 'str' { ... }` uses a string-literal name and
-		// doesn't bind a variable — addNamedDecl skips it automatically.
-		b.addNamedDecl(stmt, s, defNamespaceName, true)
-	case ast.KindImportDeclaration:
-		if !blockScope {
-			b.collectImport(stmt, s)
-		}
-	case ast.KindImportEqualsDeclaration:
-		if !blockScope {
-			b.addNamedDecl(stmt, s, defImport, true)
-		}
-	case ast.KindForStatement:
-		fs := stmt.AsForStatement()
-		if !blockScope && fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
-			b.collectVariableDeclarations(fs.Initializer, s, false)
-		}
-	case ast.KindForInStatement, ast.KindForOfStatement:
-		fs := stmt.AsForInOrOfStatement()
-		if !blockScope && fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
-			b.collectVariableDeclarations(fs.Initializer, s, false)
-		}
-	}
-
-	if blockScope {
-		return
-	}
-	// For variable-scope hoisting, recurse into wrapper statements to collect
-	// nested `var` declarations. Skip statement kinds that form scope
-	// boundaries of their own (function / class / module bodies are processed
-	// by visit*).
-	switch stmt.Kind {
-	case ast.KindBlock, ast.KindIfStatement, ast.KindWhileStatement,
-		ast.KindDoStatement, ast.KindTryStatement, ast.KindCatchClause,
-		ast.KindSwitchStatement, ast.KindCaseClause, ast.KindDefaultClause,
-		ast.KindCaseBlock, ast.KindForStatement, ast.KindForInStatement,
-		ast.KindForOfStatement, ast.KindLabeledStatement, ast.KindWithStatement,
-		ast.KindExpressionStatement, ast.KindReturnStatement, ast.KindThrowStatement:
-		stmt.ForEachChild(func(child *ast.Node) bool {
-			b.hoistVarOnly(child, s)
-			return false
-		})
-	}
-}
-
-// hoistVarOnly walks a subtree and only hoists `var` declarations (into the
-// enclosing function/module/global scope). Function-like nodes and ambient
-// module declarations terminate the walk.
-func (b *builder) hoistVarOnly(node *ast.Node, s *scope) {
-	if node == nil {
-		return
-	}
-	switch node.Kind {
-	case ast.KindVariableStatement:
-		vs := node.AsVariableStatement()
-		if vs != nil && vs.DeclarationList != nil && utils.IsVarKeyword(vs.DeclarationList) {
-			declareMod := ast.HasSyntacticModifier(node, ast.ModifierFlagsAmbient)
-			b.collectVariableDeclarations(vs.DeclarationList, s, declareMod)
-		}
-		return
-	case ast.KindForStatement:
-		fs := node.AsForStatement()
-		if fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
-			b.collectVariableDeclarations(fs.Initializer, s, false)
-		}
-	case ast.KindForInStatement, ast.KindForOfStatement:
-		fs := node.AsForInOrOfStatement()
-		if fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
-			b.collectVariableDeclarations(fs.Initializer, s, false)
-		}
-	case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
-		ast.KindArrowFunction, ast.KindMethodDeclaration,
-		ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor,
-		ast.KindClassStaticBlockDeclaration, ast.KindClassDeclaration,
-		ast.KindClassExpression, ast.KindModuleDeclaration:
-		return
-	}
-	node.ForEachChild(func(child *ast.Node) bool {
-		b.hoistVarOnly(child, s)
-		return false
-	})
-}
-
-// collectVariableDeclarations walks a VariableDeclarationList and adds each
-// binding identifier to the given scope. For destructuring patterns, the
-// innermost BindingElement is stored as `defNode` so that the rule can reach
-// the initializer/default of that specific binding site later.
-func (b *builder) collectVariableDeclarations(declList *ast.Node, s *scope, declareMod bool) {
-	utils.ForEachVariableDeclarationBinding(declList, func(declaration *ast.Node, identifier *ast.Node, name string) {
-		defNode := declaration
-		for parent := identifier.Parent; parent != nil && parent != declaration; parent = parent.Parent {
-			if parent.Kind == ast.KindBindingElement {
-				defNode = parent
-				break
-			}
-		}
-		s.add(&variable{
-			name:            name,
-			id:              identifier,
-			defNode:         defNode,
-			parent:          defNode.Parent,
-			kind:            defVariable,
-			isValueBinding:  true,
-			declareModifier: declareMod,
-		})
-	})
-}
-
-func (b *builder) collectImport(node *ast.Node, s *scope) {
-	importDecl := node.AsImportDeclaration()
-	if importDecl == nil || importDecl.ImportClause == nil {
-		return
-	}
-	clause := importDecl.ImportClause.AsImportClause()
-	if clause == nil {
-		return
-	}
-	isTypeImport := importDecl.ImportClause.IsTypeOnly()
-	// Default import.
-	if clause.Name() != nil && clause.Name().Kind == ast.KindIdentifier {
-		s.add(&variable{
-			name:             clause.Name().Text(),
-			id:               clause.Name(),
-			defNode:          node,
-			parent:           node.Parent,
-			kind:             defImport,
-			isValueBinding:   !isTypeImport,
-			isTypeOnlyImport: isTypeImport,
-		})
-	}
-	if clause.NamedBindings == nil {
-		return
-	}
-	switch clause.NamedBindings.Kind {
-	case ast.KindNamespaceImport:
-		ns := clause.NamedBindings.AsNamespaceImport()
-		if ns != nil && ns.Name() != nil && ns.Name().Kind == ast.KindIdentifier {
-			s.add(&variable{
-				name:             ns.Name().Text(),
-				id:               ns.Name(),
-				defNode:          node,
-				parent:           node.Parent,
-				kind:             defImport,
-				isValueBinding:   !isTypeImport,
-				isTypeOnlyImport: isTypeImport,
-			})
-		}
-	case ast.KindNamedImports:
-		named := clause.NamedBindings.AsNamedImports()
-		if named == nil || named.Elements == nil {
-			return
-		}
-		for _, elem := range named.Elements.Nodes {
-			if elem == nil {
-				continue
-			}
-			spec := elem.AsImportSpecifier()
-			if spec == nil || spec.Name() == nil || spec.Name().Kind != ast.KindIdentifier {
-				continue
-			}
-			specTypeOnly := spec.IsTypeOnly || isTypeImport
-			s.add(&variable{
-				name:             spec.Name().Text(),
-				id:               spec.Name(),
-				defNode:          node,
-				parent:           node.Parent,
-				kind:             defImport,
-				isValueBinding:   !specTypeOnly,
-				isTypeOnlyImport: specTypeOnly,
-			})
-		}
-	}
-}
-
-// visitStatement recurses into nodes that may create nested scopes.
-func (b *builder) visitStatement(stmt *ast.Node, parent *scope) {
-	if stmt == nil {
-		return
-	}
-	switch stmt.Kind {
-	case ast.KindFunctionDeclaration:
-		b.visitFunctionLike(stmt, parent)
-	case ast.KindClassDeclaration:
-		b.visitClass(stmt, parent, false)
-	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
-		b.visitTypeDecl(stmt, parent)
-	case ast.KindEnumDeclaration:
-		b.visitEnum(stmt, parent)
-	case ast.KindModuleDeclaration:
-		b.visitModuleDecl(stmt, parent)
-	case ast.KindBlock:
-		b.visitBlock(stmt, parent)
-	case ast.KindForStatement:
-		b.visitForStatement(stmt, parent)
-	case ast.KindForInStatement, ast.KindForOfStatement:
-		b.visitForInOrOf(stmt, parent)
-	case ast.KindIfStatement:
-		ifStmt := stmt.AsIfStatement()
-		if ifStmt != nil {
-			b.visitExpression(ifStmt.Expression, parent)
-			b.visitStatement(ifStmt.ThenStatement, parent)
-			b.visitStatement(ifStmt.ElseStatement, parent)
-		}
-	case ast.KindWhileStatement:
-		ws := stmt.AsWhileStatement()
-		if ws != nil {
-			b.visitExpression(ws.Expression, parent)
-			b.visitStatement(ws.Statement, parent)
-		}
-	case ast.KindDoStatement:
-		ds := stmt.AsDoStatement()
-		if ds != nil {
-			b.visitExpression(ds.Expression, parent)
-			b.visitStatement(ds.Statement, parent)
-		}
-	case ast.KindTryStatement:
-		ts := stmt.AsTryStatement()
-		if ts != nil {
-			b.visitStatement(ts.TryBlock, parent)
-			if ts.CatchClause != nil {
-				b.visitCatch(ts.CatchClause, parent)
-			}
-			b.visitStatement(ts.FinallyBlock, parent)
-		}
-	case ast.KindSwitchStatement:
-		sw := stmt.AsSwitchStatement()
-		if sw != nil {
-			b.visitExpression(sw.Expression, parent)
-			b.visitSwitchCases(sw, parent)
-		}
-	case ast.KindLabeledStatement:
-		ls := stmt.AsLabeledStatement()
-		if ls != nil {
-			b.visitStatement(ls.Statement, parent)
-		}
-	case ast.KindReturnStatement:
-		if rs := stmt.AsReturnStatement(); rs != nil {
-			b.visitExpression(rs.Expression, parent)
-		}
-	case ast.KindThrowStatement:
-		if ts := stmt.AsThrowStatement(); ts != nil {
-			b.visitExpression(ts.Expression, parent)
-		}
-	case ast.KindExpressionStatement:
-		if es := stmt.AsExpressionStatement(); es != nil {
-			b.visitExpression(es.Expression, parent)
-		}
-	case ast.KindVariableStatement:
-		vs := stmt.AsVariableStatement()
-		if vs != nil && vs.DeclarationList != nil {
-			b.visitVarDeclList(vs.DeclarationList, parent)
-		}
-	case ast.KindExportAssignment:
-		ea := stmt.AsExportAssignment()
-		if ea != nil {
-			b.visitExpression(ea.Expression, parent)
-		}
-	case ast.KindExportDeclaration:
-		// No new scopes.
-	case ast.KindImportDeclaration, ast.KindImportEqualsDeclaration:
-		// No new scopes.
-	case ast.KindWithStatement:
-		ws := stmt.AsWithStatement()
-		if ws != nil {
-			b.visitExpression(ws.Expression, parent)
-			b.visitStatement(ws.Statement, parent)
-		}
-	default:
-		// Catch-all — traverse children.
-		stmt.ForEachChild(func(child *ast.Node) bool {
-			b.visitStatement(child, parent)
-			return false
-		})
-	}
-}
-
-// visitVarDeclList walks a VariableDeclarationList so that any nested
-// function/class/conditional-type scopes in type annotations, initializers,
-// or destructuring defaults get created.
-func (b *builder) visitVarDeclList(declList *ast.Node, parent *scope) {
-	list := declList.AsVariableDeclarationList()
-	if list == nil || list.Declarations == nil {
-		return
-	}
-	for _, decl := range list.Declarations.Nodes {
-		vd := decl.AsVariableDeclaration()
-		if vd == nil {
-			continue
-		}
-		if vd.Type != nil {
-			b.visitExpression(vd.Type, parent)
-		}
-		if vd.Initializer != nil {
-			b.visitExpression(vd.Initializer, parent)
-		}
-		if vd.Name() != nil {
-			b.visitBindingPattern(vd.Name(), parent)
-		}
-	}
-}
-
-// visitBindingPattern recurses into destructuring defaults that may contain
-// function / class expressions creating nested scopes.
-func (b *builder) visitBindingPattern(pattern *ast.Node, parent *scope) {
-	if pattern == nil {
-		return
-	}
-	pattern.ForEachChild(func(child *ast.Node) bool {
-		if child.Kind == ast.KindBindingElement {
-			be := child.AsBindingElement()
-			if be != nil {
-				if be.Initializer != nil {
-					b.visitExpression(be.Initializer, parent)
-				}
-				if be.Name() != nil {
-					b.visitBindingPattern(be.Name(), parent)
-				}
-			}
-		}
-		return false
-	})
-}
-
-// visitExpression walks an expression to discover nested function/class
-// expressions and other scope-creating constructs.
-func (b *builder) visitExpression(expr *ast.Node, parent *scope) {
-	if expr == nil {
-		return
-	}
-	switch expr.Kind {
-	case ast.KindFunctionExpression, ast.KindArrowFunction:
-		b.visitFunctionLike(expr, parent)
-		return
-	case ast.KindMethodDeclaration, ast.KindConstructor,
-		ast.KindGetAccessor, ast.KindSetAccessor:
-		// Object-literal shorthand methods (and accessors) also need their
-		// own function scope. Class-body members are already processed by
-		// visitClass, so we only get here for the object-literal case.
-		b.visitFunctionLike(expr, parent)
-		return
-	case ast.KindClassExpression:
-		b.visitClass(expr, parent, true)
-		return
-	}
-	if ast.IsFunctionTypeNode(expr) || ast.IsConstructorTypeNode(expr) ||
-		ast.IsCallSignatureDeclaration(expr) || ast.IsConstructSignatureDeclaration(expr) ||
-		ast.IsMethodSignatureDeclaration(expr) {
-		b.visitFunctionType(expr, parent)
-		return
-	}
-	if expr.Kind == ast.KindConditionalType {
-		b.visitConditionalType(expr, parent)
-		return
-	}
-	expr.ForEachChild(func(child *ast.Node) bool {
-		b.visitExpression(child, parent)
-		return false
-	})
-}
-
-// visitConditionalType creates a scope for the conditional type so that
-// `infer X` clauses in the extends-position introduce a binding visible to
-// nested types and to the true branch. ESLint/typescript-eslint reports an
-// inner `infer X` shadowing an outer one within the same conditional chain.
-func (b *builder) visitConditionalType(node *ast.Node, outer *scope) {
-	cond := node.AsConditionalTypeNode()
-	if cond == nil {
-		return
-	}
-	condScope := b.push(scopeType, node, outer)
-	collectInferTypes(cond.ExtendsType, condScope)
-	if cond.CheckType != nil {
-		b.visitExpression(cond.CheckType, outer)
-	}
-	if cond.ExtendsType != nil {
-		b.visitExpression(cond.ExtendsType, condScope)
-	}
-	if cond.TrueType != nil {
-		b.visitExpression(cond.TrueType, condScope)
-	}
-	if cond.FalseType != nil {
-		b.visitExpression(cond.FalseType, outer)
-	}
-}
-
-// collectInferTypes walks `extendsType` and adds each `infer X` binding to
-// the conditional-type scope. Nested function/conditional types stop the
-// walk because they introduce their own scopes.
-func collectInferTypes(node *ast.Node, s *scope) {
-	if node == nil {
-		return
-	}
-	switch node.Kind {
-	case ast.KindFunctionType, ast.KindConstructorType, ast.KindConditionalType:
-		return
-	case ast.KindInferType:
-		it := node.AsInferTypeNode()
-		if it != nil && it.TypeParameter != nil {
-			tp := it.TypeParameter.AsTypeParameterDeclaration()
-			if tp != nil && tp.Name() != nil && tp.Name().Kind == ast.KindIdentifier {
-				s.add(&variable{
-					name:           tp.Name().Text(),
-					id:             tp.Name(),
-					defNode:        it.TypeParameter,
-					parent:         it.TypeParameter.Parent,
-					kind:           defTypeParameter,
-					isValueBinding: false,
-				})
-			}
-		}
-	}
-	node.ForEachChild(func(child *ast.Node) bool {
-		collectInferTypes(child, s)
-		return false
-	})
-}
-
-// visitFunctionType handles TS function/construct types and call/construct
-// signatures. Parameters introduce bindings that may trigger (or be filtered
-// out by) `ignoreFunctionTypeParameterNameValueShadow`.
-func (b *builder) visitFunctionType(node *ast.Node, outer *scope) {
-	s := b.push(scopeFunction, node, outer)
-	b.addTypeParameters(node, s)
-	b.addParameters(node, s, false)
-	node.ForEachChild(func(child *ast.Node) bool {
-		b.visitExpression(child, s)
-		return false
-	})
-}
-
-// addTypeParameters records `function f<T>` / `class C<T>` / `type X<T>`
-// generic names into `s`. Each type parameter is a type-only binding.
-func (b *builder) addTypeParameters(node *ast.Node, s *scope) {
-	for _, tp := range node.TypeParameters() {
-		if tp == nil {
-			continue
-		}
-		tpDecl := tp.AsTypeParameterDeclaration()
-		if tpDecl == nil || tpDecl.Name() == nil || tpDecl.Name().Kind != ast.KindIdentifier {
-			continue
-		}
-		s.add(&variable{
-			name:           tpDecl.Name().Text(),
-			id:             tpDecl.Name(),
-			defNode:        tp,
-			parent:         tp.Parent,
-			kind:           defTypeParameter,
-			isValueBinding: false,
-		})
-	}
-}
-
-// addParameters records the binding identifiers from each parameter of
-// `node` into `s`, optionally recursing into each parameter's type
-// annotation and initializer so that nested function types create scopes.
-func (b *builder) addParameters(node *ast.Node, s *scope, recurseAnnotations bool) {
-	for _, param := range node.Parameters() {
-		if param == nil {
-			continue
-		}
-		// Skip `this` pseudo-parameter.
-		if pn := param.Name(); pn != nil && pn.Kind == ast.KindIdentifier && pn.Text() == "this" {
-			continue
-		}
-		if recurseAnnotations {
-			// Parameter decorators (`@dec x: T`) run at class-definition time,
-			// in the enclosing class scope (s.parent for methods). Fall back
-			// to `s` for standalone functions (decorators there are illegal
-			// in TS but shouldn't crash).
-			decScope := s
-			if s.parent != nil {
-				decScope = s.parent
-			}
-			for _, dec := range param.Decorators() {
-				b.visitExpression(dec, decScope)
-			}
-			if paramDecl := param.AsParameterDeclaration(); paramDecl != nil && paramDecl.Type != nil {
-				b.visitExpression(paramDecl.Type, s)
-			}
-			if init := param.Initializer(); init != nil {
-				b.visitExpression(init, s)
-			}
-		}
-		if param.Name() == nil {
-			continue
-		}
-		if recurseAnnotations && param.Name().Kind != ast.KindIdentifier {
-			b.visitBindingPattern(param.Name(), s)
-		}
-		utils.CollectBindingNames(param.Name(), func(id *ast.Node, name string) {
-			s.add(&variable{
-				name:           name,
-				id:             id,
-				defNode:        param,
-				parent:         param.Parent,
-				kind:           defParameter,
-				isValueBinding: true,
-			})
-		})
-	}
-}
-
-// visitFunctionLike handles FunctionDeclaration, FunctionExpression,
-// ArrowFunction, MethodDeclaration, Constructor, Get/SetAccessor.
-func (b *builder) visitFunctionLike(node *ast.Node, outer *scope) {
-	// Computed method/accessor name (`[expr]`) is evaluated in the enclosing
-	// scope (class body or object literal context). Walk it before pushing
-	// the function's own scope so that shadows inside the key expression
-	// check against the right scope.
-	if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
-		if cpn := name.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
-			b.visitExpression(cpn.Expression, outer)
-		}
-	}
-
-	// Function expression with a name → intermediate scope holding just
-	// the function's own name.
-	fnExprScope := outer
-	if node.Kind == ast.KindFunctionExpression {
-		if n := node.Name(); n != nil && n.Kind == ast.KindIdentifier {
-			innerFnName := b.push(scopeFunctionExprName, node, outer)
-			innerFnName.add(&variable{
-				name:           n.Text(),
-				id:             n,
-				defNode:        node,
-				parent:         node.Parent,
-				kind:           defFnExprName,
-				isValueBinding: true,
-			})
-			fnExprScope = innerFnName
-		}
-	}
-
-	fnScope := b.push(scopeFunction, node, fnExprScope)
-	b.addTypeParameters(node, fnScope)
-	b.addParameters(node, fnScope, true)
-	if retType := node.Type(); retType != nil {
-		b.visitExpression(retType, fnScope)
-	}
-
-	// Body.
-	body := node.Body()
-	if body == nil {
-		return
-	}
-	if body.Kind == ast.KindBlock {
-		block := body.AsBlock()
-		if block != nil && block.Statements != nil {
-			b.hoistStatements(block.Statements.Nodes, fnScope)
-			for _, stmt := range block.Statements.Nodes {
-				b.visitStatement(stmt, fnScope)
-			}
-		}
-	} else {
-		// Arrow expression body.
-		b.visitExpression(body, fnScope)
-	}
-}
-
-func (b *builder) visitClass(node *ast.Node, outer *scope, isExpression bool) {
-	// Class-level decorators run BEFORE the class is defined — in the outer
-	// scope. Any shadows inside them (e.g. `@((t) => { const x = 1; })`) must
-	// be checked against outer bindings.
-	for _, dec := range node.Decorators() {
-		b.visitExpression(dec, outer)
-	}
-
-	classScope := b.push(scopeClass, node, outer)
-	// Inner scope always holds the class name (for both declarations and
-	// expressions — ESLint's scope model duplicates the name here).
-	if n := node.Name(); n != nil && n.Kind == ast.KindIdentifier {
-		_ = isExpression
-		classScope.add(&variable{
-			name:           n.Text(),
-			id:             n,
-			defNode:        node,
-			parent:         node.Parent,
-			kind:           defClassInnerName,
-			isValueBinding: true,
-		})
-	}
-	b.addTypeParameters(node, classScope)
-
-	// Heritage clauses (`extends`, `implements`): expressions here are
-	// evaluated when the class is defined and can contain IIFEs/arrows whose
-	// body may shadow outer bindings. Walk them inside classScope so that
-	// class type parameters remain visible to type arguments.
-	node.ForEachChild(func(c *ast.Node) bool {
-		if c.Kind == ast.KindHeritageClause {
-			c.ForEachChild(func(t *ast.Node) bool {
-				b.visitExpression(t, classScope)
-				return false
-			})
-		}
-		return false
-	})
-
-	for _, member := range node.Members() {
-		if member == nil {
-			continue
-		}
-		// Member decorators evaluate when the class is defined; use classScope
-		// so that class type parameters remain visible.
-		for _, dec := range member.Decorators() {
-			b.visitExpression(dec, classScope)
-		}
-		switch member.Kind {
-		case ast.KindMethodDeclaration, ast.KindConstructor,
-			ast.KindGetAccessor, ast.KindSetAccessor:
-			// visitFunctionLike handles the computed-name (if any) itself.
-			b.visitFunctionLike(member, classScope)
-		case ast.KindPropertyDeclaration:
-			// Properties don't go through visitFunctionLike — walk the
-			// computed key here.
-			if memberName := member.Name(); memberName != nil && memberName.Kind == ast.KindComputedPropertyName {
-				if cpn := memberName.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
-					b.visitExpression(cpn.Expression, classScope)
-				}
-			}
-			if init := member.Initializer(); init != nil {
-				b.visitExpression(init, classScope)
-			}
-		case ast.KindClassStaticBlockDeclaration:
-			sb := member.AsClassStaticBlockDeclaration()
-			if sb != nil && sb.Body != nil && sb.Body.Kind == ast.KindBlock {
-				// Static block is its own function-like variable scope for var purposes.
-				staticScope := b.push(scopeFunction, member, classScope)
-				block := sb.Body.AsBlock()
-				if block != nil && block.Statements != nil {
-					b.hoistStatements(block.Statements.Nodes, staticScope)
-					for _, stmt := range block.Statements.Nodes {
-						b.visitStatement(stmt, staticScope)
-					}
-				}
-			}
-		}
-	}
-}
-
-func (b *builder) visitTypeDecl(node *ast.Node, outer *scope) {
-	typeScope := b.push(scopeType, node, outer)
-	b.addTypeParameters(node, typeScope)
-	// Recurse into type body / heritage / members to discover FunctionType
-	// and similar type-level scopes.
-	node.ForEachChild(func(child *ast.Node) bool {
-		b.visitExpression(child, typeScope)
-		return false
-	})
-}
-
-func (b *builder) visitEnum(node *ast.Node, outer *scope) {
-	enumScope := b.push(scopeBlock, node, outer)
-	ed := node.AsEnumDeclaration()
-	if ed == nil || ed.Members == nil {
-		return
-	}
-	// Enum members are bindings in the enum's inner scope. An outer
-	// declaration with the same name is reported as shadowed by the member.
-	for _, m := range ed.Members.Nodes {
-		if m == nil {
-			continue
-		}
-		em := m.AsEnumMember()
-		if em == nil || em.Name() == nil {
-			continue
-		}
-		if em.Name().Kind == ast.KindIdentifier {
-			enumScope.add(&variable{
-				name:           em.Name().Text(),
-				id:             em.Name(),
-				defNode:        m,
-				parent:         m.Parent,
-				kind:           defVariable,
-				isValueBinding: true,
-			})
-		}
-		if em.Initializer != nil {
-			b.visitExpression(em.Initializer, enumScope)
-		}
-	}
-}
-
-func (b *builder) visitModuleDecl(node *ast.Node, outer *scope) {
-	md := node.AsModuleDeclaration()
-	if md == nil {
-		return
-	}
-	// `declare global { ... }` — treat as continuation of the enclosing global
-	// scope. Any bindings inside are conceptually global and the scopes under
-	// it are marked so shadowing checks are skipped.
-	if ast.IsGlobalScopeAugmentation(node) {
-		augScope := b.push(scopeModule, node, outer)
-		augScope.globalAugmentation = true
-		if md.Body != nil {
-			b.walkModuleBlock(md.Body, augScope)
-		}
-		return
-	}
-	moduleScope := b.push(scopeModule, node, outer)
-	// Inherit the global-augmentation flag from the parent chain.
-	if outer != nil && outer.globalAugmentation {
-		moduleScope.globalAugmentation = true
-	}
-	if md.Body == nil {
-		return
-	}
-	if md.Body.Kind == ast.KindModuleDeclaration {
-		// Nested namespace chain: `namespace A.B.C { }` — unwrap.
-		b.visitModuleDecl(md.Body, moduleScope)
-		return
-	}
-	b.walkModuleBlock(md.Body, moduleScope)
-}
-
-func (b *builder) walkModuleBlock(body *ast.Node, s *scope) {
-	if body == nil {
-		return
-	}
-	if body.Kind == ast.KindModuleBlock {
-		mb := body.AsModuleBlock()
-		if mb != nil && mb.Statements != nil {
-			b.hoistStatements(mb.Statements.Nodes, s)
-			for _, stmt := range mb.Statements.Nodes {
-				b.visitStatement(stmt, s)
-			}
-		}
-	}
-}
-
-func (b *builder) visitBlock(block *ast.Node, outer *scope) {
-	parent := block.Parent
-	// If this block is the body of a function-like, it has already been processed by visitFunctionLike.
-	if parent != nil {
-		switch parent.Kind {
-		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
-			ast.KindArrowFunction, ast.KindMethodDeclaration,
-			ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor,
-			ast.KindClassStaticBlockDeclaration:
-			return
-		case ast.KindCatchClause:
-			// Handled in visitCatch.
-			return
-		}
-	}
-	s := b.push(scopeBlock, block, outer)
-	blk := block.AsBlock()
-	if blk == nil || blk.Statements == nil {
-		return
-	}
-	// Block-scoped declarations (let/const/class/function-in-strict/type/...) live at this block.
-	for _, stmt := range blk.Statements.Nodes {
-		b.hoistStatement(stmt, s, true)
-	}
-	// `var` hoists up to the enclosing variable scope.
-	varHost := s.variableScope()
-	if varHost == nil {
-		varHost = s
-	}
-	for _, stmt := range blk.Statements.Nodes {
-		b.hoistVarOnly(stmt, varHost)
-	}
-	// Recurse.
-	for _, stmt := range blk.Statements.Nodes {
-		b.visitStatement(stmt, s)
-	}
-}
-
-// forInitScope handles a for/for-in/for-of initializer. A let/const
-// initializer introduces a new block scope wrapping the loop body; otherwise
-// the initializer stays in `outer`. Returns the scope the loop body lives in.
-func (b *builder) forInitScope(forNode *ast.Node, initializer *ast.Node, outer *scope) *scope {
-	if initializer != nil && initializer.Kind == ast.KindVariableDeclarationList && !utils.IsVarKeyword(initializer) {
-		forScope := b.push(scopeBlock, forNode, outer)
-		b.collectVariableDeclarations(initializer, forScope, false)
-		b.visitVarDeclList(initializer, forScope)
-		return forScope
-	}
-	if initializer != nil {
-		if initializer.Kind == ast.KindVariableDeclarationList {
-			b.visitVarDeclList(initializer, outer)
-		} else {
-			b.visitExpression(initializer, outer)
-		}
-	}
-	return outer
-}
-
-func (b *builder) visitForStatement(stmt *ast.Node, outer *scope) {
-	fs := stmt.AsForStatement()
-	if fs == nil {
-		return
-	}
-	body := b.forInitScope(stmt, fs.Initializer, outer)
-	if fs.Condition != nil {
-		b.visitExpression(fs.Condition, body)
-	}
-	if fs.Incrementor != nil {
-		b.visitExpression(fs.Incrementor, body)
-	}
-	if fs.Statement != nil {
-		b.visitStatement(fs.Statement, body)
-	}
-}
-
-func (b *builder) visitForInOrOf(stmt *ast.Node, outer *scope) {
-	fs := stmt.AsForInOrOfStatement()
-	if fs == nil {
-		return
-	}
-	body := b.forInitScope(stmt, fs.Initializer, outer)
-	if fs.Expression != nil {
-		b.visitExpression(fs.Expression, outer)
-	}
-	if fs.Statement != nil {
-		b.visitStatement(fs.Statement, body)
-	}
-}
-
-func (b *builder) visitCatch(node *ast.Node, outer *scope) {
-	cc := node.AsCatchClause()
-	if cc == nil {
-		return
-	}
-	catchScope := b.push(scopeCatch, node, outer)
-	if cc.VariableDeclaration != nil {
-		vd := cc.VariableDeclaration.AsVariableDeclaration()
-		if vd != nil && vd.Name() != nil {
-			utils.CollectBindingNames(vd.Name(), func(id *ast.Node, name string) {
-				catchScope.add(&variable{
-					name:           name,
-					id:             id,
-					defNode:        cc.VariableDeclaration,
-					parent:         node,
-					kind:           defCatch,
-					isValueBinding: true,
-				})
-			})
-		}
-	}
-	if cc.Block != nil && cc.Block.Kind == ast.KindBlock {
-		// The catch block is a BlockStatement whose direct parent is this CatchClause.
-		// We treat it as nested: create an extra block scope for its body.
-		bodyScope := b.push(scopeBlock, cc.Block, catchScope)
-		blk := cc.Block.AsBlock()
-		if blk != nil && blk.Statements != nil {
-			for _, stmt := range blk.Statements.Nodes {
-				b.hoistStatement(stmt, bodyScope, true)
-			}
-			varHost := bodyScope.variableScope()
-			if varHost == nil {
-				varHost = bodyScope
-			}
-			for _, stmt := range blk.Statements.Nodes {
-				b.hoistVarOnly(stmt, varHost)
-			}
-			for _, stmt := range blk.Statements.Nodes {
-				b.visitStatement(stmt, bodyScope)
-			}
-		}
-	}
-}
-
-func (b *builder) visitSwitchCases(sw *ast.SwitchStatement, outer *scope) {
-	if sw.CaseBlock == nil {
-		return
-	}
-	cb := sw.CaseBlock.AsCaseBlock()
-	if cb == nil || cb.Clauses == nil {
-		return
-	}
-	// Switch introduces a block scope for its clauses.
-	switchScope := b.push(scopeBlock, sw.AsNode(), outer)
-	// First: hoist block-level declarations across all clauses.
-	for _, clause := range cb.Clauses.Nodes {
-		if clause == nil {
-			continue
-		}
-		c := clause.AsCaseOrDefaultClause()
-		if c == nil || c.Statements == nil {
-			continue
-		}
-		for _, s := range c.Statements.Nodes {
-			b.hoistStatement(s, switchScope, true)
-		}
-	}
-	// Vars hoist to enclosing var scope.
-	varHost := switchScope.variableScope()
-	if varHost == nil {
-		varHost = switchScope
-	}
-	for _, clause := range cb.Clauses.Nodes {
-		if clause == nil {
-			continue
-		}
-		c := clause.AsCaseOrDefaultClause()
-		if c == nil || c.Statements == nil {
-			continue
-		}
-		for _, s := range c.Statements.Nodes {
-			b.hoistVarOnly(s, varHost)
-		}
-	}
-	// Recurse into statements.
-	for _, clause := range cb.Clauses.Nodes {
-		if clause == nil {
-			continue
-		}
-		c := clause.AsCaseOrDefaultClause()
-		if c == nil {
-			continue
-		}
-		if c.Expression != nil {
-			b.visitExpression(c.Expression, switchScope)
-		}
-		if c.Statements != nil {
-			for _, s := range c.Statements.Nodes {
-				b.visitStatement(s, switchScope)
-			}
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
 // Rule entry
 // ---------------------------------------------------------------------------
 
@@ -1262,6 +149,15 @@ func RunTSESLint(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	return runTSESLint(ctx, options)
 }
 
+// checker carries the per-run configuration that `checkVariable` needs.
+type checker struct {
+	sourceFile                          *ast.SourceFile
+	builtinGlobals                      map[string]bool
+	includeDefaultTypeScriptTypeGlobals bool
+	typeImportUsesOwnSpecifier          bool
+	reportEnumShadow                    bool
+}
+
 func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.RuleListeners {
 	return func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptionsWith(rawOptions, variant.defaults)
@@ -1269,13 +165,14 @@ func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.Rule
 			return rule.RuleListeners{}
 		}
 
-		b := &builder{
+		manager := scope.Build(ctx.SourceFile)
+
+		c := &checker{
 			sourceFile:                          ctx.SourceFile,
 			includeDefaultTypeScriptTypeGlobals: variant.includeDefaultTypeScriptTypeGlobals,
 			typeImportUsesOwnSpecifier:          variant.typeImportUsesOwnSpecifier,
 			reportEnumShadow:                    variant.reportEnumShadow,
 		}
-		b.buildProgram(ctx.SourceFile)
 
 		filename := ""
 		if ctx.SourceFile.AsNode() != nil {
@@ -1293,31 +190,31 @@ func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.Rule
 		if opts.builtinGlobals {
 			ctx.Globals.ApplyTo(builtinGlobals)
 		}
-		b.builtinGlobals = builtinGlobals
+		c.builtinGlobals = builtinGlobals
 
 		// Walk scopes top-down and check each variable. The global scope is
 		// included so that `builtinGlobals: true` can flag a module-level
 		// declaration shadowing an ECMAScript global (ESLint's module scope
 		// sits between the file and the global scope; we collapse them and
 		// compensate by letting checkVariable consult the globals table).
-		for _, s := range b.allScopes {
-			if s.globalAugmentation {
+		for _, s := range manager.Scopes {
+			if s.GlobalAugmentation {
 				continue
 			}
-			for _, v := range s.vars {
-				if opts.allow[v.name] {
+			for _, v := range s.Vars {
+				if opts.allow[v.Name] {
 					continue
 				}
-				if v.name == "this" {
+				if v.Name == "this" {
 					continue
 				}
 				if isDuplicatedClassNameInClassScope(v) {
 					continue
 				}
-				if isDeclFile && v.declareModifier {
+				if isDeclFile && v.DeclareModifier {
 					continue
 				}
-				b.checkVariable(ctx, s, v, opts)
+				c.checkVariable(ctx, s, v, opts)
 			}
 		}
 
@@ -1327,17 +224,17 @@ func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.Rule
 
 // isDuplicatedClassNameInClassScope suppresses the inner class-name binding
 // that ESLint-scope adds for ClassDeclarations.
-func isDuplicatedClassNameInClassScope(v *variable) bool {
-	return v.kind == defClassInnerName && v.defNode != nil && v.defNode.Kind == ast.KindClassDeclaration
+func isDuplicatedClassNameInClassScope(v *scope.Variable) bool {
+	return v.Kind == scope.DefClassInnerName && v.DefNode != nil && v.DefNode.Kind == ast.KindClassDeclaration
 }
 
 // checkVariable tests whether `v` shadows a variable in some outer scope.
-func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opts options) {
-	shadowed := findShadowed(v, s.parent)
+func (c *checker) checkVariable(ctx rule.RuleContext, s *scope.Scope, v *scope.Variable, opts options) {
+	shadowed := findShadowed(v, s.Parent)
 	shadowedDefaultTypeScriptGlobal := shadowed == nil && opts.builtinGlobals &&
-		b.includeDefaultTypeScriptTypeGlobals && rule.IsDefaultTypeScriptTypeGlobal(v.name)
+		c.includeDefaultTypeScriptTypeGlobals && rule.IsDefaultTypeScriptTypeGlobal(v.Name)
 	shadowedGlobal := shadowed == nil && opts.builtinGlobals &&
-		(b.builtinGlobals[v.name] || shadowedDefaultTypeScriptGlobal)
+		(c.builtinGlobals[v.Name] || shadowedDefaultTypeScriptGlobal)
 	if shadowed == nil && !shadowedGlobal {
 		return
 	}
@@ -1356,7 +253,7 @@ func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opt
 	}
 
 	// ignoreOnInitialization: shadow is inside the initializer of the outer binding,
-	// and the inner variable's own variableScope is a FunctionExpression / ArrowFunction
+	// and the inner variable's own variable scope is a FunctionExpression / ArrowFunction
 	// whose enclosing call is inside that initializer.
 	if opts.ignoreOnInitialization && shadowed != nil && isInInitPatternCall(v, shadowed) {
 		return
@@ -1370,7 +267,7 @@ func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opt
 	}
 
 	// TS: ignoreTypeValueShadow
-	if opts.ignoreTypeValueShadow && isTypeValueShadow(v, shadowed, b.typeImportUsesOwnSpecifier) {
+	if opts.ignoreTypeValueShadow && isTypeValueShadow(v, shadowed, c.typeImportUsesOwnSpecifier) {
 		return
 	}
 
@@ -1392,49 +289,49 @@ func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opt
 	}
 
 	if shadowedGlobal && shadowed == nil {
-		ctx.ReportNode(v.id, rule.RuleMessage{
+		ctx.ReportNode(v.ID, rule.RuleMessage{
 			Id:          "noShadowGlobal",
-			Description: fmt.Sprintf("'%s' is already a global variable.", v.name),
+			Description: fmt.Sprintf("'%s' is already a global variable.", v.Name),
 		})
 		return
 	}
-	if shadowed != nil && shadowed.id != nil {
-		line, column := getLineColumn(b.sourceFile, shadowed.id)
-		if b.reportEnumShadow && hasDefinitionKind(shadowed, defEnumName) {
-			ctx.ReportNode(v.id, rule.RuleMessage{
+	if shadowed != nil && shadowed.ID != nil {
+		line, column := getLineColumn(c.sourceFile, shadowed.ID)
+		if c.reportEnumShadow && hasDefinitionKind(shadowed, scope.DefEnumName) {
+			ctx.ReportNode(v.ID, rule.RuleMessage{
 				Id: "noEnumShadow",
 				Description: fmt.Sprintf(
 					"Enum members are added to the enum scope, so references to '%s' in enum member initializers resolve to this member instead of the declaration in the upper scope on line %d column %d.",
-					v.name, line, column,
+					v.Name, line, column,
 				),
 			})
 			return
 		}
-		ctx.ReportNode(v.id, rule.RuleMessage{
+		ctx.ReportNode(v.ID, rule.RuleMessage{
 			Id: "noShadow",
 			Description: fmt.Sprintf(
 				"'%s' is already declared in the upper scope on line %d column %d.",
-				v.name, line, column,
+				v.Name, line, column,
 			),
 		})
 		return
 	}
 	// Builtin-global match without an identifier (from default library).
-	ctx.ReportNode(v.id, rule.RuleMessage{
+	ctx.ReportNode(v.ID, rule.RuleMessage{
 		Id:          "noShadowGlobal",
-		Description: fmt.Sprintf("'%s' is already a global variable.", v.name),
+		Description: fmt.Sprintf("'%s' is already a global variable.", v.Name),
 	})
 }
 
 // hasDefinitionKind mirrors scope-manager's merged Variable definitions. The
-// local scope model stores each declaration separately, so inspect all
+// shared scope model stores each declaration separately, so inspect all
 // same-name declarations when upstream asks whether any definition is an enum.
-func hasDefinitionKind(v *variable, kind defKind) bool {
-	if v == nil || v.scope == nil {
+func hasDefinitionKind(v *scope.Variable, kind scope.DefKind) bool {
+	if v == nil || v.Scope == nil {
 		return false
 	}
-	for _, definition := range v.scope.byName[v.name] {
-		if definition.kind == kind {
+	for _, definition := range v.Scope.Declarations(v.Name) {
+		if definition.Kind == kind {
 			return true
 		}
 	}
@@ -1445,8 +342,8 @@ func hasDefinitionKind(v *variable, kind defKind) bool {
 // representation. TypeScript declaration merging can add several definitions
 // to that variable; no-shadow still checks it once, reports its first
 // identifier, and treats it as a value if any definition is value-capable.
-func mergeImplicitGlobalShadow(s *scope, v *variable) (*variable, bool) {
-	definitions := s.byName[v.name]
+func mergeImplicitGlobalShadow(s *scope.Scope, v *scope.Variable) (*scope.Variable, bool) {
+	definitions := s.Declarations(v.Name)
 	if len(definitions) == 0 || definitions[0] != v {
 		return v, false
 	}
@@ -1457,7 +354,7 @@ func mergeImplicitGlobalShadow(s *scope, v *variable) (*variable, bool) {
 	merged := *v
 	for _, definition := range definitions {
 		if isValueVariable(definition) {
-			merged.isValueBinding = true
+			merged.IsValueBinding = true
 			break
 		}
 	}
@@ -1467,9 +364,9 @@ func mergeImplicitGlobalShadow(s *scope, v *variable) (*variable, bool) {
 // findShadowed walks outward from `start` and returns the first outer
 // variable with the same name as `v`, or nil if none is found. Builtin
 // globals are handled separately by checkVariable.
-func findShadowed(v *variable, start *scope) *variable {
-	for cur := start; cur != nil; cur = cur.parent {
-		if matches, ok := cur.byName[v.name]; ok {
+func findShadowed(v *scope.Variable, start *scope.Scope) *scope.Variable {
+	for cur := start; cur != nil; cur = cur.Parent {
+		if matches := cur.Declarations(v.Name); len(matches) > 0 {
 			return matches[0]
 		}
 	}
@@ -1485,25 +382,25 @@ func findShadowed(v *variable, start *scope) *variable {
 // in its ImportDeclaration is type-only. The typescript-eslint extension only
 // checks the current binding's own specifier; the variant flag preserves both
 // upstream behaviors.
-func isTypeValueShadow(v *variable, shadowed *variable, typeImportUsesOwnSpecifier bool) bool {
+func isTypeValueShadow(v *scope.Variable, shadowed *scope.Variable, typeImportUsesOwnSpecifier bool) bool {
 	isInnerValue := isValueVariable(v)
 	if shadowed == nil {
 		return !isInnerValue
 	}
 
-	isTypeImport := shadowed.kind == defImport &&
-		((typeImportUsesOwnSpecifier && shadowed.isTypeOnlyImport) ||
-			(!typeImportUsesOwnSpecifier && importHasAnyTypeOnlySpecifier(shadowed.defNode)))
+	isTypeImport := shadowed.Kind == scope.DefImport &&
+		((typeImportUsesOwnSpecifier && shadowed.IsTypeOnlyImport) ||
+			(!typeImportUsesOwnSpecifier && importHasAnyTypeOnlySpecifier(shadowed.DefNode)))
 	isShadowedValue := isValueVariable(shadowed) && !isTypeImport
 
 	return isInnerValue != isShadowedValue
 }
 
-// isValueVariable translates the builder's declaration metadata to
+// isValueVariable translates the scope model's declaration metadata to
 // scope-manager's isValueVariable flag. Scope-manager considers every import
 // binding value-capable here, including `import type` bindings.
-func isValueVariable(v *variable) bool {
-	return v != nil && (v.isValueBinding || v.kind == defImport)
+func isValueVariable(v *scope.Variable) bool {
+	return v != nil && (v.IsValueBinding || v.Kind == scope.DefImport)
 }
 
 // importHasAnyTypeOnlySpecifier returns true when the ImportDeclaration
@@ -1546,11 +443,11 @@ func importHasAnyTypeOnlySpecifier(node *ast.Node) bool {
 // isGenericOfStaticMethod reports whether `v` is a type parameter declared by
 // a static method. The caller still has to verify that the shadowed binding is
 // the enclosing class's type parameter.
-func isGenericOfStaticMethod(v *variable) bool {
-	if v.kind != defTypeParameter {
+func isGenericOfStaticMethod(v *scope.Variable) bool {
+	if v.Kind != scope.DefTypeParameter {
 		return false
 	}
-	tp := v.defNode
+	tp := v.DefNode
 	if tp == nil {
 		return false
 	}
@@ -1572,11 +469,11 @@ func isGenericOfStaticMethod(v *variable) bool {
 	return false
 }
 
-func isGenericOfClass(v *variable) bool {
-	if v == nil || v.kind != defTypeParameter || v.defNode == nil {
+func isGenericOfClass(v *scope.Variable) bool {
+	if v == nil || v.Kind != scope.DefTypeParameter || v.DefNode == nil {
 		return false
 	}
-	for cur := v.defNode.Parent; cur != nil; cur = cur.Parent {
+	for cur := v.DefNode.Parent; cur != nil; cur = cur.Parent {
 		switch cur.Kind {
 		case ast.KindClassDeclaration, ast.KindClassExpression:
 			return true
@@ -1588,18 +485,18 @@ func isGenericOfClass(v *variable) bool {
 	return false
 }
 
-func isGenericOfAStaticMethodShadow(v *variable, shadowed *variable) bool {
+func isGenericOfAStaticMethodShadow(v *scope.Variable, shadowed *scope.Variable) bool {
 	return shadowed != nil && isGenericOfStaticMethod(v) && isGenericOfClass(shadowed)
 }
 
 // isFunctionTypeParameterShadow returns true when `v` is a parameter of a
 // TS function type / construct signature. Whether the option ignores it also
 // depends on the shadowed variable being value-capable.
-func isFunctionTypeParameterShadow(v *variable) bool {
-	if v.kind != defParameter {
+func isFunctionTypeParameterShadow(v *scope.Variable) bool {
+	if v.Kind != scope.DefParameter {
 		return false
 	}
-	p := v.defNode
+	p := v.DefNode
 	if p == nil {
 		return false
 	}
@@ -1620,7 +517,7 @@ func isFunctionTypeParameterShadow(v *variable) bool {
 	return false
 }
 
-func isFunctionTypeParameterNameValueShadow(v *variable, shadowed *variable, shadowedDefaultTypeScriptGlobal bool) bool {
+func isFunctionTypeParameterNameValueShadow(v *scope.Variable, shadowed *scope.Variable, shadowedDefaultTypeScriptGlobal bool) bool {
 	if !isFunctionTypeParameterShadow(v) {
 		return false
 	}
@@ -1635,19 +532,19 @@ func isFunctionTypeParameterNameValueShadow(v *variable, shadowed *variable, sha
 
 // isExternalDeclarationMerging covers the `import type Foo from 'bar'` +
 // `declare module 'bar' { interface Foo {} }` case.
-func isExternalDeclarationMerging(v *variable, shadowed *variable) bool {
-	if shadowed.kind != defImport || !shadowed.isTypeOnlyImport {
+func isExternalDeclarationMerging(v *scope.Variable, shadowed *scope.Variable) bool {
+	if shadowed.Kind != scope.DefImport || !shadowed.IsTypeOnlyImport {
 		return false
 	}
-	if shadowed.defNode == nil || shadowed.defNode.Kind != ast.KindImportDeclaration {
+	if shadowed.DefNode == nil || shadowed.DefNode.Kind != ast.KindImportDeclaration {
 		return false
 	}
-	importDecl := shadowed.defNode.AsImportDeclaration()
+	importDecl := shadowed.DefNode.AsImportDeclaration()
 	if importDecl == nil || importDecl.ModuleSpecifier == nil || !ast.IsStringLiteral(importDecl.ModuleSpecifier) {
 		return false
 	}
 	importSrc := importDecl.ModuleSpecifier.Text()
-	mod := ast.FindAncestor(v.id, func(n *ast.Node) bool {
+	mod := ast.FindAncestor(v.ID, func(n *ast.Node) bool {
 		return n.Kind == ast.KindModuleDeclaration
 	})
 	if mod == nil {
@@ -1662,11 +559,11 @@ func isExternalDeclarationMerging(v *variable, shadowed *variable) bool {
 
 // isInTdz tests whether the inner variable appears *before* the outer
 // declaration and should therefore be suppressed under the given hoist mode.
-func isInTdz(inner *variable, outer *variable, mode hoistMode) bool {
-	if inner.id == nil || outer.id == nil {
+func isInTdz(inner *scope.Variable, outer *scope.Variable, mode hoistMode) bool {
+	if inner.ID == nil || outer.ID == nil {
 		return false
 	}
-	if inner.id.End() >= outer.id.Pos() {
+	if inner.ID.End() >= outer.ID.Pos() {
 		return false
 	}
 	switch mode {
@@ -1674,17 +571,17 @@ func isInTdz(inner *variable, outer *variable, mode hoistMode) bool {
 		return false
 	case hoistTypes:
 		// Suppress only for outer type declarations.
-		if outer.kind == defType {
+		if outer.Kind == scope.DefType {
 			return false
 		}
 		return true
 	case hoistFunctionsAndTypes:
-		if outer.kind == defFunctionName || outer.kind == defType {
+		if outer.Kind == scope.DefFunctionName || outer.Kind == scope.DefType {
 			return false
 		}
 		return true
 	case hoistFunctions:
-		if outer.kind == defFunctionName {
+		if outer.Kind == scope.DefFunctionName {
 			return false
 		}
 		return true
@@ -1699,18 +596,18 @@ func isInTdz(inner *variable, outer *variable, mode hoistMode) bool {
 // their logical/conditional/default-value variants. Calls and TypeScript
 // assertion expressions are not transparent, so `wrap(function a() {})` and
 // `function a() {} as unknown` still report.
-func isFunctionNameInitializerException(inner *variable, outer *variable) bool {
-	if outer == nil || outer.id == nil || inner == nil || inner.defNode == nil {
+func isFunctionNameInitializerException(inner *scope.Variable, outer *scope.Variable) bool {
+	if outer == nil || outer.ID == nil || inner == nil || inner.DefNode == nil {
 		return false
 	}
-	if inner.kind != defFnExprName && (inner.kind != defClassInnerName || inner.defNode.Kind != ast.KindClassExpression) {
+	if inner.Kind != scope.DefFnExprName && (inner.Kind != scope.DefClassInnerName || inner.DefNode.Kind != ast.KindClassExpression) {
 		return false
 	}
-	initializer := bindingInitializer(outer.id)
+	initializer := bindingInitializer(outer.ID)
 	if initializer == nil {
 		return false
 	}
-	nodeToCheck := inner.defNode
+	nodeToCheck := inner.DefNode
 	if initializer.Pos() > nodeToCheck.Pos() || nodeToCheck.End() > initializer.End() {
 		return false
 	}
@@ -1786,45 +683,42 @@ func unwrapInitializerExpression(node *ast.Node) *ast.Node {
 }
 
 // isInInitPatternCall handles the `ignoreOnInitialization` option.
-// The inner variable's variableScope block must be a function expression or
+// The inner variable's variable-scope block must be a function expression or
 // arrow whose enclosing call lies inside the outer variable's initializer,
 // AND the function's outer variable scope must BE the scope that owns the
 // shadowed variable (matching ESLint's `getOuterScope === shadowedVariable.scope`
 // check, which prevents suppressing shadows inside nested closures).
-func isInInitPatternCall(inner *variable, outer *variable) bool {
-	if inner.scope == nil {
+func isInInitPatternCall(inner *scope.Variable, outer *scope.Variable) bool {
+	if inner.Scope == nil {
 		return false
 	}
-	vs := inner.scope.variableScope()
-	if vs == nil || vs.block == nil {
+	vs := inner.Scope.VariableScope()
+	if vs == nil || vs.Block == nil {
 		return false
 	}
-	if vs.block.Kind != ast.KindFunctionExpression && vs.block.Kind != ast.KindArrowFunction {
+	if vs.Block.Kind != ast.KindFunctionExpression && vs.Block.Kind != ast.KindArrowFunction {
 		return false
 	}
 	// The function's immediate outer variable scope must be the same variable
 	// scope that owns `outer`. ESLint additionally skips a
 	// `function-expression-name` scope between the two; we do the same by
 	// peeling it off.
-	outerOfFn := vs.parent
-	for outerOfFn != nil && outerOfFn.kind == scopeFunctionExprName {
-		outerOfFn = outerOfFn.parent
+	outerOfFn := vs.Parent
+	for outerOfFn != nil && outerOfFn.Kind == scope.KindFunctionExprName {
+		outerOfFn = outerOfFn.Parent
 	}
 	outerOfFnVS := outerOfFn
-	if outerOfFnVS != nil && outerOfFnVS.kind != scopeFunction && outerOfFnVS.kind != scopeModule && outerOfFnVS.kind != scopeGlobal {
-		outerOfFnVS = outerOfFnVS.variableScope()
+	if outerOfFnVS != nil {
+		outerOfFnVS = outerOfFnVS.VariableScope()
 	}
-	if outer.scope == nil {
+	if outer.Scope == nil {
 		return false
 	}
-	outerScopeVS := outer.scope
-	if outerScopeVS.kind != scopeFunction && outerScopeVS.kind != scopeModule && outerScopeVS.kind != scopeGlobal {
-		outerScopeVS = outerScopeVS.variableScope()
-	}
+	outerScopeVS := outer.Scope.VariableScope()
 	if outerOfFnVS != outerScopeVS {
 		return false
 	}
-	fn := vs.block
+	fn := vs.Block
 	call := ast.FindAncestor(fn, func(n *ast.Node) bool {
 		return n.Kind == ast.KindCallExpression
 	})
@@ -1833,7 +727,7 @@ func isInInitPatternCall(inner *variable, outer *variable) bool {
 	}
 	location := call.End()
 	// Walk ancestors of the outer declaration's identifier.
-	node := outer.id
+	node := outer.ID
 	for node != nil {
 		parent := node.Parent
 		if parent == nil {

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -1,0 +1,1028 @@
+package scope
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// builder walks the AST twice per scope: a hoisting pass that records the
+// declarations belonging to the scope, then a visiting pass that descends into
+// the children which open nested scopes.
+type builder struct {
+	manager *Manager
+}
+
+func (b *builder) push(kind Kind, block *ast.Node, parent *Scope) *Scope {
+	s := newScope(kind, block, parent)
+	if parent != nil && parent.GlobalAugmentation {
+		s.GlobalAugmentation = true
+	}
+	b.manager.Scopes = append(b.manager.Scopes, s)
+	return s
+}
+
+func (b *builder) buildProgram(sf *ast.SourceFile) *Scope {
+	global := b.push(KindGlobal, sf.AsNode(), nil)
+	if sf.Statements == nil {
+		return global
+	}
+	// First pass: hoist var / function / class / import names into the global scope.
+	b.hoistStatements(sf.Statements.Nodes, global)
+	// Second pass: walk children that introduce nested scopes.
+	for _, stmt := range sf.Statements.Nodes {
+		b.visitStatement(stmt, global)
+	}
+	return global
+}
+
+// hoistStatements collects declarations that belong to the enclosing
+// variable scope (var / function / class / enum / interface / type /
+// namespace / import). Block-scoped declarations (let/const/class inside
+// a nested block) are collected in visitBlock.
+func (b *builder) hoistStatements(statements []*ast.Node, s *Scope) {
+	for _, stmt := range statements {
+		b.hoistStatement(stmt, s, false)
+	}
+}
+
+// addNamedDecl records a declaration whose binding name is the Name() child
+// of `stmt` (covers function, class, interface, type alias, enum, namespace,
+// import-equals). Returns without adding when the statement has no identifier
+// name (for example anonymous default exports and ambient-module strings).
+func (b *builder) addNamedDecl(stmt *ast.Node, s *Scope, kind DefKind, isValue bool) {
+	n := stmt.Name()
+	if n == nil || n.Kind != ast.KindIdentifier {
+		return
+	}
+	isAmbient := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient)
+	// Body-less FunctionDeclarations come in two flavors: overload signatures
+	// (no `declare`, there will be a later implementation) and ambient
+	// declarations (`declare function foo(): void`). typescript-eslint's scope
+	// manager merges all signatures under one Variable, so we only need to
+	// register a single binding: skip overload signatures, but keep ambient
+	// declarations so that inner scopes detect them as shadowed.
+	if kind == DefFunctionName && stmt.Body() == nil && !isAmbient {
+		return
+	}
+	s.Add(&Variable{
+		Name:            n.Text(),
+		ID:              n,
+		DefNode:         stmt,
+		Parent:          stmt.Parent,
+		Kind:            kind,
+		IsValueBinding:  isValue,
+		DeclareModifier: isAmbient,
+	})
+}
+
+// hoistStatement records the declarations introduced by `stmt` into scope
+// `s`. When `blockScope` is true, only block-scoped bindings (let/const/
+// class/function/type/enum/namespace) are added — var is assumed to have
+// been hoisted to an outer variable scope. Otherwise, every binding kind
+// (including var) is added and the function's child statements are scanned
+// for nested `var` declarations that also hoist to this scope.
+func (b *builder) hoistStatement(stmt *ast.Node, s *Scope, blockScope bool) {
+	if stmt == nil {
+		return
+	}
+	switch stmt.Kind {
+	case ast.KindVariableStatement:
+		vs := stmt.AsVariableStatement()
+		if vs == nil || vs.DeclarationList == nil {
+			return
+		}
+		isVar := utils.IsVarKeyword(vs.DeclarationList)
+		if blockScope && isVar {
+			return
+		}
+		declareMod := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient)
+		b.collectVariableDeclarations(vs.DeclarationList, s, declareMod)
+	case ast.KindFunctionDeclaration:
+		b.addNamedDecl(stmt, s, DefFunctionName, true)
+	case ast.KindClassDeclaration:
+		b.addNamedDecl(stmt, s, DefClassName, true)
+	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+		b.addNamedDecl(stmt, s, DefType, false)
+	case ast.KindEnumDeclaration:
+		b.addNamedDecl(stmt, s, DefEnumName, true)
+	case ast.KindModuleDeclaration:
+		// Ambient `declare module 'str' { ... }` uses a string-literal name and
+		// doesn't bind a variable — addNamedDecl skips it automatically.
+		b.addNamedDecl(stmt, s, DefNamespaceName, true)
+	case ast.KindImportDeclaration:
+		if !blockScope {
+			b.collectImport(stmt, s)
+		}
+	case ast.KindImportEqualsDeclaration:
+		if !blockScope {
+			b.addNamedDecl(stmt, s, DefImport, true)
+		}
+	case ast.KindForStatement:
+		fs := stmt.AsForStatement()
+		if !blockScope && fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		fs := stmt.AsForInOrOfStatement()
+		if !blockScope && fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	}
+
+	if blockScope {
+		return
+	}
+	// For variable-scope hoisting, recurse into wrapper statements to collect
+	// nested `var` declarations. Skip statement kinds that form scope
+	// boundaries of their own (function / class / module bodies are processed
+	// by visit*).
+	switch stmt.Kind {
+	case ast.KindBlock, ast.KindIfStatement, ast.KindWhileStatement,
+		ast.KindDoStatement, ast.KindTryStatement, ast.KindCatchClause,
+		ast.KindSwitchStatement, ast.KindCaseClause, ast.KindDefaultClause,
+		ast.KindCaseBlock, ast.KindForStatement, ast.KindForInStatement,
+		ast.KindForOfStatement, ast.KindLabeledStatement, ast.KindWithStatement,
+		ast.KindExpressionStatement, ast.KindReturnStatement, ast.KindThrowStatement:
+		stmt.ForEachChild(func(child *ast.Node) bool {
+			b.hoistVarOnly(child, s)
+			return false
+		})
+	}
+}
+
+// hoistVarOnly walks a subtree and only hoists `var` declarations (into the
+// enclosing function/module/global scope). Function-like nodes and ambient
+// module declarations terminate the walk.
+func (b *builder) hoistVarOnly(node *ast.Node, s *Scope) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindVariableStatement:
+		vs := node.AsVariableStatement()
+		if vs != nil && vs.DeclarationList != nil && utils.IsVarKeyword(vs.DeclarationList) {
+			declareMod := ast.HasSyntacticModifier(node, ast.ModifierFlagsAmbient)
+			b.collectVariableDeclarations(vs.DeclarationList, s, declareMod)
+		}
+		return
+	case ast.KindForStatement:
+		fs := node.AsForStatement()
+		if fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		fs := node.AsForInOrOfStatement()
+		if fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+		ast.KindArrowFunction, ast.KindMethodDeclaration,
+		ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor,
+		ast.KindClassStaticBlockDeclaration, ast.KindClassDeclaration,
+		ast.KindClassExpression, ast.KindModuleDeclaration:
+		return
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		b.hoistVarOnly(child, s)
+		return false
+	})
+}
+
+// collectVariableDeclarations walks a VariableDeclarationList and adds each
+// binding identifier to the given scope. For destructuring patterns, the
+// innermost BindingElement is stored as `DefNode` so that a rule can reach
+// the initializer/default of that specific binding site later.
+func (b *builder) collectVariableDeclarations(declList *ast.Node, s *Scope, declareMod bool) {
+	utils.ForEachVariableDeclarationBinding(declList, func(declaration *ast.Node, identifier *ast.Node, name string) {
+		defNode := declaration
+		for parent := identifier.Parent; parent != nil && parent != declaration; parent = parent.Parent {
+			if parent.Kind == ast.KindBindingElement {
+				defNode = parent
+				break
+			}
+		}
+		s.Add(&Variable{
+			Name:            name,
+			ID:              identifier,
+			DefNode:         defNode,
+			Parent:          defNode.Parent,
+			Kind:            DefVariable,
+			IsValueBinding:  true,
+			DeclareModifier: declareMod,
+		})
+	})
+}
+
+func (b *builder) collectImport(node *ast.Node, s *Scope) {
+	importDecl := node.AsImportDeclaration()
+	if importDecl == nil || importDecl.ImportClause == nil {
+		return
+	}
+	clause := importDecl.ImportClause.AsImportClause()
+	if clause == nil {
+		return
+	}
+	isTypeImport := importDecl.ImportClause.IsTypeOnly()
+	// Default import.
+	if clause.Name() != nil && clause.Name().Kind == ast.KindIdentifier {
+		s.Add(&Variable{
+			Name:             clause.Name().Text(),
+			ID:               clause.Name(),
+			DefNode:          node,
+			Parent:           node.Parent,
+			Kind:             DefImport,
+			IsValueBinding:   !isTypeImport,
+			IsTypeOnlyImport: isTypeImport,
+		})
+	}
+	if clause.NamedBindings == nil {
+		return
+	}
+	switch clause.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		ns := clause.NamedBindings.AsNamespaceImport()
+		if ns != nil && ns.Name() != nil && ns.Name().Kind == ast.KindIdentifier {
+			s.Add(&Variable{
+				Name:             ns.Name().Text(),
+				ID:               ns.Name(),
+				DefNode:          node,
+				Parent:           node.Parent,
+				Kind:             DefImport,
+				IsValueBinding:   !isTypeImport,
+				IsTypeOnlyImport: isTypeImport,
+			})
+		}
+	case ast.KindNamedImports:
+		named := clause.NamedBindings.AsNamedImports()
+		if named == nil || named.Elements == nil {
+			return
+		}
+		for _, elem := range named.Elements.Nodes {
+			if elem == nil {
+				continue
+			}
+			spec := elem.AsImportSpecifier()
+			if spec == nil || spec.Name() == nil || spec.Name().Kind != ast.KindIdentifier {
+				continue
+			}
+			specTypeOnly := spec.IsTypeOnly || isTypeImport
+			s.Add(&Variable{
+				Name:             spec.Name().Text(),
+				ID:               spec.Name(),
+				DefNode:          node,
+				Parent:           node.Parent,
+				Kind:             DefImport,
+				IsValueBinding:   !specTypeOnly,
+				IsTypeOnlyImport: specTypeOnly,
+			})
+		}
+	}
+}
+
+// visitStatement recurses into nodes that may create nested scopes.
+func (b *builder) visitStatement(stmt *ast.Node, parent *Scope) {
+	if stmt == nil {
+		return
+	}
+	switch stmt.Kind {
+	case ast.KindFunctionDeclaration:
+		b.visitFunctionLike(stmt, parent)
+	case ast.KindClassDeclaration:
+		b.visitClass(stmt, parent, false)
+	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+		b.visitTypeDecl(stmt, parent)
+	case ast.KindEnumDeclaration:
+		b.visitEnum(stmt, parent)
+	case ast.KindModuleDeclaration:
+		b.visitModuleDecl(stmt, parent)
+	case ast.KindBlock:
+		b.visitBlock(stmt, parent)
+	case ast.KindForStatement:
+		b.visitForStatement(stmt, parent)
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		b.visitForInOrOf(stmt, parent)
+	case ast.KindIfStatement:
+		ifStmt := stmt.AsIfStatement()
+		if ifStmt != nil {
+			b.visitExpression(ifStmt.Expression, parent)
+			b.visitStatement(ifStmt.ThenStatement, parent)
+			b.visitStatement(ifStmt.ElseStatement, parent)
+		}
+	case ast.KindWhileStatement:
+		ws := stmt.AsWhileStatement()
+		if ws != nil {
+			b.visitExpression(ws.Expression, parent)
+			b.visitStatement(ws.Statement, parent)
+		}
+	case ast.KindDoStatement:
+		ds := stmt.AsDoStatement()
+		if ds != nil {
+			b.visitExpression(ds.Expression, parent)
+			b.visitStatement(ds.Statement, parent)
+		}
+	case ast.KindTryStatement:
+		ts := stmt.AsTryStatement()
+		if ts != nil {
+			b.visitStatement(ts.TryBlock, parent)
+			if ts.CatchClause != nil {
+				b.visitCatch(ts.CatchClause, parent)
+			}
+			b.visitStatement(ts.FinallyBlock, parent)
+		}
+	case ast.KindSwitchStatement:
+		sw := stmt.AsSwitchStatement()
+		if sw != nil {
+			b.visitExpression(sw.Expression, parent)
+			b.visitSwitchCases(sw, parent)
+		}
+	case ast.KindLabeledStatement:
+		ls := stmt.AsLabeledStatement()
+		if ls != nil {
+			b.visitStatement(ls.Statement, parent)
+		}
+	case ast.KindReturnStatement:
+		if rs := stmt.AsReturnStatement(); rs != nil {
+			b.visitExpression(rs.Expression, parent)
+		}
+	case ast.KindThrowStatement:
+		if ts := stmt.AsThrowStatement(); ts != nil {
+			b.visitExpression(ts.Expression, parent)
+		}
+	case ast.KindExpressionStatement:
+		if es := stmt.AsExpressionStatement(); es != nil {
+			b.visitExpression(es.Expression, parent)
+		}
+	case ast.KindVariableStatement:
+		vs := stmt.AsVariableStatement()
+		if vs != nil && vs.DeclarationList != nil {
+			b.visitVarDeclList(vs.DeclarationList, parent)
+		}
+	case ast.KindExportAssignment:
+		ea := stmt.AsExportAssignment()
+		if ea != nil {
+			b.visitExpression(ea.Expression, parent)
+		}
+	case ast.KindExportDeclaration:
+		// No new scopes.
+	case ast.KindImportDeclaration, ast.KindImportEqualsDeclaration:
+		// No new scopes.
+	case ast.KindWithStatement:
+		ws := stmt.AsWithStatement()
+		if ws != nil {
+			b.visitExpression(ws.Expression, parent)
+			b.visitStatement(ws.Statement, parent)
+		}
+	default:
+		// Catch-all — traverse children.
+		stmt.ForEachChild(func(child *ast.Node) bool {
+			b.visitStatement(child, parent)
+			return false
+		})
+	}
+}
+
+// visitVarDeclList walks a VariableDeclarationList so that any nested
+// function/class/conditional-type scopes in type annotations, initializers,
+// or destructuring defaults get created.
+func (b *builder) visitVarDeclList(declList *ast.Node, parent *Scope) {
+	list := declList.AsVariableDeclarationList()
+	if list == nil || list.Declarations == nil {
+		return
+	}
+	for _, decl := range list.Declarations.Nodes {
+		vd := decl.AsVariableDeclaration()
+		if vd == nil {
+			continue
+		}
+		if vd.Type != nil {
+			b.visitExpression(vd.Type, parent)
+		}
+		if vd.Initializer != nil {
+			b.visitExpression(vd.Initializer, parent)
+		}
+		if vd.Name() != nil {
+			b.visitBindingPattern(vd.Name(), parent)
+		}
+	}
+}
+
+// visitBindingPattern recurses into destructuring defaults that may contain
+// function / class expressions creating nested scopes.
+func (b *builder) visitBindingPattern(pattern *ast.Node, parent *Scope) {
+	if pattern == nil {
+		return
+	}
+	pattern.ForEachChild(func(child *ast.Node) bool {
+		if child.Kind == ast.KindBindingElement {
+			be := child.AsBindingElement()
+			if be != nil {
+				if be.Initializer != nil {
+					b.visitExpression(be.Initializer, parent)
+				}
+				if be.Name() != nil {
+					b.visitBindingPattern(be.Name(), parent)
+				}
+			}
+		}
+		return false
+	})
+}
+
+// visitExpression walks an expression to discover nested function/class
+// expressions and other scope-creating constructs.
+func (b *builder) visitExpression(expr *ast.Node, parent *Scope) {
+	if expr == nil {
+		return
+	}
+	switch expr.Kind {
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		b.visitFunctionLike(expr, parent)
+		return
+	case ast.KindMethodDeclaration, ast.KindConstructor,
+		ast.KindGetAccessor, ast.KindSetAccessor:
+		// Object-literal shorthand methods (and accessors) also need their
+		// own function scope. Class-body members are already processed by
+		// visitClass, so we only get here for the object-literal case.
+		b.visitFunctionLike(expr, parent)
+		return
+	case ast.KindClassExpression:
+		b.visitClass(expr, parent, true)
+		return
+	}
+	if ast.IsFunctionTypeNode(expr) || ast.IsConstructorTypeNode(expr) ||
+		ast.IsCallSignatureDeclaration(expr) || ast.IsConstructSignatureDeclaration(expr) ||
+		ast.IsMethodSignatureDeclaration(expr) {
+		b.visitFunctionType(expr, parent)
+		return
+	}
+	if expr.Kind == ast.KindConditionalType {
+		b.visitConditionalType(expr, parent)
+		return
+	}
+	expr.ForEachChild(func(child *ast.Node) bool {
+		b.visitExpression(child, parent)
+		return false
+	})
+}
+
+// visitConditionalType creates a scope for the conditional type so that
+// `infer X` clauses in the extends-position introduce a binding visible to
+// nested types and to the true branch. ESLint/typescript-eslint reports an
+// inner `infer X` shadowing an outer one within the same conditional chain.
+func (b *builder) visitConditionalType(node *ast.Node, outer *Scope) {
+	cond := node.AsConditionalTypeNode()
+	if cond == nil {
+		return
+	}
+	condScope := b.push(KindType, node, outer)
+	collectInferTypes(cond.ExtendsType, condScope)
+	if cond.CheckType != nil {
+		b.visitExpression(cond.CheckType, outer)
+	}
+	if cond.ExtendsType != nil {
+		b.visitExpression(cond.ExtendsType, condScope)
+	}
+	if cond.TrueType != nil {
+		b.visitExpression(cond.TrueType, condScope)
+	}
+	if cond.FalseType != nil {
+		b.visitExpression(cond.FalseType, outer)
+	}
+}
+
+// collectInferTypes walks `extendsType` and adds each `infer X` binding to
+// the conditional-type scope. Nested function/conditional types stop the
+// walk because they introduce their own scopes.
+func collectInferTypes(node *ast.Node, s *Scope) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindFunctionType, ast.KindConstructorType, ast.KindConditionalType:
+		return
+	case ast.KindInferType:
+		it := node.AsInferTypeNode()
+		if it != nil && it.TypeParameter != nil {
+			tp := it.TypeParameter.AsTypeParameterDeclaration()
+			if tp != nil && tp.Name() != nil && tp.Name().Kind == ast.KindIdentifier {
+				s.Add(&Variable{
+					Name:           tp.Name().Text(),
+					ID:             tp.Name(),
+					DefNode:        it.TypeParameter,
+					Parent:         it.TypeParameter.Parent,
+					Kind:           DefTypeParameter,
+					IsValueBinding: false,
+				})
+			}
+		}
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		collectInferTypes(child, s)
+		return false
+	})
+}
+
+// visitFunctionType handles TS function/construct types and call/construct
+// signatures. Parameters introduce bindings that may trigger (or be filtered
+// out by) rule-specific type-parameter exceptions.
+func (b *builder) visitFunctionType(node *ast.Node, outer *Scope) {
+	s := b.push(KindFunction, node, outer)
+	b.addTypeParameters(node, s)
+	b.addParameters(node, s, false)
+	node.ForEachChild(func(child *ast.Node) bool {
+		b.visitExpression(child, s)
+		return false
+	})
+}
+
+// addTypeParameters records `function f<T>` / `class C<T>` / `type X<T>`
+// generic names into `s`. Each type parameter is a type-only binding.
+func (b *builder) addTypeParameters(node *ast.Node, s *Scope) {
+	for _, tp := range node.TypeParameters() {
+		if tp == nil {
+			continue
+		}
+		tpDecl := tp.AsTypeParameterDeclaration()
+		if tpDecl == nil || tpDecl.Name() == nil || tpDecl.Name().Kind != ast.KindIdentifier {
+			continue
+		}
+		s.Add(&Variable{
+			Name:           tpDecl.Name().Text(),
+			ID:             tpDecl.Name(),
+			DefNode:        tp,
+			Parent:         tp.Parent,
+			Kind:           DefTypeParameter,
+			IsValueBinding: false,
+		})
+	}
+}
+
+// addParameters records the binding identifiers from each parameter of
+// `node` into `s`, optionally recursing into each parameter's type
+// annotation and initializer so that nested function types create scopes.
+func (b *builder) addParameters(node *ast.Node, s *Scope, recurseAnnotations bool) {
+	for _, param := range node.Parameters() {
+		if param == nil {
+			continue
+		}
+		// Skip `this` pseudo-parameter.
+		if pn := param.Name(); pn != nil && pn.Kind == ast.KindIdentifier && pn.Text() == "this" {
+			continue
+		}
+		if recurseAnnotations {
+			// Parameter decorators (`@dec x: T`) run at class-definition time,
+			// in the enclosing class scope (s.Parent for methods). Fall back
+			// to `s` for standalone functions (decorators there are illegal
+			// in TS but shouldn't crash).
+			decScope := s
+			if s.Parent != nil {
+				decScope = s.Parent
+			}
+			for _, dec := range param.Decorators() {
+				b.visitExpression(dec, decScope)
+			}
+			if paramDecl := param.AsParameterDeclaration(); paramDecl != nil && paramDecl.Type != nil {
+				b.visitExpression(paramDecl.Type, s)
+			}
+			if init := param.Initializer(); init != nil {
+				b.visitExpression(init, s)
+			}
+		}
+		if param.Name() == nil {
+			continue
+		}
+		if recurseAnnotations && param.Name().Kind != ast.KindIdentifier {
+			b.visitBindingPattern(param.Name(), s)
+		}
+		utils.CollectBindingNames(param.Name(), func(id *ast.Node, name string) {
+			s.Add(&Variable{
+				Name:           name,
+				ID:             id,
+				DefNode:        param,
+				Parent:         param.Parent,
+				Kind:           DefParameter,
+				IsValueBinding: true,
+			})
+		})
+	}
+}
+
+// visitFunctionLike handles FunctionDeclaration, FunctionExpression,
+// ArrowFunction, MethodDeclaration, Constructor, Get/SetAccessor.
+func (b *builder) visitFunctionLike(node *ast.Node, outer *Scope) {
+	// Computed method/accessor name (`[expr]`) is evaluated in the enclosing
+	// scope (class body or object literal context). Walk it before pushing
+	// the function's own scope so that shadows inside the key expression
+	// check against the right scope.
+	if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+		if cpn := name.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
+			b.visitExpression(cpn.Expression, outer)
+		}
+	}
+
+	// Function expression with a name → intermediate scope holding just
+	// the function's own name.
+	fnExprScope := outer
+	if node.Kind == ast.KindFunctionExpression {
+		if n := node.Name(); n != nil && n.Kind == ast.KindIdentifier {
+			innerFnName := b.push(KindFunctionExprName, node, outer)
+			innerFnName.Add(&Variable{
+				Name:           n.Text(),
+				ID:             n,
+				DefNode:        node,
+				Parent:         node.Parent,
+				Kind:           DefFnExprName,
+				IsValueBinding: true,
+			})
+			fnExprScope = innerFnName
+		}
+	}
+
+	fnScope := b.push(KindFunction, node, fnExprScope)
+	b.addTypeParameters(node, fnScope)
+	b.addParameters(node, fnScope, true)
+	if retType := node.Type(); retType != nil {
+		b.visitExpression(retType, fnScope)
+	}
+
+	// Body.
+	body := node.Body()
+	if body == nil {
+		return
+	}
+	if body.Kind == ast.KindBlock {
+		block := body.AsBlock()
+		if block != nil && block.Statements != nil {
+			b.hoistStatements(block.Statements.Nodes, fnScope)
+			for _, stmt := range block.Statements.Nodes {
+				b.visitStatement(stmt, fnScope)
+			}
+		}
+	} else {
+		// Arrow expression body.
+		b.visitExpression(body, fnScope)
+	}
+}
+
+func (b *builder) visitClass(node *ast.Node, outer *Scope, isExpression bool) {
+	// Class-level decorators run BEFORE the class is defined — in the outer
+	// scope. Any shadows inside them (e.g. `@((t) => { const x = 1; })`) must
+	// be checked against outer bindings.
+	for _, dec := range node.Decorators() {
+		b.visitExpression(dec, outer)
+	}
+
+	classScope := b.push(KindClass, node, outer)
+	// Inner scope always holds the class name (for both declarations and
+	// expressions — ESLint's scope model duplicates the name here).
+	if n := node.Name(); n != nil && n.Kind == ast.KindIdentifier {
+		_ = isExpression
+		classScope.Add(&Variable{
+			Name:           n.Text(),
+			ID:             n,
+			DefNode:        node,
+			Parent:         node.Parent,
+			Kind:           DefClassInnerName,
+			IsValueBinding: true,
+		})
+	}
+	b.addTypeParameters(node, classScope)
+
+	// Heritage clauses (`extends`, `implements`): expressions here are
+	// evaluated when the class is defined and can contain IIFEs/arrows whose
+	// body may shadow outer bindings. Walk them inside classScope so that
+	// class type parameters remain visible to type arguments.
+	node.ForEachChild(func(c *ast.Node) bool {
+		if c.Kind == ast.KindHeritageClause {
+			c.ForEachChild(func(t *ast.Node) bool {
+				b.visitExpression(t, classScope)
+				return false
+			})
+		}
+		return false
+	})
+
+	for _, member := range node.Members() {
+		if member == nil {
+			continue
+		}
+		// Member decorators evaluate when the class is defined; use classScope
+		// so that class type parameters remain visible.
+		for _, dec := range member.Decorators() {
+			b.visitExpression(dec, classScope)
+		}
+		switch member.Kind {
+		case ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor:
+			// visitFunctionLike handles the computed-name (if any) itself.
+			b.visitFunctionLike(member, classScope)
+		case ast.KindPropertyDeclaration:
+			// Properties don't go through visitFunctionLike — walk the
+			// computed key here.
+			if memberName := member.Name(); memberName != nil && memberName.Kind == ast.KindComputedPropertyName {
+				if cpn := memberName.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
+					b.visitExpression(cpn.Expression, classScope)
+				}
+			}
+			if init := member.Initializer(); init != nil {
+				b.visitExpression(init, classScope)
+			}
+		case ast.KindClassStaticBlockDeclaration:
+			sb := member.AsClassStaticBlockDeclaration()
+			if sb != nil && sb.Body != nil && sb.Body.Kind == ast.KindBlock {
+				// Static block is its own function-like variable scope for var purposes.
+				staticScope := b.push(KindFunction, member, classScope)
+				block := sb.Body.AsBlock()
+				if block != nil && block.Statements != nil {
+					b.hoistStatements(block.Statements.Nodes, staticScope)
+					for _, stmt := range block.Statements.Nodes {
+						b.visitStatement(stmt, staticScope)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (b *builder) visitTypeDecl(node *ast.Node, outer *Scope) {
+	typeScope := b.push(KindType, node, outer)
+	b.addTypeParameters(node, typeScope)
+	// Recurse into type body / heritage / members to discover FunctionType
+	// and similar type-level scopes.
+	node.ForEachChild(func(child *ast.Node) bool {
+		b.visitExpression(child, typeScope)
+		return false
+	})
+}
+
+func (b *builder) visitEnum(node *ast.Node, outer *Scope) {
+	enumScope := b.push(KindBlock, node, outer)
+	ed := node.AsEnumDeclaration()
+	if ed == nil || ed.Members == nil {
+		return
+	}
+	// Enum members are bindings in the enum's inner scope. An outer
+	// declaration with the same name is reported as shadowed by the member.
+	for _, m := range ed.Members.Nodes {
+		if m == nil {
+			continue
+		}
+		em := m.AsEnumMember()
+		if em == nil || em.Name() == nil {
+			continue
+		}
+		if em.Name().Kind == ast.KindIdentifier {
+			enumScope.Add(&Variable{
+				Name:           em.Name().Text(),
+				ID:             em.Name(),
+				DefNode:        m,
+				Parent:         m.Parent,
+				Kind:           DefVariable,
+				IsValueBinding: true,
+			})
+		}
+		if em.Initializer != nil {
+			b.visitExpression(em.Initializer, enumScope)
+		}
+	}
+}
+
+func (b *builder) visitModuleDecl(node *ast.Node, outer *Scope) {
+	md := node.AsModuleDeclaration()
+	if md == nil {
+		return
+	}
+	// `declare global { ... }` — treat as continuation of the enclosing global
+	// scope. Any bindings inside are conceptually global and the scopes under
+	// it are marked so shadowing checks are skipped.
+	if ast.IsGlobalScopeAugmentation(node) {
+		augScope := b.push(KindModule, node, outer)
+		augScope.GlobalAugmentation = true
+		if md.Body != nil {
+			b.walkModuleBlock(md.Body, augScope)
+		}
+		return
+	}
+	moduleScope := b.push(KindModule, node, outer)
+	// Inherit the global-augmentation flag from the parent chain.
+	if outer != nil && outer.GlobalAugmentation {
+		moduleScope.GlobalAugmentation = true
+	}
+	if md.Body == nil {
+		return
+	}
+	if md.Body.Kind == ast.KindModuleDeclaration {
+		// Nested namespace chain: `namespace A.B.C { }` — unwrap.
+		b.visitModuleDecl(md.Body, moduleScope)
+		return
+	}
+	b.walkModuleBlock(md.Body, moduleScope)
+}
+
+func (b *builder) walkModuleBlock(body *ast.Node, s *Scope) {
+	if body == nil {
+		return
+	}
+	if body.Kind == ast.KindModuleBlock {
+		mb := body.AsModuleBlock()
+		if mb != nil && mb.Statements != nil {
+			b.hoistStatements(mb.Statements.Nodes, s)
+			for _, stmt := range mb.Statements.Nodes {
+				b.visitStatement(stmt, s)
+			}
+		}
+	}
+}
+
+func (b *builder) visitBlock(block *ast.Node, outer *Scope) {
+	parent := block.Parent
+	// If this block is the body of a function-like, it has already been processed by visitFunctionLike.
+	if parent != nil {
+		switch parent.Kind {
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindArrowFunction, ast.KindMethodDeclaration,
+			ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor,
+			ast.KindClassStaticBlockDeclaration:
+			return
+		case ast.KindCatchClause:
+			// Handled in visitCatch.
+			return
+		}
+	}
+	s := b.push(KindBlock, block, outer)
+	blk := block.AsBlock()
+	if blk == nil || blk.Statements == nil {
+		return
+	}
+	// Block-scoped declarations (let/const/class/function-in-strict/type/...) live at this block.
+	for _, stmt := range blk.Statements.Nodes {
+		b.hoistStatement(stmt, s, true)
+	}
+	// `var` hoists up to the enclosing variable scope.
+	varHost := s.VariableScope()
+	if varHost == nil {
+		varHost = s
+	}
+	for _, stmt := range blk.Statements.Nodes {
+		b.hoistVarOnly(stmt, varHost)
+	}
+	// Recurse.
+	for _, stmt := range blk.Statements.Nodes {
+		b.visitStatement(stmt, s)
+	}
+}
+
+// forInitScope handles a for/for-in/for-of initializer. A let/const
+// initializer introduces a new block scope wrapping the loop body; otherwise
+// the initializer stays in `outer`. Returns the scope the loop body lives in.
+func (b *builder) forInitScope(forNode *ast.Node, initializer *ast.Node, outer *Scope) *Scope {
+	if initializer != nil && initializer.Kind == ast.KindVariableDeclarationList && !utils.IsVarKeyword(initializer) {
+		forScope := b.push(KindBlock, forNode, outer)
+		b.collectVariableDeclarations(initializer, forScope, false)
+		b.visitVarDeclList(initializer, forScope)
+		return forScope
+	}
+	if initializer != nil {
+		if initializer.Kind == ast.KindVariableDeclarationList {
+			b.visitVarDeclList(initializer, outer)
+		} else {
+			b.visitExpression(initializer, outer)
+		}
+	}
+	return outer
+}
+
+func (b *builder) visitForStatement(stmt *ast.Node, outer *Scope) {
+	fs := stmt.AsForStatement()
+	if fs == nil {
+		return
+	}
+	body := b.forInitScope(stmt, fs.Initializer, outer)
+	if fs.Condition != nil {
+		b.visitExpression(fs.Condition, body)
+	}
+	if fs.Incrementor != nil {
+		b.visitExpression(fs.Incrementor, body)
+	}
+	if fs.Statement != nil {
+		b.visitStatement(fs.Statement, body)
+	}
+}
+
+func (b *builder) visitForInOrOf(stmt *ast.Node, outer *Scope) {
+	fs := stmt.AsForInOrOfStatement()
+	if fs == nil {
+		return
+	}
+	body := b.forInitScope(stmt, fs.Initializer, outer)
+	if fs.Expression != nil {
+		b.visitExpression(fs.Expression, outer)
+	}
+	if fs.Statement != nil {
+		b.visitStatement(fs.Statement, body)
+	}
+}
+
+func (b *builder) visitCatch(node *ast.Node, outer *Scope) {
+	cc := node.AsCatchClause()
+	if cc == nil {
+		return
+	}
+	catchScope := b.push(KindCatch, node, outer)
+	if cc.VariableDeclaration != nil {
+		vd := cc.VariableDeclaration.AsVariableDeclaration()
+		if vd != nil && vd.Name() != nil {
+			utils.CollectBindingNames(vd.Name(), func(id *ast.Node, name string) {
+				catchScope.Add(&Variable{
+					Name:           name,
+					ID:             id,
+					DefNode:        cc.VariableDeclaration,
+					Parent:         node,
+					Kind:           DefCatch,
+					IsValueBinding: true,
+				})
+			})
+		}
+	}
+	if cc.Block != nil && cc.Block.Kind == ast.KindBlock {
+		// The catch block is a BlockStatement whose direct parent is this CatchClause.
+		// We treat it as nested: create an extra block scope for its body.
+		bodyScope := b.push(KindBlock, cc.Block, catchScope)
+		blk := cc.Block.AsBlock()
+		if blk != nil && blk.Statements != nil {
+			for _, stmt := range blk.Statements.Nodes {
+				b.hoistStatement(stmt, bodyScope, true)
+			}
+			varHost := bodyScope.VariableScope()
+			if varHost == nil {
+				varHost = bodyScope
+			}
+			for _, stmt := range blk.Statements.Nodes {
+				b.hoistVarOnly(stmt, varHost)
+			}
+			for _, stmt := range blk.Statements.Nodes {
+				b.visitStatement(stmt, bodyScope)
+			}
+		}
+	}
+}
+
+func (b *builder) visitSwitchCases(sw *ast.SwitchStatement, outer *Scope) {
+	if sw.CaseBlock == nil {
+		return
+	}
+	cb := sw.CaseBlock.AsCaseBlock()
+	if cb == nil || cb.Clauses == nil {
+		return
+	}
+	// Switch introduces a block scope for its clauses.
+	switchScope := b.push(KindBlock, sw.AsNode(), outer)
+	// First: hoist block-level declarations across all clauses.
+	for _, clause := range cb.Clauses.Nodes {
+		if clause == nil {
+			continue
+		}
+		c := clause.AsCaseOrDefaultClause()
+		if c == nil || c.Statements == nil {
+			continue
+		}
+		for _, s := range c.Statements.Nodes {
+			b.hoistStatement(s, switchScope, true)
+		}
+	}
+	// Vars hoist to enclosing var scope.
+	varHost := switchScope.VariableScope()
+	if varHost == nil {
+		varHost = switchScope
+	}
+	for _, clause := range cb.Clauses.Nodes {
+		if clause == nil {
+			continue
+		}
+		c := clause.AsCaseOrDefaultClause()
+		if c == nil || c.Statements == nil {
+			continue
+		}
+		for _, s := range c.Statements.Nodes {
+			b.hoistVarOnly(s, varHost)
+		}
+	}
+	// Recurse into statements.
+	for _, clause := range cb.Clauses.Nodes {
+		if clause == nil {
+			continue
+		}
+		c := clause.AsCaseOrDefaultClause()
+		if c == nil {
+			continue
+		}
+		if c.Expression != nil {
+			b.visitExpression(c.Expression, switchScope)
+		}
+		if c.Statements != nil {
+			for _, s := range c.Statements.Nodes {
+				b.visitStatement(s, switchScope)
+			}
+		}
+	}
+}

--- a/internal/utils/scope/scope.go
+++ b/internal/utils/scope/scope.go
@@ -1,0 +1,136 @@
+// Package scope reconstructs ESLint's lexical scope model on top of the tsgo
+// AST. rslint has no eslint-scope equivalent, so rules that need to reason
+// about "which declaration does this name belong to" share the scope tree
+// built here instead of each re-deriving one.
+//
+// The model deliberately mirrors eslint-scope / typescript-eslint's
+// scope-manager rather than tsgo's binder: block scopes, catch scopes,
+// function-expression-name scopes, and class scopes are all materialized, and
+// `var` hoisting targets the nearest function/module/global scope. Concepts
+// rslint does not expose (for example `parserOptions.globalReturn`) remain
+// unmodeled.
+package scope
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// DefKind classifies what syntactic construct introduced a binding. It maps to
+// eslint-scope's `Definition#type` closely enough for rules to branch on it.
+type DefKind int
+
+const (
+	DefVariable       DefKind = iota // var/let/const binding, binding element, enum member
+	DefParameter                     // function parameter
+	DefFunctionName                  // FunctionDeclaration name (outer scope)
+	DefFnExprName                    // FunctionExpression name (inner scope only)
+	DefClassName                     // ClassDeclaration name (outer scope)
+	DefClassInnerName                // Class name visible inside class scope
+	DefImport                        // Import specifier / default / namespace
+	DefCatch                         // Catch parameter
+	DefType                          // Interface, type alias
+	DefEnumName                      // Enum declaration
+	DefNamespaceName                 // Module/namespace declaration
+	DefTypeParameter                 // Generic type parameter
+)
+
+// Variable is a single declaration site. eslint-scope merges every declaration
+// of a name within one scope into a single `Variable` carrying several `defs`;
+// here each declaration is its own Variable and the merged view is
+// [Scope.Declarations], which returns them in declaration order.
+type Variable struct {
+	Name    string
+	ID      *ast.Node // identifier node of this declaration
+	DefNode *ast.Node // declaration node (VariableDeclaration, FunctionDeclaration, ...)
+	Parent  *ast.Node // parent of DefNode (for parsed import detection, parameter typing, etc.)
+	Kind    DefKind
+
+	IsValueBinding   bool // runtime value vs. type-only
+	IsTypeOnlyImport bool // ImportSpecifier with `type` modifier
+	DeclareModifier  bool // `declare` modifier (.d.ts handling)
+
+	Scope *Scope
+}
+
+// Kind identifies what construct a scope belongs to.
+type Kind int
+
+const (
+	KindGlobal           Kind = iota
+	KindFunction              // function-like bodies & their parameters
+	KindFunctionExprName      // FunctionExpression's name binding
+	KindBlock                 // { ... } / for-init / switch case / enum body
+	KindCatch                 // catch clause
+	KindClass                 // class body: type parameters & inner class name
+	KindModule                // TS namespace
+	KindType                  // TS type alias / interface / function type: type parameters
+)
+
+// Scope is one node of the scope tree.
+type Scope struct {
+	Kind   Kind
+	Block  *ast.Node
+	Parent *Scope
+
+	// Vars lists every declaration in this scope in declaration order.
+	Vars []*Variable
+	// ByName groups Vars by binding name, preserving declaration order.
+	ByName map[string][]*Variable
+
+	// GlobalAugmentation is true inside a `declare global { ... }` chain.
+	GlobalAugmentation bool
+}
+
+func newScope(kind Kind, block *ast.Node, parent *Scope) *Scope {
+	return &Scope{
+		Kind:   kind,
+		Block:  block,
+		Parent: parent,
+		ByName: map[string][]*Variable{},
+	}
+}
+
+// Add records a declaration in this scope.
+func (s *Scope) Add(v *Variable) {
+	v.Scope = s
+	s.Vars = append(s.Vars, v)
+	s.ByName[v.Name] = append(s.ByName[v.Name], v)
+}
+
+// Declarations returns every declaration of `name` in this scope, in
+// declaration order — eslint-scope's `Variable#defs` for that name.
+func (s *Scope) Declarations(name string) []*Variable {
+	return s.ByName[name]
+}
+
+// VariableScope returns the nearest ancestor (or self) that acts as a `var`
+// hoist target — eslint-scope's `Scope#variableScope`: function-like scopes,
+// module scopes, and the global scope.
+func (s *Scope) VariableScope() *Scope {
+	for current := s; current != nil; current = current.Parent {
+		switch current.Kind {
+		case KindFunction, KindModule, KindGlobal:
+			return current
+		}
+	}
+	return nil
+}
+
+// Manager owns a built scope tree.
+type Manager struct {
+	SourceFile *ast.SourceFile
+	// Global is the file's outermost scope. rslint collapses ESLint's module
+	// scope into it.
+	Global *Scope
+	// Scopes lists every scope in creation order, which is a pre-order walk of
+	// the scope tree.
+	Scopes []*Scope
+}
+
+// Build analyzes `sf` and returns its scope tree.
+func Build(sf *ast.SourceFile) *Manager {
+	m := &Manager{SourceFile: sf}
+	b := &builder{manager: m}
+	m.Global = b.buildProgram(sf)
+	return m
+}

--- a/internal/utils/scope/scope_test.go
+++ b/internal/utils/scope/scope_test.go
@@ -1,0 +1,177 @@
+// TestBuild* lock in the shape of the scope tree the shared model produces —
+// which scopes exist, what nests inside what, and which scope owns each
+// binding. Rules read those three things and nothing else, so a regression
+// here is a regression in every consumer.
+package scope
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+func build(t *testing.T, source string) *Manager {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+	return Build(sourceFile)
+}
+
+// lookup finds the innermost scope declaring `name` starting from the scope
+// created at index `scopeIndex`, mirroring how a rule resolves outward.
+func lookup(m *Manager, scopeIndex int, name string) *Variable {
+	for current := m.Scopes[scopeIndex]; current != nil; current = current.Parent {
+		if declarations := current.Declarations(name); len(declarations) > 0 {
+			return declarations[0]
+		}
+	}
+	return nil
+}
+
+func assertKinds(t *testing.T, m *Manager, want []Kind) {
+	t.Helper()
+	if len(m.Scopes) != len(want) {
+		t.Fatalf("got %d scopes, want %d", len(m.Scopes), len(want))
+	}
+	for i, kind := range want {
+		if m.Scopes[i].Kind != kind {
+			t.Errorf("scope %d has kind %d, want %d", i, m.Scopes[i].Kind, kind)
+		}
+	}
+}
+
+func assertDeclares(t *testing.T, s *Scope, name string, kind DefKind) {
+	t.Helper()
+	declarations := s.Declarations(name)
+	if len(declarations) == 0 {
+		t.Fatalf("scope does not declare %q", name)
+	}
+	if declarations[0].Kind != kind {
+		t.Errorf("%q has def kind %d, want %d", name, declarations[0].Kind, kind)
+	}
+}
+
+func TestBuildHoistsVarToTheVariableScope(t *testing.T) {
+	m := build(t, `
+function outer() {
+  if (cond) { var hoisted = 1; let blockOnly = 2; }
+}
+`)
+	assertKinds(t, m, []Kind{KindGlobal, KindFunction, KindBlock})
+
+	assertDeclares(t, m.Scopes[0], "outer", DefFunctionName)
+	// `var` lands in the function scope even though it is written in a block.
+	assertDeclares(t, m.Scopes[1], "hoisted", DefVariable)
+	assertDeclares(t, m.Scopes[2], "blockOnly", DefVariable)
+	if len(m.Scopes[2].Declarations("hoisted")) != 0 {
+		t.Error("var declaration should not also live in the block scope")
+	}
+	if m.Scopes[2].VariableScope() != m.Scopes[1] {
+		t.Error("block scope's variable scope should be the enclosing function")
+	}
+}
+
+func TestBuildFunctionExpressionNameGetsItsOwnScope(t *testing.T) {
+	m := build(t, `var alias = function named(param) { return named; };`)
+	assertKinds(t, m, []Kind{KindGlobal, KindFunctionExprName, KindFunction})
+
+	assertDeclares(t, m.Scopes[0], "alias", DefVariable)
+	assertDeclares(t, m.Scopes[1], "named", DefFnExprName)
+	assertDeclares(t, m.Scopes[2], "param", DefParameter)
+	// The name is reachable from the body but not from the enclosing scope.
+	if lookup(m, 2, "named") == nil {
+		t.Error("function body should see the function expression's own name")
+	}
+	if len(m.Scopes[0].Declarations("named")) != 0 {
+		t.Error("function expression name must not leak to the enclosing scope")
+	}
+}
+
+func TestBuildClassScopeHoldsInnerNameAndTypeParameters(t *testing.T) {
+	m := build(t, `class Box<T> extends Base { method(value: T) {} }`)
+	assertKinds(t, m, []Kind{KindGlobal, KindClass, KindFunction})
+
+	assertDeclares(t, m.Scopes[0], "Box", DefClassName)
+	assertDeclares(t, m.Scopes[1], "Box", DefClassInnerName)
+	assertDeclares(t, m.Scopes[1], "T", DefTypeParameter)
+	assertDeclares(t, m.Scopes[2], "value", DefParameter)
+	if lookup(m, 2, "T") == nil {
+		t.Error("method scope should see the class type parameter")
+	}
+}
+
+func TestBuildCatchClauseNestsABlockScope(t *testing.T) {
+	m := build(t, `try {} catch (err) { let inner = err; }`)
+	// The try block, the catch clause, and the catch body are separate scopes.
+	assertKinds(t, m, []Kind{KindGlobal, KindBlock, KindCatch, KindBlock})
+
+	assertDeclares(t, m.Scopes[2], "err", DefCatch)
+	assertDeclares(t, m.Scopes[3], "inner", DefVariable)
+	if lookup(m, 3, "err") == nil {
+		t.Error("catch body should resolve the catch parameter")
+	}
+}
+
+func TestBuildTypeScriptDeclarationKinds(t *testing.T) {
+	m := build(t, `
+import type { Imported } from './m';
+interface Shape {}
+type Alias = Shape;
+enum Level { Low }
+namespace Space {}
+`)
+	global := m.Scopes[0]
+	assertDeclares(t, global, "Imported", DefImport)
+	assertDeclares(t, global, "Shape", DefType)
+	assertDeclares(t, global, "Alias", DefType)
+	assertDeclares(t, global, "Level", DefEnumName)
+	assertDeclares(t, global, "Space", DefNamespaceName)
+
+	if !global.Declarations("Imported")[0].IsTypeOnlyImport {
+		t.Error("`import type` binding should be flagged type-only")
+	}
+	if global.Declarations("Shape")[0].IsValueBinding {
+		t.Error("an interface should not be a value binding")
+	}
+}
+
+func TestBuildGlobalAugmentationIsMarked(t *testing.T) {
+	m := build(t, `declare global { var injected: string; }`)
+	assertKinds(t, m, []Kind{KindGlobal, KindModule})
+	if m.Scopes[0].GlobalAugmentation {
+		t.Error("the file scope is not an augmentation")
+	}
+	if !m.Scopes[1].GlobalAugmentation {
+		t.Error("`declare global` scope should be marked as an augmentation")
+	}
+}
+
+func TestBuildMergesDeclarationsByNameInOrder(t *testing.T) {
+	m := build(t, `
+enum Merged { A }
+namespace Merged {}
+`)
+	declarations := m.Scopes[0].Declarations("Merged")
+	if len(declarations) != 2 {
+		t.Fatalf("got %d declarations of Merged, want 2", len(declarations))
+	}
+	if declarations[0].Kind != DefEnumName || declarations[1].Kind != DefNamespaceName {
+		t.Errorf("declarations should be returned in source order, got %d then %d",
+			declarations[0].Kind, declarations[1].Kind)
+	}
+}
+
+func TestBuildEmptySourceFileHasOnlyTheGlobalScope(t *testing.T) {
+	m := build(t, ``)
+	assertKinds(t, m, []Kind{KindGlobal})
+	if m.Global != m.Scopes[0] {
+		t.Error("Global should be the first created scope")
+	}
+	if m.Global.VariableScope() != m.Global {
+		t.Error("the global scope is its own variable scope")
+	}
+}


### PR DESCRIPTION
## Summary

The AST-derived reconstruction of ESLint's lexical scope tree (scope kinds, `var` hoisting, class/catch/function-expression-name scopes, TypeScript declaration kinds) lived inside `internal/rules/no_shadow`. Any other rule whose semantics are stated in terms of scopes — `no-use-before-define`, `block-scoped-var`, … — had no way to reuse it.

This moves the scope model and its builder into a shared `internal/utils/scope` package and has `no-shadow` consume it.

### What changed

- **New** `internal/utils/scope`: `Manager` / `Scope` / `Variable`, the two-pass builder, and `Scope.Declarations(name)` as the merged view of eslint-scope's `Variable#defs`.
- `no_shadow.go` keeps only the shadow-detection predicates and its options; the per-run configuration it used to hang off the builder moved to a small `checker` struct.
- Scope-tree shape tests for the new package, plus a `internal/utils/scope` entry in the porting skill's utils reference explaining when to use it versus `ctx.Refs`.

### Behavior

Unchanged. The builder body is a verbatim move — the only differences are the exported type/field names and the builder struct losing no-shadow's configuration fields. Both `no-shadow` suites (core and `@typescript-eslint`) pass untouched.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).