### PR TITLE
ci: probe the Windows Go test runner and cap its GOMAXPROCS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,47 +64,10 @@ jobs:
 
       - name: Unit Test (Windows)
         if: matrix.runner == 'rspack-windows-2022-large'
-        shell: pwsh
+        run: go test -count=1 ./cmd/... ./internal/...
         env:
           # The container sees the shared host's cores; that much concurrency only thrashes.
-          GOMAXPROCS: 16
-        run: |
-          Write-Host "== Machine =="
-          Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer, Model, NumberOfProcessors, NumberOfLogicalProcessors, TotalPhysicalMemory, HypervisorPresent | Format-List
-          Get-CimInstance Win32_OperatingSystem | Select-Object Caption, TotalVisibleMemorySize, FreePhysicalMemory, TotalVirtualMemorySize, FreeVirtualMemory, LastBootUpTime | Format-List
-
-          Write-Host "== Load before the run =="
-          Get-CimInstance Win32_PerfFormattedData_PerfOS_System | Select-Object Processes, Threads, ProcessorQueueLength, ContextSwitchesPersec | Format-List
-          Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory | Select-Object CommittedBytes, CommitLimit, PercentCommittedBytesInUse, AvailableBytes | Format-List
-
-          Write-Host "== What Go sees =="
-          $probe = Join-Path $env:RUNNER_TEMP 'cpuprobe'
-          New-Item -ItemType Directory -Force -Path $probe | Out-Null
-          Set-Content -Path (Join-Path $probe 'main.go') -Value 'package main; import ("fmt"; "runtime"); func main() { fmt.Printf("NumCPU=%d GOMAXPROCS=%d\n", runtime.NumCPU(), runtime.GOMAXPROCS(0)) }'
-          go -C $probe mod init cpuprobe
-          go -C $probe run .
-
-          $sampler = Start-Job {
-            while ($true) {
-              $sys = Get-CimInstance Win32_PerfFormattedData_PerfOS_System -ErrorAction SilentlyContinue
-              $mem = Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory -ErrorAction SilentlyContinue
-              $cpu = Get-CimInstance Win32_PerfFormattedData_PerfOS_Processor -Filter "Name='_Total'" -ErrorAction SilentlyContinue
-              '{0} cpu={1}% queue={2} threads={3} processes={4} committedMB={5}' -f (Get-Date -Format HH:mm:ss), $cpu.PercentProcessorTime, $sys.ProcessorQueueLength, $sys.Threads, $sys.Processes, [int]($mem.CommittedBytes / 1MB)
-              Start-Sleep -Seconds 10
-            }
-          }
-
-          $code = 1
-          try {
-            go test -count=1 ./cmd/... ./internal/...
-            $code = $LASTEXITCODE
-          } finally {
-            Stop-Job $sampler
-            Write-Host "== Load during the run =="
-            Receive-Job $sampler
-            Remove-Job $sampler -Force
-          }
-          exit $code
+          GOMAXPROCS: 8
 
       # Fallback for any runner without a dedicated step above.
       - name: Unit Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,35 +70,42 @@ jobs:
           # The container sees the shared host's cores; that much concurrency only thrashes.
           GOMAXPROCS: 16
         run: |
-          # The Windows runner can exhaust its commit limit with up to 64
-          # package builds/test binaries in flight. Keep every package and
-          # test, but cap inter-package concurrency to bound peak memory use.
-          $packageParallelism = 32
+          Write-Host "== Machine =="
+          Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer, Model, NumberOfProcessors, NumberOfLogicalProcessors, TotalPhysicalMemory, HypervisorPresent | Format-List
+          Get-CimInstance Win32_OperatingSystem | Select-Object Caption, TotalVisibleMemorySize, FreePhysicalMemory, TotalVirtualMemorySize, FreeVirtualMemory, LastBootUpTime | Format-List
 
-          # Pre-build shared dependencies to warm the build cache
-          go build -p $packageParallelism ./cmd/... ./internal/...
+          Write-Host "== Load before the run =="
+          Get-CimInstance Win32_PerfFormattedData_PerfOS_System | Select-Object Processes, Threads, ProcessorQueueLength, ContextSwitchesPersec | Format-List
+          Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory | Select-Object CommittedBytes, CommitLimit, PercentCommittedBytesInUse, AvailableBytes | Format-List
 
-          $packages = go list ./cmd/... ./internal/... | Where-Object { $_ -ne "" }
-          $batchSize = 64
-          $batch = @()
+          Write-Host "== What Go sees =="
+          $probe = Join-Path $env:RUNNER_TEMP 'cpuprobe'
+          New-Item -ItemType Directory -Force -Path $probe | Out-Null
+          Set-Content -Path (Join-Path $probe 'main.go') -Value 'package main; import ("fmt"; "runtime"); func main() { fmt.Printf("NumCPU=%d GOMAXPROCS=%d\n", runtime.NumCPU(), runtime.GOMAXPROCS(0)) }'
+          go -C $probe mod init cpuprobe
+          go -C $probe run .
 
-          foreach ($pkg in $packages) {
-            $batch += $pkg
-
-            if ($batch.Count -ge $batchSize) {
-              Write-Host "Running batch of $($batch.Count) packages..."
-              go test -p $packageParallelism -count=1 $batch
-              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-              $batch = @()
+          $sampler = Start-Job {
+            while ($true) {
+              $sys = Get-CimInstance Win32_PerfFormattedData_PerfOS_System -ErrorAction SilentlyContinue
+              $mem = Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory -ErrorAction SilentlyContinue
+              $cpu = Get-CimInstance Win32_PerfFormattedData_PerfOS_Processor -Filter "Name='_Total'" -ErrorAction SilentlyContinue
+              '{0} cpu={1}% queue={2} threads={3} processes={4} committedMB={5}' -f (Get-Date -Format HH:mm:ss), $cpu.PercentProcessorTime, $sys.ProcessorQueueLength, $sys.Threads, $sys.Processes, [int]($mem.CommittedBytes / 1MB)
+              Start-Sleep -Seconds 10
             }
           }
 
-          # Run remaining packages
-          if ($batch.Count -gt 0) {
-            Write-Host "Running final batch of $($batch.Count) packages..."
-            go test -p $packageParallelism -count=1 $batch
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $code = 1
+          try {
+            go test -count=1 ./cmd/... ./internal/...
+            $code = $LASTEXITCODE
+          } finally {
+            Stop-Job $sampler
+            Write-Host "== Load during the run =="
+            Receive-Job $sampler
+            Remove-Job $sampler -Force
           }
+          exit $code
 
       # Fallback for any runner without a dedicated step above.
       - name: Unit Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - rspack-ubuntu-22.04-large
-          - rspack-darwin-15.6.1-medium
+          # TEMP (probe): Linux and macOS dropped so this run only burns the Windows runner.
           - rspack-windows-2022-large
         go-version: ['1.26.0']
     steps:
@@ -113,6 +112,7 @@ jobs:
         run: go test -count=1 ./cmd/... ./internal/...
 
   lint:
+    if: false # TEMP (probe): disabled, only the Windows Go test job runs.
     name: Lint&Check
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -146,6 +146,7 @@ jobs:
         run: pnpm check-spell
 
   test-node:
+    if: false # TEMP (probe): disabled, only the Windows Go test job runs.
     name: Test npm packages
     runs-on: ${{ matrix.os }}
     strategy:
@@ -215,6 +216,7 @@ jobs:
         run: xvfb-run -a pnpm run test
 
   test-node-windows:
+    if: false # TEMP (probe): disabled, only the Windows Go test job runs.
     name: Test npm packages (rspack-windows-2022-large)
     runs-on: rspack-windows-2022-large
     steps:
@@ -283,6 +285,7 @@ jobs:
           if-no-files-found: error
 
   test-vscode-windows:
+    if: false # TEMP (probe): disabled, only the Windows Go test job runs.
     name: Test vscode-extension (windows-latest)
     runs-on: windows-latest
     needs: test-node-windows
@@ -339,6 +342,7 @@ jobs:
         run: pnpm --filter rslint test
 
   test-wasm:
+    if: false # TEMP (probe): disabled, only the Windows Go test job runs.
     name: Test WASM
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -364,6 +368,7 @@ jobs:
           pnpm --filter '@rslint/core' build:js
           pnpm --filter '@rslint/wasm' build
   test-rust:
+    if: false # TEMP (probe): disabled, only the Windows Go test job runs.
     name: Test Rust
     runs-on: ${{ matrix.os }}
     strategy:
@@ -428,7 +433,7 @@ jobs:
       - lint
       - test-wasm
       - test-rust
-    if: always()
+    if: false # TEMP (probe): disabled, only the Windows Go test job runs.
     runs-on: rspack-ubuntu-22.04-mini
     name: CI Done
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Unit Test (Windows)
         if: matrix.runner == 'rspack-windows-2022-large'
         shell: pwsh
+        env:
+          # The container sees the shared host's cores; that much concurrency only thrashes.
+          GOMAXPROCS: 16
         run: |
           # The Windows runner can exhaust its commit limit with up to 64
           # package builds/test binaries in flight. Keep every package and


### PR DESCRIPTION
Same suspicion as #1796, now on Windows: the runner is a container on a shared host, so Go reads the host's core count and sizes both `-p` and its scheduler for cores the job does not get. The batching loop caps package concurrency at 32 but cannot bound the thread count inside each test binary.

This caps GOMAXPROCS at 16, replaces the batched loop with a single `go test -count=1 ./cmd/... ./internal/...`, and logs what the runner actually is: logical processors, memory and commit limit, process/thread counts, Go's own `NumCPU`/`GOMAXPROCS`, plus a CPU/queue/threads/commit sample every 10s during the run.

Every other job is disabled and the Go matrix is trimmed to Windows, so a run costs one runner. Both are marked `TEMP (probe)` and come out before this merges.
