### PR TITLE
perf(rstest): optimize valid-expect-in-promise rule

### DIFF
--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
@@ -66,7 +67,7 @@ func sourceMayContainPromiseChain(sourceFile *ast.SourceFile) bool {
 // only costs a walk the caller would otherwise skip, and never hides one.
 func bracketOpensOnParenthesis(text string) bool {
 	for index := strings.IndexByte(text, '['); index >= 0; {
-		if next := skipTrivia(text, index+1); next < len(text) && text[next] == '(' {
+		if next := scanner.SkipTrivia(text, index+1); next < len(text) && text[next] == '(' {
 			return true
 		}
 		offset := strings.IndexByte(text[index+1:], '[')
@@ -76,40 +77,6 @@ func bracketOpensOnParenthesis(text string) bool {
 		index += offset + 1
 	}
 	return false
-}
-
-// skipTrivia returns the first index at or after index that starts neither
-// whitespace nor a comment.
-func skipTrivia(text string, index int) int {
-	for index < len(text) {
-		switch text[index] {
-		case ' ', '\t', '\r', '\n', '\v', '\f':
-			index++
-		case '/':
-			if index+1 >= len(text) {
-				return index
-			}
-			switch text[index+1] {
-			case '/':
-				end := strings.IndexByte(text[index:], '\n')
-				if end < 0 {
-					return len(text)
-				}
-				index += end + 1
-			case '*':
-				end := strings.Index(text[index+2:], "*/")
-				if end < 0 {
-					return len(text)
-				}
-				index += end + 4
-			default:
-				return index
-			}
-		default:
-			return index
-		}
-	}
-	return index
 }
 
 var promiseChainMemberNames = [...]string{"then", "catch", "finally"}

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
@@ -17,35 +17,38 @@ import (
 // `finally` reached either as a property access or as a bracket access keyed by
 // a string or no-substitution template literal.
 //
-// The two forms are gated differently. A property access spells the member as
-// an identifier — a keyword-named property is interned like any other — so the
-// source file's identifier table answers that form exactly and in O(1). It also
-// excludes the `catch` of a `try`/`catch`, which stays a keyword token and never
-// reaches the table; gating on the raw source text instead let every file with a
-// `try`/`catch`, and every file with a backslash, through to the AST walk this
-// function exists to avoid.
+// The source file's identifier table answers nearly every form exactly and in
+// O(1). A property access spells the member as an identifier, and a keyword-named
+// property is interned like any other; the parser also interns the cooked text of
+// a string, no-substitution template or numeric element-access key, so
+// promise["then"](), promise[`finally`]() and the escaped promise["\x74hen"]()
+// put the member name in the same table. The table excludes the `catch` of a
+// `try`/`catch`, which stays a keyword token and never reaches it; gating on the
+// raw source text instead let every file with a `try`/`catch`, and every file
+// with a backslash, through to the AST walk this function exists to avoid.
 //
-// A bracket access keys the member off a literal that never reaches the
-// identifier table, so it keeps a text scan. That scan stays narrow by first
-// requiring a quote or backtick directly after `[`. The backslash check remains
-// for escaped keys such as promise["\x74hen"](), whose source text does not
-// spell the member name.
+// The one form the table cannot answer is a key behind parentheses, as in
+// promise[("then")](): the parser interns a key that is a literal itself, while
+// IsPromiseChainCall reaches through parentheses with ast.SkipParentheses. Such
+// a call opens its bracket on a parenthesis, and its raw text spells the member
+// name unless the key is escaped, so requiring both keeps the fallback sound
+// without paying for the brackets a test file spells everywhere else.
 func sourceMayContainPromiseChain(sourceFile *ast.SourceFile) bool {
 	if sourceFile == nil {
 		return true
 	}
 	// Reading a nil identifier table is well defined; a file with no identifiers
-	// has no property-access chain either way.
+	// has no promise chain either way.
 	for _, name := range promiseChainMemberNames {
 		if _, ok := sourceFile.Identifiers[name]; ok {
 			return nodeContainsPromiseChain(sourceFile.AsNode())
 		}
 	}
 
+	// The bracket scan runs first: it answers almost every file with a single
+	// IndexByte pass, while the four substring searches below cost a pass each.
 	text := sourceFile.Text()
-	if !strings.Contains(text, `["`) &&
-		!strings.Contains(text, `['`) &&
-		!strings.Contains(text, "[`") {
+	if !bracketOpensOnParenthesis(text) {
 		return false
 	}
 	if !strings.Contains(text, "then") &&
@@ -55,6 +58,58 @@ func sourceMayContainPromiseChain(sourceFile *ast.SourceFile) bool {
 		return false
 	}
 	return nodeContainsPromiseChain(sourceFile.AsNode())
+}
+
+// bracketOpensOnParenthesis reports whether any `[` in the text is followed,
+// past whitespace and comments, by `(`. It reads the raw text rather than the
+// AST, so a bracket inside a string or a regular expression counts too; that
+// only costs a walk the caller would otherwise skip, and never hides one.
+func bracketOpensOnParenthesis(text string) bool {
+	for index := strings.IndexByte(text, '['); index >= 0; {
+		if next := skipTrivia(text, index+1); next < len(text) && text[next] == '(' {
+			return true
+		}
+		offset := strings.IndexByte(text[index+1:], '[')
+		if offset < 0 {
+			return false
+		}
+		index += offset + 1
+	}
+	return false
+}
+
+// skipTrivia returns the first index at or after index that starts neither
+// whitespace nor a comment.
+func skipTrivia(text string, index int) int {
+	for index < len(text) {
+		switch text[index] {
+		case ' ', '\t', '\r', '\n', '\v', '\f':
+			index++
+		case '/':
+			if index+1 >= len(text) {
+				return index
+			}
+			switch text[index+1] {
+			case '/':
+				end := strings.IndexByte(text[index:], '\n')
+				if end < 0 {
+					return len(text)
+				}
+				index += end + 1
+			case '*':
+				end := strings.Index(text[index+2:], "*/")
+				if end < 0 {
+					return len(text)
+				}
+				index += end + 4
+			default:
+				return index
+			}
+		default:
+			return index
+		}
+	}
+	return index
 }
 
 var promiseChainMemberNames = [...]string{"then", "catch", "finally"}

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
@@ -2,6 +2,7 @@ package valid_expect_in_promise
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
@@ -11,10 +12,46 @@ import (
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/valid_expect_in_promise"
 )
 
+// sourceMayContainPromiseChain reports whether the file contains a call accepted
+// by testFramework.IsPromiseChainCall. The text check avoids an AST walk for
+// the common negative case. A backslash keeps escaped static names
+// such as promise["\x74hen"]() in the exact AST scan.
+func sourceMayContainPromiseChain(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	text := sourceFile.Text()
+	if !strings.Contains(text, "then") &&
+		!strings.Contains(text, "catch") &&
+		!strings.Contains(text, "finally") &&
+		!strings.Contains(text, `\`) {
+		return false
+	}
+	return nodeContainsPromiseChain(sourceFile.AsNode())
+}
+
+func nodeContainsPromiseChain(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if testFramework.IsPromiseChainCall(node) {
+		return true
+	}
+	found := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		found = nodeContainsPromiseChain(child)
+		return found
+	})
+	return found
+}
+
 var ValidExpectInPromiseRule = shared.NewRule(shared.Config{
 	Name:               "rstest/valid-expect-in-promise",
 	MessageDescription: "This promise should either be returned or awaited to ensure the assertions in its chain are called",
 	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		if !sourceMayContainPromiseChain(ctx.SourceFile) {
+			return shared.Runtime{}
+		}
 		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
 		return shared.Runtime{
 			TestCallbackFunctions: analysis.Callbacks().Functions,

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.go
@@ -13,14 +13,41 @@ import (
 )
 
 // sourceMayContainPromiseChain reports whether the file contains a call accepted
-// by testFramework.IsPromiseChainCall. The text check avoids an AST walk for
-// the common negative case. A backslash keeps escaped static names
-// such as promise["\x74hen"]() in the exact AST scan.
+// by testFramework.IsPromiseChainCall, which recognizes `then`, `catch` and
+// `finally` reached either as a property access or as a bracket access keyed by
+// a string or no-substitution template literal.
+//
+// The two forms are gated differently. A property access spells the member as
+// an identifier — a keyword-named property is interned like any other — so the
+// source file's identifier table answers that form exactly and in O(1). It also
+// excludes the `catch` of a `try`/`catch`, which stays a keyword token and never
+// reaches the table; gating on the raw source text instead let every file with a
+// `try`/`catch`, and every file with a backslash, through to the AST walk this
+// function exists to avoid.
+//
+// A bracket access keys the member off a literal that never reaches the
+// identifier table, so it keeps a text scan. That scan stays narrow by first
+// requiring a quote or backtick directly after `[`. The backslash check remains
+// for escaped keys such as promise["\x74hen"](), whose source text does not
+// spell the member name.
 func sourceMayContainPromiseChain(sourceFile *ast.SourceFile) bool {
-	if sourceFile == nil || sourceFile.Identifiers == nil {
+	if sourceFile == nil {
 		return true
 	}
+	// Reading a nil identifier table is well defined; a file with no identifiers
+	// has no property-access chain either way.
+	for _, name := range promiseChainMemberNames {
+		if _, ok := sourceFile.Identifiers[name]; ok {
+			return nodeContainsPromiseChain(sourceFile.AsNode())
+		}
+	}
+
 	text := sourceFile.Text()
+	if !strings.Contains(text, `["`) &&
+		!strings.Contains(text, `['`) &&
+		!strings.Contains(text, "[`") {
+		return false
+	}
 	if !strings.Contains(text, "then") &&
 		!strings.Contains(text, "catch") &&
 		!strings.Contains(text, "finally") &&
@@ -30,6 +57,8 @@ func sourceMayContainPromiseChain(sourceFile *ast.SourceFile) bool {
 	return nodeContainsPromiseChain(sourceFile.AsNode())
 }
 
+var promiseChainMemberNames = [...]string{"then", "catch", "finally"}
+
 func nodeContainsPromiseChain(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -37,12 +66,9 @@ func nodeContainsPromiseChain(node *ast.Node) bool {
 	if testFramework.IsPromiseChainCall(node) {
 		return true
 	}
-	found := false
-	node.ForEachChild(func(child *ast.Node) bool {
-		found = nodeContainsPromiseChain(child)
-		return found
-	})
-	return found
+	// ForEachChild reports whether any visit returned true, so passing the
+	// recursion itself keeps the walk free of a capturing closure.
+	return node.ForEachChild(nodeContainsPromiseChain)
 }
 
 var ValidExpectInPromiseRule = shared.NewRule(shared.Config{

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
@@ -24,6 +24,8 @@ func TestSourceMayContainPromiseChain(t *testing.T) {
 		// answer, because the parser interns only a key that is a literal itself.
 		{source: `promise[("then")](value => expect(value).toBe(1))`, want: true},
 		{source: `promise[ /* c */ ("finally") ](() => expect(cleanup).toHaveBeenCalled())`, want: true},
+		{source: "promise[\uFEFF(\"then\")](value => expect(value).toBe(1))", want: true},
+		{source: "promise[// c\u2028(\"catch\")](error => expect(error).toBeDefined())", want: true},
 		{source: `promise[("\x74hen")](value => expect(value).toBe(1))`, want: true},
 		{source: `const text = "then"`, want: false},
 		{source: `const catchError = () => {}`, want: false},
@@ -83,6 +85,9 @@ func TestBracketOpensOnParenthesis(t *testing.T) {
 		{text: "promise[\n  (\"then\")\n](fn)", want: true},
 		{text: `promise[/* key */ ("then")](fn)`, want: true},
 		{text: "promise[// key\n(\"then\")](fn)", want: true},
+		{text: "promise[\uFEFF(\"then\")](fn)", want: true},
+		{text: "promise[// key\u2028(\"then\")](fn)", want: true},
+		{text: "promise[// key\u2029(\"then\")](fn)", want: true},
 		{text: `promise["then"](fn)`, want: false},
 		{text: `rows[index](fn)`, want: false},
 		{text: `rows[index] && other[(index)]`, want: true},

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
@@ -20,6 +20,11 @@ func TestSourceMayContainPromiseChain(t *testing.T) {
 		{source: `promise["then"](value => expect(value).toBe(1))`, want: true},
 		{source: "promise[`finally`](() => expect(cleanup).toHaveBeenCalled())", want: true},
 		{source: `promise["\x74hen"](value => expect(value).toBe(1))`, want: true},
+		// A key behind parentheses is the one chain the identifier table cannot
+		// answer, because the parser interns only a key that is a literal itself.
+		{source: `promise[("then")](value => expect(value).toBe(1))`, want: true},
+		{source: `promise[ /* c */ ("finally") ](() => expect(cleanup).toHaveBeenCalled())`, want: true},
+		{source: `promise[("\x74hen")](value => expect(value).toBe(1))`, want: true},
 		{source: `const text = "then"`, want: false},
 		{source: `const catchError = () => {}`, want: false},
 		{source: `const text = "\x74hen"`, want: false},
@@ -34,6 +39,13 @@ func TestSourceMayContainPromiseChain(t *testing.T) {
 		{source: `test("case", () => expect(text).toBe("a\tb"))`, want: false},
 		// A bracket access keyed by an unrelated literal stays out.
 		{source: `test("case", () => expect(map["other"]).toBe(1))`, want: false},
+		// A bracket paired with a member name the file only spells in text stays
+		// out without a walk, because no bracket opens on a parenthesis.
+		{source: `test("case", () => expect(map["other"]).toBe("then"))`, want: false},
+		// A parenthesized bracket key that is not a chain costs one walk and
+		// still stays out.
+		{source: `test("case", () => expect(rows[(index + 1)]).toBe("then"))`, want: false},
+		{source: `test("case", () => expect(rows[(index + 1)]).toBe(1))`, want: false},
 	}
 
 	for _, testCase := range testCases {
@@ -59,5 +71,35 @@ func TestSourceMayContainPromiseChain(t *testing.T) {
 func TestSourceMayContainPromiseChainKeepsUnknownSourceFile(t *testing.T) {
 	if !sourceMayContainPromiseChain(nil) {
 		t.Error("nil source file must conservatively keep the rule enabled")
+	}
+}
+
+func TestBracketOpensOnParenthesis(t *testing.T) {
+	testCases := []struct {
+		text string
+		want bool
+	}{
+		{text: `promise[("then")](fn)`, want: true},
+		{text: "promise[\n  (\"then\")\n](fn)", want: true},
+		{text: `promise[/* key */ ("then")](fn)`, want: true},
+		{text: "promise[// key\n(\"then\")](fn)", want: true},
+		{text: `promise["then"](fn)`, want: false},
+		{text: `rows[index](fn)`, want: false},
+		{text: `rows[index] && other[(index)]`, want: true},
+		{text: `no brackets at all`, want: false},
+		{text: `trailing bracket [`, want: false},
+		{text: `unterminated block comment [/*`, want: false},
+		{text: `unterminated line comment [//`, want: false},
+	}
+
+	for _, testCase := range testCases {
+		if got := bracketOpensOnParenthesis(testCase.text); got != testCase.want {
+			t.Errorf(
+				"bracketOpensOnParenthesis(%q) = %t, want %t",
+				testCase.text,
+				got,
+				testCase.want,
+			)
+		}
 	}
 }

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
@@ -1,0 +1,54 @@
+package valid_expect_in_promise
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+func TestSourceMayContainPromiseChain(t *testing.T) {
+	testCases := []struct {
+		source string
+		want   bool
+	}{
+		{source: `test("case", () => expect(value).toBe(1))`, want: false},
+		{source: `promise.then(value => expect(value).toBe(1))`, want: true},
+		{source: `promise.catch(error => expect(error).toBeDefined())`, want: true},
+		{source: `promise.finally(() => expect(cleanup).toHaveBeenCalled())`, want: true},
+		{source: `promise["then"](value => expect(value).toBe(1))`, want: true},
+		{source: "promise[`finally`](() => expect(cleanup).toHaveBeenCalled())", want: true},
+		{source: `promise["\x74hen"](value => expect(value).toBe(1))`, want: true},
+		{source: `const text = "then"`, want: false},
+		{source: `const catchError = () => {}`, want: false},
+		{source: `const text = "\x74hen"`, want: false},
+		{source: `promise.then()`, want: false},
+		{source: `promise.catch(onRejected, extra)`, want: false},
+	}
+
+	for _, testCase := range testCases {
+		sourceFile := parser.ParseSourceFile(
+			ast.SourceFileParseOptions{
+				FileName: "/source.test.ts",
+				Path:     "/source.test.ts",
+			},
+			testCase.source,
+			core.ScriptKindTS,
+		)
+		if got := sourceMayContainPromiseChain(sourceFile); got != testCase.want {
+			t.Errorf(
+				"sourceMayContainPromiseChain(%q) = %t, want %t",
+				testCase.source,
+				got,
+				testCase.want,
+			)
+		}
+	}
+}
+
+func TestSourceMayContainPromiseChainKeepsUnknownSourceFile(t *testing.T) {
+	if !sourceMayContainPromiseChain(nil) {
+		t.Error("nil source file must conservatively keep the rule enabled")
+	}
+}

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_internal_test.go
@@ -25,6 +25,15 @@ func TestSourceMayContainPromiseChain(t *testing.T) {
 		{source: `const text = "\x74hen"`, want: false},
 		{source: `promise.then()`, want: false},
 		{source: `promise.catch(onRejected, extra)`, want: false},
+		// The `catch` of a try/catch is a keyword token, so it never reaches the
+		// identifier table and must not open the walk.
+		{source: `test("case", () => { try { run() } catch (error) { fail(error) } })`, want: false},
+		// A backslash alone is not a bracket access; only an escaped bracket key
+		// needs the walk.
+		{source: `test("case", () => expect(text).toMatch(/\d+/))`, want: false},
+		{source: `test("case", () => expect(text).toBe("a\tb"))`, want: false},
+		// A bracket access keyed by an unrelated literal stays out.
+		{source: `test("case", () => expect(map["other"]).toBe(1))`, want: false},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_test.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_test.go
@@ -85,6 +85,17 @@ func TestValidExpectInPromiseRule(t *testing.T) {
 			{Code: `let handler: (value: unknown) => void; beforeEach(() => { handler = value => expect(value).toBe(1); }); test("case", () => promise.then(handler));`},
 		},
 		[]rule_tester.InvalidTestCase{
+			// A key behind parentheses is a chain the identifier table cannot
+			// answer, so it also covers the source prescan's fallback.
+			{
+				Code: `test("case", () => { promise[("then")](value => expect(value).toBe(1)); });`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expectInFloatingPromise",
+					Message:   "This promise should either be returned or awaited to ensure the assertions in its chain are called",
+					Line:      1,
+					Column:    22,
+				}},
+			},
 			{
 				Code: `test("case", (context) => { promise.then(value => context.expect(value).toBe(1)); });`,
 				Errors: []rule_tester.InvalidTestCaseError{{

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_test.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_test.go
@@ -98,6 +98,15 @@ func TestValidExpectInPromiseRule(t *testing.T) {
 				}},
 			},
 			{
+				Code: "test(\"case\", () => { promise[\uFEFF(\"then\")](value => expect(value).toBe(1)); });",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "expectInFloatingPromise",
+					Message:   "This promise should either be returned or awaited to ensure the assertions in its chain are called",
+					Line:      1,
+					Column:    22,
+				}},
+			},
+			{
 				Code: `test("case", (context) => { promise.then(value => context.expect(value).toBe(1)); });`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "expectInFloatingPromise",

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_test.go
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise_test.go
@@ -86,7 +86,8 @@ func TestValidExpectInPromiseRule(t *testing.T) {
 		},
 		[]rule_tester.InvalidTestCase{
 			// A key behind parentheses is a chain the identifier table cannot
-			// answer, so it also covers the source prescan's fallback.
+			// answer, so it also covers the raw-text fallback in
+			// sourceMayContainPromiseChain.
 			{
 				Code: `test("case", () => { promise[("then")](value => expect(value).toBe(1)); });`,
 				Errors: []rule_tester.InvalidTestCaseError{{


### PR DESCRIPTION
## Summary

- Add a prescan that skips shared Rstest call analysis, callback collection, function traversal, and control-flow analysis for files without a promise-chain call. The source file's identifier table answers nearly every form in O(1): the parser interns a property name as an identifier, and it also interns the cooked text of a string, no-substitution template or numeric element-access key, so `promise.then(...)`, `promise["then"](...)`, `` promise[`finally`](...) `` and `promise["\x74hen"](...)` all put the member name into that table. The table excludes the `catch` of a `try`/`catch`, which stays a keyword token.
- The one form the table cannot answer is a key behind parentheses, `promise[("then")](...)`: `IsPromiseChainCall` reaches through them with `ast.SkipParentheses`, while the parser interns only a key that is a literal itself. A narrow scan covers it — such a call opens a bracket on a parenthesis, past whitespace and comments, and spells the member name unless the key is escaped. That scan runs before the substring searches, because it answers almost every file in a single `IndexByte` pass while each substring search costs a pass over the whole file.
- Use the existing promise-chain predicate for the exact AST check, preserving dot access, computed string and template access, escaped property names, parentheses, and method arity behavior.
- Add focused tests covering accepted promise-chain forms, the parenthesized key, and rejected lookalikes.

## Performance

Measured with `--timing all` while running the same 15 configured Rstest rules over all `*.test.*`, `*.spec.*`, and configured in-source test files in six Rstack repositories. Each result is the median `rstest/valid-expect-in-promise` rule time from 27 timing runs, collected in three rounds alternating with the same `7b4c4f95` baseline. The benchmark covers 1,978 files in total.

The complete JSONL diagnostics were identical before and after the optimization across all six repositories, covering 528 diagnostics.

| Repository | Test Files | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Rspack | 147 | 0.4ms | 0.1ms | 4.00× |
| Rsbuild | 629 | 0.8ms | 0.3ms | 2.67× |
| Rslib | 113 | 6.4ms | 0.3ms | 21.33× |
| Rspress | 134 | 1.8ms | 0.2ms | 9.00× |
| Rsdoctor | 89 | 0.7ms | 0.1ms | 7.00× |
| Rstest | 866 | 23.7ms | 1.5ms | 15.80× |
| **Combined** | **1,978** | **33.8ms** | **2.5ms** | **13.52×** |

Gating on the identifier table rather than the raw source text is what keeps the small repositories on the winning side: across the six repositories only 16 of the test files spell `then`, `catch` or `finally` as an identifier, and 15 of those actually contain a promise chain, so almost every file is answered by three map lookups.

Where a file is not answered there, the order of the remaining checks matters as much as the gate itself, because a rule this cheap can lose to its own prescan. Timed over the same parsed test files, the four substring searches cost four passes over the file and come close to the walk they guard — 0.76ms against 0.91ms on Rsbuild's 629 files, 1.52ms against 1.71ms on Rstest's 860. The single-pass bracket scan costs 0.05ms and 0.18ms, so it runs first.
