### PR TITLE
chore: bump tsgo packages to 0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-client"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bitflags",
  "cbor4ii",

--- a/crates/tsgo-client/Cargo.toml
+++ b/crates/tsgo-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsgo-client"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 description = "TypeScript Go client library"
 license = "MIT"

--- a/npm/tsgo/darwin-arm64/package.json
+++ b/npm/tsgo/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-darwin-arm64",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "tsgo server binary for darwin arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/darwin-x64/package.json
+++ b/npm/tsgo/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-darwin-x64",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "tsgo server binary for darwin x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-arm64/package.json
+++ b/npm/tsgo/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-linux-arm64",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "tsgo server binary for linux arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-x64/package.json
+++ b/npm/tsgo/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-linux-x64",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "tsgo server binary for linux x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-arm64/package.json
+++ b/npm/tsgo/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-win32-arm64",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "tsgo server binary for windows arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-x64/package.json
+++ b/npm/tsgo/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-win32-x64",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "tsgo server binary for windows x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/packages/tsgo/package.json
+++ b/packages/tsgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "TypeScript Go semantic server",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump the `tsgo-client` crate from `0.0.7` to `0.0.8`.
- Bump `@rslint/tsgo-server` and all six platform packages to `0.0.8`.
- Keep `Cargo.lock` synchronized with the crate manifest.

## Why

Prepare the coordinated patch release of the tsgo crate and npm packages.

## Impact

This is a version-only change and does not alter runtime behavior.

## Validation

- Validated the shared tsgo release state with `scripts/tsgo-release-utils.mjs`.
- Ran the staged diff whitespace check.
- Passed the repository pre-commit formatting hooks.