### PR TITLE
feat: port rule sort-vars

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -187,6 +187,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/require_await"
 	"github.com/web-infra-dev/rslint/internal/rules/require_yield"
 	"github.com/web-infra-dev/rslint/internal/rules/sort_keys"
+	"github.com/web-infra-dev/rslint/internal/rules/sort_vars"
 	"github.com/web-infra-dev/rslint/internal/rules/strict"
 	"github.com/web-infra-dev/rslint/internal/rules/symbol_description"
 	"github.com/web-infra-dev/rslint/internal/rules/unicode_bom"
@@ -400,5 +401,6 @@ func coreRules() []rule.Rule {
 		unicode_bom.UnicodeBomRule,
 		operator_assignment.OperatorAssignmentRule,
 		sort_keys.SortKeysRule,
+		sort_vars.SortVarsRule,
 	}
 }

--- a/internal/rules/no_restricted_syntax/matcher.go
+++ b/internal/rules/no_restricted_syntax/matcher.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 	esregexp "github.com/web-infra-dev/rslint/internal/utils/ecmascript/regexp"
 )
@@ -1681,24 +1682,10 @@ func readValueAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
 }
 
 func readRawAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
-	if mc == nil || mc.sf == nil || !isEstreeLiteralKind(node.Kind) {
+	if mc == nil || mc.sf == nil || !utils.IsESTreeLiteralKind(node.Kind) {
 		return nil, false
 	}
 	return scanner.GetSourceTextOfNodeFromSourceFile(mc.sf, node, false), true
-}
-
-func isEstreeLiteralKind(kind ast.Kind) bool {
-	switch kind {
-	case ast.KindStringLiteral,
-		ast.KindNumericLiteral,
-		ast.KindBigIntLiteral,
-		ast.KindRegularExpressionLiteral,
-		ast.KindTrueKeyword,
-		ast.KindFalseKeyword,
-		ast.KindNullKeyword:
-		return true
-	}
-	return false
 }
 
 func readOptionalAttr(node *ast.Node) (interface{}, bool) {

--- a/internal/rules/sort_vars/sort_vars.go
+++ b/internal/rules/sort_vars/sort_vars.go
@@ -1,0 +1,136 @@
+package sort_vars
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+//go:embed sort_vars.schema.json
+var schemaJSON []byte
+
+type options struct {
+	ignoreCase bool
+}
+
+func parseOptions(raw []any) options {
+	var opts options
+	if len(raw) == 0 {
+		return opts
+	}
+	if object, ok := raw[0].(map[string]any); ok {
+		if ignoreCase, ok := object["ignoreCase"].(bool); ok {
+			opts.ignoreCase = ignoreCase
+		}
+	}
+	return opts
+}
+
+func sortableName(declaration *ast.Node, ignoreCase bool) string {
+	name := declaration.AsVariableDeclaration().Name().AsIdentifier().Text
+	if ignoreCase {
+		return ecmascript.StringToLowerCase(name)
+	}
+	return name
+}
+
+func identifierDeclarations(list *ast.VariableDeclarationList) []*ast.Node {
+	if list == nil || list.Declarations == nil {
+		return nil
+	}
+	declarations := make([]*ast.Node, 0, len(list.Declarations.Nodes))
+	for _, declaration := range list.Declarations.Nodes {
+		variable := declaration.AsVariableDeclaration()
+		if variable != nil && variable.Name() != nil && variable.Name().Kind == ast.KindIdentifier {
+			declarations = append(declarations, declaration)
+		}
+	}
+	return declarations
+}
+
+func buildFix(ctx rule.RuleContext, declarations []*ast.Node, ignoreCase bool) []rule.RuleFix {
+	for _, declaration := range declarations {
+		initializer := declaration.AsVariableDeclaration().Initializer
+		if initializer != nil && !utils.IsESTreeLiteralKind(ast.SkipParentheses(initializer).Kind) {
+			return nil
+		}
+	}
+
+	ordered := append([]*ast.Node(nil), declarations...)
+	// Upstream's comparator returns -1 for names that compare equal. V8's
+	// stable sort consequently reverses each equal-name group; this insertion
+	// sort spells that observable behavior out without violating sort.Interface.
+	for i := 1; i < len(ordered); i++ {
+		current := ordered[i]
+		currentName := sortableName(current, ignoreCase)
+		j := i
+		for j > 0 && ecmascript.CompareStrings(currentName, sortableName(ordered[j-1], ignoreCase)) <= 0 {
+			ordered[j] = ordered[j-1]
+			j--
+		}
+		ordered[j] = current
+	}
+
+	text := ctx.SourceFile.Text()
+	ranges := make([]core.TextRange, len(declarations))
+	for i, declaration := range declarations {
+		ranges[i] = utils.TrimNodeTextRange(ctx.SourceFile, declaration)
+	}
+
+	replacement := make([]byte, 0, ranges[len(ranges)-1].End()-ranges[0].Pos())
+	for i, declaration := range ordered {
+		r := utils.TrimNodeTextRange(ctx.SourceFile, declaration)
+		replacement = append(replacement, text[r.Pos():r.End()]...)
+		if i+1 < len(ranges) {
+			replacement = append(replacement, text[ranges[i].End():ranges[i+1].Pos()]...)
+		}
+	}
+
+	return []rule.RuleFix{rule.RuleFixReplaceRange(
+		core.NewTextRange(ranges[0].Pos(), ranges[len(ranges)-1].End()),
+		string(replacement),
+	)}
+}
+
+var sortVarsMessage = rule.RuleMessage{
+	Id:          "sortVars",
+	Description: "Variables within the same declaration block should be sorted alphabetically.",
+}
+
+// https://eslint.org/docs/latest/rules/sort-vars
+var SortVarsRule = rule.Rule{
+	Name:   "sort-vars",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		return rule.RuleListeners{
+			ast.KindVariableDeclarationList: func(node *ast.Node) {
+				declarations := identifierDeclarations(node.AsVariableDeclarationList())
+				if len(declarations) < 2 {
+					return
+				}
+
+				previous := declarations[0]
+				fixed := false
+				for _, declaration := range declarations[1:] {
+					if ecmascript.CompareStrings(sortableName(declaration, opts.ignoreCase), sortableName(previous, opts.ignoreCase)) < 0 {
+						attachFix := !fixed
+						ctx.ReportNodeWithDeferredFixes(declaration, sortVarsMessage, func() []rule.RuleFix {
+							if !attachFix {
+								return nil
+							}
+							return buildFix(ctx, declarations, opts.ignoreCase)
+						})
+						fixed = true
+						continue
+					}
+					previous = declaration
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/sort_vars/sort_vars.md
+++ b/internal/rules/sort_vars/sort_vars.md
@@ -1,0 +1,38 @@
+# sort-vars
+
+## Rule Details
+
+This rule requires identifier variables within the same declaration block to be sorted alphabetically. Destructuring declarations are ignored. By default, ordering is case-sensitive.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+let b, a;
+let c, D, e;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+let a, b, c;
+let G, f, h;
+let { b, a } = value;
+```
+
+With `{ "ignoreCase": true }`, names are compared without case sensitivity:
+
+```json
+{ "sort-vars": ["error", { "ignoreCase": true }] }
+```
+
+```javascript
+let a, A;
+let c, D, e;
+```
+
+The rule can automatically reorder declarations when every participating initializer is a literal. It reports without a fix when reordering might change evaluation order.
+
+## Original Documentation
+
+- [ESLint: sort-vars](https://eslint.org/docs/latest/rules/sort-vars)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.0/lib/rules/sort-vars.js)

--- a/internal/rules/sort_vars/sort_vars.schema.json
+++ b/internal/rules/sort_vars/sort_vars.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "ignoreCase": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/sort_vars/sort_vars_extras_test.go
+++ b/internal/rules/sort_vars/sort_vars_extras_test.go
@@ -1,0 +1,231 @@
+// TestSortVarsExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch, Dimension 4 row, or tsgo AST shape it covers, so future
+// refactors cannot silently regress it. Upstream's migrated valid/invalid suite
+// lives in sort_vars_upstream_test.go.
+package sort_vars
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestSortVarsExtras(t *testing.T) {
+	ignoreCase := map[string]any{"ignoreCase": true}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&SortVarsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: empty destructuring pattern has no sortable identifier ----
+			{Code: "var {} = value;"},
+			// ---- Dimension 4: empty array pattern has no sortable identifier ----
+			{Code: "var [] = value;"},
+			// ---- Dimension 4: one identifier needs no comparison ----
+			{Code: "let only = value;"},
+			// ---- Dimension 4: destructuring names are not sorted by this rule ----
+			{Code: "const { z, a, nested: { y, b } } = value;"},
+			// ---- Dimension 4: rest elements in binding patterns are ignored ----
+			{Code: "const [z, ...a] = value;"},
+			// ---- Dimension 4: separate declaration blocks never compare across statements ----
+			{Code: "const b = 2; const a = 1;"},
+			// ---- Real-user: eslint/eslint#2954 — a destructuring-only declaration does not crash under ignoreCase ----
+			{Code: "var source = {m: 'M'}; var {m} = source;", Options: ignoreCase},
+			// ---- Real-user: eslint/eslint#3474 — a leading empty pattern does not become an undefined comparison memo ----
+			{Code: "var {}, a;", Options: ignoreCase},
+			// ---- Locks in upstream filter(): patterns are skipped rather than treated as comparison boundaries ----
+			{Code: "var a, {z} = source, b;"},
+			// ---- N/A: access/key forms — only Identifier binding names participate ----
+			// ---- N/A: class/function declaration forms — the target is a VariableDeclarationList ----
+			// ---- N/A: overload/abstract members — they cannot contain variable declaration lists ----
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: a variable statement declaration list ----
+			{
+				Code:   "let b, a;",
+				Output: []string{"let a, b;"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortVars", Message: expectedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 9}},
+			},
+			// ---- Dimension 4: a for-loop header uses a bare VariableDeclarationList ----
+			{
+				Code:   "for (let b = 1, a = 0; a < b; a++) {}",
+				Output: []string{"for (let a = 0, b = 1; a < b; a++) {}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortVars", Line: 1, Column: 17, EndLine: 1, EndColumn: 22}},
+			},
+			// ---- Dimension 4: a TS type annotation belongs to the moved declarator ----
+			{
+				Code:   "let b: number = 2, a: number = 1;",
+				Output: []string{"let a: number = 1, b: number = 2;"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortVars", Line: 1, Column: 20}},
+			},
+			// ---- Dimension 4: parenthesized literal initializers remain fixable because ESTree erases the wrappers ----
+			{
+				Code:   "let b = ((2)), a = (1);",
+				Output: []string{"let a = (1), b = ((2));"},
+				Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 16)},
+			},
+			// ---- Dimension 4: TS non-null assertion initializer is non-literal and suppresses the fix ----
+			{Code: "let b = 2, a = value!;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12)}},
+			// ---- Dimension 4: TS `as` initializer is non-literal and suppresses the fix ----
+			{Code: "let b = 2, a = 1 as number;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12)}},
+			// ---- Dimension 4: TS `satisfies` initializer is non-literal and suppresses the fix ----
+			{Code: "let b = 2, a = 1 satisfies number;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12)}},
+			// ---- Dimension 4: optional-chain initializer is non-literal and suppresses the fix ----
+			{Code: "let b = 2, a = value?.x;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12)}},
+			// ---- Dimension 3: comments and multiline separators stay in their original layout slots ----
+			{
+				Code:   "let c = 3, /* first gap */\n    a = 1, // second gap\n    b = 2;",
+				Output: []string{"let a = 1, /* first gap */\n    b = 2, // second gap\n    c = 3;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sortVars", Line: 2, Column: 5},
+					{MessageId: "sortVars", Line: 3, Column: 5},
+				},
+			},
+			// ---- Dimension 3: a non-literal initializer anywhere in the participating list suppresses the whole fix ----
+			{Code: "let c = 3, a = 1, b = sideEffect();", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12), sortVarsError(1, 19)}},
+			// ---- Dimension 3: a non-literal initializer on an ignored pattern does not suppress the fix ----
+			{
+				Code:   "let b = 2, {x} = sideEffect(), a = 1;",
+				Output: []string{"let a = 1, {x} = sideEffect(), b = 2;"},
+				Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 32)},
+			},
+			// ---- Locks in upstream reduce() inversion arm: the previous accepted maximum is retained, producing two reports ----
+			{
+				Code:   "let d, c, a, b;",
+				Output: []string{"let a, b, c, d;"},
+				Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8), sortVarsError(1, 11), sortVarsError(1, 14)},
+			},
+			// ---- Locks in upstream fix() `fixed` arm: only the first of several reports carries the single list-wide edit ----
+			{
+				Code:   "let c, a, b;",
+				Output: []string{"let a, b, c;"},
+				Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8), sortVarsError(1, 11)},
+			},
+			// ---- Locks in upstream literal safety: every ESTree Literal family member permits a fix ----
+			{
+				Code:   "let z = /x/, y = 1n, x = null, w = false, v = 's';",
+				Output: []string{"let v = 's', w = false, x = null, y = 1n, z = /x/;"},
+				Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 14), sortVarsError(1, 22), sortVarsError(1, 32), sortVarsError(1, 43)},
+			},
+			// ---- Locks in upstream Literal distinction: a no-substitution template is still a TemplateLiteral and suppresses fixing ----
+			{Code: "let b = 2, a = `text`;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12)}},
+			// ---- Locks in JavaScript UTF-16 relational ordering for non-BMP identifier names ----
+			{
+				Code:   "let ﾚ, 𐀀;",
+				Output: []string{"let 𐀀, ﾚ;"},
+				Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)},
+			},
+			// ---- Locks in JavaScript lowercasing for the Kelvin sign under ignoreCase ----
+			{
+				Code:    "let \u212A, j;",
+				Output:  []string{"let j, \u212A;"},
+				Options: ignoreCase,
+				Errors:  []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)},
+			},
+			// ---- Locks in upstream sort comparator's equal-name arm: V8 reverses equal folded-name groups while fixing another inversion ----
+			{
+				Code:    "let a, A, z, b;",
+				Output:  []string{"let A, a, b, z;"},
+				Options: ignoreCase,
+				Errors:  []rule_tester.InvalidTestCaseError{sortVarsError(1, 14)},
+			},
+			// ---- Schema default: an explicit empty option object is case-sensitive like no options ----
+			{
+				Code:    "let a, A;",
+				Output:  []string{"let A, a;"},
+				Options: map[string]any{},
+				Errors:  []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)},
+			},
+			// ---- Dimension 2: nested declaration lists are checked independently ----
+			{
+				Code:   "let b, a; function f() { let d, c; }",
+				Output: []string{"let a, b; function f() { let c, d; }"},
+				Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8), sortVarsError(1, 33)},
+			},
+		},
+	)
+}
+
+func TestSortVarsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, "let b = 2, a = 1;", core.ScriptKindTS)
+
+	var declarationList *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindVariableDeclarationList {
+			declarationList = node
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if declarationList == nil {
+		t.Fatal("fixture has no variable declaration list")
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(SortVarsRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+		SortVarsRule.Run(ctx, nil)[ast.KindVariableDeclarationList](declarationList)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("autofix-only rule materialized suggestions")
+		}
+	}
+}

--- a/internal/rules/sort_vars/sort_vars_upstream_test.go
+++ b/internal/rules/sort_vars/sort_vars_upstream_test.go
@@ -1,0 +1,104 @@
+// TestSortVarsUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/sort-vars.js 1:1. Position assertions cover line and
+// column for every invalid case. rslint-specific lock-in cases live in
+// sort_vars_extras_test.go.
+package sort_vars
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const expectedMessage = "Variables within the same declaration block should be sorted alphabetically."
+
+func sortVarsError(line, column int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "sortVars",
+		Message:   expectedMessage,
+		Line:      line,
+		Column:    column,
+	}
+}
+
+func TestSortVarsUpstream(t *testing.T) {
+	ignoreCase := map[string]any{"ignoreCase": true}
+	es2015 := rule.LanguageOptions{ECMAVersion: 2015}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&SortVarsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "var a=10, b=4, c='abc'"},
+			{Code: "var a, b, c, d"},
+			{Code: "var b; var a; var d;"},
+			{Code: "var _a, a"},
+			{Code: "var A, a"},
+			{Code: "var A, b"},
+			{Code: "var a, A;", Options: ignoreCase},
+			{Code: "var A, a;", Options: ignoreCase},
+			{Code: "var a, B, c;", Options: ignoreCase},
+			{Code: "var A, b, C;", Options: ignoreCase},
+			{Code: "var {a, b, c} = x;", Options: ignoreCase, LanguageOptions: es2015},
+			{Code: "var {A, b, C} = x;", Options: ignoreCase, LanguageOptions: es2015},
+			{Code: "var test = [1,2,3];", LanguageOptions: es2015},
+			{Code: "var {a,b} = [1,2];", LanguageOptions: es2015},
+			{Code: "var [a, B, c] = [1, 2, 3];", Options: ignoreCase, LanguageOptions: es2015},
+			{Code: "var [A, B, c] = [1, 2, 3];", Options: ignoreCase, LanguageOptions: es2015},
+			{Code: "var [A, b, C] = [1, 2, 3];", Options: ignoreCase, LanguageOptions: es2015},
+			{Code: "let {a, b, c} = x;", LanguageOptions: es2015},
+			{Code: "let [a, b, c] = [1, 2, 3];", LanguageOptions: es2015},
+			{Code: `const {a, b, c} = {a: 1, b: true, c: "Moo"};`, Options: ignoreCase, LanguageOptions: es2015},
+			{Code: `const [a, b, c] = [1, true, "Moo"];`, Options: ignoreCase, LanguageOptions: es2015},
+			{Code: `const [c, a, b] = [1, true, "Moo"];`, Options: ignoreCase, LanguageOptions: es2015},
+			{Code: "var {a, x: {b, c}} = {};", LanguageOptions: es2015},
+			{Code: "var {c, x: {a, c}} = {};", LanguageOptions: es2015},
+			{Code: "var {a, x: [b, c]} = {};", LanguageOptions: es2015},
+			{Code: "var [a, {b, c}] = {};", LanguageOptions: es2015},
+			{Code: "var [a, {x: {b, c}}] = {};", LanguageOptions: es2015},
+			{Code: "var a = 42, {b, c } = {};", LanguageOptions: es2015},
+			{Code: "var b = 42, {a, c } = {};", LanguageOptions: es2015},
+			{Code: "var [b, {x: {a, c}}] = {};", LanguageOptions: es2015},
+			{Code: "var [b, d, a, c] = {};", LanguageOptions: es2015},
+			{Code: "var e, [a, c, d] = {};", LanguageOptions: es2015},
+			{Code: "var a, [E, c, D] = [];", Options: ignoreCase, LanguageOptions: es2015},
+			{Code: "var a, f, [e, c, d] = [1,2,3];", LanguageOptions: es2015},
+			{
+				Code:            "export default class {\n    render () {\n        let {\n            b\n        } = this,\n            a,\n            c;\n    }\n}",
+				LanguageOptions: es2015,
+			},
+			{Code: "var {} = 1, a", Options: ignoreCase, LanguageOptions: es2015},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "var b, a", Output: []string{"var a, b"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortVars", Message: expectedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 9}}},
+			{Code: "var b , a", Output: []string{"var a , b"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 9)}},
+			{Code: "var b,\n    a;", Output: []string{"var a,\n    b;"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortVars", Message: expectedMessage, Line: 2, Column: 5, EndLine: 2, EndColumn: 6}}},
+			{Code: "var b=10, a=20;", Output: []string{"var a=20, b=10;"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 11)}},
+			{Code: "var b=10, a=20, c=30;", Output: []string{"var a=20, b=10, c=30;"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 11)}},
+			{Code: "var all=10, a = 1", Output: []string{"var a = 1, all=10"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 13)}},
+			{Code: "var b, c, a, d", Output: []string{"var a, b, c, d"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 11)}},
+			{Code: "var c, d, a, b", Output: []string{"var a, b, c, d"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 11), sortVarsError(1, 14)}},
+			{Code: "var a, A;", Output: []string{"var A, a;"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+			{Code: "var a, B;", Output: []string{"var B, a;"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+			{Code: "var a, B, c;", Output: []string{"var B, a, c;"}, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+			{Code: "var B, a;", Output: []string{"var a, B;"}, Options: ignoreCase, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+			{Code: "var B, A, c;", Output: []string{"var A, B, c;"}, Options: ignoreCase, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+			{Code: "var d, a, [b, c] = {};", Output: []string{"var a, d, [b, c] = {};"}, Options: ignoreCase, LanguageOptions: es2015, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+			{Code: "var d, a, [b, {x: {c, e}}] = {};", Output: []string{"var a, d, [b, {x: {c, e}}] = {};"}, Options: ignoreCase, LanguageOptions: es2015, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+			{Code: "var {} = 1, b, a", Output: []string{"var {} = 1, a, b"}, Options: ignoreCase, LanguageOptions: es2015, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 16)}},
+			{Code: "var b=10, a=f();", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 11)}},
+			{Code: "var b=10, a=b;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 11)}},
+			{Code: "var b = 0, a = `${b}`;", LanguageOptions: es2015, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12)}},
+			{Code: "var b = 0, a = `${f()}`", LanguageOptions: es2015, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 12)}},
+			{Code: "var b = 0, c = b, a;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 19)}},
+			{Code: "var b = 0, c = 0, a = b + c;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 19)}},
+			{Code: "var b = f(), c, d, a;", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 20)}},
+			{Code: "var b = `${f()}`, c, d, a;", LanguageOptions: es2015, Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 25)}},
+			{Code: "var c, a = b = 0", Errors: []rule_tester.InvalidTestCaseError{sortVarsError(1, 8)}},
+		},
+	)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -78,6 +78,23 @@ func TrimmedNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
 	return sourceFile.Text()[r.Pos():r.End()]
 }
 
+// IsESTreeLiteralKind reports whether kind maps to ESTree's Literal node.
+// Template literals are intentionally excluded: ESTree represents them with
+// TemplateLiteral even when they contain no substitutions.
+func IsESTreeLiteralKind(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword:
+		return true
+	}
+	return false
+}
+
 // RangeEnclosingDelimiters widens the inner range [start, end) outward to the
 // nearest enclosing `open`/`close` delimiter pair and returns the widened
 // offsets. Given the span of a comma-separated list whose own range excludes

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -32,6 +32,28 @@ func TestExtractRegexPatternAndFlags(t *testing.T) {
 	}
 }
 
+func TestIsESTreeLiteralKind(t *testing.T) {
+	literals := []ast.Kind{
+		ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+	}
+	for _, kind := range literals {
+		if !IsESTreeLiteralKind(kind) {
+			t.Errorf("IsESTreeLiteralKind(%v) = false, want true", kind)
+		}
+	}
+	for _, kind := range []ast.Kind{ast.KindIdentifier, ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression} {
+		if IsESTreeLiteralKind(kind) {
+			t.Errorf("IsESTreeLiteralKind(%v) = true, want false", kind)
+		}
+	}
+}
+
 func TestHasCommentInsideNode(t *testing.T) {
 	source := "const a = \"https://example.com/*x*/\";\n" +
 		"const b = /\\/\\//;\n" +

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -526,6 +526,7 @@ export default defineConfig({
     './tests/eslint/rules/symbol-description.test.ts',
     './tests/eslint/rules/unicode-bom.test.ts',
     './tests/eslint/rules/sort-keys.test.ts',
+    './tests/eslint/rules/sort-vars.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/expect-expect.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/sort-vars.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/sort-vars.test.ts.snap
@@ -1,0 +1,667 @@
+// Rstest Snapshot v1
+
+exports[`sort-vars > invalid 1`] = `
+{
+  "code": "var b, a",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 2`] = `
+{
+  "code": "var b , a",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 3`] = `
+{
+  "code": "var b,
+    a;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 4`] = `
+{
+  "code": "var b=10, a=20;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 5`] = `
+{
+  "code": "var b=10, a=20, c=30;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 6`] = `
+{
+  "code": "var all=10, a = 1",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 7`] = `
+{
+  "code": "var b, c, a, d",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 8`] = `
+{
+  "code": "var c, d, a, b",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 9`] = `
+{
+  "code": "var a, A;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 10`] = `
+{
+  "code": "var a, B;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 11`] = `
+{
+  "code": "var a, B, c;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 12`] = `
+{
+  "code": "var B, a;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 13`] = `
+{
+  "code": "var B, A, c;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 14`] = `
+{
+  "code": "var d, a, [b, c] = {};",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 15`] = `
+{
+  "code": "var d, a, [b, {x: {c, e}}] = {};",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 16`] = `
+{
+  "code": "var {} = 1, b, a",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 17`] = `
+{
+  "code": "var b=10, a=f();",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 18`] = `
+{
+  "code": "var b=10, a=b;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 19`] = `
+{
+  "code": "var b = 0, a = \`\${b}\`;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 20`] = `
+{
+  "code": "var b = 0, a = \`\${f()}\`",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 21`] = `
+{
+  "code": "var b = 0, c = b, a;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 22`] = `
+{
+  "code": "var b = 0, c = 0, a = b + c;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 23`] = `
+{
+  "code": "var b = f(), c, d, a;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 24`] = `
+{
+  "code": "var b = \`\${f()}\`, c, d, a;",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`sort-vars > invalid 25`] = `
+{
+  "code": "var c, a = b = 0",
+  "diagnostics": [
+    {
+      "message": "Variables within the same declaration block should be sorted alphabetically.",
+      "messageId": "sortVars",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "sort-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/sort-vars.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/sort-vars.test.ts
@@ -1,0 +1,180 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+const expectedError = { messageId: 'sortVars' };
+const ignoreCase = { ignoreCase: true };
+
+ruleTester.run('sort-vars', {
+  valid: [
+    "var a=10, b=4, c='abc'",
+    'var a, b, c, d',
+    'var b; var a; var d;',
+    'var _a, a',
+    'var A, a',
+    'var A, b',
+    { code: 'var a, A;', options: ignoreCase },
+    { code: 'var A, a;', options: ignoreCase },
+    { code: 'var a, B, c;', options: ignoreCase },
+    { code: 'var A, b, C;', options: ignoreCase },
+    {
+      code: 'var {a, b, c} = x;',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var {A, b, C} = x;',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    { code: 'var test = [1,2,3];', languageOptions: { ecmaVersion: 2015 } },
+    { code: 'var {a,b} = [1,2];', languageOptions: { ecmaVersion: 2015 } },
+    {
+      code: 'var [a, B, c] = [1, 2, 3];',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var [A, B, c] = [1, 2, 3];',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var [A, b, C] = [1, 2, 3];',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    { code: 'let {a, b, c} = x;', languageOptions: { ecmaVersion: 2015 } },
+    {
+      code: 'let [a, b, c] = [1, 2, 3];',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'const {a, b, c} = {a: 1, b: true, c: "Moo"};',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'const [a, b, c] = [1, true, "Moo"];',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'const [c, a, b] = [1, true, "Moo"];',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var {a, x: {b, c}} = {};',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var {c, x: {a, c}} = {};',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var {a, x: [b, c]} = {};',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    { code: 'var [a, {b, c}] = {};', languageOptions: { ecmaVersion: 2015 } },
+    {
+      code: 'var [a, {x: {b, c}}] = {};',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var a = 42, {b, c } = {};',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var b = 42, {a, c } = {};',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var [b, {x: {a, c}}] = {};',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    { code: 'var [b, d, a, c] = {};', languageOptions: { ecmaVersion: 2015 } },
+    { code: 'var e, [a, c, d] = {};', languageOptions: { ecmaVersion: 2015 } },
+    {
+      code: 'var a, [E, c, D] = [];',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var a, f, [e, c, d] = [1,2,3];',
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: [
+        'export default class {',
+        '    render () {',
+        '        let {',
+        '            b',
+        '        } = this,',
+        '            a,',
+        '            c;',
+        '    }',
+        '}',
+      ].join('\n'),
+      languageOptions: { ecmaVersion: 2015 },
+    },
+    {
+      code: 'var {} = 1, a',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+    },
+  ],
+  invalid: [
+    { code: 'var b, a', errors: [expectedError] },
+    { code: 'var b , a', errors: [expectedError] },
+    { code: ['var b,', '    a;'].join('\n'), errors: [expectedError] },
+    { code: 'var b=10, a=20;', errors: [expectedError] },
+    { code: 'var b=10, a=20, c=30;', errors: [expectedError] },
+    { code: 'var all=10, a = 1', errors: [expectedError] },
+    { code: 'var b, c, a, d', errors: [expectedError] },
+    { code: 'var c, d, a, b', errors: [expectedError, expectedError] },
+    { code: 'var a, A;', errors: [expectedError] },
+    { code: 'var a, B;', errors: [expectedError] },
+    { code: 'var a, B, c;', errors: [expectedError] },
+    { code: 'var B, a;', options: ignoreCase, errors: [expectedError] },
+    { code: 'var B, A, c;', options: ignoreCase, errors: [expectedError] },
+    {
+      code: 'var d, a, [b, c] = {};',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+      errors: [expectedError],
+    },
+    {
+      code: 'var d, a, [b, {x: {c, e}}] = {};',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+      errors: [expectedError],
+    },
+    {
+      code: 'var {} = 1, b, a',
+      options: ignoreCase,
+      languageOptions: { ecmaVersion: 2015 },
+      errors: [expectedError],
+    },
+    { code: 'var b=10, a=f();', errors: [expectedError] },
+    { code: 'var b=10, a=b;', errors: [expectedError] },
+    {
+      code: 'var b = 0, a = `${b}`;',
+      languageOptions: { ecmaVersion: 2015 },
+      errors: [expectedError],
+    },
+    {
+      code: 'var b = 0, a = `${f()}`',
+      languageOptions: { ecmaVersion: 2015 },
+      errors: [expectedError],
+    },
+    { code: 'var b = 0, c = b, a;', errors: [expectedError] },
+    { code: 'var b = 0, c = 0, a = b + c;', errors: [expectedError] },
+    { code: 'var b = f(), c, d, a;', errors: [expectedError] },
+    {
+      code: 'var b = `${f()}`, c, d, a;',
+      languageOptions: { ecmaVersion: 2015 },
+      errors: [expectedError],
+    },
+    { code: 'var c, a = b = 0', errors: [expectedError] },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `sort-vars` rule from ESLint to rslint.

Require identifier variables within the same declaration block to be sorted alphabetically, with ESLint-compatible case-insensitive ordering and safe autofixes.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/sort-vars
- Source code: https://github.com/eslint/eslint/blob/v10.9.0/lib/rules/sort-vars.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).