### PR TITLE
fix: align no-invalid-void-type with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.go
+++ b/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.go
@@ -47,6 +47,13 @@ func isAllowInGenericTruthy(opts NoInvalidVoidTypeOptions) bool {
 	return true
 }
 
+// isAllowInGenericTrue returns true only for the boolean true option. Upstream
+// treats a whitelist differently from true outside of type references.
+func isAllowInGenericTrue(opts NoInvalidVoidTypeOptions) bool {
+	allow, ok := opts.AllowInGenericTypeArguments.(bool)
+	return ok && allow
+}
+
 // getNotReturnMessageId returns the appropriate message ID based on which options are enabled.
 func getNotReturnMessageId(opts NoInvalidVoidTypeOptions) string {
 	allowGeneric := isAllowInGenericTruthy(opts)
@@ -66,35 +73,23 @@ func getNotReturnMessageId(opts NoInvalidVoidTypeOptions) string {
 func getNotReturnDescription(messageId string) string {
 	switch messageId {
 	case "invalidVoidNotReturnOrThisParamOrGeneric":
-		return "`void` is only valid as a return type, generic type argument, or `this` parameter type."
+		return "void is only valid as a return type or generic type argument or the type of a `this` parameter."
 	case "invalidVoidNotReturnOrThisParam":
-		return "`void` is only valid as a return type or `this` parameter type."
+		return "void is only valid as return type or type of `this` parameter."
 	case "invalidVoidNotReturnOrGeneric":
-		return "`void` is only valid as a return type or generic type argument."
+		return "void is only valid as a return type or generic type argument."
 	default:
-		return "`void` is only valid as a return type."
+		return "void is only valid as a return type."
 	}
 }
 
-// getEntityNameText reconstructs the dotted name from a TypeName node
-// (Identifier or QualifiedName).
-func getEntityNameText(name *ast.Node) string {
+// getGenericName mirrors removing ASCII spaces from SourceCode#getText(typeName).
+// It intentionally preserves comments and escaped identifier spelling.
+func getGenericName(sourceFile *ast.SourceFile, name *ast.Node) string {
 	if name == nil {
 		return ""
 	}
-	if ast.IsIdentifier(name) {
-		return name.AsIdentifier().Text
-	}
-	if name.Kind == ast.KindQualifiedName {
-		qn := name.AsQualifiedName()
-		left := getEntityNameText(qn.Left)
-		if qn.Right == nil {
-			return left
-		}
-		right := qn.Right.AsIdentifier().Text
-		return left + "." + right
-	}
-	return ""
+	return normalizeGenericName(utils.TrimmedNodeText(sourceFile, name))
 }
 
 // normalizeGenericName removes all spaces for whitelist comparison.
@@ -136,36 +131,44 @@ func hasVoidTypeArgument(node *ast.Node) bool {
 	return false
 }
 
-// getParentFunctionDeclarationNode walks up from a union type node to find
-// the enclosing FunctionDeclaration or MethodDeclaration that has a body
-// (i.e., is an implementation, not a declaration). It only returns a node
-// if the union type is in the return type position (not parameter position).
+// isValidUnionType mirrors upstream's valid-union check. Generic option
+// validation is reported on the nested void keyword itself, so it must not
+// cause an additional diagnostic on a sibling void union constituent.
+func isValidUnionType(node *ast.Node) bool {
+	union := node.AsUnionTypeNode()
+	if union == nil || union.Types == nil {
+		return false
+	}
+	for _, member := range union.Types.Nodes {
+		switch member.Kind {
+		case ast.KindVoidKeyword, ast.KindNeverKeyword:
+			continue
+		case ast.KindTypeReference:
+			if hasVoidTypeArgument(member) {
+				continue
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// getParentFunctionDeclarationNode mirrors the ESTree ancestor walk used by
+// upstream. A bodyless Go FunctionDeclaration corresponds to ESTree's
+// TSDeclareFunction and is therefore skipped.
 func getParentFunctionDeclarationNode(unionNode *ast.Node) *ast.Node {
-	child := unionNode
 	current := unionNode.Parent
 	for current != nil {
 		switch current.Kind {
 		case ast.KindFunctionDeclaration:
-			// Only return implementations (nodes with a body)
-			if current.Body() != nil && current.Type() != nil {
-				// Check that we arrived through the return type path
-				if child == current.Type() {
-					return current
-				}
+			if current.Body() != nil {
+				return current
 			}
-			return nil
 		case ast.KindMethodDeclaration:
-			if current.Body() != nil && current.Type() != nil {
-				if child == current.Type() {
-					return current
-				}
+			if current.Body() != nil {
+				return current
 			}
-			return nil
-		case ast.KindParameter:
-			// In parameter position, not return type
-			return nil
 		}
-		child = current
 		current = current.Parent
 	}
 	return nil
@@ -201,6 +204,12 @@ func getContainerMembers(node *ast.Node) []*ast.Node {
 			return nil
 		}
 		return cd.Members.Nodes
+	case ast.KindClassExpression:
+		ce := node.AsClassExpression()
+		if ce == nil || ce.Members == nil {
+			return nil
+		}
+		return ce.Members.Nodes
 	}
 	return nil
 }
@@ -275,171 +284,120 @@ var NoInvalidVoidTypeRule = rule.CreateRule(rule.Rule{
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
-
-		reportNotReturn := func(node *ast.Node) {
-			msgId := getNotReturnMessageId(opts)
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          msgId,
-				Description: getNotReturnDescription(msgId),
-			})
-		}
-
-		reportUnionConstituent := func(node *ast.Node) {
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "invalidVoidUnionConstituent",
-				Description: "`void` is not valid as a constituent in a union type.",
-			})
-		}
-
-		reportForGeneric := func(node *ast.Node, genericName string) {
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "invalidVoidForGeneric",
-				Description: "`void` is not valid as a type argument for `" + genericName + "`.",
-			})
-		}
-
-		// isVoidNeverUnion checks if a union contains only void and never.
-		isVoidNeverUnion := func(unionNode *ast.Node) bool {
-			union := unionNode.AsUnionTypeNode()
-			if union == nil || union.Types == nil {
-				return false
-			}
-			for _, member := range union.Types.Nodes {
-				if member.Kind != ast.KindVoidKeyword && member.Kind != ast.KindNeverKeyword {
-					return false
-				}
-			}
-			return true
-		}
-
-		// isValidUnionWithGenerics checks whether void in a union is valid when
-		// allowInGenericTypeArguments is truthy. All non-void/never members must be
-		// allowed type references containing void (e.g., void | Promise<void>).
-		isValidUnionWithGenerics := func(unionNode *ast.Node) bool {
-			union := unionNode.AsUnionTypeNode()
-			if union == nil || union.Types == nil {
-				return false
-			}
-			for _, member := range union.Types.Nodes {
-				switch member.Kind {
-				case ast.KindVoidKeyword, ast.KindNeverKeyword:
-					continue
-				case ast.KindTypeReference:
-					if hasVoidTypeArgument(member) {
-						genericName := getEntityNameText(member.AsTypeReferenceNode().TypeName)
-						if isGenericAllowedByWhitelist(opts, genericName) {
-							continue
-						}
-					}
-					return false
-				default:
-					return false
-				}
-			}
-			return true
+		allowGeneric := isAllowInGenericTruthy(opts)
+		allowAllGenerics := isAllowInGenericTrue(opts)
+		_, hasGenericWhitelist := opts.AllowInGenericTypeArguments.([]interface{})
+		notReturnMessageId := getNotReturnMessageId(opts)
+		notReturnMessage := rule.RuleMessage{
+			Id:          notReturnMessageId,
+			Description: getNotReturnDescription(notReturnMessageId),
 		}
 
 		return rule.RuleListeners{
 			ast.KindVoidKeyword: func(node *ast.Node) {
 				parent := node.Parent
 				if parent == nil {
-					reportNotReturn(node)
+					ctx.ReportNode(node, notReturnMessage)
 					return
 				}
 
 				switch parent.Kind {
 				// --- Union type ---
 				case ast.KindUnionType:
-					// void | never is always valid
-					if isVoidNeverUnion(parent) {
+					if isValidUnionType(parent) {
 						return
 					}
-					// Check if the union is in a function/method return type that has overloads
 					if declaringFunc := getParentFunctionDeclarationNode(parent); declaringFunc != nil {
 						if hasOverloadSignatures(ctx, declaringFunc) {
 							return
 						}
 					}
-					// When generics are allowed, check for valid patterns like void | Promise<void>
-					if isAllowInGenericTruthy(opts) {
-						if isValidUnionWithGenerics(parent) {
-							return
-						}
-						reportUnionConstituent(node)
+					if allowGeneric && !opts.AllowAsThisParameter {
+						ctx.ReportNode(node, rule.RuleMessage{
+							Id:          "invalidVoidUnionConstituent",
+							Description: "void is not valid as a constituent in a union type",
+						})
 						return
 					}
-					// When generics are disabled, any non-void|never union is just invalid void
-					reportNotReturn(node)
+					ctx.ReportNode(node, notReturnMessage)
 
 				// --- Generic type arguments (type-level) ---
 				case ast.KindTypeReference:
-					if !isAllowInGenericTruthy(opts) {
-						reportNotReturn(node)
+					if !allowGeneric {
+						ctx.ReportNode(node, notReturnMessage)
 						return
 					}
-					// Check whitelist
-					if _, isArr := opts.AllowInGenericTypeArguments.([]interface{}); isArr {
-						genericName := getEntityNameText(parent.AsTypeReferenceNode().TypeName)
+					if hasGenericWhitelist {
+						genericName := getGenericName(ctx.SourceFile, parent.AsTypeReferenceNode().TypeName)
 						if !isGenericAllowedByWhitelist(opts, genericName) {
-							reportForGeneric(node, normalizeGenericName(genericName))
+							ctx.ReportNode(node, rule.RuleMessage{
+								Id:          "invalidVoidForGeneric",
+								Description: genericName + " may not have void as a type argument.",
+							})
 							return
 						}
 					}
 
-				// --- Generic type arguments in heritage clauses (extends/implements) ---
-				case ast.KindExpressionWithTypeArguments:
-					if !isAllowInGenericTruthy(opts) {
-						reportNotReturn(node)
+				// --- Non-reference generic type arguments ---
+				case ast.KindExpressionWithTypeArguments, ast.KindNewExpression,
+					ast.KindTaggedTemplateExpression, ast.KindImportType, ast.KindTypeQuery,
+					ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement:
+					if allowAllGenerics {
 						return
 					}
-					// Check whitelist
-					if _, isArr := opts.AllowInGenericTypeArguments.([]interface{}); isArr {
-						expr := parent.AsExpressionWithTypeArguments()
-						genericName := getEntityNameText(expr.Expression)
-						if !isGenericAllowedByWhitelist(opts, genericName) {
-							reportForGeneric(node, normalizeGenericName(genericName))
-							return
-						}
-					}
-
-				// --- Generic type arguments on new expressions ---
-				case ast.KindNewExpression:
-					if !isAllowInGenericTruthy(opts) {
-						reportNotReturn(node)
-						return
-					}
+					ctx.ReportNode(node, notReturnMessage)
 
 				// --- Default type parameter: <T = void> ---
 				case ast.KindTypeParameter:
 					typeParam := parent.AsTypeParameterDeclaration()
-					if typeParam.DefaultType == node && isAllowInGenericTruthy(opts) {
-						return // void as default is valid when generics are allowed
+					if allowGeneric && typeParam.DefaultType != nil && typeParam.DefaultType.Kind == ast.KindVoidKeyword {
+						if typeParam.DefaultType == node {
+							return
+						}
+						ctx.ReportNode(node, rule.RuleMessage{
+							Id:          "invalidVoidNotReturnOrGeneric",
+							Description: "void is only valid as a return type or generic type argument.",
+						})
+						return
 					}
-					reportNotReturn(node)
+					ctx.ReportNode(node, notReturnMessage)
 
 				// --- Valid return type positions ---
 				case ast.KindFunctionType, ast.KindConstructorType,
 					ast.KindFunctionDeclaration, ast.KindMethodDeclaration,
 					ast.KindArrowFunction, ast.KindFunctionExpression,
 					ast.KindMethodSignature, ast.KindCallSignature,
-					ast.KindConstructSignature, ast.KindGetAccessor:
+					ast.KindConstructSignature, ast.KindGetAccessor, ast.KindSetAccessor,
+					ast.KindConstructor, ast.KindIndexSignature, ast.KindTypePredicate:
 					return // always valid
 
-				// --- Parameter: only valid for 'this' parameter ---
+				// --- Parameters ---
 				case ast.KindParameter:
-					if opts.AllowAsThisParameter {
-						param := parent.AsParameterDeclaration()
-						if param != nil && param.Name() != nil {
+					param := parent.AsParameterDeclaration()
+					if param != nil && param.Name() != nil {
+						if param.DotDotDotToken != nil || ast.IsBindingPattern(param.Name()) {
+							return
+						}
+						if opts.AllowAsThisParameter {
 							if id := param.Name().AsIdentifier(); id != nil && id.Text == "this" {
 								return
 							}
 						}
 					}
-					reportNotReturn(node)
+					ctx.ReportNode(node, notReturnMessage)
+
+				// ESTree permits destructuring annotations because their grandparent is
+				// an ObjectPattern or ArrayPattern rather than an Identifier.
+				case ast.KindVariableDeclaration:
+					declaration := parent.AsVariableDeclaration()
+					if declaration != nil && declaration.Name() != nil && ast.IsBindingPattern(declaration.Name()) {
+						return
+					}
+					ctx.ReportNode(node, notReturnMessage)
 
 				// --- Everything else is invalid ---
 				default:
-					reportNotReturn(node)
+					ctx.ReportNode(node, notReturnMessage)
 				}
 			},
 		}

--- a/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type_test.go
+++ b/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type_test.go
@@ -96,17 +96,6 @@ interface Foo extends Deep<Map<string, void>> {}
 			{Code: `type promiseVoidUnion = Promise<void> | void;`, Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Promise"}}},
 			{Code: `type promiseNeverUnion = Promise<void> | never;`, Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Promise"}}},
 			{Code: `type voidPromiseNeverUnion = void | Promise<void> | never;`, Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Promise"}}},
-			// Heritage clause with whitelist - in whitelist
-			{Code: `
-interface Base<T> {}
-interface Foo extends Base<void> {}
-`, Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Base"}}},
-			{Code: `
-interface A<T> {}
-interface B<T> {}
-interface Foo extends A<void>, B<void> {}
-`, Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"A", "B"}}},
-
 			// === allowAsThisParameter: true ===
 			{Code: `function f(this: void) {}`, Options: map[string]interface{}{"allowAsThisParameter": true}},
 			{Code: `
@@ -486,17 +475,26 @@ class ClassName {
 					{MessageId: "invalidVoidNotReturnOrGeneric"},
 				},
 			},
-			// Heritage clause with whitelist - not in whitelist
+			// A whitelist applies only to type references upstream. Heritage type
+			// arguments use the ordinary not-return-or-generic diagnostic.
+			{
+				Code: `
+interface Base<T> {}
+interface Foo extends Base<void> {}`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Base"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidVoidNotReturnOrGeneric"},
+				},
+			},
 			{
 				Code: `
 interface Base<T> {}
 interface Foo extends Base<void> {}`,
 				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Allowed"}},
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "invalidVoidForGeneric"},
+					{MessageId: "invalidVoidNotReturnOrGeneric"},
 				},
 			},
-			// Heritage clause with whitelist - multiple extends, one allowed one not
 			{
 				Code: `
 interface Allowed<T> {}
@@ -504,7 +502,19 @@ interface Banned<T> {}
 interface Foo extends Allowed<void>, Banned<void> {}`,
 				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Allowed"}},
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "invalidVoidForGeneric"},
+					{MessageId: "invalidVoidNotReturnOrGeneric"},
+					{MessageId: "invalidVoidNotReturnOrGeneric"},
+				},
+			},
+			{
+				Code: `
+interface A<T> {}
+interface B<T> {}
+interface Foo extends A<void>, B<void> {}`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"A", "B"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidVoidNotReturnOrGeneric"},
+					{MessageId: "invalidVoidNotReturnOrGeneric"},
 				},
 			},
 
@@ -717,6 +727,160 @@ class SomeClass {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "invalidVoidForGeneric"},
 				},
+			},
+		},
+	)
+}
+
+func TestNoInvalidVoidTypeLatestUpstreamParity(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoInvalidVoidTypeRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+function overloaded(value: string): string;
+function overloaded(value: string | void): string {
+  return String(value);
+}`},
+			{Code: `
+const Overloaded = class {
+  method(): void;
+  method(value: string): string;
+  method(value?: string): string | void {
+    return value;
+  }
+};`},
+			{Code: "tag<void>`value`;"},
+			{Code: `type Imported = import("mod").Foo<void>;`},
+			{Code: `type Queried = typeof Foo<void>;`},
+			{Code: `const element = <Component<void> />;`, Tsx: true},
+			{Code: `interface Indexed { [key: string]: void }`},
+			{Code: `function predicate(value: unknown): value is void { return false; }`},
+			{Code: `const {}: void = undefined;`},
+			{Code: `const []: void = undefined;`},
+			{Code: `function objectPattern({}: void) {}`},
+			{Code: `function arrayPattern([]: void) {}`},
+			{Code: `function rest(...args: void) {}`},
+			{Code: `class Setter { set value(input: string): void {} }`},
+			{Code: `class Constructor { constructor(): void {} }`},
+			{Code: "// eslint-disable-next-line test\ntype Disabled = string | void;"},
+			{Code: "/* eslint-disable test */\ntype Disabled = string | void;\n/* eslint-enable test */"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `export type GetContext = () => ExtraData | void;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidUnionConstituent",
+					Message:   "void is not valid as a constituent in a union type",
+					Line:      1,
+					Column:    44,
+					EndLine:   1,
+					EndColumn: 48,
+				}},
+			},
+			{
+				Code:    `type Value = void;`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": false},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidNotReturn",
+					Message:   "void is only valid as a return type.",
+				}},
+			},
+			{
+				Code: `type Value = void;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidNotReturnOrGeneric",
+					Message:   "void is only valid as a return type or generic type argument.",
+				}},
+			},
+			{
+				Code:    `type BannedVoid = Banned<void>;`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Allowed"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidForGeneric",
+					Message:   "Banned may not have void as a type argument.",
+				}},
+			},
+			{
+				Code:    `type Value = void;`,
+				Options: map[string]interface{}{"allowAsThisParameter": true, "allowInGenericTypeArguments": false},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidNotReturnOrThisParam",
+					Message:   "void is only valid as return type or type of `this` parameter.",
+				}},
+			},
+			{
+				Code:    `type Value = string | void;`,
+				Options: map[string]interface{}{"allowAsThisParameter": true, "allowInGenericTypeArguments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidNotReturnOrThisParamOrGeneric",
+					Message:   "void is only valid as a return type or generic type argument or the type of a `this` parameter.",
+				}},
+			},
+			{
+				Code:    `type Value = void | Promise<void>;`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": false},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidNotReturn",
+					Message:   "void is only valid as a return type.",
+				}},
+			},
+			{
+				Code:    `type Value = void | Banned<void>;`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Allowed"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidForGeneric",
+					Message:   "Banned may not have void as a type argument.",
+				}},
+			},
+			{
+				Code:    `interface Base<T> {} interface Derived extends Base<void> {}`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Base"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "invalidVoidNotReturnOrGeneric"}},
+			},
+			{
+				Code:    `new Promise<void>(() => {});`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Promise"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "invalidVoidNotReturnOrGeneric"}},
+			},
+			{
+				Code:    "tag<void>`value`;",
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"tag"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "invalidVoidNotReturnOrGeneric"}},
+			},
+			{
+				Code:    `type Imported = import("mod").Foo<void>;`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Foo"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "invalidVoidNotReturnOrGeneric"}},
+			},
+			{
+				Code:    `type Queried = typeof Foo<void>;`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Foo"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "invalidVoidNotReturnOrGeneric"}},
+			},
+			{
+				Code:    `const element = <Component<void> />;`,
+				Tsx:     true,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Component"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "invalidVoidNotReturnOrGeneric"}},
+			},
+			{
+				Code:    `type Commented = Ex /* keep */ . Mx<void>;`,
+				Options: map[string]interface{}{"allowInGenericTypeArguments": []interface{}{"Ex.Mx"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidForGeneric",
+					Message:   "Ex/*keep*/.Mx may not have void as a type argument.",
+				}},
+			},
+			{
+				Code:    `type Value<T extends void = void> = T;`,
+				Options: map[string]interface{}{"allowAsThisParameter": true, "allowInGenericTypeArguments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidVoidNotReturnOrGeneric",
+					Message:   "void is only valid as a return type or generic type argument.",
+				}},
 			},
 		},
 	)

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-invalid-void-type.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-invalid-void-type.test.ts.snap
@@ -5,7 +5,7 @@ exports[`no-invalid-void-type > invalid 1`] = `
   "code": "type GenericVoid = Generic<void>;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -31,7 +31,7 @@ exports[`no-invalid-void-type > invalid 2`] = `
   "code": "function takeVoid(thing: void) {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -57,7 +57,7 @@ exports[`no-invalid-void-type > invalid 3`] = `
   "code": "let voidPromise: Promise<void> = new Promise<void>(() => {});",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -72,7 +72,7 @@ exports[`no-invalid-void-type > invalid 3`] = `
       "ruleName": "@typescript-eslint/no-invalid-void-type",
     },
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -98,7 +98,7 @@ exports[`no-invalid-void-type > invalid 4`] = `
   "code": "let voidMap: Map<string, void> = new Map<string, void>();",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -113,7 +113,7 @@ exports[`no-invalid-void-type > invalid 4`] = `
       "ruleName": "@typescript-eslint/no-invalid-void-type",
     },
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -139,7 +139,7 @@ exports[`no-invalid-void-type > invalid 5`] = `
   "code": "type invalidVoidUnion = void | number;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -167,7 +167,7 @@ interface Base<T> {}
 interface Foo extends Base<void> {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -196,7 +196,7 @@ interface B<T> {}
 interface C extends A<void>, B<void> {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -211,7 +211,7 @@ interface C extends A<void>, B<void> {}",
       "ruleName": "@typescript-eslint/no-invalid-void-type",
     },
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -239,7 +239,7 @@ interface A<T> {}
 class Foo implements A<void> {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -265,7 +265,7 @@ exports[`no-invalid-void-type > invalid 9`] = `
   "code": "type Foo = Promise<void>;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -291,7 +291,7 @@ exports[`no-invalid-void-type > invalid 10`] = `
   "code": "type Foo = Map<string, void>;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type.",
+      "message": "void is only valid as a return type.",
       "messageId": "invalidVoidNotReturn",
       "range": {
         "end": {
@@ -317,7 +317,7 @@ exports[`no-invalid-void-type > invalid 11`] = `
   "code": "function takeVoid(thing: void) {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -343,7 +343,7 @@ exports[`no-invalid-void-type > invalid 12`] = `
   "code": "const arrowGeneric = <T extends void>(arg: T) => {};",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -369,7 +369,7 @@ exports[`no-invalid-void-type > invalid 13`] = `
   "code": "const arrowGeneric2 = <T extends void = void>(arg: T) => {};",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -395,7 +395,7 @@ exports[`no-invalid-void-type > invalid 14`] = `
   "code": "function functionGeneric<T extends void>(arg: T) {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -421,7 +421,7 @@ exports[`no-invalid-void-type > invalid 15`] = `
   "code": "function functionGeneric2<T extends void = void>(arg: T) {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -447,7 +447,7 @@ exports[`no-invalid-void-type > invalid 16`] = `
   "code": "declare function functionDeclaration<T extends void>(arg: T): void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -473,7 +473,7 @@ exports[`no-invalid-void-type > invalid 17`] = `
   "code": "declare function functionDeclaration2<T extends void = void>(arg: T): void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -499,7 +499,7 @@ exports[`no-invalid-void-type > invalid 18`] = `
   "code": "functionGeneric<void>(undefined);",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -525,7 +525,7 @@ exports[`no-invalid-void-type > invalid 19`] = `
   "code": "let letVoid: void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -553,7 +553,7 @@ exports[`no-invalid-void-type > invalid 20`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -579,7 +579,7 @@ exports[`no-invalid-void-type > invalid 21`] = `
   "code": "type UnionType2 = string | number | void;",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -605,7 +605,7 @@ exports[`no-invalid-void-type > invalid 22`] = `
   "code": "type IntersectionType = string & number & void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -636,7 +636,7 @@ exports[`no-invalid-void-type > invalid 23`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -666,7 +666,7 @@ exports[`no-invalid-void-type > invalid 24`] = `
       ",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -692,7 +692,7 @@ exports[`no-invalid-void-type > invalid 25`] = `
   "code": "type invalidVoidUnion = void | Map<string, number>;",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -718,7 +718,7 @@ exports[`no-invalid-void-type > invalid 26`] = `
   "code": "type invalidVoidUnion = void | Map;",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -744,7 +744,7 @@ exports[`no-invalid-void-type > invalid 27`] = `
   "code": "interface Foo { (arg: void): string; }",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -770,7 +770,7 @@ exports[`no-invalid-void-type > invalid 28`] = `
   "code": "type BannedVoid = Banned<void>;",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a type argument for \`Banned\`.",
+      "message": "Banned may not have void as a type argument.",
       "messageId": "invalidVoidForGeneric",
       "range": {
         "end": {
@@ -796,7 +796,7 @@ exports[`no-invalid-void-type > invalid 29`] = `
   "code": "function takeVoid(thing: void) {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -824,8 +824,8 @@ interface Base<T> {}
 interface Foo extends Base<void> {}",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a type argument for \`Base\`.",
-      "messageId": "invalidVoidForGeneric",
+      "message": "void is only valid as a return type or generic type argument.",
+      "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
           "column": 32,
@@ -848,21 +848,20 @@ interface Foo extends Base<void> {}",
 exports[`no-invalid-void-type > invalid 31`] = `
 {
   "code": "
-interface Allowed<T> {}
-interface Banned<T> {}
-interface Foo extends Allowed<void>, Banned<void> {}",
+interface Base<T> {}
+interface Foo extends Base<void> {}",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a type argument for \`Banned\`.",
-      "messageId": "invalidVoidForGeneric",
+      "message": "void is only valid as a return type or generic type argument.",
+      "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
-          "column": 49,
-          "line": 4,
+          "column": 32,
+          "line": 3,
         },
         "start": {
-          "column": 45,
-          "line": 4,
+          "column": 28,
+          "line": 3,
         },
       },
       "ruleName": "@typescript-eslint/no-invalid-void-type",
@@ -876,10 +875,98 @@ interface Foo extends Allowed<void>, Banned<void> {}",
 
 exports[`no-invalid-void-type > invalid 32`] = `
 {
+  "code": "
+interface Allowed<T> {}
+interface Banned<T> {}
+interface Foo extends Allowed<void>, Banned<void> {}",
+  "diagnostics": [
+    {
+      "message": "void is only valid as a return type or generic type argument.",
+      "messageId": "invalidVoidNotReturnOrGeneric",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 4,
+        },
+        "start": {
+          "column": 31,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-void-type",
+    },
+    {
+      "message": "void is only valid as a return type or generic type argument.",
+      "messageId": "invalidVoidNotReturnOrGeneric",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 4,
+        },
+        "start": {
+          "column": 45,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-void-type",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-void-type > invalid 33`] = `
+{
+  "code": "
+interface A<T> {}
+interface B<T> {}
+interface Foo extends A<void>, B<void> {}",
+  "diagnostics": [
+    {
+      "message": "void is only valid as a return type or generic type argument.",
+      "messageId": "invalidVoidNotReturnOrGeneric",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-void-type",
+    },
+    {
+      "message": "void is only valid as a return type or generic type argument.",
+      "messageId": "invalidVoidNotReturnOrGeneric",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 4,
+        },
+        "start": {
+          "column": 34,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-void-type",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-void-type > invalid 34`] = `
+{
   "code": "type alias = void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type, generic type argument, or \`this\` parameter type.",
+      "message": "void is only valid as a return type or generic type argument or the type of a \`this\` parameter.",
       "messageId": "invalidVoidNotReturnOrThisParamOrGeneric",
       "range": {
         "end": {
@@ -900,12 +987,12 @@ exports[`no-invalid-void-type > invalid 32`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 33`] = `
+exports[`no-invalid-void-type > invalid 35`] = `
 {
   "code": "type alias = void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or \`this\` parameter type.",
+      "message": "void is only valid as return type or type of \`this\` parameter.",
       "messageId": "invalidVoidNotReturnOrThisParam",
       "range": {
         "end": {
@@ -926,12 +1013,12 @@ exports[`no-invalid-void-type > invalid 33`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 34`] = `
+exports[`no-invalid-void-type > invalid 36`] = `
 {
   "code": "type alias = Array<void>;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or \`this\` parameter type.",
+      "message": "void is only valid as return type or type of \`this\` parameter.",
       "messageId": "invalidVoidNotReturnOrThisParam",
       "range": {
         "end": {
@@ -952,12 +1039,12 @@ exports[`no-invalid-void-type > invalid 34`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 35`] = `
+exports[`no-invalid-void-type > invalid 37`] = `
 {
   "code": "declare function voidArray(args: void[]): void[];",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -972,7 +1059,7 @@ exports[`no-invalid-void-type > invalid 35`] = `
       "ruleName": "@typescript-eslint/no-invalid-void-type",
     },
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -993,12 +1080,12 @@ exports[`no-invalid-void-type > invalid 35`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 36`] = `
+exports[`no-invalid-void-type > invalid 38`] = `
 {
   "code": "let value = undefined as void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1019,12 +1106,12 @@ exports[`no-invalid-void-type > invalid 36`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 37`] = `
+exports[`no-invalid-void-type > invalid 39`] = `
 {
   "code": "let value = <void>undefined;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1045,12 +1132,12 @@ exports[`no-invalid-void-type > invalid 37`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 38`] = `
+exports[`no-invalid-void-type > invalid 40`] = `
 {
   "code": "function takesThings(...things: void[]): void {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1071,12 +1158,12 @@ exports[`no-invalid-void-type > invalid 38`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 39`] = `
+exports[`no-invalid-void-type > invalid 41`] = `
 {
   "code": "type KeyofVoid = keyof void;",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1097,7 +1184,7 @@ exports[`no-invalid-void-type > invalid 39`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 40`] = `
+exports[`no-invalid-void-type > invalid 42`] = `
 {
   "code": "
 class ClassName {
@@ -1105,7 +1192,7 @@ class ClassName {
 }",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1126,7 +1213,7 @@ class ClassName {
 }
 `;
 
-exports[`no-invalid-void-type > invalid 41`] = `
+exports[`no-invalid-void-type > invalid 43`] = `
 {
   "code": "
 type VoidType = void;
@@ -1135,7 +1222,7 @@ class OtherClassName {
 }",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1156,12 +1243,12 @@ class OtherClassName {
 }
 `;
 
-exports[`no-invalid-void-type > invalid 42`] = `
+exports[`no-invalid-void-type > invalid 44`] = `
 {
   "code": "type UnionType3 = string | ((number & any) | (string | void));",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1182,12 +1269,12 @@ exports[`no-invalid-void-type > invalid 42`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 43`] = `
+exports[`no-invalid-void-type > invalid 45`] = `
 {
   "code": "declare function test(): number | void;",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1208,12 +1295,12 @@ exports[`no-invalid-void-type > invalid 43`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 44`] = `
+exports[`no-invalid-void-type > invalid 46`] = `
 {
   "code": "declare function test<T extends number | void>(): T;",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1234,7 +1321,7 @@ exports[`no-invalid-void-type > invalid 44`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 45`] = `
+exports[`no-invalid-void-type > invalid 47`] = `
 {
   "code": "
 type MappedType<T> = {
@@ -1242,7 +1329,7 @@ type MappedType<T> = {
 };",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1263,7 +1350,7 @@ type MappedType<T> = {
 }
 `;
 
-exports[`no-invalid-void-type > invalid 46`] = `
+exports[`no-invalid-void-type > invalid 48`] = `
 {
   "code": "
 type ConditionalType<T> = {
@@ -1271,7 +1358,7 @@ type ConditionalType<T> = {
 };",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1292,12 +1379,12 @@ type ConditionalType<T> = {
 }
 `;
 
-exports[`no-invalid-void-type > invalid 47`] = `
+exports[`no-invalid-void-type > invalid 49`] = `
 {
   "code": "type ManyVoid = readonly void[];",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1318,12 +1405,12 @@ exports[`no-invalid-void-type > invalid 47`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 48`] = `
+exports[`no-invalid-void-type > invalid 50`] = `
 {
   "code": "function foo(arr: readonly void[]) {}",
   "diagnostics": [
     {
-      "message": "\`void\` is only valid as a return type or generic type argument.",
+      "message": "void is only valid as a return type or generic type argument.",
       "messageId": "invalidVoidNotReturnOrGeneric",
       "range": {
         "end": {
@@ -1344,7 +1431,7 @@ exports[`no-invalid-void-type > invalid 48`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 49`] = `
+exports[`no-invalid-void-type > invalid 51`] = `
 {
   "code": "
 class SomeClass {
@@ -1354,7 +1441,7 @@ class SomeClass {
 }",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1375,12 +1462,12 @@ class SomeClass {
 }
 `;
 
-exports[`no-invalid-void-type > invalid 50`] = `
+exports[`no-invalid-void-type > invalid 52`] = `
 {
   "code": "export default function (x?: string): string | void {}",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1401,12 +1488,12 @@ exports[`no-invalid-void-type > invalid 50`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 51`] = `
+exports[`no-invalid-void-type > invalid 53`] = `
 {
   "code": "export function f(x?: string): string | void {}",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1427,7 +1514,7 @@ exports[`no-invalid-void-type > invalid 51`] = `
 }
 `;
 
-exports[`no-invalid-void-type > invalid 52`] = `
+exports[`no-invalid-void-type > invalid 54`] = `
 {
   "code": "
 function f(): void;
@@ -1437,7 +1524,7 @@ function f(x?: string): string | void {
 }",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1458,7 +1545,7 @@ function f(x?: string): string | void {
 }
 `;
 
-exports[`no-invalid-void-type > invalid 53`] = `
+exports[`no-invalid-void-type > invalid 55`] = `
 {
   "code": "
 class SomeClass {
@@ -1470,7 +1557,7 @@ class SomeClass {
 }",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a constituent in a union type.",
+      "message": "void is not valid as a constituent in a union type",
       "messageId": "invalidVoidUnionConstituent",
       "range": {
         "end": {
@@ -1491,12 +1578,12 @@ class SomeClass {
 }
 `;
 
-exports[`no-invalid-void-type > invalid 54`] = `
+exports[`no-invalid-void-type > invalid 56`] = `
 {
   "code": "type BannedVoid = Ex.Mx.Tx<void>;",
   "diagnostics": [
     {
-      "message": "\`void\` is not valid as a type argument for \`Ex.Mx.Tx\`.",
+      "message": "Ex.Mx.Tx may not have void as a type argument.",
       "messageId": "invalidVoidForGeneric",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-invalid-void-type.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-invalid-void-type.test.ts
@@ -129,23 +129,6 @@ interface Foo extends Deep<Map<string, void>> {}
       code: 'type voidPromiseNeverUnion = void | Promise<void> | never;',
       options: [{ allowInGenericTypeArguments: ['Promise'] }],
     },
-    // Heritage clause with whitelist - in whitelist
-    {
-      code: `
-interface Base<T> {}
-interface Foo extends Base<void> {}
-      `,
-      options: [{ allowInGenericTypeArguments: ['Base'] }],
-    },
-    {
-      code: `
-interface A<T> {}
-interface B<T> {}
-interface Foo extends A<void>, B<void> {}
-      `,
-      options: [{ allowInGenericTypeArguments: ['A', 'B'] }],
-    },
-
     // === allowAsThisParameter: true ===
     {
       code: 'function f(this: void) {}',
@@ -654,19 +637,30 @@ class Foo implements A<void> {}`,
       ],
       options: [{ allowInGenericTypeArguments: ['Allowed'] }],
     },
-    // Heritage clause with whitelist - not in whitelist
+    // A whitelist applies only to type references upstream. Heritage type
+    // arguments use the ordinary not-return-or-generic diagnostic.
     {
       code: `
 interface Base<T> {}
 interface Foo extends Base<void> {}`,
       errors: [
         {
-          messageId: 'invalidVoidForGeneric',
+          messageId: 'invalidVoidNotReturnOrGeneric',
+        },
+      ],
+      options: [{ allowInGenericTypeArguments: ['Base'] }],
+    },
+    {
+      code: `
+interface Base<T> {}
+interface Foo extends Base<void> {}`,
+      errors: [
+        {
+          messageId: 'invalidVoidNotReturnOrGeneric',
         },
       ],
       options: [{ allowInGenericTypeArguments: ['Allowed'] }],
     },
-    // Heritage clause with whitelist - multiple extends, one allowed one not
     {
       code: `
 interface Allowed<T> {}
@@ -674,10 +668,28 @@ interface Banned<T> {}
 interface Foo extends Allowed<void>, Banned<void> {}`,
       errors: [
         {
-          messageId: 'invalidVoidForGeneric',
+          messageId: 'invalidVoidNotReturnOrGeneric',
+        },
+        {
+          messageId: 'invalidVoidNotReturnOrGeneric',
         },
       ],
       options: [{ allowInGenericTypeArguments: ['Allowed'] }],
+    },
+    {
+      code: `
+interface A<T> {}
+interface B<T> {}
+interface Foo extends A<void>, B<void> {}`,
+      errors: [
+        {
+          messageId: 'invalidVoidNotReturnOrGeneric',
+        },
+        {
+          messageId: 'invalidVoidNotReturnOrGeneric',
+        },
+      ],
+      options: [{ allowInGenericTypeArguments: ['A', 'B'] }],
     },
 
     // === allowAsThisParameter: true ===


### PR DESCRIPTION
## Summary

- Align all six `@typescript-eslint/no-invalid-void-type` diagnostic messages and ranges with typescript-eslint `main`.
- Match upstream option and AST behavior for unions, generic argument carriers, overloads, type predicates, index signatures, rest/destructuring annotations, and class expressions.
- Reduce per-file rule setup allocations by moving reusable checks out of the listener closure and precomputing option-dependent state.
- Add exact regression coverage for the reported `ExtraData | void` case and adversarial option/syntax branches.
- Refresh the JS RuleTester snapshots and move heritage-clause whitelist cases to invalid coverage, matching upstream's type-reference-only whitelist behavior.

### Verification

- `go test ./internal/plugins/typescript/rules/no_invalid_void_type -count=3`
- `pnpm --filter @rslint/test-tools exec rstest run tests/typescript-eslint/rules/no-invalid-void-type.test.ts`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_invalid_void_type/...`
- `git diff --check`

### Go benchmark

Command: `go test ./internal/plugins/typescript/rules/no_invalid_void_type -run ^$ -bench ^BenchmarkNoInvalidVoidType$ -benchmem -count=6 -benchtime=1s`

Median of six 1-second samples on Apple M5 Max:

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Invalid union, diagnostics only | 262.40 → 200.75 | 736 → 640 | 9 → 5 |
| Invalid union, autofix demand | 316.90 → 220.20 | 736 → 640 | 9 → 5 |
| Invalid union, suggestion demand | 312.70 → 228.45 | 736 → 640 | 9 → 5 |
| Valid return, no report | 200.70 → 138.05 | 576 → 480 | 8 → 4 |
| Allowed generic | 192.65 → 147.90 | 576 → 480 | 8 → 4 |
| Disallowed whitelist generic | 562.00 → 279.35 | 800 → 848 | 10 → 7 |
| Overload union, ignored | 548.20 → 167.40 | 576 → 480 | 8 → 4 |

The whitelist diagnostic retains a small byte increase because upstream's required message text is longer, while reducing allocations and execution time.

## Related Links

- [Latest upstream rule implementation](https://github.com/typescript-eslint/typescript-eslint/blob/b51279f3706236d94f443cf8e51f25de27962890/packages/eslint-plugin/src/rules/no-invalid-void-type.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
