### PR TITLE
feat(rstest): add max-expects rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -2,6 +2,7 @@ package rstest
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/expect_expect"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/max_expects"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_commented_out_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
@@ -22,6 +23,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		expect_expect.ExpectExpectRule,
+		max_expects.MaxExpectsRule,
 		no_commented_out_tests.NoCommentedOutTestsRule,
 		no_conditional_expect.NoConditionalExpectRule,
 		no_disabled_tests.NoDisabledTestsRule,

--- a/internal/plugins/rstest/rules/max_expects/max_expects.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.go
@@ -183,6 +183,29 @@ func containsFallbackFunction(node *ast.Node) bool {
 	return found
 }
 
+// fallbackCandidateRoot is the argument subtree a callback may be found in. An
+// object literal is never one: it is the options argument of an overload, and
+// a function inside it is a property, not the registered callback.
+func fallbackCandidateRoot(node *ast.Node) *ast.Node {
+	node = internalUtils.SkipAssertionsAndParens(node)
+	if node == nil || isObjectLiteralLike(node) {
+		return nil
+	}
+	return node
+}
+
+// hookFallbackCandidateRoots answers the same question for a lifecycle hook,
+// whose callback is the first argument rather than the second.
+func hookFallbackCandidateRoots(call *ast.CallExpression) []*ast.Node {
+	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return nil
+	}
+	if root := fallbackCandidateRoot(call.Arguments.Nodes[0]); root != nil {
+		return []*ast.Node{root}
+	}
+	return nil
+}
+
 func registrationFallbackCandidateRoots(call *ast.CallExpression) []*ast.Node {
 	if call == nil || call.Arguments == nil {
 		return nil
@@ -193,13 +216,7 @@ func registrationFallbackCandidateRoots(call *ast.CallExpression) []*ast.Node {
 		return nil
 	}
 
-	candidateRoot := func(node *ast.Node) *ast.Node {
-		node = internalUtils.SkipAssertionsAndParens(node)
-		if node == nil || isObjectLiteralLike(node) {
-			return nil
-		}
-		return node
-	}
+	candidateRoot := fallbackCandidateRoot
 
 	if len(args) == 2 {
 		if root := candidateRoot(args[1]); root != nil {
@@ -266,7 +283,14 @@ var MaxExpectsRule = rule.Rule{
 
 		enterFunction := func(node *ast.Node) {
 			kind := functionPushForNode(node, callbacks)
-			if kind == functionPushNone &&
+			// A callback the parser could not resolve is recognised by position:
+			// any function inside the registration's callback argument activates
+			// the registration frame. That has to be checked on the detached
+			// branch as well, because only a function whose immediate parent is
+			// the wrapping call reaches functionPushNone — nesting it in a `new`,
+			// an array, an object property, or a conditional makes it detached,
+			// and pushing an inactive frame there would leave the body uncounted.
+			if (kind == functionPushNone || kind == functionPushDetached) &&
 				node != nil &&
 				node.Body() != nil &&
 				canActivateRegistrationFallback(stack.top(), node) {
@@ -321,6 +345,21 @@ var MaxExpectsRule = rule.Rule{
 						false,
 						node,
 						registrationFallbackCandidateRoots(node.AsCallExpression()),
+					)
+					pushedRegistrations[node] = true
+					return
+				}
+
+				// A hook body is test code and gets its own tally, the same as a
+				// test body. Hooks have no resolved callback set, so the frame is
+				// activated positionally, through the same candidate roots.
+				if parsed := analysis.ParseFnCall(node); parsed != nil &&
+					parsed.Kind == rstestUtils.RstestFnTypeHook {
+					stack.push(
+						frameRegistrationFallback,
+						false,
+						node,
+						hookFallbackCandidateRoots(node.AsCallExpression()),
 					)
 					pushedRegistrations[node] = true
 					return

--- a/internal/plugins/rstest/rules/max_expects/max_expects.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.go
@@ -1,0 +1,348 @@
+package max_expects
+
+import (
+	_ "embed"
+	"fmt"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed max_expects.schema.json
+var schemaJSON []byte
+
+const defaultMax = 5
+
+type options struct {
+	Max int
+}
+
+type frameKind uint8
+
+const (
+	frameInactive frameKind = iota
+	frameTestCallback
+	frameDetachedFunction
+	frameRegistrationFallback
+)
+
+type countFrame struct {
+	kind                   frameKind
+	count                  int
+	active                 bool
+	registration           *ast.Node
+	callbackCandidateRoots []*ast.Node
+}
+
+type frameStack struct {
+	frames []countFrame
+}
+
+type functionPushKind uint8
+
+const (
+	functionPushNone functionPushKind = iota
+	functionPushTestCallback
+	functionPushDetached
+	functionActivateRegistrationFallback
+)
+
+func parseOptions(rawOptions []any) options {
+	opts := options{Max: defaultMax}
+	if len(rawOptions) == 0 {
+		return opts
+	}
+
+	optsMap, _ := rawOptions[0].(map[string]any)
+	if maxVal, ok := internalUtils.CoerceIntegral(optsMap["max"]); ok && maxVal >= 1 {
+		opts.Max = maxVal
+	}
+
+	return opts
+}
+
+func buildExceededMaxAssertionMessage(count, maxAllowed int) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "exceededMaxAssertion",
+		Description: fmt.Sprintf("Too many assertion calls (%d) - maximum allowed is %d", count, maxAllowed),
+		Data: map[string]string{
+			"count": strconv.Itoa(count),
+			"max":   strconv.Itoa(maxAllowed),
+		},
+	}
+}
+
+func newFrameStack() frameStack {
+	return frameStack{
+		frames: []countFrame{{
+			kind:   frameInactive,
+			active: false,
+		}},
+	}
+}
+
+func (stack *frameStack) top() *countFrame {
+	return &stack.frames[len(stack.frames)-1]
+}
+
+func (stack *frameStack) push(kind frameKind, active bool, registration *ast.Node, callbackCandidateRoots []*ast.Node) {
+	stack.frames = append(stack.frames, countFrame{
+		kind:                   kind,
+		count:                  0,
+		active:                 active,
+		registration:           registration,
+		callbackCandidateRoots: callbackCandidateRoots,
+	})
+}
+
+func (stack *frameStack) pop() {
+	if len(stack.frames) <= 1 {
+		return
+	}
+	stack.frames = stack.frames[:len(stack.frames)-1]
+}
+
+func (stack *frameStack) increment() int {
+	top := stack.top()
+	if !top.active {
+		return 0
+	}
+	top.count++
+	return top.count
+}
+
+func isCountedExpectCall(parsed *rstestUtils.ParsedRstestExpectCall) bool {
+	if parsed == nil ||
+		parsed.Reason != rstestUtils.RstestExpectParseReasonNone ||
+		parsed.MatcherEntry == nil ||
+		parsed.Head == nil {
+		return false
+	}
+
+	switch parsed.Entry {
+	case rstestUtils.RstestExpectEntryCall,
+		rstestUtils.RstestExpectEntrySoft,
+		rstestUtils.RstestExpectEntryPoll,
+		rstestUtils.RstestExpectEntryElement:
+		return true
+	default:
+		return false
+	}
+}
+
+func functionPushForNode(node *ast.Node, callbacks map[*ast.Node]bool) functionPushKind {
+	if node == nil || node.Body() == nil {
+		return functionPushNone
+	}
+	if callbacks[node] {
+		return functionPushTestCallback
+	}
+
+	switch node.Kind {
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		parent := node.Parent
+		for parent != nil && ast.IsOuterExpression(parent, ast.OEKParentheses|ast.OEKAssertions) {
+			parent = parent.Parent
+		}
+		if parent != nil && parent.Kind == ast.KindCallExpression {
+			return functionPushNone
+		}
+		return functionPushDetached
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		return functionPushDetached
+	case ast.KindFunctionDeclaration:
+		return functionPushNone
+	default:
+		return functionPushNone
+	}
+}
+
+func isObjectLiteralLike(node *ast.Node) bool {
+	node = internalUtils.SkipAssertionsAndParens(node)
+	return node != nil && node.Kind == ast.KindObjectLiteralExpression
+}
+
+func containsFallbackFunction(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if ast.IsFunctionExpressionOrArrowFunction(node) && node.Body() != nil {
+		return true
+	}
+	found := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		if containsFallbackFunction(child) {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func registrationFallbackCandidateRoots(call *ast.CallExpression) []*ast.Node {
+	if call == nil || call.Arguments == nil {
+		return nil
+	}
+
+	args := call.Arguments.Nodes
+	if len(args) < 2 || len(args) > 3 {
+		return nil
+	}
+
+	candidateRoot := func(node *ast.Node) *ast.Node {
+		node = internalUtils.SkipAssertionsAndParens(node)
+		if node == nil || isObjectLiteralLike(node) {
+			return nil
+		}
+		return node
+	}
+
+	if len(args) == 2 {
+		if root := candidateRoot(args[1]); root != nil {
+			return []*ast.Node{root}
+		}
+		return nil
+	}
+
+	if isObjectLiteralLike(args[1]) {
+		if root := candidateRoot(args[2]); root != nil {
+			return []*ast.Node{root}
+		}
+		return nil
+	}
+
+	// Prefer a function nested in the third argument: it identifies `(name,
+	// options, callback)`, including when options is a variable or arbitrary
+	// expression. Otherwise a function nested in the second argument identifies
+	// a wrapped callback-first registration whose third argument is a timeout.
+	// With no inline function in either position, keeping the overload-shaped
+	// third root is harmless because it cannot activate the fallback frame.
+	callbackIndex := 2
+	if !containsFallbackFunction(args[2]) && containsFallbackFunction(args[1]) {
+		callbackIndex = 1
+	}
+	if root := candidateRoot(args[callbackIndex]); root != nil {
+		return []*ast.Node{root}
+	}
+	return nil
+}
+
+func nodeWithinSubtree(node *ast.Node, root *ast.Node) bool {
+	for current := node; current != nil; current = current.Parent {
+		if current == root {
+			return true
+		}
+	}
+	return false
+}
+
+func canActivateRegistrationFallback(frame *countFrame, node *ast.Node) bool {
+	if frame == nil || frame.kind != frameRegistrationFallback || frame.active || frame.registration == nil {
+		return false
+	}
+	for _, root := range frame.callbackCandidateRoots {
+		if root != nil && nodeWithinSubtree(node, root) {
+			return true
+		}
+	}
+	return false
+}
+
+var MaxExpectsRule = rule.Rule{
+	Name:   "rstest/max-expects",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		callbacks := analysis.Callbacks().Functions
+
+		stack := newFrameStack()
+		pushedFunctions := map[*ast.Node]functionPushKind{}
+		pushedRegistrations := map[*ast.Node]bool{}
+
+		enterFunction := func(node *ast.Node) {
+			kind := functionPushForNode(node, callbacks)
+			if kind == functionPushNone &&
+				node != nil &&
+				node.Body() != nil &&
+				canActivateRegistrationFallback(stack.top(), node) {
+				kind = functionActivateRegistrationFallback
+			}
+
+			switch kind {
+			case functionPushTestCallback:
+				stack.push(frameTestCallback, true, nil, nil)
+				pushedFunctions[node] = functionPushTestCallback
+			case functionPushDetached:
+				stack.push(frameDetachedFunction, stack.top().active, nil, nil)
+				pushedFunctions[node] = functionPushDetached
+			case functionActivateRegistrationFallback:
+				stack.top().active = true
+				pushedFunctions[node] = functionActivateRegistrationFallback
+			}
+		}
+
+		exitFunction := func(node *ast.Node) {
+			switch pushedFunctions[node] {
+			case functionPushNone:
+				return
+			case functionActivateRegistrationFallback:
+				delete(pushedFunctions, node)
+				stack.top().active = false
+				return
+			}
+			delete(pushedFunctions, node)
+			stack.pop()
+		}
+
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration:                      enterFunction,
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): exitFunction,
+			ast.KindFunctionExpression:                       enterFunction,
+			rule.ListenerOnExit(ast.KindFunctionExpression):  exitFunction,
+			ast.KindArrowFunction:                            enterFunction,
+			rule.ListenerOnExit(ast.KindArrowFunction):       exitFunction,
+			ast.KindMethodDeclaration:                        enterFunction,
+			rule.ListenerOnExit(ast.KindMethodDeclaration):   exitFunction,
+			ast.KindGetAccessor:                              enterFunction,
+			rule.ListenerOnExit(ast.KindGetAccessor):         exitFunction,
+			ast.KindSetAccessor:                              enterFunction,
+			rule.ListenerOnExit(ast.KindSetAccessor):         exitFunction,
+			ast.KindConstructor:                              enterFunction,
+			rule.ListenerOnExit(ast.KindConstructor):         exitFunction,
+			ast.KindCallExpression: func(node *ast.Node) {
+				if analysis.ParseTestCall(node) != nil {
+					stack.push(
+						frameRegistrationFallback,
+						false,
+						node,
+						registrationFallbackCandidateRoots(node.AsCallExpression()),
+					)
+					pushedRegistrations[node] = true
+					return
+				}
+
+				parsed := analysis.ParseExpectCall(node)
+				if !isCountedExpectCall(parsed) {
+					return
+				}
+
+				count := stack.increment()
+				if count > opts.Max {
+					ctx.ReportNode(node, buildExceededMaxAssertionMessage(count, opts.Max))
+				}
+			},
+			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+				if !pushedRegistrations[node] {
+					return
+				}
+				delete(pushedRegistrations, node)
+				stack.pop()
+			},
+		}
+	},
+}

--- a/internal/plugins/rstest/rules/max_expects/max_expects.md
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.md
@@ -56,8 +56,24 @@ test("case", () => {
 - Chai property and chained assertions still count once per assertion factory:
   `expect(value).to.be.ok` and
   `expect(value).to.be.a("string").and.not.be.empty` each count as one.
-- Assertions outside test callbacks are ignored. Detached helpers inside a test
-  get their own count and do not leak into sibling tests.
+- A test body and a lifecycle hook body each carry their own count:
+  `beforeEach`, `beforeAll`, `afterEach`, and `afterAll` are test code and are
+  limited the same way a test is.
+- A callback the rule cannot resolve is still counted when it is written inside
+  the registration's callback argument, wherever in that argument it sits:
+  `test("a", fakeAsync(() => …))`, `test("a", new Wrapper(() => …))`,
+  `test("a", wrap({ cb: () => … }))`, and `test("a", cond ? () => … : null)`
+  all count. A function held in an options object — the `{ retry: 2 }` argument
+  of the `(name, options, callback)` overload — is not a callback and is not
+  counted.
+- A callback written outside the registration and reached through a member
+  expression is not counted: in `const suite = { run: () => … };
+  test("a", suite.run)`, and likewise for a class property, nothing at the
+  registration ties the function to it.
+- Assertions at the top level of a file, or directly in a `describe` body, are
+  ignored: they do not belong to a test body.
+- A detached helper inside a test gets its own count and does not leak into
+  sibling tests.
 
 ## Options
 

--- a/internal/plugins/rstest/rules/max_expects/max_expects.md
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.md
@@ -1,0 +1,78 @@
+# max-expects
+
+## Rule Details
+
+Enforce a maximum number of assertion calls in each Rstest test body. This
+rule counts real assertion factories such as `expect(value)`,
+`expect.soft(value)`, `expect.poll(fn)`, and `expect.element(locator)`. Once a
+test exceeds the configured maximum, each additional assertion is reported.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+test("case", () => {
+  expect(a).toBe(1);
+  expect(b).toBe(2);
+  expect(c).toBe(3);
+  expect(d).toBe(4);
+  expect(e).toBe(5);
+  expect(f).toBe(6);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+test("case", () => {
+  expect(a).toBe(1);
+  expect(b).toBe(2);
+  expect(c).toBe(3);
+});
+
+test.for(rows)("case", (row, context) => {
+  context.expect(row.ok).toBe(true);
+  context.expect(row.count).toBeGreaterThan(0);
+});
+```
+
+Examples of **correct** code for this rule with `{ "max": 1 }`:
+
+```json
+{ "rstest/max-expects": ["error", { "max": 1 }] }
+```
+
+```ts
+test("case", () => {
+  expect(value).toBe(1);
+});
+```
+
+## Rstest specifics
+
+- `expect.assertions(2)`, `expect.hasAssertions()`, `expect.any(String)`, and
+  other static `expect` helpers do not count as assertions.
+- Broken or incomplete chains such as `expect(value)` and `expect(value).toBe`
+  do not count; those are covered by `rstest/valid-expect`.
+- Chai property and chained assertions still count once per assertion factory:
+  `expect(value).to.be.ok` and
+  `expect(value).to.be.a("string").and.not.be.empty` each count as one.
+- Assertions outside test callbacks are ignored. Detached helpers inside a test
+  get their own count and do not leak into sibling tests.
+
+## Options
+
+```json
+{
+  "rstest/max-expects": ["error", { "max": 5 }]
+}
+```
+
+- `max` configures the maximum number of assertions allowed per test body.
+  The default is `5`.
+
+This rule does not provide an autofix.
+
+## Original Documentation
+
+- [eslint-plugin-jest: max-expects](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/max-expects.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/max-expects.ts)

--- a/internal/plugins/rstest/rules/max_expects/max_expects.schema.json
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "max": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/rstest/rules/max_expects/max_expects_boundaries_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_boundaries_test.go
@@ -1,0 +1,219 @@
+package max_expects_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMaxExpectsCountingBoundaries pins which bodies open a count. A callback
+// the parser cannot resolve is recognised by position, wherever inside the
+// registration's callback argument it sits, and a lifecycle hook body counts
+// like a test body. The cases the rule declines to count are listed as valid so
+// the boundary of the positional recognition stays visible.
+func TestMaxExpectsCountingBoundaries(t *testing.T) {
+	runMaxExpectsRuleTester(
+		t,
+		[]rule_tester.ValidTestCase{
+			// A callback reached through a member expression is not attributed
+			// to the registration: the function is written outside it and
+			// nothing at the registration ties the two together.
+			{
+				Code: `
+const suite = { run: () => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+} };
+test('a', suite.run);`,
+				Options: max1Option,
+			},
+			{
+				Code: `
+class Suite {
+  run = () => {
+    expect(1).toBe(1);
+    expect(2).toBe(2);
+  };
+}
+test('a', new Suite().run);`,
+				Options: max1Option,
+			},
+			// An object literal argument is the options overload, so a function
+			// held in one of its properties is not the callback.
+			{
+				Code: `
+test('a', { retry: 2 }, () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- An unresolved callback counts wherever it sits inside the
+			// registration's callback argument, not only as a direct argument
+			// of the wrapping call ----
+			{
+				Code: `
+test('a', new Wrapper(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			{
+				Code: `
+test('a', wrap([() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}]));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			{
+				Code: `
+test('a', cond ? () => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+} : null);`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			{
+				Code: `
+test('a', wrap({ cb: () => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+} }));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			{
+				Code: `
+test('a', wrap(withDb({ run: () => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+} })));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			// ---- A hook body carries its own count ----
+			{
+				Code: `
+beforeEach(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			{
+				Code: `
+afterAll(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			{
+				Code: `
+describe('d', () => {
+  beforeEach(() => {
+    expect(1).toBe(1);
+    expect(2).toBe(2);
+  });
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 5, 5, 22),
+				},
+			},
+			{
+				Code: `
+beforeEach(wrap(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3, 20),
+				},
+			},
+			// ---- Any function-valued expression between two assertions is a
+			// boundary: it takes its own count and hands the enclosing count
+			// back. Upstream resets to zero instead and stops reporting the
+			// assertions that follow ----
+			{
+				Code: `
+test('a', () => {
+  expect(1).toBe(1);
+  test('b', () => {});
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 5, 3, 20),
+				},
+			},
+			{
+				Code: `
+test('a', () => {
+  expect(1).toBe(1);
+  const o = { m() {} };
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 5, 3, 20),
+				},
+			},
+			{
+				Code: `
+test('a', () => {
+  expect(1).toBe(1);
+  new Foo(() => {});
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 5, 3, 20),
+				},
+			},
+			// A hook body and the test bodies around it are separate counts.
+			{
+				Code: `
+describe('d', () => {
+  beforeEach(() => {
+    expect(1).toBe(1);
+    expect(2).toBe(2);
+  });
+
+  test('a', () => {
+    expect(3).toBe(3);
+    expect(4).toBe(4);
+  });
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 5, 5, 22),
+					exceededMaxError(2, 1, 10, 5, 22),
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/max_expects/max_expects_extras_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_extras_test.go
@@ -315,7 +315,9 @@ function callback() {
 			{Code: `const expect = () => ({ toBe() {} }); test('case', () => { expect(1).toBe(1); });`, Options: max1Option},
 		},
 		[]rule_tester.InvalidTestCase{
-			// ---- Locks in upstream create() arm: detached helper restores outer count ----
+			// ---- Deliberate divergence: a detached helper gets its own count
+			// and restores the enclosing one, where upstream resets the count to
+			// zero on both entry and exit and loses the enclosing tally ----
 			{
 				Code: `test('restores outer count after detached helper', () => {
   expect(1).toBe(1);

--- a/internal/plugins/rstest/rules/max_expects/max_expects_extras_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_extras_test.go
@@ -1,0 +1,580 @@
+// TestMaxExpectsExtras locks in branches and edge shapes that the upstream
+// max-expects suites do not exercise on rstest. Each case names the state
+// branch, source shape, or real-user scenario it protects so refactors cannot
+// silently regress rstest-specific behavior.
+package max_expects_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/max_expects"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestMaxExpectsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&max_expects.MaxExpectsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Real-user: Jest #1193 ----
+			{
+				Code: `test('static expect APIs do not count', () => {
+  expect.assertions(5);
+  expect(a).toBe(1);
+  expect(b).toBe(2);
+  expect(c).toBe(3);
+  expect(d).toBe(4);
+  expect(e).toBe(5);
+});`,
+			},
+			{
+				Code: `test('asymmetric matchers do not count', () => {
+  expect(value).toEqual(expect.objectContaining({ ok: true }));
+  expect.any(String);
+  expect.anything();
+  expect.not.arrayContaining([]);
+});`,
+				Options: max1Option,
+			},
+
+			// ---- Real-user: Jest #1205 ----
+			{
+				Code: `function helper() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+}
+
+test('isolates helper from following test', () => {
+  expect(true).toBeDefined();
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('isolates following helper from test', () => {
+  expect(true).toBeDefined();
+});
+
+function helper() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+}`,
+				Options: max1Option,
+			},
+
+			// ---- Real-user: Jest #1516 ----
+			{
+				Code: `describe('wrapped callbacks stay per-test', () => {
+  test('a', fakeAsync(() => {
+    expect(true).toBe(true);
+    expect(true).toBe(true);
+    expect(true).toBe(true);
+  }));
+
+  test('b', fakeAsync(() => {
+    expect(true).toBe(true);
+    expect(true).toBe(true);
+    expect(true).toBe(true);
+  }));
+});`,
+				Options: max5Option,
+			},
+
+			// ---- Real-user: Vitest #891 ----
+			{
+				Code: `import { it as base } from '@rstest/core';
+const test = base.extend({ value: 1 });
+
+test('only expect destructured still counts as test callback', ({ expect }) => {
+  expect(true).toBe(true);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `import { it as base } from '@rstest/core';
+const test = base.extend({ value: 1 });
+
+test('fixture plus expect destructured still counts as test callback', ({ value, expect }) => {
+  expect(value).toBe(1);
+});`,
+				Options: max1Option,
+			},
+
+			// ---- Locks in upstream create() arm: registration arguments are outside the test body ----
+			{
+				Code: `test(expect(1).toBe(1), () => {
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('case', { timeout: expect(1).toBe(1) }, () => {
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code:    `test('case', () => {}, expect(1).toBe(1));`,
+				Options: max1Option,
+			},
+
+			// ---- Locks in upstream create() arm: broken/static chains do not count ----
+			{
+				Code: `test('broken chains do not count', () => {
+  expect(value);
+  expect(value).toBe;
+  expect.soft(value);
+  expect(value).not;
+  expect(value).toBe(1);
+});`,
+				Options: max1Option,
+			},
+
+			// ---- Dimension 4: chai property and multi-matcher chain count once ----
+			{
+				Code: `test('chai property matcher counts once', () => {
+  expect(value).to.be.ok;
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('chai chain counts once', () => {
+  expect(value).to.be.a('string').and.not.be.empty;
+});`,
+				Options: max1Option,
+			},
+
+			// ---- Dimension 4: expect sources ----
+			{
+				Code: `import { expect, test } from '@rstest/core';
+test('named import', () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `import { expect as check, test } from '@rstest/core';
+test('alias import', () => {
+  check(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `const { expect, test } = require('@rstest/core');
+test('require destructuring', () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `import * as rstest from '@rstest/core';
+rstest.test('namespace import', () => {
+  rstest.expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `const rstest = require('@rstest/core');
+rstest.test('whole-module require', () => {
+  rstest.expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `import.meta.rstest.test('import.meta direct', () => {
+  import.meta.rstest.expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `const { test, expect } = import.meta.rstest;
+test('import.meta destructuring', () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `const api = import.meta.rstest;
+api.test('import.meta alias', () => {
+  api.expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('context receiver', context => {
+  context.expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('context destructuring', ({ expect }) => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('context alias destructuring', ({ expect: check }) => {
+  check(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('browser mode element', () => {
+  expect.element(locator).toBeVisible();
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `import { test, expect } from '@rstest/playwright';
+test('playwright profile', () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+
+			// ---- Dimension 4: registration and callback shapes ----
+			{
+				Code: `test('third arg timeout', () => {
+  expect(1).toBe(1);
+}, 1000);`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('options overload', { timeout: 1 }, () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test.each([1])('each callback', value => {
+  expect(value).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test.for([1])('for callback with context', (value, context) => {
+  context.expect(value).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `const eachCase = test.each([1]);
+eachCase('factory alias', value => {
+  expect(value).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `const forCase = test.for([1]);
+forCase('factory alias', (value, context) => {
+  context.expect(value).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `const testWithFixture = test.extend({ value: 1 });
+testWithFixture('extended test', ({ value, expect }) => {
+  expect(value).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('named callback', callback);
+function callback() {
+  expect(1).toBe(1);
+}`,
+				Options: max1Option,
+			},
+
+			// ---- Dimension 4: function-position inheritance ----
+			{
+				Code: `test('call argument callback inherits outer frame', () => {
+  run(() => {
+    expect(1).toBe(1);
+  });
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('function declaration inside test inherits outer frame', () => {
+  function helper() {
+    expect(1).toBe(1);
+  }
+  helper();
+});`,
+				Options: max1Option,
+			},
+			// ---- Dimension 4: negative sources ----
+			{Code: `import { expect } from 'vitest'; expect(1).toBe(1);`, Options: max1Option},
+			{Code: `import { expect } from '@jest/globals'; expect(1).toBe(1);`, Options: max1Option},
+			{Code: `import { test, expect } from '@playwright/test'; test('case', () => { expect(1).toBe(1); });`, Options: max1Option},
+			{Code: `const expect = () => ({ toBe() {} }); test('case', () => { expect(1).toBe(1); });`, Options: max1Option},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in upstream create() arm: detached helper restores outer count ----
+			{
+				Code: `test('restores outer count after detached helper', () => {
+  expect(1).toBe(1);
+  const helper = () => {
+    expect(2).toBe(2);
+    expect(3).toBe(3);
+  };
+  expect(4).toBe(4);
+  expect(5).toBe(5);
+});`,
+				Options: max2Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(3, 2, 8, 3, 20),
+				},
+			},
+
+			// ---- Real-user: Jest #1516 ----
+			{
+				Code: `test('a', fakeAsync(() => {
+  expect(true).toBe(true);
+  expect(true).toBe(true);
+  expect(true).toBe(true);
+}));
+test('b', fakeAsync(() => {
+  expect(true).toBe(true);
+  expect(true).toBe(true);
+  expect(true).toBe(true);
+}));`,
+				Options: max2Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(3, 2, 4, 3),
+					exceededMaxError(3, 2, 9, 3),
+				},
+			},
+
+			// ---- Dimension 4: detached function frames still enforce their own max ----
+			{
+				Code: `test('detached methods are isolated', () => {
+  const helper = {
+    check() {
+      expect(1).toBe(1);
+      expect(2).toBe(2);
+    },
+  };
+  expect(3).toBe(3);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 5, 7),
+				},
+			},
+			{
+				Code: `test('constructor and accessors are isolated', () => {
+  class Helper {
+    constructor() {
+      expect(1).toBe(1);
+      expect(2).toBe(2);
+    }
+
+    get value() {
+      expect(3).toBe(3);
+      expect(4).toBe(4);
+      return 1;
+    }
+
+    set value(next) {
+      expect(next).toBe(1);
+      expect(next).toBe(2);
+    }
+  }
+
+  expect(5).toBe(5);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 5, 7, 24),
+					exceededMaxError(2, 1, 10, 7, 24),
+					exceededMaxError(2, 1, 16, 7, 27),
+				},
+			},
+
+			// ---- Real-user: Vitest #891 ----
+			{
+				Code: `import { it as base } from '@rstest/core';
+const test = base.extend({ value: 1 });
+
+test('expect-only destructuring still counts', ({ expect }) => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 6, 3),
+				},
+			},
+
+			// ---- Dimension 4: true assertion factories ----
+			{
+				Code: `test('soft counts', () => {
+  expect.soft(1).toBe(1);
+  expect.soft(2).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3),
+				},
+			},
+			{
+				Code: `test('poll counts', async () => {
+  await expect.poll(read).toBe(1);
+  await expect.poll(read).toBe(2);
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 9),
+				},
+			},
+			{
+				Code: `test('element counts', async () => {
+  await expect.element(locator).toBeVisible();
+  await expect.element(locator).toBeHidden();
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 9),
+				},
+			},
+
+			// ---- Dimension 4: callback inheritance ----
+			{
+				Code: `test('call argument callback inherits current frame', () => {
+  expect(1).toBe(1);
+  emitter.on('event', value => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+  });
+});`,
+				Options: max2Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(3, 2, 5, 5),
+				},
+			},
+			{
+				Code: `test('non-callback function declaration inherits current frame', () => {
+  expect(1).toBe(1);
+  function helper() {
+    expect(2).toBe(2);
+    expect(3).toBe(3);
+  }
+  helper();
+});`,
+				Options: max2Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(3, 2, 5, 5),
+				},
+			},
+
+			// ---- Locks in registration fallback activation timing ----
+			{
+				Code: `test(expect(1).toBe(1), fakeAsync(() => {
+  expect(2).toBe(2);
+  expect(3).toBe(3);
+}));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3),
+				},
+			},
+			{
+				Code: `test('case', { timeout: expect(1).toBe(1) }, fakeAsync(() => {
+  expect(2).toBe(2);
+  expect(3).toBe(3);
+}));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3),
+				},
+			},
+			{
+				Code: `test(makeTitle(() => {
+  expect('title').toBe('title');
+}), () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('case', {
+  timeout: makeTimeout(() => {
+    expect('options').toBe('options');
+  }),
+}, () => {
+  expect(1).toBe(1);
+});`,
+				Options: max1Option,
+			},
+			{
+				Code: `test('wrapper second arg callback-first overload', fakeAsync(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}), 1000);`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3),
+				},
+			},
+			{
+				Code: `test('wrapper third arg options overload', { timeout: 1000 }, fakeAsync(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3),
+				},
+			},
+			{
+				Code: `const options = { timeout: 1000 };
+test('wrapper third arg with non-literal options', options, fakeAsync(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}));`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3),
+				},
+			},
+			{
+				Code: `type TestCallback = () => void;
+test('callback behind as expression', (() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}) as TestCallback);`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3),
+				},
+			},
+			{
+				Code: `type TestCallback = () => void;
+test('callback behind satisfies expression', (() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}) satisfies TestCallback);`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 3),
+				},
+			},
+			{
+				Code: `test('callback behind non-null expression', (() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+})!);`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3),
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/max_expects/max_expects_upstream_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_upstream_test.go
@@ -1,0 +1,561 @@
+// TestMaxExpectsUpstream migrates the full upstream eslint-plugin-jest
+// v29.16.1 max-expects suite 1:1, plus the vitest chai-chain regression that
+// rstest shares semantically. Position assertions cover every invalid case.
+// rstest-specific lock-ins live in max_expects_extras_test.go.
+package max_expects_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/max_expects"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+var (
+	max1Option  = []any{map[string]any{"max": 1}}
+	max2Option  = []any{map[string]any{"max": 2}}
+	max3Option  = []any{map[string]any{"max": 3}}
+	max5Option  = []any{map[string]any{"max": 5}}
+	max10Option = []any{map[string]any{"max": 10}}
+)
+
+func exceededMaxError(count, maxAllowed, line, column int, endColumn ...int) rule_tester.InvalidTestCaseError {
+	err := rule_tester.InvalidTestCaseError{
+		MessageId: "exceededMaxAssertion",
+		Message:   fmt.Sprintf("Too many assertion calls (%d) - maximum allowed is %d", count, maxAllowed),
+		Line:      line,
+		Column:    column,
+	}
+	if len(endColumn) == 1 {
+		err.EndLine = line
+		err.EndColumn = endColumn[0]
+	}
+	return err
+}
+
+func runMaxExpectsRuleTester(t *testing.T, valid []rule_tester.ValidTestCase, invalid []rule_tester.InvalidTestCase) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&max_expects.MaxExpectsRule,
+		valid,
+		invalid,
+	)
+}
+
+func TestMaxExpectsUpstream(t *testing.T) {
+	runMaxExpectsRuleTester(
+		t,
+		[]rule_tester.ValidTestCase{
+			// ---- jest upstream valid ----
+			{Code: `test('should pass')`},
+			{Code: `test('should pass', () => {})`},
+			{Code: `test.skip('should pass', () => {})`},
+			{
+				Code: `test('should pass', function () {
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  // expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `it('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should pass', async () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should pass', async () => {
+  expect.hasAssertions();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should pass', async () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toEqual(expect.any(Boolean));
+});`,
+			},
+			{
+				Code: `test('should pass', async () => {
+  expect.hasAssertions();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toEqual(expect.any(Boolean));
+});`,
+			},
+			{
+				Code: `describe('test', () => {
+  test('should pass', () => {
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+  });
+});`,
+			},
+			{
+				Code: `test.each(['should', 'pass'])('case', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});
+test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should not pass', () => {
+  const checkValue = (value) => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+  };
+
+  checkValue(true);
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `test('should not pass', done => {
+  emitter.on('event', value => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+    done();
+  });
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `function myHelper() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+}
+
+test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+			},
+			{
+				Code: `function myHelper1() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+}
+
+test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});
+
+function myHelper2() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+}`,
+			},
+			{
+				Code: `test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});
+
+function myHelper() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+}`,
+			},
+			{
+				Code: `const myHelper1 = () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+};
+
+test('should pass', function() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});
+
+const myHelper2 = function() {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+};`,
+			},
+			{
+				Code: `test('should pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Options: max10Option,
+			},
+			{
+				Code: `describe('given decimal places', () => {
+  it("test 1", fakeAsync(() => {
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+  }))
+
+  it("test 2", fakeAsync(() => {
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+  }))
+})`,
+				Options: max5Option,
+			},
+
+			// ---- vitest reference parity: chai chain counts once ----
+			{
+				Code: `test('chai chain still counts once', () => {
+  expect('hey').to.be.a('string').and.not.be.empty;
+});`,
+				Options: max1Option,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- jest upstream invalid ----
+			{
+				Code: `test('should not pass', function () {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 7, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 7, 3, 29),
+				},
+			},
+			{
+				Code: `it('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 7, 3, 29),
+				},
+			},
+			{
+				Code: `it('should not pass', async () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 7, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 7, 3, 29),
+					exceededMaxError(6, 5, 15, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', () => {
+  const checkValue = (value) => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+  };
+
+  checkValue(true);
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 5, 32),
+					exceededMaxError(2, 1, 11, 3, 29),
+					exceededMaxError(3, 1, 12, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', () => {
+  const checkValue = (value) => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+  };
+
+  checkValue(true);
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Options: max2Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(3, 2, 12, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', () => {
+  const checkValue = (value) => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+  };
+
+  expect(value).toBeDefined();
+  checkValue(true);
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Options: max2Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(3, 2, 13, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', done => {
+  emitter.on('event', value => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+
+    done();
+  });
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 4, 5, 32),
+					exceededMaxError(2, 1, 11, 3, 29),
+					exceededMaxError(3, 1, 12, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', done => {
+  emitter.on('event', value => {
+    expect(value).toBeDefined();
+    expect(value).toBeDefined();
+
+    done();
+  });
+});
+test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Options: max2Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(3, 2, 12, 3, 29),
+				},
+			},
+			{
+				Code: `describe('given decimal places', () => {
+  it("test 1", fakeAsync(() => {
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+  }))
+
+  it("test 2", fakeAsync(() => {
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+    expect(true).toBeTrue();
+  }))
+})`,
+				Options: max3Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(4, 3, 12, 5, 28),
+					exceededMaxError(5, 3, 13, 5, 28),
+				},
+			},
+			{
+				Code: `describe('test', () => {
+  test('should not pass', () => {
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+    expect(true).toBeDefined();
+  });
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 8, 5, 31),
+				},
+			},
+			{
+				Code: `test.each(['should', 'not', 'pass'])('case', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 7, 3, 29),
+				},
+			},
+			{
+				Code: `test('should not pass', () => {
+  expect(true).toBeDefined();
+  expect(true).toBeDefined();
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3, 29),
+				},
+			},
+			{
+				Code: `test('x', () => {
+  expect(1).toBe(1);
+  expect(1).toBe(1);
+  expect(1).toBe(1);
+  run((() => {
+    expect(1).toBe(1);
+    expect(1).toBe(1);
+    expect(1).toBe(1);
+  }));
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(6, 5, 8, 5, 22),
+				},
+			},
+
+			// ---- vitest reference parity: chai chain counts once per factory ----
+			{
+				Code: `test('chai chains still count as assertions', () => {
+  expect(true).toBeDefined();
+  expect('hey').to.be.a('string');
+});`,
+				Options: max1Option,
+				Errors: []rule_tester.InvalidTestCaseError{
+					exceededMaxError(2, 1, 3, 3, 34),
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -574,6 +574,7 @@ export default defineConfig({
 
     // rstest
     './tests/rstest/rules/expect-expect.test.ts',
+    './tests/rstest/rules/max-expects.test.ts',
     './tests/rstest/rules/no-commented-out-tests.test.ts',
     './tests/rstest/rules/no-conditional-expect.test.ts',
     './tests/rstest/rules/no-disabled-tests.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/max-expects.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/max-expects.test.ts
@@ -1,0 +1,201 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('max-expects', {} as never, {
+  valid: [
+    { code: `test('should pass')` },
+    { code: `test('should pass', () => {})` },
+    { code: `test.skip('should pass', () => {})` },
+    {
+      code: `
+        test('should pass', function () {
+          expect(true).toBeDefined();
+        });
+      `,
+    },
+    {
+      code: `
+        test('should pass', () => {
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+        });
+      `,
+    },
+    {
+      code: `
+        test('should pass', async () => {
+          expect.hasAssertions();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toEqual(expect.any(Boolean));
+        });
+      `,
+    },
+    {
+      code: `
+        describe('given decimal places', () => {
+          it("test 1", fakeAsync(() => {
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+          }))
+
+          it("test 2", fakeAsync(() => {
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+          }))
+        })
+      `,
+      options: [{ max: 5 }],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        test('should not pass', function () {
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (6) - maximum allowed is 5',
+          line: 8,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+        test('should not pass', () => {
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (6) - maximum allowed is 5',
+          line: 8,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+        test('should not pass', () => {
+          expect(true).toBeDefined();
+          expect(true).toBeDefined();
+        });
+      `,
+      options: [{ max: 1 }],
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (2) - maximum allowed is 1',
+          line: 4,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('given decimal places', () => {
+          it("test 1", fakeAsync(() => {
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+          }))
+
+          it("test 2", fakeAsync(() => {
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+            expect(true).toBeTrue();
+          }))
+        })
+      `,
+      options: [{ max: 3 }],
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (4) - maximum allowed is 3',
+          line: 13,
+          column: 13,
+        },
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (5) - maximum allowed is 3',
+          line: 14,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: `
+        test('chai chains still count as assertions', () => {
+          expect(true).toBeDefined();
+          expect('hey').to.be.a('string');
+        });
+      `,
+      options: [{ max: 1 }],
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (2) - maximum allowed is 1',
+          line: 4,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `const options = { timeout: 1000 };
+test('wrapped callback with non-literal options', options, fakeAsync(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}));`,
+      options: [{ max: 1 }],
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (2) - maximum allowed is 1',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `type TestCallback = () => void;
+test('callback behind as expression', (() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+}) as TestCallback);`,
+      options: [{ max: 1 }],
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (2) - maximum allowed is 1',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/rstest/rules/max-expects.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/max-expects.test.ts
@@ -197,5 +197,35 @@ test('callback behind as expression', (() => {
         },
       ],
     },
+    {
+      code: `beforeEach(() => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+});`,
+      options: [{ max: 1 }],
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (2) - maximum allowed is 1',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `test('callback nested inside the wrapping argument', wrap({ cb: () => {
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+} }));`,
+      options: [{ max: 1 }],
+      errors: [
+        {
+          messageId: 'exceededMaxAssertion',
+          message: 'Too many assertion calls (2) - maximum allowed is 1',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Summary

Report each assertion past a configurable maximum (default 5) within one test body, so a test that has grown into a checklist becomes visible. Counting goes through the shared `ParseExpectCall`, so `expect(value)`, `expect.soft(value)`, `expect.poll(fn)` and `expect.element(locator)` all count, while static helpers such as `expect.assertions(2)`, `expect.hasAssertions()` and asymmetric matchers do not, and neither do broken chains such as a bare `expect(value)` — those belong to `rstest/valid-expect`. A Chai chain counts once per assertion factory, so `expect(value).to.be.a("string").and.not.be.empty` is one assertion.

Test boundaries come from `analysis.Callbacks().Functions`, which resolves inline callbacks, all three overloads, hoisted and variable-held functions, `.each`, `.for` and `test.extend`. A lifecycle hook body carries its own count as well: `beforeAll`, `beforeEach`, `afterEach` and `afterAll` are test code and are limited the same way a test is. Registered in the rstest plugin but left out of the `recommended` preset, matching upstream.

## Credits

Port from [`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest)'s `max-expects`, cross-checked against [`eslint-plugin-vitest`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `max-expects`.

## Intentional differences from upstream

- **Counts live on a stack of frames, not in one global integer.** Upstream keeps a single counter and resets it to 0 on both entry and exit of any function that is not the registration's direct callback, which discards the enclosing test's tally — the assertions that follow are counted from zero and the ones over the limit go unreported. This port pushes a frame for each counting boundary and pops back to the enclosing count, so the inner function gets its own tally without erasing the test's. The divergence is not limited to a named helper: any function-valued expression between two assertions — a nested registration, an object method, a `new` with a callback — behaves this way.

- **An unresolved callback is recognised by position, anywhere inside the registration's callback argument.** A callback passed by name has no syntactic ancestor tying it to its registration, so its assertions are attributed through the resolved callback set. When the parser cannot resolve the callback, the rule falls back to a registration frame that any function written inside the callback argument activates, whether it is a direct argument of the wrapping call (`test('x', wrap(() => …))`) or nested further in (`new Wrapper(() => …)`, `wrap([() => …])`, `wrap({ cb: () => … })`, `cond ? () => … : null`). A function held in the options object of the `(name, options, callback)` overload is not a callback and does not activate it. The fallback uses `analysis.ParseTestCall` only; nothing is added to the shared analysis.

- **A callback written outside the registration and reached through a member expression is not counted.** `const suite = { run: () => … }; test('a', suite.run)`, and the same shape with a class property, stay silent: the function is written outside the registration and nothing at the registration ties the two together. Upstream counts them because it counts assertions everywhere rather than only in test bodies — which is also why assertions at the top level of a file, or directly in a `describe` body, are ignored here.

- **Ordinary function declarations do not reset the count.** Upstream listens on function expressions and arrow functions; the rslint Jest port additionally covers methods, accessors and constructors because tsgo represents them differently from ESTree. A plain `function` declaration is a boundary in neither, so it inherits the current frame here as well.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

