### PR TITLE
fix: align large radix keys with ESLint

### DIFF
--- a/internal/rules/sort_keys/sort_keys.go
+++ b/internal/rules/sort_keys/sort_keys.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -65,7 +66,16 @@ func parseOptions(options []any) Options {
 // identifier's own name (not its runtime value) — matching upstream's
 // `node.key.name` fallback, which reads the Identifier node's `name` field
 // regardless of whether the key is computed.
-func propertyStaticName(nameNode *ast.Node) (string, bool) {
+func propertyStaticName(sf *ast.SourceFile, nameNode *ast.Node) (string, bool) {
+	literal := nameNode
+	if nameNode.Kind == ast.KindComputedPropertyName {
+		literal = ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
+	}
+	if literal.Kind == ast.KindNumericLiteral {
+		if name, ok := eslintRadixLiteralName(sf, literal); ok {
+			return name, true
+		}
+	}
 	if name, ok := utils.GetStaticPropertyName(nameNode); ok {
 		return name, true
 	}
@@ -76,6 +86,57 @@ func propertyStaticName(nameNode *ast.Node) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// eslintRadixLiteralName reproduces the parser behavior behind ESLint's
+// numeric Literal.value. It accumulates an explicit-radix literal into a
+// double one digit at a time. Converting the exact integer only after reading
+// every digit can round to the neighboring double instead when the value is
+// above 2^53. tsgo's normalized NumericLiteral.Text has already lost the raw
+// digits needed to reproduce that behavior, so read them from the source.
+func eslintRadixLiteralName(sf *ast.SourceFile, node *ast.Node) (string, bool) {
+	raw := scanner.GetSourceTextOfNodeFromSourceFile(sf, node, false)
+	if len(raw) < 3 || raw[0] != '0' {
+		return "", false
+	}
+
+	var radix int
+	switch raw[1] {
+	case 'b', 'B':
+		radix = 2
+	case 'o', 'O':
+		radix = 8
+	case 'x', 'X':
+		radix = 16
+	default:
+		return "", false
+	}
+
+	value := 0.0
+	for i := 2; i < len(raw); i++ {
+		if raw[i] == '_' {
+			continue
+		}
+		digit := radixDigit(raw[i])
+		if digit < 0 || digit >= radix {
+			return "", false
+		}
+		value = value*float64(radix) + float64(digit)
+	}
+	return ecmascript.NumberToString(value), true
+}
+
+func radixDigit(ch byte) int {
+	switch {
+	case ch >= '0' && ch <= '9':
+		return int(ch - '0')
+	case ch >= 'a' && ch <= 'f':
+		return int(ch-'a') + 10
+	case ch >= 'A' && ch <= 'F':
+		return int(ch-'A') + 10
+	default:
+		return -1
+	}
 }
 
 // keyReportNode returns the node whose range diagnostics should be reported
@@ -246,7 +307,7 @@ var SortKeysRule = rule.Rule{
 			}
 
 			oldPrevName, oldHasPrevName := st.prevName, st.hasPrevName
-			thisName, thisOk := propertyStaticName(nameNode)
+			thisName, thisOk := propertyStaticName(ctx.SourceFile, nameNode)
 
 			// Nothing below reads a blank line unless the option asking about
 			// one is on, and the scan for one has the whole file's comment

--- a/internal/rules/sort_keys/sort_keys.go
+++ b/internal/rules/sort_keys/sort_keys.go
@@ -7,7 +7,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -66,16 +65,7 @@ func parseOptions(options []any) Options {
 // identifier's own name (not its runtime value) — matching upstream's
 // `node.key.name` fallback, which reads the Identifier node's `name` field
 // regardless of whether the key is computed.
-func propertyStaticName(sf *ast.SourceFile, nameNode *ast.Node) (string, bool) {
-	literal := nameNode
-	if nameNode.Kind == ast.KindComputedPropertyName {
-		literal = ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
-	}
-	if literal.Kind == ast.KindNumericLiteral {
-		if name, ok := eslintRadixLiteralName(sf, literal); ok {
-			return name, true
-		}
-	}
+func propertyStaticName(nameNode *ast.Node) (string, bool) {
 	if name, ok := utils.GetStaticPropertyName(nameNode); ok {
 		return name, true
 	}
@@ -86,57 +76,6 @@ func propertyStaticName(sf *ast.SourceFile, nameNode *ast.Node) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-// eslintRadixLiteralName reproduces the parser behavior behind ESLint's
-// numeric Literal.value. It accumulates an explicit-radix literal into a
-// double one digit at a time. Converting the exact integer only after reading
-// every digit can round to the neighboring double instead when the value is
-// above 2^53. tsgo's normalized NumericLiteral.Text has already lost the raw
-// digits needed to reproduce that behavior, so read them from the source.
-func eslintRadixLiteralName(sf *ast.SourceFile, node *ast.Node) (string, bool) {
-	raw := scanner.GetSourceTextOfNodeFromSourceFile(sf, node, false)
-	if len(raw) < 3 || raw[0] != '0' {
-		return "", false
-	}
-
-	var radix int
-	switch raw[1] {
-	case 'b', 'B':
-		radix = 2
-	case 'o', 'O':
-		radix = 8
-	case 'x', 'X':
-		radix = 16
-	default:
-		return "", false
-	}
-
-	value := 0.0
-	for i := 2; i < len(raw); i++ {
-		if raw[i] == '_' {
-			continue
-		}
-		digit := radixDigit(raw[i])
-		if digit < 0 || digit >= radix {
-			return "", false
-		}
-		value = value*float64(radix) + float64(digit)
-	}
-	return ecmascript.NumberToString(value), true
-}
-
-func radixDigit(ch byte) int {
-	switch {
-	case ch >= '0' && ch <= '9':
-		return int(ch - '0')
-	case ch >= 'a' && ch <= 'f':
-		return int(ch-'a') + 10
-	case ch >= 'A' && ch <= 'F':
-		return int(ch-'A') + 10
-	default:
-		return -1
-	}
 }
 
 // keyReportNode returns the node whose range diagnostics should be reported
@@ -307,7 +246,7 @@ var SortKeysRule = rule.Rule{
 			}
 
 			oldPrevName, oldHasPrevName := st.prevName, st.hasPrevName
-			thisName, thisOk := propertyStaticName(ctx.SourceFile, nameNode)
+			thisName, thisOk := propertyStaticName(nameNode)
 
 			// Nothing below reads a blank line unless the option asking about
 			// one is on, and the scan for one has the whole file's comment

--- a/internal/rules/sort_keys/sort_keys_extras_test.go
+++ b/internal/rules/sort_keys/sort_keys_extras_test.go
@@ -107,6 +107,12 @@ func TestSortKeysExtras(t *testing.T) {
 				Code:    "var obj = { '\\uD800': 1, '\\uD801': 2 };",
 				Options: []any{"asc", map[string]any{"natural": true}},
 			},
+			// ---- Espree radix-literal rounding: hexadecimal keys above 2^53 ----
+			{Code: "var obj = { 0x1000000000000281: 0, '1152921504606847600': 0 };"},
+			// ---- Espree radix-literal rounding: binary keys above 2^53 ----
+			{Code: "var obj = { 0b1000000000000000000000000000000000000000000000000001010000001: 0, '1152921504606847600': 0 };"},
+			// ---- Espree radix-literal rounding: octal keys above 2^53 ----
+			{Code: "var obj = { 0o100000000000000001201: 0, '1152921504606847600': 0 };"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 1: async method ----
@@ -283,6 +289,27 @@ func TestSortKeysExtras(t *testing.T) {
 				Code: "var obj = { 1e21: 1, '1a': 2 };",
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1a' should be before '1e+21'.", Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// ---- Espree radix-literal rounding: hexadecimal keys retain the upstream name in diagnostics ----
+			{
+				Code: "var obj = { '1152921504606847600': 0, 0x1000000000000281: 0 };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1152921504606847500' should be before '1152921504606847600'.", Line: 1, Column: 39, EndLine: 1, EndColumn: 57},
+				},
+			},
+			// ---- Espree radix-literal rounding: binary keys retain the upstream name in diagnostics ----
+			{
+				Code: "var obj = { '1152921504606847600': 0, 0b1000000000000000000000000000000000000000000000000001010000001: 0 };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1152921504606847500' should be before '1152921504606847600'.", Line: 1, Column: 39, EndLine: 1, EndColumn: 102},
+				},
+			},
+			// ---- Espree radix-literal rounding: octal keys retain the upstream name in diagnostics ----
+			{
+				Code: "var obj = { '1152921504606847600': 0, 0o100000000000000001201: 0 };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1152921504606847500' should be before '1152921504606847600'.", Line: 1, Column: 39, EndLine: 1, EndColumn: 62},
 				},
 			},
 			// ---- A BigInt key is named by its decimal digits, the same as the equivalent number ----

--- a/internal/rules/sort_keys/sort_keys_extras_test.go
+++ b/internal/rules/sort_keys/sort_keys_extras_test.go
@@ -107,12 +107,14 @@ func TestSortKeysExtras(t *testing.T) {
 				Code:    "var obj = { '\\uD800': 1, '\\uD801': 2 };",
 				Options: []any{"asc", map[string]any{"natural": true}},
 			},
-			// ---- Espree radix-literal rounding: hexadecimal keys above 2^53 ----
+			// ---- Radix-literal property names: hexadecimal keys above 2^53 ----
 			{Code: "var obj = { 0x1000000000000281: 0, '1152921504606847600': 0 };"},
-			// ---- Espree radix-literal rounding: binary keys above 2^53 ----
+			// ---- Radix-literal property names: binary keys above 2^53 ----
 			{Code: "var obj = { 0b1000000000000000000000000000000000000000000000000001010000001: 0, '1152921504606847600': 0 };"},
-			// ---- Espree radix-literal rounding: octal keys above 2^53 ----
+			// ---- Radix-literal property names: octal keys above 2^53 ----
 			{Code: "var obj = { 0o100000000000000001201: 0, '1152921504606847600': 0 };"},
+			// ---- Radix-literal property names: parenthesized computed keys use the same name ----
+			{Code: "var obj = { [(0x1000000000000281)]: 0, '1152921504606847600': 0 };"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 1: async method ----
@@ -291,25 +293,32 @@ func TestSortKeysExtras(t *testing.T) {
 					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1a' should be before '1e+21'.", Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
 				},
 			},
-			// ---- Espree radix-literal rounding: hexadecimal keys retain the upstream name in diagnostics ----
+			// ---- Radix-literal property names: hexadecimal diagnostics retain the source-derived name ----
 			{
 				Code: "var obj = { '1152921504606847600': 0, 0x1000000000000281: 0 };",
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1152921504606847500' should be before '1152921504606847600'.", Line: 1, Column: 39, EndLine: 1, EndColumn: 57},
 				},
 			},
-			// ---- Espree radix-literal rounding: binary keys retain the upstream name in diagnostics ----
+			// ---- Radix-literal property names: binary diagnostics retain the source-derived name ----
 			{
 				Code: "var obj = { '1152921504606847600': 0, 0b1000000000000000000000000000000000000000000000000001010000001: 0 };",
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1152921504606847500' should be before '1152921504606847600'.", Line: 1, Column: 39, EndLine: 1, EndColumn: 102},
 				},
 			},
-			// ---- Espree radix-literal rounding: octal keys retain the upstream name in diagnostics ----
+			// ---- Radix-literal property names: octal diagnostics retain the source-derived name ----
 			{
 				Code: "var obj = { '1152921504606847600': 0, 0o100000000000000001201: 0 };",
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1152921504606847500' should be before '1152921504606847600'.", Line: 1, Column: 39, EndLine: 1, EndColumn: 62},
+				},
+			},
+			// ---- Radix-literal property names: computed-key diagnostics retain the inner literal range ----
+			{
+				Code: "var obj = { '1152921504606847600': 0, [(0x1000000000000281)]: 0 };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sortKeys", Message: "Expected object keys to be in ascending order. '1152921504606847500' should be before '1152921504606847600'.", Line: 1, Column: 41, EndLine: 1, EndColumn: 59},
 				},
 			},
 			// ---- A BigInt key is named by its decimal digits, the same as the equivalent number ----

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1669,6 +1669,8 @@ func isInAmbientAugmentation(node *ast.Node) bool {
 // GetStaticPropertyName extracts the static name from a property name node.
 // It handles Identifier, StringLiteral, NumericLiteral, and ComputedPropertyName
 // (with static string, numeric, BigInt, or template literal expressions).
+// Explicit-radix numeric literals use their source token when available because
+// tsgo's normalized NumericLiteral.Text no longer retains the digit sequence.
 // Returns the name and whether it's a static (non-computed or statically-computable) name.
 func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 	switch nameNode.Kind {
@@ -1677,7 +1679,7 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 	case ast.KindStringLiteral:
 		return nameNode.AsStringLiteral().Text, true
 	case ast.KindNumericLiteral:
-		return NormalizeNumericLiteral(nameNode.AsNumericLiteral().Text), true
+		return numericLiteralPropertyName(nameNode), true
 	case ast.KindBigIntLiteral:
 		return NormalizeBigIntLiteral(nameNode.AsBigIntLiteral().Text), true
 	case ast.KindComputedPropertyName:
@@ -1688,7 +1690,7 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 		case ast.KindStringLiteral:
 			return expr.AsStringLiteral().Text, true
 		case ast.KindNumericLiteral:
-			return NormalizeNumericLiteral(expr.AsNumericLiteral().Text), true
+			return numericLiteralPropertyName(expr), true
 		case ast.KindBigIntLiteral:
 			return NormalizeBigIntLiteral(expr.AsBigIntLiteral().Text), true
 		case ast.KindNoSubstitutionTemplateLiteral:
@@ -1708,8 +1710,86 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 	}
 }
 
+// numericLiteralPropertyName returns the static property name represented by a
+// tsgo NumericLiteral. NumericLiteral.Text is already normalized, so explicit
+// radix literals have lost the source digit sequence needed to reproduce the
+// property-name rounding above 2^53. TokenFlags let us recover the raw token
+// only for those literals; detached or synthesized nodes retain the existing
+// Text-based fallback.
+func numericLiteralPropertyName(node *ast.Node) string {
+	literal := node.AsNumericLiteral()
+	explicitRadix := literal.TokenFlags & (ast.TokenFlagsBinarySpecifier |
+		ast.TokenFlagsOctalSpecifier |
+		ast.TokenFlagsHexSpecifier)
+	if explicitRadix != 0 {
+		sourceFile := ast.GetSourceFileOfNode(node)
+		if sourceFile != nil && node.Pos() >= 0 && node.Pos() < node.End() && node.End() <= len(sourceFile.Text()) {
+			raw := scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, node, false)
+			if value, ok := radixLiteralValue(raw); ok {
+				return ecmascript.NumberToString(value)
+			}
+		}
+	}
+	return NormalizeNumericLiteral(literal.Text)
+}
+
+// radixLiteralValue accumulates an explicit binary, octal, or hexadecimal
+// literal into a float64 one source digit at a time. Numeric separators do not
+// contribute to the value.
+func radixLiteralValue(raw string) (float64, bool) {
+	if len(raw) < 3 || raw[0] != '0' {
+		return 0, false
+	}
+
+	var radix int
+	switch raw[1] {
+	case 'b', 'B':
+		radix = 2
+	case 'o', 'O':
+		radix = 8
+	case 'x', 'X':
+		radix = 16
+	default:
+		return 0, false
+	}
+
+	value := 0.0
+	digits := 0
+	previousSeparator := false
+	for i := 2; i < len(raw); i++ {
+		if raw[i] == '_' {
+			if digits == 0 || previousSeparator {
+				return 0, false
+			}
+			previousSeparator = true
+			continue
+		}
+		digit := radixDigitValue(raw[i])
+		if digit < 0 || digit >= radix {
+			return 0, false
+		}
+		value = value*float64(radix) + float64(digit)
+		digits++
+		previousSeparator = false
+	}
+	return value, digits > 0 && !previousSeparator
+}
+
+func radixDigitValue(ch byte) int {
+	switch {
+	case ch >= '0' && ch <= '9':
+		return int(ch - '0')
+	case ch >= 'a' && ch <= 'f':
+		return int(ch-'a') + 10
+	case ch >= 'A' && ch <= 'F':
+		return int(ch-'A') + 10
+	default:
+		return -1
+	}
+}
+
 // NormalizeNumericLiteral parses a numeric literal text and returns its
-// normalized string representation, matching ESLint's String(node.value) behavior.
+// ECMAScript Number string representation.
 // e.g., "0x1" -> "1", "1.0" -> "1", "1e2" -> "100", "1e-7" -> "1e-7"
 func NormalizeNumericLiteral(text string) string {
 	// ParseFloat doesn't handle JS octal (0o) or binary (0b) prefixes.

--- a/internal/utils/ts_eslint_test.go
+++ b/internal/utils/ts_eslint_test.go
@@ -8,6 +8,99 @@ import (
 	"github.com/microsoft/typescript-go/shim/parser"
 )
 
+func TestGetStaticPropertyNameNumericLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want string
+	}{
+		{
+			name: "hexadecimal above 2^53",
+			code: "({ 0x1000000000000281: 0 })",
+			want: "1152921504606847500",
+		},
+		{
+			name: "binary above 2^53",
+			code: "({ 0b1000000000000000000000000000000000000000000000000001010000001: 0 })",
+			want: "1152921504606847500",
+		},
+		{
+			name: "octal above 2^53",
+			code: "({ 0o100000000000000001201: 0 })",
+			want: "1152921504606847500",
+		},
+		{
+			name: "uppercase prefix and numeric separators",
+			code: "({ 0X1_0000_0000_0000_281: 0 })",
+			want: "1152921504606847500",
+		},
+		{
+			name: "parenthesized computed literal",
+			code: "({ [(0x1000000000000281)]: 0 })",
+			want: "1152921504606847500",
+		},
+		{
+			name: "small radix literal",
+			code: "({ 0xff: 0 })",
+			want: "255",
+		},
+		{
+			name: "decimal literal keeps normal normalization",
+			code: "({ 1e21: 0 })",
+			want: "1e+21",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+				Path:     "/test.ts",
+			}, tt.code, core.ScriptKindTS)
+			property := findFirstNodeOfKind(t, sourceFile, ast.KindPropertyAssignment)
+			nameNode := property.Name()
+			if nameNode == nil {
+				t.Fatal("property has no name")
+			}
+			got, ok := GetStaticPropertyName(nameNode)
+			if !ok || got != tt.want {
+				t.Fatalf("GetStaticPropertyName() = (%q, %v), want (%q, true)", got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetStaticPropertyNameDetachedNumericLiteral(t *testing.T) {
+	factory := ast.NewNodeFactory(ast.NodeFactoryHooks{})
+	node := factory.NewNumericLiteral("255", ast.TokenFlagsHexSpecifier)
+
+	got, ok := GetStaticPropertyName(node)
+	if !ok || got != "255" {
+		t.Fatalf("GetStaticPropertyName() = (%q, %v), want (%q, true)", got, ok, "255")
+	}
+}
+
+func TestRadixLiteralValueRejectsMalformedText(t *testing.T) {
+	for _, raw := range []string{
+		"",
+		"123",
+		"0q1",
+		"0x",
+		"0x_1",
+		"0x1_",
+		"0x1__0",
+		"0b2",
+		"0o8",
+		"0x1n",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, ok := radixLiteralValue(raw); ok {
+				t.Fatalf("radixLiteralValue(%q) unexpectedly succeeded", raw)
+			}
+		})
+	}
+}
+
 func TestGetFunctionNameWithKindCore(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- Normalize explicit binary, octal, and hexadecimal property names from their tsgo source tokens in the shared `GetStaticPropertyName` utility.
- Preserve the existing text-based fallback for detached or synthesized AST nodes.
- Prevent `sort-keys` false positives and false negatives above `2^53`, including computed keys.
- Cover all three radix forms, numeric separators, ordinary values, fallback behavior, and exact diagnostics.

## Related Links

- [ESLint: sort-keys](https://eslint.org/docs/latest/rules/sort-keys)
- [ESLint v10.8.1 source](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/sort-keys.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
