### PR TITLE
fix: align and optimize no-import-assign

### DIFF
--- a/internal/rules/no_import_assign/no_import_assign.go
+++ b/internal/rules/no_import_assign/no_import_assign.go
@@ -8,6 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 // importedBinding holds information about a single imported binding.
@@ -80,6 +81,120 @@ func checkerImportBindingSymbol(nameNode *ast.Node, ctx *rule.RuleContext) *ast.
 		return nil
 	}
 	return ctx.TypeChecker.GetSymbolAtLocation(nameNode)
+}
+
+type importedBindingReferenceMatcher struct {
+	sourceFile             *ast.SourceFile
+	resolveReferenceSymbol func(*ast.Node) *ast.Symbol
+	authoredScopes         *scope.Manager
+}
+
+type authoredJavaScriptScopeCacheKey struct{}
+
+func isOnlySynthesizedJSDocSymbol(symbol *ast.Symbol) bool {
+	if symbol == nil || len(symbol.Declarations) == 0 ||
+		symbol.Flags&(ast.SymbolFlagsAlias|ast.SymbolFlagsTypeAlias) == 0 {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if !isSynthesizedJSDocDeclaration(declaration) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSynthesizedJSDocDeclaration(node *ast.Node) bool {
+	for current := node; current != nil; current = current.Parent {
+		if current.Flags&ast.NodeFlagsReparsed != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvesToFunctionBodyFromParameter(
+	node *ast.Node,
+	symbol *ast.Symbol,
+) bool {
+	if symbol == nil || len(symbol.Declarations) == 0 {
+		return false
+	}
+	for current := node; current != nil; current = current.Parent {
+		if current.Kind != ast.KindParameter || current.Parent == nil ||
+			!ast.IsFunctionLike(current.Parent) {
+			continue
+		}
+		body := current.Parent.Body()
+		if body == nil {
+			return false
+		}
+		for _, declaration := range symbol.Declarations {
+			if declaration.Pos() < body.Pos() || declaration.End() > body.End() {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (m *importedBindingReferenceMatcher) matches(
+	node *ast.Node,
+	binding *importedBinding,
+) bool {
+	if binding.symbol == nil || m.resolveReferenceSymbol == nil {
+		return true
+	}
+	return m.matchesResolved(
+		node,
+		binding,
+		m.resolveReferenceSymbol(node),
+	)
+}
+
+func (m *importedBindingReferenceMatcher) matchesResolved(
+	node *ast.Node,
+	binding *importedBinding,
+	referenceSymbol *ast.Symbol,
+) bool {
+	if referenceSymbol == binding.symbol {
+		return true
+	}
+	if (!isOnlySynthesizedJSDocSymbol(referenceSymbol) &&
+		!resolvesToFunctionBodyFromParameter(node, referenceSymbol)) ||
+		m.sourceFile == nil {
+		return false
+	}
+	return m.matchesAuthoredScope(node, binding)
+}
+
+func (m *importedBindingReferenceMatcher) matchesAuthoredScope(
+	node *ast.Node,
+	binding *importedBinding,
+) bool {
+	if m.sourceFile == nil {
+		return false
+	}
+	// JSDoc declarations are comments to ESLint, but tsgo turns them into
+	// synthetic bindings. Its resolver also lets parameter initializers see
+	// declarations from the function body. Build the authored ESLint-like scope
+	// model only for those two rare mismatches.
+	if m.authoredScopes == nil {
+		m.authoredScopes = scope.Build(m.sourceFile, scope.Options{CollectReferences: true})
+	}
+	for _, reference := range m.authoredScopes.References {
+		if reference.Identifier != node {
+			continue
+		}
+		for _, declaration := range reference.Declarations {
+			if declaration.ID == binding.nameNode {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 // wellKnownMutationMethods maps global object names to their mutation method names.
@@ -538,6 +653,10 @@ func walkImportedBindingGroups(
 			)
 		}
 	}
+	matcher := importedBindingReferenceMatcher{
+		sourceFile:             ctx.SourceFile,
+		resolveReferenceSymbol: resolveReferenceSymbol,
+	}
 
 	var walk func(*ast.Node)
 	walk = func(node *ast.Node) {
@@ -549,27 +668,31 @@ func walkImportedBindingGroups(
 			targets := targetsByName[node.Text()]
 			if len(targets) != 0 && !isImportBindingName(node) {
 				var referenceSymbol *ast.Symbol
-				if resolveReferenceSymbol != nil {
-					referenceSymbol = resolveReferenceSymbol(node)
-				}
+				referenceSymbolResolved := false
 				for _, target := range targets {
 					binding := &groups[target.groupIndex].bindings[target.bindingIndex]
+					kind := classifyImportedBindingViolation(node, binding, ctx)
+					if kind == importedBindingViolationNone {
+						continue
+					}
 					if binding.symbol != nil && resolveReferenceSymbol != nil &&
-						referenceSymbol != binding.symbol {
+						!referenceSymbolResolved {
+						referenceSymbol = resolveReferenceSymbol(node)
+						referenceSymbolResolved = true
+					}
+					if binding.symbol != nil && resolveReferenceSymbol != nil &&
+						!matcher.matchesResolved(node, binding, referenceSymbol) {
 						continue
 					}
 
-					kind := classifyImportedBindingViolation(node, binding, ctx)
-					if kind != importedBindingViolationNone {
-						groups[target.groupIndex].violations = append(
-							groups[target.groupIndex].violations,
-							importedBindingViolation{
-								node:         node,
-								bindingIndex: target.bindingIndex,
-								kind:         kind,
-							},
-						)
-					}
+					groups[target.groupIndex].violations = append(
+						groups[target.groupIndex].violations,
+						importedBindingViolation{
+							node:         node,
+							bindingIndex: target.bindingIndex,
+							kind:         kind,
+						},
+					)
 				}
 			}
 		}
@@ -605,6 +728,10 @@ func walkImportedBindingReferences(
 		return
 	}
 
+	matcher := importedBindingReferenceMatcher{
+		sourceFile:             ctx.SourceFile,
+		resolveReferenceSymbol: resolveReferenceSymbol,
+	}
 	var walk func(*ast.Node)
 	walk = func(node *ast.Node) {
 		if node == nil {
@@ -618,23 +745,24 @@ func walkImportedBindingReferences(
 					continue
 				}
 
-				if binding.symbol != nil && resolveReferenceSymbol != nil &&
-					resolveReferenceSymbol(node) != binding.symbol {
+				// Most same-named identifiers are reads. Reject them before the
+				// comparatively expensive symbol lookup.
+				kind := classifyImportedBindingViolation(node, binding, ctx)
+				if kind == importedBindingViolationNone {
 					continue
 				}
-
-				kind := classifyImportedBindingViolation(node, binding, ctx)
-				if kind != importedBindingViolationNone {
-					reportImportedBindingViolation(
-						ctx,
-						binding,
-						importedBindingViolation{
-							node: node,
-							kind: kind,
-						},
-						nil,
-					)
+				if !matcher.matches(node, binding) {
+					continue
 				}
+				reportImportedBindingViolation(
+					ctx,
+					binding,
+					importedBindingViolation{
+						node: node,
+						kind: kind,
+					},
+					nil,
+				)
 			}
 		}
 
@@ -814,6 +942,7 @@ func collectImportedBindingViolation(
 	targets importedBindingTargets,
 	node *ast.Node,
 	resolveReferenceSymbol func(*ast.Node) *ast.Symbol,
+	usesCheckerReferenceResolution bool,
 ) {
 	if isImportBindingName(node) {
 		return
@@ -855,7 +984,25 @@ func collectImportedBindingViolation(
 		}
 		if binding.symbol != nil && resolveReferenceSymbol != nil &&
 			referenceSymbol != binding.symbol {
-			continue
+			if !isOnlySynthesizedJSDocSymbol(referenceSymbol) &&
+				(!usesCheckerReferenceResolution ||
+					!resolvesToFunctionBodyFromParameter(node, referenceSymbol)) {
+				continue
+			}
+			authoredScopes := rule.CachedByFile(
+				*ctx,
+				authoredJavaScriptScopeCacheKey{},
+				func() *scope.Manager {
+					return scope.Build(ctx.SourceFile, scope.Options{CollectReferences: true})
+				},
+			)
+			matcher := importedBindingReferenceMatcher{
+				sourceFile:     ctx.SourceFile,
+				authoredScopes: authoredScopes,
+			}
+			if !matcher.matchesAuthoredScope(node, binding) {
+				continue
+			}
 		}
 		groups[target.groupIndex].violations = append(
 			groups[target.groupIndex].violations,
@@ -910,6 +1057,7 @@ func noImportAssignIntegratedListeners(
 	resolveReferenceSymbol func(*ast.Node) *ast.Symbol,
 	checkerReferenceSymbol func(*ast.Node) *ast.Symbol,
 ) rule.RuleListeners {
+	usesCheckerReferenceResolution := ctx.Refs == nil && resolveReferenceSymbol != nil
 	if ctx.Refs != nil && ctx.TypeChecker != nil &&
 		!allBindingGroupsHaveSymbols(groups) {
 		replaceImportedBindingSymbolsWithChecker(groups, &ctx)
@@ -917,6 +1065,7 @@ func noImportAssignIntegratedListeners(
 			return checkerImportBindingSymbol(nameNode, &ctx)
 		}
 		resolveReferenceSymbol = checkerReferenceSymbol
+		usesCheckerReferenceResolution = true
 	}
 
 	targetsByName := make(map[string]importedBindingTargets, bindingCount)
@@ -937,7 +1086,6 @@ func noImportAssignIntegratedListeners(
 			targetsByName[binding.name] = targets
 		}
 	}
-
 	needsFallbackScan := false
 	needsViolationSort := false
 	checkIdentifier := func(node *ast.Node) {
@@ -954,6 +1102,7 @@ func noImportAssignIntegratedListeners(
 			targets,
 			node,
 			resolveReferenceSymbol,
+			usesCheckerReferenceResolution,
 		)
 	}
 	checkWriteTarget := func(node *ast.Node) {

--- a/internal/rules/no_import_assign/no_import_assign_test.go
+++ b/internal/rules/no_import_assign/no_import_assign_test.go
@@ -480,6 +480,154 @@ func TestNoImportAssignRuleAdversarial(t *testing.T) {
 	)
 }
 
+func TestNoImportAssignRuleUsesAuthoredJavaScriptScopes(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.allow-js.json",
+		t,
+		&NoImportAssignRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `import { value } from "mod";
+function f(value) {
+  /** @import { value } from "types" */
+  value = 1;
+}`,
+				FileName: "jsdoc-import-parameter.js",
+			},
+			{
+				Code: `import * as namespace from "mod";
+function f(namespace) {
+  /** @typedef {object} namespace */
+  namespace.member = 1;
+}`,
+				FileName: "jsdoc-typedef-parameter.js",
+			},
+			{
+				Code: `import * as namespace from "mod";
+function f(namespace) {
+  /** @typedef {object} namespace */
+  Object.assign(namespace, source);
+}`,
+				FileName: "jsdoc-typedef-mutation-parameter.js",
+			},
+			{
+				Code: `import { value } from "mod";
+const f = function value(parameter = (value = 1)) {};`,
+				FileName: "named-function-expression-parameter.js",
+			},
+			{
+				Code: `import { value } from "mod";
+function outer() {
+  let value;
+  function inner(parameter = (value = 1)) { function value() {} }
+}`,
+				FileName: "outer-local-parameter.js",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `import { value } from "mod";
+function f() {
+  /** @import { value } from "types" */
+  value = 1;
+}`,
+				FileName: "jsdoc-import-binding.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code: `import { value } from "mod";
+function f() {
+  /** @typedef {number} value */
+  value = 1;
+}`,
+				FileName: "jsdoc-typedef-binding.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code: `import * as namespace from "mod";
+function f() {
+  /** @import { namespace } from "types" */
+  namespace.member = 1;
+}`,
+				FileName: "jsdoc-namespace-binding.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonlyMember", Message: "The members of 'namespace' are read-only.", Line: 4, Column: 3},
+				},
+			},
+			{
+				Code: `import { first, second } from "mod";
+function f() {
+  /** @import { first } from "types" */
+  first = 1;
+}
+second = 2;`,
+				FileName: "jsdoc-multiple-bindings.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'first' is read-only.", Line: 4, Column: 3},
+					{MessageId: "readonly", Message: "'second' is read-only.", Line: 6, Column: 1},
+				},
+			},
+			{
+				Code: `import { callbackValue, other } from "mod";
+function f() {
+  /** @callback callbackValue */
+  callbackValue = 1;
+}
+other = 2;`,
+				FileName: "jsdoc-callback-binding.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'callbackValue' is read-only.", Line: 4, Column: 3},
+					{MessageId: "readonly", Message: "'other' is read-only.", Line: 6, Column: 1},
+				},
+			},
+			{
+				Code: `import { value } from "mod";
+function f(parameter = (value = 1)) { function value() {} }`,
+				FileName: "parameter-initializer.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 2, Column: 25},
+				},
+			},
+			{
+				Code: `import { value } from "mod";
+function f({ item = (value = 1) } = {}) { const value = 2; }`,
+				FileName: "destructured-parameter-initializer.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 2, Column: 22},
+				},
+			},
+			{
+				Code: `import { value } from "mod";
+function f() {
+  /** @import { Type as value } from "types" */
+  { let value; value = 1; }
+  value = 2;
+}`,
+				FileName: "jsdoc-alias-and-block-shadow.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 5, Column: 3},
+				},
+			},
+			{
+				Code: `import * as namespace from "mod";
+function f() {
+  /** @typedef {object} namespace */
+  Object.assign(namespace, source);
+}`,
+				FileName: "jsdoc-typedef-mutation.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonlyMember", Message: "The members of 'namespace' are read-only.", Line: 4, Column: 17},
+				},
+			},
+		},
+	)
+}
+
 func TestNoImportAssignRuleWithoutRefStore(t *testing.T) {
 	fallbackRule := NoImportAssignRule
 	fallbackRule.Run = func(ctx rule.RuleContext, options []any) rule.RuleListeners {
@@ -526,6 +674,15 @@ func TestNoImportAssignRuleWithoutRefStore(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "readonly", Message: "'second' is read-only.", Line: 2},
 					{MessageId: "readonly", Message: "'first' is read-only.", Line: 3},
+				},
+			},
+			{
+				Code: `import { value, other } from "mod";
+function f(parameter = (value = 1)) { function value() {} }`,
+				FileName: "parameter-initializer.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 2, Column: 25},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Match ESLint when TypeScript resolves JavaScript writes to synthetic JSDoc-only bindings instead of the runtime import.
- Preserve the separate parameter-initializer and function-body scopes when checker resolution incorrectly exposes body declarations.
- Resolve symbols only for actual write candidates and build/cache the authored JavaScript scope model only for rare mismatches.

### Correctness

- Added focused JavaScript cases for JSDoc `@import`, `@typedef`, and `@callback`, namespace mutations, local shadows, named function-expression bindings, destructured defaults, multiple imports, and parameter initializer/body boundaries.
- Differentially checked adversarial scope cases against ESLint 10.8.0.
- Verified the rule both with the normal reference store and with its checker fallback.

### Go benchmark

Apple M5 Max, `-cpu=1`, median of six 500 ms samples:

```console
go test ./internal/rules/no_import_assign -run '^$' -bench '^BenchmarkNoImportAssign$' -benchmem -benchtime=500ms -count=6 -cpu=1
```

| Case | Before (ns/op) | After (ns/op) | Delta |
| --- | ---: | ---: | ---: |
| NoImportNoMatch | 6,369 | 6,661 | +4.6% |
| OneImportReadOnly | 12,989 | 8,164 | -37.1% |
| MultipleImportsUnrelatedWrites | 22,492 | 19,075 | -15.2% |
| DirectWritesDiagnosticsOnly | 37,835 | 32,339 | -14.5% |
| DirectWritesAutofixDemand | 53,046 | 32,126 | -39.4% |
| DirectWritesSuggestionDemand | 39,214 | 32,053 | -18.3% |
| NamespaceMutations | 38,898 | 33,241 | -14.5% |
| LocalShadowsIgnored | 23,875 | 19,942 | -16.5% |
| JSDocImportCollision | 2,744 | 2,231 | -18.7% |

`allocs/op` is unchanged in every case. `NoImportNoMatch` exits before the import path changed by this PR; its small movement is within the observed cross-run variance.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
