### PR TITLE
ci: cap GOMAXPROCS on the Linux Go test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,11 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-name: ci-test-go
 
-      - name: Unit Test
-        if: matrix.runner != 'rspack-windows-2022-large'
-        run: go test -count=1 -p 16 -parallel 16 ./cmd/... ./internal/...
+      - name: Unit Test (Linux)
+        if: matrix.runner == 'rspack-ubuntu-22.04-large'
+        run: go test -count=1 ./cmd/... ./internal/...
+        env:
+          GOMAXPROCS: 16
 
       - name: Unit Test (Windows)
         if: matrix.runner == 'rspack-windows-2022-large'
@@ -93,6 +95,12 @@ jobs:
             go test -p $packageParallelism -count=1 $batch
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
+
+      # Fallback for any runner without a dedicated step above: macOS today,
+      # plus anything later added to the matrix. Uses the runner's own count.
+      - name: Unit Test
+        if: matrix.runner != 'rspack-ubuntu-22.04-large' && matrix.runner != 'rspack-windows-2022-large'
+        run: go test -count=1 ./cmd/... ./internal/...
 
   lint:
     name: Lint&Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         if: matrix.runner == 'rspack-ubuntu-22.04-large'
         run: go test -count=1 ./cmd/... ./internal/...
         env:
+          # The pod sees the shared node's 192 cores; that much concurrency only thrashes.
           GOMAXPROCS: 16
 
       - name: Unit Test (Windows)
@@ -96,8 +97,8 @@ jobs:
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
-      # Fallback for any runner without a dedicated step above: macOS today,
-      # plus anything later added to the matrix. Uses the runner's own count.
+      # Fallback for any runner without a dedicated step above.
+      # Uses the runner's own nprocs.
       - name: Unit Test
         if: matrix.runner != 'rspack-ubuntu-22.04-large' && matrix.runner != 'rspack-windows-2022-large'
         run: go test -count=1 ./cmd/... ./internal/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
     name: Test Go
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    env:
+      # The Linux runner is a pod on a shared 192-core node, and `go test -p`
+      # defaults to GOMAXPROCS: 192 packages in flight buries the box for no
+      # gain. The other two runners keep their own count.
+      GOMAXPROCS: "${{ matrix.runner == 'rspack-ubuntu-22.04-large' && '16' || '' }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,6 @@ jobs:
     name: Test Go
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
-    env:
-      # The Linux runner is a pod on a shared 192-core node, and `go test -p`
-      # defaults to GOMAXPROCS: 192 packages in flight buries the box for no
-      # gain. The other two runners keep their own count.
-      GOMAXPROCS: "${{ matrix.runner == 'rspack-ubuntu-22.04-large' && '16' || '' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +58,7 @@ jobs:
 
       - name: Unit Test
         if: matrix.runner != 'rspack-windows-2022-large'
-        run: go test -count=1 ./cmd/... ./internal/...
+        run: go test -count=1 -p 16 -parallel 16 ./cmd/... ./internal/...
 
       - name: Unit Test (Windows)
         if: matrix.runner == 'rspack-windows-2022-large'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
           }
 
       # Fallback for any runner without a dedicated step above.
-      # Uses the runner's own nprocs.
       - name: Unit Test
         if: matrix.runner != 'rspack-ubuntu-22.04-large' && matrix.runner != 'rspack-windows-2022-large'
         run: go test -count=1 ./cmd/... ./internal/...


### PR DESCRIPTION
The Linux runner is a pod on a shared 192-core node, and `go test -p` defaults to GOMAXPROCS, so the suite puts 192 packages in flight on a node whose load average is already ~175 before it starts. Nothing is gained by it, and the queue it builds is what leaves a wall-clock deadline inside a test — regexp2's match timeout is the one that reached us — expiring on a match that settles in microseconds.

Measured on this branch, same node, both runs green:

|  | 192 | 16 |
| --- | --- | --- |
| Unit Test | 5m59s | 5m52s |
| load average, peak | 1648 | 137 |
| threads on the node | 24k → 58k | 22k, flat |

No CPU quota is in play: `nr_throttled` is 0 in both runs and `/proc/stat` reports no steal. The runner is simply shared.

macOS and Windows keep their own count — Go reads an empty GOMAXPROCS as unset.