### PR TITLE
feat: collect source files from project references

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -51,7 +51,7 @@ func CreateProgram(config string) (*compiler.Program, error) {
 	}
 	currentDirectory = tspath.NormalizePath(currentDirectory)
 	host := utils.CreateCompilerHost(currentDirectory, fs)
-	program, err := utils.CreateProgram(
+	program, err := utils.CreateProgramUsingProjectReferenceSources(
 		true,
 		fs,
 		currentDirectory,
@@ -179,7 +179,7 @@ func runMain() int {
 	defer done()
 
 	checkResult := CheckResult{}
-	checkResult.RootFiles = program.CommandLine().FileNames()
+	checkResult.RootFiles = append(checkResult.RootFiles, program.CommandLine().FileNames()...)
 	checkResult.Semantic = NewSemantic()
 	checkResult.SourceFileExtra = []SourceFileExtra{}
 
@@ -195,6 +195,9 @@ func runMain() int {
 		fileMap[file.FileName()] = int32(sourcefileId)
 		checkResult.ModuleList = append(checkResult.ModuleList, file.FileName())
 		sourceFile := file.AsSourceFile()
+		if !sourceFile.IsDeclarationFile && program.IsSourceFromProjectReference(sourceFile.Path()) {
+			checkResult.RootFiles = append(checkResult.RootFiles, sourceFile.FileName())
+		}
 
 		encodedSourceFile, _, err := encoder.EncodeSourceFile(sourceFile)
 		if err != nil {

--- a/cmd/tsgo/semantic_test.go
+++ b/cmd/tsgo/semantic_test.go
@@ -201,17 +201,17 @@ const primitiveValue = 1;
 		}
 	}
 
-anonymousID, ok := symbols["anonymousValue"]
-if !ok || anonymousID == 0 {
-	t.Fatalf("symbol %q not found", "anonymousValue")
-}
-anonymousTypeID, ok := fixture.semantic.Sym2type[anonymousID]
-if !ok || anonymousTypeID == 0 {
-	t.Fatalf("type for symbol %q not found", "anonymousValue")
-}
-if typeInfo, ok := fixture.semantic.Typetab[anonymousTypeID]; !ok || typeInfo.Symbol == 0 {
-	t.Fatal("object literal type has no declaration symbol")
-}
+	anonymousID, ok := symbols["anonymousValue"]
+	if !ok || anonymousID == 0 {
+		t.Fatalf("symbol %q not found", "anonymousValue")
+	}
+	anonymousTypeID, ok := fixture.semantic.Sym2type[anonymousID]
+	if !ok || anonymousTypeID == 0 {
+		t.Fatalf("type for symbol %q not found", "anonymousValue")
+	}
+	if typeInfo, ok := fixture.semantic.Typetab[anonymousTypeID]; !ok || typeInfo.Symbol == 0 {
+		t.Fatal("object literal type has no declaration symbol")
+	}
 
 	primitiveID := symbols["primitiveValue"]
 	primitiveTypeID := fixture.semantic.Sym2type[primitiveID]
@@ -332,69 +332,4 @@ func TestSemanticSnapshot_InternalSymbolNameSanitized(t *testing.T) {
 			t.Fatalf("symbol name contains unsanitized \\xFE: %q", name)
 		}
 	}
-}
-
-func TestCreateProgramUsesProjectReferenceSources(t *testing.T) {
-	tmpDir := t.TempDir()
-	mainDir := filepath.Join(tmpDir, "main")
-	dependencyDir := filepath.Join(tmpDir, "dependency")
-	dependencySourceDir := filepath.Join(dependencyDir, "src")
-	declarationDir := filepath.Join(tmpDir, "decls")
-	for _, dir := range []string{mainDir, dependencySourceDir, declarationDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("Failed to create fixture directory: %v", err)
-		}
-	}
-
-	files := map[string]string{
-		filepath.Join(mainDir, "tsconfig.json"): `{
-			"compilerOptions": { "composite": true },
-			"include": ["./index.ts"],
-			"references": [{ "path": "../dependency" }]
-		}`,
-		filepath.Join(mainDir, "index.ts"): `import { value } from "../decls/value"; export const result = value;`,
-		filepath.Join(dependencyDir, "tsconfig.json"): `{
-			"compilerOptions": {
-				"composite": true,
-				"rootDir": "./src",
-				"declarationDir": "../decls"
-			},
-			"include": ["./src/**/*.ts"]
-		}`,
-		filepath.Join(dependencySourceDir, "value.ts"): `export const value = 42;`,
-	}
-	for path, contents := range files {
-		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-			t.Fatalf("Failed to write fixture file %s: %v", path, err)
-		}
-	}
-
-	t.Chdir(mainDir)
-	program, err := CreateProgram("tsconfig.json")
-	if err != nil {
-		t.Fatalf("Failed to create program: %v", err)
-	}
-
-	dependencySourcePath := filepath.ToSlash(filepath.Join(dependencySourceDir, "value.ts"))
-	dependencyDeclarationPath := filepath.ToSlash(filepath.Join(declarationDir, "value.d.ts"))
-	dependencySourceID := -1
-	for id, file := range program.GetSourceFiles() {
-		switch filepath.ToSlash(file.FileName()) {
-		case dependencySourcePath:
-			dependencySourceID = id
-		case dependencyDeclarationPath:
-			t.Fatalf("project reference used declaration output instead of source: %s", file.FileName())
-		}
-	}
-	if dependencySourceID == -1 {
-		t.Fatalf("project reference source was not included in program: %s", dependencySourcePath)
-	}
-
-	semantic := CollectSemantic(program)
-	for reference := range semantic.Node2type {
-		if reference.SourceFileId == dependencySourceID {
-			return
-		}
-	}
-	t.Fatalf("project reference source has no collected semantic type information: %s", dependencySourcePath)
 }

--- a/cmd/tsgo/semantic_test.go
+++ b/cmd/tsgo/semantic_test.go
@@ -333,3 +333,68 @@ func TestSemanticSnapshot_InternalSymbolNameSanitized(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateProgramUsesProjectReferenceSources(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "main")
+	dependencyDir := filepath.Join(tmpDir, "dependency")
+	dependencySourceDir := filepath.Join(dependencyDir, "src")
+	declarationDir := filepath.Join(tmpDir, "decls")
+	for _, dir := range []string{mainDir, dependencySourceDir, declarationDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("Failed to create fixture directory: %v", err)
+		}
+	}
+
+	files := map[string]string{
+		filepath.Join(mainDir, "tsconfig.json"): `{
+			"compilerOptions": { "composite": true },
+			"include": ["./index.ts"],
+			"references": [{ "path": "../dependency" }]
+		}`,
+		filepath.Join(mainDir, "index.ts"): `import { value } from "../decls/value"; export const result = value;`,
+		filepath.Join(dependencyDir, "tsconfig.json"): `{
+			"compilerOptions": {
+				"composite": true,
+				"rootDir": "./src",
+				"declarationDir": "../decls"
+			},
+			"include": ["./src/**/*.ts"]
+		}`,
+		filepath.Join(dependencySourceDir, "value.ts"): `export const value = 42;`,
+	}
+	for path, contents := range files {
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatalf("Failed to write fixture file %s: %v", path, err)
+		}
+	}
+
+	t.Chdir(mainDir)
+	program, err := CreateProgram("tsconfig.json")
+	if err != nil {
+		t.Fatalf("Failed to create program: %v", err)
+	}
+
+	dependencySourcePath := filepath.ToSlash(filepath.Join(dependencySourceDir, "value.ts"))
+	dependencyDeclarationPath := filepath.ToSlash(filepath.Join(declarationDir, "value.d.ts"))
+	dependencySourceID := -1
+	for id, file := range program.GetSourceFiles() {
+		switch filepath.ToSlash(file.FileName()) {
+		case dependencySourcePath:
+			dependencySourceID = id
+		case dependencyDeclarationPath:
+			t.Fatalf("project reference used declaration output instead of source: %s", file.FileName())
+		}
+	}
+	if dependencySourceID == -1 {
+		t.Fatalf("project reference source was not included in program: %s", dependencySourcePath)
+	}
+
+	semantic := CollectSemantic(program)
+	for reference := range semantic.Node2type {
+		if reference.SourceFileId == dependencySourceID {
+			return
+		}
+	}
+	t.Fatalf("project reference source has no collected semantic type information: %s", dependencySourcePath)
+}

--- a/internal/utils/create_program.go
+++ b/internal/utils/create_program.go
@@ -37,6 +37,17 @@ func configNotFoundError(resolvedConfigPath string) error {
 }
 
 func CreateProgram(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath string, host compiler.CompilerHost) (*compiler.Program, error) {
+	return createProgram(singleThreaded, fs, cwd, tsconfigPath, host, false)
+}
+
+// CreateProgramUsingProjectReferenceSources creates a Program that redirects
+// project-reference declaration outputs back to their source files. This is
+// the mode used by the TypeScript language service for live source analysis.
+func CreateProgramUsingProjectReferenceSources(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath string, host compiler.CompilerHost) (*compiler.Program, error) {
+	return createProgram(singleThreaded, fs, cwd, tsconfigPath, host, true)
+}
+
+func createProgram(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath string, host compiler.CompilerHost, useSourceOfProjectReference bool) (*compiler.Program, error) {
 	resolvedConfigPath := tspath.ResolvePath(cwd, tsconfigPath)
 	if !fs.FileExists(resolvedConfigPath) {
 		return nil, configNotFoundError(resolvedConfigPath)
@@ -44,7 +55,7 @@ func CreateProgram(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath stri
 
 	configParseResult, _ := tsoptions.GetParsedCommandLineOfConfigFile(tsconfigPath, &core.CompilerOptions{}, nil, host, nil)
 
-	return createProgramFromConfig(singleThreaded, configParseResult, host)
+	return createProgramFromConfig(singleThreaded, configParseResult, host, useSourceOfProjectReference)
 }
 
 // CreateProgramLenient creates a tsconfig-backed Program but tolerates
@@ -69,7 +80,7 @@ func CreateProgramFromOptions(singleThreaded bool, compilerOptions *core.Compile
 		CurrentDirectory:          host.GetCurrentDirectory(),
 	})
 
-	return createProgramFromConfig(singleThreaded, configParseResult, host)
+	return createProgramFromConfig(singleThreaded, configParseResult, host, false)
 }
 
 // CreateProgramFromOptionsLenient creates a Program like
@@ -106,11 +117,12 @@ func CreateProgramFromParsedConfigLenient(singleThreaded bool, config *tsoptions
 	return program, nil
 }
 
-func createProgramFromConfig(singleThreaded bool, config *tsoptions.ParsedCommandLine, host compiler.CompilerHost) (*compiler.Program, error) {
+func createProgramFromConfig(singleThreaded bool, config *tsoptions.ParsedCommandLine, host compiler.CompilerHost, useSourceOfProjectReference bool) (*compiler.Program, error) {
 	opts := compiler.ProgramOptions{
-		Config:         config,
-		SingleThreaded: core.TSTrue,
-		Host:           host,
+		Config:                      config,
+		SingleThreaded:              core.TSTrue,
+		Host:                        host,
+		UseSourceOfProjectReference: useSourceOfProjectReference,
 	}
 	if !singleThreaded {
 		opts.SingleThreaded = core.TSFalse


### PR DESCRIPTION
## Summary

- create TypeScript programs with project-reference sources enabled for the `tsgo` semantic pipeline
- include non-declaration source files from project references in the reported root files
- keep the existing program creation behavior unchanged for other callers

## Motivation

The semantic pipeline previously used declaration outputs for referenced projects, so their original source files were not included in the collected root files. Using project-reference sources gives downstream consumers access to the complete source set while preserving the default behavior elsewhere.

## Impact

Projects that use TypeScript project references now expose referenced source files to `tsgo` semantic analysis. Existing linter and program-building paths continue to use the current declaration-based behavior.

## Validation

- `go test ./cmd/tsgo ./internal/utils`
- `git diff --check origin/main...HEAD`