### PR TITLE
fix: align duplicate enum value detection

### DIFF
--- a/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values.go
+++ b/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values.go
@@ -1,8 +1,11 @@
 package no_duplicate_enum_values
 
 import (
+	"math"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 type enumValueKind uint8
@@ -11,6 +14,7 @@ const (
 	enumValueString enumValueKind = 1 << iota
 	enumValueNumber
 	enumValueNegativeNumber
+	enumValueNegativeZero
 )
 
 type enumValue struct {
@@ -73,22 +77,70 @@ func (seen *seenEnumValues) add(value enumValue, capacity int) bool {
 }
 
 func getEnumValue(initializer *ast.Node) (enumValue, bool) {
+	if initializer.Kind == ast.KindParenthesizedExpression {
+		initializer = ast.SkipParentheses(initializer)
+	}
 	switch initializer.Kind {
 	case ast.KindNumericLiteral:
 		return enumValue{text: initializer.AsNumericLiteral().Text, kind: enumValueNumber}, true
 	case ast.KindStringLiteral:
 		return enumValue{text: initializer.AsStringLiteral().Text, kind: enumValueString}, true
 	case ast.KindNoSubstitutionTemplateLiteral:
-		return enumValue{text: initializer.AsNoSubstitutionTemplateLiteral().Text, kind: enumValueString}, true
-	case ast.KindPrefixUnaryExpression:
-		unaryExpression := initializer.AsPrefixUnaryExpression()
-		if unaryExpression.Operator != ast.KindMinusToken || unaryExpression.Operand.Kind != ast.KindNumericLiteral {
+		template := initializer.AsNoSubstitutionTemplateLiteral()
+		if template.TemplateFlags&ast.TokenFlagsContainsInvalidEscape != 0 {
 			return enumValue{}, false
 		}
-		return enumValue{text: unaryExpression.Operand.AsNumericLiteral().Text, kind: enumValueNegativeNumber}, true
+		return enumValue{text: template.Text, kind: enumValueString}, true
+	case ast.KindPrefixUnaryExpression:
+		unaryExpression := initializer.AsPrefixUnaryExpression()
+		if unaryExpression.Operator != ast.KindMinusToken && unaryExpression.Operator != ast.KindPlusToken {
+			return enumValue{}, false
+		}
+		value, ok := getEnumValue(unaryExpression.Operand)
+		if !ok {
+			return enumValue{}, false
+		}
+		return applyUnaryOperator(value, unaryExpression.Operator)
 	default:
 		return enumValue{}, false
 	}
+}
+
+func applyUnaryOperator(value enumValue, operator ast.Kind) (enumValue, bool) {
+	if value.kind == enumValueString {
+		number, ok := ecmascript.StringToNumber(value.text)
+		if !ok {
+			return enumValue{}, false
+		}
+		if operator == ast.KindMinusToken {
+			number = -number
+		}
+		return numberEnumValue(number), true
+	}
+
+	if operator == ast.KindPlusToken {
+		return value, true
+	}
+	if value.kind == enumValueNegativeZero {
+		return enumValue{text: "0", kind: enumValueNumber}, true
+	}
+	if value.kind == enumValueNegativeNumber {
+		return enumValue{text: value.text, kind: enumValueNumber}, true
+	}
+	if value.text == "0" {
+		return enumValue{text: "0", kind: enumValueNegativeZero}, true
+	}
+	return enumValue{text: value.text, kind: enumValueNegativeNumber}, true
+}
+
+func numberEnumValue(number float64) enumValue {
+	if number == 0 && math.Signbit(number) {
+		return enumValue{text: "0", kind: enumValueNegativeZero}
+	}
+	if number < 0 {
+		return enumValue{text: ecmascript.NumberToString(-number), kind: enumValueNegativeNumber}
+	}
+	return enumValue{text: ecmascript.NumberToString(number), kind: enumValueNumber}
 }
 
 func duplicateValueMessage(value enumValue) rule.RuleMessage {
@@ -124,7 +176,7 @@ var NoDuplicateEnumValuesRule = rule.CreateRule(rule.Rule{
 					}
 
 					if seenValues.add(value, len(enumDecl.Members.Nodes)) {
-						ctx.ReportNode(member.Name(), duplicateValueMessage(value))
+						ctx.ReportNode(memberNode, duplicateValueMessage(value))
 					}
 				}
 			},

--- a/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values_extras_test.go
+++ b/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values_extras_test.go
@@ -1,0 +1,170 @@
+package no_duplicate_enum_values
+
+// cspell:ignore CCMWEB
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDuplicateEnumValuesAdversarial(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoDuplicateEnumValuesRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `enum E { A = +'not a number', B = +'not a number' }`},
+			{Code: `enum E { A = +'-0x1', B = -1 }`},
+			{Code: `enum E { A = +(1 + 1), B = 2 }`},
+			{Code: `enum E { A = +'-0', B = 0 }`},
+			{Code: `enum E { A = '0', B = 0 }`},
+			{Code: `enum E { A = 'Infinity', B = 1e9999 }`},
+			{Code: `enum E { A = 1n, B = 1n }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `enum E {
+  ORIGINAL = 'app_logo_24',
+  CCMWEB_COMMON_H5_LOGO = 'app_logo_24',
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "duplicateValue",
+						Message:   "Duplicate enum member value app_logo_24.",
+						Line:      3,
+						Column:    3,
+						EndLine:   3,
+						EndColumn: 40,
+					},
+				},
+			},
+			{
+				Code: `enum E { A = ((1)), B = 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 1."},
+				},
+			},
+			{
+				Code: `enum E { A = +(('1')), B = 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 1."},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +'0x10',
+  B = 16,
+  C = +'  ',
+  D = 0,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 16.", Line: 3},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 5},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +'Infinity',
+  B = 1e9999,
+  C = -'Infinity',
+  D = -1e9999,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value Infinity.", Line: 3},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value -Infinity.", Line: 5},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +'.0000001',
+  B = 1e-7,
+  C = +'.000001',
+  D = 1e-6,
+  E = +'1e21',
+  F = 1e21,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 1e-7.", Line: 3},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.000001.", Line: 5},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 1e+21.", Line: 7},
+				},
+			},
+			{
+				Code: "enum E { A = '\\x41', B = 'A', C = `\\u0042`, D = 'B' }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value A."},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value B."},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +'-0',
+  B = -0,
+  C = -(-0),
+  D = 0,
+  E = +-0,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 3},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 5},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 6},
+				},
+			},
+			{
+				Code: `enum E { A = 1_000, B = 1000 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 1000."},
+				},
+			},
+			{
+				Code: `enum E { A = +'0xffffffffffffffff', B = 18446744073709552000 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 18446744073709552000."},
+				},
+			},
+			{
+				Code: `enum E {
+  StringZero = '0',
+  PositiveZero = 0,
+  NegativeZero = -0,
+  One = 1,
+  Two = 2,
+  Three = 3,
+  Four = 4,
+  Five = 5,
+  Six = 6,
+  Seven = 7,
+  Eight = 8,
+  DuplicateStringZero = '0',
+  DuplicatePositiveZero = +0,
+  DuplicateNegativeZero = -0,
+  NegativeOne = -1,
+  DuplicateNegativeOne = -1,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0."},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0."},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0."},
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value -1."},
+				},
+			},
+		},
+	)
+}
+
+func TestGetEnumValueSkipsInvalidTemplateEscape(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/invalid-template.ts",
+		Path:     "/invalid-template.ts",
+	}, "enum E { A = `\\unicode` }", core.ScriptKindTS)
+	member := sourceFile.Statements.Nodes[0].AsEnumDeclaration().Members.Nodes[0].AsEnumMember()
+	if _, ok := getEnumValue(member.Initializer); ok {
+		t.Fatal("invalid template escape must not have a cooked enum value")
+	}
+}

--- a/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values_test.go
+++ b/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values_test.go
@@ -17,6 +17,10 @@ func TestNoDuplicateEnumValuesRule(t *testing.T) {
 			{Code: `enum E { A }`},
 			{Code: `enum E { A = 1, B }`},
 			{Code: `enum E { A = 1, B = 2 }`},
+			{Code: `enum E { A = -1, B = -2 }`},
+			{Code: `enum E { A = +1, B = +2 }`},
+			{Code: `enum E { A = +1, B = -1 }`},
+			{Code: `enum E { A = 1, B = -1 }`},
 			{Code: `enum E { A = 'A', B = 'B' }`},
 			{Code: `enum E { A = 'A', B }`},
 			{Code: `enum E { A = 'A', B = 1 + 1 }`},
@@ -26,7 +30,15 @@ func TestNoDuplicateEnumValuesRule(t *testing.T) {
 			{Code: `enum E { A = 1, B = '1' }`},
 			{Code: `enum E { A = -1, B = '-1' }`},
 			{Code: `enum E { A = 0, B = -0 }`},
+			{Code: `enum E { A = -0, B = +0 }`},
+			{Code: `enum E { A = -0, B = 0 }`},
 			{Code: `enum E { A = NaN }`},
+			{Code: `enum E { A = NaN, B = NaN }`},
+			{Code: `enum E { A = NaN, B = -NaN }`},
+			{Code: `enum E { A = 'NaN', B = NaN }`},
+			{Code: `enum E { A = -+-0, B = +-+0 }`},
+			{Code: `enum E { A = -'', B = 0 }`},
+			{Code: `enum E { A = Infinity, B = Infinity }`},
 			{Code: "const x = 'A'; enum E { A = `${x}` }"},
 		},
 		[]rule_tester.InvalidTestCase{
@@ -49,6 +61,84 @@ func TestNoDuplicateEnumValuesRule(t *testing.T) {
 						Line:      1,
 						Column:    18,
 					},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +1,
+  B = +1,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 1.", Line: 3, Column: 3, EndLine: 3, EndColumn: 9},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +0,
+  B = 0,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 3, Column: 3, EndLine: 3, EndColumn: 8},
+				},
+			},
+			{
+				Code: `enum E {
+  A = -0,
+  B = -0,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 3, Column: 3, EndLine: 3, EndColumn: 9},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +'0',
+  B = 0,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 3, Column: 3, EndLine: 3, EndColumn: 8},
+				},
+			},
+			{
+				Code: `enum E {
+  A = 0x10,
+  B = 16,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 16.", Line: 3, Column: 3, EndLine: 3, EndColumn: 9},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +'1e2',
+  B = 100,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 100.", Line: 3, Column: 3, EndLine: 3, EndColumn: 10},
+				},
+			},
+			{
+				Code: `enum E {
+  A = +'',
+  B = 0,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 3, Column: 3, EndLine: 3, EndColumn: 8},
+				},
+			},
+			{
+				Code: `enum E {
+  A = -+1,
+  B = +-1,
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value -1.", Line: 3, Column: 3, EndLine: 3, EndColumn: 10},
+				},
+			},
+			{
+				Code: "enum E {\n  A = -`0`,\n  B = -0,\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicateValue", Message: "Duplicate enum member value 0.", Line: 3, Column: 3, EndLine: 3, EndColumn: 9},
 				},
 			},
 			{

--- a/internal/utils/ecmascript/number.go
+++ b/internal/utils/ecmascript/number.go
@@ -1,7 +1,9 @@
 package ecmascript
 
 import (
+	"errors"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 )
@@ -9,15 +11,11 @@ import (
 // NumberToString writes a number the way JavaScript writes one, which is what
 // `String(n)` and string concatenation produce: the shortest run of digits that
 // reads back as the same value, no sign on a zero, and exponential notation
-// once the decimal point sits past the twenty-first place.
+// outside the [1e-6, 1e21) range.
 //
-// Go's strconv agrees on the digits — both pick the shortest representation
-// that round-trips — but not on when to leave fixed notation, nor on how to
-// spell the infinities.
-//
-// Only whole numbers are covered: a value carrying a fraction is written in
-// fixed notation whatever its size, where JavaScript switches to exponential
-// notation below 1e-6.
+// Go's strconv agrees on the significant digits — both pick the shortest
+// representation that round-trips — but not on when to leave fixed notation,
+// how to pad exponents, or how to spell the infinities.
 //
 // https://tc39.es/ecma262/2024/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-number-tostring
 func NumberToString(value float64) string {
@@ -33,20 +31,105 @@ func NumberToString(value float64) string {
 	}
 
 	sign := ""
-	digits := strconv.FormatFloat(value, 'f', -1, 64)
-	if strings.HasPrefix(digits, "-") {
-		sign, digits = "-", digits[1:]
-	}
-	if len(digits) <= 21 || strings.ContainsRune(digits, '.') {
-		return sign + digits
+	if value < 0 {
+		sign = "-"
+		value = -value
 	}
 
-	// The digits hold no decimal point by now, so the exponent is however many
-	// of them follow the first.
-	exponent := strconv.Itoa(len(digits) - 1)
-	significant := strings.TrimRight(digits, "0")
-	if len(significant) == 1 {
-		return sign + significant + "e+" + exponent
+	scientific := strconv.FormatFloat(value, 'e', -1, 64)
+	exponentMarker := strings.LastIndexByte(scientific, 'e')
+	mantissa := scientific[:exponentMarker]
+	exponent, _ := strconv.Atoi(scientific[exponentMarker+1:])
+	digits := strings.Replace(mantissa, ".", "", 1)
+
+	if exponent >= -6 && exponent < 21 {
+		decimalPosition := exponent + 1
+		switch {
+		case decimalPosition <= 0:
+			return sign + "0." + strings.Repeat("0", -decimalPosition) + digits
+		case decimalPosition >= len(digits):
+			return sign + digits + strings.Repeat("0", decimalPosition-len(digits))
+		default:
+			return sign + digits[:decimalPosition] + "." + digits[decimalPosition:]
+		}
 	}
-	return sign + significant[:1] + "." + significant[1:] + "e+" + exponent
+
+	exponentText := strconv.Itoa(exponent)
+	if exponent >= 0 {
+		exponentText = "+" + exponentText
+	}
+	if len(digits) == 1 {
+		return sign + digits + "e" + exponentText
+	}
+	return sign + digits[:1] + "." + digits[1:] + "e" + exponentText
+}
+
+// StringToNumber applies JavaScript's StringToNumber operation. The boolean is
+// false exactly when JavaScript would produce NaN; infinities and signed zero
+// are valid results.
+func StringToNumber(value string) (float64, bool) {
+	value = StringTrim(value)
+	if value == "" {
+		return 0, true
+	}
+
+	switch value {
+	case "Infinity", "+Infinity":
+		return math.Inf(1), true
+	case "-Infinity":
+		return math.Inf(-1), true
+	}
+
+	if strings.ContainsRune(value, '_') {
+		return 0, false
+	}
+
+	prefixStart := 0
+	if value[0] == '+' || value[0] == '-' {
+		prefixStart = 1
+	}
+	if len(value) > prefixStart+2 && value[prefixStart] == '0' {
+		base := 0
+		switch value[prefixStart+1] {
+		case 'x', 'X':
+			base = 16
+		case 'o', 'O':
+			base = 8
+		case 'b', 'B':
+			base = 2
+		}
+		if base != 0 {
+			// StringToNumber accepts only unsigned non-decimal prefixes.
+			if prefixStart != 0 {
+				return 0, false
+			}
+			digits := value[2:]
+			if digits[0] == '+' || digits[0] == '-' {
+				return 0, false
+			}
+			integer, ok := new(big.Int).SetString(digits, base)
+			if !ok {
+				return 0, false
+			}
+			number, _ := new(big.Float).SetInt(integer).Float64()
+			return number, true
+		}
+	}
+
+	number, err := strconv.ParseFloat(value, 64)
+	if math.IsNaN(number) {
+		return 0, false
+	}
+	if err != nil {
+		// Decimal overflow is a valid infinity. Other parse failures are NaN.
+		if errors.Is(err, strconv.ErrRange) && math.IsInf(number, 0) {
+			return number, true
+		}
+		return 0, false
+	}
+	// ParseFloat additionally accepts Go's Inf spellings; JavaScript does not.
+	if math.IsInf(number, 0) {
+		return 0, false
+	}
+	return number, true
 }

--- a/internal/utils/ecmascript/number_test.go
+++ b/internal/utils/ecmascript/number_test.go
@@ -17,6 +17,10 @@ func TestNumberToString(t *testing.T) {
 		{name: "negative zero", value: math.Copysign(0, -1), want: "0"},
 		{name: "one", value: 1, want: "1"},
 		{name: "minus one", value: -1, want: "-1"},
+		{name: "fraction", value: 1.25, want: "1.25"},
+		{name: "last small fixed", value: 1e-6, want: "0.000001"},
+		{name: "first small exponential", value: 1e-7, want: "1e-7"},
+		{name: "small fraction", value: 1.2e-7, want: "1.2e-7"},
 		{name: "large", value: 1e15, want: "1000000000000000"},
 		// The decimal point sits in the twenty-first place here and the
 		// twenty-second one below, which is where JavaScript switches.
@@ -36,6 +40,47 @@ func TestNumberToString(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := NumberToString(test.value); got != test.want {
 				t.Errorf("NumberToString(%v) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestStringToNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  float64
+		ok    bool
+	}{
+		{name: "empty", value: "", want: 0, ok: true},
+		{name: "ECMAScript whitespace", value: "\uFEFF\u00A01\u2029", want: 1, ok: true},
+		{name: "negative zero", value: "-0", want: math.Copysign(0, -1), ok: true},
+		{name: "decimal", value: "1.25", want: 1.25, ok: true},
+		{name: "exponent", value: "1e2", want: 100, ok: true},
+		{name: "hex", value: "0x10", want: 16, ok: true},
+		{name: "octal", value: "0o10", want: 8, ok: true},
+		{name: "binary", value: "0b10", want: 2, ok: true},
+		{name: "positive infinity", value: "+Infinity", want: math.Inf(1), ok: true},
+		{name: "overflow", value: "1e9999", want: math.Inf(1), ok: true},
+		{name: "malformed overflow", value: "1e9999x", ok: false},
+		{name: "not a number", value: "NaN", ok: false},
+		{name: "Go infinity", value: "Inf", ok: false},
+		{name: "case-folded infinity", value: "infinity", ok: false},
+		{name: "signed hex", value: "-0x10", ok: false},
+		{name: "sign after hex prefix", value: "0x+10", ok: false},
+		{name: "hex float", value: "0x1p2", ok: false},
+		{name: "numeric separator", value: "1_000", ok: false},
+		{name: "text", value: "value", ok: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := StringToNumber(test.value)
+			if ok != test.ok {
+				t.Fatalf("StringToNumber(%q) ok = %v, want %v", test.value, ok, test.ok)
+			}
+			if ok && math.Float64bits(got) != math.Float64bits(test.want) {
+				t.Errorf("StringToNumber(%q) = %v, want %v", test.value, got, test.want)
 			}
 		})
 	}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-duplicate-enum-values.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-duplicate-enum-values.test.ts.snap
@@ -14,7 +14,7 @@ enum E {
       "messageId": "duplicateValue",
       "range": {
         "end": {
-          "column": 4,
+          "column": 8,
           "line": 4,
         },
         "start": {
@@ -45,7 +45,7 @@ enum E {
       "messageId": "duplicateValue",
       "range": {
         "end": {
-          "column": 4,
+          "column": 10,
           "line": 4,
         },
         "start": {
@@ -78,7 +78,7 @@ enum E {
       "messageId": "duplicateValue",
       "range": {
         "end": {
-          "column": 4,
+          "column": 10,
           "line": 4,
         },
         "start": {
@@ -93,7 +93,7 @@ enum E {
       "messageId": "duplicateValue",
       "range": {
         "end": {
-          "column": 4,
+          "column": 8,
           "line": 6,
         },
         "start": {
@@ -124,7 +124,7 @@ enum E {
       "messageId": "duplicateValue",
       "range": {
         "end": {
-          "column": 4,
+          "column": 10,
           "line": 4,
         },
         "start": {
@@ -155,7 +155,7 @@ enum E {
       "messageId": "duplicateValue",
       "range": {
         "end": {
-          "column": 4,
+          "column": 10,
           "line": 4,
         },
         "start": {


### PR DESCRIPTION
## Summary

- Align no-duplicate-enum-values with typescript-eslint v8.67.0 for signed literals, nested unary expressions, JavaScript string-to-number coercion, negative zero, cooked templates, and full enum-member diagnostic ranges.
- Preserve the inline value-tracking fast path and keep common small enums allocation-free; listener-only Go benchmarks showed no allocation regression after gating parenthesis unwrapping to the uncommon path.
- Add upstream, reported-range, numeric-boundary, parenthesis, escape, and inline-to-map regression coverage.

### Validation

- go test -count=1 for the rule, ecmascript utilities, and minimatch3 consumer
- check-spell
- format:check
- golangci-lint diff mode for the two changed packages
- ESLint 10.8.1 with typescript-eslint 8.67.0 oracle corpus

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-duplicate-enum-values.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).