### PR TITLE
fix: align require-await diagnostics with upstream

### DIFF
--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -1,17 +1,198 @@
 package require_await
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func buildMissingAwaitMessage() rule.RuleMessage {
+func buildMissingAwaitMessage(node *ast.Node) rule.RuleMessage {
+	name := utils.UpperCaseFirstASCII(functionNameWithKind(node))
 	return rule.RuleMessage{
 		Id:          "missingAwait",
-		Description: "Function has no 'await' expression.",
+		Description: name + " has no 'await' expression.",
+		Data:        map[string]string{"name": name},
 	}
+}
+
+// functionNameWithKind mirrors @eslint-community/eslint-utils for tsgo's
+// function-shaped nodes. Unlike ESLint core's helper, it recovers names from
+// outer bindings and folds computed property names without a scope.
+func functionNameWithKind(node *ast.Node) string {
+	if node.Kind == ast.KindConstructor {
+		return utils.GetFunctionNameWithKindCore(node)
+	}
+
+	parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+	if parent == nil {
+		return ""
+	}
+	owner := functionPropertyOwner(node, parent)
+	tokens := make([]string, 0, 5)
+
+	if isClassFunctionOwner(node, owner) {
+		if ast.HasSyntacticModifier(owner, ast.ModifierFlagsStatic) {
+			tokens = append(tokens, "static")
+		}
+		if name := owner.Name(); name != nil && name.Kind == ast.KindPrivateIdentifier {
+			tokens = append(tokens, "private")
+		}
+	}
+	flags := ast.GetFunctionFlags(node)
+	if flags&ast.FunctionFlagsAsync != 0 {
+		tokens = append(tokens, "async")
+	}
+	if flags&ast.FunctionFlagsGenerator != 0 {
+		tokens = append(tokens, "generator")
+	}
+
+	switch {
+	case node.Kind == ast.KindGetAccessor:
+		tokens = append(tokens, "getter")
+	case node.Kind == ast.KindSetAccessor:
+		tokens = append(tokens, "setter")
+	case owner != nil:
+		tokens = append(tokens, "method")
+	case node.Kind == ast.KindArrowFunction:
+		tokens = append(tokens, "arrow", "function")
+	default:
+		tokens = append(tokens, "function")
+	}
+
+	if owner != nil {
+		if nameNode := owner.Name(); nameNode != nil && nameNode.Kind == ast.KindPrivateIdentifier {
+			tokens = append(tokens, nameNode.AsPrivateIdentifier().Text)
+		} else if name, ok := functionPropertyName(owner); ok && name != "" {
+			tokens = append(tokens, "'"+name+"'")
+		}
+	} else if name := functionOwnName(node); name != "" {
+		tokens = append(tokens, "'"+name+"'")
+	} else if name := functionOuterName(node); name != "" {
+		tokens = append(tokens, "'"+name+"'")
+	}
+
+	return strings.Join(tokens, " ")
+}
+
+func functionPropertyOwner(node *ast.Node, parent *ast.Node) *ast.Node {
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return node
+	}
+
+	switch parent.Kind {
+	case ast.KindPropertyAssignment:
+		if ast.SkipParentheses(parent.AsPropertyAssignment().Initializer) == node {
+			return parent
+		}
+	case ast.KindPropertyDeclaration:
+		declaration := parent.AsPropertyDeclaration()
+		if !ast.HasSyntacticModifier(parent, ast.ModifierFlagsAccessor) &&
+			declaration.Initializer != nil &&
+			ast.SkipParentheses(declaration.Initializer) == node {
+			return parent
+		}
+	}
+	return nil
+}
+
+func isClassFunctionOwner(node *ast.Node, owner *ast.Node) bool {
+	if owner == nil {
+		return false
+	}
+	if owner == node {
+		parent := node.Parent
+		return parent != nil && (parent.Kind == ast.KindClassDeclaration || parent.Kind == ast.KindClassExpression)
+	}
+	parent := owner.Parent
+	return parent != nil && (parent.Kind == ast.KindClassDeclaration || parent.Kind == ast.KindClassExpression)
+}
+
+func functionPropertyName(owner *ast.Node) (string, bool) {
+	nameNode := owner.Name()
+	if nameNode == nil {
+		return "", false
+	}
+	if name, ok := utils.GetStaticPropertyName(nameNode); ok {
+		return name, true
+	}
+	if nameNode.Kind != ast.KindComputedPropertyName {
+		return "", false
+	}
+	expression := ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
+	if expression == nil || expression.Kind == ast.KindIdentifier {
+		return "", false
+	}
+	return utils.NewStaticStringEvaluatorWithoutScope().EvalToString(expression)
+}
+
+func functionOwnName(node *ast.Node) string {
+	var name *ast.Node
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		name = node.AsFunctionDeclaration().Name()
+	case ast.KindFunctionExpression:
+		name = node.AsFunctionExpression().Name()
+	}
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+func functionOuterName(node *ast.Node) string {
+	if node.Name() != nil {
+		return ""
+	}
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsExportDefault) {
+		return "default"
+	}
+	parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+	if parent == nil {
+		return ""
+	}
+
+	var binding *ast.Node
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		declaration := parent.AsVariableDeclaration()
+		if declaration.Initializer != nil && ast.SkipParentheses(declaration.Initializer) == node {
+			binding = parent.Name()
+		}
+	case ast.KindParameter:
+		parameter := parent.AsParameterDeclaration()
+		if parameter.Initializer != nil && ast.SkipParentheses(parameter.Initializer) == node {
+			binding = parent.Name()
+		}
+	case ast.KindBindingElement:
+		element := parent.AsBindingElement()
+		if element.Initializer != nil && ast.SkipParentheses(element.Initializer) == node {
+			binding = parent.Name()
+		}
+	case ast.KindShorthandPropertyAssignment:
+		property := parent.AsShorthandPropertyAssignment()
+		if property.ObjectAssignmentInitializer != nil && ast.SkipParentheses(property.ObjectAssignmentInitializer) == node {
+			binding = parent.Name()
+		}
+	case ast.KindBinaryExpression:
+		assignment := parent.AsBinaryExpression()
+		if ast.IsAssignmentOperator(assignment.OperatorToken.Kind) && ast.SkipParentheses(assignment.Right) == node {
+			binding = ast.SkipParentheses(assignment.Left)
+		}
+	case ast.KindExportAssignment:
+		assignment := parent.AsExportAssignment()
+		if !assignment.IsExportEquals && ast.SkipParentheses(assignment.Expression) == node {
+			return "default"
+		}
+	}
+
+	if binding != nil && binding.Kind == ast.KindIdentifier {
+		return binding.AsIdentifier().Text
+	}
+	return ""
 }
 
 //nolint:unused
@@ -255,8 +436,7 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 				//     },
 				//   ],
 				// });
-				// TODO(port): getFunctionHeadLoc
-				ctx.ReportNode(node, buildMissingAwaitMessage())
+				ctx.ReportRange(utils.GetFunctionHeadLoc(ctx.SourceFile, node), buildMissingAwaitMessage(node))
 			}
 
 			scopes = scopes[:len(scopes)-1]

--- a/internal/plugins/typescript/rules/require_await/require_await_diagnostics_test.go
+++ b/internal/plugins/typescript/rules/require_await/require_await_diagnostics_test.go
@@ -1,0 +1,432 @@
+package require_await
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireAwaitDiagnosticPayloads(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAwaitRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `class DampingSwipe {
+  protected async isSwipeHorizontalDisAllow(left: number) {
+    return left < 0;
+  }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async method 'isSwipeHorizontalDisAllow' has no 'await' expression.",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 44,
+				}},
+			},
+			{
+				Code: `const ClipboardHelper = {
+  async loadClipboardSecuritySDK() {
+    return;
+  },
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async method 'loadClipboardSecuritySDK' has no 'await' expression.",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 33,
+				}},
+			},
+			{
+				Code: `const mockStore = {
+  async getAllKeys() {
+    return [];
+  },
+  async getItem() {
+    return {};
+  },
+  async getItems() {
+    return [];
+  },
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method 'getAllKeys' has no 'await' expression.",
+						Line:      2,
+						Column:    3,
+						EndLine:   2,
+						EndColumn: 19,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method 'getItem' has no 'await' expression.",
+						Line:      5,
+						Column:    3,
+						EndLine:   5,
+						EndColumn: 16,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method 'getItems' has no 'await' expression.",
+						Line:      8,
+						Column:    3,
+						EndLine:   8,
+						EndColumn: 17,
+					},
+				},
+			},
+			{
+				Code: `const manager = {
+  async warmup() {
+    return {};
+  },
+  async preload() {
+    return;
+  },
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method 'warmup' has no 'await' expression.",
+						Line:      2,
+						Column:    3,
+						EndLine:   2,
+						EndColumn: 15,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method 'preload' has no 'await' expression.",
+						Line:      5,
+						Column:    3,
+						EndLine:   5,
+						EndColumn: 16,
+					},
+				},
+			},
+			{
+				Code: `function render() {
+  const { data: meta, loading: isSearchingMetaData } = useRequest(async () => {
+    return 1;
+  });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async arrow function has no 'await' expression.",
+					Line:      2,
+					Column:    76,
+					EndLine:   2,
+					EndColumn: 78,
+				}},
+			},
+			{
+				Code: `const element = (
+  <LazyReadDocChatInput
+          onBeforeSendMessage={async () =>
+            true
+          }
+  />
+);`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async arrow function has no 'await' expression.",
+					Line:      3,
+					Column:    41,
+					EndLine:   3,
+					EndColumn: 43,
+				}},
+			},
+			{
+				Code: `const rawSubmit = useSubmit({
+    onBeforeSendMessage: async () => onBeforeSendMessage?.() ?? true,
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async method 'onBeforeSendMessage' has no 'await' expression.",
+					Line:      2,
+					Column:    5,
+					EndLine:   2,
+					EndColumn: 32,
+				}},
+			},
+			{
+				Code: `const getGlobalInfoService = async () => {
+  return getGlobalContainer();
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async arrow function 'getGlobalInfoService' has no 'await' expression.",
+					Line:      1,
+					Column:    39,
+					EndLine:   1,
+					EndColumn: 41,
+				}},
+			},
+			{
+				Code: `class ActionManager {
+  runResetTaskFn = async () => {
+    return;
+  };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async method 'runResetTaskFn' has no 'await' expression.",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 26,
+				}},
+			},
+			{
+				Code: `const commentSDK = {
+  commentSDKManager: async () => {
+    return {};
+  },
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async method 'commentSDKManager' has no 'await' expression.",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 28,
+				}},
+			},
+			{
+				Code: `const wrapped = {
+  field: ((async () => 1)),
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async method 'field' has no 'await' expression.",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code: `class AutoAccessor {
+  accessor field = async () => 1;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async arrow function has no 'await' expression.",
+					Line:      2,
+					Column:    29,
+					EndLine:   2,
+					EndColumn: 31,
+				}},
+			},
+			{
+				Code: `class PrivateMembers {
+  static async #method() {
+    return 1;
+  }
+  static #field = async () => 1;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingAwait",
+						Message:   "Static private async method #method has no 'await' expression.",
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Static private async method #field has no 'await' expression.",
+					},
+				},
+			},
+			{
+				Code: `const computed = {
+  ['field']: async () => 1,
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async method 'field' has no 'await' expression.",
+				}},
+			},
+			{
+				Code: `class EmptyNames {
+  async ''() {
+    return 1;
+  }
+  '' = async () => 2;
+}
+const object = {
+  '': async () => 3,
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method has no 'await' expression.",
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method has no 'await' expression.",
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method has no 'await' expression.",
+					},
+				},
+			},
+			{
+				Code: `declare function consume(value: unknown): void;
+const dynamic = 1;
+const object = {
+  [dynamic]: async function ownName() { consume(1); },
+  [1 + 1]: async () => consume(2),
+  [true ? 4 : dynamic]: async () => consume(3),
+  [String(5)]: async () => consume(4),
+  [({ key: 6 }).key]: async () => consume(5),
+};
+class Fields {
+  [dynamic] = async function ownField() { consume(6); };
+  [1 + 2] = async () => consume(7);
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method has no 'await' expression.",
+						Line:      4,
+						Column:    3,
+						EndLine:   4,
+						EndColumn: 36,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method '2' has no 'await' expression.",
+						Line:      5,
+						Column:    3,
+						EndLine:   5,
+						EndColumn: 18,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method '4' has no 'await' expression.",
+						Line:      6,
+						Column:    3,
+						EndLine:   6,
+						EndColumn: 31,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method has no 'await' expression.",
+						Line:      7,
+						Column:    3,
+						EndLine:   7,
+						EndColumn: 22,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method '6' has no 'await' expression.",
+						Line:      8,
+						Column:    3,
+						EndLine:   8,
+						EndColumn: 29,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method has no 'await' expression.",
+						Line:      11,
+						Column:    3,
+						EndLine:   11,
+						EndColumn: 38,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async method '3' has no 'await' expression.",
+						Line:      12,
+						Column:    3,
+						EndLine:   12,
+						EndColumn: 19,
+					},
+				},
+			},
+			{
+				Code: `let assigned: () => Promise<void>;
+assigned = async () => consume(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async arrow function 'assigned' has no 'await' expression.",
+				}},
+			},
+			{
+				Code: `function defaults(callback = async () => consume(1)) {
+  return callback;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async arrow function 'callback' has no 'await' expression.",
+				}},
+			},
+			{
+				Code: `export default async () => consume(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Message:   "Async arrow function 'default' has no 'await' expression.",
+				}},
+			},
+			{
+				Code: `declare function consume(value: unknown): void;
+
+function bindingElement({ callback = async () => consume(1) } = {}) {
+  return callback;
+}
+
+let shorthand: () => Promise<void>;
+({ shorthand = async () => consume(2) } = {});
+
+let compound: (() => Promise<void>) | undefined;
+compound ??= async () => consume(3);
+
+export default async function () {
+  consume(4);
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingAwait",
+						Message:   "Async arrow function 'callback' has no 'await' expression.",
+						Line:      3,
+						Column:    47,
+						EndLine:   3,
+						EndColumn: 49,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async arrow function 'shorthand' has no 'await' expression.",
+						Line:      8,
+						Column:    25,
+						EndLine:   8,
+						EndColumn: 27,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async arrow function 'compound' has no 'await' expression.",
+						Line:      11,
+						Column:    23,
+						EndLine:   11,
+						EndColumn: 25,
+					},
+					{
+						MessageId: "missingAwait",
+						Message:   "Async function 'default' has no 'await' expression.",
+						Line:      13,
+						Column:    16,
+						EndLine:   13,
+						EndColumn: 31,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -18,6 +18,7 @@ type StaticStringEvaluator struct {
 	sourceFile             *ast.SourceFile
 	referenceResolver      StaticReferenceResolver
 	evaluator              evaluator.Evaluator
+	resolveIdentifiers     bool
 	resolving              map[*ast.Symbol]bool
 	referenceFlagsComputed bool
 	referenceFlags         map[*ast.Symbol]staticReferenceFlags
@@ -44,12 +45,22 @@ func NewStaticStringEvaluatorWithReferenceResolver(
 	referenceResolver StaticReferenceResolver,
 ) *StaticStringEvaluator {
 	staticEvaluator := &StaticStringEvaluator{
-		typeChecker:       typeChecker,
-		sourceFile:        sourceFile,
-		referenceResolver: referenceResolver,
-		resolving:         map[*ast.Symbol]bool{},
+		typeChecker:        typeChecker,
+		sourceFile:         sourceFile,
+		referenceResolver:  referenceResolver,
+		resolveIdentifiers: true,
+		resolving:          map[*ast.Symbol]bool{},
 	}
 	staticEvaluator.evaluator = evaluator.NewEvaluator(staticEvaluator.evaluateEntity, ast.OEKAssertions)
+	return staticEvaluator
+}
+
+// NewStaticStringEvaluatorWithoutScope mirrors eslint-utils getStaticValue
+// when no initial scope is supplied: literal expressions can still be folded,
+// but identifiers (including built-in globals) cannot be resolved.
+func NewStaticStringEvaluatorWithoutScope() *StaticStringEvaluator {
+	staticEvaluator := NewStaticStringEvaluator(nil)
+	staticEvaluator.resolveIdentifiers = false
 	return staticEvaluator
 }
 
@@ -133,6 +144,20 @@ func (staticEvaluator *StaticStringEvaluator) Eval(node *ast.Node) (string, bool
 	return staticValueAsString(result.value)
 }
 
+// EvalToString returns JavaScript's String conversion of a statically known
+// value. This matches eslint-utils getStringIfConstant after getStaticValue has
+// evaluated an expression.
+func (staticEvaluator *StaticStringEvaluator) EvalToString(node *ast.Node) (string, bool) {
+	if staticEvaluator == nil || node == nil {
+		return "", false
+	}
+	result := staticEvaluator.evalValue(node)
+	if !result.ok {
+		return "", false
+	}
+	return staticValueToString(result.value)
+}
+
 // EvalValue returns the static value of node if it can be determined, regardless
 // of its type. It allows rules to check if a value is statically known to be a
 // non-string (like a boolean or number).
@@ -201,8 +226,14 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 	case ast.KindNullKeyword:
 		return staticEvalResult{value: staticNullValue{}, ok: true}
 	case ast.KindUndefinedKeyword:
+		if !staticEvaluator.resolveIdentifiers {
+			return staticEvalResult{}
+		}
 		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
 	case ast.KindIdentifier:
+		if !staticEvaluator.resolveIdentifiers {
+			return staticEvalResult{}
+		}
 		identifier := node.AsIdentifier()
 		if identifier != nil && identifier.Text == "undefined" && !IsShadowed(node, "undefined") {
 			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
@@ -250,6 +281,9 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalIdentifier(node *ast.Node) staticEvalResult {
+	if !staticEvaluator.resolveIdentifiers {
+		return staticEvalResult{}
+	}
 	initializer, symbol, ok := staticEvaluator.resolveIdentifierInitializer(node)
 	if !ok || staticEvaluator.resolving[symbol] {
 		return staticEvalResult{}
@@ -805,6 +839,9 @@ func staticArrayIndex(key string) (int, bool) {
 // evalObjectPassThroughCall folds `Object.freeze(x)` and its siblings to the
 // value of x.
 func (staticEvaluator *StaticStringEvaluator) evalObjectPassThroughCall(node *ast.Node) staticEvalResult {
+	if !staticEvaluator.resolveIdentifiers {
+		return staticEvalResult{}
+	}
 	argument, ok := staticEvaluator.objectPassThroughArgument(node)
 	if !ok {
 		return staticEvalResult{}
@@ -997,6 +1034,9 @@ func (staticEvaluator *StaticStringEvaluator) isStringRawTag(tag *ast.Node) bool
 }
 
 func (staticEvaluator *StaticStringEvaluator) isBuiltinStringValue(node *ast.Node, resolvingAliases map[*ast.Symbol]bool) bool {
+	if !staticEvaluator.resolveIdentifiers {
+		return false
+	}
 	node = SkipAssertionsAndParens(node)
 	if node == nil {
 		return false

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/require-await.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/require-await.test.ts.snap
@@ -9,12 +9,12 @@ async function numberOne(): Promise<number> {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function 'numberOne' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 25,
+          "line": 2,
         },
         "start": {
           "column": 1,
@@ -39,12 +39,12 @@ const numberOne = async function (): Promise<number> {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function 'numberOne' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 34,
+          "line": 2,
         },
         "start": {
           "column": 19,
@@ -65,15 +65,15 @@ exports[`require-await > invalid 3`] = `
   "code": "const numberOne = async (): Promise<number> => 1;",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async arrow function 'numberOne' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 49,
+          "column": 47,
           "line": 1,
         },
         "start": {
-          "column": 19,
+          "column": 45,
           "line": 1,
         },
       },
@@ -95,12 +95,12 @@ async function values(): Promise<Array<number>> {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function 'values' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 22,
+          "line": 2,
         },
         "start": {
           "column": 1,
@@ -127,12 +127,12 @@ exports[`require-await > invalid 5`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 6,
+          "column": 27,
+          "line": 2,
         },
         "start": {
           "column": 9,
@@ -157,12 +157,12 @@ async function* foo(): void {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 20,
+          "line": 2,
         },
         "start": {
           "column": 1,
@@ -187,12 +187,12 @@ async function* foo() {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 20,
+          "line": 2,
         },
         "start": {
           "column": 1,
@@ -217,12 +217,12 @@ const foo = async function* () {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 29,
+          "line": 2,
         },
         "start": {
           "column": 13,
@@ -247,12 +247,12 @@ async function* asyncGenerator() {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'asyncGenerator' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 31,
+          "line": 2,
         },
         "start": {
           "column": 1,
@@ -277,12 +277,12 @@ async function* asyncGenerator(source: Iterable<any>) {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'asyncGenerator' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 31,
+          "line": 2,
         },
         "start": {
           "column": 1,
@@ -312,12 +312,12 @@ async function* asyncGenerator(source: Iterable<any> | AsyncIterable<any>) {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'asyncGenerator' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 9,
+          "column": 31,
+          "line": 5,
         },
         "start": {
           "column": 1,
@@ -345,12 +345,12 @@ async function* asyncGenerator() {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'asyncGenerator' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 7,
+          "column": 31,
+          "line": 5,
         },
         "start": {
           "column": 1,
@@ -375,12 +375,12 @@ async function* asyncGenerator() {
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'asyncGenerator' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 31,
+          "line": 2,
         },
         "start": {
           "column": 1,
@@ -405,15 +405,15 @@ exports[`require-await > invalid 14`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async arrow function 'fn' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 4,
+          "column": 31,
+          "line": 2,
         },
         "start": {
-          "column": 20,
+          "column": 29,
           "line": 2,
         },
       },
@@ -436,12 +436,12 @@ exports[`require-await > invalid 15`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 5,
+          "column": 28,
+          "line": 3,
         },
         "start": {
           "column": 9,
@@ -466,12 +466,12 @@ exports[`require-await > invalid 16`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 4,
+          "column": 28,
+          "line": 2,
         },
         "start": {
           "column": 9,
@@ -496,12 +496,12 @@ exports[`require-await > invalid 17`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async generator function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 4,
+          "column": 28,
+          "line": 2,
         },
         "start": {
           "column": 9,
@@ -526,12 +526,12 @@ exports[`require-await > invalid 18`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 4,
+          "column": 27,
+          "line": 2,
         },
         "start": {
           "column": 9,
@@ -556,12 +556,12 @@ exports[`require-await > invalid 19`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 4,
+          "column": 25,
+          "line": 2,
         },
         "start": {
           "column": 10,
@@ -586,15 +586,15 @@ exports[`require-await > invalid 20`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async arrow function has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 4,
+          "column": 20,
+          "line": 2,
         },
         "start": {
-          "column": 9,
+          "column": 18,
           "line": 2,
         },
       },
@@ -612,15 +612,15 @@ exports[`require-await > invalid 21`] = `
   "code": "async () => doSomething();",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async arrow function has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 26,
+          "column": 12,
           "line": 1,
         },
         "start": {
-          "column": 1,
+          "column": 10,
           "line": 1,
         },
       },
@@ -644,12 +644,12 @@ exports[`require-await > invalid 22`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 5,
+          "column": 20,
+          "line": 3,
         },
         "start": {
           "column": 11,
@@ -676,12 +676,12 @@ exports[`require-await > invalid 23`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 5,
+          "column": 20,
+          "line": 3,
         },
         "start": {
           "column": 11,
@@ -708,12 +708,12 @@ exports[`require-await > invalid 24`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 5,
+          "column": 27,
+          "line": 3,
         },
         "start": {
           "column": 11,
@@ -740,12 +740,12 @@ exports[`require-await > invalid 25`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 5,
+          "column": 20,
+          "line": 3,
         },
         "start": {
           "column": 11,
@@ -772,12 +772,12 @@ exports[`require-await > invalid 26`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 5,
+          "column": 19,
+          "line": 3,
         },
         "start": {
           "column": 11,
@@ -804,12 +804,12 @@ exports[`require-await > invalid 27`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 6,
+          "column": 27,
+          "line": 2,
         },
         "start": {
           "column": 9,
@@ -836,15 +836,15 @@ exports[`require-await > invalid 28`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async arrow function has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 5,
+          "column": 29,
+          "line": 3,
         },
         "start": {
-          "column": 18,
+          "column": 27,
           "line": 3,
         },
       },
@@ -868,15 +868,15 @@ exports[`require-await > invalid 29`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method 'async' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 5,
+          "column": 36,
+          "line": 3,
         },
         "start": {
-          "column": 18,
+          "column": 11,
           "line": 3,
         },
       },
@@ -898,12 +898,12 @@ exports[`require-await > invalid 30`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async function 'foo' has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 4,
+          "column": 41,
+          "line": 2,
         },
         "start": {
           "column": 9,
@@ -931,12 +931,12 @@ exports[`require-await > invalid 31`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 6,
+          "column": 20,
+          "line": 4,
         },
         "start": {
           "column": 11,
@@ -962,15 +962,15 @@ exports[`require-await > invalid 32`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async arrow function has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 10,
-          "line": 5,
+          "column": 20,
+          "line": 3,
         },
         "start": {
-          "column": 9,
+          "column": 18,
           "line": 3,
         },
       },
@@ -995,12 +995,12 @@ exports[`require-await > invalid 33`] = `
       ",
   "diagnostics": [
     {
-      "message": "Function has no 'await' expression.",
+      "message": "Async method has no 'await' expression.",
       "messageId": "missingAwait",
       "range": {
         "end": {
-          "column": 12,
-          "line": 6,
+          "column": 22,
+          "line": 4,
         },
         "start": {
           "column": 11,


### PR DESCRIPTION
## Summary

- Align @typescript-eslint/require-await diagnostic names and function-head ranges with typescript-eslint 8.67.0.
- Cover all reported real-world shapes plus adversarial method, binding, export, empty-name, and computed-key cases.
- Add focused Go diagnostic regression coverage and refresh the JS rule snapshots.

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/require-await.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).