### PR TITLE
feat(unicorn): port rule no-invalid-remove-event-listener

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
@@ -25,6 +26,7 @@ func GetAllRules() []rule.Rule {
 		filename_case.FilenameCaseRule,
 		new_for_builtins.NewForBuiltinsRule,
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,
+		no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,

--- a/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener.go
+++ b/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener.go
@@ -1,0 +1,58 @@
+package no_invalid_remove_event_listener
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "no-invalid-remove-event-listener"
+
+var invalidListenerMessage = rule.RuleMessage{
+	Id:          messageID,
+	Description: "The listener argument should be a function reference.",
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-invalid-remove-event-listener.md
+var NoInvalidRemoveEventListenerRule = rule.Rule{
+	Name:   "unicorn/no-invalid-remove-event-listener",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		minimumArguments := 2
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				_, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Method:              "removeEventListener",
+					MinimumArguments:    &minimumArguments,
+					AllowOptionalMember: true,
+				})
+				if !ok {
+					return
+				}
+
+				arguments := node.Arguments()
+				if arguments[0].Kind == ast.KindSpreadElement {
+					return
+				}
+
+				listener := ast.SkipParentheses(arguments[1])
+				switch listener.Kind {
+				case ast.KindArrowFunction, ast.KindFunctionExpression:
+					ctx.ReportRange(utils.GetFunctionHeadLoc(ctx.SourceFile, listener), invalidListenerMessage)
+				case ast.KindCallExpression:
+					if ast.IsOptionalChain(listener) {
+						return
+					}
+					bindCall, isBindCall := unicornutil.MatchDotMethodCall(listener, unicornutil.DotMethodCallOptions{
+						Method: "bind",
+					})
+					if isBindCall {
+						ctx.ReportNode(bindCall.Property, invalidListenerMessage)
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener.md
+++ b/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener.md
@@ -1,0 +1,29 @@
+# no-invalid-remove-event-listener
+
+## Rule Details
+
+Prevent calling `EventTarget#removeEventListener()` with an inline function or
+the result of an inline `.bind()` call. `removeEventListener()` must receive the
+same function reference that was passed to `addEventListener()`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+window.removeEventListener("click", listener.bind(window));
+window.removeEventListener("click", () => {});
+window.removeEventListener("click", function () {});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const listener = () => {};
+window.addEventListener("click", listener);
+// ...
+window.removeEventListener("click", listener);
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-invalid-remove-event-listener](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-invalid-remove-event-listener.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-invalid-remove-event-listener.js)

--- a/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_extras_test.go
@@ -71,7 +71,7 @@ func TestNoInvalidRemoveEventListenerExtras(t *testing.T) {
 			tsInvalid(`(target satisfies EventTarget).removeEventListener('click', () => {})`, `=>`, 1),
 
 			// ---- Dimension 4: optional receiver member remains reportable ----
-			// ---- Real-user: #2253 optional receiver regression ----
+			// ---- Real-user: upstream issue 2253 optional receiver regression ----
 			tsInvalid(`this.input?.removeEventListener(event, this.onInputEvent.bind(this), true)`, `bind`, 1),
 
 			// ---- Dimension 4: function expression variants all report their function heads ----

--- a/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_extras_test.go
@@ -1,0 +1,129 @@
+package no_invalid_remove_event_listener_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_invalid_remove_event_listener "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoInvalidRemoveEventListenerExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch, Dimension 4 row, or real-user
+// scenario it covers.
+func TestNoInvalidRemoveEventListenerExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: static and dynamic element-access method keys are excluded ----
+			tsValid(`target['removeEventListener']('click', () => {})`),
+			tsValid("target[`removeEventListener`]('click', () => {})"),
+			tsValid(`target[0]('click', () => {})`),
+			tsValid(`target[Symbol.removeEventListener]('click', () => {})`),
+
+			// ---- Dimension 4: optional outer call and parenthesized optional-chain callee are excluded ----
+			tsValid(`target.removeEventListener?.('click', () => {})`),
+			tsValid(`(target.removeEventListener)?.('click', () => {})`),
+			tsValid(`(target?.removeEventListener)('click', () => {})`),
+
+			// ---- Dimension 4: TypeScript wrappers around the listener remain distinct expressions upstream ----
+			tsValid(`target.removeEventListener('click', (() => {}) as EventListener)`),
+			tsValid(`target.removeEventListener('click', handler.bind(target) as EventListener)`),
+			tsValid(`target.removeEventListener('click', handler.bind(target)!)`),
+
+			// ---- Dimension 4: optional/computed bind forms are excluded ----
+			tsValid(`target.removeEventListener('click', handler.bind?.(target))`),
+			tsValid(`target.removeEventListener('click', handler?.bind(target))`),
+			tsValid(`target.removeEventListener('click', handler?.foo.bind(target))`),
+			tsValid(`target.removeEventListener('click', handler?.foo.bar.bind(target))`),
+			tsValid(`target.removeEventListener('click', handler['bind'](target))`),
+			tsValid("target.removeEventListener('click', handler[`bind`](target))"),
+			tsValid(`target.removeEventListener('click', handler[bind](target))`),
+
+			// ---- Dimension 4: spread and empty argument forms degrade without reporting ----
+			tsValid(`target.removeEventListener(...arguments, () => {})`),
+			tsValid(`target.removeEventListener()`),
+
+			// Locks in upstream isMethodCall() rejection branches for non-call and wrong-name shapes.
+			tsValid(`new target.removeEventListener('click', () => {})`),
+			tsValid(`target.removeListener('click', () => {})`),
+
+			// N/A: declaration/container key forms, class/function container variants, body-absent declarations, and ancestor walks; the rule only inspects call expressions and their first two arguments.
+			// N/A: autofix boundaries; the rule has no fix or suggestion.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized listener and bind callees are transparent ----
+			tsInvalid(`target.removeEventListener('click', ((event) => {}))`, `=>`, 1),
+			tsInvalid(`target.removeEventListener('click', (handler.bind(target)))`, `bind`, 1),
+			tsInvalid(`target.removeEventListener('click', (handler.bind)(target))`, `bind`, 1),
+			tsInvalid(`target.removeEventListener('click', ((handler).bind(target)))`, `bind`, 1),
+			tsInvalid(`target.removeEventListener('click', (handler?.foo).bind(target))`, `bind`, 1),
+
+			// ---- Dimension 4: parenthesized and TypeScript-wrapped receivers remain reportable ----
+			tsInvalid(`(target).removeEventListener('click', () => {})`, `=>`, 1),
+			tsInvalid(`((target)).removeEventListener('click', () => {})`, `=>`, 1),
+			tsInvalid(`target!.removeEventListener('click', () => {})`, `=>`, 1),
+			tsInvalid(`(target as EventTarget).removeEventListener('click', () => {})`, `=>`, 1),
+			tsInvalid(`(target satisfies EventTarget).removeEventListener('click', () => {})`, `=>`, 1),
+
+			// ---- Dimension 4: optional receiver member remains reportable ----
+			// ---- Real-user: #2253 optional receiver regression ----
+			tsInvalid(`this.input?.removeEventListener(event, this.onInputEvent.bind(this), true)`, `bind`, 1),
+
+			// ---- Dimension 4: function expression variants all report their function heads ----
+			tsInvalid(`target.removeEventListener('click', function* () {})`, `function* `, 1),
+			tsInvalid(`target.removeEventListener('click', async function* named() {})`, `async function* named`, 1),
+
+			// ---- Dimension 4: later spread arguments do not hide the listener ----
+			tsInvalid(`target.removeEventListener('click', () => {}, ...options)`, `=>`, 1),
+
+			// ---- Dimension 4: nested matching calls report independently without traversal bleed ----
+			{
+				Code:     `outer.removeEventListener('outer', () => { inner.removeEventListener('inner', () => {}) })`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(`outer.removeEventListener('outer', () => { inner.removeEventListener('inner', () => {}) })`, `=>`, 1),
+					expectedError(`outer.removeEventListener('outer', () => { inner.removeEventListener('inner', () => {}) })`, `=>`, 2),
+				},
+			},
+
+			// ---- Real-user: #682 custom-element lifecycle removal with a fresh bound listener ----
+			tsInvalid(`class MyClass extends HTMLElement {
+	connectedCallback() {
+		this.addEventListener('click', this.handleClick.bind(this));
+	}
+	disconnectedCallback() {
+		this.removeEventListener('click', this.handleClick.bind(this));
+	}
+	handleClick() {}
+}`, `bind`, 2),
+
+			// Locks in upstream listener arm 1: an arrow reports at its arrow token.
+			tsInvalid(`target.removeEventListener('click', async event => event)`, `=>`, 1),
+
+			// Locks in upstream listener arm 2: a function expression reports its head, not its body.
+			tsInvalid(`target.removeEventListener('click', function named(event) { return event })`, `function named`, 1),
+
+			// Locks in upstream listener arm 3: a direct non-optional dot-property bind call reports only `bind`.
+			tsInvalid(`target.removeEventListener('click', createHandler().bind(target))`, `bind`, 1),
+		},
+	)
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.ts"}
+}
+
+func tsInvalid(code string, target string, occurrence int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.ts",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, occurrence),
+		},
+	}
+}

--- a/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_extras_test.go
@@ -91,7 +91,7 @@ func TestNoInvalidRemoveEventListenerExtras(t *testing.T) {
 				},
 			},
 
-			// ---- Real-user: #682 custom-element lifecycle removal with a fresh bound listener ----
+			// ---- Real-user: upstream issue 682 custom-element lifecycle removal with a fresh bound listener ----
 			tsInvalid(`class MyClass extends HTMLElement {
 	connectedCallback() {
 		this.addEventListener('click', this.handleClick.bind(this));

--- a/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_invalid_remove_event_listener/no_invalid_remove_event_listener_upstream_test.go
@@ -1,0 +1,152 @@
+package no_invalid_remove_event_listener_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_invalid_remove_event_listener "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID = "no-invalid-remove-event-listener"
+	message   = "The listener argument should be a function reference."
+)
+
+// TestNoInvalidRemoveEventListenerUpstream migrates the full valid/invalid
+// suite from upstream test/no-invalid-remove-event-listener.js 1:1. Position
+// assertions cover line/column for every invalid case. rslint-specific lock-in
+// cases live in no_invalid_remove_event_listener_extras_test.go.
+func TestNoInvalidRemoveEventListenerUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
+		[]rule_tester.ValidTestCase{
+			// ---- CallExpression ----
+			jsValid(`new el.removeEventListener("click", () => {})`),
+			jsValid(`el.removeEventListener?.("click", () => {})`),
+			jsValid(`el.notRemoveEventListener("click", () => {})`),
+			jsValid(`el[removeEventListener]("click", () => {})`),
+			jsValid(`el["removeEventListener"]("click", () => {})`),
+
+			// ---- Arguments ----
+			jsValid(`el.removeEventListener("click")`),
+			jsValid(`el.removeEventListener()`),
+			jsValid(`el.removeEventListener(() => {})`),
+			jsValid(`el.removeEventListener(...["click", () => {}], () => {})`),
+			jsValid(`el.removeEventListener(...args, () => {})`),
+			jsValid(`el.removeEventListener(() => {}, "click")`),
+			jsValid(`window.removeEventListener("click", bind())`),
+			jsValid(`window.removeEventListener("click", handler.notBind())`),
+			jsValid(`window.removeEventListener("click", handler[bind]())`),
+			jsValid(`window.removeEventListener("click", handler.bind?.())`),
+			jsValid(`window.removeEventListener("click", handler?.bind())`),
+
+			jsValid(`window.removeEventListener(handler)`),
+			jsValid(`class MyComponent {
+	handler() {}
+	disconnectedCallback() {
+		this.removeEventListener('click', this.handler);
+	}
+}`),
+			jsValid(`this.removeEventListener("click", getListener())`),
+			jsValid(`el.removeEventListener("scroll", handler)`),
+			jsValid(`el.removeEventListener("keydown", obj.listener)`),
+			jsValid(`removeEventListener("keyup", () => {})`),
+			jsValid(`removeEventListener("keydown", function () {})`),
+		},
+		[]rule_tester.InvalidTestCase{
+			bindInvalid(`window.removeEventListener("scroll", handler.bind(abc))`),
+			bindInvalid(`window.removeEventListener("scroll", this.handler.bind(abc))`),
+			arrowInvalid(`window.removeEventListener("click", () => {})`),
+			functionInvalid(`window.removeEventListener("keydown", function () {})`, `function `),
+			// Named function expression and async arrow are still inline functions.
+			functionInvalid(`el.removeEventListener("click", function handleClick() {})`, `function handleClick`),
+			arrowInvalid(`el.removeEventListener("click", async () => {})`),
+			arrowInvalid(`el.removeEventListener("click", (e) => { e.preventDefault(); })`),
+			bindInvalid(`el.removeEventListener("mouseover", fn.bind(abc))`),
+			bindInvalid(`el?.removeEventListener("mouseover", fn.bind(abc))`),
+			functionInvalid(`el.removeEventListener("mouseout", function (e) {})`, `function `),
+			functionInvalid(`el?.removeEventListener("mouseout", function (e) {})`, `function `),
+			functionInvalid(`el.removeEventListener("mouseout", function (e) {}, true)`, `function `),
+			functionInvalid(`el.removeEventListener("click", function (e) {}, ...moreArguments)`, `function `),
+			invalid(`el.removeEventListener(() => {}, () => {}, () => {})`, `=>`, 2),
+		},
+	)
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+func bindInvalid(code string) rule_tester.InvalidTestCase {
+	return invalid(code, "bind", 1)
+}
+
+func arrowInvalid(code string) rule_tester.InvalidTestCase {
+	return invalid(code, "=>", 1)
+}
+
+func functionInvalid(code string, target string) rule_tester.InvalidTestCase {
+	return invalid(code, target, 1)
+}
+
+func invalid(code string, target string, occurrence int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, occurrence),
+		},
+	}
+}
+
+func expectedError(code string, target string, occurrence int) rule_tester.InvalidTestCaseError {
+	offset := nthIndex(code, target, occurrence)
+	if offset < 0 {
+		panic("target not found in no-invalid-remove-event-listener test: " + target + " in " + code)
+	}
+
+	line, column := lineColumnForOffset(code, offset)
+	endLine, endColumn := lineColumnForOffset(code, offset+len(target))
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func nthIndex(text string, target string, occurrence int) int {
+	from := 0
+	for i := range occurrence {
+		index := strings.Index(text[from:], target)
+		if index < 0 {
+			return -1
+		}
+		from += index
+		if i+1 < occurrence {
+			from += len(target)
+		}
+	}
+	return from
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for i := range offset {
+		if code[i] == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return line, column
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -603,6 +603,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts
@@ -1,0 +1,68 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const message = 'The listener argument should be a function reference.';
+
+const valid = (code: string) => ({ code, filename: 'file.js' });
+const invalid = (code: string) => ({
+  code,
+  filename: 'file.js',
+  errors: [{ message }],
+});
+
+ruleTester.run('no-invalid-remove-event-listener', null as never, {
+  valid: [
+    // CallExpression
+    valid('new el.removeEventListener("click", () => {})'),
+    valid('el.removeEventListener?.("click", () => {})'),
+    valid('el.notRemoveEventListener("click", () => {})'),
+    valid('el[removeEventListener]("click", () => {})'),
+    valid('el["removeEventListener"]("click", () => {})'),
+
+    // Arguments
+    valid('el.removeEventListener("click")'),
+    valid('el.removeEventListener()'),
+    valid('el.removeEventListener(() => {})'),
+    valid('el.removeEventListener(...["click", () => {}], () => {})'),
+    valid('el.removeEventListener(...args, () => {})'),
+    valid('el.removeEventListener(() => {}, "click")'),
+    valid('window.removeEventListener("click", bind())'),
+    valid('window.removeEventListener("click", handler.notBind())'),
+    valid('window.removeEventListener("click", handler[bind]())'),
+    valid('window.removeEventListener("click", handler.bind?.())'),
+    valid('window.removeEventListener("click", handler?.bind())'),
+
+    valid('window.removeEventListener(handler)'),
+    valid(`class MyComponent {
+  handler() {}
+  disconnectedCallback() {
+    this.removeEventListener('click', this.handler);
+  }
+}`),
+    valid('this.removeEventListener("click", getListener())'),
+    valid('el.removeEventListener("scroll", handler)'),
+    valid('el.removeEventListener("keydown", obj.listener)'),
+    valid('removeEventListener("keyup", () => {})'),
+    valid('removeEventListener("keydown", function () {})'),
+  ],
+  invalid: [
+    invalid('window.removeEventListener("scroll", handler.bind(abc))'),
+    invalid('window.removeEventListener("scroll", this.handler.bind(abc))'),
+    invalid('window.removeEventListener("click", () => {})'),
+    invalid('window.removeEventListener("keydown", function () {})'),
+    // Named function expression and async arrow are still inline functions.
+    invalid('el.removeEventListener("click", function handleClick() {})'),
+    invalid('el.removeEventListener("click", async () => {})'),
+    invalid('el.removeEventListener("click", (e) => { e.preventDefault(); })'),
+    invalid('el.removeEventListener("mouseover", fn.bind(abc))'),
+    invalid('el?.removeEventListener("mouseover", fn.bind(abc))'),
+    invalid('el.removeEventListener("mouseout", function (e) {})'),
+    invalid('el?.removeEventListener("mouseout", function (e) {})'),
+    invalid('el.removeEventListener("mouseout", function (e) {}, true)'),
+    invalid(
+      'el.removeEventListener("click", function (e) {}, ...moreArguments)',
+    ),
+    invalid('el.removeEventListener(() => {}, () => {}, () => {})'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -105,7 +105,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-invalid-character-comparison': 'error', // not implemented
     // 'unicorn/no-invalid-fetch-options': 'error', // not implemented
     // 'unicorn/no-invalid-file-input-accept': 'off', // not implemented
-    // 'unicorn/no-invalid-remove-event-listener': 'error', // not implemented
+    'unicorn/no-invalid-remove-event-listener': 'error',
     // 'unicorn/no-invalid-well-known-symbol-methods': 'error', // not implemented
     // 'unicorn/no-keyword-prefix': 'off', // not implemented
     // 'unicorn/no-late-current-target-access': 'error', // not implemented

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -273,6 +273,7 @@ kase
 keygen
 keyshortcuts
 keytar
+keyup
 Khmr
 Knda
 koblas
@@ -329,6 +330,7 @@ Modns
 modns
 morestack
 mousein
+mouseout
 mousemove
 msvc
 multibyte


### PR DESCRIPTION
## Summary

Port the `unicorn/no-invalid-remove-event-listener` rule from ESLint to rslint.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-invalid-remove-event-listener.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-invalid-remove-event-listener.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).