### PR TITLE
perf: limit gitignore scans to CLI targets

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -901,8 +901,12 @@ Additional current behaviors:
   target's `.gitignore` sources. This preserves ESLint v10's per-target global
   ignore behavior: adding another literal target cannot change whether an
   existing target is ignored. File-only CLI/API requests read only target
-  directory chains within each governing config. The synthetic Git entry is
-  ordered before authored entries, so a later config `!` may re-include a target
+  directory chains within each governing config. Explicit JS/TS and JSON CLI
+  directory requests read the target ancestry and then recurse only below the
+  requested directories; mixed requests add the exact-file chains. Automatic
+  config discovery keeps its existing ownership walk. The synthetic Git entry
+  is ordered before authored entries, so a later config `!` may re-include a
+  target
 - when the client supports dynamic file-watch registration, Go watches
   workspace-descendant `.gitignore` files plus exact `.gitignore` paths in
   strict workspace ancestors that may contain an automatically selected config.
@@ -1008,7 +1012,10 @@ collection, and plugin dispatch may still use infrastructure goroutines.
    - Native API roots carry an exact target-ancestor trie from the tinyglobby
      result, so only sibling branches leading to supplied files enter those
      frontiers. CLI/LSP directory roots, including CLI mixed file+directory
-     invocations, remain recursively unbounded within ignore boundaries.
+     invocations, remain recursively unbounded during automatic config
+     discovery. After an explicit JS/TS config loads, its fixed-owner Git
+     projection instead carries the CLI target trie: exact-file branches stop
+     at their parent, and requested directory branches recurse from that root.
    - Directory-root ancestry is loaded outer-to-inner before the root frontier.
      Each successful owner's authored global ignores and Git cursor control
      continuation below that boundary; local Git sources are observed only after

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -497,6 +497,7 @@ func loadGitignoreAndProjects(
 	config rslintconfig.RslintConfig,
 	configDirectory string,
 	targetFiles []string,
+	targetDirectories []string,
 	singleThreaded bool,
 	session *loader.Session,
 ) (rslintconfig.RslintConfig, loader.ProjectSet, error) {
@@ -507,11 +508,12 @@ func loadGitignoreAndProjects(
 	)
 	work := core.NewWorkGroup(singleThreaded)
 	work.Queue(func() {
-		configWithIgnores = rslintconfig.ConfigWithGitignore(
+		configWithIgnores = rslintconfig.ConfigWithGitignoreForTargets(
 			config,
 			configDirectory,
 			session.FS(),
 			targetFiles,
+			targetDirectories,
 		)
 	})
 	work.Queue(func() {
@@ -807,18 +809,20 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			currentDirectory = workingDirectory
 		}
 
-		var exactTargetFiles []string
-		if len(allowFiles) > 0 && len(allowDirs) == 0 {
-			exactTargetFiles = allowFiles
-		}
 		if typeCheckOnly {
 			projectSet, err = programSession.BuildProject(currentDirectory, rslintConfig, singleThreaded)
 		} else if buildAllPrograms {
 			rslintConfig, projectSet, err = loadGitignoreAndProjects(
-				rslintConfig, currentDirectory, exactTargetFiles, singleThreaded, programSession,
+				rslintConfig, currentDirectory, allowFiles, allowDirs, singleThreaded, programSession,
 			)
 		} else {
-			rslintConfig = rslintconfig.ConfigWithGitignore(rslintConfig, currentDirectory, fs, exactTargetFiles)
+			rslintConfig = rslintconfig.ConfigWithGitignoreForTargets(
+				rslintConfig,
+				currentDirectory,
+				fs,
+				allowFiles,
+				allowDirs,
+			)
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -93,6 +93,16 @@ func runLintPipelineForTest(t *testing.T, cwd string, args lintArgs) (int, strin
 	return code, string(stdoutBytes), string(stderrBytes)
 }
 
+type directoryAccessSpyFS struct {
+	vfs.FS
+	accessedDirs []string
+}
+
+func (fs *directoryAccessSpyFS) GetAccessibleEntries(path string) vfs.Entries {
+	fs.accessedDirs = append(fs.accessedDirs, tspath.NormalizePath(path))
+	return fs.FS.GetAccessibleEntries(path)
+}
+
 // TestPrintDiagnosticUTF8 tests that the default output renderer correctly
 // handles UTF-8 characters (Chinese, Japanese, Korean, Emoji).
 func TestPrintDiagnosticUTF8(t *testing.T) {
@@ -963,6 +973,49 @@ func TestExecuteLintPipelineFocusedFileBuildsOnlyDirectProject(t *testing.T) {
 	}
 	if got := fsys.readCount(tspath.ResolvePath(dir, "tsconfig-later.json")); got != 0 {
 		t.Fatalf("project after the direct winner was parsed %d time(s)", got)
+	}
+}
+
+func TestExecuteLintPipelineDirectoryTargetSkipsUnrelatedGitignoreSubtree(t *testing.T) {
+	dir := t.TempDir()
+	selectedDir := filepath.Join(dir, "selected")
+	unrelatedDir := filepath.Join(dir, "unrelated")
+	for _, path := range []string{selectedDir, filepath.Join(selectedDir, "deep"), unrelatedDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	for path, content := range map[string]string{
+		filepath.Join(dir, "rslint.jsonc"):            `[{"rules":{"no-debugger":"error"}}]`,
+		filepath.Join(dir, ".gitignore"):              "root.generated.js\n",
+		filepath.Join(selectedDir, ".gitignore"):      "local.generated.js\n",
+		filepath.Join(selectedDir, "index.js"):        "debugger;\n",
+		filepath.Join(selectedDir, "deep/.gitignore"): "deep.generated.js\n",
+		filepath.Join(unrelatedDir, ".gitignore"):     "index.js\n",
+		filepath.Join(unrelatedDir, "index.js"):       "debugger;\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	spy := &directoryAccessSpyFS{FS: bundled.WrapFS(cachedvfs.From(osvfs.FS()))}
+
+	code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Config:         filepath.Join(dir, "rslint.jsonc"),
+		FS:             spy,
+		AllowDirs:      []string{tspath.NormalizePath(selectedDir)},
+		Format:         "jsonline",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 1 || !strings.Contains(stdout, "no-debugger") {
+		t.Fatalf("selected directory was not linted: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	unrelatedDir = tspath.NormalizePath(unrelatedDir)
+	for _, accessed := range spy.accessedDirs {
+		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
+			t.Fatalf("JSON directory target entered unrelated directory %q", accessed)
+		}
 	}
 }
 

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -95,7 +96,15 @@ func runLintPipelineForTest(t *testing.T, cwd string, args lintArgs) (int, strin
 
 type directoryAccessSpyFS struct {
 	vfs.FS
-	accessedDirs []string
+	accessedDirs   []string
+	gitignoreReads []string
+}
+
+func (fs *directoryAccessSpyFS) ReadFile(path string) (string, bool) {
+	if filepath.Base(path) == ".gitignore" {
+		fs.gitignoreReads = append(fs.gitignoreReads, tspath.NormalizePath(path))
+	}
+	return fs.FS.ReadFile(path)
 }
 
 func (fs *directoryAccessSpyFS) GetAccessibleEntries(path string) vfs.Entries {
@@ -1015,6 +1024,59 @@ func TestExecuteLintPipelineDirectoryTargetSkipsUnrelatedGitignoreSubtree(t *tes
 	for _, accessed := range spy.accessedDirs {
 		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
 			t.Fatalf("JSON directory target entered unrelated directory %q", accessed)
+		}
+	}
+}
+
+func TestExecuteLintPipelineExplicitJSONDirectoryTargetUsesInvocationCWD(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	cwd := filepath.Join(repositoryRoot, "packages", "app")
+	selectedDir := filepath.Join(cwd, "selected")
+	unrelatedDir := filepath.Join(cwd, "unrelated")
+	for _, path := range []string{selectedDir, unrelatedDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	for path, content := range map[string]string{
+		filepath.Join(repositoryRoot, "rslint.jsonc"): `[{
+			"rules": {"no-debugger": "error"}
+		}]`,
+		filepath.Join(repositoryRoot, ".gitignore"): "packages/app/selected/index.js\n",
+		filepath.Join(cwd, ".gitignore"):            "cwd.generated.js\n",
+		filepath.Join(selectedDir, ".gitignore"):    "local.generated.js\n",
+		filepath.Join(selectedDir, "index.js"):      "debugger;\n",
+		filepath.Join(unrelatedDir, ".gitignore"):   "index.js\n",
+		filepath.Join(unrelatedDir, "index.js"):     "debugger;\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	spy := &directoryAccessSpyFS{FS: bundled.WrapFS(cachedvfs.From(osvfs.FS()))}
+
+	code, stdout, stderr := runLintPipelineForTest(t, cwd, lintArgs{
+		Config:         filepath.Join(repositoryRoot, "rslint.jsonc"),
+		FS:             spy,
+		AllowDirs:      []string{tspath.NormalizePath(selectedDir)},
+		Format:         "jsonline",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 1 || !strings.Contains(stdout, "no-debugger") {
+		t.Fatalf("selected directory was not linted from invocation cwd: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	wantGitignoreReads := []string{
+		tspath.NormalizePath(filepath.Join(cwd, ".gitignore")),
+		tspath.NormalizePath(filepath.Join(selectedDir, ".gitignore")),
+	}
+	if !slices.Equal(spy.gitignoreReads, wantGitignoreReads) {
+		t.Fatalf("explicit JSON CWD-rooted Git reads = %v, want %v", spy.gitignoreReads, wantGitignoreReads)
+	}
+	unrelatedDir = tspath.NormalizePath(unrelatedDir)
+	for _, accessed := range spy.accessedDirs {
+		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
+			t.Fatalf("explicit JSON target entered unrelated directory %q", accessed)
 		}
 	}
 }

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -486,22 +486,22 @@ func discoverCLIConfigCatalog(
 	loader := &ipcConfigModuleLoader{channel: channel}
 	var catalog *discovery.ConfigCatalog
 	if payload.ConfigDiscovery.ExplicitConfigPath != "" {
-		var targetFiles []discovery.DiscoveryFile
-		switch {
-		case args.TypeCheckOnly:
+		targetFiles := append([]discovery.DiscoveryFile(nil), request.Files...)
+		targetDirectories := append([]string(nil), request.Directories...)
+		if args.TypeCheckOnly {
 			targetFiles = []discovery.DiscoveryFile{}
-		case len(args.AllowFiles) > 0 && len(args.AllowDirs) == 0:
-			targetFiles = append([]discovery.DiscoveryFile(nil), request.Files...)
+			targetDirectories = nil
 		}
 		catalog, err = discovery.LoadExplicitConfig(
 			ctx,
 			args.FS,
 			loader,
 			discovery.ExplicitConfigRequest{
-				CWD:            cwd,
-				ConfigPath:     payload.ConfigDiscovery.ExplicitConfigPath,
-				TargetFiles:    targetFiles,
-				SingleThreaded: args.SingleThreaded,
+				CWD:               cwd,
+				ConfigPath:        payload.ConfigDiscovery.ExplicitConfigPath,
+				TargetFiles:       targetFiles,
+				TargetDirectories: targetDirectories,
+				SingleThreaded:    args.SingleThreaded,
 			},
 		)
 	} else {

--- a/cmd/rslint/ipc_cli_test.go
+++ b/cmd/rslint/ipc_cli_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/config/discovery"
 	"github.com/web-infra-dev/rslint/internal/ipc"
 )
@@ -61,6 +62,90 @@ func TestClassifyPaths(t *testing.T) {
 	wantFiles := []string{tspath.NormalizePath(file), tspath.NormalizePath(missing)}
 	if len(files) != 2 || files[0] != wantFiles[0] || files[1] != wantFiles[1] {
 		t.Errorf("files = %v, want %v", files, wantFiles)
+	}
+}
+
+func TestDiscoverCLIExplicitConfigProjectsMixedTargetsOnly(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	selectedDir := filepath.Join(root, "selected")
+	unrelatedDir := filepath.Join(root, "unrelated")
+	toolsDir := filepath.Join(root, "tools")
+	for _, path := range []string{selectedDir, filepath.Join(selectedDir, "deep"), unrelatedDir, toolsDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	for path, content := range map[string]string{
+		filepath.Join(root, ".gitignore"):             "root.generated.js\n",
+		filepath.Join(selectedDir, ".gitignore"):      "selected.generated.js\n",
+		filepath.Join(selectedDir, "deep/.gitignore"): "deep.generated.js\n",
+		filepath.Join(unrelatedDir, ".gitignore"):     "unrelated.generated.js\n",
+		filepath.Join(toolsDir, ".gitignore"):         "exact.js\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	configPath := filepath.Join(root, "custom.config.cjs")
+	if err := os.WriteFile(configPath, []byte("export default [];\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exactFile := filepath.Join(toolsDir, "exact.js")
+	if err := os.WriteFile(exactFile, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cli, peer := newCLIChannelPair(t)
+	peer.SetInboundHandler(func(_ context.Context, msg *ipc.Message) (any, error) {
+		switch msg.Kind {
+		case kindLoadConfigs:
+			var request discovery.ConfigLoadBatchRequest
+			if err := msg.Decode(&request); err != nil {
+				return nil, err
+			}
+			if len(request.Candidates) != 1 || request.Candidates[0].ConfigPath != tspath.NormalizePath(configPath) {
+				return nil, fmt.Errorf("unexpected config candidates: %+v", request.Candidates)
+			}
+			return discovery.ConfigLoadBatchResponse{
+				TransactionID: request.TransactionID,
+				Results: []discovery.ConfigLoadResult{{
+					ID:     request.Candidates[0].ID,
+					Status: "loaded",
+				}},
+			}, nil
+		case kindActivateConfigs:
+			var request discovery.ConfigActivationRequest
+			if err := msg.Decode(&request); err != nil {
+				return nil, err
+			}
+			return discovery.ConfigActivationResponse{TransactionID: request.TransactionID}, nil
+		default:
+			return nil, fmt.Errorf("unexpected request kind %q", msg.Kind)
+		}
+	})
+	cli.Start()
+	peer.Start()
+	spy := &directoryAccessSpyFS{FS: osvfs.FS()}
+	args := lintArgs{
+		FS:             spy,
+		AllowFiles:     []string{tspath.NormalizePath(exactFile)},
+		AllowDirs:      []string{tspath.NormalizePath(selectedDir)},
+		SingleThreaded: true,
+	}
+	payload := initPayload{ConfigDiscovery: &configDiscoveryPayload{ExplicitConfigPath: configPath}}
+
+	if err := discoverCLIConfigCatalog(context.Background(), &args, &payload, cli); err != nil {
+		t.Fatalf("discoverCLIConfigCatalog: %v", err)
+	}
+	if args.ConfigCatalog == nil || !args.ConfigCatalog.Explicit {
+		t.Fatal("explicit config catalog was not installed")
+	}
+	unrelatedDir = tspath.NormalizePath(unrelatedDir)
+	for _, accessed := range spy.accessedDirs {
+		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
+			t.Fatalf("explicit CLI projection entered unrelated directory %q", accessed)
+		}
 	}
 }
 

--- a/internal/config/discovery/catalog.go
+++ b/internal/config/discovery/catalog.go
@@ -62,13 +62,15 @@ type ConfigDiscoveryRequest struct {
 type ExplicitConfigRequest struct {
 	CWD        string
 	ConfigPath string
-	// TargetFiles limits Git projection to the directory chains between CWD
-	// and an exact target set. A nil slice projects the complete CWD-owned
-	// subtree; a non-nil empty slice projects nothing, as used by
-	// --type-check-only.
-	TargetFiles    []DiscoveryFile
-	Fresh          bool
-	SingleThreaded bool
+	// TargetFiles limits Git projection to exact target directory chains. With
+	// no TargetDirectories, a nil slice projects the complete CWD-owned subtree
+	// and a non-nil empty slice projects nothing, as used by --type-check-only.
+	TargetFiles []DiscoveryFile
+	// TargetDirectories limits Git projection to recursive directory targets.
+	// It may be combined with TargetFiles for mixed CLI invocations.
+	TargetDirectories []string
+	Fresh             bool
+	SingleThreaded    bool
 }
 
 type configSource struct {
@@ -187,6 +189,7 @@ func LoadExplicitConfig(ctx context.Context, fsys vfs.FS, loader ConfigModuleLoa
 	automatic := ConfigDiscoveryRequest{
 		CWD:            request.CWD,
 		Files:          request.TargetFiles,
+		Directories:    request.TargetDirectories,
 		Fresh:          request.Fresh,
 		SingleThreaded: request.SingleThreaded,
 	}

--- a/internal/config/discovery/discovery.go
+++ b/internal/config/discovery/discovery.go
@@ -56,12 +56,13 @@ type discoveryWalkNode struct {
 	targets            *discoveryTargetTrie
 }
 
-// discoveryTargetTrie bounds a directory catalog walk to the lexical ancestor
-// paths of an already-expanded target set. A nil trie means an unbounded
-// directory-only walk (CLI/LSP); a non-nil leaf still visits that directory so
-// its config can govern a file located directly within it.
+// discoveryTargetTrie bounds a directory walk to branches that can govern an
+// invocation target. A nil trie means the current subtree is unbounded. A
+// recursive node makes its subtree unbounded, while a non-recursive leaf still
+// visits that directory so its sources can govern a file directly within it.
 type discoveryTargetTrie struct {
-	children map[tspath.Path]*discoveryTargetTrie
+	recursive bool
+	children  map[tspath.Path]*discoveryTargetTrie
 }
 
 type suspendedDiscoveryNode struct {
@@ -293,14 +294,14 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 
 // projectExplicitConfigGitignore freezes the invocation-scoped Git projection
 // after the exact config has loaded. Config selection is already complete:
-// full-subtree projection uses the catalog's bounded parallel frontier with one
-// fixed owner, while exact targets reuse the source-chain path used by literal
-// automatic targets. Neither path performs automatic candidate discovery.
+// full and directory-target projections use the catalog's parallel frontier
+// with one fixed owner, while exact-file-only targets reuse the source-chain
+// path used by automatic literals. Neither path discovers config candidates.
 func (builder *configCatalogBuilder) projectExplicitConfigGitignore(state *configLoadState) error {
 	if state == nil || state.failure != nil {
 		return nil
 	}
-	if builder.request.Files != nil {
+	if len(builder.request.Directories) == 0 && builder.request.Files != nil {
 		files := builder.normalizedFiles()
 		seeds := make([]*discoverySeed, 0, len(files))
 		for _, file := range files {
@@ -319,6 +320,14 @@ func (builder *configCatalogBuilder) projectExplicitConfigGitignore(state *confi
 		builder.collectExactTargetGitignore(seeds)
 		return builder.ctx.Err()
 	}
+	var targets *discoveryTargetTrie
+	if len(builder.request.Directories) > 0 {
+		var hasTargets bool
+		targets, hasTargets = builder.explicitProjectionTargets(state.candidate.directory)
+		if !hasTargets {
+			return builder.ctx.Err()
+		}
+	}
 
 	root := state.candidate.directory
 	canonicalRoot := builder.fs.Realpath(root)
@@ -333,7 +342,93 @@ func (builder *configCatalogBuilder) projectExplicitConfigGitignore(state *confi
 		gitDirectory:       root,
 		gitCursor:          gitignore.NewCursor(root, builder.fs.UseCaseSensitiveFileNames()),
 		gitActive:          true,
+		targets:            targets,
 	}})
+}
+
+func (builder *configCatalogBuilder) explicitProjectionTargets(configDir string) (*discoveryTargetTrie, bool) {
+	root := &discoveryTargetTrie{}
+	hasTargets := false
+	for _, file := range builder.normalizedFiles() {
+		collectionPath := rslintconfig.ResolveGitignoreCollectionPath(
+			file.Path,
+			file.CanonicalPath,
+			configDir,
+			builder.fs,
+		)
+		hasTargets = addDiscoveryTarget(
+			root,
+			configDir,
+			tspath.GetDirectoryPath(collectionPath),
+			false,
+			builder.fs.UseCaseSensitiveFileNames(),
+		) || hasTargets
+	}
+	for _, directory := range builder.normalizedDirectoryRoots() {
+		collectionPath := rslintconfig.ResolveGitignoreCollectionDirectory(
+			directory,
+			configDir,
+			builder.fs,
+		)
+		hasTargets = addDiscoveryTarget(
+			root,
+			configDir,
+			collectionPath,
+			true,
+			builder.fs.UseCaseSensitiveFileNames(),
+		) || hasTargets
+	}
+	return root, hasTargets
+}
+
+func addDiscoveryTarget(
+	root *discoveryTargetTrie,
+	configDir string,
+	targetDirectory string,
+	recursive bool,
+	useCaseSensitive bool,
+) bool {
+	relative, within := rslintconfig.RelativePathWithinConfigRoot(
+		targetDirectory,
+		configDir,
+		useCaseSensitive,
+	)
+	if !within {
+		if recursive {
+			if _, containsRoot := rslintconfig.RelativePathWithinConfigRoot(
+				configDir,
+				targetDirectory,
+				useCaseSensitive,
+			); containsRoot {
+				root.recursive = true
+				root.children = nil
+				return true
+			}
+		}
+		return false
+	}
+
+	node := root
+	for _, component := range splitDiscoveryPath(relative) {
+		if node.recursive {
+			return true
+		}
+		if node.children == nil {
+			node.children = make(map[tspath.Path]*discoveryTargetTrie)
+		}
+		identity := tspath.ToPath(component, "", useCaseSensitive)
+		child := node.children[identity]
+		if child == nil {
+			child = &discoveryTargetTrie{}
+			node.children[identity] = child
+		}
+		node = child
+	}
+	if recursive {
+		node.recursive = true
+		node.children = nil
+	}
+	return true
 }
 
 func (builder *configCatalogBuilder) normalizedDirectoryRoots() []string {
@@ -393,31 +488,12 @@ func (builder *configCatalogBuilder) targetAncestorTries(
 	useCaseSensitive := builder.fs.UseCaseSensitiveFileNames()
 	for _, file := range files {
 		for _, root := range roots {
-			relative, within := rslintconfig.RelativePathWithinConfigRoot(file.Path, root, useCaseSensitive)
-			if !within {
-				continue
-			}
 			trie := tries[root]
 			if trie == nil {
 				trie = &discoveryTargetTrie{}
-				tries[root] = trie
 			}
-			relativeDirectory := tspath.GetDirectoryPath(relative)
-			relativeDirectory = strings.ReplaceAll(relativeDirectory, "\\", "/")
-			for _, segment := range strings.Split(relativeDirectory, "/") {
-				if segment == "" || segment == "." {
-					continue
-				}
-				if trie.children == nil {
-					trie.children = make(map[tspath.Path]*discoveryTargetTrie)
-				}
-				key := tspath.ToPath(segment, "", useCaseSensitive)
-				child := trie.children[key]
-				if child == nil {
-					child = &discoveryTargetTrie{}
-					trie.children[key] = child
-				}
-				trie = child
+			if addDiscoveryTarget(trie, root, tspath.GetDirectoryPath(file.Path), false, useCaseSensitive) {
+				tries[root] = trie
 			}
 		}
 	}
@@ -1142,7 +1218,11 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 		node.gitCursor = nextCursor
 		result.gitignoreObservation = observation
 	}
-	if node.targets != nil && len(node.targets.children) == 0 {
+	walkTargets := node.targets
+	if walkTargets != nil && walkTargets.recursive {
+		walkTargets = nil
+	}
+	if walkTargets != nil && len(walkTargets.children) == 0 {
 		return result
 	}
 
@@ -1156,8 +1236,8 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 	children := make([]discoveryWalkNode, 0, len(directories))
 	for _, name := range directories {
 		var childTargets *discoveryTargetTrie
-		if node.targets != nil {
-			childTargets = node.targets.child(name, builder.fs.UseCaseSensitiveFileNames())
+		if walkTargets != nil {
+			childTargets = walkTargets.child(name, builder.fs.UseCaseSensitiveFileNames())
 			if childTargets == nil {
 				continue
 			}

--- a/internal/config/discovery/discovery_test.go
+++ b/internal/config/discovery/discovery_test.go
@@ -1381,6 +1381,94 @@ func TestConfigDiscoveryBoundsExpandedTargetWalkToAncestorTrie(t *testing.T) {
 	})
 }
 
+func TestConfigDiscoveryAutomaticDirectoryTargetKeepsAncestorOwnerGitChain(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	cwd := filepath.Join(repositoryRoot, "packages/app")
+	selectedDir := filepath.Join(cwd, "selected")
+	for relativePath, content := range map[string]string{
+		".gitignore":                                 "root.generated.ts\n",
+		"packages/.gitignore":                        "package.generated.ts\n",
+		"packages/app/.gitignore":                    "app.generated.ts\n",
+		"packages/app/selected/.gitignore":           "local.ts\n",
+		"packages/app/selected/deep/.gitignore":      "deep.ts\n",
+		"packages/app/selected/root.generated.ts":    "export {};\n",
+		"packages/app/selected/package.generated.ts": "export {};\n",
+		"packages/app/selected/app.generated.ts":     "export {};\n",
+		"packages/app/selected/local.ts":             "export {};\n",
+		"packages/app/selected/deep/deep.ts":         "export {};\n",
+		"packages/app/unrelated/.gitignore":          "index.ts\n",
+		"packages/app/unrelated/index.ts":            "export {};\n",
+	} {
+		writeDiscoveryFixture(t, repositoryRoot, relativePath, content)
+	}
+	configPath := writeConfigCandidate(t, repositoryRoot, "rslint.config.js")
+	entries := namedConfig("ancestor")
+	loader := newFixtureConfigLoader()
+	loader.configs[configPath] = entries
+	spy := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+	catalog, err := DiscoverAutomatic(
+		context.Background(),
+		spy,
+		loader,
+		ConfigDiscoveryRequest{
+			CWD:            cwd,
+			Directories:    []string{selectedDir},
+			SingleThreaded: true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("DiscoverAutomatic: %v", err)
+	}
+	repositoryRoot = tspath.NormalizePath(repositoryRoot)
+	cwd = tspath.NormalizePath(cwd)
+	selectedDir = tspath.NormalizePath(selectedDir)
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{repositoryRoot}) {
+		t.Fatalf("automatic owner = %v, want ancestor %q", got, repositoryRoot)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{configPath}) {
+		t.Fatalf("automatic config requests = %v, want %q", got, configPath)
+	}
+
+	projected := catalog.Configs[repositoryRoot]
+	full := rslintconfig.ConfigWithGitignore(entries, repositoryRoot, discoveryTestFS(), nil)
+	for _, test := range []struct {
+		relativePath string
+		ignored      bool
+	}{
+		{relativePath: "packages/app/selected/root.generated.ts", ignored: true},
+		{relativePath: "packages/app/selected/package.generated.ts", ignored: true},
+		{relativePath: "packages/app/selected/app.generated.ts", ignored: true},
+		{relativePath: "packages/app/selected/local.ts", ignored: true},
+		{relativePath: "packages/app/selected/deep/deep.ts", ignored: true},
+	} {
+		path := tspath.ResolvePath(repositoryRoot, test.relativePath)
+		if got := full.IsFileIgnored(path, repositoryRoot); got != test.ignored {
+			t.Fatalf("invalid full-projection fixture for %s: ignored = %t, want %t", test.relativePath, got, test.ignored)
+		}
+		if got := projected.IsFileIgnored(path, repositoryRoot); got != test.ignored {
+			t.Errorf("%s ignored by targeted projection = %t, want %t", test.relativePath, got, test.ignored)
+		}
+	}
+
+	wantGitignoreReads := []string{
+		tspath.ResolvePath(repositoryRoot, ".gitignore"),
+		tspath.ResolvePath(repositoryRoot, "packages/.gitignore"),
+		tspath.ResolvePath(cwd, ".gitignore"),
+		tspath.ResolvePath(selectedDir, ".gitignore"),
+		tspath.ResolvePath(selectedDir, "deep/.gitignore"),
+	}
+	if got := spy.gitignorePaths; !reflect.DeepEqual(got, wantGitignoreReads) {
+		t.Fatalf("automatic ancestor-owner Git reads = %v, want %v", got, wantGitignoreReads)
+	}
+	unrelatedDir := tspath.ResolvePath(cwd, "unrelated")
+	for _, accessed := range spy.accessedDirs {
+		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
+			t.Fatalf("automatic target walk entered unrelated directory %q", accessed)
+		}
+	}
+}
+
 func TestConfigDiscoveryExplicitConfigLoadsBeforeProjectingGitignore(t *testing.T) {
 	root := t.TempDir()
 	ignoredTarget := writeDiscoveryFixture(t, root, "ignored/index.ts", "export {};\n")
@@ -1796,6 +1884,103 @@ func TestConfigDiscoveryExplicitTargetsSkipUnrelatedGitignoreSubtrees(t *testing
 	for _, accessed := range spy.accessedDirs {
 		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
 			t.Fatalf("explicit projection entered unrelated directory %q", accessed)
+		}
+	}
+}
+
+func TestConfigDiscoveryExplicitDirectoryTargetUsesCWDNotPhysicalConfigDirectory(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	cwd := filepath.Join(repositoryRoot, "packages/app")
+	selectedDir := filepath.Join(cwd, "selected")
+	for relativePath, content := range map[string]string{
+		".gitignore":                              "packages/app/selected/parent-only.ts\n",
+		"packages/.gitignore":                     "app/selected/package-only.ts\n",
+		"packages/app/.gitignore":                 "*.generated.ts\n",
+		"packages/app/selected/.gitignore":        "local.ts\n",
+		"packages/app/selected/deep/.gitignore":   "deep.ts\n",
+		"packages/app/selected/index.ts":          "export {};\n",
+		"packages/app/selected/local.ts":          "export {};\n",
+		"packages/app/selected/drop.generated.ts": "export {};\n",
+		"packages/app/selected/parent-only.ts":    "export {};\n",
+		"packages/app/selected/package-only.ts":   "export {};\n",
+		"packages/app/selected/deep/deep.ts":      "export {};\n",
+		"packages/app/unrelated/.gitignore":       "index.ts\n",
+		"packages/app/unrelated/index.ts":         "export {};\n",
+	} {
+		writeDiscoveryFixture(t, repositoryRoot, relativePath, content)
+	}
+	configPath := writeConfigCandidate(t, repositoryRoot, "custom.config.cjs")
+	entries := namedConfig("explicit")
+	loader := newFixtureConfigLoader()
+	loader.configs[configPath] = entries
+	spy := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		spy,
+		loader,
+		ExplicitConfigRequest{
+			CWD:               cwd,
+			ConfigPath:        configPath,
+			TargetDirectories: []string{selectedDir},
+			SingleThreaded:    true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	repositoryRoot = tspath.NormalizePath(repositoryRoot)
+	cwd = tspath.NormalizePath(cwd)
+	selectedDir = tspath.NormalizePath(selectedDir)
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{cwd}) {
+		t.Fatalf("explicit owner = %v, want invocation cwd %q", got, cwd)
+	}
+	if got := loader.batches[0].Candidates[0].ConfigDirectory; got != cwd {
+		t.Fatalf("wire configDirectory = %q, want invocation cwd %q", got, cwd)
+	}
+
+	projected := catalog.Configs[cwd]
+	full := rslintconfig.ConfigWithGitignore(entries, cwd, discoveryTestFS(), nil)
+	for _, test := range []struct {
+		relativePath string
+		ignored      bool
+	}{
+		{relativePath: "selected/index.ts", ignored: false},
+		{relativePath: "selected/local.ts", ignored: true},
+		{relativePath: "selected/drop.generated.ts", ignored: true},
+		{relativePath: "selected/parent-only.ts", ignored: false},
+		{relativePath: "selected/package-only.ts", ignored: false},
+		{relativePath: "selected/deep/deep.ts", ignored: true},
+	} {
+		path := tspath.ResolvePath(cwd, test.relativePath)
+		if got := full.IsFileIgnored(path, cwd); got != test.ignored {
+			t.Fatalf("invalid full-CWD fixture for %s: ignored = %t, want %t", test.relativePath, got, test.ignored)
+		}
+		if got := projected.IsFileIgnored(path, cwd); got != test.ignored {
+			t.Errorf("%s ignored by targeted projection = %t, want %t", test.relativePath, got, test.ignored)
+		}
+	}
+
+	wantGitignoreReads := []string{
+		tspath.ResolvePath(cwd, ".gitignore"),
+		tspath.ResolvePath(selectedDir, ".gitignore"),
+		tspath.ResolvePath(selectedDir, "deep/.gitignore"),
+	}
+	if got := spy.gitignorePaths; !reflect.DeepEqual(got, wantGitignoreReads) {
+		t.Fatalf("explicit CWD-rooted Git reads = %v, want %v", got, wantGitignoreReads)
+	}
+	for _, excluded := range []string{
+		tspath.ResolvePath(repositoryRoot, ".gitignore"),
+		tspath.ResolvePath(repositoryRoot, "packages/.gitignore"),
+	} {
+		if slices.Contains(spy.gitignorePaths, excluded) {
+			t.Fatalf("explicit projection read physical config ancestry source %q", excluded)
+		}
+	}
+	unrelatedDir := tspath.ResolvePath(cwd, "unrelated")
+	for _, accessed := range spy.accessedDirs {
+		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
+			t.Fatalf("explicit target walk entered unrelated directory %q", accessed)
 		}
 	}
 }

--- a/internal/config/discovery/discovery_test.go
+++ b/internal/config/discovery/discovery_test.go
@@ -54,6 +54,7 @@ type configDiscoveryReadSpyFS struct {
 	mu             sync.Mutex
 	gitignoreReads int
 	gitignorePaths []string
+	accessedDirs   []string
 }
 
 type configDiscoveryCandidateFS struct {
@@ -74,6 +75,13 @@ func (fs *configDiscoveryReadSpyFS) ReadFile(path string) (string, bool) {
 		fs.mu.Unlock()
 	}
 	return fs.FS.ReadFile(path)
+}
+
+func (fs *configDiscoveryReadSpyFS) GetAccessibleEntries(path string) vfs.Entries {
+	fs.mu.Lock()
+	fs.accessedDirs = append(fs.accessedDirs, tspath.NormalizePath(path))
+	fs.mu.Unlock()
+	return fs.FS.GetAccessibleEntries(path)
 }
 
 func (fs *configDiscoveryCaseSensitivityFS) UseCaseSensitiveFileNames() bool {
@@ -1704,6 +1712,156 @@ func TestConfigDiscoveryExplicitGitProjectionMatchesStandalonePolicy(t *testing.
 				}
 			}
 		})
+	}
+}
+
+func TestConfigDiscoveryExplicitTargetsSkipUnrelatedGitignoreSubtrees(t *testing.T) {
+	root := t.TempDir()
+	for relativePath, content := range map[string]string{
+		".gitignore":                                "*.generated.ts\n",
+		"packages/selected/.gitignore":              "local.ts\n!keep.generated.ts\n",
+		"packages/selected/index.ts":                "export {};\n",
+		"packages/selected/local.ts":                "export {};\n",
+		"packages/selected/keep.generated.ts":       "export {};\n",
+		"packages/selected/deep/.gitignore":         "drop.ts\n",
+		"packages/selected/deep/drop.ts":            "export {};\n",
+		"packages/selected/deep/other.generated.ts": "export {};\n",
+		"packages/unrelated/.gitignore":             "index.ts\n",
+		"packages/unrelated/index.ts":               "export {};\n",
+		"tools/.gitignore":                          "exact.ts\n",
+		"tools/exact.ts":                            "export {};\n",
+	} {
+		writeDiscoveryFixture(t, root, relativePath, content)
+	}
+	configPath := writeConfigCandidate(t, root, "custom.config.cjs")
+	selectedConfig := writeConfigCandidate(t, root, "packages/selected/rslint.config.js")
+	unrelatedConfig := writeConfigCandidate(t, root, "packages/unrelated/rslint.config.js")
+	entries := namedConfig("explicit")
+	loader := newFixtureConfigLoader()
+	loader.configs[configPath] = entries
+	loader.configs[selectedConfig] = namedConfig("must-not-load-selected")
+	loader.configs[unrelatedConfig] = namedConfig("must-not-load-unrelated")
+	selectedDir := tspath.NormalizePath(filepath.Join(root, "packages/selected"))
+	exactFile := tspath.NormalizePath(filepath.Join(root, "tools/exact.ts"))
+	spy := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		spy,
+		loader,
+		ExplicitConfigRequest{
+			CWD:               root,
+			ConfigPath:        configPath,
+			TargetFiles:       []DiscoveryFile{{Path: exactFile}},
+			TargetDirectories: []string{selectedDir},
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	root = tspath.NormalizePath(root)
+	projected := catalog.Configs[root]
+	full := rslintconfig.ConfigWithGitignore(entries, root, discoveryTestFS(), nil)
+	for _, relativePath := range []string{
+		"packages/selected/index.ts",
+		"packages/selected/local.ts",
+		"packages/selected/keep.generated.ts",
+		"packages/selected/deep/drop.ts",
+		"packages/selected/deep/other.generated.ts",
+		"tools/exact.ts",
+	} {
+		path := tspath.ResolvePath(root, relativePath)
+		if got, want := projected.IsFileIgnored(path, root), full.IsFileIgnored(path, root); got != want {
+			t.Errorf("%s ignored by targeted projection = %t, full projection = %t", relativePath, got, want)
+		}
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{configPath}) {
+		t.Fatalf("explicit projection evaluated nested configs: %v", got)
+	}
+
+	wantGitignoreReads := []string{
+		tspath.ResolvePath(root, ".gitignore"),
+		tspath.ResolvePath(root, "packages/.gitignore"),
+		tspath.ResolvePath(root, "packages/selected/.gitignore"),
+		tspath.ResolvePath(root, "packages/selected/deep/.gitignore"),
+		tspath.ResolvePath(root, "tools/.gitignore"),
+	}
+	gotGitignoreReads := append([]string(nil), spy.gitignorePaths...)
+	sort.Strings(gotGitignoreReads)
+	sort.Strings(wantGitignoreReads)
+	if !reflect.DeepEqual(gotGitignoreReads, wantGitignoreReads) {
+		t.Fatalf("targeted Git reads = %v, want %v", gotGitignoreReads, wantGitignoreReads)
+	}
+	unrelatedDir := tspath.ResolvePath(root, "packages/unrelated")
+	for _, accessed := range spy.accessedDirs {
+		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
+			t.Fatalf("explicit projection entered unrelated directory %q", accessed)
+		}
+	}
+}
+
+func TestConfigDiscoveryExplicitCWDDirectoryProjectsFullGitTree(t *testing.T) {
+	root := t.TempDir()
+	configPath := writeConfigCandidate(t, root, "custom.config.cjs")
+	target := writeDiscoveryFixture(t, root, "nested/deep/index.ts", "export {};\n")
+	writeDiscoveryFixture(t, root, "nested/deep/.gitignore", "index.ts\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[configPath] = namedConfig("explicit")
+
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		discoveryTestFS(),
+		loader,
+		ExplicitConfigRequest{
+			CWD:               root,
+			ConfigPath:        configPath,
+			TargetDirectories: []string{root},
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	root = tspath.NormalizePath(root)
+	if got := catalog.Configs[root].GetConfigForFile(target, root); got != nil {
+		t.Fatalf("CWD target did not project nested Git ignore: %+v", got)
+	}
+}
+
+func TestConfigDiscoveryExplicitDirectoryContainingAliasedCWDProjectsFullGitTree(t *testing.T) {
+	physicalParent := t.TempDir()
+	physicalRoot := filepath.Join(physicalParent, "workspace")
+	writeConfigCandidate(t, physicalRoot, "custom.config.cjs")
+	physicalTarget := writeDiscoveryFixture(t, physicalRoot, "nested/index.ts", "export {};\n")
+	writeDiscoveryFixture(t, physicalRoot, "nested/.gitignore", "index.ts\n")
+	aliasRoot := filepath.Join(t.TempDir(), "workspace-alias")
+	if err := os.Symlink(physicalRoot, aliasRoot); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasRoot = tspath.NormalizePath(aliasRoot)
+	configPath := tspath.CombinePaths(aliasRoot, "custom.config.cjs")
+	loader := newFixtureConfigLoader()
+	loader.configs[configPath] = namedConfig("explicit")
+
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		discoveryTestFS(),
+		loader,
+		ExplicitConfigRequest{
+			CWD:               aliasRoot,
+			ConfigPath:        configPath,
+			TargetDirectories: []string{physicalParent},
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	matchFile, matchDir := rslintconfig.ResolveConfigPathSpace(
+		physicalTarget,
+		aliasRoot,
+		discoveryTestFS(),
+	)
+	if got := catalog.Configs[aliasRoot].GetConfigForFile(matchFile, matchDir); got != nil {
+		t.Fatalf("containing directory did not project aliased CWD Git ignore: %+v", got)
 	}
 }
 

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -84,6 +84,30 @@ func CollectPatternsWithBoundaries(configDir string, fsys vfs.FS, targetFiles []
 	return readGitignoreAsPatternsForFilesWithBoundaries(configDir, fsys, targetFiles, stopDirs)
 }
 
+// CollectPatternsForTargets collects the Git sources that can affect one
+// invocation containing recursive directory targets. Exact-file-only calls
+// keep using CollectPatterns so their established chain behavior remains
+// unchanged. When directories are present, collection visits only target
+// ancestor chains and target directory subtrees.
+func CollectPatternsForTargets(
+	configDir string,
+	fsys vfs.FS,
+	targetFiles []string,
+	targetDirectories []string,
+	isDirectoryBlocked func(string) bool,
+) []Pattern {
+	if len(targetDirectories) == 0 {
+		return CollectPatterns(configDir, fsys, targetFiles, isDirectoryBlocked)
+	}
+	return readGitignoreAsPatternsForTargets(
+		configDir,
+		fsys,
+		targetFiles,
+		targetDirectories,
+		isDirectoryBlocked,
+	)
+}
+
 func patternGlobs(patterns []Pattern) []string {
 	if len(patterns) == 0 {
 		return nil
@@ -124,12 +148,127 @@ func readGitignoreAsPatternsWithBoundaries(configDir string, fsys vfs.FS, isDire
 	boundaries := normalizeCollectionBoundaries(normalizedRoot, stopDirs, fsys.UseCaseSensitiveFileNames())
 	var allPatterns []Pattern
 
-	collectGitignorePatterns(normalizedRoot, "", fsys, &allPatterns, isDirectoryBlocked, nil, boundaries)
+	collectGitignorePatterns(normalizedRoot, "", fsys, &allPatterns, isDirectoryBlocked, nil, boundaries, nil)
 
 	if len(allPatterns) == 0 {
 		return nil
 	}
 	return allPatterns
+}
+
+type collectionTargetKind uint8
+
+const (
+	collectionTargetLeaf collectionTargetKind = iota + 1
+	collectionTargetBranch
+	collectionTargetRecursive
+)
+
+type collectionTargets map[tspath.Path]collectionTargetKind
+
+func readGitignoreAsPatternsForTargets(
+	configDir string,
+	fsys vfs.FS,
+	files []string,
+	directories []string,
+	isDirectoryBlocked func(string) bool,
+) []Pattern {
+	if fsys == nil {
+		return nil
+	}
+
+	normalizedRoot := normalizeGlobPath(configDir)
+	targets := buildCollectionTargets(
+		normalizedRoot,
+		files,
+		directories,
+		fsys.UseCaseSensitiveFileNames(),
+	)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	var allPatterns []Pattern
+	collectGitignorePatterns(
+		normalizedRoot,
+		"",
+		fsys,
+		&allPatterns,
+		isDirectoryBlocked,
+		nil,
+		nil,
+		targets,
+	)
+	if len(allPatterns) == 0 {
+		return nil
+	}
+	return allPatterns
+}
+
+func buildCollectionTargets(
+	configDir string,
+	files []string,
+	directories []string,
+	useCaseSensitive bool,
+) collectionTargets {
+	targets := make(collectionTargets)
+	for _, file := range files {
+		addCollectionTarget(
+			targets,
+			configDir,
+			dirOfPath(normalizeGlobPath(file)),
+			false,
+			useCaseSensitive,
+		)
+	}
+	for _, directory := range directories {
+		addCollectionTarget(
+			targets,
+			configDir,
+			normalizeGlobPath(directory),
+			true,
+			useCaseSensitive,
+		)
+	}
+	return targets
+}
+
+func addCollectionTarget(
+	targets collectionTargets,
+	configDir string,
+	targetDirectory string,
+	recursive bool,
+	useCaseSensitive bool,
+) {
+	relative, within := relativeDir(configDir, targetDirectory, useCaseSensitive)
+	if !within {
+		if !recursive {
+			return
+		}
+		if _, containsRoot := relativeDir(targetDirectory, configDir, useCaseSensitive); !containsRoot {
+			return
+		}
+		relative = ""
+	}
+
+	components := splitPathComponents(relative)
+	current := configDir
+	for index := 0; index <= len(components); index++ {
+		kind := collectionTargetBranch
+		if index == len(components) {
+			kind = collectionTargetLeaf
+			if recursive {
+				kind = collectionTargetRecursive
+			}
+		}
+		identity := tspath.ToPath(current, "", useCaseSensitive)
+		if targets[identity] < kind {
+			targets[identity] = kind
+		}
+		if index < len(components) {
+			current = tspath.CombinePaths(current, components[index])
+		}
+	}
 }
 
 // readGitignoreAsPatternsForFilesWithBoundaries reads only .gitignore files on
@@ -570,8 +709,8 @@ func filesystemPathDepth(path string) int {
 // isDirectoryBlocked provides directory-level pruning from the caller's
 // config policy. If it returns true, files below that directory cannot be
 // linted, so nested .gitignore sources there are irrelevant.
-func collectGitignorePatterns(absDir string, relDir string, fsys vfs.FS, result *[]Pattern, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string) {
-	collectGitignorePatternsRecursive(absDir, relDir, fsys, result, isDirectoryBlocked, pruneRules, boundaries, &gitignoreWalkState{
+func collectGitignorePatterns(absDir string, relDir string, fsys vfs.FS, result *[]Pattern, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string, targets collectionTargets) {
+	collectGitignorePatternsRecursive(absDir, relDir, fsys, result, isDirectoryBlocked, pruneRules, boundaries, targets, &gitignoreWalkState{
 		resolvedPaths: make(map[string]string),
 		visited:       make(map[string]struct{}),
 	})
@@ -591,7 +730,19 @@ func (s *gitignoreWalkState) realpath(path string, fsys vfs.FS) string {
 	return realpath
 }
 
-func collectGitignorePatternsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]Pattern, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string, state *gitignoreWalkState) {
+func collectGitignorePatternsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]Pattern, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string, targets collectionTargets, state *gitignoreWalkState) {
+	targetKind := collectionTargetBranch
+	if targets != nil {
+		var relevant bool
+		targetKind, relevant = targets[tspath.ToPath(absDir, "", fsys.UseCaseSensitiveFileNames())]
+		if !relevant {
+			return
+		}
+		if targetKind == collectionTargetRecursive {
+			targets = nil
+		}
+	}
+
 	gitignorePath := tspath.CombinePaths(absDir, ".gitignore")
 	if content, ok := fsys.ReadFile(gitignorePath); ok {
 		localPatterns := convertGitignoreToPatterns(content, relDir)
@@ -599,6 +750,9 @@ func collectGitignorePatternsRecursive(absDir string, relDir string, fsys vfs.FS
 		if len(localPatterns) > 0 {
 			pruneRules = append(pruneRules, gitignorePruneRule{patterns: localPatterns})
 		}
+	}
+	if targetKind == collectionTargetLeaf {
+		return
 	}
 
 	entries := fsys.GetAccessibleEntries(absDir)
@@ -608,11 +762,16 @@ func collectGitignorePatternsRecursive(absDir string, relDir string, fsys vfs.FS
 		state.visited[parentRealPath] = struct{}{}
 	}
 	for _, dir := range entries.Directories {
+		childAbs := tspath.CombinePaths(absDir, dir)
+		if targets != nil {
+			if _, relevant := targets[tspath.ToPath(childAbs, "", fsys.UseCaseSensitiveFileNames())]; !relevant {
+				continue
+			}
+		}
 		if isDefaultExcludedDirName(dir, fsys.UseCaseSensitiveFileNames()) {
 			continue
 		}
 
-		childAbs := tspath.CombinePaths(absDir, dir)
 		if isCollectionBoundary(childAbs, boundaries, fsys.UseCaseSensitiveFileNames()) {
 			continue
 		}
@@ -652,7 +811,7 @@ func collectGitignorePatternsRecursive(absDir string, relDir string, fsys vfs.FS
 			state.visited[childRealPath] = struct{}{}
 		}
 
-		collectGitignorePatternsRecursive(childAbs, childRel, fsys, result, isDirectoryBlocked, pruneRules, boundaries, state)
+		collectGitignorePatternsRecursive(childAbs, childRel, fsys, result, isDirectoryBlocked, pruneRules, boundaries, targets, state)
 	}
 }
 

--- a/internal/config/gitignore/collector_test.go
+++ b/internal/config/gitignore/collector_test.go
@@ -780,6 +780,110 @@ func TestExplicitCollectorNeverAccessesOutsideConfigDir(t *testing.T) {
 	})
 }
 
+func TestTargetCollectorVisitsOnlyDirectorySubtreesAndFileChains(t *testing.T) {
+	mock := &gitignoreMockFS{
+		FS: osvfs.FS(),
+		files: map[string]string{
+			"/repo/.gitignore":                 "root.ts\n",
+			"/repo/packages/.gitignore":        "package.ts\n",
+			"/repo/packages/a/.gitignore":      "a.ts\n",
+			"/repo/packages/a/deep/.gitignore": "deep.ts\n",
+			"/repo/packages/b/.gitignore":      "b.ts\n",
+			"/repo/tools/.gitignore":           "tool.ts\n",
+			"/repo/unrelated/.gitignore":       "unrelated.ts\n",
+		},
+		entries: map[string]vfs.Entries{
+			"/repo":                 {Directories: []string{"packages", "tools", "unrelated"}, Symlinks: map[string]struct{}{}},
+			"/repo/packages":        {Directories: []string{"a", "b"}, Symlinks: map[string]struct{}{}},
+			"/repo/packages/a":      {Directories: []string{"deep"}, Symlinks: map[string]struct{}{}},
+			"/repo/packages/a/deep": {Symlinks: map[string]struct{}{}},
+			"/repo/packages/b":      {Symlinks: map[string]struct{}{}},
+			"/repo/tools":           {Symlinks: map[string]struct{}{}},
+			"/repo/unrelated":       {Symlinks: map[string]struct{}{}},
+		},
+		caseSensitiveFS: true,
+	}
+
+	patterns := CollectPatternsForTargets(
+		"/repo",
+		mock,
+		[]string{"/repo/tools/index.ts"},
+		[]string{"/repo/packages/a"},
+		nil,
+	)
+
+	assert.DeepEqual(t, patternGlobs(patterns), []string{
+		"**/root.ts",
+		"packages/**/package.ts",
+		"packages/a/**/a.ts",
+		"packages/a/deep/**/deep.ts",
+		"tools/**/tool.ts",
+	})
+	assert.DeepEqual(t, mock.readFileCalls, []string{
+		"/repo/.gitignore",
+		"/repo/packages/.gitignore",
+		"/repo/packages/a/.gitignore",
+		"/repo/packages/a/deep/.gitignore",
+		"/repo/tools/.gitignore",
+	})
+	assert.DeepEqual(t, mock.accessedDirs, []string{
+		"/repo",
+		"/repo/packages",
+		"/repo/packages/a",
+		"/repo/packages/a/deep",
+	})
+	assert.Assert(t, len(mock.realpathCalls) == 0, "target collector resolved unexpected paths: %v", mock.realpathCalls)
+}
+
+func TestCollectionTargetsTreatContainingDirectoryAsFullRoot(t *testing.T) {
+	for _, directory := range []string{"/repo", "/"} {
+		targets := buildCollectionTargets("/repo", nil, []string{directory}, true)
+		assert.Equal(
+			t,
+			targets[tspath.ToPath("/repo", "", true)],
+			collectionTargetRecursive,
+			"containing directory %q did not cover the config root",
+			directory,
+		)
+	}
+
+	targets := buildCollectionTargets("/repo", nil, []string{"/unrelated"}, true)
+	assert.Equal(t, len(targets), 0, "unrelated directory entered the target set")
+}
+
+func TestCollectionTargetsAreVolumeAndCaseAware(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		root   string
+		target string
+	}{
+		{name: "case insensitive", root: "/Repo", target: "/repo/PACKAGES"},
+		{name: "drive", root: "C:/Repo", target: "c:/repo/Packages"},
+		{name: "UNC", root: "//server/share/repo", target: "//SERVER/SHARE/REPO/packages"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			targets := buildCollectionTargets(test.root, nil, []string{test.target}, false)
+			assert.Equal(
+				t,
+				targets[tspath.ToPath(test.target, "", false)],
+				collectionTargetRecursive,
+				"target set = %+v",
+				targets,
+			)
+		})
+	}
+
+	targets := buildCollectionTargets("C:/repo", nil, []string{"D:/repo/packages"}, false)
+	assert.Equal(t, len(targets), 0, "a different drive entered the target set")
+	targets = buildCollectionTargets(
+		"//server/share/repo",
+		nil,
+		[]string{"//server/other/repo/packages"},
+		false,
+	)
+	assert.Equal(t, len(targets), 0, "a different UNC share entered the target set")
+}
+
 func TestCollectionBoundariesAreVolumeAndCaseAware(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/config/gitignore/config_integration_test.go
+++ b/internal/config/gitignore/config_integration_test.go
@@ -255,6 +255,87 @@ func TestConfigWithGitignore_DefaultAndExplicitScopes(t *testing.T) {
 	assert.Assert(t, base[0].Ignores == nil, "ConfigWithGitignore mutated its input: %v", base)
 }
 
+func TestConfigWithGitignoreForTargetsMatchesFullProjectionWithinTargets(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                                "*.generated.ts\n",
+		"packages/selected/.gitignore":              "local.ts\n!keep.generated.ts\n",
+		"packages/selected/index.ts":                "debugger;\n",
+		"packages/selected/local.ts":                "debugger;\n",
+		"packages/selected/keep.generated.ts":       "debugger;\n",
+		"packages/selected/deep/.gitignore":         "drop.ts\n",
+		"packages/selected/deep/drop.ts":            "debugger;\n",
+		"packages/selected/deep/other.generated.ts": "debugger;\n",
+		"packages/unrelated/.gitignore":             "index.ts\n",
+		"packages/unrelated/index.ts":               "debugger;\n",
+		"tools/.gitignore":                          "exact.ts\n",
+		"tools/exact.ts":                            "debugger;\n",
+	})
+	base := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
+	selectedDir := tspath.ResolvePath(dir, "packages/selected")
+	exactFile := tspath.ResolvePath(dir, "tools/exact.ts")
+	spy := &gitignoreSpyFS{FS: osvfs.FS()}
+
+	full := config.ConfigWithGitignore(base, dir, osvfs.FS(), nil)
+	targeted := config.ConfigWithGitignoreForTargets(
+		base,
+		dir,
+		spy,
+		[]string{exactFile},
+		[]string{selectedDir},
+	)
+	for _, relativePath := range []string{
+		"packages/selected/index.ts",
+		"packages/selected/local.ts",
+		"packages/selected/keep.generated.ts",
+		"packages/selected/deep/drop.ts",
+		"packages/selected/deep/other.generated.ts",
+		"tools/exact.ts",
+	} {
+		path := tspath.ResolvePath(dir, relativePath)
+		assert.Equal(
+			t,
+			targeted.IsFileIgnored(path, dir),
+			full.IsFileIgnored(path, dir),
+			"target decision changed for %s",
+			relativePath,
+		)
+	}
+
+	unrelatedDir := tspath.ResolvePath(dir, "packages/unrelated")
+	for _, accessed := range spy.accessedDirs {
+		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
+			t.Fatalf("targeted projection entered unrelated directory %q", accessed)
+		}
+	}
+}
+
+func TestConfigWithGitignoreForDirectoryPreservesIgnoredParentReachability(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":           "blocked/\n",
+		"blocked/.gitignore":   "keep.ts\n",
+		"blocked/keep.ts":      "debugger;\n",
+		"unrelated/.gitignore": "index.ts\n",
+		"unrelated/index.ts":   "debugger;\n",
+	})
+	base := config.RslintConfig{
+		{Ignores: []string{"!blocked/**"}},
+		{Rules: config.Rules{"no-debugger": "error"}},
+	}
+	blockedDir := tspath.ResolvePath(dir, "blocked")
+	target := tspath.ResolvePath(dir, "blocked/keep.ts")
+	spy := &gitignoreSpyFS{FS: osvfs.FS()}
+
+	full := config.ConfigWithGitignore(base, dir, osvfs.FS(), nil)
+	targeted := config.ConfigWithGitignoreForTargets(base, dir, spy, nil, []string{blockedDir})
+	assert.Equal(t, targeted.IsFileIgnored(target, dir), full.IsFileIgnored(target, dir))
+	assert.Assert(t, !targeted.IsFileIgnored(target, dir))
+	for _, accessed := range spy.accessedDirs {
+		if accessed == blockedDir || tspath.StartsWithDirectory(accessed, blockedDir, true) {
+			t.Fatalf("targeted projection read a Git-inaccessible directory %q", accessed)
+		}
+	}
+}
+
 func TestConfigWithGitignore_DoesNotReadParentOfConfigDir(t *testing.T) {
 	sandbox := t.TempDir()
 	workspace := filepath.Join(sandbox, "workspace")
@@ -450,11 +531,49 @@ func TestConfigWithGitignore_SymlinkedConfigPathSpace(t *testing.T) {
 		{name: "physical config and aliased target", configDir: realRoot, target: filepath.Join(aliasRoot, "src/source.ts")},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			effective := config.ConfigWithGitignore(base, test.configDir, osvfs.FS(), []string{test.target})
+			exact := config.ConfigWithGitignore(base, test.configDir, osvfs.FS(), []string{test.target})
+			directory := config.ConfigWithGitignoreForTargets(
+				base,
+				test.configDir,
+				osvfs.FS(),
+				nil,
+				[]string{filepath.Dir(test.target)},
+			)
 			matchFile, matchDir := config.ResolveConfigPathSpace(test.target, test.configDir, osvfs.FS())
-			assert.Assert(t, effective.IsFileIgnored(matchFile, matchDir))
+			assert.Assert(t, exact.IsFileIgnored(matchFile, matchDir))
+			assert.Assert(t, directory.IsFileIgnored(matchFile, matchDir))
 		})
 	}
+}
+
+func TestConfigWithGitignore_DirectoryContainingAliasedConfigRoot(t *testing.T) {
+	physicalParent := t.TempDir()
+	physicalRoot := filepath.Join(physicalParent, "workspace")
+	if err := os.MkdirAll(filepath.Join(physicalRoot, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(physicalRoot, ".gitignore"), []byte("src/index.ts\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	physicalTarget := filepath.Join(physicalRoot, "src/index.ts")
+	if err := os.WriteFile(physicalTarget, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := filepath.Join(t.TempDir(), "workspace-alias")
+	if err := os.Symlink(physicalRoot, aliasRoot); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	base := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
+
+	effective := config.ConfigWithGitignoreForTargets(
+		base,
+		aliasRoot,
+		osvfs.FS(),
+		nil,
+		[]string{physicalParent},
+	)
+	matchFile, matchDir := config.ResolveConfigPathSpace(physicalTarget, aliasRoot, osvfs.FS())
+	assert.Assert(t, effective.IsFileIgnored(matchFile, matchDir))
 }
 
 func TestConfigWithGitignore_SymlinkedConfigDoesNotReadParents(t *testing.T) {

--- a/internal/config/gitignore_config.go
+++ b/internal/config/gitignore_config.go
@@ -42,6 +42,55 @@ func ConfigWithGitignoreWithBoundaries(config RslintConfig, configDir string, fs
 	return ConfigWithCollectedGitignore(config, patterns, caseInsensitive)
 }
 
+// ConfigWithGitignoreForTargets prepends only the .gitignore patterns that can
+// affect the supplied exact files and recursive directory targets. When both
+// target slices are nil, it retains the full-tree behavior used by no-argument
+// CLI and LSP calls.
+func ConfigWithGitignoreForTargets(
+	config RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	targetFiles []string,
+	targetDirectories []string,
+) RslintConfig {
+	if len(targetDirectories) == 0 {
+		return ConfigWithGitignore(config, configDir, fsys, targetFiles)
+	}
+
+	collectionFiles := targetFiles
+	collectionDirectories := targetDirectories
+	var isDirectoryBlocked func(string) bool
+	configIgnores := extractConfigIgnores(config)
+	if len(configIgnores) > 0 {
+		isDirectoryBlocked = func(relativePath string) bool {
+			return isDirAbsolutelyBlocked(relativePath, configIgnores)
+		}
+	}
+	if fsys != nil {
+		if len(targetFiles) > 0 {
+			collectionFiles = make([]string, len(targetFiles))
+			for i, file := range targetFiles {
+				collectionFiles[i] = ResolveGitignoreCollectionPath(file, "", configDir, fsys)
+			}
+		}
+		if len(targetDirectories) > 0 {
+			collectionDirectories = make([]string, len(targetDirectories))
+			for i, directory := range targetDirectories {
+				collectionDirectories[i] = ResolveGitignoreCollectionDirectory(directory, configDir, fsys)
+			}
+		}
+	}
+	patterns := gitignore.CollectPatternsForTargets(
+		configDir,
+		fsys,
+		collectionFiles,
+		collectionDirectories,
+		isDirectoryBlocked,
+	)
+	caseInsensitive := fsys != nil && !fsys.UseCaseSensitiveFileNames()
+	return ConfigWithCollectedGitignore(config, patterns, caseInsensitive)
+}
+
 // ConfigWithCollectedGitignore prepends one already-collected Git projection
 // without retaining a filesystem. Both the standalone collector path and
 // staged config discovery use this constructor so private Git matching metadata
@@ -132,4 +181,20 @@ func ResolveGitignoreCollectionPath(filePath string, canonicalPath string, confi
 		return tspath.ResolvePath(configDir, relative)
 	}
 	return filePath
+}
+
+// ResolveGitignoreCollectionDirectory is the directory-target form of
+// ResolveGitignoreCollectionPath. A directory that physically contains the
+// config root maps to the root because its relevant projection is the complete
+// config-owned tree.
+func ResolveGitignoreCollectionDirectory(directory string, configDir string, fsys vfs.FS) string {
+	directory = tspath.NormalizePath(directory)
+	matchDirectory, matchConfigDir := ResolveConfigPathSpace(directory, configDir, fsys)
+	if relative, ok := RelativePathWithinConfigRoot(matchDirectory, matchConfigDir, true); ok {
+		return tspath.ResolvePath(configDir, relative)
+	}
+	if _, containsConfigRoot := RelativePathWithinConfigRoot(matchConfigDir, matchDirectory, true); containsConfigRoot {
+		return tspath.NormalizePath(configDir)
+	}
+	return directory
 }


### PR DESCRIPTION
## Summary

- limit .gitignore projection for explicit JS/TS and JSON CLI directory inputs to target ancestors and requested directory subtrees
- keep no-argument, exact-file, automatic discovery, and project/type-check behavior unchanged
- add differential and filesystem-access tests for mixed inputs, ignored parents, path casing, drive/UNC boundaries, and symlink aliases

### Performance

Compared `ade81e33` (latest `main`) with `7f0cde39` (this PR) using hyperfine 1.20.0. Each scenario used 3 warmups and 10 paired rounds with alternating execution order. Config activation was excluded from timing, CPU idle stayed at or above 75.2%, and no Go build overlapped the measurements.

Wall-clock medians; a negative delta means this PR is faster:

| Repository | Mode | `main` | This PR | Delta |
| --- | --- | ---: | ---: | ---: |
| rsbuild | Plain (no target) | 423.3 ms | 423.7 ms | +0.08% |
| rsbuild | Explicit directory | 179.0 ms | 120.8 ms | -32.49% |
| rsbuild | Explicit file | 110.4 ms | 110.0 ms | -0.30% |
| rspack | Plain (no target) | 220.9 ms | 222.9 ms | +0.95% |
| rspack | Explicit directory | 150.9 ms | 128.5 ms | -14.79% |
| rspack | Explicit file | 107.9 ms | 110.3 ms | +2.28% |

- Internal rslint timing corroborated the directory gains: rsbuild improved from 153.0 ms to 94.5 ms (-38.24%), and rspack improved from 126.5 ms to 102.5 ms (-18.97%).
- The directory improvement reproduced across separate benchmark runs. Plain and explicit-file modes showed no stable performance change after execution-order and cross-run checks.
- Across rsbuild and rspack, all 60 paired formal logs had identical diagnostics and summaries after normalizing timing fields. The 120 formal measurements used the package-declared CLI bins and their corresponding native Go binaries with no main/current mismatch.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
