### PR TITLE
fix: align no-this-alias diagnostics with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
@@ -19,11 +19,11 @@ type NoThisAliasOptions struct {
 var (
 	thisAssignmentMessage = rule.RuleMessage{
 		Id:          "thisAssignment",
-		Description: "Unexpected aliasing of `this` to local variable.",
+		Description: "Unexpected aliasing of 'this' to local variable.",
 	}
 	thisDestructureMessage = rule.RuleMessage{
 		Id:          "thisDestructure",
-		Description: "Destructuring `this` is not allowed.",
+		Description: "Unexpected aliasing of members of 'this' to local variables.",
 	}
 )
 
@@ -86,10 +86,21 @@ func parseOptions(options []any) NoThisAliasOptions {
 }
 
 func reportTarget(ctx *rule.RuleContext, target *ast.Node, message rule.RuleMessage) {
-	ctx.ReportRange(
-		target.Loc.WithPos(scanner.SkipTrivia(ctx.SourceFile.Text(), target.Pos())),
-		message,
-	)
+	targetRange := target.Loc.WithPos(scanner.SkipTrivia(ctx.SourceFile.Text(), target.Pos()))
+	// TSESTree includes a variable declarator's definite-assignment marker and
+	// type annotation in the id range, including for binding patterns.
+	if target.Parent != nil && target.Parent.Kind == ast.KindVariableDeclaration {
+		declaration := target.Parent.AsVariableDeclaration()
+		if declaration.Name() == target {
+			if declaration.ExclamationToken != nil && declaration.ExclamationToken.End() > targetRange.End() {
+				targetRange = targetRange.WithEnd(declaration.ExclamationToken.End())
+			}
+			if declaration.Type != nil && declaration.Type.End() > targetRange.End() {
+				targetRange = targetRange.WithEnd(declaration.Type.End())
+			}
+		}
+	}
+	ctx.ReportRange(targetRange, message)
 }
 
 func defaultThisListener(ctx *rule.RuleContext) func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
@@ -42,7 +42,20 @@ func TestNoThisAliasRule(t *testing.T) {
 			{
 				Code: `const self = this;`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "thisAssignment"},
+					{
+						MessageId: "thisAssignment",
+						Message:   "Unexpected aliasing of 'this' to local variable.",
+						Line:      1,
+						Column:    7,
+						EndLine:   1,
+						EndColumn: 11,
+					},
+				},
+			},
+			{
+				Code: `const asThis: this = this;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment", Line: 1, Column: 7, EndLine: 1, EndColumn: 19},
 				},
 			},
 			{
@@ -96,7 +109,24 @@ value ??= this;`,
 				Code:    `const { props, state } = this;`,
 				Options: map[string]interface{}{"allowDestructuring": false},
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "thisDestructure"},
+					{
+						MessageId: "thisDestructure",
+						Message:   "Unexpected aliasing of members of 'this' to local variables.",
+					},
+				},
+			},
+			{
+				Code:    `const { value }: { value: number } = this;`,
+				Options: map[string]interface{}{"allowDestructuring": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisDestructure", Line: 1, Column: 7, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code:    `const [value]: [number] = this;`,
+				Options: map[string]interface{}{"allowDestructuring": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisDestructure", Line: 1, Column: 7, EndLine: 1, EndColumn: 24},
 				},
 			},
 			{

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-this-alias.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-this-alias.test.ts.snap
@@ -5,7 +5,7 @@ exports[`no-this-alias > invalid 1`] = `
   "code": "const self = this;",
   "diagnostics": [
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -31,7 +31,7 @@ exports[`no-this-alias > invalid 2`] = `
   "code": "const self = this;",
   "diagnostics": [
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -60,7 +60,7 @@ that = this;
       ",
   "diagnostics": [
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -86,7 +86,7 @@ exports[`no-this-alias > invalid 4`] = `
   "code": "const { props, state } = this;",
   "diagnostics": [
     {
-      "message": "Destructuring \`this\` is not allowed.",
+      "message": "Unexpected aliasing of members of 'this' to local variables.",
       "messageId": "thisDestructure",
       "range": {
         "end": {
@@ -121,7 +121,7 @@ const testLambda = () => {
       ",
   "diagnostics": [
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -136,7 +136,7 @@ const testLambda = () => {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -151,7 +151,7 @@ const testLambda = () => {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -196,7 +196,7 @@ class TestClass {
       ",
   "diagnostics": [
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -211,11 +211,11 @@ class TestClass {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
-          "column": 17,
+          "column": 23,
           "line": 5,
         },
         "start": {
@@ -226,7 +226,7 @@ class TestClass {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Unexpected aliasing of \`this\` to local variable.",
+      "message": "Unexpected aliasing of 'this' to local variable.",
       "messageId": "thisAssignment",
       "range": {
         "end": {
@@ -241,7 +241,7 @@ class TestClass {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Destructuring \`this\` is not allowed.",
+      "message": "Unexpected aliasing of members of 'this' to local variables.",
       "messageId": "thisDestructure",
       "range": {
         "end": {
@@ -256,7 +256,7 @@ class TestClass {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Destructuring \`this\` is not allowed.",
+      "message": "Unexpected aliasing of members of 'this' to local variables.",
       "messageId": "thisDestructure",
       "range": {
         "end": {
@@ -271,7 +271,7 @@ class TestClass {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Destructuring \`this\` is not allowed.",
+      "message": "Unexpected aliasing of members of 'this' to local variables.",
       "messageId": "thisDestructure",
       "range": {
         "end": {
@@ -286,7 +286,7 @@ class TestClass {
       "ruleName": "@typescript-eslint/no-this-alias",
     },
     {
-      "message": "Destructuring \`this\` is not allowed.",
+      "message": "Unexpected aliasing of members of 'this' to local variables.",
       "messageId": "thisDestructure",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/no-this-alias` diagnostic messages with typescript-eslint v8.67.0.
- Match TSESTree ranges for typed variable identifiers and typed object/array binding patterns.
- Add focused Go coverage and refresh the targeted JavaScript snapshot.

Go benchmark command: `go test ./internal/plugins/typescript/rules/no_this_alias -run '^$' -bench '^BenchmarkNoThisAliasRule$' -benchmem -benchtime=500ms -count=6`

| Case | ns/op before → after | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Default identifier | `16.188 → 16.477` | `0 → 0` | `0 → 0` |
| No alias | `1.853 → 1.761` | `0 → 0` | `0 → 0` |
| Allowed identifier | `4.097 → 4.061` | `0 → 0` | `0 → 0` |
| Configured identifier | `17.592 → 19.377` | `0 → 0` | `0 → 0` |
| Default destructuring | `2.260 → 2.128` | `0 → 0` | `0 → 0` |
| Configured destructuring | `17.393 → 16.768` | `0 → 0` | `0 → 0` |

The repeated samples show only nanosecond-scale mixed variation and no allocation changes, so this PR does not add a performance-only optimization.

Correctness and checks:

- Verified every reported real-world file individually; each retains exactly one diagnostic at the upstream range with the upstream message.
- `go test ./internal/plugins/typescript/rules/no_this_alias -count=3`
- `pnpm exec rstest run tests/typescript-eslint/rules/no-this-alias.test.ts`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_this_alias/...`

## Related Links

- [typescript-eslint v8.67.0 rule source](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-this-alias.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
