### PR TITLE
feat: port rule no-use-before-define

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -125,6 +125,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_private_class_members"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_vars"
+	"github.com/web-infra-dev/rslint/internal/rules/no_use_before_define"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_assignment"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
@@ -306,6 +307,7 @@ func GetAllRules() []rule.Rule {
 		no_unused_labels.NoUnusedLabelsRule,
 		no_unused_private_class_members.NoUnusedPrivateClassMembersRule,
 		no_unused_vars.NoUnusedVarsRule,
+		no_use_before_define.NoUseBeforeDefineRule,
 		one_var.OneVarRule,
 		prefer_arrow_callback.PreferArrowCallbackRule,
 		no_dupe_else_if.NoDupeElseIfRule,

--- a/internal/rules/no_shadow/no_shadow.go
+++ b/internal/rules/no_shadow/no_shadow.go
@@ -165,7 +165,7 @@ func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.Rule
 			return rule.RuleListeners{}
 		}
 
-		manager := scope.Build(ctx.SourceFile)
+		manager := scope.Build(ctx.SourceFile, scope.Options{})
 
 		c := &checker{
 			sourceFile:                          ctx.SourceFile,

--- a/internal/rules/no_shadow/no_shadow.go
+++ b/internal/rules/no_shadow/no_shadow.go
@@ -202,6 +202,9 @@ func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.Rule
 				continue
 			}
 			for _, v := range s.Vars {
+				if v.Anonymous {
+					continue
+				}
 				if opts.allow[v.Name] {
 					continue
 				}
@@ -231,6 +234,12 @@ func isDuplicatedClassNameInClassScope(v *scope.Variable) bool {
 // checkVariable tests whether `v` shadows a variable in some outer scope.
 func (c *checker) checkVariable(ctx rule.RuleContext, s *scope.Scope, v *scope.Variable, opts options) {
 	shadowed := findShadowed(v, s.Parent)
+	// An outer binding with no identifier — a string-literal enum member —
+	// answers the name lookup but has no declaration site to name in the
+	// report, so nothing is reported against it.
+	if shadowed != nil && shadowed.Anonymous {
+		return
+	}
 	shadowedDefaultTypeScriptGlobal := shadowed == nil && opts.builtinGlobals &&
 		c.includeDefaultTypeScriptTypeGlobals && rule.IsDefaultTypeScriptTypeGlobal(v.Name)
 	shadowedGlobal := shadowed == nil && opts.builtinGlobals &&

--- a/internal/rules/no_shadow/no_shadow_test.go
+++ b/internal/rules/no_shadow/no_shadow_test.go
@@ -484,6 +484,21 @@ function bar() { }`},
 	}
   }
 		`},
+			// ---- A string-literal enum member binds its name but declares no
+			// identifier, so it is neither reported nor reported against ----
+			{Code: `
+			const A = 2;
+			enum Test {
+				"A" = 1,
+				B = A,
+			}
+		`},
+			{Code: `
+			enum Test {
+				"A" = 1,
+				B = ((): number => { const A = 2; return A; })(),
+			}
+		`},
 		},
 
 		[]rule_tester.InvalidTestCase{

--- a/internal/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/rules/no_use_before_define/no_use_before_define.go
@@ -94,7 +94,7 @@ var NoUseBeforeDefineRule = rule.Rule{
 			}
 			declaration := ref.Resolved()
 			if ref.Identifier.End() < declaration.ID.End() ||
-				(isEvaluatedDuringInitialization(ref) && !isTypeReferenceName(ref.Identifier)) {
+				(ref.IsValueReference && isEvaluatedDuringInitialization(ref)) {
 				ctx.ReportNode(ref.Identifier, rule.RuleMessage{
 					Id:          "usedBeforeDefined",
 					Description: fmt.Sprintf("'%s' was used before it was defined.", ref.Identifier.Text()),
@@ -112,13 +112,15 @@ var NoUseBeforeDefineRule = rule.Rule{
 func shouldCheck(ref *scope.Reference, opts options) bool {
 	identifier := ref.Identifier
 
-	if opts.allowNamedExports && isExportSpecifierLocalName(identifier) {
-		return false
-	}
-
 	declaration := ref.Resolved()
 	if declaration == nil {
 		return false
+	}
+
+	// A named export is settled before any other option is consulted:
+	// `allowNamedExports` is the only one that silences it.
+	if isExportSpecifierLocalName(identifier) {
+		return !opts.allowNamedExports
 	}
 
 	if !opts.functions && isFunctionNameDef(declaration) {
@@ -137,12 +139,15 @@ func shouldCheck(ref *scope.Reference, opts options) bool {
 		return false
 	}
 
-	if !opts.typedefs && declaration.Kind == scope.DefType {
+	// Type parameters are `Type` definitions upstream, so `typedefs` covers
+	// them alongside interfaces and type aliases.
+	if !opts.typedefs &&
+		(declaration.Kind == scope.DefType || declaration.Kind == scope.DefTypeParameter) {
 		return false
 	}
 
 	if opts.ignoreTypeReferences &&
-		(referenceContainsTypeQuery(identifier) || isTypeReferenceName(identifier)) {
+		(referenceContainsTypeQuery(identifier) || ref.IsTypeReference) {
 		return false
 	}
 
@@ -322,13 +327,6 @@ func referenceContainsTypeQuery(node *ast.Node) bool {
 		}
 	}
 	return false
-}
-
-// isTypeReferenceName reports whether the identifier is the whole name of a
-// type reference (`let x: Foo`). A qualified name (`let x: A.Foo`) is not one:
-// there the identifier's parent is the qualified name.
-func isTypeReferenceName(node *ast.Node) bool {
-	return node.Parent != nil && node.Parent.Kind == ast.KindTypeReference
 }
 
 func leftMostQualifiedName(node *ast.Node) *ast.Node {

--- a/internal/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/rules/no_use_before_define/no_use_before_define.go
@@ -94,7 +94,7 @@ var NoUseBeforeDefineRule = rule.Rule{
 			}
 			declaration := ref.Resolved()
 			if ref.Identifier.End() < declaration.ID.End() ||
-				(ref.IsValueReference && isEvaluatedDuringInitialization(ref)) {
+				(isEvaluatedDuringInitialization(ref) && !isTypeReferenceName(ref.Identifier)) {
 				ctx.ReportNode(ref.Identifier, rule.RuleMessage{
 					Id:          "usedBeforeDefined",
 					Description: fmt.Sprintf("'%s' was used before it was defined.", ref.Identifier.Text()),
@@ -112,15 +112,13 @@ var NoUseBeforeDefineRule = rule.Rule{
 func shouldCheck(ref *scope.Reference, opts options) bool {
 	identifier := ref.Identifier
 
-	declaration := ref.Resolved()
-	if declaration == nil {
+	if opts.allowNamedExports && isExportSpecifierLocalName(identifier) {
 		return false
 	}
 
-	// A named export is settled before any other option is consulted:
-	// `allowNamedExports` is the only one that silences it.
-	if isExportSpecifierLocalName(identifier) {
-		return !opts.allowNamedExports
+	declaration := ref.Resolved()
+	if declaration == nil {
+		return false
 	}
 
 	if !opts.functions && isFunctionNameDef(declaration) {
@@ -147,7 +145,7 @@ func shouldCheck(ref *scope.Reference, opts options) bool {
 	}
 
 	if opts.ignoreTypeReferences &&
-		(referenceContainsTypeQuery(identifier) || ref.IsTypeReference) {
+		(referenceContainsTypeQuery(identifier) || isTypeReferenceName(identifier)) {
 		return false
 	}
 
@@ -327,6 +325,13 @@ func referenceContainsTypeQuery(node *ast.Node) bool {
 		}
 	}
 	return false
+}
+
+// isTypeReferenceName reports whether the identifier is the whole name of a
+// type reference (`let x: Foo`). A qualified name (`let x: A.Foo`) is not one:
+// there the identifier's parent is the qualified name.
+func isTypeReferenceName(node *ast.Node) bool {
+	return node.Parent != nil && node.Parent.Kind == ast.KindTypeReference
 }
 
 func leftMostQualifiedName(node *ast.Node) *ast.Node {

--- a/internal/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/rules/no_use_before_define/no_use_before_define.go
@@ -1,0 +1,380 @@
+package no_use_before_define
+
+import (
+	"cmp"
+	_ "embed"
+	"fmt"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
+)
+
+//go:embed no_use_before_define.schema.json
+var schemaJSON []byte
+
+// https://eslint.org/docs/latest/rules/no-use-before-define
+//
+// The rule walks every identifier reference recovered from the shared scope
+// model in `internal/utils/scope` and reports the ones that read a binding
+// declared later in the file, or that run while that binding is still being
+// initialized.
+
+type options struct {
+	functions            bool
+	classes              bool
+	variables            bool
+	allowNamedExports    bool
+	enums                bool
+	typedefs             bool
+	ignoreTypeReferences bool
+}
+
+func defaultOptions() options {
+	return options{
+		functions:            true,
+		classes:              true,
+		variables:            true,
+		allowNamedExports:    false,
+		enums:                true,
+		typedefs:             true,
+		ignoreTypeReferences: true,
+	}
+}
+
+func parseOptions(rawOptions []any) options {
+	opts := defaultOptions()
+	if len(rawOptions) == 0 {
+		return opts
+	}
+	// The legacy string form only turns function declarations off.
+	if s, ok := rawOptions[0].(string); ok {
+		opts.functions = s != "nofunc"
+		return opts
+	}
+	optsMap, _ := rawOptions[0].(map[string]any)
+	readBool := func(key string, target *bool) {
+		if v, ok := optsMap[key].(bool); ok {
+			*target = v
+		}
+	}
+	readBool("functions", &opts.functions)
+	readBool("classes", &opts.classes)
+	readBool("variables", &opts.variables)
+	readBool("allowNamedExports", &opts.allowNamedExports)
+	readBool("enums", &opts.enums)
+	readBool("typedefs", &opts.typedefs)
+	readBool("ignoreTypeReferences", &opts.ignoreTypeReferences)
+	return opts
+}
+
+var NoUseBeforeDefineRule = rule.Rule{
+	Name:   "no-use-before-define",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		if ctx.SourceFile == nil {
+			return rule.RuleListeners{}
+		}
+
+		manager := scope.Build(ctx.SourceFile, scope.Options{CollectReferences: true})
+
+		// ESLint walks the scope tree depth-first; ordering the flat reference
+		// list by source position gives the same sequence for every input the
+		// rule can report on, without depending on scope-creation order.
+		references := slices.Clone(manager.References)
+		slices.SortStableFunc(references, func(a, b *scope.Reference) int {
+			return cmp.Compare(a.Identifier.Pos(), b.Identifier.Pos())
+		})
+
+		for _, ref := range references {
+			if !shouldCheck(ref, opts) {
+				continue
+			}
+			declaration := ref.Resolved()
+			if ref.Identifier.End() < declaration.ID.End() ||
+				(isEvaluatedDuringInitialization(ref) && !isTypeReferenceName(ref.Identifier)) {
+				ctx.ReportNode(ref.Identifier, rule.RuleMessage{
+					Id:          "usedBeforeDefined",
+					Description: fmt.Sprintf("'%s' was used before it was defined.", ref.Identifier.Text()),
+				})
+			}
+		}
+
+		return rule.RuleListeners{}
+	},
+}
+
+// shouldCheck filters out references the options exempt, references to
+// bindings declared outside this file, and reference positions that don't
+// carry a use-before-define hazard.
+func shouldCheck(ref *scope.Reference, opts options) bool {
+	identifier := ref.Identifier
+
+	if opts.allowNamedExports && isExportSpecifierLocalName(identifier) {
+		return false
+	}
+
+	declaration := ref.Resolved()
+	if declaration == nil {
+		return false
+	}
+
+	if !opts.functions && isFunctionNameDef(declaration) {
+		return false
+	}
+
+	if ((!opts.variables && declaration.Kind == scope.DefVariable) ||
+		(!opts.classes && isClassNameDef(declaration))) &&
+		// Don't skip a reference in the same execution context: that one is a
+		// temporal dead zone error regardless of the option.
+		isFromSeparateExecutionContext(ref) {
+		return false
+	}
+
+	if !opts.enums && declaration.Kind == scope.DefEnumName {
+		return false
+	}
+
+	if !opts.typedefs && declaration.Kind == scope.DefType {
+		return false
+	}
+
+	if opts.ignoreTypeReferences &&
+		(referenceContainsTypeQuery(identifier) || isTypeReferenceName(identifier)) {
+		return false
+	}
+
+	// `import Z = A.X.Y` and `typeof A.X.Y` only read the left-most name; the
+	// rest are namespace members, not bindings.
+	if identifier.Parent != nil && identifier.Parent.Kind == ast.KindQualifiedName {
+		return leftMostQualifiedName(identifier.Parent) == identifier
+	}
+
+	// Decorators are evaluated after the class binding is initialized, so a
+	// self-reference in one is safe.
+	if isClassRefInClassDecorator(declaration, ref) {
+		return false
+	}
+
+	return true
+}
+
+func isFunctionNameDef(v *scope.Variable) bool {
+	return v.Kind == scope.DefFunctionName || v.Kind == scope.DefFnExprName
+}
+
+func isClassNameDef(v *scope.Variable) bool {
+	return v.Kind == scope.DefClassName || v.Kind == scope.DefClassInnerName
+}
+
+// isClassStaticInitializerScope reports whether a scope is a static block or
+// the initializer of a static field. Both run while the class definition is
+// being evaluated, so they belong to the enclosing execution context.
+func isClassStaticInitializerScope(s *scope.Scope) bool {
+	if s == nil {
+		return false
+	}
+	switch s.Kind {
+	case scope.KindClassStaticBlock:
+		return true
+	case scope.KindClassFieldInitializer:
+		// Scope.Block is the initializer expression; its parent is the field.
+		return s.Block != nil && s.Block.Parent != nil && ast.HasStaticModifier(s.Block.Parent)
+	}
+	return false
+}
+
+// isFromSeparateExecutionContext reports whether the reference is evaluated in
+// a different execution context than the one its binding is declared in.
+// Execution contexts are the top level, functions, class field initializers,
+// and class static blocks — with static field initializers and static blocks
+// folded into their parent context because they run during class definition.
+func isFromSeparateExecutionContext(ref *scope.Reference) bool {
+	declaration := ref.Resolved()
+	if declaration == nil || declaration.Scope == nil {
+		return false
+	}
+	declarationContext := declaration.Scope.VariableScope()
+	for current := ref.From; current != nil; {
+		context := current.VariableScope()
+		if context == declarationContext {
+			return false
+		}
+		if !isClassStaticInitializerScope(context) {
+			return true
+		}
+		current = context.Parent
+	}
+	return true
+}
+
+// isEvaluatedDuringInitialization reports whether the reference runs while the
+// binding it reads is still being initialized — `var a = a`, `class C extends
+// C {}`, and friends.
+func isEvaluatedDuringInitialization(ref *scope.Reference) bool {
+	if isFromSeparateExecutionContext(ref) {
+		// Even inside the initializer, the reference isn't evaluated during
+		// initialization: `const x = () => x;` is fine.
+		return false
+	}
+
+	location := ref.Identifier.End()
+	declaration := ref.Resolved()
+
+	if isClassNameDef(declaration) {
+		classDefinition := declaration.DefNode
+		// The class binding is initialized before its static initializers run,
+		// so `class C { static foo = C; static { bar = C; } }` is valid.
+		return isInRange(classDefinition, location) &&
+			!isInClassStaticInitializerRange(classDefinition, location)
+	}
+
+	for node := declaration.ID.Parent; node != nil; node = node.Parent {
+		switch node.Kind {
+		case ast.KindVariableDeclaration:
+			declarator := node.AsVariableDeclaration()
+			if declarator != nil && isInRange(declarator.Initializer, location) {
+				return true
+			}
+			// `for (var a in a)` / `for (var a of a)`: the right-hand side is
+			// evaluated before the binding is initialized.
+			if node.Parent != nil && node.Parent.Parent != nil {
+				loop := node.Parent.Parent
+				if loop.Kind == ast.KindForInStatement || loop.Kind == ast.KindForOfStatement {
+					if forInOrOf := loop.AsForInOrOfStatement(); forInOrOf != nil &&
+						isInRange(forInOrOf.Expression, location) {
+						return true
+					}
+				}
+			}
+			return false
+		case ast.KindBindingElement:
+			// ESTree's AssignmentPattern inside a destructuring pattern.
+			if element := node.AsBindingElement(); element != nil && isInRange(element.Initializer, location) {
+				return true
+			}
+		case ast.KindParameter:
+			// ESTree's AssignmentPattern in a parameter list.
+			if isInRange(node.Initializer(), location) {
+				return true
+			}
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindClassDeclaration, ast.KindClassExpression,
+			ast.KindArrowFunction, ast.KindCatchClause,
+			ast.KindImportDeclaration, ast.KindExportDeclaration,
+			// ESTree wraps every shorthand method and accessor body in a
+			// FunctionExpression, which the walk stops at. tsgo has no such
+			// wrapper — the member node *is* the function — so these kinds
+			// stand in for it. Without them the walk escapes the method and
+			// finds the enclosing `const x = { m(node) { node; } }`
+			// initializer, reporting every parameter read inside.
+			ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor:
+			return false
+		}
+	}
+
+	return false
+}
+
+func isInRange(node *ast.Node, location int) bool {
+	return node != nil && node.Pos() <= location && location <= node.End()
+}
+
+// isInClassStaticInitializerRange reports whether a location falls inside one
+// of the class's static initializers — a static block or the value of a static
+// field.
+func isInClassStaticInitializerRange(classNode *ast.Node, location int) bool {
+	if classNode == nil {
+		return false
+	}
+	for _, member := range classNode.Members() {
+		if member == nil {
+			continue
+		}
+		switch member.Kind {
+		case ast.KindClassStaticBlockDeclaration:
+			if isInRange(member, location) {
+				return true
+			}
+		case ast.KindPropertyDeclaration:
+			if ast.HasStaticModifier(member) && isInRange(member.Initializer(), location) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// referenceContainsTypeQuery reports whether the identifier sits inside a
+// `typeof X` type position, possibly behind a qualified name.
+func referenceContainsTypeQuery(node *ast.Node) bool {
+	for current := node; current != nil; current = current.Parent {
+		switch current.Kind {
+		case ast.KindTypeQuery:
+			return true
+		case ast.KindIdentifier, ast.KindQualifiedName:
+			continue
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// isTypeReferenceName reports whether the identifier is the whole name of a
+// type reference (`let x: Foo`). A qualified name (`let x: A.Foo`) is not one:
+// there the identifier's parent is the qualified name.
+func isTypeReferenceName(node *ast.Node) bool {
+	return node.Parent != nil && node.Parent.Kind == ast.KindTypeReference
+}
+
+func leftMostQualifiedName(node *ast.Node) *ast.Node {
+	current := node
+	for current.Kind == ast.KindQualifiedName {
+		qualified := current.AsQualifiedName()
+		if qualified == nil || qualified.Left == nil {
+			break
+		}
+		current = qualified.Left
+	}
+	return current
+}
+
+// isExportSpecifierLocalName reports whether the identifier is the local half
+// of an `export { local as exported }` specifier.
+func isExportSpecifierLocalName(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil || parent.Kind != ast.KindExportSpecifier {
+		return false
+	}
+	specifier := parent.AsExportSpecifier()
+	if specifier == nil {
+		return false
+	}
+	local := specifier.PropertyName
+	if local == nil {
+		local = specifier.Name()
+	}
+	return local == node
+}
+
+// isClassRefInClassDecorator reports whether a reference to a class binding
+// appears in one of that class's own decorators. Decorators are applied after
+// the class is defined, so the binding is already initialized.
+func isClassRefInClassDecorator(declaration *scope.Variable, ref *scope.Reference) bool {
+	if !isClassNameDef(declaration) || declaration.DefNode == nil {
+		return false
+	}
+	for _, decorator := range declaration.DefNode.Decorators() {
+		if decorator == nil {
+			continue
+		}
+		if ref.Identifier.Pos() >= decorator.Pos() && ref.Identifier.End() <= decorator.End() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/rules/no_use_before_define/no_use_before_define.go
@@ -94,7 +94,7 @@ var NoUseBeforeDefineRule = rule.Rule{
 			}
 			declaration := ref.Resolved()
 			if ref.Identifier.End() < declaration.ID.End() ||
-				(isEvaluatedDuringInitialization(ref) && !isTypeReferenceName(ref.Identifier)) {
+				(isEvaluatedDuringInitialization(ref) && !isTypeReference(ref.Identifier)) {
 				ctx.ReportNode(ref.Identifier, rule.RuleMessage{
 					Id:          "usedBeforeDefined",
 					Description: fmt.Sprintf("'%s' was used before it was defined.", ref.Identifier.Text()),
@@ -118,6 +118,12 @@ func shouldCheck(ref *scope.Reference, opts options) bool {
 
 	declaration := ref.Resolved()
 	if declaration == nil {
+		return false
+	}
+
+	// A binding with no identifier — a string-literal enum member — has no
+	// declaration site to point the reader at, so upstream leaves it alone.
+	if declaration.Anonymous {
 		return false
 	}
 
@@ -145,7 +151,7 @@ func shouldCheck(ref *scope.Reference, opts options) bool {
 	}
 
 	if opts.ignoreTypeReferences &&
-		(referenceContainsTypeQuery(identifier) || isTypeReferenceName(identifier)) {
+		(referenceContainsTypeQuery(identifier) || isTypeReference(identifier)) {
 		return false
 	}
 
@@ -161,7 +167,25 @@ func shouldCheck(ref *scope.Reference, opts options) bool {
 		return false
 	}
 
+	if isFromFunctionTypeScope(ref) {
+		return false
+	}
+
 	return true
+}
+
+// isFromFunctionTypeScope reports whether the reference is evaluated in the
+// scope a TS function type puts its type parameters and parameters in. Nothing
+// in such a signature runs, so upstream never reports a reference from one.
+func isFromFunctionTypeScope(ref *scope.Reference) bool {
+	from := ref.From
+	if from == nil || from.Kind != scope.KindFunction || from.Block == nil {
+		return false
+	}
+	block := from.Block
+	return ast.IsFunctionTypeNode(block) || ast.IsConstructorTypeNode(block) ||
+		ast.IsCallSignatureDeclaration(block) || ast.IsConstructSignatureDeclaration(block) ||
+		ast.IsMethodSignatureDeclaration(block)
 }
 
 func isFunctionNameDef(v *scope.Variable) bool {
@@ -327,11 +351,18 @@ func referenceContainsTypeQuery(node *ast.Node) bool {
 	return false
 }
 
-// isTypeReferenceName reports whether the identifier is the whole name of a
-// type reference (`let x: Foo`). A qualified name (`let x: A.Foo`) is not one:
-// there the identifier's parent is the qualified name.
-func isTypeReferenceName(node *ast.Node) bool {
-	return node.Parent != nil && node.Parent.Kind == ast.KindTypeReference
+// isTypeReference reports whether the identifier names a type — every type
+// position, plus `export = X`, which exports whichever space `X` lives in.
+// eslint-scope carries the answer on the reference; here it is read back off
+// the syntax, so that the option filters stay independent of how the scope
+// model resolves a name.
+func isTypeReference(node *ast.Node) bool {
+	if parent := node.Parent; parent != nil && parent.Kind == ast.KindExportAssignment {
+		if assignment := parent.AsExportAssignment(); assignment != nil && assignment.IsExportEquals {
+			return true
+		}
+	}
+	return scope.InTypePosition(node)
 }
 
 func leftMostQualifiedName(node *ast.Node) *ast.Node {

--- a/internal/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/rules/no_use_before_define/no_use_before_define.md
@@ -175,8 +175,8 @@ enum Level {
 
 ### `typedefs`
 
-Whether references to TypeScript `type` aliases and `interface` declarations are
-checked. Default: `true`.
+Whether references to TypeScript `type` aliases, `interface` declarations, and
+generic type parameters are checked. Default: `true`.
 
 Examples of **correct** code with `{ "typedefs": false }`:
 

--- a/internal/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/rules/no_use_before_define/no_use_before_define.md
@@ -1,0 +1,223 @@
+# no-use-before-define
+
+Disallow the use of variables before they are defined.
+
+## Rule Details
+
+In JavaScript, `var` declarations and function declarations are hoisted, so
+using them before their declaration is legal but confusing. `let`, `const`, and
+`class` declarations are not: reading them before the declaration throws at
+runtime (the temporal dead zone). This rule reports a reference that appears
+before the declaration it resolves to, and a reference that runs while that
+declaration is still being initialized.
+
+References to names that are not declared in the file — globals, ambient
+declarations, imports from other modules — are not reported.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+alert(a);
+var a = 10;
+
+f();
+function f() {}
+
+new C();
+class C {}
+
+var b = b;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var a = 10;
+alert(a);
+
+function f() {}
+f();
+
+class C {}
+new C();
+
+var b = 1;
+```
+
+Note that a reference from a different execution context still counts as
+"before" when the declaration comes later in the file — the forward call in a
+pair of mutually recursive functions is reported unless `functions` is turned
+off:
+
+```javascript
+function isEven(n) {
+  return isOdd(n - 1);
+}
+function isOdd(n) {
+  return isEven(n - 1);
+}
+```
+
+## Options
+
+This rule takes one option, either the string `"nofunc"` or an object.
+
+The string form `"nofunc"` is shorthand for `{ "functions": false }`.
+
+The object form supports the following properties.
+
+### `functions`
+
+Whether references to function declarations are checked. Default: `true`.
+
+Because function declarations are hoisted, calling one before its declaration is
+safe, so turning this off is common in codebases that define helpers at the
+bottom of a file.
+
+Examples of **correct** code with `{ "functions": false }`:
+
+```json
+{ "no-use-before-define": ["error", { "functions": false }] }
+```
+
+```javascript
+f();
+function f() {}
+```
+
+### `classes`
+
+Whether references to class declarations are checked. Default: `true`.
+
+Turning it off only exempts references from a *different* execution context — a
+function body, a method, a non-static field initializer. A reference in the same
+context as the class definition is a temporal dead zone error and is still
+reported.
+
+Examples of **correct** code with `{ "classes": false }`:
+
+```json
+{ "no-use-before-define": ["error", { "classes": false }] }
+```
+
+```javascript
+function make() {
+  return new C();
+}
+class C {}
+```
+
+Examples of **incorrect** code with `{ "classes": false }`:
+
+```json
+{ "no-use-before-define": ["error", { "classes": false }] }
+```
+
+```javascript
+new C();
+class C {}
+```
+
+### `variables`
+
+Whether references to `var`, `let`, and `const` declarations are checked.
+Default: `true`.
+
+As with `classes`, turning it off only exempts references from a different
+execution context.
+
+Examples of **correct** code with `{ "variables": false }`:
+
+```json
+{ "no-use-before-define": ["error", { "variables": false }] }
+```
+
+```javascript
+function read() {
+  return value;
+}
+let value = 1;
+```
+
+### `allowNamedExports`
+
+Whether the local names in `export { ... }` are exempt. Default: `false`.
+
+Examples of **correct** code with `{ "allowNamedExports": true }`:
+
+```json
+{ "no-use-before-define": ["error", { "allowNamedExports": true }] }
+```
+
+```javascript
+export { a };
+const a = 1;
+```
+
+### `enums`
+
+Whether references to TypeScript `enum` declarations are checked. Default:
+`true`.
+
+Examples of **correct** code with `{ "enums": false }`:
+
+```json
+{ "no-use-before-define": ["error", { "enums": false }] }
+```
+
+```typescript
+const value = Level.Low;
+
+enum Level {
+  Low,
+}
+```
+
+### `typedefs`
+
+Whether references to TypeScript `type` aliases and `interface` declarations are
+checked. Default: `true`.
+
+Examples of **correct** code with `{ "typedefs": false }`:
+
+```json
+{
+  "no-use-before-define": [
+    "error",
+    { "typedefs": false, "ignoreTypeReferences": false }
+  ]
+}
+```
+
+```typescript
+let value: Later;
+type Later = string;
+```
+
+### `ignoreTypeReferences`
+
+Whether references in type positions — a type annotation such as `let x: Foo`,
+or a `typeof Foo` type query — are exempt. Default: `true`.
+
+Because type positions are erased before the code runs, they cannot observe a
+temporal dead zone, so they are ignored by default whatever `typedefs` and
+`enums` say.
+
+Examples of **incorrect** code with `{ "ignoreTypeReferences": false }`:
+
+```json
+{ "no-use-before-define": ["error", { "ignoreTypeReferences": false }] }
+```
+
+```typescript
+interface Bar {
+  type: typeof Foo;
+}
+
+const Foo = 2;
+```
+
+## Original Documentation
+
+- [ESLint: no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-use-before-define.js)

--- a/internal/rules/no_use_before_define/no_use_before_define.schema.json
+++ b/internal/rules/no_use_before_define/no_use_before_define.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "oneOf": [
+        {
+          "enum": ["nofunc"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "functions": { "type": "boolean" },
+            "classes": { "type": "boolean" },
+            "variables": { "type": "boolean" },
+            "allowNamedExports": { "type": "boolean" },
+            "enums": { "type": "boolean" },
+            "typedefs": { "type": "boolean" },
+            "ignoreTypeReferences": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -217,6 +217,13 @@ function f(X, a = X) {
 			// ---- Type parameters are `Type` definitions upstream, so
 			// `typedefs` exempts them ----
 			{Code: `type Q<T extends U, U = string> = T;`, Options: map[string]any{"typedefs": false, "ignoreTypeReferences": false}},
+
+			// ---- `enums` exempts a reference whatever execution context it
+			// sits in, unlike `classes` and `variables` ----
+			{Code: `const v = E.A; enum E { A }`, Options: map[string]any{"enums": false}},
+			// ---- A name this file never declares is never reported, not even
+			// as the local half of a named export ----
+			{Code: `export { nothing };`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: receiver / expression wrappers must not hide the
@@ -455,6 +462,24 @@ type Later = string;
 				Code:    `type Q<T extends U, U = string> = T;`,
 				Options: map[string]any{"typedefs": true, "ignoreTypeReferences": false},
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+
+			// ---- `ignoreTypeReferences` keys off the syntactic shape of the
+			// reference, so only a plain `T` type annotation is exempt: an
+			// `implements` clause and an `export =` operand are not ----
+			{
+				Code:   `class C implements Later {} interface Later {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:   `export = X; const X = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			// ---- A type-level call signature is an ordinary reference site ----
+			{
+				Code:    `let f: (x: Later) => void; type Later = string;`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
 			},
 
 			// ---- A class index signature's key type and result type are

--- a/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -172,6 +172,51 @@ export class MyControl {}
 			// so a later binding with the same name is irrelevant ----
 			{Code: `<div />; let div;`, Tsx: true},
 			{Code: `<a:b />; let a;`, Tsx: true},
+
+			// ---- Type space and value space are resolved separately: a name
+			// only answers a reference that reads the space it declares ----
+			{Code: `
+const X = 1;
+function f() {
+  X;
+  type X = string;
+}
+`},
+			{Code: `
+type X = string;
+function f() {
+  let y: X;
+  const X = 1;
+}
+`, Options: map[string]any{"ignoreTypeReferences": false}},
+
+			// ---- A parameter default is evaluated before the function body's
+			// lexical environment exists, so it reads the outer binding ----
+			{Code: `
+const X = 0;
+
+function f(a = X) {
+  const X = 1;
+}
+`},
+			{Code: `
+const X = 0;
+
+const f = (a = X) => {
+  const X = 1;
+};
+`},
+			// A body binding that also has a parameter declaration stays visible
+			// to the defaults — only body-only names are hidden.
+			{Code: `
+function f(X, a = X) {
+  var X = 1;
+}
+`},
+
+			// ---- Type parameters are `Type` definitions upstream, so
+			// `typedefs` exempts them ----
+			{Code: `type Q<T extends U, U = string> = T;`, Options: map[string]any{"typedefs": false, "ignoreTypeReferences": false}},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: receiver / expression wrappers must not hide the
@@ -386,6 +431,57 @@ const Widget = () => null;
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "usedBeforeDefined", Message: "'Widget' was used before it was defined.", Line: 3, Column: 10, EndLine: 3, EndColumn: 16},
 				},
+			},
+
+			// ---- A type parameter's constraint and default are references in
+			// the scope that declares the parameter ----
+			{
+				Code: `
+class C<T extends Later> {}
+type Later = string;
+`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 19}},
+			},
+			{
+				Code: `
+function f<T = Later>() {}
+type Later = string;
+`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 16}},
+			},
+			{
+				Code:    `type Q<T extends U, U = string> = T;`,
+				Options: map[string]any{"typedefs": true, "ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+
+			// ---- A class index signature's key type and result type are
+			// references too ----
+			{
+				Code: `
+class C {
+  [key: string]: Later;
+}
+
+type Later = string;
+`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 18}},
+			},
+
+			// ---- Enum members are `TSEnumMemberName` definitions upstream, so
+			// neither `variables` nor `enums` exempts them ----
+			{
+				Code: `
+enum E {
+  A = ((): number => B)(),
+  B = 1,
+}
+`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 22}},
 			},
 		},
 	)

--- a/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -1,0 +1,392 @@
+// TestNoUseBeforeDefineExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in. The migrated upstream cases live in
+// no_use_before_define_upstream_test.go and
+// no_use_before_define_upstream_typescript_test.go.
+package no_use_before_define
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUseBeforeDefineExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUseBeforeDefineRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: access / key forms — only the object of a member
+			// access reads a binding, never the member name ----
+			{Code: `const o = { a: 1 }; let a;`},
+			{Code: `const o = { "a": 1 }; let a;`},
+			{Code: `const o = { 0: 1 }; let zero;`},
+			{Code: `const o = { m() {} }; let m;`},
+			{Code: `obj.a; let a;`},
+			{Code: `obj?.a; let a;`},
+			{Code: `obj.a.b.c; let b;`},
+			{Code: `obj["a"]; let a;`},
+			{Code: `class C { #a = 1; read() { return this.#a; } }`},
+			{Code: `interface I { a: string } let a;`},
+			{Code: `enum E { A } let A;`},
+			{Code: `type T = { a: string }; let a;`},
+
+			// ---- Dimension 4: labels are not bindings ----
+			{Code: `outer: while (true) { break outer; } let outer;`},
+			{Code: `loop: for (;;) { continue loop; } let loop;`},
+
+			// ---- Dimension 4: declaration / container forms ----
+			{Code: `function f() {} f();`},
+			{Code: `const f = function () {}; f();`},
+			{Code: `const f = () => {}; f();`},
+			{Code: `async function f() {} f();`},
+			{Code: `function* f() {} f();`},
+			{Code: `async function* f() {} f();`},
+			{Code: `class C { handler = () => C; }`},
+			{Code: `class C { static async m() { return C; } }`},
+			{Code: `class C { *gen() { yield C; } }`},
+			{Code: `const C = class Named { m() { return Named; } };`},
+
+			// ---- Dimension 4: nesting / traversal boundaries ----
+			{Code: `function outer() { var x; function inner() { x; } }`},
+			{Code: `class Outer { m() { class Inner { m2() { return Outer; } } return Inner; } }`},
+			{Code: `class C { static { class D { m() { return C; } } } }`},
+
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `class C {} new C();`},
+			{Code: `function f() {} f();`},
+			{Code: `const a = 1; const { } = { a };`},
+			{Code: `const a = 1; const o = { ...a };`},
+			{Code: `const a = 1; const [ , b ] = [a, a];`},
+
+			// ---- Dimension 4: body-absent forms ----
+			// Overload signatures must be adjacent to the implementation in
+			// TypeScript, so a reference can never land between them; both the
+			// signature-first and implementation-first orders resolve to the
+			// same merged binding.
+			{Code: `function f(a: string): void; function f(a: number): void; function f(a: any) {} f(1);`},
+			{Code: `declare function g(): void; g();`},
+			{Code: `declare class K { m(): void; } new K();`},
+			{Code: `abstract class A { abstract m(): void; } class B extends A { m() {} }`},
+
+			// N/A: Dimension 3 (autofix boundaries) — the rule reports only, it
+			// has no autofix and no suggestions.
+			// N/A: Dimension 4 receiver-wrapper rows for `X!.y` / `(X as T).y` on
+			// the *reported* node — the rule always reports the bare identifier,
+			// never a wrapped expression; the wrapper rows are exercised on the
+			// invalid side instead, where they must not hide the reference.
+
+			// ---- Locks in upstream isEvaluatedDuringInitialization() arm 3:
+			// SENTINEL_TYPE break, reached through a parameter with no default ----
+			{Code: `function f(a) { a; }`},
+			// ESTree wraps a shorthand method body in a FunctionExpression,
+			// which is a SENTINEL_TYPE; tsgo has no wrapper, so the walk has to
+			// stop at the member node itself. Otherwise it escapes the method
+			// and finds the enclosing initializer, flagging every parameter
+			// read inside. Caught by a differential run against ESLint.
+			{Code: `const api = { get(node, opts) { return node.range[opts]; } };`},
+			{Code: `const api = { set value(node) { use(node); } };`},
+			{Code: `const api = { get value() { return 1; } };`},
+			{Code: `class C { m(node, opts) { return node.range[opts]; } }`},
+			{Code: `class C { constructor(node) { this.node = node; } }`},
+			{Code: `class C { get value() { return 1; } set value(node) { use(node); } }`},
+			{Code: `const api = { *gen(node) { yield node; } };`},
+			{Code: `const api = { async run(node) { return node; } };`},
+			// ---- Dimension 4: an `import(...)` type qualifier names an export
+			// of the other module, not a binding here. Caught by a differential
+			// run against ESLint. ----
+			{Code: `type T = typeof import('./m').later; let later;`},
+			{Code: `type T = typeof import('./m').a.b; let a;`},
+			{Code: `type T = import('./m').Later; let Later;`},
+			// ---- Locks in upstream isEvaluatedDuringInitialization() arm 3:
+			// SENTINEL_TYPE break at an ImportDeclaration ----
+			{Code: `import { a } from './m'; a;`},
+			// ---- Locks in upstream isEvaluatedDuringInitialization() arm 1:
+			// VariableDeclarator with no initializer falls through to `return false` ----
+			{Code: `var a; a;`},
+			// ---- Locks in upstream isInRange(): a nil range never contains a
+			// location — a static field with no value can't cover a computed key ----
+			{Code: `class C { static blank; }`},
+
+			// ---- Locks in upstream isClassStaticInitializerRange() arm 1:
+			// a static block covers the location ----
+			{Code: `class C { x = 1; static { C; } }`},
+			// ---- Locks in upstream isClassStaticInitializerRange() arm 2:
+			// a static field's value covers the location ----
+			{Code: `class C { static x = C; }`},
+
+			// ---- Locks in upstream shouldCheck() TSQualifiedName arm: a
+			// namespace member is not a binding, so only the left-most name is
+			// checked ----
+			{Code: `namespace A { export const Later = 1; } import Z = A.Later; const Later = 2;`},
+
+			// ---- Locks in upstream shouldCheck() referenceContainsTypeQuery():
+			// a nested `typeof A.B.C` behind a qualified name is still a type query ----
+			{Code: `interface I { t: typeof Ns.Inner.Deep } namespace Ns { export namespace Inner { export const Deep = 1; } }`},
+
+			// ---- Locks in upstream shouldCheck() isClassRefInClassDecorator():
+			// a class self-reference inside its own decorator is safe ----
+			{Code: `@register(Widget) class Widget {}`},
+
+			// ---- Options: each boolean asserted in its non-default direction ----
+			{Code: `f(); function f() {}`, Options: map[string]any{"functions": false}},
+			{Code: `function make() { return new C(); } class C {}`, Options: map[string]any{"classes": false}},
+			{Code: `function read() { return v; } let v;`, Options: map[string]any{"variables": false}},
+			{Code: `export { later }; const later = 1;`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `const v = E.A; enum E { A }`, Options: map[string]any{"enums": false}},
+			{Code: `let v: Later; type Later = string;`, Options: map[string]any{"typedefs": false, "ignoreTypeReferences": false}},
+			{Code: `let v: Later; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": true}},
+			// All seven options set explicitly to their defaults must behave
+			// exactly like passing no options at all.
+			{Code: `const a = 1; a;`, Options: map[string]any{
+				"functions": true, "classes": true, "variables": true,
+				"allowNamedExports": false, "enums": true, "typedefs": true,
+				"ignoreTypeReferences": true,
+			}},
+
+			// ---- Real-user: mutually recursive function declarations — the shape
+			// `functions: false` exists for ----
+			{Code: `function isEven(n) { return n === 0 ? true : isOdd(n - 1); } function isOdd(n) { return n === 0 ? false : isEven(n - 1); }`, Options: map[string]any{"functions": false}},
+			// ---- Real-user: circular type references (typescript-eslint#2572
+			// family) — a type alias may name a type declared later ----
+			{Code: `interface Node { children: Leaf[] } interface Leaf { parent: Node }`},
+			{Code: `type Tree = { left: Branch }; type Branch = { value: Tree };`},
+			// ---- Real-user: typescript-eslint#2824 — Angular's forwardRef
+			// pattern names the class from inside its own decorator metadata ----
+			{Code: `
+@Component({
+  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => MyControl) }],
+})
+export class MyControl {}
+`},
+			// ---- Real-user: a component referenced from a callback that runs
+			// later is a separate execution context, which `variables: false`
+			// keys off ----
+			{Code: `const List = () => items.map(() => Row()); const Row = () => null; const items = [];`, Tsx: true, Options: map[string]any{"variables": false}},
+			// ---- Real-user: JSX intrinsic elements are strings, not bindings,
+			// so a later binding with the same name is irrelevant ----
+			{Code: `<div />; let div;`, Tsx: true},
+			{Code: `<a:b />; let a;`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: receiver / expression wrappers must not hide the
+			// reference. tsgo keeps parentheses, non-null, and type-assertion
+			// wrappers as real nodes where ESTree flattens or omits them. ----
+			{
+				Code:   `(a).b; var a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 2, EndLine: 1, EndColumn: 3}},
+			},
+			{
+				Code:   `((a)).b; var a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 3}},
+			},
+			{
+				Code:   `a!.b; var a = { b: 1 };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `(a as any).b; var a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 2}},
+			},
+			{
+				Code:   `(a satisfies unknown); var a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 2}},
+			},
+			{
+				Code:   `a?.(); var a = () => {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `(a); var a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 2}},
+			},
+
+			// ---- Dimension 4: access / key forms — the computed key and the
+			// element-access argument DO read bindings ----
+			{
+				Code:   `const o = { [a]: 1 }; let a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `const o = { a }; let a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 13}},
+			},
+			{
+				Code:   `obj[a]; let a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 5}},
+			},
+
+			// ---- Dimension 4: declaration / container forms ----
+			{
+				Code:   `f(); async function f() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `f(); function* f() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `f(); async function* f() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				// A class-field arrow is a separate execution context, so this
+				// reports only because the binding is declared later.
+				Code:   `class C { handler = () => later; } let later;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 27}},
+			},
+
+			// ---- Dimension 4: nesting / traversal boundaries — the inner
+			// function must not "inherit" the outer scope's later binding ----
+			{
+				Code:   `function outer() { function inner() { x; } var x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 39}},
+			},
+			{
+				Code:   `class Outer { m() { class Inner { m2() { return Later; } } } } class Later {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 49}},
+			},
+
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code:   `const o = { ...a }; let a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `const { ...r } = r;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+			{
+				Code:   `const {} = a; let a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+
+			// ---- Dimension 4: body-absent forms ----
+			{
+				Code:   `g(); declare function g(): void;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `f(1); function f(a: string): void; function f(a: number): void; function f(a: any) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+
+			// ---- Locks in upstream isInClassStaticInitializerRange() arm 2's
+			// `classMember.value &&` guard: a static field with no value does not
+			// cover the location, so the computed key is still a TDZ read ----
+			{
+				Code:    `class C { static blank; [C]; }`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 26}},
+			},
+
+			// ---- Locks in upstream isClassRefInClassDecorator() arm 1: a
+			// non-class binding referenced from a decorator is NOT exempt ----
+			{
+				Code:   `@register(setting) class Widget {} let setting;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 11}},
+			},
+
+			// ---- Locks in upstream shouldCheck() TSQualifiedName arm: the
+			// left-most name of a qualified reference IS checked ----
+			{
+				Code:   `import Z = A.X; namespace A { export const X = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+
+			// ---- Locks in upstream isFromSeparateExecutionContext(): a static
+			// block nested inside a static field initializer folds through two
+			// levels back to the class-definition context ----
+			{
+				Code:    `const C = class { static field = class { static { C; } }; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 51}},
+			},
+
+			// ---- Options: each boolean asserted in its default direction ----
+			{
+				Code:    `f(); function f() {}`,
+				Options: map[string]any{"functions": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:    `new C(); class C {}`,
+				Options: map[string]any{"classes": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 5}},
+			},
+			{
+				Code:    `function read() { return v; } let v;`,
+				Options: map[string]any{"variables": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 26}},
+			},
+			{
+				Code:    `const v = E.A; enum E { A }`,
+				Options: map[string]any{"enums": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 11}},
+			},
+			{
+				Code:    `let v: Later; type Later = string;`,
+				Options: map[string]any{"typedefs": true, "ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 8}},
+			},
+
+			// ---- Real-user: JSX member expressions read their left-most object
+			// whatever its casing, unlike a bare lower-case intrinsic tag ----
+			{
+				Code:   `<ns.Widget />; let ns;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 2, EndLine: 1, EndColumn: 4}},
+			},
+			// ---- Real-user: a component referenced from a JSX attribute value ----
+			{
+				Code: `<Host render={Later} />; function Host() { return null } function Later() { return null }`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 2},
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 15},
+				},
+			},
+			// ---- Real-user: mutual recursion IS reported under the default
+			// `functions: true` — the forward call really does run first ----
+			{
+				Code:   `function isEven(n) { return isOdd(n); } function isOdd(n) { return isEven(n); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 29}},
+			},
+			// ---- Dimension 4: a `let`/`const` loop binding is in its temporal
+			// dead zone while the iterated expression is evaluated ----
+			{
+				Code:   `for (let x of x) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `for (let x in x) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			// ---- Dimension 4: enum members are bindings in the enum's own
+			// scope, so one member may not read a later sibling ----
+			{
+				Code:   `enum E { A = B, B = 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 14}},
+			},
+
+			// ---- Real-user: multi-line report positions ----
+			{
+				Code: `
+function render() {
+  return Widget();
+}
+
+const Widget = () => null;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Message: "'Widget' was used before it was defined.", Line: 3, Column: 10, EndLine: 3, EndColumn: 16},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -224,6 +224,58 @@ function f(X, a = X) {
 			// ---- A name this file never declares is never reported, not even
 			// as the local half of a named export ----
 			{Code: `export { nothing };`},
+
+			// ---- `ignoreTypeReferences` exempts every type position, however
+			// the dotted name is spelled, plus the `export =` operand, which
+			// names whichever space its binding lives in ----
+			{Code: `class C implements Later {} interface Later {}`},
+			{Code: `class C implements NS.Later {} namespace NS { export interface Later {} }`},
+			{Code: `interface C extends NS.Later {} namespace NS { export interface Later {} }`},
+			{Code: `let x: NS.Later; namespace NS { export type Later = string; }`},
+			{Code: `export = X; const X = 1;`},
+			// A value-only binding does not intercept the dotted name of a
+			// heritage clause, whichever way that name is spelled.
+			{Code: `
+namespace NS {
+  export interface T {}
+}
+
+function f() {
+  class C implements NS.T {}
+  const NS = 1;
+}
+`},
+			{Code: `
+namespace NS {
+  export interface T {}
+}
+
+function f() {
+  interface C extends NS.T {}
+  const NS = 1;
+}
+`},
+
+			// ---- Nothing in a function type's signature runs, so a reference
+			// from one is never reported ----
+			{Code: `let f: (x: Later) => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `let f: (this: Later) => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `let f: new (x: Later) => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `let f: <T extends Later>() => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `interface I { (x: Later): void } type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `interface I { new (x: Later): void } type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `interface I { m(x: Later): void } type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
+
+			// ---- A `this` pseudo-parameter declares no binding, but its type
+			// annotation is a real type reference ----
+			{Code: `function f(this: Later) {} type Later = unknown;`},
+			{Code: `function f(this: number) { return this; }`},
+
+			// ---- TS resolves a string-literal member name to a real name, so
+			// the reference reads the member — which has no identifier to
+			// report at ----
+			{Code: "enum E {\n  A = ((): number => B)(),\n  \"B\" = 1,\n}", Options: map[string]any{"variables": false}},
+			{Code: "enum E {\n  A = B,\n  \"B\" = 2,\n}\nconst B = 1;"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: receiver / expression wrappers must not hide the
@@ -464,24 +516,6 @@ type Later = string;
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
 			},
 
-			// ---- `ignoreTypeReferences` keys off the syntactic shape of the
-			// reference, so only a plain `T` type annotation is exempt: an
-			// `implements` clause and an `export =` operand are not ----
-			{
-				Code:   `class C implements Later {} interface Later {}`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
-			},
-			{
-				Code:   `export = X; const X = 1;`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
-			},
-			// ---- A type-level call signature is an ordinary reference site ----
-			{
-				Code:    `let f: (x: Later) => void; type Later = string;`,
-				Options: map[string]any{"ignoreTypeReferences": false},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
-			},
-
 			// ---- A class index signature's key type and result type are
 			// references too ----
 			{
@@ -507,6 +541,36 @@ enum E {
 `,
 				Options: map[string]any{"variables": false},
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 22}},
+			},
+
+			// ---- A heritage clause spells its dotted name with property
+			// accesses; only `class ... extends` reads a value there ----
+			{
+				Code:   `class C extends NS.Base {} const NS = { Base: class {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 17}},
+			},
+			{
+				Code:    `class C implements NS.T {} namespace NS { export interface T {} }`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+
+			// ---- A `this` pseudo-parameter's type annotation is walked like
+			// any other parameter's ----
+			{
+				Code:    `function f(this: Later) {} type Later = unknown;`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+			{
+				Code:    `class K { m(this: Later) {} } type Later = unknown;`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `function f(this: NS.Later) {} namespace NS { export type Later = unknown; }`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
 			},
 		},
 	)

--- a/internal/rules/no_use_before_define/no_use_before_define_upstream_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_upstream_test.go
@@ -1,0 +1,714 @@
+// TestNoUseBeforeDefineUpstream migrates the JavaScript half of the upstream
+// valid/invalid suite from tests/lib/rules/no-use-before-define.js 1:1.
+// Position assertions cover line/column for every invalid case. The
+// TypeScript-parser half lives in no_use_before_define_upstream_typescript_test.go,
+// and rslint-specific lock-in cases live in no_use_before_define_extras_test.go.
+package no_use_before_define
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUseBeforeDefineUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUseBeforeDefineRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `unresolved`},
+			{Code: `Array`},
+			{Code: `function foo () { arguments; }`},
+			{Code: `var a=10; alert(a);`},
+			{Code: `function b(a) { alert(a); }`},
+			{Code: `Object.hasOwnProperty.call(a);`},
+			{Code: `function a() { alert(arguments);}`},
+			{Code: `a(); function a() { alert(arguments); }`, Options: "nofunc"},
+			{Code: `(() => { var a = 42; alert(a); })();`},
+			{Code: `a(); try { throw new Error() } catch (a) {}`},
+			{Code: `class A {} new A();`},
+			{Code: `var a = 0, b = a;`},
+			{Code: `var {a = 0, b = a} = {};`},
+			{Code: `var [a = 0, b = a] = {};`},
+			{Code: `function foo() { foo(); }`},
+			{Code: `var foo = function() { foo(); };`},
+			{Code: `var a; for (a in a) {}`},
+			{Code: `var a; for (a of a) {}`},
+			{Code: `let a; class C { static { a; } }`},
+			{Code: `class C { static { let a; a; } }`},
+
+			// ---- Block-level bindings ----
+			{Code: `"use strict"; a(); { function a() {} }`},
+			{Code: `"use strict"; { a(); function a() {} }`, Options: "nofunc"},
+			{Code: `switch (foo) { case 1:  { a(); } default: { let a; }}`},
+			{Code: `a(); { let a = function () {}; }`},
+
+			// ---- object style options ----
+			{Code: `a(); function a() { alert(arguments); }`, Options: map[string]any{"functions": false}},
+			{Code: `"use strict"; { a(); function a() {} }`, Options: map[string]any{"functions": false}},
+			{Code: `function foo() { new A(); } class A {};`, Options: map[string]any{"classes": false}},
+
+			// ---- "variables" option ----
+			{Code: `function foo() { bar; } var bar;`, Options: map[string]any{"variables": false}},
+			{Code: `var foo = () => bar; var bar;`, Options: map[string]any{"variables": false}},
+			{Code: `class C { static { () => foo; let foo; } }`, Options: map[string]any{"variables": false}},
+
+			// ---- Tests related to class definition evaluation. These are not TDZ errors. ----
+			{Code: `class C extends (class { method() { C; } }) {}`},
+			{Code: `(class extends (class { method() { C; } }) {});`},
+			{Code: `const C = (class extends (class { method() { C; } }) {});`},
+			{Code: `class C extends (class { field = C; }) {}`},
+			{Code: `(class extends (class { field = C; }) {});`},
+			{Code: `const C = (class extends (class { field = C; }) {});`},
+			{Code: `class C { [() => C](){} }`},
+			{Code: `(class C { [() => C](){} });`},
+			{Code: `const C = class { [() => C](){} };`},
+			{Code: `class C { static [() => C](){} }`},
+			{Code: `(class C { static [() => C](){} });`},
+			{Code: `const C = class { static [() => C](){} };`},
+			{Code: `class C { [() => C]; }`},
+			{Code: `(class C { [() => C]; });`},
+			{Code: `const C = class { [() => C]; };`},
+			{Code: `class C { static [() => C]; }`},
+			{Code: `(class C { static [() => C]; });`},
+			{Code: `const C = class { static [() => C]; };`},
+			{Code: `class C { method() { C; } }`},
+			{Code: `(class C { method() { C; } });`},
+			{Code: `const C = class { method() { C; } };`},
+			{Code: `class C { static method() { C; } }`},
+			{Code: `(class C { static method() { C; } });`},
+			{Code: `const C = class { static method() { C; } };`},
+			{Code: `class C { field = C; }`},
+			{Code: `(class C { field = C; });`},
+			{Code: `const C = class { field = C; };`},
+			{Code: `class C { static field = C; }`},
+			// `const C = class { static field = C; };` is a TDZ error — see the invalid suite.
+			{Code: `(class C { static field = C; });`},
+			{Code: `class C { static field = class { static field = C; }; }`},
+			{Code: `(class C { static field = class { static field = C; }; });`},
+			{Code: `class C { field = () => C; }`},
+			{Code: `(class C { field = () => C; });`},
+			{Code: `const C = class { field = () => C; };`},
+			{Code: `class C { static field = () => C; }`},
+			{Code: `(class C { static field = () => C; });`},
+			{Code: `const C = class { static field = () => C; };`},
+			{Code: `class C { field = class extends C {}; }`},
+			{Code: `(class C { field = class extends C {}; });`},
+			{Code: `const C = class { field = class extends C {}; }`},
+			{Code: `class C { static field = class extends C {}; }`},
+			// `const C = class { static field = class extends C {}; };` is a TDZ error.
+			{Code: `(class C { static field = class extends C {}; });`},
+			{Code: `class C { static field = class { [C]; }; }`},
+			// `const C = class { static field = class { [C]; } };` is a TDZ error.
+			{Code: `(class C { static field = class { [C]; }; });`},
+			{Code: `const C = class { static field = class { field = C; }; };`},
+			{Code: `class C { method() { a; } } let a;`, Options: map[string]any{"variables": false}},
+			{Code: `class C { static method() { a; } } let a;`, Options: map[string]any{"variables": false}},
+			// `class C { static field = a; } let a;` is a TDZ error.
+			{Code: `class C { field = a; } let a;`, Options: map[string]any{"variables": false}},
+			// `class C { static field = D; } class D {}` is a TDZ error.
+			{Code: `class C { field = D; } class D {}`, Options: map[string]any{"classes": false}},
+			// `class C { static field = class extends D {}; } class D {}` is a TDZ error.
+			{Code: `class C { field = class extends D {}; } class D {}`, Options: map[string]any{"classes": false}},
+			{Code: `class C { field = () => a; } let a;`, Options: map[string]any{"variables": false}},
+			{Code: `class C { static field = () => a; } let a;`, Options: map[string]any{"variables": false}},
+			{Code: `class C { field = () => D; } class D {}`, Options: map[string]any{"classes": false}},
+			{Code: `class C { static field = () => D; } class D {}`, Options: map[string]any{"classes": false}},
+			{Code: `class C { static field = class { field = a; }; } let a;`, Options: map[string]any{"variables": false}},
+			// `const C = class { static { C; } }` is a TDZ error.
+			{Code: `class C { static { C; } }`},
+			{Code: `class C { static { C; } static {} static { C; } }`},
+			{Code: `(class C { static { C; } })`},
+			{Code: `class C { static { class D extends C {} } }`},
+			{Code: `class C { static { (class { static { C } }) } }`},
+			{Code: `class C { static { () => C; } }`},
+			{Code: `(class C { static { () => C; } })`},
+			{Code: `const C = class { static { () => C; } }`},
+			{Code: `class C { static { () => D; } } class D {}`, Options: map[string]any{"classes": false}},
+			{Code: `class C { static { () => a; } } let a;`, Options: map[string]any{"variables": false}},
+			{Code: `const C = class C { static { C.x; } }`},
+
+			// ---- "allowNamedExports" option ----
+			{Code: `export { a }; const a = 1;`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `export { a as b }; const a = 1;`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `export { a, b }; let a, b;`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `export { a }; var a;`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `export { f }; function f() {}`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `export { C }; class C {}`, Options: map[string]any{"allowNamedExports": true}},
+
+			// ---- JSX ----
+			{Code: `const App = () => <div/>; <App />;`, Tsx: true},
+			{Code: `let Foo, Bar; <Foo><Bar /></Foo>;`, Tsx: true},
+			{Code: `function App() { return <div/> } <App />;`, Tsx: true},
+			{Code: `<App />; function App() { return <div/> }`, Tsx: true, Options: map[string]any{"functions": false}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Upstream repeats this case three times, for `sourceType: module`,
+			// `ecmaVersion: 6`, and the tester default. rslint models none of
+			// those as scope-affecting, so one case covers all three.
+			{
+				Code:   `a++; var a=19;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Message: "'a' was used before it was defined.", Line: 1, Column: 1, EndLine: 1, EndColumn: 2}},
+			},
+			{
+				Code:   `a(); var a=function() {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `alert(a[1]); var a=[1,3];`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 7}},
+			},
+			{
+				Code: `a(); function a() { alert(b); var b=10; a(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 1},
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:    `a(); var a=function() {};`,
+				Options: "nofunc",
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `(() => { alert(a); var a = 42; })();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `(() => a())(); function a() { }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 8}},
+			},
+			{
+				// SKIP: rslint does not model ESLint's ecmaVersion-dependent
+				// function-in-block hoisting. Upstream reports here only under
+				// `ecmaVersion: 5`; the `ecmaVersion: 6` copy of this exact code
+				// is a valid case above, and that is the behavior rslint has.
+				Skip:   true,
+				Code:   `"use strict"; a(); { function a() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `a(); try { throw new Error() } catch (foo) {var a;}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `var f = () => a; var a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `new A(); class A {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Message: "'A' was used before it was defined.", Line: 1, Column: 5}},
+			},
+			{
+				Code:   `function foo() { new A(); } class A {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 22}},
+			},
+			{
+				Code:   `new A(); var A = class {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 5}},
+			},
+			{
+				Code:   `function foo() { new A(); } var A = class {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 22}},
+			},
+
+			// ---- Block-level bindings ----
+			{
+				Code:   `a++; { var a; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `"use strict"; { a(); function a() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 17}},
+			},
+			{
+				Code:   `{a; let a = 1}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 2}},
+			},
+			{
+				Code:   "switch (foo) { case 1: a();\n default: \n let a;}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 24}},
+			},
+			{
+				Code:   `if (true) { function foo() { a; } let a;}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 30}},
+			},
+
+			// ---- object style options ----
+			{
+				Code:    `a(); var a=function() {};`,
+				Options: map[string]any{"functions": false, "classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+			{
+				Code:    `new A(); class A {};`,
+				Options: map[string]any{"functions": false, "classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 5}},
+			},
+			{
+				Code:    `new A(); var A = class {};`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 5}},
+			},
+			{
+				Code:    `function foo() { new A(); } var A = class {};`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 22}},
+			},
+
+			// ---- invalid initializers ----
+			{
+				Code:   `var a = a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `let a = a + b;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `const a = foo(a);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `function foo(a = a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+			{
+				Code:   `var {a = a} = [];`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var [a = a] = [];`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var {b = a, a} = {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var [b = a, a] = {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var {a = 0} = a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `var [a = 0] = a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `for (var a in a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `for (var a of a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+
+			// ---- "variables" option ----
+			{
+				Code:    `function foo() { bar; var bar = 1; } var bar;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+			{
+				Code:    `foo; var foo;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 1}},
+			},
+
+			// ---- https://github.com/eslint/eslint/issues/10227 ----
+			{
+				Code:   `for (let x = x;;); let x = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `for (let x in xs); let xs = []`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `for (let x of xs); let xs = []`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `try {} catch ({message = x}) {} let x = ''`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 26}},
+			},
+			{
+				Code:   `with (obj) x; let x = {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+
+			// ---- WithStatements ----
+			{
+				Code:   `with (x); let x = {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 7}},
+			},
+			{
+				Code:   `with (obj) { x } let x = {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `with (obj) { if (a) { x } } let x = {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 23}},
+			},
+			{
+				Code:   `with (obj) { (() => { if (a) { x } })() } let x = {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 32}},
+			},
+
+			// ---- Tests related to class definition evaluation. These are TDZ errors. ----
+			{
+				Code:    `class C extends C {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 17}},
+			},
+			{
+				Code:    `const C = class extends C {};`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 25}},
+			},
+			{
+				Code:    `class C extends (class { [C](){} }) {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 27}},
+			},
+			{
+				Code:    `const C = class extends (class { [C](){} }) {};`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 35}},
+			},
+			{
+				Code:    `class C extends (class { static field = C; }) {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 41}},
+			},
+			{
+				Code:    `const C = class extends (class { static field = C; }) {};`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 49}},
+			},
+			{
+				Code:    `class C { [C](){} }`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `(class C { [C](){} });`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 13}},
+			},
+			{
+				Code:    `const C = class { [C](){} };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `class C { static [C](){} }`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `(class C { static [C](){} });`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `const C = class { static [C](){} };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 27}},
+			},
+			{
+				Code:    `class C { [C]; }`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `(class C { [C]; });`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 13}},
+			},
+			{
+				Code:    `const C = class { [C]; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `class C { [C] = foo; }`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `(class C { [C] = foo; });`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 13}},
+			},
+			{
+				Code:    `const C = class { [C] = foo; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `class C { static [C]; }`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `(class C { static [C]; });`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `const C = class { static [C]; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 27}},
+			},
+			{
+				Code:    `class C { static [C] = foo; }`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `(class C { static [C] = foo; });`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `const C = class { static [C] = foo; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 27}},
+			},
+			{
+				Code:    `const C = class { static field = C; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 34}},
+			},
+			{
+				Code:    `const C = class { static field = class extends C {}; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 48}},
+			},
+			{
+				Code:    `const C = class { static field = class { [C]; } };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 43}},
+			},
+			{
+				Code:    `const C = class { static field = class { static field = C; }; };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 57}},
+			},
+			{
+				Code:    `class C extends D {} class D {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 17}},
+			},
+			{
+				Code:    `class C extends (class { [a](){} }) {} let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 27}},
+			},
+			{
+				Code:    `class C extends (class { static field = a; }) {} let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 41}},
+			},
+			{
+				Code:    `class C { [a]() {} } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `class C { static [a]() {} } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `class C { [a]; } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `class C { static [a]; } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `class C { [a] = foo; } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `class C { static [a] = foo; } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `class C { static field = a; } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 26}},
+			},
+			{
+				Code:    `class C { static field = D; } class D {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 26}},
+			},
+			{
+				Code:    `class C { static field = class extends D {}; } class D {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 40}},
+			},
+			{
+				Code:    `class C { static field = class { [a](){} } } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 35}},
+			},
+			{
+				Code:    `class C { static field = class { static field = a; }; } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 49}},
+			},
+			{
+				Code:    `const C = class { static { C; } };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 28}},
+			},
+			{
+				Code:    `const C = class { static { (class extends C {}); } };`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 43}},
+			},
+			{
+				Code:    `class C { static { a; } } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `class C { static { D; } } class D {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `class C { static { (class extends D {}); } } class D {}`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 35}},
+			},
+			{
+				Code:    `class C { static { (class { [a](){} }); } } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 30}},
+			},
+			{
+				Code:    `class C { static { (class { static field = a; }); } } let a;`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 44}},
+			},
+			{
+				Code:    `(class C extends C {});`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+			{
+				Code:    `(class C extends (class { [C](){} }) {});`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 28}},
+			},
+			{
+				Code:    `(class C extends (class { static field = C; }) {});`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 42}},
+			},
+
+			// ---- "allowNamedExports" option ----
+			{
+				Code:   `export { a }; const a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `export { a }; const a = 1;`,
+				Options: map[string]any{},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `export { a }; const a = 1;`,
+				Options: map[string]any{"allowNamedExports": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `export { a }; const a = 1;`,
+				Options: "nofunc",
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `export { a as b }; const a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code: `export { a, b }; let a, b;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 10},
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `export { a }; var a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `export { f }; function f() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `export { C }; class C {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `export const foo = a; const a = 1;`,
+				Options: map[string]any{"allowNamedExports": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:    `export default a; const a = 1;`,
+				Options: map[string]any{"allowNamedExports": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 16}},
+			},
+			{
+				Code:    `export function foo() { return a; }; const a = 1;`,
+				Options: map[string]any{"allowNamedExports": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 32}},
+			},
+			{
+				Code:    `export class C { foo() { return a; } }; const a = 1;`,
+				Options: map[string]any{"allowNamedExports": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 33}},
+			},
+
+			// ---- JSX ----
+			{
+				Code: `<App />; const App = () => <div />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Message: "'App' was used before it was defined.", Line: 1, Column: 2, EndLine: 1, EndColumn: 5},
+				},
+			},
+			{
+				Code: `function render() { return <Widget /> }; const Widget = () => <span />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 29, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code: `<Foo.Bar />; const Foo = { Bar: () => <div/> };`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 2, EndLine: 1, EndColumn: 5},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_use_before_define/no_use_before_define_upstream_typescript_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_upstream_typescript_test.go
@@ -1,0 +1,1010 @@
+// TestNoUseBeforeDefineUpstreamTypescript migrates the TypeScript-parser half
+// of the upstream valid/invalid suite from
+// tests/lib/rules/no-use-before-define.js 1:1 — the `ruleTesterTypeScript`
+// block covering the `enums`, `typedefs`, and `ignoreTypeReferences` options
+// plus TS-only syntax. Position assertions cover line/column for every invalid
+// case. The JavaScript half lives in no_use_before_define_upstream_test.go, and
+// rslint-specific lock-in cases live in no_use_before_define_extras_test.go.
+package no_use_before_define
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUseBeforeDefineUpstreamTypescript(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUseBeforeDefineRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+type foo = 1;
+const x: foo = 1;
+`},
+			{Code: `
+type foo = 1;
+type bar = foo;
+`},
+			{Code: `
+interface Foo {}
+const x: Foo = {};
+`},
+			{Code: `
+var a = 10;
+alert(a);
+`},
+			{Code: `
+function b(a) {
+  alert(a);
+}
+`},
+			{Code: `Object.hasOwnProperty.call(a);`},
+			{Code: `
+function a() {
+  alert(arguments);
+}
+`},
+			{Code: `declare function a();`},
+			{Code: `
+declare class a {
+  foo();
+}
+`},
+			{Code: `const updatedAt = data?.updatedAt;`},
+			{Code: `
+function f() {
+  return function t() {};
+}
+f()?.();
+`},
+			{Code: `
+var a = { b: 5 };
+alert(a?.b);
+`},
+			{Code: `
+a();
+function a() {
+  alert(arguments);
+}
+`, Options: "nofunc"},
+			{Code: `
+(() => {
+  var a = 42;
+  alert(a);
+})();
+`},
+			{Code: `
+a();
+try {
+  throw new Error();
+} catch (a) {}
+`},
+			{Code: `
+class A {}
+new A();
+`},
+			{Code: `
+var a = 0,
+  b = a;
+`},
+			{Code: `var { a = 0, b = a } = {};`},
+			{Code: `var [a = 0, b = a] = {};`},
+			{Code: `
+function foo() {
+  foo();
+}
+`},
+			{Code: `
+var foo = function () {
+  foo();
+};
+`},
+			{Code: `
+var a;
+for (a in a) {
+}
+`},
+			{Code: `
+var a;
+for (a of a) {
+}
+`},
+
+			// ---- Block-level bindings ----
+			{Code: `
+'use strict';
+a();
+{
+  function a() {}
+}
+`},
+			{Code: `
+'use strict';
+{
+  a();
+  function a() {}
+}
+`, Options: "nofunc"},
+			{Code: `
+switch (foo) {
+  case 1: {
+    a();
+  }
+  default: {
+    let a;
+  }
+}
+`},
+			{Code: `
+a();
+{
+  let a = function () {};
+}
+`},
+
+			// ---- object style options ----
+			{Code: `
+a();
+function a() {
+  alert(arguments);
+}
+`, Options: map[string]any{"functions": false}},
+			{Code: `
+'use strict';
+{
+  a();
+  function a() {}
+}
+`, Options: map[string]any{"functions": false}},
+			{Code: `
+function foo() {
+  new A();
+}
+class A {}
+`, Options: map[string]any{"classes": false}},
+
+			// ---- "variables" option ----
+			{Code: `
+function foo() {
+  bar;
+}
+var bar;
+`, Options: map[string]any{"variables": false}},
+			{Code: `
+var foo = () => bar;
+var bar;
+`, Options: map[string]any{"variables": false}},
+
+			// ---- "typedefs" option ----
+			{Code: `
+var x: Foo = 2;
+type Foo = string | number;
+`, Options: map[string]any{"typedefs": false}},
+			{Code: `
+var x: Foo = {};
+interface Foo {}
+`, Options: map[string]any{"typedefs": false, "ignoreTypeReferences": false}},
+			{Code: `
+let myVar: String;
+type String = string;
+`, Options: map[string]any{"typedefs": false, "ignoreTypeReferences": false}},
+
+			// ---- https://github.com/typescript-eslint/typescript-eslint/issues/2572 ----
+			{Code: `
+interface Bar {
+  type: typeof Foo;
+}
+
+const Foo = 2;
+`, Options: map[string]any{"ignoreTypeReferences": true}},
+			{Code: `
+interface Bar {
+  type: typeof Foo.FOO;
+}
+
+class Foo {
+  public static readonly FOO = '';
+}
+`, Options: map[string]any{"ignoreTypeReferences": true}},
+			{Code: `
+interface Bar {
+  type: typeof Foo.Bar.Baz;
+}
+
+const Foo = {
+  Bar: {
+    Baz: 1,
+  },
+};
+`, Options: map[string]any{"ignoreTypeReferences": true}},
+
+			// ---- https://github.com/bradzacher/eslint-plugin-typescript/issues/141 ----
+			{Code: `
+interface ITest {
+  first: boolean;
+  second: string;
+  third: boolean;
+}
+
+let first = () => console.log('first');
+
+export let second = () => console.log('second');
+
+export namespace Third {
+  export let third = () => console.log('third');
+}
+`},
+
+			// ---- https://github.com/eslint/typescript-eslint-parser/issues/550 ----
+			{Code: `
+function test(file: Blob) {
+  const slice: typeof file.slice =
+    file.slice || (file as any).webkitSlice || (file as any).mozSlice;
+  return slice;
+}
+`},
+
+			// ---- https://github.com/eslint/typescript-eslint-parser/issues/435 ----
+			{Code: `
+interface Foo {
+  bar: string;
+}
+const bar = 'blah';
+`},
+
+			// ---- "enums" option ----
+			{Code: `
+function foo(): Foo {
+  return Foo.FOO;
+}
+
+enum Foo {
+  FOO,
+}
+`, Options: map[string]any{"enums": false}},
+			{Code: `
+let foo: Foo;
+
+enum Foo {
+  FOO,
+}
+`, Options: map[string]any{"enums": false}},
+			{Code: `
+class Test {
+  foo(args: Foo): Foo {
+    return Foo.FOO;
+  }
+}
+
+enum Foo {
+  FOO,
+}
+`, Options: map[string]any{"enums": false}},
+
+			// ---- "allowNamedExports" option ----
+			{Code: `
+export { a };
+const a = 1;
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { a as b };
+const a = 1;
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { a, b };
+let a, b;
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { a };
+var a;
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { f };
+function f() {}
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { C };
+class C {}
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { Foo };
+
+enum Foo {
+  BAR,
+}
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { Foo };
+
+namespace Foo {
+  export let bar = () => console.log('bar');
+}
+`, Options: map[string]any{"allowNamedExports": true}},
+			{Code: `
+export { Foo, baz };
+
+enum Foo {
+  BAR,
+}
+
+let baz: Enum;
+enum Enum {}
+`, Options: map[string]any{"allowNamedExports": true}},
+
+			// ---- https://github.com/typescript-eslint/typescript-eslint/issues/2502 ----
+			{Code: `
+import * as React from 'react';
+
+<div />;
+`, Tsx: true},
+			{Code: `
+import React from 'react';
+
+<div />;
+`, Tsx: true},
+			// Upstream sets `parserOptions.jsxPragma: 'h'` here. rslint does not
+			// model a JSX pragma, so `<div />` simply references nothing — which
+			// is the same verdict.
+			{Code: `
+import { h } from 'preact';
+
+<div />;
+`, Tsx: true},
+			{Code: `
+const React = require('react');
+
+<div />;
+`, Tsx: true},
+
+			// ---- https://github.com/typescript-eslint/typescript-eslint/issues/2527 ----
+			{Code: `
+type T = (value: unknown) => value is Id;
+`},
+			{Code: `
+global.foo = true;
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      foo?: boolean;
+    }
+  }
+}
+`},
+
+			// ---- https://github.com/typescript-eslint/typescript-eslint/issues/2824 ----
+			{Code: `
+@Directive({
+  selector: '[rcCidrIpPattern]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: CidrIpPatternDirective,
+      multi: true,
+    },
+  ],
+})
+export class CidrIpPatternDirective implements Validator {}
+`},
+			{Code: `
+@Directive({
+  selector: '[rcCidrIpPattern]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: CidrIpPatternDirective,
+      multi: true,
+    },
+  ],
+})
+export class CidrIpPatternDirective implements Validator {}
+`, Options: map[string]any{"classes": false}},
+
+			// ---- https://github.com/typescript-eslint/typescript-eslint/issues/2941 ----
+			{Code: `
+class A {
+  constructor(printName) {
+    this.printName = printName;
+  }
+
+  openPort(printerName = this.printerName) {
+    this.tscOcx.ActiveXopenport(printerName);
+
+    return this;
+  }
+}
+`},
+			{Code: "\nconst obj = {\n  foo: 'foo-value',\n  bar: 'bar-value',\n} satisfies {\n  [key in 'foo' | 'bar']: `${key}-value`;\n};\n",
+				Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: "\nconst obj = {\n  foo: 'foo-value',\n  bar: 'bar-value',\n} as {\n  [key in 'foo' | 'bar']: `${key}-value`;\n};\n",
+				Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `
+const obj = {
+  foo: {
+    foo: 'foo',
+  } as {
+    [key in 'foo' | 'bar']: key;
+  },
+};
+`, Options: map[string]any{"ignoreTypeReferences": false}},
+			{Code: `
+const foo = {
+  bar: 'bar',
+} satisfies {
+  bar: typeof baz;
+};
+
+const baz = '';
+`, Options: map[string]any{"ignoreTypeReferences": true}},
+			{Code: `
+namespace A.X.Y {}
+
+import Z = A.X.Y;
+
+const X = 23;
+`},
+			{Code: `
+namespace A {
+  export namespace X {
+    export namespace Y {
+      export const foo = 40;
+    }
+  }
+}
+
+import Z = A.X.Y;
+
+const X = 23;
+`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Upstream repeats this case for `sourceType: module`,
+			// `ecmaVersion: 6`, and the tester default; rslint models none of
+			// those as scope-affecting, so one case covers all three.
+			{
+				Code: `
+a++;
+var a = 19;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Message: "'a' was used before it was defined.", Line: 2, Column: 1, EndLine: 2, EndColumn: 2}},
+			},
+			{
+				Code: `
+a();
+var a = function () {};
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+alert(a[1]);
+var a = [1, 3];
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 7}},
+			},
+			{
+				Code: `
+a();
+function a() {
+  alert(b);
+  var b = 10;
+  a();
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 2, Column: 1},
+					{MessageId: "usedBeforeDefined", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+a();
+var a = function () {};
+`,
+				Options: "nofunc",
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+(() => {
+  alert(a);
+  var a = 42;
+})();
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 9}},
+			},
+			{
+				Code: `
+(() => a())();
+function a() {}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 8}},
+			},
+			{
+				Code: `
+a();
+try {
+  throw new Error();
+} catch (foo) {
+  var a;
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+var f = () => a;
+var a;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 15}},
+			},
+			{
+				Code: `
+new A();
+class A {}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 5}},
+			},
+			{
+				Code: `
+function foo() {
+  new A();
+}
+class A {}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 7}},
+			},
+			{
+				Code: `
+new A();
+var A = class {};
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 5}},
+			},
+			{
+				Code: `
+function foo() {
+  new A();
+}
+var A = class {};
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 7}},
+			},
+
+			// ---- Block-level bindings ----
+			{
+				Code: `
+a++;
+{
+  var a;
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+'use strict';
+{
+  a();
+  function a() {}
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 4, Column: 3}},
+			},
+			{
+				Code: `
+{
+  a;
+  let a = 1;
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 3}},
+			},
+			{
+				Code: `
+switch (foo) {
+  case 1:
+    a();
+  default:
+    let a;
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 4, Column: 5}},
+			},
+			{
+				Code: `
+if (true) {
+  function foo() {
+    a;
+  }
+  let a;
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 4, Column: 5}},
+			},
+
+			// ---- object style options ----
+			{
+				Code: `
+a();
+var a = function () {};
+`,
+				Options: map[string]any{"classes": false, "functions": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+new A();
+var A = class {};
+`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 5}},
+			},
+			{
+				Code: `
+function foo() {
+  new A();
+}
+var A = class {};
+`,
+				Options: map[string]any{"classes": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 7}},
+			},
+
+			// ---- invalid initializers ----
+			{
+				Code:   `var a = a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `let a = a + b;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `const a = foo(a);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `function foo(a = a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 18}},
+			},
+			{
+				Code:   `var { a = a } = [];`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 11}},
+			},
+			{
+				Code:   `var [a = a] = [];`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var { b = a, a } = {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 11}},
+			},
+			{
+				Code:   `var [b = a, a] = {};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var { a = 0 } = a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 17}},
+			},
+			{
+				Code:   `var [a = 0] = a;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code: `
+for (var a in a) {
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 15}},
+			},
+			{
+				Code: `
+for (var a of a) {
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 15}},
+			},
+
+			// ---- "ignoreTypeReferences" option ----
+			{
+				Code: `
+interface Bar {
+  type: typeof Foo;
+}
+
+const Foo = 2;
+`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 16}},
+			},
+			{
+				Code: `
+let var1: StringOrNumber;
+
+type StringOrNumber = string | number;
+`,
+				Options: map[string]any{"ignoreTypeReferences": false, "typedefs": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 11}},
+			},
+			{
+				Code: `
+interface Bar {
+  type: typeof Foo.FOO;
+}
+
+class Foo {
+  public static readonly FOO = '';
+}
+`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 16}},
+			},
+			{
+				Code: `
+interface Bar {
+  type: typeof Foo.Bar.Baz;
+}
+
+const Foo = {
+  Bar: {
+    Baz: 1,
+  },
+};
+`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 16}},
+			},
+			{
+				Code: `
+const foo = {
+  bar: 'bar',
+} satisfies {
+  bar: typeof baz;
+};
+
+const baz = '';
+`,
+				Options: map[string]any{"ignoreTypeReferences": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 5, Column: 15}},
+			},
+
+			// ---- "variables" option ----
+			{
+				Code: `
+function foo() {
+  bar;
+  var bar = 1;
+}
+var bar;
+`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 3}},
+			},
+
+			// ---- "enums" option ----
+			{
+				Code: `
+class Test {
+  foo(args: Foo): Foo {
+    return Foo.FOO;
+  }
+}
+
+enum Foo {
+  FOO,
+}
+`,
+				Options: map[string]any{"enums": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 4, Column: 12}},
+			},
+			{
+				Code: `
+function foo(): Foo {
+  return Foo.FOO;
+}
+
+enum Foo {
+  FOO,
+}
+`,
+				Options: map[string]any{"enums": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 10}},
+			},
+			{
+				Code: `
+const foo = Foo.Foo;
+
+enum Foo {
+  FOO,
+}
+`,
+				Options: map[string]any{"enums": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 13}},
+			},
+
+			// ---- "allowNamedExports" option ----
+			{
+				Code: `
+export { a };
+const a = 1;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { a };
+const a = 1;
+`,
+				Options: map[string]any{},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { a };
+const a = 1;
+`,
+				Options: map[string]any{"allowNamedExports": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { a };
+const a = 1;
+`,
+				Options: "nofunc",
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { a as b };
+const a = 1;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { a, b };
+let a, b;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 2, Column: 10},
+					{MessageId: "usedBeforeDefined", Line: 2, Column: 13},
+				},
+			},
+			{
+				Code: `
+export { a };
+var a;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { f };
+function f() {}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { C };
+class C {}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export const foo = a;
+const a = 1;
+`,
+				Options: map[string]any{"allowNamedExports": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 20}},
+			},
+			{
+				Code: `
+export function foo() {
+  return a;
+}
+const a = 1;
+`,
+				Options: map[string]any{"allowNamedExports": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 10}},
+			},
+			{
+				Code: `
+export class C {
+  foo() {
+    return a;
+  }
+}
+const a = 1;
+`,
+				Options: map[string]any{"allowNamedExports": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 4, Column: 12}},
+			},
+			{
+				Code: `
+export { Foo };
+
+enum Foo {
+  BAR,
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { Foo };
+
+namespace Foo {
+  export let bar = () => console.log('bar');
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 10}},
+			},
+			{
+				Code: `
+export { Foo, baz };
+
+enum Foo {
+  BAR,
+}
+
+let baz: Enum;
+enum Enum {}
+`,
+				Options: map[string]any{"allowNamedExports": false, "ignoreTypeReferences": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 2, Column: 10},
+					{MessageId: "usedBeforeDefined", Line: 2, Column: 15},
+				},
+			},
+			{
+				Code: `
+f();
+function f() {}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+alert(a);
+var a = 10;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 7}},
+			},
+			{
+				Code: `
+f()?.();
+function f() {
+  return function t() {};
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+alert(a?.b);
+var a = { b: 5 };
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 2, Column: 7}},
+			},
+			{
+				Code: `
+@decorator
+class C {
+  static x = 'foo';
+  [C.x]() {}
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 5, Column: 4}},
+			},
+		},
+	)
+}

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -9,7 +9,8 @@ import (
 // declarations belonging to the scope, then a visiting pass that descends into
 // the children which open nested scopes.
 type builder struct {
-	manager *Manager
+	manager           *Manager
+	collectReferences bool
 }
 
 func (b *builder) push(kind Kind, block *ast.Node, parent *Scope) *Scope {
@@ -19,6 +20,21 @@ func (b *builder) push(kind Kind, block *ast.Node, parent *Scope) *Scope {
 	}
 	b.manager.Scopes = append(b.manager.Scopes, s)
 	return s
+}
+
+// reference records `id` as a read/write of whatever binding it resolves to.
+// Declaration names, member names, labels, and other non-reference identifier
+// positions are filtered out by isReferenceIdentifier.
+func (b *builder) reference(id *ast.Node, s *Scope) {
+	if !b.collectReferences || id == nil || s == nil {
+		return
+	}
+	if !isReferenceIdentifier(id) {
+		return
+	}
+	ref := &Reference{Identifier: id, From: s}
+	s.References = append(s.References, ref)
+	b.manager.References = append(b.manager.References, ref)
 }
 
 func (b *builder) buildProgram(sf *ast.SourceFile) *Scope {
@@ -106,9 +122,13 @@ func (b *builder) hoistStatement(stmt *ast.Node, s *Scope, blockScope bool) {
 	case ast.KindEnumDeclaration:
 		b.addNamedDecl(stmt, s, DefEnumName, true)
 	case ast.KindModuleDeclaration:
-		// Ambient `declare module 'str' { ... }` uses a string-literal name and
-		// doesn't bind a variable — addNamedDecl skips it automatically.
-		b.addNamedDecl(stmt, s, DefNamespaceName, true)
+		// `declare global { ... }` reopens the global scope rather than binding
+		// a namespace called `global`. Ambient `declare module 'str' { ... }`
+		// uses a string-literal name and doesn't bind a variable either —
+		// addNamedDecl skips that one automatically.
+		if !ast.IsGlobalScopeAugmentation(stmt) {
+			b.addNamedDecl(stmt, s, DefNamespaceName, true)
+		}
 	case ast.KindImportDeclaration:
 		if !blockScope {
 			b.collectImport(stmt, s)
@@ -363,9 +383,16 @@ func (b *builder) visitStatement(stmt *ast.Node, parent *Scope) {
 			b.visitExpression(ea.Expression, parent)
 		}
 	case ast.KindExportDeclaration:
-		// No new scopes.
-	case ast.KindImportDeclaration, ast.KindImportEqualsDeclaration:
-		// No new scopes.
+		b.visitExportDeclaration(stmt, parent)
+	case ast.KindImportDeclaration:
+		// Bindings only; nothing to reference and no new scopes.
+	case ast.KindImportEqualsDeclaration:
+		// `import Z = A.B.C` references the left-most name of the qualified
+		// module reference; `import Z = require('m')` references nothing.
+		if ied := stmt.AsImportEqualsDeclaration(); ied != nil && ied.ModuleReference != nil &&
+			ied.ModuleReference.Kind != ast.KindExternalModuleReference {
+			b.visitExpression(ied.ModuleReference, parent)
+		}
 	case ast.KindWithStatement:
 		ws := stmt.AsWithStatement()
 		if ws != nil {
@@ -378,6 +405,36 @@ func (b *builder) visitStatement(stmt *ast.Node, parent *Scope) {
 			b.visitStatement(child, parent)
 			return false
 		})
+	}
+}
+
+// visitExportDeclaration records the local name of each `export { local as
+// exported }` specifier as a reference. Re-exports (`export { x } from 'm'`)
+// name a binding in the other module, so they reference nothing here.
+func (b *builder) visitExportDeclaration(stmt *ast.Node, parent *Scope) {
+	decl := stmt.AsExportDeclaration()
+	if decl == nil || decl.ModuleSpecifier != nil || decl.ExportClause == nil {
+		return
+	}
+	if decl.ExportClause.Kind != ast.KindNamedExports {
+		return
+	}
+	named := decl.ExportClause.AsNamedExports()
+	if named == nil || named.Elements == nil {
+		return
+	}
+	for _, elem := range named.Elements.Nodes {
+		spec := elem.AsExportSpecifier()
+		if spec == nil {
+			continue
+		}
+		local := spec.PropertyName
+		if local == nil {
+			local = spec.Name()
+		}
+		if local != nil && local.Kind == ast.KindIdentifier {
+			b.reference(local, parent)
+		}
 	}
 }
 
@@ -407,7 +464,8 @@ func (b *builder) visitVarDeclList(declList *ast.Node, parent *Scope) {
 }
 
 // visitBindingPattern recurses into destructuring defaults that may contain
-// function / class expressions creating nested scopes.
+// function / class expressions creating nested scopes, and into computed
+// property keys of object patterns.
 func (b *builder) visitBindingPattern(pattern *ast.Node, parent *Scope) {
 	if pattern == nil {
 		return
@@ -416,6 +474,11 @@ func (b *builder) visitBindingPattern(pattern *ast.Node, parent *Scope) {
 		if child.Kind == ast.KindBindingElement {
 			be := child.AsBindingElement()
 			if be != nil {
+				if be.PropertyName != nil && be.PropertyName.Kind == ast.KindComputedPropertyName {
+					if cpn := be.PropertyName.AsComputedPropertyName(); cpn != nil {
+						b.visitExpression(cpn.Expression, parent)
+					}
+				}
 				if be.Initializer != nil {
 					b.visitExpression(be.Initializer, parent)
 				}
@@ -429,12 +492,16 @@ func (b *builder) visitBindingPattern(pattern *ast.Node, parent *Scope) {
 }
 
 // visitExpression walks an expression to discover nested function/class
-// expressions and other scope-creating constructs.
+// expressions and other scope-creating constructs, recording every identifier
+// that reads a binding along the way.
 func (b *builder) visitExpression(expr *ast.Node, parent *Scope) {
 	if expr == nil {
 		return
 	}
 	switch expr.Kind {
+	case ast.KindIdentifier:
+		b.reference(expr, parent)
+		return
 	case ast.KindFunctionExpression, ast.KindArrowFunction:
 		b.visitFunctionLike(expr, parent)
 		return
@@ -447,6 +514,9 @@ func (b *builder) visitExpression(expr *ast.Node, parent *Scope) {
 		return
 	case ast.KindClassExpression:
 		b.visitClass(expr, parent, true)
+		return
+	case ast.KindMappedType:
+		b.visitMappedType(expr, parent)
 		return
 	}
 	if ast.IsFunctionTypeNode(expr) || ast.IsConstructorTypeNode(expr) ||
@@ -461,6 +531,34 @@ func (b *builder) visitExpression(expr *ast.Node, parent *Scope) {
 	}
 	expr.ForEachChild(func(child *ast.Node) bool {
 		b.visitExpression(child, parent)
+		return false
+	})
+}
+
+// visitMappedType creates a scope holding the `[K in T]` type parameter, so
+// that references to `K` in the template/value position resolve to it instead
+// of leaking outward.
+func (b *builder) visitMappedType(node *ast.Node, outer *Scope) {
+	mapped := node.AsMappedTypeNode()
+	if mapped == nil {
+		return
+	}
+	mappedScope := b.push(KindType, node, outer)
+	if mapped.TypeParameter != nil {
+		if tp := mapped.TypeParameter.AsTypeParameterDeclaration(); tp != nil &&
+			tp.Name() != nil && tp.Name().Kind == ast.KindIdentifier {
+			mappedScope.Add(&Variable{
+				Name:           tp.Name().Text(),
+				ID:             tp.Name(),
+				DefNode:        mapped.TypeParameter,
+				Parent:         mapped.TypeParameter.Parent,
+				Kind:           DefTypeParameter,
+				IsValueBinding: false,
+			})
+		}
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		b.visitExpression(child, mappedScope)
 		return false
 	})
 }
@@ -612,8 +710,8 @@ func (b *builder) addParameters(node *ast.Node, s *Scope, recurseAnnotations boo
 func (b *builder) visitFunctionLike(node *ast.Node, outer *Scope) {
 	// Computed method/accessor name (`[expr]`) is evaluated in the enclosing
 	// scope (class body or object literal context). Walk it before pushing
-	// the function's own scope so that shadows inside the key expression
-	// check against the right scope.
+	// the function's own scope so that references inside the key expression
+	// resolve against the right scope.
 	if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
 		if cpn := name.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
 			b.visitExpression(cpn.Expression, outer)
@@ -666,8 +764,8 @@ func (b *builder) visitFunctionLike(node *ast.Node, outer *Scope) {
 
 func (b *builder) visitClass(node *ast.Node, outer *Scope, isExpression bool) {
 	// Class-level decorators run BEFORE the class is defined — in the outer
-	// scope. Any shadows inside them (e.g. `@((t) => { const x = 1; })`) must
-	// be checked against outer bindings.
+	// scope. Any references inside them (e.g. `@((t) => { const x = 1; })`)
+	// must resolve against outer bindings.
 	for _, dec := range node.Decorators() {
 		b.visitExpression(dec, outer)
 	}
@@ -718,20 +816,25 @@ func (b *builder) visitClass(node *ast.Node, outer *Scope, isExpression bool) {
 			b.visitFunctionLike(member, classScope)
 		case ast.KindPropertyDeclaration:
 			// Properties don't go through visitFunctionLike — walk the
-			// computed key here.
+			// computed key and the type annotation here.
 			if memberName := member.Name(); memberName != nil && memberName.Kind == ast.KindComputedPropertyName {
 				if cpn := memberName.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
 					b.visitExpression(cpn.Expression, classScope)
 				}
 			}
+			if memberType := member.Type(); memberType != nil {
+				b.visitExpression(memberType, classScope)
+			}
+			// A field initializer is its own execution context: eslint-scope
+			// materializes a `class-field-initializer` scope for it.
 			if init := member.Initializer(); init != nil {
-				b.visitExpression(init, classScope)
+				b.visitExpression(init, b.push(KindClassFieldInitializer, init, classScope))
 			}
 		case ast.KindClassStaticBlockDeclaration:
 			sb := member.AsClassStaticBlockDeclaration()
 			if sb != nil && sb.Body != nil && sb.Body.Kind == ast.KindBlock {
-				// Static block is its own function-like variable scope for var purposes.
-				staticScope := b.push(KindFunction, member, classScope)
+				// Static block is its own variable scope for `var` purposes.
+				staticScope := b.push(KindClassStaticBlock, member, classScope)
 				block := sb.Body.AsBlock()
 				if block != nil && block.Statements != nil {
 					b.hoistStatements(block.Statements.Nodes, staticScope)
@@ -915,8 +1018,12 @@ func (b *builder) visitForInOrOf(stmt *ast.Node, outer *Scope) {
 		return
 	}
 	body := b.forInitScope(stmt, fs.Initializer, outer)
+	// The iterated expression is evaluated while a `let`/`const` loop binding is
+	// still in its temporal dead zone, so it resolves against the loop scope —
+	// eslint-scope models this with a throwaway TDZ scope around the right-hand
+	// side. `var` loop bindings hoist out, leaving `body == outer`.
 	if fs.Expression != nil {
-		b.visitExpression(fs.Expression, outer)
+		b.visitExpression(fs.Expression, body)
 	}
 	if fs.Statement != nil {
 		b.visitStatement(fs.Statement, body)
@@ -942,6 +1049,9 @@ func (b *builder) visitCatch(node *ast.Node, outer *Scope) {
 					IsValueBinding: true,
 				})
 			})
+			// Destructuring defaults (`catch ({ message = x })`) are evaluated
+			// in the catch scope.
+			b.visitBindingPattern(vd.Name(), catchScope)
 		}
 	}
 	if cc.Block != nil && cc.Block.Kind == ast.KindBlock {

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -33,7 +33,7 @@ func (b *builder) reference(id *ast.Node, s *Scope) {
 		return
 	}
 	value, isType := referenceSpaces(id)
-	ref := &Reference{Identifier: id, From: s, IsValueReference: value, IsTypeReference: isType}
+	ref := &Reference{Identifier: id, From: s, isValueReference: value, isTypeReference: isType}
 	s.References = append(s.References, ref)
 	b.manager.References = append(b.manager.References, ref)
 }

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -32,7 +32,8 @@ func (b *builder) reference(id *ast.Node, s *Scope) {
 	if !isReferenceIdentifier(id) {
 		return
 	}
-	ref := &Reference{Identifier: id, From: s}
+	value, isType := referenceSpaces(id)
+	ref := &Reference{Identifier: id, From: s, IsValueReference: value, IsTypeReference: isType}
 	s.References = append(s.References, ref)
 	b.manager.References = append(b.manager.References, ref)
 }
@@ -628,13 +629,17 @@ func (b *builder) visitFunctionType(node *ast.Node, outer *Scope) {
 	b.addTypeParameters(node, s)
 	b.addParameters(node, s, false)
 	node.ForEachChild(func(child *ast.Node) bool {
-		b.visitExpression(child, s)
+		if child.Kind != ast.KindTypeParameter {
+			b.visitExpression(child, s)
+		}
 		return false
 	})
 }
 
 // addTypeParameters records `function f<T>` / `class C<T>` / `type X<T>`
-// generic names into `s`. Each type parameter is a type-only binding.
+// generic names into `s`. Each type parameter is a type-only binding. The
+// constraint and default of every parameter are evaluated in `s` too, so that
+// `<T extends U, U = V>` sees its siblings.
 func (b *builder) addTypeParameters(node *ast.Node, s *Scope) {
 	for _, tp := range node.TypeParameters() {
 		if tp == nil {
@@ -652,6 +657,8 @@ func (b *builder) addTypeParameters(node *ast.Node, s *Scope) {
 			Kind:           DefTypeParameter,
 			IsValueBinding: false,
 		})
+		b.visitExpression(tpDecl.Constraint, s)
+		b.visitExpression(tpDecl.DefaultType, s)
 	}
 }
 
@@ -830,6 +837,15 @@ func (b *builder) visitClass(node *ast.Node, outer *Scope, isExpression bool) {
 			if init := member.Initializer(); init != nil {
 				b.visitExpression(init, b.push(KindClassFieldInitializer, init, classScope))
 			}
+		case ast.KindIndexSignature:
+			// `[key: string]: T` — the key type and the result type are both
+			// evaluated in the class scope. The key itself binds nothing.
+			for _, param := range member.Parameters() {
+				if paramDecl := param.AsParameterDeclaration(); paramDecl != nil {
+					b.visitExpression(paramDecl.Type, classScope)
+				}
+			}
+			b.visitExpression(member.Type(), classScope)
 		case ast.KindClassStaticBlockDeclaration:
 			sb := member.AsClassStaticBlockDeclaration()
 			if sb != nil && sb.Body != nil && sb.Body.Kind == ast.KindBlock {
@@ -853,7 +869,9 @@ func (b *builder) visitTypeDecl(node *ast.Node, outer *Scope) {
 	// Recurse into type body / heritage / members to discover FunctionType
 	// and similar type-level scopes.
 	node.ForEachChild(func(child *ast.Node) bool {
-		b.visitExpression(child, typeScope)
+		if child.Kind != ast.KindTypeParameter {
+			b.visitExpression(child, typeScope)
+		}
 		return false
 	})
 }
@@ -880,7 +898,7 @@ func (b *builder) visitEnum(node *ast.Node, outer *Scope) {
 				ID:             em.Name(),
 				DefNode:        m,
 				Parent:         m.Parent,
-				Kind:           DefVariable,
+				Kind:           DefEnumMember,
 				IsValueBinding: true,
 			})
 		}

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -670,10 +670,10 @@ func (b *builder) addParameters(node *ast.Node, s *Scope, recurseAnnotations boo
 		if param == nil {
 			continue
 		}
-		// Skip `this` pseudo-parameter.
-		if pn := param.Name(); pn != nil && pn.Kind == ast.KindIdentifier && pn.Text() == "this" {
-			continue
-		}
+		// The `this` pseudo-parameter declares no binding, but its type
+		// annotation is a real type reference and still has to be walked.
+		pn := param.Name()
+		isThisParameter := pn != nil && pn.Kind == ast.KindIdentifier && pn.Text() == "this"
 		if recurseAnnotations {
 			// Parameter decorators (`@dec x: T`) run at class-definition time,
 			// in the enclosing class scope (s.Parent for methods). Fall back
@@ -693,13 +693,13 @@ func (b *builder) addParameters(node *ast.Node, s *Scope, recurseAnnotations boo
 				b.visitExpression(init, s)
 			}
 		}
-		if param.Name() == nil {
+		if isThisParameter || pn == nil {
 			continue
 		}
-		if recurseAnnotations && param.Name().Kind != ast.KindIdentifier {
-			b.visitBindingPattern(param.Name(), s)
+		if recurseAnnotations && pn.Kind != ast.KindIdentifier {
+			b.visitBindingPattern(pn, s)
 		}
-		utils.CollectBindingNames(param.Name(), func(id *ast.Node, name string) {
+		utils.CollectBindingNames(pn, func(id *ast.Node, name string) {
 			s.Add(&Variable{
 				Name:           name,
 				ID:             id,
@@ -892,14 +892,18 @@ func (b *builder) visitEnum(node *ast.Node, outer *Scope) {
 		if em == nil || em.Name() == nil {
 			continue
 		}
-		if em.Name().Kind == ast.KindIdentifier {
+		// TS resolves a string-literal member name to a real name, so `enum E {
+		// "a" = 1, b = a }` reads the member. The literal declares no
+		// identifier though, which keeps rules from reporting at it.
+		if name := em.Name(); name.Kind == ast.KindIdentifier || name.Kind == ast.KindStringLiteral {
 			enumScope.Add(&Variable{
-				Name:           em.Name().Text(),
-				ID:             em.Name(),
+				Name:           name.Text(),
+				ID:             name,
 				DefNode:        m,
 				Parent:         m.Parent,
 				Kind:           DefEnumMember,
 				IsValueBinding: true,
+				Anonymous:      name.Kind != ast.KindIdentifier,
 			})
 		}
 		if em.Initializer != nil {

--- a/internal/utils/scope/references.go
+++ b/internal/utils/scope/references.go
@@ -1,0 +1,113 @@
+package scope
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// isReferenceIdentifier reports whether `id` reads or writes a binding, as
+// opposed to naming one (declarations), naming a member (`a.b`, `{ b: 1 }`),
+// or naming a label.
+//
+// eslint-scope models a declaration identifier as a reference with `init:
+// true` and every consumer filters those out, so treating them as non-
+// references here is equivalent — and it keeps the two representations of the
+// same identifier from disagreeing.
+func isReferenceIdentifier(id *ast.Node) bool {
+	if id == nil || id.Kind != ast.KindIdentifier {
+		return false
+	}
+	parent := id.Parent
+	if parent == nil {
+		return false
+	}
+
+	// `typeof import('m').a.b` names exports of another module, not bindings
+	// in this file.
+	if isImportTypeQualifier(id) {
+		return false
+	}
+
+	switch parent.Kind {
+	case ast.KindPropertyAccessExpression:
+		// Only the object is a binding: `a.b` references `a`, not `b`.
+		pae := parent.AsPropertyAccessExpression()
+		return pae != nil && pae.Expression == id
+
+	case ast.KindQualifiedName:
+		// Same shape in type position: `A.B.C` references `A`.
+		qn := parent.AsQualifiedName()
+		return qn != nil && qn.Left == id
+
+	case ast.KindShorthandPropertyAssignment:
+		// `{ a }` and `({ a = b } = c)` — the name is the value.
+		return true
+
+	case ast.KindExportSpecifier:
+		// The local binding is `local` in `export { local as exported }`, and
+		// the sole name in `export { local }`.
+		spec := parent.AsExportSpecifier()
+		if spec == nil {
+			return false
+		}
+		local := spec.PropertyName
+		if local == nil {
+			local = spec.Name()
+		}
+		return local == id
+
+	case ast.KindImportSpecifier:
+		// Neither the imported name nor the local alias reads a local binding.
+		return false
+
+	case ast.KindBindingElement:
+		// `{ prop: local = init }` — only the default initializer reads.
+		be := parent.AsBindingElement()
+		return be != nil && be.Initializer == id
+
+	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement:
+		return false
+
+	case ast.KindMetaProperty:
+		// `new.target`, `import.meta`.
+		return false
+
+	case ast.KindTypePredicate:
+		// `x is T` — `x` names a parameter, it does not read it.
+		return false
+
+	case ast.KindJsxAttribute, ast.KindJsxNamespacedName:
+		return false
+
+	case ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement, ast.KindJsxClosingElement:
+		return isJsxComponentName(id)
+	}
+
+	return !ast.IsDeclarationName(id)
+}
+
+// isImportTypeQualifier reports whether `id` is part of the qualifier of an
+// `import(...)` type — the `a` or `b` in `typeof import('m').a.b`.
+func isImportTypeQualifier(id *ast.Node) bool {
+	current := id
+	for current.Parent != nil && current.Parent.Kind == ast.KindQualifiedName {
+		current = current.Parent
+	}
+	parent := current.Parent
+	if parent == nil || parent.Kind != ast.KindImportType {
+		return false
+	}
+	importType := parent.AsImportTypeNode()
+	return importType != nil && importType.Qualifier == current
+}
+
+// isJsxComponentName reports whether a JSX tag name refers to a binding.
+// A tag name starting with a lower-case letter is an intrinsic element
+// (`<div/>` is the string "div"), matching how JSX transforms resolve names.
+func isJsxComponentName(id *ast.Node) bool {
+	text := id.Text()
+	if text == "" {
+		return false
+	}
+	first := text[0]
+	return first < 'a' || first > 'z'
+}

--- a/internal/utils/scope/references.go
+++ b/internal/utils/scope/references.go
@@ -110,16 +110,27 @@ func referenceSpaces(id *ast.Node) (value bool, isType bool) {
 		}
 	}
 
-	// `A.B.C` is a type node as a whole, never in its parts, so ask about the
-	// outermost qualified name rather than the identifier itself.
-	entity := id
-	for entity.Parent != nil && entity.Parent.Kind == ast.KindQualifiedName {
-		entity = entity.Parent
-	}
-	if ast.IsPartOfTypeNode(entity) {
+	if InTypePosition(id) {
 		return false, true
 	}
 	return true, false
+}
+
+// InTypePosition reports whether `id` names a type rather than a value.
+// eslint-scope marks every identifier its type visitor reaches as a type
+// reference; this is the same question asked of the tsgo AST.
+//
+// A dotted name is a type node as a whole, never in its parts, so the
+// outermost one carries the answer. A heritage clause spells its dotted name
+// with property accesses even in type position (`implements A.B.C`), so both
+// shapes have to be climbed.
+func InTypePosition(id *ast.Node) bool {
+	entity := id
+	for entity.Parent != nil &&
+		(entity.Parent.Kind == ast.KindQualifiedName || entity.Parent.Kind == ast.KindPropertyAccessExpression) {
+		entity = entity.Parent
+	}
+	return ast.IsPartOfTypeNode(entity)
 }
 
 // isImportTypeQualifier reports whether `id` is part of the qualifier of an

--- a/internal/utils/scope/references.go
+++ b/internal/utils/scope/references.go
@@ -85,6 +85,43 @@ func isReferenceIdentifier(id *ast.Node) bool {
 	return !ast.IsDeclarationName(id)
 }
 
+// referenceSpaces reports which binding spaces `id` can resolve to. Most
+// identifiers name either a value or a type depending on where they sit; the
+// export forms name whichever space the exported binding happens to live in.
+func referenceSpaces(id *ast.Node) (value bool, isType bool) {
+	parent := id.Parent
+	switch parent.Kind {
+	case ast.KindExportSpecifier:
+		// `export type { T }` and `export { type T }` export types only.
+		if spec := parent.AsExportSpecifier(); spec != nil && spec.IsTypeOnly {
+			return false, true
+		}
+		if named := parent.Parent; named != nil && named.Parent != nil {
+			if decl := named.Parent.AsExportDeclaration(); decl != nil && decl.IsTypeOnly {
+				return false, true
+			}
+		}
+		return true, true
+	case ast.KindExportAssignment:
+		// `export = X` exports a value or a type; `export default X` is an
+		// expression and names a value.
+		if assignment := parent.AsExportAssignment(); assignment != nil && assignment.IsExportEquals {
+			return true, true
+		}
+	}
+
+	// `A.B.C` is a type node as a whole, never in its parts, so ask about the
+	// outermost qualified name rather than the identifier itself.
+	entity := id
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindQualifiedName {
+		entity = entity.Parent
+	}
+	if ast.IsPartOfTypeNode(entity) {
+		return false, true
+	}
+	return true, false
+}
+
 // isImportTypeQualifier reports whether `id` is part of the qualifier of an
 // `import(...)` type — the `a` or `b` in `typeof import('m').a.b`.
 func isImportTypeQualifier(id *ast.Node) bool {

--- a/internal/utils/scope/scope.go
+++ b/internal/utils/scope/scope.go
@@ -5,10 +5,10 @@
 //
 // The model deliberately mirrors eslint-scope / typescript-eslint's
 // scope-manager rather than tsgo's binder: block scopes, catch scopes,
-// function-expression-name scopes, and class scopes are all materialized, and
-// `var` hoisting targets the nearest function/module/global scope. Concepts
-// rslint does not expose (for example `parserOptions.globalReturn`) remain
-// unmodeled.
+// function-expression-name scopes, class scopes, class static blocks, and
+// class field initializers are all materialized, and `var` hoisting targets
+// the nearest function/module/global scope. Concepts rslint does not expose
+// (for example `parserOptions.globalReturn`) remain unmodeled.
 package scope
 
 import (
@@ -56,14 +56,16 @@ type Variable struct {
 type Kind int
 
 const (
-	KindGlobal           Kind = iota
-	KindFunction              // function-like bodies & their parameters
-	KindFunctionExprName      // FunctionExpression's name binding
-	KindBlock                 // { ... } / for-init / switch case / enum body
-	KindCatch                 // catch clause
-	KindClass                 // class body: type parameters & inner class name
-	KindModule                // TS namespace
-	KindType                  // TS type alias / interface / function type: type parameters
+	KindGlobal                Kind = iota
+	KindFunction                   // function-like bodies & their parameters
+	KindFunctionExprName           // FunctionExpression's name binding
+	KindBlock                      // { ... } / for-init / switch case / enum body
+	KindCatch                      // catch clause
+	KindClass                      // class body: type parameters & inner class name
+	KindModule                     // TS namespace
+	KindType                       // TS type alias / interface / function type: type parameters
+	KindClassStaticBlock           // `static { ... }`
+	KindClassFieldInitializer      // the initializer expression of a class field
 )
 
 // Scope is one node of the scope tree.
@@ -76,6 +78,9 @@ type Scope struct {
 	Vars []*Variable
 	// ByName groups Vars by binding name, preserving declaration order.
 	ByName map[string][]*Variable
+	// References holds the identifier references that appear directly in this
+	// scope. Populated only when [Options.CollectReferences] is set.
+	References []*Reference
 
 	// GlobalAugmentation is true inside a `declare global { ... }` chain.
 	GlobalAugmentation bool
@@ -104,16 +109,49 @@ func (s *Scope) Declarations(name string) []*Variable {
 }
 
 // VariableScope returns the nearest ancestor (or self) that acts as a `var`
-// hoist target — eslint-scope's `Scope#variableScope`: function-like scopes,
-// module scopes, and the global scope.
+// hoist target — eslint-scope's `Scope#variableScope`, which also models an
+// execution context. Class static blocks and class field initializers are
+// variable scopes, matching eslint-scope's `class-static-block` and
+// `class-field-initializer` scope types.
 func (s *Scope) VariableScope() *Scope {
 	for current := s; current != nil; current = current.Parent {
 		switch current.Kind {
-		case KindFunction, KindModule, KindGlobal:
+		case KindFunction, KindModule, KindGlobal, KindClassStaticBlock, KindClassFieldInitializer:
 			return current
 		}
 	}
 	return nil
+}
+
+// Reference is one identifier that reads or writes a binding. Declaration
+// identifiers are not references — eslint-scope models them as references with
+// `init: true`, and every consumer of that flag skips them.
+type Reference struct {
+	// Identifier is the referencing identifier node.
+	Identifier *ast.Node
+	// From is the scope the reference is evaluated in.
+	From *Scope
+	// Declarations holds every declaration of the resolved binding, in
+	// declaration order; nil when the name resolves to nothing in this file.
+	Declarations []*Variable
+}
+
+// Resolved returns the first declaration of the binding this reference
+// resolves to — eslint-scope's `reference.resolved.defs[0]` — or nil when the
+// reference is unresolved.
+func (r *Reference) Resolved() *Variable {
+	if len(r.Declarations) == 0 {
+		return nil
+	}
+	return r.Declarations[0]
+}
+
+// Options selects optional analysis passes.
+type Options struct {
+	// CollectReferences populates [Scope.References] and [Manager.References].
+	// Rules that only inspect declarations leave it off so the extra
+	// identifier walk and resolution pass are skipped.
+	CollectReferences bool
 }
 
 // Manager owns a built scope tree.
@@ -125,12 +163,32 @@ type Manager struct {
 	// Scopes lists every scope in creation order, which is a pre-order walk of
 	// the scope tree.
 	Scopes []*Scope
+	// References lists every reference in the file, in the order the builder
+	// discovered them. Populated only when [Options.CollectReferences] is set.
+	References []*Reference
 }
 
 // Build analyzes `sf` and returns its scope tree.
-func Build(sf *ast.SourceFile) *Manager {
+func Build(sf *ast.SourceFile, opts Options) *Manager {
 	m := &Manager{SourceFile: sf}
-	b := &builder{manager: m}
+	b := &builder{manager: m, collectReferences: opts.CollectReferences}
 	m.Global = b.buildProgram(sf)
+	if opts.CollectReferences {
+		m.resolveReferences()
+	}
 	return m
+}
+
+// resolveReferences links each reference to the innermost enclosing scope that
+// declares its name.
+func (m *Manager) resolveReferences() {
+	for _, ref := range m.References {
+		name := ref.Identifier.Text()
+		for current := ref.From; current != nil; current = current.Parent {
+			if declarations := current.ByName[name]; len(declarations) > 0 {
+				ref.Declarations = declarations
+				break
+			}
+		}
+	}
 }

--- a/internal/utils/scope/scope.go
+++ b/internal/utils/scope/scope.go
@@ -20,7 +20,7 @@ import (
 type DefKind int
 
 const (
-	DefVariable       DefKind = iota // var/let/const binding, binding element, enum member
+	DefVariable       DefKind = iota // var/let/const binding, binding element
 	DefParameter                     // function parameter
 	DefFunctionName                  // FunctionDeclaration name (outer scope)
 	DefFnExprName                    // FunctionExpression name (inner scope only)
@@ -30,9 +30,32 @@ const (
 	DefCatch                         // Catch parameter
 	DefType                          // Interface, type alias
 	DefEnumName                      // Enum declaration
+	DefEnumMember                    // Member of an enum declaration
 	DefNamespaceName                 // Module/namespace declaration
 	DefTypeParameter                 // Generic type parameter
 )
+
+// declaresValue reports whether the binding exists in value space — whether an
+// expression can read it. Mirrors eslint-scope's `Definition#isVariableDefinition`.
+func (k DefKind) declaresValue() bool {
+	switch k {
+	case DefType, DefTypeParameter:
+		return false
+	}
+	return true
+}
+
+// declaresType reports whether the binding exists in type space — whether a
+// type annotation can name it. Mirrors eslint-scope's
+// `Definition#isTypeDefinition`.
+func (k DefKind) declaresType() bool {
+	switch k {
+	case DefClassName, DefClassInnerName, DefImport, DefType,
+		DefEnumName, DefEnumMember, DefNamespaceName, DefTypeParameter:
+		return true
+	}
+	return false
+}
 
 // Variable is a single declaration site. eslint-scope merges every declaration
 // of a name within one scope into a single `Variable` carrying several `defs`;
@@ -134,6 +157,13 @@ type Reference struct {
 	// Declarations holds every declaration of the resolved binding, in
 	// declaration order; nil when the name resolves to nothing in this file.
 	Declarations []*Variable
+
+	// IsValueReference is true when the identifier can name a value — every
+	// expression position, plus `typeof X` and `export { x }`.
+	IsValueReference bool
+	// IsTypeReference is true when the identifier can name a type — every type
+	// position, plus `export { x }`, which exports whichever space `x` lives in.
+	IsTypeReference bool
 }
 
 // Resolved returns the first declaration of the binding this reference
@@ -180,15 +210,56 @@ func Build(sf *ast.SourceFile, opts Options) *Manager {
 }
 
 // resolveReferences links each reference to the innermost enclosing scope that
-// declares its name.
+// declares its name in a way the reference can bind to.
 func (m *Manager) resolveReferences() {
 	for _, ref := range m.References {
 		name := ref.Identifier.Text()
 		for current := ref.From; current != nil; current = current.Parent {
-			if declarations := current.ByName[name]; len(declarations) > 0 {
-				ref.Declarations = declarations
-				break
+			declarations := current.ByName[name]
+			if len(declarations) == 0 || !current.binds(ref, declarations) {
+				continue
 			}
+			ref.Declarations = declarations
+			break
 		}
 	}
+}
+
+// binds reports whether `declarations` — every declaration of the reference's
+// name in this scope — can resolve `ref`. When it can't, the reference carries
+// on to the enclosing scope, as eslint-scope's `delegateToUpperScope` does.
+func (s *Scope) binds(ref *Reference, declarations []*Variable) bool {
+	if !s.bindsBeforeBody(ref, declarations) {
+		return false
+	}
+	// A name lives in value space, type space, or both: `type X` never answers
+	// an expression's read of `X`, and `const X` never answers a type
+	// annotation naming `X`.
+	for _, declaration := range declarations {
+		if (ref.IsValueReference && declaration.Kind.declaresValue()) ||
+			(ref.IsTypeReference && declaration.Kind.declaresType()) {
+			return true
+		}
+	}
+	return false
+}
+
+// bindsBeforeBody reports whether a reference in a parameter default can see
+// these declarations. A default is evaluated before the function body's
+// lexical environment exists, so `function f(a = x) { const x = 2; }` reads the
+// outer `x` — eslint-scope's `FunctionScope#isValidResolution`.
+func (s *Scope) bindsBeforeBody(ref *Reference, declarations []*Variable) bool {
+	if s.Kind != KindFunction || s.Block == nil {
+		return true
+	}
+	body := s.Block.Body()
+	if body == nil || ref.Identifier.Pos() >= body.Pos() {
+		return true
+	}
+	for _, declaration := range declarations {
+		if declaration.ID.Pos() < body.Pos() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/utils/scope/scope.go
+++ b/internal/utils/scope/scope.go
@@ -158,12 +158,12 @@ type Reference struct {
 	// declaration order; nil when the name resolves to nothing in this file.
 	Declarations []*Variable
 
-	// IsValueReference is true when the identifier can name a value — every
+	// isValueReference is true when the identifier can name a value — every
 	// expression position, plus `typeof X` and `export { x }`.
-	IsValueReference bool
-	// IsTypeReference is true when the identifier can name a type — every type
+	isValueReference bool
+	// isTypeReference is true when the identifier can name a type — every type
 	// position, plus `export { x }`, which exports whichever space `x` lives in.
-	IsTypeReference bool
+	isTypeReference bool
 }
 
 // Resolved returns the first declaration of the binding this reference
@@ -236,8 +236,8 @@ func (s *Scope) binds(ref *Reference, declarations []*Variable) bool {
 	// an expression's read of `X`, and `const X` never answers a type
 	// annotation naming `X`.
 	for _, declaration := range declarations {
-		if (ref.IsValueReference && declaration.Kind.declaresValue()) ||
-			(ref.IsTypeReference && declaration.Kind.declaresType()) {
+		if (ref.isValueReference && declaration.Kind.declaresValue()) ||
+			(ref.isTypeReference && declaration.Kind.declaresType()) {
 			return true
 		}
 	}

--- a/internal/utils/scope/scope.go
+++ b/internal/utils/scope/scope.go
@@ -71,6 +71,11 @@ type Variable struct {
 	IsValueBinding   bool // runtime value vs. type-only
 	IsTypeOnlyImport bool // ImportSpecifier with `type` modifier
 	DeclareModifier  bool // `declare` modifier (.d.ts handling)
+	// Anonymous marks a binding declared without an identifier — a
+	// string-literal enum member (`enum E { "A" = 1 }`). eslint-scope gives
+	// those a variable with an empty `identifiers` list, so they take part in
+	// name resolution but rules never report at their declaration site.
+	Anonymous bool
 
 	Scope *Scope
 }

--- a/internal/utils/scope/scope_test.go
+++ b/internal/utils/scope/scope_test.go
@@ -18,7 +18,7 @@ func build(t *testing.T, source string) *Manager {
 		FileName: "/test.ts",
 		Path:     "/test.ts",
 	}, source, core.ScriptKindTS)
-	return Build(sourceFile)
+	return Build(sourceFile, Options{})
 }
 
 // lookup finds the innermost scope declaring `name` starting from the scope
@@ -173,5 +173,140 @@ func TestBuildEmptySourceFileHasOnlyTheGlobalScope(t *testing.T) {
 	}
 	if m.Global.VariableScope() != m.Global {
 		t.Error("the global scope is its own variable scope")
+	}
+}
+
+func buildWithReferences(t *testing.T, source string) *Manager {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.tsx",
+		Path:     "/test.tsx",
+	}, source, core.ScriptKindTSX)
+	return Build(sourceFile, Options{CollectReferences: true})
+}
+
+// referencedNames lists every reference in source order as
+// "name->resolvedDeclarationKind", using "?" when the name resolves to nothing
+// in this file.
+func referencedNames(m *Manager) []string {
+	out := make([]string, 0, len(m.References))
+	for _, ref := range m.References {
+		name := ref.Identifier.Text()
+		if resolved := ref.Resolved(); resolved != nil {
+			out = append(out, name+"->declared")
+		} else {
+			out = append(out, name+"->?")
+		}
+	}
+	return out
+}
+
+func assertReferences(t *testing.T, source string, want ...string) {
+	t.Helper()
+	got := referencedNames(buildWithReferences(t, source))
+	if len(got) != len(want) {
+		t.Fatalf("%s\n got %v\nwant %v", source, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s\n got %v\nwant %v", source, got, want)
+			return
+		}
+	}
+}
+
+func TestBuildCollectsReferencesOnlyWhenAsked(t *testing.T) {
+	if refs := build(t, `var a = 1; a;`).References; len(refs) != 0 {
+		t.Errorf("references collected without Options.CollectReferences: %d", len(refs))
+	}
+	if refs := buildWithReferences(t, `var a = 1; a;`).References; len(refs) != 1 {
+		t.Errorf("got %d references, want 1", len(refs))
+	}
+}
+
+func TestBuildReferenceIdentifierPositions(t *testing.T) {
+	// Declaration names are not references; eslint-scope models them as
+	// `init: true` references that every consumer filters out.
+	assertReferences(t, `var a = b;`, "b->?")
+	// Only the object of a member access, never the member name.
+	assertReferences(t, `a.b.c;`, "a->?")
+	assertReferences(t, `a[b];`, "a->?", "b->?")
+	// Object literal keys are not bindings, but shorthand values are.
+	assertReferences(t, `({ a: 1 });`)
+	assertReferences(t, `({ a });`, "a->?")
+	assertReferences(t, `({ [a]: 1 });`, "a->?")
+	// Labels are not bindings.
+	assertReferences(t, `outer: while (x) { break outer; }`, "x->?")
+	// Import specifiers declare; export specifiers reference their local name.
+	assertReferences(t, `import { a as b } from './m';`)
+	assertReferences(t, `const a = 1; export { a as b };`, "a->declared")
+	// Type positions reference too.
+	assertReferences(t, `let x: Foo;`, "Foo->?")
+	assertReferences(t, `let x: typeof Foo.Bar;`, "Foo->?")
+	// ...but an `import(...)` type names another module's exports.
+	assertReferences(t, `type T = typeof import('./m').a.b;`)
+	// JSX: a lower-case tag is an intrinsic element, not a binding.
+	assertReferences(t, `<div />;`)
+	assertReferences(t, `<App />;`, "App->?")
+	assertReferences(t, `<ns.Widget />;`, "ns->?")
+}
+
+func TestBuildResolvesReferencesThroughTheScopeChain(t *testing.T) {
+	m := buildWithReferences(t, `
+const outer = 1;
+function f(param) {
+  return outer + param + missing;
+}
+`)
+	if len(m.References) != 3 {
+		t.Fatalf("got %d references, want 3", len(m.References))
+	}
+	outer, param, missing := m.References[0], m.References[1], m.References[2]
+
+	if got := outer.Resolved(); got == nil || got.Kind != DefVariable || got.Scope != m.Global {
+		t.Errorf("`outer` should resolve to the global const, got %+v", got)
+	}
+	if got := param.Resolved(); got == nil || got.Kind != DefParameter {
+		t.Errorf("`param` should resolve to the parameter, got %+v", got)
+	}
+	if missing.Resolved() != nil {
+		t.Error("`missing` is declared nowhere in this file and must stay unresolved")
+	}
+	// Every reference in the body is evaluated in the function scope.
+	if outer.From != param.From || outer.From.Kind != KindFunction {
+		t.Errorf("references should come from the function scope, got %d", outer.From.Kind)
+	}
+}
+
+func TestBuildClassInitializerScopes(t *testing.T) {
+	m := buildWithReferences(t, `class C { field = 1; static staticField = 2; static { let inBlock; } }`)
+	assertKinds(t, m, []Kind{
+		KindGlobal, KindClass,
+		KindClassFieldInitializer, KindClassFieldInitializer, KindClassStaticBlock,
+	})
+
+	// Both field initializers and static blocks are execution contexts, so they
+	// are variable scopes in their own right.
+	for _, i := range []int{2, 3, 4} {
+		if m.Scopes[i].VariableScope() != m.Scopes[i] {
+			t.Errorf("scope %d should be its own variable scope", i)
+		}
+	}
+	// The class scope is not — `var` inside it hoists to the file scope.
+	if m.Scopes[1].VariableScope() != m.Global {
+		t.Error("a class scope is not a variable scope")
+	}
+	assertDeclares(t, m.Scopes[4], "inBlock", DefVariable)
+}
+
+func TestBuildGlobalAugmentationBindsNothing(t *testing.T) {
+	// `declare global { ... }` reopens the global scope; it does not declare a
+	// namespace named `global`.
+	m := buildWithReferences(t, `global.foo = true; declare global { var injected: string; }`)
+	if len(m.Global.Declarations("global")) != 0 {
+		t.Error("`declare global` must not bind the name `global`")
+	}
+	if got := referencedNames(m); len(got) != 1 || got[0] != "global->?" {
+		t.Errorf("got %v, want [global->?]", got)
 	}
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -122,6 +122,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unassigned-vars.test.ts',
     './tests/eslint/rules/no-unused-vars.test.ts',
     './tests/eslint/rules/no-unused-private-class-members.test.ts',
+    './tests/eslint/rules/no-use-before-define.test.ts',
     './tests/eslint/rules/no-var.test.ts',
     './tests/eslint/rules/one-var.test.ts',
     './tests/eslint/rules/prefer-arrow-callback.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-use-before-define.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-use-before-define.test.ts.snap
@@ -1,0 +1,1381 @@
+// Rstest Snapshot v1
+
+exports[`no-use-before-define > invalid 1`] = `
+{
+  "code": "a++; var a=19;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 2`] = `
+{
+  "code": "a(); var a=function() {};",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 3`] = `
+{
+  "code": "alert(a[1]); var a=[1,3];",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 4`] = `
+{
+  "code": "a(); function a() { alert(b); var b=10; a(); }",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+    {
+      "message": "'b' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 5`] = `
+{
+  "code": "a(); var a=function() {};",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 6`] = `
+{
+  "code": "(() => { alert(a); var a = 42; })();",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 7`] = `
+{
+  "code": "(() => a())(); function a() { }",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 8`] = `
+{
+  "code": "a(); try { throw new Error() } catch (foo) {var a;}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 9`] = `
+{
+  "code": "var f = () => a; var a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 10`] = `
+{
+  "code": "new A(); class A {};",
+  "diagnostics": [
+    {
+      "message": "'A' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 11`] = `
+{
+  "code": "function foo() { new A(); } class A {};",
+  "diagnostics": [
+    {
+      "message": "'A' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 12`] = `
+{
+  "code": "new A(); var A = class {};",
+  "diagnostics": [
+    {
+      "message": "'A' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 13`] = `
+{
+  "code": "a++; { var a; }",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 14`] = `
+{
+  "code": ""use strict"; { a(); function a() {} }",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 15`] = `
+{
+  "code": "{a; let a = 1}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 16`] = `
+{
+  "code": "switch (foo) { case 1: a();
+ default: 
+ let a;}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 17`] = `
+{
+  "code": "if (true) { function foo() { a; } let a;}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 18`] = `
+{
+  "code": "a(); var a=function() {};",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 19`] = `
+{
+  "code": "new A(); class A {};",
+  "diagnostics": [
+    {
+      "message": "'A' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 20`] = `
+{
+  "code": "var a = a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 21`] = `
+{
+  "code": "const a = foo(a);",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 22`] = `
+{
+  "code": "function foo(a = a) {}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 23`] = `
+{
+  "code": "var {a = a} = [];",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 24`] = `
+{
+  "code": "var {b = a, a} = {};",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 25`] = `
+{
+  "code": "var {a = 0} = a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 26`] = `
+{
+  "code": "for (var a in a) {}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 27`] = `
+{
+  "code": "for (var a of a) {}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 28`] = `
+{
+  "code": "function foo() { bar; var bar = 1; } var bar;",
+  "diagnostics": [
+    {
+      "message": "'bar' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 29`] = `
+{
+  "code": "foo; var foo;",
+  "diagnostics": [
+    {
+      "message": "'foo' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 30`] = `
+{
+  "code": "for (let x = x;;); let x = 0",
+  "diagnostics": [
+    {
+      "message": "'x' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 31`] = `
+{
+  "code": "for (let x in xs); let xs = []",
+  "diagnostics": [
+    {
+      "message": "'xs' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 32`] = `
+{
+  "code": "try {} catch ({message = x}) {} let x = ''",
+  "diagnostics": [
+    {
+      "message": "'x' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 33`] = `
+{
+  "code": "with (obj) x; let x = {}",
+  "diagnostics": [
+    {
+      "message": "'x' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 34`] = `
+{
+  "code": "class C extends C {}",
+  "diagnostics": [
+    {
+      "message": "'C' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 35`] = `
+{
+  "code": "const C = class extends C {};",
+  "diagnostics": [
+    {
+      "message": "'C' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 36`] = `
+{
+  "code": "class C { [C](){} }",
+  "diagnostics": [
+    {
+      "message": "'C' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 37`] = `
+{
+  "code": "const C = class { static field = C; };",
+  "diagnostics": [
+    {
+      "message": "'C' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 38`] = `
+{
+  "code": "class C { static field = a; } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 39`] = `
+{
+  "code": "class C { static { a; } } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 40`] = `
+{
+  "code": "export { a }; const a = 1;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 41`] = `
+{
+  "code": "export { a as b }; const a = 1;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 42`] = `
+{
+  "code": "export { a, b }; let a, b;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+    {
+      "message": "'b' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 43`] = `
+{
+  "code": "export const foo = a; const a = 1;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 44`] = `
+{
+  "code": "interface Bar {
+  type: typeof Foo;
+}
+
+const Foo = 2;",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 45`] = `
+{
+  "code": "let var1: StringOrNumber;
+
+type StringOrNumber = string | number;",
+  "diagnostics": [
+    {
+      "message": "'StringOrNumber' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 46`] = `
+{
+  "code": "const foo = Foo.Foo;
+
+enum Foo {
+  FOO,
+}",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 47`] = `
+{
+  "code": "export { Foo };
+
+enum Foo {
+  BAR,
+}",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 48`] = `
+{
+  "code": "export { Foo };
+
+namespace Foo {
+  export let bar = () => 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 49`] = `
+{
+  "code": "@decorator
+class C {
+  static x = "foo";
+  [C.x]() {}
+}",
+  "diagnostics": [
+    {
+      "message": "'C' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 4,
+        },
+        "start": {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 50`] = `
+{
+  "code": "<App />; const App = () => <div />;",
+  "diagnostics": [
+    {
+      "message": "'App' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 51`] = `
+{
+  "code": "<Foo.Bar />; const Foo = { Bar: () => <div/> };",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "usedBeforeDefined",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-use-before-define.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-use-before-define.test.ts
@@ -1,0 +1,435 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors Layer 1 only — the upstream valid/invalid semantic set. tsgo edge
+// shapes, upstream-branch lock-ins, and issue-tracker shapes live in the Go
+// suite (internal/rules/no_use_before_define/*_extras_test.go).
+ruleTester.run('no-use-before-define', {
+  valid: [
+    'unresolved',
+    'Array',
+    'function foo () { arguments; }',
+    'var a=10; alert(a);',
+    'function b(a) { alert(a); }',
+    'Object.hasOwnProperty.call(a);',
+    'a(); try { throw new Error() } catch (a) {}',
+    'class A {} new A();',
+    'var a = 0, b = a;',
+    'var {a = 0, b = a} = {};',
+    'var [a = 0, b = a] = {};',
+    'function foo() { foo(); }',
+    'var foo = function() { foo(); };',
+    'var a; for (a in a) {}',
+    'var a; for (a of a) {}',
+    'let a; class C { static { a; } }',
+    'class C { static { let a; a; } }',
+
+    // Block-level bindings
+    '"use strict"; a(); { function a() {} }',
+    'switch (foo) { case 1:  { a(); } default: { let a; }}',
+    'a(); { let a = function () {}; }',
+
+    // "nofunc" / object style options
+    {
+      code: 'a(); function a() { alert(arguments); }',
+      options: ['nofunc'] as any,
+    },
+    {
+      code: 'a(); function a() { alert(arguments); }',
+      options: [{ functions: false }] as any,
+    },
+    {
+      code: '"use strict"; { a(); function a() {} }',
+      options: [{ functions: false }] as any,
+    },
+    {
+      code: 'function foo() { new A(); } class A {};',
+      options: [{ classes: false }] as any,
+    },
+
+    // "variables" option
+    {
+      code: 'function foo() { bar; } var bar;',
+      options: [{ variables: false }] as any,
+    },
+    {
+      code: 'var foo = () => bar; var bar;',
+      options: [{ variables: false }] as any,
+    },
+    {
+      code: 'class C { static { () => foo; let foo; } }',
+      options: [{ variables: false }] as any,
+    },
+
+    // Class definition evaluation — not TDZ errors
+    'class C extends (class { method() { C; } }) {}',
+    'class C extends (class { field = C; }) {}',
+    'class C { [() => C](){} }',
+    'class C { method() { C; } }',
+    'class C { field = C; }',
+    'class C { static field = C; }',
+    'class C { field = class extends C {}; }',
+    'class C { static field = class { [C]; }; }',
+    'const C = class { static field = class { field = C; }; };',
+    'class C { static { C; } }',
+    'class C { static { class D extends C {} } }',
+    'class C { static { () => C; } }',
+    'const C = class C { static { C.x; } }',
+    {
+      code: 'class C { field = a; } let a;',
+      options: [{ variables: false }] as any,
+    },
+    {
+      code: 'class C { field = D; } class D {}',
+      options: [{ classes: false }] as any,
+    },
+
+    // "allowNamedExports" option
+    {
+      code: 'export { a }; const a = 1;',
+      options: [{ allowNamedExports: true }] as any,
+    },
+    {
+      code: 'export { a as b }; const a = 1;',
+      options: [{ allowNamedExports: true }] as any,
+    },
+    {
+      code: 'export { f }; function f() {}',
+      options: [{ allowNamedExports: true }] as any,
+    },
+    {
+      code: 'export { C }; class C {}',
+      options: [{ allowNamedExports: true }] as any,
+    },
+
+    // TypeScript syntax
+    'type foo = 1;\nconst x: foo = 1;',
+    'type foo = 1;\ntype bar = foo;',
+    'interface Foo {}\nconst x: Foo = {};',
+    'declare function a();',
+    'declare class a {\n  foo();\n}',
+    'const updatedAt = data?.updatedAt;',
+    'var a = { b: 5 };\nalert(a?.b);',
+    'interface Foo {\n  bar: string;\n}\nconst bar = "blah";',
+    'type T = (value: unknown) => value is Id;',
+    'namespace A.X.Y {}\n\nimport Z = A.X.Y;\n\nconst X = 23;',
+
+    // "typedefs" option
+    {
+      code: 'var x: Foo = 2;\ntype Foo = string | number;',
+      options: [{ typedefs: false }] as any,
+    },
+    {
+      code: 'var x: Foo = {};\ninterface Foo {}',
+      options: [{ typedefs: false, ignoreTypeReferences: false }] as any,
+    },
+
+    // "ignoreTypeReferences" option
+    {
+      code: 'interface Bar {\n  type: typeof Foo;\n}\n\nconst Foo = 2;',
+      options: [{ ignoreTypeReferences: true }] as any,
+    },
+    {
+      code: 'interface Bar {\n  type: typeof Foo.Bar.Baz;\n}\n\nconst Foo = { Bar: { Baz: 1 } };',
+      options: [{ ignoreTypeReferences: true }] as any,
+    },
+
+    // "enums" option
+    {
+      code: 'function foo(): Foo {\n  return Foo.FOO;\n}\n\nenum Foo {\n  FOO,\n}',
+      options: [{ enums: false }] as any,
+    },
+    {
+      code: 'let foo: Foo;\n\nenum Foo {\n  FOO,\n}',
+      options: [{ enums: false }] as any,
+    },
+
+    // Decorators run after the class binding is initialized
+    '@Directive({ providers: [{ useExisting: CidrIpPatternDirective }] })\nexport class CidrIpPatternDirective {}',
+
+    // JSX
+    { code: 'const App = () => <div/>; <App />;', filename: 'src/virtual.tsx' },
+    { code: 'let Foo, Bar; <Foo><Bar /></Foo>;', filename: 'src/virtual.tsx' },
+    {
+      code: 'function App() { return <div/> } <App />;',
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: '<App />; function App() { return <div/> }',
+      options: [{ functions: false }] as any,
+      filename: 'src/virtual.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: 'a++; var a=19;',
+      errors: [
+        {
+          messageId: 'usedBeforeDefined',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      code: 'a(); var a=function() {};',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 1 }],
+    },
+    {
+      code: 'alert(a[1]); var a=[1,3];',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 7 }],
+    },
+    {
+      code: 'a(); function a() { alert(b); var b=10; a(); }',
+      errors: [
+        { messageId: 'usedBeforeDefined', line: 1, column: 1 },
+        { messageId: 'usedBeforeDefined', line: 1, column: 27 },
+      ],
+    },
+    {
+      code: 'a(); var a=function() {};',
+      options: ['nofunc'] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 1 }],
+    },
+    {
+      code: '(() => { alert(a); var a = 42; })();',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 16 }],
+    },
+    {
+      code: '(() => a())(); function a() { }',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 8 }],
+    },
+    {
+      code: 'a(); try { throw new Error() } catch (foo) {var a;}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 1 }],
+    },
+    {
+      code: 'var f = () => a; var a;',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 15 }],
+    },
+    {
+      code: 'new A(); class A {};',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 5 }],
+    },
+    {
+      code: 'function foo() { new A(); } class A {};',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 22 }],
+    },
+    {
+      code: 'new A(); var A = class {};',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 5 }],
+    },
+
+    // Block-level bindings
+    {
+      code: 'a++; { var a; }',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 1 }],
+    },
+    {
+      code: '"use strict"; { a(); function a() {} }',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 17 }],
+    },
+    {
+      code: '{a; let a = 1}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 2 }],
+    },
+    {
+      code: 'switch (foo) { case 1: a();\n default: \n let a;}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 24 }],
+    },
+    {
+      code: 'if (true) { function foo() { a; } let a;}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 30 }],
+    },
+
+    // object style options
+    {
+      code: 'a(); var a=function() {};',
+      options: [{ functions: false, classes: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 1 }],
+    },
+    {
+      code: 'new A(); class A {};',
+      options: [{ functions: false, classes: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 5 }],
+    },
+
+    // invalid initializers
+    {
+      code: 'var a = a;',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 9 }],
+    },
+    {
+      code: 'const a = foo(a);',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 15 }],
+    },
+    {
+      code: 'function foo(a = a) {}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 18 }],
+    },
+    {
+      code: 'var {a = a} = [];',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 10 }],
+    },
+    {
+      code: 'var {b = a, a} = {};',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 10 }],
+    },
+    {
+      code: 'var {a = 0} = a;',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 15 }],
+    },
+    {
+      code: 'for (var a in a) {}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 15 }],
+    },
+    {
+      code: 'for (var a of a) {}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 15 }],
+    },
+
+    // "variables" option
+    {
+      code: 'function foo() { bar; var bar = 1; } var bar;',
+      options: [{ variables: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 18 }],
+    },
+    {
+      code: 'foo; var foo;',
+      options: [{ variables: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 1 }],
+    },
+
+    // https://github.com/eslint/eslint/issues/10227
+    {
+      code: 'for (let x = x;;); let x = 0',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 14 }],
+    },
+    {
+      code: 'for (let x in xs); let xs = []',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 15 }],
+    },
+    {
+      code: "try {} catch ({message = x}) {} let x = ''",
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 26 }],
+    },
+    {
+      code: 'with (obj) x; let x = {}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 12 }],
+    },
+
+    // Class definition evaluation — TDZ errors
+    {
+      code: 'class C extends C {}',
+      options: [{ classes: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 17 }],
+    },
+    {
+      code: 'const C = class extends C {};',
+      options: [{ variables: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 25 }],
+    },
+    {
+      code: 'class C { [C](){} }',
+      options: [{ classes: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 12 }],
+    },
+    {
+      code: 'const C = class { static field = C; };',
+      options: [{ variables: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 34 }],
+    },
+    {
+      code: 'class C { static field = a; } let a;',
+      options: [{ variables: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 26 }],
+    },
+    {
+      code: 'class C { static { a; } } let a;',
+      options: [{ variables: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 20 }],
+    },
+
+    // "allowNamedExports" option
+    {
+      code: 'export { a }; const a = 1;',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 10 }],
+    },
+    {
+      code: 'export { a as b }; const a = 1;',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 10 }],
+    },
+    {
+      code: 'export { a, b }; let a, b;',
+      errors: [
+        { messageId: 'usedBeforeDefined', line: 1, column: 10 },
+        { messageId: 'usedBeforeDefined', line: 1, column: 13 },
+      ],
+    },
+    {
+      code: 'export const foo = a; const a = 1;',
+      options: [{ allowNamedExports: true }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 20 }],
+    },
+
+    // TypeScript-specific options
+    {
+      code: 'interface Bar {\n  type: typeof Foo;\n}\n\nconst Foo = 2;',
+      options: [{ ignoreTypeReferences: false }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 2, column: 16 }],
+    },
+    {
+      code: 'let var1: StringOrNumber;\n\ntype StringOrNumber = string | number;',
+      options: [{ ignoreTypeReferences: false, typedefs: true }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 11 }],
+    },
+    {
+      code: 'const foo = Foo.Foo;\n\nenum Foo {\n  FOO,\n}',
+      options: [{ enums: true }] as any,
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 13 }],
+    },
+    {
+      code: 'export { Foo };\n\nenum Foo {\n  BAR,\n}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 10 }],
+    },
+    {
+      code: 'export { Foo };\n\nnamespace Foo {\n  export let bar = () => 1;\n}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 1, column: 10 }],
+    },
+    {
+      code: '@decorator\nclass C {\n  static x = "foo";\n  [C.x]() {}\n}',
+      errors: [{ messageId: 'usedBeforeDefined', line: 4, column: 4 }],
+    },
+
+    // JSX
+    {
+      code: '<App />; const App = () => <div />;',
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'usedBeforeDefined',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: '<Foo.Bar />; const Foo = { Bar: () => <div/> };',
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'usedBeforeDefined',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 5,
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -652,6 +652,7 @@ xjavascript
 xlink
 xoff
 xtest
+Xopenport
 yutil
 zeebo
 zigbuild


### PR DESCRIPTION
## Summary

Port the `no-use-before-define` rule from ESLint core to rslint.

It reports a reference that reads a binding declared later in the file, or one that runs while that binding is still being initialized (`var a = a`, `class C extends C {}`). ESLint 10 folded TypeScript support into the core rule, so this port covers the `enums`, `typedefs`, and `ignoreTypeReferences` options as well as the class-field-initializer / static-block execution-context semantics.

> **Stacked on #1755** — please merge that first; the base branch is `refactor/extract-scope-manager-20260816`. Only the last commit belongs to this PR.

### How it works

The rule consumes the shared scope model that #1755 extracted out of `no-shadow`. This PR extends that package with what a reference-oriented rule needs, all of it opt-in behind `scope.Options{CollectReferences: true}` so `no-shadow` pays nothing for it:

- Identifier-reference collection and scope-chain resolution (`Scope.References`, `Reference.Resolved()`).
- `class-static-block` and `class-field-initializer` scope kinds, which `Scope.VariableScope()` now treats as execution contexts — this is what makes `class C { field = C }` valid but `const C = class { static field = C }` a TDZ error.
- Traversal of export specifiers, `import Z = A.B` module references, catch-pattern defaults, class member type annotations, and mapped types.

Two latent scope-model bugs surfaced and are fixed here:

- `declare global { ... }` bound a namespace named `global`, so `global.foo` resolved to it.
- The right-hand side of `for (let x of xs)` resolved outside the loop scope, missing the temporal dead zone.

### Verification

Beyond the migrated upstream suite (215 cases across the JavaScript and TypeScript halves) and 130 rslint-added edge-shape / branch lock-in cases, the rule was diffed against ESLint v10.8.1 with `@typescript-eslint/parser` over **1123 TypeScript/TSX files** from this repo: **133 findings, byte-identical in file, line, column, and message.**

That run caught two real bugs, now locked in by tests:

- tsgo models a shorthand method as `MethodDeclaration` where ESTree has a `FunctionExpression` — which upstream's initializer walk stops at. Without that stop the walk escaped the method and flagged every parameter read inside `const api = { get(node) { return node.range } }` (110 false positives).
- `typeof import('./m').x` names an export of another module, not a local binding.

### Note for reviewers

`@typescript-eslint/no-use-before-define` already exists in this repo with its own independent implementation, and is still active upstream (`extendsBaseRule: true`, not deprecated), so both stay registered under their own keys. Consolidating the plugin rule onto this implementation — the way `no-shadow` already does via `core.RunTSESLint` — would remove ~670 lines of duplicated logic, but it is a behavior change for that rule and belongs in its own PR. Happy to follow up if you want it.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-use-before-define
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-use-before-define.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).