### PR TITLE
feat: add Rstest globals

### DIFF
--- a/packages/rslint/src/config/globals/presets.ts
+++ b/packages/rslint/src/config/globals/presets.ts
@@ -3,7 +3,20 @@
  * package. Add small presets here; they are bundled as ordinary runtime
  * objects and do not pass through the JSON asset emitter.
  */
-export const RSLINT_GLOBAL_SETS = {} as const satisfies Record<
-  string,
-  Readonly<Record<string, boolean>>
->;
+export const RSLINT_GLOBAL_SETS = {
+  rstest: {
+    afterAll: false,
+    afterEach: false,
+    assert: false,
+    beforeAll: false,
+    beforeEach: false,
+    describe: false,
+    expect: false,
+    it: false,
+    onTestFailed: false,
+    onTestFinished: false,
+    rs: false,
+    rstest: false,
+    test: false,
+  },
+} as const satisfies Record<string, Readonly<Record<string, boolean>>>;

--- a/packages/rslint/tests/globals.test.ts
+++ b/packages/rslint/tests/globals.test.ts
@@ -48,7 +48,7 @@ describe('built-in globals catalog', () => {
       expect(globals[name]).toEqual(upstreamGlobals[name]);
     }
     for (const [name, globalSet] of Object.entries(RSLINT_GLOBAL_SETS)) {
-      expect(Reflect.get(globals, name)).toBe(globalSet);
+      expect(Reflect.get(globals, name)).toEqual(globalSet);
     }
   });
 


### PR DESCRIPTION
## Summary

- add an opt-in `globals.rstest` preset containing the APIs exposed when Rstest's `globals` option is enabled

## Usage

When Rstest is configured with `globals: true`, declare the same globals for test files in `rslint.config.ts`:

```ts
import { defineConfig, globals, rstestPlugin } from '@rslint/core';

export default defineConfig([
  rstestPlugin.configs.recommended,
  {
    files: ['**/*.{test,spec}.{js,jsx,ts,tsx}'],
    languageOptions: {
      globals: globals.rstest,
    },
  },
]);
```

This prevents rules such as `no-undef` from reporting Rstest APIs like `test`, `expect`, and `rs` as undefined.

This intentionally duplicates the data being added in [sindresorhus/globals#350](https://github.com/sindresorhus/globals/pull/350). Once that PR is merged and the resulting `globals` release is consumed by Rslint, this temporary Rslint-specific preset should be removed in favor of the upstream `globals.rstest` entry.