### PR TITLE
feat(unicorn): port rule no-invalid-fetch-options

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_fill_with_reference_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
@@ -32,6 +33,7 @@ func GetAllRules() []rule.Rule {
 		no_array_fill_with_reference_type.NoArrayFillWithReferenceTypeRule,
 		no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,
+		no_invalid_fetch_options.NoInvalidFetchOptionsRule,
 		no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options.go
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options.go
@@ -1,0 +1,188 @@
+package no_invalid_fetch_options
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "no-invalid-fetch-options"
+
+func invalidBodyMessage(method string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageID,
+		Description: "\"body\" is not allowed when method is \"" + method + "\".",
+	}
+}
+
+func isIdentifierPropertyNamed(property *ast.Node, name string) bool {
+	if property == nil {
+		return false
+	}
+
+	switch property.Kind {
+	case ast.KindPropertyAssignment,
+		ast.KindShorthandPropertyAssignment,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		propertyName := property.Name()
+		return propertyName != nil && propertyName.Kind == ast.KindIdentifier &&
+			propertyName.AsIdentifier().Text == name
+	default:
+		return false
+	}
+}
+
+func findLastIdentifierProperty(properties []*ast.Node, name string) *ast.Node {
+	for i := len(properties) - 1; i >= 0; i-- {
+		if isIdentifierPropertyNamed(properties[i], name) {
+			return properties[i]
+		}
+	}
+	return nil
+}
+
+func propertyValue(property *ast.Node) *ast.Node {
+	if property == nil {
+		return nil
+	}
+
+	switch property.Kind {
+	case ast.KindPropertyAssignment:
+		return property.AsPropertyAssignment().Initializer
+	case ast.KindShorthandPropertyAssignment:
+		return property.Name()
+	default:
+		// ESTree represents object methods and accessors as Property nodes whose
+		// values are functions. Neither can be absent-body values or static strings.
+		return nil
+	}
+}
+
+func isEffectivelyAbsentBody(property *ast.Node) bool {
+	value := propertyValue(property)
+	if value == nil {
+		return false
+	}
+	value = ast.SkipParentheses(value)
+
+	switch value.Kind {
+	case ast.KindNullKeyword, ast.KindVoidExpression:
+		return true
+	case ast.KindIdentifier:
+		return value.AsIdentifier().Text == "undefined"
+	default:
+		return false
+	}
+}
+
+func secondArgumentOfDirectCall(node *ast.Node, calleeName string, rejectOptional bool) *ast.Node {
+	if node == nil {
+		return nil
+	}
+
+	var expression *ast.Node
+	var arguments []*ast.Node
+	switch node.Kind {
+	case ast.KindCallExpression:
+		if rejectOptional && ast.IsOptionalChainRoot(node) {
+			return nil
+		}
+		call := node.AsCallExpression()
+		expression = call.Expression
+		if call.Arguments != nil {
+			arguments = call.Arguments.Nodes
+		}
+	case ast.KindNewExpression:
+		newExpression := node.AsNewExpression()
+		expression = newExpression.Expression
+		if newExpression.Arguments != nil {
+			arguments = newExpression.Arguments.Nodes
+		}
+	default:
+		return nil
+	}
+
+	if len(arguments) < 2 {
+		return nil
+	}
+
+	// ESTree removes parentheses around a callee, but keeps TypeScript assertion
+	// wrappers. Skip only parentheses to preserve that distinction.
+	expression = ast.SkipOuterExpressions(expression, ast.OEKParentheses)
+	if expression == nil || expression.Kind != ast.KindIdentifier ||
+		expression.AsIdentifier().Text != calleeName {
+		return nil
+	}
+
+	return arguments[1]
+}
+
+func checkFetchOptions(ctx rule.RuleContext, staticStrings *utils.StaticStringEvaluator, node *ast.Node) {
+	node = ast.SkipParentheses(node)
+	if node == nil || node.Kind != ast.KindObjectLiteralExpression {
+		return
+	}
+
+	object := node.AsObjectLiteralExpression()
+	if object.Properties == nil {
+		return
+	}
+	properties := object.Properties.Nodes
+
+	bodyProperty := findLastIdentifierProperty(properties, "body")
+	if bodyProperty == nil || isEffectivelyAbsentBody(bodyProperty) {
+		return
+	}
+
+	methodProperty := findLastIdentifierProperty(properties, "method")
+	if methodProperty == nil {
+		for _, property := range properties {
+			if property.Kind == ast.KindSpreadAssignment {
+				return
+			}
+		}
+
+		ctx.ReportNode(bodyProperty.Name(), invalidBodyMessage("GET"))
+		return
+	}
+
+	method, valueKind := staticStrings.EvalStringValue(propertyValue(methodProperty))
+	if valueKind != utils.StaticEvalString {
+		return
+	}
+
+	method = strings.ToUpper(method)
+	if method != "GET" && method != "HEAD" {
+		return
+	}
+
+	ctx.ReportNode(bodyProperty.Name(), invalidBodyMessage(method))
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-invalid-fetch-options.js
+var NoInvalidFetchOptionsRule = rule.Rule{
+	Name:   "unicorn/no-invalid-fetch-options",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		staticStrings := utils.NewStaticStringEvaluatorWithReferenceResolver(ctx.TypeChecker, ctx.SourceFile, ctx.Refs)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				options := secondArgumentOfDirectCall(node, "fetch", true)
+				if options != nil {
+					checkFetchOptions(ctx, staticStrings, options)
+				}
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				options := secondArgumentOfDirectCall(node, "Request", false)
+				if options != nil {
+					checkFetchOptions(ctx, staticStrings, options)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options.go
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options.go
@@ -1,11 +1,10 @@
 package no_invalid_fetch_options
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 const messageID = "no-invalid-fetch-options"
@@ -155,7 +154,7 @@ func checkFetchOptions(ctx rule.RuleContext, staticStrings *utils.StaticStringEv
 		return
 	}
 
-	method = strings.ToUpper(method)
+	method = ecmascript.StringToUpperCase(method)
 	if method != "GET" && method != "HEAD" {
 		return
 	}

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options.md
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options.md
@@ -1,0 +1,27 @@
+# no-invalid-fetch-options
+
+## Rule Details
+
+Disallows request bodies in `fetch()` and `new Request()` calls whose method is
+`GET` or `HEAD`. The Fetch Standard throws a `TypeError` for these combinations.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+fetch('/', { body: 'foo=bar' });
+
+new Request('/', { method: 'HEAD', body: 'foo=bar' });
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+fetch('/', { method: 'POST', body: 'foo=bar' });
+
+new Request('/', { method: 'HEAD' });
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-invalid-fetch-options](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-invalid-fetch-options.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-invalid-fetch-options.js)

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_extras_test.go
@@ -1,0 +1,164 @@
+// TestNoInvalidFetchOptionsExtras locks in branches and edge shapes that the upstream test suite doesn't exercise.
+// Each case carries an inline comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named lock-in.
+package no_invalid_fetch_options_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoInvalidFetchOptionsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_invalid_fetch_options.NoInvalidFetchOptionsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: Optional calls do not match direct fetch calls ----
+			jsValid(`fetch?.(url, {body})`),
+			jsValid(`(fetch)?.(url, {body})`),
+
+			// ---- Dimension 4: Type wrappers around callees remain significant ----
+			tsValid(`(fetch as any)(url, {body})`),
+			tsValid(`fetch!(url, {body})`),
+			tsValid(`(fetch satisfies any)(url, {body})`),
+			tsValid(`new (Request as any)(url, {body})`),
+
+			// ---- Dimension 4: Type wrappers around the options object remain significant ----
+			tsValid(`fetch(url, ({body} as RequestInit))`),
+			tsValid(`fetch(url, ({body} satisfies RequestInit))`),
+
+			// ---- Dimension 4: Only non-computed identifier keys are recognized ----
+			jsValid(`fetch(url, {"body": data})`),
+			jsValid(`fetch(url, {0: data})`),
+			jsValid(`fetch(url, {["body"]: data})`),
+			jsValid(`fetch(url, {[` + "`body`" + `]: data})`),
+			// N/A: PrivateIdentifier is not valid as an object-literal key.
+
+			// ---- Dimension 4: Spread assignments degrade conservatively without hiding explicit methods ----
+			jsValid(`fetch(url, {body, ...options})`),
+			jsValid(`fetch(url, {...options, body, ...moreOptions})`),
+
+			// ---- Dimension 4: Empty and non-object options degrade gracefully ----
+			jsValid(`fetch()`),
+			jsValid(`fetch(url, null)`),
+			jsValid(`fetch(url, options)`),
+			jsValid(`fetch(url, {...options})`),
+			jsValid(`fetch(url, {method: "GET"})`),
+			// N/A: RestElement belongs to binding patterns, not request option literals.
+			// N/A: Body-absent overload/abstract/declare members cannot occur in object literals.
+
+			// ---- Locks in upstream isObjectPropertyWithName(): method/getter/setter values are unknown ----
+			jsValid(`fetch(url, {method() {}, body})`),
+			jsValid(`fetch(url, {get method() { return "GET" }, body})`),
+			jsValid(`fetch(url, {set method(value) {}, body})`),
+
+			// ---- Locks in upstream body-absence branches: parentheses are transparent, TS assertions are not ----
+			jsValid(`fetch(url, {body: (undefined)})`),
+			jsValid(`fetch(url, {body: ((null))})`),
+			jsValid(`fetch(url, {body: (void sideEffect())})`),
+			jsValid(`function run(undefined) { fetch(url, {body: undefined}); }`),
+
+			// ---- Locks in upstream getStaticValue(): unknown and non-string methods are ignored ----
+			jsValid(`fetch(url, {method: getMethod(), body})`),
+			jsValid(`fetch(url, {method: 1, body})`),
+			jsValid(`fetch(url, {method: true, body})`),
+			jsValid(`let method = "GET"; method = "POST"; fetch(url, {method, body})`),
+			jsValid(`fetch(url, {method: "OPTIONS", body})`),
+			jsValid(`fetch(url, {method: "TRACE", body})`),
+			jsValid(`fetch(url, {method: "CONNECT", body})`),
+
+			// ---- Locks in upstream findLast(): the last matching member controls behavior ----
+			jsValid(`fetch(url, {body() {}, body: undefined})`),
+			jsValid(`fetch(url, {method: "HEAD", body, method() {}})`),
+
+			// ---- Locks in upstream listener/callee gates ----
+			jsValid(`globalThis.fetch(url, {body})`),
+			jsValid(`new globalThis.Request(url, {body})`),
+			jsValid(`fetch.call(globalThis, url, {body})`),
+			jsValid(`new fetch(url, {body})`),
+			jsValid(`Request(url, {body})`),
+
+			// ---- Real-user: PR #2338 discussion confirms Fetch allows these methods with bodies ----
+			jsValid(`fetch("/", {method: "OPTIONS", body: "foo"})`),
+			jsValid(`fetch("/", {method: "TRACE", body: "foo"})`),
+
+			// N/A: The rule has no autofix or suggestions.
+			// N/A: The rule does not target function/class declarations or their async/generator variants.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: Parenthesized callees and options are transparent ----
+			invalid(`(fetch)(url, {body})`, "body", "GET"),
+			invalid(`((fetch))(url, (({body})))`, "body", "GET"),
+			invalid(`new (Request)(url, ({body}))`, "body", "GET"),
+
+			// ---- Dimension 4: Type arguments do not wrap the callee ----
+			tsInvalid(`fetch<string>(url, {body})`, "body", "GET"),
+
+			// ---- Dimension 4: TS wrappers are transparent to static method evaluation ----
+			tsInvalid(`fetch(url, {method: ("head" as const), body})`, "body", "HEAD"),
+			tsInvalid(`fetch(url, {method: "get"!, body})`, "body", "GET"),
+			tsInvalid(`fetch(url, {method: ("GET" satisfies string), body})`, "body", "GET"),
+
+			// ---- Dimension 4: TS wrappers prevent the body absence shortcut ----
+			tsInvalid(`fetch(url, {body: (undefined as any)})`, "body", "GET"),
+			tsInvalid(`fetch(url, {body: ((void 0) as any)})`, "body", "GET"),
+
+			// ---- Dimension 4: Object members cover shorthand, methods, getters, and setters ----
+			invalid(`fetch(url, {body() {}})`, "body", "GET"),
+			invalid(`fetch(url, {get body() { return data; }})`, "body", "GET"),
+			invalid(`fetch(url, {set body(value) {}})`, "body", "GET"),
+			invalid(`fetch(url, {body, "method": "GET"})`, "body", "GET"),
+			invalid(`fetch(url, {body, ["method"]: "GET"})`, "body", "GET"),
+
+			// ---- Dimension 4: Traversal reaches nested function, class, and object contexts ----
+			invalid(`function run() { fetch(url, {body}); }`, "body", "GET"),
+			invalid(`class Client { send() { return new Request(url, {body}); } }`, "body", "GET"),
+			invalid(`fetch(url, {body: {body: null}})`, "body", "GET"),
+
+			// ---- Locks in upstream missing-method branch: local same-name bindings still match ----
+			invalid(`function fetch() {} fetch(url, {body})`, "body", "GET"),
+			invalid(`const Request = class {}; new Request(url, {body})`, "body", "GET"),
+
+			// ---- Locks in upstream spread branch: an explicit method is still authoritative ----
+			invalid(`fetch(url, {method: "GET", ...options, body})`, "body", "GET"),
+			invalid(`fetch(url, {...options, method: "HEAD", body})`, "body", "HEAD"),
+
+			// ---- Locks in upstream getStaticValue(): string-producing expression branches ----
+			invalid(`fetch(url, {method: `+"`head`"+`, body})`, "body", "HEAD"),
+			invalid(`fetch(url, {method: "he" + "ad", body})`, "body", "HEAD"),
+			invalid(`fetch(url, {method: true ? "GET" : "POST", body})`, "body", "GET"),
+			invalid(`const method = "get"; fetch(url, {method, body})`, "body", "GET"),
+
+			// ---- Locks in upstream findLast(): last body/method wins across member kinds ----
+			invalid(`fetch(url, {body: undefined, body() {}})`, "body", "GET", 2),
+			invalid(`fetch(url, {method() {}, method: "HEAD", body})`, "body", "HEAD"),
+
+			// ---- Real-user: issue #1989 request body without an explicit POST method ----
+			invalid(`fetch("http://example.com", {body: "{}"})`, "body", "GET"),
+
+			// ---- Real-user: PR #3299 hardening keeps side-effecting void bodies absent ----
+			// This is valid upstream behavior; the paired invalid assertion ensures only
+			// the final non-void body member is selected.
+			invalid(`fetch(url, {body: void sideEffect(), body: data})`, "body", "GET", 2),
+		},
+	)
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.ts"}
+}
+
+func tsInvalid(code string, target string, method string, occurrence ...int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.ts",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, method, occurrence...),
+		},
+	}
+}

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_extras_test.go
@@ -148,6 +148,10 @@ func TestNoInvalidFetchOptionsExtras(t *testing.T) {
 			invalid(`fetch(url, {method: Array.of("GET")[0], body})`, "body", "GET"),
 			invalid(`fetch(url, {method: "xGETy".slice(1, 4), body})`, "body", "GET"),
 			invalid(`fetch(url, {method: "xHEADy".substring(1, 5), body})`, "body", "HEAD"),
+			invalid(`fetch(url, {method: "xGETy".substr(1, 3), body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "G".concat("ET"), body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "GET".charAt(0) + "ET", body})`, "body", "GET"),
+			invalid(`fetch(url, {method: +"71" === 71 ? "GET" : "POST", body})`, "body", "GET"),
 			invalid(`const S = String; fetch(url, {method: S.fromCharCode(71, 69, 84), body})`, "body", "GET"),
 			invalid(`const A = Array; fetch(url, {method: A.of("HEAD")[0], body})`, "body", "HEAD"),
 

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_extras_test.go
@@ -71,6 +71,9 @@ func TestNoInvalidFetchOptionsExtras(t *testing.T) {
 			jsValid(`fetch(url, {method: "OPTIONS", body})`),
 			jsValid(`fetch(url, {method: "TRACE", body})`),
 			jsValid(`fetch(url, {method: "CONNECT", body})`),
+			// ECMAScript does not trim U+0085 before numeric coercion, so the first
+			// character becomes NUL rather than G.
+			jsValid(`fetch(url, {method: String.fromCharCode("\u008571", 69, 84), body})`),
 
 			// ---- Locks in upstream findLast(): the last matching member controls behavior ----
 			jsValid(`fetch(url, {body() {}, body: undefined})`),
@@ -95,6 +98,8 @@ func TestNoInvalidFetchOptionsExtras(t *testing.T) {
 			invalid(`(fetch)(url, {body})`, "body", "GET"),
 			invalid(`((fetch))(url, (({body})))`, "body", "GET"),
 			invalid(`new (Request)(url, ({body}))`, "body", "GET"),
+			// Diagnostic columns count UTF-16 code units, as ESLint does.
+			invalid(`fetch("😀", {body})`, "body", "GET"),
 
 			// ---- Dimension 4: Type arguments do not wrap the callee ----
 			tsInvalid(`fetch<string>(url, {body})`, "body", "GET"),
@@ -133,6 +138,18 @@ func TestNoInvalidFetchOptionsExtras(t *testing.T) {
 			invalid(`fetch(url, {method: "he" + "ad", body})`, "body", "HEAD"),
 			invalid(`fetch(url, {method: true ? "GET" : "POST", body})`, "body", "GET"),
 			invalid(`const method = "get"; fetch(url, {method, body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "get".toUpperCase(), body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "get".toUpperCase(1), body})`, "body", "GET"),
+			invalid(`new Request(url, {method: String.fromCharCode(72, 69, 65, 68), body})`, "body", "HEAD"),
+			// StringToNumber accepts non-decimal prefixes and trims U+FEFF exactly
+			// as JavaScript does.
+			invalid(`fetch(url, {method: String.fromCharCode("0x47", 69, 84), body})`, "body", "GET"),
+			invalid(`fetch(url, {method: String.fromCharCode("\uFEFF71", 69, 84), body})`, "body", "GET"),
+			invalid(`fetch(url, {method: Array.of("GET")[0], body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "xGETy".slice(1, 4), body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "xHEADy".substring(1, 5), body})`, "body", "HEAD"),
+			invalid(`const S = String; fetch(url, {method: S.fromCharCode(71, 69, 84), body})`, "body", "GET"),
+			invalid(`const A = Array; fetch(url, {method: A.of("HEAD")[0], body})`, "body", "HEAD"),
 
 			// ---- Locks in upstream findLast(): last body/method wins across member kinds ----
 			invalid(`fetch(url, {body: undefined, body() {}})`, "body", "GET", 2),

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_upstream_test.go
@@ -7,6 +7,7 @@ package no_invalid_fetch_options_test
 import (
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
@@ -132,12 +133,12 @@ func nthIndex(value string, target string, nth int) int {
 func lineColumnForOffset(code string, offset int) (int, int) {
 	line := 1
 	column := 1
-	for i := range offset {
-		if code[i] == '\n' {
+	for _, character := range code[:offset] {
+		if character == '\n' {
 			line++
 			column = 1
 		} else {
-			column++
+			column += utf16.RuneLen(character)
 		}
 	}
 	return line, column

--- a/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_fetch_options/no_invalid_fetch_options_upstream_test.go
@@ -1,0 +1,144 @@
+// TestNoInvalidFetchOptionsUpstream migrates the full valid/invalid suite from upstream
+// v73.0.0 test/no-invalid-fetch-options.js 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases live in the
+// no_invalid_fetch_options_extras_test.go file.
+package no_invalid_fetch_options_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const messageID = "no-invalid-fetch-options"
+
+func invalidBodyMessage(method string) string {
+	return "\"body\" is not allowed when method is \"" + method + "\"."
+}
+
+func TestNoInvalidFetchOptionsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_invalid_fetch_options.NoInvalidFetchOptionsRule,
+		[]rule_tester.ValidTestCase{
+			jsValid(`fetch(url, {method: "POST", body})`),
+			jsValid(`new Request(url, {method: "POST", body})`),
+			jsValid(`fetch(url, {})`),
+			jsValid(`new Request(url, {})`),
+			jsValid(`fetch(url)`),
+			jsValid(`new Request(url)`),
+			jsValid(`fetch(url, {method: "UNKNOWN", body})`),
+			jsValid(`new Request(url, {method: "UNKNOWN", body})`),
+			jsValid(`fetch(url, {body: undefined})`),
+			jsValid(`new Request(url, {body: undefined})`),
+			jsValid(`fetch(url, {body: null})`),
+			jsValid(`new Request(url, {body: null})`),
+			// `void` always evaluates to `undefined`, so the body is effectively absent.
+			jsValid(`fetch(url, {body: void 0})`),
+			jsValid(`new Request(url, {method: "GET", body: void 0})`),
+			jsValid(`fetch(url, {...options, body})`),
+			jsValid(`new Request(url, {...options, body})`),
+			jsValid(`new fetch(url, {body})`),
+			jsValid(`Request(url, {body})`),
+			jsValid(`not_fetch(url, {body})`),
+			jsValid(`new not_Request(url, {body})`),
+			jsValid(`fetch({body}, url)`),
+			jsValid(`new Request({body}, url)`),
+			jsValid(`fetch(url, {[body]: "foo=bar"})`),
+			jsValid(`new Request(url, {[body]: "foo=bar"})`),
+			jsValid("fetch(url, {\n\tbody: 'foo=bar',\n\tbody: undefined,\n});"),
+			jsValid("new Request(url, {\n\tbody: 'foo=bar',\n\tbody: undefined,\n});"),
+			jsValid("fetch(url, {\n\tmethod: 'HEAD',\n\tbody: 'foo=bar',\n\tmethod: 'post',\n});"),
+			jsValid("new Request(url, {\n\tmethod: 'HEAD',\n\tbody: 'foo=bar',\n\tmethod: 'post',\n});"),
+		},
+		[]rule_tester.InvalidTestCase{
+			invalid(`fetch(url, {body})`, "body", "GET"),
+			invalid(`new Request(url, {body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "GET", body})`, "body", "GET"),
+			invalid(`new Request(url, {method: "GET", body})`, "body", "GET"),
+			invalid(`fetch(url, {method: "HEAD", body})`, "body", "HEAD"),
+			invalid(`new Request(url, {method: "HEAD", body})`, "body", "HEAD"),
+			invalid(`fetch(url, {method: "head", body})`, "body", "HEAD"),
+			invalid(`new Request(url, {method: "head", body})`, "body", "HEAD"),
+			invalid(`const method = "head"; new Request(url, {method, body: "foo=bar"})`, "body", "HEAD"),
+			invalid(`const method = "head"; fetch(url, {method, body: "foo=bar"})`, "body", "HEAD"),
+			invalid(`fetch(url, {body}, extraArgument)`, "body", "GET"),
+			invalid(`new Request(url, {body}, extraArgument)`, "body", "GET"),
+			invalid("fetch(url, {\n\tbody: undefined,\n\tbody: 'foo=bar',\n});", "body", "GET", 2),
+			invalid("new Request(url, {\n\tbody: undefined,\n\tbody: 'foo=bar',\n});", "body", "GET", 2),
+			invalid("fetch(url, {\n\tmethod: 'post',\n\tbody: 'foo=bar',\n\tmethod: 'HEAD',\n});", "body", "HEAD"),
+			invalid("new Request(url, {\n\tmethod: 'post',\n\tbody: 'foo=bar',\n\tmethod: 'HEAD',\n});", "body", "HEAD"),
+		},
+	)
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+func invalid(code string, target string, method string, occurrence ...int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, method, occurrence...),
+		},
+	}
+}
+
+func expectedError(code string, target string, method string, occurrence ...int) rule_tester.InvalidTestCaseError {
+	nth := 1
+	if len(occurrence) > 0 {
+		nth = occurrence[0]
+	}
+
+	offset := nthIndex(code, target, nth)
+	if offset < 0 {
+		panic("target not found in no-invalid-fetch-options test: " + target + " in " + code)
+	}
+	line, column := lineColumnForOffset(code, offset)
+	endLine, endColumn := lineColumnForOffset(code, offset+len(target))
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   invalidBodyMessage(method),
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func nthIndex(value string, target string, nth int) int {
+	searchStart := 0
+	for i := 1; i <= nth; i++ {
+		offset := strings.Index(value[searchStart:], target)
+		if offset < 0 {
+			return -1
+		}
+		searchStart += offset
+		if i == nth {
+			return searchStart
+		}
+		searchStart += len(target)
+	}
+	return -1
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for i := range offset {
+		if code[i] == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return line, column
+}

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"math"
 	"strconv"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/evaluator"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 // StaticStringEvaluator folds expressions to string constants. It wraps tsgo's
@@ -279,6 +282,9 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 			return result
 		}
 	case ast.KindCallExpression:
+		if result := staticEvaluator.evalBuiltinStaticCall(node); result.ok {
+			return result
+		}
 		if result := staticEvaluator.evalStringCall(node); result.ok {
 			return result
 		}
@@ -338,7 +344,7 @@ func (staticEvaluator *StaticStringEvaluator) ResolveIdentifierInitializer(node 
 }
 
 func (staticEvaluator *StaticStringEvaluator) resolveIdentifierInitializer(node *ast.Node) (*ast.Node, *ast.Symbol, bool) {
-	if staticEvaluator == nil || staticEvaluator.typeChecker == nil {
+	if staticEvaluator == nil || (staticEvaluator.typeChecker == nil && staticEvaluator.referenceResolver == nil) {
 		return nil, nil, false
 	}
 
@@ -1022,6 +1028,229 @@ func (staticEvaluator *StaticStringEvaluator) evalStringCall(node *ast.Node) sta
 	return staticEvalResult{value: value, ok: true}
 }
 
+// evalBuiltinStaticCall folds the narrow built-in call subset that
+// eslint-utils' getStaticValue permits and that string-consuming native rules
+// need. It intentionally recognizes only the real String / Array constructors
+// (or stable aliases) and only fully static arguments, never arbitrary methods
+// named like a built-in.
+func (staticEvaluator *StaticStringEvaluator) evalBuiltinStaticCall(node *ast.Node) staticEvalResult {
+	call := node.AsCallExpression()
+	if call == nil {
+		return staticEvalResult{}
+	}
+
+	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	if callee == nil || !ast.IsAccessExpression(callee) {
+		return staticEvalResult{}
+	}
+	method, ok := staticEvaluator.evalAccessExpressionKey(callee)
+	if !ok {
+		return staticEvalResult{}
+	}
+	arguments, ok := staticEvaluator.evalCallArguments(node)
+	if !ok {
+		return staticEvalResult{}
+	}
+
+	receiverNode := AccessExpressionObject(callee)
+	if staticEvaluator.isBuiltinStringValue(receiverNode, map[*ast.Symbol]bool{}) {
+		switch method {
+		case "fromCharCode":
+			return staticStringFromCharCode(arguments)
+		}
+	}
+	if staticEvaluator.isBuiltinArrayValue(receiverNode, map[*ast.Symbol]bool{}) && method == "of" {
+		return staticEvalResult{value: staticArrayFromValues(arguments), ok: true}
+	}
+
+	receiver := staticEvaluator.evalValue(receiverNode)
+	text, ok := staticValueAsString(receiver.value)
+	if !receiver.ok || !ok {
+		return staticEvalResult{}
+	}
+
+	switch method {
+	case "toUpperCase":
+		return staticEvalResult{value: ecmascript.StringToUpperCase(text), ok: true}
+	case "toLowerCase":
+		return staticEvalResult{value: ecmascript.StringToLowerCase(text), ok: true}
+	case "slice":
+		return staticStringSlice(text, arguments)
+	case "substring":
+		return staticStringSubstring(text, arguments)
+	}
+
+	return staticEvalResult{}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalCallArguments(node *ast.Node) ([]any, bool) {
+	values := make([]any, 0, len(node.Arguments()))
+	for _, argumentNode := range node.Arguments() {
+		if ast.IsSpreadElement(argumentNode) {
+			spread := staticEvaluator.evalValue(argumentNode.AsSpreadElement().Expression)
+			array, ok := spread.value.(*staticArrayValue)
+			if !spread.ok || !ok {
+				return nil, false
+			}
+			for index := range array.length {
+				values = append(values, array.element(index))
+			}
+			continue
+		}
+		argument := staticEvaluator.evalValue(argumentNode)
+		if !argument.ok {
+			return nil, false
+		}
+		values = append(values, argument.value)
+	}
+	return values, true
+}
+
+func staticArrayFromValues(values []any) *staticArrayValue {
+	array := &staticArrayValue{length: len(values)}
+	if array.length > len(array.inline) {
+		array.overflow = make([]any, array.length-len(array.inline))
+	}
+	for index, value := range values {
+		array.set(index, value)
+	}
+	return array
+}
+
+func staticStringFromCharCode(arguments []any) staticEvalResult {
+	units := make([]uint16, 0, len(arguments))
+	for _, argument := range arguments {
+		number, ok := staticValueToNumber(argument)
+		if !ok {
+			return staticEvalResult{}
+		}
+		units = append(units, uint16(toUint32(number)))
+	}
+	return staticEvalResult{value: string(utf16.Decode(units)), ok: true}
+}
+
+func staticStringSlice(text string, arguments []any) staticEvalResult {
+	start, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	end, ok := staticArgumentInteger(arguments, 1, math.MaxInt)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := utf16.Encode([]rune(text))
+	length := len(units)
+	from := normalizeSliceIndex(start, length)
+	to := normalizeSliceIndex(end, length)
+	if to < from {
+		to = from
+	}
+	return staticEvalResult{value: string(utf16.Decode(units[from:to])), ok: true}
+}
+
+func staticStringSubstring(text string, arguments []any) staticEvalResult {
+	start, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	end, ok := staticArgumentInteger(arguments, 1, math.MaxInt)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := utf16.Encode([]rune(text))
+	length := len(units)
+	from := clampSubstringIndex(start, length)
+	to := clampSubstringIndex(end, length)
+	if from > to {
+		from, to = to, from
+	}
+	return staticEvalResult{value: string(utf16.Decode(units[from:to])), ok: true}
+}
+
+func staticArgumentInteger(arguments []any, index int, defaultValue int) (int, bool) {
+	if index >= len(arguments) || staticValueUndefined(arguments[index]) {
+		return defaultValue, true
+	}
+	number, ok := staticValueToNumber(arguments[index])
+	if !ok {
+		return 0, false
+	}
+	if math.IsNaN(number) || number == 0 {
+		return 0, true
+	}
+	if math.IsInf(number, 1) {
+		return math.MaxInt, true
+	}
+	if math.IsInf(number, -1) {
+		return math.MinInt, true
+	}
+	if number >= float64(math.MaxInt) {
+		return math.MaxInt, true
+	}
+	if number <= float64(math.MinInt) {
+		return math.MinInt, true
+	}
+	return int(math.Trunc(number)), true
+}
+
+func normalizeSliceIndex(index, length int) int {
+	if index < 0 {
+		return max(length+index, 0)
+	}
+	return min(index, length)
+}
+
+func clampSubstringIndex(index, length int) int {
+	return min(max(index, 0), length)
+}
+
+func toUint32(number float64) uint32 {
+	if math.IsNaN(number) || math.IsInf(number, 0) || number == 0 {
+		return 0
+	}
+	remainder := math.Mod(math.Trunc(number), 1<<32)
+	if remainder < 0 {
+		remainder += 1 << 32
+	}
+	return uint32(remainder)
+}
+
+func staticValueToNumber(value any) (float64, bool) {
+	switch value := value.(type) {
+	case bool:
+		if value {
+			return 1, true
+		}
+		return 0, true
+	case staticNullValue:
+		return 0, true
+	case staticUndefinedValue:
+		return math.NaN(), true
+	case string:
+		return parseStaticNumber(value)
+	case *staticStringNode:
+		text, _ := staticValueAsString(value)
+		return parseStaticNumber(text)
+	default:
+		text, ok := staticValueToString(value)
+		if !ok {
+			return 0, false
+		}
+		return parseStaticNumber(text)
+	}
+}
+
+func parseStaticNumber(text string) (float64, bool) {
+	value, ok := ecmascript.StringToNumber(text)
+	if !ok {
+		// StringToNumber returns NaN for an invalid numeric string. NaN is still
+		// a statically known value and downstream coercions must be allowed to
+		// observe it (for example, String.fromCharCode(NaN) produces a NUL).
+		return math.NaN(), true
+	}
+	return value, true
+}
+
 func (staticEvaluator *StaticStringEvaluator) evalStringRawTag(node *ast.Node) staticEvalResult {
 	tagged := node.AsTaggedTemplateExpression()
 	if tagged == nil || tagged.Template == nil || !staticEvaluator.isStringRawTag(tagged.Tag) {
@@ -1070,6 +1299,23 @@ func (staticEvaluator *StaticStringEvaluator) isBuiltinStringValue(node *ast.Nod
 	return staticEvaluator.isBuiltinStringValue(initializer, resolvingAliases)
 }
 
+func (staticEvaluator *StaticStringEvaluator) isBuiltinArrayValue(node *ast.Node, resolvingAliases map[*ast.Symbol]bool) bool {
+	node = SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+	if isIdentifierWithText(node, "Array") && !IsShadowed(node, "Array") {
+		return true
+	}
+	initializer, symbol, ok := staticEvaluator.resolveIdentifierInitializer(node)
+	if !ok || resolvingAliases[symbol] {
+		return false
+	}
+	resolvingAliases[symbol] = true
+	defer delete(resolvingAliases, symbol)
+	return staticEvaluator.isBuiltinArrayValue(initializer, resolvingAliases)
+}
+
 func (staticEvaluator *StaticStringEvaluator) evalWithTsgo(node *ast.Node) (result staticEvalResult) {
 	defer func() {
 		if recover() != nil {
@@ -1100,14 +1346,16 @@ func (staticEvaluator *StaticStringEvaluator) evaluateEntity(expr *ast.Node, loc
 }
 
 func (staticEvaluator *StaticStringEvaluator) hasWrites(symbol *ast.Symbol) bool {
-	if staticEvaluator.sourceFile == nil || staticEvaluator.typeChecker == nil {
+	if staticEvaluator.sourceFile == nil ||
+		(staticEvaluator.typeChecker == nil && staticEvaluator.referenceResolver == nil) {
 		return true
 	}
 	return staticEvaluator.referenceFlagsFor(symbol)&staticReferenceWrite != 0
 }
 
 func (staticEvaluator *StaticStringEvaluator) hasPropertyMutation(symbol *ast.Symbol) bool {
-	if staticEvaluator.sourceFile == nil || staticEvaluator.typeChecker == nil {
+	if staticEvaluator.sourceFile == nil ||
+		(staticEvaluator.typeChecker == nil && staticEvaluator.referenceResolver == nil) {
 		return true
 	}
 	return staticEvaluator.referenceFlagsFor(symbol)&staticReferencePropertyMutation != 0

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -70,6 +70,15 @@ func NewStaticStringEvaluatorWithoutScope() *StaticStringEvaluator {
 type staticNullValue struct{}
 type staticUndefinedValue struct{}
 
+// staticNumberValue is a number this evaluator computed itself. tsgo hands
+// numbers back as jsnum.Number, a type internal/utils cannot import; the IsNaN
+// method both types carry is what tells a folded number from a folded bigint.
+type staticNumberValue float64
+
+func (value staticNumberValue) IsNaN() bool {
+	return math.IsNaN(float64(value))
+}
+
 // staticStringNode keeps literal strings backed by their existing AST node so
 // nested aggregate evaluation doesn't allocate an interface box per literal.
 type staticStringNode ast.Node
@@ -464,6 +473,20 @@ func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Nod
 			return staticEvaluator.evalValue(binary.Right)
 		}
 		return left
+	case ast.KindEqualsEqualsEqualsToken, ast.KindExclamationEqualsEqualsToken:
+		left := staticEvaluator.evalValue(binary.Left)
+		right := staticEvaluator.evalValue(binary.Right)
+		if !left.ok || !right.ok {
+			return staticEvalResult{}
+		}
+		equal, ok := staticValuesStrictEqual(left.value, right.value)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if binary.OperatorToken.Kind == ast.KindExclamationEqualsEqualsToken {
+			equal = !equal
+		}
+		return staticEvalResult{value: equal, ok: true}
 	case ast.KindPlusToken:
 		left := staticEvaluator.evalValue(binary.Left)
 		right := staticEvaluator.evalValue(binary.Right)
@@ -495,19 +518,52 @@ func (staticEvaluator *StaticStringEvaluator) concatStaticValues(left any, right
 
 func (staticEvaluator *StaticStringEvaluator) evalPrefixUnaryExpression(node *ast.Node) staticEvalResult {
 	prefix := node.AsPrefixUnaryExpression()
-	if prefix == nil || prefix.Operator != ast.KindExclamationToken {
+	if prefix == nil {
 		return staticEvaluator.evalWithTsgo(node)
 	}
 
+	switch prefix.Operator {
+	case ast.KindExclamationToken:
+		operand := staticEvaluator.evalValue(prefix.Operand)
+		if !operand.ok {
+			return staticEvalResult{}
+		}
+		truthy, ok := staticValueTruthy(operand.value)
+		if !ok {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: !truthy, ok: true}
+	case ast.KindPlusToken, ast.KindMinusToken, ast.KindTildeToken:
+		if result := staticEvaluator.evalNumericPrefix(prefix); result.ok {
+			return result
+		}
+	}
+
+	return staticEvaluator.evalWithTsgo(node)
+}
+
+// evalNumericPrefix folds `+`, `-` and `~` over any static operand. tsgo's
+// evaluator folds these operators only when the operand is already a number,
+// so string, boolean and nullish operands reach here unfolded.
+func (staticEvaluator *StaticStringEvaluator) evalNumericPrefix(prefix *ast.PrefixUnaryExpression) staticEvalResult {
 	operand := staticEvaluator.evalValue(prefix.Operand)
 	if !operand.ok {
 		return staticEvalResult{}
 	}
-	truthy, ok := staticValueTruthy(operand.value)
+	number, ok := staticValueToNumber(operand.value)
 	if !ok {
 		return staticEvalResult{}
 	}
-	return staticEvalResult{value: !truthy, ok: true}
+
+	switch prefix.Operator {
+	case ast.KindPlusToken:
+		return staticEvalResult{value: staticNumberValue(number), ok: true}
+	case ast.KindMinusToken:
+		return staticEvalResult{value: staticNumberValue(-number), ok: true}
+	case ast.KindTildeToken:
+		return staticEvalResult{value: staticNumberValue(^toInt32(number)), ok: true}
+	}
+	return staticEvalResult{}
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalConditionalExpression(node *ast.Node) staticEvalResult {
@@ -1078,6 +1134,12 @@ func (staticEvaluator *StaticStringEvaluator) evalBuiltinStaticCall(node *ast.No
 		return staticStringSlice(text, arguments)
 	case "substring":
 		return staticStringSubstring(text, arguments)
+	case "substr":
+		return staticStringSubstr(text, arguments)
+	case "charAt":
+		return staticStringCharAt(text, arguments)
+	case "concat":
+		return staticStringConcat(text, arguments)
 	}
 
 	return staticEvalResult{}
@@ -1167,6 +1229,58 @@ func staticStringSubstring(text string, arguments []any) staticEvalResult {
 	return staticEvalResult{value: string(utf16.Decode(units[from:to])), ok: true}
 }
 
+// staticStringSubstr implements the Annex B String#substr, whose second
+// argument is a length rather than an end index.
+func staticStringSubstr(text string, arguments []any) staticEvalResult {
+	start, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	count, ok := staticArgumentInteger(arguments, 1, math.MaxInt)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := utf16.Encode([]rune(text))
+	length := len(units)
+	from := normalizeSliceIndex(start, length)
+	if count <= 0 {
+		return staticEvalResult{value: "", ok: true}
+	}
+	to := length
+	if count < length-from {
+		to = from + count
+	}
+	return staticEvalResult{value: string(utf16.Decode(units[from:to])), ok: true}
+}
+
+func staticStringCharAt(text string, arguments []any) staticEvalResult {
+	index, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := utf16.Encode([]rune(text))
+	if index < 0 || index >= len(units) {
+		return staticEvalResult{value: "", ok: true}
+	}
+	return staticEvalResult{value: string(utf16.Decode(units[index : index+1])), ok: true}
+}
+
+func staticStringConcat(text string, arguments []any) staticEvalResult {
+	var builder strings.Builder
+	builder.WriteString(text)
+	for _, argument := range arguments {
+		part, ok := staticValueToString(argument)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if len(part) > maxStaticStringLength-builder.Len() {
+			return staticEvalResult{}
+		}
+		builder.WriteString(part)
+	}
+	return staticEvalResult{value: builder.String(), ok: true}
+}
+
 func staticArgumentInteger(arguments []any, index int, defaultValue int) (int, bool) {
 	if index >= len(arguments) || staticValueUndefined(arguments[index]) {
 		return defaultValue, true
@@ -1215,8 +1329,14 @@ func toUint32(number float64) uint32 {
 	return uint32(remainder)
 }
 
+func toInt32(number float64) int32 {
+	return int32(toUint32(number))
+}
+
 func staticValueToNumber(value any) (float64, bool) {
 	switch value := value.(type) {
+	case staticNumberValue:
+		return float64(value), true
 	case bool:
 		if value {
 			return 1, true
@@ -1471,7 +1591,7 @@ func isMutatingArrayMethod(name string) bool {
 
 func staticValueIsTsgoSafe(value any) bool {
 	switch value.(type) {
-	case bool, staticNullValue, staticUndefinedValue, *staticStringNode, *staticObjectValue, *staticArrayValue:
+	case bool, staticNullValue, staticUndefinedValue, staticNumberValue, *staticStringNode, *staticObjectValue, *staticArrayValue:
 		return false
 	default:
 		return value != nil
@@ -1513,6 +1633,75 @@ func staticValueUndefined(value any) bool {
 	return ok
 }
 
+// staticValueKind is the JavaScript typeof-like classification `===` needs.
+// Objects and arrays compare by identity, which folding does not model, and
+// tsgo's bigint representation cannot be inspected from this package; both stay
+// unknown.
+type staticValueKind uint8
+
+const (
+	staticKindUnknown staticValueKind = iota
+	staticKindString
+	staticKindNumber
+	staticKindBoolean
+	staticKindNull
+	staticKindUndefined
+)
+
+func staticValueKindOf(value any) staticValueKind {
+	switch value.(type) {
+	case bool:
+		return staticKindBoolean
+	case staticNullValue:
+		return staticKindNull
+	case staticUndefinedValue:
+		return staticKindUndefined
+	}
+	if staticValueIsString(value) {
+		return staticKindString
+	}
+	if _, isNumber := value.(interface{ IsNaN() bool }); isNumber {
+		return staticKindNumber
+	}
+	return staticKindUnknown
+}
+
+// staticValuesStrictEqual implements the strict equality comparison over folded
+// values. Comparing across kinds is always false, which keeps `1n === 1` right
+// even though bigint values themselves stay unknown.
+func staticValuesStrictEqual(left any, right any) (equal bool, ok bool) {
+	leftKind := staticValueKindOf(left)
+	rightKind := staticValueKindOf(right)
+	if leftKind == staticKindUnknown || rightKind == staticKindUnknown {
+		return false, false
+	}
+	if leftKind != rightKind {
+		return false, true
+	}
+
+	switch leftKind {
+	case staticKindString:
+		leftText, _ := staticValueAsString(left)
+		rightText, _ := staticValueAsString(right)
+		return leftText == rightText, true
+	case staticKindNumber:
+		leftNumber, leftOk := staticValueToNumber(left)
+		rightNumber, rightOk := staticValueToNumber(right)
+		if !leftOk || !rightOk {
+			return false, false
+		}
+		return leftNumber == rightNumber, true
+	case staticKindBoolean:
+		leftFlag, leftOk := left.(bool)
+		rightFlag, rightOk := right.(bool)
+		if !leftOk || !rightOk {
+			return false, false
+		}
+		return leftFlag == rightFlag, true
+	}
+	return true, true
+}
+
 func staticValueIsAggregate(value any) bool {
 	switch value.(type) {
 	case *staticObjectValue, *staticArrayValue:
@@ -1526,6 +1715,8 @@ func staticValueTruthy(value any) (truthy bool, ok bool) {
 	switch value := value.(type) {
 	case string:
 		return value != "", true
+	case staticNumberValue:
+		return value != 0 && !value.IsNaN(), true
 	case *staticStringNode:
 		stringValue, _ := staticValueAsString(value)
 		return stringValue != "", true
@@ -1544,6 +1735,8 @@ func staticValueToString(value any) (string, bool) {
 	switch value := value.(type) {
 	case string:
 		return value, true
+	case staticNumberValue:
+		return ecmascript.NumberToString(float64(value)), true
 	case *staticStringNode:
 		return staticValueAsString(value)
 	case bool:

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -32,6 +32,31 @@ func TestStaticStringEvaluator(t *testing.T) {
 		"const stringCall = String(\"then\");\n" +
 		"const stringNumberCall = String(1 + 2);\n" +
 		"const stringNoArgumentCall = String();\n" +
+		"const uppercase = \"get\".toUpperCase();\n" +
+		"const uppercaseExpansion = \"ß\".toUpperCase();\n" +
+		"const uppercaseStaticExtraArgument = \"get\".toUpperCase(1);\n" +
+		"const uppercaseExtraArgument = \"get\".toUpperCase(unknown);\n" +
+		"const lowercase = \"HEAD\".toLowerCase();\n" +
+		"const lowercaseFinalSigma = \"ΟΣ\".toLowerCase();\n" +
+		"const fromCharCode = String.fromCharCode(71, 69, 84);\n" +
+		"const fromCharCodeNegativeModulo = String.fromCharCode(-4294967225);\n" +
+		"const fromCharCodeHexString = String.fromCharCode(\"0x47\");\n" +
+		"const fromCharCodeNEL = String.fromCharCode(\"\u008571\");\n" +
+		"const fromCharCodeBOM = String.fromCharCode(\"\uFEFF71\");\n" +
+		"const fromCharCodeSpread = String.fromCharCode(...[72, 69, 65, 68]);\n" +
+		"const arrayOfFirst = Array.of(\"GET\")[0];\n" +
+		"const arrayOfSpread = Array.of(...[\"HEAD\"])[0];\n" +
+		"const stringSlice = \"xGETy\".slice(1, 4);\n" +
+		"const stringSliceDefault = \"GET\".slice(undefined);\n" +
+		"const stringSliceUtf16 = \"😀GETx\".slice(2, 5);\n" +
+		"const stringSubstring = \"xHEADy\".substring(1, 5);\n" +
+		"const stringSubstringReversed = \"HEAD\".substring(4, 0);\n" +
+		"const StringAlias = String;\n" +
+		"const aliasFromCharCode = StringAlias.fromCharCode(71, 69, 84);\n" +
+		"const ArrayAlias = Array;\n" +
+		"const aliasArrayOf = ArrayAlias.of(\"GET\")[0];\n" +
+		"{ const String = {fromCharCode: () => \"GET\"}; const shadowedFromCharCode = String.fromCharCode(71); }\n" +
+		"{ const Array = {of: () => [\"GET\"]}; const shadowedArrayOf = Array.of(\"GET\")[0]; }\n" +
 		"const stringRaw = String.raw`then`;\n" +
 		"const stringRawSubstitution = String.raw`th${\"e\"}n`;\n" +
 		"const RawString = String;\n" +
@@ -133,6 +158,29 @@ func TestStaticStringEvaluator(t *testing.T) {
 		{name: "stringCall", want: "then", ok: true},
 		{name: "stringNumberCall", want: "3", ok: true},
 		{name: "stringNoArgumentCall", want: "", ok: true},
+		{name: "uppercase", want: "GET", ok: true},
+		{name: "uppercaseExpansion", want: "SS", ok: true},
+		{name: "uppercaseStaticExtraArgument", want: "GET", ok: true},
+		{name: "uppercaseExtraArgument"},
+		{name: "lowercase", want: "head", ok: true},
+		{name: "lowercaseFinalSigma", want: "ος", ok: true},
+		{name: "fromCharCode", want: "GET", ok: true},
+		{name: "fromCharCodeNegativeModulo", want: "G", ok: true},
+		{name: "fromCharCodeHexString", want: "G", ok: true},
+		{name: "fromCharCodeNEL", want: "\x00", ok: true},
+		{name: "fromCharCodeBOM", want: "G", ok: true},
+		{name: "fromCharCodeSpread", want: "HEAD", ok: true},
+		{name: "arrayOfFirst", want: "GET", ok: true},
+		{name: "arrayOfSpread", want: "HEAD", ok: true},
+		{name: "stringSlice", want: "GET", ok: true},
+		{name: "stringSliceDefault", want: "GET", ok: true},
+		{name: "stringSliceUtf16", want: "GET", ok: true},
+		{name: "stringSubstring", want: "HEAD", ok: true},
+		{name: "stringSubstringReversed", want: "HEAD", ok: true},
+		{name: "aliasFromCharCode", want: "GET", ok: true},
+		{name: "aliasArrayOf", want: "GET", ok: true},
+		{name: "shadowedFromCharCode"},
+		{name: "shadowedArrayOf"},
 		{name: "stringRaw", want: "then", ok: true},
 		{name: "stringRawSubstitution", want: "then", ok: true},
 		{name: "stringRawAlias", want: "then", ok: true},

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -1,3 +1,5 @@
+// cspell:ignore truenull
+
 package utils
 
 import (

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -51,6 +51,29 @@ func TestStaticStringEvaluator(t *testing.T) {
 		"const stringSliceUtf16 = \"😀GETx\".slice(2, 5);\n" +
 		"const stringSubstring = \"xHEADy\".substring(1, 5);\n" +
 		"const stringSubstringReversed = \"HEAD\".substring(4, 0);\n" +
+		"const stringSubstr = \"xGETy\".substr(1, 3);\n" +
+		"const stringSubstrNegative = \"xxGET\".substr(-3);\n" +
+		"const stringSubstrEmptyLength = \"GET\".substr(0, 0);\n" +
+		"const stringCharAt = \"GETx\".charAt(0);\n" +
+		"const stringCharAtDefault = \"GET\".charAt();\n" +
+		"const stringCharAtOutOfRange = \"GET\".charAt(9);\n" +
+		"const stringConcat = \"G\".concat(\"ET\");\n" +
+		"const stringConcatMany = \"HE\".concat(\"A\", \"D\");\n" +
+		"const stringConcatCoercion = \"n\".concat(1, true, null);\n" +
+		"const stringConcatUnknown = \"G\".concat(unknownValue);\n" +
+		"const unaryPlusString = String(+\"71\");\n" +
+		"const unaryPlusBoolean = String(+true);\n" +
+		"const unaryMinusString = String(-\"1\");\n" +
+		"const unaryTildeString = String(~\"1\");\n" +
+		"const unaryPlusInvalid = String(+\"nope\");\n" +
+		"const unaryPlusUnknown = String(+unknownValue);\n" +
+		"const strictEqualNumbers = +\"71\" === 71 ? \"then\" : \"no\";\n" +
+		"const strictEqualStrings = \"a\" === \"a\" ? \"then\" : \"no\";\n" +
+		"const strictUnequalStrings = \"a\" !== \"b\" ? \"then\" : \"no\";\n" +
+		"const strictEqualAcrossKinds = (1 as any) === \"1\" ? \"no\" : \"then\";\n" +
+		"const strictEqualNullish = (null as any) === undefined ? \"no\" : \"then\";\n" +
+		"const strictEqualObjects = ({} as any) === {} ? \"then\" : \"no\";\n" +
+		"const strictEqualUnknown = unknownValue === \"a\" ? \"then\" : \"no\";\n" +
 		"const StringAlias = String;\n" +
 		"const aliasFromCharCode = StringAlias.fromCharCode(71, 69, 84);\n" +
 		"const ArrayAlias = Array;\n" +
@@ -177,6 +200,29 @@ func TestStaticStringEvaluator(t *testing.T) {
 		{name: "stringSliceUtf16", want: "GET", ok: true},
 		{name: "stringSubstring", want: "HEAD", ok: true},
 		{name: "stringSubstringReversed", want: "HEAD", ok: true},
+		{name: "stringSubstr", want: "GET", ok: true},
+		{name: "stringSubstrNegative", want: "GET", ok: true},
+		{name: "stringSubstrEmptyLength", want: "", ok: true},
+		{name: "stringCharAt", want: "G", ok: true},
+		{name: "stringCharAtDefault", want: "G", ok: true},
+		{name: "stringCharAtOutOfRange", want: "", ok: true},
+		{name: "stringConcat", want: "GET", ok: true},
+		{name: "stringConcatMany", want: "HEAD", ok: true},
+		{name: "stringConcatCoercion", want: "n1truenull", ok: true},
+		{name: "stringConcatUnknown"},
+		{name: "unaryPlusString", want: "71", ok: true},
+		{name: "unaryPlusBoolean", want: "1", ok: true},
+		{name: "unaryMinusString", want: "-1", ok: true},
+		{name: "unaryTildeString", want: "-2", ok: true},
+		{name: "unaryPlusInvalid", want: "NaN", ok: true},
+		{name: "unaryPlusUnknown"},
+		{name: "strictEqualNumbers", want: "then", ok: true},
+		{name: "strictEqualStrings", want: "then", ok: true},
+		{name: "strictUnequalStrings", want: "then", ok: true},
+		{name: "strictEqualAcrossKinds", want: "then", ok: true},
+		{name: "strictEqualNullish", want: "then", ok: true},
+		{name: "strictEqualObjects"},
+		{name: "strictEqualUnknown"},
 		{name: "aliasFromCharCode", want: "GET", ok: true},
 		{name: "aliasArrayOf", want: "GET", ok: true},
 		{name: "shadowedFromCharCode"},

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -623,6 +623,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-array-fill-with-reference-type.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-invalid-fetch-options.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-invalid-fetch-options.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-invalid-fetch-options.test.ts
@@ -1,0 +1,114 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const invalidBodyMessage = (method: string) =>
+  `"body" is not allowed when method is "${method}".`;
+const valid = (code: string) => ({ code, filename: 'file.js' });
+const invalid = (code: string, method: string) => ({
+  code,
+  filename: 'file.js',
+  errors: [
+    {
+      messageId: 'no-invalid-fetch-options',
+      message: invalidBodyMessage(method),
+    },
+  ],
+});
+
+ruleTester.run('no-invalid-fetch-options', null as never, {
+  valid: [
+    valid('fetch(url, {method: "POST", body})'),
+    valid('new Request(url, {method: "POST", body})'),
+    valid('fetch(url, {})'),
+    valid('new Request(url, {})'),
+    valid('fetch(url)'),
+    valid('new Request(url)'),
+    valid('fetch(url, {method: "UNKNOWN", body})'),
+    valid('new Request(url, {method: "UNKNOWN", body})'),
+    valid('fetch(url, {body: undefined})'),
+    valid('new Request(url, {body: undefined})'),
+    valid('fetch(url, {body: null})'),
+    valid('new Request(url, {body: null})'),
+    valid('fetch(url, {body: void 0})'),
+    valid('new Request(url, {method: "GET", body: void 0})'),
+    valid('fetch(url, {...options, body})'),
+    valid('new Request(url, {...options, body})'),
+    valid('new fetch(url, {body})'),
+    valid('Request(url, {body})'),
+    valid('not_fetch(url, {body})'),
+    valid('new not_Request(url, {body})'),
+    valid('fetch({body}, url)'),
+    valid('new Request({body}, url)'),
+    valid('fetch(url, {[body]: "foo=bar"})'),
+    valid('new Request(url, {[body]: "foo=bar"})'),
+    valid(`fetch(url, {
+	body: 'foo=bar',
+	body: undefined,
+});`),
+    valid(`new Request(url, {
+	body: 'foo=bar',
+	body: undefined,
+});`),
+    valid(`fetch(url, {
+	method: 'HEAD',
+	body: 'foo=bar',
+	method: 'post',
+});`),
+    valid(`new Request(url, {
+	method: 'HEAD',
+	body: 'foo=bar',
+	method: 'post',
+});`),
+  ],
+  invalid: [
+    invalid('fetch(url, {body})', 'GET'),
+    invalid('new Request(url, {body})', 'GET'),
+    invalid('fetch(url, {method: "GET", body})', 'GET'),
+    invalid('new Request(url, {method: "GET", body})', 'GET'),
+    invalid('fetch(url, {method: "HEAD", body})', 'HEAD'),
+    invalid('new Request(url, {method: "HEAD", body})', 'HEAD'),
+    invalid('fetch(url, {method: "head", body})', 'HEAD'),
+    invalid('new Request(url, {method: "head", body})', 'HEAD'),
+    invalid(
+      'const method = "head"; new Request(url, {method, body: "foo=bar"})',
+      'HEAD',
+    ),
+    invalid(
+      'const method = "head"; fetch(url, {method, body: "foo=bar"})',
+      'HEAD',
+    ),
+    invalid('fetch(url, {body}, extraArgument)', 'GET'),
+    invalid('new Request(url, {body}, extraArgument)', 'GET'),
+    invalid(
+      `fetch(url, {
+	body: undefined,
+	body: 'foo=bar',
+});`,
+      'GET',
+    ),
+    invalid(
+      `new Request(url, {
+	body: undefined,
+	body: 'foo=bar',
+});`,
+      'GET',
+    ),
+    invalid(
+      `fetch(url, {
+	method: 'post',
+	body: 'foo=bar',
+	method: 'HEAD',
+});`,
+      'HEAD',
+    ),
+    invalid(
+      `new Request(url, {
+	method: 'post',
+	body: 'foo=bar',
+	method: 'HEAD',
+});`,
+      'HEAD',
+    ),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -106,7 +106,7 @@ const recommended: RslintConfigEntry = {
     'unicorn/no-instanceof-builtins': 'error',
     // 'unicorn/no-invalid-argument-count': 'error', // not implemented
     // 'unicorn/no-invalid-character-comparison': 'error', // not implemented
-    // 'unicorn/no-invalid-fetch-options': 'error', // not implemented
+    'unicorn/no-invalid-fetch-options': 'error',
     // 'unicorn/no-invalid-file-input-accept': 'off', // not implemented
     'unicorn/no-invalid-remove-event-listener': 'error',
     // 'unicorn/no-invalid-well-known-symbol-methods': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `unicorn/no-invalid-fetch-options` rule from ESLint to Rslint.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-invalid-fetch-options.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-invalid-fetch-options.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).