### PR TITLE
perf: optimize max-statements field diagnostics

### DIFF
--- a/internal/rules/max_statements/max_statements.go
+++ b/internal/rules/max_statements/max_statements.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -35,13 +36,14 @@ var MaxStatementsRule = rule.Rule{
 			count int
 		}
 		var topLevelFunctions []topLevelEntry
+		headLocator := functionHeadLocator{sourceFile: ctx.SourceFile}
 
 		report := func(node *ast.Node, count int) {
 			if count <= opts.max {
 				return
 			}
 			name := utils.UpperCaseFirstASCII(utils.GetFunctionNameWithKindCore(node))
-			ctx.ReportRange(functionHeadLoc(ctx.SourceFile, node), rule.RuleMessage{
+			ctx.ReportRange(headLocator.loc(node), rule.RuleMessage{
 				Id: "exceed",
 				Description: fmt.Sprintf(
 					"%s has too many statements (%d). Maximum allowed is %d.",
@@ -204,12 +206,26 @@ func hasDecorator(node *ast.Node) bool {
 	return false
 }
 
-// functionHeadLoc mirrors core ESLint's getFunctionHeadLoc, which starts a
-// class member's report at the member's own start — decorators included. The
+// functionHeadLocator mirrors core ESLint's getFunctionHeadLoc, which starts
+// a class member's report at the member's own start — decorators included. The
 // shared helper follows typescript-eslint's variant, which deliberately skips
-// them, so restore the member start for decorated members.
-func functionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
-	loc := utils.GetFunctionHeadLoc(sourceFile, node)
+// them, so the locator restores the member start for decorated members.
+type functionHeadLocator struct {
+	sourceFile *ast.SourceFile
+	tokens     *scanner.Scanner
+}
+
+func (l *functionHeadLocator) loc(node *ast.Node) core.TextRange {
+	// GetFunctionHeadLoc has to reproduce SourceCode.getTokenBefore() for a
+	// single-parameter field arrow. Its general implementation scans from the
+	// start of the source file, which becomes quadratic when this rule reports
+	// many such fields in one file. The owning field gives us a narrow, local
+	// token boundary while preserving the same core-ESLint range.
+	if loc, ok := l.singleParameterFieldArrowHeadLoc(node); ok {
+		return loc
+	}
+
+	loc := utils.GetFunctionHeadLoc(l.sourceFile, node)
 
 	member := node
 	switch {
@@ -231,7 +247,71 @@ func functionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange 
 	if !hasDecorator(member) {
 		return loc
 	}
-	return core.NewTextRange(utils.TrimNodeTextRange(sourceFile, member).Pos(), loc.End())
+	return core.NewTextRange(utils.TrimNodeTextRange(l.sourceFile, member).Pos(), loc.End())
+}
+
+// singleParameterFieldArrowHeadLoc returns core ESLint's report range for an
+// arrow held directly by an object property or ordinary class field. Only
+// ParenthesizedExpression wrappers are transparent; an auto-accessor or any
+// other expression wrapper deliberately falls back to GetFunctionHeadLoc.
+func (l *functionHeadLocator) singleParameterFieldArrowHeadLoc(node *ast.Node) (core.TextRange, bool) {
+	if node.Kind != ast.KindArrowFunction {
+		return core.TextRange{}, false
+	}
+	arrow := node.AsArrowFunction()
+	if arrow.Parameters == nil || len(arrow.Parameters.Nodes) != 1 {
+		return core.TextRange{}, false
+	}
+
+	owner := ast.WalkUpParenthesizedExpressions(node.Parent)
+	if owner == nil {
+		return core.TextRange{}, false
+	}
+	switch owner.Kind {
+	case ast.KindPropertyAssignment:
+	case ast.KindPropertyDeclaration:
+		if ast.HasSyntacticModifier(owner, ast.ModifierFlagsAccessor) {
+			return core.TextRange{}, false
+		}
+	default:
+		return core.TextRange{}, false
+	}
+
+	parameterStart := utils.TrimNodeTextRange(l.sourceFile, arrow.Parameters.Nodes[0]).Pos()
+	scanStart := utils.TrimNodeTextRange(l.sourceFile, node).Pos()
+	if parent := node.Parent; parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		// A parenless arrow can itself be wrapped: `field = (value => {})`.
+		// ESLint sees no wrapper node, so that `(` is the token before `value`.
+		scanStart = utils.TrimNodeTextRange(l.sourceFile, parent).Pos()
+	}
+
+	end := parameterStart
+	var previousKind ast.Kind
+	previousStart := 0
+	foundPrevious := false
+	if l.tokens == nil {
+		l.tokens = scanner.NewScanner()
+	}
+	// Reuse one scanner per file: constructing one for every report would trade
+	// the quadratic scan for avoidable per-diagnostic allocations.
+	l.tokens.SetText(l.sourceFile.Text())
+	l.tokens.SetLanguageVariant(l.sourceFile.LanguageVariant)
+	l.tokens.ResetTokenState(scanStart)
+	l.tokens.Scan()
+	tokens := l.tokens
+	for tokens.Token() != ast.KindEndOfFile && tokens.TokenStart() < parameterStart {
+		if tokens.TokenEnd() <= parameterStart {
+			previousKind = tokens.Token()
+			previousStart = tokens.TokenStart()
+			foundPrevious = true
+		}
+		tokens.Scan()
+	}
+	if foundPrevious && previousKind == ast.KindOpenParenToken {
+		end = previousStart
+	}
+
+	return core.NewTextRange(utils.TrimNodeTextRange(l.sourceFile, owner).Pos(), end), true
 }
 
 type ruleOptions struct {

--- a/internal/rules/max_statements/max_statements_extras_test.go
+++ b/internal/rules/max_statements/max_statements_extras_test.go
@@ -61,6 +61,10 @@ func TestMaxStatementsExtras(t *testing.T) {
 			// so the lone implementation is still "the" top-level function and is
 			// exempted by the topLevelFunctions.length === 1 check, despite exceeding max.
 			{Code: "function foo(x: number): void;\nfunction foo(x: string): void;\nfunction foo(x: any) { 1; 2; 3; 4; 5; }", Options: optionsWithTopLevel(1, true)},
+
+			// The report starts on the field, even when tsgo preserves an outer
+			// ParenthesizedExpression, so disabling that field's line suppresses it.
+			{Code: "class C {\n  // eslint-disable-next-line test\n  f =\n    (x => { a; b; });\n}", Options: option(1)},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: object literal method, string-literal key ----
@@ -282,6 +286,11 @@ func TestMaxStatementsExtras(t *testing.T) {
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'f'", 2, 1), Line: 1, Column: 11, EndLine: 1, EndColumn: 15}},
 			},
 			{
+				Code:    "class C { f = x => { a; b; }; }",
+				Options: option(1),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'f'", 2, 1), Line: 1, Column: 11, EndLine: 1, EndColumn: 15}},
+			},
+			{
 				Code:    "class C { f = ((x) => { a; b; }); }",
 				Options: option(1),
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'f'", 2, 1), Line: 1, Column: 11, EndLine: 1, EndColumn: 16}},
@@ -290,6 +299,26 @@ func TestMaxStatementsExtras(t *testing.T) {
 				Code:    "const o = { f: (x => { a; b; }) };",
 				Options: option(1),
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'f'", 2, 1), Line: 1, Column: 13, EndLine: 1, EndColumn: 16}},
+			},
+			{
+				Code:    "class C { f = (/* c */ x => { a; b; }); }",
+				Options: option(1),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'f'", 2, 1), Line: 1, Column: 11, EndLine: 1, EndColumn: 15}},
+			},
+			{
+				Code:    "class C { @dec f = x => { a; b; }; }",
+				Options: option(1),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'f'", 2, 1), Line: 1, Column: 11, EndLine: 1, EndColumn: 20}},
+			},
+			{
+				Code:    "class C { f = <T extends (string | number)>(x: T) => { a; b; }; }",
+				Options: option(1),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'f'", 2, 1), Line: 1, Column: 11, EndLine: 1, EndColumn: 44}},
+			},
+			{
+				Code:    "class C { f = async x => { a; b; }; }",
+				Options: option(1),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Async method 'f'", 2, 1), Line: 1, Column: 11, EndLine: 1, EndColumn: 21}},
 			},
 			// ---- Dimension 3: decorators and parentheses compose — the head still starts
 			// at the decorated member ----
@@ -349,6 +378,11 @@ func TestMaxStatementsExtras(t *testing.T) {
 				Code:    "class C { accessor #f = () => { a; b; }; }",
 				Options: option(1),
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Arrow function", 2, 1), Line: 1, Column: 28, EndLine: 1, EndColumn: 30}},
+			},
+			{
+				Code:    "class C {\n  // eslint-disable-next-line test\n  accessor f =\n    x => { a; b; };\n}",
+				Options: option(1),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Arrow function", 2, 1), Line: 4, Column: 7, EndLine: 4, EndColumn: 9}},
 			},
 
 			// ---- Real-user: eslint/eslint#12950 — ignoreTopLevelFunctions only exempts a


### PR DESCRIPTION
## Summary

- Avoid source-wide token rescans when `max-statements` reports single-parameter arrow functions held by object properties or ordinary class fields. The old shared helper restarted at byte 0 for every report, making files with many such fields quadratic.
- Scan only the local arrow head and reuse one scanner per rule instance. Other function shapes still use the shared helper; auto-accessors and non-parenthesis expression wrappers intentionally stay on the existing fallback path.
- Keep the optimization entirely in the rule layer. Reference indexing does not help a statement-counting rule, and deferred reports only defer fixes/suggestions, which this rule does not produce.
- Add coverage for direct, wrapped, commented, decorated, generic, async, and auto-accessor field arrows, including `eslint-disable-next-line` behavior.

### Performance

Synthetic end-to-end rule benchmark on darwin/arm64 (Apple M5 Max), using one file with 4,000 violating single-parameter class-field arrows and `max: 0`:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Time | 763.3 ms/op | 2.56 ms/op | ~298x faster |
| Bytes | 3,126,944 B/op | 2,922,002 B/op | -6.6% |
| Allocations | 45,208 allocs/op | 44,451 allocs/op | -1.7% |

The baseline CPU profile attributed 50.3% of samples to the source-wide `TokenBeforePosition` path; it no longer appears as a hotspot after the change. The temporary benchmark/profile harness was removed before commit.

Real repository runs used each repository's JavaScript `rslint.config.mjs`, overlaid `max-statements: ["error", 0]`, and ran single-threaded three times:

| Repository | Files | Before median | After median |
| --- | ---: | ---: | ---: |
| rsbuild | 2,203 | 8.6 ms | 8.6 ms |
| rspack | 479 | 7.7 ms | 6.7 ms |

### Correctness

- ESLint 10.8.0 with `@typescript-eslint/parser` was used as an independent range oracle across plain, parenthesized, async, generic, commented, destructured, decorated, wrapped, and auto-accessor cases.
- rsbuild kept all 3,466 diagnostics with identical rule, message, file, start, and severity. Thirty parenthesized single-parameter field-arrow ranges now end one column earlier, at `(`, matching ESLint.
- rspack kept all 2,880 diagnostics under the same invariant. Sixty-three ranges received the same ESLint-compatible one-column correction.

Validation:

- `go test -count=1 ./internal/rules/max_statements`
- targeted `max-statements` Rstest suite (2/2 passed; no snapshot changes)
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/max_statements/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
