### PR TITLE
perf(rstest): optimize expect-expect rule

### DIFF
--- a/internal/plugins/rstest/rules/expect_expect/expect_expect.go
+++ b/internal/plugins/rstest/rules/expect_expect/expect_expect.go
@@ -41,8 +41,8 @@ var ExpectExpectRule = shared.NewRule(shared.Config{
 		return shared.Runtime{
 			IsAssertion: isAssertion,
 			ClassifyTest: func(node *ast.Node) shared.TestClassification {
-				parsed := analysis.ParseFnCall(node)
-				if parsed == nil || parsed.Kind != rstestUtils.RstestFnTypeTest {
+				parsed := analysis.ParseTestCall(node)
+				if parsed == nil {
 					return shared.TestClassification{}
 				}
 				// Todo is a semantic field that survives const aliases; the

--- a/internal/plugins/rstest/rules/expect_expect/expect_expect_test.go
+++ b/internal/plugins/rstest/rules/expect_expect/expect_expect_test.go
@@ -104,6 +104,15 @@ test("case", () => {});`},
 				Code:    `foo.todo("eventual test");`,
 				Options: []interface{}{map[string]interface{}{"additionalTestBlockFunctions": []interface{}{"foo.todo"}}},
 			},
+			// An empty additionalTestBlockFunctions entry is an accepted config
+			// (the option's items carry no minLength). It must not turn calls
+			// CalleeChainName cannot name into reported test blocks.
+			{
+				Code: `arr[0](); obj[key](); (arr[0] ?? obj[key])();`,
+				Options: []interface{}{map[string]interface{}{
+					"additionalTestBlockFunctions": []interface{}{""},
+				}},
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			{

--- a/internal/utils/test_framework/rules/expect_expect/expect_expect.go
+++ b/internal/utils/test_framework/rules/expect_expect/expect_expect.go
@@ -436,7 +436,11 @@ func NewRule(config Config) rule.Rule {
 					calleeName := ""
 					if len(additionalTestBlockSet) > 0 {
 						calleeName = testFramework.CalleeChainName(callExpr.Expression)
-						if _, ok := additionalTestBlockSet[calleeName]; ok {
+						// CalleeChainName returns "" for every callee it cannot name
+						// (`arr[i]()`, `obj[key]()`, `(a ?? b)()`). The option's items
+						// carry no minLength, so a configured "" would otherwise turn
+						// each of those ordinary calls into a reported test block.
+						if _, ok := additionalTestBlockSet[calleeName]; ok && calleeName != "" {
 							if strings.HasSuffix(calleeName, ".todo") {
 								return
 							}

--- a/internal/utils/test_framework/rules/expect_expect/expect_expect.go
+++ b/internal/utils/test_framework/rules/expect_expect/expect_expect.go
@@ -76,6 +76,17 @@ type Config struct {
 	Prepare func(ctx rule.RuleContext) Runtime
 }
 
+type assertPattern struct {
+	re           *esregexp.RegExp
+	asciiLiteral string
+	asciiRoot    string
+}
+
+type assertMatcher struct {
+	patterns    []assertPattern
+	hasFallback bool
+}
+
 func buildErrorNoAssertionsMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "noAssertions",
@@ -112,12 +123,50 @@ func stringList(raw []interface{}) []string {
 	return out
 }
 
-func compileAssertPatterns(patterns []string) []*esregexp.RegExp {
-	out := make([]*esregexp.RegExp, 0, len(patterns))
+func compileAssertPatterns(patterns []string) assertMatcher {
+	matcher := assertMatcher{patterns: make([]assertPattern, 0, len(patterns))}
 	for _, p := range patterns {
-		out = append(out, compileAssertPattern(p))
+		compiled := assertPattern{re: compileAssertPattern(p)}
+		if isASCIILiteralAssertPattern(p) {
+			compiled.asciiLiteral = p
+			compiled.asciiRoot = p
+			if dot := strings.IndexByte(p, '.'); dot >= 0 {
+				compiled.asciiRoot = p[:dot]
+			}
+		} else {
+			matcher.hasFallback = true
+		}
+		matcher.patterns = append(matcher.patterns, compiled)
 	}
-	return out
+	return matcher
+}
+
+// isASCIILiteralAssertPattern recognizes the overwhelmingly common option
+// shape (`expect`, `assert`, `expectSaga`, or a dotted identifier chain). Its
+// regexp is an anchored, case-insensitive literal prefix followed by a dot or
+// the end of the callee name, so ASCII callees can be answered without entering
+// the backtracking regexp engine. Patterns with wildcards, regexp syntax, `$`,
+// or non-ASCII text keep the JavaScript regexp path unchanged.
+func isASCIILiteralAssertPattern(pattern string) bool {
+	if pattern == "" {
+		return false
+	}
+	segmentLength := 0
+	for i := range len(pattern) {
+		c := pattern[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '_':
+			segmentLength++
+		case c == '.' && segmentLength > 0:
+			segmentLength = 0
+		default:
+			return false
+		}
+	}
+	return segmentLength > 0
 }
 
 func compileAssertPattern(pattern string) *esregexp.RegExp {
@@ -141,16 +190,82 @@ func compileAssertPattern(pattern string) *esregexp.RegExp {
 	return re
 }
 
-func matchesAssertName(name string, compiled []*esregexp.RegExp) bool {
+func (matcher assertMatcher) matches(name string) bool {
 	if name == "" {
 		return false
 	}
-	for _, re := range compiled {
-		if re != nil && re.TestOrTimeout(name) {
+	ascii := isASCII(name)
+	for _, pattern := range matcher.patterns {
+		if ascii && pattern.asciiLiteral != "" {
+			if hasASCIIFoldedPrefix(name, pattern.asciiLiteral) {
+				return true
+			}
+			continue
+		}
+		if pattern.re != nil && pattern.re.TestOrTimeout(name) {
 			return true
 		}
 	}
 	return false
+}
+
+// mayMatchCallee rejects an ordinary call from the configured-pattern path by
+// looking only at its first identifier. It is deliberately conservative: a
+// dynamic root, non-ASCII root, or any non-literal pattern falls back to the
+// full callee-name construction and regexp match.
+func (matcher assertMatcher) mayMatchCallee(expr *ast.Node) bool {
+	if matcher.hasFallback {
+		return true
+	}
+	root := testFramework.ResolveFirstIdentifier(expr)
+	if root == nil || root.Kind != ast.KindIdentifier {
+		return true
+	}
+	name := root.AsIdentifier().Text
+	if !isASCII(name) {
+		return true
+	}
+	for _, pattern := range matcher.patterns {
+		if asciiEqualFold(name, pattern.asciiRoot) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasASCIIFoldedPrefix(name string, prefix string) bool {
+	if len(name) < len(prefix) || !asciiEqualFold(name[:len(prefix)], prefix) {
+		return false
+	}
+	return len(name) == len(prefix) || name[len(prefix)] == '.'
+}
+
+func asciiEqualFold(left string, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range len(left) {
+		a, b := left[i], right[i]
+		if a >= 'A' && a <= 'Z' {
+			a += 'a' - 'A'
+		}
+		if b >= 'A' && b <= 'Z' {
+			b += 'a' - 'A'
+		}
+		if a != b {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCII(value string) bool {
+	for i := range len(value) {
+		if value[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 func indexUnchecked(unchecked []*ast.Node, call *ast.Node) int {
@@ -265,13 +380,21 @@ func checkCallExpressionUsed(
 }
 
 func NewRule(config Config) rule.Rule {
+	defaultMatcher := compileAssertPatterns(config.DefaultAssertFunctionNames)
 	return rule.Rule{
 		Name:   config.Name,
 		Schema: rule.NewSchema(schemaJSON),
 		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 			runtime := config.Prepare(ctx)
 			assertNames, additionalTestBlocks := parseOptions(options, config.DefaultAssertFunctionNames)
-			compiled := compileAssertPatterns(assertNames)
+			matcher := defaultMatcher
+			if !slices.Equal(assertNames, config.DefaultAssertFunctionNames) {
+				matcher = compileAssertPatterns(assertNames)
+			}
+			additionalTestBlockSet := make(map[string]struct{}, len(additionalTestBlocks))
+			for _, name := range additionalTestBlocks {
+				additionalTestBlockSet[name] = struct{}{}
+			}
 			var unchecked []*ast.Node
 			uncheckedByDecl := map[*ast.Node][]*ast.Node{}
 			uncheckedByName := map[string][]*ast.Node{}
@@ -285,20 +408,15 @@ func NewRule(config Config) rule.Rule {
 						return
 					}
 
-					calleeName := testFramework.CalleeChainName(callExpr.Expression)
-
 					classification := TestClassification{}
 					if runtime.ClassifyTest != nil {
 						classification = runtime.ClassifyTest(node)
 					}
-					isTest := classification.IsTest
-					isExtraBlock := calleeName != "" && slices.Contains(additionalTestBlocks, calleeName)
-
-					if isTest || isExtraBlock {
-						if classification.IsTodo || strings.HasSuffix(calleeName, ".todo") {
+					if classification.IsTest {
+						if classification.IsTodo {
 							return
 						}
-						if isTest && runtime.ResolveNamedCallback != nil {
+						if runtime.ResolveNamedCallback != nil {
 							named := runtime.ResolveNamedCallback(node)
 							if named.DeclarationNode != nil && assertedByDecl[named.DeclarationNode] ||
 								named.DeclarationNode == nil && named.Name != "" && assertedByName[named.Name] {
@@ -315,11 +433,26 @@ func NewRule(config Config) rule.Rule {
 						return
 					}
 
+					calleeName := ""
+					if len(additionalTestBlockSet) > 0 {
+						calleeName = testFramework.CalleeChainName(callExpr.Expression)
+						if _, ok := additionalTestBlockSet[calleeName]; ok {
+							if strings.HasSuffix(calleeName, ".todo") {
+								return
+							}
+							unchecked = append(unchecked, node)
+							return
+						}
+					}
+
 					// Assertions are the union of the configured name patterns and
 					// whatever the framework can resolve; patterns run first because
 					// they answer the overwhelmingly common bare `expect(...)`
 					// without touching the framework analysis.
-					if !matchesAssertName(calleeName, compiled) &&
+					if calleeName == "" && matcher.mayMatchCallee(callExpr.Expression) {
+						calleeName = testFramework.CalleeChainName(callExpr.Expression)
+					}
+					if !matcher.matches(calleeName) &&
 						(runtime.IsAssertion == nil || !runtime.IsAssertion(node)) {
 						return
 					}

--- a/internal/utils/test_framework/rules/expect_expect/expect_expect_test.go
+++ b/internal/utils/test_framework/rules/expect_expect/expect_expect_test.go
@@ -1,0 +1,98 @@
+package expect_expect
+
+import "testing"
+
+func TestAssertMatcherLiteralFastPath(t *testing.T) {
+	matcher := compileAssertPatterns([]string{"expect", "assert.equal"})
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "expect", want: true},
+		{name: "EXPECT.toBe", want: true},
+		{name: "expectSaga", want: false},
+		{name: "assert.equal", want: true},
+		{name: "assert.equal.deep", want: true},
+		{name: "assert.notEqual", want: false},
+	}
+
+	for _, test := range tests {
+		if got := matcher.matches(test.name); got != test.want {
+			t.Errorf("matches(%q) = %t, want %t", test.name, got, test.want)
+		}
+	}
+}
+
+func TestAssertMatcherLiteralFastPathMatchesRegexp(t *testing.T) {
+	patterns := []string{
+		"expect",
+		"assert.equal",
+		"expectSaga",
+		"foo_1.bar2",
+		"A.B.C",
+	}
+	names := []string{
+		"",
+		"expect",
+		"EXPECT",
+		"expect.toBe",
+		"expected",
+		"assert",
+		"assert.equal",
+		"ASSERT.EQUAL.deep",
+		"assert.equality",
+		"expectSaga",
+		"expectSaga.returns",
+		"foo_1.bar2",
+		"foo_1.bar2.baz",
+		"a.b.c",
+		"a.b.cd",
+		"K.matcher",
+		"ſ.matcher",
+	}
+
+	for _, pattern := range patterns {
+		matcher := compileAssertPatterns([]string{pattern})
+		if matcher.hasFallback {
+			t.Fatalf("literal pattern %q unexpectedly disabled the fast path", pattern)
+		}
+		re := compileAssertPattern(pattern)
+		for _, name := range names {
+			want := name != "" && re.TestOrTimeout(name)
+			if got := matcher.matches(name); got != want {
+				t.Errorf("pattern %q, name %q: fast path = %t, regexp = %t", pattern, name, got, want)
+			}
+		}
+	}
+}
+
+func TestAssertMatcherKeepsJavaScriptUnicodeCaseFolding(t *testing.T) {
+	matcher := compileAssertPatterns([]string{"k"})
+	if !matcher.matches("K.matcher") {
+		t.Error("literal fast path did not fall back to /iu matching for a non-ASCII callee")
+	}
+}
+
+func TestAssertMatcherWildcardFallback(t *testing.T) {
+	matcher := compileAssertPatterns([]string{"request.**.expect"})
+	if !matcher.matches("request.get.foo.expect") {
+		t.Error("wildcard pattern did not use the regexp fallback")
+	}
+}
+
+func TestAssertMatcherCandidateGate(t *testing.T) {
+	matcher := compileAssertPatterns([]string{"expect", "assert.equal"})
+	if matcher.hasFallback {
+		t.Fatal("literal patterns unexpectedly disabled the candidate gate")
+	}
+	for _, pattern := range matcher.patterns {
+		if pattern.asciiRoot == "" {
+			t.Fatalf("literal pattern %#v has no candidate root", pattern)
+		}
+	}
+
+	wildcard := compileAssertPatterns([]string{"expect*"})
+	if !wildcard.hasFallback {
+		t.Fatal("wildcard pattern must keep the conservative fallback")
+	}
+}


### PR DESCRIPTION
## Summary

- Compile the default assertion matchers once per rule instead of once per file.
- Add an ASCII-literal fast path for common assertion names such as `expect` and `assert`, while preserving the existing JavaScript `/iu` regexp behavior for Unicode, wildcard, escaped, and other regexp-compatible patterns.
- Add a conservative callee-root guard so unrelated calls skip full callee-chain construction and regexp matching.
- Build callee chains for `additionalTestBlockFunctions` only when the option is configured, and use a set for membership checks.
- Use the test-specific `ParseTestCall` path when classifying Rstest registrations.
- Add focused and differential tests covering prefix boundaries, case-insensitive matching, Unicode case folding, dotted assertion names, and regexp fallback behavior.

## Performance

Measured with `--timing all` while running the same 15 Rstest rules over all `*.test.*`, `*.spec.*`, and configured in-source test files in six Rstack repositories. Each result is the median `rstest/expect-expect` rule time from nine runs alternating with the same `7b4c4f95` baseline. The benchmark covers 1,972 files in total.

The complete JSONL diagnostics were identical before and after the optimization across all six repositories, covering 528 diagnostics.

| Repository | Test Files | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Rspack | 147 | 3.4ms | 0.9ms | 3.78× |
| Rsbuild | 629 | 36.4ms | 21.3ms | 1.71× |
| Rslib | 113 | 5.3ms | 2.3ms | 2.30× |
| Rspress | 134 | 10.8ms | 6.9ms | 1.57× |
| Rsdoctor | 89 | 3.7ms | 2.0ms | 1.85× |
| Rstest | 860 | 58.9ms | 21.7ms | 2.71× |
| **Combined** | **1,972** | **118.5ms** | **55.1ms** | **2.15×** |

`expect-expect` runs first and is therefore charged for constructing the shared file-scoped `RstestCallAnalysis`, so these figures include that one-time cost.
