### PR TITLE
refactor: rebuild @typescript-eslint/no-use-before-define on the shared scope model

### DIFF
--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -129,6 +129,12 @@ func check(ctx rule.RuleContext, opts options, ref *scope.Reference) {
 	if declaration == nil {
 		return
 	}
+	// A binding declared without an identifier — a string-literal enum member,
+	// `enum E { "a" = 1 }` — takes part in name resolution but has no
+	// declaration site to compare positions against, so upstream skips it.
+	if declaration.Anonymous {
+		return
+	}
 	if isDefinedBeforeUse(declaration, ref) {
 		return
 	}

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -1,15 +1,36 @@
 package no_use_before_define
 
 import (
+	"cmp"
 	_ "embed"
+	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 //go:embed no_use_before_define.schema.json
 var schemaJSON []byte
+
+// https://typescript-eslint.io/rules/no-use-before-define
+//
+// Scope semantics come from the shared scope model in
+// `internal/utils/scope`, the same one the ESLint core `no-use-before-define`
+// rule uses. The two rules deliberately do NOT share a body: typescript-eslint
+// extends an older core rule and its decision logic differs in ways that are
+// observable, not incidental —
+//
+//   - it has no class-definition-evaluation handling at all, so `class C
+//     extends C {}` and `class C { [C](){} }` are not reported;
+//   - a class field initializer and a class static block are plain separate
+//     variable scopes, with none of core's "static initializers run during
+//     class definition" folding;
+//   - `ignoreTypeReferences` covers every type position, not just a bare type
+//     annotation;
+//   - a reference from a function-type parameter list is never reported;
+//   - the options are consulted as an ordered chain in which a function
+//     declaration short-circuits the rest.
 
 // options mirrors the typescript-eslint rule schema.
 // See https://typescript-eslint.io/rules/no-use-before-define/#options
@@ -46,101 +67,191 @@ func parseOptions(rawOptions []any) options {
 	}
 
 	optsMap, _ := rawOptions[0].(map[string]interface{})
-
-	if v, ok := optsMap["functions"].(bool); ok {
-		opts.functions = v
+	readBool := func(key string, target *bool) {
+		if v, ok := optsMap[key].(bool); ok {
+			*target = v
+		}
 	}
-	if v, ok := optsMap["classes"].(bool); ok {
-		opts.classes = v
-	}
-	if v, ok := optsMap["variables"].(bool); ok {
-		opts.variables = v
-	}
-	if v, ok := optsMap["enums"].(bool); ok {
-		opts.enums = v
-	}
-	if v, ok := optsMap["typedefs"].(bool); ok {
-		opts.typedefs = v
-	}
-	if v, ok := optsMap["ignoreTypeReferences"].(bool); ok {
-		opts.ignoreTypeReferences = v
-	}
-	if v, ok := optsMap["allowNamedExports"].(bool); ok {
-		opts.allowNamedExports = v
-	}
+	readBool("functions", &opts.functions)
+	readBool("classes", &opts.classes)
+	readBool("variables", &opts.variables)
+	readBool("enums", &opts.enums)
+	readBool("typedefs", &opts.typedefs)
+	readBool("ignoreTypeReferences", &opts.ignoreTypeReferences)
+	readBool("allowNamedExports", &opts.allowNamedExports)
 
 	return opts
 }
 
-// definitionType categorizes a declaration for option-based filtering.
-// Maps to ESLint's scope-manager DefinitionType.
-type definitionType int
+var NoUseBeforeDefineRule = rule.CreateRule(rule.Rule{
+	Name:   "no-use-before-define",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		if ctx.SourceFile == nil {
+			return rule.RuleListeners{}
+		}
 
-const (
-	defUnknown definitionType = iota
-	defVariable
-	defFunctionName
-	defClassName
-	defTypeName      // interface or type alias
-	defEnumName      // enum declaration
-	defNamespaceName // module/namespace declaration
-	defImport
-	defCatchClause
-	defParameter
-)
+		manager := scope.Build(ctx.SourceFile, scope.Options{CollectReferences: true})
 
-func getDefinitionType(decl *ast.Node) definitionType {
-	if decl == nil {
-		return defUnknown
+		// Upstream walks the scope tree depth-first; ordering the flat
+		// reference list by source position gives the same sequence for every
+		// input the rule can report on, without depending on scope-creation
+		// order.
+		references := slices.Clone(manager.References)
+		slices.SortStableFunc(references, func(a, b *scope.Reference) int {
+			return cmp.Compare(a.Identifier.Pos(), b.Identifier.Pos())
+		})
+
+		for _, ref := range references {
+			check(ctx, opts, ref)
+		}
+
+		return rule.RuleListeners{}
+	},
+})
+
+func check(ctx rule.RuleContext, opts options, ref *scope.Reference) {
+	declaration := ref.Resolved()
+
+	// A named export gets its own option and a plain positional check — none
+	// of the option chain below applies to it.
+	if isNamedExport(ref.Identifier) {
+		if opts.allowNamedExports {
+			return
+		}
+		if declaration == nil || !isDefinedBeforeUse(declaration, ref) {
+			report(ctx, ref.Identifier)
+		}
+		return
 	}
-	switch decl.Kind {
-	case ast.KindVariableDeclaration, ast.KindBindingElement:
-		return defVariable
-	case ast.KindFunctionDeclaration:
-		return defFunctionName
-	case ast.KindClassDeclaration, ast.KindClassExpression:
-		return defClassName
-	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
-		return defTypeName
-	case ast.KindEnumDeclaration:
-		return defEnumName
-	case ast.KindModuleDeclaration:
-		return defNamespaceName
-	case ast.KindImportSpecifier, ast.KindImportClause, ast.KindNamespaceImport, ast.KindImportEqualsDeclaration:
-		return defImport
-	case ast.KindCatchClause:
-		return defCatchClause
-	case ast.KindParameter:
-		return defParameter
+
+	if declaration == nil {
+		return
 	}
-	return defUnknown
+	if isDefinedBeforeUse(declaration, ref) {
+		return
+	}
+	if !isForbidden(opts, declaration, ref) {
+		return
+	}
+	if isClassRefInClassDecorator(declaration, ref) {
+		return
+	}
+	// A function type's parameter list has no runtime evaluation order, so a
+	// reference from inside one is never "before" anything.
+	if isFunctionTypeScope(ref.From) {
+		return
+	}
+
+	report(ctx, ref.Identifier)
 }
 
-// isNamedExport checks if the identifier is the local name in an export specifier.
-// e.g. the `a` in `export { a }` or `export { a as b }`.
+// isDefinedBeforeUse reports whether the declaration is already in place when
+// the reference runs: it ends at or before the reference, and the reference is
+// not a value read from inside the declaration's own initializer.
+func isDefinedBeforeUse(declaration *scope.Variable, ref *scope.Reference) bool {
+	if declaration.ID.End() > ref.Identifier.End() {
+		return false
+	}
+	// A value read from inside the declaration's own initializer runs before
+	// the binding is set up, even though it sits after the name.
+	return !isValueReference(ref.Identifier) || !isInInitializer(declaration, ref)
+}
+
+// isInInitializer applies upstream's `variable.scope !== reference.from`
+// precondition before the positional walk: a reference that crosses a scope
+// boundary is never treated as part of the declaration's initialization, even
+// when it sits inside the initializer's source range.
+func isInInitializer(declaration *scope.Variable, ref *scope.Reference) bool {
+	if declaration.Scope != ref.From {
+		return false
+	}
+	return scope.IsInsideOwnInitializer(declaration.ID, ref.Identifier.End())
+}
+
+// isForbidden decides whether a use-before-define should be reported, based on
+// the options and what kind of declaration was referenced.
+//
+// The chain is ordered and short-circuits, matching upstream: a function
+// declaration is decided by `functions` alone and never falls through to the
+// later arms. For classes, variables, and enums the option only suppresses a
+// reference from a different variable scope; a same-scope reference is a
+// temporal dead zone error and is always reported.
+func isForbidden(opts options, declaration *scope.Variable, ref *scope.Reference) bool {
+	if opts.ignoreTypeReferences && isTypeReference(ref.Identifier) {
+		return false
+	}
+
+	switch {
+	case isFunctionNameDef(declaration):
+		return opts.functions
+	case isClassNameDef(declaration) && isFromOuterVariableScope(declaration, ref):
+		return opts.classes
+	case declaration.Kind == scope.DefVariable && isFromOuterVariableScope(declaration, ref):
+		return opts.variables
+	case declaration.Kind == scope.DefEnumName && isFromOuterVariableScope(declaration, ref):
+		return opts.enums
+	case declaration.Kind == scope.DefType:
+		return opts.typedefs
+	}
+
+	return true
+}
+
+func isFunctionNameDef(v *scope.Variable) bool {
+	return v.Kind == scope.DefFunctionName || v.Kind == scope.DefFnExprName
+}
+
+func isClassNameDef(v *scope.Variable) bool {
+	return v.Kind == scope.DefClassName || v.Kind == scope.DefClassInnerName
+}
+
+// isFromOuterVariableScope reports whether the reference is evaluated in a
+// different variable scope than the one holding the declaration. Unlike the
+// ESLint core rule, class field initializers and static blocks count as
+// ordinary separate scopes here — upstream does no static-initializer folding.
+func isFromOuterVariableScope(declaration *scope.Variable, ref *scope.Reference) bool {
+	if declaration.Scope == nil || ref.From == nil {
+		return false
+	}
+	return declaration.Scope.VariableScope() != ref.From.VariableScope()
+}
+
+// isNamedExport reports whether the identifier is the local name of an export
+// specifier — the `a` in `export { a }` or `export { a as b }`. The scope model
+// only ever creates a reference for that half of a specifier.
 func isNamedExport(node *ast.Node) bool {
-	if node.Parent == nil || node.Parent.Kind != ast.KindExportSpecifier {
-		return false
-	}
-	spec := node.Parent.AsExportSpecifier()
-	// For `export { a as b }`: PropertyName=a (local), Name()=b (exported).
-	if spec.PropertyName != nil {
-		return spec.PropertyName == node
-	}
-	return spec.Name() == node
+	return node.Parent != nil && node.Parent.Kind == ast.KindExportSpecifier
 }
 
-// isExportedAliasName checks if the identifier is the non-local export alias.
-// e.g. the `b` in `export { a as b }` — not a real reference.
-func isExportedAliasName(node *ast.Node) bool {
-	if node.Parent == nil || node.Parent.Kind != ast.KindExportSpecifier {
+// isFunctionTypeScope reports whether a scope is one of scope-manager's
+// `functionType` scopes: the parameter list of a function type, constructor
+// type, call/construct signature, method signature, or a body-less function
+// declaration.
+func isFunctionTypeScope(s *scope.Scope) bool {
+	if s == nil || s.Kind != scope.KindFunction || s.Block == nil {
 		return false
 	}
-	spec := node.Parent.AsExportSpecifier()
-	return spec.PropertyName != nil && spec.Name() == node
+	block := s.Block
+	if ast.IsFunctionTypeNode(block) || ast.IsConstructorTypeNode(block) ||
+		ast.IsCallSignatureDeclaration(block) || ast.IsConstructSignatureDeclaration(block) ||
+		ast.IsMethodSignatureDeclaration(block) {
+		return true
+	}
+	return ast.IsFunctionLikeDeclaration(block) && block.Body() == nil
 }
 
-// isTypeReference reports whether the identifier sits in a type-only context.
+// isValueReference reports whether the identifier is read at runtime, as
+// opposed to naming a type. Only value reads can observe a binding mid-
+// initialization.
+func isValueReference(node *ast.Node) bool {
+	return !isTypeReference(node)
+}
+
+// isTypeReference reports whether the identifier sits in a type-only context —
+// scope-manager's `Reference#isTypeReference`, which is broader than the plain
+// type-annotation check the ESLint core rule uses.
 //
 // Composes tsgo helpers that mirror the TypeScript compiler:
 //   - IsPartOfTypeNode: covers TypeReference, QualifiedName chains in type
@@ -161,6 +272,13 @@ func isTypeReference(node *ast.Node) bool {
 	if ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node) {
 		return true
 	}
+	// `export = X` and `export default X` can export a type, so scope-manager
+	// flags the exported name as a type reference too (alongside being a value
+	// reference). `export const q = X` is not one.
+	if node.Parent.Kind == ast.KindExportAssignment &&
+		node.Parent.AsExportAssignment().Expression == node {
+		return true
+	}
 	current := node.Parent
 	for current != nil && current.Kind == ast.KindPropertyAccessExpression {
 		current = current.Parent
@@ -170,501 +288,27 @@ func isTypeReference(node *ast.Node) bool {
 		!ast.IsExpressionWithTypeArgumentsInClassExtendsClause(current)
 }
 
-// isInFunctionTypeScope checks if the identifier is inside a function type
-// annotation (e.g. `type F = (x: Foo) => void`). References there live in a
-// separate scope and should not be checked.
-func isInFunctionTypeScope(node *ast.Node) bool {
-	found := ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
-		switch n.Kind {
-		case ast.KindFunctionType, ast.KindConstructorType:
-			return true
-		// Stop at real scope boundaries.
-		case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
-			ast.KindMethodDeclaration, ast.KindConstructor,
-			ast.KindClassDeclaration, ast.KindClassExpression,
-			ast.KindSourceFile:
-			return true
-		}
-		return false
-	})
-	if found == nil {
+// isClassRefInClassDecorator reports whether a reference to a class binding
+// appears in one of that class's own decorators. Decorators are applied after
+// the class is defined, so the binding is already initialized.
+func isClassRefInClassDecorator(declaration *scope.Variable, ref *scope.Reference) bool {
+	if !isClassNameDef(declaration) || declaration.DefNode == nil {
 		return false
 	}
-	return found.Kind == ast.KindFunctionType || found.Kind == ast.KindConstructorType
-}
-
-// getEnclosingFunctionScope returns the nearest enclosing function-like node
-// that creates a new variable scope, or nil for program-level code.
-//
-// This models ESLint's "variableScope" concept:
-//   - Static class field initializers and static blocks run synchronously during
-//     class evaluation, so they are part of the outer execution context (skipped).
-//   - Instance field initializers are conceptually separate execution contexts.
-func getEnclosingFunctionScope(node *ast.Node) *ast.Node {
-	current := node.Parent
-	for current != nil {
-		switch current.Kind {
-		case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
-			ast.KindMethodDeclaration, ast.KindConstructor,
-			ast.KindGetAccessor, ast.KindSetAccessor:
-			return current
-		case ast.KindClassStaticBlockDeclaration:
-			// Static blocks run during class definition — same execution context.
-			current = current.Parent
-			continue
-		case ast.KindPropertyDeclaration:
-			// Static field initializers: same execution context as class definition.
-			// Instance field initializers: separate execution context.
-			if ast.HasStaticModifier(current) && current.AsPropertyDeclaration().Initializer != nil {
-				current = current.Parent
-				continue
-			}
-			return current
-		}
-		current = current.Parent
-	}
-	return nil
-}
-
-// isFromSeparateExecutionContext returns true when reference and declaration
-// live in different function-level scopes.
-func isFromSeparateExecutionContext(refScope *ast.Node, declNode *ast.Node) bool {
-	return refScope != getEnclosingFunctionScope(declNode)
-}
-
-// isInRange checks if a source position falls within [node.Pos(), node.End()].
-func isInRange(node *ast.Node, location int) bool {
-	return node != nil && node.Pos() <= location && location <= node.End()
-}
-
-// hasScopeBoundaryBetween returns true if there is a class or function scope
-// boundary between the reference node and the declaration node. This matches
-// the typescript-eslint `variable.scope !== reference.from` check.
-func hasScopeBoundaryBetween(refNode *ast.Node, declNode *ast.Node) bool {
-	current := refNode.Parent
-	for current != nil && current != declNode {
-		switch current.Kind {
-		case ast.KindClassDeclaration, ast.KindClassExpression:
-			return true
-		}
-		current = current.Parent
-	}
-	return false
-}
-
-// isInsideModuleAugmentation checks if a declaration is inside (or is)
-// a `declare module '...' { ... }` augmentation block.
-func isInsideModuleAugmentation(node *ast.Node) bool {
-	return ast.FindAncestor(node, ast.IsExternalModuleAugmentation) != nil
-}
-
-// isClassRefInClassDecorator returns true if the reference appears inside a
-// decorator of the class it refers to. Decorators are transpiled after the
-// class declaration, so such references are safe.
-func isClassRefInClassDecorator(decl *ast.Node, refNode *ast.Node) bool {
-	if decl.Kind != ast.KindClassDeclaration {
-		return false
-	}
-	decorators := decl.Decorators()
-	if len(decorators) == 0 {
-		return false
-	}
-	refStart := refNode.Pos()
-	refEnd := refNode.End()
-	for _, deco := range decorators {
-		if refStart >= deco.Pos() && refEnd <= deco.End() {
-			return true
-		}
-	}
-	return false
-}
-
-// isSentinelKind returns true for node kinds that form scope boundaries and
-// stop the isEvaluatedDuringInitialization walk (matching ESLint's SENTINEL_TYPE).
-func isSentinelKind(kind ast.Kind) bool {
-	switch kind {
-	case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
-		ast.KindClassDeclaration, ast.KindClassExpression,
-		ast.KindArrowFunction, ast.KindCatchClause,
-		ast.KindImportDeclaration, ast.KindExportDeclaration,
-		// Method-like kinds create separate execution contexts and must stop
-		// the isEvaluatedDuringInitialization walk. Without this, parameters
-		// inside methods would incorrectly "escape" into enclosing variable
-		// initializers. ESLint doesn't need these because in its AST model
-		// methods are FunctionExpressions.
-		ast.KindMethodDeclaration, ast.KindConstructor,
-		ast.KindGetAccessor, ast.KindSetAccessor:
-		return true
-	}
-	return false
-}
-
-// isEvaluatedDuringInitialization returns true when the reference is evaluated
-// during the initialization of its own declaration. Examples:
-//
-//	var a = a         // self-referencing initializer
-//	var [a = a] = []  // destructuring default
-//	for (var a in a)  // for-in/for-of right-hand side
-//
-// NOTE: Unlike the ESLint core rule, the typescript-eslint version does NOT
-// check class body evaluation (extends clause, computed property keys, etc.).
-// It relies purely on source-position comparison for class declarations.
-// See: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-use-before-define.ts
-func isEvaluatedDuringInitialization(refNode *ast.Node, decl *ast.Node, refScope *ast.Node) bool {
-	if isFromSeparateExecutionContext(refScope, decl) {
-		return false
-	}
-
-	// The typescript-eslint rule's isInInitializer checks
-	// `variable.scope !== reference.from` first. If the reference crosses a
-	// scope boundary (class, block, etc.) relative to the declaration, it is
-	// NOT considered "in the initializer" even when positionally inside the
-	// initializer's range. We approximate this by checking whether any
-	// class/function/block scope exists between the reference and the decl.
-	if hasScopeBoundaryBetween(refNode, decl) {
-		return false
-	}
-
-	location := refNode.End()
-
-	// Only check variable/binding-element initializers (not class bodies).
-	declName := utils.GetDeclarationIdentifier(decl)
-	if declName == nil {
-		return false
-	}
-	for node := declName.Parent; node != nil; node = node.Parent {
-		switch node.Kind {
-		case ast.KindVariableDeclaration:
-			varDecl := node.AsVariableDeclaration()
-			if varDecl.Initializer != nil && isInRange(varDecl.Initializer, location) {
-				return true
-			}
-			// Check for-in/for-of right-hand side.
-			if varDeclList := node.Parent; varDeclList != nil && varDeclList.Parent != nil {
-				forStmt := varDeclList.Parent
-				if forStmt.Kind == ast.KindForInStatement || forStmt.Kind == ast.KindForOfStatement {
-					if isInRange(forStmt.AsForInOrOfStatement().Expression, location) {
-						return true
-					}
-				}
-			}
-			return false
-		case ast.KindBindingElement:
-			if init := node.AsBindingElement().Initializer; init != nil && isInRange(init, location) {
-				return true
-			}
-		case ast.KindParameter:
-			if init := node.AsParameterDeclaration().Initializer; init != nil && isInRange(init, location) {
-				return true
-			}
-		default:
-			if isSentinelKind(node.Kind) {
-				return false
-			}
-		}
-	}
-	return false
-}
-
-// ---------------------------------------------------------------------------
-// Rule definition
-// ---------------------------------------------------------------------------
-
-type definitionInfo struct {
-	declaration *ast.Node
-	name        *ast.Node
-	defType     definitionType
-}
-
-var NoUseBeforeDefineRule = rule.CreateRule(rule.Rule{
-	Name:             "no-use-before-define",
-	Schema:           rule.NewSchema(schemaJSON),
-	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
-		if ctx.TypeChecker == nil || ctx.Refs == nil {
-			return rule.RuleListeners{}
-		}
-
-		opts := parseOptions(rawOptions)
-		var executionScopes []*ast.Node
-		currentExecutionScope := func() *ast.Node {
-			if len(executionScopes) == 0 {
-				return nil
-			}
-			return executionScopes[len(executionScopes)-1]
-		}
-		pushExecutionScope := func(node *ast.Node) {
-			executionScopes = append(executionScopes, node)
-		}
-		popExecutionScope := func(*ast.Node) {
-			executionScopes = executionScopes[:len(executionScopes)-1]
-		}
-
-		listeners := rule.RuleListeners{
-			ast.KindIdentifier: func(node *ast.Node) {
-				if !utils.IsDeclarationIdentifier(node) {
-					checkIdentifier(ctx, opts, node, currentExecutionScope())
-				}
-			},
-		}
-
-		for _, kind := range []ast.Kind{
-			ast.KindFunctionDeclaration,
-			ast.KindFunctionExpression,
-			ast.KindArrowFunction,
-			ast.KindMethodDeclaration,
-			ast.KindConstructor,
-			ast.KindGetAccessor,
-			ast.KindSetAccessor,
-		} {
-			listeners[kind] = pushExecutionScope
-			listeners[rule.ListenerOnExit(kind)] = popExecutionScope
-		}
-		listeners[ast.KindPropertyDeclaration] = func(node *ast.Node) {
-			if !ast.HasStaticModifier(node) || node.AsPropertyDeclaration().Initializer == nil {
-				pushExecutionScope(node)
-			}
-		}
-		listeners[rule.ListenerOnExit(ast.KindPropertyDeclaration)] = func(node *ast.Node) {
-			if !ast.HasStaticModifier(node) || node.AsPropertyDeclaration().Initializer == nil {
-				popExecutionScope(node)
-			}
-		}
-		return listeners
-	},
-})
-
-func checkIdentifier(ctx rule.RuleContext, opts options, node *ast.Node, refScope *ast.Node) {
-	// The renamed export name in `export { a as b }` is not a reference.
-	if isExportedAliasName(node) {
-		return
-	}
-
-	// Named exports have their own `allowNamedExports` option and a simpler
-	// "declared before this line" check (no TDZ/scope-boundary nuance,
-	// matching typescript-eslint's own handling), so they're dispatched to
-	// their own path rather than falling into the general logic below.
-	if isNamedExport(node) {
-		checkNamedExport(ctx, opts, node)
-		return
-	}
-
-	sym := ctx.Refs.Resolve(node)
-	checkerResolved := false
-	if sym == nil && needsCheckerFallback(opts, node) {
-		sym = ctx.TypeChecker.GetSymbolAtLocation(node)
-		checkerResolved = sym != nil
-	}
-	if sym == nil {
-		return
-	}
-
-	declarations := sym.Declarations
-	if checkerResolved && sym.Flags&ast.SymbolFlagsAlias != 0 {
-		if resolved := ctx.TypeChecker.SkipAlias(sym); resolved != nil && len(resolved.Declarations) > 0 {
-			declarations = append(append([]*ast.Node(nil), resolved.Declarations...), sym.Declarations...)
-		}
-	}
-	info := getDefinitionInfo(ctx.SourceFile, declarations)
-	if info.declaration == nil {
-		return
-	}
-	firstDecl := info.declaration
-	declName := info.name
-
-	// In a QualifiedName chain (A.B.C), only the leftmost name is a real reference.
-	if node.Parent != nil && node.Parent.Kind == ast.KindQualifiedName {
-		topQN := node.Parent
-		for topQN.Parent != nil && topQN.Parent.Kind == ast.KindQualifiedName {
-			topQN = topQN.Parent
-		}
-		leftmost := topQN.AsQualifiedName().Left
-		for leftmost.Kind == ast.KindQualifiedName {
-			leftmost = leftmost.AsQualifiedName().Left
-		}
-		if leftmost != node {
-			return
-		}
-		// QualifiedName inside import-equals is a namespace alias, not a use.
-		if topQN.Parent != nil && topQN.Parent.Kind == ast.KindImportEqualsDeclaration {
-			return
-		}
-	}
-
-	// Defined before use — no violation, unless evaluated during its own initialization.
-	if isDefinedBeforeUse(declName, node) &&
-		(!isEvaluatedDuringInitialization(node, firstDecl, refScope) || node.Parent.Kind == ast.KindTypeReference) {
-		return
-	}
-
-	// Option-based filtering.
-	if !isForbidden(opts, info.defType, node, firstDecl, refScope) {
-		return
-	}
-
-	if isClassRefInClassDecorator(firstDecl, node) {
-		return
-	}
-
-	if isInFunctionTypeScope(node) {
-		return
-	}
-
-	reportNode(ctx, node)
-}
-
-// needsCheckerFallback covers the small set of reference forms that
-// ctx.Refs.Resolve either cannot place at all, or can only place through its
-// own TypeChecker fallback:
-//   - type-only references to namespaces with no value declaration — a real
-//     reference position, so Resolve's fallback already reaches these; this
-//     branch is then a no-op (sym is already non-nil), kept for the case
-//     ctx.TypeChecker is unavailable to Resolve but was still supplied here;
-//   - qualified heritage members (`B` in `extends ns.B`), which occupy a
-//     property-name position rather than a normal binder reference position,
-//     so Resolve — checker fallback included — never even attempts them;
-//   - parameter properties referenced through `this.name`, excluded from
-//     Resolve the same way.
-//
-// The first category can only produce a diagnostic when type references are
-// enabled. Keeping this gate narrow avoids falling back to the checker for
-// ordinary property names.
-func needsCheckerFallback(opts options, node *ast.Node) bool {
-	if !opts.ignoreTypeReferences && isTypeReference(node) {
-		return true
-	}
-
-	current := node.Parent
-	if current == nil || current.Kind != ast.KindPropertyAccessExpression ||
-		current.AsPropertyAccessExpression().Name() != node {
-		return false
-	}
-	if current.AsPropertyAccessExpression().Expression.Kind == ast.KindThisKeyword {
-		// Parameter properties are surfaced as `this.name` property symbols by
-		// the checker, while RefStore correctly excludes ordinary property
-		// names. They still matter here because class field initializers run
-		// before the constructor assigns the parameter property.
-		return true
-	}
-	for current.Parent != nil && current.Parent.Kind == ast.KindPropertyAccessExpression {
-		current = current.Parent
-	}
-	return current.Parent != nil && ast.IsExpressionWithTypeArguments(current.Parent)
-}
-
-func getDefinitionInfo(sourceFile *ast.SourceFile, declarations []*ast.Node) definitionInfo {
-	// Find the earliest declaration in this source file, skipping export
-	// specifiers (they are reference sites, not definitions) and module
-	// augmentation declarations (they appear after the real definition).
-	var firstDecl *ast.Node
-	for _, decl := range declarations {
-		if decl.Kind == ast.KindExportSpecifier || isInsideModuleAugmentation(decl) {
+	for _, decorator := range declaration.DefNode.Decorators() {
+		if decorator == nil {
 			continue
 		}
-		if ast.GetSourceFileOfNode(decl) == sourceFile &&
-			(firstDecl == nil || decl.Pos() < firstDecl.Pos()) {
-			firstDecl = decl
+		if ref.Identifier.Pos() >= decorator.Pos() && ref.Identifier.End() <= decorator.End() {
+			return true
 		}
 	}
-	if firstDecl == nil {
-		return definitionInfo{}
-	}
-	declName := utils.GetDeclarationIdentifier(firstDecl)
-	if declName == nil {
-		return definitionInfo{}
-	}
-	return definitionInfo{
-		declaration: firstDecl,
-		name:        declName,
-		defType:     getDefinitionType(firstDecl),
-	}
+	return false
 }
 
-func checkNamedExport(ctx rule.RuleContext, opts options, node *ast.Node) {
-	if opts.allowNamedExports {
-		return
-	}
-
-	// ctx.Refs.Resolve walks the binder's own scope chain, so it lands on
-	// the LOCAL symbol directly — for `export { foo }` where foo is an
-	// import, that's the import specifier's own symbol, not the remote
-	// module's. getDefinitionInfo below then finds that local declaration
-	// without any alias-chain walking through the checker.
-	sym := ctx.Refs.Resolve(node)
-	if sym == nil &&
-		ctx.TypeChecker != nil &&
-		ast.IsTypeOnlyImportOrExportDeclaration(node.Parent) &&
-		!utils.IsReExportSpecifier(node.Parent) {
-		// RefStore deliberately leaves a type-only reference unresolved when
-		// only a value binding exists. no-use-before-define is the exception:
-		// its named-export branch still compares that local value declaration
-		// with the export site. Keep this rule-specific lookup here instead of
-		// polluting RefStore's declaration-space semantics.
-		sym = ctx.TypeChecker.GetExportSpecifierLocalTargetSymbol(node.Parent)
-	}
-	if sym == nil {
-		return
-	}
-
-	info := getDefinitionInfo(ctx.SourceFile, sym.Declarations)
-	if info.declaration == nil {
-		return
-	}
-
-	if isDefinedBeforeUse(info.name, node) {
-		return
-	}
-	reportNode(ctx, node)
-}
-
-// isDefinedBeforeUse compares end positions (matching ESLint behavior).
-func isDefinedBeforeUse(declName *ast.Node, refNode *ast.Node) bool {
-	return declName.End() <= refNode.End()
-}
-
-// isForbidden decides whether a use-before-define should be reported based on
-// the rule options and the declaration type.
-//
-// For classes, variables and enums the option only suppresses cross-scope
-// references (different function scope). Same-scope TDZ violations are always
-// reported regardless of the option value.
-func isForbidden(opts options, defType definitionType, refNode *ast.Node, declNode *ast.Node, refScope *ast.Node) bool {
-	if opts.ignoreTypeReferences && isTypeReference(refNode) {
-		return false
-	}
-
-	switch defType {
-	case defFunctionName:
-		return opts.functions
-	case defClassName:
-		if isFromSeparateExecutionContext(refScope, declNode) {
-			return opts.classes
-		}
-		return true // same scope — always report (TDZ)
-	case defVariable:
-		if isFromSeparateExecutionContext(refScope, declNode) {
-			return opts.variables
-		}
-		return true
-	case defEnumName:
-		if isFromSeparateExecutionContext(refScope, declNode) {
-			return opts.enums
-		}
-		return true
-	case defTypeName:
-		return opts.typedefs
-	}
-
-	return true
-}
-
-func reportNode(ctx rule.RuleContext, node *ast.Node) {
-	name := ""
-	if ast.IsIdentifier(node) {
-		name = node.AsIdentifier().Text
-	}
+func report(ctx rule.RuleContext, node *ast.Node) {
 	ctx.ReportNode(node, rule.RuleMessage{
 		Id:          "noUseBeforeDefine",
-		Description: "'" + name + "' was used before it was defined.",
+		Description: "'" + node.Text() + "' was used before it was defined.",
 	})
 }

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
@@ -47,6 +47,27 @@ f();
 
 Also accepts `"nofunc"` as a shorthand for `{ functions: false }`.
 
+## Differences from ESLint
+
+rslint also ships the core `no-use-before-define` rule, which gained TypeScript
+support in ESLint 10 and takes the same options. Enable one or the other — the
+two disagree in a few places, because this rule extends an older version of the
+core rule:
+
+- Code that reads a class binding while the class itself is still being defined
+  — `class C extends C {}`, `class C { [C](){} }`, `const C = class { static x = C }` —
+  is reported by the core rule and not by this one.
+- A class field initializer or static block is an ordinary separate scope here,
+  so `classes`, `variables`, and `enums` exempt references from inside one. The
+  core rule treats static initializers as part of the surrounding code, and
+  still reports them.
+- `ignoreTypeReferences` covers every type position here — including
+  `implements` clauses, qualified type names, and the exported name of
+  `export = X` / `export default X`. The core rule only exempts a bare type
+  annotation and a `typeof` query.
+- A reference from the parameter list of a function type (`type F = (x: Foo) => void`)
+  is never reported here.
+
 ## Original Documentation
 
 - [typescript-eslint: no-use-before-define](https://typescript-eslint.io/rules/no-use-before-define)

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
@@ -67,6 +67,9 @@ core rule:
   annotation and a `typeof` query.
 - A reference from the parameter list of a function type (`type F = (x: Foo) => void`)
   is never reported here.
+- A reference that resolves to a string-literal enum member (`enum E { b = a, "a" = 1 }`)
+  is not reported here, because such a member declares no identifier. The core
+  rule measures it from the literal and reports it.
 
 ## Original Documentation
 

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -1,3 +1,8 @@
+// TestNoUseBeforeDefineExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise — class definitions, scoping, nesting,
+// and the tsgo AST quirks that diverge from ESTree — so future refactors can't
+// silently regress them. The migrated upstream cases live in
+// no_use_before_define_upstream_test.go.
 package no_use_before_define
 
 import (
@@ -7,9 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-// TestEdgeCases covers missing scenarios from the ESLint/typescript-eslint test suites
-// and systematically enumerates edge cases across class definitions, scoping, and nesting.
-func TestEdgeCases(t *testing.T) {
+func TestNoUseBeforeDefineExtras(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUseBeforeDefineRule,
 
 		// =====================================================================
@@ -128,12 +131,23 @@ func TestEdgeCases(t *testing.T) {
 				Options: map[string]interface{}{"allowNamedExports": true},
 			},
 
+			// ----- A parameter property read through `this` is a property
+			// access, not a reference to the constructor parameter binding -----
+			{Code: `class C { field = this.value; constructor(private value: number) {} }`},
+
+			// ----- `export = X` / `export default X` may export a type, so the
+			// ----- exported name is a type reference and the default
+			// ----- ignoreTypeReferences exempts it -----
+			{Code: `export default a; const a = 1;`, Options: map[string]interface{}{"allowNamedExports": true}},
+			{Code: `export default a; const a = 1;`},
+			{Code: `export = foobar; declare function foobar(): void;`},
+			// A value read in an exported initializer is not a type reference.
+			{Code: `const a = 1; export const q = a;`},
+
 			// ----- Type-only named exports -----
 			{Code: `let x = 1; export type { x };`},
 			{Code: `function f() {} export type { f };`},
 			{Code: `type T = number; export type { T };`},
-			// The local value does not shadow the real global type target.
-			{Code: `export type { HTMLElement }; let HTMLElement = 1;`},
 			{
 				Code:    `export type { x }; let x = 1;`,
 				Options: map[string]interface{}{"allowNamedExports": true},
@@ -245,13 +259,13 @@ declare global {
 					{MessageId: "noUseBeforeDefine", Line: 1, Column: 20},
 				},
 			},
-			// Qualified-name heritage: both `ns` and `B` resolve to later declarations.
+			// Qualified-name heritage: only the left-most name is a reference —
+			// `B` names a member of the namespace, not a binding in this scope.
 			{
 				Code:    `interface A extends ns.B {} namespace ns { export interface B {} }`,
 				Options: map[string]interface{}{"ignoreTypeReferences": false},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "noUseBeforeDefine", Line: 1, Column: 21},
-					{MessageId: "noUseBeforeDefine", Line: 1, Column: 24},
 				},
 			},
 
@@ -270,14 +284,6 @@ declare global {
 					{MessageId: "noUseBeforeDefine", Line: 1, Column: 26},
 				},
 			},
-			// ----- Field initializer before constructor parameter property assignment -----
-			{
-				Code: `class C { field = this.value; constructor(private value: number) {} }`,
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noUseBeforeDefine", Line: 1, Column: 24},
-				},
-			},
-
 			// ----- Static block referencing variable declared after -----
 			{
 				Code: `class C { static { a; } } let a: any;`,
@@ -349,12 +355,21 @@ declare global {
 				},
 			},
 
-			// ----- export default still reports with allowNamedExports -----
+			// ----- `export = X` / `export default X` can export a type, so the
+			// ----- exported name counts as a type reference and is only
+			// ----- reported once ignoreTypeReferences is off -----
 			{
 				Code:    `export default a; const a = 1;`,
-				Options: map[string]interface{}{"allowNamedExports": true},
+				Options: map[string]interface{}{"ignoreTypeReferences": false},
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noUseBeforeDefine"},
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `export = foobar; declare function foobar(): void;`,
+				Options: map[string]interface{}{"ignoreTypeReferences": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 10},
 				},
 			},
 
@@ -402,6 +417,14 @@ declare global {
 
 			// ----- Type-only named exports before define (typescript-eslint -----
 			// ----- reports these even with the default ignoreTypeReferences) -----
+			// A local binding that shares a name with a global type is no
+			// exception: the export specifier resolves to the local one.
+			{
+				Code: `export type { HTMLElement }; let HTMLElement = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+				},
+			},
 			{
 				Code: `export type { x }; let x = 1;`,
 				Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -145,8 +145,6 @@ func TestNoUseBeforeDefineExtras(t *testing.T) {
 			{Code: `const a = 1; export const q = a;`},
 
 			// ----- Type-only named exports -----
-			{Code: `let x = 1; export type { x };`},
-			{Code: `function f() {} export type { f };`},
 			{Code: `type T = number; export type { T };`},
 			{
 				Code:    `export type { x }; let x = 1;`,
@@ -220,6 +218,17 @@ declare global {
   }
 }
 `},
+
+			// ----- A string-literal enum member takes part in name resolution -----
+			// ----- but declares no identifier, so it is never a definition site -----
+			{Code: `enum E { b = a, "a" = 1 }`},
+			{Code: `enum E { "a" = 1, b = a } const a = 2;`},
+			{Code: `enum E { b = a, "a" = 1 } const a = 2;`},
+
+			// ----- A local type declaration does not bind the value space, so a -----
+			// ----- value read of a name it shares with a global is unaffected -----
+			{Code: `Map; interface Map<K, V> {}`},
+			{Code: `new Map(); interface Map<K, V> { extra(): void }`},
 		},
 
 		// =====================================================================
@@ -456,6 +465,28 @@ declare global {
 				},
 			},
 
+			// ----- A type-only export specifier only names the type space, so -----
+			// ----- it never reaches a value binding and is reported wherever -----
+			// ----- that binding sits -----
+			{
+				Code: `let x = 1; export type { x };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `function f() {} export type { f };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `let x = 1; export { type x };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 26},
+				},
+			},
+
 			// ----- Deeply nested: function inside arrow inside class method -----
 			{
 				Code: `
@@ -644,22 +675,11 @@ const a = 1;
 				},
 			},
 
-			// =========== Local declaration merged with a lib.d.ts global ===========
-			// A file-level declaration binds the name for the whole file, so the
-			// earlier use is reported even though the value itself comes from
-			// lib.d.ts. Matches ESLint, whose scope analysis merges the local
-			// declaration into the same variable as the predefined global.
-
+			// ----- An enum member reference that resolves past the enum body -----
 			{
-				Code: `Map; interface Map<K, V> {}`,
+				Code: `enum E { b = a } const a = 2;`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noUseBeforeDefine", Line: 1, Column: 1},
-				},
-			},
-			{
-				Code: `new Map(); interface Map<K, V> { extra(): void }`,
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noUseBeforeDefine", Line: 1, Column: 5},
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 14},
 				},
 			},
 		},

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_upstream_test.go
@@ -1,3 +1,7 @@
+// TestNoUseBeforeDefineUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/tests/rules/no-use-before-define.test.ts 1:1.
+// rslint-specific lock-in cases live in
+// no_use_before_define_extras_test.go.
 package no_use_before_define
 
 import (
@@ -7,7 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-func TestNoUseBeforeDefineRule(t *testing.T) {
+func TestNoUseBeforeDefineUpstream(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUseBeforeDefineRule, []rule_tester.ValidTestCase{
 		// Type declarations before use
 		{

--- a/internal/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/rules/no_use_before_define/no_use_before_define.go
@@ -258,52 +258,7 @@ func isEvaluatedDuringInitialization(ref *scope.Reference) bool {
 			!isInClassStaticInitializerRange(classDefinition, location)
 	}
 
-	for node := declaration.ID.Parent; node != nil; node = node.Parent {
-		switch node.Kind {
-		case ast.KindVariableDeclaration:
-			declarator := node.AsVariableDeclaration()
-			if declarator != nil && isInRange(declarator.Initializer, location) {
-				return true
-			}
-			// `for (var a in a)` / `for (var a of a)`: the right-hand side is
-			// evaluated before the binding is initialized.
-			if node.Parent != nil && node.Parent.Parent != nil {
-				loop := node.Parent.Parent
-				if loop.Kind == ast.KindForInStatement || loop.Kind == ast.KindForOfStatement {
-					if forInOrOf := loop.AsForInOrOfStatement(); forInOrOf != nil &&
-						isInRange(forInOrOf.Expression, location) {
-						return true
-					}
-				}
-			}
-			return false
-		case ast.KindBindingElement:
-			// ESTree's AssignmentPattern inside a destructuring pattern.
-			if element := node.AsBindingElement(); element != nil && isInRange(element.Initializer, location) {
-				return true
-			}
-		case ast.KindParameter:
-			// ESTree's AssignmentPattern in a parameter list.
-			if isInRange(node.Initializer(), location) {
-				return true
-			}
-		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
-			ast.KindClassDeclaration, ast.KindClassExpression,
-			ast.KindArrowFunction, ast.KindCatchClause,
-			ast.KindImportDeclaration, ast.KindExportDeclaration,
-			// ESTree wraps every shorthand method and accessor body in a
-			// FunctionExpression, which the walk stops at. tsgo has no such
-			// wrapper — the member node *is* the function — so these kinds
-			// stand in for it. Without them the walk escapes the method and
-			// finds the enclosing `const x = { m(node) { node; } }`
-			// initializer, reporting every parameter read inside.
-			ast.KindMethodDeclaration, ast.KindConstructor,
-			ast.KindGetAccessor, ast.KindSetAccessor:
-			return false
-		}
-	}
-
-	return false
+	return scope.IsInsideOwnInitializer(declaration.ID, location)
 }
 
 func isInRange(node *ast.Node, location int) bool {

--- a/internal/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/rules/no_use_before_define/no_use_before_define.go
@@ -93,6 +93,9 @@ var NoUseBeforeDefineRule = rule.Rule{
 				continue
 			}
 			declaration := ref.Resolved()
+			// `Variable.ID` is upstream's `variable.defs[0].name`, which for a
+			// string-literal enum member is the literal — still a definition
+			// site to measure the reference against.
 			if ref.Identifier.End() < declaration.ID.End() ||
 				(isEvaluatedDuringInitialization(ref) && !isTypeReference(ref.Identifier)) {
 				ctx.ReportNode(ref.Identifier, rule.RuleMessage{
@@ -118,12 +121,6 @@ func shouldCheck(ref *scope.Reference, opts options) bool {
 
 	declaration := ref.Resolved()
 	if declaration == nil {
-		return false
-	}
-
-	// A binding with no identifier — a string-literal enum member — has no
-	// declaration site to point the reader at, so upstream leaves it alone.
-	if declaration.Anonymous {
 		return false
 	}
 

--- a/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -272,10 +272,11 @@ function f() {
 			{Code: `function f(this: number) { return this; }`},
 
 			// ---- TS resolves a string-literal member name to a real name, so
-			// the reference reads the member — which has no identifier to
-			// report at ----
-			{Code: "enum E {\n  A = ((): number => B)(),\n  \"B\" = 1,\n}", Options: map[string]any{"variables": false}},
-			{Code: "enum E {\n  A = B,\n  \"B\" = 2,\n}\nconst B = 1;"},
+			// the reference reads the member; the literal is the member's
+			// definition site ----
+			{Code: "enum E {\n  \"B\" = 2,\n  A = B,\n}"},
+			{Code: "enum E {\n  \"B\" = 2,\n  A = B,\n}\nconst B = 1;"},
+			{Code: `enum E { "a" = a }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: receiver / expression wrappers must not hide the
@@ -541,6 +542,33 @@ enum E {
 `,
 				Options: map[string]any{"variables": false},
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 22}},
+			},
+
+			// ---- A string-literal member name is a definition site like any
+			// other, so a sibling reading it earlier is reported ----
+			{
+				Code: `
+enum E {
+  A = ((): number => B)(),
+  "B" = 1,
+}
+`,
+				Options: map[string]any{"variables": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 22}},
+			},
+			{
+				Code: `
+enum E {
+  A = B,
+  "B" = 2,
+}
+const B = 1;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 3, Column: 7}},
+			},
+			{
+				Code:   `enum E { b = a, "a" = 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 14}},
 			},
 
 			// ---- A heritage clause spells its dotted name with property

--- a/internal/utils/scope/initializer.go
+++ b/internal/utils/scope/initializer.go
@@ -1,0 +1,86 @@
+package scope
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// IsInsideOwnInitializer reports whether `location` falls inside the value a
+// binding is initialized from — eslint-scope's `isInInitializer` walk, which
+// answers "is this reference evaluated while its own binding is still being
+// set up":
+//
+//	var a = a
+//	var [a = a] = list
+//	var {a = a} = obj
+//	function f(a = a) {}
+//	for (var a in a) {}
+//	for (var a of a) {}
+//
+// `declarationID` is the identifier that binds the name. The walk climbs from
+// it looking for the construct that supplies its value, and stops at the node
+// kinds ESLint calls SENTINEL_TYPE — the boundaries a value cannot be
+// initialized across.
+//
+// Callers are responsible for the scope-level preconditions their rule needs
+// (for example "the reference and the declaration share a scope"): this
+// function is purely positional.
+func IsInsideOwnInitializer(declarationID *ast.Node, location int) bool {
+	if declarationID == nil {
+		return false
+	}
+	for node := declarationID.Parent; node != nil; node = node.Parent {
+		switch node.Kind {
+		case ast.KindVariableDeclaration:
+			declarator := node.AsVariableDeclaration()
+			if declarator != nil && rangeContains(declarator.Initializer, location) {
+				return true
+			}
+			// `for (var a in a)` / `for (var a of a)`: the iterated expression
+			// is evaluated before the binding is initialized.
+			if node.Parent != nil && node.Parent.Parent != nil {
+				loop := node.Parent.Parent
+				if loop.Kind == ast.KindForInStatement || loop.Kind == ast.KindForOfStatement {
+					if forInOrOf := loop.AsForInOrOfStatement(); forInOrOf != nil &&
+						rangeContains(forInOrOf.Expression, location) {
+						return true
+					}
+				}
+			}
+			return false
+
+		case ast.KindBindingElement:
+			// ESTree's AssignmentPattern inside a destructuring pattern.
+			if element := node.AsBindingElement(); element != nil && rangeContains(element.Initializer, location) {
+				return true
+			}
+
+		case ast.KindParameter:
+			// ESTree's AssignmentPattern in a parameter list.
+			if rangeContains(node.Initializer(), location) {
+				return true
+			}
+
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindClassDeclaration, ast.KindClassExpression,
+			ast.KindArrowFunction, ast.KindCatchClause,
+			ast.KindImportDeclaration, ast.KindExportDeclaration,
+			// ESTree wraps every shorthand method and accessor body in a
+			// FunctionExpression, which the walk stops at. tsgo has no such
+			// wrapper — the member node *is* the function — so these kinds
+			// stand in for it. Without them the walk escapes the method and
+			// finds the enclosing `const x = { m(node) { node; } }`
+			// initializer, treating every parameter read inside as a
+			// self-reference.
+			ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor:
+			return false
+		}
+	}
+	return false
+}
+
+// rangeContains reports whether `location` falls within `node`'s source range.
+// A nil node contains nothing.
+func rangeContains(node *ast.Node, location int) bool {
+	return node != nil && node.Pos() <= location && location <= node.End()
+}


### PR DESCRIPTION
## Summary

Follow-up to #1756, which noted that `@typescript-eslint/no-use-before-define` carried its own reconstruction of ESLint's scope semantics. This removes that duplication.

> **Stacked on #1756**, which is stacked on #1755. Base branch is `feat/port-rule-no_use_before_define-20260816`; only the last commit belongs to this PR.

### What was duplicated

The rule hand-rolled everything the shared `internal/utils/scope` model now provides:

| Was | Now |
|---|---|
| An execution-scope listener stack pushed/popped across 8 node kinds, plus `getEnclosingFunctionScope` | `Scope.VariableScope()` |
| `getDefinitionType` — a switch over AST kinds | `scope.DefKind` |
| `getDefinitionInfo` — earliest declaration in this file, over checker symbols, skipping export specifiers and module augmentations | `Scope.Declarations(name)[0]` |
| `hasScopeBoundaryBetween` — an approximation of `variable.scope !== reference.from` | that comparison, exactly |
| `isNamedExport` / `isExportedAliasName` / `utils.IsDeclarationIdentifier` / the QualifiedName left-most walk | the scope model's reference filter |
| `needsCheckerFallback`, alias-chain skipping, `GetExportSpecifierLocalTargetSymbol` | not needed |
| Its own copy of the SENTINEL_TYPE initializer walk | `scope.IsInsideOwnInitializer`, now shared with the core rule |

**−617 / +257 lines**, and `RequiresTypeInfo` goes away — the rule no longer needs a TypeChecker to run.

The two rules deliberately keep separate bodies: typescript-eslint extends an *older* core rule and disagrees with today's core rule in ways that are observable, not incidental (no class-definition-evaluation handling; class field initializers and static blocks as plain separate scopes; a broader `ignoreTypeReferences`; the function-type-parameter exemption; a different option-precedence chain). Those differences are now documented in the rule's `.md` so users can pick between the two.

### Behavior changes, each checked against typescript-eslint v8.67.0

Three existing test expectations encoded behavior the checker-based resolution invented:

| Case | Was | typescript-eslint | Now |
|---|---|---|---|
| `interface A extends ns.B {} namespace ns { export interface B {} }` | 2 errors | 1 error (`ns`) | 1 error |
| `class C { field = this.value; constructor(private value: number) {} }` | 1 error | none | none |
| `export type { X }; let X = 1;` | valid | reports | reports |

And two upstream behaviors were missing, now covered: the exported name of `export = X` / `export default X` counts as a type reference (so it is exempt under the default `ignoreTypeReferences`, and reported when it is off), and `export type` specifiers resolve to the local binding.

### Test file naming

The rule's two test files also move to the documented split, each with a header docstring saying what it covers and pointing at its sibling:

- `no_use_before_define_test.go` → `no_use_before_define_upstream_test.go` (`TestNoUseBeforeDefineUpstream`)
- `edge_cases_test.go` → `no_use_before_define_extras_test.go` (`TestNoUseBeforeDefineExtras`)

Git tracks both as renames; the content diff is the header and the function name.

### Verification

Diffed against typescript-eslint v8.67.0 over the same **1123 TypeScript/TSX files** used in #1756: **132 findings, identical in file, line, column, and message.** Both no-shadow suites, both no-use-before-define suites, the config sweep, and both JS suites pass; the JS snapshots are unchanged.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
