### PR TITLE
fix: align no-use-before-define semantics

### DIFF
--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -28,7 +28,8 @@ var schemaJSON []byte
 //     class definition" folding;
 //   - `ignoreTypeReferences` covers every type position, not just a bare type
 //     annotation;
-//   - a reference from a function-type parameter list is never reported;
+//   - a reference from a function/constructor type or call/construct/method
+//     signature is never reported;
 //   - the options are consulted as an ordered chain in which a function
 //     declaration short-circuits the rest.
 
@@ -113,6 +114,7 @@ var NoUseBeforeDefineRule = rule.CreateRule(rule.Rule{
 
 func check(ctx rule.RuleContext, opts options, ref *scope.Reference) {
 	declaration := ref.Resolved()
+	definitionIdentifier := ref.ResolvedIdentifier()
 
 	// A named export gets its own option and a plain positional check — none
 	// of the option chain below applies to it.
@@ -120,22 +122,20 @@ func check(ctx rule.RuleContext, opts options, ref *scope.Reference) {
 		if opts.allowNamedExports {
 			return
 		}
-		if declaration == nil || !isDefinedBeforeUse(declaration, ref) {
+		if declaration == nil || definitionIdentifier == nil ||
+			!isDefinedBeforeUse(declaration, definitionIdentifier, ref) {
 			report(ctx, ref.Identifier)
 		}
 		return
 	}
 
-	if declaration == nil {
+	// Definitions without identifiers — string-literal enum members, for
+	// example — still participate in resolution. Upstream skips the binding
+	// only when none of its merged definitions supplies an identifier.
+	if declaration == nil || definitionIdentifier == nil {
 		return
 	}
-	// A binding declared without an identifier — a string-literal enum member,
-	// `enum E { "a" = 1 }` — takes part in name resolution but has no
-	// declaration site to compare positions against, so upstream skips it.
-	if declaration.Anonymous {
-		return
-	}
-	if isDefinedBeforeUse(declaration, ref) {
+	if isDefinedBeforeUse(declaration, definitionIdentifier, ref) {
 		return
 	}
 	if !isForbidden(opts, declaration, ref) {
@@ -156,24 +156,24 @@ func check(ctx rule.RuleContext, opts options, ref *scope.Reference) {
 // isDefinedBeforeUse reports whether the declaration is already in place when
 // the reference runs: it ends at or before the reference, and the reference is
 // not a value read from inside the declaration's own initializer.
-func isDefinedBeforeUse(declaration *scope.Variable, ref *scope.Reference) bool {
-	if declaration.ID.End() > ref.Identifier.End() {
+func isDefinedBeforeUse(declaration *scope.Variable, definitionIdentifier *ast.Node, ref *scope.Reference) bool {
+	if definitionIdentifier.End() > ref.Identifier.End() {
 		return false
 	}
 	// A value read from inside the declaration's own initializer runs before
 	// the binding is set up, even though it sits after the name.
-	return !isValueReference(ref.Identifier) || !isInInitializer(declaration, ref)
+	return !ref.IsValueReference() || !isInInitializer(declaration, definitionIdentifier, ref)
 }
 
 // isInInitializer applies upstream's `variable.scope !== reference.from`
 // precondition before the positional walk: a reference that crosses a scope
 // boundary is never treated as part of the declaration's initialization, even
 // when it sits inside the initializer's source range.
-func isInInitializer(declaration *scope.Variable, ref *scope.Reference) bool {
+func isInInitializer(declaration *scope.Variable, definitionIdentifier *ast.Node, ref *scope.Reference) bool {
 	if declaration.Scope != ref.From {
 		return false
 	}
-	return scope.IsInsideOwnInitializer(declaration.ID, ref.Identifier.End())
+	return scope.IsInsideOwnInitializer(definitionIdentifier, ref.Identifier.End())
 }
 
 // isForbidden decides whether a use-before-define should be reported, based on
@@ -185,7 +185,7 @@ func isInInitializer(declaration *scope.Variable, ref *scope.Reference) bool {
 // reference from a different variable scope; a same-scope reference is a
 // temporal dead zone error and is always reported.
 func isForbidden(opts options, declaration *scope.Variable, ref *scope.Reference) bool {
-	if opts.ignoreTypeReferences && isTypeReference(ref.Identifier) {
+	if opts.ignoreTypeReferences && isTypeReference(ref) {
 		return false
 	}
 
@@ -232,66 +232,17 @@ func isNamedExport(node *ast.Node) bool {
 }
 
 // isFunctionTypeScope reports whether a scope is one of scope-manager's
-// `functionType` scopes: the parameter list of a function type, constructor
-// type, call/construct signature, method signature, or a body-less function
-// declaration.
+// `functionType` scopes: a function/constructor type or call/construct/method
+// signature.
 func isFunctionTypeScope(s *scope.Scope) bool {
-	if s == nil || s.Kind != scope.KindFunction || s.Block == nil {
-		return false
-	}
-	block := s.Block
-	if ast.IsFunctionTypeNode(block) || ast.IsConstructorTypeNode(block) ||
-		ast.IsCallSignatureDeclaration(block) || ast.IsConstructSignatureDeclaration(block) ||
-		ast.IsMethodSignatureDeclaration(block) {
-		return true
-	}
-	return ast.IsFunctionLikeDeclaration(block) && block.Body() == nil
+	return s != nil && s.Kind == scope.KindFunctionType
 }
 
-// isValueReference reports whether the identifier is read at runtime, as
-// opposed to naming a type. Only value reads can observe a binding mid-
-// initialization.
-func isValueReference(node *ast.Node) bool {
-	return !isTypeReference(node)
-}
-
-// isTypeReference reports whether the identifier sits in a type-only context —
-// scope-manager's `Reference#isTypeReference`, which is broader than the plain
-// type-annotation check the ESLint core rule uses.
-//
-// Composes tsgo helpers that mirror the TypeScript compiler:
-//   - IsPartOfTypeNode: covers TypeReference, QualifiedName chains in type
-//     nodes, and ExpressionWithTypeArguments in every heritage clause except
-//     a class's own `extends` (evaluated as a value at runtime).
-//   - IsPartOfTypeQuery: covers identifiers inside `typeof T`.
-//
-// IsPartOfTypeNode only walks up through the RIGHT side of property access
-// chains, so the leftmost identifier of a qualified heritage target (e.g. the
-// `ns` in `extends ns.B`) is not caught. The final block handles that by
-// walking up through PropertyAccessExpression to its enclosing
-// ExpressionWithTypeArguments and reusing
-// IsExpressionWithTypeArgumentsInClassExtendsClause to exclude class extends.
-func isTypeReference(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-	if ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node) {
-		return true
-	}
-	// `export = X` and `export default X` can export a type, so scope-manager
-	// flags the exported name as a type reference too (alongside being a value
-	// reference). `export const q = X` is not one.
-	if node.Parent.Kind == ast.KindExportAssignment &&
-		node.Parent.AsExportAssignment().Expression == node {
-		return true
-	}
-	current := node.Parent
-	for current != nil && current.Kind == ast.KindPropertyAccessExpression {
-		current = current.Parent
-	}
-	return current != nil &&
-		ast.IsExpressionWithTypeArguments(current) &&
-		!ast.IsExpressionWithTypeArgumentsInClassExtendsClause(current)
+// isTypeReference mirrors upstream's effective predicate. Most type-space
+// information comes directly from the shared Reference; a type query is the
+// one syntax form upstream additionally recognizes from the reference's AST.
+func isTypeReference(ref *scope.Reference) bool {
+	return ref != nil && (ref.IsTypeReference() || ast.IsPartOfTypeQuery(ref.Identifier))
 }
 
 // isClassRefInClassDecorator reports whether a reference to a class binding

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
@@ -63,10 +63,10 @@ core rule:
   still reports them.
 - `ignoreTypeReferences` covers every type position here — including
   `implements` clauses, qualified type names, and the exported name of
-  `export = X` / `export default X`. The core rule only exempts a bare type
-  annotation and a `typeof` query.
-- A reference from the parameter list of a function type (`type F = (x: Foo) => void`)
-  is never reported here.
+  `export = X` / `export default X`. The core rule only exempts direct type
+  references and `typeof` queries.
+- References from a function/constructor type or call/construct/method signature
+  are never reported here, including its parameter and return types.
 - A reference that resolves to a string-literal enum member (`enum E { b = a, "a" = 1 }`)
   is not reported here, because such a member declares no identifier. The core
   rule measures it from the literal and reports it.

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_extras_scope_regressions_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_extras_scope_regressions_test.go
@@ -1,0 +1,196 @@
+// TestNoUseBeforeDefineExtrasScopeRegressions locks in scope-manager details
+// that are easy to lose when consuming the shared scope model: merged binding
+// identifiers, function-type boundaries, and independent value/type reference
+// spaces. The migrated upstream suite lives in
+// no_use_before_define_upstream_test.go; other rslint-specific cases live in
+// no_use_before_define_extras_test.go.
+package no_use_before_define
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUseBeforeDefineExtrasScopeRegressions(t *testing.T) {
+	checkTypes := func() map[string]interface{} {
+		return map[string]interface{}{"ignoreTypeReferences": false}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUseBeforeDefineRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Merged declarations: the first overload is already a definition ----
+			{Code: `function f(x: string): void; f(); function f(x: any) {}`},
+			{Code: `function f(x: string): void; f(); function f(x: number): void; function f(x: any) {}`},
+
+			// ---- True functionType scopes remain exempt with type checks enabled ----
+			{Code: `type F = (x: Later) => void; interface Later {}`, Options: checkTypes()},
+			{Code: `type F = () => Later; interface Later {}`, Options: checkTypes()},
+			{Code: `type F = new (x: Later) => Result; interface Later {} interface Result {}`, Options: checkTypes()},
+			{Code: `interface I { (x: Later): void } interface Later {}`, Options: checkTypes()},
+			{Code: `interface I { new (x: Later): Result } interface Later {} interface Result {}`, Options: checkTypes()},
+			{Code: `interface I { method(x: Later): void } interface Later {}`, Options: checkTypes()},
+
+			// ---- A binding with no declaration identifier is skipped ----
+			{Code: `enum E { b = a, "a" = 1 }`},
+			{Code: `enum E { b = a, "a" = 1, "a" = 2 }`},
+			{Code: `enum E { "a" = 1, a = 2, b = a }`},
+
+			// ---- ignoreTypeReferences still exempts dual type/value references ----
+			{Code: `const x = 1 as typeof x;`},
+			{Code: `export default T; type T = number;`},
+
+			// ---- A type query outside the binding's evaluated initializer is safe ----
+			{Code: `const x: typeof x = 1;`, Options: checkTypes()},
+			{Code: `const x = () => 1 as typeof x;`, Options: checkTypes()},
+
+			// ---- A predicate naming its own parameter is defined before the use ----
+			{Code: `function isString(value: unknown): value is string { return typeof value === "string"; }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Merged declarations: a use before the first overload still reports ----
+			{
+				Code: `f(); function f(x: string): void; function f(x: any) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `function f(x: Later): void; interface Later {} function f(x: any) {}`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Body-less runtime declarations are ordinary function scopes ----
+			{
+				Code:    `declare function f(x: Later): void; interface Later {}`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `abstract class C { abstract m(x: Later): void } interface Later {}`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 34},
+				},
+			},
+			{
+				Code:    `declare class C { m(x: Later): void } interface Later {}`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:    `declare namespace N { function f(x: Later): void } interface Later {}`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 37},
+				},
+			},
+			{
+				Code:    `class C { m(x: Later): void; m(x: any): void {} } interface Later {}`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- Type queries retain their value-reference semantics ----
+			{
+				Code:    `const x = 1 as typeof x;`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `const [x = 1 as typeof x] = [];`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 24},
+				},
+			},
+
+			// ---- Skip only bindings with no identifier, not one anonymous definition ----
+			{
+				Code: `enum E { b = a, "a" = 1, a = 2 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- A method-signature computed key is evaluated in the outer scope ----
+			{
+				Code: `interface I { [key](): void } declare const key: unique symbol;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `interface I { [((key))](): void } declare const key: unique symbol;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `interface I { [makeKey()](): void } declare function makeKey(): unique symbol;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `interface I { [keys.x](): void } declare const keys: { x: unique symbol };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- A default-export identifier can resolve to the type space ----
+			{
+				Code:    `export default T; type T = number;`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `export default ((T)); type T = number;`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:    `export = ((T)); type T = number;`,
+				Options: checkTypes(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- A type-predicate parameter name is a value reference ----
+			{
+				Code: `function f(): x is string { return true; } const x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `function f(): asserts x is string {} const x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 23},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_shadow/no_shadow.go
+++ b/internal/rules/no_shadow/no_shadow.go
@@ -205,6 +205,9 @@ func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.Rule
 				if v.Anonymous {
 					continue
 				}
+				if isLaterFunctionDefinition(v) {
+					continue
+				}
 				if opts.allow[v.Name] {
 					continue
 				}
@@ -223,6 +226,24 @@ func runWithVariant(variant ruleVariant) func(rule.RuleContext, []any) rule.Rule
 
 		return rule.RuleListeners{}
 	}
+}
+
+// isLaterFunctionDefinition suppresses the additional definitions in a
+// same-scope function overload/redeclaration group. Scope-manager exposes the
+// group as one Variable, which no-shadow checks once at its first definition.
+func isLaterFunctionDefinition(v *scope.Variable) bool {
+	if v == nil || v.Kind != scope.DefFunctionName || v.Scope == nil {
+		return false
+	}
+	for _, definition := range v.Scope.Declarations(v.Name) {
+		if definition == v {
+			return false
+		}
+		if definition.Kind == scope.DefFunctionName {
+			return true
+		}
+	}
+	return false
 }
 
 // isDuplicatedClassNameInClassScope suppresses the inner class-name binding

--- a/internal/rules/no_shadow/no_shadow_test.go
+++ b/internal/rules/no_shadow/no_shadow_test.go
@@ -1333,6 +1333,14 @@ function bar() { }`},
 				},
 			},
 
+			// ---- Function overload definitions form one shadowing variable ----
+			{
+				Code: `const f = 0; { function f(x: string): void; function f(x: any) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 25},
+				},
+			},
+
 			// ---- Factory returning object method with generic shadow ----
 			{
 				Code: `function mk<T>(x: T) { return { get<T>(): T { return null as any; } }; }`,

--- a/internal/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/rules/no_use_before_define/no_use_before_define.go
@@ -164,25 +164,7 @@ func shouldCheck(ref *scope.Reference, opts options) bool {
 		return false
 	}
 
-	if isFromFunctionTypeScope(ref) {
-		return false
-	}
-
 	return true
-}
-
-// isFromFunctionTypeScope reports whether the reference is evaluated in the
-// scope a TS function type puts its type parameters and parameters in. Nothing
-// in such a signature runs, so upstream never reports a reference from one.
-func isFromFunctionTypeScope(ref *scope.Reference) bool {
-	from := ref.From
-	if from == nil || from.Kind != scope.KindFunction || from.Block == nil {
-		return false
-	}
-	block := from.Block
-	return ast.IsFunctionTypeNode(block) || ast.IsConstructorTypeNode(block) ||
-		ast.IsCallSignatureDeclaration(block) || ast.IsConstructSignatureDeclaration(block) ||
-		ast.IsMethodSignatureDeclaration(block)
 }
 
 func isFunctionNameDef(v *scope.Variable) bool {
@@ -303,18 +285,11 @@ func referenceContainsTypeQuery(node *ast.Node) bool {
 	return false
 }
 
-// isTypeReference reports whether the identifier names a type — every type
-// position, plus `export = X`, which exports whichever space `X` lives in.
-// eslint-scope carries the answer on the reference; here it is read back off
-// the syntax, so that the option filters stay independent of how the scope
-// model resolves a name.
+// isTypeReference mirrors ESLint core's deliberately narrow syntax check: only
+// an identifier directly inside a TSTypeReference is covered here. Type queries
+// are handled separately by referenceContainsTypeQuery.
 func isTypeReference(node *ast.Node) bool {
-	if parent := node.Parent; parent != nil && parent.Kind == ast.KindExportAssignment {
-		if assignment := parent.AsExportAssignment(); assignment != nil && assignment.IsExportEquals {
-			return true
-		}
-	}
-	return scope.InTypePosition(node)
+	return node != nil && node.Parent != nil && node.Parent.Kind == ast.KindTypeReference
 }
 
 func leftMostQualifiedName(node *ast.Node) *ast.Node {

--- a/internal/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/rules/no_use_before_define/no_use_before_define.md
@@ -196,12 +196,10 @@ type Later = string;
 
 ### `ignoreTypeReferences`
 
-Whether references in type positions — a type annotation such as `let x: Foo`,
-or a `typeof Foo` type query — are exempt. Default: `true`.
-
-Because type positions are erased before the code runs, they cannot observe a
-temporal dead zone, so they are ignored by default whatever `typedefs` and
-`enums` say.
+Whether direct type references such as `let x: Foo`, and `typeof Foo` type
+queries, are exempt. Default: `true`. As in ESLint core, this exemption does not
+cover heritage names (`implements Foo`), qualified-name roots (`NS.Foo`),
+export assignments, or type-predicate parameter names.
 
 Examples of **incorrect** code with `{ "ignoreTypeReferences": false }`:
 

--- a/internal/rules/no_use_before_define/no_use_before_define_extras_scope_regressions_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_extras_scope_regressions_test.go
@@ -1,0 +1,136 @@
+// TestNoUseBeforeDefineExtrasScopeRegressions locks in shared-scope behavior
+// that affects the ESLint core rule: overload anchors, computed signature keys,
+// type-predicate value references, and TypeScript signature type references.
+// The migrated upstream suites and other edge cases live in the sibling
+// no_use_before_define_*_test.go files.
+package no_use_before_define
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUseBeforeDefineExtrasScopeRegressions(t *testing.T) {
+	checkTypes := func() map[string]any {
+		return map[string]any{"ignoreTypeReferences": false}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUseBeforeDefineRule,
+		[]rule_tester.ValidTestCase{
+			// The first overload signature defines the binding before this call.
+			{Code: `function f(x: string): void; f(); function f(x: any) {}`},
+			// Direct TSTypeReference children remain ignored by default.
+			{Code: `let f: (x: Later) => void; type Later = string;`},
+			{Code: `interface I { m(x: Later): void } type Later = string;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ESLint core's default type-reference exemption is deliberately
+			// narrow: heritage/qualified/export positions remain checked.
+			{
+				Code: `class C implements Later {} interface Later {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `class C implements NS.Later {} namespace NS { export interface Later {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `interface C extends NS.Later {} namespace NS { export interface Later {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `let x: NS.Later; namespace NS { export type Later = string; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `export = X; const X = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 10},
+				},
+			},
+
+			// ESLint core checks signature type references when the option is off.
+			{
+				Code:    `let f: (x: Later) => void; type Later = string;`,
+				Options: checkTypes(),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `let f: (this: Later) => void; type Later = string;`,
+				Options: checkTypes(),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 15}},
+			},
+			{
+				Code:    `let f: new (x: Later) => void; type Later = string;`,
+				Options: checkTypes(),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 16}},
+			},
+			{
+				Code:    `let f: <T extends Later>() => void; type Later = string;`,
+				Options: checkTypes(),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `interface I { (x: Later): void } type Later = string;`,
+				Options: checkTypes(),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:    `interface I { new (x: Later): void } type Later = string;`,
+				Options: checkTypes(),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 23}},
+			},
+			{
+				Code:    `interface I { m(x: Later): void } type Later = string;`,
+				Options: checkTypes(),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedBeforeDefined", Line: 1, Column: 20}},
+			},
+
+			// A method-signature computed key is evaluated in the outer scope.
+			{
+				Code: `interface I { [key](): void } declare const key: unique symbol;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 16},
+				},
+			},
+
+			// Parentheses do not stop a default export from resolving both spaces.
+			{
+				Code: `export default ((T)); type T = number;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 18},
+				},
+			},
+
+			// A type-predicate parameter name references a value binding.
+			{
+				Code: `function f(): x is string { return true; } const x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 15},
+				},
+			},
+
+			// Core measures an anonymous enum definition from its literal name.
+			{
+				Code: `enum E { b = a, "a" = 1, a = 2 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "usedBeforeDefined", Line: 1, Column: 14},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
+++ b/internal/rules/no_use_before_define/no_use_before_define_extras_test.go
@@ -225,15 +225,7 @@ function f(X, a = X) {
 			// as the local half of a named export ----
 			{Code: `export { nothing };`},
 
-			// ---- `ignoreTypeReferences` exempts every type position, however
-			// the dotted name is spelled, plus the `export =` operand, which
-			// names whichever space its binding lives in ----
-			{Code: `class C implements Later {} interface Later {}`},
-			{Code: `class C implements NS.Later {} namespace NS { export interface Later {} }`},
-			{Code: `interface C extends NS.Later {} namespace NS { export interface Later {} }`},
-			{Code: `let x: NS.Later; namespace NS { export type Later = string; }`},
-			{Code: `export = X; const X = 1;`},
-			// A value-only binding does not intercept the dotted name of a
+			// ---- A value-only binding does not intercept the dotted name of a
 			// heritage clause, whichever way that name is spelled.
 			{Code: `
 namespace NS {
@@ -255,16 +247,6 @@ function f() {
   const NS = 1;
 }
 `},
-
-			// ---- Nothing in a function type's signature runs, so a reference
-			// from one is never reported ----
-			{Code: `let f: (x: Later) => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
-			{Code: `let f: (this: Later) => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
-			{Code: `let f: new (x: Later) => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
-			{Code: `let f: <T extends Later>() => void; type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
-			{Code: `interface I { (x: Later): void } type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
-			{Code: `interface I { new (x: Later): void } type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
-			{Code: `interface I { m(x: Later): void } type Later = string;`, Options: map[string]any{"ignoreTypeReferences": false}},
 
 			// ---- A `this` pseudo-parameter declares no binding, but its type
 			// annotation is a real type reference ----

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -71,16 +71,10 @@ func (b *builder) addNamedDecl(stmt *ast.Node, s *Scope, kind DefKind, isValue b
 	if n == nil || n.Kind != ast.KindIdentifier {
 		return
 	}
-	isAmbient := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient)
-	// Body-less FunctionDeclarations come in two flavors: overload signatures
-	// (no `declare`, there will be a later implementation) and ambient
-	// declarations (`declare function foo(): void`). typescript-eslint's scope
-	// manager merges all signatures under one Variable, so we only need to
-	// register a single binding: skip overload signatures, but keep ambient
-	// declarations so that inner scopes detect them as shadowed.
-	if kind == DefFunctionName && stmt.Body() == nil && !isAmbient {
-		return
-	}
+	// NodeFlagsAmbient also covers declarations nested in `declare namespace`
+	// and declarations parsed from a .d.ts file, where no local `declare`
+	// modifier is present.
+	isAmbient := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient) || utils.IsInAmbientContext(stmt)
 	s.Add(&Variable{
 		Name:            n.Text(),
 		ID:              n,
@@ -625,11 +619,24 @@ func collectInferTypes(node *ast.Node, s *Scope) {
 // signatures. Parameters introduce bindings that may trigger (or be filtered
 // out by) rule-specific type-parameter exceptions.
 func (b *builder) visitFunctionType(node *ast.Node, outer *Scope) {
-	s := b.push(KindFunction, node, outer)
+	// A method signature's computed key is evaluated in the enclosing scope.
+	// Only its type parameters, parameters, and return type belong to the
+	// function-type scope.
+	var computedName *ast.Node
+	if ast.IsMethodSignatureDeclaration(node) {
+		if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+			computedName = name
+			if cpn := name.AsComputedPropertyName(); cpn != nil {
+				b.visitExpression(cpn.Expression, outer)
+			}
+		}
+	}
+
+	s := b.push(KindFunctionType, node, outer)
 	b.addTypeParameters(node, s)
 	b.addParameters(node, s, false)
 	node.ForEachChild(func(child *ast.Node) bool {
-		if child.Kind != ast.KindTypeParameter {
+		if child.Kind != ast.KindTypeParameter && child != computedName {
 			b.visitExpression(child, s)
 		}
 		return false

--- a/internal/utils/scope/references.go
+++ b/internal/utils/scope/references.go
@@ -72,8 +72,9 @@ func isReferenceIdentifier(id *ast.Node) bool {
 		return false
 
 	case ast.KindTypePredicate:
-		// `x is T` — `x` names a parameter, it does not read it.
-		return false
+		// `x is T` / `asserts x is T` references the value binding named by
+		// the predicate. `this is T` uses a ThisType node, not an Identifier.
+		return true
 
 	case ast.KindJsxAttribute, ast.KindJsxNamespacedName:
 		return false
@@ -90,6 +91,18 @@ func isReferenceIdentifier(id *ast.Node) bool {
 // export forms name whichever space the exported binding happens to live in.
 func referenceSpaces(id *ast.Node) (value bool, isType bool) {
 	parent := id.Parent
+	// TSESTree erases parentheses, so a parenthesized bare identifier remains
+	// the direct declaration of `export default (X)` / `export = (X)` there.
+	// Recover that shape before switching on the immediate tsgo parent.
+	if parent.Kind == ast.KindExportAssignment || parent.Kind == ast.KindParenthesizedExpression {
+		if exportParent := ast.WalkUpParenthesizedExpressions(parent); exportParent != nil &&
+			exportParent.Kind == ast.KindExportAssignment {
+			if assignment := exportParent.AsExportAssignment(); assignment != nil &&
+				ast.SkipParentheses(assignment.Expression) == id {
+				return true, true
+			}
+		}
+	}
 	switch parent.Kind {
 	case ast.KindExportSpecifier:
 		// `export type { T }` and `export { type T }` export types only.
@@ -102,12 +115,10 @@ func referenceSpaces(id *ast.Node) (value bool, isType bool) {
 			}
 		}
 		return true, true
-	case ast.KindExportAssignment:
-		// `export = X` exports a value or a type; `export default X` is an
-		// expression and names a value.
-		if assignment := parent.AsExportAssignment(); assignment != nil && assignment.IsExportEquals {
-			return true, true
-		}
+	case ast.KindTypePredicate:
+		// The parameter name is a value reference even though the surrounding
+		// predicate is a type node.
+		return true, false
 	}
 
 	if InTypePosition(id) {

--- a/internal/utils/scope/scope.go
+++ b/internal/utils/scope/scope.go
@@ -70,7 +70,7 @@ type Variable struct {
 
 	IsValueBinding   bool // runtime value vs. type-only
 	IsTypeOnlyImport bool // ImportSpecifier with `type` modifier
-	DeclareModifier  bool // `declare` modifier (.d.ts handling)
+	DeclareModifier  bool // declaration is in an ambient context (`declare` / .d.ts)
 	// Anonymous marks a binding declared without an identifier — a
 	// string-literal enum member (`enum E { "A" = 1 }`). eslint-scope gives
 	// those a variable with an empty `identifiers` list, so they take part in
@@ -86,12 +86,13 @@ type Kind int
 const (
 	KindGlobal                Kind = iota
 	KindFunction                   // function-like bodies & their parameters
+	KindFunctionType               // TS function/constructor types and call/construct/method signatures
 	KindFunctionExprName           // FunctionExpression's name binding
 	KindBlock                      // { ... } / for-init / switch case / enum body
 	KindCatch                      // catch clause
 	KindClass                      // class body: type parameters & inner class name
 	KindModule                     // TS namespace
-	KindType                       // TS type alias / interface / function type: type parameters
+	KindType                       // TS type alias / interface: type parameters
 	KindClassStaticBlock           // `static { ... }`
 	KindClassFieldInitializer      // the initializer expression of a class field
 )
@@ -144,7 +145,7 @@ func (s *Scope) Declarations(name string) []*Variable {
 func (s *Scope) VariableScope() *Scope {
 	for current := s; current != nil; current = current.Parent {
 		switch current.Kind {
-		case KindFunction, KindModule, KindGlobal, KindClassStaticBlock, KindClassFieldInitializer:
+		case KindFunction, KindFunctionType, KindModule, KindGlobal, KindClassStaticBlock, KindClassFieldInitializer:
 			return current
 		}
 	}
@@ -179,6 +180,36 @@ func (r *Reference) Resolved() *Variable {
 		return nil
 	}
 	return r.Declarations[0]
+}
+
+// ResolvedIdentifier returns the first declaration identifier of the binding
+// this reference resolves to — eslint-scope's
+// reference.resolved.identifiers[0]. A binding may have definitions without
+// identifiers (for example a string-literal enum member), so this can differ
+// from [Reference.Resolved] and can be nil even when Resolved is not.
+func (r *Reference) ResolvedIdentifier() *ast.Node {
+	if r == nil {
+		return nil
+	}
+	for _, declaration := range r.Declarations {
+		if declaration != nil && !declaration.Anonymous && declaration.ID != nil &&
+			declaration.ID.Kind == ast.KindIdentifier {
+			return declaration.ID
+		}
+	}
+	return nil
+}
+
+// IsValueReference reports whether the identifier can resolve in value space.
+// Value and type references are independent: a reference may be both.
+func (r *Reference) IsValueReference() bool {
+	return r != nil && r.isValueReference
+}
+
+// IsTypeReference reports whether the identifier can resolve in type space.
+// Value and type references are independent: a reference may be both.
+func (r *Reference) IsTypeReference() bool {
+	return r != nil && r.isTypeReference
 }
 
 // Options selects optional analysis passes.

--- a/internal/utils/scope/scope_test.go
+++ b/internal/utils/scope/scope_test.go
@@ -310,3 +310,106 @@ func TestBuildGlobalAugmentationBindsNothing(t *testing.T) {
 		t.Errorf("got %v, want [global->?]", got)
 	}
 }
+
+func findReference(t *testing.T, m *Manager, name string) *Reference {
+	t.Helper()
+	for _, ref := range m.References {
+		if ref.Identifier.Text() == name {
+			return ref
+		}
+	}
+	t.Fatalf("reference %q not found", name)
+	return nil
+}
+
+func TestBuildKeepsTheFirstFunctionOverloadAsTheBindingAnchor(t *testing.T) {
+	m := buildWithReferences(t, `function f(x: string): void; f(); function f(x: any) {}`)
+	declarations := m.Global.Declarations("f")
+	if len(declarations) != 2 {
+		t.Fatalf("got %d f definitions, want the overload and implementation", len(declarations))
+	}
+	if declarations[0].DefNode.Body() != nil {
+		t.Fatal("the first overload signature should be the binding anchor")
+	}
+
+	ref := findReference(t, m, "f")
+	if ref.Resolved() != declarations[0] {
+		t.Fatal("the call should resolve to the overload binding")
+	}
+	if got := ref.ResolvedIdentifier(); got != declarations[0].ID {
+		t.Fatalf("resolved identifier = %p, want first overload identifier %p", got, declarations[0].ID)
+	}
+}
+
+func TestBuildMarksBodylessFunctionsInAmbientContexts(t *testing.T) {
+	m := build(t, `declare namespace N { function f(): void }`)
+	for _, s := range m.Scopes {
+		if declarations := s.Declarations("f"); len(declarations) > 0 {
+			if !declarations[0].DeclareModifier {
+				t.Fatal("function nested in a declare namespace should be ambient")
+			}
+			return
+		}
+	}
+	t.Fatal("ambient function declaration not found")
+}
+
+func TestBuildKeepsReferenceSpacesIndependent(t *testing.T) {
+	t.Run("type query is a value reference", func(t *testing.T) {
+		ref := findReference(t, buildWithReferences(t, `const x = 1 as typeof x;`), "x")
+		if !ref.IsValueReference() {
+			t.Fatal("typeof query must retain its value-space reference")
+		}
+	})
+
+	t.Run("default export identifier is dual", func(t *testing.T) {
+		for _, source := range []string{
+			`export default T; type T = number;`,
+			`export default ((T)); type T = number;`,
+		} {
+			ref := findReference(t, buildWithReferences(t, source), "T")
+			if !ref.IsValueReference() || !ref.IsTypeReference() {
+				t.Fatalf("%s: export default identifier spaces = value:%v type:%v, want both", source, ref.IsValueReference(), ref.IsTypeReference())
+			}
+			if ref.Resolved() == nil || ref.Resolved().Kind != DefType {
+				t.Fatalf("%s: dual default-export reference should resolve to a type-only binding", source)
+			}
+		}
+	})
+
+	t.Run("type predicate parameter is a value reference", func(t *testing.T) {
+		ref := findReference(t, buildWithReferences(t, `function f(): x is string { return true; } const x = 1;`), "x")
+		if !ref.IsValueReference() || ref.IsTypeReference() {
+			t.Fatalf("type predicate spaces = value:%v type:%v, want value-only", ref.IsValueReference(), ref.IsTypeReference())
+		}
+		if ref.Resolved() == nil || ref.Resolved().Kind != DefVariable {
+			t.Fatal("type predicate parameter should resolve to the value binding")
+		}
+	})
+}
+
+func TestBuildFunctionTypeScopeKeepsComputedMethodKeyOutside(t *testing.T) {
+	m := buildWithReferences(t, `interface I { [key](arg: Later): Result } declare const key: unique symbol; interface Later {} interface Result {}`)
+	key := findReference(t, m, "key")
+	if key.From == nil || key.From.Kind == KindFunctionType {
+		t.Fatal("computed method key must be evaluated outside the function-type scope")
+	}
+	for _, name := range []string{"Later", "Result"} {
+		ref := findReference(t, m, name)
+		if ref.From == nil || ref.From.Kind != KindFunctionType {
+			t.Fatalf("%s reference scope = %v, want KindFunctionType", name, ref.From)
+		}
+	}
+}
+
+func TestResolvedIdentifierSkipsAnonymousMergedDefinitions(t *testing.T) {
+	m := buildWithReferences(t, `enum E { b = a, "a" = 1, a = 2 }`)
+	ref := findReference(t, m, "a")
+	if ref.Resolved() == nil || !ref.Resolved().Anonymous {
+		t.Fatal("the first resolved definition should remain the string-literal member")
+	}
+	identifier := ref.ResolvedIdentifier()
+	if identifier == nil || identifier.Kind != ast.KindIdentifier || identifier.Text() != "a" {
+		t.Fatalf("resolved identifier = %#v, want the later named enum member", identifier)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the earliest overload declaration and the first real identifier of merged bindings
- distinguish signature-only type contexts from body-less runtime declarations, while evaluating computed signature keys in the enclosing context
- retain independent value/type reference metadata for type queries, exports, and type predicates
- align the core and TypeScript variants for anonymous enum members, overloads, signatures, and `ignoreTypeReferences`, without duplicating `no-shadow` reports

## Verification

- `go test -count=1 ./internal/utils/scope ./internal/plugins/typescript/rules/no_use_before_define ./internal/rules/no_use_before_define ./internal/rules/no_shadow`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/utils/scope ./internal/plugins/typescript/rules/no_use_before_define ./internal/rules/no_use_before_define ./internal/rules/no_shadow`
- `pnpm run build:bin`
- `npx rstest run --testTimeout=10000 no-use-before-define` (2 files, 4 tests)
- differential checks against `@typescript-eslint/eslint-plugin` 8.67.0 (30 adversarial files) and ESLint 10.8.1 (28 adversarial files)
- targeted Prettier and cspell checks for changed documentation and sources
