### PR TITLE
docs: clarify Plugin API preset sources

### DIFF
--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -1,6 +1,6 @@
 import type { RslintConfigEntry } from '../define-config.js';
 
-// Aligned with official eslint-plugin-unicorn@72.x recommended.
+// Aligned with official eslint-plugin-unicorn@73.x recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
 // The official preset also injects `languageOptions.globals` (Array, Promise, Map, …);
 // rslint declares those ECMAScript built-ins as readonly globals already, so that
@@ -20,6 +20,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/catch-error-name': 'error', // not implemented
     // 'unicorn/class-reference-in-static-methods': 'error', // not implemented
     // 'unicorn/comment-content': 'off', // not implemented
+    // 'unicorn/consistent-arrow-return-style': 'off', // not implemented
     // 'unicorn/consistent-assert': 'error', // not implemented
     // 'unicorn/consistent-boolean-name': 'error', // not implemented
     // 'unicorn/consistent-class-member-order': 'error', // not implemented
@@ -49,6 +50,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/id-match': 'off', // not implemented
     // 'unicorn/import-style': 'error', // not implemented
     // 'unicorn/isolated-functions': 'error', // not implemented
+    // 'unicorn/iteration-fallback-style': 'off', // not implemented
     // 'unicorn/logical-assignment-operators': 'error', // not implemented
     // 'unicorn/max-nested-calls': 'error', // not implemented
     // 'unicorn/name-replacements': 'error', // not implemented
@@ -72,6 +74,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-async-promise-finally': 'error', // not implemented
     // 'unicorn/no-await-expression-member': 'error', // not implemented
     'unicorn/no-await-in-promise-methods': 'error',
+    // 'unicorn/no-barrel-files': 'off', // not implemented
     // 'unicorn/no-blob-to-file': 'error', // not implemented
     // 'unicorn/no-boolean-sort-comparator': 'error', // not implemented
     // 'unicorn/no-break-in-nested-loop': 'error', // not implemented
@@ -170,6 +173,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-unsafe-dom-html': 'off', // not implemented
     // 'unicorn/no-unsafe-promise-all-settled-values': 'error', // not implemented
     // 'unicorn/no-unsafe-property-key': 'error', // not implemented
+    // 'unicorn/no-unsafe-sqlite-interpolation': 'error', // not implemented
     // 'unicorn/no-unsafe-string-replacement': 'error', // not implemented
     // 'unicorn/no-unused-array-method-return': 'error', // not implemented
     // 'unicorn/no-unused-properties': 'off', // not implemented
@@ -342,6 +346,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/require-passive-events': 'error', // not implemented
     // 'unicorn/require-post-message-target-origin': 'off', // not implemented
     // 'unicorn/require-proxy-trap-boolean-return': 'error', // not implemented
+    // 'unicorn/single-line-block-comment-style': 'error', // not implemented
     // 'unicorn/string-content': 'off', // not implemented
     // 'unicorn/switch-case-braces': 'error', // not implemented
     // 'unicorn/switch-case-break-position': 'error', // not implemented

--- a/website/docs/en/api/_meta.json
+++ b/website/docs/en/api/_meta.json
@@ -13,7 +13,7 @@
   {
     "type": "dir",
     "name": "presets",
-    "label": "Presets",
+    "label": "Plugin API",
     "collapsed": false
   },
   {

--- a/website/docs/en/api/index.md
+++ b/website/docs/en/api/index.md
@@ -16,9 +16,13 @@ Use the configuration exports to compose flat configs without constructing inter
 | [`globalIgnores`](/api/configuration/global-ignores) | Creates a global ignore entry               |
 | [`globals`](/api/configuration/globals)              | Lazily loaded runtime-global catalog        |
 
-## Presets
+## Plugin API
 
-| API                                                   | Presets                                             |
+These exports provide the configuration API for Rslint's built-in rule groups and plugins. The rules are compiled into Rslint, so the upstream ESLint plugins do not need to be installed. Each page lists the upstream project its rules are based on and maps every available Rslint preset to its upstream configuration source.
+
+An upstream mapping describes the compatibility source, not a byte-for-byte copy. Rslint presets include the rules Rslint currently supports and may contain adaptations for its native runtime.
+
+| API                                                   | Description                                         |
 | ----------------------------------------------------- | --------------------------------------------------- |
 | [`js`](/api/presets/js)                               | JavaScript                                          |
 | [`ts`](/api/presets/ts)                               | TypeScript baseline, strict, and stylistic variants |

--- a/website/docs/en/api/presets/import-plugin.md
+++ b/website/docs/en/api/presets/import-plugin.md
@@ -1,6 +1,6 @@
 # importPlugin
 
-`importPlugin` contains Rslint's bundled import/export preset.
+`importPlugin` exposes Rslint's built-in implementation of supported rules from [`eslint-plugin-import` 2.x](https://github.com/import-js/eslint-plugin-import/tree/v2.32.0). Its preset follows the upstream flat recommended configuration for the rules Rslint currently supports.
 
 ```ts
 import { defineConfig, importPlugin } from '@rslint/core';
@@ -10,8 +10,8 @@ export default defineConfig([importPlugin.configs.recommended]);
 
 ## Presets
 
-| Preset                             | Description         | View rules                                                      |
-| ---------------------------------- | ------------------- | --------------------------------------------------------------- |
-| `importPlugin.configs.recommended` | Import/export rules | [View rules →](/rules/?preset=importPlugin.configs.recommended) |
+| Preset                             | Description         | View rules                                                      | Source                                                                                                                                          |
+| ---------------------------------- | ------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `importPlugin.configs.recommended` | Import/export rules | [View rules →](/rules/?preset=importPlugin.configs.recommended) | [`eslint-plugin-import` `flatConfigs.recommended`](https://github.com/import-js/eslint-plugin-import/tree/v2.32.0#config---flat-eslintconfigjs) |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/jest-plugin.md
+++ b/website/docs/en/api/presets/jest-plugin.md
@@ -1,6 +1,6 @@
 # jestPlugin
 
-`jestPlugin` contains Rslint's bundled Jest presets.
+`jestPlugin` exposes Rslint's built-in implementation of supported rules from [`eslint-plugin-jest` 29.x](https://github.com/jest-community/eslint-plugin-jest/tree/v29.16.0). Its presets follow the corresponding upstream flat configurations for the rules Rslint currently supports.
 
 ```ts
 import { defineConfig, jestPlugin } from '@rslint/core';
@@ -17,9 +17,9 @@ export default defineConfig([
 
 ## Presets
 
-| Preset                           | Description      | View rules                                                    |
-| -------------------------------- | ---------------- | ------------------------------------------------------------- |
-| `jestPlugin.configs.recommended` | Jest rules       | [View rules →](/rules/?preset=jestPlugin.configs.recommended) |
-| `jestPlugin.configs.style`       | Jest style rules | [View rules →](/rules/?preset=jestPlugin.configs.style)       |
+| Preset                           | Description      | View rules                                                    | Source                                                                                                                               |
+| -------------------------------- | ---------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `jestPlugin.configs.recommended` | Jest rules       | [View rules →](/rules/?preset=jestPlugin.configs.recommended) | [`eslint-plugin-jest` `configs["flat/recommended"]`](https://github.com/jest-community/eslint-plugin-jest/tree/v29.16.0#recommended) |
+| `jestPlugin.configs.style`       | Jest style rules | [View rules →](/rules/?preset=jestPlugin.configs.style)       | [`eslint-plugin-jest` `configs["flat/style"]`](https://github.com/jest-community/eslint-plugin-jest/tree/v29.16.0#style)             |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/js.md
+++ b/website/docs/en/api/presets/js.md
@@ -1,6 +1,6 @@
 # js
 
-`js` contains Rslint's bundled JavaScript preset.
+`js` exposes presets for Rslint's built-in implementation of supported [ESLint 10.x core rules](https://eslint.org/docs/v10.x/rules/). Its preset is based on the configuration published by `@eslint/js` 10.x.
 
 ```ts
 import { defineConfig, js } from '@rslint/core';
@@ -10,8 +10,8 @@ export default defineConfig([js.configs.recommended]);
 
 ## Presets
 
-| Preset                   | Description                  | View rules                                            |
-| ------------------------ | ---------------------------- | ----------------------------------------------------- |
-| `js.configs.recommended` | JavaScript recommended rules | [View rules →](/rules/?preset=js.configs.recommended) |
+| Preset                   | Description                  | View rules                                            | Source                                                                                                                             |
+| ------------------------ | ---------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `js.configs.recommended` | JavaScript recommended rules | [View rules →](/rules/?preset=js.configs.recommended) | [`@eslint/js` `configs.recommended`](https://eslint.org/docs/v10.x/use/configure/migration-guide#predefined-and-shareable-configs) |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/jsx-a11y-plugin.md
+++ b/website/docs/en/api/presets/jsx-a11y-plugin.md
@@ -1,6 +1,6 @@
 # jsxA11yPlugin
 
-`jsxA11yPlugin` contains Rslint's bundled JSX accessibility preset.
+`jsxA11yPlugin` exposes Rslint's built-in implementation of supported rules from [`eslint-plugin-jsx-a11y` 6.x](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/v6.10.2). Its preset follows the upstream flat recommended configuration for the rules Rslint currently supports.
 
 ```ts
 import { defineConfig, jsxA11yPlugin } from '@rslint/core';
@@ -10,8 +10,8 @@ export default defineConfig([jsxA11yPlugin.configs.recommended]);
 
 ## Presets
 
-| Preset                              | Description    | View rules                                                       |
-| ----------------------------------- | -------------- | ---------------------------------------------------------------- |
-| `jsxA11yPlugin.configs.recommended` | JSX a11y rules | [View rules →](/rules/?preset=jsxA11yPlugin.configs.recommended) |
+| Preset                              | Description    | View rules                                                       | Source                                                                                                                                    |
+| ----------------------------------- | -------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `jsxA11yPlugin.configs.recommended` | JSX a11y rules | [View rules →](/rules/?preset=jsxA11yPlugin.configs.recommended) | [`eslint-plugin-jsx-a11y` `flatConfigs.recommended`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/v6.10.2#shareable-configs) |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/promise-plugin.md
+++ b/website/docs/en/api/presets/promise-plugin.md
@@ -1,6 +1,6 @@
 # promisePlugin
 
-`promisePlugin` contains Rslint's bundled Promise preset.
+`promisePlugin` exposes Rslint's built-in implementation of supported rules from [`eslint-plugin-promise` 7.x](https://github.com/eslint-community/eslint-plugin-promise/tree/v7.3.0). Its preset follows the upstream flat recommended configuration for the rules Rslint currently supports.
 
 ```ts
 import { defineConfig, promisePlugin } from '@rslint/core';
@@ -10,8 +10,8 @@ export default defineConfig([promisePlugin.configs.recommended]);
 
 ## Presets
 
-| Preset                              | Description   | View rules                                                       |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------- |
-| `promisePlugin.configs.recommended` | Promise rules | [View rules →](/rules/?preset=promisePlugin.configs.recommended) |
+| Preset                              | Description   | View rules                                                       | Source                                                                                                                               |
+| ----------------------------------- | ------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `promisePlugin.configs.recommended` | Promise rules | [View rules →](/rules/?preset=promisePlugin.configs.recommended) | [`eslint-plugin-promise` `configs["flat/recommended"]`](https://github.com/eslint-community/eslint-plugin-promise/tree/v7.3.0#usage) |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/react-hooks-plugin.md
+++ b/website/docs/en/api/presets/react-hooks-plugin.md
@@ -1,6 +1,6 @@
 # reactHooksPlugin
 
-`reactHooksPlugin` contains Rslint's bundled React Hooks preset.
+`reactHooksPlugin` exposes Rslint's built-in implementation of supported rules from [`eslint-plugin-react-hooks` 7.x](https://react.dev/reference/eslint-plugin-react-hooks). Its preset follows the upstream flat recommended configuration for the rules Rslint currently supports.
 
 ```ts
 import { defineConfig, reactHooksPlugin } from '@rslint/core';
@@ -10,8 +10,8 @@ export default defineConfig([reactHooksPlugin.configs.recommended]);
 
 ## Presets
 
-| Preset                                 | Description       | View rules                                                          |
-| -------------------------------------- | ----------------- | ------------------------------------------------------------------- |
-| `reactHooksPlugin.configs.recommended` | React Hooks rules | [View rules →](/rules/?preset=reactHooksPlugin.configs.recommended) |
+| Preset                                 | Description       | View rules                                                          | Source                                                                                                                                                                                             |
+| -------------------------------------- | ----------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reactHooksPlugin.configs.recommended` | React Hooks rules | [View rules →](/rules/?preset=reactHooksPlugin.configs.recommended) | [`eslint-plugin-react-hooks` `configs.flat.recommended`](https://github.com/facebook/react/tree/eslint-plugin-react-hooks%407.1.1/packages/eslint-plugin-react-hooks#flat-config-eslintconfigjsts) |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/react-plugin.md
+++ b/website/docs/en/api/presets/react-plugin.md
@@ -1,6 +1,6 @@
 # reactPlugin
 
-`reactPlugin` contains Rslint's bundled React preset.
+`reactPlugin` exposes Rslint's built-in implementation of supported rules from [`eslint-plugin-react` 7.x](https://github.com/jsx-eslint/eslint-plugin-react/tree/v7.37.5). Its preset follows the upstream flat recommended configuration for the rules Rslint currently supports.
 
 ```ts
 import { defineConfig, reactPlugin } from '@rslint/core';
@@ -10,8 +10,8 @@ export default defineConfig([reactPlugin.configs.recommended]);
 
 ## Presets
 
-| Preset                            | Description | View rules                                                     |
-| --------------------------------- | ----------- | -------------------------------------------------------------- |
-| `reactPlugin.configs.recommended` | React rules | [View rules →](/rules/?preset=reactPlugin.configs.recommended) |
+| Preset                            | Description | View rules                                                     | Source                                                                                                                          |
+| --------------------------------- | ----------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `reactPlugin.configs.recommended` | React rules | [View rules →](/rules/?preset=reactPlugin.configs.recommended) | [`eslint-plugin-react` `configs.flat.recommended`](https://github.com/jsx-eslint/eslint-plugin-react/tree/v7.37.5#flat-configs) |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/rstest-plugin.md
+++ b/website/docs/en/api/presets/rstest-plugin.md
@@ -1,6 +1,6 @@
 # rstestPlugin
 
-`rstestPlugin` contains Rslint's bundled Rstest preset.
+`rstestPlugin` is Rslint's [built-in Rstest-specific plugin](/rules/?group=rstest).
 
 ```ts
 import { defineConfig, rstestPlugin } from '@rslint/core';

--- a/website/docs/en/api/presets/ts.md
+++ b/website/docs/en/api/presets/ts.md
@@ -1,6 +1,6 @@
 # ts
 
-`ts` contains Rslint's bundled TypeScript baseline, type-checked, strict, and stylistic presets.
+`ts` exposes Rslint's built-in implementation of supported [typescript-eslint 8.x](https://v8--typescript-eslint.netlify.app/rules/) rules and its baseline, type-checked, strict, and stylistic presets.
 
 ```ts
 import { defineConfig, ts } from '@rslint/core';
@@ -12,15 +12,15 @@ export default defineConfig([ts.configs.recommended]);
 
 ## Presets
 
-| Preset                              | Description                                                | View rules                                                       |
-| ----------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------- |
-| `ts.configs.base`                   | Declares the TypeScript plugin and enables project service | —                                                                |
-| `ts.configs.recommended`            | TypeScript recommended rules                               | [View rules →](/rules/?preset=ts.configs.recommended)            |
-| `ts.configs.recommendedTypeChecked` | TypeScript recommended rules, including typed ones         | [View rules →](/rules/?preset=ts.configs.recommendedTypeChecked) |
-| `ts.configs.strict`                 | TypeScript recommended rules plus opinionated extras       | [View rules →](/rules/?preset=ts.configs.strict)                 |
-| `ts.configs.strictTypeChecked`      | TypeScript strict rules, including typed ones              | [View rules →](/rules/?preset=ts.configs.strictTypeChecked)      |
-| `ts.configs.stylistic`              | TypeScript consistency rules                               | [View rules →](/rules/?preset=ts.configs.stylistic)              |
-| `ts.configs.stylisticTypeChecked`   | TypeScript consistency rules, including typed ones         | [View rules →](/rules/?preset=ts.configs.stylisticTypeChecked)   |
+| Preset                              | Description                                                | View rules                                                       | Source                                                                                                                                    |
+| ----------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `ts.configs.base`                   | Declares the TypeScript plugin and enables project service | —                                                                | [`typescript-eslint` `configs.base`](https://v8--typescript-eslint.netlify.app/users/configs/#base)                                       |
+| `ts.configs.recommended`            | TypeScript recommended rules                               | [View rules →](/rules/?preset=ts.configs.recommended)            | [`typescript-eslint` `configs.recommended`](https://v8--typescript-eslint.netlify.app/users/configs/#recommended)                         |
+| `ts.configs.recommendedTypeChecked` | TypeScript recommended rules, including typed ones         | [View rules →](/rules/?preset=ts.configs.recommendedTypeChecked) | [`typescript-eslint` `configs.recommendedTypeChecked`](https://v8--typescript-eslint.netlify.app/users/configs/#recommended-type-checked) |
+| `ts.configs.strict`                 | TypeScript recommended rules plus opinionated extras       | [View rules →](/rules/?preset=ts.configs.strict)                 | [`typescript-eslint` `configs.strict`](https://v8--typescript-eslint.netlify.app/users/configs/#strict)                                   |
+| `ts.configs.strictTypeChecked`      | TypeScript strict rules, including typed ones              | [View rules →](/rules/?preset=ts.configs.strictTypeChecked)      | [`typescript-eslint` `configs.strictTypeChecked`](https://v8--typescript-eslint.netlify.app/users/configs/#strict-type-checked)           |
+| `ts.configs.stylistic`              | TypeScript consistency rules                               | [View rules →](/rules/?preset=ts.configs.stylistic)              | [`typescript-eslint` `configs.stylistic`](https://v8--typescript-eslint.netlify.app/users/configs/#stylistic)                             |
+| `ts.configs.stylisticTypeChecked`   | TypeScript consistency rules, including typed ones         | [View rules →](/rules/?preset=ts.configs.stylisticTypeChecked)   | [`typescript-eslint` `configs.stylisticTypeChecked`](https://v8--typescript-eslint.netlify.app/users/configs/#stylistic-type-checked)     |
 
 `ts.configs.base` has no filtered rules view. Add one baseline and optionally one stylistic layer; you normally do not need to add `ts.configs.base` separately.
 

--- a/website/docs/en/api/presets/unicorn-plugin.md
+++ b/website/docs/en/api/presets/unicorn-plugin.md
@@ -1,6 +1,6 @@
 # unicornPlugin
 
-`unicornPlugin` contains Rslint's bundled Unicorn preset.
+`unicornPlugin` exposes Rslint's built-in implementation of supported rules from [`eslint-plugin-unicorn` 73.x](https://github.com/sindresorhus/eslint-plugin-unicorn/tree/v73.0.0). Its preset follows the upstream recommended configuration for the rules Rslint currently supports.
 
 ```ts
 import { defineConfig, unicornPlugin } from '@rslint/core';
@@ -10,8 +10,8 @@ export default defineConfig([unicornPlugin.configs.recommended]);
 
 ## Presets
 
-| Preset                              | Description   | View rules                                                       |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------- |
-| `unicornPlugin.configs.recommended` | Unicorn rules | [View rules →](/rules/?preset=unicornPlugin.configs.recommended) |
+| Preset                              | Description   | View rules                                                       | Source                                                                                                                                 |
+| ----------------------------------- | ------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `unicornPlugin.configs.recommended` | Unicorn rules | [View rules →](/rules/?preset=unicornPlugin.configs.recommended) | [`eslint-plugin-unicorn` `configs.recommended`](https://github.com/sindresorhus/eslint-plugin-unicorn/tree/v73.0.0#recommended-config) |
 
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.


### PR DESCRIPTION
## Summary

- Rename the API presets group to Plugin API.
- Document the upstream rule and preset sources with versioned official documentation or tagged GitHub fallbacks.
- Align the Unicorn preset metadata and documentation with eslint-plugin-unicorn v73.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).