### PR TITLE
fix: align filename-case diagnostics with upstream

### DIFF
--- a/internal/plugins/unicorn/rules/filename_case/filename_case.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.go
@@ -670,7 +670,66 @@ func isInsideCwd(relativePath string) bool {
 		!tspath.IsRootedDiskPath(relativePath)
 }
 
+// getCanonicalPOSIXPathSegments handles the hot path produced by the normal
+// lint planner: absolute, normalized POSIX filenames under an absolute,
+// normalized cwd. Less common path forms fall back to tspath below so their
+// Node-compatible normalization stays centralized there.
+func getCanonicalPOSIXPathSegments(fileName string, cwd string) ([]string, bool) {
+	if !isCanonicalAbsolutePOSIXPath(fileName) || !isCanonicalAbsolutePOSIXPath(cwd) {
+		return nil, false
+	}
+
+	basename := fileName[strings.LastIndexByte(fileName, '/')+1:]
+	if fileName == cwd {
+		return []string{basename}, true
+	}
+
+	var relative string
+	if cwd == "/" {
+		relative = fileName[1:]
+	} else {
+		if !strings.HasPrefix(fileName, cwd) || len(fileName) <= len(cwd) || fileName[len(cwd)] != '/' {
+			return []string{basename}, true
+		}
+		relative = fileName[len(cwd)+1:]
+	}
+	if relative == "" {
+		return []string{basename}, true
+	}
+	return strings.Split(relative, "/"), true
+}
+
+func isCanonicalAbsolutePOSIXPath(path string) bool {
+	if path == "/" {
+		return true
+	}
+	if len(path) < 2 || path[0] != '/' || path[len(path)-1] == '/' || strings.IndexByte(path, '\\') >= 0 {
+		return false
+	}
+
+	segmentStart := 1
+	for index := 1; index <= len(path); index++ {
+		if index < len(path) && path[index] != '/' {
+			continue
+		}
+		segment := path[segmentStart:index]
+		if segment == "" || segment == "." || segment == ".." || segment == "^" ||
+			len(segment) == 2 && tspath.IsVolumeCharacter(segment[0]) && segment[1] == ':' {
+			return false
+		}
+		segmentStart = index + 1
+	}
+	return true
+}
+
 func getPathSegments(fileName string, cwd string) []string {
+	if segments, ok := getCanonicalPOSIXPathSegments(fileName, cwd); ok {
+		return segments
+	}
+	return getPathSegmentsWithTspath(fileName, cwd)
+}
+
+func getPathSegmentsWithTspath(fileName string, cwd string) []string {
 	basename := tspath.GetBaseFileName(fileName)
 	if cwd == "" {
 		return []string{basename}
@@ -699,7 +758,12 @@ func getPathSegments(fileName string, cwd string) []string {
 	return filtered
 }
 
-const filenameCaseRuleName = "unicorn/filename-case"
+const (
+	filenameCaseRuleName       = "unicorn/filename-case"
+	messageIDFilenameCase      = "filename-case"
+	messageIDDirectoryCase     = "directory-case"
+	messageIDFilenameExtension = "filename-extension"
+)
 
 var FilenameCaseRule = rule.Rule{
 	Name:   filenameCaseRuleName,
@@ -772,7 +836,7 @@ var FilenameCaseRule = rule.Rule{
 				}
 				renamed := fixFilename(words, cases, invalidWord, invalidCandidates, leading, "")
 				ctx.ReportRange(reportRange, rule.RuleMessage{
-					Id: "directoryCase",
+					Id: messageIDDirectoryCase,
 					Description: "Directory name `" + directory + "` is not in " +
 						englishishCaseNames(cases) + ". Rename it to " + englishishBacktickJoin(renamed) + ".",
 				})
@@ -805,7 +869,7 @@ var FilenameCaseRule = rule.Rule{
 					return nil
 				}
 				ctx.ReportRange(reportRange, rule.RuleMessage{
-					Id: "filenameExtension",
+					Id: messageIDFilenameExtension,
 					Description: "File extension `" + ext + "` is not in lowercase. Rename it to `" +
 						filename + middle + lowerExt + "`.",
 				})
@@ -823,7 +887,7 @@ var FilenameCaseRule = rule.Rule{
 
 		renamed := fixFilename(words, cases, invalidWord, invalidCandidates, leading, middle+lowerExt)
 		ctx.ReportRange(reportRange, rule.RuleMessage{
-			Id: "filenameCase",
+			Id: messageIDFilenameCase,
 			Description: "Filename is not in " + englishishCaseNames(cases) + ". Rename it to " +
 				englishishBacktickJoin(renamed) + ".",
 		})

--- a/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
@@ -421,7 +421,7 @@ func TestFilenameCase(t *testing.T) {
 				FileName: "src/foo/foo_bar.js",
 				Options:  caseOpt("kebabCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 				}},
 			},
@@ -431,7 +431,7 @@ func TestFilenameCase(t *testing.T) {
 				Code:     `// k`,
 				FileName: "src/foo/foo_bar.js",
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
 				}},
@@ -442,21 +442,21 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// c`, FileName: "src/foo/foo_bar.JS", Options: caseOpt("camelCase"),
 				Skip: true, /* SKIP: TS program rejects `.JS`; covered in JS test set */
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `fooBar.js`.",
 				}},
 			},
 			{
 				Code: `// c`, FileName: "src/foo/foo_bar.test.js", Options: caseOpt("camelCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `fooBar.test.js`.",
 				}},
 			},
 			{
 				Code: `// c`, FileName: "test/foo/foo_bar.test_utils.js", Options: caseOpt("camelCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `fooBar.test_utils.js`.",
 				}},
 			},
@@ -465,21 +465,21 @@ func TestFilenameCase(t *testing.T) {
 			{
 				Code: `// s`, FileName: "test/foo/fooBar.js", Options: caseOpt("snakeCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `foo_bar.js`.",
 				}},
 			},
 			{
 				Code: `// s`, FileName: "test/foo/fooBar.test.js", Options: caseOpt("snakeCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `foo_bar.test.js`.",
 				}},
 			},
 			{
 				Code: `// s`, FileName: "test/foo/fooBar.testUtils.js", Options: caseOpt("snakeCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `foo_bar.testUtils.js`.",
 				}},
 			},
@@ -488,21 +488,21 @@ func TestFilenameCase(t *testing.T) {
 			{
 				Code: `// k`, FileName: "test/foo/fooBar.js", Options: caseOpt("kebabCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 				}},
 			},
 			{
 				Code: `// k`, FileName: "test/foo/fooBar.test.js", Options: caseOpt("kebabCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.test.js`.",
 				}},
 			},
 			{
 				Code: `// k`, FileName: "test/foo/fooBar.testUtils.js", Options: caseOpt("kebabCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.testUtils.js`.",
 				}},
 			},
@@ -511,21 +511,21 @@ func TestFilenameCase(t *testing.T) {
 			{
 				Code: `// p`, FileName: "test/foo/fooBar.js", Options: caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `FooBar.js`.",
 				}},
 			},
 			{
 				Code: `// p`, FileName: "test/foo/foo_bar.test.js", Options: caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `FooBar.test.js`.",
 				}},
 			},
 			{
 				Code: `// p`, FileName: "test/foo/foo-bar.test-utils.js", Options: caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `FooBar.test-utils.js`.",
 				}},
 			},
@@ -534,56 +534,56 @@ func TestFilenameCase(t *testing.T) {
 			{
 				Code: `// _c`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("camelCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `_fooBar.js`.",
 				}},
 			},
 			{
 				Code: `// _c`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("camelCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `___fooBar.js`.",
 				}},
 			},
 			{
 				Code: `// _s`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("snakeCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `_foo_bar.js`.",
 				}},
 			},
 			{
 				Code: `// _s`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("snakeCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `___foo_bar.js`.",
 				}},
 			},
 			{
 				Code: `// _k`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("kebabCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `_foo-bar.js`.",
 				}},
 			},
 			{
 				Code: `// _k`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("kebabCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `___foo-bar.js`.",
 				}},
 			},
 			{
 				Code: `// _p`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `_FooBar.js`.",
 				}},
 			},
 			{
 				Code: `// _p`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `___FooBar.js`.",
 				}},
 			},
@@ -592,7 +592,7 @@ func TestFilenameCase(t *testing.T) {
 			{
 				Code: `// many-default-kebab`, FileName: "src/foo/foo_bar.js", Options: casesOpt(nil),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 				}},
 			},
@@ -600,7 +600,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// many-c+p`, FileName: "src/foo/foo-bar.js",
 				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true}),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case or pascal case. Rename it to `fooBar.js` or `FooBar.js`.",
 				}},
 			},
@@ -608,7 +608,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// many-c+p+k`, FileName: "src/foo/_foo_bar.js",
 				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true, "kebabCase": true}),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case, kebab case, or pascal case. Rename it to `_fooBar.js`, `_foo-bar.js`, or `_FooBar.js`.",
 				}},
 			},
@@ -616,7 +616,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// many-snake`, FileName: "src/foo/_FOO-BAR.js",
 				Options: casesOpt(map[string]bool{"snakeCase": true}),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `_foo_bar.js`.",
 				}},
 			},
@@ -625,14 +625,14 @@ func TestFilenameCase(t *testing.T) {
 			{
 				Code: `// dec`, FileName: "src/foo/[foo_bar].js",
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `[foo-bar].js`.",
 				}},
 			},
 			{
 				Code: `// dec`, FileName: "src/foo/foo$Bar.js",
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo$bar.js`.",
 				}},
 			},
@@ -640,7 +640,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// dec-many`, FileName: "src/foo/{foo_bar}.js",
 				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true, "kebabCase": true}),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case, kebab case, or pascal case. Rename it to `{fooBar}.js`, `{foo-bar}.js`, or `{FooBar}.js`.",
 				}},
 			},
@@ -650,7 +650,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// ignore-miss`, FileName: "src/foo/barBaz.js",
 				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `bar-baz.js`.",
 				}},
 			},
@@ -661,7 +661,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// ignore-miss-slashes`, FileName: "src/foo/barBaz.js",
 				Options: withIgnore(caseOpt("kebabCase"), `/FOOBAR\.js/`),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `bar-baz.js`.",
 				}},
 			},
@@ -669,7 +669,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// ignore-miss`, FileName: "src/foo/fooBar.js",
 				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 				}},
 			},
@@ -677,7 +677,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// ignore-miss-multi`, FileName: "src/foo/fooBar.js",
 				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`, `foobar\.js`),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 				}},
 			},
@@ -689,7 +689,7 @@ func TestFilenameCase(t *testing.T) {
 					"ignore": []interface{}{`FOOBAR\.js`},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
 				}},
 			},
@@ -700,7 +700,7 @@ func TestFilenameCase(t *testing.T) {
 					"ignore": []interface{}{`BaRbAz\.js`},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
 				}},
 			},
@@ -711,7 +711,7 @@ func TestFilenameCase(t *testing.T) {
 					"ignore": []interface{}{`^foo`},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
 				}},
 			},
@@ -722,7 +722,7 @@ func TestFilenameCase(t *testing.T) {
 					"ignore": []interface{}{`^foo`, `^bar`},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
 				}},
 			},
@@ -732,7 +732,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// 1_-multi`, FileName: "src/foo/1_.js",
 				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true, "kebabCase": true}),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case, kebab case, or pascal case. Rename it to `1.js`.",
 				}},
 			},
@@ -741,56 +741,56 @@ func TestFilenameCase(t *testing.T) {
 			{
 				Code: `// mfe-false`, FileName: "src/foo/foo_bar.test.js", Options: withMfe(caseOpt("camelCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `fooBar.test.js`.",
 				}},
 			},
 			{
 				Code: `// mfe-false`, FileName: "test/foo/foo_bar.test_utils.js", Options: withMfe(caseOpt("camelCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `fooBar.testUtils.js`.",
 				}},
 			},
 			{
 				Code: `// mfe-false`, FileName: "test/foo/fooBar.test.js", Options: withMfe(caseOpt("snakeCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `foo_bar.test.js`.",
 				}},
 			},
 			{
 				Code: `// mfe-false`, FileName: "test/foo/fooBar.testUtils.js", Options: withMfe(caseOpt("snakeCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in snake case. Rename it to `foo_bar.test_utils.js`.",
 				}},
 			},
 			{
 				Code: `// mfe-false`, FileName: "test/foo/fooBar.test.js", Options: withMfe(caseOpt("kebabCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.test.js`.",
 				}},
 			},
 			{
 				Code: `// mfe-false`, FileName: "test/foo/fooBar.testUtils.js", Options: withMfe(caseOpt("kebabCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.test-utils.js`.",
 				}},
 			},
 			{
 				Code: `// mfe-false`, FileName: "test/foo/foo_bar.test.js", Options: withMfe(caseOpt("pascalCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `FooBar.Test.js`.",
 				}},
 			},
 			{
 				Code: `// mfe-false`, FileName: "test/foo/foo-bar.test-utils.js", Options: withMfe(caseOpt("pascalCase"), false),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `FooBar.TestUtils.js`.",
 				}},
 			},
@@ -801,7 +801,7 @@ func TestFilenameCase(t *testing.T) {
 				Options: casesOpt(map[string]bool{"camelCase": true, "kebabCase": true}),
 				Skip:    true, /* SKIP: TS program rejects `.mJS`; covered in JS tests */
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case or kebab case. Rename it to `fooBar.mjs` or `foo-bar.mjs`.",
 				}},
 			},
@@ -809,7 +809,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// snap-foo.JS`, FileName: "foo.JS",
 				Skip: true, /* SKIP: TS program rejects `.JS` */
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameExtension",
+					MessageId: "filename-extension",
 					Message:   "File extension `.JS` is not in lowercase. Rename it to `foo.js`.",
 				}},
 			},
@@ -817,7 +817,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// snap-foo.Js`, FileName: "foo.Js",
 				Skip: true, /* SKIP: TS program rejects `.Js` */
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameExtension",
+					MessageId: "filename-extension",
 					Message:   "File extension `.Js` is not in lowercase. Rename it to `foo.js`.",
 				}},
 			},
@@ -825,7 +825,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// snap-foo.jS`, FileName: "foo.jS",
 				Skip: true, /* SKIP: TS program rejects `.jS` */
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameExtension",
+					MessageId: "filename-extension",
 					Message:   "File extension `.jS` is not in lowercase. Rename it to `foo.js`.",
 				}},
 			},
@@ -833,7 +833,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// snap-index.JS`, FileName: "index.JS",
 				Skip: true, /* SKIP: TS program rejects `.JS` */
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameExtension",
+					MessageId: "filename-extension",
 					Message:   "File extension `.JS` is not in lowercase. Rename it to `index.js`.",
 				}},
 			},
@@ -841,7 +841,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// snap-foo..JS`, FileName: "foo..JS",
 				Skip: true, /* SKIP: TS program rejects `.JS` */
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameExtension",
+					MessageId: "filename-extension",
 					Message:   "File extension `.JS` is not in lowercase. Rename it to `foo..js`.",
 				}},
 			},
@@ -856,7 +856,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// lock-in: digit-prefixed second word (camel)`, FileName: "src/foo/iss-47-spec.js",
 				Options: caseOpt("camelCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `iss_47Spec.js`.",
 				}},
 			},
@@ -864,7 +864,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// lock-in: digit-prefixed second word (pascal)`, FileName: "src/foo/iss-47-spec.js",
 				Options: caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `Iss_47Spec.js`.",
 				}},
 			},
@@ -874,7 +874,7 @@ func TestFilenameCase(t *testing.T) {
 				Code: `// lock-in: canonical case-name ordering`, FileName: "src/foo/foo-bar.js",
 				Options: casesOpt(map[string]bool{"pascalCase": true, "camelCase": true}),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case or pascal case. Rename it to `fooBar.js` or `FooBar.js`.",
 				}},
 			},
@@ -922,7 +922,7 @@ func TestFilenameCase(t *testing.T) {
 			},
 			// Locks in: a malformed ignore pattern fires the configuration
 			// diagnostic even when the basename would have passed case
-			// validation (i.e. NO `filenameCase` would have been reported
+			// validation (i.e. NO `filename-case` would have been reported
 			// either way). This proves the short-circuit isn't masking a
 			// case error — it's a deliberate "fix your config first" gate
 			// even on otherwise-clean files.
@@ -992,7 +992,7 @@ func TestFilenameCase(t *testing.T) {
 					"ignore": []interface{}{map[string]interface{}{}, `FOOBAR\.js`},
 				},
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 				}},
 			},
@@ -1024,7 +1024,7 @@ func TestFilenameCase(t *testing.T) {
 					"kebabCase": true, "pascalCase": true,
 				}),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case, kebab case, snake case, or pascal case. Rename it to `fooBar.js`, `foo-bar.js`, `foo_bar.js`, or `FooBar.js`.",
 				}},
 			},
@@ -1037,7 +1037,7 @@ func TestFilenameCase(t *testing.T) {
 				FileName: "src/foo/123-foo.js",
 				Options:  caseOpt("camelCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in camel case. Rename it to `123Foo.js`.",
 				}},
 			},
@@ -1049,7 +1049,7 @@ func TestFilenameCase(t *testing.T) {
 				FileName: "src/foo/123-foo.js",
 				Options:  caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `123Foo.js`.",
 				}},
 			},
@@ -1060,7 +1060,7 @@ func TestFilenameCase(t *testing.T) {
 				FileName: "src/foo/FAQPageFOO.js",
 				Options:  caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `FaqPageFoo.js`.",
 				}},
 			},
@@ -1069,7 +1069,7 @@ func TestFilenameCase(t *testing.T) {
 				FileName: "src/foo/UIPath.js",
 				Options:  caseOpt("pascalCase"),
 				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
+					MessageId: "filename-case",
 					Message:   "Filename is not in pascal case. Rename it to `UiPath.js`.",
 				}},
 			},

--- a/internal/plugins/unicorn/rules/filename_case/filename_case_upstream_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case_upstream_test.go
@@ -2,6 +2,7 @@
 package filename_case
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -78,6 +79,78 @@ func TestGetPathSegments(t *testing.T) {
 	}
 }
 
+func TestCanonicalPOSIXPathSegments(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		cwd      string
+		want     []string
+		wantFast bool
+	}{
+		{name: "inside cwd", fileName: "/repo/src/file.js", cwd: "/repo", want: []string{"src", "file.js"}, wantFast: true},
+		{name: "root cwd", fileName: "/src/file.js", cwd: "/", want: []string{"src", "file.js"}, wantFast: true},
+		{name: "outside cwd", fileName: "/other/src/file.js", cwd: "/repo", want: []string{"file.js"}, wantFast: true},
+		{name: "cwd prefix collision", fileName: "/repository/file.js", cwd: "/repo", want: []string{"file.js"}, wantFast: true},
+		{name: "same path", fileName: "/repo", cwd: "/repo", want: []string{"repo"}, wantFast: true},
+		{name: "relative filename", fileName: "src/file.js", cwd: "/repo"},
+		{name: "relative cwd", fileName: "/repo/src/file.js", cwd: "repo"},
+		{name: "dot segment", fileName: "/repo/src/../file.js", cwd: "/repo"},
+		{name: "duplicate separator", fileName: "/repo//file.js", cwd: "/repo"},
+		{name: "untitled root segment", fileName: "/^/file.js", cwd: "/"},
+		{name: "DOS volume segment", fileName: "/repo/C:/file.js", cwd: "/repo"},
+		{name: "trailing cwd separator", fileName: "/repo/file.js", cwd: "/repo/"},
+		{name: "backslash", fileName: `/repo/src\file.js`, cwd: "/repo"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := getCanonicalPOSIXPathSegments(test.fileName, test.cwd)
+			if ok != test.wantFast {
+				t.Fatalf("fast path = %v, want %v", ok, test.wantFast)
+			}
+			if len(got) != len(test.want) {
+				t.Fatalf("segments = %v, want %v", got, test.want)
+			}
+			for index := range got {
+				if got[index] != test.want[index] {
+					t.Fatalf("segments = %v, want %v", got, test.want)
+				}
+			}
+			if ok {
+				slow := getPathSegmentsWithTspath(test.fileName, test.cwd)
+				if !slices.Equal(got, slow) {
+					t.Fatalf("fast segments = %v, tspath segments = %v", got, slow)
+				}
+			}
+		})
+	}
+}
+
+func FuzzCanonicalPOSIXPathSegments(f *testing.F) {
+	seeds := [][2]string{
+		{"/repo/src/file.js", "/repo"},
+		{"/repo", "/repo"},
+		{"/repository/file.js", "/repo"},
+		{"/src/file.js", "/"},
+		{"/repo/目录/file.js", "/repo"},
+		{"/$route/a-b_0/file.js", "/$route"},
+	}
+	for _, seed := range seeds {
+		f.Add(seed[0], seed[1])
+	}
+
+	f.Fuzz(func(t *testing.T, fileName string, cwd string) {
+		got, ok := getCanonicalPOSIXPathSegments(fileName, cwd)
+		if !ok {
+			return
+		}
+		want := getPathSegmentsWithTspath(fileName, cwd)
+		if !slices.Equal(got, want) {
+			t.Fatalf("fast segments = %v, tspath segments = %v for file %q cwd %q", got, want, fileName, cwd)
+		}
+	})
+}
+
 func TestLatestUpstreamPathBehavior(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -91,21 +164,21 @@ func TestLatestUpstreamPathBehavior(t *testing.T) {
 			name:   "checks directory",
 			cwd:    "/repo",
 			file:   "/repo/src/FooBar/file.js",
-			wantID: "directoryCase",
+			wantID: "directory-case",
 			want:   "Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.",
 		},
 		{
 			name:   "checks index parent directory",
 			cwd:    "/repo",
 			file:   "/repo/src/FooBar/index.js",
-			wantID: "directoryCase",
+			wantID: "directory-case",
 			want:   "Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.",
 		},
 		{
 			name:   "checks complete dotted directory segment",
 			cwd:    "/repo",
 			file:   "/repo/src/foo.JS/bar.js",
-			wantID: "directoryCase",
+			wantID: "directory-case",
 			want:   "Directory name `foo.JS` is not in kebab case. Rename it to `foo.js`.",
 		},
 		{
@@ -115,7 +188,7 @@ func TestLatestUpstreamPathBehavior(t *testing.T) {
 			options: []any{map[string]any{
 				"case": "kebabCase", "checkDirectories": false,
 			}},
-			wantID: "filenameCase",
+			wantID: "filename-case",
 			want:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 		},
 		{
@@ -130,14 +203,14 @@ func TestLatestUpstreamPathBehavior(t *testing.T) {
 			name:   "dollar directory skipped",
 			cwd:    "/repo",
 			file:   "/repo/src/$UserId/fooBar.js",
-			wantID: "filenameCase",
+			wantID: "filename-case",
 			want:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 		},
 		{
 			name:   "dollar filename still checks extension",
 			cwd:    "/repo",
 			file:   "/repo/src/foo/$userId.TSX",
-			wantID: "filenameExtension",
+			wantID: "filename-extension",
 			want:   "File extension `.TSX` is not in lowercase. Rename it to `$userId.tsx`.",
 		},
 		{
@@ -149,14 +222,14 @@ func TestLatestUpstreamPathBehavior(t *testing.T) {
 			name:   "outside cwd checks basename only",
 			cwd:    "/repo",
 			file:   "/other/Src/fooBar.js",
-			wantID: "filenameCase",
+			wantID: "filename-case",
 			want:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
 		},
 		{
 			name:   "first invalid directory wins",
 			cwd:    "/repo",
 			file:   "/repo/src/FooBar/BazQux.js",
-			wantID: "directoryCase",
+			wantID: "directory-case",
 			want:   "Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.",
 		},
 		{
@@ -166,7 +239,7 @@ func TestLatestUpstreamPathBehavior(t *testing.T) {
 			options: []any{map[string]any{"cases": map[string]any{
 				"pascalCase": true, "camelCase": true,
 			}}},
-			wantID: "directoryCase",
+			wantID: "directory-case",
 			want:   "Directory name `foo-bar` is not in camel case or pascal case. Rename it to `fooBar` or `FooBar`.",
 		},
 	}

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rule-tester.ts
@@ -225,6 +225,9 @@ export class RuleTester {
                 if (typeof error.message === 'string') {
                   assertMessageMatches(message.message, error.message);
                 }
+                if (error.messageId !== undefined) {
+                  assert.strictEqual(message.messageId, error.messageId);
+                }
               }
             }
           }

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
@@ -36,7 +36,7 @@ function invalid(filename: string, c: string | undefined, message: string) {
     code: `/* Filename: ${filename} */`,
     filename,
     options: c ? [{ case: c, checkDirectories: false }] : [],
-    errors: [{ message }],
+    errors: [{ message, messageId: 'filename-case' }],
   };
 }
 
@@ -49,7 +49,7 @@ function invalidCases(
     code: `/* Filename: ${filename} */`,
     filename,
     options: cases ? [{ cases, checkDirectories: false }] : [],
-    errors: [{ message }],
+    errors: [{ message, messageId: 'filename-case' }],
   };
 }
 
@@ -58,7 +58,7 @@ function invalidWithOptions(filename: string, options: any[], message: string) {
     code: `/* Filename: ${filename} */`,
     filename,
     options: [{ checkDirectories: false, ...options[0] }, ...options.slice(1)],
-    errors: [{ message }],
+    errors: [{ message, messageId: 'filename-case' }],
   };
 }
 
@@ -544,6 +544,7 @@ ruleTester.run('filename-case', {} as never, {
       filename: 'src/FooBar/file.js',
       errors: [
         {
+          messageId: 'directory-case',
           message:
             'Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.',
         },
@@ -554,6 +555,7 @@ ruleTester.run('filename-case', {} as never, {
       filename: 'src/FooBar/index.js',
       errors: [
         {
+          messageId: 'directory-case',
           message:
             'Directory name `FooBar` is not in kebab case. Rename it to `foo-bar`.',
         },
@@ -569,6 +571,7 @@ ruleTester.run('filename-case', {} as never, {
       filename: 'src/$UserId/fooBar.js',
       errors: [
         {
+          messageId: 'filename-case',
           message: 'Filename is not in kebab case. Rename it to `foo-bar.js`.',
         },
       ],


### PR DESCRIPTION
## Summary

- Align `unicorn/filename-case` message IDs with eslint-plugin-unicorn v73: `filename-case`, `directory-case`, and `filename-extension`.
- Add a guarded fast path for canonical absolute POSIX paths while retaining the existing `tspath` implementation for every non-canonical, Windows, URL, untitled-root, and volume-path form.
- Extend Go and JS coverage for upstream message IDs, path boundaries, and differential fuzzing.
- Verify all 302 reported files individually; diagnostic counts and messages remain aligned with upstream.
- Improve median Go benchmark time from 681 ns/op to 320 ns/op for valid files and from 2385 ns/op to 2152 ns/op for reported filenames, while removing 16 allocations per operation in both cases. The benchmark file is not included.
- Pass targeted Go tests, race detection, 30 seconds of differential fuzzing, the targeted JS test, `check-spell`, `format:check`, and changed-code Go lint. No snapshots changed.

## Related Links

- [eslint-plugin-unicorn v73 filename-case source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/filename-case.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).