### PR TITLE
fix: align TypeScript dot-notation with upstream

### DIFF
--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.go
@@ -2,21 +2,18 @@ package dot_notation
 
 import (
 	_ "embed"
-	"regexp"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
-	"github.com/microsoft/typescript-go/shim/core"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
-	esregexp "github.com/web-infra-dev/rslint/internal/utils/ecmascript/regexp"
+	coreDotNotation "github.com/web-infra-dev/rslint/internal/rules/dot_notation"
 )
 
 //go:embed dot_notation.schema.json
 var schemaJSON []byte
 
-// Options mirrors @typescript-eslint/dot-notation options
+// Options mirrors @typescript-eslint/dot-notation options.
 type Options struct {
 	AllowIndexSignaturePropertyAccess bool   `json:"allowIndexSignaturePropertyAccess"`
 	AllowKeywords                     bool   `json:"allowKeywords"`
@@ -54,343 +51,105 @@ func parseOptions(options []any) Options {
 	return opts
 }
 
-func buildUseDotMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useDot",
-		Description: "Use dot notation instead of bracket notation.",
-	}
-}
-
-func buildUseBracketsMessage(key string) rule.RuleMessage {
-	// Keep key for parity with ESLint message data (not used in printing now)
-	_ = key
-	return rule.RuleMessage{
-		Id:          "useBrackets",
-		Description: "Property is a keyword - use bracket notation.",
-	}
-}
-
-// Reserved word set mirrored from ESLint's core dot-notation rule
-// (see eslint/lib/rules/utils/keywords.js). This is the ES3 reserved-word
-// list, which is what the core rule uses for its keyword check — regardless
-// of ECMAScript version, because bracket notation on these names is the only
-// ES3-compatible form.
-var keywordSet = map[string]struct{}{
-	"abstract": {}, "boolean": {}, "break": {}, "byte": {}, "case": {}, "catch": {},
-	"char": {}, "class": {}, "const": {}, "continue": {}, "debugger": {}, "default": {},
-	"delete": {}, "do": {}, "double": {}, "else": {}, "enum": {}, "export": {},
-	"extends": {}, "false": {}, "final": {}, "finally": {}, "float": {}, "for": {},
-	"function": {}, "goto": {}, "if": {}, "implements": {}, "import": {}, "in": {},
-	"instanceof": {}, "int": {}, "interface": {}, "long": {}, "native": {}, "new": {},
-	"null": {}, "package": {}, "private": {}, "protected": {}, "public": {}, "return": {},
-	"short": {}, "static": {}, "super": {}, "switch": {}, "synchronized": {}, "this": {},
-	"throw": {}, "throws": {}, "transient": {}, "true": {}, "try": {}, "typeof": {},
-	"var": {}, "void": {}, "volatile": {}, "while": {}, "with": {},
-}
-
-var identRE = regexp.MustCompile(`^[A-Za-z_$][A-Za-z0-9_$]*$`)
-
-func isValidIdentifier(name string) bool {
-	return identRE.MatchString(name)
-}
-
-func isKeyword(name string) bool {
-	_, ok := keywordSet[name]
-	return ok
-}
-
 // hasStringLikeIndexSignature reports whether the type exposes an index
-// signature whose key is string-like. Uses the type checker so that mapped
-// types (including Record<K, V>) and template literal index keys are
-// recognized — not just inline `[key: …]: …` declarations.
-//
-// Passes the type through unchanged: on union types the checker returns only
-// index signatures present on *every* member, and on intersections it merges
-// signatures from the parts — which matches typescript-eslint's
-// `checker.getIndexInfosOfType(objectType)` behavior exactly.
+// signature whose key is string-like. The checker handles mapped types,
+// template-literal keys, unions, and intersections with TypeScript semantics.
 func hasStringLikeIndexSignature(tc *checker.Checker, t *checker.Type) bool {
 	if t == nil || tc == nil {
 		return false
 	}
 	for _, info := range tc.GetIndexInfosOfType(t) {
-		if info == nil || info.KeyType() == nil {
-			continue
-		}
-		if info.KeyType().Flags()&checker.TypeFlagsStringLike != 0 {
+		if info != nil && info.KeyType() != nil && info.KeyType().Flags()&checker.TypeFlagsStringLike != 0 {
 			return true
 		}
 	}
 	return false
 }
 
-// literalKey returns the property key string for the argument of a bracket
-// access, matching the set ESLint's core rule handles: string literals,
-// no-substitution template literals (`a[`foo`]`), and the bare `null` /
-// `true` / `false` keyword literals (`a[null]` / `a[true]` / `a[false]`).
-// Computed expressions and number literals are intentionally skipped.
-func literalKey(n *ast.Node) (string, bool) {
-	if ast.IsStringLiteralLike(n) {
-		return n.Text(), true
-	}
-	switch n.Kind {
-	case ast.KindNullKeyword:
-		return "null", true
-	case ast.KindTrueKeyword:
-		return "true", true
-	case ast.KindFalseKeyword:
-		return "false", true
-	}
-	return "", false
-}
-
-type dotNotationFixer struct {
-	sourceFile *ast.SourceFile
-	sourceText string
-}
-
-// buildUseDotFix constructs the bracket-to-dot replacement after the rule has
-// already decided to report. Keeping source ranges, comment inspection, and
-// replacement text construction here lets diagnostics-only consumers skip
-// every fix-specific source operation.
-func (f *dotNotationFixer) buildUseDotFix(
-	node *ast.Node,
-	elem *ast.ElementAccessExpression,
-	propName string,
-) []rule.RuleFix {
-	nodeRange := utils.TrimNodeTextRange(f.sourceFile, node)
-	exprRange := utils.TrimNodeTextRange(f.sourceFile, elem.Expression)
-
-	bracketStart := exprRange.End()
-	for bracketStart < nodeRange.End() && f.sourceText[bracketStart] != '[' {
-		bracketStart++
-	}
-	bracketEnd := nodeRange.End() - 1
-	for bracketEnd > bracketStart && f.sourceText[bracketEnd] != ']' {
-		bracketEnd--
-	}
-
-	insideBrackets := core.NewTextRange(bracketStart+1, bracketEnd)
-	if utils.HasCommentsInRange(f.sourceFile, insideBrackets) {
-		return nil
-	}
-
-	whitespace := ""
-	if bracketStart > exprRange.End() {
-		whitespace = f.sourceText[exprRange.End():bracketStart]
-	}
-	objectText := f.sourceText[exprRange.Pos():exprRange.End()]
-	replacement := objectText + whitespace + "." + propName
-
-	return []rule.RuleFix{rule.RuleFixReplace(f.sourceFile, node, replacement)}
-}
-
-// buildUseBracketsFix constructs the dot-to-bracket replacement after the
-// keyword access has been detected. It deliberately preserves the existing
-// whole-node replacement and trivia behavior; this helper only changes when
-// the work is materialized.
-func (f *dotNotationFixer) buildUseBracketsFix(
-	node *ast.Node,
-	pae *ast.PropertyAccessExpression,
-	name string,
-	isOptional bool,
-) []rule.RuleFix {
-	nameRange := utils.TrimNodeTextRange(f.sourceFile, pae.Name())
-	objRange := utils.TrimNodeTextRange(f.sourceFile, pae.Expression)
-
-	// Locate the start of the access operator — either `?.` (optional
-	// chain) or `.`. Any whitespace between the object end and the
-	// operator belongs to the replacement.
-	accessStart := objRange.End()
-	for accessStart < nameRange.Pos() && f.sourceText[accessStart] != '?' && f.sourceText[accessStart] != '.' {
-		accessStart++
-	}
-
-	// Suppress autofix if a comment lives between the operator and the
-	// property name (ESLint parity). The operator is 1 byte for `.` or
-	// 2 bytes for `?.`.
-	opLen := 1
-	if f.sourceText[accessStart] == '?' {
-		opLen = 2
-	}
-	gapStart := accessStart + opLen
-	if gapStart > nameRange.Pos() {
-		gapStart = nameRange.Pos()
-	}
-	if utils.HasCommentsInRange(f.sourceFile, core.NewTextRange(gapStart, nameRange.Pos())) {
-		return nil
-	}
-
-	objectText := f.sourceText[objRange.Pos():objRange.End()]
-	preOp := f.sourceText[objRange.End():accessStart] // whitespace before operator
-	var replacement string
-	if isOptional {
-		replacement = objectText + preOp + "?.[\"" + name + "\"]"
-	} else {
-		replacement = objectText + preOp + "[\"" + name + "\"]"
-	}
-	return []rule.RuleFix{rule.RuleFixReplace(f.sourceFile, node, replacement)}
-}
-
-// DotNotationRule enforces dot-notation when safe and allowed by options.
-//
-// KNOWN LIMITATION: The test infrastructure in /packages/rule-tester doesn't properly pass
-// TypeScript compiler options from individual test cases. This means tests that rely on
-// specific tsconfig settings (like noPropertyAccessFromIndexSignature) may not work correctly.
-// The test runner always uses the same rslint.json config file for all test cases, which
-// references a fixed tsconfig.json. Individual test cases can specify different tsconfig files
-// via languageOptions.parserOptions.project, but these are ignored by the test runner.
-// See: /packages/rule-tester/src/index.ts line 273 - the lint() call doesn't use per-test config.
+// DotNotationRule extends ESLint core's dot-notation rule with TypeScript's
+// private, protected, and index-signature allowances. Delegating base
+// diagnostics and fixes keeps messages, ranges, and edit behavior aligned with
+// the exact core rule that typescript-eslint extends upstream.
 var DotNotationRule = rule.CreateRule(rule.Rule{
 	Name:             "dot-notation",
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
-		// ECMAScript + Unicode flags mirror ESLint's `new RegExp(pattern, 'u')`
-		// so user patterns using lookaround, backreferences, or `\p{...}` work
-		// identically to the original rule (Go's standard `regexp` / RE2 does not
-		// support those). Invalid regex patterns are silently ignored for parity.
-		var allowRE *esregexp.RegExp
-		if opts.AllowPattern != "" {
-			if re, err := esregexp.Compile(opts.AllowPattern, "u"); err == nil {
-				allowRE = re
-			}
-		}
+		baseListeners := coreDotNotation.DotNotationRule.Run(ctx, options)
 
-		// Derive allowIndexSignaturePropertyAccess from tsconfig option as well (currently not used directly)
-		if ctx.Program() != nil {
-			_ = ctx.Program().Options()
-		}
-
-		fixer := dotNotationFixer{
-			sourceFile: ctx.SourceFile,
-			sourceText: ctx.SourceFile.Text(),
-		}
-		listeners := rule.RuleListeners{}
-
-		// Compute allowIndexSignaturePropertyAccess once — respects both the
-		// rule option and the `noPropertyAccessFromIndexSignature` tsconfig flag
-		// (same derivation as typescript-eslint).
 		allowIndexAccess := opts.AllowIndexSignaturePropertyAccess
-		if ctx.Program() != nil {
-			if copts := ctx.Program().Options(); copts != nil && copts.NoPropertyAccessFromIndexSignature.IsTrue() {
+		if program := ctx.Program(); program != nil {
+			if compilerOptions := program.Options(); compilerOptions != nil && compilerOptions.NoPropertyAccessFromIndexSignature.IsTrue() {
 				allowIndexAccess = true
 			}
 		}
 
-		// Handle bracket → dot (ElementAccessExpression)
-		listeners[ast.KindElementAccessExpression] = func(node *ast.Node) {
-			elem := node.AsElementAccessExpression()
-			if elem == nil || elem.ArgumentExpression == nil {
-				return
+		hasTypeAwareAllowance := opts.AllowPrivateClassPropertyAccess ||
+			opts.AllowProtectedClassPropertyAccess ||
+			allowIndexAccess
+		if !hasTypeAwareAllowance {
+			// The core property-access listener cannot report when keywords are
+			// allowed. Omitting it avoids a callback for every ordinary dot access.
+			if opts.AllowKeywords {
+				delete(baseListeners, ast.KindPropertyAccessExpression)
 			}
+			return baseListeners
+		}
 
-			// Unwrap parentheses on the key so shapes like `a[('foo')]`
-			// are still recognized as a literal key.
-			propName, ok := literalKey(ast.SkipParentheses(elem.ArgumentExpression))
-			if !ok {
-				return
-			}
-
-			// Option: allow pattern — matches the regex filter from the core
-			// rule (JS uses the `u` flag, Go regexp is UTF-8 aware; simple
-			// patterns behave identically, ES-only features like lookbehind
-			// are not supported).
-			if allowRE != nil {
-				if allowRE.TestOrTimeout(propName) {
+		baseElementListener := baseListeners[ast.KindElementAccessExpression]
+		listeners := rule.RuleListeners{
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				elem := node.AsElementAccessExpression()
+				if elem == nil || elem.ArgumentExpression == nil {
 					return
 				}
-			}
 
-			// Base-rule gating: only flag when value is a valid identifier
-			// AND, when allowKeywords is off, it's not an ES3 reserved word.
-			if !isValidIdentifier(propName) {
-				return
-			}
-			if !opts.AllowKeywords && isKeyword(propName) {
-				return
-			}
-
-			// typescript-eslint only performs the type-based skip when one of
-			// the allow-* options is turned on — skip the checker round-trip
-			// otherwise.
-			if opts.AllowPrivateClassPropertyAccess ||
-				opts.AllowProtectedClassPropertyAccess ||
-				allowIndexAccess {
-
-				objType := ctx.TypeChecker.GetTypeAtLocation(elem.Expression)
-				nnType := ctx.TypeChecker.GetNonNullableType(objType)
-				appType := checker.Checker_getApparentType(ctx.TypeChecker, nnType)
-
-				// Prefer the symbol resolved by the checker at the property
-				// node; fall back to scanning the object type's members.
-				sym := ctx.TypeChecker.GetSymbolAtLocation(elem.ArgumentExpression)
-				if sym == nil {
-					sym = checker.Checker_getPropertyOfType(ctx.TypeChecker, appType, propName)
-				}
-				if sym == nil {
-					for _, s := range checker.Checker_getPropertiesOfType(ctx.TypeChecker, appType) {
-						if s != nil && s.Name == propName {
-							sym = s
-							break
+				tc := ctx.TypeChecker
+				propertySymbol := tc.GetSymbolAtLocation(elem.ArgumentExpression)
+				var objectType *checker.Type
+				if propertySymbol == nil {
+					objectType = tc.GetNonNullableType(tc.GetTypeAtLocation(elem.Expression))
+					keyNode := ast.SkipParentheses(elem.ArgumentExpression)
+					if ast.IsStringLiteral(keyNode) {
+						propertyName := keyNode.Text()
+						apparentType := checker.Checker_getApparentType(tc, objectType)
+						propertySymbol = checker.Checker_getPropertyOfType(tc, apparentType, propertyName)
+						if propertySymbol == nil {
+							for _, candidate := range checker.Checker_getPropertiesOfType(tc, apparentType) {
+								if candidate != nil && candidate.Name == propertyName {
+									propertySymbol = candidate
+									break
+								}
+							}
 						}
 					}
 				}
 
-				if sym != nil {
-					flags := checker.GetDeclarationModifierFlagsFromSymbol(sym)
-					if opts.AllowPrivateClassPropertyAccess && (flags&ast.ModifierFlagsPrivate) != 0 {
+				if propertySymbol != nil {
+					flags := checker.GetDeclarationModifierFlagsFromSymbol(propertySymbol)
+					if opts.AllowPrivateClassPropertyAccess && flags&ast.ModifierFlagsPrivate != 0 {
 						return
 					}
-					if opts.AllowProtectedClassPropertyAccess && (flags&ast.ModifierFlagsProtected) != 0 {
+					if opts.AllowProtectedClassPropertyAccess && flags&ast.ModifierFlagsProtected != 0 {
 						return
 					}
 				} else if allowIndexAccess {
-					// No named property symbol — allowed via string-like index signature.
-					if hasStringLikeIndexSignature(ctx.TypeChecker, appType) {
+					if objectType == nil {
+						objectType = tc.GetNonNullableType(tc.GetTypeAtLocation(elem.Expression))
+					}
+					if hasStringLikeIndexSignature(tc, objectType) {
 						return
 					}
 				}
-			}
 
-			ctx.ReportNodeWithDeferredFixes(elem.ArgumentExpression, buildUseDotMessage(), func() []rule.RuleFix {
-				return fixer.buildUseDotFix(node, elem, propName)
-			})
+				baseElementListener(node)
+			},
 		}
 
-		// Handle dot → bracket (PropertyAccessExpression) when keywords are disallowed.
-		// Mirrors ESLint core behavior: only when property is an Identifier
-		// whose name is in the ES3 reserved-word list.
-		listeners[ast.KindPropertyAccessExpression] = func(node *ast.Node) {
-			if opts.AllowKeywords {
-				return
-			}
-			pae := node.AsPropertyAccessExpression()
-			if pae == nil || pae.Name() == nil || pae.Expression == nil {
-				return
-			}
-			if !ast.IsIdentifier(pae.Name()) {
-				return
-			}
-			name := pae.Name().Text()
-			if !isKeyword(name) {
-				return
-			}
-
-			// `let[...]` parses as a destructuring variable declaration. Skip
-			// the autofix in that exact shape (non-optional access on a bare
-			// `let` identifier).
-			isOptional := pae.QuestionDotToken != nil
-			if !isOptional && ast.IsIdentifier(pae.Expression) && pae.Expression.Text() == "let" {
-				ctx.ReportNode(pae.Name(), buildUseBracketsMessage(name))
-				return
-			}
-
-			ctx.ReportNodeWithDeferredFixes(pae.Name(), buildUseBracketsMessage(name), func() []rule.RuleFix {
-				return fixer.buildUseBracketsFix(node, pae, name, isOptional)
-			})
+		if !opts.AllowKeywords {
+			listeners[ast.KindPropertyAccessExpression] = baseListeners[ast.KindPropertyAccessExpression]
 		}
-
 		return listeners
 	},
 })

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
@@ -161,7 +161,14 @@ func TestDotNotationRule(t *testing.T) {
 		{
 			Code:   "a['b'];",
 			Output: []string{"a.b;"},
-			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot", Line: 1, Column: 3}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "useDot",
+				Message:   `["b"] is better written in dot notation.`,
+				Line:      1,
+				Column:    3,
+				EndLine:   1,
+				EndColumn: 6,
+			}},
 		},
 		{
 			Code:   "a['test'];",
@@ -222,7 +229,10 @@ func TestDotNotationRule(t *testing.T) {
 			Code:    "a?.while;",
 			Options: map[string]interface{}{"allowKeywords": false},
 			Output:  []string{"a?.[\"while\"];"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "useBrackets",
+				Message:   ".while is a syntax error.",
+			}},
 		},
 		// Parenthesized literal key is still a literal key.
 		{
@@ -230,14 +240,10 @@ func TestDotNotationRule(t *testing.T) {
 			Output: []string{"a.b;"},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
 		},
-		// Chained bracket access: three separate reports, three fix passes.
+		// Chained bracket access: all non-overlapping bracket ranges fix in one pass.
 		{
-			Code: "a['b']['c']['d'];",
-			Output: []string{
-				"a.b['c']['d'];",
-				"a.b.c['d'];",
-				"a.b.c.d;",
-			},
+			Code:   "a['b']['c']['d'];",
+			Output: []string{"a.b.c.d;"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "useDot"},
 				{MessageId: "useDot"},
@@ -250,7 +256,73 @@ func TestDotNotationRule(t *testing.T) {
 		{
 			Code:   "a['\\u0062'];",
 			Output: []string{"a.b;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "useDot",
+				Message:   `["b"] is better written in dot notation.`,
+			}},
+		},
+
+		// Static template and keyword literals preserve upstream message data formatting.
+		{
+			Code:   "a[`time`];",
+			Output: []string{"a.time;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "useDot",
+				Message:   "[`time`] is better written in dot notation.",
+			}},
+		},
+		{
+			Code:   "a[null];",
+			Output: []string{"a.null;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "useDot",
+				Message:   "[null] is better written in dot notation.",
+			}},
+		},
+		{
+			Code:   "a[true];",
+			Output: []string{"a.true;"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "useDot",
+				Message:   "[true] is better written in dot notation.",
+			}},
+		},
+
+		// Base-rule fixer boundaries inherited by the TypeScript extension.
+		{
+			Code:   "obj?.['prop'];",
+			Output: []string{"obj?.prop;"},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		{
+			Code:   "1['toString'];",
+			Output: []string{"1 .toString;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		{
+			Code:   "foo['bar']instanceof baz;",
+			Output: []string{"foo.bar instanceof baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		{
+			Code:   "foo /* [ */ ['bar'];",
+			Output: []string{"foo /* [ */ .bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		{
+			Code:    "foo /* ? */ .while;",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Output:  []string{`foo /* ? */ ["while"];`},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+		},
+		{
+			Code:    "a.if.while;",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Output:  []string{`a["if"]["while"];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useBrackets"},
+				{MessageId: "useBrackets"},
+			},
 		},
 
 		// --- #6 allowKeywords:false + dot access to null/true/false ---
@@ -400,10 +472,24 @@ func TestDotNotationEditDemand(t *testing.T) {
 	}
 
 	wantFix := []bool{true, false, true, false, false}
-	wantText := []string{"object.property", "", "object?.[\"while\"]", "", ""}
+	wantText := []string{".property", "", "?.[\"while\"]", "", ""}
+	wantMessage := []string{
+		`["property"] is better written in dot notation.`,
+		`["commented"] is better written in dot notation.`,
+		`.while is a syntax error.`,
+		`.while is a syntax error.`,
+		`.if is a syntax error.`,
+	}
+	wantKey := []string{`"property"`, `"commented"`, "while", "while", "if"}
 	for index, shouldFix := range wantFix {
 		autofix := diagnostics[rule.EditDemandAutofix][index].FixesPtr
 		allEdits := diagnostics[rule.EditDemandAll][index].FixesPtr
+		if got := diagnostics[rule.EditDemandNone][index].Message.Description; got != wantMessage[index] {
+			t.Errorf("diagnostic %d message = %q, want %q", index, got, wantMessage[index])
+		}
+		if got := diagnostics[rule.EditDemandNone][index].Message.Data["key"]; got != wantKey[index] {
+			t.Errorf("diagnostic %d key data = %q, want %q", index, got, wantKey[index])
+		}
 		if (autofix != nil) != shouldFix {
 			t.Errorf("diagnostic %d fix presence = %v, want %v", index, autofix != nil, shouldFix)
 		}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/dot-notation.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/dot-notation.test.ts.snap
@@ -12,7 +12,7 @@ x['priv_prop'] = 123;
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["priv_prop"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -53,7 +53,7 @@ x['pub_prop'] = 123;
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["pub_prop"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -87,7 +87,7 @@ exports[`dot-notation > invalid 3`] = `
   "code": "a['true'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["true"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -114,7 +114,7 @@ exports[`dot-notation > invalid 4`] = `
   "code": "a['time'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["time"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -141,7 +141,7 @@ exports[`dot-notation > invalid 5`] = `
   "code": "a[null];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "[null] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -168,7 +168,7 @@ exports[`dot-notation > invalid 6`] = `
   "code": "a[true];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "[true] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -195,7 +195,7 @@ exports[`dot-notation > invalid 7`] = `
   "code": "a[false];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "[false] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -222,7 +222,7 @@ exports[`dot-notation > invalid 8`] = `
   "code": "a['b'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["b"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -249,7 +249,7 @@ exports[`dot-notation > invalid 9`] = `
   "code": "a.b['c'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["c"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -276,7 +276,7 @@ exports[`dot-notation > invalid 10`] = `
   "code": "a['_dangle'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["_dangle"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -303,7 +303,7 @@ exports[`dot-notation > invalid 11`] = `
   "code": "a['SHOUT_CASE'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["SHOUT_CASE"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -333,7 +333,7 @@ a
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["SHOUT_CASE"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -367,7 +367,7 @@ exports[`dot-notation > invalid 13`] = `
     ["catch"](function(){});",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["catch"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -382,7 +382,7 @@ exports[`dot-notation > invalid 13`] = `
       "ruleName": "@typescript-eslint/dot-notation",
     },
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["catch"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -416,7 +416,7 @@ foo
       ",
   "diagnostics": [
     {
-      "message": "Property is a keyword - use bracket notation.",
+      "message": ".while is a syntax error.",
       "messageId": "useBrackets",
       "range": {
         "end": {
@@ -446,7 +446,7 @@ exports[`dot-notation > invalid 15`] = `
   "code": "foo[/* comment */ 'bar'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["bar"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -473,7 +473,7 @@ exports[`dot-notation > invalid 16`] = `
   "code": "foo['bar' /* comment */];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["bar"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -500,7 +500,7 @@ exports[`dot-notation > invalid 17`] = `
   "code": "foo['bar'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["bar"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -527,7 +527,7 @@ exports[`dot-notation > invalid 18`] = `
   "code": "foo./* comment */ while;",
   "diagnostics": [
     {
-      "message": "Property is a keyword - use bracket notation.",
+      "message": ".while is a syntax error.",
       "messageId": "useBrackets",
       "range": {
         "end": {
@@ -554,7 +554,7 @@ exports[`dot-notation > invalid 19`] = `
   "code": "foo[null];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "[null] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -581,7 +581,7 @@ exports[`dot-notation > invalid 20`] = `
   "code": "foo['bar'] instanceof baz;",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["bar"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -608,7 +608,7 @@ exports[`dot-notation > invalid 21`] = `
   "code": "let.if();",
   "diagnostics": [
     {
-      "message": "Property is a keyword - use bracket notation.",
+      "message": ".if is a syntax error.",
       "messageId": "useBrackets",
       "range": {
         "end": {
@@ -642,7 +642,7 @@ x['protected_prop'] = 123;
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["protected_prop"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -684,7 +684,7 @@ x['prop'] = 'hello';
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["prop"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -725,7 +725,7 @@ foo['key_baz'];
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["key_baz"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -769,7 +769,7 @@ function f<T extends Foo>(x: T) {
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["extraKey"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -811,7 +811,7 @@ m['foo'];
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -846,7 +846,7 @@ m['bar'];
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["bar"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -877,7 +877,7 @@ exports[`dot-notation > invalid 28`] = `
   "code": "a['\\u0062'];",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["b"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -904,7 +904,7 @@ exports[`dot-notation > invalid 29`] = `
   "code": "a.null;",
   "diagnostics": [
     {
-      "message": "Property is a keyword - use bracket notation.",
+      "message": ".null is a syntax error.",
       "messageId": "useBrackets",
       "range": {
         "end": {
@@ -931,7 +931,7 @@ exports[`dot-notation > invalid 30`] = `
   "code": "a.true;",
   "diagnostics": [
     {
-      "message": "Property is a keyword - use bracket notation.",
+      "message": ".true is a syntax error.",
       "messageId": "useBrackets",
       "range": {
         "end": {
@@ -958,7 +958,7 @@ exports[`dot-notation > invalid 31`] = `
   "code": "a.false;",
   "diagnostics": [
     {
-      "message": "Property is a keyword - use bracket notation.",
+      "message": ".false is a syntax error.",
       "messageId": "useBrackets",
       "range": {
         "end": {
@@ -985,7 +985,7 @@ exports[`dot-notation > invalid 32`] = `
   "code": "a['foo'] = 1;",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -1012,7 +1012,7 @@ exports[`dot-notation > invalid 33`] = `
   "code": "a['foo'] += 1;",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -1039,7 +1039,7 @@ exports[`dot-notation > invalid 34`] = `
   "code": "a['foo']++;",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -1069,7 +1069,7 @@ x['foo'];
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -1104,7 +1104,7 @@ class X {
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["a"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -1141,7 +1141,7 @@ class X extends B {
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -1176,7 +1176,7 @@ const el = <div>{p['foo']}</div>;
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {
@@ -1211,7 +1211,7 @@ namespace N {
       ",
   "diagnostics": [
     {
-      "message": "Use dot notation instead of bracket notation.",
+      "message": "["foo"] is better written in dot notation.",
       "messageId": "useDot",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/dot-notation` with typescript-eslint 8.67.0 by delegating base diagnostics and fixes to the ESLint core rule it extends upstream.
- Preserve TypeScript-specific private, protected, and index-signature allowances, while avoiding the property-access listener when `allowKeywords` makes it unable to report.
- Add focused regressions for exact messages/data/ranges, optional chains, numeric receivers, adjacent tokens, comment traps, nested fixes, and edit-demand behavior.

### Validation

- `go test ./internal/plugins/typescript/rules/dot_notation -count=3`
- `pnpm --filter @rslint/test-tools exec rstest run tests/typescript-eslint/rules/dot-notation.test.ts`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/dot_notation/...`
- `git diff --check`

### Go benchmark

Command: `go test ./internal/plugins/typescript/rules/dot_notation -run '^$' -bench '^BenchmarkDotNotation$' -benchmem -benchtime=500ms -count=5`

Each case lints 64 accesses; values below are the means of five samples.

| Case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Index signature allowed | 17,602.2 → 11,217.2 (-36.3%) | 2,937.2 → 3,333.2 (+13.5%) | 37 → 40 (+8.1%) |
| Pattern allowed | 11,157.8 → 19,223.6 (+72.3%) | 9,973.0 → 13,197.2 (+32.3%) | 148 → 340 (+129.7%) |
| Dynamic no-match | 5,201.8 → 4,985.4 (-4.2%) | 2,930.0 → 3,074.0 (+4.9%) | 37 → 37 (0.0%) |
| Dot-to-brackets autofix | 43,683.0 → 26,062.6 (-40.3%) | 150,918.2 → 81,940.8 (-45.7%) | 1,317 → 742 (-43.7%) |
| Dot-to-brackets diagnostics | 9,112.0 → 15,509.4 (+70.2%) | 13,172.2 → 36,879.6 (+180.0%) | 101 → 294 (+191.1%) |
| Brackets-to-dot autofix | 46,353.2 → 40,089.8 (-13.5%) | 150,939.8 → 86,059.8 (-43.0%) | 1,317 → 997 (-24.3%) |
| Commented brackets autofix | 42,353.6 → 96,683.2 (+128.3%) | 128,918.8 → 221,679.8 (+72.0%) | 805 → 4,423 (+449.4%) |
| Brackets-to-dot diagnostics | 13,257.4 → 24,684.8 (+86.2%) | 13,176.0 → 40,983.0 (+211.0%) | 101 → 485 (+380.2%) |

The diagnostic regressions are the cost of producing upstream-compatible dynamic message text and structured data. The commented-fix regression comes from the shared core rule's token-aware comment safety checks; it is retained for correctness. Autofix construction and index-signature handling improve materially.

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/dot-notation.ts
- https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/dot-notation.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
