### PR TITLE
fix: report sparse array commas

### DIFF
--- a/internal/rules/no_sparse_arrays/no_sparse_arrays.go
+++ b/internal/rules/no_sparse_arrays/no_sparse_arrays.go
@@ -2,6 +2,7 @@ package no_sparse_arrays
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -12,19 +13,26 @@ var NoSparseArraysRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindArrayLiteralExpression: func(node *ast.Node) {
-				// Array literals used as destructuring assignment targets (e.g. `[, a] = b`)
-				// are parsed as ArrayLiteralExpression too, but omitted elements there are
-				// valid ES6 syntax for skipping items, not sparse array literals.
-				if ast.IsAssignmentTarget(node) {
-					return
-				}
+				checkedAssignmentTarget := false
 				for _, v := range node.AsArrayLiteralExpression().Elements.Nodes {
-					if v.Kind == ast.KindOmittedExpression {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "unexpectedSparseArray",
-							Description: "Unexpected comma in middle of array.",
-						})
+					if v.Kind != ast.KindOmittedExpression {
+						continue
 					}
+
+					// TypeScript parses array destructuring assignment targets (e.g.
+					// `[, a] = b`) as ArrayLiteralExpression too. Their omitted elements
+					// skip values rather than create sparse arrays.
+					if !checkedAssignmentTarget {
+						if ast.IsAssignmentTarget(node) {
+							return
+						}
+						checkedAssignmentTarget = true
+					}
+
+					ctx.ReportRange(scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, v.Pos()), rule.RuleMessage{
+						Id:          "unexpectedSparseArray",
+						Description: "Unexpected comma in middle of array.",
+					})
 				}
 			},
 		}

--- a/internal/rules/no_sparse_arrays/no_sparse_arrays_test.go
+++ b/internal/rules/no_sparse_arrays/no_sparse_arrays_test.go
@@ -25,41 +25,42 @@ func TestNoSparseArraysRule(t *testing.T) {
 			{Code: `[a, , b] = [1, 2, 3];`},
 			{Code: `for ([, x] of y) {}`},
 			{Code: `[[, a]] = b;`},
+			{Code: `({ value: [, a] } = b);`},
+			{Code: `[...[, a]] = b;`},
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
 			{
 				Code: `var a = [,];`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpectedSparseArray", Line: 1, Column: 9},
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
 				},
 			},
 			{
 				Code: `var a = [ 1,, 2];`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpectedSparseArray", Line: 1, Column: 9},
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
 				},
 			},
-			// This test case is commented out because it produces a TypeScript compilation error:
-			// error creating TS program for /tsconfig.json: found 5 syntactic errors. [Invalid character. [\r\n\t/* comment */,\n// comment\n ,]; Invalid character. [\r\n\t/* comment */,\n// comment\n ,]; Invalid character. [\r\n\t/* comment */,\n// comment\n ,]; Invalid character. [\r\n\t/* comment */,\n// comment\n ,]; ']' expected. [\r\n\t/* comment */,\n// comment\n ,];]
-			//{
-			//	Code: `[\r\n\t/* comment */,\n// comment\n ,];`,
-			//	Errors: []rule_tester.InvalidTestCaseError{
-			//		{MessageId: "unexpectedSparseArray", Line: 1, Column: 9},
-			//	},
-			//},
+			{
+				Code: "[\r\n\t/* comment */,\n// comment\n ,];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSparseArray", Line: 2, Column: 15, EndLine: 2, EndColumn: 16},
+					{MessageId: "unexpectedSparseArray", Line: 4, Column: 2, EndLine: 4, EndColumn: 3},
+				},
+			},
 			{
 				Code: `[(( [a,] )),,,];`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpectedSparseArray", Line: 1, Column: 1},
-					{MessageId: "unexpectedSparseArray", Line: 1, Column: 1},
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
 				},
 			},
 			{
 				Code: `[,(( [a,] )),,];`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpectedSparseArray", Line: 1, Column: 1},
-					{MessageId: "unexpectedSparseArray", Line: 1, Column: 1},
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
 				},
 			},
 			{
@@ -67,7 +68,21 @@ func TestNoSparseArraysRule(t *testing.T) {
 				// RHS is a genuine sparse array literal and must still be flagged.
 				Code: `[a, b] = [1, , 2];`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpectedSparseArray", Line: 1, Column: 10},
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				// An array literal used as a destructuring default remains a real
+				// array expression, even though the surrounding array is a target.
+				Code: `[value = [,]] = source;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: `const emoji = "😀"; const values = [1,, 2];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 39, EndLine: 1, EndColumn: 40},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Report each `no-sparse-arrays` diagnostic on the offending comma, matching ESLint v10.8.1.
- Preserve TypeScript destructuring-assignment behavior while skipping assignment-target checks for dense arrays.
- Port upstream location coverage and add regressions for nested destructuring defaults and UTF-16 columns.

## Related Links

- https://github.com/eslint/eslint/pull/18579

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).