### PR TITLE
fix: align filename-case with latest unicorn

### DIFF
--- a/internal/plugins/unicorn/rules/filename_case/filename_case.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.go
@@ -18,28 +18,24 @@ import (
 //go:embed filename_case.schema.json
 var schemaJSON []byte
 
-// caseStyle is one of the four supported filename case styles.
+// caseStyle is one of the supported filename case styles.
 type caseStyle struct {
 	key  string
 	name string
 	fn   func(string) string
 }
 
-const caseStyleCount = 4
+const caseStyleCount = 5
 
-// allCases keeps a stable canonical iteration order for the `cases` option.
-//
-// NOTE: Unlike ESLint, where Object.keys() over `options.cases` preserves the
-// user's literal-property insertion order, we always use this canonical order
-// in the diagnostic message. The reason is that rslint receives options as a
-// `map[string]interface{}` after JSON parsing; Go map iteration is not
-// order-preserving, and the original key order is unrecoverable. Locking the
-// order here keeps message text deterministic.
+// allCases follows the upstream case registry order. Go maps do not preserve
+// the authored order of `cases`, so this order also keeps diagnostics and
+// suggestions deterministic when multiple cases are enabled.
 var allCases = [caseStyleCount]caseStyle{
 	{key: "camelCase", name: "camel case", fn: toCamelCase},
-	{key: "snakeCase", name: "snake case", fn: toSnakeCase},
+	{key: "camelCaseWithAcronyms", name: "camel case with acronyms", fn: toCamelCaseWithAcronyms},
 	{key: "kebabCase", name: "kebab case", fn: toKebabCase},
-	{key: "pascalCase", name: "pascal case", fn: toPascalCase},
+	{key: "snakeCase", name: "snake case", fn: toSnakeCase},
+	{key: "pascalCase", name: "pascal case", fn: toPascalCaseWithLeadingAcronym},
 }
 
 func caseForKey(key string) (caseStyle, bool) {
@@ -71,7 +67,7 @@ type invalidIgnore struct {
 }
 
 // options is the parsed shape of the user's rule configuration. Cases use a
-// fixed-size array because the schema permits exactly four known styles; this
+// fixed-size array because the schema permits exactly five known styles; this
 // keeps the option parsing done for every file allocation-free unless ignore
 // patterns are configured.
 type options struct {
@@ -80,10 +76,11 @@ type options struct {
 	ignores                []*esregexp.RegExp
 	invalidIgnores         []invalidIgnore
 	multipleFileExtensions bool
+	checkDirectories       bool
 }
 
 func parseOptions(rawOpts []any) options {
-	opts := options{caseCount: 1, multipleFileExtensions: true}
+	opts := options{caseCount: 1, multipleFileExtensions: true, checkDirectories: true}
 	opts.cases[0] = allCases[2] // kebabCase
 	if len(rawOpts) == 0 {
 		return opts
@@ -126,6 +123,9 @@ func parseOptions(rawOpts []any) options {
 
 	if v, ok := optsMap["multipleFileExtensions"].(bool); ok {
 		opts.multipleFileExtensions = v
+	}
+	if v, ok := optsMap["checkDirectories"].(bool); ok {
+		opts.checkDirectories = v
 	}
 
 	return opts
@@ -296,6 +296,54 @@ func toCamelCase(s string) string {
 	return sb.String()
 }
 
+func toCamelCaseWithAcronyms(s string) string {
+	if isCamelCaseWithAcronyms(s) {
+		return s
+	}
+	return toCamelCase(s)
+}
+
+func isCamelCaseWithAcronyms(s string) bool {
+	if len(s) == 0 || !isASCIILower(s[0]) {
+		return false
+	}
+	for index := 1; index < len(s); index++ {
+		char := s[index]
+		if isASCIILower(char) || isASCIIByteDigit(char) {
+			continue
+		}
+		if !isASCIIUpper(char) {
+			return false
+		}
+
+		uppercaseStart := index
+		for index+1 < len(s) && isASCIIUpper(s[index+1]) {
+			index++
+		}
+		if index == uppercaseStart {
+			continue
+		}
+		if index+1 < len(s) && isASCIILower(s[index+1]) {
+			index--
+			continue
+		}
+		for index+1 < len(s) && isASCIIByteDigit(s[index+1]) {
+			index++
+		}
+		if index == len(s)-1 {
+			return true
+		}
+		if !isASCIIUpper(s[index+1]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIILower(char byte) bool     { return char >= 'a' && char <= 'z' }
+func isASCIIUpper(char byte) bool     { return char >= 'A' && char <= 'Z' }
+func isASCIIByteDigit(char byte) bool { return char >= '0' && char <= '9' }
+
 func toPascalCase(s string) string {
 	words := splitWords(s)
 	if len(words) == 0 {
@@ -307,6 +355,54 @@ func toPascalCase(s string) string {
 		sb.WriteString(pascalLikeTransform(w, i))
 	}
 	return sb.String()
+}
+
+func toPascalCaseWithLeadingAcronym(s string) string {
+	if acronymEnd := leadingPascalAcronymEnd(s); acronymEnd > 0 {
+		suffix := s[acronymEnd:]
+		if toPascalCase(suffix) == suffix {
+			return s
+		}
+	}
+	return toPascalCase(s)
+}
+
+// leadingPascalAcronymEnd matches upstream's
+// /^[A-Z]{3,}(?=\d*[A-Z](?:[a-z]|\d+[a-z]))/ without routing source text
+// through a regexp engine.
+func leadingPascalAcronymEnd(s string) int {
+	for index := range len(s) {
+		char := s[index]
+		if !isASCIILower(char) && !isASCIIUpper(char) && !isASCIIByteDigit(char) {
+			return 0
+		}
+	}
+
+	uppercaseEnd := 0
+	for uppercaseEnd < len(s) && isASCIIUpper(s[uppercaseEnd]) {
+		uppercaseEnd++
+	}
+	for acronymEnd := uppercaseEnd; acronymEnd >= 3; acronymEnd-- {
+		index := acronymEnd
+		for index < len(s) && isASCIIByteDigit(s[index]) {
+			index++
+		}
+		if index >= len(s) || !isASCIIUpper(s[index]) {
+			continue
+		}
+		index++
+		if index < len(s) && isASCIILower(s[index]) {
+			return acronymEnd
+		}
+		digitStart := index
+		for index < len(s) && isASCIIByteDigit(s[index]) {
+			index++
+		}
+		if index > digitStart && index < len(s) && isASCIILower(s[index]) {
+			return acronymEnd
+		}
+	}
+	return 0
 }
 
 func toKebabCase(s string) string { return joinNoCase(splitWords(s), "-") }
@@ -437,9 +533,8 @@ func validateFilename(words []filenameWord, cases []caseStyle) (valid bool, inva
 
 // fixFilename builds the deduplicated, ordered list of suggested filenames by
 // taking the cartesian product of each non-ignored chunk's case-conversion
-// candidates. The order matches change-case's left-to-right output, so all
-// four styles produce `fooBar`, `foo_bar`, `foo-bar`, `FooBar` in canonical
-// camel, snake, kebab, pascal order.
+// candidates. Candidate order follows allCases so output remains stable even
+// though the source configuration was decoded into a Go map.
 type filenameReplacements struct {
 	items [caseStyleCount]string
 	count int
@@ -568,6 +663,42 @@ func englishishBacktickJoin(items []string) string {
 	return sb.String()
 }
 
+func isInsideCwd(relativePath string) bool {
+	return relativePath != "" &&
+		relativePath != ".." &&
+		!strings.HasPrefix(relativePath, "../") &&
+		!tspath.IsRootedDiskPath(relativePath)
+}
+
+func getPathSegments(fileName string, cwd string) []string {
+	basename := tspath.GetBaseFileName(fileName)
+	if cwd == "" {
+		return []string{basename}
+	}
+	resolved := tspath.ResolvePath(cwd, fileName)
+	if (tspath.GetRootLength(cwd) > 0) != (tspath.GetRootLength(resolved) > 0) {
+		return []string{basename}
+	}
+	relative := tspath.GetRelativePathFromDirectory(cwd, resolved, tspath.ComparePathsOptions{
+		CurrentDirectory:          cwd,
+		UseCaseSensitiveFileNames: true,
+	})
+	if !isInsideCwd(relative) {
+		return []string{basename}
+	}
+	segments := strings.Split(relative, "/")
+	filtered := segments[:0]
+	for _, segment := range segments {
+		if segment != "." && segment != "" {
+			filtered = append(filtered, segment)
+		}
+	}
+	if len(filtered) == 0 {
+		return []string{basename}
+	}
+	return filtered
+}
+
 const filenameCaseRuleName = "unicorn/filename-case"
 
 var FilenameCaseRule = rule.Rule{
@@ -586,9 +717,8 @@ var FilenameCaseRule = rule.Rule{
 		if fileName == "" {
 			return nil
 		}
-		// `tspath.GetBaseFileName` normalizes `\` → `/` first, so a Windows
-		// path like `src\foo\bar.js` resolves the basename correctly.
-		basename := tspath.GetBaseFileName(fileName)
+		pathSegments := getPathSegments(fileName, ctx.ProcessCurrentDirectory())
+		basename := pathSegments[len(pathSegments)-1]
 		// Skip ESLint's stdin / inline-source virtual filenames.
 		if basename == "<input>" || basename == "<text>" {
 			return nil
@@ -619,13 +749,38 @@ var FilenameCaseRule = rule.Rule{
 			return nil
 		}
 
-		if isIgnoredByDefault(basename) {
-			return nil
+		for _, segment := range pathSegments {
+			for _, re := range opts.ignores {
+				if re.TestOrTimeout(segment) {
+					return nil
+				}
+			}
 		}
-		for _, re := range opts.ignores {
-			if re.TestOrTimeout(basename) {
+		cases := opts.selectedCases()
+		if opts.checkDirectories {
+			for _, directory := range pathSegments[:len(pathSegments)-1] {
+				if strings.HasPrefix(directory, "$") {
+					continue
+				}
+				leading, words := splitFilename(directory)
+				valid, invalidWord, invalidCandidates := validateFilename(words, cases)
+				if valid {
+					continue
+				}
+				if ctx.DisableManager.IsRuleDisabled(filenameCaseRuleName, reportRange.Pos()) {
+					return nil
+				}
+				renamed := fixFilename(words, cases, invalidWord, invalidCandidates, leading, "")
+				ctx.ReportRange(reportRange, rule.RuleMessage{
+					Id: "directoryCase",
+					Description: "Directory name `" + directory + "` is not in " +
+						englishishCaseNames(cases) + ". Rename it to " + englishishBacktickJoin(renamed) + ".",
+				})
 				return nil
 			}
+		}
+		if isIgnoredByDefault(basename) {
+			return nil
 		}
 
 		ext := nodeExtname(basename)
@@ -639,8 +794,10 @@ var FilenameCaseRule = rule.Rule{
 		}
 
 		leading, words := splitFilename(filename)
-		cases := opts.selectedCases()
 		valid, invalidWord, invalidCandidates := validateFilename(words, cases)
+		if strings.HasPrefix(filename, "$") {
+			valid = true
+		}
 		lowerExt := ecmascript.StringToLowerCase(ext)
 		if valid {
 			if ext != lowerExt {

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.md
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.md
@@ -2,11 +2,13 @@
 
 ## Rule Details
 
-Enforces all linted files to have their names in a certain case style and a lowercase file extension. The default is `kebabCase`.
+Enforces filenames and directory names of linted files to use a certain case style and a lowercase file extension. The default is `kebabCase`.
 
-Files named `index.js`, `index.mjs`, `index.cjs`, `index.ts`, `index.tsx`, `index.vue` are ignored as they can't change case (only a problem with `pascalCase`).
+Directory names are checked only when the file is inside the current working directory. Files outside the current working directory only have their filename checked.
 
-Characters in the filename other than `a-z`, `A-Z`, `0-9`, `-`, and `_` are ignored.
+Files named `index.js`, `index.mjs`, `index.cjs`, `index.ts`, `index.tsx`, and `index.vue` are ignored because they cannot change case. Their parent directories are still checked.
+
+Characters other than `a-z`, `A-Z`, `0-9`, `-`, and `_` are ignored for casing and kept as-is in suggested names. Path segments starting with `$` are also ignored, as they are commonly used for route parameters.
 
 ### Cases
 
@@ -22,6 +24,14 @@ Characters in the filename other than `a-z`, `A-Z`, `0-9`, `-`, and `_` are igno
 - `fooBar.test.js`
 - `fooBar.testUtils.js`
 
+#### `camelCaseWithAcronyms`
+
+- `innerHTML.js`
+- `getDOMRangeRect.js`
+- `apiURL.js`
+
+This is still lower camel case. Leading acronyms are lowercased, so `HTMLParser.js` should be `htmlParser.js`.
+
 #### `snakeCase`
 
 - `foo_bar.js`
@@ -31,6 +41,7 @@ Characters in the filename other than `a-z`, `A-Z`, `0-9`, `-`, and `_` are igno
 #### `pascalCase`
 
 - `FooBar.js`
+- `FAQPage.js`
 - `FooBar.Test.js`
 - `FooBar.TestUtils.js`
 
@@ -38,7 +49,7 @@ Characters in the filename other than `a-z`, `A-Z`, `0-9`, `-`, and `_` are igno
 
 ### case
 
-Type: `"camelCase" | "snakeCase" | "kebabCase" | "pascalCase"`
+Type: `"camelCase" | "camelCaseWithAcronyms" | "snakeCase" | "kebabCase" | "pascalCase"`
 
 Set a single allowed case style:
 
@@ -48,7 +59,7 @@ Set a single allowed case style:
 
 ### cases
 
-Type: `{ camelCase?: boolean; snakeCase?: boolean; kebabCase?: boolean; pascalCase?: boolean }`
+Type: `{ camelCase?: boolean; camelCaseWithAcronyms?: boolean; snakeCase?: boolean; kebabCase?: boolean; pascalCase?: boolean }`
 
 Allow several case styles at once. Setting a key to `true` enables that style; the file passes if it matches any enabled style.
 
@@ -61,7 +72,7 @@ Allow several case styles at once. Setting a key to `true` enables that style; t
 Type: `string[]`\
 Default: `[]`
 
-A list of regular-expression patterns (as strings) that match filenames the rule should skip.
+A list of regular-expression patterns (as strings) matched against every path segment. If any directory or the filename matches, the file is skipped.
 
 ```json
 {
@@ -69,11 +80,18 @@ A list of regular-expression patterns (as strings) that match filenames the rule
     "error",
     {
       "case": "kebabCase",
-      "ignore": ["^FOOBAR\\.js$", "^(B|b)az", "\\.SOMETHING\\.js$"]
+      "ignore": ["^FOOBAR\\.js$", "^vendor$", "^(B|b)az", "\\.SOMETHING\\.js$"]
     }
   ]
 }
 ```
+
+### checkDirectories
+
+Type: `boolean`\
+Default: `true`
+
+Whether to check directory names. Filenames are always checked.
 
 ### multipleFileExtensions
 
@@ -82,12 +100,19 @@ Default: `true`
 
 When `true`, additional `.`-separated parts of the basename are treated as part of the extension and are not subject to case checking. When `false`, only the final extension is treated as such, and the rest of the basename must match the chosen case styles.
 
+This option only affects filenames. Directory names are always checked as complete path segments when `checkDirectories` is enabled.
+
 ## Differences from ESLint
 
-- When the `cases` option enables more than one style, the diagnostic message lists the case names and rename suggestions in a fixed order: camel case, snake case, kebab case, pascal case. ESLint lists them in the order the keys appear in your `cases` object. So `{ pascalCase: true, camelCase: true }` against `foo-bar.js` reports `Filename is not in camel case or pascal case. Rename it to ` `` `fooBar.js` `` ` or ` `` `FooBar.js` `` `.` here, and `Filename is not in pascal case or camel case. Rename it to ` `` `FooBar.js` `` ` or ` `` `fooBar.js` `` `.` in ESLint.
-- A regular-expression literal in `ignore` (for example `/^vendor/i`) does not match anything. Write the pattern as a string — for example `"^vendor"` for `/^vendor/`, or `"(?i)^vendor"` for `/^vendor/i`.
+- When several entries in `cases` are enabled, rslint uses a fixed order for
+  diagnostic text and suggestions: `camelCase`, `camelCaseWithAcronyms`,
+  `kebabCase`, `snakeCase`, then `pascalCase`. ESLint derives this presentation
+  order from `Object.keys(options.cases)`. This does not change whether a path
+  is valid or which replacements are suggested.
+
+- JavaScript `RegExp` objects do not survive the native configuration's JSON boundary, so a regular-expression literal in `ignore` (for example `/^vendor/i`) does not match anything. Write the pattern as a string — for example `"^vendor"` for `/^vendor/`, or `"(?i)^vendor"` for `/^vendor/i`.
 
 ## Original Documentation
 
-- [eslint-plugin-unicorn: filename-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/filename-case.md)
-- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/rules/filename-case.js)
+- [eslint-plugin-unicorn: filename-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/filename-case.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/filename-case.js)

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
@@ -2,21 +2,36 @@
   "type": "array",
   "items": [
     {
-      "oneOf": [
+      "description": "The rule options.",
+      "anyOf": [
         {
           "properties": {
             "case": {
-              "enum": ["camelCase", "snakeCase", "kebabCase", "pascalCase"],
-              "description": "The filename case style."
+              "enum": [
+                "camelCase",
+                "camelCaseWithAcronyms",
+                "snakeCase",
+                "kebabCase",
+                "pascalCase"
+              ],
+              "description": "The filename and directory name case style."
             },
             "ignore": {
               "type": "array",
+              "items": {
+                "type": ["string", "object"],
+                "additionalProperties": true
+              },
               "uniqueItems": true,
-              "description": "Patterns to ignore."
+              "description": "Path segment patterns to ignore."
             },
             "multipleFileExtensions": {
               "type": "boolean",
               "description": "Whether to treat additional, dot-separated parts of a filename as file extensions."
+            },
+            "checkDirectories": {
+              "type": "boolean",
+              "description": "Whether to check directory names."
             }
           },
           "additionalProperties": false
@@ -27,32 +42,44 @@
               "properties": {
                 "camelCase": {
                   "type": "boolean",
-                  "description": "Whether to allow camelCase filenames."
+                  "description": "Whether to allow camelCase filenames and directory names."
+                },
+                "camelCaseWithAcronyms": {
+                  "type": "boolean",
+                  "description": "Whether to allow camelCase filenames and directory names with acronym segments."
                 },
                 "snakeCase": {
                   "type": "boolean",
-                  "description": "Whether to allow snake_case filenames."
+                  "description": "Whether to allow snake_case filenames and directory names."
                 },
                 "kebabCase": {
                   "type": "boolean",
-                  "description": "Whether to allow kebab-case filenames."
+                  "description": "Whether to allow kebab-case filenames and directory names."
                 },
                 "pascalCase": {
                   "type": "boolean",
-                  "description": "Whether to allow PascalCase filenames."
+                  "description": "Whether to allow PascalCase filenames and directory names."
                 }
               },
               "additionalProperties": false,
-              "description": "The allowed filename case styles."
+              "description": "The allowed filename and directory name case styles."
             },
             "ignore": {
               "type": "array",
+              "items": {
+                "type": ["string", "object"],
+                "additionalProperties": true
+              },
               "uniqueItems": true,
-              "description": "Patterns to ignore."
+              "description": "Path segment patterns to ignore."
             },
             "multipleFileExtensions": {
               "type": "boolean",
               "description": "Whether to treat additional, dot-separated parts of a filename as file extensions."
+            },
+            "checkDirectories": {
+              "type": "boolean",
+              "description": "Whether to check directory names."
             }
           },
           "additionalProperties": false

--- a/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
@@ -46,7 +46,7 @@ func withIgnore(base map[string]interface{}, patterns ...string) map[string]inte
 	return out
 }
 
-// All upstream `valid` / `invalid` cases are migrated below in the same
+// The original upstream `valid` / `invalid` cases are migrated below in the same
 // declaration order. Cases that the rule_tester cannot exercise (TypeScript's
 // program builder skips files whose extension or basename it does not
 // recognize, leaving us with a nil source file) are kept as `Skip: true`
@@ -62,7 +62,7 @@ func TestFilenameCase(t *testing.T) {
 		t,
 		&filename_case.FilenameCaseRule,
 		[]rule_tester.ValidTestCase{
-			// ---- Single `case` option, all four styles ----
+			// ---- Single `case` option, original four styles ----
 			{Code: `// camel`, FileName: "src/foo/bar.js", Options: caseOpt("camelCase")},
 			{Code: `// camel`, FileName: "src/foo/fooBar.js", Options: caseOpt("camelCase")},
 			{Code: `// camel`, FileName: "src/foo/bar.test.js", Options: caseOpt("camelCase")},
@@ -352,11 +352,11 @@ func TestFilenameCase(t *testing.T) {
 
 			// ---- Snapshot-block valid cases (basename-only handling) ----
 			{Code: `// snap-undef`}, /* upstream `undefined` filename — defaults to `file.ts`, valid for kebab */
-			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo.JS/bar.js"},
-			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo.JS/bar.spec.js"},
-			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo.JS/.spec.js",
+			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo-js/bar.js"},
+			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo-js/bar.spec.js"},
+			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo-js/.spec.js",
 				Skip: true /* SKIP: dot-prefixed basename */},
-			{Code: `// snap-dir-no-ext`, FileName: "src/foo.JS/bar",
+			{Code: `// snap-dir-no-ext`, FileName: "src/foo-js/bar",
 				Skip: true /* SKIP: TS program does not pick up extensionless files */},
 			{Code: `// snap-dotted-uppercase-middle`, FileName: "foo.SPEC.js"},
 			{Code: `// snap-leading-dot`, FileName: ".SPEC.js",
@@ -372,17 +372,14 @@ func TestFilenameCase(t *testing.T) {
 			// behaviour. Here we lock the equivalent already-camel form.
 			{Code: `// lock-in: digit-prefixed second word`, FileName: "src/foo/iss_47Spec.js", Options: caseOpt("camelCase")},
 
-			// Locks in: non-string `ignore` entries don't poison the array —
-			// the valid string pattern still ignores its target. Companion
-			// to the invalid-list case above; together they prove non-string
-			// items are dropped silently and the rest of the array still
-			// applies normally.
+			// A RegExp literal arrives as an object over the JSON bridge. It does
+			// not poison the array; the valid string pattern still applies.
 			{
-				Code: `// lock-in: non-string ignore entries silently dropped, valid sibling still ignores`,
+				Code: `// lock-in: object ignore entry silently dropped, valid sibling still ignores`,
 				FileName: "src/foo/FOOBAR.js",
 				Options: map[string]interface{}{
 					"case":   "kebabCase",
-					"ignore": []interface{}{nil, 42, map[string]interface{}{}, `FOOBAR\.js`},
+					"ignore": []interface{}{map[string]interface{}{}, `FOOBAR\.js`},
 				},
 			},
 			// Locks in: an empty `ignore` array works the same as omitting
@@ -393,13 +390,10 @@ func TestFilenameCase(t *testing.T) {
 				Options: map[string]interface{}{"case": "kebabCase", "ignore": []interface{}{}},
 			},
 
-			// Locks in `splitWords` Pass 2 multi-fire end-to-end: an
-			// XMLHttp-style basename in pascalCase splits into ALL-CAPS +
-			// Title chunks (`XML/Http/Request`) and pascal-reassembles
-			// each word with non-first letters lowered (`Xml/Http/
-			// Request` → `XmlHttpRequest`). This proves Pass 2 fired AND
-			// pascalCase honoured the per-word lowercasing — both could
-			// regress independently. (See moved-to-invalid block below.)
+			// Latest upstream preserves a leading acronym when the remainder
+			// is already PascalCase.
+			{Code: `// leading acronym preserved`, FileName: "src/foo/XMLHttpRequest.js", Options: caseOpt("pascalCase")},
+			{Code: `// leading acronym preserved`, FileName: "src/foo/HTTPSConnection.js", Options: caseOpt("pascalCase")},
 
 			// (fixFilename dedupe is already locked in by `1_.js` invalid
 			// test above, where camel/pascal/kebab all collapse to `1`.)
@@ -636,17 +630,10 @@ func TestFilenameCase(t *testing.T) {
 				}},
 			},
 			{
-				Code: `// dec`, FileName: "src/foo/$foo_bar.js",
+				Code: `// dec`, FileName: "src/foo/foo$Bar.js",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "filenameCase",
-					Message:   "Filename is not in kebab case. Rename it to `$foo-bar.js`.",
-				}},
-			},
-			{
-				Code: `// dec`, FileName: "src/foo/$fooBar.js",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
-					Message:   "Filename is not in kebab case. Rename it to `$foo-bar.js`.",
+					Message:   "Filename is not in kebab case. Rename it to `foo$bar.js`.",
 				}},
 			},
 			{
@@ -995,38 +982,28 @@ func TestFilenameCase(t *testing.T) {
 					Message:   "Invalid regular expression in `ignore` option: `*invalid`: error parsing regexp: missing argument to repetition operator in `*invalid`",
 				}},
 			},
-			// Locks in: non-string entries (`null`, numbers, objects) in the
-			// `ignore` array are silently skipped — they are NOT treated as
-			// malformed patterns. Without this, a JSON-stringified RegExp
-			// object (which lands as `{}` on the Go side) or any other
-			// stray non-string would fire spurious `invalidIgnorePattern`
-			// diagnostics. Here the only valid string pattern doesn't match
-			// `foo_bar.js`, so we get a normal case-violation report — the
-			// crucial assertion is that we do NOT see any
-			// `invalidIgnorePattern` diagnostic alongside it.
+			// A JSON-stringified RegExp object is skipped and does not become
+			// an invalid pattern. The valid sibling does not match this file.
 			{
-				Code: `// lock-in: non-string ignore entries do not fire invalidIgnorePattern`,
+				Code: `// lock-in: object ignore entry does not fire invalidIgnorePattern`,
 				FileName: "src/foo/foo_bar.js",
 				Options: map[string]interface{}{
 					"case":   "kebabCase",
-					"ignore": []interface{}{nil, 42, map[string]interface{}{}, `FOOBAR\.js`},
+					"ignore": []interface{}{map[string]interface{}{}, `FOOBAR\.js`},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "filenameCase",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 				}},
 			},
-			// Locks in: when non-string + valid string + invalid string ignore
-			// entries co-exist, the invalid string still wins (fatal short-
-			// circuit), the valid string never gets to apply, and the
-			// non-string is silently dropped. End-to-end coverage of all
-			// three ignore-entry classes interacting.
+			// When object + valid string + invalid string entries coexist, the
+			// invalid string still wins and aborts filename checking.
 			{
-				Code: `// lock-in: non-string + valid + invalid ignore entries together`,
+				Code: `// lock-in: object + valid + invalid ignore entries together`,
 				FileName: "src/foo/FOOBAR.js",
 				Options: map[string]interface{}{
 					"case":   "kebabCase",
-					"ignore": []interface{}{nil, `FOOBAR\.js`, `[unclosed`},
+					"ignore": []interface{}{map[string]interface{}{}, `FOOBAR\.js`, `[unclosed`},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "invalidIgnorePattern",
@@ -1034,13 +1011,13 @@ func TestFilenameCase(t *testing.T) {
 				}},
 			},
 			// Locks in `englishishJoin` 4-item oxford comma + `or` end-to-end:
-			// all four `cases` enabled + a basename violating all four of
-			// them yields `camel case, snake case, kebab case, or pascal
+			// the four legacy `cases` enabled + a basename violating all four of
+			// them yields `camel case, kebab case, snake case, or pascal
 			// case` and four rename suggestions in canonical order. (Unit
 			// test in splitwords_test.go locks the formatter directly; this
 			// proves the rule produces it via the real diagnostic path.)
 			{
-				Code: `// lock-in: oxford-comma 4-item, all four cases enabled`,
+				Code: `// lock-in: oxford-comma 4-item, four legacy cases enabled`,
 				FileName: "src/foo/FOO_BAR.js",
 				Options: casesOpt(map[string]bool{
 					"camelCase": true, "snakeCase": true,
@@ -1048,7 +1025,7 @@ func TestFilenameCase(t *testing.T) {
 				}),
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "filenameCase",
-					Message:   "Filename is not in camel case, snake case, kebab case, or pascal case. Rename it to `fooBar.js`, `foo_bar.js`, `foo-bar.js`, or `FooBar.js`.",
+					Message:   "Filename is not in camel case, kebab case, snake case, or pascal case. Rename it to `fooBar.js`, `foo-bar.js`, `foo_bar.js`, or `FooBar.js`.",
 				}},
 			},
 			// Locks in `pascalLikeTransform` first-word-digit branch end-to-
@@ -1076,27 +1053,24 @@ func TestFilenameCase(t *testing.T) {
 					Message:   "Filename is not in pascal case. Rename it to `123Foo.js`.",
 				}},
 			},
-			// Locks in `splitWords` Pass 2 multi-fire end-to-end: pascalCase
-			// applied to `XMLHttpRequest` splits into 3 words and rejoins
-			// with per-word lowercasing → `XmlHttpRequest`. Proves both
-			// the ALL-CAPS+Title boundary cut AND the non-first-letter
-			// lowering pipeline.
+			// Leading acronyms are preserved only when the suffix is already
+			// PascalCase; these latest-upstream counterexamples are normalized.
 			{
-				Code: `// lock-in: Pass 2 multi-fire (pascal lowers non-first letters)`,
-				FileName: "src/foo/XMLHttpRequest.js",
+				Code: `// leading acronym followed by invalid suffix`,
+				FileName: "src/foo/FAQPageFOO.js",
 				Options:  caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "filenameCase",
-					Message:   "Filename is not in pascal case. Rename it to `XmlHttpRequest.js`.",
+					Message:   "Filename is not in pascal case. Rename it to `FaqPageFoo.js`.",
 				}},
 			},
 			{
-				Code: `// lock-in: Pass 2 single-fire (pascal lowers non-first letters)`,
-				FileName: "src/foo/HTTPSConnection.js",
+				Code: `// two-letter prefix is not a preserved acronym`,
+				FileName: "src/foo/UIPath.js",
 				Options:  caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "filenameCase",
-					Message:   "Filename is not in pascal case. Rename it to `HttpsConnection.js`.",
+					Message:   "Filename is not in pascal case. Rename it to `UiPath.js`.",
 				}},
 			},
 			// Locks in Node `path.extname` parity for an all-dots basename.

--- a/internal/plugins/unicorn/rules/filename_case/filename_case_upstream_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case_upstream_test.go
@@ -1,0 +1,215 @@
+// cspell:ignore FAQI Qpage
+package filename_case
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func TestLatestUpstreamAcronymCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		fn    func(string) string
+		want  string
+	}{
+		{name: "camel inner HTML", input: "innerHTML", fn: toCamelCaseWithAcronyms, want: "innerHTML"},
+		{name: "camel DOM range", input: "getDOMRangeRect", fn: toCamelCaseWithAcronyms, want: "getDOMRangeRect"},
+		{name: "camel URL suffix", input: "apiURL", fn: toCamelCaseWithAcronyms, want: "apiURL"},
+		{name: "camel numbered acronym", input: "getHTML5Parser", fn: toCamelCaseWithAcronyms, want: "getHTML5Parser"},
+		{name: "camel leading acronym", input: "HTMLParser", fn: toCamelCaseWithAcronyms, want: "htmlParser"},
+		{name: "camel mixed acronym", input: "XMLHttpRequest", fn: toCamelCaseWithAcronyms, want: "xmlHttpRequest"},
+		{name: "pascal FAQ", input: "FAQPage", fn: toPascalCaseWithLeadingAcronym, want: "FAQPage"},
+		{name: "pascal DIY", input: "DIYWidget", fn: toPascalCaseWithLeadingAcronym, want: "DIYWidget"},
+		{name: "pascal numbered separator", input: "URL2Path", fn: toPascalCaseWithLeadingAcronym, want: "URL2Path"},
+		{name: "pascal numbered suffix", input: "FAQI18n", fn: toPascalCaseWithLeadingAcronym, want: "FAQI18n"},
+		{name: "pascal acronym not leading", input: "PageFAQ", fn: toPascalCaseWithLeadingAcronym, want: "PageFaq"},
+		{name: "pascal separated acronym", input: "FAQ-Page", fn: toPascalCaseWithLeadingAcronym, want: "FaqPage"},
+		{name: "pascal lowercase suffix", input: "FAQpage", fn: toPascalCaseWithLeadingAcronym, want: "FaQpage"},
+		{name: "pascal invalid suffix", input: "FAQPageFOO", fn: toPascalCaseWithLeadingAcronym, want: "FaqPageFoo"},
+		{name: "pascal lowercase after number", input: "URL2path", fn: toPascalCaseWithLeadingAcronym, want: "Url2path"},
+		{name: "pascal two-letter prefix", input: "UIPath", fn: toPascalCaseWithLeadingAcronym, want: "UiPath"},
+		{name: "pascal two-letter numbered prefix", input: "UI2Path", fn: toPascalCaseWithLeadingAcronym, want: "Ui2Path"},
+		{name: "pascal terminal acronym", input: "FOO2", fn: toPascalCaseWithLeadingAcronym, want: "Foo2"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.fn(test.input); got != test.want {
+				t.Fatalf("transform(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestGetPathSegments(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		cwd      string
+		want     []string
+	}{
+		{name: "absolute inside cwd", fileName: "/repo/src/FooBar/file.js", cwd: "/repo", want: []string{"src", "FooBar", "file.js"}},
+		{name: "relative inside cwd", fileName: "src/FooBar/file.js", cwd: "/repo", want: []string{"src", "FooBar", "file.js"}},
+		{name: "outside cwd", fileName: "/other/Src/fooBar.js", cwd: "/repo", want: []string{"fooBar.js"}},
+		{name: "cwd prefix collision", fileName: "/repository/Src/fooBar.js", cwd: "/repo", want: []string{"fooBar.js"}},
+		{name: "root cwd", fileName: "/src/FooBar/file.js", cwd: "/", want: []string{"src", "FooBar", "file.js"}},
+		{name: "dot segments use general path resolution", fileName: "/repo/src/../FooBar/file.js", cwd: "/repo", want: []string{"FooBar", "file.js"}},
+		{name: "empty cwd", fileName: "/repo/src/FooBar/file.js", want: []string{"file.js"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := getPathSegments(test.fileName, test.cwd)
+			if len(got) != len(test.want) {
+				t.Fatalf("getPathSegments(%q, %q) = %v, want %v", test.fileName, test.cwd, got, test.want)
+			}
+			for index := range got {
+				if got[index] != test.want[index] {
+					t.Fatalf("getPathSegments(%q, %q) = %v, want %v", test.fileName, test.cwd, got, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestLatestUpstreamPathBehavior(t *testing.T) {
+	tests := []struct {
+		name    string
+		cwd     string
+		file    string
+		options []any
+		wantID  string
+		want    string
+	}{
+		{
+			name:   "checks directory",
+			cwd:    "/repo",
+			file:   "/repo/src/FooBar/file.js",
+			wantID: "directoryCase",
+			want:   "Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.",
+		},
+		{
+			name:   "checks index parent directory",
+			cwd:    "/repo",
+			file:   "/repo/src/FooBar/index.js",
+			wantID: "directoryCase",
+			want:   "Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.",
+		},
+		{
+			name:   "checks complete dotted directory segment",
+			cwd:    "/repo",
+			file:   "/repo/src/foo.JS/bar.js",
+			wantID: "directoryCase",
+			want:   "Directory name `foo.JS` is not in kebab case. Rename it to `foo.js`.",
+		},
+		{
+			name: "directory checking disabled",
+			cwd:  "/repo",
+			file: "/repo/src/FooBar/foo_bar.js",
+			options: []any{map[string]any{
+				"case": "kebabCase", "checkDirectories": false,
+			}},
+			wantID: "filenameCase",
+			want:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+		},
+		{
+			name: "ignore matches directory segment",
+			cwd:  "/repo",
+			file: "/repo/src/meta/BadName.js",
+			options: []any{map[string]any{
+				"case": "kebabCase", "ignore": []any{"^meta$"},
+			}},
+		},
+		{
+			name:   "dollar directory skipped",
+			cwd:    "/repo",
+			file:   "/repo/src/$UserId/fooBar.js",
+			wantID: "filenameCase",
+			want:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+		},
+		{
+			name:   "dollar filename still checks extension",
+			cwd:    "/repo",
+			file:   "/repo/src/foo/$userId.TSX",
+			wantID: "filenameExtension",
+			want:   "File extension `.TSX` is not in lowercase. Rename it to `$userId.tsx`.",
+		},
+		{
+			name: "dollar filename skips case",
+			cwd:  "/repo",
+			file: "/repo/src/foo/$foo_bar.js",
+		},
+		{
+			name:   "outside cwd checks basename only",
+			cwd:    "/repo",
+			file:   "/other/Src/fooBar.js",
+			wantID: "filenameCase",
+			want:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+		},
+		{
+			name:   "first invalid directory wins",
+			cwd:    "/repo",
+			file:   "/repo/src/FooBar/BazQux.js",
+			wantID: "directoryCase",
+			want:   "Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.",
+		},
+		{
+			name: "canonical case order applies to directories",
+			cwd:  "/repo",
+			file: "/repo/src/foo-bar/file.js",
+			options: []any{map[string]any{"cases": map[string]any{
+				"pascalCase": true, "camelCase": true,
+			}}},
+			wantID: "directoryCase",
+			want:   "Directory name `foo-bar` is not in camel case or pascal case. Rename it to `fooBar` or `FooBar`.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := runFilenameCaseForPath(t, test.cwd, test.file, test.options)
+			if test.want == "" {
+				if len(diagnostics) != 0 {
+					t.Fatalf("diagnostics = %v, want none", diagnostics)
+				}
+				return
+			}
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %v, want one", diagnostics)
+			}
+			if got := diagnostics[0].Message.Id; got != test.wantID {
+				t.Fatalf("message id = %q, want %q", got, test.wantID)
+			}
+			if got := diagnostics[0].Message.Description; got != test.want {
+				t.Fatalf("message = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func runFilenameCaseForPath(t *testing.T, cwd string, fileName string, options []any) []rule.RuleDiagnostic {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: fileName,
+		Path:     tspath.Path(fileName),
+	}, "export {};", core.ScriptKindTS)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := (rule.RuleContext{
+		SourceFile:     sourceFile,
+		DisableManager: rule.NewDisableManager(sourceFile, rule.NewCommentStore(sourceFile)),
+	}).WithFileCache(rule.NewFileCacheWithProcessCurrentDirectory(cwd)).WithReporter(
+		filenameCaseRuleName,
+		rule.SeverityWarning,
+		func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	)
+	FilenameCaseRule.Run(ctx, options)
+	return diagnostics
+}

--- a/internal/plugins/unicorn/rules/filename_case/options_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/options_test.go
@@ -1,0 +1,21 @@
+package filename_case
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseOptionsUsesCanonicalCasesOrder(t *testing.T) {
+	opts := parseOptions([]any{map[string]any{"cases": map[string]any{
+		"snakeCase": true,
+		"kebabCase": true,
+	}}})
+	got := make([]string, opts.caseCount)
+	for index, configuredCase := range opts.selectedCases() {
+		got[index] = configuredCase.key
+	}
+	want := []string{"kebabCase", "snakeCase"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("selected cases = %v, want %v", got, want)
+	}
+}

--- a/internal/plugins/unicorn/rules/filename_case/splitwords_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/splitwords_test.go
@@ -104,7 +104,7 @@ func TestFixFilenameDecoratedCartesianProduct(t *testing.T) {
 
 	t.Run("deduplicate each chunk", func(t *testing.T) {
 		leading, words := splitFilename("1_[1_]")
-		cases := []caseStyle{allCases[0], allCases[2], allCases[3]} // camel, kebab, pascal
+		cases := []caseStyle{allCases[0], allCases[2], allCases[4]} // camel, kebab, pascal
 		valid, invalidWord, candidates := validateFilename(words, cases)
 		if valid {
 			t.Fatal("expected filename to be invalid")
@@ -165,8 +165,8 @@ func TestPascalLikeTransformDigitBranch(t *testing.T) {
 }
 
 // TestEnglishishJoinOxford locks in oxford-comma + `or` formatting for 0/1/2/3/4
-// items. The 4-item case is reachable only when all four `cases` are enabled
-// and the filename violates all four (rare in practice but covered here so
+// items. The 4-item case is reachable when four `cases` are enabled and the
+// filename violates all four (rare in practice but covered here so
 // future ListFormat-style refactors can't silently change wording).
 func TestEnglishishJoinOxford(t *testing.T) {
 	cases := []struct {

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
@@ -6,7 +6,9 @@ function valid(filename: string | undefined, c?: string) {
   return {
     code: `/* Filename: ${filename ?? '<none>'} */`,
     filename,
-    options: c ? [{ case: c }] : [],
+    // This helper exercises basename behavior. Directory behavior has focused
+    // cases below whose path is relative to the rslint working directory.
+    options: c ? [{ case: c, checkDirectories: false }] : [],
   };
 }
 
@@ -14,7 +16,7 @@ function validCases(filename: string, cases: Record<string, boolean>) {
   return {
     code: `/* Filename: ${filename} */`,
     filename,
-    options: [{ cases }],
+    options: [{ cases, checkDirectories: false }],
   };
 }
 
@@ -22,7 +24,10 @@ function validWithOptions(filename: string | undefined, options: any[] = []) {
   return {
     code: `/* Filename: ${filename ?? '<none>'} */`,
     filename,
-    options,
+    options:
+      options.length > 0
+        ? [{ checkDirectories: false, ...options[0] }, ...options.slice(1)]
+        : options,
   };
 }
 
@@ -30,7 +35,7 @@ function invalid(filename: string, c: string | undefined, message: string) {
   return {
     code: `/* Filename: ${filename} */`,
     filename,
-    options: c ? [{ case: c }] : [],
+    options: c ? [{ case: c, checkDirectories: false }] : [],
     errors: [{ message }],
   };
 }
@@ -43,7 +48,7 @@ function invalidCases(
   return {
     code: `/* Filename: ${filename} */`,
     filename,
-    options: cases ? [{ cases }] : [],
+    options: cases ? [{ cases, checkDirectories: false }] : [],
     errors: [{ message }],
   };
 }
@@ -52,7 +57,7 @@ function invalidWithOptions(filename: string, options: any[], message: string) {
   return {
     code: `/* Filename: ${filename} */`,
     filename,
-    options,
+    options: [{ checkDirectories: false, ...options[0] }, ...options.slice(1)],
     errors: [{ message }],
   };
 }
@@ -67,6 +72,10 @@ ruleTester.run('filename-case', {} as never, {
     valid('src/foo/fooBar.test-utils.js', 'camelCase'),
     valid('src/foo/fooBar.test_utils.js', 'camelCase'),
     valid('src/foo/.test_utils.js', 'camelCase'),
+    valid('src/foo/innerHTML.js', 'camelCaseWithAcronyms'),
+    valid('src/foo/getDOMRangeRect.js', 'camelCaseWithAcronyms'),
+    valid('src/foo/apiURL.js', 'camelCaseWithAcronyms'),
+    valid('src/foo/getHTML5Parser.js', 'camelCaseWithAcronyms'),
     valid('src/foo/foo.js', 'snakeCase'),
     valid('src/foo/foo_bar.js', 'snakeCase'),
     valid('src/foo/foo.test.js', 'snakeCase'),
@@ -88,6 +97,11 @@ ruleTester.run('filename-case', {} as never, {
     valid('src/foo/FooBar.test-utils.js', 'pascalCase'),
     valid('src/foo/FooBar.test_utils.js', 'pascalCase'),
     valid('src/foo/.test_utils.js', 'pascalCase'),
+    valid('src/foo/FAQPage.js', 'pascalCase'),
+    valid('src/foo/DIYWidget.js', 'pascalCase'),
+    valid('src/foo/URL2Path.js', 'pascalCase'),
+    valid('src/foo/FAQI18n.js', 'pascalCase'),
+    valid('src/foo/URL2I18n.js', 'pascalCase'),
 
     // ---- Numeric / mixed identifier cases ----
     valid('spec/iss47Spec.js', 'camelCase'),
@@ -117,6 +131,8 @@ ruleTester.run('filename-case', {} as never, {
 
     // ---- Default kebab + special chars at start ----
     valid('src/foo/$foo.js'),
+    valid('src/foo/$foo_bar.js'),
+    valid('src/foo/$fooBar.js'),
 
     // ---- `cases` option ----
     {
@@ -125,6 +141,9 @@ ruleTester.run('filename-case', {} as never, {
       options: [{ cases: {} }],
     },
     validCases('src/foo/fooBar.js', { camelCase: true }),
+    validCases('src/foo/innerHTML.js', {
+      camelCaseWithAcronyms: true,
+    }),
     validCases('src/foo/FooBar.js', { kebabCase: true, pascalCase: true }),
     validCases('src/foo/___foo_bar.js', { snakeCase: true, pascalCase: true }),
 
@@ -245,6 +264,16 @@ ruleTester.run('filename-case', {} as never, {
       },
     ]),
 
+    // ---- Latest upstream path behavior ----
+    { code: '', filename: 'src/foo-bar/file.js' },
+    { code: '', filename: 'src/$UserId/page.js' },
+    validWithOptions('src/FooBar/file.js', [
+      { case: 'kebabCase', checkDirectories: false },
+    ]),
+    validWithOptions('src/meta/BadName.js', [
+      { case: 'kebabCase', ignore: ['^meta$'], checkDirectories: true },
+    ]),
+
     // ---- multipleFileExtensions=false ----
     validWithOptions('index.tsx', [
       { case: 'pascalCase', multipleFileExtensions: false },
@@ -297,10 +326,10 @@ ruleTester.run('filename-case', {} as never, {
     validWithOptions('test/foo/FooBar.TestUtils.js', [{ case: 'pascalCase' }]),
     validWithOptions('test/foo/.TestUtils.js', [{ case: 'pascalCase' }]),
 
-    // ---- Snapshot-style: directory with uppercase ext doesn't matter ----
-    { code: '', filename: 'src/foo.JS/bar.js' },
-    { code: '', filename: 'src/foo.JS/bar.spec.js' },
-    { code: '', filename: 'src/foo.JS/.spec.js' },
+    // ---- Snapshot-style dotted filename parts ----
+    { code: '', filename: 'src/foo-js/bar.js' },
+    { code: '', filename: 'src/foo-js/bar.spec.js' },
+    { code: '', filename: 'src/foo-js/.spec.js' },
     { code: '', filename: 'foo.SPEC.js' },
     { code: '', filename: '.SPEC.js' },
   ],
@@ -375,6 +404,26 @@ ruleTester.run('filename-case', {} as never, {
       'pascalCase',
       'Filename is not in pascal case. Rename it to `FooBar.test-utils.js`.',
     ),
+    invalid(
+      'src/foo/FAQPageFOO.js',
+      'pascalCase',
+      'Filename is not in pascal case. Rename it to `FaqPageFoo.js`.',
+    ),
+    invalid(
+      'src/foo/UIPath.js',
+      'pascalCase',
+      'Filename is not in pascal case. Rename it to `UiPath.js`.',
+    ),
+    invalid(
+      'src/foo/HTMLParser.js',
+      'camelCaseWithAcronyms',
+      'Filename is not in camel case with acronyms. Rename it to `htmlParser.js`.',
+    ),
+    invalid(
+      'src/foo/XMLHttpRequest.js',
+      'camelCaseWithAcronyms',
+      'Filename is not in camel case with acronyms. Rename it to `xmlHttpRequest.js`.',
+    ),
 
     // ---- Leading underscores preserved verbatim ----
     invalid(
@@ -418,7 +467,7 @@ ruleTester.run('filename-case', {} as never, {
       'Filename is not in pascal case. Rename it to `___FooBar.js`.',
     ),
 
-    // ---- `cases` option failures (canonical case order in our message) ----
+    // ---- `cases` option failures (canonical case order in messages) ----
     invalidCases(
       'src/foo/foo_bar.js',
       undefined,
@@ -447,14 +496,9 @@ ruleTester.run('filename-case', {} as never, {
       'Filename is not in kebab case. Rename it to `[foo-bar].js`.',
     ),
     invalid(
-      'src/foo/$foo_bar.js',
+      'src/foo/foo$Bar.js',
       undefined,
-      'Filename is not in kebab case. Rename it to `$foo-bar.js`.',
-    ),
-    invalid(
-      'src/foo/$fooBar.js',
-      undefined,
-      'Filename is not in kebab case. Rename it to `$foo-bar.js`.',
+      'Filename is not in kebab case. Rename it to `foo$bar.js`.',
     ),
     invalidCases(
       'src/foo/{foo_bar}.js',
@@ -493,6 +537,42 @@ ruleTester.run('filename-case', {} as never, {
       ],
       'Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.',
     ),
+
+    // ---- Latest upstream directory behavior ----
+    {
+      code: '',
+      filename: 'src/FooBar/file.js',
+      errors: [
+        {
+          message:
+            'Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.',
+        },
+      ],
+    },
+    {
+      code: '',
+      filename: 'src/FooBar/index.js',
+      errors: [
+        {
+          message:
+            'Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.',
+        },
+      ],
+    },
+    invalidWithOptions(
+      'src/FooBar/foo_bar.js',
+      [{ case: 'kebabCase', checkDirectories: false }],
+      'Filename is not in kebab case. Rename it to `foo-bar.js`.',
+    ),
+    {
+      code: '',
+      filename: 'src/$UserId/fooBar.js',
+      errors: [
+        {
+          message: 'Filename is not in kebab case. Rename it to `foo-bar.js`.',
+        },
+      ],
+    },
 
     // ---- #1136: trailing underscore on a digit-only word ----
     invalidCases(


### PR DESCRIPTION
## Summary

- Align `unicorn/filename-case` with `eslint-plugin-unicorn` v73, including directory checks, `camelCaseWithAcronyms`, PascalCase leading acronyms, ignored path segments, and `$`-prefixed path segments.
- Keep multi-case output deterministic inside the rule using the upstream case registry order; no config, registry, or `RuleContext` framework changes are included.
- Verify all 302 documented rows (293 unique files across 28 working directories) against v73 with zero count, message, or start-position mismatches, plus 525 adversarial comparisons with zero mismatches.
- Re-benchmark the reported configuration. A proposed path fast path did not produce a stable runtime improvement, so no performance-only implementation was retained.

## Related Links

- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/filename-case.js
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/filename-case.md

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
