### PR TITLE
fix: align no-case-declarations with ESLint

### DIFF
--- a/internal/rules/no_case_declarations/no_case_declarations.go
+++ b/internal/rules/no_case_declarations/no_case_declarations.go
@@ -7,7 +7,12 @@ import (
 
 var unexpectedMessage = rule.RuleMessage{
 	Id:          "unexpected",
-	Description: "Unexpected lexical declaration in case clause.",
+	Description: "Unexpected lexical declaration in case block.",
+}
+
+var addBracketsMessage = rule.RuleMessage{
+	Id:          "addBrackets",
+	Description: "Add {} brackets around the case block.",
 }
 
 // https://eslint.org/docs/latest/rules/no-case-declarations
@@ -26,12 +31,26 @@ var NoCaseDeclarationsRule = rule.Rule{
 				// for every case/default clause.
 				for _, clauseNode := range caseBlock.Clauses.Nodes {
 					clause := clauseNode.AsCaseOrDefaultClause()
-					if clause == nil || clause.Statements == nil {
+					if clause == nil || clause.Statements == nil || len(clause.Statements.Nodes) == 0 {
 						continue
 					}
-					for _, statement := range clause.Statements.Nodes {
+
+					statements := clause.Statements.Nodes
+					firstStatement := statements[0]
+					lastStatement := statements[len(statements)-1]
+					buildSuggestion := func() []rule.RuleSuggestion {
+						return []rule.RuleSuggestion{{
+							Message: addBracketsMessage,
+							FixesArr: []rule.RuleFix{
+								rule.RuleFixInsertBefore(ctx.SourceFile, firstStatement, "{ "),
+								rule.RuleFixInsertAfter(lastStatement, " }"),
+							},
+						}}
+					}
+
+					for _, statement := range statements {
 						if isLexicalDeclaration(statement) {
-							ctx.ReportNode(statement, unexpectedMessage)
+							ctx.ReportNodeWithDeferredSuggestions(statement, unexpectedMessage, buildSuggestion)
 						}
 					}
 				}
@@ -49,8 +68,8 @@ func isLexicalDeclaration(node *ast.Node) bool {
 	case ast.KindVariableStatement:
 		varStmt := node.AsVariableStatement()
 		if varStmt != nil && varStmt.DeclarationList != nil {
-			// NOTE: We also check `using` (TC39 Stage 3) since it has the same block-scoping
-			// semantics as let/const. ESLint does not check `using` yet.
+			// BlockScoped covers let, const, using, and await using, matching
+			// upstream's check for every variable declaration kind except var.
 			return varStmt.DeclarationList.Flags&ast.NodeFlagsBlockScoped != 0
 		}
 	}

--- a/internal/rules/no_case_declarations/no_case_declarations_test.go
+++ b/internal/rules/no_case_declarations/no_case_declarations_test.go
@@ -3,9 +3,27 @@ package no_case_declarations
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
+
+func unexpectedError(line int, column int, suggestionOutput string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "unexpected",
+		Message:   "Unexpected lexical declaration in case block.",
+		Line:      line,
+		Column:    column,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+			MessageId: "addBrackets",
+			Output:    suggestionOutput,
+		}},
+	}
+}
 
 func TestNoCaseDeclarationsRule(t *testing.T) {
 	rule_tester.RunRuleTester(
@@ -22,38 +40,40 @@ func TestNoCaseDeclarationsRule(t *testing.T) {
 			{Code: `switch (a) { default: var x = 1; break; }`},
 			{Code: `switch (a) { case 1: break; }`},
 			{Code: `switch (a) {}`},
+			{Code: `switch (a) { case 1: case 2: {} }`},
 			{Code: `switch (a) { case 1: if (a) { const x = 1; } break; }`},
 			{Code: `switch (a) { case 1: type T = string; interface I { value: T } break; }`},
+			{Code: `switch (a) { case 1: enum E { A } namespace N {} break; }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
 				Code: `switch (a) { case 1: let x = 1; break; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 22},
+					unexpectedError(1, 22, `switch (a) { case 1: { let x = 1; break; } }`),
 				},
 			},
 			{
 				Code: `switch (a) { case 1: const x = 1; break; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 22},
+					unexpectedError(1, 22, `switch (a) { case 1: { const x = 1; break; } }`),
 				},
 			},
 			{
 				Code: `switch (a) { case 1: function f() {} break; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 22},
+					unexpectedError(1, 22, `switch (a) { case 1: { function f() {} break; } }`),
 				},
 			},
 			{
 				Code: `switch (a) { case 1: class C {} break; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 22},
+					unexpectedError(1, 22, `switch (a) { case 1: { class C {} break; } }`),
 				},
 			},
 			{
 				Code: `switch (a) { default: let x = 1; break; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 23},
+					unexpectedError(1, 23, `switch (a) { default: { let x = 1; break; } }`),
 				},
 			},
 			{
@@ -67,23 +87,261 @@ func TestNoCaseDeclarationsRule(t *testing.T) {
     class C {}
 }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 3, Column: 5},
-					{MessageId: "unexpected", Line: 4, Column: 5},
-					{MessageId: "unexpected", Line: 8, Column: 5},
+					unexpectedError(3, 5, `switch (a) {
+  case 1:
+    { let x = 1;
+    const y = 2;
+    break; }
+  case 2:
+  default:
+    class C {}
+}`),
+					unexpectedError(4, 5, `switch (a) {
+  case 1:
+    { let x = 1;
+    const y = 2;
+    break; }
+  case 2:
+  default:
+    class C {}
+}`),
+					unexpectedError(8, 5, `switch (a) {
+  case 1:
+    let x = 1;
+    const y = 2;
+    break;
+  case 2:
+  default:
+    { class C {} }
+}`),
 				},
 			},
 			{
 				Code: `switch (a) { case 1: using resource = acquire(); break; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected"},
+					unexpectedError(1, 0, `switch (a) { case 1: { using resource = acquire(); break; } }`),
 				},
 			},
 			{
 				Code: `async function f() { switch (a) { case 1: await using resource = acquire(); break; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected"},
+					unexpectedError(1, 0, `async function f() { switch (a) { case 1: { await using resource = acquire(); break; } } }`),
+				},
+			},
+			{
+				Code: `switch (a) {
+  case 1:
+    {}
+    function f() {}
+    break;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedError(4, 5, `switch (a) {
+  case 1:
+    { {}
+    function f() {}
+    break; }
+}`),
+				},
+			},
+			{
+				Code: `switch (a) {
+  case 1:
+  case 2:
+    let x;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedError(4, 5, `switch (a) {
+  case 1:
+  case 2:
+    { let x; }
+}`),
 				},
 			},
 		},
 	)
+}
+
+func lintNoCaseDeclarationsSource(t *testing.T, source string, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/no-case-declarations.ts",
+		Path:     "/no-case-declarations.ts",
+	}, source, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(NoCaseDeclarationsRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+		Demand: demand,
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	listeners := NoCaseDeclarationsRule.Run(ctx, nil)
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
+}
+
+func TestNoCaseDeclarationsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const source = `switch (value) {
+  case 0:
+    // keep before first statement
+    let first = 1;
+    const second = 2;
+    break; // keep after last statement
+}`
+	const suggested = `switch (value) {
+  case 0:
+    // keep before first statement
+    { let first = 1;
+    const second = 2;
+    break; } // keep after last statement
+}`
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		diagnostics := lintNoCaseDeclarationsSource(t, source, demand)
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{}
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		diagnostics[demand] = run(demand)
+	}
+
+	wantRangeText := []string{"let first = 1;", "const second = 2;"}
+	for index, text := range wantRangeText {
+		baseline := diagnostics[rule.EditDemandNone][index]
+		if got := source[baseline.Range.Pos():baseline.Range.End()]; got != text {
+			t.Errorf("diagnostic %d range text = %q, want %q", index, got, text)
+		}
+		for demand, got := range diagnostics {
+			actual := got[index]
+			if actual.Range != baseline.Range || actual.Message.Id != baseline.Message.Id ||
+				actual.Message.Description != baseline.Message.Description || actual.RuleName != baseline.RuleName {
+				t.Errorf("demand %d changed diagnostic %d identity", demand, index)
+			}
+			if actual.FixesPtr != nil {
+				t.Errorf("demand %d diagnostic %d unexpectedly materialized autofixes", demand, index)
+			}
+		}
+
+		for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix} {
+			if diagnostics[demand][index].Suggestions != nil {
+				t.Errorf("demand %d diagnostic %d unexpectedly materialized suggestions", demand, index)
+			}
+		}
+		for _, demand := range []rule.EditDemand{rule.EditDemandSuggestion, rule.EditDemandAll} {
+			attached := diagnostics[demand][index].Suggestions
+			if attached == nil || len(*attached) != 1 {
+				t.Fatalf("demand %d diagnostic %d suggestions = %#v, want one", demand, index, attached)
+			}
+			suggestion := (*attached)[0]
+			if suggestion.Message.Id != "addBrackets" || suggestion.Message.Description != "Add {} brackets around the case block." {
+				t.Errorf("demand %d diagnostic %d has unexpected suggestion message %#v", demand, index, suggestion.Message)
+			}
+			output, _, _ := linter.ApplyRuleFixes(source, []rule.RuleSuggestion{suggestion})
+			if output != suggested {
+				t.Errorf("demand %d diagnostic %d suggestion output:\n%s\nwant:\n%s", demand, index, output, suggested)
+			}
+		}
+	}
+}
+
+func TestNoCaseDeclarationsDisableDirectives(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name           string
+		source         string
+		wantRangeText  string
+		wantSuggestion string
+	}{
+		{
+			name: "next-line",
+			source: `switch (a) {
+  case 1:
+    /* eslint-disable-next-line no-case-declarations */
+    let suppressed = 1;
+    const reported = 2;
+    break;
+}`,
+			wantRangeText: "const reported = 2;",
+			wantSuggestion: `switch (a) {
+  case 1:
+    /* eslint-disable-next-line no-case-declarations */
+    { let suppressed = 1;
+    const reported = 2;
+    break; }
+}`,
+		},
+		{
+			name: "block-disable-enable",
+			source: `/* eslint-disable no-case-declarations */
+switch (a) {
+  case 1:
+    let suppressed = 1;
+}
+/* eslint-enable no-case-declarations */
+switch (a) {
+  default:
+    const reported = 2;
+    break;
+}`,
+			wantRangeText: "const reported = 2;",
+			wantSuggestion: `/* eslint-disable no-case-declarations */
+switch (a) {
+  case 1:
+    let suppressed = 1;
+}
+/* eslint-enable no-case-declarations */
+switch (a) {
+  default:
+    { const reported = 2;
+    break; }
+}`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostics := lintNoCaseDeclarationsSource(t, testCase.source, rule.EditDemandAll)
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+			}
+			diagnostic := diagnostics[0]
+			if got := testCase.source[diagnostic.Range.Pos():diagnostic.Range.End()]; got != testCase.wantRangeText {
+				t.Errorf("range text = %q, want %q", got, testCase.wantRangeText)
+			}
+			if diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != 1 {
+				t.Fatalf("suggestions = %#v, want one", diagnostic.Suggestions)
+			}
+			output, _, _ := linter.ApplyRuleFixes(testCase.source, []rule.RuleSuggestion{(*diagnostic.Suggestions)[0]})
+			if output != testCase.wantSuggestion {
+				t.Errorf("suggestion output:\n%s\nwant:\n%s", output, testCase.wantSuggestion)
+			}
+		})
+	}
 }

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-case-declarations.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-case-declarations.test.ts.snap
@@ -5,7 +5,7 @@ exports[`no-case-declarations > invalid 1`] = `
   "code": "switch (a) { case 1: let x = 1; break; }",
   "diagnostics": [
     {
-      "message": "Unexpected lexical declaration in case clause.",
+      "message": "Unexpected lexical declaration in case block.",
       "messageId": "unexpected",
       "range": {
         "end": {
@@ -31,7 +31,7 @@ exports[`no-case-declarations > invalid 2`] = `
   "code": "switch (a) { case 1: const x = 1; break; }",
   "diagnostics": [
     {
-      "message": "Unexpected lexical declaration in case clause.",
+      "message": "Unexpected lexical declaration in case block.",
       "messageId": "unexpected",
       "range": {
         "end": {
@@ -57,7 +57,7 @@ exports[`no-case-declarations > invalid 3`] = `
   "code": "switch (a) { case 1: function f() {} break; }",
   "diagnostics": [
     {
-      "message": "Unexpected lexical declaration in case clause.",
+      "message": "Unexpected lexical declaration in case block.",
       "messageId": "unexpected",
       "range": {
         "end": {
@@ -83,7 +83,7 @@ exports[`no-case-declarations > invalid 4`] = `
   "code": "switch (a) { case 1: class C {} break; }",
   "diagnostics": [
     {
-      "message": "Unexpected lexical declaration in case clause.",
+      "message": "Unexpected lexical declaration in case block.",
       "messageId": "unexpected",
       "range": {
         "end": {
@@ -109,7 +109,7 @@ exports[`no-case-declarations > invalid 5`] = `
   "code": "switch (a) { default: let x = 1; break; }",
   "diagnostics": [
     {
-      "message": "Unexpected lexical declaration in case clause.",
+      "message": "Unexpected lexical declaration in case block.",
       "messageId": "unexpected",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Align the `no-case-declarations` diagnostic message with ESLint 10.8.1.
- Add the upstream `addBrackets` suggestion with deferred edit construction.
- Add focused coverage for case/default and fallthrough branches, comments, using declarations, disable directives, and edit-demand isolation; update the JavaScript snapshot.

## Related Links

- https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-case-declarations.js

## Go Benchmark

Temporary package-local benchmark command: `go test ./internal/rules/no_case_declarations -run "^$" -bench "^BenchmarkNoCaseDeclarations$" -benchmem -count=6`. Values are medians of six samples.

| Path | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| Diagnostics only | `324.5 → 308.9` | `800 → 800` | `5 → 5` |
| Suggestions | `326.9 → 842.5` | `800 → 2280` | `5 → 25` |
| Autofix-only demand | `295.0 → 297.5` | `800 → 800` | `5 → 5` |
| No match | `3.989 → 5.351` | `0 → 0` | `0 → 0` |
| Disabled match | `119.30 → 119.75` | `320 → 320` | `2 → 2` |

The suggestion row is not a like-for-like optimization comparison: the before implementation did not produce the upstream-required suggestion. Diagnostic-only, wrong-demand, and disabled paths retain their allocation counts. No separate performance-only change was kept.

Correctness checks:

- `go test ./internal/rules/no_case_declarations -count=3`
- Targeted JavaScript `no-case-declarations` snapshot test
- All 29 reported files and 297 diagnostics compared exactly with upstream ESLint for severity, ranges, and messages
- `pnpm run check-spell`
- `pnpm run format:check`
- Changed-package Go lint with `--new-from-rev=origin/main`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).