### PR TITLE
feat(rstest): add no-import-node-test rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_focused_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
+	no_import_node "github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_import_node_test"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_interpolation_in_snapshots"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_expect"
@@ -22,6 +23,7 @@ func GetAllRules() []rule.Rule {
 		no_disabled_tests.NoDisabledTestsRule,
 		no_focused_tests.NoFocusedTestsRule,
 		no_identical_title.NoIdenticalTitleRule,
+		no_import_node.NoImportNodeTestRule,
 		no_interpolation_in_snapshots.NoInterpolationInSnapshotsRule,
 		no_mocks_import.NoMocksImportRule,
 		valid_expect.ValidExpectRule,

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
@@ -2,9 +2,9 @@
 
 ## Rule Details
 
-This rule reports static imports from `node:test` in Rstest test files. Such imports are commonly added accidentally by editor auto-import and select Node's test runner instead of Rstest.
+This rule reports imports of Node's test runner in Rstest test files, whether through an `import` declaration or a `require()` call, and whether the module is `node:test` itself or one of its sub-paths such as `node:test/reporters`. Such imports are commonly added accidentally by editor auto-import and select Node's test runner instead of Rstest.
 
-Named imports containing only `test`, `it`, and `describe` can be safely fixed by changing the module to `@rstest/core`. Other imports are still reported, but are not fixed because the two modules do not have equivalent exports.
+Named imports of `node:test` containing only `test`, `it`, and `describe` can be safely fixed by changing the module to `@rstest/core`. Everything else is still reported, but is not fixed because the two modules do not have equivalent exports.
 
 Examples of **incorrect** code for this rule:
 
@@ -12,12 +12,14 @@ Examples of **incorrect** code for this rule:
 import { test } from 'node:test';
 import * as nodeTest from 'node:test';
 import { mock } from 'node:test';
+import { tap } from 'node:test/reporters';
+const nodeTest = require('node:test');
 ```
 
 Examples of **correct** code for this rule:
 
 ```typescript
 import { test } from '@rstest/core';
-import { test } from 'node:test/reporters';
-const nodeTest = require('node:test');
+import { rs } from '@rstest/core';
+const assert = require('node:assert');
 ```

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
@@ -1,0 +1,23 @@
+# no-import-node-test
+
+## Rule Details
+
+This rule reports static imports from `node:test` in Rstest test files. Such imports are commonly added accidentally by editor auto-import and select Node's test runner instead of Rstest.
+
+Named imports containing only `test`, `it`, and `describe` can be safely fixed by changing the module to `@rstest/core`. Other imports are still reported, but are not fixed because the two modules do not have equivalent exports.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+import { test } from 'node:test';
+import * as nodeTest from 'node:test';
+import { mock } from 'node:test';
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+import { test } from '@rstest/core';
+import { test } from 'node:test/reporters';
+const nodeTest = require('node:test');
+```

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule reports imports of Node's test runner in Rstest test files, whether through an `import` declaration or a `require()` call, and whether the module is `node:test` itself or one of its sub-paths such as `node:test/reporters`. Such imports are commonly added accidentally by editor auto-import and select Node's test runner instead of Rstest.
+This rule reports imports of Node's test runner in Rstest test files, whether through an `import` declaration, a `require()` call, or an `import ... = require(...)` declaration, and whether the module is `node:test` itself or one of its sub-paths such as `node:test/reporters`. Such imports are commonly added accidentally by editor auto-import and select Node's test runner instead of Rstest.
 
 Named imports of `node:test` containing only `test`, `it`, and `describe` can be safely fixed by changing the module to `@rstest/core`. Everything else is still reported, but is not fixed because the two modules do not have equivalent exports.
 
@@ -14,6 +14,7 @@ import * as nodeTest from 'node:test';
 import { mock } from 'node:test';
 import { tap } from 'node:test/reporters';
 const nodeTest = require('node:test');
+import nodeTest = require('node:test');
 ```
 
 Examples of **correct** code for this rule:

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
@@ -20,6 +20,7 @@ func TestNoImportNodeTestRule(t *testing.T) {
 			{Code: `import { test } from 'node:testing'`},
 			{Code: `const assert = require('node:assert')`},
 			{Code: `const t = import('node:test')`},
+			{Code: `import assert = require('node:assert')`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -87,6 +88,22 @@ func TestNoImportNodeTestRule(t *testing.T) {
 			},
 			{
 				Code:   `const { tap } = require('node:test/reporters')`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import nodeTest = require('node:test')`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import reporters = require('node:test/reporters')`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `const nodeTest = (require)('node:test')`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `const nodeTest = require(('node:test'))`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
 			},
 			{

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
@@ -17,8 +17,9 @@ func TestNoImportNodeTestRule(t *testing.T) {
 		[]rule_tester.ValidTestCase{
 			{Code: `import { test } from '@rstest/core'`},
 			{Code: `import { test } from 'vitest'`},
-			{Code: `import { test } from 'node:test/reporters'`},
-			{Code: `const t = require('node:test')`},
+			{Code: `import { test } from 'node:testing'`},
+			{Code: `const assert = require('node:assert')`},
+			{Code: `const t = import('node:test')`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -26,7 +27,7 @@ func TestNoImportNodeTestRule(t *testing.T) {
 				Output: []string{`import { test } from '@rstest/core'`},
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "noImportNodeTest",
-					Message:   "Do not import from `node:test` in Rstest test files",
+					Message:   "Do not import the Node test runner in Rstest test files",
 					Line:      1,
 					Column:    1,
 					EndLine:   1,
@@ -70,6 +71,22 @@ func TestNoImportNodeTestRule(t *testing.T) {
 			},
 			{
 				Code:   `import nodeTest, { test } from 'node:test'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import { tap } from 'node:test/reporters'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import { test } from 'node:test/reporters'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `const nodeTest = require('node:test')`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `const { tap } = require('node:test/reporters')`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
 			},
 			{

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
@@ -21,6 +21,7 @@ func TestNoImportNodeTestRule(t *testing.T) {
 			{Code: `const assert = require('node:assert')`},
 			{Code: `const t = import('node:test')`},
 			{Code: `import assert = require('node:assert')`},
+			{Code: `import x from a.b;`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test_test.go
@@ -1,0 +1,82 @@
+package no_import_node_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	no_import_node "github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_import_node_test"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoImportNodeTestRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_import_node.NoImportNodeTestRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `import { test } from '@rstest/core'`},
+			{Code: `import { test } from 'vitest'`},
+			{Code: `import { test } from 'node:test/reporters'`},
+			{Code: `const t = require('node:test')`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `import { test } from 'node:test'`,
+				Output: []string{`import { test } from '@rstest/core'`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noImportNodeTest",
+					Message:   "Do not import from `node:test` in Rstest test files",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 33,
+				}},
+			},
+			{
+				Code:   `import { test } from "node:test"`,
+				Output: []string{`import { test } from "@rstest/core"`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import { test, describe } from 'node:test'`,
+				Output: []string{`import { test, describe } from '@rstest/core'`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import { test as nodeTest, describe } from 'node:test'`,
+				Output: []string{`import { test as nodeTest, describe } from '@rstest/core'`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import nodeTest from 'node:test'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import * as nodeTest from 'node:test'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import 'node:test'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import { mock } from 'node:test'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import { test, mock } from 'node:test'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import nodeTest, { test } from 'node:test'`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+			{
+				Code:   `import { test as mock } from 'node:test'`,
+				Output: []string{`import { test as mock } from '@rstest/core'`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noImportNodeTest"}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_import_node_test/rule.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/rule.go
@@ -93,12 +93,21 @@ var NoImportNodeTestRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindImportDeclaration: func(node *ast.Node) {
 				declaration := node.AsImportDeclaration()
+				// The parser accepts an arbitrary expression as the module
+				// specifier and only rejects non-literals in a later grammar
+				// check, so recoverable-but-invalid source such as
+				// `import x from a.b` reaches this listener. `Text()` panics on
+				// those kinds, so the specifier has to be narrowed first.
 				if declaration == nil || declaration.ModuleSpecifier == nil ||
-					!isNodeTestModule(declaration.ModuleSpecifier.Text()) {
+					!isStringNode(declaration.ModuleSpecifier) {
+					return
+				}
+				specifier := declaration.ModuleSpecifier.Text()
+				if !isNodeTestModule(specifier) {
 					return
 				}
 				message := noImportNodeTestMessage()
-				if declaration.ModuleSpecifier.Text() != nodeTestModule || !canSafelyReplaceModule(declaration) {
+				if specifier != nodeTestModule || !canSafelyReplaceModule(declaration) {
 					ctx.ReportNode(node, message)
 					return
 				}

--- a/internal/plugins/rstest/rules/no_import_node_test/rule.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/rule.go
@@ -1,12 +1,26 @@
 package no_import_node
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
-const replacementModule = "@rstest/core"
+const (
+	nodeTestModule     = "node:test"
+	replacementModule  = "@rstest/core"
+	nodeTestSubpathPfx = nodeTestModule + "/"
+)
+
+// isNodeTestModule reports whether a module specifier resolves to Node's test
+// runner: `node:test` itself, or one of its subpaths such as
+// `node:test/reporters`. Only the exact `node:test` specifier has a candidate
+// replacement in `@rstest/core`, but every form is reported.
+func isNodeTestModule(specifier string) bool {
+	return specifier == nodeTestModule || strings.HasPrefix(specifier, nodeTestSubpathPfx)
+}
 
 var safeImportedNames = map[string]bool{
 	"describe": true,
@@ -17,8 +31,13 @@ var safeImportedNames = map[string]bool{
 func noImportNodeTestMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "noImportNodeTest",
-		Description: "Do not import from `node:test` in Rstest test files",
+		Description: "Do not import the Node test runner in Rstest test files",
 	}
+}
+
+func isStringNode(node *ast.Node) bool {
+	return node.Kind == ast.KindStringLiteral ||
+		node.Kind == ast.KindNoSubstitutionTemplateLiteral
 }
 
 func canSafelyReplaceModule(declaration *ast.ImportDeclaration) bool {
@@ -75,11 +94,11 @@ var NoImportNodeTestRule = rule.Rule{
 			ast.KindImportDeclaration: func(node *ast.Node) {
 				declaration := node.AsImportDeclaration()
 				if declaration == nil || declaration.ModuleSpecifier == nil ||
-					declaration.ModuleSpecifier.Text() != "node:test" {
+					!isNodeTestModule(declaration.ModuleSpecifier.Text()) {
 					return
 				}
 				message := noImportNodeTestMessage()
-				if !canSafelyReplaceModule(declaration) {
+				if declaration.ModuleSpecifier.Text() != nodeTestModule || !canSafelyReplaceModule(declaration) {
 					ctx.ReportNode(node, message)
 					return
 				}
@@ -96,6 +115,24 @@ var NoImportNodeTestRule = rule.Rule{
 						replacement,
 					),
 				)
+			},
+			// `require('node:test')` is reported as well, but never fixed: the
+			// binding forms a require can take do not map onto a specifier
+			// rewrite the way a static import does.
+			ast.KindCallExpression: func(node *ast.Node) {
+				callee := node.AsCallExpression().Expression
+				if callee.Kind != ast.KindIdentifier || callee.AsIdentifier().Text != "require" {
+					return
+				}
+				arguments := node.Arguments()
+				if len(arguments) == 0 {
+					return
+				}
+				firstArg := arguments[0]
+				if firstArg == nil || !isStringNode(firstArg) || !isNodeTestModule(firstArg.Text()) {
+					return
+				}
+				ctx.ReportNode(firstArg, noImportNodeTestMessage())
 			},
 		}
 	},

--- a/internal/plugins/rstest/rules/no_import_node_test/rule.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/rule.go
@@ -1,0 +1,102 @@
+package no_import_node
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const replacementModule = "@rstest/core"
+
+var safeImportedNames = map[string]bool{
+	"describe": true,
+	"it":       true,
+	"test":     true,
+}
+
+func noImportNodeTestMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noImportNodeTest",
+		Description: "Do not import from `node:test` in Rstest test files",
+	}
+}
+
+func canSafelyReplaceModule(declaration *ast.ImportDeclaration) bool {
+	if declaration == nil || declaration.ImportClause == nil {
+		return false
+	}
+	clause := declaration.ImportClause.AsImportClause()
+	if clause == nil || clause.Name() != nil || clause.NamedBindings == nil ||
+		clause.NamedBindings.Kind != ast.KindNamedImports {
+		return false
+	}
+	named := clause.NamedBindings.AsNamedImports()
+	if named == nil || named.Elements == nil || len(named.Elements.Nodes) == 0 {
+		return false
+	}
+	for _, element := range named.Elements.Nodes {
+		specifier := element.AsImportSpecifier()
+		if specifier == nil || specifier.Name() == nil {
+			return false
+		}
+		importedName := specifier.Name().Text()
+		if specifier.PropertyName != nil {
+			importedName = specifier.PropertyName.Text()
+		}
+		if !safeImportedNames[importedName] {
+			return false
+		}
+	}
+	return true
+}
+
+func replacementForModuleSpecifier(sourceFile *ast.SourceFile, node *ast.Node) (string, bool) {
+	if sourceFile == nil || node == nil {
+		return "", false
+	}
+	trimmed := internalUtils.TrimNodeTextRange(sourceFile, node)
+	text := sourceFile.Text()
+	if trimmed.Pos() < 0 || trimmed.End() > len(text) || trimmed.End()-trimmed.Pos() < 2 {
+		return "", false
+	}
+	raw := text[trimmed.Pos():trimmed.End()]
+	quote := raw[0]
+	if (quote != '\'' && quote != '"') || raw[len(raw)-1] != quote {
+		return "", false
+	}
+	return string(quote) + replacementModule + string(quote), true
+}
+
+var NoImportNodeTestRule = rule.Rule{
+	Name:   "rstest/no-import-node-test",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindImportDeclaration: func(node *ast.Node) {
+				declaration := node.AsImportDeclaration()
+				if declaration == nil || declaration.ModuleSpecifier == nil ||
+					declaration.ModuleSpecifier.Text() != "node:test" {
+					return
+				}
+				message := noImportNodeTestMessage()
+				if !canSafelyReplaceModule(declaration) {
+					ctx.ReportNode(node, message)
+					return
+				}
+				replacement, ok := replacementForModuleSpecifier(ctx.SourceFile, declaration.ModuleSpecifier)
+				if !ok {
+					ctx.ReportNode(node, message)
+					return
+				}
+				ctx.ReportNodeWithFixes(
+					node,
+					message,
+					rule.RuleFixReplaceRange(
+						internalUtils.TrimNodeTextRange(ctx.SourceFile, declaration.ModuleSpecifier),
+						replacement,
+					),
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/rstest/rules/no_import_node_test/rule.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/rule.go
@@ -15,7 +15,7 @@ const (
 )
 
 // isNodeTestModule reports whether a module specifier resolves to Node's test
-// runner: `node:test` itself, or one of its subpaths such as
+// runner: `node:test` itself, or one of its sub-paths such as
 // `node:test/reporters`. Only the exact `node:test` specifier has a candidate
 // replacement in `@rstest/core`, but every form is reported.
 func isNodeTestModule(specifier string) bool {

--- a/internal/plugins/rstest/rules/no_import_node_test/rule.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/rule.go
@@ -116,19 +116,41 @@ var NoImportNodeTestRule = rule.Rule{
 					),
 				)
 			},
+			// `import nodeTest = require('node:test')` is a static runner import
+			// too, but TypeScript parses it as its own declaration kind rather
+			// than a call expression, so it needs its own listener. Like
+			// `require()`, it is reported without a fix.
+			ast.KindImportEqualsDeclaration: func(node *ast.Node) {
+				declaration := node.AsImportEqualsDeclaration()
+				if declaration == nil || declaration.ModuleReference == nil ||
+					declaration.ModuleReference.Kind != ast.KindExternalModuleReference {
+					return
+				}
+				reference := declaration.ModuleReference.AsExternalModuleReference()
+				if reference == nil || reference.Expression == nil {
+					return
+				}
+				specifier := ast.SkipParentheses(reference.Expression)
+				if specifier == nil || !isStringNode(specifier) || !isNodeTestModule(specifier.Text()) {
+					return
+				}
+				ctx.ReportNode(node, noImportNodeTestMessage())
+			},
 			// `require('node:test')` is reported as well, but never fixed: the
 			// binding forms a require can take do not map onto a specifier
 			// rewrite the way a static import does.
 			ast.KindCallExpression: func(node *ast.Node) {
-				callee := node.AsCallExpression().Expression
-				if callee.Kind != ast.KindIdentifier || callee.AsIdentifier().Text != "require" {
+				// Parentheses are transparent, so `(require)('node:test')` and
+				// `require(('node:test'))` are the same import as the bare form.
+				callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+				if callee == nil || callee.Kind != ast.KindIdentifier || callee.AsIdentifier().Text != "require" {
 					return
 				}
 				arguments := node.Arguments()
 				if len(arguments) == 0 {
 					return
 				}
-				firstArg := arguments[0]
+				firstArg := ast.SkipParentheses(arguments[0])
 				if firstArg == nil || !isStringNode(firstArg) || !isNodeTestModule(firstArg.Text()) {
 					return
 				}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -564,6 +564,7 @@ export default defineConfig({
     './tests/rstest/rules/no-disabled-tests.test.ts',
     './tests/rstest/rules/no-focused-tests.test.ts',
     './tests/rstest/rules/no-identical-title.test.ts',
+    './tests/rstest/rules/no-import-node-test.test.ts',
     './tests/rstest/rules/no-interpolation-in-snapshots.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
     './tests/rstest/rules/valid-expect.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -149,6 +149,7 @@ describe('defineConfig and config presets', () => {
       'rstest/no-disabled-tests': 'warn',
       'rstest/no-focused-tests': 'error',
       'rstest/no-identical-title': 'error',
+      'rstest/no-import-node-test': 'error',
       'rstest/no-interpolation-in-snapshots': 'error',
       'rstest/no-mocks-import': 'error',
       'rstest/valid-expect': 'error',

--- a/packages/rslint-test-tools/tests/rstest/rules/no-import-node-test.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-import-node-test.test.ts
@@ -8,6 +8,7 @@ ruleTester.run('no-import-node-test', {} as never, {
     { code: `import { test } from 'vitest'` },
     { code: `import { test } from 'node:testing'` },
     { code: `const assert = require('node:assert')` },
+    { code: `import assert = require('node:assert')` },
   ],
   invalid: [
     {
@@ -67,6 +68,21 @@ ruleTester.run('no-import-node-test', {} as never, {
     },
     {
       code: `const nodeTest = require('node:test')`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import nodeTest = require('node:test')`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `const nodeTest = (require)('node:test')`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `const nodeTest = require(('node:test'))`,
       output: null,
       errors: [{ messageId: 'noImportNodeTest' }],
     },

--- a/packages/rslint-test-tools/tests/rstest/rules/no-import-node-test.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-import-node-test.test.ts
@@ -1,0 +1,64 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-import-node-test', {} as never, {
+  valid: [
+    { code: `import { test } from '@rstest/core'` },
+    { code: `import { test } from 'vitest'` },
+    { code: `import { test } from 'node:test/reporters'` },
+    { code: `const t = require('node:test')` },
+  ],
+  invalid: [
+    {
+      code: `import { test } from 'node:test'`,
+      output: `import { test } from '@rstest/core'`,
+      errors: [
+        {
+          messageId: 'noImportNodeTest',
+          message: 'Do not import from `node:test` in Rstest test files',
+        },
+      ],
+    },
+    {
+      code: `import { test } from "node:test"`,
+      output: `import { test } from "@rstest/core"`,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import { test, describe } from 'node:test'`,
+      output: `import { test, describe } from '@rstest/core'`,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import { test as nodeTest } from 'node:test'`,
+      output: `import { test as nodeTest } from '@rstest/core'`,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import nodeTest from 'node:test'`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import * as nodeTest from 'node:test'`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import 'node:test'`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import { mock } from 'node:test'`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import { test, mock } from 'node:test'`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/rstest/rules/no-import-node-test.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-import-node-test.test.ts
@@ -6,8 +6,8 @@ ruleTester.run('no-import-node-test', {} as never, {
   valid: [
     { code: `import { test } from '@rstest/core'` },
     { code: `import { test } from 'vitest'` },
-    { code: `import { test } from 'node:test/reporters'` },
-    { code: `const t = require('node:test')` },
+    { code: `import { test } from 'node:testing'` },
+    { code: `const assert = require('node:assert')` },
   ],
   invalid: [
     {
@@ -16,7 +16,7 @@ ruleTester.run('no-import-node-test', {} as never, {
       errors: [
         {
           messageId: 'noImportNodeTest',
-          message: 'Do not import from `node:test` in Rstest test files',
+          message: 'Do not import the Node test runner in Rstest test files',
         },
       ],
     },
@@ -57,6 +57,16 @@ ruleTester.run('no-import-node-test', {} as never, {
     },
     {
       code: `import { test, mock } from 'node:test'`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `import { tap } from 'node:test/reporters'`,
+      output: null,
+      errors: [{ messageId: 'noImportNodeTest' }],
+    },
+    {
+      code: `const nodeTest = require('node:test')`,
       output: null,
       errors: [{ messageId: 'noImportNodeTest' }],
     },

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -9,6 +9,7 @@ const recommended: RslintConfigEntry = {
     'rstest/no-disabled-tests': 'warn',
     'rstest/no-focused-tests': 'error',
     'rstest/no-identical-title': 'error',
+    'rstest/no-import-node-test': 'error',
     'rstest/no-interpolation-in-snapshots': 'error',
     'rstest/no-mocks-import': 'error',
     'rstest/valid-expect': 'error',


### PR DESCRIPTION
## Summary

Report imports of Node's test runner — `import` declarations and `require()` calls alike, `node:test` and its sub-paths — which editors frequently insert by accident when auto-importing `describe` / `test` / `it`. Named imports of `node:test` containing only `test`, `it` and `describe` are fixed by rewriting the module to `@rstest/core`, preserving the original quote style; every other form is reported without a fix, because the two modules do not have equivalent export surfaces. Added to the rstest `recommended` preset at `error`.

## Credits

Port from [`eslint-plugin-vitest`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `no-import-node-test`.

## Intentional differences from upstream

- **Every form that reaches Node's test runner is reported, not only a bare `node:test` import.** Upstream matches an `ImportDeclaration` whose specifier is exactly `node:test`. Sub-paths such as `node:test/reporters`, and `require('node:test')`, pull in the same runner and are reported too. Neither is fixed, so the wider reporting introduces no new rewrites.

- **The fix is withheld unless the rewrite is provably safe.** Upstream rewrites the specifier for any import shape, which can turn working code into code that does not resolve: the two modules do not have equivalent export surfaces, so a default import, a namespace import, a side-effect import, or a named import of something like `mock` has nothing to be rewritten to. Only a declaration whose bindings are all named imports drawn from `test`, `it` and `describe` is fixed. The reported set matches upstream's; only the fixed set narrows.

- **The message states the prohibition instead of prescribing a replacement module.** Upstream's text tells the reader to import from `vitest` instead. This rule reports forms that have no `@rstest/core` counterpart — sub-paths, `require()`, and imports of bindings the two modules do not share — so naming one replacement in the message would be advice the reader often cannot act on. The message is `Do not import the Node test runner in Rstest test files`, and the rewrite to `@rstest/core` is offered as a fix wherever one is safe.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).