### PR TITLE
fix: remove no-undef from JavaScript recommended preset

### DIFF
--- a/packages/rslint/src/config/presets/javascript.ts
+++ b/packages/rslint/src/config/presets/javascript.ts
@@ -1,6 +1,6 @@
 import type { RslintConfigEntry } from '../define-config.js';
 
-// Based on official eslint:recommended (@eslint/js@10.x), with `no-undef` intentionally omitted.
+// Based on official eslint:recommended (@eslint/js@10.x).
 // Rules commented out with "not implemented" are in the official preset but not yet available.
 const recommended: RslintConfigEntry = {
   rules: {
@@ -31,6 +31,7 @@ const recommended: RslintConfigEntry = {
     'no-setter-return': 'error',
     'no-shadow-restricted-names': 'error',
     'no-this-before-super': 'error',
+    // 'no-undef': 'error', // intentionally omitted
     'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',

--- a/packages/rslint/src/config/presets/javascript.ts
+++ b/packages/rslint/src/config/presets/javascript.ts
@@ -1,6 +1,6 @@
 import type { RslintConfigEntry } from '../define-config.js';
 
-// Aligned with official eslint:recommended (@eslint/js@10.x).
+// Based on official eslint:recommended (@eslint/js@10.x), with `no-undef` intentionally omitted.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
 const recommended: RslintConfigEntry = {
   rules: {
@@ -31,7 +31,6 @@ const recommended: RslintConfigEntry = {
     'no-setter-return': 'error',
     'no-shadow-restricted-names': 'error',
     'no-this-before-super': 'error',
-    'no-undef': 'error',
     'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',

--- a/website/docs/en/api/presets/js.md
+++ b/website/docs/en/api/presets/js.md
@@ -14,4 +14,31 @@ export default defineConfig([js.configs.recommended]);
 | ------------------------ | ---------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `js.configs.recommended` | JavaScript recommended rules | [View rules →](/rules/?preset=js.configs.recommended) | [`@eslint/js` `configs.recommended`](https://eslint.org/docs/v10.x/use/configure/migration-guide#predefined-and-shareable-configs) |
 
+## Differences from ESLint
+
+Unlike the upstream preset, `js.configs.recommended` intentionally omits `no-undef`.
+
+The rule is only accurate when all globals provided by browsers, Node.js, and other environments are declared in the configuration. Because a general-purpose preset cannot know which environments apply to each file, enabling the rule by default would report valid global references until users add the corresponding environment-specific configuration.
+
+To enable this check, declare the globals available to matching files first:
+
+```ts
+import { defineConfig, globals, js } from '@rslint/core';
+
+export default defineConfig([
+  js.configs.recommended,
+  {
+    files: ['src/**/*.{js,jsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+    },
+    rules: {
+      'no-undef': 'error',
+    },
+  },
+]);
+```
+
 See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.

--- a/website/docs/en/api/presets/js.md
+++ b/website/docs/en/api/presets/js.md
@@ -14,6 +14,8 @@ export default defineConfig([js.configs.recommended]);
 | ------------------------ | ---------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `js.configs.recommended` | JavaScript recommended rules | [View rules →](/rules/?preset=js.configs.recommended) | [`@eslint/js` `configs.recommended`](https://eslint.org/docs/v10.x/use/configure/migration-guide#predefined-and-shareable-configs) |
 
+See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.
+
 ## Differences from ESLint
 
 Unlike the upstream preset, `js.configs.recommended` intentionally omits `no-undef`.
@@ -40,5 +42,3 @@ export default defineConfig([
   },
 ]);
 ```
-
-See [Rules & Presets](/config/rules-and-presets) for guidance on choosing and layering presets.


### PR DESCRIPTION
## Summary

The JavaScript recommended preset currently enables `no-undef`, which requires environment-specific globals configuration and can report valid runtime-provided globals. This PR removes the rule from `js.configs.recommended` and documents the difference from ESLint with an explicit opt-in example.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).