### PR TITLE
docs: fix invalid code blocks

### DIFF
--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.md
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.md
@@ -41,7 +41,9 @@ import { y } from './bar';
 When set to `true`, imports with different query strings are treated as different modules.
 
 ```json
-"import/no-duplicates": ["error", { "considerQueryString": true }]
+{
+  "import/no-duplicates": ["error", { "considerQueryString": true }]
+}
 ```
 
 ### `prefer-inline`
@@ -49,7 +51,9 @@ When set to `true`, imports with different query strings are treated as differen
 When set to `true`, supports TypeScript inline type imports, allowing `import type { X }` to be merged into `import { type X }`.
 
 ```json
-"import/no-duplicates": ["error", { "prefer-inline": true }]
+{
+  "import/no-duplicates": ["error", { "prefer-inline": true }]
+}
 ```
 
 ## Original Documentation

--- a/internal/plugins/rstest/rules/expect_expect/expect_expect.md
+++ b/internal/plugins/rstest/rules/expect_expect/expect_expect.md
@@ -27,8 +27,11 @@ it("uses assert", () => {
   assert.equal(value, 1);
 });
 
-it("in a promise callback", () =>
-  loadUser().then((user) => expect(user).toBeDefined()));
+it("in a promise callback", () => {
+  return loadUser().then((user) => {
+    expect(user).toBeDefined();
+  });
+});
 
 it("named callback", run);
 function run() {

--- a/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.md
+++ b/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.md
@@ -21,7 +21,7 @@ Array(0, 1, 2);
 
 Examples of **correct** code for this rule:
 
-```javascript
+```typescript
 [];
 [x, y];
 [0, 1, 2];

--- a/internal/rules/no_restricted_imports/no_restricted_imports.md
+++ b/internal/rules/no_restricted_imports/no_restricted_imports.md
@@ -26,23 +26,34 @@ The rule accepts either an array of strings/objects or an object with `paths` an
 ### String format
 
 ```json
-"no-restricted-imports": ["error", "fs", "path"]
+{
+  "no-restricted-imports": ["error", "fs", "path"]
+}
 ```
 
 ### Object format with paths and patterns
 
 ```json
-"no-restricted-imports": ["error", {
-  "paths": [{
-    "name": "import-foo",
-    "importNames": ["Bar"],
-    "message": "Please use Bar from /import-bar/ instead."
-  }],
-  "patterns": [{
-    "group": ["import1/private/*"],
-    "message": "usage of import1 private modules not allowed."
-  }]
-}]
+{
+  "no-restricted-imports": [
+    "error",
+    {
+      "paths": [
+        {
+          "name": "import-foo",
+          "importNames": ["Bar"],
+          "message": "Please use Bar from /import-bar/ instead."
+        }
+      ],
+      "patterns": [
+        {
+          "group": ["import1/private/*"],
+          "message": "usage of import1 private modules not allowed."
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ### Path options

--- a/packages/rslint-test-tools/rule-manifest.md
+++ b/packages/rslint-test-tools/rule-manifest.md
@@ -20,12 +20,11 @@ The `rule-manifest.json` file provides a machine-readable manifest of all implem
   "rules": [
     {
       "name": "array_type",
-      "status": "full" | "partial-impl" | "partial-test" | "none",
+      "status": "partial-impl",
       "failing_case": [
         { "name": "caseName", "url": "relative/path/to/test.ts#L123" }
       ]
-    },
-    // ...
+    }
   ]
 }
 ```


### PR DESCRIPTION
## Summary

Some rule documentation contained invalid or misleading fenced code examples that could not be parsed or copied as written.

This PR wraps partial rule configurations as valid JSON, marks a TypeScript-only example correctly, and clarifies the async assertion callback example.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).