### PR TITLE
fix: align no-inferrable-types with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
@@ -89,6 +89,12 @@ func getInferrableTypeAnnotation(typeNode *ast.Node) inferrableType {
 	if typeNode == nil {
 		return inferrableTypeNone
 	}
+	if typeNode.Kind == ast.KindParenthesizedType {
+		typeNode = ast.SkipTypeParentheses(typeNode)
+		if typeNode == nil {
+			return inferrableTypeNone
+		}
+	}
 
 	switch typeNode.Kind {
 	case ast.KindBigIntKeyword:
@@ -141,12 +147,33 @@ func isNumberConstant(node *ast.Node) bool {
 	return name == "Infinity" || name == "NaN"
 }
 
+// isESTreeLiteral covers the tsgo kinds represented by a TSESTree Literal.
+func isESTreeLiteral(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return node.Kind == ast.KindBigIntLiteral ||
+		node.Kind == ast.KindFalseKeyword ||
+		node.Kind == ast.KindNullKeyword ||
+		node.Kind == ast.KindNumericLiteral ||
+		node.Kind == ast.KindRegularExpressionLiteral ||
+		node.Kind == ast.KindStringLiteral ||
+		node.Kind == ast.KindTrueKeyword
+}
+
+func skipParentheses(node *ast.Node) *ast.Node {
+	if node != nil && node.Kind == ast.KindParenthesizedExpression {
+		return ast.SkipParentheses(node)
+	}
+	return node
+}
+
 func isCallTo(node *ast.Node, name string) bool {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return false
 	}
 	call := node.AsCallExpression()
-	return call != nil && isIdentifierNamed(call.Expression, name)
+	return call != nil && isIdentifierNamed(skipParentheses(call.Expression), name)
 }
 
 func isNewRegExp(node *ast.Node) bool {
@@ -154,7 +181,7 @@ func isNewRegExp(node *ast.Node) bool {
 		return false
 	}
 	newExpression := node.AsNewExpression()
-	return newExpression != nil && isIdentifierNamed(newExpression.Expression, "RegExp")
+	return newExpression != nil && isIdentifierNamed(skipParentheses(newExpression.Expression), "RegExp")
 }
 
 // isInferrableInitializer is deliberately keyed by the annotation first. Most
@@ -164,18 +191,22 @@ func isInferrableInitializer(init *ast.Node, expectedType inferrableType) bool {
 	if init == nil {
 		return false
 	}
+	init = skipParentheses(init)
 
 	switch expectedType {
 	case inferrableTypeBigInt:
-		if init.Kind == ast.KindBigIntLiteral || isCallTo(init, "BigInt") {
+		if isESTreeLiteral(init) || isCallTo(init, "BigInt") {
 			return true
 		}
 		if init.Kind == ast.KindPrefixUnaryExpression {
 			unary := init.AsPrefixUnaryExpression()
-			return unary != nil &&
-				unary.Operand != nil &&
-				(unary.Operator == ast.KindPlusToken || unary.Operator == ast.KindMinusToken) &&
-				(unary.Operand.Kind == ast.KindBigIntLiteral || isCallTo(unary.Operand, "BigInt"))
+			if unary == nil {
+				return false
+			}
+			operand := skipParentheses(unary.Operand)
+			return operand != nil &&
+				unary.Operator == ast.KindMinusToken &&
+				(isESTreeLiteral(operand) || isCallTo(operand, "BigInt"))
 		}
 
 	case inferrableTypeBoolean:
@@ -195,17 +226,21 @@ func isInferrableInitializer(init *ast.Node, expectedType inferrableType) bool {
 		}
 		if init.Kind == ast.KindPrefixUnaryExpression {
 			unary := init.AsPrefixUnaryExpression()
-			return unary != nil &&
-				unary.Operand != nil &&
+			if unary == nil {
+				return false
+			}
+			operand := skipParentheses(unary.Operand)
+			return operand != nil &&
 				(unary.Operator == ast.KindPlusToken || unary.Operator == ast.KindMinusToken) &&
-				(unary.Operand.Kind == ast.KindNumericLiteral ||
-					isNumberConstant(unary.Operand) ||
-					isCallTo(unary.Operand, "Number"))
+				(operand.Kind == ast.KindNumericLiteral ||
+					isNumberConstant(operand) ||
+					isCallTo(operand, "Number"))
 		}
 
 	case inferrableTypeString:
 		return init.Kind == ast.KindStringLiteral ||
 			init.Kind == ast.KindNoSubstitutionTemplateLiteral ||
+			init.Kind == ast.KindTemplateExpression ||
 			isCallTo(init, "String")
 
 	case inferrableTypeNull:
@@ -264,8 +299,8 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 		opts := parseOptions(options)
 		sourceText := ctx.SourceFile.Text()
 
-		checkDeclaration := func(reportNode *ast.Node, typeAnnotation *ast.Node, initializer *ast.Node, postfixToken *ast.Node) {
-			if typeAnnotation == nil || initializer == nil {
+		checkDeclaration := func(reportStartNode *ast.Node, reportEndNode *ast.Node, typeAnnotation *ast.Node, initializer *ast.Node, postfixToken *ast.Node) {
+			if reportStartNode == nil || reportEndNode == nil || typeAnnotation == nil || initializer == nil {
 				return
 			}
 
@@ -274,10 +309,10 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			// Report range spans from the first declaration token to the end of
-			// the initializer, matching typescript-eslint without allocating a
-			// scanner for every diagnostic.
-			reportRange := core.NewTextRange(scanner.SkipTrivia(sourceText, reportNode.Pos()), initializer.End())
+			reportRange := core.NewTextRange(
+				scanner.SkipTrivia(sourceText, reportStartNode.Pos()),
+				reportEndNode.End(),
+			)
 			ctx.ReportRangeWithDeferredFixes(
 				reportRange,
 				noInferrableTypesMessages[inferrableType],
@@ -298,7 +333,7 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 				if reportNode == nil {
 					reportNode = node
 				}
-				checkDeclaration(reportNode, varDecl.Type, varDecl.Initializer, nil)
+				checkDeclaration(reportNode, varDecl.Initializer, varDecl.Type, varDecl.Initializer, nil)
 			},
 		}
 
@@ -313,7 +348,7 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 				if reportNode == nil {
 					reportNode = node
 				}
-				checkDeclaration(reportNode, param.Type, param.Initializer, param.QuestionToken)
+				checkDeclaration(reportNode, param.Initializer, param.Type, param.Initializer, param.QuestionToken)
 			}
 		}
 
@@ -334,19 +369,9 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 					return
 				}
 
-				// For auto-accessor properties, report from the accessor keyword (full node)
-				// For regular properties, report from the name node
-				var reportNode *ast.Node
-				if modifierFlags&ast.ModifierFlagsAccessor != 0 {
-					// Use the full property declaration node for auto-accessors
-					reportNode = node
-				} else {
-					reportNode = prop.Name()
-					if reportNode == nil {
-						reportNode = node
-					}
-				}
-				checkDeclaration(reportNode, prop.Type, prop.Initializer, prop.PostfixToken)
+				// Upstream reports the complete property definition, including
+				// decorators, modifiers, and a trailing semicolon.
+				checkDeclaration(node, node, prop.Type, prop.Initializer, prop.PostfixToken)
 			}
 		}
 

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
@@ -23,6 +23,9 @@ func TestNoInferrableTypesRule(t *testing.T) {
 		{Code: `const a = /a/;`},
 		{Code: `const a = 10n;`},
 		{Code: `const a = Symbol('a');`},
+		{Code: `const a: bigint = +10n;`},
+		{Code: `const a: bigint = +BigInt(10);`},
+		{Code: `const a: bigint = (+10n);`},
 
 		// Type annotation with different type - valid
 		{Code: `const a: unknown = 10;`},
@@ -85,6 +88,51 @@ func TestNoInferrableTypesRule(t *testing.T) {
 			},
 		},
 
+		// Upstream treats every ESTree Literal as inferrable for bigint,
+		// including semantically invalid TypeScript programs.
+		{
+			Code:   `const a: bigint = 10;`,
+			Output: []string{`const a = 10;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: bigint = '10';`,
+			Output: []string{`const a = '10';`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: bigint = true;`,
+			Output: []string{`const a = true;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: bigint = null;`,
+			Output: []string{`const a = null;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: bigint = /a/;`,
+			Output: []string{`const a = /a/;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: bigint = -10;`,
+			Output: []string{`const a = -10;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+
 		// boolean
 		{
 			Code:   `const a: boolean = true;`,
@@ -105,6 +153,8 @@ func TestNoInferrableTypesRule(t *testing.T) {
 					MessageId: "noInferrableType",
 					Line:      1,
 					Column:    7,
+					EndLine:   1,
+					EndColumn: 25,
 				},
 			},
 		},
@@ -271,6 +321,28 @@ func TestNoInferrableTypesRule(t *testing.T) {
 			},
 		},
 		{
+			Code:   "declare const value: unknown;\nconst a: string = `${value}`;",
+			Output: []string{"declare const value: unknown;\nconst a = `${value}`;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      2,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   "const fn = (name: string, description: string = `Description for ${name}`) => {};",
+			Output: []string{"const fn = (name: string, description = `Description for ${name}`) => {};"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    27,
+				},
+			},
+		},
+		{
 			Code:   `const a: string = String(1);`,
 			Output: []string{`const a = String(1);`},
 			Errors: []rule_tester.InvalidTestCaseError{
@@ -319,6 +391,50 @@ func TestNoInferrableTypesRule(t *testing.T) {
 			},
 		},
 
+		// Parentheses are transparent in ESTree but explicit nodes in tsgo.
+		{
+			Code:   `const a: number = (10);`,
+			Output: []string{`const a = (10);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: number = -(10);`,
+			Output: []string{`const a = -(10);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: number = (Number)('10');`,
+			Output: []string{`const a = (Number)('10');`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: RegExp = new (RegExp)('a');`,
+			Output: []string{`const a = new (RegExp)('a');`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   "declare const value: unknown;\nconst a: string = (`${value}`);",
+			Output: []string{"declare const value: unknown;\nconst a = (`${value}`);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 2, Column: 7},
+			},
+		},
+		{
+			Code:   `const a: (number) = 10;`,
+			Output: []string{`const a = 10;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInferrableType", Line: 1, Column: 7},
+			},
+		},
+
 		// Function parameters (without ignoreParameters option)
 		{
 			Code:   `function fn(a: number = 5) {}`,
@@ -328,6 +444,8 @@ func TestNoInferrableTypesRule(t *testing.T) {
 					MessageId: "noInferrableType",
 					Line:      1,
 					Column:    13,
+					EndLine:   1,
+					EndColumn: 26,
 				},
 			},
 		},
@@ -339,6 +457,25 @@ func TestNoInferrableTypesRule(t *testing.T) {
 					MessageId: "noInferrableType",
 					Line:      1,
 					Column:    13,
+					EndLine:   1,
+					EndColumn: 30,
+				},
+			},
+		},
+		{
+			Code: `class Foo {
+  constructor(public a: boolean = true) {}
+}`,
+			Output: []string{`class Foo {
+  constructor(public a = true) {}
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      2,
+					Column:    22,
+					EndLine:   2,
+					EndColumn: 39,
 				},
 			},
 		},
@@ -352,6 +489,8 @@ func TestNoInferrableTypesRule(t *testing.T) {
 					MessageId: "noInferrableType",
 					Line:      1,
 					Column:    13,
+					EndLine:   1,
+					EndColumn: 30,
 				},
 			},
 		},
@@ -386,6 +525,44 @@ func TestNoInferrableTypesRule(t *testing.T) {
 					MessageId: "noInferrableType",
 					Line:      2,
 					Column:    3,
+					EndLine:   2,
+					EndColumn: 26,
+				},
+			},
+		},
+		{
+			Code: `class Foo {
+  public static prop: number = 5;
+}`,
+			Output: []string{`class Foo {
+  public static prop = 5;
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 34,
+				},
+			},
+		},
+		{
+			Code: `declare const dec: PropertyDecorator;
+class Foo {
+  @dec decorated: boolean = false;
+}`,
+			Output: []string{`declare const dec: PropertyDecorator;
+class Foo {
+  @dec decorated = false;
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      3,
+					Column:    3,
+					EndLine:   3,
+					EndColumn: 35,
 				},
 			},
 		},
@@ -439,7 +616,17 @@ func TestNoInferrableTypesEditDemand(t *testing.T) {
 function fn(optional?: boolean = true) {}
 class Example {
   property!: string = 'value';
-}`
+}
+declare const dec: PropertyDecorator;
+class Disabled {
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+  @dec
+  decorated: boolean = false;
+  sameLine: boolean = false; // eslint-disable-line @typescript-eslint/no-inferrable-types
+}
+/* eslint-disable @typescript-eslint/no-inferrable-types */
+const scoped: number = 1;
+/* eslint-enable @typescript-eslint/no-inferrable-types */`
 
 	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
 	program, sourceFile, err := helper.CreateTestProgram(
@@ -462,7 +649,7 @@ class Example {
 			ExcludePaths: []string{},
 			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
 				return []linter.ConfiguredRule{{
-					Name:     NoInferrableTypesRule.Name,
+					Name:     "@typescript-eslint/no-inferrable-types",
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {
 						return NoInferrableTypesRule.Run(ctx, nil)
@@ -550,7 +737,17 @@ class Example {
 function fn(optional = true) {}
 class Example {
   property = 'value';
-}`
+}
+declare const dec: PropertyDecorator;
+class Disabled {
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+  @dec
+  decorated: boolean = false;
+  sameLine: boolean = false; // eslint-disable-line @typescript-eslint/no-inferrable-types
+}
+/* eslint-disable @typescript-eslint/no-inferrable-types */
+const scoped: number = 1;
+/* eslint-enable @typescript-eslint/no-inferrable-types */`
 	if !fixed || fixedSource != wantFixed {
 		t.Fatalf("fixed source:\n%s\nwant:\n%s", fixedSource, wantFixed)
 	}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-inferrable-types.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-inferrable-types.test.ts.snap
@@ -1093,7 +1093,7 @@ class A {
       "messageId": "noInferrableType",
       "range": {
         "end": {
-          "column": 17,
+          "column": 18,
           "line": 3,
         },
         "start": {
@@ -1187,7 +1187,7 @@ class Foo {
       "messageId": "noInferrableType",
       "range": {
         "end": {
-          "column": 16,
+          "column": 17,
           "line": 3,
         },
         "start": {
@@ -1202,7 +1202,7 @@ class Foo {
       "messageId": "noInferrableType",
       "range": {
         "end": {
-          "column": 20,
+          "column": 21,
           "line": 4,
         },
         "start": {
@@ -1217,7 +1217,7 @@ class Foo {
       "messageId": "noInferrableType",
       "range": {
         "end": {
-          "column": 20,
+          "column": 21,
           "line": 5,
         },
         "start": {
@@ -1289,7 +1289,7 @@ class Foo {
       "messageId": "noInferrableType",
       "range": {
         "end": {
-          "column": 25,
+          "column": 26,
           "line": 3,
         },
         "start": {


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/no-inferrable-types` with typescript-eslint 8.67.0 for parenthesized expressions/types, interpolated templates, bigint literals, and unary bigint prefixes.
- Report the full class property range so decorators, modifiers, and trailing semicolons match upstream, while preserving variable and parameter ranges.
- Update the three affected JS snapshots (five end columns) for plain, definite-assignment, and auto-accessor class properties.
- Add focused coverage for fixes, exact ranges, parameter properties, disable directives, edit demand, and tsgo/ESTree AST differences.
- Verify the reported real-world file now matches ESLint at `29:3-29:29`, including the diagnostic message.

### Go benchmark

Command: `go test ./internal/plugins/typescript/rules/no_inferrable_types -run '^$' -bench '^BenchmarkNoInferrableTypesRule$' -benchmem -count=6`

| Case | Before | After | Result |
| --- | ---: | ---: | ---: |
| Property diagnostics | 1.938 us/op | 2.014 us/op | statistically unchanged |
| Property autofix | 2.261 us/op | 2.268 us/op | statistically unchanged |
| Property suggestion demand | 2.158 us/op | 2.099 us/op | statistically unchanged |
| Variable diagnostics | 2.551 us/op | 2.294 us/op | -10.08% |
| Ignored properties | 1.818 us/op | 1.788 us/op | statistically unchanged |
| Property no-match | 1.956 us/op | 2.048 us/op | statistically unchanged |

`B/op` and `allocs/op` were unchanged in every case. The benchmark source was temporary and is not included in this PR.

Validation:

- Exact diagnostic payload parity across 31 adversarial cases against typescript-eslint 8.67.0.
- `go test ./internal/plugins/typescript/rules/no_inferrable_types -count=3`
- `pnpm --filter @rslint/test-tools exec rstest run tests/typescript-eslint/rules/no-inferrable-types.test.ts`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_inferrable_types/...`

## Related Links

- [Upstream rule source](https://github.com/typescript-eslint/typescript-eslint/blob/b51279f3706236d94f443cf8e51f25de27962890/packages/eslint-plugin/src/rules/no-inferrable-types.ts)
- [Upstream rule tests](https://github.com/typescript-eslint/typescript-eslint/blob/b51279f3706236d94f443cf8e51f25de27962890/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
