### PR TITLE
test: lock CLI lint target contracts

### DIFF
--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1792,6 +1792,9 @@ func TestCLIExplicitFileOutsideFilesCountsWithNoRules(t *testing.T) {
 	if strings.Contains(stdout, "no-debugger") {
 		t.Fatalf("files-scope miss must not run no-debugger, stdout=%q", stdout)
 	}
+	if strings.Contains(stderr, "explicit.js") {
+		t.Fatalf("files-scope miss must not be reported as skipped, stderr=%q", stderr)
+	}
 }
 
 func TestCLIExplicitMalformedFileOutsideFilesReportsSyntaxDiagnostic(t *testing.T) {
@@ -1821,6 +1824,12 @@ func TestCLIExplicitMalformedFileOutsideFilesReportsSyntaxDiagnostic(t *testing.
 	}
 	if !strings.Contains(stdout, "TypeScript(TS1134)") {
 		t.Fatalf("selected zero-rule target must surface syntax diagnostics, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if strings.Contains(stdout, "no-debugger") {
+		t.Fatalf("files-scope miss must not run no-debugger, stdout=%q", stdout)
+	}
+	if strings.Contains(stderr, "explicit.js") {
+		t.Fatalf("files-scope miss must not be reported as skipped, stderr=%q", stderr)
 	}
 }
 

--- a/cmd/rslint/lint_target_contract_test.go
+++ b/cmd/rslint/lint_target_contract_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+)
+
+type lintTargetContractDiagnostic struct {
+	RuleName string `json:"ruleName"`
+	FilePath string `json:"filePath"`
+}
+
+func writeLintTargetContractFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for relative, content := range files {
+		fileName := filepath.Join(root, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(fileName), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(fileName), err)
+		}
+		if err := os.WriteFile(fileName, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", fileName, err)
+		}
+	}
+}
+
+func parseLintTargetContractDiagnostics(t *testing.T, stdout string) []lintTargetContractDiagnostic {
+	t.Helper()
+	var diagnostics []lintTargetContractDiagnostic
+	scanner := bufio.NewScanner(strings.NewReader(stdout))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var diagnostic lintTargetContractDiagnostic
+		if err := json.Unmarshal([]byte(line), &diagnostic); err != nil {
+			t.Fatalf("decode JSONLine diagnostic %q: %v", line, err)
+		}
+		diagnostics = append(diagnostics, diagnostic)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan JSONLine diagnostics: %v", err)
+	}
+	return diagnostics
+}
+
+func lintTargetContractPaths(
+	t *testing.T,
+	cwd string,
+	diagnostics []lintTargetContractDiagnostic,
+	matchRule func(string) bool,
+) []string {
+	t.Helper()
+	paths := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if !matchRule(diagnostic.RuleName) {
+			continue
+		}
+		fileName := filepath.FromSlash(diagnostic.FilePath)
+		if !filepath.IsAbs(fileName) {
+			fileName = filepath.Join(cwd, fileName)
+		}
+		paths = append(paths, tspath.NormalizePath(fileName))
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func TestCLINoArgsUsesDefaultScriptExtensions(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"rslint.jsonc": `[{
+			"rules": {"no-debugger": "error"}
+		}]`,
+		"source.js":   "debugger;\n",
+		"source.mjs":  "debugger;\n",
+		"source.cjs":  "debugger;\n",
+		"source.jsx":  "debugger;\n",
+		"source.ts":   "debugger;\n",
+		"source.mts":  "debugger;\n",
+		"source.cts":  "debugger;\n",
+		"source.tsx":  "debugger;\n",
+		"source.css":  "debugger;\n",
+		"source.json": "debugger;\n",
+	}
+	writeLintTargetContractFiles(t, dir, files)
+
+	code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Config:         "rslint.jsonc",
+		Format:         "default",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 1 {
+		t.Fatalf("default-extension lint exit code = %d, want 1; stdout=%q stderr=%q", code, stdout, stderr)
+	}
+
+	for _, extension := range []string{".js", ".mjs", ".cjs", ".jsx", ".ts", ".mts", ".cts", ".tsx"} {
+		if !strings.Contains(stdout, "source"+extension+":") {
+			t.Errorf("default scan missed source%s: stdout=%q stderr=%q", extension, stdout, stderr)
+		}
+	}
+	for _, extension := range []string{".css", ".json"} {
+		if strings.Contains(stdout, "source"+extension+":") {
+			t.Errorf("default scan linted unsupported source%s: stdout=%q stderr=%q", extension, stdout, stderr)
+		}
+	}
+	if !strings.Contains(stdout, "linted 8 files") {
+		t.Fatalf("default scan did not lint exactly 8 script files: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestCLITypeCheckKeepsLintTargetsAndChecksWholeProject(t *testing.T) {
+	dir := t.TempDir()
+	writeLintTargetContractFiles(t, dir, map[string]string{
+		"rslint.jsonc": `[{
+			"files": ["**/*.ts"],
+			"languageOptions": {"parserOptions": {"project": ["./tsconfig.json"]}},
+			"rules": {"no-debugger": "error"}
+		}]`,
+		"tsconfig.json": `{
+			"compilerOptions": {"strict": true},
+			"files": ["selected.ts", "unselected.ts"]
+		}`,
+		"selected.ts":   "debugger;\nexport const selected = true;\n",
+		"unselected.ts": "debugger;\nexport const broken: number = 'value';\n",
+	})
+	selected := tspath.NormalizePath(filepath.Join(dir, "selected.ts"))
+	unselected := tspath.NormalizePath(filepath.Join(dir, "unselected.ts"))
+
+	run := func(t *testing.T, typeCheck bool) []lintTargetContractDiagnostic {
+		t.Helper()
+		code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+			Config:         "rslint.jsonc",
+			AllowFiles:     []string{selected},
+			Format:         "jsonline",
+			NoColor:        true,
+			SingleThreaded: true,
+			TypeCheck:      typeCheck,
+		})
+		if code != 1 {
+			t.Fatalf("typeCheck=%v exit code = %d, want 1; stdout=%q stderr=%q", typeCheck, code, stdout, stderr)
+		}
+		return parseLintTargetContractDiagnostics(t, stdout)
+	}
+
+	plainDiagnostics := run(t, false)
+	typeCheckDiagnostics := run(t, true)
+	wantLintTargets := []string{selected}
+	for name, diagnostics := range map[string][]lintTargetContractDiagnostic{
+		"plain":      plainDiagnostics,
+		"type-check": typeCheckDiagnostics,
+	} {
+		got := lintTargetContractPaths(t, dir, diagnostics, func(ruleName string) bool {
+			return ruleName == "no-debugger"
+		})
+		if !slices.Equal(got, wantLintTargets) {
+			t.Fatalf("%s no-debugger targets = %v, want %v", name, got, wantLintTargets)
+		}
+	}
+
+	plainTypeCheckPaths := lintTargetContractPaths(t, dir, plainDiagnostics, func(ruleName string) bool {
+		return strings.HasPrefix(ruleName, "TypeScript(TS")
+	})
+	if len(plainTypeCheckPaths) != 0 {
+		t.Fatalf("plain lint unexpectedly reported project diagnostics: diagnostics=%+v", plainDiagnostics)
+	}
+	typeCheckPaths := lintTargetContractPaths(t, dir, typeCheckDiagnostics, func(ruleName string) bool {
+		return strings.HasPrefix(ruleName, "TypeScript(TS")
+	})
+	if !slices.Equal(typeCheckPaths, []string{unselected}) {
+		t.Fatalf("--type-check project diagnostic targets = %v, want [%s]: diagnostics=%+v", typeCheckPaths, unselected, typeCheckDiagnostics)
+	}
+	if !slices.ContainsFunc(typeCheckDiagnostics, func(diagnostic lintTargetContractDiagnostic) bool {
+		return diagnostic.RuleName == "TypeScript(TS2322)"
+	}) {
+		t.Fatalf("--type-check did not report TS2322 from the unselected tsconfig file: diagnostics=%+v", typeCheckDiagnostics)
+	}
+}
+
+func TestCLIFixOnlyWritesSelectedTargets(t *testing.T) {
+	dir := t.TempDir()
+	writeLintTargetContractFiles(t, dir, map[string]string{
+		"rslint.jsonc": `[{
+			"files": ["**/*.js"],
+			"rules": {"no-var": "error"}
+		}]`,
+		"selected.js":   "var selected = 1;\nexport { selected };\n",
+		"unselected.js": "var unselected = 1;\nexport { unselected };\n",
+	})
+	selected := tspath.NormalizePath(filepath.Join(dir, "selected.js"))
+	unselected := filepath.Join(dir, "unselected.js")
+
+	code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Config:         "rslint.jsonc",
+		AllowFiles:     []string{selected},
+		Fix:            true,
+		Format:         "jsonline",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 0 || stdout != "" {
+		t.Fatalf("targeted fix failed: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	selectedContent, err := os.ReadFile(selected)
+	if err != nil {
+		t.Fatalf("read selected file: %v", err)
+	}
+	if strings.Contains(string(selectedContent), "var selected") {
+		t.Fatalf("selected file was not fixed: %q", selectedContent)
+	}
+	unselectedContent, err := os.ReadFile(unselected)
+	if err != nil {
+		t.Fatalf("read unselected file: %v", err)
+	}
+	if string(unselectedContent) != "var unselected = 1;\nexport { unselected };\n" {
+		t.Fatalf("--fix changed an unselected file: %q", unselectedContent)
+	}
+}

--- a/packages/rslint/tests/lint-targets.test.mjs
+++ b/packages/rslint/tests/lint-targets.test.mjs
@@ -1,0 +1,315 @@
+import { describe, expect, test } from '@rstest/core';
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const cliScript = path.resolve(import.meta.dirname, '../bin/rslint.js');
+const cliTimeoutMs = 30_000;
+const cliOutputLimitBytes = 1024 * 1024;
+const cliTerminationGraceMs = 1_000;
+
+async function writeFixture(root, files) {
+  for (const [relative, content] of Object.entries(files)) {
+    const fileName = path.join(root, ...relative.split('/'));
+    await mkdir(path.dirname(fileName), { recursive: true });
+    await writeFile(fileName, content);
+  }
+}
+
+async function runCLI(cwd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        cliScript,
+        '--no-color',
+        '--singleThreaded',
+        '--format',
+        'jsonline',
+        ...args,
+      ],
+      {
+        cwd,
+        detached: process.platform !== 'win32',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      },
+    );
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    let outputBytes = 0;
+    let settled = false;
+    let failure;
+    let timeoutTimer;
+    let hardKillTimer;
+
+    const terminateProcessTree = () => {
+      if (child.pid === undefined) return;
+      if (process.platform === 'win32') {
+        const windowsTreeKill = spawn(
+          // cspell:disable-next-line
+          'taskkill',
+          ['/pid', String(child.pid), '/t', '/f'],
+          { stdio: 'ignore', windowsHide: true },
+        );
+        windowsTreeKill.once('error', () => child.kill('SIGKILL'));
+        return;
+      }
+      try {
+        process.kill(-child.pid, 'SIGTERM');
+      } catch {
+        child.kill('SIGTERM');
+      }
+      hardKillTimer = setTimeout(() => {
+        try {
+          process.kill(-child.pid, 'SIGKILL');
+        } catch {
+          child.kill('SIGKILL');
+        }
+      }, cliTerminationGraceMs);
+      hardKillTimer.unref();
+    };
+    const requestFailure = (error) => {
+      if (failure !== undefined || settled) return;
+      failure = error;
+      clearTimeout(timeoutTimer);
+      if (child.pid === undefined) {
+        settled = true;
+        reject(error);
+        return;
+      }
+      terminateProcessTree();
+    };
+    const collect = (chunks) => (chunk) => {
+      outputBytes += chunk.length;
+      if (outputBytes > cliOutputLimitBytes) {
+        requestFailure(
+          new Error(`rslint CLI output exceeded ${cliOutputLimitBytes} bytes`),
+        );
+        return;
+      }
+      chunks.push(chunk);
+    };
+
+    child.stdout.on('data', collect(stdoutChunks));
+    child.stderr.on('data', collect(stderrChunks));
+    child.once('error', requestFailure);
+    child.once('close', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      clearTimeout(hardKillTimer);
+      const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf8');
+      if (failure !== undefined) {
+        reject(
+          new Error(
+            `${failure.message}\ncode=${String(code)} signal=${String(signal)}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      if (signal !== null || code === null) {
+        reject(
+          new Error(
+            `rslint CLI exited abnormally: code=${String(code)} signal=${String(signal)}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve({ code, stdout, stderr });
+    });
+
+    timeoutTimer = setTimeout(() => {
+      requestFailure(new Error(`rslint CLI timed out after ${cliTimeoutMs}ms`));
+    }, cliTimeoutMs);
+    timeoutTimer.unref();
+  });
+}
+
+function parseDiagnostics(stdout) {
+  return stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function absoluteDiagnosticPaths(cwd, diagnostics, ruleName) {
+  return diagnostics
+    .filter((diagnostic) => diagnostic.ruleName === ruleName)
+    .map((diagnostic) => path.normalize(path.resolve(cwd, diagnostic.filePath)))
+    .sort();
+}
+
+function normalizedDiagnostics(cwd, diagnostics) {
+  return diagnostics
+    .map(({ filePath, ruleName }) => ({
+      filePath: path.normalize(path.resolve(cwd, filePath)),
+      ruleName,
+    }))
+    .sort((left, right) => {
+      const leftKey = `${left.ruleName}\0${left.filePath}`;
+      const rightKey = `${right.ruleName}\0${right.filePath}`;
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    });
+}
+
+describe('CLI lint target contracts', () => {
+  test('external config keeps authored paths and invocation target scope', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'rslint-cli-external-'));
+    const configDir = path.join(root, 'configs');
+    const cwd = path.join(root, 'packages', 'app');
+    const configPath = path.join(configDir, 'rslint.config.mjs');
+    try {
+      await writeFixture(root, {
+        'configs/rslint.config.mjs': `export default [
+  { ignores: ['../packages/app/src/config-ignored.ts'] },
+  {
+    files: ['../packages/app/src/**/*.ts'],
+    languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+    rules: { 'no-debugger': 'error' },
+  },
+  { files: ['*.ts'], rules: { 'no-console': 'error' } },
+];\n`,
+        'configs/tsconfig.json': JSON.stringify({
+          compilerOptions: { strict: true },
+          files: ['../packages/app/src/visible.ts'],
+        }),
+        'configs/.gitignore': 'visible.ts\nrslint.config.mjs\n',
+        'configs/config-only.ts': 'console.log("config");\n',
+        'packages/app/.gitignore': 'src/git-ignored.ts\n',
+        'packages/app/src/visible.ts':
+          "debugger;\nexport const broken: number = 'value';\n",
+        'packages/app/src/git-ignored.ts': 'debugger;\n',
+        'packages/app/src/config-ignored.ts': 'debugger;\n',
+      });
+
+      const configArgument = path.relative(cwd, configPath);
+      const implicit = await runCLI(cwd, [
+        '--type-check',
+        '--config',
+        configArgument,
+      ]);
+      const explicit = await runCLI(cwd, [
+        '--type-check',
+        '--config',
+        configArgument,
+        '.',
+      ]);
+      const visible = path.join(cwd, 'src', 'visible.ts');
+      const expected = [
+        { filePath: visible, ruleName: 'TypeScript(TS2322)' },
+        { filePath: visible, ruleName: 'no-debugger' },
+      ];
+
+      for (const result of [implicit, explicit]) {
+        expect(result.code).toBe(1);
+        expect(
+          normalizedDiagnostics(cwd, parseDiagnostics(result.stdout)),
+        ).toEqual(expected);
+        expect(result.stderr).not.toContain('warning:');
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('multiple files and directories form one deduplicated union', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'rslint-cli-union-'));
+    try {
+      await writeFixture(root, {
+        'rslint.config.mjs':
+          "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+        'standalone-a.js': 'debugger;\n',
+        'standalone-b.js': 'debugger;\n',
+        'first/one.js': 'debugger;\n',
+        'first/nested/two.js': 'debugger;\n',
+        'second/three.js': 'debugger;\n',
+        'unselected.js': 'debugger;\n',
+      });
+
+      const result = await runCLI(root, [
+        '--config',
+        'rslint.config.mjs',
+        'standalone-a.js',
+        'standalone-b.js',
+        'first',
+        'first/nested',
+        'first/one.js',
+        'second',
+      ]);
+      expect(result.code).toBe(1);
+      expect(
+        absoluteDiagnosticPaths(
+          root,
+          parseDiagnostics(result.stdout),
+          'no-debugger',
+        ),
+      ).toEqual(
+        [
+          'standalone-a.js',
+          'standalone-b.js',
+          'first/one.js',
+          'first/nested/two.js',
+          'second/three.js',
+        ]
+          .map((relative) => path.join(root, ...relative.split('/')))
+          .sort(),
+      );
+      expect(result.stderr).not.toContain('warning:');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('explicit file outcomes distinguish syntax, ignored, and missing files', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'rslint-cli-files-'));
+    try {
+      await writeFixture(root, {
+        'rslint.config.mjs': `export default [{
+  files: ['**/*.ts'],
+  rules: { 'no-debugger': 'error' },
+}];\n`,
+        '.gitignore': 'rslint.config.mjs\nignored.ts\n',
+        'outside-files.js': 'debugger;\nconst = ;\n',
+        'linted.ts': 'debugger;\n',
+        'ignored.ts': 'debugger;\n',
+      });
+
+      const result = await runCLI(root, [
+        '--config',
+        'rslint.config.mjs',
+        'outside-files.js',
+        'linted.ts',
+        'ignored.ts',
+        'missing.ts',
+      ]);
+      const diagnostics = parseDiagnostics(result.stdout);
+      expect(result.code).toBe(1);
+      const syntaxDiagnostics = diagnostics.filter(({ ruleName }) =>
+        /^TypeScript\(TS\d+\)$/.test(ruleName),
+      );
+      expect(syntaxDiagnostics.length).toBeGreaterThan(0);
+      expect(
+        syntaxDiagnostics.every(
+          ({ filePath }) =>
+            path.resolve(root, filePath) ===
+            path.join(root, 'outside-files.js'),
+        ),
+      ).toBe(true);
+      expect(absoluteDiagnosticPaths(root, diagnostics, 'no-debugger')).toEqual(
+        [path.join(root, 'linted.ts')],
+      );
+      expect(diagnostics).toHaveLength(syntaxDiagnostics.length + 1);
+      expect(result.stderr).toContain(
+        'ignored.ts is ignored because of a matching ignore pattern',
+      );
+      expect(result.stderr).toContain('missing.ts was not found, skipping');
+      expect(result.stderr).not.toContain('outside-files.js');
+      expect(result.stderr).not.toContain('linted.ts');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds regression coverage for the target semantics defined in #1851. It changes no runtime code.

- Add focused Go CLI-pipeline contracts for default discovery and mode boundaries.
- Add real Node CLI coverage for argv parsing, JS config loading, IPC, target unions, and explicit-file outcomes.
- Tighten the existing files-scope-miss assertions so selected zero-rule files never emit skip warnings.

## Behavior covered

| Scenario | Expected result |
| --- | --- |
| No path or `.` | Recursively lint the invocation cwd; both forms select the same targets. |
| `files` omitted | Discover `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.mts`, `.cts`, and `.tsx`; do not discover CSS or JSON by default. |
| Multiple files, directories, and overlaps | Lint the exact deduplicated union. |
| External `--config` | Keep invocation targets unchanged; resolve relative `files`, `ignores`, and `project` from the config directory. |
| `.gitignore` | Silently exclude directory-discovered files, warn for explicitly selected ignored files, and never suppress an explicitly selected config file. |
| Explicit supported file outside every `files` selector | Keep the file selected with zero matching rules, report syntax diagnostics, and emit no skip warning. |
| Missing explicit file | Skip it and emit the not-found warning. |
| `--type-check` | Keep the same lint-rule targets while type-checking the complete configured tsconfig Program. |
| `--fix` | Write fixes only to selected lint targets. |

## Tests

- `go test ./cmd/rslint -run TestCLI -count=1` with the target-contract test selection
- `pnpm --filter @rslint/core exec rstest run tests/lint-targets.test.mjs`
- `pnpm exec prettier --check packages/rslint/tests/lint-targets.test.mjs`
- Targeted existing config, ignore-conformance, and LSP tests