### PR TITLE
feat: port rule prefer-object-has-own

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -157,6 +157,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_destructuring"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_exponentiation_operator"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_numeric_literals"
+	"github.com/web-infra-dev/rslint/internal/rules/prefer_object_has_own"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_object_spread"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_regex_literals"
@@ -293,6 +294,7 @@ func GetAllRules() []rule.Rule {
 		prefer_destructuring.PreferDestructuringRule,
 		prefer_exponentiation_operator.PreferExponentiationOperatorRule,
 		prefer_numeric_literals.PreferNumericLiteralsRule,
+		prefer_object_has_own.PreferObjectHasOwnRule,
 		prefer_object_spread.PreferObjectSpreadRule,
 		prefer_promise_reject_errors.PreferPromiseRejectErrorsRule,
 		preserve_caught_error.PreserveCaughtErrorRule,

--- a/internal/rules/prefer_object_has_own/prefer_object_has_own.go
+++ b/internal/rules/prefer_object_has_own/prefer_object_has_own.go
@@ -49,16 +49,33 @@ func isMemberAccess(node *ast.Node) bool {
 		(node.Kind == ast.KindPropertyAccessExpression || node.Kind == ast.KindElementAccessExpression)
 }
 
-// memberObject returns the receiver of a member access with parentheses
-// removed. Only parentheses: a TypeScript wrapper such as `(Object as any)` or
+// unwrapParens removes the parentheses around an expression, and returns nil
+// when those parentheses end an optional chain.
+//
+// Only parentheses come off: a TypeScript wrapper such as `(Object as any)` or
 // `Object!` is an expression of its own, and the receiver it wraps no longer
 // counts as `Object` itself.
-func memberObject(node *ast.Node) *ast.Node {
-	object := utils.AccessExpressionObject(node)
-	if object == nil {
+//
+// Parentheses end an optional chain, and ESTree marks that with a
+// `ChainExpression` node wrapping the chain — a node kind this rule matches
+// nowhere, so `(a?.b).c` reads as a different shape from `a?.b.c` and goes
+// unreported. tsgo has no such node: it flags the chain on each access, which
+// is why the flag is read only where a parenthesis actually came off.
+func unwrapParens(node *ast.Node) *ast.Node {
+	if node == nil {
 		return nil
 	}
-	return ast.SkipParentheses(object)
+	inner := ast.SkipParentheses(node)
+	if inner != node && ast.IsOptionalChain(inner) {
+		return nil
+	}
+	return inner
+}
+
+// memberObject returns the receiver of a member access, read through
+// parentheses by [unwrapParens].
+func memberObject(node *ast.Node) *ast.Node {
+	return unwrapParens(utils.AccessExpressionObject(node))
 }
 
 // hasLeftHandObject reports whether the receiver of `.hasOwnProperty` is an
@@ -97,7 +114,7 @@ var PreferObjectHasOwnRule = rule.Rule{
 			ast.KindCallExpression: func(node *ast.Node) {
 				// ESTree drops parentheses, so a callee wrapped in them is the
 				// member access itself; tsgo keeps them as nodes of their own.
-				callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+				callee := unwrapParens(node.AsCallExpression().Expression)
 				if !isMemberAccess(callee) {
 					return
 				}
@@ -119,8 +136,12 @@ var PreferObjectHasOwnRule = rule.Rule{
 				// `Object` has to be the global one for `Object.hasOwn` to be
 				// the same call: a local binding of that name, or a config
 				// `/* global Object: off */` entry that un-declares it, means
-				// the name resolves elsewhere and the rule stays silent.
-				if utils.IsShadowed(node, "Object") || !ctx.Globals.Access("Object").IsDeclared() {
+				// the name resolves elsewhere and the rule stays silent. A call
+				// in a parameter default sees the body's bindings as well, one
+				// scope wider than the runtime lookup.
+				if utils.IsShadowed(node, "Object") ||
+					utils.IsShadowedFromParameterInitializer(node, "Object") ||
+					!ctx.Globals.Access("Object").IsDeclared() {
 					return
 				}
 
@@ -131,10 +152,18 @@ var PreferObjectHasOwnRule = rule.Rule{
 					if utils.HasCommentInSpan(ctx.Comments.All(), calleeRange.Pos(), calleeRange.End()) {
 						return nil
 					}
-					return []rule.RuleFix{rule.RuleFixReplaceRange(
-						calleeRange,
-						utils.SafeReplacementText(ctx.SourceFile, callee, hasOwnReplacement),
-					)}
+					// The replacement opens with an identifier, so it needs a
+					// space when the character in front of it closes one —
+					// otherwise `return{}.hasOwnProperty.call(a, b)` fuses into
+					// `returnObject.hasOwn(a, b)`. Nothing that can sit against
+					// the callee ends in an identifier character except an
+					// identifier or a keyword, so that character decides it on
+					// its own.
+					replacement := hasOwnReplacement
+					if utils.NeedsLeadingSpaceForReplacement(ctx.SourceFile.Text(), calleeRange.Pos(), replacement) {
+						replacement = " " + replacement
+					}
+					return []rule.RuleFix{rule.RuleFixReplaceRange(calleeRange, replacement)}
 				})
 			},
 		}

--- a/internal/rules/prefer_object_has_own/prefer_object_has_own.go
+++ b/internal/rules/prefer_object_has_own/prefer_object_has_own.go
@@ -1,0 +1,142 @@
+package prefer_object_has_own
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildUseHasOwnMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useHasOwn",
+		Description: "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+	}
+}
+
+// hasOwnReplacement is the text the autofix puts in place of the callee.
+const hasOwnReplacement = "Object.hasOwn"
+
+// staticMemberName returns the property a member access names, when that name
+// is known statically. A private name (`obj.#call`) never names a static
+// property, so it matches nothing this rule looks for.
+//
+// A computed key is read through parentheses only. `utils.AccessExpressionStaticName`
+// also reads through a TypeScript assertion, but `Object[("prototype" as any)]`
+// is an assertion expression rather than a string, so upstream reads no static
+// name from it at all.
+func staticMemberName(node *ast.Node) (string, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		name := node.AsPropertyAccessExpression().Name()
+		if name == nil || name.Kind == ast.KindPrivateIdentifier {
+			return "", false
+		}
+		return name.Text(), true
+	case ast.KindElementAccessExpression:
+		key := node.AsElementAccessExpression().ArgumentExpression
+		if key == nil {
+			return "", false
+		}
+		return utils.GetStaticExpressionValue(ast.SkipParentheses(key))
+	}
+	return "", false
+}
+
+// isMemberAccess reports whether node is one of the two forms ESTree calls a
+// `MemberExpression`.
+func isMemberAccess(node *ast.Node) bool {
+	return node != nil &&
+		(node.Kind == ast.KindPropertyAccessExpression || node.Kind == ast.KindElementAccessExpression)
+}
+
+// memberObject returns the receiver of a member access with parentheses
+// removed. Only parentheses: a TypeScript wrapper such as `(Object as any)` or
+// `Object!` is an expression of its own, and the receiver it wraps no longer
+// counts as `Object` itself.
+func memberObject(node *ast.Node) *ast.Node {
+	object := utils.AccessExpressionObject(node)
+	if object == nil {
+		return nil
+	}
+	return ast.SkipParentheses(object)
+}
+
+// hasLeftHandObject reports whether the receiver of `.hasOwnProperty` is an
+// access to a property of `Object.prototype` — that is, `Object`,
+// `Object.prototype`, or an empty object literal. An object literal with
+// properties in it is a different object, so `({ foo }).hasOwnProperty` is not
+// one of these.
+func hasLeftHandObject(node *ast.Node) bool {
+	object := memberObject(node)
+	if object == nil {
+		return false
+	}
+
+	if object.Kind == ast.KindObjectLiteralExpression {
+		literal := object.AsObjectLiteralExpression()
+		return literal.Properties == nil || len(literal.Properties.Nodes) == 0
+	}
+
+	objectToCheck := object
+	if isMemberAccess(object) {
+		if name, ok := staticMemberName(object); ok && name == "prototype" {
+			objectToCheck = memberObject(object)
+		}
+	}
+
+	return objectToCheck != nil && objectToCheck.Kind == ast.KindIdentifier &&
+		objectToCheck.AsIdentifier().Text == "Object"
+}
+
+// https://eslint.org/docs/latest/rules/prefer-object-has-own
+var PreferObjectHasOwnRule = rule.Rule{
+	Name:   "prefer-object-has-own",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				// ESTree drops parentheses, so a callee wrapped in them is the
+				// member access itself; tsgo keeps them as nodes of their own.
+				callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+				if !isMemberAccess(callee) {
+					return
+				}
+				calleeObject := memberObject(callee)
+				if !isMemberAccess(calleeObject) {
+					return
+				}
+
+				if name, ok := staticMemberName(callee); !ok || name != "call" {
+					return
+				}
+				if name, ok := staticMemberName(calleeObject); !ok || name != "hasOwnProperty" {
+					return
+				}
+				if !hasLeftHandObject(calleeObject) {
+					return
+				}
+
+				// `Object` has to be the global one for `Object.hasOwn` to be
+				// the same call: a local binding of that name, or a config
+				// `/* global Object: off */` entry that un-declares it, means
+				// the name resolves elsewhere and the rule stays silent.
+				if utils.IsShadowed(node, "Object") || !ctx.Globals.Access("Object").IsDeclared() {
+					return
+				}
+
+				ctx.ReportNodeWithDeferredFixes(node, buildUseHasOwnMessage(), func() []rule.RuleFix {
+					calleeRange := utils.TrimNodeTextRange(ctx.SourceFile, callee)
+					// A comment anywhere inside the callee would be dropped by
+					// the replacement, so the diagnostic carries no fix.
+					if utils.HasCommentInSpan(ctx.Comments.All(), calleeRange.Pos(), calleeRange.End()) {
+						return nil
+					}
+					return []rule.RuleFix{rule.RuleFixReplaceRange(
+						calleeRange,
+						utils.SafeReplacementText(ctx.SourceFile, callee, hasOwnReplacement),
+					)}
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/prefer_object_has_own/prefer_object_has_own.md
+++ b/internal/rules/prefer_object_has_own/prefer_object_has_own.md
@@ -1,0 +1,52 @@
+# prefer-object-has-own
+
+## Rule Details
+
+`Object.prototype.hasOwnProperty.call(object, property)` is the long-standing way to ask whether an object has a property of its own without going through the object's own `hasOwnProperty`, which may be missing or redefined. `Object.hasOwn()`, introduced in ES2022, asks the same question directly.
+
+This rule reports a call to `hasOwnProperty` reached through the global `Object`, `Object.prototype`, or an empty object literal, and offers `Object.hasOwn()` in its place.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Object.prototype.hasOwnProperty.call(object, 'foo');
+
+Object.hasOwnProperty.call(object, 'foo');
+
+({}).hasOwnProperty.call(object, 'foo');
+
+const hasProperty = Object.prototype.hasOwnProperty.call(object, property);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Object.hasOwn(object, 'foo');
+
+const hasProperty = Object.hasOwn(object, property);
+
+object.hasOwnProperty('foo');
+
+foo.hasOwnProperty.call(object, 'foo');
+
+function check(Object) {
+  return Object.prototype.hasOwnProperty.call(object, 'foo');
+}
+```
+
+## Options
+
+This rule has no options.
+
+## When Not To Use It
+
+Use this rule only where ES2022 is available: `Object.hasOwn()` does not exist in older runtimes.
+
+## Differences from ESLint
+
+- A TypeScript declaration that binds the name `Object` as a type only — a `type` alias, an `interface`, or a type parameter — leaves the call reported; ESLint stays silent on the whole file. A value declaration (`const Object`, `class Object`, `import Object from …`, `declare const Object`) silences the report in both.
+
+## Original Documentation
+
+- [ESLint: prefer-object-has-own](https://eslint.org/docs/latest/rules/prefer-object-has-own)
+- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/prefer-object-has-own.js)

--- a/internal/rules/prefer_object_has_own/prefer_object_has_own_extras_test.go
+++ b/internal/rules/prefer_object_has_own/prefer_object_has_own_extras_test.go
@@ -1,0 +1,456 @@
+// Dimension walk notes for prefer-object-has-own:
+//   - Dimension 4 (declaration / container forms): N/A — the rule targets a
+//     call expression, never a function or class declaration, so the form the
+//     surrounding declaration takes cannot affect detection.
+//   - Dimension 4 (graceful degradation: overload signatures / abstract /
+//     declare members): N/A — a body-absent member holds no call expression
+//     for the rule to see.
+package prefer_object_has_own
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreferObjectHasOwnExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the specific
+// branch / Dimension 4 row / tsgo AST quirk it covers, so future refactors can't silently
+// regress them without breaking a named lock-in.
+func TestPreferObjectHasOwnExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferObjectHasOwnRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TypeScript expression wrappers around the receiver ----
+			// A wrapper is an expression of its own, so the receiver it wraps is no
+			// longer `Object` / `Object.prototype` / an object literal.
+			{Code: `Object!.prototype.hasOwnProperty.call(a, b);`},
+			{Code: `(Object as any).prototype.hasOwnProperty.call(a, b);`},
+			{Code: `(Object satisfies unknown).prototype.hasOwnProperty.call(a, b);`},
+			{Code: `({} as Record<string, unknown>).hasOwnProperty.call(a, b);`},
+			{Code: `Object.prototype!.hasOwnProperty.call(a, b);`},
+			{Code: `Object.prototype.hasOwnProperty!.call(a, b);`},
+			{Code: `(Object.prototype.hasOwnProperty as any).call(a, b);`},
+
+			// ---- Dimension 4: computed keys that name nothing statically ----
+			{Code: "Object[`${'prototype'}`].hasOwnProperty.call(a, b);"},
+			{Code: `Object[('prototype' as any)].hasOwnProperty.call(a, b);`},
+			{Code: `Object.prototype[('hasOwnProperty' as const)].call(a, b);`},
+			{Code: `Object.prototype.hasOwnProperty[('call' as any)](a, b);`},
+
+			// ---- Dimension 4: numeric keys are a separate equivalence class ----
+			{Code: `Object[0].hasOwnProperty.call(a, b);`},
+			{Code: `Object.prototype[0].call(a, b);`},
+			{Code: `Object.prototype.hasOwnProperty[0](a, b);`},
+
+			// ---- Dimension 4: object literals that are not empty ----
+			{Code: `({ ...spread }).hasOwnProperty.call(a, b);`},
+			{Code: `({ foo: 1 }).hasOwnProperty.call(a, b);`},
+			{Code: `({ [key]: 1 }).hasOwnProperty.call(a, b);`},
+			{Code: `({ method() {} }).hasOwnProperty.call(a, b);`},
+
+			// ---- Dimension 4: the callee must be a call, not a construction or a tag ----
+			{Code: `new ({}.hasOwnProperty.call)(a, b);`},
+			{Code: `new Object.prototype.hasOwnProperty.call(a, b);`},
+
+			// ---- Dimension 4: nesting boundary — an inner scope shadows only itself ----
+			{Code: `function f() { function g() { return {}.hasOwnProperty.call(a, b); } const Object = 1; return [g, Object]; }`},
+			{Code: `{ const Object = 1; ({}).hasOwnProperty.call(a, b); }`},
+			{Code: `for (const Object of list) { ({}).hasOwnProperty.call(a, b); }`},
+			{Code: `try { foo(); } catch (Object) { ({}).hasOwnProperty.call(a, b); }`},
+			{Code: `class C { m(Object: unknown) { return {}.hasOwnProperty.call(a, b); } }`},
+
+			// ---- Dimension 4: value declarations of `Object` in every form ----
+			{Code: `const Object = globalThis.Object;
+({}).hasOwnProperty.call(a, b);`},
+			{Code: `class Object {}
+({}).hasOwnProperty.call(a, b);`},
+			{Code: `declare const Object: any;
+({}).hasOwnProperty.call(a, b);`},
+			{Code: `import Object from "mod";
+({}).hasOwnProperty.call(a, b);`},
+			{Code: `enum Object { A }
+({}).hasOwnProperty.call(a, b);`},
+			{Code: `function Object() {}
+({}).hasOwnProperty.call(a, b);`},
+
+			// ---- Dimension 4: `Object` un-declared through config globals ----
+			{
+				Code:    `({}).hasOwnProperty.call(a, b);`,
+				Globals: map[string]any{"Object": "off"},
+			},
+
+			// Locks in upstream CallExpression() arm 1: the callee is not a member access.
+			{Code: `call(a, b);`},
+			{Code: `(function () {})(a, b);`},
+
+			// Locks in upstream CallExpression() arm 2: the callee's own receiver is not a
+			// member access, so there is no `Object` / `Object.prototype` in front of it.
+			{Code: `Object.call(a, b);`},
+			{Code: `hasOwnProperty.call(a, b);`},
+
+			// Locks in upstream hasLeftHandObject() arm 2 false-branch: a receiver that is
+			// a member access but does not name `prototype` stays as it is, and a member
+			// access is never the `Object` identifier.
+			{Code: `Object.foo.hasOwnProperty.call(a, b);`},
+			{Code: `Object['proto'].hasOwnProperty.call(a, b);`},
+
+			// Locks in upstream hasLeftHandObject() arm 3: an identifier receiver that is
+			// not named `Object`.
+			{Code: `Reflect.prototype.hasOwnProperty.call(a, b);`},
+			{Code: `Object2.hasOwnProperty.call(a, b);`},
+
+			// ---- Real-user: rule-change request to also report `obj.hasOwnProperty(key)`,
+			// declined — only the `Object.prototype.hasOwnProperty.call()` shape is reported ----
+			{Code: `obj.hasOwnProperty('a');`},
+			{Code: `Object.prototype.hasOwnProperty(obj, 'a');`},
+
+			// ---- Real-user: rule-change requests to also report `Object.keys().includes()`
+			// and the `in` operator, both declined ----
+			{Code: `Object.keys(obj).includes(key);`},
+			{Code: `'a' in obj;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: optional chain — tsgo flags the access instead of wrapping
+			// it, and every link of the chain still names the same call ----
+			{
+				Code:   `Object?.hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:   `Object?.prototype.hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 44},
+				},
+			},
+			{
+				Code:   `Object.prototype?.hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 44},
+				},
+			},
+			{
+				Code:   `Object.prototype.hasOwnProperty?.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 44},
+				},
+			},
+			{
+				Code:   `Object.prototype.hasOwnProperty.call?.(a, b);`,
+				Output: []string{`Object.hasOwn?.(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 45},
+				},
+			},
+			{
+				Code:   `({})?.hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 32},
+				},
+			},
+
+			// ---- Dimension 4: multi-level parenthesized receiver ----
+			{
+				Code:   `(((Object))).prototype.hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 49},
+				},
+			},
+			{
+				Code:   `((({}))).hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 35},
+				},
+			},
+			// A parenthesized computed key still names the property it spells.
+			{
+				Code:   `Object[('prototype')].hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 48},
+				},
+			},
+
+			// ---- Dimension 4: dotted and computed keys mix freely ----
+			{
+				Code:   `Object.prototype['hasOwnProperty'].call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 46},
+				},
+			},
+			{
+				Code:   `Object['prototype'].hasOwnProperty['call'](a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 49},
+				},
+			},
+
+			// ---- Dimension 4: TypeScript call syntax around a reported call ----
+			{
+				Code:   `Object.prototype.hasOwnProperty.call<any>(a, b);`,
+				Output: []string{`Object.hasOwn<any>(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 48},
+				},
+			},
+
+			// ---- Dimension 4: graceful degradation on the argument list ----
+			{
+				Code:   `Object.prototype.hasOwnProperty.call();`,
+				Output: []string{`Object.hasOwn();`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 39},
+				},
+			},
+			{
+				Code:   `Object.prototype.hasOwnProperty.call(...args);`,
+				Output: []string{`Object.hasOwn(...args);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 46},
+				},
+			},
+
+			// ---- Dimension 4: nesting boundary — an outer and an inner call both report ----
+			{
+				Code:   `({}).hasOwnProperty.call({}.hasOwnProperty.call(a, b), c);`,
+				Output: []string{`Object.hasOwn(Object.hasOwn(a, b), c);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 58},
+					{MessageId: "useHasOwn", Line: 1, Column: 26, EndLine: 1, EndColumn: 54},
+				},
+			},
+
+			// ---- Dimension 4: a block-scoped `Object` does not reach the outer call ----
+			{
+				Code:   `{ let Object; } ({}).hasOwnProperty.call(a, b);`,
+				Output: []string{`{ let Object; } Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 17, EndLine: 1, EndColumn: 47},
+				},
+			},
+
+			// Locks in the message text for the rule's only messageId.
+			{
+				Code:   `Object.prototype.hasOwnProperty.call(a, b);`,
+				Output: []string{`Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Message:   "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 43,
+					},
+				},
+			},
+
+			// Locks in the report range on a call spread over several lines.
+			{
+				Code: `const has = Object.prototype.hasOwnProperty.call(
+	object,
+	property,
+);`,
+				Output: []string{`const has = Object.hasOwn(
+	object,
+	property,
+);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 13, EndLine: 4, EndColumn: 2},
+				},
+			},
+
+			// Locks in upstream fix() arm 1: a comment inside the callee suppresses the fix
+			// but not the diagnostic. A line comment ends the line the callee continues on.
+			{
+				Code: `Object.prototype.hasOwnProperty // why
+	.call(a, b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 2, EndColumn: 13},
+				},
+			},
+			{
+				Code: `({} /* empty */).hasOwnProperty.call(a, b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 43},
+				},
+			},
+			// A comment outside the callee leaves the fix alone.
+			{
+				Code:   `Object.prototype.hasOwnProperty.call(/* key */ a, b);`,
+				Output: []string{`Object.hasOwn(/* key */ a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 1, EndLine: 1, EndColumn: 53},
+				},
+			},
+
+			// Locks in upstream fix() arm 2: the replacement starts an identifier, so it
+			// takes a space when the token in front of it ends one.
+			{
+				Code:   `const has = typeof{}.hasOwnProperty.call(a, b);`,
+				Output: []string{`const has = typeof Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 19, EndLine: 1, EndColumn: 47},
+				},
+			},
+			{
+				Code:   `const has = void{}.hasOwnProperty.call(a, b);`,
+				Output: []string{`const has = void Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 17, EndLine: 1, EndColumn: 45},
+				},
+			},
+			// Locks in upstream fix() arm 3: a punctuator in front of the callee needs no
+			// space, and neither does a block comment.
+			{
+				Code:   `const has = 1+{}.hasOwnProperty.call(a, b);`,
+				Output: []string{`const has = 1+Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 15, EndLine: 1, EndColumn: 43},
+				},
+			},
+
+			// ---- Real-user: the shape the rule was reported not to fix cleanly —
+			// a returned call with no space in front of it ----
+			{
+				Code:   `const f = () => {return{}.hasOwnProperty.call(object, property)};`,
+				Output: []string{`const f = () => {return Object.hasOwn(object, property)};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 24, EndLine: 1, EndColumn: 64},
+				},
+			},
+
+			// ---- Dimension 4: TypeScript type-only declarations do not shadow a value ----
+			// ESLint's scope manager gives `type Object` a variable of its own and stays
+			// silent here; rslint reads only value declarations, so the call still reports.
+			{
+				Code: `type Object = string;
+({}).hasOwnProperty.call(a, b);`,
+				Output: []string{`type Object = string;
+Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 2, Column: 1, EndLine: 2, EndColumn: 31},
+				},
+			},
+			{
+				Code:   `function f<Object>() { return {}.hasOwnProperty.call(a, b); }`,
+				Output: []string{`function f<Object>() { return Object.hasOwn(a, b); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 31, EndLine: 1, EndColumn: 59},
+				},
+			},
+		},
+	)
+}
+
+// TestPreferObjectHasOwnEditDemand exercises Dimension 3 (autofix boundaries):
+// diagnostic count, message, and range must stay identical across every edit
+// demand, and the fix must materialize only when autofix is requested.
+func TestPreferObjectHasOwnEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"const has = Object.prototype.hasOwnProperty.call(object, property);\nconst had = ({}).hasOwnProperty.call(object, property);",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      lintprogram.NewFromCompiler(program),
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     PreferObjectHasOwnRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferObjectHasOwnRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got, want := withoutEdits(diagnostics[index]), withoutEdits(allEdits[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if fixes := *allEdits[index].FixesPtr; len(fixes) != 1 || fixes[0].Text != hasOwnReplacement {
+			t.Fatalf("diagnostic %d: unexpected autofix %#v", index, fixes)
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{
+		diagnosticsOnly,
+		autofixOnly,
+		suggestionOnly,
+		allEdits,
+	} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+	}
+}

--- a/internal/rules/prefer_object_has_own/prefer_object_has_own_extras_test.go
+++ b/internal/rules/prefer_object_has_own/prefer_object_has_own_extras_test.go
@@ -41,6 +41,24 @@ func TestPreferObjectHasOwnExtras(t *testing.T) {
 			{Code: `Object.prototype.hasOwnProperty!.call(a, b);`},
 			{Code: `(Object.prototype.hasOwnProperty as any).call(a, b);`},
 
+			// ---- Dimension 4: parentheses that end an optional chain ----
+			// ESTree records the end of a chain as a node of its own, and the rule
+			// matches neither a chain-terminated callee nor a chain-terminated
+			// receiver — unlike the same code without the parentheses.
+			{Code: `(Object.prototype.hasOwnProperty?.call)(a, b);`},
+			{Code: `(Object.prototype.hasOwnProperty?.['call'])(a, b);`},
+			{Code: `(Object.prototype?.hasOwnProperty).call(a, b);`},
+			{Code: `(Object.prototype?.['hasOwnProperty']).call(a, b);`},
+			{Code: `((Object.prototype?.hasOwnProperty)).call(a, b);`},
+			{Code: `(Object.prototype?.hasOwnProperty).call?.(a, b);`},
+			{Code: `(Object?.prototype.hasOwnProperty).call(a, b);`},
+			{Code: `(Object?.prototype).hasOwnProperty.call(a, b);`},
+			{Code: `(Object?.hasOwnProperty).call(a, b);`},
+			{Code: `(Object?.foo).prototype.hasOwnProperty.call(a, b);`},
+			{Code: `({}?.hasOwnProperty).call(a, b);`},
+			{Code: `(({}?.hasOwnProperty)).call(a, b);`},
+			{Code: `({}?.hasOwnProperty).call?.(a, b);`},
+
 			// ---- Dimension 4: computed keys that name nothing statically ----
 			{Code: "Object[`${'prototype'}`].hasOwnProperty.call(a, b);"},
 			{Code: `Object[('prototype' as any)].hasOwnProperty.call(a, b);`},
@@ -82,6 +100,23 @@ func TestPreferObjectHasOwnExtras(t *testing.T) {
 ({}).hasOwnProperty.call(a, b);`},
 			{Code: `function Object() {}
 ({}).hasOwnProperty.call(a, b);`},
+
+			// ---- Dimension 4: `var` hoisted inside a class static block ----
+			// The static block holds the `var`, so it shadows `Object` for the
+			// whole block however deeply the declaration is nested in it.
+			{Code: `class C { static { { var Object; } ({}).hasOwnProperty.call(a, b); } }`},
+			{Code: `class C { static { if (x) { var Object; } ({}).hasOwnProperty.call(a, b); } }`},
+			{Code: `class C { static { for (var Object of x) {} ({}).hasOwnProperty.call(a, b); } }`},
+			{Code: `class C { static { const g = () => ({}).hasOwnProperty.call(a, b); { var Object; } } }`},
+
+			// ---- Dimension 4: a parameter default sees the body's bindings ----
+			{Code: `function f(a = Object.prototype.hasOwnProperty.call(x, y)) { var Object; }`},
+			{Code: `function f(a = Object.prototype.hasOwnProperty.call(x, y)) { let Object; }`},
+			{Code: `function f(a = Object.prototype.hasOwnProperty.call(x, y)) { class Object {} }`},
+			{Code: `class D { m(a = Object.prototype.hasOwnProperty.call(x, y)) { var Object; } }`},
+			{Code: `function f({ k = ({}).hasOwnProperty.call(x, y) }) { var Object; }`},
+			{Code: `function f(a = (() => ({}).hasOwnProperty.call(x, y))()) { var Object; }`},
+			{Code: `function f(a = ({}).hasOwnProperty.call(x, y)) { { var Object; } }`},
 
 			// ---- Dimension 4: `Object` un-declared through config globals ----
 			{
@@ -330,6 +365,22 @@ func TestPreferObjectHasOwnExtras(t *testing.T) {
 				},
 			},
 
+			// A regular expression earlier in the file must not disturb the
+			// space the replacement needs in front of it.
+			{
+				Code:   `function f(s) { if (/^https?:\/\//.test(s)) return{}.hasOwnProperty.call(a, b); }`,
+				Output: []string{`function f(s) { if (/^https?:\/\//.test(s)) return Object.hasOwn(a, b); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 51, EndLine: 1, EndColumn: 79},
+				},
+			},
+			{
+				Code:   `const t = /don't/.test(s) ? typeof{}.hasOwnProperty.call(a, b) : 0;`,
+				Output: []string{`const t = /don't/.test(s) ? typeof Object.hasOwn(a, b) : 0;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 35, EndLine: 1, EndColumn: 63},
+				},
+			},
 			// ---- Real-user: the shape the rule was reported not to fix cleanly —
 			// a returned call with no space in front of it ----
 			{
@@ -357,6 +408,22 @@ Object.hasOwn(a, b);`},
 				Output: []string{`function f<Object>() { return Object.hasOwn(a, b); }`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useHasOwn", Line: 1, Column: 31, EndLine: 1, EndColumn: 59},
+				},
+			},
+			{
+				Code: `interface Object { z(): void }
+({}).hasOwnProperty.call(a, b);`,
+				Output: []string{`interface Object { z(): void }
+Object.hasOwn(a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 2, Column: 1, EndLine: 2, EndColumn: 31},
+				},
+			},
+			{
+				Code:   `class C<Object> { m() { return {}.hasOwnProperty.call(a, b); } }`,
+				Output: []string{`class C<Object> { m() { return Object.hasOwn(a, b); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHasOwn", Line: 1, Column: 32, EndLine: 1, EndColumn: 60},
 				},
 			},
 		},

--- a/internal/rules/prefer_object_has_own/prefer_object_has_own_upstream_test.go
+++ b/internal/rules/prefer_object_has_own/prefer_object_has_own_upstream_test.go
@@ -1,0 +1,523 @@
+package prefer_object_has_own
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreferObjectHasOwnUpstream migrates the full valid/invalid suite from upstream
+// tests/lib/rules/prefer-object-has-own.js 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases live in the
+// prefer_object_has_own_extras_test.go file.
+func TestPreferObjectHasOwnUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferObjectHasOwnRule,
+		[]rule_tester.ValidTestCase{
+			// ---- `Object` receiver ----
+			{Code: `Object`},
+			{Code: `Object(obj, prop)`},
+			{Code: `Object.hasOwnProperty`},
+			{Code: `Object.hasOwnProperty(prop)`},
+			{Code: `hasOwnProperty(obj, prop)`},
+			{Code: `foo.hasOwnProperty(prop)`},
+			{Code: `foo.hasOwnProperty(obj, prop)`},
+			{Code: `Object.hasOwnProperty.call`},
+			{Code: `foo.Object.hasOwnProperty.call(obj, prop)`},
+			{Code: `foo.hasOwnProperty.call(obj, prop)`},
+			{Code: `foo.call(Object.prototype.hasOwnProperty, Object.prototype.hasOwnProperty.call)`},
+			{Code: `Object.foo.call(obj, prop)`},
+			{Code: `Object.hasOwnProperty.foo(obj, prop)`},
+			{Code: `Object.hasOwnProperty.call.foo(obj, prop)`},
+			{Code: `Object[hasOwnProperty].call(obj, prop)`},
+			{Code: `Object.hasOwnProperty[call](obj, prop)`},
+			{Code: `class C { #hasOwnProperty; foo() { Object.#hasOwnProperty.call(obj, prop) } }`},
+			{Code: `class C { #call; foo() { Object.hasOwnProperty.#call(obj, prop) } }`},
+			{Code: `(Object) => Object.hasOwnProperty.call(obj, prop)`}, // not global Object
+			// ---- `Object.prototype` receiver ----
+			{Code: `Object.prototype`},
+			{Code: `Object.prototype(obj, prop)`},
+			{Code: `Object.prototype.hasOwnProperty`},
+			{Code: `Object.prototype.hasOwnProperty(obj, prop)`},
+			{Code: `Object.prototype.hasOwnProperty.call`},
+			{Code: `foo.Object.prototype.hasOwnProperty.call(obj, prop)`},
+			{Code: `foo.prototype.hasOwnProperty.call(obj, prop)`},
+			{Code: `Object.foo.hasOwnProperty.call(obj, prop)`},
+			{Code: `Object.prototype.foo.call(obj, prop)`},
+			{Code: `Object.prototype.hasOwnProperty.foo(obj, prop)`},
+			{Code: `Object.prototype.hasOwnProperty.call.foo(obj, prop)`},
+			{Code: `Object.prototype.prototype.hasOwnProperty.call(a, b);`},
+			{Code: `Object.hasOwnProperty.prototype.hasOwnProperty.call(a, b);`},
+			{Code: `Object.prototype[hasOwnProperty].call(obj, prop)`},
+			{Code: `Object.prototype.hasOwnProperty[call](obj, prop)`},
+			{Code: `class C { #hasOwnProperty; foo() { Object.prototype.#hasOwnProperty.call(obj, prop) } }`},
+			{Code: `class C { #call; foo() { Object.prototype.hasOwnProperty.#call(obj, prop) } }`},
+			{Code: `Object[prototype].hasOwnProperty.call(obj, prop)`},
+			{Code: `class C { #prototype; foo() { Object.#prototype.hasOwnProperty.call(obj, prop) } }`},
+			{Code: `(Object) => Object.prototype.hasOwnProperty.call(obj, prop)`}, // not global Object
+			// ---- object-literal receiver ----
+			{Code: `({})`},
+			{Code: `({}(obj, prop))`},
+			{Code: `({}.hasOwnProperty)`},
+			{Code: `({}.hasOwnProperty(prop))`},
+			{Code: `({}.hasOwnProperty(obj, prop))`},
+			{Code: `({}.hasOwnProperty.call)`},
+			{Code: `({}).prototype.hasOwnProperty.call(a, b);`},
+			{Code: `({}.foo.call(obj, prop))`},
+			{Code: `({}.hasOwnProperty.foo(obj, prop))`},
+			{Code: `({}[hasOwnProperty].call(obj, prop))`},
+			{Code: `({}.hasOwnProperty[call](obj, prop))`},
+			{Code: `({}).hasOwnProperty[call](object, property)`},
+			{Code: `({})[hasOwnProperty].call(object, property)`},
+			{Code: `class C { #hasOwnProperty; foo() { ({}.#hasOwnProperty.call(obj, prop)) } }`},
+			{Code: `class C { #call; foo() { ({}.hasOwnProperty.#call(obj, prop)) } }`},
+			{Code: `({ foo }.hasOwnProperty.call(obj, prop))`},        // object literal should be empty
+			{Code: `(Object) => ({}).hasOwnProperty.call(obj, prop)`}, // Object is shadowed, so Object.hasOwn cannot be used here
+			// ---- already using `Object.hasOwn` ----
+			{Code: `
+        let obj = {};
+        Object.hasOwn(obj,"");
+        `},
+			{Code: `const hasProperty = Object.hasOwn(object, property);`},
+			{Code: `/* global Object: off */
+        ({}).hasOwnProperty.call(a, b);`}},
+		[]rule_tester.InvalidTestCase{
+			// ---- dotted receivers ----
+			{
+				Code:   `Object.hasOwnProperty.call(obj, 'foo')`,
+				Output: []string{`Object.hasOwn(obj, 'foo')`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 39,
+					},
+				},
+			},
+			{
+				Code:   `Object.hasOwnProperty.call(obj, property)`,
+				Output: []string{`Object.hasOwn(obj, property)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 42,
+					},
+				},
+			},
+			{
+				Code:   `Object.prototype.hasOwnProperty.call(obj, 'foo')`,
+				Output: []string{`Object.hasOwn(obj, 'foo')`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 49,
+					},
+				},
+			},
+			{
+				Code:   `({}).hasOwnProperty.call(obj, 'foo')`,
+				Output: []string{`Object.hasOwn(obj, 'foo')`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 37,
+					},
+				},
+			},
+			// prevent autofixing if there are any comments
+			{
+				Code: `Object/* comment */.prototype.hasOwnProperty.call(a, b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 56,
+					},
+				},
+			},
+			// ---- parenthesized receivers ----
+			{
+				Code:   `const hasProperty = Object.prototype.hasOwnProperty.call(object, property);`,
+				Output: []string{`const hasProperty = Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 75,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( Object.prototype.hasOwnProperty.call(object, property) ));`,
+				Output: []string{`const hasProperty = (( Object.hasOwn(object, property) ));`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    24,
+						EndLine:   1,
+						EndColumn: 78,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( Object.prototype.hasOwnProperty.call ))(object, property);`,
+				Output: []string{`const hasProperty = (( Object.hasOwn ))(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 81,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( Object.prototype.hasOwnProperty )).call(object, property);`,
+				Output: []string{`const hasProperty = Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 81,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( Object.prototype )).hasOwnProperty.call(object, property);`,
+				Output: []string{`const hasProperty = Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 81,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( Object )).prototype.hasOwnProperty.call(object, property);`,
+				Output: []string{`const hasProperty = Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 81,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = {}.hasOwnProperty.call(object, property);`,
+				Output: []string{`const hasProperty = Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 61,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty={}.hasOwnProperty.call(object, property);`,
+				Output: []string{`const hasProperty=Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    19,
+						EndLine:   1,
+						EndColumn: 59,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( {}.hasOwnProperty.call(object, property) ));`,
+				Output: []string{`const hasProperty = (( Object.hasOwn(object, property) ));`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    24,
+						EndLine:   1,
+						EndColumn: 64,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( {}.hasOwnProperty.call ))(object, property);`,
+				Output: []string{`const hasProperty = (( Object.hasOwn ))(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 67,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( {}.hasOwnProperty )).call(object, property);`,
+				Output: []string{`const hasProperty = Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 67,
+					},
+				},
+			},
+			{
+				Code:   `const hasProperty = (( {} )).hasOwnProperty.call(object, property);`,
+				Output: []string{`const hasProperty = Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 67,
+					},
+				},
+			},
+			{
+				Code:   `function foo(){return {}.hasOwnProperty.call(object, property)}`,
+				Output: []string{`function foo(){return Object.hasOwn(object, property)}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    23,
+						EndLine:   1,
+						EndColumn: 63,
+					},
+				},
+			},
+			// ---- the replacement must not fuse with the token in front of it ----
+			{
+				Code:   `function foo(){return{}.hasOwnProperty.call(object, property)}`,
+				Output: []string{`function foo(){return Object.hasOwn(object, property)}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    22,
+						EndLine:   1,
+						EndColumn: 62,
+					},
+				},
+			},
+			{
+				Code:   `function foo(){return/*comment*/{}.hasOwnProperty.call(object, property)}`,
+				Output: []string{`function foo(){return/*comment*/Object.hasOwn(object, property)}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    33,
+						EndLine:   1,
+						EndColumn: 73,
+					},
+				},
+			},
+			{
+				Code:   `async function foo(){return await{}.hasOwnProperty.call(object, property)}`,
+				Output: []string{`async function foo(){return await Object.hasOwn(object, property)}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    34,
+						EndLine:   1,
+						EndColumn: 74,
+					},
+				},
+			},
+			{
+				Code:   `async function foo(){return await/*comment*/{}.hasOwnProperty.call(object, property)}`,
+				Output: []string{`async function foo(){return await/*comment*/Object.hasOwn(object, property)}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    45,
+						EndLine:   1,
+						EndColumn: 85,
+					},
+				},
+			},
+			{
+				Code:   `for (const x of{}.hasOwnProperty.call(object, property).toString());`,
+				Output: []string{`for (const x of Object.hasOwn(object, property).toString());`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    16,
+						EndLine:   1,
+						EndColumn: 56,
+					},
+				},
+			},
+			{
+				Code:   `for (const x of/*comment*/{}.hasOwnProperty.call(object, property).toString());`,
+				Output: []string{`for (const x of/*comment*/Object.hasOwn(object, property).toString());`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    27,
+						EndLine:   1,
+						EndColumn: 67,
+					},
+				},
+			},
+			{
+				Code:   `for (const x in{}.hasOwnProperty.call(object, property).toString());`,
+				Output: []string{`for (const x in Object.hasOwn(object, property).toString());`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    16,
+						EndLine:   1,
+						EndColumn: 56,
+					},
+				},
+			},
+			{
+				Code:   `for (const x in/*comment*/{}.hasOwnProperty.call(object, property).toString());`,
+				Output: []string{`for (const x in/*comment*/Object.hasOwn(object, property).toString());`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    27,
+						EndLine:   1,
+						EndColumn: 67,
+					},
+				},
+			},
+			{
+				Code:   `function foo(){return({}.hasOwnProperty.call)(object, property)}`,
+				Output: []string{`function foo(){return(Object.hasOwn)(object, property)}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    22,
+						EndLine:   1,
+						EndColumn: 64,
+					},
+				},
+			},
+			// ---- computed receivers ----
+			{
+				Code:   `Object['prototype']['hasOwnProperty']['call'](object, property);`,
+				Output: []string{`Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 64,
+					},
+				},
+			},
+			{
+				Code:   "Object[`prototype`][`hasOwnProperty`][`call`](object, property);",
+				Output: []string{`Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 64,
+					},
+				},
+			},
+			{
+				Code:   `Object['hasOwnProperty']['call'](object, property);`,
+				Output: []string{`Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 51,
+					},
+				},
+			},
+			{
+				Code:   "Object[`hasOwnProperty`][`call`](object, property);",
+				Output: []string{`Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 51,
+					},
+				},
+			},
+			{
+				Code:   `({})['hasOwnProperty']['call'](object, property);`,
+				Output: []string{`Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 49,
+					},
+				},
+			},
+			{
+				Code:   "({})[`hasOwnProperty`][`call`](object, property);",
+				Output: []string{`Object.hasOwn(object, property);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useHasOwn",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 49,
+					},
+				},
+			}},
+	)
+}

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -485,6 +485,16 @@ func IsShadowed(node *ast.Node, name string) bool {
 				return true
 			}
 
+		// A class static block is a variable environment of its own: a `var`
+		// inside it hoists to the block rather than out of it, so it shadows
+		// the outer binding for the whole block. The static block is not a
+		// function-like declaration, so the arm below never reaches its body.
+		case ast.KindClassStaticBlockDeclaration:
+			if body := current.AsClassStaticBlockDeclaration().Body; body != nil &&
+				HasHoistedVarDeclaration(body, name) {
+				return true
+			}
+
 		case ast.KindCaseBlock:
 			if HasShadowingDeclarationInCaseBlock(current, name) || hasHoistedFunctionDeclaration(current, name) {
 				return true

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -137,6 +137,7 @@ export default defineConfig({
     './tests/eslint/rules/prefer-destructuring.test.ts',
     './tests/eslint/rules/prefer-exponentiation-operator.test.ts',
     './tests/eslint/rules/prefer-numeric-literals.test.ts',
+    './tests/eslint/rules/prefer-object-has-own.test.ts',
     './tests/eslint/rules/prefer-object-spread.test.ts',
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-object-has-own.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-object-has-own.test.ts.snap
@@ -1,0 +1,859 @@
+// Rstest Snapshot v1
+
+exports[`prefer-object-has-own > invalid 1`] = `
+{
+  "code": "Object.hasOwnProperty.call(obj, 'foo')",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 2`] = `
+{
+  "code": "Object.hasOwnProperty.call(obj, property)",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 3`] = `
+{
+  "code": "Object.prototype.hasOwnProperty.call(obj, 'foo')",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 4`] = `
+{
+  "code": "({}).hasOwnProperty.call(obj, 'foo')",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 5`] = `
+{
+  "code": "Object/* comment */.prototype.hasOwnProperty.call(a, b);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 6`] = `
+{
+  "code": "const hasProperty = Object.prototype.hasOwnProperty.call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 7`] = `
+{
+  "code": "const hasProperty = (( Object.prototype.hasOwnProperty.call(object, property) ));",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 8`] = `
+{
+  "code": "const hasProperty = (( Object.prototype.hasOwnProperty.call ))(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 9`] = `
+{
+  "code": "const hasProperty = (( Object.prototype.hasOwnProperty )).call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 10`] = `
+{
+  "code": "const hasProperty = (( Object.prototype )).hasOwnProperty.call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 11`] = `
+{
+  "code": "const hasProperty = (( Object )).prototype.hasOwnProperty.call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 12`] = `
+{
+  "code": "const hasProperty = {}.hasOwnProperty.call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 13`] = `
+{
+  "code": "const hasProperty={}.hasOwnProperty.call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 14`] = `
+{
+  "code": "const hasProperty = (( {}.hasOwnProperty.call(object, property) ));",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 15`] = `
+{
+  "code": "const hasProperty = (( {}.hasOwnProperty.call ))(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 16`] = `
+{
+  "code": "const hasProperty = (( {}.hasOwnProperty )).call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 17`] = `
+{
+  "code": "const hasProperty = (( {} )).hasOwnProperty.call(object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 18`] = `
+{
+  "code": "function foo(){return {}.hasOwnProperty.call(object, property)}",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 19`] = `
+{
+  "code": "function foo(){return{}.hasOwnProperty.call(object, property)}",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 20`] = `
+{
+  "code": "function foo(){return/*comment*/{}.hasOwnProperty.call(object, property)}",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 21`] = `
+{
+  "code": "async function foo(){return await{}.hasOwnProperty.call(object, property)}",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 22`] = `
+{
+  "code": "async function foo(){return await/*comment*/{}.hasOwnProperty.call(object, property)}",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 23`] = `
+{
+  "code": "for (const x of{}.hasOwnProperty.call(object, property).toString());",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 24`] = `
+{
+  "code": "for (const x of/*comment*/{}.hasOwnProperty.call(object, property).toString());",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 25`] = `
+{
+  "code": "for (const x in{}.hasOwnProperty.call(object, property).toString());",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 26`] = `
+{
+  "code": "for (const x in/*comment*/{}.hasOwnProperty.call(object, property).toString());",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 27`] = `
+{
+  "code": "function foo(){return({}.hasOwnProperty.call)(object, property)}",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 28`] = `
+{
+  "code": "Object['prototype']['hasOwnProperty']['call'](object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 29`] = `
+{
+  "code": "Object[\`prototype\`][\`hasOwnProperty\`][\`call\`](object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 30`] = `
+{
+  "code": "Object['hasOwnProperty']['call'](object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 31`] = `
+{
+  "code": "Object[\`hasOwnProperty\`][\`call\`](object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 32`] = `
+{
+  "code": "({})['hasOwnProperty']['call'](object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-object-has-own > invalid 33`] = `
+{
+  "code": "({})[\`hasOwnProperty\`][\`call\`](object, property);",
+  "diagnostics": [
+    {
+      "message": "Use 'Object.hasOwn()' instead of 'Object.prototype.hasOwnProperty.call()'.",
+      "messageId": "useHasOwn",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-object-has-own",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-object-has-own.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-object-has-own.test.ts
@@ -1,0 +1,201 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-object-has-own', {
+  valid: [
+    'Object',
+    'Object(obj, prop)',
+    'Object.hasOwnProperty',
+    'Object.hasOwnProperty(prop)',
+    'hasOwnProperty(obj, prop)',
+    'foo.hasOwnProperty(prop)',
+    'foo.hasOwnProperty(obj, prop)',
+    'Object.hasOwnProperty.call',
+    'foo.Object.hasOwnProperty.call(obj, prop)',
+    'foo.hasOwnProperty.call(obj, prop)',
+    'foo.call(Object.prototype.hasOwnProperty, Object.prototype.hasOwnProperty.call)',
+    'Object.foo.call(obj, prop)',
+    'Object.hasOwnProperty.foo(obj, prop)',
+    'Object.hasOwnProperty.call.foo(obj, prop)',
+    'Object[hasOwnProperty].call(obj, prop)',
+    'Object.hasOwnProperty[call](obj, prop)',
+    'class C { #hasOwnProperty; foo() { Object.#hasOwnProperty.call(obj, prop) } }',
+    'class C { #call; foo() { Object.hasOwnProperty.#call(obj, prop) } }',
+    '(Object) => Object.hasOwnProperty.call(obj, prop)',
+    'Object.prototype',
+    'Object.prototype(obj, prop)',
+    'Object.prototype.hasOwnProperty',
+    'Object.prototype.hasOwnProperty(obj, prop)',
+    'Object.prototype.hasOwnProperty.call',
+    'foo.Object.prototype.hasOwnProperty.call(obj, prop)',
+    'foo.prototype.hasOwnProperty.call(obj, prop)',
+    'Object.foo.hasOwnProperty.call(obj, prop)',
+    'Object.prototype.foo.call(obj, prop)',
+    'Object.prototype.hasOwnProperty.foo(obj, prop)',
+    'Object.prototype.hasOwnProperty.call.foo(obj, prop)',
+    'Object.prototype.prototype.hasOwnProperty.call(a, b);',
+    'Object.hasOwnProperty.prototype.hasOwnProperty.call(a, b);',
+    'Object.prototype[hasOwnProperty].call(obj, prop)',
+    'Object.prototype.hasOwnProperty[call](obj, prop)',
+    'class C { #hasOwnProperty; foo() { Object.prototype.#hasOwnProperty.call(obj, prop) } }',
+    'class C { #call; foo() { Object.prototype.hasOwnProperty.#call(obj, prop) } }',
+    'Object[prototype].hasOwnProperty.call(obj, prop)',
+    'class C { #prototype; foo() { Object.#prototype.hasOwnProperty.call(obj, prop) } }',
+    '(Object) => Object.prototype.hasOwnProperty.call(obj, prop)',
+    '({})',
+    '({}(obj, prop))',
+    '({}.hasOwnProperty)',
+    '({}.hasOwnProperty(prop))',
+    '({}.hasOwnProperty(obj, prop))',
+    '({}.hasOwnProperty.call)',
+    '({}).prototype.hasOwnProperty.call(a, b);',
+    '({}.foo.call(obj, prop))',
+    '({}.hasOwnProperty.foo(obj, prop))',
+    '({}[hasOwnProperty].call(obj, prop))',
+    '({}.hasOwnProperty[call](obj, prop))',
+    '({}).hasOwnProperty[call](object, property)',
+    '({})[hasOwnProperty].call(object, property)',
+    'class C { #hasOwnProperty; foo() { ({}.#hasOwnProperty.call(obj, prop)) } }',
+    'class C { #call; foo() { ({}.hasOwnProperty.#call(obj, prop)) } }',
+    '({ foo }.hasOwnProperty.call(obj, prop))',
+    '(Object) => ({}).hasOwnProperty.call(obj, prop)',
+    '\n        let obj = {};\n        Object.hasOwn(obj,"");\n        ',
+    'const hasProperty = Object.hasOwn(object, property);',
+    '/* global Object: off */\n        ({}).hasOwnProperty.call(a, b);',
+  ],
+  invalid: [
+    {
+      code: "Object.hasOwnProperty.call(obj, 'foo')",
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'Object.hasOwnProperty.call(obj, property)',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: "Object.prototype.hasOwnProperty.call(obj, 'foo')",
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: "({}).hasOwnProperty.call(obj, 'foo')",
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'Object/* comment */.prototype.hasOwnProperty.call(a, b);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = Object.prototype.hasOwnProperty.call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( Object.prototype.hasOwnProperty.call(object, property) ));',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( Object.prototype.hasOwnProperty.call ))(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( Object.prototype.hasOwnProperty )).call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( Object.prototype )).hasOwnProperty.call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( Object )).prototype.hasOwnProperty.call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = {}.hasOwnProperty.call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty={}.hasOwnProperty.call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( {}.hasOwnProperty.call(object, property) ));',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( {}.hasOwnProperty.call ))(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( {}.hasOwnProperty )).call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'const hasProperty = (( {} )).hasOwnProperty.call(object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'function foo(){return {}.hasOwnProperty.call(object, property)}',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'function foo(){return{}.hasOwnProperty.call(object, property)}',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'function foo(){return/*comment*/{}.hasOwnProperty.call(object, property)}',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'async function foo(){return await{}.hasOwnProperty.call(object, property)}',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'async function foo(){return await/*comment*/{}.hasOwnProperty.call(object, property)}',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'for (const x of{}.hasOwnProperty.call(object, property).toString());',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'for (const x of/*comment*/{}.hasOwnProperty.call(object, property).toString());',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'for (const x in{}.hasOwnProperty.call(object, property).toString());',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'for (const x in/*comment*/{}.hasOwnProperty.call(object, property).toString());',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'function foo(){return({}.hasOwnProperty.call)(object, property)}',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: "Object['prototype']['hasOwnProperty']['call'](object, property);",
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'Object[`prototype`][`hasOwnProperty`][`call`](object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: "Object['hasOwnProperty']['call'](object, property);",
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: 'Object[`hasOwnProperty`][`call`](object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: "({})['hasOwnProperty']['call'](object, property);",
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+    {
+      code: '({})[`hasOwnProperty`][`call`](object, property);',
+      errors: [{ messageId: 'useHasOwn' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `prefer-object-has-own` rule from ESLint to rslint.

The rule reports `Object.prototype.hasOwnProperty.call(object, property)` — along with the `Object.hasOwnProperty.call()` and `({}).hasOwnProperty.call()` spellings of it — and autofixes the callee to `Object.hasOwn`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/prefer-object-has-own
- Source code: https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/prefer-object-has-own.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).