### PR TITLE
refactor: define config target semantics

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -788,8 +788,9 @@ The transport and target phase differ by surface:
 - Each selected runtime starts `rslint/configRefresh`. With no `configPath`, Go
   scans that process's workspace-folder cwd with a transaction-scoped cached
   VFS. A client may instead repeat one fixed absolute JS/TS `configPath` on
-  every refresh; Go loads exactly that module while retaining the process cwd
-  as its invocation-wide matching root. The client owns change notifications
+  every refresh; Go loads exactly that module, uses the module's directory as
+  its authored config base, and retains the process cwd as the invocation-wide
+  target scope. The client owns change notifications
   for the explicit path, while Go's existing `.gitignore` watcher refreshes
   the already-fixed source. Go sends
   `rslint/loadConfigs` and
@@ -823,8 +824,9 @@ model. The independent numeric document generation only rejects stale async
 diagnostics after edits, closes, or config commits.
 
 An explicit JS/TS `--config` or API `overrideConfigFile` bypasses automatic
-candidate selection and loads the exact module. The invocation cwd remains its
-matching directory. The exact config path is never gated by `.gitignore`;
+candidate selection and loads the exact module. Its directory remains the
+authored base for relative config content, while the invocation cwd remains the
+implicit scan and response-path root. The exact config path is never gated by `.gitignore`;
 only after it loads does a fixed-owner frontier freeze the invocation-scoped
 Git projection used to filter lint targets. That frontier never probes or
 activates nested config candidates. Automatic candidates instead use Git
@@ -868,15 +870,70 @@ immutable effective config/rule plan. Files with the same set share one plan for
 that resolver's lifetime. Shape identity is collision-free (`uint64` for the
 first 64 entries plus the complete remaining bitset), resolver-local, and
 independent of path identity. File-cache keys remain the exact caller strings;
-the resolver does not clean, case-fold, canonicalize, or merge symlink aliases.
-The direct `GetConfigForFile()` compatibility path uses the same match/merge
-primitives without retaining a cache.
+filesystem identity may select the matching space, but it never changes the
+cache identity or merges distinct lexical targets.
+The direct `GetConfigForFile()` compatibility path retains its allocation-light
+single-origin matcher and delegates composed multi-origin arrays to the target
+resolver; both paths feed the same ordered merge policy without retaining a
+plan cache.
 
 The staged coordinator builds the effective catalog used by
-`ConfigOwnerResolver.Resolve()` before `GetConfigForFile()` merges the selected
-entries. Staged CLI, native API, and transactional LSP paths therefore reuse the
-same Go ownership rules instead of independently reconstructing hierarchy on
-the Node side.
+`ConfigOwnerResolver` before the target resolver merges the selected entries.
+CLI/API target plans call ownership once during discovery and carry that owner
+through Program binding. Each target records four separate facts: the caller's
+lexical `Path`, the file's `CanonicalPath`, the lexical parent's physical
+`CanonicalParentPath`, and the governing `ConfigDirectory`. The parent identity
+distinguishes a leaf file symlink from a directory alias; it is not treated as
+proof of the target's complete ancestor chain. Native-case owner aliases may be
+verified once while the target's owner is selected. LSP then freezes one
+document lint snapshot containing the same complete target plus its selected
+owner, resolved config, and project paths; native rules, plugin rules,
+diagnostics, resident Programs, and every fix pass consume that snapshot. No
+later stage resolves the target file or selects its owner again. Staged CLI,
+native API, and transactional LSP paths therefore reuse the same Go ownership
+rules instead of independently reconstructing hierarchy on the Node side.
+
+Configuration meaning and invocation scope are separate inputs. For one
+invocation-wide config, `ConfigDirectory` is the config file's directory and is
+the authored base used by `files`, `ignores`, and `parserOptions.project`;
+`ScanRoot` is the invocation working directory used by implicit/no-argument
+target discovery and the default `.gitignore` collection scope. Supplying an external config therefore does not scan
+the config directory unless the user also targets it, and does not rebase the
+config's relative patterns onto the invocation cwd. A composed config entry may
+retain a different authored base (the native API's inline `overrideConfig` is
+the current case), so matching resolves every entry from its own origin before
+merging the matched shape, and project declarations resolve from that same
+origin before they reach the Program loader. Automatic config catalogs already
+encode one owner directory per config and do not use the invocation-wide
+`ScanRoot` to infer ownership.
+
+`LintTargetPlanRequest` is the config-layer boundary for CLI/API target
+selection. Explicit files and recursive directories form one union; omitted
+CLI targets become the invocation cwd, and multiple files/directories do not
+change one another's config matching. Each planned target retains its
+caller-visible path, file and parent filesystem identities, and established
+config owner. For each literal file request, the plan also carries the
+existence and ignore outcome produced by that same discovery decision; CLI
+warning rendering never re-reads the filesystem or re-resolves ownership. The
+plan retains the authored config-base path spaces observed during discovery,
+but not the execution config value: CLI `--rule` and API overrides are layered
+after target selection and are evaluated in those same frozen path spaces.
+`internal/program/loader` consumes the plan but cannot add targets, change
+ownership, or reinterpret config-relative paths.
+
+Git collection scope is independent from config-entry origin. Targets
+representable beneath `ScanRoot` share its scope; every requested directory
+outside that tree creates an independent scope, while an exact outside file
+does not invent a directory scope. The synthetic Git entry retains every active
+scope, including a scope that produced no patterns. Matching first assigns a
+target to exactly one scope by lexical containment, falling back to the same
+ordered scope list by canonical-to-physical containment only when no lexical
+scope applies. Final ignore decisions, directory pruning, and negation-based
+reopening all consume that one assignment, so aliases and sibling directory
+arguments cannot borrow or override one another's `.gitignore` policy. A
+requested physical ancestor of an aliased `ScanRoot` is outside, not beneath,
+that root and therefore receives its own scope; this keeps every directory the
+target walker can scan covered by the same Git-source frontier.
 
 Ownership lookup never compares depth across lexical and physical path spaces:
 the nearest exact lexical config wins, a native case alias is accepted only
@@ -891,12 +948,15 @@ allowed alias.
 Additional current behaviors:
 
 - `.gitignore` is injected as a global-ignore entry through the shared
-  `ConfigWithCollectedGitignore`/`ConfigWithGitignore` policy. The governing
-  config directory is a hard upper boundary: its own and nested `.gitignore`
-  files apply, while parent `.gitignore` files do not. In staged JS/TS catalogs,
-  the walk records sources by owner and case-aware source identity, orders them
-  parent-before-child, and materializes the synthetic Git entry before
-  publishing. Direct automatically reachable child config directories are
+  `ConfigWithCollectedGitignore`/`ConfigWithGitignore` policy. Automatic config
+  owners use their config directory as the hard upper collection boundary; an
+  explicit invocation-wide config instead uses the invocation Git scopes
+  described above, even when the config file is external. Sources below each
+  scope boundary apply, while sources in its parents do not. In staged JS/TS
+  catalogs, the walk records sources by owner, scope, and case-aware source
+  identity, orders them parent-before-child within that scope, and
+  materializes the synthetic Git entry before publishing. Direct automatically
+  reachable child config directories are
   downward ownership handoff boundaries; an explicitly selected config remains
   the fixed invocation-wide owner and never creates nested handoffs.
   Configs loaded only for explicit targets bound only their literal target
@@ -938,6 +998,7 @@ Additional current behaviors:
 - CLI/API lint target selection is independent from TypeScript `Program` membership and considers only rslint-supported script extensions. The `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts` default baseline is always selected; explicit config `files` contributes candidates only within the supported set. Global ignores and `.gitignore` remove targets, while an entry-level ignore prevents only its own selector/config contribution
 - selected CLI/API targets can still appear as 0-rule lint results when no config entry contributes rules; this applies to default-baseline directory discovery and explicit supported files, and syntax diagnostics remain available in that state
 - under automatic discovery, each selected file is governed by its nearest loadable config; an explicitly selected config is used directly. In either case, a target can bind only to a tsconfig declared by its governing config. The first declared project whose parsed root set contains the file wins. Only when no declared root contains it does the first declaration-order Program containing it through imports win
+- omitting `parserOptions.project` enables the governing config directory's default `tsconfig.json` fallback; an explicit empty project list disables that fallback
 - `files`/`ignores` matching uses the stable target path in the governing config's path space; a ts-go Program source alias is used only to locate the AST and type information, so moving a target into or out of a tsconfig cannot change its rule configuration
 - within each Program-registry build, normalized declared tsconfig paths are deduplicated across config associations; CLI fix passes create a new source/Program generation and rerun focused project selection from the request's metadata view. Import-only fallback membership is therefore recomputed after source edits. File-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Selected CLI files outside the governing config's ts-go Programs are parsed and bound as independent rslint Programs. Targets whose names collide under a case-insensitive ts-go path key are partitioned across independent Programs so distinct physical files and package scopes remain distinct
 - `--type-check` and `--type-check-only` build every real tsconfig declared by the effective loaded config catalog. Git reachability may change which automatic configs enter that catalog; once it is established, program-wide checking is not filtered by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments. Only those project-backed source generations expose the program-diagnostics capability consumed by Phase 2; `--type-check-only` skips the separate lint-target walk.
@@ -1451,7 +1512,7 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 - **Diagnostic**: A lint finding reported by a rule or by TypeScript semantic diagnostics
 - **Flat Config**: ESLint-style array-based configuration model used by rslint to merge rule settings per file
 - **Inspector**: Auxiliary backend path that returns node, type, symbol, signature, and flow information for Playground inspection
-- **IPC API**: Length-prefixed JSON message protocol exposed by `cmd/rslint --api` for Node and WASM clients; config path resolution and third-party plugin routing use separate keys when API overrides rebase relative patterns
+- **IPC API**: Length-prefixed JSON message protocol exposed by `cmd/rslint --api` for Node and WASM clients; config path resolution and third-party plugin routing have separate identities
 - **Listener**: Callback registered by a rule for an AST kind or synthetic listener kind
 - **Nearest Config**: In multi-config mode, the governing config selected by lexical-first ownership resolution
 - **Node Kind**: Enumerated AST kind value used by ts-go and by the listener dispatcher to identify node types

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -277,6 +277,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			if err := rslintconfig.ValidateConfig(overrideConfig); err != nil {
 				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
 			}
+			overrideConfig = rslintconfig.ConfigWithAuthoredPathBase(overrideConfig, currentDirectory)
 		}
 		discoveryRequest := discovery.ConfigDiscoveryRequest{
 			CWD:                       currentDirectory,
@@ -326,10 +327,11 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 				fs,
 				loader,
 				discovery.ExplicitConfigRequest{
-					CWD:         currentDirectory,
-					ConfigPath:  resolveRequestPath(configDiscovery.ExplicitConfigPath),
-					TargetFiles: targetFiles,
-					Fresh:       true,
+					CWD:               currentDirectory,
+					ConfigPath:        resolveRequestPath(configDiscovery.ExplicitConfigPath),
+					TargetFiles:       targetFiles,
+					TargetDirectories: append([]string(nil), discoveryRequest.Directories...),
+					Fresh:             true,
 				},
 			)
 		} else {
@@ -384,7 +386,14 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	}
 
 	if configMap == nil && !configGitignoreFrozen {
-		rslintConfig = rslintconfig.ConfigWithGitignore(rslintConfig, configDirectory, fs, allowedFiles)
+		rslintConfig = rslintconfig.ConfigWithGitignoreForTargetsFromRoot(
+			rslintConfig,
+			configDirectory,
+			currentDirectory,
+			fs,
+			allowedFiles,
+			nil,
+		)
 	}
 	var optionsMessages []string
 	configMap, rslintConfig, optionsMessages = validateResolvedRuleOptions(configMap, rslintConfig)
@@ -414,7 +423,10 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	}
 
 	responsePathBase := configDirectory
-	if configMap != nil {
+	if req.ConfigDiscovery != nil {
+		// ConfigDiscovery is the high-level API: request and response paths use
+		// WorkingDirectory even when an explicitly selected config lives elsewhere.
+		// The low-level Config API keeps its ConfigDirectory-relative contract.
 		responsePathBase = currentDirectory
 	}
 	comparePathOptions := tspath.ComparePathsOptions{
@@ -430,7 +442,15 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	// invocation-wide single-config paths.
 	// The --api path never runs the type-check phase (RunLinterOptions.TypeCheck
 	// stays false), so there is no per-program type-check skip mask to build.
-	targetPlan, err := rslintconfig.ResolveLintTargetPlan(configMap, rslintConfig, configDirectory, configTargetScopes, fs, allowedFiles, nil, false)
+	targetPlan, err := rslintconfig.ResolveLintTargetPlan(rslintconfig.LintTargetPlanRequest{
+		ConfigMap:       configMap,
+		Config:          rslintConfig,
+		ConfigDirectory: configDirectory,
+		ScanRoot:        currentDirectory,
+		ConfigScopes:    configTargetScopes,
+		FS:              fs,
+		Files:           allowedFiles,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("resolve lint targets: %w", err)
 	}
@@ -463,20 +483,19 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	}
 	programs := binding.Programs
 	targetsByProgram := binding.TargetsByProgram
-	targetPathBySourcePath := binding.TargetPathBySourcePath
 	fileConfigResolver := newLintConfigResolver(lintConfigResolverOptions{
-		ConfigMap:                  configMap,
-		Config:                     rslintConfig,
-		CurrentDirectory:           configDirectory,
-		EnforcePlugins:             true,
-		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
-		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
-		SourceMappingsCanonical:    true,
-		FS:                         fs,
+		ConfigMap:               configMap,
+		Config:                  rslintConfig,
+		CurrentDirectory:        configDirectory,
+		EnforcePlugins:          true,
+		LintTargetBySourcePath:  binding.LintTargetBySourcePath,
+		SourceMappingsCanonical: true,
+		TargetPlan:              &targetPlan,
+		FS:                      fs,
 	})
 	targetPathForSourcePath := func(sourcePath string) string {
-		if targetPath := targetPathBySourcePath[sourcePath]; targetPath != "" {
-			return targetPath
+		if target, bound := fileConfigResolver.targetForFile(sourcePath); bound {
+			return target.Path
 		}
 		return sourcePath
 	}

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	api "github.com/web-infra-dev/rslint/internal/api"
@@ -659,6 +660,49 @@ func TestHandleLint_LowLevelResponsePathsRemainRelativeToConfigDirectory(t *test
 	}
 	if !reflect.DeepEqual(response.LintedFiles, []string{"src/source.js"}) {
 		t.Fatalf("linted files = %v, want config-relative source", response.LintedFiles)
+	}
+}
+
+func TestHandleLint_LowLevelExternalConfigSeparatesAuthoredAndScanRoots(t *testing.T) {
+	root := t.TempDir()
+	configDirectory := filepath.Join(root, "config")
+	physicalWorkingDirectory := filepath.Join(root, "physical-workspace")
+	workingDirectory := filepath.Join(root, "workspace-alias")
+	for _, directory := range []string{configDirectory, physicalWorkingDirectory} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(physicalWorkingDirectory, workingDirectory); err != nil {
+		t.Skipf("working-directory symlink unavailable: %v", err)
+	}
+	target := filepath.Join(physicalWorkingDirectory, "target.js")
+	ignored := filepath.Join(physicalWorkingDirectory, "ignored.js")
+	for path, content := range map[string]string{
+		filepath.Join(configDirectory, ".gitignore"):  "target.js\n",
+		filepath.Join(workingDirectory, ".gitignore"): "ignored.js\n",
+		target:  "debugger;\n",
+		ignored: "debugger;\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	target = tspath.NormalizePath(osvfs.FS().Realpath(target))
+	ignored = tspath.NormalizePath(osvfs.FS().Realpath(ignored))
+
+	response, err := (&IPCHandler{}).HandleLint(api.LintRequest{
+		Config:           json.RawMessage(`[{"files":["../physical-workspace/*.js"],"rules":{"no-debugger":"error"}}]`),
+		ConfigDirectory:  configDirectory,
+		WorkingDirectory: workingDirectory,
+		Files:            []string{target, ignored},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.FileCount != 1 || len(response.Diagnostics) != 1 ||
+		filepath.Base(response.Diagnostics[0].FilePath) != "target.js" {
+		t.Fatalf("external config roots were conflated: %+v", response)
 	}
 }
 
@@ -1990,6 +2034,60 @@ func TestHandleLint_ExplicitConfigUsesOnlyWorkingDirectoryGitignore(t *testing.T
 		response.Diagnostics[0].RuleName != "no-debugger" ||
 		filepath.Base(response.Diagnostics[0].FilePath) != "outside.js" {
 		t.Fatalf("explicit config Git projection crossed its working-directory boundary: %+v", response)
+	}
+}
+
+func TestHandleLint_ExplicitExternalConfigUsesWorkingDirectoryResponsePaths(t *testing.T) {
+	root := t.TempDir()
+	configDirectory := filepath.Join(root, "configuration")
+	workingDirectory := filepath.Join(root, "workspace", "deep")
+	configPath := filepath.Join(configDirectory, "custom.config.mjs")
+	targetPath := filepath.Join(workingDirectory, "src", "index.js")
+	writeProgramTestFiles(t, root, map[string]string{
+		"configuration/custom.config.mjs": "export default [];\n",
+		"workspace/deep/src/index.js":     "debugger;\n",
+	})
+
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		switch kind {
+		case api.KindLoadConfigs:
+			request := payload.(discovery.ConfigLoadBatchRequest)
+			if len(request.Candidates) != 1 || filepath.Clean(request.Candidates[0].ConfigDirectory) != filepath.Clean(configDirectory) {
+				return nil, fmt.Errorf("unexpected explicit candidate: %+v", request.Candidates)
+			}
+			return ipc.NewMessage(ipc.KindResponse, 1, discovery.ConfigLoadBatchResponse{
+				TransactionID: request.TransactionID,
+				Results: []discovery.ConfigLoadResult{{
+					ID:      request.Candidates[0].ID,
+					Status:  "loaded",
+					Entries: mustAPIConfig(t, `[{"files":["../workspace/deep/src/*.js"],"rules":{"no-debugger":"error"}}]`),
+				}},
+			})
+		case api.KindActivateConfigs:
+			request := payload.(discovery.ConfigActivationRequest)
+			return ipc.NewMessage(ipc.KindResponse, 1, discovery.ConfigActivationResponse{TransactionID: request.TransactionID})
+		default:
+			return nil, fmt.Errorf("unexpected reverse request kind %q", kind)
+		}
+	})
+
+	response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Files:            []string{targetPath},
+		WorkingDirectory: workingDirectory,
+		ConfigDiscovery: &api.ConfigDiscoveryRequest{
+			ExplicitConfigPath: configPath,
+			ExplicitFiles:      []bool{true},
+		},
+	}, requester)
+	if err != nil {
+		t.Fatalf("HandleLintWithContext: %v", err)
+	}
+	wantPath := tspath.NormalizePath(filepath.Join("src", "index.js"))
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].FilePath != wantPath {
+		t.Fatalf("diagnostic paths = %+v, want working-directory-relative %q", response.Diagnostics, wantPath)
+	}
+	if !reflect.DeepEqual(response.LintedFiles, []string{wantPath}) {
+		t.Fatalf("linted files = %v, want working-directory-relative %q", response.LintedFiles, wantPath)
 	}
 }
 

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -121,8 +121,12 @@ func groupDiagsByFile(diags []rule.RuleDiagnostic) map[string][]rule.RuleDiagnos
 // space when a TypeScript Program represents that target by another lexical or
 // canonical source-file path. SourceFile remains unchanged because ranges and
 // fixes are defined against its text; FilePath controls display and disk writes.
-func remapDiagnosticTargetPaths(diags []rule.RuleDiagnostic, targetPathBySourcePath map[string]string, filesystems ...vfs.FS) {
-	if len(targetPathBySourcePath) == 0 {
+func remapDiagnosticTargetPaths(
+	diags []rule.RuleDiagnostic,
+	lintTargetBySourcePath map[string]rslintconfig.DiscoveredLintTarget,
+	filesystems ...vfs.FS,
+) {
+	if len(lintTargetBySourcePath) == 0 {
 		return
 	}
 	var fsys vfs.FS
@@ -130,12 +134,8 @@ func remapDiagnosticTargetPaths(diags []rule.RuleDiagnostic, targetPathBySourceP
 		fsys = filesystems[0]
 	}
 	for i := range diags {
-		targetPath := targetPathBySourcePath[diags[i].FilePath]
-		if targetPath == "" {
-			targetPath = targetPathBySourcePath[canonicalFilesystemPathID(diags[i].FilePath, fsys)]
-		}
-		if targetPath != "" {
-			diags[i].FilePath = targetPath
+		if target, ok := lookupLintTarget(lintTargetBySourcePath, diags[i].FilePath, fsys); ok {
+			diags[i].FilePath = target.Path
 		}
 	}
 }
@@ -307,11 +307,11 @@ func formatAllowFileWarning(w allowFileWarning, opts tspath.ComparePathsOptions)
 	return ""
 }
 
-// collectAllowFileWarnings explains, for each CLI-specified file in
-// allowFiles, why it won't be visited by Phase 1 (lint). Program membership
-// is deliberately not consulted: lint targets are resolved before type-info
-// binding, so a file outside every tsconfig can still be linted.
-// Returns nil for empty allowFiles.
+// collectAllowFileWarnings maps config-owned explicit-file outcomes to CLI
+// messages. It performs no filesystem or config lookup: target selection has
+// already frozen the file identity, owner, ignore decision, and existence.
+// Program membership is deliberately not consulted because a file outside
+// every tsconfig can still be linted.
 //
 // This is a Phase-1 concern only. In --type-check-only mode the lint phase
 // is skipped, so callers MUST gate emission on `!typeCheckOnly` — otherwise
@@ -320,57 +320,20 @@ func formatAllowFileWarning(w allowFileWarning, opts tspath.ComparePathsOptions)
 // file. See website/docs/en/guide/type-checking.md ("type-check is not
 // constrained by `files`/`ignores`").
 func collectAllowFileWarnings(
-	allowFiles []string,
-	configMap map[string]rslintconfig.RslintConfig,
-	rslintConfig rslintconfig.RslintConfig,
-	currentDirectory string,
-	useCaseSensitive bool,
-	filesystems ...vfs.FS,
+	outcomes []rslintconfig.ExplicitFileOutcome,
 ) []allowFileWarning {
-	if len(allowFiles) == 0 {
+	if len(outcomes) == 0 {
 		return nil
 	}
 
-	var fsys vfs.FS
-	if len(filesystems) > 0 {
-		fsys = filesystems[0]
-	}
-	var configOwnerResolver *rslintconfig.ConfigOwnerResolver
-	if configMap != nil {
-		configOwnerResolver = rslintconfig.NewConfigOwnerResolver(configMap, fsys)
-	}
-
 	var out []allowFileWarning
-	for _, f := range allowFiles {
-		var cfgDir string
-		var cfg rslintconfig.RslintConfig
-		if configMap != nil {
-			// Canonical fallback is file-specific: two symlinked files in the
-			// same lexical directory can resolve to different config roots.
-			cfgDir, cfg = configOwnerResolver.Resolve(f)
-		} else {
-			cfgDir = currentDirectory
-			cfg = rslintConfig
-		}
-		matchFile := f
-		matchDir := cfgDir
-		if fsys != nil && cfgDir != "" {
-			canonicalPath := authoritativeFilesystemPath(f, fsys)
-			matchFile = (rslintconfig.DiscoveredLintTarget{
-				Path:            tspath.NormalizePath(f),
-				CanonicalPath:   canonicalPath,
-				ConfigDirectory: cfgDir,
-			}).MatchPath(fsys)
-			matchDir = authoritativeFilesystemPath(cfgDir, fsys)
-		}
-		if rslintconfig.IsDefaultExcludedPath(matchFile, matchDir, useCaseSensitive) ||
-			(cfg != nil && cfg.IsFileIgnored(matchFile, matchDir)) {
-			out = append(out, allowFileWarning{Path: f, Kind: allowFileIgnored})
+	for _, outcome := range outcomes {
+		if outcome.Ignored {
+			out = append(out, allowFileWarning{Path: outcome.Path, Kind: allowFileIgnored})
 			continue
 		}
-
-		if _, err := os.Stat(f); err != nil {
-			out = append(out, allowFileWarning{Path: f, Kind: allowFileNotFound})
+		if !outcome.Exists {
+			out = append(out, allowFileWarning{Path: outcome.Path, Kind: allowFileNotFound})
 			continue
 		}
 	}
@@ -496,6 +459,7 @@ func resolveStartTime(startTimeMs int64) time.Time {
 func loadGitignoreAndProjects(
 	config rslintconfig.RslintConfig,
 	configDirectory string,
+	gitignoreRoot string,
 	targetFiles []string,
 	targetDirectories []string,
 	singleThreaded bool,
@@ -508,9 +472,10 @@ func loadGitignoreAndProjects(
 	)
 	work := core.NewWorkGroup(singleThreaded)
 	work.Queue(func() {
-		configWithIgnores = rslintconfig.ConfigWithGitignoreForTargets(
+		configWithIgnores = rslintconfig.ConfigWithGitignoreForTargetsFromRoot(
 			config,
 			configDirectory,
+			gitignoreRoot,
 			session.FS(),
 			targetFiles,
 			targetDirectories,
@@ -802,23 +767,17 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
 		}
-		if config != "" {
-			// Explicit --config follows flat-config invocation semantics: file,
-			// ignore, project, and implicit no-args target scope are rooted at
-			// the cwd where rslint was invoked, not the config file's directory.
-			currentDirectory = workingDirectory
-		}
-
 		if typeCheckOnly {
 			projectSet, err = programSession.BuildProject(currentDirectory, rslintConfig, singleThreaded)
 		} else if buildAllPrograms {
 			rslintConfig, projectSet, err = loadGitignoreAndProjects(
-				rslintConfig, currentDirectory, allowFiles, allowDirs, singleThreaded, programSession,
+				rslintConfig, currentDirectory, workingDirectory, allowFiles, allowDirs, singleThreaded, programSession,
 			)
 		} else {
-			rslintConfig = rslintconfig.ConfigWithGitignoreForTargets(
+			rslintConfig = rslintconfig.ConfigWithGitignoreForTargetsFromRoot(
 				rslintConfig,
 				currentDirectory,
+				workingDirectory,
 				fs,
 				allowFiles,
 				allowDirs,
@@ -895,26 +854,25 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	programConfigMap := configMap
 	buildSingleConfigPrograms := buildAllPrograms
 	var (
-		targetPlan                 rslintconfig.LintTargetPlan
-		loadedPrograms             loader.LoadResult
-		targetsByProgram           [][]string
-		targetPathBySourcePath     map[string]string
-		configPathBySourcePath     map[string]string
-		ownerConfigDirBySourcePath map[string]string
+		targetPlan             rslintconfig.LintTargetPlan
+		loadedPrograms         loader.LoadResult
+		targetsByProgram       [][]string
+		lintTargetBySourcePath map[string]rslintconfig.DiscoveredLintTarget
 	)
 	// --type-check-only is program-wide and pays no lint-target discovery,
 	// target binding/parsing, config-resolution, or Program-loading cost.
 	if !typeCheckOnly {
-		targetPlan, err = rslintconfig.ResolveLintTargetPlan(
-			targetConfigMap,
-			targetRslintConfig,
-			currentDirectory,
-			configTargetScopes,
-			fs,
-			allowFiles,
-			allowDirs,
-			singleThreaded,
-		)
+		targetPlan, err = rslintconfig.ResolveLintTargetPlan(rslintconfig.LintTargetPlanRequest{
+			ConfigMap:       targetConfigMap,
+			Config:          targetRslintConfig,
+			ConfigDirectory: currentDirectory,
+			ScanRoot:        workingDirectory,
+			ConfigScopes:    configTargetScopes,
+			FS:              fs,
+			Files:           allowFiles,
+			Directories:     allowDirs,
+			SingleThreaded:  singleThreaded,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
@@ -947,9 +905,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		}
 		programs = loadedPrograms.Programs
 		targetsByProgram = loadedPrograms.TargetsByProgram
-		targetPathBySourcePath = loadedPrograms.TargetPathBySourcePath
-		configPathBySourcePath = loadedPrograms.ConfigPathBySourcePath
-		ownerConfigDirBySourcePath = loadedPrograms.OwnerConfigDirBySourcePath
+		lintTargetBySourcePath = loadedPrograms.LintTargetBySourcePath
 	}
 
 	// Rebuild ts-go Programs and bind the original stable target plan again on
@@ -996,14 +952,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 
 	enforcePlugins := usesJSConfig
 	fileConfigResolver := newLintConfigResolver(lintConfigResolverOptions{
-		ConfigMap:                  configMap,
-		Config:                     rslintConfig,
-		CurrentDirectory:           currentDirectory,
-		EnforcePlugins:             enforcePlugins,
-		ConfigPathBySourcePath:     configPathBySourcePath,
-		OwnerConfigDirBySourcePath: ownerConfigDirBySourcePath,
-		SourceMappingsCanonical:    true,
-		FS:                         fs,
+		ConfigMap:               configMap,
+		Config:                  rslintConfig,
+		CurrentDirectory:        currentDirectory,
+		EnforcePlugins:          enforcePlugins,
+		LintTargetBySourcePath:  lintTargetBySourcePath,
+		SourceMappingsCanonical: true,
+		TargetPlan:              &targetPlan,
+		FS:                      fs,
 	})
 	getRulesForFile := func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
 		return fileConfigResolver.EnabledRulesForFile(sourceFile.FileName())
@@ -1092,15 +1048,15 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	if pluginCh != nil {
 		allDiags = append(allDiags, (<-pluginCh)...)
 	}
-	remapDiagnosticTargetPaths(allDiags, targetPathBySourcePath, fs)
+	remapDiagnosticTargetPaths(allDiags, lintTargetBySourcePath, fs)
 
 	// Emit per-file warnings for CLI-specified files that won't be linted.
-	// Distinguishes "not found in project" vs "ignored by pattern", aligned
+	// Distinguishes "not found on disk" vs "ignored by pattern", aligned
 	// with ESLint v10's warning behavior. Skipped in --type-check-only mode:
 	// these are lint-phase concepts and would mislead users about Phase 2
 	// (which runs program-wide regardless of CLI scope and rslint ignores).
 	if !typeCheckOnly {
-		warnings := collectAllowFileWarnings(allowFiles, configMap, rslintConfig, currentDirectory, fs.UseCaseSensitiveFileNames(), fs)
+		warnings := collectAllowFileWarnings(targetPlan.ExplicitFileOutcomes)
 		for _, w := range warnings {
 			fmt.Fprintln(os.Stderr, formatAllowFileWarning(w, comparePathOptions))
 		}
@@ -1144,16 +1100,16 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 
 			// Re-lint using the fresh binding derived from the stable target plan.
 			fixTargetsByProgram := newBinding.TargetsByProgram
-			fixTargetPathBySourcePath := newBinding.TargetPathBySourcePath
+			fixLintTargetBySourcePath := newBinding.LintTargetBySourcePath
 			fixConfigResolver := newLintConfigResolver(lintConfigResolverOptions{
-				ConfigMap:                  configMap,
-				Config:                     rslintConfig,
-				CurrentDirectory:           currentDirectory,
-				EnforcePlugins:             enforcePlugins,
-				ConfigPathBySourcePath:     newBinding.ConfigPathBySourcePath,
-				OwnerConfigDirBySourcePath: newBinding.OwnerConfigDirBySourcePath,
-				SourceMappingsCanonical:    true,
-				FS:                         fs,
+				ConfigMap:               configMap,
+				Config:                  rslintConfig,
+				CurrentDirectory:        currentDirectory,
+				EnforcePlugins:          enforcePlugins,
+				LintTargetBySourcePath:  newBinding.LintTargetBySourcePath,
+				SourceMappingsCanonical: true,
+				TargetPlan:              &targetPlan,
+				FS:                      fs,
 			})
 			fixGetRulesForFile := func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
 				return fixConfigResolver.EnabledRulesForFile(sourceFile.FileName())
@@ -1228,7 +1184,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// Merge this pass's plugin diagnostics before applying fixes so
 			// plugin fixes participate and plugin diagnostics survive.
 			passDiags = append(passDiags, fixPluginDiags...)
-			remapDiagnosticTargetPaths(passDiags, fixTargetPathBySourcePath, fs)
+			remapDiagnosticTargetPaths(passDiags, fixLintTargetBySourcePath, fs)
 
 			// Replace allDiags with latest post-fix diagnostics.
 			allDiags = passDiags

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1081,6 +1081,68 @@ func TestExecuteLintPipelineExplicitJSONDirectoryTargetUsesInvocationCWD(t *test
 	}
 }
 
+func TestExecuteLintPipelineExplicitJSONKeepsDirectoryGitScopesIndependent(t *testing.T) {
+	root := t.TempDir()
+	invocationDir := filepath.Join(root, "invocation")
+	configDir := filepath.Join(root, "config")
+	firstDir := filepath.Join(root, "first")
+	secondDir := filepath.Join(root, "second")
+	for _, directory := range []string{invocationDir, configDir, firstDir, secondDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", directory, err)
+		}
+	}
+	paths := map[string]string{
+		filepath.Join(configDir, "rslint.jsonc"): `[{
+			"rules": {"no-debugger": "error"}
+		}]`,
+		filepath.Join(firstDir, ".gitignore"):  "ignored.js\n",
+		filepath.Join(firstDir, "ignored.js"):  "debugger;\n",
+		filepath.Join(firstDir, "visible.js"):  "debugger;\n",
+		filepath.Join(secondDir, ".gitignore"): "hidden.js\n",
+		filepath.Join(secondDir, "ignored.js"): "debugger;\n",
+		filepath.Join(secondDir, "hidden.js"):  "debugger;\n",
+	}
+	for path, content := range paths {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	code, stdout, stderr := runLintPipelineForTest(t, invocationDir, lintArgs{
+		Config:         filepath.Join(configDir, "rslint.jsonc"),
+		FS:             bundled.WrapFS(cachedvfs.From(osvfs.FS())),
+		AllowDirs:      []string{tspath.NormalizePath(firstDir), tspath.NormalizePath(secondDir)},
+		Format:         "jsonline",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 1 {
+		t.Fatalf("multi-directory JSON lint failed: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	outputPath := func(path string) string {
+		relative, err := filepath.Rel(invocationDir, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tspath.NormalizePath(relative)
+	}
+	firstIgnored := outputPath(filepath.Join(firstDir, "ignored.js"))
+	firstVisible := outputPath(filepath.Join(firstDir, "visible.js"))
+	secondIgnored := outputPath(filepath.Join(secondDir, "ignored.js"))
+	secondHidden := outputPath(filepath.Join(secondDir, "hidden.js"))
+	for _, visible := range []string{firstVisible, secondIgnored} {
+		if !strings.Contains(stdout, visible) {
+			t.Errorf("expected lint result for %q: %s", visible, stdout)
+		}
+	}
+	for _, ignored := range []string{firstIgnored, secondHidden} {
+		if strings.Contains(stdout, ignored) {
+			t.Errorf("unexpected lint result for Git-ignored path %q: %s", ignored, stdout)
+		}
+	}
+}
+
 func TestExecuteLintPipelineTypedCatalogEnforcesPluginDeclarations(t *testing.T) {
 	dir := t.TempDir()
 	target := tspath.NormalizePath(filepath.Join(dir, "index.ts"))
@@ -1245,16 +1307,29 @@ func TestFormatAllowFileWarning_UnknownKindIsEmpty(t *testing.T) {
 }
 
 func TestCollectAllowFileWarnings_EmptyReturnsNil(t *testing.T) {
-	// No allowFiles → no work, no warnings. Important so callers can rely
+	// No outcomes → no work, no warnings. Important so callers can rely
 	// on a non-nil result implying actual user-specified files.
-	got := collectAllowFileWarnings(nil, nil, nil, "/work", true)
+	got := collectAllowFileWarnings(nil)
 	if got != nil {
-		t.Errorf("empty allowFiles should produce nil, got %+v", got)
+		t.Errorf("nil outcomes should produce nil, got %+v", got)
 	}
-	got = collectAllowFileWarnings([]string{}, nil, nil, "/work", true)
+	got = collectAllowFileWarnings([]rslintconfig.ExplicitFileOutcome{})
 	if got != nil {
-		t.Errorf("empty allowFiles (non-nil slice) should still produce nil, got %+v", got)
+		t.Errorf("empty outcomes should still produce nil, got %+v", got)
 	}
+}
+
+func explicitFileWarningsForTest(
+	t *testing.T,
+	request rslintconfig.LintTargetPlanRequest,
+) []allowFileWarning {
+	t.Helper()
+	request.SingleThreaded = true
+	plan, err := rslintconfig.ResolveLintTargetPlan(request)
+	if err != nil {
+		t.Fatalf("ResolveLintTargetPlan: %v", err)
+	}
+	return collectAllowFileWarnings(plan.ExplicitFileOutcomes)
 }
 
 func TestCollectAllowFileWarnings_NoWarningForFilesScopeMiss(t *testing.T) {
@@ -1264,15 +1339,15 @@ func TestCollectAllowFileWarnings_NoWarningForFilesScopeMiss(t *testing.T) {
 	target := findProgramFileForTest(t, program, "src/app.ts")
 	configDir := tspath.GetDirectoryPath(tspath.GetDirectoryPath(target))
 
-	warnings := collectAllowFileWarnings(
-		[]string{target},
-		nil,
-		rslintconfig.RslintConfig{
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files: []string{target},
+		Config: rslintconfig.RslintConfig{
 			{Files: []string{"**/*.js"}, Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
-		configDir,
-		true,
-	)
+		ConfigDirectory: configDir,
+		ScanRoot:        configDir,
+		FS:              osvfs.FS(),
+	})
 	if len(warnings) != 0 {
 		t.Fatalf("files scope miss should not emit warning, got %+v", warnings)
 	}
@@ -1285,15 +1360,15 @@ func TestCollectAllowFileWarnings_NoWarningForExistingFile(t *testing.T) {
 	}
 	target = tspath.NormalizePath(target)
 
-	warnings := collectAllowFileWarnings(
-		[]string{target},
-		nil,
-		rslintconfig.RslintConfig{
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files: []string{target},
+		Config: rslintconfig.RslintConfig{
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
-		tspath.GetDirectoryPath(target),
-		true,
-	)
+		ConfigDirectory: tspath.GetDirectoryPath(target),
+		ScanRoot:        tspath.GetDirectoryPath(target),
+		FS:              osvfs.FS(),
+	})
 	if len(warnings) != 0 {
 		t.Fatalf("existing files should not produce warnings, got %+v", warnings)
 	}
@@ -1301,15 +1376,15 @@ func TestCollectAllowFileWarnings_NoWarningForExistingFile(t *testing.T) {
 
 func TestCollectAllowFileWarnings_MissingFileWarns(t *testing.T) {
 	target := tspath.NormalizePath(filepath.Join(t.TempDir(), "missing.ts"))
-	warnings := collectAllowFileWarnings(
-		[]string{target},
-		nil,
-		rslintconfig.RslintConfig{
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files: []string{target},
+		Config: rslintconfig.RslintConfig{
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
-		tspath.GetDirectoryPath(target),
-		true,
-	)
+		ConfigDirectory: tspath.GetDirectoryPath(target),
+		ScanRoot:        tspath.GetDirectoryPath(target),
+		FS:              osvfs.FS(),
+	})
 	if len(warnings) != 1 {
 		t.Fatalf("expected one missing-file warning, got %+v", warnings)
 	}
@@ -1325,16 +1400,16 @@ func TestCollectAllowFileWarnings_GlobalIgnoreStillWarns(t *testing.T) {
 	target := findProgramFileForTest(t, program, "src/app.ts")
 	configDir := tspath.GetDirectoryPath(tspath.GetDirectoryPath(target))
 
-	warnings := collectAllowFileWarnings(
-		[]string{target},
-		nil,
-		rslintconfig.RslintConfig{
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files: []string{target},
+		Config: rslintconfig.RslintConfig{
 			{Ignores: []string{"src/**"}},
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
-		configDir,
-		true,
-	)
+		ConfigDirectory: configDir,
+		ScanRoot:        configDir,
+		FS:              osvfs.FS(),
+	})
 	if len(warnings) != 1 {
 		t.Fatalf("expected one warning, got %+v", warnings)
 	}
@@ -1353,20 +1428,97 @@ func TestCollectAllowFileWarnings_DefaultExcludedFileWarns(t *testing.T) {
 		t.Fatalf("write target: %v", err)
 	}
 
-	warnings := collectAllowFileWarnings(
-		[]string{target},
-		nil,
-		rslintconfig.RslintConfig{
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files: []string{target},
+		Config: rslintconfig.RslintConfig{
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
-		tspath.NormalizePath(dir),
-		true,
-	)
+		ConfigDirectory: tspath.NormalizePath(dir),
+		ScanRoot:        tspath.NormalizePath(dir),
+		FS:              osvfs.FS(),
+	})
 	if len(warnings) != 1 {
 		t.Fatalf("expected one warning, got %+v", warnings)
 	}
 	if warnings[0].Kind != allowFileIgnored {
 		t.Fatalf("expected allowFileIgnored, got %+v", warnings[0])
+	}
+}
+
+func TestCollectAllowFileWarningsUsesScanRootBeforeConfigProjection(t *testing.T) {
+	root := t.TempDir()
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	configDir := tspath.NormalizePath(filepath.Join(root, "physical", "package"))
+	aliasDir := tspath.CombinePaths(scanRoot, "node_modules", "package")
+	for _, directory := range []string{scanRoot, configDir, tspath.GetDirectoryPath(aliasDir)} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	physicalTarget := tspath.CombinePaths(configDir, "index.ts")
+	if err := os.WriteFile(physicalTarget, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(configDir, aliasDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasTarget := tspath.CombinePaths(aliasDir, "index.ts")
+
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files:           []string{aliasTarget},
+		Config:          rslintconfig.RslintConfig{{Rules: rslintconfig.Rules{"no-console": "error"}}},
+		ConfigDirectory: configDir,
+		ScanRoot:        scanRoot,
+		FS:              osvfs.FS(),
+	})
+	if len(warnings) != 1 || warnings[0].Kind != allowFileIgnored {
+		t.Fatalf("scan-root default exclusion was lost in warning recomputation: %+v", warnings)
+	}
+}
+
+func TestCollectAllowFileWarningsPreservesGitignoreTargetIdentity(t *testing.T) {
+	root := t.TempDir()
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	configDir := tspath.NormalizePath(filepath.Join(root, "physical", "package"))
+	physicalSourceDir := tspath.CombinePaths(configDir, "src")
+	aliasSourceDir := tspath.CombinePaths(scanRoot, "linked-src")
+	for _, directory := range []string{scanRoot, physicalSourceDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(physicalSourceDir, aliasSourceDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasTarget := tspath.CombinePaths(aliasSourceDir, "ignored.ts")
+	if err := os.WriteFile(aliasTarget, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(scanRoot, ".gitignore"),
+		[]byte("linked-src/ignored.ts\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	effective := rslintconfig.ConfigWithGitignoreForTargetsFromRoot(
+		rslintconfig.RslintConfig{{Rules: rslintconfig.Rules{"no-console": "error"}}},
+		configDir,
+		scanRoot,
+		osvfs.FS(),
+		[]string{aliasTarget},
+		nil,
+	)
+
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files:           []string{aliasTarget},
+		Config:          effective,
+		ConfigDirectory: configDir,
+		ScanRoot:        scanRoot,
+		FS:              osvfs.FS(),
+	})
+	if len(warnings) != 1 || warnings[0].Kind != allowFileIgnored {
+		t.Fatalf("Git-ignore target identity was lost in warning recomputation: %+v", warnings)
 	}
 }
 
@@ -1394,17 +1546,16 @@ func TestCollectAllowFileWarnings_KeepsLexicalConfigOwnersSeparate(t *testing.T)
 	targetA := tspath.ResolvePath(ownerA, "link/index.ts")
 	targetB := tspath.ResolvePath(ownerB, "link/index.ts")
 	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	warnings := collectAllowFileWarnings(
-		[]string{targetA, targetB},
-		map[string]rslintconfig.RslintConfig{
+	warnings := explicitFileWarningsForTest(t, rslintconfig.LintTargetPlanRequest{
+		Files: []string{targetA, targetB},
+		ConfigMap: map[string]rslintconfig.RslintConfig{
 			ownerA: {{Ignores: []string{"link/**"}}},
 			ownerB: {{}},
 		},
-		nil,
-		root,
-		true,
-		fsys,
-	)
+		ConfigDirectory: root,
+		ScanRoot:        root,
+		FS:              fsys,
+	})
 	if len(warnings) != 1 || warnings[0].Path != targetA || warnings[0].Kind != allowFileIgnored {
 		t.Fatalf("expected only the target owned by config A to be ignored, got %+v", warnings)
 	}
@@ -1438,7 +1589,14 @@ func TestCLIRuleOverlayDoesNotAlterTargetDiscovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildProject: %v", err)
 	}
-	targetPlan, err := rslintconfig.ResolveLintTargetPlan(nil, targetConfig, dir, nil, fs, nil, []string{tspath.NormalizePath(dir)}, true)
+	targetPlan, err := rslintconfig.ResolveLintTargetPlan(rslintconfig.LintTargetPlanRequest{
+		Config:          targetConfig,
+		ConfigDirectory: dir,
+		ScanRoot:        dir,
+		FS:              fs,
+		Directories:     []string{tspath.NormalizePath(dir)},
+		SingleThreaded:  true,
+	})
 	if err != nil {
 		t.Fatalf("ResolveLintTargetPlan: %v", err)
 	}
@@ -1456,14 +1614,21 @@ func TestCLIRuleOverlayDoesNotAlterTargetDiscovery(t *testing.T) {
 	}
 
 	rslintconfig.RegisterAllRules()
+	fileConfigResolver := newLintConfigResolver(lintConfigResolverOptions{
+		Config:                  activeConfig,
+		CurrentDirectory:        dir,
+		LintTargetBySourcePath:  binding.LintTargetBySourcePath,
+		SourceMappingsCanonical: true,
+		TargetPlan:              &targetPlan,
+		FS:                      fs,
+	})
 	var diagnostics []rule.RuleDiagnostic
 	_, err = linter.RunLinter(linter.RunLinterOptions{
 		Programs:       binding.Programs,
 		SingleThreaded: true,
 		TargetFiles:    targetsByProgram,
 		GetRulesForFile: func(sf *ast.SourceFile) []linter.ConfiguredRule {
-			rules, _ := rslintconfig.GlobalRuleRegistry.GetEnabledRules(activeConfig, sf.FileName(), dir, false)
-			return rules
+			return fileConfigResolver.EnabledRulesForFile(sf.FileName())
 		},
 		Consumer: rule.DiagnosticConsumer{
 			Demand: rule.EditDemandAll,
@@ -1528,10 +1693,13 @@ func TestPlainLintSkipsProjectResolutionWhenAllTargetsAreIgnored(t *testing.T) {
 }
 
 func TestCLIExplicitJSONConfigNoArgsScopesToInvocationCWD(t *testing.T) {
-	dir := t.TempDir()
-	childDir := filepath.Join(dir, "child")
-	if err := os.MkdirAll(childDir, 0o755); err != nil {
-		t.Fatalf("mkdir child: %v", err)
+	root := t.TempDir()
+	configDir := filepath.Join(root, "config")
+	workspaceDir := filepath.Join(root, "workspace")
+	for _, directory := range []string{configDir, workspaceDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", directory, err)
+		}
 	}
 	write := func(base, name, content string) {
 		t.Helper()
@@ -1539,24 +1707,60 @@ func TestCLIExplicitJSONConfigNoArgsScopesToInvocationCWD(t *testing.T) {
 			t.Fatalf("write %s: %v", name, err)
 		}
 	}
-	write(dir, "rslint.jsonc", `[{ "files": ["*.js"], "rules": { "no-debugger": "error" } }]`)
-	write(dir, "parent.js", "debugger;\n")
-	write(childDir, "child.js", "debugger;\n")
+	write(configDir, "rslint.jsonc", `[{ "files": ["../workspace/*.js"], "rules": { "no-debugger": "error" } }]`)
+	write(configDir, "config-only.js", "debugger;\n")
+	write(workspaceDir, "workspace.js", "debugger;\n")
 
-	code, stdout, stderr := runLintPipelineForTest(t, childDir, lintArgs{
-		Config:         "../rslint.jsonc",
+	code, stdout, stderr := runLintPipelineForTest(t, workspaceDir, lintArgs{
+		Config:         "../config/rslint.jsonc",
 		Format:         "jsonline",
 		NoColor:        true,
 		SingleThreaded: true,
 	})
 	if code != 1 {
-		t.Fatalf("expected no-debugger to fail on child.js, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+		t.Fatalf("expected no-debugger to fail on workspace.js, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
 	}
-	if !strings.Contains(stdout, `"filePath":"child.js"`) {
-		t.Fatalf("expected child.js diagnostic relative to invocation cwd, stdout=%q stderr=%q", stdout, stderr)
+	if !strings.Contains(stdout, `"filePath":"workspace.js"`) {
+		t.Fatalf("expected workspace.js diagnostic relative to invocation cwd, stdout=%q stderr=%q", stdout, stderr)
 	}
-	if strings.Contains(stdout, "parent.js") {
+	if strings.Contains(stdout, "config-only.js") {
 		t.Fatalf("explicit --config must not widen no-args scope to config dir, stdout=%q", stdout)
+	}
+}
+
+func TestCLIExplicitExternalConfigSkipsDefaultExcludedWorkingDirectory(t *testing.T) {
+	root := t.TempDir()
+	workingDirectory := filepath.Join(root, "node_modules", "pkg")
+	if err := os.MkdirAll(workingDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(root, "rslint.jsonc")
+	if err := os.WriteFile(configPath, []byte(`[{"rules":{"no-debugger":"error"}}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workingDirectory, "index.js"), []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name      string
+		allowDirs []string
+	}{
+		{name: "implicit cwd"},
+		{name: "explicit cwd", allowDirs: []string{tspath.NormalizePath(workingDirectory)}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			code, stdout, stderr := runLintPipelineForTest(t, workingDirectory, lintArgs{
+				Config:         configPath,
+				AllowDirs:      test.allowDirs,
+				Format:         "jsonline",
+				NoColor:        true,
+				SingleThreaded: true,
+			})
+			if code != 0 || stdout != "" {
+				t.Fatalf("default-excluded cwd was linted: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+		})
 	}
 }
 
@@ -1758,8 +1962,8 @@ func TestRemapDiagnosticTargetPaths(t *testing.T) {
 		{FilePath: "/program/link.ts"},
 		{FilePath: "/program/unchanged.ts"},
 	}
-	remapDiagnosticTargetPaths(diagnostics, map[string]string{
-		"/program/link.ts": "/requested/real.ts",
+	remapDiagnosticTargetPaths(diagnostics, map[string]rslintconfig.DiscoveredLintTarget{
+		"/program/link.ts": {Path: "/requested/real.ts"},
 	})
 
 	if diagnostics[0].FilePath != "/requested/real.ts" {

--- a/cmd/rslint/eslint_plugin.go
+++ b/cmd/rslint/eslint_plugin.go
@@ -28,8 +28,7 @@ func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *
 	if r.lintResolver == nil {
 		return "", nil
 	}
-	configPath := r.lintResolver.configPathFor(filePath)
-	cfgDir, resolver, ok := r.lintResolver.resolverForFile(filePath, configPath)
+	cfgDir, resolved, ok := r.lintResolver.resolveFile(filePath)
 	if !ok {
 		return "", nil
 	}
@@ -37,7 +36,7 @@ func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *
 	if pluginConfigDir, ok := r.pluginConfigDirByOwner[cfgDir]; ok {
 		wireKey = pluginConfigDir
 	}
-	return wireKey, resolver.ConfigForFile(configPath)
+	return wireKey, resolved.MergedConfig
 }
 
 // buildPluginFileInputs projects third-party plugin inputs from the same

--- a/cmd/rslint/eslint_plugin_test.go
+++ b/cmd/rslint/eslint_plugin_test.go
@@ -23,10 +23,20 @@ func TestPluginConfigResolver_UsesGoOwnedCatalogKey(t *testing.T) {
 	configMap := map[string]rslintconfig.RslintConfig{
 		configDir: {{Rules: rslintconfig.Rules{"no-debugger": "error"}}},
 	}
+	sourcePath := configDir + "/src/a.ts"
 	r := pluginConfigResolver{
-		lintResolver: newLintConfigResolver(lintConfigResolverOptions{ConfigMap: configMap}),
+		lintResolver: newLintConfigResolver(lintConfigResolverOptions{
+			ConfigMap: configMap,
+			LintTargetBySourcePath: map[string]rslintconfig.DiscoveredLintTarget{
+				sourcePath: {
+					Path:            sourcePath,
+					CanonicalPath:   sourcePath,
+					ConfigDirectory: configDir,
+				},
+			},
+		}),
 	}
-	wireKey, merged := r.resolve(configDir + "/src/a.ts")
+	wireKey, merged := r.resolve(sourcePath)
 	if wireKey != configDir {
 		t.Errorf("wire configKey = %q, want Go-owned catalog key %q", wireKey, configDir)
 	}
@@ -38,6 +48,13 @@ func TestPluginConfigResolver_UsesGoOwnedCatalogKey(t *testing.T) {
 	posix := pluginConfigResolver{
 		lintResolver: newLintConfigResolver(lintConfigResolverOptions{
 			ConfigMap: map[string]rslintconfig.RslintConfig{"/posix/proj": configMap[configDir]},
+			LintTargetBySourcePath: map[string]rslintconfig.DiscoveredLintTarget{
+				"/posix/proj/a.ts": {
+					Path:            "/posix/proj/a.ts",
+					CanonicalPath:   "/posix/proj/a.ts",
+					ConfigDirectory: "/posix/proj",
+				},
+			},
 		}),
 	}
 	if wk, m := posix.resolve("/posix/proj/a.ts"); wk != "/posix/proj" || m == nil {
@@ -127,7 +144,7 @@ func TestPluginConfigResolver_Branches(t *testing.T) {
 	}
 }
 
-func TestLintConfigResolver_NearestConfigWithoutProgramPolicy(t *testing.T) {
+func TestLintConfigResolver_UsesOnlyBoundTargetOwnership(t *testing.T) {
 	rslintconfig.RegisterAllRules()
 
 	configMap := map[string]rslintconfig.RslintConfig{
@@ -145,6 +162,23 @@ func TestLintConfigResolver_NearestConfigWithoutProgramPolicy(t *testing.T) {
 	}
 	resolver := newLintConfigResolver(lintConfigResolverOptions{
 		ConfigMap: configMap,
+		LintTargetBySourcePath: map[string]rslintconfig.DiscoveredLintTarget{
+			"/repo/packages/app/src/gap.ts": {
+				Path:            "/repo/packages/app/src/gap.ts",
+				CanonicalPath:   "/repo/packages/app/src/gap.ts",
+				ConfigDirectory: "/repo/packages/app",
+			},
+			"/repo/packages/app/src/typed.ts": {
+				Path:            "/repo/packages/app/src/typed.ts",
+				CanonicalPath:   "/repo/packages/app/src/typed.ts",
+				ConfigDirectory: "/repo/packages/app",
+			},
+			"/repo/root.ts": {
+				Path:            "/repo/root.ts",
+				CanonicalPath:   "/repo/root.ts",
+				ConfigDirectory: "/repo",
+			},
+		},
 	})
 
 	gapRules := configuredRuleNameSet(resolver.EnabledRulesForFile("/repo/packages/app/src/gap.ts"))
@@ -184,8 +218,14 @@ func TestLintConfigResolver_UsesBoundOwnerForAliasedSource(t *testing.T) {
 	}
 	sourcePath := "/repo/packages/app/a.ts"
 	resolver := newLintConfigResolver(lintConfigResolverOptions{
-		ConfigMap:                  configMap,
-		OwnerConfigDirBySourcePath: map[string]string{sourcePath: "/repo"},
+		ConfigMap: configMap,
+		LintTargetBySourcePath: map[string]rslintconfig.DiscoveredLintTarget{
+			sourcePath: {
+				Path:            sourcePath,
+				CanonicalPath:   sourcePath,
+				ConfigDirectory: "/repo",
+			},
+		},
 	})
 
 	rules := configuredRuleNameSet(resolver.EnabledRulesForFile(sourcePath))
@@ -194,7 +234,7 @@ func TestLintConfigResolver_UsesBoundOwnerForAliasedSource(t *testing.T) {
 	}
 }
 
-func TestLintConfigResolver_UsesConfigPathAliasForRulesAndGlobals(t *testing.T) {
+func TestLintConfigResolver_UsesBoundTargetForRulesAndGlobals(t *testing.T) {
 	rslintconfig.RegisterAllRules()
 
 	cfg := rslintconfig.RslintConfig{{
@@ -207,9 +247,15 @@ func TestLintConfigResolver_UsesConfigPathAliasForRulesAndGlobals(t *testing.T) 
 		Rules: rslintconfig.Rules{"no-console": "error"},
 	}}
 	resolver := newLintConfigResolver(lintConfigResolverOptions{
-		Config:                 cfg,
-		CurrentDirectory:       "/repo",
-		ConfigPathBySourcePath: map[string]string{"/outside/real-a.ts": "/repo/src/a.ts"},
+		Config:           cfg,
+		CurrentDirectory: "/repo",
+		LintTargetBySourcePath: map[string]rslintconfig.DiscoveredLintTarget{
+			"/outside/real-a.ts": {
+				Path:            "/repo/src/a.ts",
+				CanonicalPath:   "/outside/real-a.ts",
+				ConfigDirectory: "/repo",
+			},
+		},
 	})
 
 	rules := resolver.EnabledRulesForFile("/outside/real-a.ts")
@@ -244,9 +290,12 @@ func TestLintConfigResolver_SourceMappingsUseCanonicalFilesystemIdentity(t *test
 				Rules: rslintconfig.Rules{"no-console": "error"},
 			}},
 		},
-		ConfigPathBySourcePath: map[string]string{"C:/REPO/SRC/A.ts": "c:/repo/src/a.ts"},
-		OwnerConfigDirBySourcePath: map[string]string{
-			"C:/REPO/SRC/A.ts": "c:/repo",
+		LintTargetBySourcePath: map[string]rslintconfig.DiscoveredLintTarget{
+			"C:/REPO/SRC/A.ts": {
+				Path:            "c:/repo/src/a.ts",
+				CanonicalPath:   "c:/repo/src/a.ts",
+				ConfigDirectory: "c:/repo",
+			},
 		},
 		FS: fsys,
 	})

--- a/cmd/rslint/lint_config_resolver.go
+++ b/cmd/rslint/lint_config_resolver.go
@@ -3,55 +3,68 @@ package main
 import (
 	"sort"
 
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 type lintConfigResolver struct {
-	configMap                  map[string]rslintconfig.RslintConfig
-	currentDirectory           string
-	configPathBySourcePath     map[string]string
-	ownerConfigDirBySourcePath map[string]string
-	fsys                       vfs.FS
-	singleResolver             *rslintconfig.FileConfigResolver
-	configResolvers            map[string]*rslintconfig.FileConfigResolver
-	matchConfigMap             map[string]rslintconfig.RslintConfig
-	ownerByMatchConfigDir      map[string]string
-	configOwnerResolver        *rslintconfig.ConfigOwnerResolver
-	matchConfigOwnerResolver   *rslintconfig.ConfigOwnerResolver
+	configMap              map[string]rslintconfig.RslintConfig
+	currentDirectory       string
+	lintTargetBySourcePath map[string]rslintconfig.DiscoveredLintTarget
+	fsys                   vfs.FS
+	singleResolver         *rslintconfig.FileConfigResolver
+	configResolvers        map[string]*rslintconfig.FileConfigResolver
 }
 
 type lintConfigResolverOptions struct {
-	ConfigMap                  map[string]rslintconfig.RslintConfig
-	Config                     rslintconfig.RslintConfig
-	CurrentDirectory           string
-	EnforcePlugins             bool
-	ConfigPathBySourcePath     map[string]string
-	OwnerConfigDirBySourcePath map[string]string
+	ConfigMap              map[string]rslintconfig.RslintConfig
+	Config                 rslintconfig.RslintConfig
+	CurrentDirectory       string
+	EnforcePlugins         bool
+	LintTargetBySourcePath map[string]rslintconfig.DiscoveredLintTarget
 	// SourceMappingsCanonical indicates that binding already supplied both
 	// lexical and canonical source keys, so normalization needs no filesystem IO.
 	SourceMappingsCanonical bool
+	TargetPlan              *rslintconfig.LintTargetPlan
 	FS                      vfs.FS
 }
 
 func newLintConfigResolver(opts lintConfigResolverOptions) *lintConfigResolver {
 	resolver := &lintConfigResolver{
-		configMap:                  opts.ConfigMap,
-		currentDirectory:           opts.CurrentDirectory,
-		configPathBySourcePath:     normalizeSourcePathMappings(opts.ConfigPathBySourcePath, opts.FS, opts.SourceMappingsCanonical),
-		ownerConfigDirBySourcePath: normalizeSourcePathMappings(opts.OwnerConfigDirBySourcePath, opts.FS, opts.SourceMappingsCanonical),
-		fsys:                       opts.FS,
+		configMap:              opts.ConfigMap,
+		currentDirectory:       opts.CurrentDirectory,
+		lintTargetBySourcePath: normalizeSourceTargetMappings(opts.LintTargetBySourcePath, opts.FS, opts.SourceMappingsCanonical),
+		fsys:                   opts.FS,
+	}
+	newFileResolver := func(
+		entries rslintconfig.RslintConfig,
+		configDirectory string,
+	) *rslintconfig.FileConfigResolver {
+		if opts.TargetPlan != nil {
+			return opts.TargetPlan.NewFileConfigResolver(
+				entries,
+				configDirectory,
+				opts.FS,
+				opts.EnforcePlugins,
+			)
+		}
+		return rslintconfig.NewFileConfigResolverWithFS(
+			entries,
+			configDirectory,
+			opts.FS,
+			opts.EnforcePlugins,
+		)
 	}
 	if opts.ConfigMap == nil {
-		matchRoot := authoritativeFilesystemPath(opts.CurrentDirectory, opts.FS)
-		resolver.singleResolver = rslintconfig.NewFileConfigResolver(opts.Config, matchRoot, opts.EnforcePlugins)
+		resolver.singleResolver = newFileResolver(
+			opts.Config,
+			opts.CurrentDirectory,
+		)
 		return resolver
 	}
 	resolver.configResolvers = make(map[string]*rslintconfig.FileConfigResolver, len(opts.ConfigMap)*2)
-	resolver.matchConfigMap = make(map[string]rslintconfig.RslintConfig, len(opts.ConfigMap))
-	resolver.ownerByMatchConfigDir = make(map[string]string, len(opts.ConfigMap))
-	resolver.configOwnerResolver = rslintconfig.NewConfigOwnerResolver(opts.ConfigMap, opts.FS)
 	configDirs := make([]string, 0, len(opts.ConfigMap))
 	for configDir := range opts.ConfigMap {
 		configDirs = append(configDirs, configDir)
@@ -59,43 +72,52 @@ func newLintConfigResolver(opts lintConfigResolverOptions) *lintConfigResolver {
 	sort.Strings(configDirs)
 	for _, configDir := range configDirs {
 		cfg := opts.ConfigMap[configDir]
-		matchRoot := authoritativeFilesystemPath(configDir, opts.FS)
-		fileResolver := rslintconfig.NewFileConfigResolver(cfg, matchRoot, opts.EnforcePlugins)
+		fileResolver := newFileResolver(
+			cfg,
+			configDir,
+		)
 		resolver.configResolvers[configDir] = fileResolver
 		resolver.configResolvers[canonicalFilesystemPathID(configDir, opts.FS)] = fileResolver
-		matchRootID := canonicalFilesystemPathID(matchRoot, opts.FS)
-		if _, exists := resolver.ownerByMatchConfigDir[matchRootID]; !exists {
-			resolver.matchConfigMap[matchRoot] = cfg
-			resolver.ownerByMatchConfigDir[matchRootID] = configDir
-		}
 	}
-	resolver.matchConfigOwnerResolver = rslintconfig.NewConfigOwnerResolver(resolver.matchConfigMap, opts.FS)
 	return resolver
 }
 
-func normalizeSourcePathMappings(mapping map[string]string, fsys vfs.FS, canonicalKeysPresent bool) map[string]string {
+func normalizeSourceTargetMappings(
+	mapping map[string]rslintconfig.DiscoveredLintTarget,
+	fsys vfs.FS,
+	canonicalKeysPresent bool,
+) map[string]rslintconfig.DiscoveredLintTarget {
 	if len(mapping) == 0 {
 		return mapping
 	}
-	normalized := make(map[string]string, len(mapping)*2)
-	for sourcePath, value := range mapping {
+	normalized := make(map[string]rslintconfig.DiscoveredLintTarget, len(mapping)*2)
+	for sourcePath, target := range mapping {
+		target.Path = tspath.NormalizePath(target.Path)
+		target.CanonicalPath = tspath.NormalizePath(target.CanonicalPath)
+		target.CanonicalParentPath = tspath.NormalizePath(target.CanonicalParentPath)
+		target.ConfigDirectory = tspath.NormalizePath(target.ConfigDirectory)
 		normalizedPath := exactFilesystemPathID(sourcePath)
-		normalized[normalizedPath] = value
+		normalized[normalizedPath] = target
 		if !canonicalKeysPresent {
-			normalized[canonicalFilesystemPathID(normalizedPath, fsys)] = value
+			normalized[canonicalFilesystemPathID(normalizedPath, fsys)] = target
 		}
 	}
 	return normalized
 }
 
-func (r *lintConfigResolver) pathMappingValue(mapping map[string]string, filePath string) string {
+func lookupLintTarget(
+	mapping map[string]rslintconfig.DiscoveredLintTarget,
+	filePath string,
+	fsys vfs.FS,
+) (rslintconfig.DiscoveredLintTarget, bool) {
 	if len(mapping) == 0 {
-		return ""
+		return rslintconfig.DiscoveredLintTarget{}, false
 	}
-	if value := mapping[exactFilesystemPathID(filePath)]; value != "" {
-		return value
+	if target, ok := mapping[exactFilesystemPathID(filePath)]; ok {
+		return target, true
 	}
-	return mapping[canonicalFilesystemPathID(filePath, r.fsys)]
+	target, ok := mapping[canonicalFilesystemPathID(filePath, fsys)]
+	return target, ok
 }
 
 func (r *lintConfigResolver) configResolver(configDir string) *rslintconfig.FileConfigResolver {
@@ -105,60 +127,47 @@ func (r *lintConfigResolver) configResolver(configDir string) *rslintconfig.File
 	return r.configResolvers[canonicalFilesystemPathID(configDir, r.fsys)]
 }
 
-func (r *lintConfigResolver) resolverForFile(sourcePath string, configPath string) (string, *rslintconfig.FileConfigResolver, bool) {
-	if r.configMap != nil {
-		ownerConfigDir := r.pathMappingValue(r.ownerConfigDirBySourcePath, sourcePath)
-		if ownerConfigDir != "" {
-			resolver := r.configResolver(ownerConfigDir)
-			return ownerConfigDir, resolver, resolver != nil
+func (r *lintConfigResolver) targetForFile(filePath string) (rslintconfig.DiscoveredLintTarget, bool) {
+	if r != nil {
+		if target, ok := lookupLintTarget(r.lintTargetBySourcePath, filePath, r.fsys); ok {
+			return target, true
 		}
-
-		// Path-based fallback for current low-level callers that do not provide a
-		// target binding, and for focused resolver tests.
-		cfgDir, cfg := r.configOwnerResolver.Resolve(sourcePath)
-		if cfg != nil {
-			resolver := r.configResolver(cfgDir)
-			return cfgDir, resolver, resolver != nil
-		}
-		matchDir, cfg := r.matchConfigOwnerResolver.Resolve(configPath)
-		if cfg == nil {
-			return "", nil, false
-		}
-		ownerConfigDir = r.ownerByMatchConfigDir[canonicalFilesystemPathID(matchDir, r.fsys)]
-		resolver := r.configResolver(ownerConfigDir)
-		return ownerConfigDir, resolver, resolver != nil
 	}
-	return r.currentDirectory, r.singleResolver, true
+	return rslintconfig.DiscoveredLintTarget{Path: tspath.NormalizePath(filePath)}, false
 }
 
-func (r *lintConfigResolver) configPathFor(filePath string) string {
-	if r == nil || len(r.configPathBySourcePath) == 0 {
-		return filePath
+func (r *lintConfigResolver) resolveFile(
+	sourcePath string,
+) (string, rslintconfig.ResolvedFileConfig, bool) {
+	target, bound := r.targetForFile(sourcePath)
+	if r.configMap != nil {
+		if bound {
+			resolver := r.configResolver(target.ConfigDirectory)
+			if resolver == nil {
+				return "", rslintconfig.ResolvedFileConfig{}, false
+			}
+			return target.ConfigDirectory, resolver.ResolveTarget(target), true
+		}
+		return "", rslintconfig.ResolvedFileConfig{}, false
 	}
-	if configPath := r.pathMappingValue(r.configPathBySourcePath, filePath); configPath != "" {
-		return configPath
-	}
-	return filePath
+	return r.currentDirectory, r.singleResolver.ResolveTarget(target), true
 }
 
 func (r *lintConfigResolver) ConfigForFile(filePath string) *rslintconfig.MergedConfig {
-	configPath := r.configPathFor(filePath)
-	_, resolver, ok := r.resolverForFile(filePath, configPath)
+	_, resolved, ok := r.resolveFile(filePath)
 	if !ok {
 		return nil
 	}
-	return resolver.ConfigForFile(configPath)
+	return resolved.MergedConfig
 }
 
 // EnabledRulesForFile returns the complete configured rule set. Program
 // capabilities are applied once by the lint planner, not while resolving
 // configuration.
 func (r *lintConfigResolver) EnabledRulesForFile(filePath string) []rule.ConfiguredRule {
-	configPath := r.configPathFor(filePath)
-	_, resolver, ok := r.resolverForFile(filePath, configPath)
+	_, resolved, ok := r.resolveFile(filePath)
 	if !ok {
 		return nil
 	}
-	enabledRules, _ := resolver.EnabledRulesForFile(configPath)
-	return enabledRules
+	return resolved.EnabledRules
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -100,12 +100,12 @@ type LintRequest struct {
 	// ConfigDiscovery enables the high-level host-filesystem path. It is
 	// mutually exclusive with Config and intentionally unsupported by WASM.
 	ConfigDiscovery *ConfigDiscoveryRequest `json:"configDiscovery,omitempty"`
-	// Anchor directory for resolving the config's relative
-	// files / ignores / parserOptions.project. Defaults to the working dir.
+	// Anchor directory for resolving relative paths in the low-level Config.
+	// High-level ConfigDiscovery entries use their owning config directory;
+	// ConfigDiscovery.OverrideConfig entries use WorkingDirectory.
 	ConfigDirectory string `json:"configDirectory,omitempty"`
 	// PluginConfigDirectory is the opaque worker routing key for community
-	// plugins. It can differ from ConfigDirectory when overrideConfig rebases
-	// authored path patterns to the API cwd.
+	// plugins. It is independent from the directory used to resolve config paths.
 	PluginConfigDirectory string            `json:"pluginConfigDirectory,omitempty"`
 	WorkingDirectory      string            `json:"workingDirectory,omitempty"`
 	FileContents          map[string]string `json:"fileContents,omitempty"` // Map of file paths to their contents for VFS
@@ -127,8 +127,10 @@ type ConfigDiscoveryRequest struct {
 	ExplicitConfigPath string `json:"explicitConfigPath,omitempty"`
 	// Directories are static roots for the already-expanded Files set. Go limits
 	// config discovery below them to branches that can govern those files.
-	Directories    []string        `json:"directories,omitempty"`
-	ExplicitFiles  []bool          `json:"explicitFiles,omitempty"`
+	Directories   []string `json:"directories,omitempty"`
+	ExplicitFiles []bool   `json:"explicitFiles,omitempty"`
+	// OverrideConfig is appended to every selected config while retaining
+	// LintRequest.WorkingDirectory as its authored relative-path base.
 	OverrideConfig json.RawMessage `json:"overrideConfig,omitempty"`
 }
 
@@ -154,10 +156,12 @@ type LintResponse struct {
 	FileCount           int `json:"fileCount"`
 	RuleCount           int `json:"ruleCount"`
 	// LintedFiles lists the files actually linted (config `ignores` excluded),
-	// using each caller-visible target path relative to the config directory.
-	// This is the same path space as Diagnostic.FilePath and Output. The JS side
-	// seeds one LintResult per entry, so ignored glob matches yield no phantom
-	// results. Present for lintFiles; lintText seeds its own explicit path.
+	// using each caller-visible target path. Low-level Config requests return
+	// paths relative to ConfigDirectory; high-level ConfigDiscovery requests
+	// return paths relative to WorkingDirectory. This is the same path space as
+	// Diagnostic.FilePath and Output. The JS side seeds one LintResult per entry,
+	// so ignored glob matches yield no phantom results. Present for lintFiles;
+	// lintText seeds its own explicit path.
 	//
 	// MUST NOT be omitempty: an all-ignored lint produces an empty (non-nil)
 	// slice that has to serialize as `[]`, distinct from an old binary that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,10 +50,67 @@ type ConfigEntry struct {
 	// matchers. Keeping the uncommon metadata behind one pointer preserves the
 	// original ConfigEntry footprint for every ordinary authored config entry.
 	collectedGitignore *collectedGitignoreMetadata
+	// authoredPathBase is present only when this entry was authored in a
+	// different directory from the config array that owns it. The native API's
+	// inline overrideConfig is the primary case: it is appended after each
+	// discovered config but keeps the invocation cwd as the base for its
+	// config-relative files, ignores, and parserOptions.project values. Target
+	// matching and project resolution consume this immutable origin instead of
+	// rebasing authored strings during composition.
+	authoredPathBase *configEntryPathBase
 }
 
 type collectedGitignoreMetadata struct {
 	ignores []IgnorePattern
+	scopes  []collectedGitignoreScope
+}
+
+// collectedGitignoreScope is one authoritative Git collection boundary. The
+// slice order is semantic: target resolution first chooses the earliest scope
+// containing the caller's lexical path and only then falls back, in the same
+// order, to canonical-to-physical containment. Patterns from every other
+// scope are inapplicable to that target.
+type collectedGitignoreScope struct {
+	matchDirectory    string
+	physicalDirectory string
+	lexicalDirectory  string
+	caseInsensitive   bool
+}
+
+type configEntryPathBase struct {
+	directory string
+}
+
+// ConfigWithAuthoredPathBase returns a shallow config snapshot whose entries
+// retain directory as their authored origin. It is used when a flat-config
+// suffix is composed from a different origin; the input config and its
+// maps/slices are not mutated.
+func ConfigWithAuthoredPathBase(config RslintConfig, directory string) RslintConfig {
+	if len(config) == 0 {
+		return config
+	}
+	directory = tspath.NormalizePath(directory)
+	effective := append(RslintConfig(nil), config...)
+	for index := range effective {
+		effective[index].authoredPathBase = &configEntryPathBase{directory: directory}
+	}
+	return effective
+}
+
+func configEntryBaseDirectory(entry ConfigEntry, defaultDirectory string) string {
+	if entry.authoredPathBase != nil && entry.authoredPathBase.directory != "" {
+		return entry.authoredPathBase.directory
+	}
+	return defaultDirectory
+}
+
+func configNeedsTargetResolver(config RslintConfig) bool {
+	for _, entry := range config {
+		if entry.authoredPathBase != nil || entry.collectedGitignore != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (entry ConfigEntry) MarshalJSON() ([]byte, error) {
@@ -415,6 +472,21 @@ type ParserOptions struct {
 	Project        ProjectPaths `json:"project,omitempty"`
 }
 
+// MarshalJSON preserves the three project states used by resolution: omitted,
+// an explicit empty array, and one or more explicit paths. The default
+// `omitempty` encoder collapses a non-nil empty slice into omission, which
+// would re-enable tsconfig.json fallback after a config round trip.
+func (options ParserOptions) MarshalJSON() ([]byte, error) {
+	encoded := make(map[string]any, 2)
+	if options.ProjectService != nil {
+		encoded["projectService"] = *options.ProjectService
+	}
+	if options.Project != nil {
+		encoded["project"] = options.Project
+	}
+	return json.Marshal(encoded)
+}
+
 // BoolPtr returns a pointer to the given bool value.
 func BoolPtr(b bool) *bool {
 	return &b
@@ -734,8 +806,42 @@ func normalizePattern(pattern string) string {
 // aligns with ESLint v10: `dir/**` blocks directory traversal entirely, and
 // `!` negation cannot undo it.
 func isDirBlockedByIgnores(filePath string, patterns []IgnorePattern, cwd string) bool {
+	if hasPatternMatchDirectory(patterns) {
+		for _, pattern := range patterns {
+			if pattern.Negated || pattern.Kind != dirAbsoluteBlock {
+				continue
+			}
+			dirPath, ok := ignoreDirectoryPathForPattern(filePath, cwd, pattern)
+			if ok && directoryPatternAbsolutelyBlocks(pattern, dirPath) {
+				return true
+			}
+		}
+		return false
+	}
 	dirPath, ok := ignoreDirectoryPath(filePath, cwd)
 	return ok && isDirAbsolutelyBlocked(dirPath, patterns)
+}
+
+func ignoreDirectoryPathForPattern(filePath string, defaultDirectory string, pattern IgnorePattern) (string, bool) {
+	matchDirectories := patternMatchDirectories(pattern, defaultDirectory)
+	for index, directory := range matchDirectories {
+		if directory == "" || repeatedMatchDirectory(matchDirectories, index) {
+			continue
+		}
+		dirPath, ok := ignoreDirectoryPath(filePath, directory)
+		if !ok {
+			continue
+		}
+		if pathEscapesCwd(dirPath) && pattern.CaseInsensitive {
+			parent := tspath.GetDirectoryPath(filePath)
+			dirPath = normalizePathWithCaseSensitivity(parent, directory, false)
+			dirPath = strings.TrimSuffix(strings.ReplaceAll(dirPath, "\\", "/"), "/")
+		}
+		if !pathEscapesCwd(dirPath) {
+			return dirPath, true
+		}
+	}
+	return "", false
 }
 
 func ignoreDirectoryPath(filePath string, cwd string) (string, bool) {
@@ -775,8 +881,7 @@ func (matcher *directoryBlockMatcher) blocksFileDirectory(filePath string) bool 
 	}
 	lexicalDirectory := tspath.GetDirectoryPath(filePath)
 	return matcher.results.getOrInit(lexicalDirectory, func() bool {
-		dirPath, ok := ignoreDirectoryPath(filePath, matcher.cwd)
-		return ok && isDirAbsolutelyBlocked(dirPath, matcher.patterns)
+		return isDirBlockedByIgnores(filePath, matcher.patterns, matcher.cwd)
 	})
 }
 
@@ -861,6 +966,10 @@ func extractConfigIgnores(config RslintConfig) []IgnorePattern {
 // this method. Program-wide type-check diagnostics are intentionally governed
 // by tsconfig membership instead.
 func (config RslintConfig) IsFileIgnored(filePath string, cwd string) bool {
+	if configNeedsTargetResolver(config) {
+		return newConfigTargetResolver(config, cwd, nil).
+			resolve(filePath, "").globallyIgnored
+	}
 	patterns := extractConfigIgnores(config)
 	if len(patterns) == 0 {
 		return false
@@ -882,6 +991,13 @@ func (config RslintConfig) IsFileIgnored(filePath string, cwd string) bool {
 // After global ignore check, entries are merged in order if their files match and ignores don't.
 // cwd is the directory the config lives in; file paths are resolved relative to it.
 func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *MergedConfig {
+	if configNeedsTargetResolver(config) {
+		decision := newConfigTargetResolver(config, cwd, nil).resolve(filePath, "")
+		if !decision.matched || !decision.selected || decision.globallyIgnored {
+			return nil
+		}
+		return config.mergeConfigEntries(decision.key)
+	}
 	// Collect all global ignore patterns and evaluate once. This allows `!`
 	// negation patterns in separate entries to work correctly, aligned with
 	// ESLint v10 which merges all global ignores before evaluating. Callers

--- a/internal/config/config_resolution.go
+++ b/internal/config/config_resolution.go
@@ -25,16 +25,6 @@ func (key configMatchKey) contains(index int) bool {
 	return key.tail[tailIndex/8]&byte(1<<(tailIndex%8)) != 0
 }
 
-func parseEntryIgnorePatterns(config RslintConfig) [][]IgnorePattern {
-	patterns := make([][]IgnorePattern, len(config))
-	for index, entry := range config {
-		if !isGlobalIgnoreEntry(entry) {
-			patterns[index] = ParseIgnorePatterns(entry.Ignores)
-		}
-	}
-	return patterns
-}
-
 // matchConfigEntries applies the flat-config selection policy once and returns
 // the exact set of contributing entries. A nil entryIgnorePatterns asks the
 // direct compatibility path to parse entry ignores on demand; run-scoped

--- a/internal/config/config_target_resolver.go
+++ b/internal/config/config_target_resolver.go
@@ -1,0 +1,594 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+)
+
+// configTargetResolver matches one immutable flat-config array while retaining
+// the authored base of every composed entry. Most entries share the owning
+// config directory; API overrideConfig entries may instead use invocation cwd.
+// Each distinct base resolves the target identity once per decision, so target
+// selection and effective config merging cannot drift onto different spaces.
+type configTargetResolver struct {
+	config             RslintConfig
+	fs                 vfs.FS
+	bases              []configTargetBase
+	entries            []configTargetEntry
+	globalEntryIndexes []int
+	directoryBlocks    publishOnceCache[configTargetIdentity, bool]
+}
+
+type configTargetBase struct {
+	directory              string
+	physicalDirectory      string
+	physicalAliasAncestors []string
+}
+
+type configTargetEntry struct {
+	baseIndex           int
+	ignorePatterns      []IgnorePattern
+	gitScopes           []collectedGitignoreScope
+	ignorePatternGroups []ignorePatternCoordinateGroup
+}
+
+// ignorePatternCoordinateGroup is one contiguous ignore-pattern segment whose
+// decisions use the same target coordinate and matching semantics. The
+// grouping is frozen with the resolver so both file matching and directory
+// pruning project their path once per authored root instead of once per
+// pattern.
+type ignorePatternCoordinateGroup struct {
+	patterns      []IgnorePattern
+	negationReach negReach
+}
+
+type configTargetMatch struct {
+	path      string
+	directory string
+	matcher   fileMatchPath
+}
+
+// configTargetIdentity is the immutable caller-visible/canonical pair for one
+// target decision. Entry matching may project this pair into several authored
+// config bases, but root-scoped matchers such as collected .gitignore rules
+// must always derive their coordinates from this original identity.
+type configTargetIdentity struct {
+	path               string
+	canonicalMatchPath string
+}
+
+type configTargetDecision struct {
+	key             configMatchKey
+	matched         bool
+	selected        bool
+	globallyIgnored bool
+}
+
+func newConfigTargetResolver(config RslintConfig, defaultDirectory string, fsys vfs.FS) *configTargetResolver {
+	return newConfigTargetResolverWithBases(config, defaultDirectory, fsys, nil)
+}
+
+func newConfigTargetResolverWithBases(
+	config RslintConfig,
+	defaultDirectory string,
+	fsys vfs.FS,
+	frozenBases map[string]configTargetBase,
+) *configTargetResolver {
+	resolver := &configTargetResolver{
+		config:  config,
+		fs:      fsys,
+		entries: make([]configTargetEntry, len(config)),
+	}
+	baseIndexByDirectory := make(map[string]int)
+	for index, entry := range config {
+		directory := tspath.NormalizePath(configEntryBaseDirectory(entry, defaultDirectory))
+		baseID := exactPathID(directory)
+		baseIndex, exists := baseIndexByDirectory[baseID]
+		if !exists {
+			base, frozen := frozenBases[baseID]
+			if !frozen {
+				base = freezeConfigTargetBase(directory, fsys)
+			}
+			baseIndex = len(resolver.bases)
+			baseIndexByDirectory[baseID] = baseIndex
+			resolver.bases = append(resolver.bases, base)
+		}
+		patterns := configEntryIgnorePatterns(entry)
+		resolver.entries[index] = configTargetEntry{
+			baseIndex:      baseIndex,
+			ignorePatterns: patterns,
+		}
+		if entry.collectedGitignore != nil {
+			resolver.entries[index].gitScopes = entry.collectedGitignore.scopes
+		}
+		if isGlobalIgnoreEntry(entry) {
+			resolver.entries[index].ignorePatternGroups = buildIgnorePatternCoordinateGroups(patterns)
+			resolver.globalEntryIndexes = append(resolver.globalEntryIndexes, index)
+		}
+	}
+	return resolver
+}
+
+func freezeConfigTargetBase(directory string, fsys vfs.FS) configTargetBase {
+	directory = tspath.NormalizePath(directory)
+	physicalDirectory := directory
+	if fsys != nil {
+		if realPath := fsys.Realpath(directory); realPath != "" {
+			physicalDirectory = tspath.NormalizePath(realPath)
+		}
+	}
+	return configTargetBase{
+		directory:              directory,
+		physicalDirectory:      physicalDirectory,
+		physicalAliasAncestors: verifiedConfigAliasAncestors(directory, physicalDirectory, fsys),
+	}
+}
+
+func configEntryIgnorePatterns(entry ConfigEntry) []IgnorePattern {
+	if entry.collectedGitignore != nil {
+		return entry.collectedGitignore.ignores
+	}
+	return ParseIgnorePatterns(entry.Ignores)
+}
+
+func buildIgnorePatternCoordinateGroups(patterns []IgnorePattern) []ignorePatternCoordinateGroup {
+	var groups []ignorePatternCoordinateGroup
+	for start := 0; start < len(patterns); {
+		end := start + 1
+		for end < len(patterns) && patternsShareTargetCoordinate(patterns[start], patterns[end]) {
+			end++
+		}
+		groupPatterns := patterns[start:end]
+		groups = append(groups, ignorePatternCoordinateGroup{
+			patterns:      groupPatterns,
+			negationReach: buildNegReach(groupPatterns),
+		})
+		start = end
+	}
+	return groups
+}
+
+func patternsShareTargetCoordinate(left IgnorePattern, right IgnorePattern) bool {
+	if left.GitPattern != right.GitPattern || left.CaseInsensitive != right.CaseInsensitive {
+		return false
+	}
+	leftScoped := patternHasMatchDirectory(left)
+	rightScoped := patternHasMatchDirectory(right)
+	if leftScoped != rightScoped {
+		return false
+	}
+	if !leftScoped {
+		return true
+	}
+	return left.gitScope == right.gitScope &&
+		left.MatchDirectory == right.MatchDirectory &&
+		left.PhysicalMatchDirectory == right.PhysicalMatchDirectory &&
+		left.LexicalMatchDirectory == right.LexicalMatchDirectory
+}
+
+func (resolver *configTargetResolver) resolve(path string, canonicalPath string) configTargetDecision {
+	return resolver.resolveTarget(DiscoveredLintTarget{
+		Path:          path,
+		CanonicalPath: canonicalPath,
+	})
+}
+
+func (resolver *configTargetResolver) resolveTarget(
+	discovered DiscoveredLintTarget,
+) configTargetDecision {
+	target, matches := resolver.resolvePathSpacesWithCanonicalParent(
+		discovered.Path,
+		discovered.CanonicalPath,
+		discovered.CanonicalParentPath,
+		false,
+	)
+
+	decision := configTargetDecision{selected: isDefaultLintFile(target.path)}
+	decision.globallyIgnored = resolver.globallyIgnores(target, matches)
+	if decision.globallyIgnored {
+		return decision
+	}
+
+	var tail []byte
+	if tailEntryCount := len(resolver.config) - 64; tailEntryCount > 0 {
+		tail = make([]byte, (tailEntryCount+7)/8)
+	}
+	for index, entry := range resolver.config {
+		if isGlobalIgnoreEntry(entry) {
+			continue
+		}
+		prepared := resolver.entries[index]
+		match := &matches[prepared.baseIndex]
+		if hasFileSelectors(entry) && !match.matcher.matchesConfigEntry(entry) {
+			continue
+		}
+		if match.matcher.isIgnored(prepared.ignorePatterns) {
+			continue
+		}
+
+		decision.matched = true
+		if hasFileSelectors(entry) {
+			decision.selected = true
+		}
+		decision.key.add(index, tail)
+	}
+	if tail != nil {
+		decision.key.tail = string(tail)
+	}
+	return decision
+}
+
+func (resolver *configTargetResolver) resolvePathSpaces(
+	path string,
+	canonicalPath string,
+	directory bool,
+) (configTargetIdentity, []configTargetMatch) {
+	return resolver.resolvePathSpacesWithCanonicalParent(
+		path,
+		canonicalPath,
+		"",
+		directory,
+	)
+}
+
+func (resolver *configTargetResolver) resolvePathSpacesWithCanonicalParent(
+	path string,
+	canonicalPath string,
+	canonicalParentPath string,
+	directory bool,
+) (configTargetIdentity, []configTargetMatch) {
+	path = tspath.NormalizePath(path)
+	if canonicalPath != "" {
+		canonicalPath = tspath.NormalizePath(canonicalPath)
+	} else if resolver.fs != nil && resolver.needsCanonicalPath(path) {
+		if realPath := resolver.fs.Realpath(path); realPath != "" {
+			canonicalPath = tspath.NormalizePath(realPath)
+		}
+	}
+	if canonicalParentPath != "" {
+		canonicalParentPath = tspath.NormalizePath(canonicalParentPath)
+	}
+	matches := make([]configTargetMatch, len(resolver.bases))
+	for index, base := range resolver.bases {
+		matchPath, matchDirectory := resolveConfigPathSpaceWithCanonicalParent(
+			path,
+			canonicalPath,
+			canonicalParentPath,
+			base.directory,
+			base.physicalDirectory,
+			base.physicalAliasAncestors,
+			resolver.fs,
+			!directory,
+		)
+		matches[index] = configTargetMatch{
+			path:      matchPath,
+			directory: matchDirectory,
+			matcher:   newFileMatchPath(matchPath, matchDirectory),
+		}
+	}
+	canonicalMatchPath := canonicalPath
+	if canonicalMatchPath == "" && resolver.fs == nil {
+		// Filesystem-free compatibility callers cannot distinguish a canonical
+		// spelling from an ordinary lexical one. After lexical scope selection
+		// has failed, allow the supplied path itself to represent a physical
+		// spelling. Filesystem-aware paths still protect leaf symlinks below.
+		canonicalMatchPath = path
+	}
+	if !directory && canonicalMatchPath != "" {
+		identityAlreadyExact := canonicalMatchPath == path &&
+			(canonicalParentPath == "" || canonicalParentPath == tspath.GetDirectoryPath(path))
+		if !identityAlreadyExact && hasDistinctFileIdentityWithCanonicalParent(
+			path,
+			canonicalMatchPath,
+			canonicalParentPath,
+			resolver.fs,
+		) {
+			canonicalMatchPath = ""
+		}
+	}
+	target := configTargetIdentity{
+		path:               path,
+		canonicalMatchPath: canonicalMatchPath,
+	}
+	return target, matches
+}
+
+// needsCanonicalPath reports whether lexical containment alone cannot resolve
+// every authored config base and collected Git scope. Directory walks normally
+// stay inside both, so they avoid a redundant filesystem Realpath per node;
+// aliases, native-casing fallbacks, external configs, and independent Git
+// scopes still request the canonical identity before the shared decision.
+func (resolver *configTargetResolver) needsCanonicalPath(path string) bool {
+	for _, base := range resolver.bases {
+		if isPathWithinNormalizedRoot(path, base.directory) {
+			continue
+		}
+		if !isPathWithinNormalizedRoot(path, base.physicalDirectory) {
+			return true
+		}
+	}
+	for _, entry := range resolver.entries {
+		if len(entry.gitScopes) == 0 {
+			continue
+		}
+		withinLexicalScope := false
+		for _, scope := range entry.gitScopes {
+			if (!scope.caseInsensitive && isPathWithinNormalizedRoot(path, scope.lexicalDirectory)) ||
+				(scope.caseInsensitive && isPathWithinRootCaseInsensitive(path, scope.lexicalDirectory)) {
+				withinLexicalScope = true
+				break
+			}
+		}
+		if !withinLexicalScope {
+			return true
+		}
+	}
+	return false
+}
+
+func isPathWithinRootCaseInsensitive(path string, root string) bool {
+	_, within := RelativePathWithinConfigRoot(path, root, false)
+	return within
+}
+
+// selectGitScope chooses exactly one collection scope for a target. Lexical
+// containment is authoritative. Canonical-to-physical containment is only a
+// fallback for targets that have no lexical scope, and uses the same stable
+// scope order produced by collection planning. A projected config-owner path
+// never participates in authority selection.
+func (entry configTargetEntry) selectGitScope(target configTargetIdentity) uint32 {
+	for index, scope := range entry.gitScopes {
+		if (!scope.caseInsensitive && isPathWithinNormalizedRoot(target.path, scope.lexicalDirectory)) ||
+			(scope.caseInsensitive && isPathWithinRootCaseInsensitive(target.path, scope.lexicalDirectory)) {
+			return uint32(index + 1)
+		}
+	}
+	if target.canonicalMatchPath == "" {
+		return 0
+	}
+	for index, scope := range entry.gitScopes {
+		if (!scope.caseInsensitive && isPathWithinNormalizedRoot(target.canonicalMatchPath, scope.physicalDirectory)) ||
+			(scope.caseInsensitive && isPathWithinRootCaseInsensitive(target.canonicalMatchPath, scope.physicalDirectory)) {
+			return uint32(index + 1)
+		}
+	}
+	return 0
+}
+
+func (resolver *configTargetResolver) globallyIgnores(
+	target configTargetIdentity,
+	matches []configTargetMatch,
+) bool {
+	ignored := false
+	if resolver.hasAbsoluteDirectoryBlock(target, matches, true) {
+		return true
+	}
+	for _, entryIndex := range resolver.globalEntryIndexes {
+		entry := resolver.entries[entryIndex]
+		match := &matches[entry.baseIndex]
+		ignored = target.applyIgnorePatternGroups(
+			match,
+			entry.ignorePatternGroups,
+			entry.selectGitScope(target),
+			ignored,
+		)
+	}
+	return ignored
+}
+
+func (target configTargetIdentity) applyIgnorePatternGroups(
+	match *configTargetMatch,
+	groups []ignorePatternCoordinateGroup,
+	selectedGitScope uint32,
+	ignored bool,
+) bool {
+	for _, group := range groups {
+		patterns := group.patterns
+		var normalizedPath, unixPath string
+		var ok bool
+		if patternHasMatchDirectory(patterns[0]) {
+			if patterns[0].gitScope != 0 && patterns[0].gitScope != selectedGitScope {
+				continue
+			}
+			normalizedPath, unixPath, ok = target.pathsForPatternGroup(match, patterns)
+		} else {
+			normalizedPath, unixPath, ok = match.matcher.pathsForPatternGroup(patterns)
+		}
+		if ok {
+			ignored = applyIgnorePatternGroup(patterns, normalizedPath, unixPath, ignored)
+		}
+	}
+	return ignored
+}
+
+func (target configTargetIdentity) pathsForPatternGroup(
+	match *configTargetMatch,
+	patterns []IgnorePattern,
+) (string, string, bool) {
+	pattern := patterns[0]
+	lexicalRoot := pattern.LexicalMatchDirectory
+	if lexicalRoot == "" {
+		lexicalRoot = pattern.MatchDirectory
+	}
+	if target.path == match.path && lexicalRoot == match.directory {
+		normalizedPath, unixPath := match.matcher.normalizedPaths()
+		if pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
+			normalizedPath = normalizePathWithCaseSensitivity(match.path, match.directory, false)
+			unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
+		}
+		if !pathEscapesCwd(unixPath) {
+			return normalizedPath, unixPath, true
+		}
+	}
+	return pathsForGitPatternGroup(
+		target.path,
+		target.canonicalMatchPath,
+		match.path,
+		patterns,
+	)
+}
+
+func (resolver *configTargetResolver) blocksDirectory(path string, canonicalPath string) bool {
+	target, matches := resolver.resolvePathSpaces(path, canonicalPath, true)
+	return resolver.hasAbsoluteDirectoryBlock(target, matches, false)
+}
+
+func (resolver *configTargetResolver) hasAbsoluteDirectoryBlock(
+	target configTargetIdentity,
+	matches []configTargetMatch,
+	fileTarget bool,
+) bool {
+	if fileTarget {
+		target.path = tspath.GetDirectoryPath(target.path)
+		if target.canonicalMatchPath != "" {
+			target.canonicalMatchPath = tspath.GetDirectoryPath(target.canonicalMatchPath)
+		}
+		return resolver.directoryBlocks.getOrInit(target, func() bool {
+			return resolver.hasAbsoluteDirectoryBlockForDirectory(target, matches, true)
+		})
+	}
+	return resolver.hasAbsoluteDirectoryBlockForDirectory(target, matches, false)
+}
+
+func (resolver *configTargetResolver) hasAbsoluteDirectoryBlockForDirectory(
+	target configTargetIdentity,
+	matches []configTargetMatch,
+	fileTarget bool,
+) bool {
+	for _, entryIndex := range resolver.globalEntryIndexes {
+		entry := resolver.entries[entryIndex]
+		match := &matches[entry.baseIndex]
+		selectedGitScope := entry.selectGitScope(target)
+		directoryMatch := match
+		if fileTarget {
+			path := tspath.GetDirectoryPath(match.path)
+			directoryMatch = &configTargetMatch{
+				path:      path,
+				directory: match.directory,
+				matcher:   newFileMatchPath(path, match.directory),
+			}
+		}
+		for _, group := range entry.ignorePatternGroups {
+			relative, ok := targetPathForPatternGroup(
+				target,
+				directoryMatch,
+				group.patterns,
+				selectedGitScope,
+			)
+			if ok && isDirAbsolutelyBlocked(relative, group.patterns) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// canPruneDirectory proves that no global-ignore negation can select a file
+// below path. Unlike the final file decision, pruning must stay conservative:
+// one reachable negation in any authored path space keeps the subtree open.
+func (resolver *configTargetResolver) canPruneDirectory(path string, canonicalPath string) bool {
+	target, matches := resolver.resolvePathSpaces(path, canonicalPath, true)
+	negationCanReach := false
+	fileLevelCovered := false
+	for _, entryIndex := range resolver.globalEntryIndexes {
+		entry := resolver.entries[entryIndex]
+		match := &matches[entry.baseIndex]
+		selectedGitScope := entry.selectGitScope(target)
+		for _, group := range entry.ignorePatternGroups {
+			relative, ok := targetPathForPatternGroup(
+				target,
+				match,
+				group.patterns,
+				selectedGitScope,
+			)
+			if !ok {
+				continue
+			}
+			if isDirAbsolutelyBlocked(relative, group.patterns) {
+				return true
+			}
+			if !negationCanReach && group.negationReach.overlaps(relative) {
+				negationCanReach = true
+			}
+			if !fileLevelCovered {
+				for _, pattern := range group.patterns {
+					if !pattern.Negated && pattern.Kind == dirFileLevelCover &&
+						ignorePatternMatches(pattern, relative+"/x") {
+						fileLevelCovered = true
+						break
+					}
+				}
+			}
+		}
+	}
+	return fileLevelCovered && !negationCanReach
+}
+
+func targetPathForPatternGroup(
+	target configTargetIdentity,
+	match *configTargetMatch,
+	patterns []IgnorePattern,
+	selectedGitScope uint32,
+) (string, bool) {
+	pattern := patterns[0]
+	if !patternHasMatchDirectory(pattern) {
+		_, relative := match.matcher.normalizedPaths()
+		relative = strings.TrimSuffix(relative, "/")
+		if pathEscapesCwd(relative) && hasCaseInsensitivePattern(patterns) {
+			relative = normalizePathWithCaseSensitivity(match.path, match.directory, false)
+			relative = strings.TrimSuffix(strings.ReplaceAll(relative, "\\", "/"), "/")
+		}
+		return relative, relative != "" && relative != "."
+	}
+	if pattern.gitScope != 0 && pattern.gitScope != selectedGitScope {
+		return "", false
+	}
+
+	_, relative, ok := target.pathsForPatternGroup(match, patterns)
+	if !ok {
+		return "", false
+	}
+	relative = strings.TrimSuffix(relative, "/")
+	return relative, relative != "" && relative != "."
+}
+
+func (resolver *configTargetResolver) reopensDirectory(path string, canonicalPath string) bool {
+	target, matches := resolver.resolvePathSpaces(path, canonicalPath, true)
+	reopened := false
+	for _, entryIndex := range resolver.globalEntryIndexes {
+		entry := resolver.entries[entryIndex]
+		match := &matches[entry.baseIndex]
+		selectedGitScope := entry.selectGitScope(target)
+		for _, group := range entry.ignorePatternGroups {
+			relativePath, ok := targetPathForPatternGroup(
+				target,
+				match,
+				group.patterns,
+				selectedGitScope,
+			)
+			if !ok {
+				continue
+			}
+			for patternIndex := range group.patterns {
+				pattern := &group.patterns[patternIndex]
+				matched := false
+				if pattern.GitPattern {
+					gitPath := relativePath
+					if pattern.CaseInsensitive {
+						gitPath = strings.ToLower(gitPath)
+					}
+					matched = gitIgnorePatternMatchesNode(pattern, gitPath)
+				} else {
+					matched = ignorePatternMatches(*pattern, relativePath) ||
+						ignorePatternMatches(*pattern, relativePath+"/")
+				}
+				if matched {
+					reopened = pattern.Negated
+				}
+			}
+		}
+	}
+	return reopened
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,25 @@ func TestParserOptionsUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestParserOptionsProjectEmptyArraySurvivesJSONRoundTrip(t *testing.T) {
+	before := ParserOptions{Project: ProjectPaths{}}
+	encoded, err := json.Marshal(before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) != `{"project":[]}` {
+		t.Fatalf("MarshalJSON = %s, want explicit empty project", encoded)
+	}
+
+	var after ParserOptions
+	if err := json.Unmarshal(encoded, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.Project == nil || len(after.Project) != 0 {
+		t.Fatalf("round-trip project = %#v, want non-nil empty slice", after.Project)
+	}
+}
+
 func TestParserOptionsProjectServicePtr(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/config/discovery/discovery.go
+++ b/internal/config/discovery/discovery.go
@@ -39,6 +39,7 @@ type discoverySeed struct {
 	explicitFile       bool
 	ownerDir           string
 	ownerPath          string
+	gitignoreRoot      string
 	gitDirectory       string
 	gitCursor          gitignore.Cursor
 	gitActive          bool
@@ -93,6 +94,7 @@ type directorySeedResolution struct {
 
 type gitignoreObservation struct {
 	ownerDirectory  string
+	scopeRoot       string
 	sourceDirectory string
 	patterns        []gitignore.Pattern
 }
@@ -117,6 +119,7 @@ type configCatalogBuilder struct {
 	scopes               map[string]rslintconfig.LintDiscoveryScope
 	failureByPath        map[string]ConfigFailure
 	gitignoreSources     map[string]map[tspath.Path]gitignoreObservation
+	gitignoreScopes      map[string][]string
 	gitignoreReadMu      sync.Mutex
 	gitignoreReadCache   map[tspath.Path]gitignoreReadResult
 	gitignoreReadPending map[tspath.Path]chan struct{}
@@ -137,11 +140,12 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 	builder.request.CWD = cwd
 
 	if builder.explicitConfigPath != "" {
+		configPath := normalizeDiscoveryPath(builder.explicitConfigPath, cwd)
 		candidate := configCandidate{
-			path: normalizeDiscoveryPath(builder.explicitConfigPath, cwd),
-			// Explicit flat configs resolve files/ignores/projects from the
-			// invocation cwd, not the module's physical directory.
-			directory: cwd,
+			path: configPath,
+			// The invocation cwd controls the default scan scope. Relative paths
+			// authored inside the selected config use the config file's directory.
+			directory: tspath.GetDirectoryPath(configPath),
 		}
 		builder.hadCandidates = true
 		if err := builder.ensureCandidates([]configCandidate{candidate}); err != nil {
@@ -301,78 +305,101 @@ func (builder *configCatalogBuilder) projectExplicitConfigGitignore(state *confi
 	if state == nil || state.failure != nil {
 		return nil
 	}
-	if len(builder.request.Directories) == 0 && builder.request.Files != nil {
-		files := builder.normalizedFiles()
-		seeds := make([]*discoverySeed, 0, len(files))
+	files := builder.normalizedFiles()
+	var filePaths []string
+	if builder.request.Files != nil {
+		filePaths = make([]string, 0, len(files))
 		for _, file := range files {
-			seed := &discoverySeed{
-				path: rslintconfig.ResolveGitignoreCollectionPath(
-					file.Path,
-					file.CanonicalPath,
-					state.candidate.directory,
-					builder.fs,
-				),
-				ownerDir:  state.candidate.directory,
-				ownerPath: state.candidate.path,
-			}
-			seeds = append(seeds, seed)
+			filePaths = append(filePaths, file.Path)
 		}
-		builder.collectExactTargetGitignore(seeds)
+	}
+	var directoryPaths []string
+	if builder.request.Directories != nil {
+		directoryPaths = builder.normalizedDirectoryRoots()
+	}
+	scopes := rslintconfig.PlanGitignoreCollectionScopes(
+		builder.request.CWD,
+		builder.fs,
+		filePaths,
+		directoryPaths,
+	)
+	var walkRoots []discoveryWalkNode
+	for _, scope := range scopes {
+		builder.recordGitignoreScope(state.candidate.directory, scope.Root)
+		if len(scope.Directories) == 0 && scope.Files != nil {
+			seeds := make([]*discoverySeed, 0, len(scope.Files))
+			for _, file := range scope.Files {
+				seeds = append(seeds, &discoverySeed{
+					path: rslintconfig.ResolveGitignoreCollectionPath(
+						file,
+						"",
+						scope.Root,
+						builder.fs,
+					),
+					ownerDir:      state.candidate.directory,
+					ownerPath:     state.candidate.path,
+					gitignoreRoot: scope.Root,
+				})
+			}
+			builder.collectExactTargetGitignore(seeds)
+			continue
+		}
+		var targets *discoveryTargetTrie
+		if scope.Files != nil || scope.Directories != nil {
+			var hasTargets bool
+			targets, hasTargets = builder.explicitProjectionTargets(scope)
+			if !hasTargets {
+				continue
+			}
+		}
+		canonicalRoot := builder.fs.Realpath(scope.Root)
+		if discoveryPathsEqual(scope.Root, canonicalRoot, builder.fs.UseCaseSensitiveFileNames()) {
+			canonicalRoot = ""
+		}
+		walkRoots = append(walkRoots, discoveryWalkNode{
+			directory:          scope.Root,
+			canonicalDirectory: canonicalRoot,
+			ownerDir:           state.candidate.directory,
+			ownerPath:          state.candidate.path,
+			gitDirectory:       scope.Root,
+			gitCursor:          gitignore.NewCursor(scope.Root, builder.fs.UseCaseSensitiveFileNames()),
+			gitActive:          true,
+			targets:            targets,
+		})
+	}
+	if len(walkRoots) == 0 {
 		return builder.ctx.Err()
 	}
-	var targets *discoveryTargetTrie
-	if len(builder.request.Directories) > 0 {
-		var hasTargets bool
-		targets, hasTargets = builder.explicitProjectionTargets(state.candidate.directory)
-		if !hasTargets {
-			return builder.ctx.Err()
-		}
-	}
-
-	root := state.candidate.directory
-	canonicalRoot := builder.fs.Realpath(root)
-	if discoveryPathsEqual(root, canonicalRoot, builder.fs.UseCaseSensitiveFileNames()) {
-		canonicalRoot = ""
-	}
-	return builder.walkDirectories([]discoveryWalkNode{{
-		directory:          root,
-		canonicalDirectory: canonicalRoot,
-		ownerDir:           root,
-		ownerPath:          state.candidate.path,
-		gitDirectory:       root,
-		gitCursor:          gitignore.NewCursor(root, builder.fs.UseCaseSensitiveFileNames()),
-		gitActive:          true,
-		targets:            targets,
-	}})
+	return builder.walkDirectories(walkRoots)
 }
 
-func (builder *configCatalogBuilder) explicitProjectionTargets(configDir string) (*discoveryTargetTrie, bool) {
+func (builder *configCatalogBuilder) explicitProjectionTargets(scope rslintconfig.GitignoreCollectionScope) (*discoveryTargetTrie, bool) {
 	root := &discoveryTargetTrie{}
 	hasTargets := false
-	for _, file := range builder.normalizedFiles() {
+	for _, file := range scope.Files {
 		collectionPath := rslintconfig.ResolveGitignoreCollectionPath(
-			file.Path,
-			file.CanonicalPath,
-			configDir,
+			file,
+			"",
+			scope.Root,
 			builder.fs,
 		)
 		hasTargets = addDiscoveryTarget(
 			root,
-			configDir,
+			scope.Root,
 			tspath.GetDirectoryPath(collectionPath),
 			false,
 			builder.fs.UseCaseSensitiveFileNames(),
 		) || hasTargets
 	}
-	for _, directory := range builder.normalizedDirectoryRoots() {
+	for _, directory := range scope.Directories {
 		collectionPath := rslintconfig.ResolveGitignoreCollectionDirectory(
 			directory,
-			configDir,
+			scope.Root,
 			builder.fs,
 		)
 		hasTargets = addDiscoveryTarget(
 			root,
-			configDir,
+			scope.Root,
 			collectionPath,
 			true,
 			builder.fs.UseCaseSensitiveFileNames(),
@@ -1332,8 +1359,16 @@ func (builder *configCatalogBuilder) readGitignoreSource(
 	if len(patterns) == 0 {
 		return next, nil
 	}
+	matchRoot := cursor.RootDirectory()
+	patterns = rslintconfig.CollectedGitignorePatternsForRoot(
+		patterns,
+		ownerDirectory,
+		matchRoot,
+		builder.fs,
+	)
 	return next, &gitignoreObservation{
 		ownerDirectory:  ownerDirectory,
+		scopeRoot:       matchRoot,
 		sourceDirectory: matchDirectory,
 		patterns:        patterns,
 	}
@@ -1410,9 +1445,10 @@ func (builder *configCatalogBuilder) observeGitignoreSource(
 }
 
 func (builder *configCatalogBuilder) recordGitignoreObservation(observation gitignoreObservation) {
-	if observation.ownerDirectory == "" || observation.sourceDirectory == "" || len(observation.patterns) == 0 {
+	if observation.ownerDirectory == "" || observation.scopeRoot == "" || observation.sourceDirectory == "" || len(observation.patterns) == 0 {
 		return
 	}
+	builder.recordGitignoreScope(observation.ownerDirectory, observation.scopeRoot)
 	if builder.gitignoreSources == nil {
 		builder.gitignoreSources = make(map[string]map[tspath.Path]gitignoreObservation)
 	}
@@ -1421,16 +1457,39 @@ func (builder *configCatalogBuilder) recordGitignoreObservation(observation giti
 		sources = make(map[tspath.Path]gitignoreObservation)
 		builder.gitignoreSources[observation.ownerDirectory] = sources
 	}
-	identity := tspath.ToPath(
+	scopeIdentity := tspath.ToPath(
+		tspath.NormalizePath(observation.scopeRoot),
+		"",
+		builder.fs.UseCaseSensitiveFileNames(),
+	)
+	sourceIdentity := tspath.ToPath(
 		tspath.NormalizePath(observation.sourceDirectory),
 		"",
 		builder.fs.UseCaseSensitiveFileNames(),
 	)
+	identity := tspath.Path(string(scopeIdentity) + "\x00" + string(sourceIdentity))
 	if _, exists := sources[identity]; exists {
 		return
 	}
 	observation.patterns = append([]gitignore.Pattern(nil), observation.patterns...)
 	sources[identity] = observation
+}
+
+func (builder *configCatalogBuilder) recordGitignoreScope(ownerDirectory string, scopeRoot string) {
+	if ownerDirectory == "" || scopeRoot == "" {
+		return
+	}
+	if builder.gitignoreScopes == nil {
+		builder.gitignoreScopes = make(map[string][]string)
+	}
+	scopeRoot = tspath.NormalizePath(scopeRoot)
+	identity := tspath.ToPath(scopeRoot, "", builder.fs.UseCaseSensitiveFileNames())
+	for _, existing := range builder.gitignoreScopes[ownerDirectory] {
+		if tspath.ToPath(existing, "", builder.fs.UseCaseSensitiveFileNames()) == identity {
+			return
+		}
+	}
+	builder.gitignoreScopes[ownerDirectory] = append(builder.gitignoreScopes[ownerDirectory], scopeRoot)
 }
 
 func splitDiscoveryPath(path string) []string {
@@ -1484,11 +1543,15 @@ func (builder *configCatalogBuilder) collectExactTargetGitignoreChain(
 	barriers map[tspath.Path]struct{},
 	useCaseSensitive bool,
 ) {
+	gitignoreRoot := seed.gitignoreRoot
+	if gitignoreRoot == "" {
+		gitignoreRoot = seed.ownerDir
+	}
 	targetDirectory := tspath.GetDirectoryPath(seed.path)
 	matchDirectory := targetDirectory
 	if _, within := rslintconfig.RelativePathWithinConfigRoot(
 		matchDirectory,
-		seed.ownerDir,
+		gitignoreRoot,
 		useCaseSensitive,
 	); !within {
 		matchDirectory = seed.canonicalSearchDir
@@ -1497,7 +1560,7 @@ func (builder *configCatalogBuilder) collectExactTargetGitignoreChain(
 		}
 		if _, within = rslintconfig.RelativePathWithinConfigRoot(
 			matchDirectory,
-			seed.ownerDir,
+			gitignoreRoot,
 			useCaseSensitive,
 		); !within {
 			return
@@ -1506,15 +1569,15 @@ func (builder *configCatalogBuilder) collectExactTargetGitignoreChain(
 
 	relative, within := rslintconfig.RelativePathWithinConfigRoot(
 		matchDirectory,
-		seed.ownerDir,
+		gitignoreRoot,
 		useCaseSensitive,
 	)
 	if !within {
 		return
 	}
-	cursor := gitignore.NewCursor(seed.ownerDir, useCaseSensitive)
-	currentMatch := seed.ownerDir
-	currentSource := seed.ownerDir
+	cursor := gitignore.NewCursor(gitignoreRoot, useCaseSensitive)
+	currentMatch := gitignoreRoot
+	currentSource := gitignoreRoot
 	components := splitDiscoveryPath(relative)
 	for index := 0; ; index++ {
 		identity := tspath.ToPath(currentMatch, "", useCaseSensitive)
@@ -1634,6 +1697,9 @@ func (builder *configCatalogBuilder) installSource(state *configLoadState, expli
 		CandidatePath: state.candidate.path,
 		ExplicitOnly:  explicitOnly,
 	}
+	if builder.explicitConfigPath == "" {
+		builder.recordGitignoreScope(directory, directory)
+	}
 }
 
 func (builder *configCatalogBuilder) catalog() (*ConfigCatalog, error) {
@@ -1698,9 +1764,19 @@ func (builder *configCatalogBuilder) materializeGitignoreConfigs() {
 		for _, observation := range sources {
 			observations = append(observations, observation)
 		}
+		scopeRoots := builder.gitignoreScopes[ownerDirectory]
+		scopeOrder := make(map[tspath.Path]int, len(scopeRoots))
+		for index, root := range scopeRoots {
+			scopeOrder[tspath.ToPath(root, "", builder.fs.UseCaseSensitiveFileNames())] = index
+		}
 		sort.Slice(observations, func(i, j int) bool {
-			leftDepth := builder.gitignoreSourceDepth(ownerDirectory, observations[i].sourceDirectory)
-			rightDepth := builder.gitignoreSourceDepth(ownerDirectory, observations[j].sourceDirectory)
+			leftScope := scopeOrder[tspath.ToPath(observations[i].scopeRoot, "", builder.fs.UseCaseSensitiveFileNames())]
+			rightScope := scopeOrder[tspath.ToPath(observations[j].scopeRoot, "", builder.fs.UseCaseSensitiveFileNames())]
+			if leftScope != rightScope {
+				return leftScope < rightScope
+			}
+			leftDepth := builder.gitignoreSourceDepth(observations[i].scopeRoot, observations[i].sourceDirectory)
+			rightDepth := builder.gitignoreSourceDepth(observations[j].scopeRoot, observations[j].sourceDirectory)
 			if leftDepth != rightDepth {
 				return leftDepth < rightDepth
 			}
@@ -1719,18 +1795,21 @@ func (builder *configCatalogBuilder) materializeGitignoreConfigs() {
 		for _, observation := range observations {
 			patterns = append(patterns, observation.patterns...)
 		}
-		builder.configs[ownerDirectory] = rslintconfig.ConfigWithCollectedGitignore(
+		builder.configs[ownerDirectory] = rslintconfig.ConfigWithCollectedGitignoreScopes(
 			entries,
 			patterns,
+			scopeRoots,
+			ownerDirectory,
+			builder.fs,
 			caseInsensitive,
 		)
 	}
 }
 
-func (builder *configCatalogBuilder) gitignoreSourceDepth(ownerDirectory string, sourceDirectory string) int {
+func (builder *configCatalogBuilder) gitignoreSourceDepth(scopeRoot string, sourceDirectory string) int {
 	relative, within := rslintconfig.RelativePathWithinConfigRoot(
 		sourceDirectory,
-		ownerDirectory,
+		scopeRoot,
 		builder.fs.UseCaseSensitiveFileNames(),
 	)
 	if !within || relative == "" {

--- a/internal/config/discovery/discovery_test.go
+++ b/internal/config/discovery/discovery_test.go
@@ -1471,12 +1471,16 @@ func TestConfigDiscoveryAutomaticDirectoryTargetKeepsAncestorOwnerGitChain(t *te
 
 func TestConfigDiscoveryExplicitConfigLoadsBeforeProjectingGitignore(t *testing.T) {
 	root := t.TempDir()
-	ignoredTarget := writeDiscoveryFixture(t, root, "ignored/index.ts", "export {};\n")
-	visibleTarget := writeDiscoveryFixture(t, root, "src/index.ts", "export {};\n")
-	writeDiscoveryFixture(t, root, ".gitignore", "ignored/\n")
+	ignoredTarget := writeDiscoveryFixture(t, root, "config/index.ts", "export {};\n")
+	visibleTarget := writeDiscoveryFixture(t, root, "config/visible.ts", "export {};\n")
+	writeDiscoveryFixture(t, root, ".gitignore", "config/custom.config.cjs\nconfig/index.ts\n")
 	loader := newFixtureConfigLoader()
-	configPath := writeConfigCandidate(t, root, "ignored/custom.config.cjs")
-	loader.configs[configPath] = namedConfig("explicit")
+	configPath := writeConfigCandidate(t, root, "config/custom.config.cjs")
+	loader.configs[configPath] = rslintconfig.RslintConfig{{
+		Name:  "explicit",
+		Files: []string{"*.ts"},
+		Rules: rslintconfig.Rules{},
+	}}
 
 	catalog, err := LoadExplicitConfig(
 		context.Background(),
@@ -1487,9 +1491,9 @@ func TestConfigDiscoveryExplicitConfigLoadsBeforeProjectingGitignore(t *testing.
 	if err != nil {
 		t.Fatalf("LoadExplicitConfig: %v", err)
 	}
-	root = tspath.NormalizePath(root)
-	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{root}) {
-		t.Fatalf("explicit config should be anchored at cwd: %v", got)
+	configDir := tspath.GetDirectoryPath(tspath.NormalizePath(configPath))
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{configDir}) {
+		t.Fatalf("explicit config should be anchored at its directory: %v", got)
 	}
 	if !catalog.Explicit {
 		t.Fatal("explicit discovery catalog was not marked invocation-wide")
@@ -1497,14 +1501,14 @@ func TestConfigDiscoveryExplicitConfigLoadsBeforeProjectingGitignore(t *testing.
 	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{configPath}) {
 		t.Fatalf("explicit source = %v, want %q", got, configPath)
 	}
-	if got := loader.batches[0].Candidates[0].ConfigDirectory; got != root {
-		t.Fatalf("wire configDirectory = %q, want cwd %q", got, root)
+	if got := loader.batches[0].Candidates[0].ConfigDirectory; got != configDir {
+		t.Fatalf("wire configDirectory = %q, want config directory %q", got, configDir)
 	}
-	config := catalog.Configs[root]
-	if got := config.GetConfigForFile(ignoredTarget, root); got != nil {
+	config := catalog.Configs[configDir]
+	if got := config.GetConfigForFile(ignoredTarget, configDir); got != nil {
 		t.Fatalf("Git-ignored target received explicit config: %+v", got)
 	}
-	if got := config.GetConfigForFile(visibleTarget, root); got == nil {
+	if got := config.GetConfigForFile(visibleTarget, configDir); got == nil {
 		t.Fatal("visible target did not receive explicit config")
 	}
 }
@@ -1588,15 +1592,16 @@ func TestConfigDiscoveryExplicitConfigTargetProjectionUsesConfigPathSpace(t *tes
 	canonicalTarget := discoveryTestFS().Realpath(physicalTarget)
 
 	for _, test := range []struct {
-		name      string
-		cwd       string
-		target    string
-		canonical string
+		name        string
+		cwd         string
+		target      string
+		canonical   string
+		wantIgnored bool
 	}{
-		{name: "aliased CWD and physical target", cwd: aliasRoot, target: physicalTarget},
-		{name: "physical CWD and aliased target", cwd: physicalRoot, target: aliasTarget},
+		{name: "aliased CWD and physical target", cwd: aliasRoot, target: physicalTarget, wantIgnored: true},
+		{name: "physical CWD and aliased target", cwd: physicalRoot, target: aliasTarget, wantIgnored: true},
 		{
-			name:      "canonical target hint maps an external spelling",
+			name:      "canonical target hint does not move an external lexical spelling into the Git root",
 			cwd:       physicalRoot,
 			target:    externalSpelling,
 			canonical: canonicalTarget,
@@ -1625,24 +1630,30 @@ func TestConfigDiscoveryExplicitConfigTargetProjectionUsesConfigPathSpace(t *tes
 				t.Fatalf("LoadExplicitConfig: %v", err)
 			}
 			cwd := tspath.NormalizePath(test.cwd)
-			matchFile, matchDir := rslintconfig.ResolveConfigPathSpaceWithCanonical(
+			matchFile, matchDir := rslintconfig.ResolveConfigFilePathSpaceWithCanonical(
 				test.target,
 				test.canonical,
 				cwd,
 				spyFS,
 			)
-			if got := catalog.Configs[cwd].GetConfigForFile(matchFile, matchDir); got != nil {
+			ignored := catalog.Configs[cwd].GetConfigForFile(matchFile, matchDir) == nil
+			if ignored != test.wantIgnored {
 				t.Fatalf(
-					"path-space Git ignore was not projected: config=%+v match=(%q,%q) reads=%v",
+					"path-space Git ignore = %t, want %t: config=%+v match=(%q,%q) reads=%v",
+					ignored,
+					test.wantIgnored,
 					catalog.Configs[cwd],
 					matchFile,
 					matchDir,
 					spyFS.gitignorePaths,
 				)
 			}
-			wantReads := []string{
-				tspath.CombinePaths(cwd, ".gitignore"),
-				tspath.CombinePaths(cwd, "src/.gitignore"),
+			var wantReads []string
+			if test.wantIgnored {
+				wantReads = []string{
+					tspath.CombinePaths(cwd, ".gitignore"),
+					tspath.CombinePaths(cwd, "src/.gitignore"),
+				}
 			}
 			if got := spyFS.gitignorePaths; !reflect.DeepEqual(got, wantReads) {
 				t.Fatalf("path-space Git reads = %v, want %v", got, wantReads)
@@ -1888,7 +1899,7 @@ func TestConfigDiscoveryExplicitTargetsSkipUnrelatedGitignoreSubtrees(t *testing
 	}
 }
 
-func TestConfigDiscoveryExplicitDirectoryTargetUsesCWDNotPhysicalConfigDirectory(t *testing.T) {
+func TestConfigDiscoveryExplicitDirectoryUsesConfigBaseAndInvocationGitRoot(t *testing.T) {
 	repositoryRoot := t.TempDir()
 	cwd := filepath.Join(repositoryRoot, "packages/app")
 	selectedDir := filepath.Join(cwd, "selected")
@@ -1932,15 +1943,22 @@ func TestConfigDiscoveryExplicitDirectoryTargetUsesCWDNotPhysicalConfigDirectory
 	repositoryRoot = tspath.NormalizePath(repositoryRoot)
 	cwd = tspath.NormalizePath(cwd)
 	selectedDir = tspath.NormalizePath(selectedDir)
-	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{cwd}) {
-		t.Fatalf("explicit owner = %v, want invocation cwd %q", got, cwd)
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{repositoryRoot}) {
+		t.Fatalf("explicit owner = %v, want config directory %q", got, repositoryRoot)
 	}
-	if got := loader.batches[0].Candidates[0].ConfigDirectory; got != cwd {
-		t.Fatalf("wire configDirectory = %q, want invocation cwd %q", got, cwd)
+	if got := loader.batches[0].Candidates[0].ConfigDirectory; got != repositoryRoot {
+		t.Fatalf("wire configDirectory = %q, want config directory %q", got, repositoryRoot)
 	}
 
-	projected := catalog.Configs[cwd]
-	full := rslintconfig.ConfigWithGitignore(entries, cwd, discoveryTestFS(), nil)
+	projected := catalog.Configs[repositoryRoot]
+	full := rslintconfig.ConfigWithGitignoreForTargetsFromRoot(
+		entries,
+		repositoryRoot,
+		cwd,
+		discoveryTestFS(),
+		nil,
+		[]string{selectedDir},
+	)
 	for _, test := range []struct {
 		relativePath string
 		ignored      bool
@@ -1953,10 +1971,10 @@ func TestConfigDiscoveryExplicitDirectoryTargetUsesCWDNotPhysicalConfigDirectory
 		{relativePath: "selected/deep/deep.ts", ignored: true},
 	} {
 		path := tspath.ResolvePath(cwd, test.relativePath)
-		if got := full.IsFileIgnored(path, cwd); got != test.ignored {
-			t.Fatalf("invalid full-CWD fixture for %s: ignored = %t, want %t", test.relativePath, got, test.ignored)
+		if got := full.IsFileIgnored(path, repositoryRoot); got != test.ignored {
+			t.Fatalf("invalid invocation-root fixture for %s: ignored = %t, want %t", test.relativePath, got, test.ignored)
 		}
-		if got := projected.IsFileIgnored(path, cwd); got != test.ignored {
+		if got := projected.IsFileIgnored(path, repositoryRoot); got != test.ignored {
 			t.Errorf("%s ignored by targeted projection = %t, want %t", test.relativePath, got, test.ignored)
 		}
 	}
@@ -1967,14 +1985,14 @@ func TestConfigDiscoveryExplicitDirectoryTargetUsesCWDNotPhysicalConfigDirectory
 		tspath.ResolvePath(selectedDir, "deep/.gitignore"),
 	}
 	if got := spy.gitignorePaths; !reflect.DeepEqual(got, wantGitignoreReads) {
-		t.Fatalf("explicit CWD-rooted Git reads = %v, want %v", got, wantGitignoreReads)
+		t.Fatalf("explicit invocation-rooted Git reads = %v, want %v", got, wantGitignoreReads)
 	}
 	for _, excluded := range []string{
 		tspath.ResolvePath(repositoryRoot, ".gitignore"),
 		tspath.ResolvePath(repositoryRoot, "packages/.gitignore"),
 	} {
 		if slices.Contains(spy.gitignorePaths, excluded) {
-			t.Fatalf("explicit projection read physical config ancestry source %q", excluded)
+			t.Fatalf("explicit projection read config ancestry source %q", excluded)
 		}
 	}
 	unrelatedDir := tspath.ResolvePath(cwd, "unrelated")
@@ -1982,6 +2000,99 @@ func TestConfigDiscoveryExplicitDirectoryTargetUsesCWDNotPhysicalConfigDirectory
 		if accessed == unrelatedDir || tspath.StartsWithDirectory(accessed, unrelatedDir, true) {
 			t.Fatalf("explicit target walk entered unrelated directory %q", accessed)
 		}
+	}
+}
+
+func TestConfigDiscoveryExplicitConfigGitignoreMatchesPhysicalInvocationTarget(t *testing.T) {
+	configRoot := t.TempDir()
+	physicalWorkspace := t.TempDir()
+	aliasWorkspace := filepath.Join(t.TempDir(), "workspace-alias")
+	if err := os.Symlink(physicalWorkspace, aliasWorkspace); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	physicalIgnored := filepath.Join(physicalWorkspace, "ignored.js")
+	aliasIgnored := filepath.Join(aliasWorkspace, "ignored.js")
+	configVisible := filepath.Join(configRoot, "ignored.js")
+	for _, filePath := range []string{physicalIgnored, configVisible} {
+		if err := os.WriteFile(filePath, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(aliasWorkspace, ".gitignore"), []byte("ignored.js\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	physicalIgnored = tspath.NormalizePath(discoveryTestFS().Realpath(physicalIgnored))
+	configPath := writeConfigCandidate(t, configRoot, "custom.config.cjs")
+	loader := newFixtureConfigLoader()
+	loader.configs[configPath] = namedConfig("explicit")
+
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		discoveryTestFS(),
+		loader,
+		ExplicitConfigRequest{
+			CWD:         aliasWorkspace,
+			ConfigPath:  configPath,
+			TargetFiles: []DiscoveryFile{{Path: physicalIgnored, Explicit: true}},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configRoot = tspath.NormalizePath(configRoot)
+	projected := catalog.Configs[configRoot]
+	for _, filePath := range []string{physicalIgnored, aliasIgnored} {
+		if !projected.IsFileIgnored(tspath.NormalizePath(filePath), configRoot) {
+			t.Fatalf("projected Git ignore missed invocation-root identity %q", filePath)
+		}
+	}
+	if projected.IsFileIgnored(tspath.NormalizePath(configVisible), configRoot) {
+		t.Fatalf("projected Git ignore escaped invocation root onto %q", configVisible)
+	}
+}
+
+func TestConfigDiscoveryExplicitDirectoriesKeepGitScopesIndependent(t *testing.T) {
+	configRoot := t.TempDir()
+	invocationRoot := t.TempDir()
+	physicalRoot := t.TempDir()
+	aliasDirectory := filepath.Join(invocationRoot, "link")
+	if err := os.Symlink(physicalRoot, aliasDirectory); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	physicalIgnored := writeDiscoveryFixture(t, physicalRoot, "ignored.ts", "debugger;\n")
+	writeDiscoveryFixture(t, physicalRoot, ".gitignore", "ignored.ts\n")
+
+	configPath := writeConfigCandidate(t, configRoot, "custom.config.cjs")
+	loader := newFixtureConfigLoader()
+	loader.configs[configPath] = namedConfig("explicit")
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		discoveryTestFS(),
+		loader,
+		ExplicitConfigRequest{
+			CWD:               invocationRoot,
+			ConfigPath:        configPath,
+			TargetDirectories: []string{invocationRoot, physicalRoot},
+			SingleThreaded:    true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+
+	configRoot = tspath.NormalizePath(configRoot)
+	physicalIgnored = tspath.NormalizePath(physicalIgnored)
+	aliasIgnored := tspath.NormalizePath(filepath.Join(aliasDirectory, "ignored.ts"))
+	matcher := rslintconfig.NewGlobalIgnoreMatcher(
+		catalog.Configs[configRoot],
+		configRoot,
+		discoveryTestFS(),
+	)
+	if !matcher.IgnoresPath(physicalIgnored, discoveryTestFS().Realpath(physicalIgnored)) {
+		t.Fatal("physical directory scope did not apply its own .gitignore")
+	}
+	if matcher.IgnoresPath(aliasIgnored, discoveryTestFS().Realpath(aliasIgnored)) {
+		t.Fatal("empty invocation scope borrowed the physical directory scope's .gitignore")
 	}
 }
 
@@ -2040,13 +2151,55 @@ func TestConfigDiscoveryExplicitDirectoryContainingAliasedCWDProjectsFullGitTree
 	if err != nil {
 		t.Fatalf("LoadExplicitConfig: %v", err)
 	}
-	matchFile, matchDir := rslintconfig.ResolveConfigPathSpace(
+	matchFile, matchDir := rslintconfig.ResolveConfigFilePathSpace(
 		physicalTarget,
 		aliasRoot,
 		discoveryTestFS(),
 	)
 	if got := catalog.Configs[aliasRoot].GetConfigForFile(matchFile, matchDir); got != nil {
 		t.Fatalf("containing directory did not project aliased CWD Git ignore: %+v", got)
+	}
+}
+
+func TestConfigDiscoveryExplicitPhysicalAncestorCollectsSiblingGitignore(t *testing.T) {
+	physicalParent := t.TempDir()
+	physicalWorkspace := filepath.Join(physicalParent, "workspace")
+	configPath := writeConfigCandidate(t, physicalWorkspace, "custom.config.cjs")
+	sibling := writeDiscoveryFixture(t, physicalParent, "sibling.ts", "debugger;\n")
+	writeDiscoveryFixture(t, physicalParent, ".gitignore", "sibling.ts\n")
+	aliasRoot := filepath.Join(t.TempDir(), "workspace-alias")
+	if err := os.Symlink(physicalWorkspace, aliasRoot); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasRoot = tspath.NormalizePath(aliasRoot)
+	aliasConfigPath := tspath.CombinePaths(aliasRoot, filepath.Base(configPath))
+	loader := newFixtureConfigLoader()
+	loader.configs[aliasConfigPath] = namedConfig("explicit")
+
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		discoveryTestFS(),
+		loader,
+		ExplicitConfigRequest{
+			CWD:               aliasRoot,
+			ConfigPath:        aliasConfigPath,
+			TargetDirectories: []string{tspath.NormalizePath(physicalParent)},
+			SingleThreaded:    true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	matcher := rslintconfig.NewGlobalIgnoreMatcher(
+		catalog.Configs[aliasRoot],
+		aliasRoot,
+		discoveryTestFS(),
+	)
+	if !matcher.IgnoresPath(
+		tspath.NormalizePath(sibling),
+		tspath.NormalizePath(discoveryTestFS().Realpath(sibling)),
+	) {
+		t.Fatal("requested physical ancestor lost its sibling .gitignore")
 	}
 }
 

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -26,14 +26,6 @@ var defaultLintFileExtensionSet = func() map[string]struct{} {
 	return m
 }()
 
-func defaultLintFilePatterns() []string {
-	patterns := make([]string, 0, len(DefaultLintFileExtensions))
-	for _, ext := range DefaultLintFileExtensions {
-		patterns = append(patterns, "**/*"+ext)
-	}
-	return patterns
-}
-
 // IsSupportedLintFile reports whether rslint can parse and lint this path.
 func IsSupportedLintFile(filePath string) bool {
 	_, ok := defaultLintFileExtensionSet[strings.ToLower(path.Ext(filePath))]
@@ -50,6 +42,10 @@ func isDefaultLintFile(filePath string) bool {
 // extends it only for paths not excluded by that same entry's `ignores`.
 // Another matching entry or the default baseline may still select the path.
 func isFileSelectedByConfig(config RslintConfig, filePath string, configDir string) bool {
+	if configNeedsTargetResolver(config) {
+		decision := newConfigTargetResolver(config, configDir, nil).resolve(filePath, "")
+		return decision.selected && !decision.globallyIgnored
+	}
 	if isDefaultLintFile(filePath) {
 		return true
 	}
@@ -95,7 +91,9 @@ func DiscoverLintFiles(
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
-	targets := discoverLintTargetsWithStopDirs(config, configDir, fsys, allowFiles, allowDirs, nil, singleThreaded)
+	targets := discoverLintTargetsWithStopDirs(
+		config, configDir, configDir, fsys, allowFiles, allowDirs, nil, singleThreaded, nil,
+	)
 	files := make([]string, 0, len(targets))
 	for _, target := range targets {
 		files = append(files, target.Path)
@@ -117,20 +115,148 @@ func DiscoverLintTargets(
 	allowDirs []string,
 	singleThreaded bool,
 ) []DiscoveredLintTarget {
-	return discoverLintTargetsWithStopDirs(config, configDir, fsys, allowFiles, allowDirs, nil, singleThreaded)
+	return discoverLintTargetsFromRoot(config, configDir, configDir, fsys, allowFiles, allowDirs, singleThreaded)
+}
+
+// discoverLintTargetsFromRoot is the single-config target walker with separate
+// authored-config and filesystem-scan directories. Most callers use the same
+// directory through DiscoverLintTargets. An explicit external config keeps its
+// own ConfigDirectory on every result while searching only ScanRoot and the
+// requested file/directory scope below it.
+func discoverLintTargetsFromRoot(
+	config RslintConfig,
+	configDir string,
+	scanRoot string,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []DiscoveredLintTarget {
+	return discoverLintTargetsWithStopDirs(
+		config,
+		configDir,
+		scanRoot,
+		fsys,
+		allowFiles,
+		allowDirs,
+		nil,
+		singleThreaded,
+		nil,
+	)
 }
 
 func discoverLintTargetsWithStopDirs(
 	config RslintConfig,
 	configDir string,
+	scanRoot string,
 	fsys vfs.FS,
 	allowFiles []string,
 	allowDirs []string,
 	stopDirs []string,
 	singleThreaded bool,
+	frozenBases map[string]configTargetBase,
 ) []DiscoveredLintTarget {
-	globalIgnores := extractConfigIgnores(config)
-	globalIgnores = append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), globalIgnores...)
+	explicitSet := newExplicitLintTargetSet(allowFiles, fsys)
+	return discoverLintTargetsWithPreparedFiles(
+		config,
+		configDir,
+		scanRoot,
+		fsys,
+		explicitSet.targetsForPaths(allowFiles),
+		allowDirs,
+		stopDirs,
+		singleThreaded,
+		frozenBases,
+	)
+}
+
+func discoverLintTargetsWithPreparedFiles(
+	config RslintConfig,
+	configDir string,
+	scanRoot string,
+	fsys vfs.FS,
+	explicitFiles []*explicitLintTarget,
+	allowDirs []string,
+	stopDirs []string,
+	singleThreaded bool,
+	frozenBases map[string]configTargetBase,
+) []DiscoveredLintTarget {
+	configDir = tspath.NormalizePath(configDir)
+	scanRoot = tspath.NormalizePath(scanRoot)
+	if scanRoot == "" {
+		scanRoot = configDir
+	}
+	if allowDirs == nil {
+		return discoverLintTargetsWithinRoot(
+			config, configDir, scanRoot, fsys, explicitFiles, nil, stopDirs, singleThreaded, frozenBases,
+		)
+	}
+
+	targets := []DiscoveredLintTarget{}
+	if explicitFiles != nil {
+		targets = discoverLintTargetsWithinRoot(
+			config, configDir, scanRoot, fsys, explicitFiles, nil, stopDirs, singleThreaded, frozenBases,
+		)
+	}
+	if len(allowDirs) == 0 {
+		return targets
+	}
+
+	useCaseSensitive := fsys == nil || fsys.UseCaseSensitiveFileNames()
+	targetResolver := newConfigTargetResolverWithBases(config, configDir, fsys, frozenBases)
+	scanRootCanonical := scanRoot
+	if fsys != nil {
+		if realPath := fsys.Realpath(scanRoot); realPath != "" {
+			scanRootCanonical = tspath.NormalizePath(realPath)
+		}
+	}
+	for _, root := range coalesceRequestedDirectories(allowDirs, fsys) {
+		isDefaultRoot := pathsEqual(root.lexicalPath, scanRoot, true) ||
+			pathsEqual(root.canonicalPath, scanRootCanonical, true)
+		if !isDefaultRoot && (IsDefaultExcludedPath(root.lexicalPath, scanRoot, useCaseSensitive) ||
+			targetResolver.canPruneDirectory(root.lexicalPath, root.canonicalPath)) {
+			continue
+		}
+		targets = append(targets, discoverLintTargetsWithinRoot(
+			config,
+			configDir,
+			root.lexicalPath,
+			fsys,
+			nil,
+			[]string{root.lexicalPath},
+			stopDirs,
+			singleThreaded,
+			frozenBases,
+		)...)
+	}
+
+	seen := make(map[string]struct{}, len(targets))
+	deduplicated := targets[:0]
+	for _, target := range targets {
+		key := exactPathID(target.Path)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduplicated = append(deduplicated, target)
+	}
+	sort.Slice(deduplicated, func(i, j int) bool {
+		return deduplicated[i].Path < deduplicated[j].Path
+	})
+	return deduplicated
+}
+
+func discoverLintTargetsWithinRoot(
+	config RslintConfig,
+	configDir string,
+	scanRoot string,
+	fsys vfs.FS,
+	explicitFiles []*explicitLintTarget,
+	allowDirs []string,
+	stopDirs []string,
+	singleThreaded bool,
+	frozenBases map[string]configTargetBase,
+) []DiscoveredLintTarget {
 	useCaseSensitive := true
 	if fsys != nil {
 		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
@@ -139,47 +265,92 @@ func discoverLintTargetsWithStopDirs(
 		return string(tspath.ToPath(tspath.NormalizePath(filePath), "", true))
 	}
 	configDir = tspath.NormalizePath(configDir)
-	configMatchDir := configDir
-	if fsys != nil {
-		if realPath := fsys.Realpath(configDir); realPath != "" {
-			configMatchDir = tspath.NormalizePath(realPath)
-		}
+	scanRoot = tspath.NormalizePath(scanRoot)
+	if scanRoot == "" {
+		scanRoot = configDir
 	}
+	configBase, frozen := frozenBases[exactPathID(configDir)]
+	if !frozen {
+		configBase = freezeConfigTargetBase(configDir, fsys)
+	}
+	configMatchDir := configBase.physicalDirectory
+	configAliasAncestors := configBase.physicalAliasAncestors
 	configPathForMatching := func(filePath string) string {
-		return resolveConfigPathSpace(
+		matchPath, _ := resolveConfigPathSpace(
 			tspath.NormalizePath(filePath),
 			"",
 			configDir,
 			configMatchDir,
+			configAliasAncestors,
 			fsys,
+			true,
 		)
+		return matchPath
 	}
 	resolvedAllowDirs := resolveAllowedDirectories(allowDirs, fsys)
+	directWalkRoot := resolvedAllowedDirectory{
+		lexicalPath:   scanRoot,
+		canonicalPath: scanRoot,
+	}
+	directWalkProjection := allowDirs == nil
+	if len(resolvedAllowDirs) == 1 &&
+		exactPathID(resolvedAllowDirs[0].lexicalPath) == exactPathID(scanRoot) {
+		directWalkRoot = resolvedAllowDirs[0]
+		directWalkProjection = true
+	}
+	directProjectionForPath := func(fullPath string) (requestedPathProjection, bool) {
+		projection := requestedPathProjection{path: fullPath}
+		if directWalkRoot.lexicalPath == directWalkRoot.canonicalPath {
+			return projection, true
+		}
+		relative, within := RelativePathWithinConfigRoot(
+			fullPath,
+			directWalkRoot.lexicalPath,
+			true,
+		)
+		if !within {
+			return requestedPathProjection{}, false
+		}
+		projection.canonicalPath = tspath.ResolvePath(
+			directWalkRoot.canonicalPath,
+			relative,
+		)
+		return projection, true
+	}
 
-	filesPatterns := collectLintFilePatterns(config)
-	filesMatcher := buildFilesMatcher(filesPatterns)
-	directoryBlocks := newDirectoryBlockMatcher(globalIgnores, configMatchDir)
+	targetResolver := newConfigTargetResolverWithBases(config, configDir, fsys, frozenBases)
 
-	var allowFileSet map[string]string
-	if allowFiles != nil {
-		allowFileSet = make(map[string]string, len(allowFiles))
-		for _, f := range allowFiles {
-			normalized := tspath.NormalizePath(f)
-			key := comparisonKey(normalized)
+	var allowFileSet map[string]*explicitLintTarget
+	if explicitFiles != nil {
+		allowFileSet = make(map[string]*explicitLintTarget, len(explicitFiles))
+		for _, explicitFile := range explicitFiles {
+			if explicitFile == nil {
+				continue
+			}
+			key := comparisonKey(explicitFile.target.Path)
 			if _, exists := allowFileSet[key]; !exists {
-				allowFileSet[key] = normalized
+				allowFileSet[key] = explicitFile
 			}
 		}
 	}
 
 	targetFiles := []DiscoveredLintTarget{}
 	seenTargets := make(map[string]struct{})
-	addTarget := func(filePath string, canonicalPath string) {
+	addTarget := func(
+		filePath string,
+		canonicalPath string,
+		canonicalParentPath string,
+	) {
 		filePath = tspath.NormalizePath(filePath)
 		if canonicalPath == "" {
 			canonicalPath = filePath
 		} else {
 			canonicalPath = tspath.NormalizePath(canonicalPath)
+		}
+		if canonicalParentPath == "" {
+			canonicalParentPath = tspath.GetDirectoryPath(canonicalPath)
+		} else {
+			canonicalParentPath = tspath.NormalizePath(canonicalParentPath)
 		}
 		key := comparisonKey(filePath)
 		if _, seen := seenTargets[key]; seen {
@@ -187,84 +358,57 @@ func discoverLintTargetsWithStopDirs(
 		}
 		seenTargets[key] = struct{}{}
 		targetFiles = append(targetFiles, DiscoveredLintTarget{
-			Path:            filePath,
-			CanonicalPath:   canonicalPath,
-			ConfigDirectory: configDir,
+			Path:                filePath,
+			CanonicalPath:       canonicalPath,
+			CanonicalParentPath: canonicalParentPath,
+			ConfigDirectory:     configDir,
 		})
 	}
-	isGloballyIgnored := func(matchPath string) bool {
-		return directoryBlocks.blocksFileDirectory(matchPath) ||
-			isFileIgnored(matchPath, globalIgnores, configMatchDir)
-	}
-
-	includeExplicitFile := func(filePath string) (bool, string) {
-		if !IsSupportedLintFile(filePath) {
-			return false, ""
+	includeDiscoveredFile := func(target DiscoveredLintTarget) bool {
+		if !IsSupportedLintFile(target.Path) {
+			return false
 		}
-		if fsys != nil && !fsys.FileExists(filePath) {
-			return false, ""
-		}
-		matchPath := configPathForMatching(filePath)
-		if IsDefaultExcludedPath(matchPath, configMatchDir, useCaseSensitive) {
-			return false, ""
-		}
-		if isGloballyIgnored(matchPath) {
-			return false, ""
-		}
-		canonicalPath := filePath
-		if fsys != nil {
-			if realPath := fsys.Realpath(filePath); realPath != "" {
-				canonicalPath = realPath
-			}
-		}
-		return true, canonicalPath
-	}
-
-	includeDiscoveredFile := func(filePath string) (bool, string) {
-		if !IsSupportedLintFile(filePath) {
-			return false, ""
-		}
-		matchPath := configPathForMatching(filePath)
-		if len(filesPatterns) == 0 || !filesMatcher(matchPath, configMatchDir) {
-			return false, ""
-		}
-		// Candidate patterns for an AND group intentionally form a superset.
-		// Apply the complete selector here so negated and additional group
-		// members cannot leak candidates into the target set.
-		if !isFileSelectedByConfig(config, matchPath, configMatchDir) {
-			return false, ""
-		}
-		if isGloballyIgnored(matchPath) {
-			return false, ""
-		}
-		return true, matchPath
+		decision := targetResolver.resolveTarget(target)
+		return decision.selected && !decision.globallyIgnored
 	}
 
 	addExplicitTargets := func() {
-		for _, f := range allowFileSet {
-			if include, canonicalPath := includeExplicitFile(f); include {
-				addTarget(f, canonicalPath)
+		for _, explicitFile := range allowFileSet {
+			if explicitFile.selectedBy(
+				configDir,
+				scanRoot,
+				useCaseSensitive,
+				targetResolver,
+			) {
+				addTarget(
+					explicitFile.target.Path,
+					explicitFile.target.CanonicalPath,
+					explicitFile.target.CanonicalParentPath,
+				)
 			}
 		}
 	}
 
-	// Fast path for explicit file-only invocations, e.g. lint-staged.
-	if allowFileSet != nil && allowDirs == nil {
+	// Literal targets establish their frozen identity before any overlapping
+	// directory walk can discover the same lexical path with a later filesystem
+	// observation. The file-only case then returns immediately (lint-staged).
+	if allowFileSet != nil {
 		addExplicitTargets()
-		sort.Slice(targetFiles, func(i, j int) bool { return targetFiles[i].Path < targetFiles[j].Path })
-		return targetFiles
+		if allowDirs == nil {
+			sort.Slice(targetFiles, func(i, j int) bool { return targetFiles[i].Path < targetFiles[j].Path })
+			return targetFiles
+		}
 	}
 
-	normalizedConfigDir := normalizeGlobPath(configDir)
-	fsAdapter := &vfsAdapter{vfs: fsys, root: normalizedConfigDir}
+	normalizedScanRoot := normalizeGlobPath(scanRoot)
+	fsAdapter := &vfsAdapter{vfs: fsys, root: normalizedScanRoot}
 
 	var (
 		targetMu  sync.Mutex
 		dirIgnore sync.Map // map[string]bool — pattern check cache
 	)
 
-	neg := buildNegReach(globalIgnores)
-	stopWalkDirs := normalizeStopWalkDirs(normalizedConfigDir, stopDirs, useCaseSensitive)
+	stopWalkDirs := normalizeStopWalkDirs(normalizedScanRoot, stopDirs, useCaseSensitive)
 
 	workers := runtime.GOMAXPROCS(0)
 	if workers < 2 {
@@ -274,47 +418,94 @@ func discoverLintTargetsWithStopDirs(
 		workers = 1
 	}
 
-	processFile := func(walkPath string, needsRealpath bool) {
-		fullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedConfigDir, walkPath))
-		matchPath := configPathForMatching(fullPath)
-		targetPath := fullPath
-		scopedCanonicalPath := ""
+	pathProjectionsForWalk := func(fullPath string) []requestedPathProjection {
+		if directWalkProjection {
+			projection, ok := directProjectionForPath(fullPath)
+			if !ok {
+				return nil
+			}
+			return []requestedPathProjection{projection}
+		}
+		return projectPathThroughRequestedDirectories(
+			fullPath,
+			configPathForMatching(fullPath),
+			resolvedAllowDirs,
+			useCaseSensitive,
+		)
+	}
+	allProjectedDirectoriesMatch := func(
+		fullPath string,
+		predicate func(requestedPathProjection) bool,
+	) bool {
+		if directWalkProjection {
+			projection, ok := directProjectionForPath(fullPath)
+			if !ok {
+				return false
+			}
+			return predicate(projection)
+		}
+		projections := pathProjectionsForWalk(fullPath)
+		if len(projections) == 0 {
+			// An unresolved projection is not proof that a physical subtree is
+			// irrelevant. Keep walking conservatively.
+			return false
+		}
+		for _, projection := range projections {
+			if !predicate(projection) {
+				return false
+			}
+		}
+		return true
+	}
 
-		if allowFileSet != nil || allowDirs != nil {
-			inScope := false
-			if allowFileSet != nil {
-				if _, ok := allowFileSet[comparisonKey(fullPath)]; ok {
-					inScope = true
-				}
-			}
-			if !inScope && allowDirs != nil {
-				inScope, targetPath, scopedCanonicalPath = resolvePathThroughAllowedDirectories(
-					fullPath,
-					matchPath,
-					resolvedAllowDirs,
-					useCaseSensitive,
-				)
-			}
-			if !inScope {
+	processFile := func(walkPath string, needsRealpath bool) {
+		fullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedScanRoot, walkPath))
+		projections := pathProjectionsForWalk(fullPath)
+		if len(projections) == 0 {
+			if allowFileSet == nil {
 				return
 			}
-		}
-
-		include, canonicalPath := includeDiscoveredFile(fullPath)
-		if !include {
-			return
-		}
-		if needsRealpath && fsys != nil {
-			if realPath := fsys.Realpath(fullPath); realPath != "" {
-				canonicalPath = realPath
+			if _, ok := allowFileSet[comparisonKey(fullPath)]; !ok {
+				return
 			}
-		} else if scopedCanonicalPath != "" {
-			canonicalPath = scopedCanonicalPath
+			projections = []requestedPathProjection{{path: fullPath}}
 		}
+		resolvedCanonicalPath := ""
+		resolvedCanonicalParentPath := ""
+		if needsRealpath && fsys != nil {
+			identity := FreezeLintTargetIdentity(fullPath, fsys)
+			resolvedCanonicalPath = identity.CanonicalPath
+			resolvedCanonicalParentPath = identity.CanonicalParentPath
+		}
+		for _, projection := range projections {
+			canonicalPath := projection.canonicalPath
+			if resolvedCanonicalPath != "" {
+				canonicalPath = resolvedCanonicalPath
+			}
+			if canonicalPath == "" {
+				canonicalPath = fullPath
+			}
+			canonicalParentPath := resolvedCanonicalParentPath
+			if canonicalParentPath == "" {
+				canonicalParentPath = tspath.GetDirectoryPath(canonicalPath)
+			}
+			if IsDefaultExcludedPath(projection.path, scanRoot, useCaseSensitive) {
+				continue
+			}
+			target := DiscoveredLintTarget{
+				Path:                projection.path,
+				CanonicalPath:       canonicalPath,
+				CanonicalParentPath: canonicalParentPath,
+				ConfigDirectory:     configDir,
+			}
+			if !includeDiscoveredFile(target) {
+				continue
+			}
 
-		targetMu.Lock()
-		addTarget(targetPath, canonicalPath)
-		targetMu.Unlock()
+			targetMu.Lock()
+			addTarget(projection.path, canonicalPath, canonicalParentPath)
+			targetMu.Unlock()
+		}
 	}
 
 	work := func(walkPath string) []string {
@@ -347,7 +538,16 @@ func discoverLintTargetsWithStopDirs(
 						continue
 					}
 				} else {
-					blocked := canPruneDir(childPath, globalIgnores, neg)
+					childFullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedScanRoot, childPath))
+					blocked := allProjectedDirectoriesMatch(
+						childFullPath,
+						func(projection requestedPathProjection) bool {
+							return targetResolver.canPruneDirectory(
+								projection.path,
+								projection.canonicalPath,
+							)
+						},
+					)
 					dirIgnore.Store(childPath, blocked)
 					if blocked {
 						continue
@@ -366,17 +566,79 @@ func discoverLintTargetsWithStopDirs(
 	}
 
 	pool := newWalkPool(workers)
-	walkRoots := discoverWalkRoots(normalizedConfigDir, allowDirs, fsys)
-	walkRoots = filterInitialWalkRoots(walkRoots, globalIgnores, neg, stopWalkDirs, useCaseSensitive)
+	walkRoots := discoverWalkRoots(normalizedScanRoot, allowDirs, fsys)
+	walkRoots = filterInitialWalkRoots(
+		walkRoots,
+		func(walkPath string) bool {
+			fullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedScanRoot, walkPath))
+			return allProjectedDirectoriesMatch(
+				fullPath,
+				func(projection requestedPathProjection) bool {
+					return IsDefaultExcludedPath(projection.path, scanRoot, useCaseSensitive)
+				},
+			)
+		},
+		func(walkPath string) bool {
+			fullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedScanRoot, walkPath))
+			return allProjectedDirectoriesMatch(
+				fullPath,
+				func(projection requestedPathProjection) bool {
+					return targetResolver.canPruneDirectory(
+						projection.path,
+						projection.canonicalPath,
+					)
+				},
+			)
+		},
+		stopWalkDirs,
+		useCaseSensitive,
+	)
 	pool.submitMany(walkRoots)
 	pool.run(work)
 
-	if allowFileSet != nil {
-		addExplicitTargets()
-	}
-
 	sort.Slice(targetFiles, func(i, j int) bool { return targetFiles[i].Path < targetFiles[j].Path })
 	return targetFiles
+}
+
+// FreezeLintTargetIdentity captures the lexical file plus a physical
+// file/parent pair. Reading the parent on both sides detects one concurrent
+// directory-symlink move and retries, reducing the chance of combining two
+// filesystem observations without claiming an atomic filesystem snapshot.
+func FreezeLintTargetIdentity(filePath string, fsys vfs.FS) DiscoveredLintTarget {
+	filePath = tspath.NormalizePath(filePath)
+	parentPath := tspath.GetDirectoryPath(filePath)
+	canonicalPath := filePath
+	canonicalParentPath := parentPath
+	if fsys == nil {
+		return DiscoveredLintTarget{
+			Path:                filePath,
+			CanonicalPath:       canonicalPath,
+			CanonicalParentPath: canonicalParentPath,
+		}
+	}
+	for range 2 {
+		parentBefore := canonicalPathOrSelf(parentPath, fsys)
+		canonicalPath = canonicalPathOrSelf(filePath, fsys)
+		parentAfter := canonicalPathOrSelf(parentPath, fsys)
+		canonicalParentPath = parentAfter
+		if parentBefore == parentAfter {
+			break
+		}
+	}
+	return DiscoveredLintTarget{
+		Path:                filePath,
+		CanonicalPath:       canonicalPath,
+		CanonicalParentPath: canonicalParentPath,
+	}
+}
+
+func canonicalPathOrSelf(filePath string, fsys vfs.FS) string {
+	if fsys != nil {
+		if realPath := fsys.Realpath(filePath); realPath != "" {
+			return tspath.NormalizePath(realPath)
+		}
+	}
+	return tspath.NormalizePath(filePath)
 }
 
 func normalizeStopWalkDirs(configDir string, stopDirs []string, useCaseSensitive bool) []string {
@@ -412,8 +674,8 @@ func normalizeStopWalkDirs(configDir string, stopDirs []string, useCaseSensitive
 
 func filterInitialWalkRoots(
 	roots []string,
-	globalIgnores []IgnorePattern,
-	neg negReach,
+	isDefaultExcluded func(string) bool,
+	canPrune func(string) bool,
 	stopWalkDirs []string,
 	useCaseSensitive bool,
 ) []string {
@@ -427,10 +689,15 @@ func filterInitialWalkRoots(
 		if root == "" {
 			root = "."
 		}
+		// A root represented as "." may still be nested below a default-excluded
+		// directory in the config's path space when ConfigDirectory and ScanRoot
+		// differ (for example an external config invoked from node_modules/pkg).
+		if isDefaultExcluded != nil && isDefaultExcluded(root) {
+			continue
+		}
 		if root != "." {
-			if hasDefaultExcludedSegment(root, useCaseSensitive) ||
-				isStoppedWalkPath(root, stopWalkDirs, useCaseSensitive) ||
-				canPruneDir(root, globalIgnores, neg) {
+			if isStoppedWalkPath(root, stopWalkDirs, useCaseSensitive) ||
+				(canPrune != nil && canPrune(root)) {
 				continue
 			}
 		}
@@ -440,15 +707,19 @@ func filterInitialWalkRoots(
 }
 
 // IsDefaultExcludedPath reports whether filePath contains one of rslint's
-// always-excluded directory names, interpreted relative to configDir when
-// possible.
-func IsDefaultExcludedPath(filePath string, configDir string, useCaseSensitive bool) bool {
+// always-excluded directory names, interpreted relative to scanRoot when
+// possible. Default excludes belong to the invocation's lexical scan scope,
+// not to any config entry's authored path base.
+func IsDefaultExcludedPath(filePath string, scanRoot string, useCaseSensitive bool) bool {
 	filePath = tspath.NormalizePath(filePath)
-	configDir = tspath.NormalizePath(configDir)
-	if pathsEqual(filePath, configDir, useCaseSensitive) ||
-		tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive) {
-		rel := tspath.GetRelativePathFromDirectory(configDir, filePath, tspath.ComparePathsOptions{
-			CurrentDirectory:          configDir,
+	scanRoot = tspath.NormalizePath(scanRoot)
+	if hasDefaultExcludedSegment(scanRoot, useCaseSensitive) {
+		return true
+	}
+	if pathsEqual(filePath, scanRoot, useCaseSensitive) ||
+		tspath.StartsWithDirectory(filePath, scanRoot, useCaseSensitive) {
+		rel := tspath.GetRelativePathFromDirectory(scanRoot, filePath, tspath.ComparePathsOptions{
+			CurrentDirectory:          scanRoot,
 			UseCaseSensitiveFileNames: useCaseSensitive,
 		})
 		return hasDefaultExcludedSegment(rel, useCaseSensitive)
@@ -536,6 +807,69 @@ type resolvedAllowedDirectory struct {
 	canonicalPath string
 }
 
+type requestedPathProjection struct {
+	path          string
+	canonicalPath string
+}
+
+// coalesceRequestedDirectories returns the smallest set of independent walk
+// roots that covers the user's directory arguments. A nested root is dropped
+// only when both lexical and canonical containment produce the same relative
+// suffix, so a differently spelled symlink scope remains independent. Keeping
+// roots independent also avoids invalid common-parent calculations across
+// Windows drives and UNC shares.
+func coalesceRequestedDirectories(directories []string, fsys vfs.FS) []resolvedAllowedDirectory {
+	if len(directories) == 0 {
+		return nil
+	}
+	roots := make([]resolvedAllowedDirectory, 0, len(directories))
+	contains := func(parent resolvedAllowedDirectory, child resolvedAllowedDirectory) bool {
+		lexicalRelative, lexicalWithin := RelativePathWithinConfigRoot(
+			child.lexicalPath,
+			parent.lexicalPath,
+			true,
+		)
+		canonicalRelative, canonicalWithin := RelativePathWithinConfigRoot(
+			child.canonicalPath,
+			parent.canonicalPath,
+			true,
+		)
+		return lexicalWithin && canonicalWithin &&
+			exactPathID(lexicalRelative) == exactPathID(canonicalRelative)
+	}
+	for _, directory := range directories {
+		lexicalPath := tspath.NormalizePath(directory)
+		canonicalPath := lexicalPath
+		if fsys != nil {
+			if realPath := fsys.Realpath(lexicalPath); realPath != "" {
+				canonicalPath = tspath.NormalizePath(realPath)
+			}
+		}
+		candidate := resolvedAllowedDirectory{
+			lexicalPath:   lexicalPath,
+			canonicalPath: canonicalPath,
+		}
+		covered := false
+		for _, existing := range roots {
+			if contains(existing, candidate) {
+				covered = true
+				break
+			}
+		}
+		if covered {
+			continue
+		}
+		kept := roots[:0]
+		for _, existing := range roots {
+			if !contains(candidate, existing) {
+				kept = append(kept, existing)
+			}
+		}
+		roots = append(kept, candidate)
+	}
+	return roots
+}
+
 func resolveAllowedDirectories(allowDirs []string, fsys vfs.FS) []resolvedAllowedDirectory {
 	if allowDirs == nil {
 		return nil
@@ -557,26 +891,70 @@ func resolveAllowedDirectories(allowDirs []string, fsys vfs.FS) []resolvedAllowe
 	return resolved
 }
 
-func resolvePathThroughAllowedDirectories(
+// projectPathThroughRequestedDirectories returns every caller-visible spelling
+// of one walked physical path. Multiple requested directory aliases may point
+// at the same subtree, and each spelling remains a legitimate config target;
+// callers perform selection for every projection and canonical-deduplicate
+// only after selection.
+func projectPathThroughRequestedDirectories(
 	filePath string,
 	matchPath string,
 	allowDirs []resolvedAllowedDirectory,
 	useCaseSensitive bool,
-) (bool, string, string) {
-	inScope := false
-	bestLexicalLength := -1
-	bestCanonicalLength := -1
-	lexicalPath := filePath
-	canonicalPath := ""
+) []requestedPathProjection {
+	projections := make([]requestedPathProjection, 0, len(allowDirs))
+	seen := make(map[string]struct{}, len(allowDirs))
+	appendProjection := func(path string, canonicalPath string) {
+		path = tspath.NormalizePath(path)
+		if canonicalPath != "" {
+			canonicalPath = tspath.NormalizePath(canonicalPath)
+		}
+		key := exactPathID(path)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		projections = append(projections, requestedPathProjection{
+			path:          path,
+			canonicalPath: canonicalPath,
+		})
+	}
 	for _, dir := range allowDirs {
-		if relative, within := RelativePathWithinConfigRoot(filePath, dir.lexicalPath, useCaseSensitive); within {
-			inScope = true
-			if dir.lexicalPath != dir.canonicalPath && len(dir.lexicalPath) > bestLexicalLength {
-				bestLexicalLength = len(dir.lexicalPath)
+		if _, within := RelativePathWithinConfigRoot(filePath, dir.lexicalPath, useCaseSensitive); within {
+			relative, exactWithin := RelativePathWithinConfigRoot(
+				filePath,
+				dir.lexicalPath,
+				true,
+			)
+			if !exactWithin {
+				// A case-insensitive lexical resemblance is authoritative only
+				// when the frozen physical spelling verifies the same root. This
+				// keeps native casing aliases while rejecting a distinct tree that
+				// differs only by case on a case-sensitive filesystem facade.
+				physicalRelative, verified := RelativePathWithinConfigRoot(
+					filePath,
+					dir.canonicalPath,
+					true,
+				)
+				if !verified && matchPath != filePath {
+					physicalRelative, verified = RelativePathWithinConfigRoot(
+						matchPath,
+						dir.canonicalPath,
+						true,
+					)
+				}
+				if !verified {
+					continue
+				}
+				relative = physicalRelative
+			}
+			canonicalPath := ""
+			if dir.lexicalPath != dir.canonicalPath {
 				canonicalPath = tspath.ResolvePath(dir.canonicalPath, relative)
 			}
+			appendProjection(tspath.ResolvePath(dir.lexicalPath, relative), canonicalPath)
 		}
-		if dir.lexicalPath == dir.canonicalPath || len(dir.canonicalPath) <= bestCanonicalLength {
+		if dir.lexicalPath == dir.canonicalPath {
 			continue
 		}
 		relative, within := RelativePathWithinConfigRoot(filePath, dir.canonicalPath, true)
@@ -584,12 +962,16 @@ func resolvePathThroughAllowedDirectories(
 			relative, within = RelativePathWithinConfigRoot(matchPath, dir.canonicalPath, true)
 		}
 		if within {
-			inScope = true
-			bestCanonicalLength = len(dir.canonicalPath)
-			lexicalPath = tspath.ResolvePath(dir.lexicalPath, relative)
+			appendProjection(
+				tspath.ResolvePath(dir.lexicalPath, relative),
+				tspath.ResolvePath(dir.canonicalPath, relative),
+			)
 		}
 	}
-	return inScope, lexicalPath, canonicalPath
+	sort.Slice(projections, func(i, j int) bool {
+		return projections[i].path < projections[j].path
+	})
+	return projections
 }
 
 func discoverWalkRoots(configDir string, allowDirs []string, fsys vfs.FS) []string {
@@ -684,96 +1066,145 @@ func pathsEqual(a, b string, useCaseSensitive bool) bool {
 	return strings.EqualFold(a, b)
 }
 
-func collectLintFilePatterns(config RslintConfig) []string {
-	patterns := defaultLintFilePatterns()
-	for _, entry := range config {
-		if isGlobalIgnoreEntry(entry) {
-			continue
-		}
-		for _, pattern := range entry.Files {
-			if candidate, ok := positiveFilesCandidate(pattern); ok {
-				patterns = append(patterns, candidate)
-			} else {
-				patterns = append(patterns, "**/*")
-			}
-		}
-		for _, group := range entry.FilePatternGroups {
-			hasPositiveCandidate := false
-			for _, pattern := range group {
-				if candidate, ok := positiveFilesCandidate(pattern); ok {
-					patterns = append(patterns, candidate)
-					hasPositiveCandidate = true
-				}
-			}
-			if !hasPositiveCandidate {
-				patterns = append(patterns, "**/*")
-			}
-		}
-	}
-	return deduplicate(patterns)
+// DiscoveredLintTarget preserves the caller-visible path, physical file and
+// parent identities, and config owner established at the target boundary.
+// CanonicalParentPath distinguishes a leaf file symlink from a directory
+// alias without asking the live filesystem again during config matching.
+type DiscoveredLintTarget struct {
+	Path                string
+	CanonicalPath       string
+	CanonicalParentPath string
+	ConfigDirectory     string
 }
 
-func positiveFilesCandidate(pattern string) (string, bool) {
-	negated := false
-	for strings.HasPrefix(pattern, "!") {
-		negated = !negated
-		pattern = strings.TrimPrefix(pattern, "!")
-	}
-	return pattern, !negated && pattern != ""
+// ExplicitFileOutcome records the target-selection facts needed by a caller
+// that reports skipped literal files. Ignored and Exists are deliberately
+// independent: the CLI historically reports an ignored missing path as
+// ignored, so presentation can preserve that priority without re-reading the
+// filesystem or re-running config ownership after the lint plan is frozen.
+type ExplicitFileOutcome struct {
+	Path    string
+	Ignored bool
+	Exists  bool
 }
 
-func buildFilesMatcher(patterns []string) func(filePath string, configDir string) bool {
-	hasDefaultBaseline := patternsIncludeAllDefaultExtensions(patterns)
-	if !hasDefaultBaseline {
-		return func(filePath string, configDir string) bool {
-			return isFileMatched(filePath, patterns, configDir)
-		}
-	}
-
-	defaultPatterns := make(map[string]struct{}, len(DefaultLintFileExtensions))
-	for _, pattern := range defaultLintFilePatterns() {
-		defaultPatterns[tspath.NormalizePath(pattern)] = struct{}{}
-	}
-	additionalPatterns := make([]string, 0, len(patterns)-len(defaultPatterns))
-	for _, pattern := range patterns {
-		if _, isDefault := defaultPatterns[tspath.NormalizePath(pattern)]; !isDefault {
-			additionalPatterns = append(additionalPatterns, pattern)
-		}
-	}
-
-	return func(filePath string, configDir string) bool {
-		// ESLint's default extension globs are case-sensitive even on a
-		// case-insensitive filesystem. Keep this fast path exact-case; explicit
-		// user patterns are evaluated normally below.
-		if isDefaultLintFile(filePath) {
-			return true
-		}
-		return len(additionalPatterns) > 0 && isFileMatched(filePath, additionalPatterns, configDir)
-	}
+type explicitLintTarget struct {
+	target    DiscoveredLintTarget
+	supported bool
+	exists    bool
+	ignored   bool
+	evaluated bool
 }
 
-func patternsIncludeAllDefaultExtensions(patterns []string) bool {
-	if len(patterns) < len(DefaultLintFileExtensions) {
+type explicitLintTargetSet struct {
+	byPath         map[tspath.Path]*explicitLintTarget
+	requestedPaths []string
+}
+
+func (target *explicitLintTarget) selectedBy(
+	configDirectory string,
+	scanRoot string,
+	useCaseSensitive bool,
+	resolver *configTargetResolver,
+) bool {
+	if target == nil {
 		return false
 	}
-	seen := make(map[string]struct{}, len(patterns))
-	for _, pattern := range patterns {
-		seen[tspath.NormalizePath(pattern)] = struct{}{}
-	}
-	for _, pattern := range defaultLintFilePatterns() {
-		if _, ok := seen[tspath.NormalizePath(pattern)]; !ok {
-			return false
+	if !target.evaluated {
+		target.target.ConfigDirectory = tspath.NormalizePath(configDirectory)
+		target.ignored = IsDefaultExcludedPath(
+			target.target.Path,
+			scanRoot,
+			useCaseSensitive,
+		)
+		if resolver != nil && resolver.resolveTarget(target.target).globallyIgnored {
+			target.ignored = true
 		}
+		target.evaluated = true
 	}
-	return true
+	return target.supported && target.exists && !target.ignored
 }
 
-// DiscoveredLintTarget preserves the config owner established during the
-// directory walk so later stages do not need to infer ownership from paths.
-type DiscoveredLintTarget struct {
-	Path            string
-	CanonicalPath   string
-	ConfigDirectory string
+func newExplicitLintTargetSet(
+	filePaths []string,
+	fsys vfs.FS,
+) *explicitLintTargetSet {
+	if filePaths == nil {
+		return nil
+	}
+	set := &explicitLintTargetSet{
+		byPath:         make(map[tspath.Path]*explicitLintTarget, len(filePaths)),
+		requestedPaths: make([]string, 0, len(filePaths)),
+	}
+	set.add(filePaths, true, fsys)
+	return set
+}
+
+func (set *explicitLintTargetSet) add(
+	filePaths []string,
+	requested bool,
+	fsys vfs.FS,
+) {
+	if set == nil {
+		return
+	}
+	for _, filePath := range filePaths {
+		filePath = tspath.NormalizePath(filePath)
+		if requested {
+			set.requestedPaths = append(set.requestedPaths, filePath)
+		}
+		pathID := tspath.ToPath(filePath, "", true)
+		if _, exists := set.byPath[pathID]; exists {
+			continue
+		}
+		exists := true
+		if fsys != nil {
+			exists = fsys.FileExists(filePath)
+		}
+		set.byPath[pathID] = &explicitLintTarget{
+			target:    FreezeLintTargetIdentity(filePath, fsys),
+			supported: IsSupportedLintFile(filePath),
+			exists:    exists,
+		}
+	}
+}
+
+func (set *explicitLintTargetSet) targetsForPaths(filePaths []string) []*explicitLintTarget {
+	if filePaths == nil {
+		return nil
+	}
+	targets := make([]*explicitLintTarget, 0, len(filePaths))
+	seen := make(map[tspath.Path]struct{}, len(filePaths))
+	for _, filePath := range filePaths {
+		pathID := tspath.ToPath(tspath.NormalizePath(filePath), "", true)
+		if _, exists := seen[pathID]; exists {
+			continue
+		}
+		seen[pathID] = struct{}{}
+		if target := set.byPath[pathID]; target != nil {
+			targets = append(targets, target)
+		}
+	}
+	return targets
+}
+
+func (set *explicitLintTargetSet) outcomes() []ExplicitFileOutcome {
+	if set == nil || len(set.requestedPaths) == 0 {
+		return nil
+	}
+	outcomes := make([]ExplicitFileOutcome, 0, len(set.requestedPaths))
+	for _, filePath := range set.requestedPaths {
+		target := set.byPath[tspath.ToPath(filePath, "", true)]
+		if target == nil {
+			continue
+		}
+		outcomes = append(outcomes, ExplicitFileOutcome{
+			Path:    filePath,
+			Ignored: target.ignored,
+			Exists:  target.exists,
+		})
+	}
+	return outcomes
 }
 
 // DiscoverLintTargetsMultiConfig resolves owned lint targets across a config
@@ -785,6 +1216,49 @@ func DiscoverLintTargetsMultiConfig(
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
+) []DiscoveredLintTarget {
+	return discoverLintTargetsMultiConfigWithOwner(
+		configMap,
+		scopes,
+		fsys,
+		allowFiles,
+		allowDirs,
+		singleThreaded,
+		NewConfigOwnerResolver(configMap, fsys),
+	)
+}
+
+func discoverLintTargetsMultiConfigWithOwner(
+	configMap map[string]RslintConfig,
+	scopes map[string]LintDiscoveryScope,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+	ownerResolver *ConfigOwnerResolver,
+) []DiscoveredLintTarget {
+	explicitSet := newExplicitLintTargetSet(allowFiles, fsys)
+	return discoverLintTargetsMultiConfigWithPreparedFiles(
+		configMap,
+		scopes,
+		fsys,
+		allowFiles,
+		allowDirs,
+		singleThreaded,
+		ownerResolver,
+		explicitSet,
+	)
+}
+
+func discoverLintTargetsMultiConfigWithPreparedFiles(
+	configMap map[string]RslintConfig,
+	scopes map[string]LintDiscoveryScope,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+	ownerResolver *ConfigOwnerResolver,
+	explicitSet *explicitLintTargetSet,
 ) []DiscoveredLintTarget {
 	if len(configMap) == 0 {
 		return nil
@@ -802,7 +1276,11 @@ func DiscoverLintTargetsMultiConfig(
 	// map is still processed below so catalog-scoped literal files use their
 	// explicit-only config.
 	automaticConfigMap := configMapForAutomaticTargets(configMap, scopes)
-	automaticIndex := newConfigDirectoryIndex(automaticConfigMap, fsys)
+	automaticOwnerResolver := newConfigOwnerResolverWithBases(
+		automaticConfigMap,
+		fsys,
+		ownerResolver.frozenBases,
+	)
 
 	// Explicit files are assigned to their nearest config once. Passing the
 	// complete list to every config makes lint-staged-style invocations
@@ -810,7 +1288,7 @@ func DiscoverLintTargetsMultiConfig(
 	// it cannot own. A non-nil empty bucket is preserved below so the explicit
 	// file-only fast path still suppresses directory walking for configs that own
 	// no requested files.
-	scopedFileOwners := make(map[tspath.Path]string)
+	assignedExplicitOwners := make(map[tspath.Path]string)
 	for _, configDir := range configDirs {
 		scope, ok := scopes[configDir]
 		if !ok || scope.Files == nil {
@@ -818,22 +1296,32 @@ func DiscoverLintTargetsMultiConfig(
 		}
 		for _, filePath := range scope.Files {
 			key := tspath.ToPath(tspath.NormalizePath(filePath), "", true)
-			if _, exists := scopedFileOwners[key]; !exists {
-				scopedFileOwners[key] = configDir
+			if _, exists := assignedExplicitOwners[key]; !exists {
+				assignedExplicitOwners[key] = configDir
 			}
 		}
 	}
-	unscopedAllowFiles := allowFiles
-	if len(scopedFileOwners) > 0 {
-		unscopedAllowFiles = make([]string, 0, len(allowFiles))
-		for _, filePath := range allowFiles {
-			key := tspath.ToPath(tspath.NormalizePath(filePath), "", true)
-			if _, scoped := scopedFileOwners[key]; !scoped {
-				unscopedAllowFiles = append(unscopedAllowFiles, filePath)
-			}
+	if explicitSet == nil {
+		explicitSet = newExplicitLintTargetSet([]string{}, fsys)
+	}
+	for _, scope := range scopes {
+		explicitSet.add(scope.Files, false, fsys)
+	}
+	filesByConfig := make(map[string][]*explicitLintTarget)
+	for _, explicitFile := range explicitSet.targetsForPaths(allowFiles) {
+		pathID := tspath.ToPath(explicitFile.target.Path, "", true)
+		if _, assigned := assignedExplicitOwners[pathID]; assigned {
+			continue
+		}
+		owner, _ := automaticOwnerResolver.ResolveTarget(explicitFile.target)
+		if owner != "" {
+			assignedExplicitOwners[pathID] = owner
+			filesByConfig[owner] = appendUniqueExplicitLintTarget(
+				filesByConfig[owner],
+				explicitFile,
+			)
 		}
 	}
-	filesByConfig := automaticIndex.assignExplicitFiles(unscopedAllowFiles)
 	filesSpecifiedByConfig := make(map[string]bool, len(configDirs))
 	if allowFiles != nil {
 		for _, configDir := range configDirs {
@@ -848,19 +1336,23 @@ func DiscoverLintTargetsMultiConfig(
 		// target whose parent-ignore exception selected another candidate. Config
 		// discovery resolves that collision to one automatic boundary; retain its
 		// automatically assigned files when adding the catalog-owned literal scope.
-		merged := append([]string(nil), filesByConfig[configDir]...)
-		filesByConfig[configDir] = deduplicate(append(merged, scope.Files...))
+		for _, explicitFile := range explicitSet.targetsForPaths(scope.Files) {
+			filesByConfig[configDir] = appendUniqueExplicitLintTarget(
+				filesByConfig[configDir],
+				explicitFile,
+			)
+		}
 		filesSpecifiedByConfig[configDir] = true
 	}
 
 	seen := make(map[tspath.Path]struct{})
 	var allTargets []DiscoveredLintTarget
 	for _, configDir := range configDirs {
-		var configAllowFiles []string
+		var configAllowFiles []*explicitLintTarget
 		if filesSpecifiedByConfig[configDir] {
 			configAllowFiles = filesByConfig[configDir]
 			if configAllowFiles == nil {
-				configAllowFiles = []string{}
+				configAllowFiles = []*explicitLintTarget{}
 			}
 		}
 		configAllowDirs := allowDirs
@@ -869,13 +1361,14 @@ func DiscoverLintTargetsMultiConfig(
 		}
 		targets := discoverLintTargetsForConfigInMap(
 			configMap,
-			automaticIndex,
-			scopedFileOwners,
+			automaticOwnerResolver,
+			assignedExplicitOwners,
 			configDir,
 			fsys,
 			configAllowFiles,
 			configAllowDirs,
 			singleThreaded,
+			ownerResolver.frozenBases,
 		)
 		for _, target := range targets {
 			pathID := tspath.ToPath(tspath.NormalizePath(target.Path), "", true)
@@ -889,6 +1382,22 @@ func DiscoverLintTargetsMultiConfig(
 		return allTargets[i].Path < allTargets[j].Path
 	})
 	return allTargets
+}
+
+func appendUniqueExplicitLintTarget(
+	targets []*explicitLintTarget,
+	target *explicitLintTarget,
+) []*explicitLintTarget {
+	if target == nil {
+		return targets
+	}
+	pathID := tspath.ToPath(target.target.Path, "", true)
+	for _, existing := range targets {
+		if existing != nil && tspath.ToPath(existing.target.Path, "", true) == pathID {
+			return targets
+		}
+	}
+	return append(targets, target)
 }
 
 // DiscoverLintFilesMultiConfig resolves lint target paths across a config map.
@@ -918,15 +1427,18 @@ func DiscoverLintFilesForConfigInMap(
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
+	ownerResolver := NewConfigOwnerResolver(configMap, fsys)
+	explicitSet := newExplicitLintTargetSet(allowFiles, fsys)
 	targets := discoverLintTargetsForConfigInMap(
 		configMap,
-		newConfigDirectoryIndex(configMap, fsys),
+		ownerResolver,
 		nil,
 		configDir,
 		fsys,
-		allowFiles,
+		explicitSet.targetsForPaths(allowFiles),
 		allowDirs,
 		singleThreaded,
+		ownerResolver.frozenBases,
 	)
 	files := make([]string, 0, len(targets))
 	for _, target := range targets {
@@ -937,21 +1449,32 @@ func DiscoverLintFilesForConfigInMap(
 
 func discoverLintTargetsForConfigInMap(
 	configMap map[string]RslintConfig,
-	index *configDirectoryIndex,
-	scopedFileOwners map[tspath.Path]string,
+	ownerResolver *ConfigOwnerResolver,
+	assignedExplicitOwners map[tspath.Path]string,
 	configDir string,
 	fsys vfs.FS,
-	allowFiles []string,
+	explicitFiles []*explicitLintTarget,
 	allowDirs []string,
 	singleThreaded bool,
+	frozenBases map[string]configTargetBase,
 ) []DiscoveredLintTarget {
 	cfg, ok := configMap[configDir]
 	if !ok {
 		return nil
 	}
 
-	stopDirs := index.childConfigDirs(configDir)
-	targets := discoverLintTargetsWithStopDirs(cfg, configDir, fsys, allowFiles, allowDirs, stopDirs, singleThreaded)
+	stopDirs := ownerResolver.ChildConfigDirs(configDir)
+	targets := discoverLintTargetsWithinRoot(
+		cfg,
+		configDir,
+		configDir,
+		fsys,
+		explicitFiles,
+		allowDirs,
+		stopDirs,
+		singleThreaded,
+		frozenBases,
+	)
 	if len(targets) == 0 {
 		return targets
 	}
@@ -959,14 +1482,14 @@ func discoverLintTargetsForConfigInMap(
 	ownedTargets := make([]DiscoveredLintTarget, 0, len(targets))
 	for _, target := range targets {
 		targetID := tspath.ToPath(tspath.NormalizePath(target.Path), "", true)
-		if scopedOwner, assigned := scopedFileOwners[targetID]; assigned {
-			if scopedOwner == configDir {
+		if assignedOwner, assigned := assignedExplicitOwners[targetID]; assigned {
+			if assignedOwner == configDir {
 				target.ConfigDirectory = configDir
 				ownedTargets = append(ownedTargets, target)
 			}
 			continue
 		}
-		ownerDir, _ := index.nearestConfigWithCanonicalPath(target.Path, target.CanonicalPath)
+		ownerDir, _ := ownerResolver.ResolveTarget(target)
 		if ownerDir == configDir {
 			target.ConfigDirectory = configDir
 			ownedTargets = append(ownedTargets, target)
@@ -987,6 +1510,14 @@ type configDirectoryIndex struct {
 }
 
 func newConfigDirectoryIndex(configMap map[string]RslintConfig, fsys vfs.FS) *configDirectoryIndex {
+	return newConfigDirectoryIndexWithBases(configMap, fsys, nil)
+}
+
+func newConfigDirectoryIndexWithBases(
+	configMap map[string]RslintConfig,
+	fsys vfs.FS,
+	frozenBases map[string]configTargetBase,
+) *configDirectoryIndex {
 	index := &configDirectoryIndex{
 		fsys:                     fsys,
 		configKeyByPath:          make(map[tspath.Path]string, len(configMap)),
@@ -1016,7 +1547,9 @@ func newConfigDirectoryIndex(configMap map[string]RslintConfig, fsys vfs.FS) *co
 		index.caseFoldedConfigKeys[foldedPathID] = append(index.caseFoldedConfigKeys[foldedPathID], configKey)
 
 		canonical := normalized
-		if fsys != nil {
+		if base, frozen := frozenBases[exactPathID(normalized)]; frozen {
+			canonical = base.physicalDirectory
+		} else if fsys != nil {
 			if realPath := fsys.Realpath(normalized); realPath != "" {
 				canonical = tspath.NormalizePath(realPath)
 			}
@@ -1188,19 +1721,6 @@ func (index *configDirectoryIndex) nearestConfigInPathSpace(
 	return "", false
 }
 
-func (index *configDirectoryIndex) assignExplicitFiles(files []string) map[string][]string {
-	if index == nil || files == nil {
-		return nil
-	}
-	filesByConfig := make(map[string][]string)
-	for _, filePath := range files {
-		if owner, ok := index.nearestConfig(filePath); ok {
-			filesByConfig[owner] = append(filesByConfig[owner], filePath)
-		}
-	}
-	return filesByConfig
-}
-
 // walkPool is a fixed-size worker pool with an unbounded internal LIFO queue,
 // used by lint-target discovery to walk directory trees with a bounded number of
 // live goroutines. Properties:
@@ -1308,20 +1828,4 @@ func (p *walkPool) run(work func(string) []string) {
 		}()
 	}
 	wg.Wait()
-}
-
-// deduplicate returns a copy of the input slice with duplicates removed, preserving order.
-func deduplicate(items []string) []string {
-	if len(items) == 0 {
-		return items
-	}
-	seen := make(map[string]struct{}, len(items))
-	result := make([]string, 0, len(items))
-	for _, item := range items {
-		if _, exists := seen[item]; !exists {
-			seen[item] = struct{}{}
-			result = append(result, item)
-		}
-	}
-	return result
 }

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -567,6 +567,40 @@ func TestDiscoverLintFiles_ExplicitFileSkipsNestedDefaultExcludedDir(t *testing.
 	assert.DeepEqual(t, targets, []string{})
 }
 
+func TestDiscoverLintTargetsFromRootExplicitFileUsesScanRootDefaultExcludes(t *testing.T) {
+	root := t.TempDir()
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	configDir := tspath.NormalizePath(filepath.Join(root, "physical", "package"))
+	aliasDir := tspath.CombinePaths(scanRoot, "node_modules", "package")
+	for _, directory := range []string{scanRoot, configDir, tspath.GetDirectoryPath(aliasDir)} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	physicalTarget := tspath.CombinePaths(configDir, "index.ts")
+	if err := os.WriteFile(physicalTarget, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(configDir, aliasDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasTarget := tspath.CombinePaths(aliasDir, "index.ts")
+
+	targets := discoverLintTargetsFromRoot(
+		RslintConfig{{
+			Files: []string{"**/*.ts"},
+			Rules: Rules{"test-rule": "error"},
+		}},
+		configDir,
+		scanRoot,
+		osvfs.FS(),
+		[]string{aliasTarget},
+		nil,
+		true,
+	)
+	assert.DeepEqual(t, targets, []DiscoveredLintTarget{})
+}
+
 func TestDiscoverLintFiles_OverlappingAllowDirsWalkChildOnce(t *testing.T) {
 	configDir, paths := setupDiscoveryFixture(t, []string{
 		"packages/app/src/a.ts",
@@ -595,7 +629,361 @@ func TestDiscoverLintFiles_OverlappingAllowDirsWalkChildOnce(t *testing.T) {
 	assert.Equal(t, srcAccesses, 1, "overlapping allowDirs should not walk child roots twice")
 }
 
-func TestDiscoverLintTargets_DirectoryWalkAvoidsPerFileRealpath(t *testing.T) {
+func TestDiscoverLintTargetsFromRoot_WalksEveryRequestedDirectory(t *testing.T) {
+	root := t.TempDir()
+	configDir := tspath.NormalizePath(filepath.Join(root, "config"))
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	firstDir := tspath.NormalizePath(filepath.Join(root, "first"))
+	secondDir := tspath.NormalizePath(filepath.Join(root, "second"))
+	for _, directory := range []string{configDir, scanRoot, firstDir, secondDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstFile := tspath.CombinePaths(firstDir, "a.ts")
+	secondFile := tspath.CombinePaths(secondDir, "b.ts")
+	for _, filePath := range []string{firstFile, secondFile} {
+		if err := os.WriteFile(filePath, []byte("export {};\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	targets := discoverLintTargetsFromRoot(
+		RslintConfig{{Rules: Rules{"test-rule": "error"}}},
+		configDir,
+		scanRoot,
+		osvfs.FS(),
+		nil,
+		[]string{firstDir, secondDir},
+		true,
+	)
+	assert.DeepEqual(t, targets, []DiscoveredLintTarget{
+		{Path: firstFile, CanonicalPath: tspath.NormalizePath(osvfs.FS().Realpath(firstFile)), CanonicalParentPath: tspath.NormalizePath(osvfs.FS().Realpath(firstDir)), ConfigDirectory: configDir},
+		{Path: secondFile, CanonicalPath: tspath.NormalizePath(osvfs.FS().Realpath(secondFile)), CanonicalParentPath: tspath.NormalizePath(osvfs.FS().Realpath(secondDir)), ConfigDirectory: configDir},
+	})
+}
+
+func TestDiscoverLintTargetsFromRoot_PreservesDistinctLexicalDirectorySelectors(t *testing.T) {
+	configDir := tspath.NormalizePath(t.TempDir())
+	physicalDir := tspath.NormalizePath(t.TempDir())
+	physicalChild := tspath.CombinePaths(physicalDir, "sub")
+	if err := os.MkdirAll(physicalChild, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	physicalFile := tspath.CombinePaths(physicalChild, "x.TS")
+	if err := os.WriteFile(physicalFile, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasA := tspath.CombinePaths(configDir, "a")
+	aliasB := tspath.CombinePaths(configDir, "b")
+	if err := os.Symlink(physicalDir, aliasA); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	if err := os.Symlink(physicalChild, aliasB); err != nil {
+		t.Skipf("second directory symlink unavailable: %v", err)
+	}
+
+	plan, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		Config: RslintConfig{{
+			Files: []string{"b/*.TS"},
+			Rules: Rules{"rule": "error"},
+		}},
+		ConfigDirectory: configDir,
+		ScanRoot:        configDir,
+		FS:              osvfs.FS(),
+		Directories:     []string{aliasA, aliasB},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPath := tspath.CombinePaths(aliasB, "x.TS")
+	if len(plan.Targets) != 1 || plan.Targets[0].Path != wantPath {
+		t.Fatalf("targets = %+v, want only %q", plan.Targets, wantPath)
+	}
+}
+
+func TestDiscoverLintTargetsFromRoot_DirectoryAliasDoesNotRewriteSiblingScope(t *testing.T) {
+	root := tspath.NormalizePath(t.TempDir())
+	physicalDir := tspath.CombinePaths(root, "real")
+	if err := os.MkdirAll(physicalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	physicalFile := tspath.CombinePaths(physicalDir, "x.TS")
+	if err := os.WriteFile(physicalFile, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := tspath.CombinePaths(root, "zalias")
+	if err := os.Symlink(physicalDir, aliasDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+
+	plan, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		Config: RslintConfig{{
+			Files: []string{"real/*.TS"},
+			Rules: Rules{"rule": "error"},
+		}},
+		ConfigDirectory: root,
+		ScanRoot:        root,
+		FS:              osvfs.FS(),
+		Directories:     []string{root, aliasDir},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Targets) != 1 || plan.Targets[0].Path != physicalFile {
+		t.Fatalf("targets = %+v, want only real-directory spelling %q", plan.Targets, physicalFile)
+	}
+}
+
+func TestDiscoverLintTargetsMultiConfig_PreservesProjectedCanonicalIdentity(t *testing.T) {
+	root := tspath.NormalizePath(t.TempDir())
+	physicalConfigDir := tspath.CombinePaths(root, "real")
+	physicalTargetDir := tspath.CombinePaths(physicalConfigDir, "sub")
+	if err := os.MkdirAll(physicalTargetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	physicalFile := tspath.CombinePaths(physicalTargetDir, "x.ts")
+	if err := os.WriteFile(physicalFile, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configAlias := tspath.CombinePaths(root, "config-alias")
+	targetAlias := tspath.CombinePaths(root, "target-alias")
+	if err := os.Symlink(physicalConfigDir, configAlias); err != nil {
+		t.Skipf("config directory symlink unavailable: %v", err)
+	}
+	if err := os.Symlink(physicalTargetDir, targetAlias); err != nil {
+		t.Skipf("target directory symlink unavailable: %v", err)
+	}
+
+	targets := DiscoverLintTargetsMultiConfig(
+		map[string]RslintConfig{
+			configAlias: {{Rules: Rules{"rule": "error"}}},
+		},
+		nil,
+		osvfs.FS(),
+		nil,
+		[]string{targetAlias},
+		true,
+	)
+	wantPath := tspath.CombinePaths(targetAlias, "x.ts")
+	if len(targets) != 1 || targets[0].Path != wantPath ||
+		targets[0].CanonicalPath != tspath.NormalizePath(osvfs.FS().Realpath(physicalFile)) ||
+		targets[0].ConfigDirectory != configAlias {
+		t.Fatalf("projected target identity = %+v", targets)
+	}
+}
+
+func TestDiscoverLintTargetsFromRoot_SharedAliasAncestorKeepsRelativeConfigMeaning(t *testing.T) {
+	physicalRoot := tspath.NormalizePath(t.TempDir())
+	physicalConfigDir := tspath.CombinePaths(physicalRoot, "config")
+	physicalWorkspace := tspath.CombinePaths(physicalRoot, "workspace")
+	for _, directory := range []string{physicalConfigDir, physicalWorkspace} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	visible := tspath.CombinePaths(physicalWorkspace, "visible.ts")
+	ignored := tspath.CombinePaths(physicalWorkspace, "ignored.ts")
+	for _, filePath := range []string{visible, ignored} {
+		if err := os.WriteFile(filePath, []byte("export {};\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	aliasRoot := tspath.CombinePaths(tspath.NormalizePath(t.TempDir()), "root-alias")
+	if err := os.Symlink(physicalRoot, aliasRoot); err != nil {
+		t.Skipf("root symlink unavailable: %v", err)
+	}
+	configDir := tspath.CombinePaths(aliasRoot, "config")
+	entries := RslintConfig{
+		{Ignores: []string{"../workspace/ignored.ts"}},
+		{Files: []string{"../workspace/*.ts"}, Rules: Rules{"rule": "error"}},
+	}
+	targets := discoverLintTargetsFromRoot(
+		entries,
+		configDir,
+		physicalWorkspace,
+		osvfs.FS(),
+		nil,
+		[]string{physicalWorkspace},
+		true,
+	)
+	if len(targets) != 1 || targets[0].Path != visible {
+		t.Fatalf("shared-alias targets = %+v, want only %q", targets, visible)
+	}
+	merged := NewFileConfigResolverWithFS(entries, configDir, osvfs.FS(), false).ConfigForFile(visible)
+	if merged == nil || merged.Rules["rule"] == nil {
+		t.Fatalf("shared-alias effective config = %#v", merged)
+	}
+}
+
+func TestDiscoverLintTargetsFromRoot_UnionsFilesAndDirectories(t *testing.T) {
+	root := t.TempDir()
+	configDir := tspath.NormalizePath(filepath.Join(root, "config"))
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	directoryRoot := tspath.NormalizePath(filepath.Join(root, "directory"))
+	exactRoot := tspath.NormalizePath(filepath.Join(root, "exact"))
+	for _, directory := range []string{configDir, scanRoot, directoryRoot, exactRoot} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	directoryFile := tspath.CombinePaths(directoryRoot, "from-dir.ts")
+	exactFile := tspath.CombinePaths(exactRoot, "exact.ts")
+	for _, filePath := range []string{directoryFile, exactFile} {
+		if err := os.WriteFile(filePath, []byte("export {};\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	targets := discoverLintTargetsFromRoot(
+		nil,
+		configDir,
+		scanRoot,
+		osvfs.FS(),
+		[]string{exactFile},
+		[]string{directoryRoot},
+		true,
+	)
+	assert.DeepEqual(t, targets, []DiscoveredLintTarget{
+		{Path: directoryFile, CanonicalPath: tspath.NormalizePath(osvfs.FS().Realpath(directoryFile)), CanonicalParentPath: tspath.NormalizePath(osvfs.FS().Realpath(directoryRoot)), ConfigDirectory: configDir},
+		{Path: exactFile, CanonicalPath: tspath.NormalizePath(osvfs.FS().Realpath(exactFile)), CanonicalParentPath: tspath.NormalizePath(osvfs.FS().Realpath(filepath.Dir(exactFile))), ConfigDirectory: configDir},
+	})
+}
+
+func TestDiscoverLintTargetsFromRoot_RequestedAncestorWidensOnlyScanScope(t *testing.T) {
+	root := t.TempDir()
+	configDir := tspath.NormalizePath(filepath.Join(root, "config"))
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace", "nested"))
+	insideFile := tspath.CombinePaths(scanRoot, "inside.ts")
+	siblingFile := tspath.CombinePaths(root, "sibling.ts")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(scanRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, filePath := range []string{insideFile, siblingFile} {
+		if err := os.WriteFile(filePath, []byte("export {};\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	targets := discoverLintTargetsFromRoot(nil, configDir, scanRoot, osvfs.FS(), nil, []string{tspath.NormalizePath(root)}, true)
+	paths := make([]string, 0, len(targets))
+	for _, target := range targets {
+		paths = append(paths, target.Path)
+	}
+	assert.DeepEqual(t, paths, []string{siblingFile, insideFile})
+	for _, target := range targets {
+		assert.Equal(t, target.ConfigDirectory, configDir)
+	}
+}
+
+func TestDiscoverLintTargetsFromRoot_SkipsIgnoredExternalRootBeforeWalking(t *testing.T) {
+	root := t.TempDir()
+	configDir := tspath.NormalizePath(filepath.Join(root, "config"))
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	externalDir := tspath.NormalizePath(filepath.Join(root, "external"))
+	for _, directory := range []string{configDir, scanRoot, externalDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(tspath.CombinePaths(externalDir, "ignored.ts"), []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	spy := &spyFS{FS: osvfs.FS()}
+	targets := discoverLintTargetsFromRoot(
+		RslintConfig{
+			{Ignores: []string{"../external/**"}},
+			{Rules: Rules{"test-rule": "error"}},
+		},
+		configDir,
+		scanRoot,
+		spy,
+		nil,
+		[]string{externalDir},
+		true,
+	)
+	assert.DeepEqual(t, targets, []DiscoveredLintTarget{})
+	for _, accessed := range spy.snapshotAccessedDirs() {
+		if pathsEqual(accessed, externalDir, true) || tspath.StartsWithDirectory(accessed, externalDir, true) {
+			t.Fatalf("ignored external root was entered: %v", spy.snapshotAccessedDirs())
+		}
+	}
+}
+
+func TestDiscoverLintTargetsFromRoot_SkipsDefaultExcludedScanRoot(t *testing.T) {
+	root := t.TempDir()
+	configDir := tspath.NormalizePath(root)
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "node_modules", "pkg"))
+	if err := os.MkdirAll(scanRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tspath.CombinePaths(scanRoot, "index.ts"), []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name        string
+		directories []string
+	}{
+		{name: "implicit scan root"},
+		{name: "explicit scan root", directories: []string{scanRoot}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			spy := &spyFS{FS: osvfs.FS()}
+			targets := discoverLintTargetsFromRoot(
+				RslintConfig{{Rules: Rules{"test-rule": "error"}}},
+				configDir,
+				scanRoot,
+				spy,
+				nil,
+				test.directories,
+				true,
+			)
+			assert.DeepEqual(t, targets, []DiscoveredLintTarget{})
+			for _, accessed := range spy.snapshotAccessedDirs() {
+				if pathsEqual(accessed, scanRoot, true) || tspath.StartsWithDirectory(accessed, scanRoot, true) {
+					t.Fatalf("default-excluded scan root was entered: %v", spy.snapshotAccessedDirs())
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverLintTargetsFromRoot_DistinctCanonicalRootsDoNotCaseFold(t *testing.T) {
+	const (
+		configDir = "/config"
+		scanRoot  = "/workspace"
+		upperDir  = "/repo/Foo"
+		lowerDir  = "/repo/foo"
+	)
+	fake := &discoveryMockFS{
+		FS: osvfs.FS(),
+		entries: map[string]vfs.Entries{
+			upperDir: {Files: []string{"upper.ts"}, Symlinks: map[string]struct{}{}},
+			lowerDir: {Files: []string{"lower.ts"}, Symlinks: map[string]struct{}{}},
+		},
+		resolvedPaths: map[string]string{
+			configDir: "/physical/config",
+			scanRoot:  "/physical/workspace",
+			upperDir:  "/physical/Foo",
+			lowerDir:  "/physical/foo",
+		},
+		caseSensitiveFS: false,
+	}
+	targets := discoverLintTargetsFromRoot(nil, configDir, scanRoot, fake, nil, []string{upperDir, lowerDir}, true)
+	paths := make([]string, 0, len(targets))
+	for _, target := range targets {
+		paths = append(paths, target.Path)
+	}
+	assert.DeepEqual(t, paths, []string{"/repo/Foo/upper.ts", "/repo/foo/lower.ts"})
+}
+
+func TestDiscoverLintTargets_DirectoryWalkAvoidsPerNodeRealpath(t *testing.T) {
 	configDir, paths := setupDiscoveryFixture(t, []string{
 		"src/a.ts",
 		"src/b.ts",
@@ -614,6 +1002,12 @@ func TestDiscoverLintTargets_DirectoryWalkAvoidsPerFileRealpath(t *testing.T) {
 	for _, filePath := range paths {
 		assert.Equal(t, fsys.callCount(filePath), 0, "regular walk target should use the config-root canonical hint")
 	}
+	assert.Equal(
+		t,
+		fsys.callCount(tspath.CombinePaths(configDir, "src")),
+		0,
+		"lexically contained walk directory should not resolve its physical path",
+	)
 }
 
 func TestDiscoverLintTargets_ExplicitFileResolvesPhysicalIdentity(t *testing.T) {
@@ -669,9 +1063,10 @@ func TestDiscoverLintTargets_MissingSymlinkMetadataResolvesFileIdentity(t *testi
 
 	targets := DiscoverLintTargets(nil, configDir, fsys, nil, nil, true)
 	assert.DeepEqual(t, targets, []DiscoveredLintTarget{{
-		Path:            filePath,
-		CanonicalPath:   physicalPath,
-		ConfigDirectory: configDir,
+		Path:                filePath,
+		CanonicalPath:       physicalPath,
+		CanonicalParentPath: "/repo/src",
+		ConfigDirectory:     configDir,
 	}})
 }
 
@@ -917,11 +1312,16 @@ func TestDiscoverLintFilesMultiConfig_DoesNotWalkChildConfigFromParent(t *testin
 	assert.DeepEqual(t, targets, expected)
 
 	childAccesses := 0
+	rootAccesses := 0
 	for _, accessed := range spy.snapshotAccessedDirs() {
+		if accessed == rootDir {
+			rootAccesses++
+		}
 		if accessed == childDir {
 			childAccesses++
 		}
 	}
+	assert.Equal(t, rootAccesses, 1, "each child config must not rescan the invocation root")
 	assert.Equal(t, childAccesses, 1, "child config directory should be entered only by its owning config")
 }
 
@@ -1007,9 +1407,10 @@ func TestDiscoverLintTargetsMultiConfig_MatchesIgnoresInPhysicalConfigSpace(t *t
 		true,
 	)
 	assert.DeepEqual(t, targets, []DiscoveredLintTarget{{
-		Path:            paths["src/keep.ts"],
-		CanonicalPath:   tspath.NormalizePath(fsys.Realpath(paths["src/keep.ts"])),
-		ConfigDirectory: linkDir,
+		Path:                paths["src/keep.ts"],
+		CanonicalPath:       tspath.NormalizePath(fsys.Realpath(paths["src/keep.ts"])),
+		CanonicalParentPath: tspath.NormalizePath(fsys.Realpath(filepath.Dir(paths["src/keep.ts"]))),
+		ConfigDirectory:     linkDir,
 	}})
 }
 
@@ -1096,14 +1497,16 @@ func TestDiscoverLintTargetsMultiConfig_MergesAutomaticAndHostAssignedFilesForSa
 
 	assert.DeepEqual(t, targets, []DiscoveredLintTarget{
 		{
-			Path:            paths["pkg/automatic.ts"],
-			CanonicalPath:   tspath.NormalizePath(fsys.Realpath(paths["pkg/automatic.ts"])),
-			ConfigDirectory: childDir,
+			Path:                paths["pkg/automatic.ts"],
+			CanonicalPath:       tspath.NormalizePath(fsys.Realpath(paths["pkg/automatic.ts"])),
+			CanonicalParentPath: tspath.NormalizePath(fsys.Realpath(filepath.Dir(paths["pkg/automatic.ts"]))),
+			ConfigDirectory:     childDir,
 		},
 		{
-			Path:            paths["pkg/explicit.ts"],
-			CanonicalPath:   tspath.NormalizePath(fsys.Realpath(paths["pkg/explicit.ts"])),
-			ConfigDirectory: childDir,
+			Path:                paths["pkg/explicit.ts"],
+			CanonicalPath:       tspath.NormalizePath(fsys.Realpath(paths["pkg/explicit.ts"])),
+			CanonicalParentPath: tspath.NormalizePath(fsys.Realpath(filepath.Dir(paths["pkg/explicit.ts"]))),
+			ConfigDirectory:     childDir,
 		},
 	})
 }
@@ -1138,9 +1541,10 @@ func TestDiscoverLintTargetsMultiConfig_ExplicitOnlyConfigDoesNotOwnAutomaticFil
 	)
 
 	assert.DeepEqual(t, targets, []DiscoveredLintTarget{{
-		Path:            paths["ignored/explicit.ts"],
-		CanonicalPath:   tspath.NormalizePath(fsys.Realpath(paths["ignored/explicit.ts"])),
-		ConfigDirectory: ignoredDir,
+		Path:                paths["ignored/explicit.ts"],
+		CanonicalPath:       tspath.NormalizePath(fsys.Realpath(paths["ignored/explicit.ts"])),
+		CanonicalParentPath: tspath.NormalizePath(fsys.Realpath(filepath.Dir(paths["ignored/explicit.ts"]))),
+		ConfigDirectory:     ignoredDir,
 	}})
 }
 
@@ -1226,6 +1630,270 @@ func TestDiscoverLintTargets_PhysicalConfigFallbackPreservesDirectoryAliasPath(t
 	}
 	assert.Equal(t, targets[0].Path, tspath.ResolvePath(linkDir, "index.ts"))
 	assert.Equal(t, targets[0].CanonicalPath, tspath.NormalizePath(fSys.Realpath(paths["real/sub/index.ts"])))
+}
+
+func TestDiscoverLintTargetsMultiConfig_AliasAuthoredEntrySelectsNonDefaultExtension(t *testing.T) {
+	rootDir := tspath.NormalizePath(t.TempDir())
+	realConfigDir := tspath.CombinePaths(rootDir, "real")
+	realTargetDir := tspath.CombinePaths(realConfigDir, "sub")
+	if err := os.MkdirAll(realTargetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	physicalTarget := tspath.CombinePaths(realTargetDir, "index.TS")
+	if err := os.WriteFile(physicalTarget, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := tspath.CombinePaths(rootDir, "link")
+	if err := os.Symlink(realTargetDir, linkDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+
+	inlineOverride := ConfigWithAuthoredPathBase(RslintConfig{{
+		Files: []string{"link/**/*.TS"},
+		Rules: Rules{"inline": "error"},
+	}}, rootDir)
+	entries := append(RslintConfig{{
+		Files: []string{"sub/**/*.ts"},
+		Rules: Rules{"physical": "error"},
+	}}, inlineOverride...)
+	fSys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	targets := DiscoverLintTargetsMultiConfig(
+		map[string]RslintConfig{realConfigDir: entries},
+		nil,
+		fSys,
+		nil,
+		[]string{linkDir},
+		true,
+	)
+	wantPath := tspath.CombinePaths(linkDir, "index.TS")
+	if len(targets) != 1 ||
+		targets[0].Path != wantPath ||
+		targets[0].CanonicalPath != tspath.NormalizePath(fSys.Realpath(physicalTarget)) ||
+		targets[0].ConfigDirectory != realConfigDir {
+		t.Fatalf("alias-authored target = %+v, want %q owned by %q", targets, wantPath, realConfigDir)
+	}
+}
+
+func TestDiscoverLintTargetsMultiConfig_PrunesUsingCallerVisibleDirectoryAlias(t *testing.T) {
+	rootDir := tspath.NormalizePath(t.TempDir())
+	realConfigDir := tspath.CombinePaths(rootDir, "real")
+	realTargetDir := tspath.CombinePaths(realConfigDir, "sub")
+	if err := os.MkdirAll(realTargetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	physicalTarget := tspath.CombinePaths(realTargetDir, "index.TS")
+	if err := os.WriteFile(physicalTarget, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := tspath.CombinePaths(rootDir, "link")
+	if err := os.Symlink(realTargetDir, linkDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+
+	inlineIgnore := ConfigWithAuthoredPathBase(
+		RslintConfig{{Ignores: []string{"real/**"}}},
+		rootDir,
+	)
+	entries := append(RslintConfig{{
+		Files: []string{"sub/**/*.TS"},
+		Rules: Rules{"physical": "error"},
+	}}, inlineIgnore...)
+	fSys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	targets := DiscoverLintTargetsMultiConfig(
+		map[string]RslintConfig{realConfigDir: entries},
+		nil,
+		fSys,
+		nil,
+		[]string{linkDir},
+		true,
+	)
+	wantPath := tspath.CombinePaths(linkDir, "index.TS")
+	if len(targets) != 1 || targets[0].Path != wantPath {
+		t.Fatalf("directory alias was pruned in the physical path space: %+v", targets)
+	}
+}
+
+func TestDiscoverLintTargetsMultiConfig_EvaluatesEveryRequestedDirectoryAlias(t *testing.T) {
+	rootDir := tspath.NormalizePath(t.TempDir())
+	realConfigDir := tspath.CombinePaths(rootDir, "real")
+	realTargetDir := tspath.CombinePaths(realConfigDir, "sub")
+	if err := os.MkdirAll(realTargetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	physicalTarget := tspath.CombinePaths(realTargetDir, "index.TS")
+	if err := os.WriteFile(physicalTarget, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasA := tspath.CombinePaths(rootDir, "a")
+	aliasB := tspath.CombinePaths(rootDir, "b")
+	for _, alias := range []string{aliasA, aliasB} {
+		if err := os.Symlink(realTargetDir, alias); err != nil {
+			t.Skipf("directory symlink unavailable: %v", err)
+		}
+	}
+	entries := ConfigWithAuthoredPathBase(RslintConfig{{
+		Files: []string{"b/**/*.TS"},
+		Rules: Rules{"inline": "error"},
+	}}, rootDir)
+	fSys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	wantPath := tspath.CombinePaths(aliasB, "index.TS")
+	for _, directories := range [][]string{{aliasA, aliasB}, {aliasB, aliasA}} {
+		targets := DiscoverLintTargetsMultiConfig(
+			map[string]RslintConfig{realConfigDir: entries},
+			nil,
+			fSys,
+			nil,
+			directories,
+			true,
+		)
+		if len(targets) != 1 || targets[0].Path != wantPath {
+			t.Fatalf("requested aliases %v produced %+v, want %q", directories, targets, wantPath)
+		}
+	}
+}
+
+func TestDiscoverLintTargetsMultiConfig_DefaultExcludesUseRequestedDirectoryAlias(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		physicalParts []string
+		aliasParts    []string
+		wantTargets   int
+	}{
+		{
+			name:          "lexical node_modules remains excluded",
+			physicalParts: []string{"real", "sub"},
+			aliasParts:    []string{"node_modules", "link"},
+			wantTargets:   0,
+		},
+		{
+			name:          "physical node_modules hidden by lexical alias remains visible",
+			physicalParts: []string{"real", "node_modules", "pkg"},
+			aliasParts:    []string{"link"},
+			wantTargets:   1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rootDir := tspath.NormalizePath(t.TempDir())
+			realConfigDir := tspath.CombinePaths(rootDir, "real")
+			physicalTargetDir := realConfigDir
+			for _, part := range test.physicalParts[1:] {
+				physicalTargetDir = tspath.CombinePaths(physicalTargetDir, part)
+			}
+			if err := os.MkdirAll(physicalTargetDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			physicalTarget := tspath.CombinePaths(physicalTargetDir, "index.TS")
+			if err := os.WriteFile(physicalTarget, []byte("debugger;\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			aliasDir := rootDir
+			for _, part := range test.aliasParts {
+				aliasDir = tspath.CombinePaths(aliasDir, part)
+			}
+			if err := os.MkdirAll(tspath.GetDirectoryPath(aliasDir), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(physicalTargetDir, aliasDir); err != nil {
+				t.Skipf("directory symlink unavailable: %v", err)
+			}
+
+			physicalRelative, ok := RelativePathWithinConfigRoot(physicalTargetDir, realConfigDir, true)
+			if !ok {
+				t.Fatal("invalid physical fixture")
+			}
+			entries := RslintConfig{{
+				Files: []string{physicalRelative + "/**/*.TS"},
+				Rules: Rules{"physical": "error"},
+			}}
+			fSys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+			targets := DiscoverLintTargetsMultiConfig(
+				map[string]RslintConfig{realConfigDir: entries},
+				nil,
+				fSys,
+				nil,
+				[]string{aliasDir},
+				true,
+			)
+			if len(targets) != test.wantTargets {
+				t.Fatalf("targets = %+v, want %d", targets, test.wantTargets)
+			}
+			if test.wantTargets == 1 && targets[0].Path != tspath.CombinePaths(aliasDir, "index.TS") {
+				t.Fatalf("visible alias target = %+v", targets)
+			}
+		})
+	}
+}
+
+func TestDiscoverLintTargetsMultiConfig_DefaultExcludeFiltersEachDirectoryAlias(t *testing.T) {
+	rootDir := tspath.NormalizePath(t.TempDir())
+	realConfigDir := tspath.CombinePaths(rootDir, "real")
+	realTargetDir := tspath.CombinePaths(realConfigDir, "sub")
+	if err := os.MkdirAll(realTargetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	physicalTarget := tspath.CombinePaths(realTargetDir, "index.TS")
+	if err := os.WriteFile(physicalTarget, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	excludedAlias := tspath.CombinePaths(rootDir, "a", "node_modules", "link")
+	visibleAlias := tspath.CombinePaths(rootDir, "z")
+	if err := os.MkdirAll(tspath.GetDirectoryPath(excludedAlias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, alias := range []string{excludedAlias, visibleAlias} {
+		if err := os.Symlink(realTargetDir, alias); err != nil {
+			t.Skipf("directory symlink unavailable: %v", err)
+		}
+	}
+	entries := RslintConfig{{
+		Files: []string{"sub/**/*.TS"},
+		Rules: Rules{"physical": "error"},
+	}}
+	fSys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	targets := DiscoverLintTargetsMultiConfig(
+		map[string]RslintConfig{realConfigDir: entries},
+		nil,
+		fSys,
+		nil,
+		[]string{excludedAlias, visibleAlias},
+		true,
+	)
+	wantPath := tspath.CombinePaths(visibleAlias, "index.TS")
+	if len(targets) != 1 || targets[0].Path != wantPath {
+		t.Fatalf("per-alias default exclusion produced %+v, want only %q", targets, wantPath)
+	}
+}
+
+func TestProjectPathThroughRequestedDirectoriesPreservesCallerCasing(t *testing.T) {
+	projections := projectPathThroughRequestedDirectories(
+		"C:/Repo/src/a.TS",
+		"C:/Repo/src/a.TS",
+		[]resolvedAllowedDirectory{{
+			lexicalPath:   "c:/repo/src",
+			canonicalPath: "C:/Repo/src",
+		}},
+		false,
+	)
+	if len(projections) != 1 ||
+		projections[0].path != "c:/repo/src/a.TS" ||
+		projections[0].canonicalPath != "C:/Repo/src/a.TS" {
+		t.Fatalf("projections = %+v", projections)
+	}
+
+	projections = projectPathThroughRequestedDirectories(
+		"C:/Repo/src/a.TS",
+		"C:/Repo/src/a.TS",
+		[]resolvedAllowedDirectory{
+			{lexicalPath: "C:/Repo/src", canonicalPath: "C:/Repo/src"},
+			{lexicalPath: "c:/repo/src", canonicalPath: "c:/repo/src"},
+		},
+		false,
+	)
+	if len(projections) != 1 ||
+		projections[0].path != "C:/Repo/src/a.TS" ||
+		projections[0].canonicalPath != "" {
+		t.Fatalf("distinct case-only roots produced projections %+v", projections)
+	}
 }
 
 func TestDiscoverFilesOutsideProgramsMultiConfig_UsesNearestConfigOwner(t *testing.T) {

--- a/internal/config/file_resolver.go
+++ b/internal/config/file_resolver.go
@@ -1,10 +1,35 @@
 package config
 
-import "github.com/web-infra-dev/rslint/internal/rule"
+import (
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
 
 type effectiveConfigPlan struct {
 	mergedConfig *MergedConfig
 	enabledRules []rule.ConfiguredRule
+}
+
+// ResolvedFileConfig is the immutable result of evaluating one frozen lint
+// target against a flat config. A nil MergedConfig means no config entry
+// selected the target; GloballyIgnored distinguishes the case where linting
+// must be skipped entirely from the case where syntax diagnostics still apply.
+type ResolvedFileConfig struct {
+	MergedConfig    *MergedConfig
+	EnabledRules    []rule.ConfiguredRule
+	GloballyIgnored bool
+}
+
+type configTargetResolution struct {
+	plan            *effectiveConfigPlan
+	globallyIgnored bool
+}
+
+type configTargetCacheKey struct {
+	path                string
+	canonicalPath       string
+	canonicalParentPath string
 }
 
 // FileConfigResolver resolves config and rules for one immutable config root.
@@ -12,37 +37,45 @@ type effectiveConfigPlan struct {
 // lifetime and is safe for concurrent use by native and plugin lint workers.
 type FileConfigResolver struct {
 	config         RslintConfig
-	cwd            string
 	enforcePlugins bool
-	// globalIgnorePatterns is parsed once per run instead of per file: the
-	// config's global `ignores` set is fixed for the whole run, so
-	// re-deriving it (string parsing + allocation) on every ConfigForFile
-	// call is pure waste at thousands-of-files scale.
-	globalIgnorePatterns []IgnorePattern
-	entryIgnorePatterns  [][]IgnorePattern
-	directoryBlocks      *directoryBlockMatcher
+	targetResolver *configTargetResolver
 
-	filePlans  publishOnceCache[string, *effectiveConfigPlan]
+	filePlans  publishOnceCache[configTargetCacheKey, *configTargetResolution]
 	shapePlans publishOnceCache[configMatchKey, *effectiveConfigPlan]
 }
 
 // NewFileConfigResolver creates a per-run resolver for one config root.
 func NewFileConfigResolver(config RslintConfig, cwd string, enforcePlugins bool) *FileConfigResolver {
-	globalIgnorePatterns := extractConfigIgnores(config)
+	return NewFileConfigResolverWithFS(config, cwd, nil, enforcePlugins)
+}
+
+// NewFileConfigResolverWithFS creates a resolver that keeps lexical and
+// canonical target identity together while matching authored path bases.
+func NewFileConfigResolverWithFS(
+	config RslintConfig,
+	cwd string,
+	fsys vfs.FS,
+	enforcePlugins bool,
+) *FileConfigResolver {
 	return &FileConfigResolver{
-		config:               config,
-		cwd:                  cwd,
-		enforcePlugins:       enforcePlugins,
-		globalIgnorePatterns: globalIgnorePatterns,
-		entryIgnorePatterns:  parseEntryIgnorePatterns(config),
-		directoryBlocks:      newDirectoryBlockMatcher(globalIgnorePatterns, cwd),
+		config:         config,
+		enforcePlugins: enforcePlugins,
+		targetResolver: newConfigTargetResolver(config, cwd, fsys),
 	}
 }
 
 // ConfigForFile returns the merged config for filePath, caching nil misses.
 // The returned value is shared immutable resolver state and must be read-only.
 func (r *FileConfigResolver) ConfigForFile(filePath string) *MergedConfig {
-	plan := r.planForFile(filePath)
+	return r.ConfigForTarget(filePath, "")
+}
+
+// ConfigForTarget returns the merged config for one stable lint-target
+// identity. The resolver projects the lexical and canonical paths into every
+// entry's authored path space; callers must not pre-project them to one config
+// directory.
+func (r *FileConfigResolver) ConfigForTarget(filePath string, canonicalPath string) *MergedConfig {
+	plan := r.planForTarget(filePath, canonicalPath)
 	if plan == nil {
 		return nil
 	}
@@ -52,32 +85,80 @@ func (r *FileConfigResolver) ConfigForFile(filePath string) *MergedConfig {
 // EnabledRulesForFile returns cached enabled rules and their merged config.
 // Both returned values are shared immutable resolver state and must be read-only.
 func (r *FileConfigResolver) EnabledRulesForFile(filePath string) ([]rule.ConfiguredRule, *MergedConfig) {
-	plan := r.planForFile(filePath)
+	return r.EnabledRulesForTarget(filePath, "")
+}
+
+// EnabledRulesForTarget is EnabledRulesForFile with the canonical identity
+// frozen during target discovery.
+func (r *FileConfigResolver) EnabledRulesForTarget(filePath string, canonicalPath string) ([]rule.ConfiguredRule, *MergedConfig) {
+	plan := r.planForTarget(filePath, canonicalPath)
 	if plan == nil {
 		return nil, nil
 	}
 	return plan.enabledRules, plan.mergedConfig
 }
 
+// ResolveTarget evaluates a complete target identity once. Callers that pass
+// a CanonicalParentPath avoid every later filesystem lookup needed to
+// distinguish a leaf symlink from an aliased directory tree.
+func (r *FileConfigResolver) ResolveTarget(
+	target DiscoveredLintTarget,
+) ResolvedFileConfig {
+	resolution := r.resolutionForTarget(target)
+	if resolution == nil {
+		return ResolvedFileConfig{}
+	}
+	result := ResolvedFileConfig{GloballyIgnored: resolution.globallyIgnored}
+	if resolution.plan != nil {
+		result.MergedConfig = resolution.plan.mergedConfig
+		result.EnabledRules = resolution.plan.enabledRules
+	}
+	return result
+}
+
 func (r *FileConfigResolver) planForFile(filePath string) *effectiveConfigPlan {
-	return r.filePlans.getOrInit(filePath, func() *effectiveConfigPlan {
-		key, matched := r.config.matchConfigEntries(
-			filePath,
-			r.cwd,
-			r.globalIgnorePatterns,
-			r.entryIgnorePatterns,
-			r.directoryBlocks,
-		)
-		if !matched {
-			return nil
+	return r.planForTarget(filePath, "")
+}
+
+func (r *FileConfigResolver) planForTarget(filePath string, canonicalPath string) *effectiveConfigPlan {
+	resolution := r.resolutionForTarget(DiscoveredLintTarget{
+		Path:          filePath,
+		CanonicalPath: canonicalPath,
+	})
+	if resolution == nil {
+		return nil
+	}
+	return resolution.plan
+}
+
+func (r *FileConfigResolver) resolutionForTarget(
+	target DiscoveredLintTarget,
+) *configTargetResolution {
+	key := configTargetCacheKey{
+		path:                tspath.NormalizePath(target.Path),
+		canonicalPath:       tspath.NormalizePath(target.CanonicalPath),
+		canonicalParentPath: tspath.NormalizePath(target.CanonicalParentPath),
+	}
+	return r.filePlans.getOrInit(key, func() *configTargetResolution {
+		decision := r.targetResolver.resolveTarget(DiscoveredLintTarget{
+			Path:                key.path,
+			CanonicalPath:       key.canonicalPath,
+			CanonicalParentPath: key.canonicalParentPath,
+		})
+		resolution := &configTargetResolution{
+			globallyIgnored: decision.globallyIgnored,
+		}
+		if !decision.matched || !decision.selected || decision.globallyIgnored {
+			return resolution
 		}
 
-		return r.shapePlans.getOrInit(key, func() *effectiveConfigPlan {
-			mergedConfig := r.config.mergeConfigEntries(key)
+		resolution.plan = r.shapePlans.getOrInit(decision.key, func() *effectiveConfigPlan {
+			mergedConfig := r.config.mergeConfigEntries(decision.key)
 			return &effectiveConfigPlan{
 				mergedConfig: mergedConfig,
 				enabledRules: GlobalRuleRegistry.GetEnabledRulesForMergedConfig(mergedConfig, r.enforcePlugins),
 			}
 		})
+		return resolution
 	})
 }

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -28,6 +28,13 @@ type Pattern struct {
 	Negated       bool
 	DirectoryOnly bool
 	ContentsOnly  bool
+	// MatchDirectory is the config owner's matching-space projection of the Git
+	// root in which Glob and NodeGlob are interpreted. PhysicalMatchDirectory
+	// and LexicalMatchDirectory retain the Git root's own filesystem identities
+	// when they differ from that projection.
+	MatchDirectory         string
+	PhysicalMatchDirectory string
+	LexicalMatchDirectory  string
 }
 
 func normalizeGlobPath(path string) string {
@@ -443,6 +450,12 @@ func NewCursor(ownerRoot string, useCaseSensitive bool) Cursor {
 // current directory's .gitignore.
 func (cursor Cursor) SourceReachable() bool {
 	return cursor.sourceReachable
+}
+
+// RootDirectory returns the path space in which AppendSourcePatterns projects
+// its globs. It is immutable for the cursor's lifetime.
+func (cursor Cursor) RootDirectory() string {
+	return cursor.rootDir
 }
 
 // BlockSourceTraversal preserves already-observed matching rules while making

--- a/internal/config/gitignore/config_integration_test.go
+++ b/internal/config/gitignore/config_integration_test.go
@@ -539,7 +539,7 @@ func TestConfigWithGitignore_SymlinkedConfigPathSpace(t *testing.T) {
 				nil,
 				[]string{filepath.Dir(test.target)},
 			)
-			matchFile, matchDir := config.ResolveConfigPathSpace(test.target, test.configDir, osvfs.FS())
+			matchFile, matchDir := config.ResolveConfigFilePathSpace(test.target, test.configDir, osvfs.FS())
 			assert.Assert(t, exact.IsFileIgnored(matchFile, matchDir))
 			assert.Assert(t, directory.IsFileIgnored(matchFile, matchDir))
 		})
@@ -572,7 +572,7 @@ func TestConfigWithGitignore_DirectoryContainingAliasedConfigRoot(t *testing.T) 
 		nil,
 		[]string{physicalParent},
 	)
-	matchFile, matchDir := config.ResolveConfigPathSpace(physicalTarget, aliasRoot, osvfs.FS())
+	matchFile, matchDir := config.ResolveConfigFilePathSpace(physicalTarget, aliasRoot, osvfs.FS())
 	assert.Assert(t, effective.IsFileIgnored(matchFile, matchDir))
 }
 
@@ -592,7 +592,7 @@ func TestConfigWithGitignore_SymlinkedConfigDoesNotReadParents(t *testing.T) {
 		t.Skipf("directory symlink unavailable: %v", err)
 	}
 	base := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
-	matchFile, matchDir := config.ResolveConfigPathSpace(target, aliasRoot, osvfs.FS())
+	matchFile, matchDir := config.ResolveConfigFilePathSpace(target, aliasRoot, osvfs.FS())
 
 	t.Run("lexical parent does not apply", func(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(workspace, ".gitignore"), []byte("/alias/src/source.ts\n"), 0o644); err != nil {
@@ -628,7 +628,7 @@ func TestConfigWithGitignore_ExplicitSkipsDescendantSymlinkSource(t *testing.T) 
 		t.Skipf("directory symlink unavailable: %v", err)
 	}
 	target := filepath.Join(dir, "link/source.ts")
-	matchFile, matchDir := config.ResolveConfigPathSpace(target, dir, osvfs.FS())
+	matchFile, matchDir := config.ResolveConfigFilePathSpace(target, dir, osvfs.FS())
 	base := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
 
 	full := config.ConfigWithGitignore(base, dir, osvfs.FS(), nil)

--- a/internal/config/gitignore_config.go
+++ b/internal/config/gitignore_config.go
@@ -25,10 +25,13 @@ func ConfigWithGitignoreWithBoundaries(config RslintConfig, configDir string, fs
 	collectionFiles := targetFiles
 	var isDirectoryBlocked func(string) bool
 	if targetFiles == nil {
-		configIgnores := extractConfigIgnores(config)
-		if len(configIgnores) > 0 {
+		if hasGlobalIgnoreEntries(config) {
+			matcher := NewGlobalIgnoreMatcher(config, configDir, fsys)
 			isDirectoryBlocked = func(relativePath string) bool {
-				return isDirAbsolutelyBlocked(relativePath, configIgnores)
+				return matcher.BlocksDirectory(
+					tspath.ResolvePath(configDir, relativePath),
+					"",
+				)
 			}
 		}
 	} else if fsys != nil && len(targetFiles) > 0 {
@@ -37,9 +40,55 @@ func ConfigWithGitignoreWithBoundaries(config RslintConfig, configDir string, fs
 			collectionFiles[i] = ResolveGitignoreCollectionPath(file, "", configDir, fsys)
 		}
 	}
+	return configWithGitignoreCollectionFiles(
+		config,
+		configDir,
+		fsys,
+		collectionFiles,
+		isDirectoryBlocked,
+		stopDirs,
+	)
+}
+
+// ConfigWithGitignoreForExactTarget collects the .gitignore chain for one
+// target whose lexical and canonical identities were already frozen by the
+// caller. It never resolves the target through the filesystem again.
+func ConfigWithGitignoreForExactTarget(
+	config RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	target DiscoveredLintTarget,
+) RslintConfig {
+	collectionFile := resolveGitignoreCollectionTargetPath(target, configDir, fsys)
+	return configWithGitignoreCollectionFiles(
+		config,
+		configDir,
+		fsys,
+		[]string{collectionFile},
+		nil,
+		nil,
+	)
+}
+
+func configWithGitignoreCollectionFiles(
+	config RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	collectionFiles []string,
+	isDirectoryBlocked func(string) bool,
+	stopDirs []string,
+) RslintConfig {
 	patterns := gitignore.CollectPatternsWithBoundaries(configDir, fsys, collectionFiles, isDirectoryBlocked, stopDirs)
 	caseInsensitive := fsys != nil && !fsys.UseCaseSensitiveFileNames()
-	return ConfigWithCollectedGitignore(config, patterns, caseInsensitive)
+	patterns = CollectedGitignorePatternsForRoot(patterns, configDir, configDir, fsys)
+	return ConfigWithCollectedGitignoreScopes(
+		config,
+		patterns,
+		[]string{configDir},
+		configDir,
+		fsys,
+		caseInsensitive,
+	)
 }
 
 // ConfigWithGitignoreForTargets prepends only the .gitignore patterns that can
@@ -53,56 +102,167 @@ func ConfigWithGitignoreForTargets(
 	targetFiles []string,
 	targetDirectories []string,
 ) RslintConfig {
-	if len(targetDirectories) == 0 {
-		return ConfigWithGitignore(config, configDir, fsys, targetFiles)
-	}
-
-	collectionFiles := targetFiles
-	collectionDirectories := targetDirectories
-	var isDirectoryBlocked func(string) bool
-	configIgnores := extractConfigIgnores(config)
-	if len(configIgnores) > 0 {
-		isDirectoryBlocked = func(relativePath string) bool {
-			return isDirAbsolutelyBlocked(relativePath, configIgnores)
-		}
-	}
-	if fsys != nil {
-		if len(targetFiles) > 0 {
-			collectionFiles = make([]string, len(targetFiles))
-			for i, file := range targetFiles {
-				collectionFiles[i] = ResolveGitignoreCollectionPath(file, "", configDir, fsys)
-			}
-		}
-		if len(targetDirectories) > 0 {
-			collectionDirectories = make([]string, len(targetDirectories))
-			for i, directory := range targetDirectories {
-				collectionDirectories[i] = ResolveGitignoreCollectionDirectory(directory, configDir, fsys)
-			}
-		}
-	}
-	patterns := gitignore.CollectPatternsForTargets(
+	return ConfigWithGitignoreForTargetsFromRoot(
+		config,
+		configDir,
 		configDir,
 		fsys,
-		collectionFiles,
-		collectionDirectories,
-		isDirectoryBlocked,
+		targetFiles,
+		targetDirectories,
 	)
-	caseInsensitive := fsys != nil && !fsys.UseCaseSensitiveFileNames()
-	return ConfigWithCollectedGitignore(config, patterns, caseInsensitive)
 }
 
-// ConfigWithCollectedGitignore prepends one already-collected Git projection
-// without retaining a filesystem. Both the standalone collector path and
-// staged config discovery use this constructor so private Git matching metadata
-// cannot diverge between them.
+// ConfigWithGitignoreForTargetsFromRoot keeps the authored config path space
+// separate from the invocation's Git-ignore root. This matters for an explicit
+// config outside cwd: files and ignores remain relative to configDir, while
+// .gitignore sources still come from the files and directories the user asked
+// Rslint to scan.
+func ConfigWithGitignoreForTargetsFromRoot(
+	config RslintConfig,
+	configDir string,
+	gitignoreRoot string,
+	fsys vfs.FS,
+	targetFiles []string,
+	targetDirectories []string,
+) RslintConfig {
+	useCaseSensitive := fsys == nil || fsys.UseCaseSensitiveFileNames()
+	configDir = tspath.NormalizePath(configDir)
+	matcher := NewGlobalIgnoreMatcher(config, configDir, fsys)
+	hasGlobalIgnores := hasGlobalIgnoreEntries(config)
+	var patterns []gitignore.Pattern
+	scopes := PlanGitignoreCollectionScopes(
+		gitignoreRoot,
+		fsys,
+		targetFiles,
+		targetDirectories,
+	)
+	roots := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		roots = append(roots, scope.Root)
+		var collectionFiles []string
+		if scope.Files != nil {
+			collectionFiles = make([]string, len(scope.Files))
+			for index, file := range scope.Files {
+				collectionFiles[index] = ResolveGitignoreCollectionPath(file, "", scope.Root, fsys)
+			}
+		}
+		var collectionDirectories []string
+		if scope.Directories != nil {
+			collectionDirectories = make([]string, len(scope.Directories))
+			for index, directory := range scope.Directories {
+				collectionDirectories[index] = ResolveGitignoreCollectionDirectory(directory, scope.Root, fsys)
+			}
+		}
+		var isDirectoryBlocked func(string) bool
+		if hasGlobalIgnores {
+			root := scope.Root
+			isDirectoryBlocked = func(relativePath string) bool {
+				absolutePath := tspath.ResolvePath(root, relativePath)
+				return matcher.BlocksDirectory(absolutePath, "")
+			}
+		}
+		collected := gitignore.CollectPatternsForTargets(
+			scope.Root,
+			fsys,
+			collectionFiles,
+			collectionDirectories,
+			isDirectoryBlocked,
+		)
+		patterns = append(patterns, CollectedGitignorePatternsForRoot(
+			collected,
+			configDir,
+			scope.Root,
+			fsys,
+		)...)
+	}
+	caseInsensitive := !useCaseSensitive
+	return ConfigWithCollectedGitignoreScopes(
+		config,
+		patterns,
+		roots,
+		configDir,
+		fsys,
+		caseInsensitive,
+	)
+}
+
+func hasGlobalIgnoreEntries(config RslintConfig) bool {
+	for _, entry := range config {
+		if isGlobalIgnoreEntry(entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// ConfigWithCollectedGitignore prepends an already-collected Git projection
+// whose patterns carry their own root metadata. Filesystem-aware collection
+// paths use ConfigWithCollectedGitignoreScopes so empty active scopes are also
+// retained.
 func ConfigWithCollectedGitignore(config RslintConfig, patterns []gitignore.Pattern, caseInsensitive bool) RslintConfig {
 	if len(patterns) == 0 {
 		return config
 	}
+	parsed := parseCollectedGitignorePatterns(patterns, caseInsensitive)
+	return configWithCollectedGitignoreMetadata(
+		config,
+		patterns,
+		parsed,
+		collectedGitignoreScopesFromPatterns(parsed),
+	)
+}
+
+// ConfigWithCollectedGitignoreScopes prepends one collected Git projection and
+// retains every active collection root, including roots that produced no
+// patterns. Empty roots are still semantically relevant when another root has
+// patterns: they prevent canonical aliases from borrowing that other root's
+// Git policy.
+func ConfigWithCollectedGitignoreScopes(
+	config RslintConfig,
+	patterns []gitignore.Pattern,
+	scopeRoots []string,
+	configDirectory string,
+	fsys vfs.FS,
+	caseInsensitive bool,
+) RslintConfig {
+	if len(patterns) == 0 {
+		return config
+	}
+	parsed := parseCollectedGitignorePatterns(patterns, caseInsensitive)
+	scopes := make([]collectedGitignoreScope, 0, len(scopeRoots))
+	for _, root := range scopeRoots {
+		resolved := resolveCollectedGitignoreScope(
+			configDirectory,
+			root,
+			fsys,
+			caseInsensitive,
+		)
+		duplicate := false
+		for _, existing := range scopes {
+			if existing == resolved {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			scopes = append(scopes, resolved)
+		}
+	}
+	return configWithCollectedGitignoreMetadata(config, patterns, parsed, scopes)
+}
+
+func configWithCollectedGitignoreMetadata(
+	config RslintConfig,
+	patterns []gitignore.Pattern,
+	parsed []IgnorePattern,
+	scopes []collectedGitignoreScope,
+) RslintConfig {
+	bindCollectedGitignorePatterns(parsed, scopes)
 	gitignoreEntry := ConfigEntry{
 		Ignores: make([]string, len(patterns)),
 		collectedGitignore: &collectedGitignoreMetadata{
-			ignores: parseCollectedGitignorePatterns(patterns, caseInsensitive),
+			ignores: parsed,
+			scopes:  scopes,
 		},
 	}
 	for index, pattern := range patterns {
@@ -112,6 +272,66 @@ func ConfigWithCollectedGitignore(config RslintConfig, patterns []gitignore.Patt
 	effective = append(effective, gitignoreEntry)
 	effective = append(effective, config...)
 	return effective
+}
+
+func collectedGitignoreScopesFromPatterns(patterns []IgnorePattern) []collectedGitignoreScope {
+	var scopes []collectedGitignoreScope
+	for _, pattern := range patterns {
+		if !pattern.GitPattern || !patternHasMatchDirectory(pattern) {
+			continue
+		}
+		scope := collectedGitignoreScope{
+			matchDirectory:    pattern.MatchDirectory,
+			physicalDirectory: pattern.PhysicalMatchDirectory,
+			lexicalDirectory:  pattern.LexicalMatchDirectory,
+			caseInsensitive:   pattern.CaseInsensitive,
+		}
+		if scope.lexicalDirectory == "" {
+			scope.lexicalDirectory = scope.matchDirectory
+		}
+		if scope.physicalDirectory == "" {
+			scope.physicalDirectory = scope.matchDirectory
+		}
+		duplicate := false
+		for _, existing := range scopes {
+			if existing == scope {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			scopes = append(scopes, scope)
+		}
+	}
+	return scopes
+}
+
+func bindCollectedGitignorePatterns(patterns []IgnorePattern, scopes []collectedGitignoreScope) {
+	for patternIndex := range patterns {
+		pattern := &patterns[patternIndex]
+		if !pattern.GitPattern || !patternHasMatchDirectory(*pattern) {
+			continue
+		}
+		pattern.gitScope = unmatchedGitScope
+		scope := collectedGitignoreScope{
+			matchDirectory:    pattern.MatchDirectory,
+			physicalDirectory: pattern.PhysicalMatchDirectory,
+			lexicalDirectory:  pattern.LexicalMatchDirectory,
+			caseInsensitive:   pattern.CaseInsensitive,
+		}
+		if scope.lexicalDirectory == "" {
+			scope.lexicalDirectory = scope.matchDirectory
+		}
+		if scope.physicalDirectory == "" {
+			scope.physicalDirectory = scope.matchDirectory
+		}
+		for scopeIndex, candidate := range scopes {
+			if candidate == scope {
+				pattern.gitScope = uint32(scopeIndex + 1)
+				break
+			}
+		}
+	}
 }
 
 // parseCollectedGitignorePatterns projects collected Git patterns onto the
@@ -152,6 +372,9 @@ func parseCollectedGitignorePatterns(collected []gitignore.Pattern, caseInsensit
 		pattern.GitPattern = true
 		pattern.GitDirectoryOnly = source.DirectoryOnly
 		pattern.GitContentsOnly = source.ContentsOnly
+		pattern.MatchDirectory = source.MatchDirectory
+		pattern.PhysicalMatchDirectory = source.PhysicalMatchDirectory
+		pattern.LexicalMatchDirectory = source.LexicalMatchDirectory
 		if caseInsensitive {
 			// Git patterns are immutable after parsing. Fold them once here;
 			// the per-file matcher then only needs to fold the target path once,
@@ -175,12 +398,23 @@ func parseCollectedGitignorePatterns(collected []gitignore.Pattern, caseInsensit
 // lexical path space. This keeps Git source lookup stable when the config root
 // and target use different symlink, casing, or canonical spellings.
 func ResolveGitignoreCollectionPath(filePath string, canonicalPath string, configDir string, fsys vfs.FS) string {
-	filePath = tspath.NormalizePath(filePath)
-	matchFile, matchDir := ResolveConfigPathSpaceWithCanonical(filePath, canonicalPath, configDir, fsys)
+	return resolveGitignoreCollectionTargetPath(DiscoveredLintTarget{
+		Path:          filePath,
+		CanonicalPath: canonicalPath,
+	}, configDir, fsys)
+}
+
+func resolveGitignoreCollectionTargetPath(
+	target DiscoveredLintTarget,
+	configDir string,
+	fsys vfs.FS,
+) string {
+	target.Path = tspath.NormalizePath(target.Path)
+	matchFile, matchDir := ResolveConfigFilePathSpaceForTarget(target, configDir, fsys)
 	if relative, ok := RelativePathWithinConfigRoot(matchFile, matchDir, true); ok {
 		return tspath.ResolvePath(configDir, relative)
 	}
-	return filePath
+	return target.Path
 }
 
 // ResolveGitignoreCollectionDirectory is the directory-target form of
@@ -189,7 +423,7 @@ func ResolveGitignoreCollectionPath(filePath string, canonicalPath string, confi
 // config-owned tree.
 func ResolveGitignoreCollectionDirectory(directory string, configDir string, fsys vfs.FS) string {
 	directory = tspath.NormalizePath(directory)
-	matchDirectory, matchConfigDir := ResolveConfigPathSpace(directory, configDir, fsys)
+	matchDirectory, matchConfigDir := ResolveConfigDirectoryPathSpace(directory, configDir, fsys)
 	if relative, ok := RelativePathWithinConfigRoot(matchDirectory, matchConfigDir, true); ok {
 		return tspath.ResolvePath(configDir, relative)
 	}

--- a/internal/config/gitignore_match_directory_test.go
+++ b/internal/config/gitignore_match_directory_test.go
@@ -1,0 +1,574 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/config/gitignore"
+)
+
+type gitignoreReadSpyFS struct {
+	vfs.FS
+	reads []string
+}
+
+func (fsys *gitignoreReadSpyFS) ReadFile(path string) (string, bool) {
+	fsys.reads = append(fsys.reads, tspath.NormalizePath(path))
+	return fsys.FS.ReadFile(path)
+}
+
+func TestCollectedGitignoreUsesItsOwnMatchDirectory(t *testing.T) {
+	config := ConfigWithCollectedGitignore(
+		RslintConfig{
+			{Ignores: []string{"../workspace/config-ignored.ts"}},
+			{Rules: Rules{"rule": "error"}},
+		},
+		[]gitignore.Pattern{{
+			Glob:           "git-ignored.ts",
+			NodeGlob:       "git-ignored.ts",
+			MatchDirectory: "/repo/workspace",
+		}},
+		false,
+	)
+
+	for _, test := range []struct {
+		name    string
+		path    string
+		ignored bool
+	}{
+		{name: "Git pattern uses invocation root", path: "/repo/workspace/git-ignored.ts", ignored: true},
+		{name: "authored ignore uses config directory", path: "/repo/workspace/config-ignored.ts", ignored: true},
+		{name: "same basename outside Git-ignore root", path: "/repo/config/git-ignored.ts", ignored: false},
+		{name: "visible target", path: "/repo/workspace/visible.ts", ignored: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := config.IsFileIgnored(test.path, "/repo/config"); got != test.ignored {
+				t.Fatalf("IsFileIgnored(%q) = %t, want %t", test.path, got, test.ignored)
+			}
+		})
+	}
+}
+
+func TestCollectedGitignoreUsesConfigMatchSpaceBeforeLexicalFallback(t *testing.T) {
+	config := ConfigWithCollectedGitignore(
+		RslintConfig{{Rules: Rules{"rule": "error"}}},
+		[]gitignore.Pattern{{
+			Glob:                  "ignored.js",
+			NodeGlob:              "ignored.js",
+			MatchDirectory:        "/physical/workspace",
+			LexicalMatchDirectory: "/repo/workspace",
+		}},
+		false,
+	)
+
+	if !config.IsFileIgnored("/physical/workspace/ignored.js", "/physical/config") {
+		t.Fatal("Git pattern did not match the config-space projection")
+	}
+	if !config.IsFileIgnored("/repo/workspace/ignored.js", "/repo/config-link") {
+		t.Fatal("Git pattern lost its lexical compatibility fallback")
+	}
+	if config.IsFileIgnored("/physical/config/ignored.js", "/physical/config") {
+		t.Fatal("Git pattern escaped its projected invocation root")
+	}
+}
+
+func TestCollectedGitignoreMatchDirectoryIsCaseInsensitiveOnWindows(t *testing.T) {
+	config := ConfigWithCollectedGitignore(
+		RslintConfig{{Rules: Rules{"rule": "error"}}},
+		[]gitignore.Pattern{{
+			Glob:           "src/generated.ts",
+			NodeGlob:       "src/generated.ts",
+			MatchDirectory: "C:/Repo/Workspace",
+		}},
+		true,
+	)
+
+	if !config.IsFileIgnored("c:/repo/workspace/SRC/GENERATED.TS", "D:/Config") {
+		t.Fatal("case-insensitive Git pattern did not match the Windows path alias")
+	}
+	if config.IsFileIgnored("D:/Config/src/generated.ts", "D:/Config") {
+		t.Fatal("Git pattern escaped its Windows drive/root")
+	}
+}
+
+func TestCollectedGitignoreMatchDirectoryControlsDirectoryPruning(t *testing.T) {
+	config := ConfigWithCollectedGitignore(
+		RslintConfig{{Rules: Rules{"rule": "error"}}},
+		[]gitignore.Pattern{{
+			Glob:           "generated/**/*",
+			NodeGlob:       "generated",
+			DirectoryOnly:  true,
+			MatchDirectory: "/repo/workspace",
+		}},
+		false,
+	)
+	resolver := newConfigTargetResolver(config, "/repo/config", nil)
+	if !resolver.canPruneDirectory("/repo/workspace/generated", "") {
+		t.Fatal("Git-ignore-rooted directory was not pruned")
+	}
+	if resolver.canPruneDirectory("/repo/config/generated", "") {
+		t.Fatal("same relative directory outside the Git-ignore root was pruned")
+	}
+}
+
+func TestCollectedGitignoreChoosesOneAuthoritativeScope(t *testing.T) {
+	root := t.TempDir()
+	physicalRoot := tspath.NormalizePath(filepath.Join(root, "physical"))
+	physicalChild := tspath.CombinePaths(physicalRoot, "child")
+	aliasRoot := tspath.NormalizePath(filepath.Join(root, "alias-root"))
+	aliasChild := tspath.NormalizePath(filepath.Join(root, "alias-child"))
+	for _, directory := range []string{physicalChild, tspath.CombinePaths(physicalChild, "nested")} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	target := tspath.CombinePaths(physicalChild, "ignored.ts")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalRoot, aliasRoot); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	if err := os.Symlink(physicalChild, aliasChild); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	first := CollectedGitignorePatternsForRoot([]gitignore.Pattern{{
+		Glob:     "child/ignored.ts",
+		NodeGlob: "child/ignored.ts",
+	}}, "/config", aliasRoot, osvfs.FS())
+	second := CollectedGitignorePatternsForRoot([]gitignore.Pattern{{
+		Glob:     "ignored.ts",
+		NodeGlob: "ignored.ts",
+		Negated:  true,
+	}}, "/config", aliasChild, osvfs.FS())
+	effective := ConfigWithCollectedGitignoreScopes(
+		RslintConfig{{Rules: Rules{"rule": "error"}}},
+		append(first, second...),
+		[]string{aliasRoot, aliasChild},
+		"/config",
+		osvfs.FS(),
+		false,
+	)
+
+	// The physical spelling falls under both physical roots. Stable scope order
+	// assigns it to aliasRoot, so aliasChild's negation cannot override it.
+	resolver := newConfigTargetResolver(effective, "/config", osvfs.FS())
+	if !resolver.resolve(target, osvfs.FS().Realpath(target)).globallyIgnored {
+		t.Fatal("physical target borrowed patterns from more than one Git scope")
+	}
+}
+
+func TestConfigWithGitignoreForTargetsKeepsEmptyAliasScopeAuthoritative(t *testing.T) {
+	root := t.TempDir()
+	invocationRoot := tspath.NormalizePath(filepath.Join(root, "invocation"))
+	physicalRoot := tspath.NormalizePath(filepath.Join(root, "physical"))
+	aliasDirectory := tspath.CombinePaths(invocationRoot, "link")
+	configDirectory := tspath.NormalizePath(filepath.Join(root, "config"))
+	for _, directory := range []string{invocationRoot, physicalRoot, configDirectory} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(physicalRoot, aliasDirectory); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(physicalRoot, ".gitignore"), []byte("ignored.ts\nblocked/\nreopen/*\n!reopen/keep/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		tspath.CombinePaths(physicalRoot, "ignored.ts"),
+		tspath.CombinePaths(physicalRoot, "blocked", "file.ts"),
+		tspath.CombinePaths(physicalRoot, "reopen", "keep", "file.ts"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	effective := ConfigWithGitignoreForTargetsFromRoot(
+		RslintConfig{{Rules: Rules{"rule": "error"}}},
+		configDirectory,
+		invocationRoot,
+		osvfs.FS(),
+		nil,
+		[]string{invocationRoot, physicalRoot},
+	)
+	resolver := newConfigTargetResolver(effective, configDirectory, osvfs.FS())
+	physicalIgnored := tspath.CombinePaths(physicalRoot, "ignored.ts")
+	aliasIgnored := tspath.CombinePaths(aliasDirectory, "ignored.ts")
+	if !resolver.resolve(physicalIgnored, physicalIgnored).globallyIgnored {
+		t.Fatal("physical scope did not apply its own .gitignore")
+	}
+	if resolver.resolve(aliasIgnored, physicalIgnored).globallyIgnored {
+		t.Fatal("empty lexical scope borrowed an aliased physical scope's .gitignore")
+	}
+
+	physicalBlocked := tspath.CombinePaths(physicalRoot, "blocked")
+	aliasBlocked := tspath.CombinePaths(aliasDirectory, "blocked")
+	if !resolver.canPruneDirectory(physicalBlocked, physicalBlocked) {
+		t.Fatal("physical scope did not prune its ignored directory")
+	}
+	if resolver.canPruneDirectory(aliasBlocked, physicalBlocked) {
+		t.Fatal("directory pruning crossed from the physical scope into the empty alias scope")
+	}
+	physicalKeep := tspath.CombinePaths(physicalRoot, "reopen", "keep")
+	aliasKeep := tspath.CombinePaths(aliasDirectory, "reopen", "keep")
+	if !resolver.reopensDirectory(physicalKeep, physicalKeep) {
+		t.Fatal("physical scope did not apply its own Git negation")
+	}
+	if resolver.reopensDirectory(aliasKeep, physicalKeep) {
+		t.Fatal("directory reopening crossed from the physical scope into the empty alias scope")
+	}
+}
+
+func TestGitignoreCollectionPruningUsesEachConfigEntryAuthoredBase(t *testing.T) {
+	root := t.TempDir()
+	configDirectory := tspath.NormalizePath(filepath.Join(root, "config"))
+	invocationRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	blockedDirectory := tspath.CombinePaths(invocationRoot, "blocked")
+	for _, directory := range []string{configDirectory, blockedDirectory} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	blockedGitignore := tspath.CombinePaths(blockedDirectory, ".gitignore")
+	if err := os.WriteFile(blockedGitignore, []byte("ignored.ts\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tspath.CombinePaths(blockedDirectory, "ignored.ts"), []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inlineOverride := ConfigWithAuthoredPathBase(
+		RslintConfig{{Ignores: []string{"blocked/**"}}},
+		invocationRoot,
+	)
+	entries := append(
+		RslintConfig{{Rules: Rules{"no-debugger": "error"}}},
+		inlineOverride...,
+	)
+	spy := &gitignoreReadSpyFS{FS: osvfs.FS()}
+	_ = ConfigWithGitignoreForTargetsFromRoot(
+		entries,
+		configDirectory,
+		invocationRoot,
+		spy,
+		nil,
+		[]string{invocationRoot},
+	)
+	for _, read := range spy.reads {
+		if read == blockedGitignore {
+			t.Fatal("collection rebased an invocation-authored ignore to the external config directory")
+		}
+	}
+}
+
+func TestCollectedGitignoreScopesStayIndependentOnWindowsAndUNCPaths(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		firstRoot     string
+		secondRoot    string
+		firstTarget   string
+		secondTarget  string
+		caseSensitive bool
+	}{
+		{
+			name:         "Windows drive and case",
+			firstRoot:    "C:/Repo/One",
+			secondRoot:   "D:/Repo/Two",
+			firstTarget:  "c:/repo/one/SHARED.TS",
+			secondTarget: "d:/repo/two/SHARED.TS",
+		},
+		{
+			name:          "UNC shares",
+			firstRoot:     "//server/share-one/repo",
+			secondRoot:    "//server/share-two/repo",
+			firstTarget:   "//server/share-one/repo/shared.ts",
+			secondTarget:  "//server/share-two/repo/shared.ts",
+			caseSensitive: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			patterns := []gitignore.Pattern{
+				{Glob: "shared.ts", NodeGlob: "shared.ts", MatchDirectory: test.firstRoot},
+				{Glob: "shared.ts", NodeGlob: "shared.ts", Negated: true, MatchDirectory: test.secondRoot},
+			}
+			effective := ConfigWithCollectedGitignoreScopes(
+				RslintConfig{{Rules: Rules{"rule": "error"}}},
+				patterns,
+				[]string{test.firstRoot, test.secondRoot},
+				"C:/config",
+				nil,
+				!test.caseSensitive,
+			)
+			if !effective.IsFileIgnored(test.firstTarget, "C:/config") {
+				t.Fatal("first scope lost its positive pattern")
+			}
+			if effective.IsFileIgnored(test.secondTarget, "C:/config") {
+				t.Fatal("a positive pattern crossed into the second scope")
+			}
+		})
+	}
+}
+
+func TestConfigWithGitignoreForTargetsUsesExternalScanRoot(t *testing.T) {
+	root := t.TempDir()
+	configDir := tspath.NormalizePath(filepath.Join(root, "config"))
+	scanRoot := tspath.NormalizePath(filepath.Join(root, "workspace"))
+	for _, directory := range []string{configDir, scanRoot} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	visible := tspath.CombinePaths(scanRoot, "visible.js")
+	ignored := tspath.CombinePaths(scanRoot, "ignored.js")
+	for _, filePath := range []string{visible, ignored} {
+		if err := os.WriteFile(filePath, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(scanRoot, ".gitignore"), []byte("ignored.js\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := ConfigWithGitignoreForTargetsFromRoot(
+		RslintConfig{{
+			Files: []string{"../workspace/*.js"},
+			Rules: Rules{"no-debugger": "error"},
+		}},
+		configDir,
+		scanRoot,
+		osvfs.FS(),
+		[]string{visible, ignored},
+		nil,
+	)
+	resolver := newConfigTargetResolver(entries, configDir, osvfs.FS())
+	if decision := resolver.resolve(ignored, ""); !decision.globallyIgnored {
+		t.Fatalf("external scan-root Git ignore did not exclude %q: %+v", ignored, decision)
+	}
+	if decision := resolver.resolve(visible, ""); decision.globallyIgnored || !decision.selected {
+		t.Fatalf("external scan-root visible target was not selected: %+v", decision)
+	}
+}
+
+func TestConfigWithGitignoreForTargetsMatchesPhysicalAndLexicalScanRoots(t *testing.T) {
+	configDir := tspath.NormalizePath(t.TempDir())
+	physicalScanRoot := tspath.NormalizePath(t.TempDir())
+	aliasScanRoot := tspath.CombinePaths(tspath.NormalizePath(t.TempDir()), "workspace-alias")
+	if err := os.Symlink(physicalScanRoot, aliasScanRoot); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	physicalIgnored := tspath.CombinePaths(physicalScanRoot, "ignored.js")
+	aliasIgnored := tspath.CombinePaths(aliasScanRoot, "ignored.js")
+	configVisible := tspath.CombinePaths(configDir, "ignored.js")
+	for _, filePath := range []string{physicalIgnored, configVisible} {
+		if err := os.WriteFile(filePath, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(aliasScanRoot, ".gitignore"), []byte("ignored.js\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	physicalIgnored = tspath.NormalizePath(osvfs.FS().Realpath(physicalIgnored))
+
+	entries := ConfigWithGitignoreForTargetsFromRoot(
+		RslintConfig{{Rules: Rules{"no-debugger": "error"}}},
+		configDir,
+		aliasScanRoot,
+		osvfs.FS(),
+		[]string{physicalIgnored},
+		nil,
+	)
+	resolver := newConfigTargetResolver(entries, configDir, osvfs.FS())
+	for _, filePath := range []string{physicalIgnored, aliasIgnored} {
+		if decision := resolver.resolve(filePath, ""); !decision.globallyIgnored {
+			t.Fatalf("Git ignore did not cover scan-root identity %q: %+v", filePath, decision)
+		}
+	}
+	if decision := resolver.resolve(configVisible, ""); decision.globallyIgnored {
+		t.Fatalf("Git ignore escaped the scan root onto %q: %+v", configVisible, decision)
+	}
+}
+
+func TestConfigWithGitignoreForTargetsRequestedPhysicalAncestorStartsIndependentScope(t *testing.T) {
+	physicalParent := tspath.NormalizePath(t.TempDir())
+	physicalWorkspace := tspath.CombinePaths(physicalParent, "workspace")
+	if err := os.MkdirAll(physicalWorkspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasWorkspace := tspath.CombinePaths(tspath.NormalizePath(t.TempDir()), "workspace-alias")
+	if err := os.Symlink(physicalWorkspace, aliasWorkspace); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	sibling := tspath.CombinePaths(physicalParent, "sibling.ts")
+	if err := os.WriteFile(sibling, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		tspath.CombinePaths(physicalParent, ".gitignore"),
+		[]byte("sibling.ts\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	effective := ConfigWithGitignoreForTargetsFromRoot(
+		RslintConfig{{Rules: Rules{"no-debugger": "error"}}},
+		aliasWorkspace,
+		aliasWorkspace,
+		osvfs.FS(),
+		nil,
+		[]string{physicalParent},
+	)
+	resolver := newConfigTargetResolver(effective, aliasWorkspace, osvfs.FS())
+	if decision := resolver.resolve(sibling, tspath.NormalizePath(osvfs.FS().Realpath(sibling))); !decision.globallyIgnored {
+		t.Fatalf("requested physical ancestor lost its own Git scope: %+v", decision)
+	}
+}
+
+func TestExternalConfigGitignoreMatchesRawLexicalTargetBeforeOwnerProjection(t *testing.T) {
+	root := tspath.NormalizePath(t.TempDir())
+	scanRoot := tspath.CombinePaths(root, "workspace")
+	configDir := tspath.CombinePaths(root, "physical", "package")
+	physicalTargetDir := tspath.CombinePaths(configDir, "src")
+	aliasTargetDir := tspath.CombinePaths(scanRoot, "linked-src")
+	for _, directory := range []string{scanRoot, physicalTargetDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(physicalTargetDir, aliasTargetDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	physicalTarget := tspath.CombinePaths(physicalTargetDir, "ignored.js")
+	aliasTarget := tspath.CombinePaths(aliasTargetDir, "ignored.js")
+	physicalGeneratedDir := tspath.CombinePaths(physicalTargetDir, "generated")
+	aliasGeneratedDir := tspath.CombinePaths(aliasTargetDir, "generated")
+	physicalReopenedDir := tspath.CombinePaths(physicalTargetDir, "reopened")
+	aliasReopenedDir := tspath.CombinePaths(aliasTargetDir, "reopened")
+	for _, directory := range []string{physicalGeneratedDir, physicalReopenedDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(physicalTarget, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(scanRoot, ".gitignore"),
+		[]byte("linked-src/ignored.js\nlinked-src/generated/\n!linked-src/reopened/\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := ConfigWithGitignoreForTargetsFromRoot(
+		RslintConfig{{
+			Files: []string{"src/**/*.js"},
+			Rules: Rules{"no-debugger": "error"},
+		}},
+		configDir,
+		scanRoot,
+		osvfs.FS(),
+		[]string{aliasTarget},
+		[]string{aliasTargetDir},
+	)
+	resolver := newConfigTargetResolver(entries, configDir, osvfs.FS())
+	canonicalTarget := tspath.NormalizePath(osvfs.FS().Realpath(aliasTarget))
+	if decision := resolver.resolve(aliasTarget, canonicalTarget); !decision.globallyIgnored {
+		t.Fatalf("Git ignore lost the caller-visible symlink path: %+v", decision)
+	}
+	if decision := resolver.resolve(physicalTarget, physicalTarget); decision.globallyIgnored {
+		t.Fatalf("lexical Git pattern leaked onto the physical target spelling: %+v", decision)
+	}
+	canonicalGeneratedDir := tspath.NormalizePath(osvfs.FS().Realpath(aliasGeneratedDir))
+	if !resolver.canPruneDirectory(aliasGeneratedDir, canonicalGeneratedDir) {
+		t.Fatal("Git directory pattern lost the caller-visible symlink path while pruning")
+	}
+	if resolver.canPruneDirectory(physicalGeneratedDir, physicalGeneratedDir) {
+		t.Fatal("lexical Git directory pattern leaked onto the physical directory spelling")
+	}
+	canonicalReopenedDir := tspath.NormalizePath(osvfs.FS().Realpath(aliasReopenedDir))
+	if !resolver.reopensDirectory(aliasReopenedDir, canonicalReopenedDir) {
+		t.Fatal("Git negation lost the caller-visible symlink path while reopening")
+	}
+	if resolver.reopensDirectory(physicalReopenedDir, physicalReopenedDir) {
+		t.Fatal("lexical Git negation leaked onto the physical directory spelling")
+	}
+}
+
+func TestExternalGitignoreDistinguishesFileAndDirectorySymlinks(t *testing.T) {
+	root := tspath.NormalizePath(t.TempDir())
+	gitRoot := tspath.CombinePaths(root, "workspace")
+	configDir := tspath.CombinePaths(root, "config")
+	outsideDir := tspath.CombinePaths(root, "outside")
+	physicalDirectoryTarget := tspath.CombinePaths(gitRoot, "generated")
+	for _, directory := range []string{gitRoot, configDir, outsideDir, physicalDirectoryTarget} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	physicalFileTarget := tspath.CombinePaths(gitRoot, "ignored.js")
+	visibleTarget := tspath.CombinePaths(gitRoot, "visible.js")
+	physicalDirectoryFile := tspath.CombinePaths(physicalDirectoryTarget, "nested.js")
+	for _, filePath := range []string{physicalFileTarget, visibleTarget, physicalDirectoryFile} {
+		if err := os.WriteFile(filePath, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(
+		filepath.Join(gitRoot, ".gitignore"),
+		[]byte("ignored.js\ngenerated/\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	fileAlias := tspath.CombinePaths(outsideDir, "file-alias.js")
+	directoryAlias := tspath.CombinePaths(outsideDir, "directory-alias")
+	if err := os.Symlink(physicalFileTarget, fileAlias); err != nil {
+		t.Skipf("file symlink unavailable: %v", err)
+	}
+	if err := os.Symlink(physicalDirectoryTarget, directoryAlias); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	directoryAliasFile := tspath.CombinePaths(directoryAlias, "nested.js")
+
+	entries := ConfigWithGitignoreForTargetsFromRoot(
+		RslintConfig{{Rules: Rules{"no-debugger": "error"}}},
+		configDir,
+		gitRoot,
+		osvfs.FS(),
+		[]string{visibleTarget, fileAlias, directoryAliasFile},
+		nil,
+	)
+	resolver := newConfigTargetResolver(entries, configDir, osvfs.FS())
+	if decision := resolver.resolve(physicalFileTarget, physicalFileTarget); !decision.globallyIgnored {
+		t.Fatalf("Git rule did not ignore its physical in-root target: %+v", decision)
+	}
+	if decision := resolver.resolve(
+		fileAlias,
+		tspath.NormalizePath(osvfs.FS().Realpath(fileAlias)),
+	); decision.globallyIgnored {
+		t.Fatalf("Git rule escaped its root through an external file symlink: %+v", decision)
+	}
+	if decision := resolver.resolve(
+		directoryAliasFile,
+		tspath.NormalizePath(osvfs.FS().Realpath(directoryAliasFile)),
+	); !decision.globallyIgnored {
+		t.Fatalf("Git rule lost a verified directory-alias target: %+v", decision)
+	}
+	if !resolver.canPruneDirectory(
+		directoryAlias,
+		tspath.NormalizePath(osvfs.FS().Realpath(directoryAlias)),
+	) {
+		t.Fatal("Git rule did not prune a verified directory alias into its root")
+	}
+}

--- a/internal/config/gitignore_scope.go
+++ b/internal/config/gitignore_scope.go
@@ -1,0 +1,231 @@
+package config
+
+import (
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/web-infra-dev/rslint/internal/config/gitignore"
+)
+
+// GitignoreCollectionScope is one independent lexical root used to collect Git
+// ignore sources for an invocation-wide config. Targets representable in the
+// invocation cwd share that root. A requested directory outside cwd starts its
+// own root. Exact files outside every supplied directory scope do not invent a
+// new Git boundary; they retain the established cwd-bounded policy. This keeps
+// multiple sibling directory targets independent without changing the authored
+// base of the governing rslint config.
+type GitignoreCollectionScope struct {
+	Root        string
+	Files       []string
+	Directories []string
+}
+
+// PlanGitignoreCollectionScopes converts one invocation cwd plus its target
+// union into deterministic Git collection roots. The cwd remains the implicit
+// full-scan root. Descendant and verified alias targets stay in that scope;
+// sibling directory targets get independent roots.
+func PlanGitignoreCollectionScopes(
+	defaultRoot string,
+	fsys vfs.FS,
+	targetFiles []string,
+	targetDirectories []string,
+) []GitignoreCollectionScope {
+	defaultRoot = tspath.NormalizePath(defaultRoot)
+	useCaseSensitive := fsys == nil || fsys.UseCaseSensitiveFileNames()
+	pathID := func(path string) tspath.Path {
+		return tspath.ToPath(tspath.NormalizePath(path), "", useCaseSensitive)
+	}
+
+	var defaultScope *GitignoreCollectionScope
+	ensureDefaultScope := func() *GitignoreCollectionScope {
+		if defaultScope == nil {
+			defaultScope = &GitignoreCollectionScope{Root: defaultRoot}
+		}
+		return defaultScope
+	}
+	if targetFiles == nil && targetDirectories == nil {
+		ensureDefaultScope()
+	}
+
+	scopeByRoot := make(map[tspath.Path]*GitignoreCollectionScope)
+	outsideScopes := make([]*GitignoreCollectionScope, 0, len(targetDirectories))
+	ensureOutsideScope := func(root string) *GitignoreCollectionScope {
+		root = tspath.NormalizePath(root)
+		identity := pathID(root)
+		if scope := scopeByRoot[identity]; scope != nil {
+			return scope
+		}
+		scope := &GitignoreCollectionScope{Root: root}
+		scopeByRoot[identity] = scope
+		outsideScopes = append(outsideScopes, scope)
+		return scope
+	}
+
+	for _, directory := range coalesceRequestedDirectories(targetDirectories, fsys) {
+		if directoryWithinGitignoreRoot(
+			directory.lexicalPath,
+			directory.canonicalPath,
+			defaultRoot,
+			fsys,
+			useCaseSensitive,
+		) {
+			scope := ensureDefaultScope()
+			scope.Directories = appendUniquePath(scope.Directories, directory.lexicalPath, pathID)
+			continue
+		}
+		scope := ensureOutsideScope(directory.lexicalPath)
+		scope.Directories = appendUniquePath(scope.Directories, directory.lexicalPath, pathID)
+	}
+
+	sort.Slice(outsideScopes, func(i, j int) bool {
+		return outsideScopes[i].Root < outsideScopes[j].Root
+	})
+	for _, file := range targetFiles {
+		file = tspath.NormalizePath(file)
+		if collectionPathWithinGitignoreRoot(file, defaultRoot, fsys, useCaseSensitive) {
+			scope := ensureDefaultScope()
+			scope.Files = appendUniquePath(scope.Files, file, pathID)
+			continue
+		}
+
+		var selected *GitignoreCollectionScope
+		for _, scope := range outsideScopes {
+			if _, within := RelativePathWithinConfigRoot(file, scope.Root, useCaseSensitive); within {
+				selected = scope
+				break
+			}
+		}
+		if selected == nil {
+			for _, scope := range outsideScopes {
+				if collectionPathWithinGitignoreRoot(file, scope.Root, fsys, useCaseSensitive) {
+					selected = scope
+					break
+				}
+			}
+		}
+		if selected == nil {
+			continue
+		}
+		selected.Files = appendUniquePath(selected.Files, file, pathID)
+	}
+
+	scopes := make([]GitignoreCollectionScope, 0, len(outsideScopes)+1)
+	if defaultScope != nil {
+		scopes = append(scopes, *defaultScope)
+	}
+	for _, scope := range outsideScopes {
+		if defaultScope != nil && pathID(scope.Root) == pathID(defaultScope.Root) {
+			continue
+		}
+		scopes = append(scopes, *scope)
+	}
+	return scopes
+}
+
+func directoryWithinGitignoreRoot(
+	lexicalDirectory string,
+	canonicalDirectory string,
+	root string,
+	fsys vfs.FS,
+	useCaseSensitive bool,
+) bool {
+	if _, within := RelativePathWithinConfigRoot(
+		lexicalDirectory,
+		root,
+		useCaseSensitive,
+	); within {
+		return true
+	}
+	if fsys == nil {
+		return false
+	}
+	physicalRoot := fsys.Realpath(root)
+	if physicalRoot == "" {
+		return false
+	}
+	physicalRoot = tspath.NormalizePath(physicalRoot)
+	if canonicalDirectory == "" {
+		canonicalDirectory = fsys.Realpath(lexicalDirectory)
+	}
+	if canonicalDirectory == "" {
+		return false
+	}
+	_, within := RelativePathWithinConfigRoot(
+		tspath.NormalizePath(canonicalDirectory),
+		physicalRoot,
+		useCaseSensitive,
+	)
+	return within
+}
+
+func collectionPathWithinGitignoreRoot(
+	filePath string,
+	root string,
+	fsys vfs.FS,
+	useCaseSensitive bool,
+) bool {
+	collectionPath := ResolveGitignoreCollectionPath(filePath, "", root, fsys)
+	_, within := RelativePathWithinConfigRoot(collectionPath, root, useCaseSensitive)
+	return within
+}
+
+func appendUniquePath(
+	paths []string,
+	path string,
+	pathID func(string) tspath.Path,
+) []string {
+	identity := pathID(path)
+	for _, existing := range paths {
+		if pathID(existing) == identity {
+			return paths
+		}
+	}
+	return append(paths, tspath.NormalizePath(path))
+}
+
+// CollectedGitignorePatternsForRoot binds one collected pattern group to the
+// exact lexical, physical, and config-projected identities of its Git root.
+// Keeping all three explicit lets final matching, pruning, and reopening use
+// the same target/root pair without rebasing the config entry itself.
+func CollectedGitignorePatternsForRoot(
+	patterns []gitignore.Pattern,
+	configDirectory string,
+	gitignoreRoot string,
+	fsys vfs.FS,
+) []gitignore.Pattern {
+	if len(patterns) == 0 {
+		return nil
+	}
+	root := resolveCollectedGitignoreScope(configDirectory, gitignoreRoot, fsys, false)
+	bound := append([]gitignore.Pattern(nil), patterns...)
+	for index := range bound {
+		bound[index].MatchDirectory = root.matchDirectory
+		bound[index].PhysicalMatchDirectory = root.physicalDirectory
+		bound[index].LexicalMatchDirectory = root.lexicalDirectory
+	}
+	return bound
+}
+
+func resolveCollectedGitignoreScope(
+	configDirectory string,
+	gitignoreRoot string,
+	fsys vfs.FS,
+	caseInsensitive bool,
+) collectedGitignoreScope {
+	configDirectory = tspath.NormalizePath(configDirectory)
+	gitignoreRoot = tspath.NormalizePath(gitignoreRoot)
+	matchDirectory, _ := ResolveConfigDirectoryPathSpace(gitignoreRoot, configDirectory, fsys)
+	physicalDirectory := gitignoreRoot
+	if fsys != nil {
+		if realPath := fsys.Realpath(gitignoreRoot); realPath != "" {
+			physicalDirectory = tspath.NormalizePath(realPath)
+		}
+	}
+	return collectedGitignoreScope{
+		matchDirectory:    matchDirectory,
+		physicalDirectory: physicalDirectory,
+		lexicalDirectory:  gitignoreRoot,
+		caseInsensitive:   caseInsensitive,
+	}
+}

--- a/internal/config/ignore_pattern.go
+++ b/internal/config/ignore_pattern.go
@@ -13,24 +13,19 @@ import (
 // paths plus an optional canonical fallback; matcher internals stay private so
 // both discovery flows cannot accidentally diverge on ignore semantics.
 type GlobalIgnoreMatcher struct {
-	configDir string
-	fs        vfs.FS
-	patterns  []IgnorePattern
+	resolver *configTargetResolver
 }
 
 func NewGlobalIgnoreMatcher(config RslintConfig, configDir string, fsys vfs.FS) GlobalIgnoreMatcher {
 	return GlobalIgnoreMatcher{
-		configDir: tspath.NormalizePath(configDir),
-		fs:        fsys,
-		patterns:  extractConfigIgnores(config),
+		resolver: newConfigTargetResolver(config, configDir, fsys),
 	}
 }
 
 // BlocksDirectory reports whether global ignores form an absolute traversal
 // boundary at directory.
 func (matcher GlobalIgnoreMatcher) BlocksDirectory(directory string, canonicalDirectory string) bool {
-	relative, ok := matcher.relativePath(directory, canonicalDirectory)
-	return ok && len(matcher.patterns) > 0 && isDirAbsolutelyBlocked(relative, matcher.patterns)
+	return matcher.resolver != nil && matcher.resolver.blocksDirectory(directory, canonicalDirectory)
 }
 
 // ReopensDirectoryNode reports whether the ordered authored global-ignore
@@ -42,50 +37,22 @@ func (matcher GlobalIgnoreMatcher) BlocksDirectory(directory string, canonicalDi
 // semantics and are checked by BlocksDirectory before callers consult this
 // method.
 func (matcher GlobalIgnoreMatcher) ReopensDirectoryNode(directory string, canonicalDirectory string) bool {
-	relative, ok := matcher.relativePath(directory, canonicalDirectory)
-	if !ok || len(matcher.patterns) == 0 {
-		return false
-	}
-	relative = strings.TrimSuffix(relative, "/")
-	reopened := false
-	for _, pattern := range matcher.patterns {
-		if ignorePatternMatches(pattern, relative) ||
-			ignorePatternMatches(pattern, relative+"/") {
-			reopened = pattern.Negated
-		}
-	}
-	return reopened
+	return matcher.resolver != nil && matcher.resolver.reopensDirectory(directory, canonicalDirectory)
 }
 
 // IgnoresPath reports whether global ignores exclude a config candidate.
 func (matcher GlobalIgnoreMatcher) IgnoresPath(filePath string, canonicalPath string) bool {
-	relative, ok := matcher.relativePath(filePath, canonicalPath)
-	if !ok || len(matcher.patterns) == 0 {
+	if matcher.resolver == nil {
 		return false
 	}
-	return isDirBlockedByIgnores(relative, matcher.patterns, "") ||
-		isFileIgnored(relative, matcher.patterns, "")
+	target, matches := matcher.resolver.resolvePathSpaces(filePath, canonicalPath, false)
+	return matcher.resolver.globallyIgnores(target, matches)
 }
 
-func (matcher GlobalIgnoreMatcher) relativePath(targetPath string, canonicalPath string) (string, bool) {
-	if matcher.configDir == "" {
-		return "", false
-	}
-	caseSensitive := matcher.fs == nil || matcher.fs.UseCaseSensitiveFileNames()
-	relative, ok := RelativePathWithinConfigRoot(targetPath, matcher.configDir, caseSensitive)
-	if !ok && canonicalPath != "" {
-		matchPath, matchConfigDir := ResolveConfigPathSpaceWithCanonical(
-			targetPath,
-			canonicalPath,
-			matcher.configDir,
-			matcher.fs,
-		)
-		relative, ok = RelativePathWithinConfigRoot(matchPath, matchConfigDir, true)
-	}
-	if !ok || relative == "" {
-		return "", false
-	}
-	return strings.ReplaceAll(tspath.NormalizePath(relative), "\\", "/"), true
+// IgnoresTarget evaluates a frozen file and parent identity without resolving
+// either target path through the filesystem again.
+func (matcher GlobalIgnoreMatcher) IgnoresTarget(target DiscoveredLintTarget) bool {
+	return matcher.resolver != nil && matcher.resolver.resolveTarget(target).globallyIgnored
 }
 
 // dirKind classifies an ignore pattern by how it bears on DIRECTORY decisions.
@@ -128,7 +95,22 @@ type IgnorePattern struct {
 	GitPattern       bool
 	GitDirectoryOnly bool
 	GitContentsOnly  bool
+	// MatchDirectory is the Git root projected into the config owner's match
+	// space. PhysicalMatchDirectory and LexicalMatchDirectory retain the Git
+	// root's own identities. Target matching pairs lexical-to-lexical and
+	// canonical-to-physical first, then uses the projected pair as a compatibility
+	// fallback; it never mixes an arbitrary target identity with an unrelated
+	// root identity.
+	MatchDirectory         string
+	PhysicalMatchDirectory string
+	LexicalMatchDirectory  string
+	// gitScope is the one-based index of the active collection scope that
+	// supplied this Git pattern. Zero is reserved for authored/unscoped ignore
+	// patterns. It is process-local matcher metadata and is never serialized.
+	gitScope uint32
 }
+
+const unmatchedGitScope = ^uint32(0)
 
 // ParseIgnorePattern parses one raw ignore string (user config or a
 // gitignore-converted glob) into the structured form. This is the SINGLE place
@@ -203,8 +185,20 @@ func isFileIgnored(filePath string, patterns []IgnorePattern, cwd string) bool {
 }
 
 func (path *fileMatchPath) isIgnored(patterns []IgnorePattern) bool {
+	return path.applyIgnorePatterns(patterns, false)
+}
+
+// applyIgnorePatterns applies one ordered pattern segment on top of an
+// existing ignore state. This is used when a flat config contains global
+// ignore entries authored from different base directories: each segment gets
+// its own target-relative path, while later matches still override earlier
+// segments exactly as one flat ordered list would.
+func (path *fileMatchPath) applyIgnorePatterns(patterns []IgnorePattern, ignored bool) bool {
 	if len(patterns) == 0 {
-		return false
+		return ignored
+	}
+	if hasPatternMatchDirectory(patterns) {
+		return path.applyIgnorePatternsAcrossMatchDirectories(patterns, ignored)
 	}
 	normalizedPath, unixPath := path.normalizedPaths()
 	if path.cwd != "" && pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
@@ -216,7 +210,222 @@ func (path *fileMatchPath) isIgnored(patterns []IgnorePattern) bool {
 		normalizedPath = normalizePathWithCaseSensitivity(path.original, path.cwd, false)
 		unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
 	}
-	return isFileIgnoredNormalized(normalizedPath, unixPath, patterns)
+	return applyFileIgnorePatternsNormalized(normalizedPath, unixPath, patterns, ignored)
+}
+
+func hasPatternMatchDirectory(patterns []IgnorePattern) bool {
+	for _, pattern := range patterns {
+		if patternHasMatchDirectory(pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func patternHasMatchDirectory(pattern IgnorePattern) bool {
+	return pattern.MatchDirectory != "" ||
+		pattern.PhysicalMatchDirectory != "" ||
+		pattern.LexicalMatchDirectory != ""
+}
+
+// applyIgnorePatternsAcrossMatchDirectories keeps the ordered flat-config ignore
+// sequence while evaluating each collected Git group in the path space where
+// it was authored. This is the uncommon explicit-config-outside-cwd path; the
+// ordinary single-directory path stays on isFileIgnoredNormalized above.
+func (path *fileMatchPath) applyIgnorePatternsAcrossMatchDirectories(patterns []IgnorePattern, ignored bool) bool {
+	return applyIgnorePatternsAcrossPathGroups(patterns, ignored, path.pathsForPatternGroup)
+}
+
+// applyIgnorePatternsAcrossPathGroups preserves the ordered ignore sequence
+// while letting the caller choose the target coordinate for each pattern
+// group. Config-authored patterns use their entry's projected path; collected
+// Git patterns use the original lint target relative to the Git root that
+// supplied the group.
+func applyIgnorePatternsAcrossPathGroups(
+	patterns []IgnorePattern,
+	ignored bool,
+	pathsForGroup func([]IgnorePattern) (string, string, bool),
+) bool {
+	for index := 0; index < len(patterns); {
+		pattern := patterns[index]
+		if pattern.GitPattern {
+			end := index + 1
+			for end < len(patterns) &&
+				patterns[end].GitPattern &&
+				patterns[end].gitScope == pattern.gitScope &&
+				patterns[end].MatchDirectory == pattern.MatchDirectory &&
+				patterns[end].PhysicalMatchDirectory == pattern.PhysicalMatchDirectory &&
+				patterns[end].LexicalMatchDirectory == pattern.LexicalMatchDirectory {
+				end++
+			}
+			normalizedPath, unixPath, ok := pathsForGroup(patterns[index:end])
+			if ok {
+				ignored = applyIgnorePatternGroup(
+					patterns[index:end],
+					normalizedPath,
+					unixPath,
+					ignored,
+				)
+			}
+			index = end
+			continue
+		}
+
+		normalizedPath, unixPath, ok := pathsForGroup(patterns[index : index+1])
+		if ok {
+			ignored = applyIgnorePatternGroup(
+				patterns[index:index+1],
+				normalizedPath,
+				unixPath,
+				ignored,
+			)
+		}
+		index++
+	}
+	return ignored
+}
+
+// applyIgnorePatternGroup evaluates one pre-grouped segment against a single
+// target coordinate. Collected Git rules share one path-state evaluation;
+// authored rules retain their ordered last-match-wins behavior.
+func applyIgnorePatternGroup(
+	patterns []IgnorePattern,
+	normalizedPath string,
+	unixPath string,
+	ignored bool,
+) bool {
+	if len(patterns) == 0 {
+		return ignored
+	}
+	if patterns[0].GitPattern {
+		gitState := newGitIgnorePathState(unixPath)
+		groupIgnored := gitState.evaluate(patterns)
+		if gitState.matched {
+			return groupIgnored
+		}
+		return ignored
+	}
+	for index := range patterns {
+		pattern := patterns[index]
+		matched := ignorePatternMatches(pattern, normalizedPath)
+		if !matched && unixPath != normalizedPath {
+			matched = ignorePatternMatches(pattern, unixPath)
+		}
+		if matched {
+			ignored = !pattern.Negated
+		}
+	}
+	return ignored
+}
+
+// pathsForGitPatternGroup derives one Git-relative target spelling directly
+// from the immutable lexical/canonical target pair. The caller-visible lexical
+// path wins whenever it is inside a verified identity of the Git root;
+// canonical identity is only a fallback. This prevents projection into a
+// config owner's path space from erasing a symlink component named by
+// .gitignore, while still supporting a Git root itself reached through an
+// alias.
+func pathsForGitPatternGroup(
+	lexicalPath string,
+	canonicalPath string,
+	projectedPath string,
+	patterns []IgnorePattern,
+) (string, string, bool) {
+	pattern := patterns[0]
+	lexicalRoot := pattern.LexicalMatchDirectory
+	if lexicalRoot == "" {
+		lexicalRoot = pattern.MatchDirectory
+	}
+	physicalRoot := pattern.PhysicalMatchDirectory
+	if physicalRoot == "" {
+		physicalRoot = pattern.MatchDirectory
+	}
+	candidates := [3]struct {
+		path string
+		root string
+	}{
+		{path: lexicalPath, root: lexicalRoot},
+		{path: canonicalPath, root: physicalRoot},
+		{path: projectedPath, root: pattern.MatchDirectory},
+	}
+	for index := range candidates {
+		candidate := candidates[index]
+		if candidate.path == "" || candidate.root == "" {
+			continue
+		}
+		duplicate := false
+		for previous := range index {
+			if candidates[previous] == candidate {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		matchPath := newFileMatchPath(candidate.path, candidate.root)
+		normalizedPath, unixPath := matchPath.normalizedPaths()
+		if pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
+			normalizedPath = normalizePathWithCaseSensitivity(candidate.path, candidate.root, false)
+			unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
+		}
+		if !pathEscapesCwd(unixPath) {
+			return normalizedPath, unixPath, true
+		}
+	}
+	return "", "", false
+}
+
+func (path *fileMatchPath) pathsForPatternGroup(patterns []IgnorePattern) (string, string, bool) {
+	if !patternHasMatchDirectory(patterns[0]) {
+		normalizedPath, unixPath := path.normalizedPaths()
+		if path.cwd != "" && pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
+			normalizedPath = normalizePathWithCaseSensitivity(path.original, path.cwd, false)
+			unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
+		}
+		return normalizedPath, unixPath, true
+	}
+
+	matchDirectories := patternMatchDirectories(patterns[0], path.cwd)
+	for index, directory := range matchDirectories {
+		if directory == "" || repeatedMatchDirectory(matchDirectories, index) {
+			continue
+		}
+		matchPath := newFileMatchPath(path.original, directory)
+		normalizedPath, unixPath := matchPath.normalizedPaths()
+		if pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
+			normalizedPath = normalizePathWithCaseSensitivity(path.original, directory, false)
+			unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
+		}
+		if !pathEscapesCwd(unixPath) {
+			return normalizedPath, unixPath, true
+		}
+	}
+	// A .gitignore rooted at one invocation directory never governs a target
+	// outside every verified identity of that directory. Authored config patterns retain
+	// the existing ability to select ../ paths because MatchDirectory is empty.
+	return "", "", false
+}
+
+func patternMatchDirectories(pattern IgnorePattern, defaultDirectory string) [3]string {
+	matchDirectory := pattern.MatchDirectory
+	if matchDirectory == "" {
+		matchDirectory = defaultDirectory
+	}
+	return [3]string{
+		matchDirectory,
+		pattern.PhysicalMatchDirectory,
+		pattern.LexicalMatchDirectory,
+	}
+}
+
+func repeatedMatchDirectory(directories [3]string, index int) bool {
+	for previous := range index {
+		if directories[previous] == directories[index] {
+			return true
+		}
+	}
+	return false
 }
 
 func pathEscapesCwd(path string) bool {
@@ -251,7 +460,10 @@ func isFileIgnoredSimple(filePath string, patterns []IgnorePattern) bool {
 }
 
 func isFileIgnoredNormalized(path string, unixPath string, patterns []IgnorePattern) bool {
-	ignored := false
+	return applyFileIgnorePatternsNormalized(path, unixPath, patterns, false)
+}
+
+func applyFileIgnorePatternsNormalized(path string, unixPath string, patterns []IgnorePattern, ignored bool) bool {
 	for index := 0; index < len(patterns); {
 		p := patterns[index]
 		if p.GitPattern {
@@ -331,7 +543,7 @@ func newGitIgnorePathState(path string) gitIgnorePathState {
 
 func (state *gitIgnorePathState) evaluate(patterns []IgnorePattern) bool {
 	for index := len(patterns) - 1; index >= 0 && state.unresolved > 0; index-- {
-		if state.apply(patterns[index]) {
+		if state.apply(&patterns[index]) {
 			return true
 		}
 	}
@@ -341,7 +553,7 @@ func (state *gitIgnorePathState) evaluate(patterns []IgnorePattern) bool {
 // apply reports whether pattern is the final positive decision for any still
 // unresolved path node. That is enough to ignore the target immediately:
 // reverse traversal guarantees no earlier rule can override that node.
-func (state *gitIgnorePathState) apply(pattern IgnorePattern) bool {
+func (state *gitIgnorePathState) apply(pattern *IgnorePattern) bool {
 	if state.fileDepth < 0 {
 		return false
 	}
@@ -399,7 +611,7 @@ func (state *gitIgnorePathState) apply(pattern IgnorePattern) bool {
 // basename glob against path components avoids repeatedly running a **/ glob
 // over growing full-path prefixes. A rooted "/**/name" rule has the same
 // config-root semantics and is safe to take through this path too.
-func gitIgnoreRootBasenameGlob(pattern IgnorePattern) (string, bool) {
+func gitIgnoreRootBasenameGlob(pattern *IgnorePattern) (string, bool) {
 	const prefix = "**/"
 	nodeGlob := gitIgnoreNodeGlob(pattern)
 	if !strings.HasPrefix(nodeGlob, prefix) ||
@@ -410,7 +622,7 @@ func gitIgnoreRootBasenameGlob(pattern IgnorePattern) (string, bool) {
 	return glob, glob != "" && !strings.Contains(glob, "/")
 }
 
-func (state *gitIgnorePathState) applyRootBasename(pattern IgnorePattern, path string, glob string) bool {
+func (state *gitIgnorePathState) applyRootBasename(pattern *IgnorePattern, path string, glob string) bool {
 	var end int
 	depth := state.fileDepth
 	if pattern.GitDirectoryOnly {
@@ -496,7 +708,7 @@ func (state *gitIgnorePathState) resolveDepth(depth int) {
 	state.resolvedDepthsOverflow[index] = true
 }
 
-func gitIgnorePatternMatchesNode(pattern IgnorePattern, path string) bool {
+func gitIgnorePatternMatchesNode(pattern *IgnorePattern, path string) bool {
 	if pattern.GitContentsOnly {
 		// Glob is NodeGlob with a required final component (/**/*), which
 		// expresses Git's true trailing-/** semantics without ambiguity when
@@ -506,7 +718,7 @@ func gitIgnorePatternMatchesNode(pattern IgnorePattern, path string) bool {
 	return utils.MatchGlob(gitIgnoreNodeGlob(pattern), path)
 }
 
-func gitIgnoreNodeGlob(pattern IgnorePattern) string {
+func gitIgnoreNodeGlob(pattern *IgnorePattern) string {
 	if pattern.GitNodeGlobEnd <= 0 || pattern.GitNodeGlobEnd > len(pattern.Glob) {
 		return ""
 	}

--- a/internal/config/lint_target_plan.go
+++ b/internal/config/lint_target_plan.go
@@ -10,52 +10,105 @@ import (
 // LintTargetPlan is the stable, config-owned projection of one lint target
 // discovery pass. Targets retain both the caller-visible lexical path and the
 // canonical filesystem identity established by discovery, together with the
-// config owner that selected them.
+// config owner that selected them. ExplicitFileOutcomes carries the same-pass
+// existence and ignore decisions needed for caller-facing skip messages.
 type LintTargetPlan struct {
-	Targets []DiscoveredLintTarget
+	Targets              []DiscoveredLintTarget
+	ExplicitFileOutcomes []ExplicitFileOutcome
+
+	frozenConfigBases map[string]configTargetBase
+}
+
+// LintTargetPlanRequest keeps the two directory roles explicit. ConfigDirectory
+// is the base for authored files/ignores content and the owner recorded
+// on every target. ScanRoot is the filesystem root searched for a single
+// invocation-wide config; when empty it defaults to ConfigDirectory. A
+// directory-keyed ConfigMap owns its own walk roots and ignores ScanRoot.
+type LintTargetPlanRequest struct {
+	ConfigMap       map[string]RslintConfig
+	Config          RslintConfig
+	ConfigDirectory string
+	ScanRoot        string
+	ConfigScopes    map[string]LintDiscoveryScope
+	FS              vfs.FS
+	Files           []string
+	Directories     []string
+	SingleThreaded  bool
 }
 
 // ResolveLintTargetPlan discovers the exact lint target set and rejects
 // physical aliases governed by different configs. Program membership is
 // deliberately not consulted at this stage.
-func ResolveLintTargetPlan(
-	configMap map[string]RslintConfig,
-	config RslintConfig,
-	currentDirectory string,
-	configTargetScopes map[string]LintDiscoveryScope,
-	fsys vfs.FS,
-	allowFiles []string,
-	allowDirs []string,
-	singleThreaded bool,
-) (LintTargetPlan, error) {
+func ResolveLintTargetPlan(request LintTargetPlanRequest) (LintTargetPlan, error) {
+	configDirectory := tspath.NormalizePath(request.ConfigDirectory)
+	scanRoot := tspath.NormalizePath(request.ScanRoot)
+	if scanRoot == "" {
+		scanRoot = configDirectory
+	}
+	plan := LintTargetPlan{}
+	explicitFiles := newExplicitLintTargetSet(request.Files, request.FS)
 	var discoveredTargets []DiscoveredLintTarget
-	if configMap != nil {
-		discoveredTargets = DiscoverLintTargetsMultiConfig(
-			configMap,
-			configTargetScopes,
-			fsys,
-			allowFiles,
-			allowDirs,
-			singleThreaded,
+	if request.ConfigMap != nil {
+		ownerResolver := NewConfigOwnerResolver(request.ConfigMap, request.FS)
+		plan.frozenConfigBases = ownerResolver.frozenBases
+		discoveredTargets = discoverLintTargetsMultiConfigWithPreparedFiles(
+			request.ConfigMap,
+			request.ConfigScopes,
+			request.FS,
+			request.Files,
+			request.Directories,
+			request.SingleThreaded,
+			ownerResolver,
+			explicitFiles,
 		)
 	} else {
-		discoveredTargets = DiscoverLintTargets(
-			config,
-			currentDirectory,
-			fsys,
-			allowFiles,
-			allowDirs,
-			singleThreaded,
+		configMap := map[string]RslintConfig{configDirectory: request.Config}
+		frozenBases := freezeConfigTargetBases(configMap, request.FS)
+		plan.frozenConfigBases = frozenBases
+		discoveredTargets = discoverLintTargetsWithPreparedFiles(
+			request.Config,
+			configDirectory,
+			scanRoot,
+			request.FS,
+			explicitFiles.targetsForPaths(request.Files),
+			request.Directories,
+			nil,
+			request.SingleThreaded,
+			frozenBases,
 		)
 	}
+	useCaseSensitive := request.FS == nil || request.FS.UseCaseSensitiveFileNames()
+	if explicitFiles != nil {
+		for _, explicitFile := range explicitFiles.byPath {
+			if !explicitFile.evaluated {
+				explicitFile.selectedBy(
+					configDirectory,
+					scanRoot,
+					useCaseSensitive,
+					nil,
+				)
+			}
+		}
+		plan.ExplicitFileOutcomes = explicitFiles.outcomes()
+	}
 
-	plan := LintTargetPlan{Targets: make([]DiscoveredLintTarget, 0, len(discoveredTargets))}
+	plan.Targets = make([]DiscoveredLintTarget, 0, len(discoveredTargets))
 	seenCanonical := make(map[string]DiscoveredLintTarget, len(discoveredTargets))
 	for _, discovered := range discoveredTargets {
-		target := normalizeLintTarget(discovered, currentDirectory, fsys)
+		target := normalizeLintTarget(discovered, configDirectory, request.FS)
 		canonicalKey := exactPathID(target.CanonicalPath)
 		if existing, exists := seenCanonical[canonicalKey]; exists {
-			if canonicalPathID(existing.ConfigDirectory, fsys) != canonicalPathID(target.ConfigDirectory, fsys) {
+			// ConfigDirectory is the authoritative catalog key selected during
+			// discovery. Do not re-resolve either owner here: distinct lexical
+			// aliases may carry different rules even when their directories share
+			// a physical identity. Only a verified native-case spelling of the
+			// same frozen owner is equivalent.
+			if !sameFrozenConfigOwner(
+				existing.ConfigDirectory,
+				target.ConfigDirectory,
+				useCaseSensitive,
+				plan.frozenConfigBases,
+			) {
 				return LintTargetPlan{}, fmt.Errorf(
 					"lint target aliases %q and %q resolve to the same file but are governed by different configs %q and %q",
 					existing.Path,
@@ -72,6 +125,36 @@ func ResolveLintTargetPlan(
 	return plan, nil
 }
 
+// NewFileConfigResolver evaluates the supplied execution config using the
+// authored path spaces frozen by target discovery. The config value remains a
+// caller concern because CLI --rule and API overrides may intentionally be
+// applied after the target set is selected.
+func (plan LintTargetPlan) NewFileConfigResolver(
+	config RslintConfig,
+	configDirectory string,
+	fsys vfs.FS,
+	enforcePlugins bool,
+) *FileConfigResolver {
+	if len(plan.frozenConfigBases) == 0 {
+		return NewFileConfigResolverWithFS(
+			config,
+			configDirectory,
+			fsys,
+			enforcePlugins,
+		)
+	}
+	return &FileConfigResolver{
+		config:         config,
+		enforcePlugins: enforcePlugins,
+		targetResolver: newConfigTargetResolverWithBases(
+			config,
+			configDirectory,
+			fsys,
+			plan.frozenConfigBases,
+		),
+	}
+}
+
 func normalizeLintTarget(target DiscoveredLintTarget, defaultConfigDirectory string, fsys vfs.FS) DiscoveredLintTarget {
 	target.Path = tspath.NormalizePath(target.Path)
 	if target.CanonicalPath == "" {
@@ -83,6 +166,15 @@ func normalizeLintTarget(target DiscoveredLintTarget, defaultConfigDirectory str
 		}
 	}
 	target.CanonicalPath = tspath.NormalizePath(target.CanonicalPath)
+	if target.CanonicalParentPath == "" {
+		target.CanonicalParentPath = tspath.GetDirectoryPath(target.Path)
+		if fsys != nil {
+			if realPath := fsys.Realpath(target.CanonicalParentPath); realPath != "" {
+				target.CanonicalParentPath = realPath
+			}
+		}
+	}
+	target.CanonicalParentPath = tspath.NormalizePath(target.CanonicalParentPath)
 	if target.ConfigDirectory == "" {
 		target.ConfigDirectory = defaultConfigDirectory
 	}
@@ -121,29 +213,26 @@ func (plan LintTargetPlan) PreferredCallerPaths() map[string]string {
 	return preferred
 }
 
-// MatchPath returns the target path used for files/ignores matching. Program
-// source aliases are deliberately excluded: Program membership must not change
-// the lint configuration selected for a target.
-func (target DiscoveredLintTarget) MatchPath(fsys vfs.FS) string {
-	matchPath, _ := ResolveConfigPathSpaceWithCanonical(
-		target.Path,
-		target.CanonicalPath,
-		target.ConfigDirectory,
-		fsys,
-	)
-	return matchPath
-}
-
 func exactPathID(filePath string) string {
 	return string(tspath.ToPath(tspath.NormalizePath(filePath), "", true))
 }
 
-func canonicalPathID(filePath string, fsys vfs.FS) string {
-	filePath = tspath.NormalizePath(filePath)
-	if fsys != nil {
-		if realPath := fsys.Realpath(filePath); realPath != "" {
-			filePath = tspath.NormalizePath(realPath)
-		}
+func sameFrozenConfigOwner(
+	left string,
+	right string,
+	useCaseSensitive bool,
+	frozenBases map[string]configTargetBase,
+) bool {
+	left = tspath.NormalizePath(left)
+	right = tspath.NormalizePath(right)
+	if exactPathID(left) == exactPathID(right) {
+		return true
 	}
-	return exactPathID(filePath)
+	if useCaseSensitive || !pathsEqual(left, right, false) {
+		return false
+	}
+	leftBase, leftFrozen := frozenBases[exactPathID(left)]
+	rightBase, rightFrozen := frozenBases[exactPathID(right)]
+	return leftFrozen && rightFrozen &&
+		exactPathID(leftBase.physicalDirectory) == exactPathID(rightBase.physicalDirectory)
 }

--- a/internal/config/lint_target_plan_test.go
+++ b/internal/config/lint_target_plan_test.go
@@ -14,6 +14,33 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 )
 
+type retargetingExplicitOwnerFS struct {
+	vfs.FS
+	targetPath       string
+	targetParentPath string
+	parentCalls      int
+}
+
+func (fsys *retargetingExplicitOwnerFS) UseCaseSensitiveFileNames() bool { return false }
+func (fsys *retargetingExplicitOwnerFS) FileExists(filePath string) bool {
+	return tspath.NormalizePath(filePath) == fsys.targetPath
+}
+func (fsys *retargetingExplicitOwnerFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	switch filePath {
+	case fsys.targetPath:
+		return "/repo/shared.ts"
+	case fsys.targetParentPath:
+		fsys.parentCalls++
+		if fsys.parentCalls <= 3 {
+			return "/repo/Project"
+		}
+		return "/moved"
+	default:
+		return filePath
+	}
+}
+
 func TestLintTargetPlanSelectsActiveConfigsAndCallerPaths(t *testing.T) {
 	configA := RslintConfig{{Rules: Rules{"no-debugger": "error"}}}
 	configB := RslintConfig{{Rules: Rules{"no-console": "error"}}}
@@ -41,6 +68,153 @@ func TestLintTargetPlanSelectsActiveConfigsAndCallerPaths(t *testing.T) {
 	preferred := plan.PreferredCallerPaths()
 	if got := preferred[exactPathID("/physical/a.ts")]; got != "/repo/a/alias.ts" {
 		t.Fatalf("preferred caller path = %q, want first lexical target", got)
+	}
+}
+
+func TestLintTargetPlanAppliesExecutionConfigOverFrozenPathSpaces(t *testing.T) {
+	directory := tspath.NormalizePath(t.TempDir())
+	filePath := tspath.CombinePaths(directory, "index.ts")
+	if err := os.WriteFile(filePath, []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		Config: RslintConfig{{
+			Settings: Settings{"generation": "discovery"},
+		}},
+		ConfigDirectory: directory,
+		ScanRoot:        directory,
+		FS:              osvfs.FS(),
+		Files:           []string{filePath},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Targets) != 1 {
+		t.Fatalf("planned targets = %+v", plan.Targets)
+	}
+	executionConfig := RslintConfig{{
+		Settings: Settings{"generation": "execution"},
+	}}
+	resolved := plan.NewFileConfigResolver(
+		executionConfig,
+		directory,
+		osvfs.FS(),
+		false,
+	).ResolveTarget(plan.Targets[0])
+	if resolved.MergedConfig == nil ||
+		resolved.MergedConfig.Settings["generation"] != "execution" {
+		t.Fatalf("execution config was replaced by discovery config: %+v", resolved.MergedConfig)
+	}
+}
+
+func TestLintTargetPlanFreezesExplicitOwnerAndWarningOutcome(t *testing.T) {
+	targetPath := "/repo/project/link.ts"
+	fsys := &retargetingExplicitOwnerFS{
+		FS:               &configPathSpaceFS{caseSensitive: false},
+		targetPath:       targetPath,
+		targetParentPath: tspath.GetDirectoryPath(targetPath),
+	}
+	plan, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		ConfigMap: map[string]RslintConfig{
+			"/repo/Project": {{}},
+		},
+		ConfigDirectory: "/repo",
+		ScanRoot:        "/repo",
+		FS:              fsys,
+		Files:           []string{targetPath},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Targets) != 1 || plan.Targets[0].ConfigDirectory != "/repo/Project" {
+		t.Fatalf("explicit target lost its assigned owner: %+v", plan.Targets)
+	}
+	if len(plan.ExplicitFileOutcomes) != 1 ||
+		plan.ExplicitFileOutcomes[0].Ignored ||
+		!plan.ExplicitFileOutcomes[0].Exists {
+		t.Fatalf("explicit outcome = %+v", plan.ExplicitFileOutcomes)
+	}
+	if fsys.parentCalls != 3 {
+		t.Fatalf("target parent Realpath calls = %d, want two identity reads plus one owner selection", fsys.parentCalls)
+	}
+}
+
+func TestLintTargetPlanPreservesIgnoredBeforeMissingWarningPriority(t *testing.T) {
+	root := tspath.NormalizePath(t.TempDir())
+	target := tspath.CombinePaths(root, "node_modules/pkg/missing.ts")
+	plan, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		Config:          RslintConfig{{}},
+		ConfigDirectory: root,
+		ScanRoot:        root,
+		FS:              osvfs.FS(),
+		Files:           []string{target},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Targets) != 0 || len(plan.ExplicitFileOutcomes) != 1 {
+		t.Fatalf("plan = %+v", plan)
+	}
+	outcome := plan.ExplicitFileOutcomes[0]
+	if !outcome.Ignored || outcome.Exists {
+		t.Fatalf("ignored missing outcome = %+v", outcome)
+	}
+}
+
+func TestResolveLintTargetPlanSeparatesConfigDirectoryFromScanRoot(t *testing.T) {
+	root := t.TempDir()
+	configDirectory := filepath.Join(root, "config")
+	scanRoot := filepath.Join(root, "workspace")
+	target := filepath.Join(scanRoot, "src", "target.ts")
+	for _, directory := range []string{
+		configDirectory,
+		filepath.Dir(target),
+	} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, content := range map[string]string{
+		target: "export const target = 1;\n",
+		filepath.Join(configDirectory, "config-only.ts"): "export const configOnly = 1;\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	configDirectory = tspath.NormalizePath(configDirectory)
+	scanRoot = tspath.NormalizePath(scanRoot)
+	target = tspath.NormalizePath(target)
+	entries := RslintConfig{{
+		Files: []string{"../workspace/src/*.ts"},
+		Rules: Rules{"no-debugger": "error"},
+	}}
+	plan, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		Config:          entries,
+		ConfigDirectory: configDirectory,
+		ScanRoot:        scanRoot,
+		FS:              osvfs.FS(),
+		Directories:     []string{scanRoot},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Targets) != 1 || plan.Targets[0].Path != target {
+		t.Fatalf("targets = %+v, want only %q", plan.Targets, target)
+	}
+	if got := plan.Targets[0].ConfigDirectory; got != configDirectory {
+		t.Fatalf("target config directory = %q, want %q", got, configDirectory)
+	}
+	resolvedTarget := plan.Targets[0]
+	merged := NewFileConfigResolverWithFS(entries, configDirectory, osvfs.FS(), false).
+		ConfigForTarget(resolvedTarget.Path, resolvedTarget.CanonicalPath)
+	if merged == nil || merged.Rules["no-debugger"] == nil {
+		t.Fatalf("external target %q did not retain config-relative matching: %#v", resolvedTarget.Path, merged)
 	}
 }
 
@@ -78,16 +252,52 @@ func TestResolveLintTargetPlanRejectsPhysicalAliasesWithDifferentOwners(t *testi
 	}
 	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
 
-	_, err := ResolveLintTargetPlan(
-		configs,
-		nil,
-		tspath.NormalizePath(ownersRoot),
-		nil,
-		fsys,
-		[]string{targetA, targetB},
-		nil,
-		true,
-	)
+	_, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		ConfigMap:       configs,
+		ConfigDirectory: tspath.NormalizePath(ownersRoot),
+		FS:              fsys,
+		Files:           []string{targetA, targetB},
+		SingleThreaded:  true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "governed by different configs") {
+		t.Fatalf("ownership conflict error = %v", err)
+	}
+}
+
+func TestResolveLintTargetPlanRejectsSamePhysicalConfigAliasesAsDifferentOwners(t *testing.T) {
+	physicalOwner := t.TempDir()
+	physicalTarget := filepath.Join(physicalOwner, "target.ts")
+	if err := os.WriteFile(physicalTarget, []byte("export const value = 1;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	aliasesRoot := t.TempDir()
+	ownerA := filepath.Join(aliasesRoot, "owner-a")
+	ownerB := filepath.Join(aliasesRoot, "owner-b")
+	if err := os.Symlink(physicalOwner, ownerA); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Symlink(physicalOwner, ownerB); err != nil {
+		t.Skipf("second symlink unavailable: %v", err)
+	}
+
+	ownerA = tspath.NormalizePath(ownerA)
+	ownerB = tspath.NormalizePath(ownerB)
+	targetA := tspath.CombinePaths(ownerA, "target.ts")
+	targetB := tspath.CombinePaths(ownerB, "target.ts")
+	configs := map[string]RslintConfig{
+		ownerA: {{Rules: Rules{"owner-a": "error"}}},
+		ownerB: {{Rules: Rules{"owner-b": "error"}}},
+	}
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+
+	_, err := ResolveLintTargetPlan(LintTargetPlanRequest{
+		ConfigMap:       configs,
+		ConfigDirectory: tspath.NormalizePath(aliasesRoot),
+		FS:              fsys,
+		Files:           []string{targetA, targetB},
+		SingleThreaded:  true,
+	})
 	if err == nil || !strings.Contains(err.Error(), "governed by different configs") {
 		t.Fatalf("ownership conflict error = %v", err)
 	}
@@ -128,36 +338,24 @@ func discoverFilesOutsideProgramsMultiConfigForTest(
 		return nil
 	}
 
-	index := newConfigDirectoryIndex(configMap, fsys)
-	configDirs := make([]string, 0, len(configMap))
-	for configDir := range configMap {
-		configDirs = append(configDirs, configDir)
-	}
-	sort.Strings(configDirs)
-
 	seen := make(map[string]struct{})
 	var result []string
-	for _, configDir := range configDirs {
-		targets := discoverLintTargetsForConfigInMap(
-			configMap,
-			index,
-			nil,
-			configDir,
-			fsys,
-			allowFiles,
-			allowDirs,
-			singleThreaded,
-		)
-		for _, target := range targets {
-			if _, exists := programFiles[target.Path]; exists {
-				continue
-			}
-			if _, exists := seen[target.Path]; exists {
-				continue
-			}
-			seen[target.Path] = struct{}{}
-			result = append(result, target.Path)
+	for _, target := range DiscoverLintTargetsMultiConfig(
+		configMap,
+		nil,
+		fsys,
+		allowFiles,
+		allowDirs,
+		singleThreaded,
+	) {
+		if _, exists := programFiles[target.Path]; exists {
+			continue
 		}
+		if _, exists := seen[target.Path]; exists {
+			continue
+		}
+		seen[target.Path] = struct{}{}
+		result = append(result, target.Path)
 	}
 
 	sort.Strings(result)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -123,8 +123,11 @@ func (loader *ConfigLoader) LoadDefaultRslintConfig() (RslintConfig, string, err
 }
 
 // LoadTsConfigsFromRslintConfig extracts and validates TypeScript configuration paths from rslint config.
-// Returns an empty slice (no error) when no parserOptions.project is specified — this is valid
-// for pure JS projects that don't need explicit TypeScript configuration.
+// Each explicit project path is resolved from the authored base of the entry
+// that declares it. Most entries use configDirectory; composed entries such as
+// API overrideConfig may retain a different origin.
+// Returns an empty slice (no error) when no project path is declared. Callers
+// separately distinguish an omitted project field from an explicit empty list.
 func (loader *ConfigLoader) LoadTsConfigsFromRslintConfig(rslintConfig RslintConfig, configDirectory string) ([]string, error) {
 	tsConfigs := []string{}
 	seenPaths := make(map[string]struct{})
@@ -133,10 +136,11 @@ func (loader *ConfigLoader) LoadTsConfigsFromRslintConfig(rslintConfig RslintCon
 		if entry.LanguageOptions == nil || entry.LanguageOptions.ParserOptions == nil {
 			continue
 		}
+		entryBaseDirectory := configEntryBaseDirectory(entry, configDirectory)
 
 		for _, config := range entry.LanguageOptions.ParserOptions.Project {
 			if containsGlobPattern(config) {
-				matches, err := loader.expandProjectGlob(configDirectory, config)
+				matches, err := loader.expandProjectGlob(entryBaseDirectory, config)
 				if err != nil {
 					return nil, err
 				}
@@ -149,7 +153,7 @@ func (loader *ConfigLoader) LoadTsConfigsFromRslintConfig(rslintConfig RslintCon
 				continue
 			}
 
-			tsconfigPath := tspath.ResolvePath(configDirectory, config)
+			tsconfigPath := tspath.ResolvePath(entryBaseDirectory, config)
 
 			if !loader.fs.FileExists(tsconfigPath) {
 				return nil, fmt.Errorf("tsconfig file %q doesn't exist", tsconfigPath)
@@ -176,6 +180,12 @@ func ResolveTsConfigPaths(rslintConfig RslintConfig, cwd string, fs vfs.FS) ([]s
 		return nil, err
 	}
 	if len(tsConfigs) == 0 {
+		// An explicit empty list means "use no TypeScript project". It must not
+		// silently turn into the default tsconfig.json; callers that want the
+		// default discovery behavior omit parserOptions.project.
+		if hasExplicitProjectSetting(rslintConfig) {
+			return nil, nil
+		}
 		defaultTsConfig := tspath.ResolvePath(cwd, "tsconfig.json")
 		if fs.FileExists(defaultTsConfig) {
 			return []string{defaultTsConfig}, nil
@@ -183,6 +193,17 @@ func ResolveTsConfigPaths(rslintConfig RslintConfig, cwd string, fs vfs.FS) ([]s
 		return nil, nil
 	}
 	return tsConfigs, nil
+}
+
+func hasExplicitProjectSetting(config RslintConfig) bool {
+	for _, entry := range config {
+		if entry.LanguageOptions != nil &&
+			entry.LanguageOptions.ParserOptions != nil &&
+			entry.LanguageOptions.ParserOptions.Project != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func appendUniqueConfigPath(paths []string, seenPaths map[string]struct{}, configPath string) []string {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"gotest.tools/v3/assert"
@@ -477,6 +478,22 @@ func TestResolveTsConfigPaths_FallbackToDefaultTsConfig(t *testing.T) {
 	}
 }
 
+func TestResolveTsConfigPaths_ExplicitEmptyProjectDisablesFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTestFile(t, filepath.Join(tmpDir, "tsconfig.json"))
+	cfg := RslintConfig{{
+		LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+			Project: ProjectPaths{},
+		}},
+	}}
+
+	paths, err := ResolveTsConfigPaths(cfg, tmpDir, osvfs.FS())
+	assert.NilError(t, err)
+	if paths != nil {
+		t.Fatalf("explicit project: [] selected an implicit tsconfig: %v", paths)
+	}
+}
+
 func TestResolveTsConfigPaths_NilFS(t *testing.T) {
 	paths, err := ResolveTsConfigPaths(RslintConfig{{}}, "/any", nil)
 	assert.NilError(t, err)
@@ -501,4 +518,77 @@ func TestResolveTsConfigPaths_ErrorOnNonExistentTsConfig(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-existent tsconfig")
 	}
+}
+
+func TestAuthoredPathBaseAppliesToFilesIgnoresAndProjects(t *testing.T) {
+	root := t.TempDir()
+	configDirectory := filepath.Join(root, "config")
+	authoredDirectory := filepath.Join(root, "workspace")
+	target := filepath.Join(authoredDirectory, "src", "index.ts")
+	ignored := filepath.Join(authoredDirectory, "src", "ignored.ts")
+	ownerProject := filepath.Join(configDirectory, "tsconfig.json")
+	authoredProject := filepath.Join(authoredDirectory, "tsconfig.json")
+	for _, path := range []string{target, ignored, ownerProject, authoredProject} {
+		createTestFile(t, path)
+	}
+
+	base := RslintConfig{{
+		LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+			Project: ProjectPaths{"./tsconfig.json"},
+		}},
+	}}
+	override := RslintConfig{
+		{Ignores: []string{"src/ignored.ts"}},
+		{
+			Files: []string{"src/**/*.ts"},
+			LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+				Project: ProjectPaths{"./tsconfig.json"},
+			}},
+			Rules: Rules{"no-debugger": "error"},
+		},
+	}
+	composed := append(base, ConfigWithAuthoredPathBase(override, authoredDirectory)...)
+	if override[0].authoredPathBase != nil || override[1].authoredPathBase != nil {
+		t.Fatal("ConfigWithAuthoredPathBase mutated its input")
+	}
+	composed, optionErrors := ValidateRuleOptions(composed, NewRuleRegistry())
+	if len(optionErrors) != 0 {
+		t.Fatalf("ValidateRuleOptions returned errors: %v", optionErrors)
+	}
+
+	merged := composed.GetConfigForFile(target, configDirectory)
+	if merged == nil || merged.Rules["no-debugger"] == nil {
+		t.Fatalf("authored files base did not select target: %+v", merged)
+	}
+	if !composed.IsFileIgnored(ignored, configDirectory) {
+		t.Fatal("authored ignores base did not exclude target")
+	}
+
+	projects, err := ResolveTsConfigPaths(composed, configDirectory, osvfs.FS())
+	assert.NilError(t, err)
+	wantProjects := []string{
+		tspath.NormalizePath(ownerProject),
+		tspath.NormalizePath(authoredProject),
+	}
+	assert.DeepEqual(t, projects, wantProjects)
+}
+
+func TestResolveTsConfigPathsDefaultRemainsAtOwningConfigBase(t *testing.T) {
+	root := t.TempDir()
+	configDirectory := filepath.Join(root, "config")
+	authoredDirectory := filepath.Join(root, "workspace")
+	ownerProject := filepath.Join(configDirectory, "tsconfig.json")
+	for _, path := range []string{
+		ownerProject,
+		filepath.Join(authoredDirectory, "tsconfig.json"),
+	} {
+		createTestFile(t, path)
+	}
+
+	config := ConfigWithAuthoredPathBase(RslintConfig{{
+		Rules: Rules{"no-debugger": "error"},
+	}}, authoredDirectory)
+	projects, err := ResolveTsConfigPaths(config, configDirectory, osvfs.FS())
+	assert.NilError(t, err)
+	assert.DeepEqual(t, projects, []string{tspath.NormalizePath(ownerProject)})
 }

--- a/internal/config/owner_resolver.go
+++ b/internal/config/owner_resolver.go
@@ -39,19 +39,62 @@ func configMapForAutomaticTargets(
 // tries lexical ancestors, including verified native case aliases, and consults
 // realpath ancestry only when no lexical owner exists.
 type ConfigOwnerResolver struct {
-	configMap map[string]RslintConfig
-	index     *configDirectoryIndex
+	configMap       map[string]RslintConfig
+	index           *configDirectoryIndex
+	targetResolvers map[string]*configTargetResolver
+	frozenBases     map[string]configTargetBase
 }
 
 func NewConfigOwnerResolver(configMap map[string]RslintConfig, fsys vfs.FS) *ConfigOwnerResolver {
+	frozenBases := freezeConfigTargetBases(configMap, fsys)
+	return newConfigOwnerResolverWithBases(configMap, fsys, frozenBases)
+}
+
+func freezeConfigTargetBases(
+	configMap map[string]RslintConfig,
+	fsys vfs.FS,
+) map[string]configTargetBase {
+	frozenBases := make(map[string]configTargetBase, len(configMap))
+	freezeBase := func(directory string) {
+		directory = tspath.NormalizePath(directory)
+		baseID := exactPathID(directory)
+		if _, exists := frozenBases[baseID]; !exists {
+			frozenBases[baseID] = freezeConfigTargetBase(directory, fsys)
+		}
+	}
+	for configDir, entries := range configMap {
+		freezeBase(configDir)
+		for _, entry := range entries {
+			freezeBase(configEntryBaseDirectory(entry, configDir))
+		}
+	}
+	return frozenBases
+}
+
+func newConfigOwnerResolverWithBases(
+	configMap map[string]RslintConfig,
+	fsys vfs.FS,
+	frozenBases map[string]configTargetBase,
+) *ConfigOwnerResolver {
 	configSnapshot := make(map[string]RslintConfig, len(configMap))
 	for configDir, entries := range configMap {
 		configSnapshot[configDir] = entries
 	}
-	return &ConfigOwnerResolver{
-		configMap: configSnapshot,
-		index:     newConfigDirectoryIndex(configSnapshot, fsys),
+	resolver := &ConfigOwnerResolver{
+		configMap:       configSnapshot,
+		index:           newConfigDirectoryIndexWithBases(configSnapshot, fsys, frozenBases),
+		targetResolvers: make(map[string]*configTargetResolver, len(configSnapshot)),
+		frozenBases:     frozenBases,
 	}
+	for configDir, entries := range configSnapshot {
+		resolver.targetResolvers[configDir] = newConfigTargetResolverWithBases(
+			entries,
+			configDir,
+			fsys,
+			frozenBases,
+		)
+	}
+	return resolver
 }
 
 // NewConfigOwnerResolverForAutomaticTargets excludes configs that were loaded
@@ -77,6 +120,71 @@ func (resolver *ConfigOwnerResolver) Resolve(filePath string) (string, RslintCon
 	return configDir, resolver.configMap[configDir]
 }
 
+// ResolveTarget resolves ownership from an already-frozen target identity.
+// It does not re-resolve the file itself. Native-case lexical ancestry may be
+// verified once while this lookup selects the owner; the selected owner and
+// effective config can then be frozen with the target for every later stage.
+func (resolver *ConfigOwnerResolver) ResolveTarget(target DiscoveredLintTarget) (string, RslintConfig) {
+	if resolver == nil || resolver.index == nil {
+		return "", nil
+	}
+	configDir, ok := resolver.index.nearestConfigWithCanonicalPath(
+		target.Path,
+		target.CanonicalPath,
+	)
+	if !ok {
+		return "", nil
+	}
+	return configDir, resolver.configMap[configDir]
+}
+
+// ResolveTargetConfig resolves ownership and evaluates the target against the
+// exact authored path-space snapshot captured with the owner catalog. This
+// prevents an aliased config directory from changing meaning between owner
+// selection and files/ignores matching.
+func (resolver *ConfigOwnerResolver) ResolveTargetConfig(
+	target DiscoveredLintTarget,
+	enforcePlugins bool,
+) (string, RslintConfig, ResolvedFileConfig, bool) {
+	configDir, _ := resolver.ResolveTarget(target)
+	if configDir == "" {
+		return "", nil, ResolvedFileConfig{}, false
+	}
+	entries, resolved, ok := resolver.ResolveConfigTarget(
+		configDir,
+		target,
+		enforcePlugins,
+	)
+	return configDir, entries, resolved, ok
+}
+
+// ResolveConfigTarget evaluates target against a known config key while still
+// reusing the key's frozen authored path spaces. It is the explicit-config and
+// invocation-wide counterpart to ResolveTargetConfig's ancestry lookup.
+func (resolver *ConfigOwnerResolver) ResolveConfigTarget(
+	configDir string,
+	target DiscoveredLintTarget,
+	enforcePlugins bool,
+) (RslintConfig, ResolvedFileConfig, bool) {
+	if resolver == nil {
+		return nil, ResolvedFileConfig{}, false
+	}
+	entries, exists := resolver.configMap[configDir]
+	if !exists {
+		return nil, ResolvedFileConfig{}, false
+	}
+	targetResolver := resolver.targetResolvers[configDir]
+	if targetResolver == nil {
+		return nil, ResolvedFileConfig{}, false
+	}
+	fileResolver := &FileConfigResolver{
+		config:         entries,
+		enforcePlugins: enforcePlugins,
+		targetResolver: targetResolver,
+	}
+	return entries, fileResolver.ResolveTarget(target), true
+}
+
 // ChildConfigDirs returns the direct lexical child config directories that
 // form ownership handoff boundaries for configDir. The returned slice is a
 // copy and may be used concurrently with resolver lookups.
@@ -87,20 +195,38 @@ func (resolver *ConfigOwnerResolver) ChildConfigDirs(configDir string) []string 
 	return append([]string(nil), resolver.index.childConfigDirs(configDir)...)
 }
 
-// ResolveConfigPathSpace returns the physical path pair used for files and
-// ignores matching. It preserves the file's path relative to the authored
-// config directory, then anchors both paths on the config directory's realpath.
-// Lexical and symlink aliases therefore share one matching space without
-// case-folding distinct path identities.
-func ResolveConfigPathSpace(filePath string, configDir string, fsys vfs.FS) (string, string) {
-	return ResolveConfigPathSpaceWithCanonical(filePath, "", configDir, fsys)
+// ResolveConfigFilePathSpace returns the path pair used for files and ignores
+// matching. User-authored paths keep their lexical relationship to the config
+// directory; when both paths are aliases of one physical config tree, the pair
+// is instead anchored on that physical tree. Canonical file identity is never
+// allowed to rewrite an external lexical file symlink into a different relative
+// selector path.
+func ResolveConfigFilePathSpace(filePath string, configDir string, fsys vfs.FS) (string, string) {
+	return ResolveConfigFilePathSpaceWithCanonical(filePath, "", configDir, fsys)
 }
 
-// ResolveConfigPathSpaceWithCanonical is ResolveConfigPathSpace with an
+// ResolveConfigFilePathSpaceWithCanonical is ResolveConfigFilePathSpace with an
 // optional physical file identity already established by target discovery.
-func ResolveConfigPathSpaceWithCanonical(filePath string, canonicalPath string, configDir string, fsys vfs.FS) (string, string) {
+func ResolveConfigFilePathSpaceWithCanonical(filePath string, canonicalPath string, configDir string, fsys vfs.FS) (string, string) {
+	return ResolveConfigFilePathSpaceForTarget(DiscoveredLintTarget{
+		Path:          filePath,
+		CanonicalPath: canonicalPath,
+	}, configDir, fsys)
+}
+
+// ResolveConfigFilePathSpaceForTarget projects a frozen file and parent
+// identity into one authored config base without resolving the target again.
+func ResolveConfigFilePathSpaceForTarget(
+	target DiscoveredLintTarget,
+	configDir string,
+	fsys vfs.FS,
+) (string, string) {
+	filePath := target.Path
 	filePath = tspath.NormalizePath(filePath)
 	configDir = tspath.NormalizePath(configDir)
+	if configDir == "" {
+		return filePath, ""
+	}
 	physicalConfigDir := configDir
 	if fsys != nil {
 		if realPath := fsys.Realpath(configDir); realPath != "" {
@@ -108,7 +234,117 @@ func ResolveConfigPathSpaceWithCanonical(filePath string, canonicalPath string, 
 		}
 	}
 
-	return resolveConfigPathSpace(filePath, canonicalPath, configDir, physicalConfigDir, fsys), physicalConfigDir
+	return resolveConfigPathSpaceWithCanonicalParent(
+		filePath,
+		target.CanonicalPath,
+		target.CanonicalParentPath,
+		configDir,
+		physicalConfigDir,
+		verifiedConfigAliasAncestors(configDir, physicalConfigDir, fsys),
+		fsys,
+		true,
+	)
+}
+
+// ResolveConfigDirectoryPathSpace is the directory-root counterpart to
+// ResolveConfigFilePathSpace. A directory alias that resolves into the
+// physical config tree belongs to that tree's matching space; unlike a file
+// symlink, the directory root is itself a coordinate system and must not retain
+// a competing lexical base.
+func ResolveConfigDirectoryPathSpace(directory string, configDir string, fsys vfs.FS) (string, string) {
+	directory = tspath.NormalizePath(directory)
+	configDir = tspath.NormalizePath(configDir)
+	if configDir == "" {
+		return directory, ""
+	}
+	physicalConfigDir := configDir
+	canonicalDirectory := directory
+	if fsys != nil {
+		if realPath := fsys.Realpath(configDir); realPath != "" {
+			physicalConfigDir = tspath.NormalizePath(realPath)
+		}
+		if realPath := fsys.Realpath(directory); realPath != "" {
+			canonicalDirectory = tspath.NormalizePath(realPath)
+		}
+	}
+	// A requested directory that physically contains the config root selects
+	// that complete config-owned tree. Retain the physical containment pair so
+	// directory discovery and Git projection can recognize it even when the
+	// config was reached through a symlink in an unrelated lexical parent.
+	if _, containsConfigRoot := RelativePathWithinConfigRoot(
+		physicalConfigDir,
+		canonicalDirectory,
+		true,
+	); containsConfigRoot {
+		return canonicalDirectory, physicalConfigDir
+	}
+	return resolveConfigPathSpace(
+		directory,
+		canonicalDirectory,
+		configDir,
+		physicalConfigDir,
+		verifiedConfigAliasAncestors(configDir, physicalConfigDir, fsys),
+		fsys,
+		false,
+	)
+}
+
+// verifiedConfigAliasAncestors returns physical ancestor roots that preserve
+// the config directory's complete lexical suffix. They let sibling paths use
+// one coordinate system when an ancestor (for example macOS /tmp) is aliased,
+// without treating a symlink on the config directory alone as authority over
+// unrelated physical siblings. Filesystem roots are deliberately excluded.
+func verifiedConfigAliasAncestors(configDir string, physicalConfigDir string, fsys vfs.FS) []string {
+	if fsys == nil {
+		return nil
+	}
+	var ancestors []string
+	for current := configDir; current != ""; {
+		parent := tspath.GetDirectoryPath(current)
+		if parent == current {
+			break
+		}
+		physicalCurrent := ""
+		if current == configDir {
+			physicalCurrent = physicalConfigDir
+		} else {
+			physicalCurrent = fsys.Realpath(current)
+		}
+		if physicalCurrent != "" {
+			physicalCurrent = tspath.NormalizePath(physicalCurrent)
+			if !pathsEqual(current, physicalCurrent, true) {
+				relativeConfig, within := RelativePathWithinConfigRoot(configDir, current, true)
+				preservesSuffix := within && pathsEqual(
+					tspath.ResolvePath(physicalCurrent, relativeConfig),
+					physicalConfigDir,
+					true,
+				)
+				if preservesSuffix {
+					duplicate := false
+					for _, ancestor := range ancestors {
+						if pathsEqual(ancestor, physicalCurrent, true) {
+							duplicate = true
+							break
+						}
+					}
+					if !duplicate {
+						ancestors = append(ancestors, physicalCurrent)
+					}
+				}
+			}
+		}
+		current = parent
+	}
+	return ancestors
+}
+
+func pathUsesVerifiedConfigAlias(path string, physicalAncestors []string) bool {
+	for _, ancestor := range physicalAncestors {
+		if _, within := RelativePathWithinConfigRoot(path, ancestor, true); within {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveConfigPathSpace(
@@ -116,23 +352,74 @@ func resolveConfigPathSpace(
 	canonicalPath string,
 	configDir string,
 	physicalConfigDir string,
+	physicalAliasAncestors []string,
 	fsys vfs.FS,
-) string {
+	preserveDistinctFileSymlink bool,
+) (string, string) {
+	return resolveConfigPathSpaceWithCanonicalParent(
+		filePath,
+		canonicalPath,
+		"",
+		configDir,
+		physicalConfigDir,
+		physicalAliasAncestors,
+		fsys,
+		preserveDistinctFileSymlink,
+	)
+}
+
+func resolveConfigPathSpaceWithCanonicalParent(
+	filePath string,
+	canonicalPath string,
+	canonicalParentPath string,
+	configDir string,
+	physicalConfigDir string,
+	physicalAliasAncestors []string,
+	fsys vfs.FS,
+	preserveDistinctFileSymlink bool,
+) (string, string) {
+	// The ordinary path is already in the config's exact lexical/physical
+	// coordinate system. Returning it directly avoids decomposing and rebuilding
+	// the same absolute path for every discovered file.
+	if configDir == physicalConfigDir && isPathWithinNormalizedRoot(filePath, configDir) {
+		return filePath, configDir
+	}
 	if relative, ok := RelativePathWithinConfigRoot(filePath, configDir, true); ok {
-		return tspath.ResolvePath(physicalConfigDir, relative)
+		return tspath.ResolvePath(physicalConfigDir, relative), physicalConfigDir
+	}
+	// Match paths may already have been projected onto the physical config
+	// directory by target binding. Preserve their relative spelling so applying
+	// this resolver twice cannot erase a config-observable directory alias.
+	if relative, ok := RelativePathWithinConfigRoot(filePath, physicalConfigDir, true); ok {
+		return tspath.ResolvePath(physicalConfigDir, relative), physicalConfigDir
 	}
 	if relative, ok := RelativePathWithinConfigRoot(filePath, configDir, false); ok && fsys != nil {
-		aliasRoot := filePath
-		for remaining := relative; remaining != ""; remaining = tspath.GetDirectoryPath(remaining) {
-			aliasRoot = tspath.GetDirectoryPath(aliasRoot)
-		}
-		if realRoot := fsys.Realpath(aliasRoot); realRoot != "" &&
-			tspath.ComparePaths(
-				tspath.NormalizePath(realRoot),
+		if canonicalParentPath != "" {
+			expectedPhysicalFile := expectedPhysicalFileFromLexicalPathWithCanonicalParent(
+				filePath,
+				canonicalParentPath,
+				fsys,
+			)
+			if _, within := RelativePathWithinConfigRoot(
+				expectedPhysicalFile,
 				physicalConfigDir,
-				tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true},
-			) == 0 {
-			return tspath.ResolvePath(physicalConfigDir, relative)
+				true,
+			); within {
+				return tspath.ResolvePath(physicalConfigDir, relative), physicalConfigDir
+			}
+		} else {
+			aliasRoot := filePath
+			for remaining := relative; remaining != ""; remaining = tspath.GetDirectoryPath(remaining) {
+				aliasRoot = tspath.GetDirectoryPath(aliasRoot)
+			}
+			if realRoot := fsys.Realpath(aliasRoot); realRoot != "" &&
+				tspath.ComparePaths(
+					tspath.NormalizePath(realRoot),
+					physicalConfigDir,
+					tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true},
+				) == 0 {
+				return tspath.ResolvePath(physicalConfigDir, relative), physicalConfigDir
+			}
 		}
 	}
 
@@ -148,10 +435,94 @@ func resolveConfigPathSpace(
 			}
 		}
 	}
-	if relative, ok := RelativePathWithinConfigRoot(physicalFilePath, physicalConfigDir, true); ok {
-		return tspath.ResolvePath(physicalConfigDir, relative)
+	if _, caseAlias := RelativePathWithinConfigRoot(filePath, configDir, false); caseAlias {
+		// The case-insensitive spelling looked like the config tree, but native
+		// realpath verification above proved it was a distinct physical root.
+		// Preserve that distinction rather than manufacturing a mixed-case path.
+		return physicalFilePath, physicalConfigDir
 	}
-	return physicalFilePath
+	// Compare the physical file with its physical parent plus lexical basename.
+	// A difference at that final component identifies a file symlink (or an
+	// explicit canonical identity hint) whose user-visible selector path must be
+	// retained. Differences introduced only by an ancestor directory alias,
+	// native casing, or a platform path such as macOS /var -> /private/var still
+	// share the physical config space.
+	expectedPhysicalFile := physicalFilePath
+	if preserveDistinctFileSymlink {
+		expectedPhysicalFile = expectedPhysicalFileFromLexicalPathWithCanonicalParent(
+			filePath,
+			canonicalParentPath,
+			fsys,
+		)
+	}
+	targetHasDistinctLeafIdentity := preserveDistinctFileSymlink &&
+		hasDistinctFileIdentityWithCanonicalParent(
+			filePath,
+			physicalFilePath,
+			canonicalParentPath,
+			fsys,
+		)
+	// A verified ancestor alias establishes the coordinate system independently
+	// of the leaf's identity. Keep the lexical basename on the physical parent
+	// so a file symlink still matches the path the user selected, while its
+	// canonical destination remains only an identity for deduplication.
+	if pathUsesVerifiedConfigAlias(expectedPhysicalFile, physicalAliasAncestors) {
+		return expectedPhysicalFile, physicalConfigDir
+	}
+	if !targetHasDistinctLeafIdentity {
+		if relative, ok := RelativePathWithinConfigRoot(physicalFilePath, physicalConfigDir, true); ok {
+			return tspath.ResolvePath(physicalConfigDir, relative), physicalConfigDir
+		}
+	}
+
+	// The target is outside both identities of the config tree. This is valid
+	// for an invocation-wide external config whose files/ignores selectors use
+	// ../ paths, and it includes an external lexical symlink whose physical file
+	// happens to live inside the config tree. Keep the complete lexical pair:
+	// projecting only the target onto physicalConfigDir would normalize away
+	// meaningful ../ segments whenever the lexical and physical config roots
+	// have different parent layouts.
+	return filePath, configDir
+}
+
+func expectedPhysicalFileFromLexicalPathWithCanonicalParent(
+	filePath string,
+	canonicalParentPath string,
+	fsys vfs.FS,
+) string {
+	expectedPhysicalFile := filePath
+	physicalParent := canonicalParentPath
+	if physicalParent == "" && fsys != nil {
+		physicalParent = fsys.Realpath(tspath.GetDirectoryPath(filePath))
+	}
+	if physicalParent == "" {
+		return expectedPhysicalFile
+	}
+	return tspath.ResolvePath(
+		tspath.NormalizePath(physicalParent),
+		tspath.GetBaseFileName(filePath),
+	)
+}
+
+// hasDistinctFileIdentityWithCanonicalParent distinguishes a leaf symlink
+// (whose caller-visible name remains a matcher coordinate) from a
+// directory/root alias (whose canonical descendant path may be used as a
+// fallback coordinate).
+func hasDistinctFileIdentityWithCanonicalParent(
+	filePath string,
+	canonicalPath string,
+	canonicalParentPath string,
+	fsys vfs.FS,
+) bool {
+	return tspath.ComparePaths(
+		expectedPhysicalFileFromLexicalPathWithCanonicalParent(
+			filePath,
+			canonicalParentPath,
+			fsys,
+		),
+		canonicalPath,
+		tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true},
+	) != 0
 }
 
 // RelativePathWithinConfigRoot returns filePath relative to configDir when it
@@ -168,4 +539,10 @@ func RelativePathWithinConfigRoot(filePath string, configDir string, useCaseSens
 		return "", false
 	}
 	return tspath.GetRelativePathFromDirectory(configDir, filePath, options), true
+}
+
+// isPathWithinNormalizedRoot is the allocation-free containment check for
+// already-normalized, case-sensitive paths used by frozen target identities.
+func isPathWithinNormalizedRoot(filePath string, root string) bool {
+	return filePath == root || tspath.StartsWithDirectory(filePath, root, true)
 }

--- a/internal/config/owner_resolver_test.go
+++ b/internal/config/owner_resolver_test.go
@@ -12,6 +12,24 @@ type configPathSpaceFS struct {
 	caseSensitive bool
 }
 
+type retargetingConfigDirectoryFS struct {
+	vfs.FS
+	configPath  string
+	configCalls int
+}
+
+func (fs *retargetingConfigDirectoryFS) UseCaseSensitiveFileNames() bool { return true }
+func (fs *retargetingConfigDirectoryFS) Realpath(filePath string) string {
+	if filePath != fs.configPath {
+		return filePath
+	}
+	fs.configCalls++
+	if fs.configCalls == 1 {
+		return "/owner-a"
+	}
+	return "/owner-b"
+}
+
 func (fs *configPathSpaceFS) UseCaseSensitiveFileNames() bool { return fs.caseSensitive }
 func (fs *configPathSpaceFS) Realpath(filePath string) string {
 	if realPath := fs.realPaths[filePath]; realPath != "" {
@@ -24,7 +42,7 @@ func resolveConfigOwner(filePath string, configMap map[string]RslintConfig) (str
 	return NewConfigOwnerResolver(configMap, nil).Resolve(filePath)
 }
 
-func TestResolveConfigPathSpace(t *testing.T) {
+func TestResolveConfigFilePathSpace(t *testing.T) {
 	t.Run("symlink aliases use the physical config root", func(t *testing.T) {
 		fs := &configPathSpaceFS{
 			caseSensitive: true,
@@ -35,9 +53,9 @@ func TestResolveConfigPathSpace(t *testing.T) {
 			},
 		}
 		for _, filePath := range []string{"/alias/src/a.ts", "/real/src/a.ts"} {
-			matchFile, matchDir := ResolveConfigPathSpace(filePath, "/alias", fs)
+			matchFile, matchDir := ResolveConfigFilePathSpace(filePath, "/alias", fs)
 			if matchFile != "/real/src/a.ts" || matchDir != "/real" {
-				t.Fatalf("ResolveConfigPathSpace(%q) = (%q, %q)", filePath, matchFile, matchDir)
+				t.Fatalf("ResolveConfigFilePathSpace(%q) = (%q, %q)", filePath, matchFile, matchDir)
 			}
 		}
 	})
@@ -50,7 +68,7 @@ func TestResolveConfigPathSpace(t *testing.T) {
 				"c:/repo/src/index.ts": "C:/Repo/src/index.ts",
 			},
 		}
-		matchFile, matchDir := ResolveConfigPathSpace("c:/repo/src/index.ts", "C:/Repo", fs)
+		matchFile, matchDir := ResolveConfigFilePathSpace("c:/repo/src/index.ts", "C:/Repo", fs)
 		if matchFile != "C:/Repo/src/index.ts" || matchDir != "C:/Repo" {
 			t.Fatalf("case-insensitive path space = (%q, %q)", matchFile, matchDir)
 		}
@@ -64,7 +82,7 @@ func TestResolveConfigPathSpace(t *testing.T) {
 				"c:/repo/src/index.ts": "c:/repo/src/index.ts",
 			},
 		}
-		matchFile, matchDir := ResolveConfigPathSpace("c:/repo/src/index.ts", "C:/Repo", fs)
+		matchFile, matchDir := ResolveConfigFilePathSpace("c:/repo/src/index.ts", "C:/Repo", fs)
 		if matchFile != "c:/repo/src/index.ts" || matchDir != "C:/Repo" {
 			t.Fatalf("distinct physical roots were collapsed: (%q, %q)", matchFile, matchDir)
 		}
@@ -79,11 +97,154 @@ func TestResolveConfigPathSpace(t *testing.T) {
 				"/repo/project/link.ts": "/repo/shared.ts",
 			},
 		}
-		matchFile, matchDir := ResolveConfigPathSpace("/repo/project/link.ts", "/repo/Project", fs)
+		matchFile, matchDir := ResolveConfigFilePathSpace("/repo/project/link.ts", "/repo/Project", fs)
 		if matchFile != "/repo/Project/link.ts" || matchDir != "/repo/Project" {
 			t.Fatalf("native alias path space = (%q, %q)", matchFile, matchDir)
 		}
 	})
+
+	t.Run("external target canonical identity does not replace its lexical selector path", func(t *testing.T) {
+		fs := &configPathSpaceFS{
+			caseSensitive: true,
+			realPaths: map[string]string{
+				"/repo/config":            "/physical/config",
+				"/repo/workspace/link.js": "/elsewhere/source.js",
+			},
+		}
+		matchFile, matchDir := ResolveConfigFilePathSpaceWithCanonical(
+			"/repo/workspace/link.js",
+			"/elsewhere/source.js",
+			"/repo/config",
+			fs,
+		)
+		if matchFile != "/repo/workspace/link.js" || matchDir != "/repo/config" {
+			t.Fatalf("external lexical path space = (%q, %q)", matchFile, matchDir)
+		}
+
+		matchFile, matchDir = ResolveConfigFilePathSpaceWithCanonical(
+			"/repo/workspace/inside-link.js",
+			"/physical/config/source.js",
+			"/repo/config",
+			fs,
+		)
+		if matchFile != "/repo/workspace/inside-link.js" || matchDir != "/repo/config" {
+			t.Fatalf("external link into config tree changed selector path = (%q, %q)", matchFile, matchDir)
+		}
+	})
+
+	t.Run("shared alias ancestor keeps sibling relative selectors", func(t *testing.T) {
+		fs := &configPathSpaceFS{
+			caseSensitive: true,
+			realPaths: map[string]string{
+				"/alias":                     "/real",
+				"/alias/config":              "/real/config",
+				"/real/workspace":            "/real/workspace",
+				"/real/workspace/visible.ts": "/real/workspace/visible.ts",
+			},
+		}
+		matchFile, matchDir := ResolveConfigFilePathSpace(
+			"/real/workspace/visible.ts",
+			"/alias/config",
+			fs,
+		)
+		if matchFile != "/real/workspace/visible.ts" || matchDir != "/real/config" {
+			t.Fatalf("shared alias path space = (%q, %q)", matchFile, matchDir)
+		}
+
+		entries := RslintConfig{{
+			Files: []string{"../workspace/*.ts"},
+			Rules: Rules{"rule": "error"},
+		}}
+		if merged := NewFileConfigResolverWithFS(entries, "/alias/config", fs, false).
+			ConfigForFile("/real/workspace/visible.ts"); merged == nil || merged.Rules["rule"] == nil {
+			t.Fatalf("shared alias selector did not match: %#v", merged)
+		}
+	})
+
+	t.Run("shared alias ancestor preserves a file symlink basename", func(t *testing.T) {
+		fs := &configPathSpaceFS{
+			caseSensitive: true,
+			realPaths: map[string]string{
+				"/alias":                  "/real",
+				"/alias/config":           "/real/config",
+				"/real/workspace":         "/real/workspace",
+				"/real/workspace/link.ts": "/elsewhere/source.ts",
+				"/elsewhere/source.ts":    "/elsewhere/source.ts",
+			},
+		}
+		matchFile, matchDir := ResolveConfigFilePathSpace(
+			"/real/workspace/link.ts",
+			"/alias/config",
+			fs,
+		)
+		if matchFile != "/real/workspace/link.ts" || matchDir != "/real/config" {
+			t.Fatalf("shared alias file-symlink path space = (%q, %q)", matchFile, matchDir)
+		}
+
+		entries := RslintConfig{{
+			Files: []string{"../workspace/link.ts"},
+			Rules: Rules{"rule": "error"},
+		}}
+		if merged := NewFileConfigResolverWithFS(entries, "/alias/config", fs, false).
+			ConfigForFile("/real/workspace/link.ts"); merged == nil || merged.Rules["rule"] == nil {
+			t.Fatalf("shared alias file-symlink selector did not match: %#v", merged)
+		}
+	})
+}
+
+func TestResolveConfigDirectoryPathSpace(t *testing.T) {
+	fs := &configPathSpaceFS{
+		caseSensitive: true,
+		realPaths: map[string]string{
+			"/repo/config-link": "/physical/config",
+			"/repo/workspace":   "/repo/workspace",
+		},
+	}
+
+	matchDirectory, matchConfigDirectory := ResolveConfigDirectoryPathSpace(
+		"/repo/config-link",
+		"/physical/config",
+		fs,
+	)
+	if matchDirectory != "/physical/config" || matchConfigDirectory != "/physical/config" {
+		t.Fatalf("directory alias into config tree = (%q, %q)", matchDirectory, matchConfigDirectory)
+	}
+
+	matchDirectory, matchConfigDirectory = ResolveConfigDirectoryPathSpace(
+		"/repo/workspace",
+		"/repo/config-link",
+		fs,
+	)
+	if matchDirectory != "/repo/workspace" || matchConfigDirectory != "/repo/config-link" {
+		t.Fatalf("external directory projection = (%q, %q)", matchDirectory, matchConfigDirectory)
+	}
+}
+
+func TestResolveConfigFilePathSpacePreservesExternalRelativeDepth(t *testing.T) {
+	fs := &configPathSpaceFS{
+		caseSensitive: true,
+		realPaths: map[string]string{
+			"/alias/config":        "/real/config",
+			"/real/workspace/a.ts": "/real/workspace/a.ts",
+			"/real/workspace":      "/real/workspace",
+		},
+	}
+	matchFile, matchDirectory := ResolveConfigFilePathSpaceWithCanonical(
+		"/real/workspace/a.ts",
+		"/real/workspace/a.ts",
+		"/alias/config",
+		fs,
+	)
+	if matchFile != "/real/workspace/a.ts" || matchDirectory != "/alias/config" {
+		t.Fatalf("external lexical pair = (%q, %q)", matchFile, matchDirectory)
+	}
+	config := RslintConfig{{
+		Files: []string{"../../real/workspace/**"},
+		Rules: Rules{"rule": "error"},
+	}}
+	if config.GetConfigForFile(matchFile, matchDirectory) == nil {
+		t.Fatal("external selector lost its lexical ../ depth")
+	}
 }
 
 func TestConfigOwnerResolverUsesVerifiedNativeCaseAliasBeforeFileRealpath(t *testing.T) {
@@ -101,6 +262,36 @@ func TestConfigOwnerResolverUsesVerifiedNativeCaseAliasBeforeFileRealpath(t *tes
 	dir, cfg := NewConfigOwnerResolver(configMap, fs).Resolve("/repo/project/link.ts")
 	if dir != "/repo/Project" || cfg == nil {
 		t.Fatalf("native case alias did not retain config owner: dir=%q cfg=%v", dir, cfg)
+	}
+}
+
+func TestConfigOwnerResolverFreezesOwnerAndAuthoredBaseTogether(t *testing.T) {
+	const configDirectory = "/config-link"
+	fs := &retargetingConfigDirectoryFS{
+		FS:         &configPathSpaceFS{caseSensitive: true},
+		configPath: configDirectory,
+	}
+	resolver := NewConfigOwnerResolver(map[string]RslintConfig{
+		configDirectory: {{
+			Files: []string{"src/*.ts"},
+			Rules: Rules{"selected": "error"},
+		}},
+	}, fs)
+	target := DiscoveredLintTarget{
+		Path:                "/outside-link/src/index.ts",
+		CanonicalPath:       "/owner-a/src/index.ts",
+		CanonicalParentPath: "/owner-a/src",
+	}
+
+	configDir, _, resolved, ok := resolver.ResolveTargetConfig(target, false)
+	if !ok || configDir != configDirectory || resolved.MergedConfig == nil {
+		t.Fatalf("frozen owner/config resolution = %q, %+v, %v", configDir, resolved, ok)
+	}
+	if _, selected := resolved.MergedConfig.Rules["selected"]; !selected {
+		t.Fatalf("frozen authored base lost selected rules: %+v", resolved.MergedConfig.Rules)
+	}
+	if fs.configCalls != 1 {
+		t.Fatalf("config directory Realpath calls = %d, want one catalog observation", fs.configCalls)
 	}
 }
 

--- a/internal/lsp/config_discovery.go
+++ b/internal/lsp/config_discovery.go
@@ -301,6 +301,7 @@ type lspDiscoveredConfigSnapshot struct {
 	ownerResolver       *config.ConfigOwnerResolver
 	unavailableConfigs  map[string]struct{}
 	jsonConfig          config.RslintConfig
+	jsonConfigResolver  *config.ConfigOwnerResolver
 	jsonConfigPath      string
 	jsonTsConfigPaths   []string
 	transactionID       string
@@ -663,6 +664,10 @@ func (s *Server) prepareDiscoveredConfigSnapshot(
 		nil,
 		jsonBoundaryResolver.ChildConfigDirs(jsonCWD),
 	)
+	snapshot.jsonConfigResolver = config.NewConfigOwnerResolver(
+		map[string]config.RslintConfig{jsonCWD: snapshot.jsonConfig},
+		fsys,
+	)
 	snapshot.jsonConfigPath = jsonPath
 	snapshot.jsonTsConfigPaths = jsonTsConfigs
 	return snapshot, nil
@@ -748,6 +753,7 @@ func (s *Server) commitDiscoveredConfigSnapshot(ctx context.Context, snapshot *l
 	s.jsConfigOwnerResolver = snapshot.ownerResolver
 	s.jsUnavailableConfigs = snapshot.unavailableConfigs
 	s.jsonConfig = snapshot.jsonConfig
+	s.jsonConfigResolver = snapshot.jsonConfigResolver
 	s.rslintConfigPath = snapshot.jsonConfigPath
 	s.tsConfigPaths = snapshot.jsonTsConfigPaths
 	s.eslintPluginConfigGeneration = snapshot.transactionID

--- a/internal/lsp/config_discovery_test.go
+++ b/internal/lsp/config_discovery_test.go
@@ -445,9 +445,21 @@ func TestHandleConfigRefreshUsesFixedExplicitConfig(t *testing.T) {
 	if err := os.WriteFile(configPath, []byte("module.exports = [];\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	targetPath := filepath.Join(root, "src", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	relativeTarget, err := filepath.Rel(externalRoot, targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	initial := startExplicitConfigRefreshForTest(s, "initial", configPath)
 	loadRequest := completeSuccessfulConfigRefreshForTest(t, s, outgoing, config.RslintConfig{{
+		Files: []string{filepath.ToSlash(relativeTarget)},
 		Rules: config.Rules{"no-debugger": "error"},
 	}})
 	if completed := awaitConfigRefreshResult(t, initial); completed.err != nil {
@@ -456,8 +468,9 @@ func TestHandleConfigRefreshUsesFixedExplicitConfig(t *testing.T) {
 	if len(loadRequest.Candidates) != 1 || loadRequest.Candidates[0].ConfigPath != tspath.NormalizePath(configPath) {
 		t.Fatalf("explicit candidates = %+v, want only %q", loadRequest.Candidates, configPath)
 	}
-	if loadRequest.Candidates[0].ConfigDirectory != root {
-		t.Fatalf("explicit configDirectory = %q, want cwd %q", loadRequest.Candidates[0].ConfigDirectory, root)
+	configDir := tspath.NormalizePath(externalRoot)
+	if loadRequest.Candidates[0].ConfigDirectory != configDir {
+		t.Fatalf("explicit configDirectory = %q, want config directory %q", loadRequest.Candidates[0].ConfigDirectory, configDir)
 	}
 	if !s.configRefreshInitialized || s.configRefreshConfigPath != tspath.NormalizePath(configPath) {
 		t.Fatalf("fixed config path = %q, initialized=%t", s.configRefreshConfigPath, s.configRefreshInitialized)
@@ -465,8 +478,13 @@ func TestHandleConfigRefreshUsesFixedExplicitConfig(t *testing.T) {
 	if s.rslintConfigPath != "" || len(s.jsonConfig) != 0 {
 		t.Fatalf("explicit config retained JSON fallback: path=%q config=%+v", s.rslintConfigPath, s.jsonConfig)
 	}
-	if value, found := configRuleValue(s.jsConfigs[root], "no-debugger"); !found || value != "error" {
-		t.Fatalf("explicit config was not committed at cwd: %+v", s.jsConfigs)
+	if value, found := configRuleValue(s.jsConfigs[configDir], "no-debugger"); !found || value != "error" {
+		t.Fatalf("explicit config was not committed at its directory: %+v", s.jsConfigs)
+	}
+	entries, resolvedDirectory, isJSConfig := s.getConfigForURI(documentURIFromPath(targetPath))
+	if !isJSConfig || resolvedDirectory != configDir ||
+		config.NewFileConfigResolverWithFS(entries, resolvedDirectory, s.fs, false).ConfigForFile(targetPath) == nil {
+		t.Fatalf("explicit external config did not govern workspace target from its authored base")
 	}
 
 	reload := startExplicitConfigRefreshForTest(s, "config-change", configPath)
@@ -527,7 +545,7 @@ func TestHandleConfigRefreshUsesFixedExplicitConfig(t *testing.T) {
 
 func TestHandleConfigRefreshKeepsExplicitPathAfterInitialLoadFailure(t *testing.T) {
 	config.RegisterAllRules()
-	s, outgoing, root := newConfigRefreshTestServer(t)
+	s, outgoing, _ := newConfigRefreshTestServer(t)
 	configPath := filepath.Join(t.TempDir(), "generated-rstack-config.mjs")
 	if err := os.WriteFile(configPath, []byte("export default [];\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -552,7 +570,8 @@ func TestHandleConfigRefreshKeepsExplicitPathAfterInitialLoadFailure(t *testing.
 	if s.configRefreshConfigPath != tspath.NormalizePath(configPath) || !s.configRefreshInitialized {
 		t.Fatalf("failed initial load lost fixed path: path=%q initialized=%t", s.configRefreshConfigPath, s.configRefreshInitialized)
 	}
-	if _, unavailable := s.jsUnavailableConfigs[root]; !unavailable || s.configDiscoveryHasLastGood {
+	configDir := tspath.NormalizePath(filepath.Dir(configPath))
+	if _, unavailable := s.jsUnavailableConfigs[configDir]; !unavailable || s.configDiscoveryHasLastGood {
 		t.Fatalf("explicit failure state: unavailable=%t lastGood=%t", unavailable, s.configDiscoveryHasLastGood)
 	}
 	if _, err := s.handleConfigRefresh(context.Background(), configRefreshRequest{

--- a/internal/lsp/config_snapshot_fs.go
+++ b/internal/lsp/config_snapshot_fs.go
@@ -19,6 +19,7 @@ type configSnapshotFS struct {
 
 	mu                sync.Mutex
 	gitignoreSnapshot map[string]configSnapshotFile
+	realpathSnapshot  map[string]string
 	caseSensitive     bool
 }
 
@@ -35,8 +36,31 @@ func newConfigSnapshotFS(fsys vfs.FS) *configSnapshotFS {
 	return &configSnapshotFS{
 		FS:                fsys,
 		gitignoreSnapshot: make(map[string]configSnapshotFile),
+		realpathSnapshot:  make(map[string]string),
 		caseSensitive:     caseSensitive,
 	}
+}
+
+// Realpath freezes normalized path lookups for this config evaluation. Cache
+// identity follows the filesystem's case sensitivity so alternate casing
+// cannot observe two physical generations on a case-insensitive filesystem.
+// It is intentionally scoped outside target capture: FreezeLintTargetIdentity
+// must observe its parent-before/file/parent-after sequence directly, while
+// owner selection, Git projection, and authored-base matching that follow it
+// must agree with one another.
+func (fsys *configSnapshotFS) Realpath(filePath string) string {
+	if fsys == nil || fsys.FS == nil {
+		return ""
+	}
+	key := fsys.snapshotKey(filePath)
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+	if realPath, ok := fsys.realpathSnapshot[key]; ok {
+		return realPath
+	}
+	realPath := fsys.FS.Realpath(filePath)
+	fsys.realpathSnapshot[key] = realPath
+	return realPath
 }
 
 func (fsys *configSnapshotFS) ReadFile(filePath string) (string, bool) {
@@ -48,10 +72,7 @@ func (fsys *configSnapshotFS) ReadFile(filePath string) (string, bool) {
 		return fsys.FS.ReadFile(filePath)
 	}
 
-	key := filePath
-	if !fsys.caseSensitive {
-		key = strings.ToLower(key)
-	}
+	key := fsys.snapshotKey(filePath)
 	fsys.mu.Lock()
 	defer fsys.mu.Unlock()
 	if file, ok := fsys.gitignoreSnapshot[key]; ok {
@@ -60,4 +81,12 @@ func (fsys *configSnapshotFS) ReadFile(filePath string) (string, bool) {
 	content, exists := fsys.FS.ReadFile(filePath)
 	fsys.gitignoreSnapshot[key] = configSnapshotFile{content: content, exists: exists}
 	return content, exists
+}
+
+func (fsys *configSnapshotFS) snapshotKey(filePath string) string {
+	key := tspath.NormalizePath(filePath)
+	if !fsys.caseSensitive {
+		key = strings.ToLower(key)
+	}
+	return key
 }

--- a/internal/lsp/config_snapshot_fs_test.go
+++ b/internal/lsp/config_snapshot_fs_test.go
@@ -1,0 +1,34 @@
+package lsp
+
+import (
+	"fmt"
+	"testing"
+)
+
+type caseInsensitiveConfigSnapshotFS struct {
+	mockFS
+	realpathCalls int
+}
+
+func (fsys *caseInsensitiveConfigSnapshotFS) UseCaseSensitiveFileNames() bool {
+	return false
+}
+
+func (fsys *caseInsensitiveConfigSnapshotFS) Realpath(filePath string) string {
+	fsys.realpathCalls++
+	return fmt.Sprintf("%s#%d", filePath, fsys.realpathCalls)
+}
+
+func TestConfigSnapshotFSCaseInsensitiveRealpathIdentity(t *testing.T) {
+	underlying := &caseInsensitiveConfigSnapshotFS{}
+	fsys := newConfigSnapshotFS(underlying)
+
+	first := fsys.Realpath("/Project/Config")
+	second := fsys.Realpath("/project/config")
+	if first != second {
+		t.Fatalf("alternate casing observed two snapshots: first %q, second %q", first, second)
+	}
+	if underlying.realpathCalls != 1 {
+		t.Fatalf("Realpath calls = %d, want one case-insensitive observation", underlying.realpathCalls)
+	}
+}

--- a/internal/lsp/document_changes_test.go
+++ b/internal/lsp/document_changes_test.go
@@ -363,8 +363,9 @@ func TestUnicodeBomIsNotServedToEditors(t *testing.T) {
 			cfg := config.RslintConfig{{Rules: config.Rules{"unicode-bom": test.option}}}
 			resolver := config.NewFileConfigResolver(cfg, dir, false)
 
+			target := lspConfigTarget(file, dir, fs)
 			served := lintSingleFile(
-				program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, context.Background(),
+				program, sourceFile, target, dir, true, resolver.ResolveTarget(target).EnabledRules, rule.EditDemandAll, context.Background(),
 			).Diagnostics
 
 			if len(served) != 0 {
@@ -409,8 +410,9 @@ func TestOtherRulesStillRunInTheEditor(t *testing.T) {
 	}}
 	resolver := config.NewFileConfigResolver(cfg, dir, false)
 
+	target := lspConfigTarget(file, dir, fs)
 	served := lintSingleFile(
-		program, sourceFile, file, dir, true, resolver, rule.EditDemandAll, context.Background(),
+		program, sourceFile, target, dir, true, resolver.ResolveTarget(target).EnabledRules, rule.EditDemandAll, context.Background(),
 	).Diagnostics
 
 	byRule := make(map[string][]rule.RuleFix, len(served))

--- a/internal/lsp/eslint_plugin.go
+++ b/internal/lsp/eslint_plugin.go
@@ -69,11 +69,11 @@ func (s *Server) installEslintPluginDispatch() linter.EslintPluginDispatcher {
 // Must be called from the main dispatch loop: it reads s.jsConfigs (lock-free)
 // and the s.documents overlay.
 func (s *Server) buildPluginFileInput(uri lsproto.DocumentUri, textOverride *string) (linter.EslintPluginFileInput, bool) {
-	if s.isUnavailableConfigForURI(uri) {
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.unavailable {
 		return linter.EslintPluginFileInput{}, false
 	}
-	rslintConfig, configCwd, isJSConfig := s.getLintConfigForURI(uri)
-	return s.buildPluginFileInputWithConfig(uri, textOverride, rslintConfig, configCwd, isJSConfig)
+	return s.buildPluginFileInputWithSnapshot(uri, textOverride, snapshot)
 }
 
 func (s *Server) buildPluginFileInputWithConfig(
@@ -83,15 +83,38 @@ func (s *Server) buildPluginFileInputWithConfig(
 	configCwd string,
 	isJSConfig bool,
 ) (linter.EslintPluginFileInput, bool) {
-	configKey := s.pluginConfigKeyForURI(uri)
-	filePath := uriToPath(uri)
-	configFilePath, matchConfigDir := config.ResolveConfigPathSpace(filePath, configCwd, s.fs)
-	if isDefaultExcludedLintPath(configFilePath, matchConfigDir, s.fs) {
+	return s.buildPluginFileInputWithSnapshot(
+		uri,
+		textOverride,
+		resolveDocumentLintSnapshotConfig(documentLintSnapshot{
+			target:               lspConfigTarget(uriToPath(uri), configCwd, s.fs),
+			config:               rslintConfig,
+			usesJavaScriptConfig: isJSConfig,
+		}, s.fs),
+	)
+}
+
+func (s *Server) buildPluginFileInputWithSnapshot(
+	uri lsproto.DocumentUri,
+	textOverride *string,
+	snapshot documentLintSnapshot,
+) (linter.EslintPluginFileInput, bool) {
+	if !snapshot.configResolved {
+		snapshot = resolveDocumentLintSnapshotConfig(snapshot, s.fs)
+	}
+	target := snapshot.target
+	filePath := target.Path
+	configCwd := target.ConfigDirectory
+	configKey := ""
+	if snapshot.usesJavaScriptConfig {
+		configKey = configCwd
+	}
+	if isDefaultExcludedLintPath(target.Path, s.cwd, s.fs) {
 		return linter.EslintPluginFileInput{}, false
 	}
 
-	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, matchConfigDir, isJSConfig)
-	enabledRules, merged := fileConfigResolver.EnabledRulesForFile(configFilePath)
+	enabledRules := snapshot.resolvedConfig.EnabledRules
+	merged := snapshot.resolvedConfig.MergedConfig
 	if merged == nil {
 		// File is globally ignored — no plugin (or native) diagnostics.
 		return linter.EslintPluginFileInput{}, false
@@ -181,20 +204,18 @@ func (s *Server) pluginConfigKeyForURI(uri lsproto.DocumentUri) string {
 // Must be called from the main dispatch loop (it reads jsConfigs + documents
 // to build the input and the generation map).
 func (s *Server) dispatchPluginLint(uri lsproto.DocumentUri, generation uint64) {
-	if s.isUnavailableConfigForURI(uri) {
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.unavailable {
 		s.cancelInflightPluginDispatch(uri)
 		return
 	}
-	rslintConfig, configCwd, isJSConfig := s.getLintConfigForURI(uri)
-	s.dispatchPluginLintWithConfig(uri, generation, rslintConfig, configCwd, isJSConfig)
+	s.dispatchPluginLintWithSnapshot(uri, generation, snapshot)
 }
 
-func (s *Server) dispatchPluginLintWithConfig(
+func (s *Server) dispatchPluginLintWithSnapshot(
 	uri lsproto.DocumentUri,
 	generation uint64,
-	rslintConfig config.RslintConfig,
-	configCwd string,
-	isJSConfig bool,
+	snapshot documentLintSnapshot,
 ) {
 	// Supersede any prior in-flight dispatch for this URI FIRST — before the
 	// no-plugin-work early return below. Even a relint that yields no plugin
@@ -204,7 +225,7 @@ func (s *Server) dispatchPluginLintWithConfig(
 	// a $/cancelRequest tells the client to stop the worker.
 	s.cancelInflightPluginDispatch(uri)
 
-	input, ok := s.buildPluginFileInputWithConfig(uri, nil, rslintConfig, configCwd, isJSConfig)
+	input, ok := s.buildPluginFileInputWithSnapshot(uri, nil, snapshot)
 	if !ok {
 		return
 	}
@@ -362,24 +383,22 @@ func (s *Server) mergePluginDiagnostics(r pluginLintResult) {
 //
 // Must be called from the main dispatch loop (it reads jsConfigs + documents).
 func (s *Server) lintPluginRulesSync(ctx context.Context, uri lsproto.DocumentUri, content string, fix bool, suggestionsMode string) []rule.RuleDiagnostic {
-	if s.isUnavailableConfigForURI(uri) {
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.unavailable {
 		return nil
 	}
-	rslintConfig, configCwd, isJSConfig := s.getLintConfigForURI(uri)
-	return s.lintPluginRulesSyncWithConfig(ctx, uri, content, fix, suggestionsMode, rslintConfig, configCwd, isJSConfig)
+	return s.lintPluginRulesSyncWithSnapshot(ctx, uri, content, fix, suggestionsMode, snapshot)
 }
 
-func (s *Server) lintPluginRulesSyncWithConfig(
+func (s *Server) lintPluginRulesSyncWithSnapshot(
 	ctx context.Context,
 	uri lsproto.DocumentUri,
 	content string,
 	fix bool,
 	suggestionsMode string,
-	rslintConfig config.RslintConfig,
-	configCwd string,
-	isJSConfig bool,
+	snapshot documentLintSnapshot,
 ) []rule.RuleDiagnostic {
-	input, ok := s.buildPluginFileInputWithConfig(uri, &content, rslintConfig, configCwd, isJSConfig)
+	input, ok := s.buildPluginFileInputWithSnapshot(uri, &content, snapshot)
 	if !ok {
 		return nil
 	}

--- a/internal/lsp/eslint_plugin_test.go
+++ b/internal/lsp/eslint_plugin_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/jsonrpc"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
@@ -313,6 +314,100 @@ func TestBuildPluginFileInput_RespectsFiles(t *testing.T) {
 	}
 }
 
+func TestBuildPluginFileInputPreservesTargetIdentityAcrossAuthoredConfigBases(t *testing.T) {
+	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
+		{Prefix: "tpauthoredbase", RuleNames: []string{"no-foo"}},
+	})
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	configDir := filepath.Join(root, "physical", "package")
+	physicalSourceDir := filepath.Join(configDir, "src")
+	aliasSourceDir := filepath.Join(workspace, "linked-src")
+	for _, directory := range []string{workspace, physicalSourceDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(physicalSourceDir, aliasSourceDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasFile := filepath.Join(aliasSourceDir, "index.ts")
+	if err := os.WriteFile(aliasFile, []byte("foo();\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	effective := config.ConfigWithAuthoredPathBase(config.RslintConfig{{
+		Files:   []string{"linked-src/**/*.ts"},
+		Plugins: []string{"tpauthoredbase"},
+		Rules:   config.Rules{"tpauthoredbase/no-foo": "error"},
+	}}, workspace)
+
+	s := newTestServer()
+	s.cwd = workspace
+	s.fs = osvfs.FS()
+	uri := documentURIFromPath(aliasFile)
+	s.documents[uri] = "foo();\n"
+	input, ok := s.buildPluginFileInputWithConfig(uri, nil, effective, configDir, true)
+	if !ok {
+		t.Fatal("workspace-authored plugin rule lost the lexical symlink target")
+	}
+	if len(input.Rules) != 1 || input.Rules[0].Name != "tpauthoredbase/no-foo" {
+		t.Fatalf("unexpected plugin rules: %+v", input.Rules)
+	}
+}
+
+func TestBuildPluginFileInputExternalConfigPreservesGitignoreTargetIdentity(t *testing.T) {
+	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
+		{Prefix: "tpexternalgit", RuleNames: []string{"no-foo"}},
+	})
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	configDir := filepath.Join(root, "physical", "package")
+	physicalSourceDir := filepath.Join(configDir, "src")
+	aliasSourceDir := filepath.Join(workspace, "linked-src")
+	for _, directory := range []string{workspace, physicalSourceDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(physicalSourceDir, aliasSourceDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasFile := filepath.Join(aliasSourceDir, "ignored.ts")
+	if err := os.WriteFile(aliasFile, []byte("foo();\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workspace, ".gitignore"),
+		[]byte("linked-src/ignored.ts\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	effective := config.ConfigWithGitignoreForTargetsFromRoot(
+		config.RslintConfig{{
+			Files:   []string{"src/**/*.ts"},
+			Plugins: []string{"tpexternalgit"},
+			Rules:   config.Rules{"tpexternalgit/no-foo": "error"},
+		}},
+		configDir,
+		workspace,
+		osvfs.FS(),
+		[]string{aliasFile},
+		nil,
+	)
+
+	s := newTestServer()
+	s.cwd = workspace
+	s.fs = osvfs.FS()
+	uri := documentURIFromPath(aliasFile)
+	s.documents[uri] = "foo();\n"
+	if input, ok := s.buildPluginFileInputWithConfig(uri, nil, effective, configDir, true); ok {
+		t.Fatalf("external-config Git ignore produced plugin input: %+v", input)
+	}
+}
+
 func TestBuildPluginFileInput_RespectsGitignore(t *testing.T) {
 	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
 		{Prefix: "tpgitignore", RuleNames: []string{"no-foo"}},
@@ -586,7 +681,7 @@ func TestComputeFixAllContent_FoldsPluginFixes(t *testing.T) {
 	// Injected native lint: fix the first "1" → "2" wherever it appears. Returns
 	// no fix once the digit is gone (so the loop converges).
 	var nativePasses int
-	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ config.RslintConfig, _ string, _ bool, _ []string) (lintPassResult, error) {
+	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ documentLintSnapshot) (lintPassResult, error) {
 		nativePasses++
 		idx := strings.Index(content, "1")
 		if idx < 0 {
@@ -601,8 +696,7 @@ func TestComputeFixAllContent_FoldsPluginFixes(t *testing.T) {
 		}}}, nil
 	}
 
-	effective, configCwd, isJSConfig := s.getLintConfigForURI(uri)
-	got := s.computeFixAllContent(context.Background(), uri, original, effective, configCwd, isJSConfig, nil)
+	got := s.computeFixAllContent(context.Background(), uri, original, s.documentLintSnapshot(uri))
 
 	// Both fixes applied (native "1"→"2" AND plugin "bar"→"baz") proves the
 	// fold: the plugin fix survived alongside the native one in the same pass.
@@ -612,6 +706,220 @@ func TestComputeFixAllContent_FoldsPluginFixes(t *testing.T) {
 	// Pass 0 fixes both; pass 1 sees neither "1" nor "bar" → no fix → converge.
 	if nativePasses != 2 || pluginPasses != 2 {
 		t.Errorf("expected 2 native + 2 plugin passes (1 fixing, 1 converging), got native=%d plugin=%d", nativePasses, pluginPasses)
+	}
+}
+
+type retargetingDocumentFS struct {
+	mockFS
+	targetPath string
+	targets    []string
+	targetCall int
+}
+
+type retargetingConfigEvaluationFS struct {
+	mockFS
+	targetPath       string
+	targetParentPath string
+	configPath       string
+	configCalls      int
+}
+
+func (fsys *retargetingConfigEvaluationFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	switch filePath {
+	case fsys.targetPath:
+		return "/owner-a/src/index.ts"
+	case fsys.targetParentPath:
+		return "/owner-a/src"
+	case fsys.configPath:
+		fsys.configCalls++
+		if fsys.configCalls == 1 {
+			return "/owner-a"
+		}
+		return "/owner-b"
+	default:
+		return filePath
+	}
+}
+
+func TestDocumentLintSnapshotCollectsGitignoreFromFrozenTarget(t *testing.T) {
+	uri := lsproto.DocumentUri("file:///alias/source.ts")
+	filePath := tspath.NormalizePath(uriToPath(uri))
+	fsys := &retargetingDocumentFS{
+		targetPath: filePath,
+		targets:    []string{"/owner-a/source.ts", "/owner-b/source.ts"},
+	}
+	s := newTestServer()
+	s.cwd = "/alias"
+	s.fs = fsys
+	s.jsonConfig = config.RslintConfig{{}}
+
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.target.CanonicalPath != "/owner-a/source.ts" {
+		t.Fatalf("snapshot target = %+v", snapshot.target)
+	}
+	if fsys.targetCall != 1 {
+		t.Fatalf("target Realpath calls = %d, want one identity observation", fsys.targetCall)
+	}
+}
+
+func TestDocumentLintSnapshotFreezesBootstrapConfigEvaluation(t *testing.T) {
+	uri := lsproto.DocumentUri("file:///outside-link/src/index.ts")
+	filePath := tspath.NormalizePath(uriToPath(uri))
+	configPath := "/config-link"
+	fsys := &retargetingConfigEvaluationFS{
+		targetPath:       filePath,
+		targetParentPath: tspath.GetDirectoryPath(filePath),
+		configPath:       configPath,
+	}
+	s := newTestServer()
+	s.cwd = configPath
+	s.fs = fsys
+	s.jsonConfig = config.RslintConfig{{
+		Files: []string{"src/*.ts"},
+		Rules: config.Rules{"no-debugger": "error"},
+	}}
+
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.target.CanonicalPath != "/owner-a/src/index.ts" ||
+		snapshot.resolvedConfig.MergedConfig == nil {
+		t.Fatalf("bootstrap snapshot mixed config generations: %+v", snapshot)
+	}
+	if fsys.configCalls != 1 {
+		t.Fatalf("config directory Realpath calls = %d, want one evaluation observation", fsys.configCalls)
+	}
+}
+
+func TestNativeFixPassUsesFrozenTargetOverlay(t *testing.T) {
+	config.RegisterAllRules()
+	uri := lsproto.DocumentUri("file:///alias/source.ts")
+	filePath := tspath.NormalizePath(uriToPath(uri))
+	fsys := &retargetingDocumentFS{
+		targetPath: filePath,
+		targets:    []string{"/owner-a/source.ts", "/owner-b/source.ts"},
+	}
+	s := newTestServer()
+	s.cwd = "/alias"
+	s.fs = fsys
+	s.configSnapshotIncludesGitignore = true
+	s.jsonConfig = config.RslintConfig{{
+		Rules: config.Rules{"no-debugger": "error"},
+	}}
+	const content = "debugger;\n"
+	s.documents[uri] = content
+	snapshot := s.documentLintSnapshot(uri)
+
+	result, err := s.runConfiguredLintForContentWithSnapshot(
+		uri,
+		context.Background(),
+		content,
+		snapshot,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Diagnostics) != 1 || result.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("native diagnostics = %+v", result.Diagnostics)
+	}
+	if fsys.targetCall != 1 {
+		t.Fatalf("target Realpath calls = %d, want one frozen observation", fsys.targetCall)
+	}
+}
+
+func (fsys *retargetingDocumentFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	if filePath != fsys.targetPath {
+		return filePath
+	}
+	index := fsys.targetCall
+	fsys.targetCall++
+	if index >= len(fsys.targets) {
+		index = len(fsys.targets) - 1
+	}
+	return fsys.targets[index]
+}
+
+func TestComputeFixAllContentSharesFrozenTargetWithNativeAndPlugin(t *testing.T) {
+	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
+		{Prefix: "tpfrozentarget", RuleNames: []string{"owner-a", "owner-b"}},
+	})
+	uri := lsproto.DocumentUri("file:///alias/source.ts")
+	filePath := tspath.NormalizePath(uriToPath(uri))
+	fsys := &retargetingDocumentFS{
+		targetPath: filePath,
+		targets:    []string{"/owner-a/source.ts", "/owner-b/source.ts"},
+	}
+	s := newTestServer()
+	s.cwd = "/alias"
+	s.fs = fsys
+	s.configSnapshotIncludesGitignore = true
+	installJSConfigsForTest(s, map[string]config.RslintConfig{
+		"/owner-a": {{
+			Files:   []string{"**/*.ts"},
+			Plugins: []string{"tpfrozentarget"},
+			Rules:   config.Rules{"tpfrozentarget/owner-a": "error"},
+		}},
+		"/owner-b": {{
+			Files:   []string{"**/*.ts"},
+			Plugins: []string{"tpfrozentarget"},
+			Rules:   config.Rules{"tpfrozentarget/owner-b": "error"},
+		}},
+	})
+	s.tsConfigPathsByConfig = map[string][]string{
+		"/owner-a": {"/owner-a/tsconfig.json"},
+		"/owner-b": {"/owner-b/tsconfig.json"},
+	}
+	const source = "const value = 1;"
+	s.documents[uri] = source
+
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.target.CanonicalPath != "/owner-a/source.ts" ||
+		snapshot.target.ConfigDirectory != "/owner-a" ||
+		len(snapshot.typeScriptConfigPaths) != 1 ||
+		snapshot.typeScriptConfigPaths[0] != "/owner-a/tsconfig.json" {
+		t.Fatalf("snapshot mixed target/config/project owners: %+v", snapshot)
+	}
+
+	nativeCalls := 0
+	s.fixAllNativeLint = func(
+		_ context.Context,
+		_ lsproto.DocumentUri,
+		_ int,
+		_ string,
+		got documentLintSnapshot,
+	) (lintPassResult, error) {
+		nativeCalls++
+		if got.target != snapshot.target ||
+			len(got.typeScriptConfigPaths) != 1 ||
+			got.typeScriptConfigPaths[0] != "/owner-a/tsconfig.json" {
+			t.Fatalf("native pass received a different snapshot: %+v", got)
+		}
+		return lintPassResult{}, nil
+	}
+	pluginCalls := 0
+	s.eslintPluginDispatch = func(
+		_ context.Context,
+		req linter.EslintPluginLintRequest,
+	) (*linter.EslintPluginLintResult, error) {
+		pluginCalls++
+		_, hasOwnerA := req.Rules["tpfrozentarget/owner-a"]
+		if len(req.Files) != 1 || len(req.Rules) != 1 || !hasOwnerA ||
+			req.Files[0].ConfigKey != "/owner-a" {
+			t.Fatalf("plugin pass received a different owner: %+v", req.Files)
+		}
+		return &linter.EslintPluginLintResult{Results: []linter.EslintPluginFileResult{{
+			FilePath: req.Files[0].Path,
+		}}}, nil
+	}
+
+	if got := s.computeFixAllContent(context.Background(), uri, source, snapshot); got != source {
+		t.Fatalf("fixAll changed source without fixes: %q", got)
+	}
+	if nativeCalls != 1 || pluginCalls != 1 {
+		t.Fatalf("native/plugin calls = %d/%d, want 1/1", nativeCalls, pluginCalls)
+	}
+	if fsys.targetCall != 1 {
+		t.Fatalf("target Realpath calls = %d, want one frozen observation", fsys.targetCall)
 	}
 }
 
@@ -645,7 +953,7 @@ func TestComputeFixAllContent_PluginTimeoutFallsBackNativeOnly(t *testing.T) {
 		return nil, ctx.Err()
 	}
 	// Injected native lint: fix the first "1" → "2", nothing once it is gone.
-	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ config.RslintConfig, _ string, _ bool, _ []string) (lintPassResult, error) {
+	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ documentLintSnapshot) (lintPassResult, error) {
 		idx := strings.Index(content, "1")
 		if idx < 0 {
 			return lintPassResult{}, nil
@@ -660,8 +968,7 @@ func TestComputeFixAllContent_PluginTimeoutFallsBackNativeOnly(t *testing.T) {
 	}
 
 	start := time.Now()
-	effective, configCwd, isJSConfig := s.getLintConfigForURI(uri)
-	got := s.computeFixAllContent(context.Background(), uri, original, effective, configCwd, isJSConfig, nil)
+	got := s.computeFixAllContent(context.Background(), uri, original, s.documentLintSnapshot(uri))
 	elapsed := time.Since(start)
 
 	// Native fix applied; the wedged plugin pass timed out and was dropped
@@ -694,11 +1001,16 @@ func TestComputeFixAllContent_SyntaxErrorSkipsPluginPass(t *testing.T) {
 		pluginCalls++
 		return &linter.EslintPluginLintResult{}, nil
 	}
-	s.fixAllNativeLint = func(context.Context, lsproto.DocumentUri, int, string, config.RslintConfig, string, bool, []string) (lintPassResult, error) {
+	s.fixAllNativeLint = func(context.Context, lsproto.DocumentUri, int, string, documentLintSnapshot) (lintPassResult, error) {
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}, HasSyntaxErrors: true}, nil
 	}
 
-	got := s.computeFixAllContent(context.Background(), uri, malformed, config.RslintConfig{}, "", true, nil)
+	got := s.computeFixAllContent(
+		context.Background(),
+		uri,
+		malformed,
+		documentLintSnapshotForTest(s, uri, config.RslintConfig{}, "", true, nil),
+	)
 	if got != malformed {
 		t.Fatalf("syntax-error fixAll changed content to %q", got)
 	}

--- a/internal/lsp/lint_program_store.go
+++ b/internal/lsp/lint_program_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 
+	"github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -41,7 +42,7 @@ type lintProgramRequest struct {
 	ctx               context.Context
 	uri               lsproto.DocumentUri
 	overlayFS         vfs.FS
-	targetPath        string
+	target            config.DiscoveredLintTarget
 	freshOnly         bool
 	overlayPrepared   bool
 	usedConfig        string
@@ -67,11 +68,20 @@ func (s *lintProgramStore) Usable() bool {
 func (s *lintProgramStore) Request(
 	ctx context.Context,
 	uri lsproto.DocumentUri,
+	target config.DiscoveredLintTarget,
 ) (lintProgramLoader, lintProjectMetadataLoader, func()) {
+	target.Path = tspath.NormalizePath(target.Path)
+	if target.CanonicalPath != "" {
+		target.CanonicalPath = tspath.NormalizePath(target.CanonicalPath)
+	}
+	if target.CanonicalParentPath != "" {
+		target.CanonicalParentPath = tspath.NormalizePath(target.CanonicalParentPath)
+	}
 	request := &lintProgramRequest{
 		store:             s,
 		ctx:               ctx,
 		uri:               uri,
+		target:            target,
 		projectMetadata:   make(map[string]*lintProjectMetadata),
 		transientMetadata: make(map[string]struct{}),
 	}
@@ -92,8 +102,7 @@ func (r *lintProgramRequest) prepareOverlay() {
 	r.overlayPrepared = true
 	var aliasesConflict bool
 	r.overlayFS, aliasesConflict =
-		r.store.server.currentEditorOverlayFSWithConflicts(r.uri)
-	r.targetPath = uriToPath(r.uri)
+		r.store.server.currentEditorOverlayFSForTargetWithConflicts(r.uri, r.target)
 	if aliasesConflict {
 		r.store.Invalidate()
 		r.freshOnly = true
@@ -194,7 +203,10 @@ func (r *lintProgramRequest) load(
 		return r.rebuild(configFileName, r.projectMetadata[configFileName])
 	}
 
-	targetSource := state.sources.SourceFileForPath(r.targetPath)
+	targetSource := state.sources.SourceFileForTarget(
+		r.target.Path,
+		r.target.CanonicalPath,
+	)
 	if content, open := r.store.server.documents[r.uri]; open {
 		r.store.markStateSourceContent(state, targetSource, content)
 	}
@@ -234,7 +246,10 @@ func (r *lintProgramRequest) load(
 	clear(state.dirtyFiles)
 	added, safe := r.cover(state)
 	if !safe {
-		return program, state.sources.SourceFileForPath(r.targetPath), nil
+		return program, state.sources.SourceFileForTarget(
+			r.target.Path,
+			r.target.CanonicalPath,
+		), nil
 	}
 	if added {
 		return r.rebuild(configFileName, state.metadata)
@@ -253,7 +268,7 @@ func (r *lintProgramRequest) loadFresh(
 	if err != nil {
 		return nil, nil, err
 	}
-	return program, sourceFileForPath(program, r.targetPath, r.overlayFS), nil
+	return program, sourceFileForTarget(program, r.target, r.overlayFS), nil
 }
 
 func (r *lintProgramRequest) rebuild(
@@ -274,7 +289,7 @@ func (r *lintProgramRequest) rebuild(
 		if err != nil {
 			return nil, nil, err
 		}
-		return program, sourceFileForPath(program, r.targetPath, r.overlayFS), nil
+		return program, sourceFileForTarget(program, r.target, r.overlayFS), nil
 	}
 
 	// Register every dependency discovered by the first build, then rebuild
@@ -294,7 +309,10 @@ func (r *lintProgramRequest) rebuild(
 			selectedSourceIdentities: make(map[tspath.Path]tspath.Path),
 			metadata:                 metadata,
 		}
-		sourceFile := state.sources.SourceFileForPath(r.targetPath)
+		sourceFile := state.sources.SourceFileForTarget(
+			r.target.Path,
+			r.target.CanonicalPath,
+		)
 		if sourceFile == nil {
 			// A fallback probe that did not contain this target must not make an
 			// unrelated Program resident. Previously selected resident Programs
@@ -324,9 +342,12 @@ func (r *lintProgramRequest) result(
 	configFileName string,
 	state *lintProgramState,
 ) (*compiler.Program, *ast.SourceFile, error) {
-	sourceFile := state.sources.SourceFileForPath(r.targetPath)
+	sourceFile := state.sources.SourceFileForTarget(
+		r.target.Path,
+		r.target.CanonicalPath,
+	)
 	if sourceFile != nil {
-		state.rememberSelectedSource(r.targetPath, r.store.server.fs)
+		state.rememberSelectedTarget(r.target, r.store.server.fs)
 		r.usedConfig = configFileName
 		r.usedState = state
 	}
@@ -595,9 +616,20 @@ func (s *lintProgramState) failedLookupPathMatches(path tspath.Path) bool {
 	return false
 }
 
-func (s *lintProgramState) rememberSelectedSource(fileName string, fs vfs.FS) {
-	s.selectedSourceIdentities[lintProgramLexicalPathID(fileName, fs)] =
-		tspath.Path(lspFilesystemPathID(fileName, fs))
+func (s *lintProgramState) rememberSelectedTarget(
+	target config.DiscoveredLintTarget,
+	fs vfs.FS,
+) {
+	canonicalPath := target.CanonicalPath
+	if canonicalPath == "" {
+		canonicalPath = target.Path
+	}
+	caseSensitive := true
+	if fs != nil {
+		caseSensitive = fs.UseCaseSensitiveFileNames()
+	}
+	s.selectedSourceIdentities[lintProgramLexicalPathID(target.Path, fs)] =
+		tspath.Path(lspLexicalPathID(canonicalPath, caseSensitive))
 }
 
 func lintProgramLexicalPathID(fileName string, fs vfs.FS) tspath.Path {

--- a/internal/lsp/lint_program_store_test.go
+++ b/internal/lsp/lint_program_store_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
@@ -73,9 +74,19 @@ func newLintProgramStoreFixture(t *testing.T, source string) *lintProgramStoreFi
 	return fixture
 }
 
+func (f *lintProgramStoreFixture) request(
+	uri lsproto.DocumentUri,
+) (lintProgramLoader, lintProjectMetadataLoader, func()) {
+	return f.store.Request(
+		context.Background(),
+		uri,
+		lspConfigTarget(uriToPath(uri), f.server.cwd, f.server.fs),
+	)
+}
+
 func (f *lintProgramStoreFixture) load(t *testing.T) *compiler.Program {
 	t.Helper()
-	loader, _, finalize := f.store.Request(context.Background(), f.sourceURI)
+	loader, _, finalize := f.request(f.sourceURI)
 	program, _, err := loader(f.configPath)
 	if err != nil {
 		t.Fatalf("load lint Program: %v", err)
@@ -119,7 +130,7 @@ func TestLintProgramStoreReusesAndUpdatesSource(t *testing.T) {
 
 func TestLintProgramStorePersistsWatcherProtectedProjectMetadata(t *testing.T) {
 	fixture := newLintProgramStoreFixture(t, "export const value = 1;\n")
-	_, loadMetadata, finalize := fixture.store.Request(context.Background(), fixture.sourceURI)
+	_, loadMetadata, finalize := fixture.request(fixture.sourceURI)
 	metadata, available, err := loadMetadata(fixture.configPath)
 	if err != nil {
 		t.Fatalf("load metadata: %v", err)
@@ -131,7 +142,7 @@ func TestLintProgramStorePersistsWatcherProtectedProjectMetadata(t *testing.T) {
 	if metadata == nil || !metadata.Contains(fixture.sourcePath, fixture.sourcePath) {
 		t.Fatalf("project metadata did not contain the configured source: %v", metadata)
 	}
-	_, loadMetadata, finalize = fixture.store.Request(context.Background(), fixture.sourceURI)
+	_, loadMetadata, finalize = fixture.request(fixture.sourceURI)
 	reused, available, err := loadMetadata(fixture.configPath)
 	if err != nil {
 		t.Fatalf("reuse metadata: %v", err)
@@ -153,7 +164,7 @@ func TestLintProgramStorePersistsWatcherProtectedProjectMetadata(t *testing.T) {
 	if err := os.WriteFile(fixture.configPath, []byte(`{"files":[]}`), 0o644); err != nil {
 		t.Fatalf("rewrite config: %v", err)
 	}
-	_, loadMetadata, finalize = fixture.store.Request(context.Background(), fixture.sourceURI)
+	_, loadMetadata, finalize = fixture.request(fixture.sourceURI)
 	metadata, available, err = loadMetadata(fixture.configPath)
 	if err != nil {
 		t.Fatalf("reload metadata: %v", err)
@@ -170,10 +181,7 @@ func TestLintProgramStorePersistsWatcherProtectedProjectMetadata(t *testing.T) {
 func TestLintProgramStoreOpeningNewIncludedFileInvalidatesProjectMetadata(t *testing.T) {
 	const content = "export const value = 1;\n"
 	fixture := newLintProgramStoreFixture(t, content)
-	_, loadMetadata, finalize := fixture.store.Request(
-		context.Background(),
-		fixture.sourceURI,
-	)
+	_, loadMetadata, finalize := fixture.request(fixture.sourceURI)
 	before, available, err := loadMetadata(fixture.configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -194,7 +202,7 @@ func TestLintProgramStoreOpeningNewIncludedFileInvalidatesProjectMetadata(t *tes
 		t.Fatal("newly included source retained stale project metadata")
 	}
 
-	_, loadMetadata, finalize = fixture.store.Request(context.Background(), newURI)
+	_, loadMetadata, finalize = fixture.request(newURI)
 	after, available, err := loadMetadata(fixture.configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -218,10 +226,7 @@ func TestLintProgramStoreDoesNotRetainNonContainingFallbackProgram(t *testing.T)
 	outsideURI := documentURIFromPath(outsidePath)
 	fixture.server.documents[outsideURI] = outsideContent
 
-	loadProgram, loadMetadata, finalize := fixture.store.Request(
-		context.Background(),
-		outsideURI,
-	)
+	loadProgram, loadMetadata, finalize := fixture.request(outsideURI)
 	metadata, available, err := loadMetadata(fixture.configPath)
 	if err != nil {
 		t.Fatalf("load metadata: %v", err)
@@ -263,6 +268,11 @@ func TestLintProgramStoreDoesNotRetainProgramWithTransientProjectMetadata(t *tes
 		store: fixture.store,
 		ctx:   context.Background(),
 		uri:   fixture.sourceURI,
+		target: lspConfigTarget(
+			fixture.sourcePath,
+			fixture.server.cwd,
+			fixture.server.fs,
+		),
 		projectMetadata: map[string]*lintProjectMetadata{
 			configPath: metadata,
 		},
@@ -347,7 +357,7 @@ func TestLintProgramStoreUnsavedFileSaveRemainsIncremental(t *testing.T) {
 	fixture.server.documents[newURI] = content
 	fixture.store.DidOpen(newURI, content, false)
 
-	loader, _, finalize := fixture.store.Request(context.Background(), newURI)
+	loader, _, finalize := fixture.request(newURI)
 	first, sourceFile, err := loader(fixture.configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -363,7 +373,7 @@ func TestLintProgramStoreUnsavedFileSaveRemainsIncremental(t *testing.T) {
 	}
 	identityAfterSave := lspFilesystemPathID(newPath, fixture.server.fs)
 	fixture.store.DidSave(newURI, true)
-	loader, _, finalize = fixture.store.Request(context.Background(), newURI)
+	loader, _, finalize = fixture.request(newURI)
 	saved, _, err := loader(fixture.configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -376,7 +386,7 @@ func TestLintProgramStoreUnsavedFileSaveRemainsIncremental(t *testing.T) {
 	const changed = "export const value = 2;\n"
 	fixture.server.documents[newURI] = changed
 	fixture.store.DidChange(newURI, changed)
-	loader, _, finalize = fixture.store.Request(context.Background(), newURI)
+	loader, _, finalize = fixture.request(newURI)
 	updated, updatedSource, err := loader(fixture.configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -395,7 +405,7 @@ func TestLintProgramStoreUnsavedFileCloseInvalidates(t *testing.T) {
 	fixture.server.documents[newURI] = content
 	fixture.store.DidOpen(newURI, content, false)
 
-	loader, _, finalize := fixture.store.Request(context.Background(), newURI)
+	loader, _, finalize := fixture.request(newURI)
 	if _, sourceFile, err := loader(fixture.configPath); err != nil {
 		t.Fatal(err)
 	} else if sourceFile == nil {
@@ -573,7 +583,7 @@ func TestLintProgramStoreOpeningNewIncludedFileRebuilds(t *testing.T) {
 		t.Fatal("newly included source retained a Program built before the file existed")
 	}
 
-	loader, _, finalize := fixture.store.Request(context.Background(), newURI)
+	loader, _, finalize := fixture.request(newURI)
 	defer finalize()
 	rebuilt, sourceFile, err := loader(fixture.configPath)
 	if err != nil {
@@ -621,7 +631,7 @@ func TestLintProgramStoreOpeningNewImportedFileRebuildsBeforeWatchEvent(t *testi
 		t.Fatal("newly resolved import retained a Program built while it was missing")
 	}
 
-	loader, _, finalize := fixture.store.Request(context.Background(), importedURI)
+	loader, _, finalize := fixture.request(importedURI)
 	defer finalize()
 	rebuilt, sourceFile, err := loader(fixture.configPath)
 	if err != nil {
@@ -650,7 +660,7 @@ func TestLintProgramStoreConflictingAliasesUseFreshPrograms(t *testing.T) {
 
 	load := func() *compiler.Program {
 		t.Helper()
-		loader, _, finalize := fixture.store.Request(context.Background(), fixture.sourceURI)
+		loader, _, finalize := fixture.request(fixture.sourceURI)
 		defer finalize()
 		program, _, err := loader(fixture.configPath)
 		if err != nil {
@@ -675,6 +685,69 @@ type realpathCountingFS struct {
 func (fs *realpathCountingFS) Realpath(path string) string {
 	fs.calls++
 	return fs.FS.Realpath(path)
+}
+
+type retargetingLintProgramFS struct {
+	vfs.FS
+	targetPath string
+	firstPath  string
+	laterPath  string
+	targetCall int
+}
+
+func (fs *retargetingLintProgramFS) Realpath(filePath string) string {
+	if tspath.NormalizePath(filePath) != fs.targetPath {
+		return fs.FS.Realpath(filePath)
+	}
+	fs.targetCall++
+	if fs.targetCall == 1 {
+		return fs.firstPath
+	}
+	return fs.laterPath
+}
+
+func TestLintProgramStoreReusesFrozenTargetForResidentAndRebuild(t *testing.T) {
+	const content = "export const value = 1;\n"
+	fixture := newLintProgramStoreFixture(t, content)
+	fixture.load(t)
+	canonicalPath := tspath.NormalizePath(fixture.server.fs.Realpath(fixture.sourcePath))
+	laterPath := tspath.NormalizePath(filepath.Join(filepath.Dir(fixture.sourcePath), "moved.ts"))
+	if err := os.WriteFile(laterPath, []byte("export const moved = 2;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	retargetingFS := &retargetingLintProgramFS{
+		FS:         fixture.server.fs,
+		targetPath: fixture.sourcePath,
+		firstPath:  canonicalPath,
+		laterPath:  laterPath,
+	}
+	fixture.server.fs = retargetingFS
+	target := lspConfigTarget(fixture.sourcePath, fixture.server.cwd, retargetingFS)
+
+	load := func() *ast.SourceFile {
+		t.Helper()
+		loader, _, finalize := fixture.store.Request(
+			context.Background(),
+			fixture.sourceURI,
+			target,
+		)
+		defer finalize()
+		_, sourceFile, err := loader(fixture.configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sourceFile
+	}
+	if sourceFile := load(); sourceFile == nil || sourceFile.Text() != content {
+		t.Fatalf("resident Program source = %v", sourceFile)
+	}
+	fixture.store.Invalidate()
+	if sourceFile := load(); sourceFile == nil || sourceFile.Text() != content {
+		t.Fatalf("rebuilt Program source = %v", sourceFile)
+	}
+	if retargetingFS.targetCall != 1 {
+		t.Fatalf("target Realpath calls = %d, want one frozen observation", retargetingFS.targetCall)
+	}
 }
 
 func TestLintProgramStoreUnrelatedOpenDoesNotScanProgramSources(t *testing.T) {
@@ -752,7 +825,11 @@ func TestLintProgramStoreWatchesExternalEmptyIncludeDirectory(t *testing.T) {
 		return nil
 	}
 
-	loader, _, finalize := store.Request(context.Background(), sourceURI)
+	loader, _, finalize := store.Request(
+		context.Background(),
+		sourceURI,
+		lspConfigTarget(sourcePath, workspace, server.fs),
+	)
 	if _, _, err := loader(configPath); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lsp/lint_project_selection.go
+++ b/internal/lsp/lint_project_selection.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 
+	"github.com/web-infra-dev/rslint/internal/config"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -126,7 +127,7 @@ type selectedLintProject struct {
 
 func selectConfiguredLintProject(
 	tsConfigPaths []string,
-	targetPath string,
+	target config.DiscoveredLintTarget,
 	loaders lintProjectLoaders,
 ) (selectedLintProject, bool, error) {
 	metadataByProject := make([]*lintProjectMetadata, len(tsConfigPaths))
@@ -145,11 +146,11 @@ func selectConfiguredLintProject(
 			}
 			metadataByProject[index] = metadata
 			if metadata == nil || metadata.rootFiles == nil ||
-				!metadata.rootFiles.Contains(targetPath, "") {
+				!metadata.rootFiles.Contains(target.Path, target.CanonicalPath) {
 				continue
 			}
 			if loaders.program == nil {
-				return selectedLintProject{}, false, fmt.Errorf("configured project root %q cannot load %q", targetPath, tsConfigPath)
+				return selectedLintProject{}, false, fmt.Errorf("configured project root %q cannot load %q", target.Path, tsConfigPath)
 			}
 			program, sourceFile, err := loaders.program(tsConfigPath)
 			if err != nil {
@@ -158,7 +159,7 @@ func selectConfiguredLintProject(
 			if program == nil || sourceFile == nil {
 				return selectedLintProject{}, false, fmt.Errorf(
 					"configured project root %q was absent from %q",
-					targetPath,
+					target.Path,
 					tsConfigPath,
 				)
 			}
@@ -176,7 +177,7 @@ func selectConfiguredLintProject(
 	}
 	for index, tsConfigPath := range tsConfigPaths {
 		metadata := metadataByProject[index]
-		if metadata != nil && !metadata.supportsFileName(targetPath) {
+		if metadata != nil && !metadata.supportsFileName(target.Path) {
 			continue
 		}
 		program, sourceFile, err := loaders.program(tsConfigPath)
@@ -201,28 +202,32 @@ func selectConfiguredLintProject(
 // project snapshot. Root probing and Program construction share it, so a
 // config cannot be parsed twice or change meaning halfway through selection.
 type standaloneLintProjectRequest struct {
-	targetPath string
-	fs         vfs.FS
-	loadFS     func() vfs.FS
-	projects   map[string]*lintProjectMetadata
+	target   config.DiscoveredLintTarget
+	fs       vfs.FS
+	loadFS   func() vfs.FS
+	projects map[string]*lintProjectMetadata
 }
 
 func newStandaloneLintProjectRequest(
-	targetPath string,
+	target config.DiscoveredLintTarget,
 	loadFS func() vfs.FS,
 ) *standaloneLintProjectRequest {
+	target.Path = tspath.NormalizePath(target.Path)
+	if target.CanonicalPath != "" {
+		target.CanonicalPath = tspath.NormalizePath(target.CanonicalPath)
+	}
 	return &standaloneLintProjectRequest{
-		targetPath: tspath.NormalizePath(targetPath),
-		loadFS:     loadFS,
-		projects:   make(map[string]*lintProjectMetadata),
+		target:   target,
+		loadFS:   loadFS,
+		projects: make(map[string]*lintProjectMetadata),
 	}
 }
 
 func newStandaloneLintProjectRequestWithFS(
-	targetPath string,
+	target config.DiscoveredLintTarget,
 	fs vfs.FS,
 ) *standaloneLintProjectRequest {
-	request := newStandaloneLintProjectRequest(targetPath, nil)
+	request := newStandaloneLintProjectRequest(target, nil)
 	request.fs = fs
 	return request
 }
@@ -262,7 +267,7 @@ func (request *standaloneLintProjectRequest) program(
 	if err != nil {
 		return nil, nil, err
 	}
-	return program, sourceFileForPath(program, request.targetPath, request.filesystem()), nil
+	return program, sourceFileForTarget(program, request.target, request.filesystem()), nil
 }
 
 func (request *standaloneLintProjectRequest) loadMetadata(

--- a/internal/lsp/lint_project_selection_test.go
+++ b/internal/lsp/lint_project_selection_test.go
@@ -52,7 +52,7 @@ func TestSelectConfiguredLintProjectDirectRootOutranksEarlierImport(t *testing.T
 	var programCalls []string
 	selected, found, err := selectConfiguredLintProject(
 		[]string{firstConfig, secondConfig},
-		target,
+		config.DiscoveredLintTarget{Path: target, CanonicalPath: target},
 		lintProjectLoaders{
 			metadata: func(configPath string) (*lintProjectMetadata, bool, error) {
 				return metadata[configPath], true, nil
@@ -98,7 +98,7 @@ func TestSelectConfiguredLintProjectFallbackOrderAndExtensionFilter(t *testing.T
 	var programCalls []string
 	selected, found, err := selectConfiguredLintProject(
 		[]string{firstConfig, secondConfig},
-		target,
+		config.DiscoveredLintTarget{Path: target, CanonicalPath: target},
 		lintProjectLoaders{
 			metadata: func(configPath string) (*lintProjectMetadata, bool, error) {
 				return metadata[configPath], true, nil
@@ -150,7 +150,13 @@ func TestStandaloneLintProjectRequestReusesParsedConfigSnapshot(t *testing.T) {
 		FS:     bundled.WrapFS(osvfs.FS()),
 		target: tspath.NormalizePath(configPath),
 	}
-	request := newStandaloneLintProjectRequestWithFS(firstSource, fs)
+	request := newStandaloneLintProjectRequestWithFS(
+		config.DiscoveredLintTarget{
+			Path:          firstSource,
+			CanonicalPath: firstSource,
+		},
+		fs,
+	)
 	metadata, err := request.metadata(configPath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -175,6 +175,9 @@ type Server struct {
 	// The resolver is rebuilt atomically with each config transaction. Its keys
 	// are the same filesystem paths stored in jsConfigs.
 	jsConfigOwnerResolver *config.ConfigOwnerResolver
+	// jsonConfigResolver freezes the invocation-wide JSON config's authored
+	// path space when that config generation is loaded.
+	jsonConfigResolver *config.ConfigOwnerResolver
 	// configDiscoveryActive becomes true after the first structurally valid
 	// configRefresh request. It lets Go's supplemental strict-ancestor JS and
 	// config-scoped .gitignore watchers trigger a fresh transaction without
@@ -247,7 +250,13 @@ type Server struct {
 	// computeFixAllContent. Production leaves it nil (defaultFixAllNativeLint is
 	// used, driving an isolated overlay Program); tests inject a mock to exercise the
 	// plugin-fix fold loop without spinning up a language service.
-	fixAllNativeLint func(ctx context.Context, uri lsproto.DocumentUri, pass int, content string, rslintConfig config.RslintConfig, configCwd string, isJSConfig bool, tsConfigPaths []string) (lintPassResult, error)
+	fixAllNativeLint func(
+		ctx context.Context,
+		uri lsproto.DocumentUri,
+		pass int,
+		content string,
+		snapshot documentLintSnapshot,
+	) (lintPassResult, error)
 
 	// pluginReverseTimeout bounds each eslint-plugin reverse request to the
 	// client (rslint/pluginLint) on BOTH paths: source.fixAll (summed across

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
@@ -25,6 +26,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/tsoptions"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 
 	"github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/config/discovery"
@@ -41,6 +43,35 @@ const ancestorJSConfigWatcherID project.WatcherID = "rslint-ancestor-js-config"
 type lintPassResult struct {
 	Diagnostics     []rule.RuleDiagnostic
 	HasSyntaxErrors bool
+}
+
+// documentLintSnapshot freezes every config-sensitive fact for one editor
+// operation. Owner selection, project selection, native rules, plugin rules,
+// and fixes must all consume this same target/config pair; none may rediscover
+// the target identity from the filesystem mid-operation.
+type documentLintSnapshot struct {
+	target                config.DiscoveredLintTarget
+	config                config.RslintConfig
+	resolvedConfig        config.ResolvedFileConfig
+	configResolved        bool
+	typeScriptConfigPaths []string
+	usesJavaScriptConfig  bool
+	unavailable           bool
+}
+
+func resolveDocumentLintSnapshotConfig(
+	snapshot documentLintSnapshot,
+	fs vfs.FS,
+) documentLintSnapshot {
+	resolver := config.NewFileConfigResolverWithFS(
+		snapshot.config,
+		snapshot.target.ConfigDirectory,
+		fs,
+		snapshot.usesJavaScriptConfig,
+	)
+	snapshot.resolvedConfig = resolver.ResolveTarget(snapshot.target)
+	snapshot.configResolved = true
+	return snapshot
 }
 
 // ruleFixToTextEdit converts a rule fix into an LSP TextEdit using the
@@ -258,6 +289,12 @@ func (s *Server) reloadConfig() error {
 		return fmt.Errorf("could not resolve tsconfig paths for %q: %w", s.rslintConfigPath, err)
 	}
 	s.jsonConfig = rslintConfig
+	s.jsonConfigResolver = config.NewConfigOwnerResolver(
+		map[string]config.RslintConfig{
+			tspath.NormalizePath(s.cwd): rslintConfig,
+		},
+		s.fs,
+	)
 	s.tsConfigPaths = paths
 	s.invalidateLintProjectCaches()
 	return nil
@@ -500,6 +537,12 @@ func (s *Server) reloadConfigAndRelint() {
 	if !found {
 		log.Printf("rslint config file no longer exists, clearing config")
 		s.jsonConfig = config.RslintConfig{}
+		s.jsonConfigResolver = config.NewConfigOwnerResolver(
+			map[string]config.RslintConfig{
+				tspath.NormalizePath(s.cwd): s.jsonConfig,
+			},
+			s.fs,
+		)
 		s.rslintConfigPath = ""
 		s.tsConfigPaths = nil
 		s.invalidateLintProjectCaches()
@@ -766,15 +809,13 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 	if !isLintableScriptFile(uri) {
 		return empty, nil
 	}
-	if s.isUnavailableConfigForURI(uri) {
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.unavailable {
 		return empty, nil
 	}
-
-	rslintConfig, configCwd, isJSConfig := s.getLintConfigForURI(uri)
-	tsConfigPaths := s.tsConfigPathsForURI(uri)
 	originalContent := s.documents[uri]
 
-	currentContent := s.computeFixAllContent(ctx, uri, originalContent, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
+	currentContent := s.computeFixAllContent(ctx, uri, originalContent, snapshot)
 
 	if currentContent == originalContent {
 		return empty, nil
@@ -816,7 +857,12 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 // the SAME content (so their byte offsets align with ApplyRuleFixes's input).
 // The per-pass native lint goes through s.fixAllNativeLint, which tests override
 // to drive the fold loop without a real TS session.
-func (s *Server) computeFixAllContent(ctx context.Context, uri lsproto.DocumentUri, originalContent string, rslintConfig config.RslintConfig, configCwd string, isJSConfig bool, tsConfigPaths []string) string {
+func (s *Server) computeFixAllContent(
+	ctx context.Context,
+	uri lsproto.DocumentUri,
+	originalContent string,
+	snapshot documentLintSnapshot,
+) string {
 	nativeLint := s.fixAllNativeLint
 	if nativeLint == nil {
 		nativeLint = s.defaultFixAllNativeLint
@@ -839,7 +885,7 @@ func (s *Server) computeFixAllContent(ctx context.Context, uri lsproto.DocumentU
 
 	currentContent := originalContent
 	for pass := range maxFixPasses {
-		lintResult, err := nativeLint(ctx, uri, pass, currentContent, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
+		lintResult, err := nativeLint(ctx, uri, pass, currentContent, snapshot)
 		if err != nil {
 			log.Printf("Error running lint for fixAll pass %d: %v", pass, err)
 			break
@@ -857,15 +903,13 @@ func (s *Server) computeFixAllContent(ctx context.Context, uri lsproto.DocumentU
 		// already-expired pluginCtx would still enqueue a (wasted) reverse request
 		// to the client before returning nil.
 		if pluginCtx.Err() == nil {
-			if pluginDiags := s.lintPluginRulesSyncWithConfig(
+			if pluginDiags := s.lintPluginRulesSyncWithSnapshot(
 				pluginCtx,
 				uri,
 				currentContent,
 				true,
 				linter.SuggestionsModeOff,
-				rslintConfig,
-				configCwd,
-				isJSConfig,
+				snapshot,
 			); len(pluginDiags) > 0 {
 				ruleDiags = append(ruleDiags, pluginDiags...)
 			}
@@ -886,8 +930,14 @@ func (s *Server) computeFixAllContent(ctx context.Context, uri lsproto.DocumentU
 // defaultFixAllNativeLint builds each pass from an isolated editor overlay.
 // The pass number is intentionally unused: speculative content never enters
 // the real TypeScript Session, regardless of how many fix cycles run.
-func (s *Server) defaultFixAllNativeLint(ctx context.Context, uri lsproto.DocumentUri, _ int, content string, rslintConfig config.RslintConfig, configCwd string, isJSConfig bool, tsConfigPaths []string) (lintPassResult, error) {
-	return s.runConfiguredLintForContent(uri, ctx, content, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
+func (s *Server) defaultFixAllNativeLint(
+	ctx context.Context,
+	uri lsproto.DocumentUri,
+	_ int,
+	content string,
+	snapshot documentLintSnapshot,
+) (lintPassResult, error) {
+	return s.runConfiguredLintForContentWithSnapshot(uri, ctx, content, snapshot)
 }
 
 // computeEndPosition returns the line and UTF-16 character offset of the end
@@ -979,15 +1029,18 @@ type LintResponse struct {
 }
 
 func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx context.Context, rslintConfig config.RslintConfig, cwd string, enforcePlugins bool, tsConfigPaths []string, fs vfs.FS) ([]rule.RuleDiagnostic, error) {
+	snapshot := resolveDocumentLintSnapshotConfig(documentLintSnapshot{
+		target:                lspConfigTarget(uriToPath(uri), cwd, fs),
+		config:                rslintConfig,
+		typeScriptConfigPaths: tsConfigPaths,
+		usesJavaScriptConfig:  enforcePlugins,
+	}, fs)
 	result, err := runLintWithProgramLoader(
 		uri,
 		session,
 		ctx,
-		rslintConfig,
+		snapshot,
 		cwd,
-		cwd,
-		enforcePlugins,
-		tsConfigPaths,
 		fs,
 		lintProjectLoaders{},
 		nil,
@@ -1003,33 +1056,32 @@ func runLintWithProgramLoader(
 	uri lsproto.DocumentUri,
 	session *project.Session,
 	ctx context.Context,
-	rslintConfig config.RslintConfig,
-	cwd string,
+	snapshot documentLintSnapshot,
 	processCwd string,
-	enforcePlugins bool,
-	tsConfigPaths []string,
 	fs vfs.FS,
 	loaders lintProjectLoaders,
 	sessionRoots *lintSessionProjectRootCache,
 ) (lintPassResult, error) {
-	filename := uriToPath(uri)
-	configFilePath, configCwd := config.ResolveConfigPathSpace(filename, cwd, fs)
-	if isDefaultExcludedLintPath(configFilePath, configCwd, fs) {
+	if !snapshot.configResolved {
+		snapshot = resolveDocumentLintSnapshotConfig(snapshot, fs)
+	}
+	target := snapshot.target
+	if isDefaultExcludedLintPath(target.Path, processCwd, fs) {
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
 	}
 
 	// Files excluded by the config's `ignores` patterns produce no diagnostics,
 	// matching CLI behavior. Return early before spinning up the language service.
-	if rslintConfig.IsFileIgnored(configFilePath, configCwd) {
+	if snapshot.resolvedConfig.GloballyIgnored {
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
 	}
-	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, configCwd, enforcePlugins)
 
 	program, sourceFile, hasTypeInfo, err := selectLintProgram(
 		uri,
+		target,
 		session,
 		ctx,
-		tsConfigPaths,
+		snapshot.typeScriptConfigPaths,
 		fs,
 		loaders,
 		sessionRoots,
@@ -1040,10 +1092,10 @@ func runLintWithProgramLoader(
 	return lintSingleFile(
 		program,
 		sourceFile,
-		configFilePath,
+		target,
 		processCwd,
 		hasTypeInfo,
-		fileConfigResolver,
+		snapshot.resolvedConfig.EnabledRules,
 		rule.EditDemandAll,
 		ctx,
 	), nil
@@ -1084,10 +1136,10 @@ func rulesServedToEditors(rules []rule.ConfiguredRule) []rule.ConfiguredRule {
 func lintSingleFile(
 	program *compiler.Program,
 	sourceFile *ast.SourceFile,
-	configFilePath string,
+	target config.DiscoveredLintTarget,
 	processCwd string,
 	hasTypeInfo bool,
-	fileConfigResolver *config.FileConfigResolver,
+	enabledRules []rule.ConfiguredRule,
 	editDemand rule.EditDemand,
 	ctx context.Context,
 ) lintPassResult {
@@ -1129,8 +1181,7 @@ func lintSingleFile(
 		Cwd:         processCwd,
 		HasTypeInfo: hasTypeInfo,
 		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
-			rules, _ := fileConfigResolver.EnabledRulesForFile(configFilePath)
-			return rulesServedToEditors(rules)
+			return rulesServedToEditors(enabledRules)
 		},
 		Consumer: rule.DiagnosticConsumer{
 			Demand: editDemand,
@@ -1146,6 +1197,7 @@ func lintSingleFile(
 
 func selectLintProgram(
 	uri lsproto.DocumentUri,
+	target config.DiscoveredLintTarget,
 	session *project.Session,
 	ctx context.Context,
 	tsConfigPaths []string,
@@ -1153,7 +1205,6 @@ func selectLintProgram(
 	fallbackLoaders lintProjectLoaders,
 	sessionRoots *lintSessionProjectRootCache,
 ) (*compiler.Program, *ast.SourceFile, bool, error) {
-	filename := uriToPath(uri)
 	// Flush pending document changes and collect every already-loaded project
 	// containing the file. The default language service remains the
 	// non-project-backed fallback when none of the config's declared projects
@@ -1207,7 +1258,7 @@ func selectLintProgram(
 		},
 		program: func(tsConfigPath string) (*compiler.Program, *ast.SourceFile, error) {
 			if loadedProject, ok := loadedByConfig[lintProgramLexicalPathID(tsConfigPath, fs)]; ok {
-				return loadedProject.program, sourceFileForPath(loadedProject.program, filename, fs), nil
+				return loadedProject.program, sourceFileForTarget(loadedProject.program, target, fs), nil
 			}
 			if fallbackLoaders.program == nil {
 				return nil, nil, nil
@@ -1215,62 +1266,174 @@ func selectLintProgram(
 			return fallbackLoaders.program(tsConfigPath)
 		},
 	}
-	selected, found, err := selectConfiguredLintProject(tsConfigPaths, filename, loaders)
+	selected, found, err := selectConfiguredLintProject(tsConfigPaths, target, loaders)
 	if err != nil {
 		return nil, nil, false, err
 	}
 	if found {
 		return selected.program, selected.sourceFile, true, nil
 	}
-	return program, sourceFileForPath(program, filename, fs), false, nil
+	return program, sourceFileForTarget(program, target, fs), false, nil
 }
 
 func sourceFileForPath(program *compiler.Program, filename string, fs vfs.FS) *ast.SourceFile {
 	return utils.NewProgramSourceLookup(program, fs).SourceFileForPath(filename)
 }
 
-func (s *Server) currentEditorOverlayFS(preferred ...lsproto.DocumentUri) vfs.FS {
-	return utils.NewOverlayVFS(s.fs, s.currentEditorOverlayFiles(preferred...))
+func sourceFileForTarget(
+	program *compiler.Program,
+	target config.DiscoveredLintTarget,
+	fs vfs.FS,
+) *ast.SourceFile {
+	return utils.NewProgramSourceLookup(program, fs).
+		SourceFileForTarget(target.Path, target.CanonicalPath)
 }
 
-func (s *Server) currentEditorOverlayFSWithConflicts(
-	preferred ...lsproto.DocumentUri,
+func (s *Server) currentEditorOverlayFSForTarget(
+	uri lsproto.DocumentUri,
+	target config.DiscoveredLintTarget,
+) vfs.FS {
+	content, open := s.documents[uri]
+	files, _ := s.currentEditorOverlayFilesForFrozenTarget(
+		uri,
+		target,
+		content,
+		open,
+	)
+	return newFrozenLintTargetOverlayFS(s.fs, files, target)
+}
+
+func (s *Server) currentEditorOverlayFSForTargetWithConflicts(
+	uri lsproto.DocumentUri,
+	target config.DiscoveredLintTarget,
 ) (vfs.FS, bool) {
-	files, aliasesConflict := s.currentEditorOverlayFilesWithConflicts(preferred...)
-	return utils.NewOverlayVFS(s.fs, files), aliasesConflict
+	content, open := s.documents[uri]
+	files, aliasesConflict := s.currentEditorOverlayFilesForFrozenTarget(
+		uri,
+		target,
+		content,
+		open,
+	)
+	return newFrozenLintTargetOverlayFS(s.fs, files, target), aliasesConflict
 }
 
-func (s *Server) currentEditorOverlayFiles(preferred ...lsproto.DocumentUri) map[string]string {
-	files, _ := s.currentEditorOverlayFilesWithConflicts(preferred...)
+func (s *Server) currentEditorOverlayFilesForTarget(
+	uri lsproto.DocumentUri,
+	target config.DiscoveredLintTarget,
+	content string,
+) map[string]string {
+	files, _ := s.currentEditorOverlayFilesForFrozenTarget(
+		uri,
+		target,
+		content,
+		true,
+	)
 	return files
 }
 
-func (s *Server) currentEditorOverlayFilesWithConflicts(
-	preferred ...lsproto.DocumentUri,
+// currentEditorOverlayFilesForFrozenTarget resolves every other open document
+// normally, but inserts the selected document only under the identity frozen
+// by documentLintSnapshot. Re-resolving the selected URI here could mix two
+// symlink generations between config/project selection and Program creation.
+func (s *Server) currentEditorOverlayFilesForFrozenTarget(
+	uri lsproto.DocumentUri,
+	target config.DiscoveredLintTarget,
+	targetContent string,
+	includeTarget bool,
 ) (map[string]string, bool) {
 	files := make(map[string]string, len(s.documents)*2)
 	contentByPhysicalPath := make(map[string]string, len(s.documents))
 	aliasesConflict := false
-	add := func(uri lsproto.DocumentUri, content string) {
-		physicalPath := s.addEditorOverlayFile(files, uriToPath(uri), content)
+	add := func(filePath string, content string) {
+		physicalPath := s.addEditorOverlayFile(files, filePath, content)
 		if previous, exists := contentByPhysicalPath[physicalPath]; exists &&
 			previous != content {
 			aliasesConflict = true
 		}
 		contentByPhysicalPath[physicalPath] = content
 	}
-	for uri, content := range s.documents {
-		if len(preferred) > 0 && uri == preferred[0] {
+	for documentURI, documentContent := range s.documents {
+		if documentURI == uri {
 			continue
 		}
-		add(uri, content)
+		add(uriToPath(documentURI), documentContent)
 	}
-	if len(preferred) > 0 {
-		if content, ok := s.documents[preferred[0]]; ok {
-			add(preferred[0], content)
+	if includeTarget {
+		physicalPath := frozenLintTargetPhysicalPathID(target, s.fs)
+		if previous, exists := contentByPhysicalPath[physicalPath]; exists &&
+			previous != targetContent {
+			aliasesConflict = true
 		}
+		contentByPhysicalPath[physicalPath] = targetContent
+		addEditorOverlayTarget(files, target, targetContent)
 	}
 	return files, aliasesConflict
+}
+
+func frozenLintTargetPhysicalPathID(
+	target config.DiscoveredLintTarget,
+	fs vfs.FS,
+) string {
+	filePath := target.CanonicalPath
+	if filePath == "" {
+		filePath = target.Path
+	}
+	caseSensitive := true
+	if fs != nil {
+		caseSensitive = fs.UseCaseSensitiveFileNames()
+	}
+	return lspLexicalPathID(filePath, caseSensitive)
+}
+
+type frozenLintTargetOverlayFS struct {
+	vfs.FS
+	lexicalPathID   string
+	canonicalPathID string
+	canonicalPath   string
+}
+
+func newFrozenLintTargetOverlayFS(
+	baseFS vfs.FS,
+	files map[string]string,
+	target config.DiscoveredLintTarget,
+) vfs.FS {
+	caseSensitive := true
+	if baseFS != nil {
+		caseSensitive = baseFS.UseCaseSensitiveFileNames()
+	}
+	canonicalPath := target.CanonicalPath
+	if canonicalPath == "" {
+		canonicalPath = target.Path
+	}
+	canonicalPath = tspath.NormalizePath(canonicalPath)
+	return &frozenLintTargetOverlayFS{
+		FS:              utils.NewOverlayVFS(baseFS, files),
+		lexicalPathID:   lspLexicalPathID(target.Path, caseSensitive),
+		canonicalPathID: lspLexicalPathID(canonicalPath, caseSensitive),
+		canonicalPath:   canonicalPath,
+	}
+}
+
+func (fs *frozenLintTargetOverlayFS) Realpath(filePath string) string {
+	caseSensitive := fs.UseCaseSensitiveFileNames()
+	pathID := lspLexicalPathID(filePath, caseSensitive)
+	if pathID == fs.lexicalPathID || pathID == fs.canonicalPathID {
+		return fs.canonicalPath
+	}
+	return fs.FS.Realpath(filePath)
+}
+
+func addEditorOverlayTarget(
+	files map[string]string,
+	target config.DiscoveredLintTarget,
+	content string,
+) {
+	if target.Path != "" {
+		files[tspath.NormalizePath(target.Path)] = content
+	}
+	if target.CanonicalPath != "" {
+		files[tspath.NormalizePath(target.CanonicalPath)] = content
+	}
 }
 
 func (s *Server) addEditorOverlayFile(
@@ -1310,19 +1473,20 @@ func createStandaloneFallbackProgram(filename string, cwd string, fs vfs.FS) (*c
 func (s *Server) runConfiguredLint(
 	uri lsproto.DocumentUri,
 	ctx context.Context,
-	rslintConfig config.RslintConfig,
-	cwd string,
-	enforcePlugins bool,
-	tsConfigPaths []string,
+	snapshot documentLintSnapshot,
 ) (lintPassResult, error) {
 	request := newStandaloneLintProjectRequest(
-		uriToPath(uri),
-		func() vfs.FS { return s.currentEditorOverlayFS(uri) },
+		snapshot.target,
+		func() vfs.FS { return s.currentEditorOverlayFSForTarget(uri, snapshot.target) },
 	)
 	loaders := request.loaders()
 	finalize := func() {}
 	if s.lintPrograms != nil && s.lintPrograms.Usable() {
-		loadProgram, loadMetadata, requestFinalize := s.lintPrograms.Request(ctx, uri)
+		loadProgram, loadMetadata, requestFinalize := s.lintPrograms.Request(
+			ctx,
+			uri,
+			snapshot.target,
+		)
 		loaders = lintProjectLoaders{
 			program:  loadProgram,
 			metadata: loadMetadata,
@@ -1334,11 +1498,8 @@ func (s *Server) runConfiguredLint(
 		uri,
 		s.session,
 		ctx,
-		rslintConfig,
-		cwd,
+		snapshot,
 		s.cwd,
-		enforcePlugins,
-		tsConfigPaths,
 		s.fs,
 		loaders,
 		s.lintSessionRoots,
@@ -1357,26 +1518,43 @@ func (s *Server) runConfiguredLintForContent(
 	enforcePlugins bool,
 	tsConfigPaths []string,
 ) (lintPassResult, error) {
-	filename := tspath.NormalizePath(uriToPath(uri))
-	configFilePath, configCwd := config.ResolveConfigPathSpace(filename, cwd, s.fs)
-	if isDefaultExcludedLintPath(configFilePath, configCwd, s.fs) {
-		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
-	}
-	if rslintConfig.IsFileIgnored(configFilePath, configCwd) {
-		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
-	}
-	resolver := config.NewFileConfigResolver(rslintConfig, configCwd, enforcePlugins)
+	snapshot := resolveDocumentLintSnapshotConfig(documentLintSnapshot{
+		target:                lspConfigTarget(uriToPath(uri), cwd, s.fs),
+		config:                rslintConfig,
+		typeScriptConfigPaths: tsConfigPaths,
+		usesJavaScriptConfig:  enforcePlugins,
+	}, s.fs)
+	return s.runConfiguredLintForContentWithSnapshot(uri, ctx, content, snapshot)
+}
 
-	files := s.currentEditorOverlayFiles()
+func (s *Server) runConfiguredLintForContentWithSnapshot(
+	uri lsproto.DocumentUri,
+	ctx context.Context,
+	content string,
+	snapshot documentLintSnapshot,
+) (lintPassResult, error) {
+	if !snapshot.configResolved {
+		snapshot = resolveDocumentLintSnapshotConfig(snapshot, s.fs)
+	}
+	target := snapshot.target
+	cwd := target.ConfigDirectory
+	if isDefaultExcludedLintPath(target.Path, s.cwd, s.fs) {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
+	}
+	if snapshot.resolvedConfig.GloballyIgnored {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
+	}
+
 	// Apply the speculative target last so it wins over every open URI alias
-	// that resolves to the same physical file.
-	s.addEditorOverlayFile(files, filename, content)
-	overlayFS := utils.NewOverlayVFS(s.fs, files)
+	// that resolves to the same physical file, without resolving the frozen
+	// target through the filesystem again.
+	files := s.currentEditorOverlayFilesForTarget(uri, target, content)
+	overlayFS := newFrozenLintTargetOverlayFS(s.fs, files, target)
 
-	request := newStandaloneLintProjectRequestWithFS(filename, overlayFS)
+	request := newStandaloneLintProjectRequestWithFS(target, overlayFS)
 	selected, found, err := selectConfiguredLintProject(
-		tsConfigPaths,
-		filename,
+		snapshot.typeScriptConfigPaths,
+		target,
 		request.loaders(),
 	)
 	if err != nil {
@@ -1386,26 +1564,26 @@ func (s *Server) runConfiguredLintForContent(
 		return lintSingleFile(
 			selected.program,
 			selected.sourceFile,
-			configFilePath,
+			target,
 			s.cwd,
 			true,
-			resolver,
+			snapshot.resolvedConfig.EnabledRules,
 			rule.EditDemandAutofix,
 			ctx,
 		), nil
 	}
 
-	program, err := createStandaloneFallbackProgram(filename, configCwd, overlayFS)
+	program, err := createStandaloneFallbackProgram(target.Path, cwd, overlayFS)
 	if err != nil {
 		return lintPassResult{}, fmt.Errorf("create fallback lint program: %w", err)
 	}
 	return lintSingleFile(
 		program,
-		sourceFileForPath(program, filename, overlayFS),
-		configFilePath,
+		sourceFileForTarget(program, target, overlayFS),
+		target,
 		s.cwd,
 		false,
-		resolver,
+		snapshot.resolvedConfig.EnabledRules,
 		rule.EditDemandAutofix,
 		ctx,
 	), nil
@@ -1423,20 +1601,22 @@ func lspFilesystemPathID(filePath string, fs vfs.FS) string {
 	return lspLexicalPathID(filePath, caseSensitive)
 }
 
+func lspTargetIdentity(filePath string, fs vfs.FS) config.DiscoveredLintTarget {
+	return config.FreezeLintTargetIdentity(filePath, fs)
+}
+
+func lspConfigTarget(filePath string, configDirectory string, fs vfs.FS) config.DiscoveredLintTarget {
+	target := lspTargetIdentity(filePath, fs)
+	target.ConfigDirectory = tspath.NormalizePath(configDirectory)
+	return target
+}
+
 func isDefaultExcludedLintPath(filePath string, cwd string, fs vfs.FS) bool {
 	useCaseSensitive := true
 	if fs != nil {
 		useCaseSensitive = fs.UseCaseSensitiveFileNames()
 	}
 	return config.IsDefaultExcludedPath(filePath, cwd, useCaseSensitive)
-}
-
-func lspActiveRulesForFile(rslintConfig config.RslintConfig, filePath string, cwd string, enforcePlugins bool, hasTypeInfo bool) []rule.ConfiguredRule {
-	rules, _ := config.NewFileConfigResolver(rslintConfig, cwd, enforcePlugins).EnabledRulesForFile(filePath)
-	if !hasTypeInfo {
-		return rule.FilterNonTypeAwareRules(rules)
-	}
-	return rules
 }
 
 // Helper function to check if two ranges overlap
@@ -1603,39 +1783,162 @@ func createDisableRuleForFileAction(ruleDiag rule.RuleDiagnostic, uri lsproto.Do
 	}
 }
 
-// getConfigForURI resolves a file against the committed JS/TS config catalog.
-// It falls back to the JSON config when that catalog has no owner for the file.
-// Returns the config entries, the directory to use as cwd for glob matching,
-// and whether the config is from a JS/TS config (for plugin enforcement).
-// For JS configs the cwd is the config's own directory; for the JSON fallback
-// it is s.cwd.
-func (s *Server) getConfigForURI(uri lsproto.DocumentUri) (config.RslintConfig, string, bool) {
-	if configKey, ok := s.nearestJSConfigKey(uri); ok {
-		return s.jsConfigs[configKey], configKey, true
-	}
-	return s.jsonConfig, s.cwd, false
+type documentConfigSelection struct {
+	entries       config.RslintConfig
+	resolved      config.ResolvedFileConfig
+	directory     string
+	configKey     string
+	usesJSConfig  bool
+	configMissing bool
 }
 
-// getLintConfigForURI applies the shared .gitignore policy to one explicit
-// editor target without mutating the stored config catalog.
-func (s *Server) getLintConfigForURI(uri lsproto.DocumentUri) (config.RslintConfig, string, bool) {
-	rslintConfig, configCwd, isJSConfig := s.getConfigForURI(uri)
+func (s *Server) selectDocumentConfig(
+	target config.DiscoveredLintTarget,
+) documentConfigSelection {
+	evaluationFS := s.fs
+	jsOwnerResolver := s.jsConfigOwnerResolver
 	if !s.configSnapshotIncludesGitignore {
-		// Before the first transactional snapshot commits, the startup JSON
-		// config still needs the live exact-target policy. Committed snapshots
-		// already contain their frozen .gitignore matcher.
-		rslintConfig = config.ConfigWithGitignore(
-			rslintConfig,
-			configCwd,
-			s.fs,
-			[]string{uriToPath(uri)},
-		)
+		// The target identity was frozen before entering this function. Bootstrap
+		// config evaluation now gets its own short-lived filesystem generation so
+		// owner selection, Git collection, and authored path bases cannot observe
+		// different config-directory aliases within one document operation.
+		if s.fs != nil {
+			evaluationFS = newConfigSnapshotFS(bundled.WrapFS(cachedvfs.From(s.fs)))
+		}
+		if len(s.jsConfigs) > 0 {
+			jsOwnerResolver = config.NewConfigOwnerResolver(s.jsConfigs, evaluationFS)
+		}
 	}
-	return rslintConfig, configCwd, isJSConfig
+	evaluateKnownConfig := func(
+		entries config.RslintConfig,
+		configDirectory string,
+		ownerResolver *config.ConfigOwnerResolver,
+		enforcePlugins bool,
+	) (config.RslintConfig, config.ResolvedFileConfig, bool) {
+		configDirectory = tspath.NormalizePath(configDirectory)
+		if !s.configSnapshotIncludesGitignore {
+			entries = config.ConfigWithGitignoreForExactTarget(
+				entries,
+				configDirectory,
+				evaluationFS,
+				target,
+			)
+			ownerResolver = nil
+		}
+		if ownerResolver == nil {
+			ownerResolver = config.NewConfigOwnerResolver(
+				map[string]config.RslintConfig{configDirectory: entries},
+				evaluationFS,
+			)
+		}
+		resolvedEntries, resolved, ok := ownerResolver.ResolveConfigTarget(
+			configDirectory,
+			target,
+			enforcePlugins,
+		)
+		return resolvedEntries, resolved, ok
+	}
+
+	if len(s.jsConfigs) > 0 {
+		if s.configRefreshConfigPath != "" {
+			configKey := tspath.GetDirectoryPath(
+				tspath.NormalizePath(s.configRefreshConfigPath),
+			)
+			if entries, active := s.jsConfigs[configKey]; active {
+				entries, resolved, ok := evaluateKnownConfig(
+					entries,
+					configKey,
+					jsOwnerResolver,
+					true,
+				)
+				return documentConfigSelection{
+					entries:       entries,
+					resolved:      resolved,
+					directory:     configKey,
+					configKey:     configKey,
+					usesJSConfig:  true,
+					configMissing: !ok,
+				}
+			}
+		} else if jsOwnerResolver != nil {
+			configKey, entries, resolved, ok :=
+				jsOwnerResolver.ResolveTargetConfig(target, true)
+			if ok {
+				if !s.configSnapshotIncludesGitignore {
+					entries, resolved, ok = evaluateKnownConfig(
+						entries,
+						configKey,
+						nil,
+						true,
+					)
+				}
+				return documentConfigSelection{
+					entries:       entries,
+					resolved:      resolved,
+					directory:     configKey,
+					configKey:     configKey,
+					usesJSConfig:  true,
+					configMissing: !ok,
+				}
+			}
+		}
+	}
+
+	configDirectory := tspath.NormalizePath(s.cwd)
+	entries, resolved, ok := evaluateKnownConfig(
+		s.jsonConfig,
+		configDirectory,
+		s.jsonConfigResolver,
+		false,
+	)
+	return documentConfigSelection{
+		entries:       entries,
+		resolved:      resolved,
+		directory:     configDirectory,
+		configMissing: !ok,
+	}
+}
+
+// documentLintSnapshot resolves one immutable target identity, then derives
+// its owner, config, and TypeScript projects from that same identity. This is
+// the only production entry from an editor URI into lint configuration.
+func (s *Server) documentLintSnapshot(uri lsproto.DocumentUri) documentLintSnapshot {
+	target := lspTargetIdentity(uriToPath(uri), s.fs)
+	selection := s.selectDocumentConfig(target)
+	target.ConfigDirectory = selection.directory
+	typeScriptConfigPaths := s.tsConfigPaths
+	if selection.usesJSConfig {
+		typeScriptConfigPaths = s.tsConfigPathsByConfig[selection.configKey]
+	}
+	_, unavailable := s.jsUnavailableConfigs[selection.configKey]
+	return documentLintSnapshot{
+		target:                target,
+		config:                selection.entries,
+		resolvedConfig:        selection.resolved,
+		configResolved:        !selection.configMissing,
+		typeScriptConfigPaths: typeScriptConfigPaths,
+		usesJavaScriptConfig:  selection.usesJSConfig,
+		unavailable:           selection.usesJSConfig && unavailable,
+	}
+}
+
+// getConfigForURI is retained for package-level helpers and tests. Production
+// lint operations use documentLintSnapshot so config and project ownership
+// cannot be resolved in separate filesystem observations.
+func (s *Server) getConfigForURI(uri lsproto.DocumentUri) (config.RslintConfig, string, bool) {
+	target := lspTargetIdentity(uriToPath(uri), s.fs)
+	selection := s.selectDocumentConfig(target)
+	return selection.entries, selection.directory, selection.usesJSConfig
+}
+
+func (s *Server) getLintConfigForURI(uri lsproto.DocumentUri) (config.RslintConfig, string, bool) {
+	snapshot := s.documentLintSnapshot(uri)
+	return snapshot.config, snapshot.target.ConfigDirectory, snapshot.usesJavaScriptConfig
 }
 
 func (s *Server) isUnavailableConfigForURI(uri lsproto.DocumentUri) bool {
-	configKey, ok := s.nearestJSConfigKey(uri)
+	target := lspTargetIdentity(uriToPath(uri), s.fs)
+	configKey, ok := s.jsConfigKeyForTarget(target)
 	if !ok {
 		return false
 	}
@@ -1647,14 +1950,25 @@ func (s *Server) isUnavailableConfigForURI(uri lsproto.DocumentUri) bool {
 // uri. Matching uses normalized filesystem paths instead of URI identity;
 // lexical ownership is tried before a realpath fallback.
 func (s *Server) nearestJSConfigKey(uri lsproto.DocumentUri) (string, bool) {
+	return s.jsConfigKeyForTarget(lspTargetIdentity(uriToPath(uri), s.fs))
+}
+
+func (s *Server) jsConfigKeyForTarget(target config.DiscoveredLintTarget) (string, bool) {
 	if len(s.jsConfigs) == 0 {
 		return "", false
 	}
-	filePath := tspath.NormalizePath(uriToPath(uri))
+	// An explicitly selected config governs every editor target, while its
+	// directory remains the base for files/ignores matching. Ancestry
+	// models automatic config discovery, not this invocation-wide scope.
+	if s.configRefreshConfigPath != "" {
+		configDir := tspath.GetDirectoryPath(tspath.NormalizePath(s.configRefreshConfigPath))
+		_, active := s.jsConfigs[configDir]
+		return configDir, active
+	}
 	if s.jsConfigOwnerResolver == nil {
 		return "", false
 	}
-	configDir, _ := s.jsConfigOwnerResolver.Resolve(filePath)
+	configDir, _ := s.jsConfigOwnerResolver.ResolveTarget(target)
 	if configDir == "" {
 		return "", false
 	}
@@ -1669,7 +1983,8 @@ func (s *Server) nearestJSConfigKey(uri lsproto.DocumentUri) (string, bool) {
 // A nil return means the governing config has no resolved tsconfig, so callers
 // must disable type-aware rules for this file.
 func (s *Server) tsConfigPathsForURI(uri lsproto.DocumentUri) []string {
-	if configKey, ok := s.nearestJSConfigKey(uri); ok {
+	target := lspTargetIdentity(uriToPath(uri), s.fs)
+	if configKey, ok := s.jsConfigKeyForTarget(target); ok {
 		return s.tsConfigPathsByConfig[configKey]
 	}
 	return s.tsConfigPaths
@@ -1695,7 +2010,8 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 	s.docGeneration[uri]++
 	generation := s.docGeneration[uri]
 	s.cancelInflightPluginDispatch(uri)
-	if s.isUnavailableConfigForURI(uri) {
+	snapshot := s.documentLintSnapshot(uri)
+	if snapshot.unavailable {
 		delete(s.diagnostics, uri)
 		if err := s.PublishDiagnostics(ctx, &lsproto.PublishDiagnosticsParams{
 			Uri:         uri,
@@ -1706,9 +2022,7 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 		return
 	}
 
-	rslintConfig, configCwd, isJSConfig := s.getLintConfigForURI(uri)
-	tsConfigPaths := s.tsConfigPathsForURI(uri)
-	lintResult, err := s.runConfiguredLint(uri, ctx, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
+	lintResult, err := s.runConfiguredLint(uri, ctx, snapshot)
 	if err != nil {
 		log.Printf("Error running lint for push diagnostics: %v", err)
 		delete(s.diagnostics, uri)
@@ -1742,7 +2056,7 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 	// thus all editor interaction) until the Node worker replies. Results merge
 	// back via pluginResultCh on the main loop (s.diagnostics is lock-free).
 	if !lintResult.HasSyntaxErrors {
-		s.dispatchPluginLintWithConfig(uri, generation, rslintConfig, configCwd, isJSConfig)
+		s.dispatchPluginLintWithSnapshot(uri, generation, snapshot)
 	}
 
 	// The pacer cannot see that the lint just dropped what it derived.

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -50,6 +50,37 @@ func installJSConfigsForTest(s *Server, configs map[string]config.RslintConfig) 
 	s.jsUnavailableConfigs = make(map[string]struct{})
 }
 
+func configuredRulesForLSPTest(
+	entries config.RslintConfig,
+	target config.DiscoveredLintTarget,
+	configDirectory string,
+	enforcePlugins bool,
+	hasTypeInfo bool,
+) []rule.ConfiguredRule {
+	rules, _ := config.NewFileConfigResolver(entries, configDirectory, enforcePlugins).
+		EnabledRulesForTarget(target.Path, target.CanonicalPath)
+	if !hasTypeInfo {
+		return rule.FilterNonTypeAwareRules(rules)
+	}
+	return rules
+}
+
+func documentLintSnapshotForTest(
+	s *Server,
+	uri lsproto.DocumentUri,
+	entries config.RslintConfig,
+	configDirectory string,
+	usesJavaScriptConfig bool,
+	typeScriptConfigPaths []string,
+) documentLintSnapshot {
+	return documentLintSnapshot{
+		target:                lspConfigTarget(uriToPath(uri), configDirectory, s.fs),
+		config:                entries,
+		typeScriptConfigPaths: typeScriptConfigPaths,
+		usesJavaScriptConfig:  usesJavaScriptConfig,
+	}
+}
+
 func documentURIFromPath(filePath string) lsproto.DocumentUri {
 	uriPath := filepath.ToSlash(filePath)
 	if len(uriPath) >= 2 && uriPath[1] == ':' {
@@ -1627,7 +1658,18 @@ func TestLSPActiveRulesForFile_RespectsFiles(t *testing.T) {
 			Program: lintprogram.NewFromCompiler(program),
 			File:    file,
 			GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
-				return lspActiveRulesForFile(cfg, sourceFile.FileName(), dir, false, true)
+				targetPath := sourceFile.FileName()
+				return configuredRulesForLSPTest(
+					cfg,
+					config.DiscoveredLintTarget{
+						Path:            targetPath,
+						CanonicalPath:   targetPath,
+						ConfigDirectory: dir,
+					},
+					dir,
+					false,
+					true,
+				)
 			},
 			Consumer: rule.DiagnosticConsumer{
 				Demand: rule.EditDemandAll,
@@ -1805,13 +1847,16 @@ func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) 
 
 	sourceURI := toURI(sourcePath)
 	standaloneLoaders := func(uri lsproto.DocumentUri) lintProjectLoaders {
+		target := lspConfigTarget(uriToPath(uri), dir, fsys)
 		return newStandaloneLintProjectRequest(
-			uriToPath(uri),
-			func() vfs.FS { return s.currentEditorOverlayFS(uri) },
+			target,
+			func() vfs.FS { return s.currentEditorOverlayFSForTarget(uri, target) },
 		).loaders()
 	}
+	sourceTarget := lspConfigTarget(sourcePath, dir, fsys)
 	program, _, hasTypeInfo, err := selectLintProgram(
 		sourceURI,
+		sourceTarget,
 		s.session,
 		ctx,
 		[]string{secondConfig, firstConfig},
@@ -1831,6 +1876,7 @@ func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) 
 
 	directProgram, _, directHasTypeInfo, err := selectLintProgram(
 		sourceURI,
+		sourceTarget,
 		s.session,
 		ctx,
 		[]string{importConfig, firstConfig},
@@ -1856,10 +1902,14 @@ func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) 
 		toURI(sourcePath),
 		1,
 		"export const value = 2;\n",
-		config.RslintConfig{{}},
-		dir,
-		false,
-		[]string{secondConfig},
+		documentLintSnapshotForTest(
+			s,
+			toURI(sourcePath),
+			config.RslintConfig{{}},
+			dir,
+			false,
+			[]string{secondConfig},
+		),
 	); err != nil {
 		t.Fatalf("isolated fix pass: %v", err)
 	}
@@ -1872,8 +1922,10 @@ func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) 
 	}
 
 	gapURI := toURI(gapPath)
+	gapTarget := lspConfigTarget(gapPath, dir, fsys)
 	gapProgram, _, gapHasTypeInfo, err := selectLintProgram(
 		gapURI,
+		gapTarget,
 		s.session,
 		ctx,
 		[]string{secondConfig, firstConfig},
@@ -1941,6 +1993,7 @@ func TestSelectLintProgram_PrefersSessionProjectBeforeStandaloneLoader(t *testin
 	rootLoaderCalls := 0
 	program, sourceFile, hasTypeInfo, err := selectLintProgram(
 		uri,
+		lspConfigTarget(sourcePath, dir, fsys),
 		s.session,
 		ctx,
 		[]string{configPath},
@@ -2131,7 +2184,10 @@ func TestRunConfiguredLintForContent_OverlaysLexicalAndRealpath(t *testing.T) {
 	s.documents[realURI] = "const competingAliasValue = 3;\n"
 	s.documents[uri] = openContent
 
-	editorOverlay := s.currentEditorOverlayFS(uri)
+	editorOverlay := s.currentEditorOverlayFSForTarget(
+		uri,
+		lspConfigTarget(aliasFile, aliasRoot, s.fs),
+	)
 	for _, filePath := range []string{aliasFile, realFile} {
 		if got, ok := editorOverlay.ReadFile(tspath.NormalizePath(filePath)); !ok || got != openContent {
 			t.Fatalf("editor overlay read %q = %q, %v; want open content", filePath, got, ok)
@@ -2332,6 +2388,134 @@ func TestConfigCatalog_PrefersLexicalOwnerOverPhysicalConfig(t *testing.T) {
 	}
 }
 
+func TestConfiguredLintPreservesTargetIdentityAcrossAuthoredConfigBases(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	configDir := filepath.Join(root, "physical", "package")
+	physicalSourceDir := filepath.Join(configDir, "src")
+	aliasSourceDir := filepath.Join(workspace, "linked-src")
+	if err := os.MkdirAll(physicalSourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalSourceDir, aliasSourceDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	const source = "export function f() {\n  debugger;\n  var value = 1;\n  return value;\n}\n"
+	aliasFile := filepath.Join(aliasSourceDir, "index.ts")
+	if err := os.WriteFile(aliasFile, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config.RegisterAllRules()
+	effective := config.RslintConfig{{
+		Files: []string{"src/**/*.ts"},
+		Rules: config.Rules{"no-debugger": "error"},
+	}}
+	effective = append(effective, config.ConfigWithAuthoredPathBase(
+		config.RslintConfig{{
+			Files: []string{"linked-src/**/*.ts"},
+			Rules: config.Rules{"no-var": "error"},
+		}},
+		workspace,
+	)...)
+
+	s := newTestServer()
+	s.cwd = workspace
+	s.fs = osvfs.FS()
+	uri := documentURIFromPath(aliasFile)
+	s.documents[uri] = source
+	result, err := s.runConfiguredLintForContent(
+		uri,
+		context.Background(),
+		source,
+		effective,
+		configDir,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("runConfiguredLintForContent failed: %v", err)
+	}
+	diagnosticsByRule := make(map[string]rule.RuleDiagnostic, len(result.Diagnostics))
+	for _, diagnostic := range result.Diagnostics {
+		diagnosticsByRule[diagnostic.RuleName] = diagnostic
+	}
+	if _, ok := diagnosticsByRule["no-debugger"]; !ok {
+		t.Fatalf("config-directory rule did not match the shared target: %+v", result.Diagnostics)
+	}
+	noVar, ok := diagnosticsByRule["no-var"]
+	if !ok {
+		t.Fatalf("workspace-authored rule lost the lexical symlink target: %+v", result.Diagnostics)
+	}
+	if len(noVar.Fixes()) == 0 {
+		t.Fatalf("workspace-authored fix was not preserved: %+v", noVar)
+	}
+}
+
+func TestConfiguredLintExternalConfigPreservesGitignoreTargetIdentity(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	configDir := filepath.Join(root, "physical", "package")
+	physicalSourceDir := filepath.Join(configDir, "src")
+	aliasSourceDir := filepath.Join(workspace, "linked-src")
+	for _, directory := range []string{workspace, physicalSourceDir} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(physicalSourceDir, aliasSourceDir); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	const source = "debugger;\n"
+	aliasFile := filepath.Join(aliasSourceDir, "ignored.ts")
+	if err := os.WriteFile(aliasFile, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workspace, ".gitignore"),
+		[]byte("linked-src/ignored.ts\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	effective := config.ConfigWithGitignoreForTargetsFromRoot(
+		config.RslintConfig{{
+			Files: []string{"src/**/*.ts"},
+			Rules: config.Rules{"no-debugger": "error"},
+		}},
+		configDir,
+		workspace,
+		osvfs.FS(),
+		[]string{aliasFile},
+		nil,
+	)
+
+	config.RegisterAllRules()
+	s := newTestServer()
+	s.cwd = workspace
+	s.fs = osvfs.FS()
+	uri := documentURIFromPath(aliasFile)
+	s.documents[uri] = source
+	result, err := s.runConfiguredLintForContent(
+		uri,
+		context.Background(),
+		source,
+		effective,
+		configDir,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("runConfiguredLintForContent failed: %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("external-config Git ignore lost the lexical symlink target: %+v", result.Diagnostics)
+	}
+}
+
 func TestComputeFixAllContent_DefaultExcludedFileIsUnchanged(t *testing.T) {
 	root := t.TempDir()
 	filePath := filepath.Join(root, ".git", "hooks", "check.ts")
@@ -2353,10 +2537,14 @@ func TestComputeFixAllContent_DefaultExcludedFileIsUnchanged(t *testing.T) {
 		context.Background(),
 		uri,
 		source,
-		config.RslintConfig{{Rules: config.Rules{"no-var": "error"}}},
-		root,
-		false,
-		nil,
+		documentLintSnapshotForTest(
+			s,
+			uri,
+			config.RslintConfig{{Rules: config.Rules{"no-var": "error"}}},
+			root,
+			false,
+			nil,
+		),
 	)
 	if got != source {
 		t.Fatalf("fixAll modified a default-excluded file: %q", got)
@@ -2396,10 +2584,7 @@ func TestComputeFixAllContent_NoTsconfigKeepsNativeFixes(t *testing.T) {
 		context.Background(),
 		uri,
 		source,
-		cfg,
-		configDir,
-		true,
-		nil,
+		documentLintSnapshotForTest(s, uri, cfg, configDir, true, nil),
 	)
 	const want = "export const orphan = (() => { let output = 1; return output; })();\n"
 	if got != want {
@@ -2426,12 +2611,17 @@ func TestLSPActiveRulesForFile_NoTsconfigFiltersTypeAwareNativeRules(t *testing.
 		Plugins: []string{"@typescript-eslint"},
 	}}
 
-	withoutTypeInfo := lspActiveRulesForFile(cfg, "/project/index.ts", "/project", true, false)
+	target := config.DiscoveredLintTarget{
+		Path:            "/project/index.ts",
+		CanonicalPath:   "/project/index.ts",
+		ConfigDirectory: "/project",
+	}
+	withoutTypeInfo := configuredRulesForLSPTest(cfg, target, "/project", true, false)
 	if len(withoutTypeInfo) != 1 || withoutTypeInfo[0].Name != "no-debugger" {
 		t.Fatalf("expected only non-type-aware native rule without tsconfig, got %+v", withoutTypeInfo)
 	}
 
-	withTypeInfo := lspActiveRulesForFile(cfg, "/project/index.ts", "/project", true, true)
+	withTypeInfo := configuredRulesForLSPTest(cfg, target, "/project", true, true)
 	if len(withTypeInfo) != 2 {
 		t.Fatalf("expected both native rules with type info, got %+v", withTypeInfo)
 	}

--- a/internal/program/loader/binding.go
+++ b/internal/program/loader/binding.go
@@ -15,17 +15,15 @@ import (
 )
 
 // LoadResult is the complete Program input for one lint generation. It carries
-// only the unified Program sequence, lint projection, and source/config path
+// only the unified Program sequence, lint projection, and source/target path
 // mappings needed by integrations; compiler and parser assembly details remain
 // private to the loader. Its slices and maps are immutable after LoadCLI or
 // LoadAPI returns.
 type LoadResult struct {
-	compilerPrograms           []*compiler.Program
-	Programs                   []*lintprogram.Program
-	TargetsByProgram           [][]string
-	TargetPathBySourcePath     map[string]string
-	ConfigPathBySourcePath     map[string]string
-	OwnerConfigDirBySourcePath map[string]string
+	compilerPrograms       []*compiler.Program
+	Programs               []*lintprogram.Program
+	TargetsByProgram       [][]string
+	LintTargetBySourcePath map[string]rslintconfig.DiscoveredLintTarget
 }
 
 func sourceOnlyCompilerOptions() *core.CompilerOptions {
@@ -53,14 +51,19 @@ func canonicalPathID(filePath string, fsys vfs.FS) string {
 	return exactPathID(authoritativePath(filePath, fsys))
 }
 
-func storeSourcePathMapping(mapping map[string]string, sourcePath string, canonicalSourcePath string, value string) {
+func storeSourceTargetMapping(
+	mapping map[string]rslintconfig.DiscoveredLintTarget,
+	sourcePath string,
+	canonicalSourcePath string,
+	target rslintconfig.DiscoveredLintTarget,
+) {
 	if mapping == nil {
 		return
 	}
 	normalizedSource := tspath.NormalizePath(sourcePath)
-	mapping[normalizedSource] = value
+	mapping[normalizedSource] = target
 	if canonicalSourcePath != "" {
-		mapping[exactPathID(canonicalSourcePath)] = value
+		mapping[exactPathID(canonicalSourcePath)] = target
 	}
 }
 
@@ -445,11 +448,7 @@ func (s *Session) appendCompatibilityPrograms(
 			}
 			sourcePath := sourceFile.FileName()
 			binding.TargetsByProgram[programIndex] = append(binding.TargetsByProgram[programIndex], sourcePath)
-			if tspath.NormalizePath(sourcePath) != target.Path {
-				storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, target.CanonicalPath, target.ConfigDirectory)
-				storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, target.CanonicalPath, binding.ConfigPathBySourcePath[tspath.NormalizePath(target.Path)])
-				storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, target.CanonicalPath, target.Path)
-			}
+			storeSourceTargetMapping(binding.LintTargetBySourcePath, sourcePath, target.CanonicalPath, target)
 		}
 	}
 	return nil
@@ -459,8 +458,8 @@ func finalizeResult(binding *LoadResult) {
 	for i := range binding.TargetsByProgram {
 		sort.Strings(binding.TargetsByProgram[i])
 	}
-	if len(binding.TargetPathBySourcePath) == 0 {
-		binding.TargetPathBySourcePath = nil
+	if len(binding.LintTargetBySourcePath) == 0 {
+		binding.LintTargetBySourcePath = nil
 	}
 }
 

--- a/internal/program/loader/loader_integration_test.go
+++ b/internal/program/loader/loader_integration_test.go
@@ -31,6 +31,22 @@ type targetPlanRealpathCountingFS struct {
 	calls map[string]int
 }
 
+type retargetingFrozenTargetFS struct {
+	vfs.FS
+	targetPath        string
+	liveCanonicalPath string
+	targetCalls       int
+}
+
+func (fsys *retargetingFrozenTargetFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	if filePath == fsys.targetPath {
+		fsys.targetCalls++
+		return fsys.liveCanonicalPath
+	}
+	return fsys.FS.Realpath(filePath)
+}
+
 type blockingProgramConfigFS struct {
 	vfs.FS
 	paths      map[string]struct{}
@@ -519,7 +535,7 @@ func TestLoadProgramsBindsRealpathTargetToProgramSourceName(t *testing.T) {
 	programs = binding.compilerPrograms
 	targetFiles := []string{plan.Targets[0].Path}
 	targetsByProgram := binding.TargetsByProgram
-	targetPathBySourcePath := binding.TargetPathBySourcePath
+	lintTargetBySourcePath := binding.LintTargetBySourcePath
 	if len(programs) != 1 {
 		t.Fatalf("realpath target should reuse existing Program, got %d programs", len(programs))
 	}
@@ -529,8 +545,8 @@ func TestLoadProgramsBindsRealpathTargetToProgramSourceName(t *testing.T) {
 	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 || targetsByProgram[0][0] != sourceName {
 		t.Fatalf("expected realpath target to bind back to source name %q, got %v", sourceName, targetsByProgram)
 	}
-	if targetPathBySourcePath[sourceName] != realTarget {
-		t.Fatalf("expected source path %q to resolve config through target path %q, got %v", sourceName, realTarget, targetPathBySourcePath)
+	if target := lintTargetBySourcePath[sourceName]; target.Path != realTarget {
+		t.Fatalf("expected source path %q to retain lint target %q, got %+v", sourceName, realTarget, target)
 	}
 }
 
@@ -570,18 +586,17 @@ func TestLoadProgramsUsesPhysicalConfigSpaceForSymlinkedConfigRoot(t *testing.T)
 		t.Fatalf("expected real target to bind to config Program, got %v", binding.TargetsByProgram)
 	}
 	sourcePath := binding.TargetsByProgram[0][0]
-	configPath := binding.ConfigPathBySourcePath[sourcePath]
-	if canonicalPathID(configPath, fsys) != canonicalPathID(realTarget, fsys) {
-		t.Fatalf("config path must stay in the physical config-root space: source=%q config=%q target=%q", sourcePath, configPath, realTarget)
+	lintTarget := binding.LintTargetBySourcePath[sourcePath]
+	if canonicalPathID(lintTarget.CanonicalPath, fsys) != canonicalPathID(realTarget, fsys) {
+		t.Fatalf("binding lost canonical target identity: source=%q binding=%+v target=%q", sourcePath, lintTarget, realTarget)
 	}
 
 	rslintconfig.RegisterAllRules()
 	resolver := newLintConfigResolver(lintConfigResolverOptions{
-		Config:                     cfg,
-		CurrentDirectory:           linkDir,
-		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
-		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
-		FS:                         fsys,
+		Config:                 cfg,
+		CurrentDirectory:       linkDir,
+		LintTargetBySourcePath: binding.LintTargetBySourcePath,
+		FS:                     fsys,
 	})
 	rules := resolver.EnabledRulesForFile(sourcePath)
 	if len(rules) != 1 || rules[0].Name != "no-debugger" {
@@ -630,18 +645,17 @@ func TestLoadProgramsConfigMatchingDoesNotDependOnProgramSourcePath(t *testing.T
 	if canonicalPathID(sourcePath, fsys) != canonicalPathID(expectedSourcePath, fsys) {
 		t.Fatalf("fixture must bind through physical Program source %q, got %q", expectedSourcePath, sourcePath)
 	}
-	expectedConfigPath := tspath.ResolvePath(authoritativePath(rootDir, fsys), "link.ts")
-	if configPath := binding.ConfigPathBySourcePath[sourcePath]; configPath != expectedConfigPath {
-		t.Fatalf("config matching must retain lexical target %q, got %q", expectedConfigPath, configPath)
+	expectedTargetPath := linkPath
+	if target := binding.LintTargetBySourcePath[sourcePath]; target.Path != expectedTargetPath {
+		t.Fatalf("binding must retain lexical target %q, got %+v", expectedTargetPath, target)
 	}
 
 	rslintconfig.RegisterAllRules()
 	resolver := newLintConfigResolver(lintConfigResolverOptions{
-		Config:                     cfg,
-		CurrentDirectory:           rootDir,
-		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
-		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
-		FS:                         fsys,
+		Config:                 cfg,
+		CurrentDirectory:       rootDir,
+		LintTargetBySourcePath: binding.LintTargetBySourcePath,
+		FS:                     fsys,
 	})
 	rules := resolver.EnabledRulesForFile(sourcePath)
 	if len(rules) != 1 || rules[0].Name != "no-console" {
@@ -698,8 +712,8 @@ func TestLoadProgramsBindsFileSymlinkOutsideProgramRoot(t *testing.T) {
 	if len(binding.TargetsByProgram[0]) != 1 || binding.TargetsByProgram[0][0] != sourceName {
 		t.Fatalf("expected target to bind to Program source %q, got %v", sourceName, binding.TargetsByProgram)
 	}
-	if owner := binding.OwnerConfigDirBySourcePath[sourceName]; owner != repoDir {
-		t.Fatalf("expected bound source owner %q, got %q", repoDir, owner)
+	if target := binding.LintTargetBySourcePath[sourceName]; target.ConfigDirectory != repoDir {
+		t.Fatalf("expected bound source owner %q, got %+v", repoDir, target)
 	}
 }
 
@@ -759,8 +773,8 @@ func TestLoadProgramsDoesNotBorrowParentConfigProgram(t *testing.T) {
 		t.Fatalf("expected target only in a source-only Program, got targets=%v", binding.TargetsByProgram)
 	}
 	sourceOnlySource := binding.TargetsByProgram[1][0]
-	if owner := binding.OwnerConfigDirBySourcePath[sourceOnlySource]; owner != tspath.NormalizePath(childDir) {
-		t.Fatalf("expected source-only owner %q, got %q", tspath.NormalizePath(childDir), owner)
+	if target := binding.LintTargetBySourcePath[sourceOnlySource]; target.ConfigDirectory != tspath.NormalizePath(childDir) {
+		t.Fatalf("expected source-only owner %q, got %+v", tspath.NormalizePath(childDir), target)
 	}
 	if binding.Programs[1].CanProvideTypeChecker(binding.Programs[1].SourceFiles()[0]) {
 		t.Fatal("child-owned target unexpectedly received type services")
@@ -802,7 +816,7 @@ func TestTypeCheckDeduplicatesSyntaxFromSourceOnlyAndParentProgram(t *testing.T)
 		t.Fatalf("expected one malformed source-only lint target, got %v", diagnostics)
 	}
 	diagnostics = append(diagnostics, collectProgramTypeDiagnostics(t, binding.Programs)...)
-	remapDiagnosticTargetPaths(diagnostics, binding.TargetPathBySourcePath)
+	remapDiagnosticTargetPaths(diagnostics, binding.LintTargetBySourcePath)
 	if len(diagnostics) < 2 {
 		t.Fatalf("fixture must exercise both source-only syntax and parent Program type-check paths, got %+v", diagnostics)
 	}
@@ -1517,6 +1531,85 @@ func TestBuildTargetProjectStreamsConfirmedBuildsDuringRootScan(t *testing.T) {
 	}
 	if err := <-done; err != nil {
 		t.Fatalf("BuildTargetProject: %v", err)
+	}
+}
+
+func TestBuildTargetProjectUsesFrozenTargetIdentityForMembership(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "direct root validation",
+			files: map[string]string{
+				"target.ts":     `export const target = 1;`,
+				"tsconfig.json": `{"files":["target.ts"],"compilerOptions":{"noLib":true}}`,
+			},
+		},
+		{
+			name: "import fallback membership",
+			files: map[string]string{
+				"main.ts":       `import "./target";`,
+				"target.ts":     `export const target = 1;`,
+				"tsconfig.json": `{"files":["main.ts"],"compilerOptions":{"noLib":true}}`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			projectDir := tspath.NormalizePath(t.TempDir())
+			writeProgramTestFiles(t, projectDir, test.files)
+			baseFS := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+			frozenCanonicalPath := tspath.NormalizePath(
+				baseFS.Realpath(tspath.ResolvePath(projectDir, "target.ts")),
+			)
+			frozenCanonicalParent := tspath.NormalizePath(baseFS.Realpath(projectDir))
+
+			requestDir := tspath.NormalizePath(t.TempDir())
+			requestedPath := tspath.ResolvePath(requestDir, "target.ts")
+			liveDir := tspath.NormalizePath(t.TempDir())
+			writeProgramTestFiles(t, liveDir, map[string]string{
+				"target.ts": `export const replacement = 2;`,
+			})
+			fsys := &retargetingFrozenTargetFS{
+				FS:         baseFS,
+				targetPath: requestedPath,
+				liveCanonicalPath: tspath.NormalizePath(
+					baseFS.Realpath(tspath.ResolvePath(liveDir, "target.ts")),
+				),
+			}
+			plan := rslintconfig.LintTargetPlan{Targets: []rslintconfig.DiscoveredLintTarget{{
+				Path:                requestedPath,
+				CanonicalPath:       frozenCanonicalPath,
+				CanonicalParentPath: frozenCanonicalParent,
+				ConfigDirectory:     projectDir,
+			}}}
+
+			session := sessionForTest(newBuildContext(fsys))
+			set, err := session.BuildTargetProject(
+				projectDir,
+				projectConfig("./tsconfig.json"),
+				plan,
+				true,
+			)
+			if err != nil {
+				t.Fatalf("BuildTargetProject: %v", err)
+			}
+			if set.Len() != 1 {
+				t.Fatalf("selected projects = %d, want frozen project", set.Len())
+			}
+			binding, err := session.LoadAPI(set, plan, projectDir, true)
+			if err != nil {
+				t.Fatalf("LoadAPI: %v", err)
+			}
+			if len(binding.TargetsByProgram) != 1 || len(binding.TargetsByProgram[0]) != 1 {
+				t.Fatalf("frozen target binding = %v, want one project target", binding.TargetsByProgram)
+			}
+			if fsys.targetCalls != 0 {
+				t.Fatalf("requested target Realpath calls = %d, want frozen identity only", fsys.targetCalls)
+			}
+		})
 	}
 }
 

--- a/internal/program/loader/root_programs_test.go
+++ b/internal/program/loader/root_programs_test.go
@@ -505,16 +505,17 @@ func resolveTargetPlanForTest(
 	allowDirs []string,
 	singleThreaded bool,
 ) (rslintconfig.LintTargetPlan, error) {
-	return rslintconfig.ResolveLintTargetPlan(
-		configMap,
-		config,
-		currentDirectory,
-		scopes,
-		fsys,
-		allowFiles,
-		allowDirs,
-		singleThreaded,
-	)
+	return rslintconfig.ResolveLintTargetPlan(rslintconfig.LintTargetPlanRequest{
+		ConfigMap:       configMap,
+		Config:          config,
+		ConfigDirectory: currentDirectory,
+		ScanRoot:        currentDirectory,
+		ConfigScopes:    scopes,
+		FS:              fsys,
+		Files:           allowFiles,
+		Directories:     allowDirs,
+		SingleThreaded:  singleThreaded,
+	})
 }
 
 func activeConfigsForTest(
@@ -620,10 +621,13 @@ func collectTargetSyntacticDiagnostics(
 	return diagnostics
 }
 
-func remapDiagnosticTargetPaths(diagnostics []rule.RuleDiagnostic, mapping map[string]string) {
+func remapDiagnosticTargetPaths(
+	diagnostics []rule.RuleDiagnostic,
+	mapping map[string]rslintconfig.DiscoveredLintTarget,
+) {
 	for index := range diagnostics {
-		if target := mapping[diagnostics[index].FilePath]; target != "" {
-			diagnostics[index].FilePath = target
+		if target, ok := mapping[diagnostics[index].FilePath]; ok {
+			diagnostics[index].FilePath = target.Path
 		}
 	}
 }
@@ -673,30 +677,35 @@ func deduplicateTypeScriptDiagnostics(
 }
 
 type lintConfigResolverOptions struct {
-	Config                     rslintconfig.RslintConfig
-	CurrentDirectory           string
-	ConfigPathBySourcePath     map[string]string
-	OwnerConfigDirBySourcePath map[string]string
-	FS                         vfs.FS
+	Config                 rslintconfig.RslintConfig
+	CurrentDirectory       string
+	LintTargetBySourcePath map[string]rslintconfig.DiscoveredLintTarget
+	FS                     vfs.FS
 }
 
 type testLintConfigResolver struct {
-	resolver   *rslintconfig.FileConfigResolver
-	pathByFile map[string]string
+	resolver           *rslintconfig.FileConfigResolver
+	lintTargetBySource map[string]rslintconfig.DiscoveredLintTarget
 }
 
 func newLintConfigResolver(opts lintConfigResolverOptions) *testLintConfigResolver {
 	return &testLintConfigResolver{
-		resolver:   rslintconfig.NewFileConfigResolver(opts.Config, authoritativePath(opts.CurrentDirectory, opts.FS), false),
-		pathByFile: opts.ConfigPathBySourcePath,
+		resolver: rslintconfig.NewFileConfigResolverWithFS(
+			opts.Config,
+			opts.CurrentDirectory,
+			opts.FS,
+			false,
+		),
+		lintTargetBySource: opts.LintTargetBySourcePath,
 	}
 }
 
 func (resolver *testLintConfigResolver) EnabledRulesForFile(fileName string) []rule.ConfiguredRule {
-	if mapped := resolver.pathByFile[fileName]; mapped != "" {
-		fileName = mapped
+	target, ok := resolver.lintTargetBySource[fileName]
+	if !ok {
+		target.Path = fileName
 	}
-	rules, _ := resolver.resolver.EnabledRulesForFile(fileName)
+	rules, _ := resolver.resolver.EnabledRulesForTarget(target.Path, target.CanonicalPath)
 	return rules
 }
 

--- a/internal/program/loader/target_binding.go
+++ b/internal/program/loader/target_binding.go
@@ -199,7 +199,6 @@ func bindTargetToProgram(
 	programIndexes []int,
 	programIndex int,
 	target rslintconfig.DiscoveredLintTarget,
-	fsys vfs.FS,
 ) bool {
 	if programIndex < 0 || programIndex >= len(set.compilerPrograms) {
 		return false
@@ -213,11 +212,7 @@ func bindTargetToProgram(
 	}
 	sourcePath := sourceFile.FileName()
 	binding.TargetsByProgram[programIndex] = append(binding.TargetsByProgram[programIndex], sourcePath)
-	storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, target.CanonicalPath, target.ConfigDirectory)
-	storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, target.CanonicalPath, target.MatchPath(fsys))
-	if tspath.NormalizePath(sourcePath) != target.Path {
-		storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, target.CanonicalPath, target.Path)
-	}
+	storeSourceTargetMapping(binding.LintTargetBySourcePath, sourcePath, target.CanonicalPath, target)
 	return true
 }
 
@@ -228,12 +223,10 @@ func (s *Session) bindTargetsToProjects(
 ) (LoadResult, []rslintconfig.DiscoveredLintTarget) {
 	fsys := s.FS()
 	binding := LoadResult{
-		compilerPrograms:           append([]*compiler.Program(nil), set.compilerPrograms...),
-		Programs:                   append([]*lintprogram.Program(nil), set.programs...),
-		TargetsByProgram:           make([][]string, len(set.compilerPrograms)),
-		TargetPathBySourcePath:     make(map[string]string),
-		ConfigPathBySourcePath:     make(map[string]string),
-		OwnerConfigDirBySourcePath: make(map[string]string),
+		compilerPrograms:       append([]*compiler.Program(nil), set.compilerPrograms...),
+		Programs:               append([]*lintprogram.Program(nil), set.programs...),
+		TargetsByProgram:       make([][]string, len(set.compilerPrograms)),
+		LintTargetBySourcePath: make(map[string]rslintconfig.DiscoveredLintTarget),
 	}
 
 	var unbound []rslintconfig.DiscoveredLintTarget
@@ -253,7 +246,6 @@ func (s *Session) bindTargetsToProjects(
 			programIndexes,
 			directOwners[targetIndex],
 			target,
-			fsys,
 		) {
 			continue
 		}
@@ -267,7 +259,6 @@ func (s *Session) bindTargetsToProjects(
 				programIndexes,
 				programIndex,
 				target,
-				fsys,
 			) {
 				bound = true
 				break
@@ -275,8 +266,7 @@ func (s *Session) bindTargetsToProjects(
 		}
 		if !bound {
 			unbound = append(unbound, target)
-			storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, target.Path, target.CanonicalPath, target.ConfigDirectory)
-			storeSourcePathMapping(binding.ConfigPathBySourcePath, target.Path, target.CanonicalPath, target.MatchPath(fsys))
+			storeSourceTargetMapping(binding.LintTargetBySourcePath, target.Path, target.CanonicalPath, target)
 		}
 	}
 	return binding, unbound

--- a/internal/program/loader/targeted_projects.go
+++ b/internal/program/loader/targeted_projects.go
@@ -185,7 +185,7 @@ func (execution *targetedProjectExecution) containsTarget(
 	})
 	slot.lookupMu.Lock()
 	defer slot.lookupMu.Unlock()
-	return slot.lookup.SourceFileForPath(target.Path) != nil
+	return slot.lookup.SourceFileForTarget(target.Path, target.CanonicalPath) != nil
 }
 
 func (execution *targetedProjectExecution) supportsTarget(

--- a/internal/utils/program_source_lookup.go
+++ b/internal/utils/program_source_lookup.go
@@ -66,6 +66,13 @@ func (lookup *ProgramSourceLookup) CanonicalSourceFile(canonicalPath string) *as
 	if lookup == nil || lookup.program == nil || lookup.fs == nil || canonicalPath == "" {
 		return nil
 	}
+	return lookup.canonicalSourceFileByID(lookup.canonicalPathID(canonicalPath))
+}
+
+func (lookup *ProgramSourceLookup) canonicalSourceFileByID(canonicalID string) *ast.SourceFile {
+	if lookup == nil || lookup.program == nil || lookup.fs == nil || canonicalID == "" {
+		return nil
+	}
 	if !lookup.canonicalIndexBuilt {
 		lookup.canonicalIndexBuilt = true
 		lookup.canonicalSources = make(map[string]*ast.SourceFile)
@@ -77,7 +84,37 @@ func (lookup *ProgramSourceLookup) CanonicalSourceFile(canonicalPath string) *as
 			}
 		}
 	}
-	return lookup.canonicalSources[lookup.canonicalPathID(canonicalPath)]
+	return lookup.canonicalSources[canonicalID]
+}
+
+// SourceFileForTarget resolves a caller-visible path using a canonical target
+// identity that was frozen by an earlier discovery/snapshot boundary. It never
+// performs another filesystem identity lookup for either spelling, so source
+// selection cannot observe a different generation from config selection.
+func (lookup *ProgramSourceLookup) SourceFileForTarget(filePath string, canonicalPath string) *ast.SourceFile {
+	if lookup == nil || lookup.program == nil || filePath == "" {
+		return nil
+	}
+	filePath = tspath.NormalizePath(filePath)
+	if sourceFile := lookup.SourceFileForCandidate(filePath, ""); sourceFile != nil {
+		return sourceFile
+	}
+	if canonicalPath == "" {
+		return nil
+	}
+	canonicalPath = tspath.NormalizePath(canonicalPath)
+	canonicalID := exactProgramSourcePathID(canonicalPath)
+	if sourceFile := lookup.program.GetSourceFile(filePath); sourceFile != nil &&
+		lookup.canonicalPathID(sourceFile.FileName()) == canonicalID {
+		return sourceFile
+	}
+	if exactProgramSourcePathID(canonicalPath) != exactProgramSourcePathID(filePath) {
+		if sourceFile := lookup.program.GetSourceFile(canonicalPath); sourceFile != nil &&
+			lookup.canonicalPathID(sourceFile.FileName()) == canonicalID {
+			return sourceFile
+		}
+	}
+	return lookup.canonicalSourceFileByID(canonicalID)
 }
 
 // SourceFileForPath resolves a lexical filesystem path through exact and

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -44,12 +44,19 @@ import type {
 } from '../types.js';
 
 export interface RslintOptions {
-  /** Base directory for config discovery and relative path resolution. */
+  /**
+   * Working directory for targets and discovery; also the base of inline
+   * `overrideConfig` paths.
+   */
   cwd?: string;
-  /** Extra config appended after the resolved/discovered config (ESLint's overrideConfig). */
+  /**
+   * Extra config appended after the resolved/discovered config. Relative
+   * `files`, `ignores`, and `parserOptions.project` paths resolve from `cwd`.
+   */
   overrideConfig?: RslintConfigEntry | RslintConfig | null;
   /**
-   * `string` — use this JS/TS config module (no discovery).
+   * `string` — use this JS/TS config module (no discovery); its relative
+   *            config paths resolve from the module's directory.
    * `true`   — use only `overrideConfig` (no file, no discovery).
    * `null`/absent — auto-discover the nearest config (ESLint v10 semantics; no `false`).
    */

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -96,6 +96,8 @@ export interface ParserOptions {
   projectService?: boolean;
   /**
    * tsconfig.json path(s) used for typed linting. Glob patterns are supported.
+   * Omit this field to use a governing config's default `tsconfig.json`; pass
+   * an empty array to disable that fallback.
    *
    * @example
    * project: './tsconfig.json'

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -54,9 +54,10 @@ export interface LintResponse {
   fixableWarningCount: number;
   fileCount: number;
   ruleCount: number;
-  // Files actually linted (config `ignores` excluded), each a requested target
-  // path relative to configDirectory — same path space as Diagnostic.filePath.
-  // Present for lintFiles so the Rslint class seeds one result per linted file.
+  // Files actually linted (config `ignores` excluded), in the same path space
+  // as Diagnostic.filePath: low-level requests use configDirectory and native
+  // discovery requests use workingDirectory. Present for lintFiles so the
+  // Rslint class seeds one result per linted file.
   lintedFiles?: string[];
   output?: Record<string, string>; // Per-file fixed source, present when fix:true applied a fix
   encodedSourceFiles?: Record<string, string>; // Binary encoded source files as base64-encoded strings
@@ -87,17 +88,21 @@ export interface LintOptions {
     directories?: string[];
     /** Parallel to `files`; true only for caller-literal file targets. */
     explicitFiles?: boolean[];
-    /** Normalized API override entries appended to every selected config. */
+    /**
+     * Normalized API override entries appended to every selected config;
+     * relative paths retain workingDirectory as their authored base.
+     */
     overrideConfig?: Record<string, unknown>[];
   };
   // Community ESLint-plugin rules available to this request. Go registers
   // request-scoped placeholder rules from this metadata, then asks the Node
   // peer to execute them through a reverse `pluginLint` request.
   eslintPlugins?: Array<{ prefix: string; ruleNames: string[] }>;
-  // Anchor dir for resolving the config's relative files/ignores/project.
+  // Anchor for relative paths in low-level `config`. Native discovery entries
+  // use their owning config directory; inline overrides use workingDirectory.
   configDirectory?: string;
-  // Opaque routing key for community-plugin workers. High-level APIs set this
-  // when config path rebasing makes it differ from configDirectory.
+  // Opaque community-plugin worker identity, independent from the directory
+  // used to resolve config paths.
   pluginConfigDirectory?: string;
   workingDirectory?: string;
   fileContents?: Record<string, string>; // Map of file paths to their contents for VFS

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -5,6 +5,7 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import os from 'node:os';
 import { pathToFileURL } from 'node:url';
+import { convertPathToPattern } from 'tinyglobby';
 import {
   writeFile,
   rm,
@@ -580,7 +581,7 @@ describe('Rslint class', () => {
     }
   });
 
-  test('overrideConfigFile outside cwd still resolves files from cwd', async () => {
+  test('overrideConfigFile outside cwd resolves files from its config directory', async () => {
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-override-cwd-'));
     const projectDir = path.join(tmp, 'project');
     const configDir = path.join(tmp, 'configs');
@@ -590,7 +591,7 @@ describe('Rslint class', () => {
       const configFile = path.join(configDir, 'custom.config.mjs');
       await writeFile(
         configFile,
-        "export default [{ files: ['src/**/*.ts'], rules: { 'no-console': 'error' } }];\n",
+        "export default [{ files: ['../project/src/**/*.ts'], rules: { 'no-console': 'error' } }];\n",
       );
       await writeFile(
         path.join(projectDir, 'src', 'index.ts'),
@@ -607,6 +608,58 @@ describe('Rslint class', () => {
         expect(results[0].messages.map((m) => m.ruleId)).toContain(
           'no-console',
         );
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('overrideConfigFile keeps multiple directory Git scopes independent', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-multi-root-'));
+    const invocationDir = path.join(tmp, 'invocation');
+    const configDir = path.join(tmp, 'config');
+    const firstDir = path.join(tmp, 'first');
+    const secondDir = path.join(tmp, 'second');
+    try {
+      await Promise.all(
+        [invocationDir, configDir, firstDir, secondDir].map((directory) =>
+          mkdir(directory, { recursive: true }),
+        ),
+      );
+      const configFile = path.join(configDir, 'custom.config.mjs');
+      await writeFile(
+        configFile,
+        "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await Promise.all([
+        writeFile(path.join(firstDir, '.gitignore'), 'ignored.ts\n'),
+        writeFile(path.join(firstDir, 'ignored.ts'), 'debugger;\n'),
+        writeFile(path.join(firstDir, 'visible.ts'), 'debugger;\n'),
+        writeFile(path.join(secondDir, '.gitignore'), 'hidden.ts\n'),
+        writeFile(path.join(secondDir, 'ignored.ts'), 'debugger;\n'),
+        writeFile(path.join(secondDir, 'hidden.ts'), 'debugger;\n'),
+      ]);
+
+      const rslint = new Rslint({
+        cwd: invocationDir,
+        overrideConfigFile: configFile,
+      });
+      try {
+        const results = await rslint.lintFiles([
+          `${convertPathToPattern(firstDir)}/**/*.ts`,
+          `${convertPathToPattern(secondDir)}/**/*.ts`,
+        ]);
+        expect(results.map((result) => result.filePath)).toEqual([
+          path.join(firstDir, 'visible.ts'),
+          path.join(secondDir, 'ignored.ts'),
+        ]);
+        for (const result of results) {
+          expect(result.messages.map((message) => message.ruleId)).toContain(
+            'no-debugger',
+          );
+        }
       } finally {
         await rslint.close();
       }
@@ -1126,7 +1179,7 @@ module.exports = config;`
     }
   });
 
-  test('nested configs resolve overrideConfig paths from each discovered config', async () => {
+  test('nested configs preserve the cwd base of inline overrideConfig paths', async () => {
     const tmp = await mkdtemp(
       path.join(os.tmpdir(), 'rslint-api-nested-override-'),
     );
@@ -1162,12 +1215,12 @@ module.exports = config;`
       const rslint = new Rslint({
         cwd: tmp,
         overrideConfig: [
-          { ignores: ['src/ignored.ts'] },
+          { ignores: ['packages/app/src/ignored.ts'] },
           {
-            files: ['src/**/*.ts'],
+            files: ['packages/*/src/**/*.ts'],
             plugins: ['@typescript-eslint'],
             languageOptions: {
-              parserOptions: { project: ['./tsconfig.json'] },
+              parserOptions: { project: ['./packages/*/tsconfig.json'] },
             },
             rules: {
               '@typescript-eslint/array-type': [
@@ -1849,7 +1902,7 @@ module.exports = config;`
     }
   });
 
-  test('lintFiles scans an explicit directory symlink with its physical ancestor config', async () => {
+  test('lintFiles preserves inline cwd matching through a physical ancestor config', async () => {
     const tmp = await mkdtemp(
       path.join(os.tmpdir(), 'rslint-api-explicit-directory-symlink-'),
     );
@@ -1862,7 +1915,10 @@ module.exports = config;`
         path.join(realRoot, 'rslint.config.mjs'),
         "export default [{ files: ['sub/**/*.ts'], rules: { 'no-debugger': 'error' } }];\n",
       );
-      await writeFile(path.join(realSubdir, 'index.ts'), 'debugger;\n');
+      await writeFile(
+        path.join(realSubdir, 'index.ts'),
+        "debugger;\nconsole.log('value');\n",
+      );
       try {
         await symlink(
           realSubdir,
@@ -1873,7 +1929,15 @@ module.exports = config;`
         return;
       }
 
-      const rslint = new Rslint({ cwd: tmp });
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfig: [
+          {
+            files: ['link/**/*.ts'],
+            rules: { 'no-console': 'error' },
+          },
+        ],
+      });
       try {
         for (const pattern of ['link', 'link/**/*.ts']) {
           const results = await rslint.lintFiles(pattern);
@@ -1881,6 +1945,7 @@ module.exports = config;`
           expect(results[0].filePath).toBe(path.join(linkDir, 'index.ts'));
           expect(results[0].messages.map((message) => message.ruleId)).toEqual([
             'no-debugger',
+            'no-console',
           ]);
         }
       } finally {

--- a/website/docs/en/api/rslint.md
+++ b/website/docs/en/api/rslint.md
@@ -46,13 +46,13 @@ Both `lintFiles` and `lintText` return ESLint-shaped `LintResult[]` values.
 const rslint = new Rslint(options);
 ```
 
-| Option               | Type                                        | Default         | Description                                                                                                         |
-| -------------------- | ------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `cwd`                | `string`                                    | `process.cwd()` | Base directory for config discovery and relative path resolution                                                    |
-| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —               | Extra config appended after the discovered or explicitly selected config                                            |
-| `overrideConfigFile` | `string \| true \| null`                    | `null`          | A config path disables discovery; `true` uses only `overrideConfig`; `null` or omission enables automatic discovery |
-| `fix`                | `boolean`                                   | `false`         | Applies auto-fixes and includes changed source in `result.output`                                                   |
-| `virtualFiles`       | `Record<string, string>`                    | —               | In-memory path-to-content overlay for project inputs; unresolved reads may still fall back to disk                  |
+| Option               | Type                                        | Default         | Description                                                                                                                                          |
+| -------------------- | ------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cwd`                | `string`                                    | `process.cwd()` | Working directory for targets and discovery; also the base of inline `overrideConfig` paths                                                          |
+| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —               | Extra config appended after the selected config; relative `files`, `ignores`, and `parserOptions.project` paths use `cwd`                            |
+| `overrideConfigFile` | `string \| true \| null`                    | `null`          | A config path disables discovery and uses its own directory as its config path base; `true` uses only the override; otherwise configs are discovered |
+| `fix`                | `boolean`                                   | `false`         | Applies auto-fixes and includes changed source in `result.output`                                                                                    |
+| `virtualFiles`       | `Record<string, string>`                    | —               | In-memory path-to-content overlay for project inputs; unresolved reads may still fall back to disk                                                   |
 
 With automatic discovery, Go selects each file's nearest config and owns ignore and target-admission semantics. The JavaScript host evaluates and normalizes the JS or TS config modules selected for that run.
 

--- a/website/docs/en/config/configuration-file.md
+++ b/website/docs/en/config/configuration-file.md
@@ -62,9 +62,7 @@ You can specify a config file explicitly, which overrides automatic discovery:
 rslint --config path/to/rslint.config.ts .
 ```
 
-For automatically discovered configs, relative `files`, `ignores`, and `languageOptions.parserOptions.project` patterns are resolved from the config file's directory.
-
-For a config supplied with `--config`, those patterns are resolved from the current working directory.
+Relative `files`, `ignores`, and `languageOptions.parserOptions.project` patterns are resolved from the config file's directory, whether the config is discovered automatically or supplied with `--config`.
 
 To generate a default config, run:
 

--- a/website/docs/en/config/files.md
+++ b/website/docs/en/config/files.md
@@ -42,4 +42,4 @@ File selection is independent of a tsconfig's `include`. A file in tsconfig but 
 Selected files not covered by a tsconfig declared by their governing config automatically receive a reduced rule set: only rules that do not require type information run. To enable type-aware rules, add the file to one of that config's tsconfigs. See [`languageOptions.parserOptions.project`](/config/language-options#languageoptionsparseroptionsproject).
 :::
 
-Relative patterns are resolved from the config file's directory for automatically discovered configs, or from the current working directory when the config is supplied with `--config`.
+Relative patterns in a config file are resolved from that file's directory. Relative patterns in the JavaScript API's inline `overrideConfig` are resolved from the API `cwd`.

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -100,11 +100,12 @@ For directory-level patterns (`dir/**`), `!` negation cannot re-include files be
 
 ## .gitignore integration
 
-The CLI, JavaScript API, and LSP automatically read `.gitignore` files and treat their patterns as additional global ignores. Collection starts at the directory of the governing rslint config and never searches its parents. In a multi-config repository, a child config starts a new `.gitignore` scope, so put package-specific ignores beside that package's config. In the editor, saved `.gitignore` changes refresh diagnostics for open files.
+The CLI, JavaScript API, and LSP automatically read `.gitignore` files and treat their patterns as additional global ignores. Automatically discovered configs and ordinary LSP files start collection at the governing config directory. An explicitly selected invocation-wide config (`--config`, API `overrideConfigFile`, or the LSP `configPath` setting) starts at the invocation or workspace-folder `cwd`, even when the config file is elsewhere. A requested directory outside `cwd` gets its own independent Git scope. Collection never searches a scope's parents. In the editor, saved `.gitignore` changes refresh diagnostics for open files.
 
-- **Nested `.gitignore` files** inside one config-owned tree are supported — each one only affects its own directory subtree
-- **Parent patterns cascade** to child directories within that tree (e.g., root `dist/` also ignores `packages/app/dist/` when both use the root config)
+- **Nested `.gitignore` files** inside one Git scope are supported — each one only affects its own directory subtree
+- **Parent patterns cascade** to child directories within that scope (e.g., root `dist/` also ignores `packages/app/dist/`)
 - **Child `.gitignore` can override** parent patterns with `!` negation
+- **Multiple requested directory scopes stay independent** — patterns from one sibling directory never apply to another, including through filesystem aliases
 - **Child configs are boundaries** — they do not inherit `.gitignore` files from a parent config directory
 - Config `!` negation can also override `.gitignore` patterns (they are evaluated sequentially in the same global ignores list)
 

--- a/website/docs/en/config/language-options.md
+++ b/website/docs/en/config/language-options.md
@@ -55,7 +55,9 @@ Files outside all tsconfigs are still linted, but only rules that do not require
 }
 ```
 
-Relative project patterns are resolved from the config file's directory for automatically discovered configs, or from the current working directory when the config is supplied with `--config`.
+Relative project patterns in a config file are resolved from that file's directory. Relative project patterns in the JavaScript API's inline `overrideConfig` are resolved from the API `cwd`.
+
+Omit `project` to use the governing config directory's default `tsconfig.json`. Set `project: []` to disable that fallback explicitly.
 
 ## languageOptions.globals
 

--- a/website/docs/en/guide/js-api.md
+++ b/website/docs/en/guide/js-api.md
@@ -173,10 +173,10 @@ Each `LintMessage`:
 
 [`new Rslint(options)`](/api/rslint#constructor) accepts:
 
-| Option               | Type                                        | Default     | Description                                                                                                                                    |
-| -------------------- | ------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cwd`                | `string`                                    | current cwd | Base directory for config discovery and relative path resolution                                                                               |
-| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —           | Extra config appended after the resolved/discovered config (ESLint's `overrideConfig`); a preset array may be listed as one element            |
-| `overrideConfigFile` | `string \| true \| null`                    | `null`      | `string`: use this JS/TS config module (no discovery); `true`: use only `overrideConfig` (no file, no discovery); `null`/absent: auto-discover |
-| `fix`                | `boolean`                                   | `false`     | Apply rule auto-fixes; results carry `output`                                                                                                  |
-| `virtualFiles`       | `Record<string, string>`                    | —           | In-memory file overlay (path → content); unresolved reads may fall back to disk                                                                |
+| Option               | Type                                        | Default     | Description                                                                                                                                      |
+| -------------------- | ------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cwd`                | `string`                                    | current cwd | Working directory for targets and discovery; also the base of inline `overrideConfig` paths                                                      |
+| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —           | Extra config appended after the resolved/discovered config; relative `files`, `ignores`, and `parserOptions.project` paths use `cwd`             |
+| `overrideConfigFile` | `string \| true \| null`                    | `null`      | `string`: use this config module and resolve its config-relative paths from its directory; `true`: use only `overrideConfig`; otherwise discover |
+| `fix`                | `boolean`                                   | `false`     | Apply rule auto-fixes; results carry `output`                                                                                                    |
+| `virtualFiles`       | `Record<string, string>`                    | —           | In-memory file overlay (path → content); unresolved reads may fall back to disk                                                                  |

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -28,7 +28,7 @@ rslint --type-check .         # lint + type-check
 rslint --type-check-only .    # type-check only
 ```
 
-When `parserOptions.project` is omitted, rslint uses `tsconfig.json` in the governing config directory when present. If neither configured projects nor that fallback tsconfig exist, no real TypeScript Program is built and type-check produces no diagnostics for that config.
+When `parserOptions.project` is omitted, rslint uses `tsconfig.json` in the governing config directory when present. Set `project: []` to disable that fallback explicitly. If neither configured projects nor that fallback tsconfig exist, no real TypeScript Program is built and type-check produces no diagnostics for that config.
 
 ## What gets type-checked
 


### PR DESCRIPTION
## Summary

- Make `internal/config` the single authority for target discovery, config ownership, authored path bases, ignores, and the immutable lint-target plan.
- Make CLI, IPC API, and LSP consume the same target/config decisions instead of rebuilding them in later stages.
- Keep caller-visible paths separate from physical identity, including symlinks, native case aliases, Windows paths, and overlapping targets.
- Keep rule behavior unchanged. This refactor only corrects target/config semantics that were internally inconsistent or contrary to the authored config location.

## Architecture

1. Config discovery builds one config catalog and freezes every authored base directory.
2. `LintTargetPlan` selects targets once and records each target's visible path, physical identity, config owner, and literal-file skip outcome.
3. `FileConfigResolver` evaluates the execution config in those frozen path spaces. CLI `--rule` and API overrides cannot change target selection.
4. Program loading binds the planned targets but cannot add targets, select another config owner, or reinterpret relative config paths. LSP stores the equivalent per-document snapshot for native rules, plugins, fixes, and resident Programs.

## Expected behavior

| Request | Lint target scope | Config owner and relative paths | `.gitignore` scope |
| --- | --- | --- | --- |
| No path arguments | Recursively scan the invocation cwd | Automatic discovery uses the nearest reachable config; an explicit config owns the whole request | Invocation cwd |
| `.` | Same as an explicit cwd directory | Same as above | That directory tree |
| One or more files | Exact union of the named files; no parent or sibling widening | Each file keeps its selected owner | Only the ancestry needed for those files |
| One or more directories | Exact union of the named subtrees | Each discovered file keeps its nearest owner | Every requested directory is an independent scope |
| Mixed files and directories | Exact union; overlaps are deduplicated by physical file identity | A physical file cannot silently use two different config owners | File ancestry plus the requested directory scopes |
| `--config` inside or outside cwd | Does not change the target scope above; omitted targets still mean cwd | `files`, `ignores`, and `parserOptions.project` are relative to the config file's directory | Still follows the invocation targets, not the config directory |
| API `overrideConfigFile` | Same request target scope | Relative to that config file's directory | Same request scopes |
| API inline `overrideConfig` | Same request target scope | Relative to `WorkingDirectory` | Same request scopes |
| LSP document | The open supported document | One frozen owner/config/project snapshot is shared by native lint, plugins, fixes, and resident Programs | The committed document/config snapshot |

## Config content behavior

| Config content | Behavior |
| --- | --- |
| `files` omitted | The default supported script extensions remain discoverable; entries without `files` cascade over the effective selector union |
| Multiple top-level `files` values | OR alternatives |
| One nested `files` array | AND conditions |
| Entry-local `ignores` | Stops only that entry from selecting or configuring the file |
| Global ignore entry | Removes the target entirely |
| Explicit supported file misses every `files` selector | Keeps the target. Applicable entries without `files` still cascade; if no entry contributes, only syntax diagnostics run. No skip warning is emitted. |
| Explicit missing file | Skipped with a not-found warning |
| Explicit globally/default-ignored file | Skipped with an ignored warning; ignored takes priority if the path is also missing |
| `parserOptions.project` omitted | Uses the owning config directory's default `tsconfig.json` fallback |
| `parserOptions.project: []` | Selects no TypeScript project; it no longer means “use the default tsconfig” |
| Relative project paths in composed entries | Resolve from each entry's authored base, matching `files` and `ignores` |

Literal files, directory walks, and config evaluation reuse the same frozen decision. Warning rendering, Program membership checks, fix passes, and LSP plugin/native paths do not re-read a target identity or select its owner again.

## Intentional corrections

- An external explicit config no longer rebases authored `files`, `ignores`, or project paths onto the invocation cwd.
- Multiple requested directories no longer share or borrow one another's Git-ignore policy.
- An explicit empty project list now disables the default tsconfig fallback.
- Literal-file warnings now describe the same selection decision that the linter actually executed.
- Focused Program validation uses the already-frozen target identity, so a later symlink retarget cannot change project membership.

## Verification

- Affected Go packages: config, discovery, Program loader, CLI, IPC API, LSP, and shared lookup utilities
- Targeted race tests for target planning, focused Program binding, CLI warnings, and LSP snapshots/fixes
- `golangci-lint` on all affected Go packages
- Windows and Linux cross-compilation of all affected packages; final config/loader cross-compilation repeated after the last fix
- `@rslint/core` JS build and the changed `tests/rslint.test.mjs` suite: 69 passed
- Prettier, CSpell, and `git diff --check`
- Independent adversarial votes: architecture ACCEPT, product semantics ACCEPT, regression/cross-platform coverage ACCEPT
- Independent real-repository verification against `main@39346760`: 53/53 repositories and all four modes matched exactly, with zero hangs or orphan processes; 20-sample quiet stage-prime medians ranged from -0.88% to +1.05%, with no attributable regression.

Full rule tests were intentionally not run because this refactor does not modify rule implementations or rule behavior.

Broader rule/runtime performance work remains a separate PR; the optimization here only removes overhead introduced by this refactor.
