### PR TITLE
fix: align consistent-type-definitions with typescript-eslint

### DIFF
--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.go
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
-	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 //go:embed consistent_type_definitions.schema.json
@@ -42,61 +41,54 @@ type consistentTypeDefinitionsFixer struct {
 	sourceFile *ast.SourceFile
 }
 
-// modifiersInfo builds a modifier prefix such as "export declare ". The
-// default modifier is intentionally excluded because export default
-// interfaces need to become a type declaration plus a separate default
-// export.
-func modifiersInfo(modifiers *ast.ModifierList) (prefix string, hasExport bool, hasDefault bool) {
-	if modifiers == nil {
-		return "", false, false
-	}
-	hasDeclare := false
-	for _, mod := range modifiers.Nodes {
-		switch mod.Kind {
-		case ast.KindExportKeyword:
-			hasExport = true
-		case ast.KindDefaultKeyword:
-			hasDefault = true
-		case ast.KindDeclareKeyword:
-			hasDeclare = true
+func (f consistentTypeDefinitionsFixer) tokenBounds(from int, to int, kind ast.Kind) (int, int, bool) {
+	sourceScanner := scanner.GetScannerForSourceFile(f.sourceFile, from)
+	for sourceScanner.TokenStart() < to {
+		if sourceScanner.Token() == kind {
+			return sourceScanner.TokenStart(), sourceScanner.TokenEnd(), true
 		}
+		if sourceScanner.Token() == ast.KindEndOfFile {
+			break
+		}
+		sourceScanner.Scan()
 	}
-	var parts []string
-	if hasExport {
-		parts = append(parts, "export")
-	}
-	if hasDeclare {
-		parts = append(parts, "declare")
-	}
-	if len(parts) > 0 {
-		prefix = strings.Join(parts, " ") + " "
-	}
-	return prefix, hasExport, hasDefault
+	return 0, 0, false
 }
 
-func (f consistentTypeDefinitionsFixer) typeParametersText(sourceText string, typeParameters *ast.NodeList) string {
-	if typeParameters == nil || len(typeParameters.Nodes) == 0 {
-		return ""
+// beforeEqualsEnd mirrors sourceCode.getTokenBefore(equalsToken,
+// { includeComments: true }).range[1] from the upstream fixer. Between a type
+// name (or its type parameters) and '=' only trivia can occur, so the last
+// comment is the only token that can supersede the name as the preserved end.
+func (f consistentTypeDefinitionsFixer) beforeEqualsEnd(from int, to int) (int, bool) {
+	sourceScanner := scanner.GetScannerForSourceFile(f.sourceFile, from)
+	sourceScanner.ResetTokenState(from)
+	sourceScanner.SetSkipTrivia(false)
+	sourceScanner.Scan()
+
+	end := from
+	for sourceScanner.TokenStart() < to {
+		switch sourceScanner.Token() {
+		case ast.KindEqualsToken:
+			return end, true
+		case ast.KindSingleLineCommentTrivia, ast.KindMultiLineCommentTrivia:
+			end = sourceScanner.TokenEnd()
+		case ast.KindEndOfFile:
+			return 0, false
+		}
+		sourceScanner.Scan()
 	}
-	firstParameter := typeParameters.Nodes[0]
-	lastParameter := typeParameters.Nodes[len(typeParameters.Nodes)-1]
-	firstRange := utils.TrimNodeTextRange(f.sourceFile, firstParameter)
-	lastRange := utils.TrimNodeTextRange(f.sourceFile, lastParameter)
-	return sourceText[firstRange.Pos()-1 : lastRange.End()+1]
+	return 0, false
 }
 
 func (f consistentTypeDefinitionsFixer) typeAliasFix(node *ast.Node, typeAlias *ast.TypeAliasDeclaration) []rule.RuleFix {
 	sourceText := f.sourceFile.Text()
+	declarationRange := utils.TrimNodeTextRange(f.sourceFile, node)
+	typeKeywordStart, typeKeywordEnd, ok := f.tokenBounds(declarationRange.Pos(), declarationRange.End(), ast.KindTypeKeyword)
+	if !ok {
+		return nil
+	}
+
 	nameRange := utils.TrimNodeTextRange(f.sourceFile, typeAlias.Name())
-	nameText := sourceText[nameRange.Pos():nameRange.End()]
-	typeParametersText := f.typeParametersText(sourceText, typeAlias.TypeParameters)
-	prefix, _, _ := modifiersInfo(typeAlias.Modifiers())
-
-	unwrapped := ast.SkipTypeParentheses(typeAlias.Type)
-	bodyRange := utils.TrimNodeTextRange(f.sourceFile, unwrapped)
-	bodyText := sourceText[bodyRange.Pos():bodyRange.End()]
-
-	var commentText string
 	nameOrTypeParametersEnd := nameRange.End()
 	if typeAlias.TypeParameters != nil && len(typeAlias.TypeParameters.Nodes) > 0 {
 		lastParameter := typeAlias.TypeParameters.Nodes[len(typeAlias.TypeParameters.Nodes)-1]
@@ -104,42 +96,43 @@ func (f consistentTypeDefinitionsFixer) typeAliasFix(node *ast.Node, typeAlias *
 		nameOrTypeParametersEnd = lastRange.End() + 1
 	}
 
-	typeRange := utils.TrimNodeTextRange(f.sourceFile, typeAlias.Type)
-	betweenText := sourceText[nameOrTypeParametersEnd:typeRange.Pos()]
-	if index := strings.Index(betweenText, "/*"); index >= 0 {
-		endIndex := strings.Index(betweenText, "*/")
-		if endIndex >= 0 {
-			commentText = " " + ecmascript.StringTrim(betweenText[index:endIndex+2]) + " "
-		}
+	bodyRange := utils.TrimNodeTextRange(f.sourceFile, ast.SkipTypeParentheses(typeAlias.Type))
+	beforeEqualsEnd, ok := f.beforeEqualsEnd(nameOrTypeParametersEnd, bodyRange.Pos())
+	if !ok {
+		return nil
 	}
 
-	replacement := prefix + "interface " + nameText + typeParametersText + " " + bodyText
-	if commentText != "" {
-		replacement = prefix + "interface " + nameText + typeParametersText + commentText + bodyText
-	}
-
-	declarationRange := utils.TrimNodeTextRange(f.sourceFile, node)
+	replacement := sourceText[declarationRange.Pos():typeKeywordStart] +
+		"interface" +
+		sourceText[typeKeywordEnd:beforeEqualsEnd] +
+		" " +
+		sourceText[bodyRange.Pos():bodyRange.End()]
 	return []rule.RuleFix{rule.RuleFixReplaceRange(declarationRange, replacement)}
 }
 
 func (f consistentTypeDefinitionsFixer) interfaceFix(node *ast.Node, interfaceDeclaration *ast.InterfaceDeclaration) []rule.RuleFix {
 	sourceText := f.sourceFile.Text()
+	declarationRange := utils.TrimNodeTextRange(f.sourceFile, node)
+	interfaceKeywordStart, interfaceKeywordEnd, ok := f.tokenBounds(declarationRange.Pos(), declarationRange.End(), ast.KindInterfaceKeyword)
+	if !ok {
+		return nil
+	}
+
 	nameRange := utils.TrimNodeTextRange(f.sourceFile, interfaceDeclaration.Name())
 	nameText := sourceText[nameRange.Pos():nameRange.End()]
-	typeParametersText := f.typeParametersText(sourceText, interfaceDeclaration.TypeParameters)
-	prefix, hasExport, hasDefault := modifiersInfo(interfaceDeclaration.Modifiers())
-	declarationRange := utils.TrimNodeTextRange(f.sourceFile, node)
+	typeNameEnd := nameRange.End()
+	if interfaceDeclaration.TypeParameters != nil && len(interfaceDeclaration.TypeParameters.Nodes) > 0 {
+		lastParameter := interfaceDeclaration.TypeParameters.Nodes[len(interfaceDeclaration.TypeParameters.Nodes)-1]
+		lastRange := utils.TrimNodeTextRange(f.sourceFile, lastParameter)
+		typeNameEnd = lastRange.End() + 1
+	}
 
 	var bodyStartScanPosition int
 	if interfaceDeclaration.HeritageClauses != nil && len(interfaceDeclaration.HeritageClauses.Nodes) > 0 {
 		lastClause := interfaceDeclaration.HeritageClauses.Nodes[len(interfaceDeclaration.HeritageClauses.Nodes)-1]
 		bodyStartScanPosition = lastClause.End()
-	} else if interfaceDeclaration.TypeParameters != nil && len(interfaceDeclaration.TypeParameters.Nodes) > 0 {
-		lastParameter := interfaceDeclaration.TypeParameters.Nodes[len(interfaceDeclaration.TypeParameters.Nodes)-1]
-		lastRange := utils.TrimNodeTextRange(f.sourceFile, lastParameter)
-		bodyStartScanPosition = lastRange.End() + 1
 	} else {
-		bodyStartScanPosition = nameRange.End()
+		bodyStartScanPosition = typeNameEnd
 	}
 
 	sourceScanner := scanner.GetScannerForSourceFile(f.sourceFile, bodyStartScanPosition)
@@ -172,25 +165,17 @@ func (f consistentTypeDefinitionsFixer) interfaceFix(node *ast.Node, interfaceDe
 		}
 	}
 
-	if hasExport && hasDefault {
-		replacement := "type " + nameText + typeParametersText + " = " + bodyText
-		if len(extendsTypes) > 0 {
-			replacement += " & " + strings.Join(extendsTypes, " & ")
-		}
-		replacement += "\nexport default " + nameText
-		return []rule.RuleFix{rule.RuleFixReplaceRange(declarationRange, replacement)}
+	isDefaultExport := ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) && ast.HasSyntacticModifier(node, ast.ModifierFlagsDefault)
+	prefix := sourceText[declarationRange.Pos():interfaceKeywordStart]
+	if isDefaultExport {
+		prefix = ""
 	}
-
-	replacement := prefix + "type " + nameText + typeParametersText + " = " + bodyText
+	replacement := prefix + "type" + sourceText[interfaceKeywordEnd:typeNameEnd] + " = " + bodyText
 	if len(extendsTypes) > 0 {
 		replacement += " & " + strings.Join(extendsTypes, " & ")
 	}
-
-	declarationEnd := declarationRange.End()
-	if declarationEnd < len(sourceText) && sourceText[declarationEnd] == ';' {
-		fixRange := declarationRange.WithEnd(declarationEnd + 1)
-		replacement += ";"
-		return []rule.RuleFix{rule.RuleFixReplaceRange(fixRange, replacement)}
+	if isDefaultExport {
+		replacement += "\nexport default " + nameText
 	}
 
 	return []rule.RuleFix{rule.RuleFixReplaceRange(declarationRange, replacement)}
@@ -203,6 +188,26 @@ var ConsistentTypeDefinitionsRule = rule.CreateRule(rule.Rule{
 	Run:    run,
 })
 
+var (
+	interfaceOverTypeMessage = rule.RuleMessage{
+		Id:          "interfaceOverType",
+		Description: "Use an `interface` instead of a `type`.",
+	}
+	typeOverInterfaceMessage = rule.RuleMessage{
+		Id:          "typeOverInterface",
+		Description: "Use a `type` instead of an `interface`.",
+	}
+)
+
+func isInDeclareGlobal(node *ast.Node) bool {
+	for current := node.Parent; current != nil; current = current.Parent {
+		if ast.IsGlobalScopeAugmentation(current) && ast.HasSyntacticModifier(current, ast.ModifierFlagsAmbient) {
+			return true
+		}
+	}
+	return false
+}
+
 func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	opts := parseOptions(options)
 
@@ -210,114 +215,40 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		sourceFile: ctx.SourceFile,
 	}
 
-	// Helper to check if a type is an object type literal
-	isObjectTypeLiteral := func(typeNode *ast.Node) bool {
-		if typeNode == nil {
-			return false
-		}
-		return typeNode.Kind == ast.KindTypeLiteral
-	}
-
-	// Helper to check if a type alias is a simple object type (not a union, intersection, etc.)
-	// Unwraps any number of parenthesized type wrappers before checking.
-	isSimpleObjectType := func(typeNode *ast.Node) bool {
-		if typeNode == nil {
-			return false
-		}
-
-		// Unwrap all layers of parenthesized types
-		unwrapped := ast.SkipTypeParentheses(typeNode)
-		return isObjectTypeLiteral(unwrapped)
-	}
-
-	// Helper to check if a modifier list includes a specific modifier kind
-	hasModifier := func(modifiers *ast.ModifierList, kind ast.Kind) bool {
-		if modifiers == nil {
-			return false
-		}
-		for _, mod := range modifiers.Nodes {
-			if mod.Kind == kind {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Helper to check if interface is in a declare global module
-	isInDeclareGlobal := func(node *ast.Node) bool {
-		current := node.Parent
-		for current != nil {
-			if current.Kind == ast.KindModuleDeclaration {
-				moduleDecl := current.AsModuleDeclaration()
-				if moduleDecl != nil && moduleDecl.Name() != nil {
-					if ast.IsIdentifier(moduleDecl.Name()) {
-						ident := moduleDecl.Name().AsIdentifier()
-						if ident != nil && ident.Text == "global" {
-							// Only return true if module has 'declare' keyword
-							if hasModifier(moduleDecl.Modifiers(), ast.KindDeclareKeyword) {
-								return true
-							}
-						}
-					}
+	switch opts.Style {
+	case DefinitionStyleInterface:
+		return rule.RuleListeners{
+			ast.KindTypeAliasDeclaration: func(node *ast.Node) {
+				typeAlias := node.AsTypeAliasDeclaration()
+				if typeAlias == nil || typeAlias.Type == nil || ast.SkipTypeParentheses(typeAlias.Type).Kind != ast.KindTypeLiteral {
+					return
 				}
-			}
-			current = current.Parent
+
+				ctx.ReportNodeWithDeferredFixes(typeAlias.Name(), interfaceOverTypeMessage, func() []rule.RuleFix {
+					return fixer.typeAliasFix(node, typeAlias)
+				})
+			},
 		}
-		return false
-	}
+	case DefinitionStyleType:
+		return rule.RuleListeners{
+			ast.KindInterfaceDeclaration: func(node *ast.Node) {
+				interfaceDeclaration := node.AsInterfaceDeclaration()
+				if interfaceDeclaration == nil {
+					return
+				}
 
-	interfaceOverTypeMessage := rule.RuleMessage{
-		Id:          "interfaceOverType",
-		Description: "Use an interface instead of a type literal.",
-	}
-	typeOverInterfaceMessage := rule.RuleMessage{
-		Id:          "typeOverInterface",
-		Description: "Use a type literal instead of an interface.",
-	}
+				// Don't fix interfaces in declare global modules (see typescript-eslint #2707).
+				if isInDeclareGlobal(node) {
+					ctx.ReportNode(interfaceDeclaration.Name(), typeOverInterfaceMessage)
+					return
+				}
 
-	checkTypeAlias := func(node *ast.Node) {
-		if opts.Style != DefinitionStyleInterface {
-			return
+				ctx.ReportNodeWithDeferredFixes(interfaceDeclaration.Name(), typeOverInterfaceMessage, func() []rule.RuleFix {
+					return fixer.interfaceFix(node, interfaceDeclaration)
+				})
+			},
 		}
-
-		typeAlias := node.AsTypeAliasDeclaration()
-		if typeAlias == nil {
-			return
-		}
-
-		// Only report if it's a simple object type literal
-		if !isSimpleObjectType(typeAlias.Type) {
-			return
-		}
-
-		ctx.ReportNodeWithDeferredFixes(typeAlias.Name(), interfaceOverTypeMessage, func() []rule.RuleFix {
-			return fixer.typeAliasFix(node, typeAlias)
-		})
-	}
-
-	checkInterface := func(node *ast.Node) {
-		if opts.Style != DefinitionStyleType {
-			return
-		}
-
-		interfaceDecl := node.AsInterfaceDeclaration()
-		if interfaceDecl == nil {
-			return
-		}
-
-		// Don't fix interfaces in declare global modules (see typescript-eslint #2707)
-		if isInDeclareGlobal(node) {
-			ctx.ReportNode(interfaceDecl.Name(), typeOverInterfaceMessage)
-			return
-		}
-
-		ctx.ReportNodeWithDeferredFixes(interfaceDecl.Name(), typeOverInterfaceMessage, func() []rule.RuleFix {
-			return fixer.interfaceFix(node, interfaceDecl)
-		})
-	}
-
-	return rule.RuleListeners{
-		ast.KindTypeAliasDeclaration: checkTypeAlias,
-		ast.KindInterfaceDeclaration: checkInterface,
+	default:
+		return nil
 	}
 }

--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions_test.go
@@ -48,7 +48,14 @@ func TestConsistentTypeDefinitionsRule(t *testing.T) {
 			Code:   `type T = { [K: string]: number };`,
 			Output: []string{`interface T { [K: string]: number }`},
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "interfaceOverType"},
+				{
+					MessageId: "interfaceOverType",
+					Message:   "Use an `interface` instead of a `type`.",
+					Line:      1,
+					Column:    6,
+					EndLine:   1,
+					EndColumn: 7,
+				},
 			},
 		},
 		{
@@ -136,6 +143,41 @@ func TestConsistentTypeDefinitionsRule(t *testing.T) {
 				{MessageId: "interfaceOverType"},
 			},
 		},
+		{
+			Code:   `type /* before-name */ T = { x: number };`,
+			Output: []string{`interface /* before-name */ T { x: number }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "interfaceOverType"},
+			},
+		},
+		{
+			Code:   `export /* before-type */ type T = { x: number };`,
+			Output: []string{`export /* before-type */ interface T { x: number }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "interfaceOverType"},
+			},
+		},
+		{
+			Code:   `type T /* first */ /* second */ = { x: number };`,
+			Output: []string{`interface T /* first */ /* second */ { x: number }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "interfaceOverType"},
+			},
+		},
+		{
+			Code:   `type T = /* after-equals */ { x: number };`,
+			Output: []string{`interface T { x: number }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "interfaceOverType"},
+			},
+		},
+		{
+			Code:   `type T</* parameter */ U> /* before-equals */ = (/* after-equals */ { x: U });`,
+			Output: []string{`interface T</* parameter */ U> /* before-equals */ { x: U }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "interfaceOverType"},
+			},
+		},
 		// type → interface with excessive whitespace
 		{
 			Code:   `type T=                         { x: number; };`,
@@ -191,7 +233,14 @@ func TestConsistentTypeDefinitionsRule(t *testing.T) {
 			Options: []interface{}{"type"},
 			Output:  []string{`type T = { x: number; }`},
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "typeOverInterface"},
+				{
+					MessageId: "typeOverInterface",
+					Message:   "Use a `type` instead of an `interface`.",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 12,
+				},
 			},
 		},
 		{
@@ -258,6 +307,22 @@ func TestConsistentTypeDefinitionsRule(t *testing.T) {
 				{MessageId: "typeOverInterface"},
 			},
 		},
+		{
+			Code:    `interface /* before-name */ T { x: number }`,
+			Options: []interface{}{"type"},
+			Output:  []string{`type /* before-name */ T = { x: number }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "typeOverInterface"},
+			},
+		},
+		{
+			Code:    `export /* before-interface */ interface T { x: number }`,
+			Options: []interface{}{"type"},
+			Output:  []string{`export /* before-interface */ type T = { x: number }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "typeOverInterface"},
+			},
+		},
 		// interface → type with excessive whitespace
 		{
 			Code:    `interface T                          { x: number; }`,
@@ -294,11 +359,43 @@ func TestConsistentTypeDefinitionsRule(t *testing.T) {
 				{MessageId: "typeOverInterface"},
 			},
 		},
+		{
+			Code:    `declare namespace global { interface A {} }`,
+			Options: []interface{}{"type"},
+			Output:  []string{`declare namespace global { type A = {} }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "typeOverInterface"},
+			},
+		},
+		{
+			Code:    `declare module global { interface A {} }`,
+			Options: []interface{}{"type"},
+			Output:  []string{`declare module global { type A = {} }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "typeOverInterface"},
+			},
+		},
+		{
+			Code:    `declare namespace Outer { global { interface A {} } }`,
+			Options: []interface{}{"type"},
+			Output:  []string{`declare namespace Outer { global { type A = {} } }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "typeOverInterface"},
+			},
+		},
 		// export default interface
 		{
 			Code:    "export default interface Test {\n  bar(): string;\n  foo(): number;\n}",
 			Options: []interface{}{"type"},
 			Output:  []string{"type Test = {\n  bar(): string;\n  foo(): number;\n}\nexport default Test"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "typeOverInterface"},
+			},
+		},
+		{
+			Code:    `export default interface Test extends Base<T>, Extra { x: T };`,
+			Options: []interface{}{"type"},
+			Output:  []string{"type Test = { x: T } & Base<T> & Extra\nexport default Test;"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "typeOverInterface"},
 			},

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-type-definitions.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-type-definitions.test.ts.snap
@@ -5,7 +5,7 @@ exports[`consistent-type-definitions > invalid 1`] = `
   "code": "type T = { x: number; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -32,7 +32,7 @@ exports[`consistent-type-definitions > invalid 2`] = `
   "code": "type T={ x: number; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -59,7 +59,7 @@ exports[`consistent-type-definitions > invalid 3`] = `
   "code": "type T=                         { x: number; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -86,7 +86,7 @@ exports[`consistent-type-definitions > invalid 4`] = `
   "code": "type T /* comment */={ x: number; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -117,7 +117,7 @@ export type W<T> = {
       ",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -148,7 +148,7 @@ exports[`consistent-type-definitions > invalid 6`] = `
   "code": "type T = { [K: string]: number };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -175,7 +175,7 @@ exports[`consistent-type-definitions > invalid 7`] = `
   "code": "type T= { x: number; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -202,7 +202,7 @@ exports[`consistent-type-definitions > invalid 8`] = `
   "code": "type T = { x: number };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -229,7 +229,7 @@ exports[`consistent-type-definitions > invalid 9`] = `
   "code": "type T = { x: number; y: string; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -256,7 +256,7 @@ exports[`consistent-type-definitions > invalid 10`] = `
   "code": "type T = { x: number; y: { z: string; }; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -283,7 +283,7 @@ exports[`consistent-type-definitions > invalid 11`] = `
   "code": "type T<U> = { x: U; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -310,7 +310,7 @@ exports[`consistent-type-definitions > invalid 12`] = `
   "code": "type Foo = { a: string; };",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -337,7 +337,7 @@ exports[`consistent-type-definitions > invalid 13`] = `
   "code": "type Foo = (  { a: string; });",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -364,7 +364,7 @@ exports[`consistent-type-definitions > invalid 14`] = `
   "code": "interface T { x: number; }",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -391,7 +391,7 @@ exports[`consistent-type-definitions > invalid 15`] = `
   "code": "interface T{ x: number; }",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -418,7 +418,7 @@ exports[`consistent-type-definitions > invalid 16`] = `
   "code": "interface T                          { x: number; }",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -445,7 +445,7 @@ exports[`consistent-type-definitions > invalid 17`] = `
   "code": "interface A extends B, C { x: number; };",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -472,7 +472,7 @@ exports[`consistent-type-definitions > invalid 18`] = `
   "code": "interface A extends B<T1>, C<T2> { x: number; };",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -503,7 +503,7 @@ export interface W<T> {
       ",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -534,7 +534,7 @@ exports[`consistent-type-definitions > invalid 20`] = `
   "code": "interface T { x: number }",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -561,7 +561,7 @@ exports[`consistent-type-definitions > invalid 21`] = `
   "code": "interface T { x: number; y: string; }",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -588,7 +588,7 @@ exports[`consistent-type-definitions > invalid 22`] = `
   "code": "export interface W<T> { x: T; };",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -615,7 +615,7 @@ exports[`consistent-type-definitions > invalid 23`] = `
   "code": "interface T<U> { x: U; };",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -642,7 +642,7 @@ exports[`consistent-type-definitions > invalid 24`] = `
   "code": "interface Foo { a: string; }",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -669,7 +669,7 @@ exports[`consistent-type-definitions > invalid 25`] = `
   "code": "namespace Foo { export interface Bar {} }",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -702,7 +702,7 @@ namespace JSX {
       ",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -741,7 +741,7 @@ global {
       ",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -780,7 +780,7 @@ declare global {
       ",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -813,7 +813,7 @@ declare global {
       ",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -845,7 +845,7 @@ export default interface Test {
       ",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -883,7 +883,7 @@ export declare type Test = {
       ",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -920,7 +920,7 @@ export declare interface Test {
       ",
   "diagnostics": [
     {
-      "message": "Use a type literal instead of an interface.",
+      "message": "Use a \`type\` instead of an \`interface\`.",
       "messageId": "typeOverInterface",
       "range": {
         "end": {
@@ -956,7 +956,7 @@ type Foo = ({
       ",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -991,7 +991,7 @@ type Foo = ((((((((({
       ",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -1026,7 +1026,7 @@ type Foo = {
       ",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -1062,7 +1062,7 @@ type Bar = string;
       ",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {
@@ -1100,7 +1100,7 @@ const bar = 1;
       ",
   "diagnostics": [
     {
-      "message": "Use an interface instead of a type literal.",
+      "message": "Use an \`interface\` instead of a \`type\`.",
       "messageId": "interfaceOverType",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Align `consistent-type-definitions` diagnostic messages and autofix comment handling with typescript-eslint v8.67.0.
- Distinguish actual `declare global` augmentations from namespaces and modules merely named `global`, preserving upstream fix eligibility.
- Register only the listener required by the configured style; the targeted benchmark improves the median from 226.1 µs to 204.3 µs in `interface` mode and from 219.1 µs to 208.3 µs in `type` mode.

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
- https://github.com/typescript-eslint/typescript-eslint/issues/2707

## Validation

- `go test -race ./internal/plugins/typescript/rules/consistent_type_definitions -run "^TestConsistentTypeDefinitions" -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.go internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions_test.go`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).