### PR TITLE
fix: align no-unused-vars diagnostics with upstream

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -19,6 +19,15 @@ type EnableAutofixRemoval struct {
 	Imports bool `json:"imports"`
 }
 
+type variableType uint8
+
+const (
+	variableTypeVariable variableType = iota
+	variableTypeArrayDestructure
+	variableTypeCatchClause
+	variableTypeParameter
+)
+
 type Config struct {
 	Vars                           string               `json:"vars"`
 	VarsIgnorePattern              string               `json:"varsIgnorePattern"`
@@ -342,8 +351,30 @@ func hasAssignment(definition *ast.Node, writeRefs []*ast.Node) bool {
 				return true
 			}
 		case ast.KindBindingElement:
-			// Destructured element: `const { a } = obj`
-			return true
+			// Variable destructuring writes every binding. Parameter and catch
+			// bindings are definitions unless their own/containing pattern has a
+			// default initializer (or they are reassigned later).
+			definitionOnly := isParameterNode(definition) || isCaughtErrorNode(definition)
+			for current := definition; current != nil; current = current.Parent {
+				switch current.Kind {
+				case ast.KindBindingElement:
+					if element := current.AsBindingElement(); element != nil && element.Initializer != nil {
+						return true
+					}
+				case ast.KindParameter:
+					if parameter := current.AsParameterDeclaration(); parameter != nil && parameter.Initializer != nil {
+						return true
+					}
+					return len(writeRefs) > 0
+				case ast.KindCatchClause:
+					return len(writeRefs) > 0
+				case ast.KindVariableDeclaration:
+					if definitionOnly {
+						return len(writeRefs) > 0
+					}
+					return true
+				}
+			}
 		case ast.KindParameter:
 			// Parameters with default values: `function f(x = 1)`
 			paramDecl := definition.AsParameterDeclaration()
@@ -751,23 +782,30 @@ func isForInOfDeclaration(node *ast.Node) *ast.Node {
 	return nil
 }
 
-// hasArrayDestructuringWrite checks if the variable has any write reference
-// via array destructuring assignment (e.g., `[_x] = arr`).
-func hasArrayDestructuringWrite(writeRefs []*ast.Node) bool {
+// hasDirectArrayDestructuringWrite checks the same direct ArrayPattern shape
+// that typescript-eslint sees for a write reference. Defaults and rest
+// elements have an intermediate ESTree node and intentionally do not match.
+func hasDirectArrayDestructuringWrite(writeRefs []*ast.Node) bool {
 	for _, ref := range writeRefs {
-		parent := ref.Parent
-		for parent != nil {
-			if parent.Kind == ast.KindArrayLiteralExpression {
-				return true
-			}
-			if parent.Kind != ast.KindSpreadElement &&
-				parent.Kind != ast.KindParenthesizedExpression {
-				break
-			}
-			parent = parent.Parent
+		if ref.Parent != nil && ref.Parent.Kind == ast.KindArrayLiteralExpression &&
+			utils.IsInDestructuringAssignment(ref.Parent) {
+			return true
 		}
 	}
 	return false
+}
+
+// isDirectArrayDestructuredIdentifier recreates ESTree's direct-parent test
+// for declaration bindings. tsgo stores defaults and rest markers on the
+// BindingElement, so exclude those wrappers explicitly.
+func isDirectArrayDestructuredIdentifier(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBindingElement || node.Parent == nil ||
+		node.Parent.Kind != ast.KindArrayBindingPattern {
+		return false
+	}
+	element := node.AsBindingElement()
+	return element != nil && element.DotDotDotToken == nil && element.Initializer == nil &&
+		element.Name() != nil && ast.IsIdentifier(element.Name())
 }
 
 // isParameterInWithoutBodyDeclaration checks if a parameter is in a function-like
@@ -795,6 +833,36 @@ func isParameterInWithoutBodyDeclaration(node *ast.Node) bool {
 		ast.KindConstructSignature,
 		ast.KindIndexSignature:
 		return true
+	}
+	return false
+}
+
+// isUsedInFunctionTypeSignatureParameter mirrors the extra marking performed
+// by typescript-eslint's UnusedVarsVisitor. Identifiers anywhere in a function
+// type signature parameter are marked as used; identifiers in the return type
+// are not. The bodyless function cases correspond to TSDeclareFunction and
+// TSEmptyBodyFunctionExpression in typescript-estree.
+func isUsedInFunctionTypeSignatureParameter(node *ast.Node) bool {
+	for current := node; current != nil; current = current.Parent {
+		if current.Kind != ast.KindParameter {
+			continue
+		}
+		owner := current.Parent
+		if owner == nil {
+			return false
+		}
+		switch owner.Kind {
+		case ast.KindFunctionType,
+			ast.KindConstructorType,
+			ast.KindCallSignature,
+			ast.KindConstructSignature,
+			ast.KindMethodSignature:
+			return true
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression:
+			return owner.Body() == nil
+		default:
+			return false
+		}
 	}
 	return false
 }
@@ -984,65 +1052,142 @@ func hasStaticInitBlock(classNode *ast.Node) bool {
 	return found
 }
 
-func isDestructuredArrayElement(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-	parent := node.Parent
-	// Walk up through BindingElements to find the containing pattern.
-	for parent != nil {
-		if parent.Kind == ast.KindArrayBindingPattern {
-			return true
-		}
-		if parent.Kind != ast.KindBindingElement {
-			break
-		}
-		parent = parent.Parent
-	}
-	return false
-}
-
 // matchesIgnorePattern checks if a variable name matches its category's
 // ignore pattern, and whether the match should result in ignoring or
 // reporting (when reportUsedIgnorePattern is true and the variable is used).
-// Returns: (shouldIgnore bool, matchesPattern bool)
-func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts *Config, writeRefs []*ast.Node) (bool, bool) {
+// Returns: (shouldIgnore bool, matchesPattern bool, matched variable type)
+func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts *Config, writeRefs []*ast.Node) (bool, bool, variableType) {
 	var re *esregexp.RegExp
+	kind := variableTypeVariable
+	matched := false
 
-	if isParameterNode(varInfo.Definition) {
+	// typescript-eslint evaluates destructuredArrayIgnorePattern before the
+	// binding's ordinary category. This also determines the wording used by
+	// reportUsedIgnorePattern when both patterns match.
+	if opts.destructuredArrayIgnoreRe != nil &&
+		(isDirectArrayDestructuredIdentifier(varInfo.Definition) || hasDirectArrayDestructuringWrite(writeRefs)) &&
+		opts.destructuredArrayIgnoreRe.TestOrTimeout(varName) {
+		kind = variableTypeArrayDestructure
+		matched = true
+	} else if isParameterNode(varInfo.Definition) {
+		kind = variableTypeParameter
 		if opts.Args == "none" {
-			return true, false
+			return true, false, kind
 		}
 		re = opts.argsIgnoreRe
 	} else if isCaughtErrorNode(varInfo.Definition) {
+		kind = variableTypeCatchClause
 		if opts.CaughtErrors == "none" {
-			return true, false
+			return true, false, kind
 		}
 		re = opts.caughtErrorsIgnoreRe
 	} else {
 		re = opts.varsIgnoreRe
 	}
 
-	matched := re.TestOrTimeout(varName)
-
-	// destructuredArrayIgnorePattern applies to array-destructured elements,
-	// checking both the declaration site AND assignment sites (e.g., `let _x; [_x] = arr`).
-	if !matched && opts.destructuredArrayIgnoreRe != nil {
-		if isDestructuredArrayElement(varInfo.Definition) || hasArrayDestructuringWrite(writeRefs) {
-			matched = opts.destructuredArrayIgnoreRe.TestOrTimeout(varName)
-		}
+	if !matched {
+		matched = re != nil && re.TestOrTimeout(varName)
 	}
 
 	if !matched {
-		return false, false
+		return false, false, kind
 	}
 
 	// Pattern matches. If used + reportUsedIgnorePattern, don't ignore — report instead.
 	if varInfo.Used && opts.ReportUsedIgnorePattern {
-		return false, true
+		return false, true, kind
 	}
 
-	return true, true
+	return true, true, kind
+}
+
+func ignorePatternAdditional(kind variableType, opts *Config, used bool) string {
+	var description, pattern string
+	switch kind {
+	case variableTypeArrayDestructure:
+		description = "elements of array destructuring"
+		pattern = opts.DestructuredArrayIgnorePattern
+	case variableTypeCatchClause:
+		description = "caught errors"
+		pattern = opts.CaughtErrorsIgnorePattern
+	case variableTypeParameter:
+		description = "args"
+		pattern = opts.ArgsIgnorePattern
+	default:
+		description = "vars"
+		pattern = opts.VarsIgnorePattern
+	}
+	if pattern == "" {
+		return ""
+	}
+	return ignorePatternMessage(description, pattern, used)
+}
+
+// ignorePatternMessage appends the RegExp display form directly to the message
+// so diagnostics allocate one string instead of separately allocating a
+// prefix, `/pattern/u`, and the final additional message. The escaping mirrors
+// RegExp.prototype.toString(): literal slashes and line terminators are escaped
+// even when the original option was passed to the constructor as a string.
+func ignorePatternMessage(description string, source string, used bool) string {
+	if !strings.ContainsAny(source, "/\n\r\u2028\u2029") {
+		if used {
+			return ". Used " + description + " must not match /" + source + "/u"
+		}
+		return ". Allowed unused " + description + " must match /" + source + "/u"
+	}
+
+	var display strings.Builder
+	display.Grow(len(description) + len(source) + 38)
+	if used {
+		display.WriteString(". Used ")
+		display.WriteString(description)
+		display.WriteString(" must not match ")
+	} else {
+		display.WriteString(". Allowed unused ")
+		display.WriteString(description)
+		display.WriteString(" must match ")
+	}
+	display.WriteByte('/')
+	precedingBackslashes := 0
+	for _, char := range source {
+		switch char {
+		case '\\':
+			display.WriteByte('\\')
+			precedingBackslashes++
+			continue
+		case '/':
+			if precedingBackslashes%2 == 0 {
+				display.WriteByte('\\')
+			}
+			display.WriteByte('/')
+		case '\n':
+			display.WriteString(`\n`)
+		case '\r':
+			display.WriteString(`\r`)
+		case '\u2028':
+			display.WriteString(`\u2028`)
+		case '\u2029':
+			display.WriteString(`\u2029`)
+		default:
+			display.WriteRune(char)
+		}
+		precedingBackslashes = 0
+	}
+	display.WriteString("/u")
+	return display.String()
+}
+
+func definitionVariableType(definition *ast.Node, opts *Config) variableType {
+	if opts.DestructuredArrayIgnorePattern != "" && isDirectArrayDestructuredIdentifier(definition) {
+		return variableTypeArrayDestructure
+	}
+	if isCaughtErrorNode(definition) {
+		return variableTypeCatchClause
+	}
+	if isParameterNode(definition) {
+		return variableTypeParameter
+	}
+	return variableTypeVariable
 }
 
 // isBeforeLastUsedParam checks if a parameter appears before a later parameter
@@ -1172,32 +1317,46 @@ doneParentWalk:
 	return false
 }
 
-func buildUnusedVarMessage(varName string, hasAssignment bool) rule.RuleMessage {
-	desc := "'" + varName + "' is defined but never used."
+func buildUnusedVarMessage(varName string, hasAssignment bool, additional string) rule.RuleMessage {
+	action := "defined"
 	if hasAssignment {
-		desc = "'" + varName + "' is assigned a value but never used."
+		action = "assigned a value"
 	}
 	return rule.RuleMessage{
 		Id:          "unusedVar",
-		Description: desc,
+		Description: "'" + varName + "' is " + action + " but never used" + additional + ".",
+		Data: map[string]string{
+			"varName":    varName,
+			"action":     action,
+			"additional": additional,
+		},
 	}
 }
 
-func buildUsedOnlyAsTypeMessage(varName string, hasAssignment bool) rule.RuleMessage {
-	desc := "'" + varName + "' is defined but only used as a type."
+func buildUsedOnlyAsTypeMessage(varName string, hasAssignment bool, additional string) rule.RuleMessage {
+	action := "defined"
 	if hasAssignment {
-		desc = "'" + varName + "' is assigned a value but only used as a type."
+		action = "assigned a value"
 	}
 	return rule.RuleMessage{
 		Id:          "usedOnlyAsType",
-		Description: desc,
+		Description: "'" + varName + "' is " + action + " but only used as a type" + additional + ".",
+		Data: map[string]string{
+			"varName":    varName,
+			"action":     action,
+			"additional": additional,
+		},
 	}
 }
 
-func buildUsedIgnoredVarMessage(varName string) rule.RuleMessage {
+func buildUsedIgnoredVarMessage(varName string, additional string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "usedIgnoredVar",
-		Description: "'" + varName + "' is marked as ignored but is used.",
+		Description: "'" + varName + "' is marked as ignored but is used" + additional + ".",
+		Data: map[string]string{
+			"varName":    varName,
+			"additional": additional,
+		},
 	}
 }
 
@@ -1903,6 +2062,19 @@ func implicitJSXReference(
 	return nil
 }
 
+func lastWriteInDeclarationScope(definition *ast.Node, refs []*ast.Node) *ast.Node {
+	if len(refs) == 0 {
+		return nil
+	}
+	declarationScope := utils.FindEnclosingScope(definition)
+	for index := len(refs) - 1; index >= 0; index-- {
+		if utils.FindEnclosingScope(refs[index]) == declarationScope {
+			return refs[index]
+		}
+	}
+	return nil
+}
+
 // processVariable determines whether a single declared variable/parameter/import
 // is unused and, if so, reports it. The decision pipeline:
 //  1. Read binder-resolved usages from ctx.Refs (checker fallback for residual cases)
@@ -1970,7 +2142,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 				continue
 			}
 			hasUsage = true
-			if !isTypeOnlyReference(usage) {
+			if !isTypeOnlyReference(usage) || isUsedInFunctionTypeSignatureParameter(usage) {
 				onlyUsedAsType = false
 				break
 			}
@@ -2021,7 +2193,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	// Check ignore patterns (varsIgnorePattern / argsIgnorePattern / caughtErrorsIgnorePattern).
 	// If the variable matches its category's pattern and is unused → ignore silently.
 	// If it matches but IS used and reportUsedIgnorePattern is true → report as usedIgnoredVar.
-	shouldIgnore, matchedPattern := matchesIgnorePattern(name, varInfo, opts, info.writeRefs)
+	shouldIgnore, matchedPattern, matchedType := matchesIgnorePattern(name, varInfo, opts, info.writeRefs)
 	if shouldIgnore {
 		return
 	}
@@ -2034,10 +2206,11 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 		// and reportUsedIgnorePattern is true (e.g., `export const x = _Foo`).
 		if matchedPattern && varInfo.Used && opts.ReportUsedIgnorePattern {
 			reportNode := varInfo.Variable
-			if len(info.writeRefs) > 0 {
-				reportNode = info.writeRefs[len(info.writeRefs)-1]
+			if lastWrite := lastWriteInDeclarationScope(definition, info.writeRefs); lastWrite != nil {
+				reportNode = lastWrite
 			}
-			ctx.ReportNode(reportNode, buildUsedIgnoredVarMessage(name))
+			additional := ignorePatternAdditional(matchedType, opts, true)
+			ctx.ReportNode(reportNode, buildUsedIgnoredVarMessage(name, additional))
 		}
 		return
 	}
@@ -2053,17 +2226,20 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	// ESLint reports at the last write reference position (e.g., `a = a + 1` reports
 	// at the LHS `a`). Fall back to the declaration name node if no write refs found.
 	reportNode := varInfo.Variable
-	if len(info.writeRefs) > 0 {
-		reportNode = info.writeRefs[len(info.writeRefs)-1]
+	if lastWrite := lastWriteInDeclarationScope(definition, info.writeRefs); lastWrite != nil {
+		reportNode = lastWrite
 	}
 
 	assigned := hasAssignment(definition, info.writeRefs)
 
 	if matchedPattern && varInfo.Used && opts.ReportUsedIgnorePattern {
-		ctx.ReportNode(reportNode, buildUsedIgnoredVarMessage(name))
+		additional := ignorePatternAdditional(matchedType, opts, true)
+		ctx.ReportNode(reportNode, buildUsedIgnoredVarMessage(name, additional))
 	} else if varInfo.OnlyUsedAsType && opts.Vars == "all" {
-		ctx.ReportNode(reportNode, buildUsedOnlyAsTypeMessage(name, assigned))
+		unusedAdditional := ignorePatternAdditional(definitionVariableType(definition, opts), opts, false)
+		ctx.ReportNode(reportNode, buildUsedOnlyAsTypeMessage(name, assigned, unusedAdditional))
 	} else if !varInfo.Used {
+		unusedAdditional := ignorePatternAdditional(definitionVariableType(definition, opts), opts, false)
 		isImport := isImportDefinition(definition)
 
 		// Track unused imports for allImportSpecifiersUnused check
@@ -2076,13 +2252,13 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 				ctx,
 				reportNode,
 				definition,
-				buildUnusedVarMessage(name, assigned),
+				buildUnusedVarMessage(name, assigned, unusedAdditional),
 				opts.EnableAutofixRemoval.Imports,
 				ac.reportedUnused,
 			)
 			return
 		}
-		ctx.ReportNode(reportNode, buildUnusedVarMessage(name, assigned))
+		ctx.ReportNode(reportNode, buildUnusedVarMessage(name, assigned, unusedAdditional))
 	}
 }
 

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_regression_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_regression_test.go
@@ -1,0 +1,341 @@
+package no_unused_vars
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedVarsIgnorePatternMessages(t *testing.T) {
+	options := map[string]interface{}{
+		"args":                           "all",
+		"argsIgnorePattern":              "^_",
+		"caughtErrors":                   "all",
+		"caughtErrorsIgnorePattern":      "^_",
+		"destructuredArrayIgnorePattern": "^_",
+		"varsIgnorePattern":              "^_",
+	}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    `const value = 1;`,
+				Options: options,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   "'value' is assigned a value but never used. Allowed unused vars must match /^_/u.",
+					Line:      1,
+					Column:    7,
+				}},
+			},
+			{
+				Code:    `const value = 1;`,
+				Options: map[string]interface{}{"varsIgnorePattern": "a/b"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   `'value' is assigned a value but never used. Allowed unused vars must match /a\/b/u.`,
+					Line:      1,
+					Column:    7,
+				}},
+			},
+			{
+				Code:    `const value = 1;`,
+				Options: map[string]interface{}{"varsIgnorePattern": `a\/b`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   `'value' is assigned a value but never used. Allowed unused vars must match /a\/b/u.`,
+					Line:      1,
+					Column:    7,
+				}},
+			},
+			{
+				Code:    `const value = 1;`,
+				Options: map[string]interface{}{"varsIgnorePattern": "a\nb"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   `'value' is assigned a value but never used. Allowed unused vars must match /a\nb/u.`,
+					Line:      1,
+					Column:    7,
+				}},
+			},
+			{
+				Code:    `export function run(value: number) {}`,
+				Options: options,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   "'value' is defined but never used. Allowed unused args must match /^_/u.",
+					Line:      1,
+					Column:    21,
+				}},
+			},
+			{
+				Code:    `try {} catch (error) {}`,
+				Options: options,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   "'error' is defined but never used. Allowed unused caught errors must match /^_/u.",
+					Line:      1,
+					Column:    15,
+				}},
+			},
+			{
+				Code: `declare const source: { value?: number, nested?: { value?: number } };
+export function objectParameter({ value }: { value?: number }) {}
+export function defaultedObjectParameter({ value = 1 }: { value?: number }) {}
+export function arrayParameter([value]: number[]) {}
+export function defaultedArrayParameter([value = 1]: number[]) {}
+export function defaultedParameter(value = 1) {}
+export function defaultedPattern({ nested: { value } } = { nested: {} }) {}
+export function nestedDefault({ nested: { value = 1 } }) {}
+try { throw source; } catch ({ value }) {}
+try { throw source; } catch ({ value = 1 }) {}`,
+				Options: options,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unusedVar", Message: "'value' is defined but never used. Allowed unused args must match /^_/u.", Line: 2, Column: 35},
+					{MessageId: "unusedVar", Message: "'value' is assigned a value but never used. Allowed unused args must match /^_/u.", Line: 3, Column: 44},
+					{MessageId: "unusedVar", Message: "'value' is defined but never used. Allowed unused elements of array destructuring must match /^_/u.", Line: 4, Column: 33},
+					{MessageId: "unusedVar", Message: "'value' is assigned a value but never used. Allowed unused args must match /^_/u.", Line: 5, Column: 42},
+					{MessageId: "unusedVar", Message: "'value' is assigned a value but never used. Allowed unused args must match /^_/u.", Line: 6, Column: 36},
+					{MessageId: "unusedVar", Message: "'value' is assigned a value but never used. Allowed unused args must match /^_/u.", Line: 7, Column: 46},
+					{MessageId: "unusedVar", Message: "'value' is assigned a value but never used. Allowed unused args must match /^_/u.", Line: 8, Column: 43},
+					{MessageId: "unusedVar", Message: "'value' is defined but never used. Allowed unused caught errors must match /^_/u.", Line: 9, Column: 32},
+					{MessageId: "unusedVar", Message: "'value' is assigned a value but never used. Allowed unused caught errors must match /^_/u.", Line: 10, Column: 32},
+				},
+			},
+			{
+				Code:    `const [value] = [1];`,
+				Options: options,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   "'value' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u.",
+					Line:      1,
+					Column:    8,
+				}},
+			},
+			{
+				Code:    `const [value = 1] = [];`,
+				Options: options,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   "'value' is assigned a value but never used. Allowed unused vars must match /^_/u.",
+					Line:      1,
+					Column:    8,
+				}},
+			},
+			{
+				Code:    `const value = 1; export type Value = typeof value;`,
+				Options: options,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "usedOnlyAsType",
+					Message:   "'value' is assigned a value but only used as a type. Allowed unused vars must match /^_/u.",
+					Line:      1,
+					Column:    7,
+				}},
+			},
+			{
+				Code:    `const _value = 1; console.log(_value);`,
+				Options: map[string]interface{}{"varsIgnorePattern": "^_", "reportUsedIgnorePattern": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "usedIgnoredVar",
+					Message:   "'_value' is marked as ignored but is used. Used vars must not match /^_/u.",
+					Line:      1,
+					Column:    7,
+				}},
+			},
+			{
+				Code:    `const [_value] = [1]; console.log(_value);`,
+				Options: map[string]interface{}{"destructuredArrayIgnorePattern": "^_", "varsIgnorePattern": "^_", "reportUsedIgnorePattern": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "usedIgnoredVar",
+					Message:   "'_value' is marked as ignored but is used. Used elements of array destructuring must not match /^_/u.",
+					Line:      1,
+					Column:    8,
+				}},
+			},
+		},
+	)
+}
+
+func TestNoUnusedVarsMessageData(t *testing.T) {
+	tests := []struct {
+		name    string
+		message rule.RuleMessage
+		want    map[string]string
+	}{
+		{
+			name:    "unused",
+			message: buildUnusedVarMessage("value", true, ". Allowed unused vars must match /^_/u"),
+			want: map[string]string{
+				"varName":    "value",
+				"action":     "assigned a value",
+				"additional": ". Allowed unused vars must match /^_/u",
+			},
+		},
+		{
+			name:    "used only as type",
+			message: buildUsedOnlyAsTypeMessage("value", false, ""),
+			want: map[string]string{
+				"varName":    "value",
+				"action":     "defined",
+				"additional": "",
+			},
+		},
+		{
+			name:    "used ignored",
+			message: buildUsedIgnoredVarMessage("_value", ". Used vars must not match /^_/u"),
+			want: map[string]string{
+				"varName":    "_value",
+				"additional": ". Used vars must not match /^_/u",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !reflect.DeepEqual(test.message.Data, test.want) {
+				t.Fatalf("message data = %#v, want %#v", test.message.Data, test.want)
+			}
+		})
+	}
+}
+
+func TestNoUnusedVarsIgnorePatternMessageEscaping(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "slash", source: "a/b", want: `. Allowed unused vars must match /a\/b/u`},
+		{name: "escaped slash", source: `a\/b`, want: `. Allowed unused vars must match /a\/b/u`},
+		{name: "even backslashes before slash", source: `a\\/b`, want: `. Allowed unused vars must match /a\\\/b/u`},
+		{name: "line feed", source: "a\nb", want: `. Allowed unused vars must match /a\nb/u`},
+		{name: "carriage return", source: "a\rb", want: `. Allowed unused vars must match /a\rb/u`},
+		{name: "line separator", source: "a\u2028b", want: `. Allowed unused vars must match /a\u2028b/u`},
+		{name: "paragraph separator", source: "a\u2029b", want: `. Allowed unused vars must match /a\u2029b/u`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ignorePatternMessage("vars", test.source, false); got != test.want {
+				t.Fatalf("message = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNoUnusedVarsFunctionTypeSignatureParameterReferences(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `const functionTypeParameter = 'key';
+export type FunctionType = (value: typeof functionTypeParameter) => void;
+
+const constructorTypeParameter = 'key';
+export type ConstructorType = new (value: typeof constructorTypeParameter) => object;
+
+const callSignatureParameter = 'key';
+export interface CallSignature { (value: typeof callSignatureParameter): void; }
+
+const constructSignatureParameter = 'key';
+export interface ConstructSignature { new (value: typeof constructSignatureParameter): object; }
+
+const methodSignatureParameter = 'key';
+export interface MethodSignature { method(value: typeof methodSignatureParameter): void; }
+
+const declaredFunctionParameter = 'key';
+declare function declaredFunction(value: typeof declaredFunctionParameter): void;
+export { declaredFunction };`,
+			},
+			{
+				Code: `const MOBILE_AUTH_FACE_NOT_SUPPORT_TIP_KEY = 'mobile_auth_face_not_support_tip';
+export const getMobileAuthFaceNotSupportTip = (
+  t: (key: typeof MOBILE_AUTH_FACE_NOT_SUPPORT_TIP_KEY) => string,
+) => t('mobile_auth_face_not_support_tip');`,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `const functionTypeReturn = 'key';
+export type FunctionType = () => typeof functionTypeReturn;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "usedOnlyAsType",
+					Line:      1,
+					Column:    7,
+				}},
+			},
+			{
+				Code: `const methodSignatureReturn = 'key';
+export interface MethodSignature { method(): typeof methodSignatureReturn; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "usedOnlyAsType",
+					Line:      1,
+					Column:    7,
+				}},
+			},
+		},
+	)
+}
+
+func TestNoUnusedVarsReportsWriteFromDeclarationScope(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{{
+			Code: `// eslint-disable-next-line test
+let pendingShareInfo: unknown;
+export function update(value: unknown) {
+  pendingShareInfo = value;
+}`,
+		}},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `let pendingShareInfo: unknown;
+export function update(value: unknown) {
+  pendingShareInfo = value;
+}`,
+				Options: map[string]interface{}{"varsIgnorePattern": "^_"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Message:   "'pendingShareInfo' is assigned a value but never used. Allowed unused vars must match /^_/u.",
+					Line:      1,
+					Column:    5,
+				}},
+			},
+			{
+				Code: `let pendingShareInfo: unknown;
+export function update(value: unknown) {
+  // eslint-disable-next-line test
+  pendingShareInfo = value;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Line:      1,
+					Column:    5,
+				}},
+			},
+			{
+				Code: `let pendingShareInfo: unknown;
+pendingShareInfo = "same scope";
+export function update(value: unknown) {
+  pendingShareInfo = value;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unusedVar",
+					Line:      2,
+					Column:    1,
+				}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-declare.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-declare.test.ts.snap
@@ -258,7 +258,7 @@ exports[`no-unused-vars > invalid 9`] = `
   "code": "const foo = 1;",
   "diagnostics": [
     {
-      "message": "'foo' is assigned a value but never used.",
+      "message": "'foo' is assigned a value but never used. Allowed unused vars must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -286,7 +286,7 @@ const _foo = 1; console.log(_foo);
       ",
   "diagnostics": [
     {
-      "message": "'_foo' is marked as ignored but is used.",
+      "message": "'_foo' is marked as ignored but is used. Used vars must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -315,7 +315,7 @@ foo(1);
       ",
   "diagnostics": [
     {
-      "message": "'_x' is marked as ignored but is used.",
+      "message": "'_x' is marked as ignored but is used. Used args must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -341,7 +341,7 @@ exports[`no-unused-vars > invalid 12`] = `
   "code": "try { throw 1; } catch (_e) { console.log(_e); }",
   "diagnostics": [
     {
-      "message": "'_e' is marked as ignored but is used.",
+      "message": "'_e' is marked as ignored but is used. Used caught errors must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -422,7 +422,7 @@ exports[`no-unused-vars > invalid 15`] = `
   "code": "export function foo(bar: number) {}",
   "diagnostics": [
     {
-      "message": "'bar' is defined but never used.",
+      "message": "'bar' is defined but never used. Allowed unused args must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -448,7 +448,7 @@ exports[`no-unused-vars > invalid 16`] = `
   "code": "try {} catch (err) {}",
   "diagnostics": [
     {
-      "message": "'err' is defined but never used.",
+      "message": "'err' is defined but never used. Allowed unused caught errors must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -1140,7 +1140,7 @@ foo({ a: 1, b: "x" });
       ",
   "diagnostics": [
     {
-      "message": "'b' is assigned a value but never used.",
+      "message": "'b' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -1166,7 +1166,7 @@ exports[`no-unused-vars > invalid 40`] = `
   "code": "const [foo] = [1];",
   "diagnostics": [
     {
-      "message": "'foo' is assigned a value but never used.",
+      "message": "'foo' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-advanced.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-advanced.test.ts.snap
@@ -5,7 +5,7 @@ exports[`no-unused-vars > invalid 1`] = `
   "code": "(function (a, b, c) {});",
   "diagnostics": [
     {
-      "message": "'a' is defined but never used.",
+      "message": "'a' is defined but never used. Allowed unused args must match /c/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -20,7 +20,7 @@ exports[`no-unused-vars > invalid 1`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'b' is defined but never used.",
+      "message": "'b' is defined but never used. Allowed unused args must match /c/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -46,7 +46,7 @@ exports[`no-unused-vars > invalid 2`] = `
   "code": "(function (a, b, { c, d }) {});",
   "diagnostics": [
     {
-      "message": "'a' is defined but never used.",
+      "message": "'a' is defined but never used. Allowed unused args must match /[cd]/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -61,7 +61,7 @@ exports[`no-unused-vars > invalid 2`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'b' is defined but never used.",
+      "message": "'b' is defined but never used. Allowed unused args must match /[cd]/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -87,7 +87,7 @@ exports[`no-unused-vars > invalid 3`] = `
   "code": "(function (a, b, { c, d }) {});",
   "diagnostics": [
     {
-      "message": "'a' is defined but never used.",
+      "message": "'a' is defined but never used. Allowed unused args must match /c/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -102,7 +102,7 @@ exports[`no-unused-vars > invalid 3`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'b' is defined but never used.",
+      "message": "'b' is defined but never used. Allowed unused args must match /c/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -117,7 +117,7 @@ exports[`no-unused-vars > invalid 3`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'d' is assigned a value but never used.",
+      "message": "'d' is defined but never used. Allowed unused args must match /c/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -143,7 +143,7 @@ exports[`no-unused-vars > invalid 4`] = `
   "code": "(function (a, b, { c, d }) {});",
   "diagnostics": [
     {
-      "message": "'a' is defined but never used.",
+      "message": "'a' is defined but never used. Allowed unused args must match /d/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -158,7 +158,7 @@ exports[`no-unused-vars > invalid 4`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'b' is defined but never used.",
+      "message": "'b' is defined but never used. Allowed unused args must match /d/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -173,7 +173,7 @@ exports[`no-unused-vars > invalid 4`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'c' is assigned a value but never used.",
+      "message": "'c' is defined but never used. Allowed unused args must match /d/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -203,7 +203,7 @@ exports[`no-unused-vars > invalid 5`] = `
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -233,7 +233,7 @@ exports[`no-unused-vars > invalid 6`] = `
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -248,7 +248,7 @@ exports[`no-unused-vars > invalid 6`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'c' is assigned a value but never used.",
+      "message": "'c' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -861,7 +861,7 @@ exports[`no-unused-vars > invalid 27`] = `
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -876,7 +876,7 @@ exports[`no-unused-vars > invalid 27`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'c' is assigned a value but never used.",
+      "message": "'c' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -906,7 +906,7 @@ exports[`no-unused-vars > invalid 28`] = `
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -936,7 +936,7 @@ exports[`no-unused-vars > invalid 29`] = `
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -951,7 +951,7 @@ exports[`no-unused-vars > invalid 29`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'c' is assigned a value but never used.",
+      "message": "'c' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -981,7 +981,7 @@ exports[`no-unused-vars > invalid 30`] = `
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -996,7 +996,7 @@ exports[`no-unused-vars > invalid 30`] = `
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'c' is assigned a value but never used.",
+      "message": "'c' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -1292,6 +1292,21 @@ function foo() {
       ",
   "diagnostics": [
     {
+      "message": "'a' is assigned a value but never used.",
+      "messageId": "unusedVar",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+    {
       "message": "'foo' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
@@ -1302,21 +1317,6 @@ function foo() {
         "start": {
           "column": 10,
           "line": 4,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-unused-vars",
-    },
-    {
-      "message": "'a' is assigned a value but never used.",
-      "messageId": "unusedVar",
-      "range": {
-        "end": {
-          "column": 6,
-          "line": 7,
-        },
-        "start": {
-          "column": 5,
-          "line": 7,
         },
       },
       "ruleName": "@typescript-eslint/no-unused-vars",
@@ -1344,12 +1344,12 @@ function init() {
       "messageId": "unusedVar",
       "range": {
         "end": {
-          "column": 6,
-          "line": 6,
+          "column": 4,
+          "line": 4,
         },
         "start": {
-          "column": 3,
-          "line": 6,
+          "column": 1,
+          "line": 4,
         },
       },
       "ruleName": "@typescript-eslint/no-unused-vars",

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-basic.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-basic.test.ts.snap
@@ -933,12 +933,12 @@ function f() {
       "messageId": "unusedVar",
       "range": {
         "end": {
-          "column": 9,
-          "line": 5,
+          "column": 8,
+          "line": 3,
         },
         "start": {
-          "column": 8,
-          "line": 5,
+          "column": 7,
+          "line": 3,
         },
       },
       "ruleName": "@typescript-eslint/no-unused-vars",
@@ -985,7 +985,7 @@ export function fn2({ x, y }) {
       ",
   "diagnostics": [
     {
-      "message": "'y' is assigned a value but never used.",
+      "message": "'y' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-catch-loops.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-catch-loops.test.ts.snap
@@ -260,7 +260,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'err' is defined but never used.",
+      "message": "'err' is defined but never used. Allowed unused caught errors must match /^ignore/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -349,7 +349,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'err' is defined but never used.",
+      "message": "'err' is defined but never used. Allowed unused caught errors must match /^ignore/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -380,7 +380,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'error' is defined but never used.",
+      "message": "'error' is defined but never used. Allowed unused caught errors must match /^ignore/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -395,7 +395,7 @@ try {
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'err' is defined but never used.",
+      "message": "'err' is defined but never used. Allowed unused caught errors must match /^ignore/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-patterns.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-patterns.test.ts.snap
@@ -8,7 +8,7 @@ foo();
       ",
   "diagnostics": [
     {
-      "message": "'a' is defined but never used.",
+      "message": "'a' is defined but never used. Allowed unused args must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -39,7 +39,7 @@ foo();
       ",
   "diagnostics": [
     {
-      "message": "'c' is defined but never used.",
+      "message": "'c' is defined but never used. Allowed unused args must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -68,7 +68,7 @@ foo();
       ",
   "diagnostics": [
     {
-      "message": "'_a' is defined but never used.",
+      "message": "'_a' is defined but never used. Allowed unused args must match /[iI]gnored/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -94,7 +94,7 @@ exports[`no-unused-vars > invalid 4`] = `
   "code": "var [firstItemIgnored, secondItem] = items;",
   "diagnostics": [
     {
-      "message": "'secondItem' is assigned a value but never used.",
+      "message": "'secondItem' is assigned a value but never used. Allowed unused vars must match /[iI]gnored/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -153,7 +153,7 @@ const [a, _b, c] = array;
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -168,7 +168,7 @@ const [a, _b, c] = array;
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'c' is assigned a value but never used.",
+      "message": "'c' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -200,7 +200,7 @@ const ignoreArray = ['ignore'];
       ",
   "diagnostics": [
     {
-      "message": "'a' is assigned a value but never used.",
+      "message": "'a' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -215,7 +215,7 @@ const ignoreArray = ['ignore'];
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'c' is assigned a value but never used.",
+      "message": "'c' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -230,7 +230,7 @@ const ignoreArray = ['ignore'];
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'fooArray' is assigned a value but never used.",
+      "message": "'fooArray' is assigned a value but never used. Allowed unused vars must match /ignore/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -245,7 +245,7 @@ const ignoreArray = ['ignore'];
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'barArray' is assigned a value but never used.",
+      "message": "'barArray' is assigned a value but never used. Allowed unused vars must match /ignore/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -306,7 +306,7 @@ foo();
       ",
   "diagnostics": [
     {
-      "message": "'_a' is assigned a value but never used.",
+      "message": "'_a' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -518,7 +518,7 @@ exports[`no-unused-vars > invalid 16`] = `
   "code": "({ a, ...rest }) => {};",
   "diagnostics": [
     {
-      "message": "'rest' is assigned a value but never used.",
+      "message": "'rest' is defined but never used.",
       "messageId": "unusedVar",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-report-used.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars-eslint-report-used.test.ts.snap
@@ -8,7 +8,7 @@ const _b = _a + 5;
       ",
   "diagnostics": [
     {
-      "message": "'_a' is marked as ignored but is used.",
+      "message": "'_a' is marked as ignored but is used. Used vars must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -37,7 +37,7 @@ foo(() => _a);
       ",
   "diagnostics": [
     {
-      "message": "'_a' is marked as ignored but is used.",
+      "message": "'_a' is marked as ignored but is used. Used vars must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -67,7 +67,7 @@ exports[`no-unused-vars > invalid 3`] = `
       ",
   "diagnostics": [
     {
-      "message": "'_a' is marked as ignored but is used.",
+      "message": "'_a' is marked as ignored but is used. Used args must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -96,7 +96,7 @@ console.log(a + _b);
       ",
   "diagnostics": [
     {
-      "message": "'_b' is marked as ignored but is used.",
+      "message": "'_b' is marked as ignored but is used. Used elements of array destructuring must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -128,7 +128,7 @@ foo(_x);
       ",
   "diagnostics": [
     {
-      "message": "'_x' is marked as ignored but is used.",
+      "message": "'_x' is marked as ignored but is used. Used elements of array destructuring must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -157,7 +157,7 @@ foo(ignored);
       ",
   "diagnostics": [
     {
-      "message": "'ignored' is marked as ignored but is used.",
+      "message": "'ignored' is marked as ignored but is used. Used vars must not match /[iI]gnored/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -188,7 +188,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'_err' is marked as ignored but is used.",
+      "message": "'_err' is marked as ignored but is used. Used caught errors must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -219,7 +219,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'_' is assigned a value but never used.",
+      "message": "'_' is assigned a value but never used. Allowed unused caught errors must match /foo/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -250,7 +250,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'_' is assigned a value but never used.",
+      "message": "'_' is assigned a value but never used. Allowed unused caught errors must match /ignored/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -279,7 +279,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'message' is assigned a value but never used.",
+      "message": "'message' is defined but never used. Allowed unused caught errors must match /foo/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -294,7 +294,7 @@ try {
       "ruleName": "@typescript-eslint/no-unused-vars",
     },
     {
-      "message": "'firstError' is assigned a value but never used.",
+      "message": "'firstError' is defined but never used. Allowed unused caught errors must match /foo/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -325,7 +325,7 @@ try {
       ",
   "diagnostics": [
     {
-      "message": "'$' is assigned a value but never used.",
+      "message": "'$' is assigned a value but never used. Allowed unused caught errors must match /\\w/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {
@@ -355,7 +355,7 @@ _ => {
       ",
   "diagnostics": [
     {
-      "message": "'_' is assigned a value but never used.",
+      "message": "'_' is assigned a value but never used. Allowed unused args must match /ignored/u.",
       "messageId": "unusedVar",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars.test.ts.snap
@@ -1298,7 +1298,7 @@ export const x: _Foo = 1;
       ",
   "diagnostics": [
     {
-      "message": "'_Foo' is marked as ignored but is used.",
+      "message": "'_Foo' is marked as ignored but is used. Used vars must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -1327,7 +1327,7 @@ export const x: _Foo = 1;
       ",
   "diagnostics": [
     {
-      "message": "'_Foo' is marked as ignored but is used.",
+      "message": "'_Foo' is marked as ignored but is used. Used vars must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -1358,7 +1358,7 @@ export const x = _Foo.A;
       ",
   "diagnostics": [
     {
-      "message": "'_Foo' is marked as ignored but is used.",
+      "message": "'_Foo' is marked as ignored but is used. Used vars must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {
@@ -1387,7 +1387,7 @@ export const x = _Foo;
       ",
   "diagnostics": [
     {
-      "message": "'_Foo' is marked as ignored but is used.",
+      "message": "'_Foo' is marked as ignored but is used. Used vars must not match /^_/u.",
       "messageId": "usedIgnoredVar",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Align the Go `@typescript-eslint/no-unused-vars` messages, structured message data, report locations, destructured-binding actions, and function-type-signature usage semantics with typescript-eslint v8.67.0.
- Preserve JavaScript `RegExp#toString()` formatting in ignore-pattern messages and avoid intermediate message allocations.
- Update focused Go regressions and the seven affected JavaScript snapshot suites.
- Verify every documented discrepancy: 138 files and 296 rows now match the 295 latest-upstream diagnostics exactly, with no rslint-only or upstream-only results.

Validation:

- `go test ./internal/plugins/typescript/rules/no_unused_vars -count=3`
- Seven targeted `no-unused-vars` rstest files (14 tests)
- `pnpm check-spell`
- `pnpm format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_unused_vars/...`

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unused-vars.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
