### PR TITLE
feat: expose language options through rule context

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -285,6 +285,7 @@ instead of re-exporting aliases.
 type RuleContext struct {
     SourceFile     *ast.SourceFile
     Settings       map[string]interface{}
+    LanguageOptions LanguageOptions
     Globals        Globals
     Comments       *CommentStore
     Refs           *RefStore
@@ -366,8 +367,11 @@ supports scope rules whose query location is not itself an identifier
 reference. `HasNonGlobalTopLevelScope` exposes the corresponding scope fact
 without exposing a language mode or requiring rules to parse paths.
 Config resolution normalizes the per-file `ecmaVersion` into `LanguageOptions`;
-its zero value means the moving `latest` edition. The linter uses it to build
-one `Globals` value for each native rule context. `Globals` owns the
+its zero value means the moving `latest` edition. The linter exposes the
+normalized value through `RuleContext.LanguageOptions` and also uses it to
+build one `Globals` value for each native rule context. Rules read
+`LanguageOptions` when upstream behavior depends on language configuration;
+they use `Globals` for variable-availability decisions. `Globals` owns the
 ESLint-versioned language-global set, resolved language defaults, the authored
 `languageOptions.globals` source, inline `/* global */` settings and ranges,
 and the effective access after applying their precedence. Rules use
@@ -376,9 +380,8 @@ accessors only when upstream behavior depends on provenance, instead of
 rebuilding the merge. A rule whose upstream semantics add another source, such
 as TypeScript library globals, applies this view last so `ecmaVersion` and
 authored overrides remain authoritative. This keeps the language-global
-composition point extensible for future language options such as `sourceType`
-without exposing those options directly to every rule; non-global wrapper
-bindings remain a `RefStore` initialization concern.
+composition point extensible for future language options such as `sourceType`;
+non-global wrapper bindings remain a `RefStore` initialization concern.
 
 Before constructing rule contexts, the linter calls `ResolveLanguageDefaults`
 once and passes its concrete `GlobalsInit` and `RefStoreInit` results to their

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -246,14 +246,15 @@ func runLintRulesInProgram(plan *programLintPlan, opts programRunOptions, consum
 			environment = *filePlan.environment
 		}
 		baseContext := (rule.RuleContext{
-			SourceFile:     file,
-			Settings:       environment.Settings,
-			Globals:        rule.NewGlobals(environment.LanguageOptions, globalsInit, environment.Globals, inlineGlobals, inlineGlobalDeclarations),
-			Comments:       comments,
-			Refs:           refs,
-			BOM:            sourceBOM,
-			TypeChecker:    fileChecker,
-			DisableManager: disableManager,
+			SourceFile:      file,
+			Settings:        environment.Settings,
+			LanguageOptions: environment.LanguageOptions,
+			Globals:         rule.NewGlobals(environment.LanguageOptions, globalsInit, environment.Globals, inlineGlobals, inlineGlobalDeclarations),
+			Comments:        comments,
+			Refs:            refs,
+			BOM:             sourceBOM,
+			TypeChecker:     fileChecker,
+			DisableManager:  disableManager,
 		}).WithProgram(sourceProgram).WithFileCache(fileCache)
 
 		for ruleIndex, r := range rules {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -180,6 +180,9 @@ func TestRunLinter_GlobalDeclarationMetadata(t *testing.T) {
 		t.Fatalf("captured context = %v, linted files = %d; want one", captured != nil, result.LintedFileCount)
 		return
 	}
+	if got := captured.LanguageOptions; got != languageOptions {
+		t.Fatalf("RuleContext.LanguageOptions = %#v, want %#v", got, languageOptions)
+	}
 
 	for name, want := range configGlobals {
 		if got := captured.Globals.ConfigOverride(name); got != want {

--- a/internal/rule/configured.go
+++ b/internal/rule/configured.go
@@ -23,8 +23,8 @@ type ConfiguredRule struct {
 // configured rule in one resolved config shape.
 type RuleEnvironment struct {
 	Settings map[string]interface{}
-	// LanguageOptions is normalized once and used to construct ctx.Globals. Its
-	// zero value selects latest.
+	// LanguageOptions is normalized once and exposed through ctx.LanguageOptions;
+	// it also selects the language-global catalog. Its zero value selects latest.
 	LanguageOptions LanguageOptions
 	// Globals contains config-declared language globals. Inline declarations
 	// are merged once per source file during execution.

--- a/internal/rule/context.go
+++ b/internal/rule/context.go
@@ -39,11 +39,15 @@ type DiagnosticConsumer struct {
 type RuleContext struct {
 	SourceFile *ast.SourceFile
 	Settings   map[string]interface{}
-	fileCache  *FileCache
+	// LanguageOptions is the normalized per-file language config.
+	// Rules should use its Effective methods when they need ESLint defaults.
+	LanguageOptions LanguageOptions
+	fileCache       *FileCache
 	// Globals owns the file's complete global-variable view: the selected
 	// ECMAScript edition, languageOptions.globals, inline /* global */ comments,
 	// their effective access, and inline declaration metadata. Rules should use
-	// its accessors instead of reimplementing precedence or version selection.
+	// its accessors instead of reimplementing global precedence or edition-global
+	// selection.
 	Globals Globals
 	// Comments lazily provides every comment in SourceFile, in source order.
 	// Rules should call Comments.All instead of walking the token tree with

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -26,8 +26,9 @@ type ValidTestCase struct {
 	Skip     bool                   `json:"skip"`
 	Options  any                    `json:"options"`
 	Settings map[string]interface{} `json:"settings"`
-	// LanguageOptions is the normalized per-file language configuration used
-	// to construct native rule globals. Its zero value means latest.
+	// LanguageOptions is the normalized per-file language configuration exposed
+	// through ctx.LanguageOptions and used to construct native rule globals. Its
+	// zero value means latest.
 	LanguageOptions rule.LanguageOptions `json:"languageOptions"`
 	// Globals simulates a config-declared `languageOptions.globals` for rules
 	// that read ctx.Globals (e.g. no-undef). Values are authored exactly as in
@@ -65,8 +66,9 @@ type InvalidTestCase struct {
 	Output   []string               `json:"output"`
 	Errors   []InvalidTestCaseError `json:"errors"`
 	Settings map[string]interface{} `json:"settings"`
-	// LanguageOptions is the normalized per-file language configuration used
-	// to construct native rule globals. Its zero value means latest.
+	// LanguageOptions is the normalized per-file language configuration exposed
+	// through ctx.LanguageOptions and used to construct native rule globals. Its
+	// zero value means latest.
 	LanguageOptions rule.LanguageOptions `json:"languageOptions"`
 	// Globals simulates a config-declared `languageOptions.globals` for rules
 	// that read ctx.Globals (e.g. no-undef). Values are authored exactly as in


### PR DESCRIPTION
## Summary

- expose the normalized per-file `LanguageOptions` value through `RuleContext.LanguageOptions`
- populate the context from the same immutable `RuleEnvironment` value already used to select ECMAScript globals
- document the boundary: rules read `LanguageOptions` for language configuration and `Globals` for variable availability
- update the native rule test harness documentation and verify linter propagation

## Motivation

ESLint exposes language configuration to rules through `context.languageOptions`. Native rslint rules currently receive the normalized value indirectly only through the globals model, which conflates configuration queries with global-variable lookup. Exposing the complete `LanguageOptions` value also gives future options such as `sourceType` one standard extension point instead of adding individual context fields.

The zero value continues to mean the moving `latest` ECMAScript edition.

## Verification

```sh
go test ./internal/rule ./internal/linter -count=1
```

- `internal/rule`: pass
- `internal/linter`: pass
- `git diff --check`: pass

## Related

- ESLint custom rule context: https://eslint.org/docs/latest/extend/custom-rules
- Existing `sourceType` design discussion: https://github.com/web-infra-dev/rslint/pull/1605
