### PR TITLE
chore: release npm 0.8.1

### DIFF
--- a/npm/rslint/darwin-arm64/package.json
+++ b/npm/rslint/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-arm64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for darwin-arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/darwin-x64/package.json
+++ b/npm/rslint/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-x64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for darwin-x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-gnu/package.json
+++ b/npm/rslint/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-gnu",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-musl/package.json
+++ b/npm/rslint/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-musl",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-gnu/package.json
+++ b/npm/rslint/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-gnu",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-musl/package.json
+++ b/npm/rslint/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-musl",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-arm64-msvc/package.json
+++ b/npm/rslint/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-arm64-msvc",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for win32-arm64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-x64-msvc/package.json
+++ b/npm/rslint/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-x64-msvc",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "rslint native binaries for win32-x64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rslint-monorepo",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Rslint Monorepo",
   "homepage": "https://github.com/web-infra-dev/rslint#readme",

--- a/packages/rslint-api/package.json
+++ b/packages/rslint-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Rslint AST library",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/test-tools",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "main": "src/index.ts",
   "private": true,

--- a/packages/rslint-wasm/package.json
+++ b/packages/rslint-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/wasm",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "rslint wasm package",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "exports": {
     ".": {
       "@typescript/source": "./src/index.ts",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/rule-tester",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/utils",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "main": "index.ts",
   "private": true,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "rslint",
   "displayName": "Rslint",
   "description": "Language support for Rslint",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "icon": "images/icon.png",
   "private": true,
   "publisher": "rstack",

--- a/website/rule-releases.json
+++ b/website/rule-releases.json
@@ -672,5 +672,33 @@
       "rstest:no-interpolation-in-snapshots",
       "rstest:valid-title"
     ]
+  },
+  {
+    "version": "0.8.1",
+    "rules": [
+      "eslint-plugin-jest:valid-expect-in-promise",
+      "eslint:block-scoped-var",
+      "eslint:init-declarations",
+      "eslint:max-classes-per-file",
+      "eslint:max-statements",
+      "eslint:no-continue",
+      "eslint:no-div-regex",
+      "eslint:no-eq-null",
+      "eslint:no-negated-condition",
+      "eslint:no-plusplus",
+      "eslint:no-promise-executor-return",
+      "eslint:no-ternary",
+      "eslint:no-undefined",
+      "eslint:no-use-before-define",
+      "eslint:no-void",
+      "eslint:no-warning-comments",
+      "eslint:operator-assignment",
+      "rstest:expect-expect",
+      "rstest:no-focused-tests",
+      "rstest:no-import-node-test",
+      "rstest:no-standalone-expect",
+      "rstest:valid-expect",
+      "rstest:valid-expect-in-promise"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- npm packages: `0.8.0` → `0.8.1`
- add rule release metadata for 23 newly added rules
- keep the independently released tsgo packages unchanged

## Testing

- `pnpm run format:check`
- full test validation is left to CI for this version-only change

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).