### PR TITLE
fix: align no-static-only-class JSDoc modifiers

### DIFF
--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
@@ -13,12 +13,35 @@ import (
 // modifierFlagsDisqualifying captures the TS-only modifiers that exclude a
 // member from "valid static" status: the three accessibility keywords
 // (`public` / `private` / `protected`), `readonly`, `declare` (ambient), and
-// any class-element decorator. tsgo carries decorators on the same modifier
-// list as keywords, so a single flag check covers both.
+// any class-element decorator. TypeScript-Go carries decorators on the same
+// modifier list as keywords, so the same mask covers both.
 const modifierFlagsDisqualifying = ast.ModifierFlagsAccessibilityModifier |
 	ast.ModifierFlagsReadonly |
 	ast.ModifierFlagsAmbient |
 	ast.ModifierFlagsDecorator
+
+// hasDisqualifyingSyntacticModifier excludes JSDoc modifiers synthesized by
+// TypeScript-Go's JavaScript reparser. Upstream reads ESTree syntax fields, so
+// tags such as `@public`, `@private`, `@protected`, and `@readonly` must not
+// disqualify an otherwise static-only JavaScript class.
+func hasDisqualifyingSyntacticModifier(member *ast.Node) bool {
+	if member.ModifierFlags()&modifierFlagsDisqualifying == 0 {
+		return false
+	}
+	modifiers := member.Modifiers()
+	if modifiers == nil {
+		return false
+	}
+	for _, modifier := range modifiers.Nodes {
+		if modifier == nil || modifier.Flags&ast.NodeFlagsReparsed != 0 {
+			continue
+		}
+		if ast.ModifierToFlag(modifier.Kind)&modifierFlagsDisqualifying != 0 {
+			return true
+		}
+	}
+	return false
+}
 
 // isClassElementMethodLike reports whether a class element is one of the
 // kinds the upstream rule treats as `MethodDefinition`: regular method,
@@ -53,7 +76,7 @@ func isStaticMember(member *ast.Node) bool {
 	if ast.IsPrivateIdentifierClassElementDeclaration(member) {
 		return false
 	}
-	if ast.HasSyntacticModifier(member, modifierFlagsDisqualifying) {
+	if hasDisqualifyingSyntacticModifier(member) {
 		return false
 	}
 	return true

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.md
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.md
@@ -90,5 +90,5 @@ is still reported in all of them.
 
 ## Original Documentation
 
-- [eslint-plugin-unicorn: no-static-only-class](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/no-static-only-class.md)
-- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/rules/no-static-only-class.js)
+- [eslint-plugin-unicorn: no-static-only-class](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-static-only-class.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-static-only-class.js)

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
@@ -136,9 +136,52 @@ func TestNoStaticOnlyClass(t *testing.T) {
 			// alone are still all-static and reported (covered in invalid)
 			// — here, mixing one non-static numeric key blocks the rule.
 			{Code: `class A { static 0() {} 1() {} }`},
+
+			// A newly detected JSDoc-tagged JavaScript class must still respect
+			// both scoped and line disable directives.
+			{
+				Code:     "/* eslint-disable test */\nclass A { /** @public */ static a() {} }",
+				FileName: "scoped-disable.js",
+			},
+			{
+				Code:     "// eslint-disable-next-line test\nclass A { /** @private */ static a() {} }",
+				FileName: "line-disable.js",
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- JS snapshot block: invalid ----
+
+			// TypeScript-Go synthesizes JSDoc accessibility/readonly tags as
+			// synthetic modifiers in JavaScript. They are comments rather than
+			// ESTree syntax fields, so upstream still reports these classes.
+			{
+				Code:     "class AnnotationFactory {\n\tstatic create() {}\n\t/** @private */\n\tstatic _create() {}\n\t/** @private */\n\tstatic async _getPageIndex() {}\n}",
+				FileName: "annotation.js",
+				Output:   []string{"const AnnotationFactory = {\n\tcreate() {},\n\t/** @private */\n\t_create() {},\n\t/** @private */\n\tasync _getPageIndex() {},\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Message:   "Use an object instead of a class with only static members.",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 24,
+				}},
+			},
+			{
+				Code:     "class AnnotationLayer {\n\t/** @public */\n\tstatic render() {}\n\t/** @public */\n\tstatic update() {}\n}",
+				FileName: "annotation_layer.js",
+				Output:   []string{"const AnnotationLayer = {\n\t/** @public */\n\trender() {},\n\t/** @public */\n\tupdate() {},\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 22,
+				}},
+			},
+			{
+				Code:     "class A {\n\t/** @protected */\n\tstatic a() {}\n\t/** @readonly */\n\tstatic b = 1;\n}",
+				FileName: "jsdoc-modifiers.js",
+				Output:   []string{"const A = {\n\t/** @protected */\n\ta() {},\n\t/** @readonly */\n\tb : 1,\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
 
 			// `class A { static a() {}; }` — head is `class A` (length 7).
 			// Autofix: class → const, insert `= ` before `{`, append `;`.

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts
@@ -31,6 +31,26 @@ ruleTester.run('no-static-only-class', null as never, {
     valid('class A { static declare a = 1; }'),
   ],
   invalid: [
+    {
+      filename: 'src/annotation.js',
+      code:
+        'class AnnotationFactory {\n' +
+        '\tstatic create() {}\n' +
+        '\t/** @private */\n' +
+        '\tstatic _create() {}\n' +
+        '}',
+      errors: 1,
+    },
+    {
+      filename: 'src/annotation_layer.js',
+      code:
+        'class AnnotationLayer {\n' +
+        '\t/** @public */\n' +
+        '\tstatic render() {}\n' +
+        '\tstatic update() {}\n' +
+        '}',
+      errors: 1,
+    },
     { code: 'class A { static a() {}; }', errors: 1 },
     { code: 'class A { static a() {} }', errors: 1 },
     { code: 'const A = class A { static a() {}; }', errors: 1 },


### PR DESCRIPTION
## Summary

- Align `unicorn/no-static-only-class` with `eslint-plugin-unicorn` v73 by ignoring TypeScript-Go modifiers synthesized from JavaScript JSDoc tags while continuing to reject real TypeScript accessibility, `readonly`, `declare`, and decorator syntax.
- Add Go regression/fix/range/disable coverage and JS integration coverage for the reported `AnnotationFactory` and `AnnotationLayer` cases.
- Update the rule documentation links to the latest upstream implementation.

## Related Links

- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-static-only-class.js
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-static-only-class.md

## Verification

- Verified all four reported executions individually: both affected files from the nested `pdfjs-web` package and from its parent package. Diagnostic line/column ranges match upstream v73.
- `go test ./internal/plugins/unicorn/rules/no_static_only_class -count=3`
- `pnpm --filter @rslint/test-tools exec rstest run tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts` (snapshot changes: 0)
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/unicorn/rules/no_static_only_class/...`

## Go benchmark

Measured with six one-second runs before and after the fix while CPU idle was above 70%:

- `autofix`: 1629.50 -> 1614.00 ns/op; 3368 B/op and 36 allocs/op unchanged.
- `no_match_instance_member`: 1306.50 -> 1302.83 ns/op; 2512 B/op and 30 allocs/op unchanged.
- The corrected `jsdoc_accessibility` path now emits its required diagnostic, increasing from 2512 B/op and 30 allocs/op to 2672 B/op and 31 allocs/op.

No performance-only change was justified.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
