### PR TITLE
fix: align consistent-type-definitions fix ranges

### DIFF
--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.go
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -81,7 +82,6 @@ func (f consistentTypeDefinitionsFixer) beforeEqualsEnd(from int, to int) (int, 
 }
 
 func (f consistentTypeDefinitionsFixer) typeAliasFix(node *ast.Node, typeAlias *ast.TypeAliasDeclaration) []rule.RuleFix {
-	sourceText := f.sourceFile.Text()
 	declarationRange := utils.TrimNodeTextRange(f.sourceFile, node)
 	typeKeywordStart, typeKeywordEnd, ok := f.tokenBounds(declarationRange.Pos(), declarationRange.End(), ast.KindTypeKeyword)
 	if !ok {
@@ -91,9 +91,7 @@ func (f consistentTypeDefinitionsFixer) typeAliasFix(node *ast.Node, typeAlias *
 	nameRange := utils.TrimNodeTextRange(f.sourceFile, typeAlias.Name())
 	nameOrTypeParametersEnd := nameRange.End()
 	if typeAlias.TypeParameters != nil && len(typeAlias.TypeParameters.Nodes) > 0 {
-		lastParameter := typeAlias.TypeParameters.Nodes[len(typeAlias.TypeParameters.Nodes)-1]
-		lastRange := utils.TrimNodeTextRange(f.sourceFile, lastParameter)
-		nameOrTypeParametersEnd = lastRange.End() + 1
+		nameOrTypeParametersEnd = scanner.GetRangeOfTokenAtPosition(f.sourceFile, typeAlias.TypeParameters.End()).End()
 	}
 
 	bodyRange := utils.TrimNodeTextRange(f.sourceFile, ast.SkipTypeParentheses(typeAlias.Type))
@@ -102,12 +100,13 @@ func (f consistentTypeDefinitionsFixer) typeAliasFix(node *ast.Node, typeAlias *
 		return nil
 	}
 
-	replacement := sourceText[declarationRange.Pos():typeKeywordStart] +
-		"interface" +
-		sourceText[typeKeywordEnd:beforeEqualsEnd] +
-		" " +
-		sourceText[bodyRange.Pos():bodyRange.End()]
-	return []rule.RuleFix{rule.RuleFixReplaceRange(declarationRange, replacement)}
+	return []rule.RuleFix{
+		// Match the upstream fixer's three edits so the merged ESLint-compatible
+		// fix starts at `type`, leaving modifiers such as `export` untouched.
+		rule.RuleFixReplaceRange(core.NewTextRange(typeKeywordStart, typeKeywordEnd), "interface"),
+		rule.RuleFixReplaceRange(core.NewTextRange(beforeEqualsEnd, bodyRange.Pos()), " "),
+		rule.RuleFixRemoveRange(core.NewTextRange(bodyRange.End(), declarationRange.End())),
+	}
 }
 
 func (f consistentTypeDefinitionsFixer) interfaceFix(node *ast.Node, interfaceDeclaration *ast.InterfaceDeclaration) []rule.RuleFix {
@@ -122,9 +121,10 @@ func (f consistentTypeDefinitionsFixer) interfaceFix(node *ast.Node, interfaceDe
 	nameText := sourceText[nameRange.Pos():nameRange.End()]
 	typeNameEnd := nameRange.End()
 	if interfaceDeclaration.TypeParameters != nil && len(interfaceDeclaration.TypeParameters.Nodes) > 0 {
-		lastParameter := interfaceDeclaration.TypeParameters.Nodes[len(interfaceDeclaration.TypeParameters.Nodes)-1]
-		lastRange := utils.TrimNodeTextRange(f.sourceFile, lastParameter)
-		typeNameEnd = lastRange.End() + 1
+		// NodeList.End() points at the closing `>` token's full start. Scanning
+		// from there preserves comments, trailing commas, and whitespace before
+		// `>` that a last-parameter-end + 1 calculation would truncate.
+		typeNameEnd = scanner.GetRangeOfTokenAtPosition(f.sourceFile, interfaceDeclaration.TypeParameters.End()).End()
 	}
 
 	var bodyStartScanPosition int
@@ -148,7 +148,6 @@ func (f consistentTypeDefinitionsFixer) interfaceFix(node *ast.Node, interfaceDe
 		return nil
 	}
 
-	bodyText := sourceText[openBracePosition:declarationRange.End()]
 	var extendsTypes []string
 	if interfaceDeclaration.HeritageClauses != nil {
 		for _, clause := range interfaceDeclaration.HeritageClauses.Nodes {
@@ -166,19 +165,36 @@ func (f consistentTypeDefinitionsFixer) interfaceFix(node *ast.Node, interfaceDe
 	}
 
 	isDefaultExport := ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) && ast.HasSyntacticModifier(node, ast.ModifierFlagsDefault)
-	prefix := sourceText[declarationRange.Pos():interfaceKeywordStart]
+	fixCount := 2
 	if isDefaultExport {
-		prefix = ""
+		fixCount += 2 // Remove the export wrapper and append a default export.
+	} else if len(extendsTypes) > 0 {
+		fixCount++ // Append the heritage types after the body.
 	}
-	replacement := prefix + "type" + sourceText[interfaceKeywordEnd:typeNameEnd] + " = " + bodyText
+	fixes := make([]rule.RuleFix, 0, fixCount)
+	if isDefaultExport {
+		fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(declarationRange.Pos(), interfaceKeywordStart)))
+	}
+	fixes = append(fixes,
+		rule.RuleFixReplaceRange(core.NewTextRange(interfaceKeywordStart, interfaceKeywordEnd), "type"),
+		rule.RuleFixReplaceRange(core.NewTextRange(typeNameEnd, openBracePosition), " = "),
+	)
+
+	var suffix string
 	if len(extendsTypes) > 0 {
-		replacement += " & " + strings.Join(extendsTypes, " & ")
+		suffix += " & " + strings.Join(extendsTypes, " & ")
 	}
 	if isDefaultExport {
-		replacement += "\nexport default " + nameText
+		suffix += "\nexport default " + nameText
+	}
+	if suffix != "" {
+		fixes = append(fixes, rule.RuleFixReplaceRange(
+			core.NewTextRange(declarationRange.End(), declarationRange.End()),
+			suffix,
+		))
 	}
 
-	return []rule.RuleFix{rule.RuleFixReplaceRange(declarationRange, replacement)}
+	return fixes
 }
 
 // ConsistentTypeDefinitionsRule enforces consistent type definitions

--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions_test.go
@@ -2,6 +2,8 @@ package consistent_type_definitions
 
 import (
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -544,4 +546,192 @@ declare global { interface Array<T> { item: T; } }`,
 			}
 		})
 	}
+}
+
+func TestConsistentTypeDefinitionsFixEdits(t *testing.T) {
+	testCases := []struct {
+		name             string
+		code             string
+		options          []any
+		wantMergedSource string
+		wantMergedText   string
+		wantOutput       string
+	}{
+		{
+			name: "reported DoActionV2Resp export",
+			code: `export type DoActionV2Resp = {
+  code?: number;
+  msg?: string;
+  data?: {
+    resp?: string;
+    success?: boolean;
+  };
+};`,
+			wantMergedSource: `type DoActionV2Resp = {
+  code?: number;
+  msg?: string;
+  data?: {
+    resp?: string;
+    success?: boolean;
+  };
+};`,
+			wantMergedText: `interface DoActionV2Resp {
+  code?: number;
+  msg?: string;
+  data?: {
+    resp?: string;
+    success?: boolean;
+  };
+}`,
+			wantOutput: `export interface DoActionV2Resp {
+  code?: number;
+  msg?: string;
+  data?: {
+    resp?: string;
+    success?: boolean;
+  };
+}`,
+		},
+		{
+			name: "reported GetShareDeepResearchPodcastResp export",
+			code: `export type GetShareDeepResearchPodcastResp = {
+  podcast_gen_status?: PodcastGenStatus;
+  audit_status?: AuditStatus;
+  episode?: Episode;
+};`,
+			wantMergedSource: `type GetShareDeepResearchPodcastResp = {
+  podcast_gen_status?: PodcastGenStatus;
+  audit_status?: AuditStatus;
+  episode?: Episode;
+};`,
+			wantMergedText: `interface GetShareDeepResearchPodcastResp {
+  podcast_gen_status?: PodcastGenStatus;
+  audit_status?: AuditStatus;
+  episode?: Episode;
+}`,
+			wantOutput: `export interface GetShareDeepResearchPodcastResp {
+  podcast_gen_status?: PodcastGenStatus;
+  audit_status?: AuditStatus;
+  episode?: Episode;
+}`,
+		},
+		{
+			name:             "type alias parameters preserve trivia before close",
+			code:             `export type T<U /* before close */,> /* before equals */ = ({ x: U });`,
+			wantMergedSource: `type T<U /* before close */,> /* before equals */ = ({ x: U });`,
+			wantMergedText:   `interface T<U /* before close */,> /* before equals */ { x: U }`,
+			wantOutput:       `export interface T<U /* before close */,> /* before equals */ { x: U }`,
+		},
+		{
+			name:             "export interface keeps modifier outside fix",
+			code:             `export interface T { x: number }`,
+			options:          []any{"type"},
+			wantMergedSource: `interface T `,
+			wantMergedText:   `type T = `,
+			wantOutput:       `export type T = { x: number }`,
+		},
+		{
+			name:             "type parameters comments and heritage",
+			code:             `export declare interface T<U /* before close */> extends A, B<U> { x: U }`,
+			options:          []any{"type"},
+			wantMergedSource: `interface T<U /* before close */> extends A, B<U> { x: U }`,
+			wantMergedText:   `type T<U /* before close */> = { x: U } & A & B<U>`,
+			wantOutput:       `export declare type T<U /* before close */> = { x: U } & A & B<U>`,
+		},
+		{
+			name:             "default export spans wrapper",
+			code:             `export default interface T extends A, B { x: number }`,
+			options:          []any{"type"},
+			wantMergedSource: `export default interface T extends A, B { x: number }`,
+			wantMergedText:   "type T = { x: number } & A & B\nexport default T",
+			wantOutput:       "type T = { x: number } & A & B\nexport default T",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			diagnostics := lintConsistentTypeDefinitions(t, testCase.code, testCase.options, rule.EditDemandAutofix)
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+			}
+			if diagnostics[0].FixesPtr == nil {
+				t.Fatal("diagnostic has no fixes")
+			}
+
+			merged := mergeFixesForTest(testCase.code, *diagnostics[0].FixesPtr)
+			if got := testCase.code[merged.Range.Pos():merged.Range.End()]; got != testCase.wantMergedSource {
+				t.Errorf("merged fix source = %q, want %q", got, testCase.wantMergedSource)
+			}
+			if merged.Text != testCase.wantMergedText {
+				t.Errorf("merged fix text = %q, want %q", merged.Text, testCase.wantMergedText)
+			}
+
+			output, unapplied, fixed := linter.ApplyRuleFixes(testCase.code, diagnostics)
+			if !fixed || len(unapplied) != 0 {
+				t.Fatalf("ApplyRuleFixes fixed = %v, unapplied = %d", fixed, len(unapplied))
+			}
+			if output != testCase.wantOutput {
+				t.Errorf("fixed output = %q, want %q", output, testCase.wantOutput)
+			}
+		})
+	}
+}
+
+func lintConsistentTypeDefinitions(
+	t *testing.T,
+	code string,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(code, "fix-edits.ts", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:      lintprogram.NewFromCompiler(program),
+		File:         sourceFile.FileName(),
+		ExcludePaths: []string{},
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     ConsistentTypeDefinitionsRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return ConsistentTypeDefinitionsRule.Run(ctx, options)
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}
+
+func mergeFixesForTest(source string, fixes []rule.RuleFix) rule.RuleFix {
+	fixes = slices.Clone(fixes)
+	slices.SortFunc(fixes, func(a rule.RuleFix, b rule.RuleFix) int {
+		if byStart := a.Range.Pos() - b.Range.Pos(); byStart != 0 {
+			return byStart
+		}
+		return a.Range.End() - b.Range.End()
+	})
+
+	start := fixes[0].Range.Pos()
+	end := fixes[len(fixes)-1].Range.End()
+	lastEnd := start
+	var text strings.Builder
+	for _, fix := range fixes {
+		text.WriteString(source[lastEnd:fix.Range.Pos()])
+		text.WriteString(fix.Text)
+		lastEnd = fix.Range.End()
+	}
+	return rule.RuleFixReplaceRange(fixes[0].Range.WithEnd(end), text.String())
 }


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/consistent-type-definitions` autofix edit boundaries with typescript-eslint v8.67.0 in both directions.
- Preserve generic parameter trivia when locating the closing `>` token.
- Add regression coverage for merged public fix payloads and final fix application.

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-type-definitions.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
