### PR TITLE
fix: align rules-of-hooks diagnostics with upstream

### DIFF
--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -682,7 +682,10 @@ func GetFunctionName(fn *ast.Node) *ast.Node {
 		// fall through to anonymous handling
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
 		if fn.Parent != nil && ast.IsObjectLiteralExpression(fn.Parent) {
-			return fn.Name()
+			name := fn.Name()
+			if name != nil && !ast.IsComputedPropertyName(name) {
+				return name
+			}
 		}
 		return nil
 	case ast.KindArrowFunction:
@@ -719,7 +722,7 @@ func GetFunctionName(fn *ast.Node) *ast.Node {
 		}
 	case ast.KindPropertyAssignment:
 		pa := p.AsPropertyAssignment()
-		if pa.Initializer == child {
+		if pa.Initializer == child && p.Name() != nil && !ast.IsComputedPropertyName(p.Name()) {
 			return p.Name()
 		}
 	case ast.KindBindingElement:

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/code_path.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/code_path.go
@@ -1,0 +1,103 @@
+package rules_of_hooks
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/utils/cfg"
+)
+
+// hookCodePath is the thin rules-of-hooks view over the shared CFG. The graph
+// is built once per code path root and records only hook calls; all graph-shape
+// reasoning remains in internal/utils/cfg.
+type hookCodePath struct {
+	root      *ast.Node
+	paths     *cfg.PathAnalysis[struct{}]
+	locations map[*ast.Node]*cfg.Block[struct{}]
+}
+
+type hookPathState struct {
+	reachable           bool
+	cyclic              bool
+	onEveryFinalPath    bool
+	possiblyEarlyReturn bool
+}
+
+func buildHookCodePath(root *ast.Node) *hookCodePath {
+	locations := make(map[*ast.Node]*cfg.Block[struct{}])
+	graph := cfg.Build(root, cfg.Hooks[struct{}]{
+		Expression: func(builder *cfg.Builder[struct{}], node *ast.Node) {
+			if node.Kind != ast.KindCallExpression {
+				return
+			}
+			call := node.AsCallExpression()
+			if call != nil && isHookCallee(call.Expression) {
+				// A finally block is laid out once for normal flow and again for
+				// abrupt flow. ESLint visits its AST once while the latter segment
+				// is active, so the last layout is the observable location.
+				locations[node] = builder.Current()
+			}
+		},
+	})
+	return &hookCodePath{
+		root:      root,
+		paths:     cfg.AnalyzePaths(graph),
+		locations: locations,
+	}
+}
+
+func (codePath *hookCodePath) state(hook *ast.Node) hookPathState {
+	if codePath == nil || codePath.paths == nil {
+		return hookPathState{}
+	}
+	location := codePath.locations[hook]
+	state := hookPathState{}
+	if location == nil {
+		return state
+	}
+	shortestHookPath, reachesFromStart := codePath.paths.ShortestPathFromStart(location)
+	if !location.Reachable {
+		// ESLint ends a function segment at an abrupt statement before its
+		// AST traversal reaches later unreachable nodes. Those nodes are then
+		// observed on the still-active outer segment. Reproduce that shared
+		// CodePathAnalyzer behavior without pretending the CFG block itself is
+		// executable. A Program has no outer segment (and upstream can even
+		// throw there), so retain the ordinary unreachable result at the root.
+		if codePath.root == nil || codePath.root.Kind == ast.KindSourceFile {
+			return state
+		}
+		state.reachable = true
+		state.onEveryFinalPath = codePath.paths.HasSingleFinalPath()
+		if shortestExit, ok := codePath.paths.ShortestExitPathFromStart(); ok {
+			state.possiblyEarlyReturn = shortestExit <= 1
+		}
+		return state
+	}
+	// A for-loop incrementor is laid out before its body so the shared CFG can
+	// preserve all of its events. If every body path exits abruptly, the block
+	// remains provisionally reachable but has no path from the graph entry.
+	// ESLint settles that segment as unreachable before this rule processes it.
+	if !reachesFromStart {
+		return state
+	}
+	state.reachable = true
+	state.cyclic = codePath.paths.IsCyclic(location)
+	state.onEveryFinalPath = codePath.paths.IsOnEveryFinalPath(location)
+	shortestFinalPath, hasFinal := codePath.paths.ShortestExitPathFromStart()
+	if hasFinal && shortestHookPath != 0 {
+		if codePath.paths.IsExit(location) {
+			state.possiblyEarlyReturn = shortestFinalPath <= shortestHookPath
+		} else {
+			state.possiblyEarlyReturn = shortestFinalPath < shortestHookPath
+		}
+	}
+	return state
+}
+
+func isInsideDoWhileLoop(node *ast.Node, root *ast.Node) bool {
+	for current := node; current != nil && current != root; current = current.Parent {
+		if current.Kind == ast.KindDoStatement {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/cfg"
 	esregexp "github.com/web-infra-dev/rslint/internal/utils/ecmascript/regexp"
 )
 
@@ -38,14 +39,13 @@ var (
 )
 
 // All AST predicates above (stripReactNamespace, isFunctionLikeContainer,
-// findEnclosingFunction, getFunctionBody, hasAsyncModifier, ...) live in
+// findEnclosingFunction, hasAsyncModifier, ...) live in
 // `react_hooksutil`. The aliases below keep the call sites unchanged
 // while removing the second copy.
 var (
 	stripReactNamespace     = react_hooksutil.StripReactNamespace
 	isFunctionLikeContainer = react_hooksutil.IsFunctionLikeContainer
 	findEnclosingFunction   = react_hooksutil.FindEnclosingFunction
-	getFunctionBody         = react_hooksutil.GetFunctionBody
 	hasAsyncModifier        = react_hooksutil.HasAsyncModifier
 )
 
@@ -96,49 +96,6 @@ func isInsideTryCatchOfFunction(node *ast.Node, fn *ast.Node) bool {
 	return false
 }
 
-// isInsideLoopOfFunction reports whether `node` is inside any loop construct
-// (while / for / for-in / for-of / do/while) within `fn`. Approximates
-// upstream's CFG `cycled` set: any segment reachable through a back-edge.
-//
-// Position-aware for the C-style and for-in/of variants:
-//   - `for (init; cond; incr) body`: `init` runs once BEFORE the loop and
-//     is NOT cycled; the condition / incrementor / body all are.
-//   - `for (var of expr) body`: `expr` is evaluated once before iteration
-//     starts (per ECMA-262) and is NOT cycled; `var`'s binding pattern
-//     re-binds per iteration and the body is cycled.
-//
-// Without the position split, hooks placed in `for (let x = useFoo(); ...; )`
-// or `for (const x of useArr()) {}` would be misclassified as cycled and
-// emit a spurious loopError.
-func isInsideLoopOfFunction(node *ast.Node, fn *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	cur := node
-	for cur != nil && cur.Parent != nil && cur.Parent != fn {
-		parent := cur.Parent
-		switch parent.Kind {
-		case ast.KindDoStatement, ast.KindWhileStatement:
-			return true
-		case ast.KindForStatement:
-			fs := parent.AsForStatement()
-			if cur != fs.Initializer {
-				return true
-			}
-		case ast.KindForInStatement, ast.KindForOfStatement:
-			fos := parent.AsForInOrOfStatement()
-			if cur != fos.Expression {
-				return true
-			}
-		}
-		if isFunctionLikeContainer(parent) {
-			return false
-		}
-		cur = parent
-	}
-	return false
-}
-
 // All function-name / forwardRef / classifier predicates live in the
 // shared `react_hooksutil` package. The aliases below preserve the
 // existing call sites unchanged.
@@ -149,326 +106,6 @@ var (
 	isClassMember           = react_hooksutil.IsClassMember
 )
 
-// isConditionalAncestor reports whether the position of `child` within `parent`
-// places it on a conditional execution path (only entered on certain
-// runtime branches). Used by `isConditional` during the parent-walk.
-//
-// NOTE: TryStatement is handled by `isInsideTryBlockWithPriorStmt` instead
-// — being inside a try block is only conditional if a prior sibling could
-// throw before the hook is reached.
-func isConditionalAncestor(parent *ast.Node, child *ast.Node) bool {
-	switch parent.Kind {
-	case ast.KindIfStatement:
-		is := parent.AsIfStatement()
-		// `if (cond) then else` — `then` and `else` are conditional; the
-		// condition expression itself is unconditional and is intentionally
-		// not flagged.
-		return child == is.ThenStatement || child == is.ElseStatement
-	case ast.KindConditionalExpression:
-		ce := parent.AsConditionalExpression()
-		return child == ce.WhenTrue || child == ce.WhenFalse
-	case ast.KindBinaryExpression:
-		be := parent.AsBinaryExpression()
-		if be.OperatorToken == nil {
-			return false
-		}
-		switch be.OperatorToken.Kind {
-		case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
-			// Right operand of `&&` / `||` / `??` is conditional; the left
-			// is always evaluated.
-			return child == be.Right
-		}
-		return false
-	case ast.KindWhileStatement:
-		// The condition is always evaluated at least once, so we don't flag
-		// `while (useFoo()) {}` here — but the body is conditional. The
-		// "in-loop" detection separately reports it as a loop violation,
-		// which takes precedence.
-		return child == parent.AsWhileStatement().Statement
-	case ast.KindForStatement:
-		fs := parent.AsForStatement()
-		// init runs once before the loop and is unconditional. The body
-		// is conditional (and the in-loop detection takes precedence).
-		// Condition / incrementor: also conditional in the sense that they
-		// re-execute per iteration — but the in-loop detection covers them.
-		return child == fs.Statement
-	case ast.KindForInStatement, ast.KindForOfStatement:
-		fos := parent.AsForInOrOfStatement()
-		// `for (const x of expr) body` — `expr` is evaluated once before
-		// iteration starts (ECMA-262 step 1 of ForIn/OfBodyEvaluation),
-		// so it's NOT conditional. The body / binding pattern run per
-		// iteration and are loop-conditional (handled by in-loop detection).
-		return child != fos.Expression
-	case ast.KindCaseClause, ast.KindDefaultClause:
-		// Any descendant of a switch case body is conditional.
-		return true
-	case ast.KindCatchClause:
-		// Catch body only executes on an exception.
-		return true
-	}
-	return false
-}
-
-// isInsideTryBlockWithPriorStmt reports whether `node` sits inside a try
-// block AND has at least one preceding sibling statement in that block.
-// Mirrors upstream's CFG behavior: every statement in a try block has a
-// "could throw" exit, so a hook reached only after a prior throwable
-// statement is conditionally executed. A hook that is the very first
-// statement in a try block (no prior statement) is unconditional in
-// upstream's path counting and is NOT flagged here.
-func isInsideTryBlockWithPriorStmt(node *ast.Node, fn *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	cur := node
-	for cur != nil && cur.Parent != nil && cur.Parent != fn {
-		parent := cur.Parent
-		if parent.Kind == ast.KindBlock {
-			grand := parent.Parent
-			if grand != nil && grand.Kind == ast.KindTryStatement {
-				ts := grand.AsTryStatement()
-				if ts.TryBlock != nil && ts.TryBlock.AsNode() == parent {
-					block := parent.AsBlock()
-					if block.Statements != nil {
-						for _, stmt := range block.Statements.Nodes {
-							if stmt == cur {
-								return false
-							}
-							if stmt.Pos() >= cur.Pos() {
-								return false
-							}
-							return true
-						}
-					}
-					return false
-				}
-			}
-		}
-		if isFunctionLikeContainer(parent) {
-			return false
-		}
-		cur = parent
-	}
-	return false
-}
-
-// isConditional walks the parent chain from `node` up to (but not crossing)
-// `fn`. Returns true once any conditional placement is observed.
-// Approximation of upstream's `pathsFromStartToEnd !== allPathsFromStartToEnd`
-// signal for the structural cases; sibling-based early return / labeled break
-// detection lives in `hasEarlyReturnBefore` and `hasLabeledBreakBefore`.
-func isConditional(node *ast.Node, fn *ast.Node) bool {
-	cur := node
-	for cur != nil && cur.Parent != nil && cur != fn {
-		if isConditionalAncestor(cur.Parent, cur) {
-			return true
-		}
-		cur = cur.Parent
-	}
-	return false
-}
-
-// containsEarlyReturn reports whether `node` (recursively, but never crossing
-// a nested function-like) contains a ReturnStatement. ThrowStatement is
-// intentionally excluded: upstream's CFG models thrown segments as
-// `thrownSegments`, which are excluded from path counting — so a hook
-// reached only when an exception did NOT throw is treated as unconditional.
-// Mirroring that, throw-inside-if does not trigger the "early return" suffix
-// here.
-func containsEarlyReturn(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	found := false
-	var visit func(n *ast.Node) bool
-	visit = func(n *ast.Node) bool {
-		if found {
-			return true
-		}
-		if n.Kind == ast.KindReturnStatement {
-			found = true
-			return true
-		}
-		if isFunctionLikeContainer(n) {
-			return false
-		}
-		n.ForEachChild(visit)
-		return false
-	}
-	visit(node)
-	return found
-}
-
-// isPrecededByDirectTerminator reports whether `hookNode` lies after an
-// unconditional `return` or `throw` statement in the same enclosing block
-// (recursively walking up to the function body). Such a hook is unreachable
-// in upstream's CFG (`!segment.reachable`) and the rule loop `continue`s
-// without checking — we model that by short-circuiting all reports here.
-func isPrecededByDirectTerminator(hookNode *ast.Node, fn *ast.Node) bool {
-	if hookNode == nil {
-		return false
-	}
-	cur := hookNode
-	for cur != nil && cur.Parent != nil && cur.Parent != fn {
-		parent := cur.Parent
-		if parent.Kind == ast.KindBlock {
-			block := parent.AsBlock()
-			if block.Statements != nil {
-				for _, stmt := range block.Statements.Nodes {
-					if stmt == cur {
-						break
-					}
-					if stmt.Pos() >= cur.Pos() {
-						break
-					}
-					switch stmt.Kind {
-					case ast.KindReturnStatement, ast.KindThrowStatement:
-						return true
-					}
-				}
-			}
-		}
-		if isFunctionLikeContainer(parent) {
-			break
-		}
-		cur = parent
-	}
-	return false
-}
-
-// hasEarlyReturnBefore walks up from `hookNode` through enclosing Block
-// ancestors (stopping at the function body) and, at each level, checks
-// preceding siblings for early-return markers (return inside any
-// non-function-like child). Triggers the "early return" suffix on
-// `conditionalError`.
-func hasEarlyReturnBefore(hookNode *ast.Node, fn *ast.Node) bool {
-	if hookNode == nil || fn == nil {
-		return false
-	}
-	body := getFunctionBody(fn)
-	cur := hookNode
-	for cur != nil && cur.Parent != nil && cur.Parent != fn {
-		parent := cur.Parent
-		if parent.Kind == ast.KindBlock {
-			block := parent.AsBlock()
-			if block.Statements != nil {
-				for _, stmt := range block.Statements.Nodes {
-					if stmt == cur {
-						break
-					}
-					if stmt.Pos() >= cur.Pos() {
-						break
-					}
-					if containsEarlyReturn(stmt) {
-						return true
-					}
-				}
-			}
-		}
-		if parent == body {
-			break
-		}
-		cur = parent
-	}
-	return false
-}
-
-// collectEnclosingLabels walks up from `node` and returns a set of
-// LabeledStatement labels enclosing `node` within `fn`. Used by
-// `hasLabeledBreakBefore` to recognize `break <label>` references.
-func collectEnclosingLabels(node *ast.Node, fn *ast.Node) map[string]bool {
-	var labels map[string]bool
-	p := node.Parent
-	for p != nil && p != fn {
-		if p.Kind == ast.KindLabeledStatement {
-			ls := p.AsLabeledStatement()
-			if ls.Label != nil && ls.Label.Kind == ast.KindIdentifier {
-				if labels == nil {
-					labels = make(map[string]bool)
-				}
-				labels[ls.Label.AsIdentifier().Text] = true
-			}
-		}
-		if isFunctionLikeContainer(p) {
-			break
-		}
-		p = p.Parent
-	}
-	return labels
-}
-
-// containsLabeledBreak recursively looks for a BreakStatement whose label
-// matches one of `labels`, without descending into nested function-likes
-// (where the break would refer to its own enclosing label scope).
-func containsLabeledBreak(node *ast.Node, labels map[string]bool) bool {
-	if node == nil || len(labels) == 0 {
-		return false
-	}
-	found := false
-	var visit func(n *ast.Node) bool
-	visit = func(n *ast.Node) bool {
-		if found {
-			return true
-		}
-		if n.Kind == ast.KindBreakStatement {
-			bs := n.AsBreakStatement()
-			if bs.Label != nil && bs.Label.Kind == ast.KindIdentifier {
-				if labels[bs.Label.AsIdentifier().Text] {
-					found = true
-					return true
-				}
-			}
-		}
-		if isFunctionLikeContainer(n) {
-			return false
-		}
-		n.ForEachChild(visit)
-		return false
-	}
-	visit(node)
-	return found
-}
-
-// hasLabeledBreakBefore reports whether `hookNode` lies after a `break <label>`
-// targeting an enclosing LabeledStatement. Used to catch the
-// `label: { if (cond) break label; useFoo(); }` family of conditional patterns
-// that upstream detects via CFG cycle / segment analysis but are otherwise
-// invisible to the parent-walk version of `isConditional`.
-func hasLabeledBreakBefore(hookNode *ast.Node, fn *ast.Node) bool {
-	if hookNode == nil || fn == nil {
-		return false
-	}
-	labels := collectEnclosingLabels(hookNode, fn)
-	if len(labels) == 0 {
-		return false
-	}
-	cur := hookNode
-	for cur != nil && cur.Parent != nil && cur.Parent != fn {
-		parent := cur.Parent
-		if parent.Kind == ast.KindBlock {
-			block := parent.AsBlock()
-			if block.Statements != nil {
-				for _, stmt := range block.Statements.Nodes {
-					if stmt == cur {
-						break
-					}
-					if stmt.Pos() >= cur.Pos() {
-						break
-					}
-					if containsLabeledBreak(stmt, labels) {
-						return true
-					}
-				}
-			}
-		}
-		if isFunctionLikeContainer(parent) {
-			break
-		}
-		cur = parent
-	}
-	return false
-}
-
 // nameText returns the source text for a function-name node, or "" when nil.
 // Used to format `functionError` messages with the enclosing function's name.
 func nameText(node *ast.Node, sf *ast.SourceFile) string {
@@ -476,7 +113,8 @@ func nameText(node *ast.Node, sf *ast.SourceFile) string {
 		return ""
 	}
 	if node.Kind == ast.KindIdentifier {
-		return node.AsIdentifier().Text
+		textRange := utils.GetESTreeBindingIdentifierRange(sf, node)
+		return sf.Text()[textRange.Pos():textRange.End()]
 	}
 	return utils.TrimmedNodeText(sf, node)
 }
@@ -926,12 +564,10 @@ func reportRange(sourceText string, node *ast.Node) core.TextRange {
 
 // RulesOfHooksRule is the rslint port of upstream `react-hooks/rules-of-hooks`.
 //
-// Departure from upstream: rslint has no CodePathAnalyzer, so the conditional /
-// loop / early-return / cycled-segment detections are AST-shape based rather
-// than CFG-based. The implementation matches upstream observably for every
-// test in upstream's `valid` and `invalid` suites that doesn't rely on
-// BigInt-precise path counting (and we add a `hasLabeledBreakBefore` walk
-// for the `label: { if (cond) break label; useFoo(); }` case).
+// Conditional, loop, early-return, and cycled-segment decisions are derived
+// from internal/utils/cfg. Its path analysis exposes the same observable
+// questions this rule asks of ESLint's CodePathAnalyzer while remaining shared
+// with the other rules that need control flow.
 //
 // Identifier resolution for `useEffectEvent` references uses the shared Refs
 // index first (correct under shadowing), then the TypeChecker compatibility
@@ -955,6 +591,19 @@ var RulesOfHooksRule = rule.Rule{
 		sourceText := sf.Text()
 		flowSuppressionChecked := false
 		mayHaveFlowSuppression := false
+		codePaths := make(map[*ast.Node]*hookCodePath)
+		pathStateFor := func(node *ast.Node) (hookPathState, *ast.Node) {
+			root := cfg.RootOf(node)
+			if root == nil {
+				return hookPathState{}, nil
+			}
+			codePath := codePaths[root]
+			if codePath == nil {
+				codePath = buildHookCodePath(root)
+				codePaths[root] = codePath
+			}
+			return codePath.state(node), root
+		}
 		isFlowSuppressed := func(node *ast.Node) bool {
 			if !flowSuppressionChecked {
 				flowSuppressionChecked = true
@@ -992,12 +641,11 @@ var RulesOfHooksRule = rule.Rule{
 
 				fn := findEnclosingFunction(node)
 				isUse := isUseIdentifier(callee)
+				pathState, codePathRoot := pathStateFor(node)
 
-				// Skip unreachable hooks (preceded by a direct `return` or
-				// `throw` in the same block). Upstream's CFG marks the
-				// segment as `!reachable` and the rule loop `continue`s,
-				// emitting no diagnostic of any kind.
-				if fn != nil && isPrecededByDirectTerminator(node, fn) {
+				// Upstream skips every rule-of-hooks diagnostic for an
+				// unreachable code path segment.
+				if !pathState.reachable {
 					return
 				}
 
@@ -1006,11 +654,11 @@ var RulesOfHooksRule = rule.Rule{
 					report(callee, fmt.Sprintf(`React Hook "%s" cannot be called in a try/catch block.`, makeHookText(callee, sf)))
 				}
 
-				// Loop check (cycled || do-while). Skipped for use(), which
-				// upstream allows in loops.
-				inAnyLoop := false
+				// ESLint checks both cyclic code path segments and a syntactic
+				// do/while ancestor. The latter is an explicit upstream special
+				// case, while cycle membership comes from the shared CFG.
+				inAnyLoop := pathState.cyclic || isInsideDoWhileLoop(node, codePathRoot)
 				if !isUse {
-					inAnyLoop = isInsideLoopOfFunction(node, fn)
 					if inAnyLoop {
 						report(callee, fmt.Sprintf(
 							`React Hook "%s" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`,
@@ -1036,13 +684,9 @@ var RulesOfHooksRule = rule.Rule{
 					if isUse || inAnyLoop {
 						return
 					}
-					cond := isConditional(node, fn)
-					early := hasEarlyReturnBefore(node, fn)
-					labeled := hasLabeledBreakBefore(node, fn)
-					tryWithPrior := isInsideTryBlockWithPriorStmt(node, fn)
-					if cond || early || labeled || tryWithPrior {
+					if !pathState.onEveryFinalPath {
 						suffix := ""
-						if early {
+						if pathState.possiblyEarlyReturn {
 							suffix = " Did you accidentally call a React Hook after an early return?"
 						}
 						report(callee, fmt.Sprintf(

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_extras_test.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_extras_test.go
@@ -49,9 +49,8 @@ var rulesOfHooksExtrasValid = []rule_tester.ValidTestCase{
 				useFoo();
 			}
 		`, Tsx: true},
-		// Hook inside a `finally` block — finally runs on every path, so the
-		// hook is unconditional. (Upstream's CFG includes finally on the
-		// natural exit.)
+		// A hook after a `finally` block is reached through the natural
+		// continuation in upstream's CFG.
 		{Code: `
 			function ComponentWithFinally() {
 				try { mayThrow(); } finally { /* no hook here */ }
@@ -66,7 +65,7 @@ var rulesOfHooksExtrasValid = []rule_tester.ValidTestCase{
 			}
 		`, Tsx: true},
 
-		// ---- Path-counting edge cases (where AST heuristic vs upstream CFG could diverge) ----
+		// ---- Path-counting edge cases ----
 		// for-loop initializer: hook runs once before the loop starts.
 		// Upstream CFG places the init segment outside the loop; we must
 		// not trigger loopError here.
@@ -104,14 +103,16 @@ var rulesOfHooksExtrasValid = []rule_tester.ValidTestCase{
 				} catch {}
 			}
 		`, Tsx: true},
-		// finally block first statement: finally runs on every code path,
-		// so the hook is unconditional.
+		// A hook after a throwable node in a try/finally remains on every
+		// non-thrown final path. ESLint excludes the abrupt thrown segment
+		// from its path count.
 		{Code: `
 			function Component() {
 				try {
 					foo();
-				} finally {
 					useHook();
+				} finally {
+					bar();
 				}
 			}
 		`, Tsx: true},
@@ -187,10 +188,59 @@ var rulesOfHooksExtrasValid = []rule_tester.ValidTestCase{
 				return (a, useHook());
 			}
 		`, Tsx: true},
-		// for-loop CONDITION position: every iteration evaluates the
-		// condition, including the very first one — this DOES make the
-		// hook cycled. (Sanity check: confirm we still flag it as a loop.)
-		// — moved to invalid below.
+		// ESLint keeps a for-loop test on the repeated loop header segment.
+		// Its cycle collector deliberately excludes that repeated segment
+		// itself, so a hook in the test is not reported.
+		{Code: `
+			function Component() {
+				for (; useHook(); ) {}
+			}
+		`, Tsx: true},
+		// With no condition or incrementor, ESLint keeps the top of the body
+		// on the repeated loop-header segment and excludes that segment from
+		// its cycle set.
+		{Code: `
+			function Component() {
+				for (;;) {
+					useHook();
+				}
+			}
+		`, Tsx: true},
+		// The incrementor is laid out before the body, but ESLint settles its
+		// segment as unreachable when the body always returns.
+		{Code: `
+			function Component(condition) {
+				for (; condition; useHook()) {
+					return null;
+				}
+			}
+		`, Tsx: true},
+		// A yield does not end the generator's ESLint code path. A hook after
+		// it remains on the same ordinary path.
+		{Code: `
+			function* useGenerator() {
+				yield 1;
+				useAfterYield();
+			}
+		`, Tsx: true},
+		// After a return, ESLint's AST listener observes the outer segment.
+		// A one-path component therefore gets no conditional diagnostic.
+		{Code: `
+			function Component() {
+				return null;
+				useAfterReturn();
+			}
+		`, Tsx: true},
+		// The same detached-segment behavior after continue still compares as
+		// one path through a loop that has no break path.
+		{Code: `
+			function Component(condition) {
+				while (condition) {
+					continue;
+					useAfterContinue();
+				}
+			}
+		`, Tsx: true},
 
 		// ---- Callee-shape edge cases (rslint-only) ----
 		// Element access form: `Foo['useBar']()` — upstream rejects
@@ -327,6 +377,19 @@ var rulesOfHooksExtrasValid = []rule_tester.ValidTestCase{
 			function Component() {
 				try {
 					return 1;
+				} finally {
+					useHook();
+				}
+			}
+		`, Tsx: true},
+		// ESLint combines return and throw into the same abrupt finally
+		// segment. With no normal continuation, that segment is not
+		// conditional even though it represents both completion kinds.
+		{Code: `
+			function Component(condition) {
+				try {
+					if (condition) return null;
+					throw condition;
 				} finally {
 					useHook();
 				}
@@ -679,7 +742,7 @@ var rulesOfHooksExtrasValid = []rule_tester.ValidTestCase{
 			},
 		},
 
-		// ---- Edge cases of "AST heuristic vs BigInt path counting" ----
+		// ---- Edge cases with many control-flow paths ----
 		// #5 multiple `break outer` jumping to the same label, hook AFTER
 		// the outer loop. useBar is on every reachable path.
 		{Code: `
@@ -854,20 +917,7 @@ var rulesOfHooksExtrasInvalid = []rule_tester.InvalidTestCase{
 				{Message: `React Hook "useState" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
 			},
 		},
-		// for-loop CONDITION: hook in `for (; useFoo(); ) {}` IS cycled
-		// (re-evaluated each iteration) — should still report loopError.
-		{
-			Code: `
-				function Component() {
-					for (; useHook(); ) {}
-				}
-			`,
-			Tsx: true,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
-			},
-		},
-		// for-loop INCREMENTOR: same as condition — runs each iteration.
+		// Unlike the loop test, the incrementor is inside the collected cycle.
 		{
 			Code: `
 				function Component() {
@@ -879,9 +929,82 @@ var rulesOfHooksExtrasInvalid = []rule_tester.InvalidTestCase{
 				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
 			},
 		},
+		// A short-circuit operand in a loop test occupies a later segment than
+		// the repeated header, so upstream includes it in the cycle.
+		{
+			Code: `
+				function Component(condition) {
+					for (; condition && useHook(); ) {}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// A branch inside an otherwise empty for-loop creates a later segment,
+		// which is included in the cycle even though the header itself is not.
+		{
+			Code: `
+				function Component(condition) {
+					for (;;) {
+						if (condition) useHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// A resumable yield does not hide the loop back edge from ESLint's
+		// cycle collector.
+		{
+			Code: `
+				function* useGenerator(condition) {
+					while (condition) {
+						useBeforeYield();
+						yield condition;
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useBeforeYield" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// The detached outer segment after an uncaught throw has one path,
+		// while the function has zero non-thrown paths.
+		{
+			Code: `
+				function Component() {
+					throw error;
+					useAfterThrow();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useAfterThrow" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
+			},
+		},
+		// A loop break adds a second final path, so a hook visited on the
+		// detached outer segment compares as conditional without an early exit.
+		{
+			Code: `
+				function Component(condition) {
+					while (condition) {
+						break;
+						useAfterBreak();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useAfterBreak" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
 		// Try block with prior throwable statement: still conditional (mirrors
-		// upstream's existing test, kept here too as a position-aware check
-		// for our `isInsideTryBlockWithPriorStmt` helper).
+		// upstream's existing test, kept here too as a CFG position check).
 		{
 			Code: `
 				function Component() {
@@ -1285,8 +1408,8 @@ var rulesOfHooksExtrasInvalid = []rule_tester.InvalidTestCase{
 			`,
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
-				{Message: `React Hook "useFoo" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
-				{Message: `React Hook "useBar" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+				{Message: `React Hook "useFoo" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
+				{Message: `React Hook "useBar" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
 			},
 		},
 
@@ -1322,31 +1445,48 @@ var rulesOfHooksExtrasInvalid = []rule_tester.InvalidTestCase{
 			},
 		},
 
-		// ---- Try-finally without catch, hook AFTER throwable in try ----
-		// (Potential divergence point: upstream's path counting reasoning
-		// vs our "any prior throwable in try" heuristic.)
+		// A finally hook is recorded on ESLint's abrupt segment. When the try
+		// body can throw, that segment is excluded from the ordinary path count
+		// while the separate normal continuation remains, so upstream reports
+		// the hook as conditional with its early-return suffix.
 		{
 			Code: `
 				function Component() {
 					try {
 						foo();
-						useHook();
 					} finally {
-						bar();
+						useHook();
 					}
 				}
 			`,
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
-				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
+			},
+		},
+		// A normal and a returned path use different finally layouts. ESLint
+		// observes the abrupt layout while visiting the hook, so it reports the
+		// normal layout as the skipped path and adds the early-return suffix.
+		{
+			Code: `
+				function Component(condition) {
+					try {
+						if (condition) return null;
+					} finally {
+						useHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
 			},
 		},
 
-		// ---- Edge: BigInt-territory checks ----
+		// ---- Edge: many-path checks ----
 		// #1 N if-else with one branch returning each time, then hook.
 		// Upstream's path counting: useState segment path = 1 / total = 2^N.
-		// Our sibling-walk catches the first `if (...) return;` and reports
-		// early-return; both implementations report.
+		// The shared CFG must report the conditional call and early-return suffix.
 		{
 			Code: `
 				function useFoo() {

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_test.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_test.go
@@ -199,3 +199,235 @@ function MyComponent() {
 		nil,
 	)
 }
+
+func TestRulesOfHooksDocumentRegressions(t *testing.T) {
+	const (
+		conditional       = `React Hook "useFirst" is called conditionally. React Hooks must be called in the exact same order in every component render.`
+		conditionalSecond = `React Hook "useSecond" is called conditionally. React Hooks must be called in the exact same order in every component render.`
+		early             = `React Hook "useSecond" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`
+		loop              = `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`
+		named             = `React Hook "useHook" is called in function "lower" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`
+		callback          = `React Hook "useHook" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`
+	)
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RulesOfHooksRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `
+const handlers = {
+  [key]: () => {
+    useHook();
+  },
+  [otherKey]() {
+    useOtherHook();
+  },
+};
+`,
+				Tsx: true,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+const _Component: React.FC<Props> = () => {
+  useHook();
+};
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					Message: `React Hook "useHook" is called in function "_Component: React.FC<Props>" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`,
+				}},
+			},
+			{
+				Code: `
+function Component() {
+  const handlers = {
+    [key]: () => {
+      useHook();
+    },
+    [otherKey]() {
+      useOtherHook();
+    },
+  };
+  return handlers;
+}
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: callback},
+					{Message: `React Hook "useOtherHook" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`},
+				},
+			},
+			{
+				Code: `
+function Component(value) {
+  if (!value) return null;
+  useFirst();
+  const resolved = value ?? fallback;
+  useSecond();
+  return resolved;
+}
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: conditional},
+					{Message: early},
+				},
+			},
+			{
+				Code: `
+function Component(value) {
+  switch (value) {
+    case 0:
+      useFirst();
+      if (flag) log();
+      return;
+    default:
+      useSecond();
+  }
+}
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: conditional},
+					{Message: conditionalSecond},
+				},
+			},
+			{
+				Code: `
+function useThing(value) {
+  switch (value) {
+    case 0:
+      if (!value || missing) return;
+      useFirst();
+      break;
+    case 1:
+      if (!value) return;
+      useSecond();
+      break;
+  }
+}
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: conditional + ` Did you accidentally call a React Hook after an early return?`},
+					{Message: early},
+				},
+			},
+			{
+				Code: `
+function useThing(value) {
+  switch (value) {
+    case 0:
+      if (!value) return;
+      useFirst();
+      break;
+    case 1:
+      break;
+  }
+}
+`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{Message: conditional}},
+			},
+			{
+				Code: `
+function Component(value) {
+  switch (value) {
+    case 0:
+      useFirst();
+      return;
+    default:
+      useSecond();
+  }
+}
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: conditional + ` Did you accidentally call a React Hook after an early return?`},
+					{Message: early},
+				},
+			},
+			{
+				Code: `
+function lower(values) {
+  for (const value of values) {
+    switch (value) {
+      case 0:
+        break;
+      case 1:
+        useHook();
+        break;
+    }
+  }
+}
+`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{Message: named}},
+			},
+			{
+				Code: `
+function lower(values) {
+  for (const value of values) {
+    switch (value) {
+      case 0:
+        log(value);
+      case 1:
+        useHook();
+        break;
+    }
+  }
+}
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: loop},
+					{Message: named},
+				},
+			},
+			{
+				Code: `
+function lower(values) {
+  for (const value of values) {
+    switch (value) {
+      case 0:
+        return;
+      case 1:
+        useHook();
+        break;
+    }
+  }
+}
+`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: loop},
+					{Message: named},
+				},
+			},
+			{
+				Code: `
+function lower(values) {
+  for (const value of values) {
+    switch (value) {
+      case 0:
+        try {
+          break;
+        } catch {}
+      case 1:
+        useHook();
+        break;
+    }
+  }
+}
+`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{Message: named}},
+			},
+		},
+	)
+}

--- a/internal/utils/cfg/cfg.go
+++ b/internal/utils/cfg/cfg.go
@@ -49,19 +49,35 @@ type Block[E any] struct {
 	// laid out inside it, which is unreachable whenever the block itself is.
 	Reachable bool
 
-	index       int
-	hasIncoming bool
+	index        int32
+	hasIncoming  bool
+	final        bool
+	thrown       bool
+	cycleBarrier []bool
+	successors   [2]*Block[E]
 }
+
+const blockChunkSize = 8
+
+type blockChunk[E any] [blockChunkSize]Block[E]
 
 // Index reports the block's position in Graph.Blocks, so a consumer can hold
 // per-block analysis state in a slice rather than a map.
 func (blk *Block[E]) Index() int {
-	return blk.index
+	return int(blk.index)
 }
 
 // Graph is the control-flow graph of one code path root, unreachable blocks
 // included. Blocks[0] is the entry block; the rest are in construction order,
 // which no analysis should depend on.
+//
+// FinalBlocks are the reachable blocks where the root completes normally,
+// returns, or is suspended by a yield. ThrownBlocks are the reachable blocks
+// where an uncaught throw leaves the root. A block can be in both sets when a
+// yield gives the caller both ways to terminate the generator. Keeping the two
+// sets separate lets consumers mirror analyses, such as ESLint code paths,
+// that deliberately exclude thrown exits. Different abrupt completions can
+// also share one block after a finally clause, placing that block in both sets.
 //
 // EndReachable reports whether control can run off the end of the root — the
 // question ESLint answers with `isAnySegmentReachable(codePath.currentSegments)`
@@ -69,6 +85,8 @@ func (blk *Block[E]) Index() int {
 // throws, or loops forever.
 type Graph[E any] struct {
 	Blocks       []*Block[E]
+	FinalBlocks  []*Block[E]
+	ThrownBlocks []*Block[E]
 	EndReachable bool
 }
 
@@ -108,6 +126,7 @@ type tryFrame[E any] struct {
 	finallyEntry *Block[E]
 	thrownForked bool
 	thrownAny    bool
+	implicit     []*Block[E]
 	returnedAny  bool
 }
 
@@ -127,6 +146,7 @@ type jumpTarget[E any] struct {
 	continueTo *Block[E]
 	loop       *ast.Node
 	breakable  bool
+	broken     bool
 }
 
 // Builder lays out a graph. Consumers only see it through their Hooks, where
@@ -134,8 +154,11 @@ type jumpTarget[E any] struct {
 type Builder[E any] struct {
 	hooks Hooks[E]
 
-	blocks []*Block[E]
-	cur    *Block[E]
+	blocks      []*Block[E]
+	cur         *Block[E]
+	finals      []*Block[E]
+	thrown      []*Block[E]
+	blockChunks []*blockChunk[E]
 
 	jumps      []jumpTarget[E]
 	tryStack   []*tryFrame[E]
@@ -144,7 +167,7 @@ type Builder[E any] struct {
 
 // Build lays out the control-flow graph of one code path root.
 func Build[E any](root *ast.Node, hooks Hooks[E]) *Graph[E] {
-	b := &Builder[E]{hooks: hooks}
+	b := &Builder[E]{hooks: hooks, blocks: make([]*Block[E], 0, blockChunkSize)}
 	b.cur = b.newBlock()
 	b.cur.hasIncoming = true
 	b.cur.Reachable = true
@@ -175,7 +198,16 @@ func Build[E any](root *ast.Node, hooks Hooks[E]) *Graph[E] {
 		}
 	}
 
-	return &Graph[E]{Blocks: b.blocks, EndReachable: b.cur.Reachable}
+	endReachable := b.cur.Reachable
+	if endReachable {
+		b.markFinal(b.cur)
+	}
+	return &Graph[E]{
+		Blocks:       b.blocks,
+		FinalBlocks:  b.finals,
+		ThrownBlocks: b.thrown,
+		EndReachable: endReachable,
+	}
 }
 
 // parameter models a parameter binding: its default value is skipped when an
@@ -208,19 +240,75 @@ func (b *Builder[E]) Emit(e E) (*Block[E], int) {
 }
 
 func (b *Builder[E]) newBlock() *Block[E] {
-	blk := &Block[E]{index: len(b.blocks)}
+	index := len(b.blocks)
+	chunkIndex := index / blockChunkSize
+	if chunkIndex == len(b.blockChunks) {
+		b.blockChunks = append(b.blockChunks, new(blockChunk[E]))
+	}
+	blk := &b.blockChunks[chunkIndex][index%blockChunkSize]
+	blk.index = int32(index)
 	b.blocks = append(b.blocks, blk)
 	return blk
 }
 
-func (b *Builder[E]) link(from, to *Block[E]) {
-	if from == nil || to == nil {
+func (b *Builder[E]) markFinal(blk *Block[E]) {
+	if blk == nil || !blk.Reachable || blk.final {
 		return
 	}
-	from.Successors = append(from.Successors, to)
+	blk.final = true
+	b.finals = append(b.finals, blk)
+}
+
+func (b *Builder[E]) markThrown(blk *Block[E]) {
+	if blk == nil || !blk.Reachable || blk.thrown {
+		return
+	}
+	blk.thrown = true
+	b.thrown = append(b.thrown, blk)
+}
+
+func (b *Builder[E]) link(from, to *Block[E]) {
+	b.linkWithCycleBarrier(from, to, false)
+}
+
+func (b *Builder[E]) linkWithCycleBarrier(from, to *Block[E], barrier bool) int {
+	if from == nil || to == nil {
+		return -1
+	}
+	index := len(from.Successors)
+	b.appendSuccessor(from, to)
+	b.setCycleBarrier(from, index, barrier)
 	if from.Reachable {
 		to.hasIncoming = true
 	}
+	return index
+}
+
+func (b *Builder[E]) appendSuccessor(from, to *Block[E]) {
+	index := len(from.Successors)
+	if index < len(from.successors) {
+		from.successors[index] = to
+		from.Successors = from.successors[:index+1]
+		return
+	}
+	from.Successors = append(from.Successors, to)
+}
+
+func (b *Builder[E]) setCycleBarrier(from *Block[E], index int, barrier bool) {
+	if from == nil || index < 0 {
+		return
+	}
+	if from.cycleBarrier == nil {
+		if !barrier {
+			return
+		}
+		from.cycleBarrier = make([]bool, len(from.Successors))
+	} else {
+		for len(from.cycleBarrier) < len(from.Successors) {
+			from.cycleBarrier = append(from.cycleBarrier, false)
+		}
+	}
+	from.cycleBarrier[index] = barrier
 }
 
 // enter makes blk the current block and settles its reachability, so every edge
@@ -237,7 +325,10 @@ func (b *Builder[E]) enter(blk *Block[E]) {
 // block is never entered: its reachability is settled here, as false.
 func (b *Builder[E]) makeUnreachable() {
 	next := b.newBlock()
-	b.cur.Successors = append(b.cur.Successors, next)
+	b.appendSuccessor(b.cur, next)
+	if b.cur.cycleBarrier != nil {
+		b.cur.cycleBarrier = append(b.cur.cycleBarrier, false)
+	}
 	b.cur = next
 }
 
@@ -325,6 +416,16 @@ func (b *Builder[E]) firstThrowableFork() {
 		return
 	}
 	f.thrownForked = true
+	if f.position == posCatch && f.hasFinally {
+		// ESLint merges an implicit exception from a catch body into the
+		// catch's ordinary finally continuation. An explicit throw still uses
+		// the abrupt layout through makeThrow.
+		f.implicit = append(f.implicit, b.cur)
+		next := b.newBlock()
+		b.link(b.cur, next)
+		b.enter(next)
+		return
+	}
 	f.thrownAny = true
 	b.link(b.cur, throwTarget(f))
 	next := b.newBlock()

--- a/internal/utils/cfg/expressions.go
+++ b/internal/utils/cfg/expressions.go
@@ -62,6 +62,89 @@ func (b *Builder[E]) expr(node *ast.Node) {
 	}
 }
 
+// condition evaluates node while keeping its truthy and falsy continuations
+// separate. A plain expr may merge short-circuit branches because its value is
+// all the consumer needs; a control-flow condition cannot merge them before it
+// decides which statement executes, or impossible paths can appear across the
+// join (for example, the short branch of `a || b` reaching an `else` body).
+func (b *Builder[E]) condition(node *ast.Node, whenTrue, whenFalse *Block[E]) {
+	if node == nil {
+		b.link(b.cur, whenTrue)
+		b.link(b.cur, whenFalse)
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindParenthesizedExpression:
+		if b.hooks.Expression != nil {
+			b.hooks.Expression(b, node)
+		}
+		b.condition(node.AsParenthesizedExpression().Expression, whenTrue, whenFalse)
+
+	case ast.KindPrefixUnaryExpression:
+		unary := node.AsPrefixUnaryExpression()
+		if unary.Operator != ast.KindExclamationToken {
+			b.expr(node)
+			b.link(b.cur, whenTrue)
+			b.link(b.cur, whenFalse)
+			return
+		}
+		if b.hooks.Expression != nil {
+			b.hooks.Expression(b, node)
+		}
+		b.condition(unary.Operand, whenFalse, whenTrue)
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		operator := binary.OperatorToken.Kind
+		if operator != ast.KindAmpersandAmpersandToken &&
+			operator != ast.KindBarBarToken &&
+			operator != ast.KindQuestionQuestionToken {
+			b.expr(node)
+			b.link(b.cur, whenTrue)
+			b.link(b.cur, whenFalse)
+			return
+		}
+		if b.hooks.Expression != nil {
+			b.hooks.Expression(b, node)
+		}
+		right := b.newBlock()
+		switch operator {
+		case ast.KindAmpersandAmpersandToken:
+			b.condition(binary.Left, right, whenFalse)
+		case ast.KindBarBarToken:
+			b.condition(binary.Left, whenTrue, right)
+		case ast.KindQuestionQuestionToken:
+			// A non-nullish left operand may itself be truthy or falsy; a
+			// nullish one evaluates the right operand.
+			b.expr(binary.Left)
+			b.link(b.cur, whenTrue)
+			b.link(b.cur, whenFalse)
+			b.link(b.cur, right)
+		}
+		b.enter(right)
+		b.condition(binary.Right, whenTrue, whenFalse)
+
+	case ast.KindConditionalExpression:
+		if b.hooks.Expression != nil {
+			b.hooks.Expression(b, node)
+		}
+		conditional := node.AsConditionalExpression()
+		trueEntry := b.newBlock()
+		falseEntry := b.newBlock()
+		b.condition(conditional.Condition, trueEntry, falseEntry)
+		b.enter(trueEntry)
+		b.condition(conditional.WhenTrue, whenTrue, whenFalse)
+		b.enter(falseEntry)
+		b.condition(conditional.WhenFalse, whenTrue, whenFalse)
+
+	default:
+		b.expr(node)
+		b.link(b.cur, whenTrue)
+		b.link(b.cur, whenFalse)
+	}
+}
+
 // visitUnknown routes a child of a node the builder has no dedicated handler
 // for. Statements and expressions are handled by their own walkers so control
 // flow inside them is still modelled.

--- a/internal/utils/cfg/paths.go
+++ b/internal/utils/cfg/paths.go
@@ -1,0 +1,446 @@
+package cfg
+
+// PathAnalysis answers graph-shape questions shared by rules that consume an
+// ESLint-style code path. Thrown exits are deliberately excluded from final
+// paths, matching ESLint analyses that treat thrown segments separately.
+//
+// All per-block state is indexed by Block.Index, so ordinary queries do not
+// allocate or hash block pointers.
+type PathAnalysis[E any] struct {
+	graph        *Graph[E]
+	blocks       []pathBlockState
+	cyclePaths   *cyclePaths[E]
+	shortestExit int
+	finalPaths   uint8
+	hasFinal     bool
+	hasExit      bool
+}
+
+type pathBlockState struct {
+	shortest int32
+	flags    uint8
+	paths    uint8
+}
+
+const (
+	pathFinal uint8 = 1 << iota
+	pathThrown
+	pathExit
+	pathCyclic
+	pathOnEveryFinal
+	pathCounting
+	pathCountKnown
+)
+
+// AnalyzePaths computes reachability-derived path information for graph.
+func AnalyzePaths[E any](graph *Graph[E]) *PathAnalysis[E] {
+	if graph == nil || len(graph.Blocks) == 0 {
+		return &PathAnalysis[E]{}
+	}
+
+	blockCount := len(graph.Blocks)
+	analysis := &PathAnalysis[E]{
+		graph:  graph,
+		blocks: make([]pathBlockState, blockCount),
+	}
+	for _, block := range graph.ThrownBlocks {
+		if block != nil && block.Reachable {
+			analysis.blocks[block.Index()].flags |= pathThrown | pathExit
+			analysis.hasExit = true
+		}
+	}
+	for _, block := range graph.FinalBlocks {
+		if block != nil && block.Reachable {
+			analysis.blocks[block.Index()].flags |= pathExit
+			analysis.hasExit = true
+			if analysis.blocks[block.Index()].flags&pathThrown != 0 {
+				continue
+			}
+			analysis.blocks[block.Index()].flags |= pathFinal
+			analysis.hasFinal = true
+		}
+	}
+
+	analysis.cyclePaths = newCyclePaths(graph, analysis.blocks)
+	analysis.cyclePaths.countToEnd(0)
+	analysis.finalPaths = analysis.countFinalPaths(0)
+	analysis.findShortestPaths(graph)
+	analysis.findFinalPathDominators(graph)
+	return analysis
+}
+
+// IsCyclic reports whether block belongs to a reachable graph cycle.
+func (a *PathAnalysis[E]) IsCyclic(block *Block[E]) bool {
+	if a == nil || block == nil || block.Index() >= len(a.blocks) {
+		return false
+	}
+	if a.cyclePaths != nil {
+		a.cyclePaths.countToEnd(block.Index())
+	}
+	return a.blocks[block.Index()].flags&pathCyclic != 0
+}
+
+// IsOnEveryFinalPath reports whether every non-throwing path from the graph
+// entry to a final block passes through block. It is true when the graph has no
+// non-throwing final path, matching the vacuous path-count comparison used by
+// ESLint consumers.
+func (a *PathAnalysis[E]) IsOnEveryFinalPath(block *Block[E]) bool {
+	return a != nil && block != nil && block.Index() < len(a.blocks) && a.blocks[block.Index()].flags&pathOnEveryFinal != 0
+}
+
+// IsExit reports whether block is a reachable final segment, including an
+// uncaught thrown segment. ESLint includes thrown segments in codePath's
+// finalSegments even though path counting deliberately assigns them zero
+// paths.
+func (a *PathAnalysis[E]) IsExit(block *Block[E]) bool {
+	return a != nil && block != nil && block.Index() < len(a.blocks) && a.blocks[block.Index()].flags&pathExit != 0
+}
+
+// ShortestPathFromStart returns the number of blocks on the shortest path from
+// the graph entry to block. The second result is false for an unreachable or
+// unknown block.
+func (a *PathAnalysis[E]) ShortestPathFromStart(block *Block[E]) (int, bool) {
+	if a == nil || block == nil || block.Index() >= len(a.blocks) {
+		return 0, false
+	}
+	distance := a.blocks[block.Index()].shortest
+	return int(distance), distance != 0
+}
+
+// ShortestExitPathFromStart returns the number of blocks on the shortest path
+// from the graph entry to any reachable final segment, thrown exits included.
+func (a *PathAnalysis[E]) ShortestExitPathFromStart() (int, bool) {
+	if a == nil || !a.hasExit {
+		return 0, false
+	}
+	return a.shortestExit, true
+}
+
+// HasSingleFinalPath reports whether exactly one non-thrown path reaches a
+// final block. The count saturates at two because consumers asking about a
+// detached ESLint code-path segment only need to distinguish zero, one, and
+// multiple paths.
+func (a *PathAnalysis[E]) HasSingleFinalPath() bool {
+	return a != nil && a.finalPaths == 1
+}
+
+func (a *PathAnalysis[E]) countFinalPaths(index int) uint8 {
+	state := &a.blocks[index]
+	if state.flags&pathCounting != 0 {
+		return 0
+	}
+	if state.flags&pathCountKnown != 0 {
+		return state.paths
+	}
+	state.flags |= pathCounting
+	count := uint8(0)
+	if state.flags&pathThrown == 0 {
+		if state.flags&pathFinal != 0 {
+			count = 1
+		} else {
+			for _, successor := range a.graph.Blocks[index].Successors {
+				if successor == nil || !successor.Reachable {
+					continue
+				}
+				count += a.countFinalPaths(successor.Index())
+				if count > 1 {
+					count = 2
+					break
+				}
+			}
+		}
+	}
+	state.flags &^= pathCounting
+	state.flags |= pathCountKnown
+	state.paths = count
+	return count
+}
+
+func (a *PathAnalysis[E]) findShortestPaths(graph *Graph[E]) {
+	var queue []int
+	if a.cyclePaths != nil && cap(a.cyclePaths.path) >= len(graph.Blocks) {
+		queue = a.cyclePaths.path[:1]
+	} else {
+		queue = make([]int, 1, len(graph.Blocks))
+	}
+	queue[0] = 0
+	a.blocks[0].shortest = 1
+	for head := 0; head < len(queue); head++ {
+		index := queue[head]
+		distance := a.blocks[index].shortest + 1
+		for _, successor := range graph.Blocks[index].Successors {
+			if successor == nil || !successor.Reachable {
+				continue
+			}
+			successorIndex := successor.Index()
+			if a.blocks[successorIndex].shortest != 0 {
+				continue
+			}
+			a.blocks[successorIndex].shortest = distance
+			queue = append(queue, successorIndex)
+		}
+	}
+	if a.cyclePaths != nil {
+		a.cyclePaths.path = queue[:0]
+	}
+
+	for index := range a.blocks {
+		distance := a.blocks[index].shortest
+		if distance == 0 {
+			continue
+		}
+		if a.blocks[index].flags&pathExit != 0 && (a.shortestExit == 0 || int(distance) < a.shortestExit) {
+			a.shortestExit = int(distance)
+		}
+	}
+}
+
+// cyclePaths mirrors the traversal and caching order used by ESLint's
+// countPathsFromStart/countPathsToEnd helpers. That order is observable: once
+// a shared successor is cached, a later switch clause may no longer walk the
+// back edge that marked an earlier clause as cyclic.
+type cyclePaths[E any] struct {
+	graph  *Graph[E]
+	blocks []pathBlockState
+	state  []cycleBlockState
+	path   []int
+}
+
+type cycleBlockState struct {
+	activeAt int32
+	flags    uint8
+}
+
+const (
+	cycleThrown uint8 = 1 << iota
+	cycleToKnown
+	cycleToEnd
+)
+
+func newCyclePaths[E any](graph *Graph[E], blocks []pathBlockState) *cyclePaths[E] {
+	blockCount := len(graph.Blocks)
+	paths := &cyclePaths[E]{
+		graph:  graph,
+		blocks: blocks,
+		state:  make([]cycleBlockState, blockCount),
+		path:   make([]int, 0, blockCount),
+	}
+	for index := range paths.state {
+		paths.state[index].activeAt = -1
+	}
+	for _, block := range graph.ThrownBlocks {
+		if block != nil && block.Reachable {
+			paths.state[block.Index()].flags |= cycleThrown
+		}
+	}
+	return paths
+}
+
+func (p *cyclePaths[E]) countToEnd(index int) bool {
+	return p.count(index, -1)
+}
+
+func (p *cyclePaths[E]) count(index int, barrierStart int) bool {
+	if active := p.state[index].activeAt; active >= 0 {
+		// ESLint records the segment after its loop context as the start of the
+		// cycle, then marks only the later segments in pathArray. Excluding the
+		// repeated header here gives the same observable result: a for-loop test
+		// is not cyclic, while its body and incrementor are.
+		cycleStart := int(active) + 1
+		cycleEnd := len(p.path)
+		if barrierStart > int(active) {
+			cycleEnd = barrierStart
+		}
+		for _, member := range p.path[cycleStart:cycleEnd] {
+			p.blocks[member].flags |= pathCyclic
+		}
+		return false
+	}
+	if p.state[index].flags&cycleToKnown != 0 {
+		return p.state[index].flags&cycleToEnd != 0
+	}
+
+	p.state[index].activeAt = int32(len(p.path))
+	p.path = append(p.path, index)
+	hasPath := false
+	// An uncaught throw is not a path to a normal exit. A yield is different:
+	// it also has a reachable resumption successor, which must still be walked
+	// to discover a loop back edge.
+	block := p.graph.Blocks[index]
+	traverse := p.state[index].flags&cycleThrown == 0
+	if !traverse {
+		for _, successor := range block.Successors {
+			if successor != nil && successor.Reachable {
+				traverse = true
+				break
+			}
+		}
+	}
+	if traverse {
+		hasPath = p.blocks[index].flags&pathFinal != 0
+		hasSuccessor := false
+		for successorIndex, successor := range block.Successors {
+			if successor == nil || !successor.Reachable {
+				continue
+			}
+			hasSuccessor = true
+			nextBarrier := barrierStart
+			if successorIndex < len(block.cycleBarrier) && block.cycleBarrier[successorIndex] {
+				nextBarrier = len(p.path)
+			}
+			if p.count(successor.Index(), nextBarrier) {
+				hasPath = true
+			}
+		}
+		if !hasSuccessor && p.state[index].flags&cycleThrown == 0 {
+			hasPath = true
+		}
+	}
+	p.path = p.path[:len(p.path)-1]
+	p.state[index].activeAt = -1
+
+	if hasPath || !p.graph.Blocks[index].Reachable {
+		p.state[index].flags |= cycleToKnown
+		if hasPath {
+			p.state[index].flags |= cycleToEnd
+		} else {
+			p.state[index].flags &^= cycleToEnd
+		}
+	} else {
+		p.state[index].flags &^= cycleToKnown
+	}
+	return hasPath
+}
+
+// findFinalPathDominators adds one synthetic exit reached by every final block
+// and computes immediate dominators with the Cooper-Harvey-Kennedy algorithm.
+// The real blocks on the synthetic exit's dominator chain are exactly those on
+// every non-throwing final path.
+func (a *PathAnalysis[E]) findFinalPathDominators(graph *Graph[E]) {
+	blockCount := len(graph.Blocks)
+	if !a.hasFinal {
+		for index, block := range graph.Blocks {
+			if block.Reachable {
+				a.blocks[index].flags |= pathOnEveryFinal
+			}
+		}
+		return
+	}
+
+	exit := blockCount
+	predCounts := make([]int, blockCount+2)
+	for index, block := range graph.Blocks {
+		if !block.Reachable {
+			continue
+		}
+		for _, successor := range block.Successors {
+			if successor != nil && successor.Reachable {
+				predCounts[successor.Index()+1]++
+			}
+		}
+		if a.blocks[index].flags&pathFinal != 0 {
+			predCounts[exit+1]++
+		}
+	}
+	for index := 1; index < len(predCounts); index++ {
+		predCounts[index] += predCounts[index-1]
+	}
+	totalPredecessors := predCounts[len(predCounts)-1]
+	nodeCount := blockCount + 1
+	work := make([]int, totalPredecessors+nodeCount*4)
+	predecessors := work[:totalPredecessors]
+	predCursor := work[totalPredecessors : totalPredecessors+nodeCount]
+	postOrderStorage := work[totalPredecessors+nodeCount : totalPredecessors+nodeCount*2]
+	rpoPosition := work[totalPredecessors+nodeCount*2 : totalPredecessors+nodeCount*3]
+	immediate := work[totalPredecessors+nodeCount*3:]
+	copy(predCursor, predCounts[:nodeCount])
+	for index, block := range graph.Blocks {
+		if !block.Reachable {
+			continue
+		}
+		for _, successor := range block.Successors {
+			if successor == nil || !successor.Reachable {
+				continue
+			}
+			successorIndex := successor.Index()
+			predecessors[predCursor[successorIndex]] = index
+			predCursor[successorIndex]++
+		}
+		if a.blocks[index].flags&pathFinal != 0 {
+			predecessors[predCursor[exit]] = index
+			predCursor[exit]++
+		}
+	}
+
+	for index := range rpoPosition {
+		rpoPosition[index] = -1
+		immediate[index] = -1
+	}
+	postOrder := postOrderStorage[:0]
+	var visit func(int)
+	visit = func(index int) {
+		rpoPosition[index] = 0
+		if index < blockCount {
+			for _, successor := range graph.Blocks[index].Successors {
+				if successor != nil && successor.Reachable && rpoPosition[successor.Index()] == -1 {
+					visit(successor.Index())
+				}
+			}
+			if a.blocks[index].flags&pathFinal != 0 && rpoPosition[exit] == -1 {
+				visit(exit)
+			}
+		}
+		postOrder = append(postOrder, index)
+	}
+	visit(0)
+
+	for left, right := 0, len(postOrder)-1; left < right; left, right = left+1, right-1 {
+		postOrder[left], postOrder[right] = postOrder[right], postOrder[left]
+	}
+	for index, block := range postOrder {
+		rpoPosition[block] = index
+	}
+	immediate[0] = 0
+	intersect := func(left int, right int) int {
+		for left != right {
+			for rpoPosition[left] > rpoPosition[right] {
+				left = immediate[left]
+			}
+			for rpoPosition[right] > rpoPosition[left] {
+				right = immediate[right]
+			}
+		}
+		return left
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for _, index := range postOrder[1:] {
+			start := predCounts[index]
+			end := predCounts[index+1]
+			newImmediate := -1
+			for _, predecessor := range predecessors[start:end] {
+				if immediate[predecessor] == -1 {
+					continue
+				}
+				if newImmediate == -1 {
+					newImmediate = predecessor
+				} else {
+					newImmediate = intersect(predecessor, newImmediate)
+				}
+			}
+			if immediate[index] != newImmediate {
+				immediate[index] = newImmediate
+				changed = true
+			}
+		}
+	}
+
+	for index := immediate[exit]; index >= 0; index = immediate[index] {
+		a.blocks[index].flags |= pathOnEveryFinal
+		if index == 0 {
+			break
+		}
+	}
+}

--- a/internal/utils/cfg/paths_test.go
+++ b/internal/utils/cfg/paths_test.go
@@ -1,0 +1,278 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+func TestPathAnalysis(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name          string
+		code          string
+		event         string
+		wantReachable bool
+		wantCyclic    bool
+		wantEvery     bool
+		wantEarly     bool
+	}{
+		{
+			name:          "unconditional after branch",
+			code:          `function f(x) { if (x) consume(); markHook(); }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantEvery:     true,
+		},
+		{
+			name:          "conditional branch",
+			code:          `function f(x) { if (x) markHook(); }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantEvery:     false,
+		},
+		{
+			name:          "short circuit before early return",
+			code:          `function f(x, y) { if (!x || y) return; markHook(); }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantEvery:     false,
+			wantEarly:     true,
+		},
+		{
+			name:          "loop condition",
+			code:          `function f() { for (; markHook(); ) {} }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantCyclic:    false,
+			wantEvery:     true,
+		},
+		{
+			name:          "short circuit inside loop condition",
+			code:          `function f(x) { for (; x && markHook(); ) {} }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantCyclic:    true,
+			wantEvery:     false,
+		},
+		{
+			name:          "empty for loop header",
+			code:          `function f() { for (;;) { markHook(); } }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantCyclic:    false,
+			wantEvery:     true,
+		},
+		{
+			name:          "branch inside empty for loop",
+			code:          `function f(x) { for (;;) { if (x) markHook(); } }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantCyclic:    true,
+			wantEvery:     true,
+		},
+		{
+			name:          "loop body",
+			code:          `function f(x) { for (; x; ) { markHook(); } }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantCyclic:    true,
+			wantEvery:     false,
+		},
+		{
+			name: "switch break stops outer cycle",
+			code: `function f(xs) {
+				for (const x of xs) switch (x) {
+					case 0: break;
+					case 1: markHook(); break;
+				}
+			}`,
+			event:         "markHook",
+			wantReachable: true,
+			wantCyclic:    false,
+			wantEvery:     false,
+			wantEarly:     true,
+		},
+		{
+			name: "switch return keeps outer cycle",
+			code: `function f(xs) {
+				for (const x of xs) switch (x) {
+					case 0: return;
+					case 1: markHook(); break;
+				}
+			}`,
+			event:         "markHook",
+			wantReachable: true,
+			wantCyclic:    true,
+			wantEvery:     false,
+			wantEarly:     true,
+		},
+		{
+			name:          "uncaught throw is not a final path",
+			code:          `function f(x) { if (x) throw x; markHook(); }`,
+			event:         "markHook",
+			wantReachable: true,
+			wantEvery:     true,
+		},
+		{
+			name:          "unreachable",
+			code:          `function f() { return; markHook(); }`,
+			event:         "markHook",
+			wantReachable: false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			graph, locations := buildPathTestGraph(t, testCase.code)
+			analysis := AnalyzePaths(graph)
+			blocks := locations[testCase.event]
+			if len(blocks) != 1 {
+				t.Fatalf("event %q was laid out in %d blocks, want 1", testCase.event, len(blocks))
+			}
+			block := blocks[0]
+			if got := block.Reachable; got != testCase.wantReachable {
+				t.Fatalf("reachable = %v, want %v", got, testCase.wantReachable)
+			}
+			if !block.Reachable {
+				return
+			}
+			if got := analysis.IsCyclic(block); got != testCase.wantCyclic {
+				t.Errorf("cyclic = %v, want %v", got, testCase.wantCyclic)
+			}
+			if got := analysis.IsOnEveryFinalPath(block); got != testCase.wantEvery {
+				t.Errorf("on every final path = %v, want %v", got, testCase.wantEvery)
+			}
+			shortestFinal, hasFinal := analysis.ShortestExitPathFromStart()
+			shortestEvent, reachable := analysis.ShortestPathFromStart(block)
+			gotEarly := hasFinal && reachable && shortestFinal < shortestEvent
+			if analysis.IsExit(block) {
+				gotEarly = hasFinal && reachable && shortestFinal <= shortestEvent
+			}
+			gotEarly = gotEarly && !analysis.IsOnEveryFinalPath(block)
+			if gotEarly != testCase.wantEarly {
+				t.Errorf("early final = %v (final=%d, event=%d), want %v", gotEarly, shortestFinal, shortestEvent, testCase.wantEarly)
+			}
+		})
+	}
+}
+
+func TestPossibleThrowThroughFinallyIsExcluded(t *testing.T) {
+	t.Parallel()
+	graph, locations := buildPathTestGraph(t, `
+		function f() {
+			try {
+				mayThrow();
+				markInside();
+			} finally {
+				cleanup();
+			}
+			markAfter();
+		}
+	`)
+	analysis := AnalyzePaths(graph)
+	if !analysis.IsOnEveryFinalPath(locations["markInside"][0]) {
+		t.Fatal("the thrown path that bypasses markInside should not count as a final path")
+	}
+	if !analysis.IsOnEveryFinalPath(locations["markAfter"][0]) {
+		t.Fatal("a possible throw through finally should rejoin before markAfter")
+	}
+}
+
+func TestYieldDoesNotHideLoopBackEdge(t *testing.T) {
+	t.Parallel()
+	graph, locations := buildPathTestGraph(t, `
+		function* f(condition) {
+			while (condition) {
+				markHook();
+				yield condition;
+			}
+		}
+	`)
+	block := locations["markHook"][0]
+	if analysis := AnalyzePaths(graph); !analysis.IsCyclic(block) {
+		t.Fatal("a resumable yield must not hide the loop back edge")
+	}
+}
+
+func TestFinalPathCountSaturates(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name string
+		code string
+		want bool
+	}{
+		{name: "return", code: `function f() { return; }`, want: true},
+		{name: "throw", code: `function f() { throw value; }`, want: false},
+		{name: "continue plus loop exit", code: `function f(x) { while (x) { continue; } }`, want: true},
+		{name: "break plus loop exit", code: `function f(x) { while (x) { break; } }`, want: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			graph, _ := buildPathTestGraph(t, testCase.code)
+			if got := AnalyzePaths(graph).HasSingleFinalPath(); got != testCase.want {
+				t.Fatalf("single final path = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestPathAnalysisRejectsProvisionallyReachableLayout(t *testing.T) {
+	t.Parallel()
+	graph, locations := buildPathTestGraph(t, `
+		function f(condition) {
+			for (; condition; markHook()) {
+				return;
+			}
+		}
+	`)
+	block := locations["markHook"][0]
+	if !block.Reachable {
+		t.Fatal("the incrementor should be provisionally reachable while it is laid out")
+	}
+	if _, reachable := AnalyzePaths(graph).ShortestPathFromStart(block); reachable {
+		t.Fatal("the incrementor should have no actual path from the graph entry")
+	}
+}
+
+func buildPathTestGraph(t *testing.T, code string) (*Graph[string], map[string][]*Block[string]) {
+	t.Helper()
+	source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, code, core.ScriptKindTS)
+	var root *ast.Node
+	source.AsNode().ForEachChild(func(node *ast.Node) bool {
+		if ast.IsFunctionLike(node) {
+			root = node
+			return true
+		}
+		return false
+	})
+	if root == nil {
+		t.Fatal("test source has no function root")
+	}
+
+	graph := Build(root, Hooks[string]{
+		Expression: func(builder *Builder[string], node *ast.Node) {
+			if node.Kind != ast.KindCallExpression {
+				return
+			}
+			callee := node.AsCallExpression().Expression
+			if callee != nil && callee.Kind == ast.KindIdentifier {
+				name := callee.AsIdentifier().Text
+				if len(name) >= 4 && name[:4] == "mark" {
+					builder.Emit(name)
+				}
+			}
+		},
+	})
+	locations := make(map[string][]*Block[string])
+	for _, block := range graph.Blocks {
+		for _, event := range block.Events {
+			locations[event] = append(locations[event], block)
+		}
+	}
+	return graph, locations
+}

--- a/internal/utils/cfg/statements.go
+++ b/internal/utils/cfg/statements.go
@@ -141,24 +141,22 @@ func (b *Builder[E]) variableDeclaration(node *ast.Node) {
 
 func (b *Builder[E]) ifStatement(node *ast.Node) {
 	stmt := node.AsIfStatement()
-	b.expr(stmt.Expression)
-	testEnd := b.cur
 	after := b.newBlock()
-
 	thenEntry := b.newBlock()
-	b.link(testEnd, thenEntry)
+	elseEntry := after
+	if stmt.ElseStatement != nil {
+		elseEntry = b.newBlock()
+	}
+	b.condition(stmt.Expression, thenEntry, elseEntry)
+
 	b.enter(thenEntry)
 	b.statement(stmt.ThenStatement)
 	b.link(b.cur, after)
 
 	if stmt.ElseStatement != nil {
-		elseEntry := b.newBlock()
-		b.link(testEnd, elseEntry)
 		b.enter(elseEntry)
 		b.statement(stmt.ElseStatement)
 		b.link(b.cur, after)
-	} else {
-		b.link(testEnd, after)
 	}
 
 	b.enter(after)
@@ -169,15 +167,13 @@ func (b *Builder[E]) whileStatement(node *ast.Node) {
 	test := b.newBlock()
 	b.link(b.cur, test)
 	b.enter(test)
-	b.expr(stmt.Expression)
-	testEnd := b.cur
-
 	after := b.newBlock()
-	if !isAlwaysTruthyTest(stmt.Expression) {
-		b.link(testEnd, after)
-	}
 	body := b.newBlock()
-	b.link(testEnd, body)
+	falseEntry := after
+	if isAlwaysTruthyTest(stmt.Expression) {
+		falseEntry = nil
+	}
+	b.condition(stmt.Expression, body, falseEntry)
 
 	b.pushJump(node, after, test, node)
 	b.enter(body)
@@ -224,21 +220,34 @@ func (b *Builder[E]) forStatement(node *ast.Node) {
 			b.expr(stmt.Initializer)
 		}
 	}
+	if stmt.Condition == nil && stmt.Incrementor == nil {
+		// ESLint keeps the body of `for (;;) { ... }` on the loop-header
+		// segment itself. Model that shape as one self-looping block: events at
+		// the top of the body stay on the repeated header, while a branch in the
+		// body still creates later blocks that cycle analysis can identify.
+		body := b.newBlock()
+		b.link(b.cur, body)
+		after := b.newBlock()
+		b.pushJump(node, after, body, node)
+		b.enter(body)
+		b.statement(stmt.Statement)
+		b.loop(node)
+		b.link(b.cur, body)
+		b.popJump()
+		b.enter(after)
+		return
+	}
 
 	test := b.newBlock()
 	b.link(b.cur, test)
 	b.enter(test)
-	if stmt.Condition != nil {
-		b.expr(stmt.Condition)
-	}
-	testEnd := b.cur
-
 	after := b.newBlock()
-	if stmt.Condition != nil && !isAlwaysTruthyTest(stmt.Condition) {
-		b.link(testEnd, after)
-	}
 	body := b.newBlock()
-	b.link(testEnd, body)
+	falseEntry := after
+	if stmt.Condition == nil || isAlwaysTruthyTest(stmt.Condition) {
+		falseEntry = nil
+	}
+	b.condition(stmt.Condition, body, falseEntry)
 
 	// The incrementor runs after the body and is laid out before it, so a body
 	// that always leaves abruptly does not make it unreachable and lose the
@@ -317,38 +326,59 @@ func (b *Builder[E]) switchStatement(node *ast.Node) {
 	}
 
 	bodies := make([]*Block[E], len(clauses))
+	dispatchFrom := make([]*Block[E], len(clauses))
+	dispatchEdge := make([]int, len(clauses))
+	for i := range dispatchEdge {
+		dispatchEdge[i] = -1
+	}
 	for i := range clauses {
 		bodies[i] = b.newBlock()
 	}
 
 	defaultIndex := -1
+	firstCaseIndex := -1
 	testCur := b.cur
 	for i, clause := range clauses {
 		if clause.Kind == ast.KindDefaultClause {
 			defaultIndex = i
 			continue
 		}
+		if firstCaseIndex == -1 {
+			firstCaseIndex = i
+		}
 		b.cur = testCur
 		b.expr(clause.AsCaseOrDefaultClause().Expression)
-		b.link(b.cur, bodies[i])
+		dispatchFrom[i] = b.cur
+		dispatchEdge[i] = b.linkWithCycleBarrier(b.cur, bodies[i], false)
 		nextTest := b.newBlock()
 		b.link(b.cur, nextTest)
 		b.enter(nextTest)
 		testCur = b.cur
 	}
 	if defaultIndex >= 0 {
-		b.link(testCur, bodies[defaultIndex])
+		dispatchFrom[defaultIndex] = testCur
+		dispatchEdge[defaultIndex] = b.linkWithCycleBarrier(testCur, bodies[defaultIndex], false)
 	} else {
 		b.link(testCur, after)
 	}
 
 	b.pushJump(node, after, nil, nil)
+	switchJump := len(b.jumps) - 1
+	hadSwitchBreak := false
 	var fallthroughFrom *Block[E]
 	for i, clause := range clauses {
-		b.link(fallthroughFrom, bodies[i])
+		beforeFirstCase := firstCaseIndex == -1 || clause.Kind == ast.KindDefaultClause && i < firstCaseIndex
+		barrier := hadSwitchBreak || beforeFirstCase
+		if from := dispatchFrom[i]; from != nil && dispatchEdge[i] >= 0 {
+			b.setCycleBarrier(from, dispatchEdge[i], barrier)
+		}
+		b.linkWithCycleBarrier(fallthroughFrom, bodies[i], barrier)
 		b.enter(bodies[i])
 		b.statements(clause.AsCaseOrDefaultClause().Statements)
 		fallthroughFrom = b.cur
+		if i >= firstCaseIndex && firstCaseIndex != -1 {
+			hadSwitchBreak = b.jumps[switchJump].broken
+		}
 	}
 	b.link(fallthroughFrom, after)
 	b.popJump()
@@ -408,6 +438,9 @@ func (b *Builder[E]) tryStatement(node *ast.Node) {
 	for _, end := range normalEnds {
 		b.link(end, normalEntry)
 	}
+	for _, source := range frame.implicit {
+		b.link(source, normalEntry)
+	}
 	b.enter(normalEntry)
 	b.statement(stmt.FinallyBlock)
 	b.link(b.cur, after)
@@ -428,6 +461,8 @@ func (b *Builder[E]) tryStatement(node *ast.Node) {
 					outer := b.tryStack[i]
 					outer.returnedAny = true
 					b.link(b.cur, outer.finallyEntry)
+				} else {
+					b.markFinal(b.cur)
 				}
 			}
 			if frame.thrownAny {
@@ -435,6 +470,8 @@ func (b *Builder[E]) tryStatement(node *ast.Node) {
 					outer := b.tryStack[i]
 					outer.thrownAny = true
 					b.link(b.cur, throwTarget(outer))
+				} else {
+					b.markThrown(b.cur)
 				}
 			}
 		}
@@ -484,6 +521,7 @@ func (b *Builder[E]) makeBreak(label *ast.Node) {
 		} else if !slices.Contains(target.labels, name) {
 			continue
 		}
+		b.jumps[i].broken = true
 		b.link(b.cur, target.breakTo)
 		break
 	}
@@ -520,6 +558,8 @@ func (b *Builder[E]) makeReturn() {
 		frame := b.tryStack[i]
 		frame.returnedAny = true
 		b.link(b.cur, frame.finallyEntry)
+	} else {
+		b.markFinal(b.cur)
 	}
 	b.makeUnreachable()
 }
@@ -532,6 +572,8 @@ func (b *Builder[E]) makeThrow() {
 		frame := b.tryStack[i]
 		frame.thrownAny = true
 		b.link(b.cur, throwTarget(frame))
+	} else {
+		b.markThrown(b.cur)
 	}
 	b.makeUnreachable()
 }
@@ -547,11 +589,15 @@ func (b *Builder[E]) makeYield() {
 		frame := b.tryStack[i]
 		frame.returnedAny = true
 		b.link(b.cur, frame.finallyEntry)
+	} else {
+		b.markFinal(b.cur)
 	}
 	if i := b.throwFrame(); i >= 0 {
 		frame := b.tryStack[i]
 		frame.thrownAny = true
 		b.link(b.cur, throwTarget(frame))
+	} else {
+		b.markThrown(b.cur)
 	}
 	next := b.newBlock()
 	b.link(b.cur, next)


### PR DESCRIPTION
## Summary

- Align `react-hooks/rules-of-hooks` diagnostics with the latest stable `eslint-plugin-react-hooks@7.1.1`, including typed binding names and computed object keys.
- Replace rule-private control-flow heuristics with reusable path analysis in `internal/utils/cfg`, and improve the shared CFG for short-circuit loop conditions, switch cycles, abrupt exits, and try/finally layouts.
- Add regression coverage; validate all 20 physical files from the reported audit with exact severity, range, and message parity.

## Related Links

- https://github.com/facebook/react/blob/eslint-plugin-react-hooks%407.1.1/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts

## Verification

- Targeted Go tests for the changed rule, shared CFG, and every CFG consumer
- Targeted JS `rules-of-hooks` test: 0 snapshot changes
- `check-spell`, `format:check`, and Go lint limited to changed packages
- Audit replay: 20/20 files and 69/69 diagnostics match ESLint 9.39.0 with plugin 7.1.1

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).