### PR TITLE
chore: bump globals to 17.11.0

### DIFF
--- a/packages/rslint/THIRD-PARTY-NOTICES.md
+++ b/packages/rslint/THIRD-PARTY-NOTICES.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-This distribution includes software and data from `globals` 17.9.0:
+This distribution includes software and data from `globals` 17.11.0:
 https://github.com/sindresorhus/globals
 
 MIT License

--- a/packages/rslint/src/config/globals/upstream.ts
+++ b/packages/rslint/src/config/globals/upstream.ts
@@ -44,6 +44,7 @@ export const UPSTREAM_GLOBAL_SET_NAMES = [
   'prototypejs',
   'protractor',
   'qunit',
+  'react-native',
   'rhino',
   'rspack',
   'serviceworker',

--- a/packages/rslint/tests/globals.test.ts
+++ b/packages/rslint/tests/globals.test.ts
@@ -59,6 +59,8 @@ describe('built-in globals catalog', () => {
     expect(globals.node.require).toBe(false);
     expect(globals.nodeBuiltin.process).toBe(false);
     expect(Object.hasOwn(globals.nodeBuiltin, 'require')).toBe(false);
+    expect(globals.greasemonkey.GM_cookie).toBe(false);
+    expect(globals['react-native'].__DEV__).toBe(false);
   });
 
   test('includes language catalogs for parity with the upstream API', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ catalogs:
       specifier: ^3.3.3
       version: 3.3.3
     globals:
-      specifier: 17.9.0
-      version: 17.9.0
+      specifier: 17.11.0
+      version: 17.11.0
     husky:
       specifier: ^9.1.7
       version: 9.1.7
@@ -381,7 +381,7 @@ importers:
         version: 1.7.0
       globals:
         specifier: 'catalog:'
-        version: 17.9.0
+        version: 17.11.0
       json-schema-to-typescript:
         specifier: 'catalog:'
         version: 15.0.4
@@ -4280,6 +4280,10 @@ packages:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globals@17.11.0:
+    resolution: {integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==}
+    engines: {node: '>=18'}
 
   globals@17.9.0:
     resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
@@ -10149,6 +10153,8 @@ snapshots:
       inherits: 2.0.4
       minimatch: 5.1.9
       once: 1.4.0
+
+  globals@17.11.0: {}
 
   globals@17.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   espree: ^11.2.0
   esquery: ^1.7.0
   # Public API data shipped by @rslint/core; review the catalog diff before updating.
-  globals: 17.9.0
+  globals: 17.11.0
   '@codspeed/tinybench-plugin': ^5.7.1
   '@rstest/core': ^0.11.3
   tinybench: ^6.1.1


### PR DESCRIPTION
## Summary

- bump the pinned globals dependency from 17.9.0 to 17.11.0
- expose the new react-native catalog and cover the new GM_cookie data
- update the bundled third-party notice and lockfile

## Related Links

- N/A

## Testing

- pnpm --filter @rslint/core run build:js
- pnpm --filter @rslint/core exec rstest run tests/globals.test.ts
- pnpm typecheck
- pnpm exec prettier --check pnpm-workspace.yaml pnpm-lock.yaml packages/rslint/THIRD-PARTY-NOTICES.md packages/rslint/src/config/globals/upstream.ts packages/rslint/tests/globals.test.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).