### PR TITLE
fix: align no-dupe-keys with ESLint

### DIFF
--- a/internal/rules/no_dupe_keys/no_dupe_keys.go
+++ b/internal/rules/no_dupe_keys/no_dupe_keys.go
@@ -26,11 +26,16 @@ const (
 // generated or configuration-heavy objects.
 const inlineObjectStateCapacity = 16
 
+// Bound the lazy overflow allocation when a large object contains mostly
+// spreads or dynamic keys that never enter the state.
+const maxObjectStateCapacityHint = inlineObjectStateCapacity * 4
+
 type objectState struct {
-	names    [inlineObjectStateCapacity]string
-	states   [inlineObjectStateCapacity]propertyState
-	count    int
-	overflow map[string]propertyState
+	names                [inlineObjectStateCapacity]string
+	states               [inlineObjectStateCapacity]propertyState
+	count                int
+	overflowCapacityHint int
+	overflow             map[string]propertyState
 }
 
 func registerProperty(state propertyState, kind propertyKind) (propertyState, bool) {
@@ -72,7 +77,11 @@ func (state *objectState) register(name string, kind propertyKind) bool {
 		return false
 	}
 
-	state.overflow = make(map[string]propertyState, inlineObjectStateCapacity*2)
+	capacity := state.overflowCapacityHint
+	if capacity <= inlineObjectStateCapacity {
+		capacity = inlineObjectStateCapacity * 2
+	}
+	state.overflow = make(map[string]propertyState, capacity)
 	for index := range state.count {
 		state.overflow[state.names[index]] = state.states[index]
 	}
@@ -91,7 +100,12 @@ var NoDupeKeysRule = rule.Rule{
 				if objLit == nil || objLit.Properties == nil || len(objLit.Properties.Nodes) < 2 {
 					return
 				}
-				state := objectState{}
+				// tsgo represents assignment destructuring with object literals,
+				// while ESTree exposes ObjectPattern nodes that ESLint skips.
+				if ast.IsAssignmentTarget(node) && utils.IsInDestructuringAssignment(node) {
+					return
+				}
+				state := objectState{overflowCapacityHint: min(len(objLit.Properties.Nodes), maxObjectStateCapacityHint)}
 
 				for _, prop := range objLit.Properties.Nodes {
 					var kind propertyKind
@@ -134,7 +148,11 @@ var NoDupeKeysRule = rule.Rule{
 					}
 
 					if state.register(name, kind) {
-						ctx.ReportNode(prop, rule.RuleMessage{
+						reportNode := nameNode
+						if nameNode.Kind == ast.KindComputedPropertyName {
+							reportNode = ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
+						}
+						ctx.ReportNode(reportNode, rule.RuleMessage{
 							Id:          "unexpected",
 							Description: "Duplicate key '" + name + "'.",
 						})

--- a/internal/rules/no_dupe_keys/no_dupe_keys_test.go
+++ b/internal/rules/no_dupe_keys/no_dupe_keys_test.go
@@ -26,97 +26,137 @@ func TestNoDupeKeysRule(t *testing.T) {
 			{Code: `var x = { "__proto__": foo, "__proto__": bar };`},
 			{Code: `var x = { __proto__: null, ["__proto__"]: null };`},
 			{Code: `var x = { ["__proto__"]: null, __proto__: null };`},
+			// Assignment destructuring is represented as an object literal by tsgo,
+			// but as an ObjectPattern skipped by the upstream rule.
+			{Code: `({ a: first, a: second } = source);`},
+			{Code: `({ ["a"]: first, ["a"]: second } = source);`},
+			{Code: `((({ nested: { a: first, a: second } }))) = source;`},
+			{Code: `([{ a: first, a: second }] = source);`},
+			{Code: `for ({ a: first, a: second } of source) {}`},
+			{Code: `for ({ a: first, a: second } in source) {}`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
 				Code: `var x = { a: 1, a: 2 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 17},
+					{MessageId: "unexpected", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
 				},
 			},
 			{
 				Code: `var x = { a: 1, b: 2, a: 3 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 23},
+					{MessageId: "unexpected", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
 				},
 			},
 			{
 				Code: `var x = { a: 1, b: 2, a: 3, a: 4 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 23},
-					{MessageId: "unexpected", Line: 1, Column: 29},
+					{MessageId: "unexpected", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+					{MessageId: "unexpected", Line: 1, Column: 29, EndLine: 1, EndColumn: 30},
 				},
 			},
 			{
 				Code: `var x = { "a": 1, "a": 2 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 19},
+					{MessageId: "unexpected", Line: 1, Column: 19, EndLine: 1, EndColumn: 22},
 				},
 			},
 			{
 				Code: `var x = { "a": 1, a: 2 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 19},
+					{MessageId: "unexpected", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
 				},
 			},
 			{
 				Code: `var x = { get a() {}, set a(v) {}, get a() {} };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 36},
+					{MessageId: "unexpected", Line: 1, Column: 40, EndLine: 1, EndColumn: 41},
 				},
 			},
 			{
 				Code: `var x = { set a(v) {}, get a() {}, set a(v) {} };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 36},
+					{MessageId: "unexpected", Line: 1, Column: 40, EndLine: 1, EndColumn: 41},
 				},
 			},
 			{
 				Code: `var x = { get a() {}, set a(v) {}, a: 1 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 36},
+					{MessageId: "unexpected", Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
 				},
 			},
 			{
 				Code: `var x = { a: 1, get a() {}, set a(v) {} };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 17},
-					{MessageId: "unexpected", Line: 1, Column: 29},
+					{MessageId: "unexpected", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+					{MessageId: "unexpected", Line: 1, Column: 33, EndLine: 1, EndColumn: 34},
 				},
 			},
 			// Computed __proto__ is a regular property, not a proto setter
 			{
 				Code: `var x = { ["__proto__"]: 1, ["__proto__"]: 2 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 29},
+					{MessageId: "unexpected", Line: 1, Column: 30, EndLine: 1, EndColumn: 41},
 				},
 			},
 			// Numeric literal equivalence: 0x1 and 1 are the same key
 			{
 				Code: `var x = { 0x1: "a", 1: "b" };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 21},
+					{MessageId: "unexpected", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
 				},
 			},
 			// BigInt literal equivalence: 0x1n and 1n normalize to the same key
 			{
 				Code: `var x = { [0x1n]: "a", [1n]: "b" };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 24},
+					{MessageId: "unexpected", Line: 1, Column: 25, EndLine: 1, EndColumn: 27},
 				},
 			},
 			// Template literal computed property
 			{
 				Code: "var x = { [`key`]: 1, [`key`]: 2 };",
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 23},
+					{MessageId: "unexpected", Line: 1, Column: 24, EndLine: 1, EndColumn: 29},
 				},
 			},
 			// Numeric overflow to Infinity: 1e309 and 1e999 both normalize to "Infinity"
 			{
 				Code: `var x = { [1e309]: "a", [1e999]: "b" };`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpected", Line: 1, Column: 25},
+					{MessageId: "unexpected", Line: 1, Column: 26, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				// A TypeScript-only wrapper prevents the object from becoming an
+				// ESTree ObjectPattern, so the upstream rule still checks it.
+				Code: `({ a: first, a: second }! = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: `({ value = { a: 1, a: 2 } } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `({ [{ a: 1, a: 2 }]: target } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `target = ({ a: 1, a: 2 });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code: `({ a: first, a: second } as any) = source;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
 				},
 			},
 			{
@@ -186,7 +226,7 @@ func TestRegisterPropertyExhaustive(t *testing.T) {
 
 func TestObjectStateMatchesReference(t *testing.T) {
 	nameCount := inlineObjectStateCapacity*2 + 3
-	state := objectState{}
+	state := objectState{overflowCapacityHint: nameCount}
 	reference := make(map[string]referencePropertyInfo, nameCount)
 	seed := uint64(0x9e3779b97f4a7c15)
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-dupe-keys.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-dupe-keys.test.ts.snap
@@ -9,7 +9,7 @@ exports[`no-dupe-keys > invalid 1`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 21,
+          "column": 18,
           "line": 1,
         },
         "start": {
@@ -35,7 +35,7 @@ exports[`no-dupe-keys > invalid 2`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 27,
+          "column": 24,
           "line": 1,
         },
         "start": {
@@ -61,7 +61,7 @@ exports[`no-dupe-keys > invalid 3`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 27,
+          "column": 24,
           "line": 1,
         },
         "start": {
@@ -76,7 +76,7 @@ exports[`no-dupe-keys > invalid 3`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 33,
+          "column": 30,
           "line": 1,
         },
         "start": {
@@ -102,7 +102,7 @@ exports[`no-dupe-keys > invalid 4`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 25,
+          "column": 22,
           "line": 1,
         },
         "start": {
@@ -128,11 +128,11 @@ exports[`no-dupe-keys > invalid 5`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 45,
+          "column": 41,
           "line": 1,
         },
         "start": {
-          "column": 29,
+          "column": 30,
           "line": 1,
         },
       },
@@ -154,7 +154,7 @@ exports[`no-dupe-keys > invalid 6`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 27,
+          "column": 22,
           "line": 1,
         },
         "start": {
@@ -180,11 +180,11 @@ exports[`no-dupe-keys > invalid 7`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 33,
+          "column": 27,
           "line": 1,
         },
         "start": {
-          "column": 24,
+          "column": 25,
           "line": 1,
         },
       },
@@ -206,11 +206,11 @@ exports[`no-dupe-keys > invalid 8`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 33,
+          "column": 29,
           "line": 1,
         },
         "start": {
-          "column": 23,
+          "column": 24,
           "line": 1,
         },
       },
@@ -232,11 +232,37 @@ exports[`no-dupe-keys > invalid 9`] = `
       "messageId": "unexpected",
       "range": {
         "end": {
-          "column": 37,
+          "column": 31,
           "line": 1,
         },
         "start": {
-          "column": 25,
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-keys",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-keys > invalid 10`] = `
+{
+  "code": "var x = { [("a")]: 1, [(("a"))]: 2 };",
+  "diagnostics": [
+    {
+      "message": "Duplicate key 'a'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
           "line": 1,
         },
       },

--- a/packages/rslint-test-tools/tests/eslint/rules/no-dupe-keys.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-dupe-keys.test.ts
@@ -12,6 +12,8 @@ ruleTester.run('no-dupe-keys', {
     // __proto__ as proto setter is allowed to appear multiple times
     'var x = { __proto__: foo, __proto__: bar };',
     'var x = { "__proto__": foo, "__proto__": bar };',
+    '({ a: first, a: second } = source);',
+    '({ ["a"]: first, ["a"]: second } = source);',
   ],
   invalid: [
     {
@@ -54,6 +56,11 @@ ruleTester.run('no-dupe-keys', {
     // Numeric overflow to Infinity: 1e309 and 1e999 both normalize to "Infinity"
     {
       code: 'var x = { [1e309]: "a", [1e999]: "b" };',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Parentheses and computed-property brackets are outside ESLint's key range.
+    {
+      code: 'var x = { [("a")]: 1, [(("a"))]: 2 };',
       errors: [{ messageId: 'unexpected' }],
     },
   ],


### PR DESCRIPTION
## Summary

- report duplicate object keys on the key range, matching ESLint 10.8.1 diagnostics
- skip object literals used as assignment destructuring patterns while preserving TypeScript wrapper behavior
- keep small objects allocation-free and reduce lazy overflow-map growth for large static-key objects
- add adversarial Go coverage and update the JavaScript snapshot

## Related Links

- https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-dupe-keys.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
