### PR TITLE
fix: align no-cond-assign with ESLint

### DIFF
--- a/internal/rules/no_cond_assign/no_cond_assign.go
+++ b/internal/rules/no_cond_assign/no_cond_assign.go
@@ -10,113 +10,130 @@ import (
 //go:embed no_cond_assign.schema.json
 var schemaJSON []byte
 
-// Message builders
-func buildMissingMessage() rule.RuleMessage {
-	return rule.RuleMessage{
+var (
+	missingMessage = rule.RuleMessage{
 		Id:          "missing",
 		Description: "Expected a conditional expression and instead saw an assignment.",
 	}
-}
-
-func buildUnexpectedMessage(nodeType string) rule.RuleMessage {
-	return rule.RuleMessage{
+	unexpectedIfMessage = rule.RuleMessage{
 		Id:          "unexpected",
-		Description: "Unexpected assignment within " + nodeType + ".",
+		Description: "Unexpected assignment within an 'if' statement.",
+		Data:        map[string]string{"type": "an 'if' statement"},
+	}
+	unexpectedWhileMessage = rule.RuleMessage{
+		Id:          "unexpected",
+		Description: "Unexpected assignment within a 'while' statement.",
+		Data:        map[string]string{"type": "a 'while' statement"},
+	}
+	unexpectedDoWhileMessage = rule.RuleMessage{
+		Id:          "unexpected",
+		Description: "Unexpected assignment within a 'do...while' statement.",
+		Data:        map[string]string{"type": "a 'do...while' statement"},
+	}
+	unexpectedForMessage = rule.RuleMessage{
+		Id:          "unexpected",
+		Description: "Unexpected assignment within a 'for' statement.",
+		Data:        map[string]string{"type": "a 'for' statement"},
+	}
+	unexpectedConditionalMessage = rule.RuleMessage{
+		Id:          "unexpected",
+		Description: "Unexpected assignment within ConditionalExpression.",
+		Data:        map[string]string{"type": "ConditionalExpression"},
+	}
+)
+
+func unexpectedMessage(conditional *ast.Node) rule.RuleMessage {
+	switch conditional.Kind {
+	case ast.KindIfStatement:
+		return unexpectedIfMessage
+	case ast.KindWhileStatement:
+		return unexpectedWhileMessage
+	case ast.KindDoStatement:
+		return unexpectedDoWhileMessage
+	case ast.KindForStatement:
+		return unexpectedForMessage
+	case ast.KindConditionalExpression:
+		return unexpectedConditionalMessage
+	default:
+		return unexpectedConditionalMessage
 	}
 }
 
-// isAssignmentExpression checks if a node is an assignment expression
 func isAssignmentExpression(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	return node.Kind == ast.KindBinaryExpression && isAssignmentOperator(node)
-}
-
-// isAssignmentOperator checks if a binary expression uses an assignment operator
-func isAssignmentOperator(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindBinaryExpression {
 		return false
 	}
-
 	binary := node.AsBinaryExpression()
-	if binary == nil || binary.OperatorToken == nil {
-		return false
-	}
-
-	// Check for all assignment operators
-	switch binary.OperatorToken.Kind {
-	case ast.KindEqualsToken, // =
-		ast.KindPlusEqualsToken,                              // +=
-		ast.KindMinusEqualsToken,                             // -=
-		ast.KindAsteriskEqualsToken,                          // *=
-		ast.KindSlashEqualsToken,                             // /=
-		ast.KindPercentEqualsToken,                           // %=
-		ast.KindAsteriskAsteriskEqualsToken,                  // **=
-		ast.KindLessThanLessThanEqualsToken,                  // <<=
-		ast.KindGreaterThanGreaterThanEqualsToken,            // >>=
-		ast.KindGreaterThanGreaterThanGreaterThanEqualsToken, // >>>=
-		ast.KindAmpersandEqualsToken,                         // &=
-		ast.KindBarEqualsToken,                               // |=
-		ast.KindCaretEqualsToken:                             // ^=
-		return true
-	}
-	return false
+	return binary != nil && binary.OperatorToken != nil && ast.IsAssignmentOperator(binary.OperatorToken.Kind)
 }
 
-// getTestExpression returns the test expression for a conditional statement
-func getTestExpression(node *ast.Node) *ast.Node {
+// conditionalTest returns a conditional node's test expression and the number
+// of explicit parenthesis wrappers needed to permit a top-level assignment in
+// the default mode. Statement grammar supplies ESLint's outer parenthesis pair,
+// while a ConditionalExpression has no grammar parentheses and therefore needs
+// two explicit pairs.
+func conditionalTest(node *ast.Node) (test *ast.Node, requiredParenDepth int) {
 	if node == nil {
-		return nil
+		return nil, 0
 	}
-
 	switch node.Kind {
 	case ast.KindIfStatement:
-		ifStmt := node.AsIfStatement()
-		if ifStmt != nil {
-			return ifStmt.Expression
+		if statement := node.AsIfStatement(); statement != nil {
+			return statement.Expression, 1
 		}
 	case ast.KindWhileStatement:
-		whileStmt := node.AsWhileStatement()
-		if whileStmt != nil {
-			return whileStmt.Expression
+		if statement := node.AsWhileStatement(); statement != nil {
+			return statement.Expression, 1
 		}
 	case ast.KindDoStatement:
-		doStmt := node.AsDoStatement()
-		if doStmt != nil {
-			return doStmt.Expression
+		if statement := node.AsDoStatement(); statement != nil {
+			return statement.Expression, 1
 		}
 	case ast.KindForStatement:
-		forStmt := node.AsForStatement()
-		if forStmt != nil {
-			return forStmt.Condition
+		if statement := node.AsForStatement(); statement != nil {
+			return statement.Condition, 1
 		}
 	case ast.KindConditionalExpression:
-		// For ternary, return the entire expression
-		return node
+		if expression := node.AsConditionalExpression(); expression != nil {
+			return expression.Condition, 2
+		}
+	}
+	return nil, 0
+}
+
+func unwrapParentheses(node *ast.Node) (expression *ast.Node, depth int) {
+	expression = node
+	for expression != nil && expression.Kind == ast.KindParenthesizedExpression {
+		parenthesized := expression.AsParenthesizedExpression()
+		if parenthesized == nil || parenthesized.Expression == nil {
+			break
+		}
+		expression = parenthesized.Expression
+		depth++
+	}
+	return expression, depth
+}
+
+// findConditionalAncestor mirrors ESLint's bottom-up search: a conditional is
+// selected only when the current child is exactly its test slot. In particular,
+// assignments in ternary branches are not attributed to that ternary, though
+// the whole ternary can itself be the test of an outer conditional.
+func findConditionalAncestor(node *ast.Node) *ast.Node {
+	current := node
+	for current != nil {
+		parent := current.Parent
+		if parent == nil {
+			return nil
+		}
+		if test, _ := conditionalTest(parent); test == current {
+			return parent
+		}
+		if ast.IsFunctionLikeDeclaration(parent) {
+			return nil
+		}
+		current = parent
 	}
 	return nil
-}
-
-// getConditionalTypeName returns a human-readable name for the conditional statement type
-func getConditionalTypeName(node *ast.Node) string {
-	if node == nil {
-		return ""
-	}
-
-	switch node.Kind {
-	case ast.KindIfStatement:
-		return "an 'if' statement"
-	case ast.KindWhileStatement:
-		return "a 'while' statement"
-	case ast.KindDoStatement:
-		return "a 'do...while' statement"
-	case ast.KindForStatement:
-		return "a 'for' statement"
-	case ast.KindConditionalExpression:
-		return "a conditional expression"
-	}
-	return ""
 }
 
 // parseOptions returns the configured mode, defaulting to "except-parens".
@@ -130,128 +147,40 @@ func parseOptions(options []any) string {
 	return "except-parens"
 }
 
-// NoCondAssignRule disallows assignment operators in conditional expressions
+// NoCondAssignRule disallows assignment operators in conditional test expressions.
 var NoCondAssignRule = rule.Rule{
 	Name:   "no-cond-assign",
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		mode := parseOptions(options)
-
-		return rule.RuleListeners{
-			ast.KindBinaryExpression: func(node *ast.Node) {
-				// Check if this is an assignment expression
-				if !isAssignmentExpression(node) {
-					return
-				}
-
-				// Walk up to find if we're directly in a conditional test (not nested in other expressions)
-				var conditionalAncestor *ast.Node
-				current := node.Parent
-
-				// Walk up the tree to find the conditional ancestor
-				// Track whether we encounter any non-parenthesis expressions
-				// If the assignment is nested in any expression (like ||, &&, ===, etc.),
-				// it's allowed in "except-parens" mode
-				hasNonParenExpression := false
-
-				for current != nil {
-					if current.Kind == ast.KindIfStatement ||
-						current.Kind == ast.KindWhileStatement ||
-						current.Kind == ast.KindDoStatement ||
-						current.Kind == ast.KindForStatement ||
-						current.Kind == ast.KindConditionalExpression {
-						conditionalAncestor = current
-						break
-					}
-					// Check if this is a non-parenthesis expression
-					// Any expression besides ParenthesizedExpression means the assignment
-					// is nested in a larger expression context
-					if current.Kind != ast.KindParenthesizedExpression {
-						hasNonParenExpression = true
-					}
-					// Stop at function boundaries
-					if current.Kind == ast.KindFunctionDeclaration ||
-						current.Kind == ast.KindFunctionExpression ||
-						current.Kind == ast.KindArrowFunction ||
-						current.Kind == ast.KindMethodDeclaration {
-						break
-					}
-					current = current.Parent
-				}
-
-				if conditionalAncestor == nil {
-					return
-				}
-
-				// Get the actual test expression
-				testExpr := getTestExpression(conditionalAncestor)
-				if testExpr == nil {
-					return
-				}
-
-				// Check if the assignment is in the test part of the conditional
-				if !containsNode(testExpr, node) {
-					return
-				}
-
-				// Apply the rule based on mode
-				switch mode {
-				case "always":
-					// Always report assignments in conditionals
-					ctx.ReportNode(node, buildUnexpectedMessage(getConditionalTypeName(conditionalAncestor)))
-				case "except-parens":
-					// In "except-parens" mode, assignments are allowed if:
-					// 1. They are nested in any expression (like ||, &&, ===, etc.)
-					// 2. OR they are wrapped in double parentheses (for most conditionals)
-					// 3. OR they are wrapped in single parentheses (for for-loop conditions only)
-
-					if hasNonParenExpression {
-						// Assignment is nested in a larger expression (e.g., a || (a = b), (a = b) !== null)
-						// This is allowed because the assignment is not the direct test expression
+		if parseOptions(options) == "always" {
+			return rule.RuleListeners{
+				ast.KindBinaryExpression: func(node *ast.Node) {
+					if !isAssignmentExpression(node) {
 						return
 					}
-
-					// Count consecutive ParenthesizedExpression nodes wrapping the assignment
-					parenLevels := 0
-					current := node.Parent
-
-					// Count consecutive parenthesized expressions
-					for current != nil && current.Kind == ast.KindParenthesizedExpression {
-						parenLevels++
-						current = current.Parent
+					conditional := findConditionalAncestor(node)
+					if conditional != nil {
+						ctx.ReportNode(node, unexpectedMessage(conditional))
 					}
+				},
+			}
+		}
 
-					// NOTE: In the TypeScript-Go AST, it appears that ((a = b)) only creates
-					// one ParenthesizedExpression node, not two. So we only require >= 1 parenthesis level.
-					// This differs from how ESLint checks by counting actual token positions.
-					isProperlyParenthesized := parenLevels >= 1
+		checkConditional := func(node *ast.Node) {
+			test, requiredParenDepth := conditionalTest(node)
+			test, parenDepth := unwrapParentheses(test)
+			if !isAssignmentExpression(test) || parenDepth >= requiredParenDepth {
+				return
+			}
+			ctx.ReportNode(test, missingMessage)
+		}
 
-					if !isProperlyParenthesized {
-						ctx.ReportNode(node, buildMissingMessage())
-					}
-				}
-			},
+		return rule.RuleListeners{
+			ast.KindIfStatement:           checkConditional,
+			ast.KindWhileStatement:        checkConditional,
+			ast.KindDoStatement:           checkConditional,
+			ast.KindForStatement:          checkConditional,
+			ast.KindConditionalExpression: checkConditional,
 		}
 	},
-}
-
-// containsNode checks if a root node contains a target node in its subtree
-func containsNode(root, target *ast.Node) bool {
-	if root == nil || target == nil {
-		return false
-	}
-	if root == target {
-		return true
-	}
-
-	// Walk up from target to see if we reach root
-	current := target.Parent
-	for current != nil {
-		if current == root {
-			return true
-		}
-		current = current.Parent
-	}
-
-	return false
 }

--- a/internal/rules/no_cond_assign/no_cond_assign.md
+++ b/internal/rules/no_cond_assign/no_cond_assign.md
@@ -2,19 +2,19 @@
 
 ## Rule Details
 
-Disallows assignment operators in conditional expressions (`if`, `while`, `do-while`, `for`, and ternary). Assignments in conditional statements are frequently a typo where the developer meant to use a comparison operator (`===`) instead of an assignment operator (`=`).
+Disallows assignment operators in test expressions (`if`, `while`, `do-while`, `for`, and ternary). Assignments in tests are frequently a typo where the developer meant to use a comparison operator (`===`) instead of an assignment operator (`=`).
 
-In the default `"except-parens"` mode, assignments are allowed if they are wrapped in extra parentheses, which signals the assignment is intentional. In `"always"` mode, all assignments in conditionals are flagged.
+In the default `"except-parens"` mode, a top-level assignment is allowed when extra parentheses signal that it is intentional. A ternary test needs two explicit pairs because, unlike a statement test, it has no grammar parentheses. In `"always"` mode, assignments descended from a test expression are flagged, stopping at nested function boundaries. An assignment in a ternary branch is not part of that ternary's test, so it is allowed when the ternary is outside another conditional test. If the whole ternary is itself an outer test, `"always"` mode reports the assignment against that outer conditional. Assignments in statement bodies are allowed in both modes.
 
 Examples of **incorrect** code for this rule:
 
 ```javascript
-if ((x = 0)) {
+if (x = 0) {
 }
 
-while ((x = next())) {}
+while (x = next()) {}
 
-var result = x ? (y = 1) : z;
+var result = (x = next()) ? y : z;
 ```
 
 Examples of **correct** code for this rule:
@@ -29,6 +29,10 @@ if (x === 0 || (y = getValue())) {
 }
 
 for (; (a = b); ) {}
+
+var result = ((x = next())) ? y : z;
+
+var branchResult = x ? (y = 1) : z; // assignment is in a branch, not the test
 ```
 
 ## Original Documentation

--- a/internal/rules/no_cond_assign/no_cond_assign_test.go
+++ b/internal/rules/no_cond_assign/no_cond_assign_test.go
@@ -1,10 +1,18 @@
 package no_cond_assign
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"gotest.tools/v3/assert"
 )
 
 func TestNoCondAssignRule(t *testing.T) {
@@ -20,6 +28,7 @@ func TestNoCondAssignRule(t *testing.T) {
 			{Code: `var x = 5; while (x < 5) { x = x + 1; }`},
 			{Code: `x = 0;`},
 			{Code: `var x; var b = (x === 0) ? 1 : 0;`},
+			{Code: `var x; var b = ((x = 0)) ? 1 : 0;`},
 
 			// With "except-parens" option - properly parenthesized assignments are allowed
 			{Code: `if ((someNode = someNode.parentNode) !== null) { }`, Options: "except-parens"},
@@ -32,9 +41,19 @@ func TestNoCondAssignRule(t *testing.T) {
 			{Code: `do { } while (someNode || (someNode = parentNode));`, Options: "except-parens"},
 			{Code: `for (;someNode || (someNode = parentNode););`, Options: "except-parens"},
 
+			// Assignments in ternary branches are not part of the ternary test.
+			{Code: `var x, y; var result = condition ? x = 1 : y = 2;`},
+			{Code: `var x, y; var result = condition ? x = 1 : y = 2;`, Options: "always"},
+			{Code: `var result = condition ? value = { id: value.id } : typeof value === "function" && (value = callback);`},
+			{Code: `var result = condition ? value = { id: value.id } : typeof value === "function" && (value = callback);`, Options: "always"},
+
 			// Arrow functions
 			{Code: `if ((node => node = parentNode)(someNode)) { }`, Options: "except-parens"},
 			{Code: `if ((function(node) { return node = parentNode; })(someNode)) { }`, Options: "except-parens"},
+			{Code: `if ((node => node = parentNode)(someNode)) { }`, Options: "always"},
+			{Code: `if ((function(node) { return node = parentNode; })(someNode)) { }`, Options: "always"},
+			{Code: `if (function(node) { return node = parentNode; }) { }`, Options: "always"},
+			{Code: `if (class { method() { value = next(); } }) { }`, Options: "always"},
 
 			// Switch statements - assignments in case clauses are not in test expressions
 			{Code: `switch (foo) { case a = b: bar(); }`},
@@ -43,6 +62,12 @@ func TestNoCondAssignRule(t *testing.T) {
 			// Assignments outside of conditionals
 			{Code: `var x; x = 0;`},
 			{Code: `var x = 1; x += 1;`},
+			{Code: `for (x = 0; x < 10; x += 1) { }`, Options: "always"},
+
+			// Disable directives suppress the assignment's exact report range.
+			{Code: "/* eslint-disable test */\nif (x = y) { }"},
+			{Code: "// eslint-disable-next-line test\nif (x = y) { }"},
+			{Code: `if (x = y) { } // eslint-disable-line test`},
 
 			// Comparisons (not assignments)
 			{Code: `if (x === 0) { }`},
@@ -56,7 +81,14 @@ func TestNoCondAssignRule(t *testing.T) {
 			{
 				Code: `var x; if (x = 0) { var b = 1; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "missing", Line: 1, Column: 12},
+					{
+						MessageId: "missing",
+						Message:   "Expected a conditional expression and instead saw an assignment.",
+						Line:      1,
+						Column:    12,
+						EndLine:   1,
+						EndColumn: 17,
+					},
 				},
 			},
 			{
@@ -84,12 +116,19 @@ func TestNoCondAssignRule(t *testing.T) {
 				},
 			},
 
-			// With "always" option - all assignments in conditionals are forbidden
+			// With "always" option - all assignments descended from conditional tests are forbidden
 			{
 				Code:    `if (x = 0) { }`,
 				Options: "always",
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 5},
+					{
+						MessageId: "unexpected",
+						Message:   "Unexpected assignment within an 'if' statement.",
+						Line:      1,
+						Column:    5,
+						EndLine:   1,
+						EndColumn: 10,
+					},
 				},
 			},
 			{
@@ -170,12 +209,61 @@ func TestNoCondAssignRule(t *testing.T) {
 				},
 			},
 
-			// Ternary conditionals
+			// Ternary tests require two explicit parenthesis pairs in the default mode.
 			{
-				Code:    `var x = 0 ? (x = 1) : 2;`,
+				Code: `var x; var b = (x = 0) ? 1 : 0;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 17, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code:    `var x; var b = (x = 0) ? 1 : 0;`,
 				Options: "always",
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 14},
+					{
+						MessageId: "unexpected",
+						Message:   "Unexpected assignment within ConditionalExpression.",
+						Line:      1,
+						Column:    17,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+				},
+			},
+			{
+				Code:    `if (condition ? (x = 1) : fallback) { }`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "Unexpected assignment within an 'if' statement.",
+					},
+				},
+			},
+			{
+				Code:    `if ((x = y) ? ready : fallback) { }`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "Unexpected assignment within ConditionalExpression.",
+					},
+				},
+			},
+			{
+				Code:    `for (; (typeof l === 'undefined' ? (l = 0) : l); i++) { }`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "Unexpected assignment within a 'for' statement.",
+					},
+				},
+			},
+			{
+				Code: `(((3496.29)).property = 2e308) ? foo : bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing"},
 				},
 			},
 
@@ -198,6 +286,108 @@ func TestNoCondAssignRule(t *testing.T) {
 					{MessageId: "missing", Line: 1, Column: 15},
 				},
 			},
+			{
+				Code: `if (x &&= next()) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `while (x ||= next()) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `for (; x ??= next(); ) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `if (a = b = c) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code:    `if (a = b = c) { }`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 5},
+					{MessageId: "unexpected", Line: 1, Column: 9},
+				},
+			},
 		},
 	)
+}
+
+func TestNoCondAssignEditDemandParity(t *testing.T) {
+	const code = `if (/* before */ value = next()) { }`
+	wantStart := strings.Index(code, "value = next()")
+	wantEnd := wantStart + len("value = next()")
+
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		diagnostics := runNoCondAssign(t, code, nil, demand)
+		assert.Equal(t, len(diagnostics), 1)
+		diagnostic := diagnostics[0]
+		assert.Equal(t, diagnostic.Message.Id, "missing")
+		assert.Equal(t, diagnostic.Message.Description, "Expected a conditional expression and instead saw an assignment.")
+		assert.Equal(t, diagnostic.Range.Pos(), wantStart)
+		assert.Equal(t, diagnostic.Range.End(), wantEnd)
+		assert.Assert(t, diagnostic.FixesPtr == nil)
+		assert.Assert(t, diagnostic.Suggestions == nil)
+	}
+}
+
+func TestNoCondAssignAlwaysMessageData(t *testing.T) {
+	diagnostics := runNoCondAssign(t, `if (condition ? (value = next()) : fallback) { }`, []any{"always"}, rule.EditDemandNone)
+	assert.Equal(t, len(diagnostics), 1)
+	assert.Equal(t, diagnostics[0].Message.Description, "Unexpected assignment within an 'if' statement.")
+	assert.Equal(t, diagnostics[0].Message.Data["type"], "an 'if' statement")
+}
+
+func runNoCondAssign(t *testing.T, code string, options []any, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+
+	root := fixtures.GetRootDir()
+	const fileName = "file.ts"
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{
+		tspath.ResolvePath(root.Dir, fileName): code,
+	})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	compilerProgram, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", host)
+	assert.NilError(t, err)
+	sourceFile := compilerProgram.GetSourceFile(fileName)
+	assert.Assert(t, sourceFile != nil)
+
+	var diagnostics []rule.RuleDiagnostic
+	_, err = linter.RunLinter(linter.RunLinterOptions{
+		Programs:       []*lintprogram.Program{lintprogram.NewFromCompiler(compilerProgram)},
+		SingleThreaded: true,
+		Scope:          linter.FileScope{Files: []string{sourceFile.FileName()}},
+		ExcludePaths:   []string{},
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
+				Name:     NoCondAssignRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return NoCondAssignRule.Run(ctx, options)
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	assert.NilError(t, err)
+	return diagnostics
 }


### PR DESCRIPTION
## Summary

- align `no-cond-assign` with ESLint 10.8.1 by checking only conditional test slots in the default mode
- mirror ESLint's nearest-test-ancestor and function-boundary behavior in `always` mode, including exact messages and modern logical assignment operators
- add regression coverage for ternary branches, parenthesis depth, nested conditionals, edit demand, disable directives, and diagnostic ranges; update the rule documentation

The reported vendor case now matches ESLint exactly: the six branch-assignment false positives are removed and the previously missed top-level ternary-test assignment is reported.

### Go benchmark

Command (five samples; table shows medians):

```text
go test ./internal/rules/no_cond_assign -run '^$' -bench '^BenchmarkNoCondAssign$' -benchmem -benchtime=500ms -count=5
```

| Case | Before ns/op | After ns/op | Before B/op | After B/op | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| except-parens/direct/none | 40,917 | 40,725 | 34,205 | 34,220 | 344 | 348 |
| except-parens/direct/autofix | 41,750 | 40,593 | 34,205 | 34,220 | 344 | 348 |
| except-parens/direct/suggestion | 41,687 | 44,046 | 34,205 | 34,222 | 344 | 348 |
| except-parens/parenthesized | 40,851 | 42,775 | 34,044 | 34,061 | 343 | 347 |
| except-parens/nested | 40,775 | 42,698 | 34,044 | 34,061 | 343 | 347 |
| except-parens/outside | 40,959 | 40,831 | 34,044 | 34,061 | 343 | 347 |
| always/nested diagnostic | 41,191 | 41,410 | 34,253 | 34,188 | 345 | 344 |
| always/function boundary | 41,344 | 40,949 | 34,045 | 34,029 | 343 | 343 |
| always/outside | 40,694 | 40,537 | 34,044 | 34,028 | 343 | 343 |

The default implementation registers the five conditional node kinds instead of receiving every binary expression; this adds four small per-run listener-map allocations in this parser-dominated microbenchmark. The `always` diagnostic path removes one allocation by reusing immutable messages.

Validation:

- `go test ./internal/rules/no_cond_assign -count=3`
- `go test -race ./internal/rules/no_cond_assign`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/no_cond_assign/...`
- `pnpm run check-spell`
- `pnpm run format:check`

## Related Links

- [ESLint 10.8.1 rule source](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-cond-assign.js)
- [ESLint 10.8.1 rule tests](https://github.com/eslint/eslint/blob/v10.8.1/tests/lib/rules/no-cond-assign.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
