### PR TITLE
feat(unicorn): port rule no-await-in-promise-methods

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/error_message"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
@@ -24,6 +25,7 @@ func GetAllRules() []rule.Rule {
 		error_message.ErrorMessageRule,
 		filename_case.FilenameCaseRule,
 		new_for_builtins.NewForBuiltinsRule,
+		no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,

--- a/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods.go
+++ b/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods.go
@@ -1,0 +1,98 @@
+package no_await_in_promise_methods
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+const (
+	messageIDError      = "no-await-in-promise-methods/error"
+	messageIDSuggestion = "no-await-in-promise-methods/suggestion"
+)
+
+var promiseMethods = []string{"all", "allSettled", "any", "race"}
+
+func errorMessage(method string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDError,
+		Description: fmt.Sprintf("Promise in `Promise.%s()` should not be awaited.", method),
+		Data:        map[string]string{"method": method},
+	}
+}
+
+var suggestionMessage = rule.RuleMessage{
+	Id:          messageIDSuggestion,
+	Description: "Remove `await`.",
+}
+
+func removeAwaitSuggestion(sourceFile *ast.SourceFile, awaitExpression *ast.Node) []rule.RuleSuggestion {
+	text := sourceFile.Text()
+	awaitRange := utils.TrimNodeTextRange(sourceFile, awaitExpression)
+	awaitEnd := awaitRange.Pos() + len("await")
+	whitespaceEnd := ecmascript.SkipLeadingWhitespace(text, awaitEnd, len(text))
+
+	return []rule.RuleSuggestion{{
+		Message: suggestionMessage,
+		FixesArr: []rule.RuleFix{
+			rule.RuleFixRemoveRange(core.NewTextRange(awaitRange.Pos(), whitespaceEnd)),
+		},
+	}}
+}
+
+// NoAwaitInPromiseMethodsRule disallows awaiting direct elements passed to
+// Promise combinator methods.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-await-in-promise-methods.js
+var NoAwaitInPromiseMethodsRule = rule.Rule{
+	Name:   "unicorn/no-await-in-promise-methods",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		oneArgument := 1
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Methods:             promiseMethods,
+					ArgumentsLength:     &oneArgument,
+					RejectSpreadElement: true,
+				})
+				if !ok {
+					return
+				}
+
+				object := ast.SkipParentheses(call.Object)
+				if object == nil || !ast.IsIdentifier(object) ||
+					object.AsIdentifier().Text != "Promise" {
+					return
+				}
+
+				argument := ast.SkipParentheses(node.Arguments()[0])
+				if argument == nil || argument.Kind != ast.KindArrayLiteralExpression {
+					return
+				}
+
+				method := call.Property.AsIdentifier().Text
+				for _, element := range argument.AsArrayLiteralExpression().Elements.Nodes {
+					element = ast.SkipParentheses(element)
+					if element == nil || element.Kind != ast.KindAwaitExpression {
+						continue
+					}
+
+					ctx.ReportNodeWithDeferredSuggestions(
+						element,
+						errorMessage(method),
+						func() []rule.RuleSuggestion {
+							return removeAwaitSuggestion(ctx.SourceFile, element)
+						},
+					)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods.md
+++ b/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods.md
@@ -1,0 +1,31 @@
+# no-await-in-promise-methods
+
+## Rule Details
+
+Disallow using `await` on promises passed directly to `Promise.all()`,
+`Promise.allSettled()`, `Promise.any()`, or `Promise.race()`. Awaiting an
+individual promise before passing it to one of these methods prevents that
+promise from running concurrently with the others and is likely a mistake.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Promise.all([await promise, anotherPromise]);
+Promise.allSettled([await promise, anotherPromise]);
+Promise.any([await promise, anotherPromise]);
+Promise.race([await promise, anotherPromise]);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Promise.all([promise, anotherPromise]);
+Promise.allSettled([promise, anotherPromise]);
+Promise.any([promise, anotherPromise]);
+Promise.race([promise, anotherPromise]);
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-await-in-promise-methods](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-await-in-promise-methods.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-await-in-promise-methods.js)

--- a/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods_extras_test.go
@@ -1,0 +1,231 @@
+// TestNoAwaitInPromiseMethodsExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / upstream issue it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+package no_await_in_promise_methods_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_await_in_promise_methods "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAwaitInPromiseMethodsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: optional-chain roots remain unmatched ----
+			tsValid(`Promise?.all([await promise])`),
+			tsValid(`Promise.all?.([await promise])`),
+			tsValid(`(Promise?.all)([await promise])`),
+
+			// ---- Dimension 4: TypeScript receiver wrappers are not transparent in ESTree ----
+			tsValid(`Promise!.all([await promise])`),
+			tsValid(`(Promise as any).all([await promise])`),
+			tsValid(`(Promise satisfies PromiseConstructor).all([await promise])`),
+
+			// ---- Dimension 4: computed and non-identifier access keys do not match ----
+			tsValid(`Promise["all"]([await promise])`),
+			tsValid("Promise[`all`]([await promise])"),
+			tsValid(`Promise[0]([await promise])`),
+			tsValid(`Promise[Symbol.iterator]([await promise])`),
+
+			// ---- Dimension 4: TypeScript wrappers around the array or element are not direct ESTree matches ----
+			tsValid(`Promise.all([await promise] as const)`),
+			tsValid(`Promise.all([(await promise)!])`),
+			tsValid(`Promise.all([(await promise) as unknown])`),
+			tsValid(`Promise.all([(await promise) satisfies unknown])`),
+
+			// ---- Dimension 4: spreads, nested arrays, and empty containers degrade without masking siblings ----
+			tsValid(`Promise.all([...(await promise)])`),
+			tsValid(`Promise.all([[await promise]])`),
+			tsValid(`Promise.all([])`),
+
+			// ---- Dimension 4: calls/new expressions and non-array argument containers stay unmatched ----
+			tsValid(`Promise.all({value: await promise})`),
+			tsValid(`new Promise.all([await promise])`),
+
+			// N/A: declaration/container variants for functions, classes, properties,
+			// private names, overloads, abstract members, and destructuring are not
+			// inspected by this CallExpression-and-array-element rule.
+
+			// Locks in isPromiseMethodCallWithArrayExpression(): only direct array elements are examined.
+			tsValid(`Promise.all([Promise.resolve(await promise)])`),
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: ESTree-transparent parentheses around receivers, callees, arguments, and elements ----
+			tsInvalid(`((Promise)).all([await promise])`, `await promise`, "all", `((Promise)).all([promise])`),
+			tsInvalid(`(Promise.all)([await promise])`, `await promise`, "all", `(Promise.all)([promise])`),
+			tsInvalid(`Promise.all((([await promise])))`, `await promise`, "all", `Promise.all((([promise])))`),
+			tsInvalid(`Promise.all([((await promise))])`, `await promise`, "all", `Promise.all([((promise))])`),
+
+			// ---- Dimension 4: generic calls preserve the ordinary CallExpression match ----
+			tsInvalid(`Promise.all<string>([await promise])`, `await promise`, "all", `Promise.all<string>([promise])`),
+
+			// ---- Dimension 4: nested calls report only the matching direct element in each call ----
+			tsInvalid(
+				`Promise.all([Promise.any([await promise])])`,
+				`await promise`,
+				"any",
+				`Promise.all([Promise.any([promise])])`,
+			),
+
+			// ---- Dimension 4: local bindings do not change upstream's syntactic Promise-name match ----
+			tsInvalid(
+				`const Promise = customPromise; Promise.all([await promise])`,
+				`await promise`,
+				"all",
+				`const Promise = customPromise; Promise.all([promise])`,
+			),
+
+			// Locks in matchesNameConstraint(): escaped identifier spelling is compared by identifier value.
+			tsInvalid(`Promise.\u0061ll([await promise])`, `await promise`, "all", `Promise.\u0061ll([promise])`),
+
+			// Locks in removeSpacesAfter(): all consecutive ECMAScript whitespace after `await` is removed.
+			tsInvalid(`Promise.all([await	promise])`, `await	promise`, "all", `Promise.all([promise])`),
+			tsInvalid("Promise.all([await\u00A0promise])", "await\u00A0promise", "all", `Promise.all([promise])`),
+			tsInvalid(`Promise.all([await(promise)])`, `await(promise)`, "all", `Promise.all([(promise)])`),
+
+			// Locks in removeSpacesAfter(): comments stop whitespace removal and remain in place.
+			tsInvalid(
+				"Promise.all([await // keep this comment\n  promise])",
+				"await // keep this comment\n  promise",
+				"all",
+				"Promise.all([// keep this comment\n  promise])",
+			),
+
+			// ---- Real-user: #2257 proposal shape with an awaited request among concurrent work ----
+			tsInvalid(
+				`async function load() { return Promise.race([await first(), second()]) }`,
+				`await first()`,
+				"race",
+				`async function load() { return Promise.race([first(), second()]) }`,
+			),
+
+			// ---- Real-user: #2257 proposal shape using Promise.all with mixed awaited and pending work ----
+			tsInvalid(
+				`Promise.all([await promise, anotherPromise])`,
+				`await promise`,
+				"all",
+				`Promise.all([promise, anotherPromise])`,
+			),
+
+			// Locks in upstream create() loop arms: holes and spreads are skipped, while a direct awaited sibling reports.
+			tsInvalid(
+				`Promise.all([, await /* preserve */ request, anotherRequest])`,
+				`await /* preserve */ request`,
+				"all",
+				`Promise.all([, /* preserve */ request, anotherRequest])`,
+			),
+
+			// Locks in the full multi-line diagnostic range and suggestion output.
+			tsInvalid(
+				"Promise.all([\n  await first,\n  second,\n])",
+				`await first`,
+				"all",
+				"Promise.all([\n  first,\n  second,\n])",
+			),
+		},
+	)
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.mts"}
+}
+
+func tsInvalid(code, target, method, suggestionOutput string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mts",
+		Errors: []rule_tester.InvalidTestCaseError{
+			upstreamError(code, target, method, suggestionOutput),
+		},
+	}
+}
+
+// TestNoAwaitInPromiseMethodsEditDemand verifies that suggestions are built
+// only when requested and diagnostic identity is independent of edit demand.
+func TestNoAwaitInPromiseMethodsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const source = "Promise.all([await\n  promise])\n"
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(source, "edit-demand.mts", "tsconfig.json")
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+
+	diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		var got []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     no_await_in_promise_methods.NoAwaitInPromiseMethodsRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return no_await_in_promise_methods.NoAwaitInPromiseMethodsRule.Run(ctx, nil)
+					},
+				}}
+			},
+			ExcludePaths: []string{},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					got = append(got, diagnostic)
+				},
+			},
+		})
+		if len(got) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+		}
+		diagnostics[demand] = got[0]
+	}
+
+	base := diagnostics[rule.EditDemandNone]
+	for demand, diagnostic := range diagnostics {
+		if diagnostic.Range != base.Range ||
+			diagnostic.Message.Id != base.Message.Id ||
+			diagnostic.Message.Description != base.Message.Description ||
+			!reflect.DeepEqual(diagnostic.Message.Data, base.Message.Data) {
+			t.Errorf("demand %d changed diagnostic identity", demand)
+		}
+		if diagnostic.FixesPtr != nil {
+			t.Errorf("demand %d materialized an autofix for a suggestion-only rule", demand)
+		}
+	}
+
+	if diagnostics[rule.EditDemandNone].Suggestions != nil ||
+		diagnostics[rule.EditDemandAutofix].Suggestions != nil {
+		t.Fatal("suggestions materialized without suggestion demand")
+	}
+	suggestionOnly := diagnostics[rule.EditDemandSuggestion].Suggestions
+	allSuggestions := diagnostics[rule.EditDemandAll].Suggestions
+	if suggestionOnly == nil || allSuggestions == nil ||
+		!reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
+		t.Fatal("suggestion artifacts differ between suggestion-only and all demand")
+	}
+	output, _, _ := linter.ApplyRuleFixes(source, []rule.RuleSuggestion{(*allSuggestions)[0]})
+	if output != "Promise.all([promise])\n" {
+		t.Fatalf("suggestion output = %q, want %q", output, "Promise.all([promise])\n")
+	}
+}

--- a/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods_upstream_test.go
@@ -1,0 +1,192 @@
+// TestNoAwaitInPromiseMethodsUpstream migrates the full valid/invalid suite
+// from upstream test/no-await-in-promise-methods.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in no_await_in_promise_methods_extras_test.go.
+package no_await_in_promise_methods_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_await_in_promise_methods "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageIDError      = "no-await-in-promise-methods/error"
+	messageIDSuggestion = "no-await-in-promise-methods/suggestion"
+)
+
+func TestNoAwaitInPromiseMethodsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
+		[]rule_tester.ValidTestCase{
+			jsValid(`Promise.all([promise1, promise2, promise3, promise4])`),
+			jsValid(`Promise.allSettled([promise1, promise2, promise3, promise4])`),
+			jsValid(`Promise.any([promise1, promise2, promise3, promise4])`),
+			jsValid(`Promise.race([promise1, promise2, promise3, promise4])`),
+			jsValid(`Promise.all(...[await promise])`),
+			jsValid(`Promise.all([await promise], extraArguments)`),
+			jsValid(`Promise.all()`),
+			jsValid(`Promise.all(notArrayExpression)`),
+			jsValid(`Promise.all([,])`),
+			jsValid(`Promise[all]([await promise])`),
+			jsValid(`Promise.all?.([await promise])`),
+			jsValid(`Promise?.all([await promise])`),
+			jsValid(`Promise.notListedMethod([await promise])`),
+			jsValid(`NotPromise.all([await promise])`),
+			jsValid(`Promise.all([(await promise, 0)])`),
+			jsValid(`new Promise.all([await promise])`),
+
+			// We are not checking these cases.
+			jsValid(`globalThis.Promise.all([await promise])`),
+			jsValid(`Promise["all"]([await promise])`),
+		},
+		[]rule_tester.InvalidTestCase{
+			upstreamInvalid(
+				`Promise.all([await promise])`,
+				upstreamError(`Promise.all([await promise])`, `await promise`, "all", `Promise.all([promise])`),
+			),
+			upstreamInvalid(
+				`Promise.allSettled([await promise])`,
+				upstreamError(`Promise.allSettled([await promise])`, `await promise`, "allSettled", `Promise.allSettled([promise])`),
+			),
+			upstreamInvalid(
+				`Promise.any([await promise])`,
+				upstreamError(`Promise.any([await promise])`, `await promise`, "any", `Promise.any([promise])`),
+			),
+			upstreamInvalid(
+				`Promise.race([await promise])`,
+				upstreamError(`Promise.race([await promise])`, `await promise`, "race", `Promise.race([promise])`),
+			),
+			upstreamInvalid(
+				`Promise.all([, await promise])`,
+				upstreamError(`Promise.all([, await promise])`, `await promise`, "all", `Promise.all([, promise])`),
+			),
+			upstreamInvalid(
+				`Promise.all([await promise,])`,
+				upstreamError(`Promise.all([await promise,])`, `await promise`, "all", `Promise.all([promise,])`),
+			),
+			upstreamInvalid(
+				`Promise.all([await promise],)`,
+				upstreamError(`Promise.all([await promise],)`, `await promise`, "all", `Promise.all([promise],)`),
+			),
+			upstreamInvalid(
+				`Promise.all([await (0, promise)],)`,
+				upstreamError(`Promise.all([await (0, promise)],)`, `await (0, promise)`, "all", `Promise.all([(0, promise)],)`),
+			),
+			upstreamInvalid(
+				`Promise.all([await (( promise ))])`,
+				upstreamError(`Promise.all([await (( promise ))])`, `await (( promise ))`, "all", `Promise.all([(( promise ))])`),
+			),
+			upstreamInvalid(
+				`Promise.all([await await promise])`,
+				upstreamError(`Promise.all([await await promise])`, `await await promise`, "all", `Promise.all([await promise])`),
+			),
+			upstreamInvalid(
+				`Promise.all([...foo, await promise1, await promise2])`,
+				upstreamError(
+					`Promise.all([...foo, await promise1, await promise2])`,
+					`await promise1`,
+					"all",
+					`Promise.all([...foo, promise1, await promise2])`,
+				),
+				upstreamError(
+					`Promise.all([...foo, await promise1, await promise2])`,
+					`await promise2`,
+					"all",
+					`Promise.all([...foo, await promise1, promise2])`,
+				),
+			),
+			// Multiple awaited elements without a spread.
+			upstreamInvalid(
+				`Promise.all([await promise1, await promise2])`,
+				upstreamError(
+					`Promise.all([await promise1, await promise2])`,
+					`await promise1`,
+					"all",
+					`Promise.all([promise1, await promise2])`,
+				),
+				upstreamError(
+					`Promise.all([await promise1, await promise2])`,
+					`await promise2`,
+					"all",
+					`Promise.all([await promise1, promise2])`,
+				),
+			),
+			upstreamInvalid(
+				`Promise.any([await a, await b, await c])`,
+				upstreamError(`Promise.any([await a, await b, await c])`, `await a`, "any", `Promise.any([a, await b, await c])`),
+				upstreamError(`Promise.any([await a, await b, await c])`, `await b`, "any", `Promise.any([await a, b, await c])`),
+				upstreamError(`Promise.any([await a, await b, await c])`, `await c`, "any", `Promise.any([await a, await b, c])`),
+			),
+			upstreamInvalid(
+				`Promise.all([await /* comment*/ promise])`,
+				upstreamError(
+					`Promise.all([await /* comment*/ promise])`,
+					`await /* comment*/ promise`,
+					"all",
+					`Promise.all([/* comment*/ promise])`,
+				),
+			),
+		},
+	)
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.mjs"}
+}
+
+func upstreamInvalid(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mjs",
+		Errors:   errors,
+	}
+}
+
+func upstreamError(code, target, method, suggestionOutput string) rule_tester.InvalidTestCaseError {
+	offset := strings.Index(code, target)
+	if offset < 0 {
+		panic("target not found in no-await-in-promise-methods test: " + target)
+	}
+
+	line, column := lineColumnForOffset(code, offset)
+	endLine, endColumn := lineColumnForOffset(code, offset+len(target))
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageIDError,
+		Message:   fmt.Sprintf("Promise in `Promise.%s()` should not be awaited.", method),
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+			MessageId: messageIDSuggestion,
+			Output:    suggestionOutput,
+		}},
+	}
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for index := 0; index < offset; {
+		r, size := utf8.DecodeRuneInString(code[index:])
+		if r == '\n' {
+			line++
+			column = 1
+		} else if r > 0xFFFF {
+			column += 2
+		} else {
+			column++
+		}
+		index += size
+	}
+	return line, column
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -602,6 +602,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/error-message.test.ts',
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts
@@ -1,0 +1,92 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code, filename: 'file.mjs' });
+const invalid = (
+  code: string,
+  method: string,
+  suggestionOutputs: string[],
+) => ({
+  code,
+  filename: 'file.mjs',
+  errors: suggestionOutputs.map((output) => ({
+    message: `Promise in \`Promise.${method}()\` should not be awaited.`,
+    suggestions: [
+      {
+        messageId: 'no-await-in-promise-methods/suggestion',
+        desc: 'Remove `await`.',
+        output,
+      },
+    ],
+  })),
+});
+
+ruleTester.run('no-await-in-promise-methods', null as never, {
+  valid: [
+    valid('Promise.all([promise1, promise2, promise3, promise4])'),
+    valid('Promise.allSettled([promise1, promise2, promise3, promise4])'),
+    valid('Promise.any([promise1, promise2, promise3, promise4])'),
+    valid('Promise.race([promise1, promise2, promise3, promise4])'),
+    valid('Promise.all(...[await promise])'),
+    valid('Promise.all([await promise], extraArguments)'),
+    valid('Promise.all()'),
+    valid('Promise.all(notArrayExpression)'),
+    valid('Promise.all([,])'),
+    valid('Promise[all]([await promise])'),
+    valid('Promise.all?.([await promise])'),
+    valid('Promise?.all([await promise])'),
+    valid('Promise.notListedMethod([await promise])'),
+    valid('NotPromise.all([await promise])'),
+    valid('Promise.all([(await promise, 0)])'),
+    valid('new Promise.all([await promise])'),
+
+    // We are not checking these cases.
+    valid('globalThis.Promise.all([await promise])'),
+    valid('Promise["all"]([await promise])'),
+  ],
+  invalid: [
+    invalid('Promise.all([await promise])', 'all', ['Promise.all([promise])']),
+    invalid('Promise.allSettled([await promise])', 'allSettled', [
+      'Promise.allSettled([promise])',
+    ]),
+    invalid('Promise.any([await promise])', 'any', ['Promise.any([promise])']),
+    invalid('Promise.race([await promise])', 'race', [
+      'Promise.race([promise])',
+    ]),
+    invalid('Promise.all([, await promise])', 'all', [
+      'Promise.all([, promise])',
+    ]),
+    invalid('Promise.all([await promise,])', 'all', [
+      'Promise.all([promise,])',
+    ]),
+    invalid('Promise.all([await promise],)', 'all', [
+      'Promise.all([promise],)',
+    ]),
+    invalid('Promise.all([await (0, promise)],)', 'all', [
+      'Promise.all([(0, promise)],)',
+    ]),
+    invalid('Promise.all([await (( promise ))])', 'all', [
+      'Promise.all([(( promise ))])',
+    ]),
+    invalid('Promise.all([await await promise])', 'all', [
+      'Promise.all([await promise])',
+    ]),
+    invalid('Promise.all([...foo, await promise1, await promise2])', 'all', [
+      'Promise.all([...foo, promise1, await promise2])',
+      'Promise.all([...foo, await promise1, promise2])',
+    ]),
+    invalid('Promise.all([await promise1, await promise2])', 'all', [
+      'Promise.all([promise1, await promise2])',
+      'Promise.all([await promise1, promise2])',
+    ]),
+    invalid('Promise.any([await a, await b, await c])', 'any', [
+      'Promise.any([a, await b, await c])',
+      'Promise.any([await a, b, await c])',
+      'Promise.any([await a, await b, c])',
+    ]),
+    invalid('Promise.all([await /* comment*/ promise])', 'all', [
+      'Promise.all([/* comment*/ promise])',
+    ]),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -71,7 +71,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-asterisk-prefix-in-documentation-comments': 'off', // not implemented
     // 'unicorn/no-async-promise-finally': 'error', // not implemented
     // 'unicorn/no-await-expression-member': 'error', // not implemented
-    // 'unicorn/no-await-in-promise-methods': 'error', // not implemented
+    'unicorn/no-await-in-promise-methods': 'error',
     // 'unicorn/no-blob-to-file': 'error', // not implemented
     // 'unicorn/no-boolean-sort-comparator': 'error', // not implemented
     // 'unicorn/no-break-in-nested-loop': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `unicorn/no-await-in-promise-methods` rule from ESLint to Rslint.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-await-in-promise-methods.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-await-in-promise-methods.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).