### PR TITLE
fix: preserve catch error name bindings

### DIFF
--- a/internal/plugins/unicorn/rules/catch_error_name/catch_error_name.go
+++ b/internal/plugins/unicorn/rules/catch_error_name/catch_error_name.go
@@ -3,11 +3,11 @@ package catch_error_name
 import (
 	_ "embed"
 	"fmt"
-	"sort"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -163,6 +163,7 @@ func isPromiseCatchParameter(identifier *ast.Node) bool {
 	if match, ok := unicornutil.MatchDotMethodCall(callback.Parent, unicornutil.DotMethodCallOptions{
 		Method:              method,
 		ArgumentsLength:     &argumentsLength,
+		RejectSpreadElement: true,
 		AllowOptionalMember: true,
 	}); ok && match.Call.Arguments()[0] == callback {
 		return true
@@ -173,6 +174,7 @@ func isPromiseCatchParameter(identifier *ast.Node) bool {
 	match, ok := unicornutil.MatchDotMethodCall(callback.Parent, unicornutil.DotMethodCallOptions{
 		Method:              method,
 		ArgumentsLength:     &argumentsLength,
+		RejectSpreadElement: true,
 		AllowOptionalMember: true,
 	})
 	return ok && match.Call.Arguments()[1] == callback
@@ -194,6 +196,17 @@ func handlerBody(identifier *ast.Node) *ast.Node {
 	return parent.Body()
 }
 
+func handlerScope(identifier *ast.Node) *ast.Node {
+	declaration := bindingDeclaration(identifier)
+	if declaration == nil || declaration.Parent == nil {
+		return nil
+	}
+	if declaration.Parent.Kind == ast.KindCatchClause {
+		return declaration.Parent.AsCatchClause().Block
+	}
+	return declaration.Parent
+}
+
 func bodyHasExternalReference(ctx rule.RuleContext, body *ast.Node, originalSymbol *ast.Symbol, candidate string) bool {
 	conflict := false
 	var walk func(*ast.Node)
@@ -206,7 +219,7 @@ func bodyHasExternalReference(ctx rule.RuleContext, body *ast.Node, originalSymb
 			(!ast.IsJsxTagName(node) || !scanner.IsIntrinsicJsxName(node.Text())) &&
 			!utils.IsNonReferenceIdentifier(node) {
 			symbol := ctx.Refs.Resolve(node)
-			conflict = symbol != originalSymbol && !utils.IsValueSymbolDeclaredInFile(symbol, ctx.SourceFile)
+			conflict = symbol != originalSymbol
 			if conflict {
 				return
 			}
@@ -317,10 +330,21 @@ func availableName(ctx rule.RuleContext, identifier *ast.Node, references []*ast
 	}
 	originalSymbol := bindingDeclaration(identifier).Symbol()
 	body := handlerBody(identifier)
+	scope := handlerScope(identifier)
 	for {
 		available := !ctx.Globals.Access(candidate).IsDeclared() &&
 			!utils.IsShadowed(identifier, candidate) &&
 			!hasTypeDeclarationInScope(identifier, candidate)
+		if available && ctx.Refs.IsNameDefinedInFileWithMeaning(
+			identifier,
+			candidate,
+			ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+		) {
+			available = false
+		}
+		if available && !ast.IsInJSFile(identifier) && rule.IsDefaultTypeScriptTypeGlobal(candidate) {
+			available = false
+		}
 		if available && candidate == "arguments" {
 			available = false
 		}
@@ -332,7 +356,7 @@ func availableName(ctx rule.RuleContext, identifier *ast.Node, references []*ast
 				}
 			}
 		}
-		if available && bodyHasExternalReference(ctx, body, originalSymbol, candidate) {
+		if available && bodyHasExternalReference(ctx, scope, originalSymbol, candidate) {
 			available = false
 		}
 		// NOTE: Unlike ESLint, avoid a known unsafe fix when an unused handler
@@ -352,6 +376,27 @@ func availableName(ctx rule.RuleContext, identifier *ast.Node, references []*ast
 		}
 		candidate += "_"
 	}
+}
+
+func mergeReferences(left, right []*ast.Node) []*ast.Node {
+	if len(left) == 0 {
+		return right
+	}
+	if len(right) == 0 {
+		return left
+	}
+	merged := make([]*ast.Node, 0, len(left)+len(right))
+	for len(left) > 0 && len(right) > 0 {
+		if left[0].Pos() < right[0].Pos() {
+			merged = append(merged, left[0])
+			left = left[1:]
+		} else {
+			merged = append(merged, right[0])
+			right = right[1:]
+		}
+	}
+	merged = append(merged, left...)
+	return append(merged, right...)
 }
 
 func renameFixes(ctx rule.RuleContext, identifier *ast.Node, references []*ast.Node, name string) []rule.RuleFix {
@@ -386,9 +431,10 @@ var CatchErrorNameRule = rule.Rule{
 				if declaration == nil || ctx.Refs == nil || declaration.Symbol() == nil {
 					return
 				}
-				references := append([]*ast.Node(nil), ctx.Refs.References(declaration.Symbol())...)
-				references = append(references, jsxNamespaceReferences(identifier, handlerBody(identifier), originalName)...)
-				sort.Slice(references, func(i, j int) bool { return references[i].Pos() < references[j].Pos() })
+				references := ctx.Refs.References(declaration.Symbol())
+				if ctx.SourceFile.LanguageVariant == core.LanguageVariantJSX {
+					references = mergeReferences(references, jsxNamespaceReferences(identifier, handlerScope(identifier), originalName))
+				}
 				if originalName == "_" && len(references) == 0 {
 					return
 				}

--- a/internal/plugins/unicorn/rules/catch_error_name/catch_error_name.schema.json
+++ b/internal/plugins/unicorn/rules/catch_error_name/catch_error_name.schema.json
@@ -11,7 +11,7 @@
         },
         "ignore": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "type": "string", "format": "regex" },
           "uniqueItems": true,
           "description": "Patterns to ignore."
         }

--- a/internal/plugins/unicorn/rules/catch_error_name/catch_error_name_extras_test.go
+++ b/internal/plugins/unicorn/rules/catch_error_name/catch_error_name_extras_test.go
@@ -4,6 +4,7 @@
 package catch_error_name_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
@@ -37,6 +38,9 @@ func TestCatchErrorNameExtras(t *testing.T) {
 			{Code: "try {} catch (xSSad) {}", Options: map[string]any{"name": "ßad"}},
 			{Code: "try {} catch (_) { const x = <div _:attr=\"1\" /> }", Tsx: true},
 			{Code: "try {} catch (_) { function g(_) { return <_:foo /> } }", Tsx: true},
+			// Spread arguments make the apparent callback position indeterminate.
+			{Code: "promise.catch(...xs, bad => bad)"},
+			{Code: "promise.then(...xs, bad => bad)"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// Locks in upstream isPromiseCatchParameter() arm 1: catch callback.
@@ -45,6 +49,11 @@ func TestCatchErrorNameExtras(t *testing.T) {
 			invalid("promise.catch((bad => use(bad)))", "promise.catch((error => use(error)))", "bad", "error"),
 			// Locks in upstream isPromiseCatchParameter() arm 2: then rejection callback.
 			invalid("promise.then(ok => ok, bad => bad)", "promise.then(ok => ok, error => error)", "bad", "error"),
+			// Parameter initializers share the handler's function scope.
+			invalid("promise.catch((bad, x = error) => use(bad, x))", "promise.catch((error_, x = error) => use(error_, x))", "bad", "error_"),
+			invalid("promise.catch((bad, error = 1) => use(bad, error))", "promise.catch((error_, error = 1) => use(error_, error))", "bad", "error_"),
+			invalid("promise.catch(<error,>(bad: error) => use(bad))", "promise.catch(<error,>(error_: error) => use(error_))", "bad", "error_"),
+			invalidTSX("promise.catch((bad, x = <bad:foo />) => use(bad, x))", "promise.catch((error, x = <error:foo />) => use(error, x))", "bad", "error"),
 			// Locks in upstream collision arm: append an underscore.
 			invalid("const error = 1; try {} catch (bad) { use(bad, error) }", "const error = 1; try {} catch (error_) { use(error_, error) }", "bad", "error_"),
 			// Locks in renameVariable() shorthand expansion.
@@ -82,6 +91,8 @@ func TestCatchErrorNameExtras(t *testing.T) {
 			invalid("try {} catch (bad) { enum error {} }", "try {} catch (error) { enum error {} }", "bad", "error"),
 			// Namespace bodies expose their complete value-space bindings.
 			invalid("namespace N { const error = 1; try {} catch (bad) { use(bad) } }", "namespace N { const error = 1; try {} catch (error_) { use(error_) } }", "bad", "error_"),
+			invalid("namespace N { export const error = 1 } namespace N { try {} catch (bad) { use(bad, error) } }", "namespace N { export const error = 1 } namespace N { try {} catch (error_) { use(error_, error) } }", "bad", "error_"),
+			invalid("namespace N { export const error = 1 } namespace N { try {} catch (bad) { use(bad) } }", "namespace N { export const error = 1 } namespace N { try {} catch (error_) { use(error_) } }", "bad", "error_"),
 			invalid("namespace N { function error() {}; try {} catch (bad) { use(bad) } }", "namespace N { function error() {}; try {} catch (error_) { use(error_) } }", "bad", "error_"),
 			invalid("namespace N { { var error = 1 }; try {} catch (bad) { use(bad) } }", "namespace N { { var error = 1 }; try {} catch (error_) { use(error_) } }", "bad", "error_"),
 			invalid("namespace N { for (var error of xs) {}; try {} catch (bad) { use(bad) } }", "namespace N { for (var error of xs) {}; try {} catch (error_) { use(error_) } }", "bad", "error_"),
@@ -91,6 +102,12 @@ func TestCatchErrorNameExtras(t *testing.T) {
 			// Reserved and implicit names are suffixed when necessary.
 			invalid("try {} catch (bad) { use(bad) }", "try {} catch (await_) { use(await_) }", "bad", "await_", map[string]any{"name": "await"}),
 			invalid("try {} catch (bad) { use(bad) }", "try {} catch (undefined_) { use(undefined_) }", "bad", "undefined_", map[string]any{"name": "undefined"}),
+			invalid("try {} catch (bad) { use(bad) }", "try {} catch (Readonly_) { use(Readonly_) }", "bad", "Readonly_", map[string]any{"name": "Readonly"}),
+			func() rule_tester.InvalidTestCase {
+				result := invalid("try {} catch (bad) { use(bad) }", "try {} catch (Readonly) { use(Readonly) }", "bad", "Readonly", map[string]any{"name": "Readonly"})
+				result.FileName = "file.js"
+				return result
+			}(),
 			invalid("promise.catch(function (bad) { use(bad) })", "promise.catch(function (arguments_) { use(arguments_) })", "bad", "arguments_", map[string]any{"name": "arguments"}),
 			invalid("try {} catch (bad) { use(bad) }", "try {} catch (arguments_) { use(arguments_) }", "bad", "arguments_", map[string]any{"name": "arguments"}),
 			// `var` declarations nested in a rejection handler still hoist to its scope.
@@ -120,4 +137,12 @@ func TestCatchErrorNameExtras(t *testing.T) {
 			invalid("try {} catch (bad) { const error = 1 }", "try {} catch (error_) { const error = 1 }", "bad", "error_"),
 		},
 	)
+}
+
+func TestCatchErrorNameRejectsInvalidIgnorePattern(t *testing.T) {
+	options := []any{map[string]any{"ignore": []any{"["}}}
+	err := catch_error_name.CatchErrorNameRule.Schema.Validate(options)
+	if err == nil || !strings.Contains(err.Error(), "ignore") {
+		t.Fatalf("expected invalid ignore regexp to be rejected, got %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Preserve lexical bindings when renaming Promise rejection parameters, including parameter initializers, TSX namespaces, and merged TypeScript namespaces.
- Reject ambiguous spread-based Promise handlers and invalid `ignore` regular expressions.
- Avoid TypeScript default type globals and skip unnecessary JSX reference scans in non-JSX files.

### Go benchmark

Five samples per case with `go test ./internal/plugins/unicorn/rules/catch_error_name -run "^$" -bench "^BenchmarkCatchErrorName$" -benchmem -count=5`:

| Case | ns/op (median) | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| diagnostics only | 48,380 → 42,620 | 32,985 → 32,967 | 341 → 340 |
| autofix | 124,720 → 40,828 | 33,395 → 33,359 | 345 → 344 |
| catch clause | 108,905 → 39,322 | 33,371 → 33,319 | 342 → 340 |
| no match | 107,831 → 37,552 | 31,582 → 31,561 | 321 → 321 |
| ignored option | 109,944 → 39,739 | 36,622 → 36,602 | 371 → 371 |

The timing baseline was noisy under host load; allocation reductions are stable and the correctness checks below are the acceptance gate.

## Related Links

- [eslint-plugin-unicorn documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/catch-error-name.md)
- [eslint-plugin-unicorn source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/catch-error-name.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Target Go tests pass three times and under the race detector.
- [x] JS end-to-end rule tests pass.
- [x] `check-spell`, `format:check`, and changed-package Go lint pass.