### PR TITLE
perf(rstest): optimize max-expects rule

### DIFF
--- a/internal/plugins/rstest/rules/max_expects/max_expects.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.go
@@ -51,6 +51,9 @@ const (
 )
 
 const (
+	// Listener events follow AST nesting, so ordinary files only use a few
+	// slots. Keep that path allocation-free while retaining a sound overflow
+	// path for generated or adversarially deep expressions.
 	inlineFunctionEventCapacity = 8
 	inlineCallEventCapacity     = 16
 )

--- a/internal/plugins/rstest/rules/max_expects/max_expects.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.go
@@ -29,11 +29,20 @@ const (
 	frameRegistrationFallback
 )
 
+// owner is the node whose exit tears the frame down: the registration call for
+// a fallback frame, the function itself for a callback or detached frame. Node
+// identity is stable across the traversal and the traversal is strictly nested,
+// so matching the owner on exit is enough to pair enter with exit — no separate
+// record of what each enter did is needed.
+//
+// activationOwner is the function that positionally activated a fallback frame;
+// its exit deactivates the frame again without popping it.
 type countFrame struct {
 	kind                   frameKind
 	count                  int
 	active                 bool
-	registration           *ast.Node
+	owner                  *ast.Node
+	activationOwner        *ast.Node
 	callbackCandidateRoots []*ast.Node
 }
 
@@ -49,84 +58,6 @@ const (
 	functionPushDetached
 	functionActivateRegistrationFallback
 )
-
-const (
-	// Listener events follow AST nesting, so ordinary files only use a few
-	// slots. Keep that path allocation-free while retaining a sound overflow
-	// path for generated or adversarially deep expressions.
-	inlineFunctionEventCapacity = 8
-	inlineCallEventCapacity     = 16
-)
-
-type functionEventStack struct {
-	inline   [inlineFunctionEventCapacity]functionPushKind
-	overflow []functionPushKind
-	depth    int
-}
-
-func (events *functionEventStack) push(kind functionPushKind) {
-	if events.depth < len(events.inline) {
-		events.inline[events.depth] = kind
-	} else {
-		events.overflow = append(events.overflow, kind)
-	}
-	events.depth++
-}
-
-func (events *functionEventStack) pop() functionPushKind {
-	if events.depth == 0 {
-		return functionPushNone
-	}
-	events.depth--
-	if events.depth < len(events.inline) {
-		return events.inline[events.depth]
-	}
-	last := len(events.overflow) - 1
-	kind := events.overflow[last]
-	events.overflow = events.overflow[:last]
-	return kind
-}
-
-type callEventStack struct {
-	inline   [inlineCallEventCapacity]bool
-	overflow []bool
-	depth    int
-}
-
-func (events *callEventStack) push(didPushRegistrationFrame bool) {
-	if events.depth < len(events.inline) {
-		events.inline[events.depth] = didPushRegistrationFrame
-	} else {
-		events.overflow = append(events.overflow, didPushRegistrationFrame)
-	}
-	events.depth++
-}
-
-func (events *callEventStack) markRegistrationFrame() {
-	if events.depth == 0 {
-		return
-	}
-	index := events.depth - 1
-	if index < len(events.inline) {
-		events.inline[index] = true
-	} else {
-		events.overflow[index-len(events.inline)] = true
-	}
-}
-
-func (events *callEventStack) pop() bool {
-	if events.depth == 0 {
-		return false
-	}
-	events.depth--
-	if events.depth < len(events.inline) {
-		return events.inline[events.depth]
-	}
-	last := len(events.overflow) - 1
-	didPushRegistrationFrame := events.overflow[last]
-	events.overflow = events.overflow[:last]
-	return didPushRegistrationFrame
-}
 
 func parseOptions(rawOptions []any) options {
 	opts := options{Max: defaultMax}
@@ -166,12 +97,12 @@ func (stack *frameStack) top() *countFrame {
 	return &stack.frames[len(stack.frames)-1]
 }
 
-func (stack *frameStack) push(kind frameKind, active bool, registration *ast.Node, callbackCandidateRoots []*ast.Node) {
+func (stack *frameStack) push(kind frameKind, active bool, owner *ast.Node, callbackCandidateRoots []*ast.Node) {
 	stack.frames = append(stack.frames, countFrame{
 		kind:                   kind,
 		count:                  0,
 		active:                 active,
-		registration:           registration,
+		owner:                  owner,
 		callbackCandidateRoots: callbackCandidateRoots,
 	})
 }
@@ -336,7 +267,7 @@ func nodeWithinSubtree(node *ast.Node, root *ast.Node) bool {
 }
 
 func canActivateRegistrationFallback(frame *countFrame, node *ast.Node) bool {
-	if frame == nil || frame.kind != frameRegistrationFallback || frame.active || frame.registration == nil {
+	if frame == nil || frame.kind != frameRegistrationFallback || frame.active || frame.owner == nil {
 		return false
 	}
 	for _, root := range frame.callbackCandidateRoots {
@@ -356,8 +287,6 @@ var MaxExpectsRule = rule.Rule{
 		callbacks := analysis.Callbacks().Functions
 
 		stack := newFrameStack()
-		functionEvents := functionEventStack{}
-		callEvents := callEventStack{}
 
 		enterFunction := func(node *ast.Node) {
 			kind := functionPushForNode(node, callbacks)
@@ -374,27 +303,30 @@ var MaxExpectsRule = rule.Rule{
 				canActivateRegistrationFallback(stack.top(), node) {
 				kind = functionActivateRegistrationFallback
 			}
-			functionEvents.push(kind)
-
 			switch kind {
 			case functionPushTestCallback:
-				stack.push(frameTestCallback, true, nil, nil)
+				stack.push(frameTestCallback, true, node, nil)
 			case functionPushDetached:
-				stack.push(frameDetachedFunction, stack.top().active, nil, nil)
+				stack.push(frameDetachedFunction, stack.top().active, node, nil)
 			case functionActivateRegistrationFallback:
-				stack.top().active = true
+				top := stack.top()
+				top.active = true
+				top.activationOwner = node
 			}
 		}
 
-		exitFunction := func(_ *ast.Node) {
-			switch functionEvents.pop() {
-			case functionPushNone:
-				return
-			case functionActivateRegistrationFallback:
-				stack.top().active = false
+		// A function that changed no state owns neither the top frame nor its
+		// activation, so both comparisons miss and the exit is a no-op.
+		exitFunction := func(node *ast.Node) {
+			top := stack.top()
+			if top.owner == node {
+				stack.pop()
 				return
 			}
-			stack.pop()
+			if top.activationOwner == node {
+				top.active = false
+				top.activationOwner = nil
+			}
 		}
 
 		return rule.RuleListeners{
@@ -413,7 +345,6 @@ var MaxExpectsRule = rule.Rule{
 			ast.KindConstructor:                              enterFunction,
 			rule.ListenerOnExit(ast.KindConstructor):         exitFunction,
 			ast.KindCallExpression: func(node *ast.Node) {
-				callEvents.push(false)
 				if analysis.ParseTestCall(node) != nil {
 					stack.push(
 						frameRegistrationFallback,
@@ -421,7 +352,6 @@ var MaxExpectsRule = rule.Rule{
 						node,
 						registrationFallbackCandidateRoots(node.AsCallExpression()),
 					)
-					callEvents.markRegistrationFrame()
 					return
 				}
 
@@ -436,7 +366,6 @@ var MaxExpectsRule = rule.Rule{
 						node,
 						hookFallbackCandidateRoots(node.AsCallExpression()),
 					)
-					callEvents.markRegistrationFrame()
 					return
 				}
 
@@ -450,11 +379,12 @@ var MaxExpectsRule = rule.Rule{
 					ctx.ReportNode(node, buildExceededMaxAssertionMessage(count, opts.Max))
 				}
 			},
-			rule.ListenerOnExit(ast.KindCallExpression): func(_ *ast.Node) {
-				if !callEvents.pop() {
-					return
+			// Only a registration call owns a frame; every ordinary call misses
+			// the comparison and does no bookkeeping at all.
+			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+				if stack.top().owner == node {
+					stack.pop()
 				}
-				stack.pop()
 			},
 		}
 	},

--- a/internal/plugins/rstest/rules/max_expects/max_expects.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.go
@@ -50,41 +50,78 @@ const (
 	functionActivateRegistrationFallback
 )
 
-type functionEventStack []functionPushKind
+const (
+	inlineFunctionEventCapacity = 8
+	inlineCallEventCapacity     = 16
+)
+
+type functionEventStack struct {
+	inline   [inlineFunctionEventCapacity]functionPushKind
+	overflow []functionPushKind
+	depth    int
+}
 
 func (events *functionEventStack) push(kind functionPushKind) {
-	*events = append(*events, kind)
+	if events.depth < len(events.inline) {
+		events.inline[events.depth] = kind
+	} else {
+		events.overflow = append(events.overflow, kind)
+	}
+	events.depth++
 }
 
 func (events *functionEventStack) pop() functionPushKind {
-	if len(*events) == 0 {
+	if events.depth == 0 {
 		return functionPushNone
 	}
-	last := len(*events) - 1
-	kind := (*events)[last]
-	*events = (*events)[:last]
+	events.depth--
+	if events.depth < len(events.inline) {
+		return events.inline[events.depth]
+	}
+	last := len(events.overflow) - 1
+	kind := events.overflow[last]
+	events.overflow = events.overflow[:last]
 	return kind
 }
 
-type callEventStack []bool
+type callEventStack struct {
+	inline   [inlineCallEventCapacity]bool
+	overflow []bool
+	depth    int
+}
 
 func (events *callEventStack) push(didPushRegistrationFrame bool) {
-	*events = append(*events, didPushRegistrationFrame)
+	if events.depth < len(events.inline) {
+		events.inline[events.depth] = didPushRegistrationFrame
+	} else {
+		events.overflow = append(events.overflow, didPushRegistrationFrame)
+	}
+	events.depth++
 }
 
 func (events *callEventStack) markRegistrationFrame() {
-	if len(*events) != 0 {
-		(*events)[len(*events)-1] = true
+	if events.depth == 0 {
+		return
+	}
+	index := events.depth - 1
+	if index < len(events.inline) {
+		events.inline[index] = true
+	} else {
+		events.overflow[index-len(events.inline)] = true
 	}
 }
 
 func (events *callEventStack) pop() bool {
-	if len(*events) == 0 {
+	if events.depth == 0 {
 		return false
 	}
-	last := len(*events) - 1
-	didPushRegistrationFrame := (*events)[last]
-	*events = (*events)[:last]
+	events.depth--
+	if events.depth < len(events.inline) {
+		return events.inline[events.depth]
+	}
+	last := len(events.overflow) - 1
+	didPushRegistrationFrame := events.overflow[last]
+	events.overflow = events.overflow[:last]
 	return didPushRegistrationFrame
 }
 

--- a/internal/plugins/rstest/rules/max_expects/max_expects.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.go
@@ -50,6 +50,44 @@ const (
 	functionActivateRegistrationFallback
 )
 
+type functionEventStack []functionPushKind
+
+func (events *functionEventStack) push(kind functionPushKind) {
+	*events = append(*events, kind)
+}
+
+func (events *functionEventStack) pop() functionPushKind {
+	if len(*events) == 0 {
+		return functionPushNone
+	}
+	last := len(*events) - 1
+	kind := (*events)[last]
+	*events = (*events)[:last]
+	return kind
+}
+
+type callEventStack []bool
+
+func (events *callEventStack) push(didPushRegistrationFrame bool) {
+	*events = append(*events, didPushRegistrationFrame)
+}
+
+func (events *callEventStack) markRegistrationFrame() {
+	if len(*events) != 0 {
+		(*events)[len(*events)-1] = true
+	}
+}
+
+func (events *callEventStack) pop() bool {
+	if len(*events) == 0 {
+		return false
+	}
+	last := len(*events) - 1
+	didPushRegistrationFrame := (*events)[last]
+	*events = (*events)[:last]
+	return didPushRegistrationFrame
+}
+
 func parseOptions(rawOptions []any) options {
 	opts := options{Max: defaultMax}
 	if len(rawOptions) == 0 {
@@ -278,8 +316,8 @@ var MaxExpectsRule = rule.Rule{
 		callbacks := analysis.Callbacks().Functions
 
 		stack := newFrameStack()
-		pushedFunctions := map[*ast.Node]functionPushKind{}
-		pushedRegistrations := map[*ast.Node]bool{}
+		functionEvents := functionEventStack{}
+		callEvents := callEventStack{}
 
 		enterFunction := func(node *ast.Node) {
 			kind := functionPushForNode(node, callbacks)
@@ -296,30 +334,26 @@ var MaxExpectsRule = rule.Rule{
 				canActivateRegistrationFallback(stack.top(), node) {
 				kind = functionActivateRegistrationFallback
 			}
+			functionEvents.push(kind)
 
 			switch kind {
 			case functionPushTestCallback:
 				stack.push(frameTestCallback, true, nil, nil)
-				pushedFunctions[node] = functionPushTestCallback
 			case functionPushDetached:
 				stack.push(frameDetachedFunction, stack.top().active, nil, nil)
-				pushedFunctions[node] = functionPushDetached
 			case functionActivateRegistrationFallback:
 				stack.top().active = true
-				pushedFunctions[node] = functionActivateRegistrationFallback
 			}
 		}
 
-		exitFunction := func(node *ast.Node) {
-			switch pushedFunctions[node] {
+		exitFunction := func(_ *ast.Node) {
+			switch functionEvents.pop() {
 			case functionPushNone:
 				return
 			case functionActivateRegistrationFallback:
-				delete(pushedFunctions, node)
 				stack.top().active = false
 				return
 			}
-			delete(pushedFunctions, node)
 			stack.pop()
 		}
 
@@ -339,6 +373,7 @@ var MaxExpectsRule = rule.Rule{
 			ast.KindConstructor:                              enterFunction,
 			rule.ListenerOnExit(ast.KindConstructor):         exitFunction,
 			ast.KindCallExpression: func(node *ast.Node) {
+				callEvents.push(false)
 				if analysis.ParseTestCall(node) != nil {
 					stack.push(
 						frameRegistrationFallback,
@@ -346,7 +381,7 @@ var MaxExpectsRule = rule.Rule{
 						node,
 						registrationFallbackCandidateRoots(node.AsCallExpression()),
 					)
-					pushedRegistrations[node] = true
+					callEvents.markRegistrationFrame()
 					return
 				}
 
@@ -361,7 +396,7 @@ var MaxExpectsRule = rule.Rule{
 						node,
 						hookFallbackCandidateRoots(node.AsCallExpression()),
 					)
-					pushedRegistrations[node] = true
+					callEvents.markRegistrationFrame()
 					return
 				}
 
@@ -375,11 +410,10 @@ var MaxExpectsRule = rule.Rule{
 					ctx.ReportNode(node, buildExceededMaxAssertionMessage(count, opts.Max))
 				}
 			},
-			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
-				if !pushedRegistrations[node] {
+			rule.ListenerOnExit(ast.KindCallExpression): func(_ *ast.Node) {
+				if !callEvents.pop() {
 					return
 				}
-				delete(pushedRegistrations, node)
 				stack.pop()
 			},
 		}

--- a/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
@@ -1,0 +1,52 @@
+package max_expects
+
+import "testing"
+
+func TestFunctionEventStackPairsNestedActions(t *testing.T) {
+	events := functionEventStack{}
+	events.push(functionPushNone)
+	events.push(functionPushTestCallback)
+	events.push(functionActivateRegistrationFallback)
+	events.push(functionPushDetached)
+
+	want := []functionPushKind{
+		functionPushDetached,
+		functionActivateRegistrationFallback,
+		functionPushTestCallback,
+		functionPushNone,
+	}
+	for index, expected := range want {
+		if got := events.pop(); got != expected {
+			t.Fatalf("pop %d = %d, want %d", index, got, expected)
+		}
+	}
+	if got := events.pop(); got != functionPushNone {
+		t.Fatalf("underflow pop = %d, want functionPushNone", got)
+	}
+}
+
+func TestCallEventStackPairsRegistrationFrames(t *testing.T) {
+	events := callEventStack{}
+	events.push(false)
+	events.push(false)
+	events.markRegistrationFrame()
+	events.push(false)
+
+	want := []bool{false, true, false}
+	for index, expected := range want {
+		if got := events.pop(); got != expected {
+			t.Fatalf("pop %d = %t, want %t", index, got, expected)
+		}
+	}
+	if events.pop() {
+		t.Fatal("underflow pop must not claim a registration frame")
+	}
+}
+
+func TestCallEventStackIgnoresMarkWithoutEnter(t *testing.T) {
+	events := callEventStack{}
+	events.markRegistrationFrame()
+	if events.pop() {
+		t.Fatal("mark without an enter event must stay a no-op")
+	}
+}

--- a/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
@@ -50,3 +50,32 @@ func TestCallEventStackIgnoresMarkWithoutEnter(t *testing.T) {
 		t.Fatal("mark without an enter event must stay a no-op")
 	}
 }
+
+func TestFunctionEventStackPairsOverflow(t *testing.T) {
+	events := functionEventStack{}
+	for index := 0; index < inlineFunctionEventCapacity+3; index++ {
+		events.push(functionPushKind(index%int(functionActivateRegistrationFallback) + 1))
+	}
+	for index := inlineFunctionEventCapacity + 2; index >= 0; index-- {
+		expected := functionPushKind(index%int(functionActivateRegistrationFallback) + 1)
+		if got := events.pop(); got != expected {
+			t.Fatalf("overflow pop %d = %d, want %d", index, got, expected)
+		}
+	}
+}
+
+func TestCallEventStackMarksOverflow(t *testing.T) {
+	events := callEventStack{}
+	for range inlineCallEventCapacity + 2 {
+		events.push(false)
+	}
+	events.markRegistrationFrame()
+	if !events.pop() {
+		t.Fatal("mark must update the top overflow event")
+	}
+	for range inlineCallEventCapacity + 1 {
+		if events.pop() {
+			t.Fatal("mark must not affect an earlier event")
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
@@ -53,7 +53,7 @@ func TestCallEventStackIgnoresMarkWithoutEnter(t *testing.T) {
 
 func TestFunctionEventStackPairsOverflow(t *testing.T) {
 	events := functionEventStack{}
-	for index := 0; index < inlineFunctionEventCapacity+3; index++ {
+	for index := range inlineFunctionEventCapacity + 3 {
 		events.push(functionPushKind(index%int(functionActivateRegistrationFallback) + 1))
 	}
 	for index := inlineFunctionEventCapacity + 2; index >= 0; index-- {

--- a/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
@@ -1,81 +1,106 @@
 package max_expects
 
-import "testing"
+import (
+	"testing"
 
-func TestFunctionEventStackPairsNestedActions(t *testing.T) {
-	events := functionEventStack{}
-	events.push(functionPushNone)
-	events.push(functionPushTestCallback)
-	events.push(functionActivateRegistrationFallback)
-	events.push(functionPushDetached)
+	"github.com/microsoft/typescript-go/shim/ast"
+)
 
-	want := []functionPushKind{
-		functionPushDetached,
-		functionActivateRegistrationFallback,
-		functionPushTestCallback,
-		functionPushNone,
+// popIfOwned and deactivateIfOwned mirror the exit listeners, which pair enter
+// with exit purely through node ownership.
+func popIfOwned(stack *frameStack, node *ast.Node) bool {
+	if stack.top().owner != node {
+		return false
 	}
-	for index, expected := range want {
-		if got := events.pop(); got != expected {
-			t.Fatalf("pop %d = %d, want %d", index, got, expected)
+	stack.pop()
+	return true
+}
+
+func deactivateIfOwned(stack *frameStack, node *ast.Node) bool {
+	top := stack.top()
+	if top.activationOwner != node {
+		return false
+	}
+	top.active = false
+	top.activationOwner = nil
+	return true
+}
+
+func TestOwnershipPairsNestedFrames(t *testing.T) {
+	registration, callback, detached := &ast.Node{}, &ast.Node{}, &ast.Node{}
+
+	stack := newFrameStack()
+	stack.push(frameRegistrationFallback, false, registration, nil)
+	stack.push(frameTestCallback, true, callback, nil)
+	stack.push(frameDetachedFunction, true, detached, nil)
+
+	for _, owner := range []*ast.Node{detached, callback, registration} {
+		if !popIfOwned(&stack, owner) {
+			t.Fatalf("owner %p did not pop the frame it pushed", owner)
 		}
 	}
-	if got := events.pop(); got != functionPushNone {
-		t.Fatalf("underflow pop = %d, want functionPushNone", got)
+	if len(stack.frames) != 1 {
+		t.Fatalf("frames after unwinding = %d, want only the sentinel", len(stack.frames))
 	}
 }
 
-func TestCallEventStackPairsRegistrationFrames(t *testing.T) {
-	events := callEventStack{}
-	events.push(false)
-	events.push(false)
-	events.markRegistrationFrame()
-	events.push(false)
+func TestOwnershipIgnoresNodesThatPushedNothing(t *testing.T) {
+	registration, ordinary := &ast.Node{}, &ast.Node{}
 
-	want := []bool{false, true, false}
-	for index, expected := range want {
-		if got := events.pop(); got != expected {
-			t.Fatalf("pop %d = %t, want %t", index, got, expected)
-		}
+	stack := newFrameStack()
+	stack.push(frameRegistrationFallback, false, registration, nil)
+
+	if popIfOwned(&stack, ordinary) {
+		t.Fatal("a node that pushed no frame must not pop one")
 	}
-	if events.pop() {
-		t.Fatal("underflow pop must not claim a registration frame")
+	if deactivateIfOwned(&stack, ordinary) {
+		t.Fatal("a node that activated nothing must not deactivate a frame")
+	}
+	if len(stack.frames) != 2 {
+		t.Fatalf("frames = %d, want the registration frame untouched", len(stack.frames))
 	}
 }
 
-func TestCallEventStackIgnoresMarkWithoutEnter(t *testing.T) {
-	events := callEventStack{}
-	events.markRegistrationFrame()
-	if events.pop() {
-		t.Fatal("mark without an enter event must stay a no-op")
+func TestOwnershipCannotUnwindTheSentinel(t *testing.T) {
+	stack := newFrameStack()
+	if stack.top().owner != nil {
+		t.Fatal("the sentinel frame must have no owner")
+	}
+	if popIfOwned(&stack, &ast.Node{}) {
+		t.Fatal("an exit without a matching enter must not unwind the sentinel")
 	}
 }
 
-func TestFunctionEventStackPairsOverflow(t *testing.T) {
-	events := functionEventStack{}
-	for index := range inlineFunctionEventCapacity + 3 {
-		events.push(functionPushKind(index%int(functionActivateRegistrationFallback) + 1))
-	}
-	for index := inlineFunctionEventCapacity + 2; index >= 0; index-- {
-		expected := functionPushKind(index%int(functionActivateRegistrationFallback) + 1)
-		if got := events.pop(); got != expected {
-			t.Fatalf("overflow pop %d = %d, want %d", index, got, expected)
-		}
-	}
-}
+func TestActivationDeactivatesWithoutPopping(t *testing.T) {
+	registration, callback := &ast.Node{}, &ast.Node{}
+	root := &ast.Node{}
 
-func TestCallEventStackMarksOverflow(t *testing.T) {
-	events := callEventStack{}
-	for range inlineCallEventCapacity + 2 {
-		events.push(false)
+	stack := newFrameStack()
+	stack.push(frameRegistrationFallback, false, registration, []*ast.Node{root})
+	callback.Parent = root
+
+	if !canActivateRegistrationFallback(stack.top(), callback) {
+		t.Fatal("a function inside the candidate root must activate the frame")
 	}
-	events.markRegistrationFrame()
-	if !events.pop() {
-		t.Fatal("mark must update the top overflow event")
+	stack.top().active = true
+	stack.top().activationOwner = callback
+
+	if canActivateRegistrationFallback(stack.top(), callback) {
+		t.Fatal("an already active frame must not activate a second time")
 	}
-	for range inlineCallEventCapacity + 1 {
-		if events.pop() {
-			t.Fatal("mark must not affect an earlier event")
-		}
+	if popIfOwned(&stack, callback) {
+		t.Fatal("the activating function must not own the frame it activated")
+	}
+	if !deactivateIfOwned(&stack, callback) {
+		t.Fatal("the activating function must deactivate the frame on exit")
+	}
+	if len(stack.frames) != 2 || stack.top().owner != registration {
+		t.Fatal("deactivation must leave the frame and its ownership in place")
+	}
+
+	// A later sibling in the same candidate root activates the frame again.
+	sibling := &ast.Node{Parent: root}
+	if !canActivateRegistrationFallback(stack.top(), sibling) {
+		t.Fatal("a deactivated frame must be activatable again")
 	}
 }

--- a/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
+++ b/internal/plugins/rstest/rules/max_expects/max_expects_internal_test.go
@@ -101,6 +101,6 @@ func TestActivationDeactivatesWithoutPopping(t *testing.T) {
 	// A later sibling in the same candidate root activates the frame again.
 	sibling := &ast.Node{Parent: root}
 	if !canActivateRegistrationFallback(stack.top(), sibling) {
-		t.Fatal("a deactivated frame must be activatable again")
+		t.Fatal("a deactivated frame must be able to activate again")
 	}
 }


### PR DESCRIPTION
## Summary

- Replace per-node function and call listener bookkeeping maps with node ownership recorded directly on the existing count frames, so enter and exit pair through the traversal's own nesting.
- Each frame stores the node whose exit tears it down; a fallback frame activated by position also stores the function that activated it. An ordinary call, or a function that changes no state, does no bookkeeping at all.
- Keep frame activation, callback fallback, assertion counting, diagnostic order, messages, options, and schema unchanged.
- Add focused tests covering nested owner pairing, nodes that pushed nothing, the sentinel frame, and activation followed by reactivation.

## Correctness

The same 19 configured Rstest rules were run over all test, spec, and configured in-source test files in six Rstack repositories, against `origin/main@63cd63c0a` and against this branch, covering 1,978 files.

Complete JSONL diagnostics were identical before and after, on stdout and stderr, so files that fail to parse are covered too:

| Configuration | Diagnostics | Result |
| --- | ---: | --- |
| All 19 Rstest rules | 1,987 | byte-for-byte identical |
| `max-expects` alone | 809 | byte-for-byte identical |

This rule emits no fixes or suggestions, and both runs confirm none were produced.

## Performance

Repository-level `--timing` cannot resolve an effect of this size on the hardware available here. Across seven rounds, a single unchanged binary ranged from 94 ms to 149 ms on the largest repository, so round-to-round drift is an order of magnitude larger than the change being measured, and running the two variants in separate blocks reproduces whichever sign the drift happens to take.

The measurement that does resolve is an isolated benchmark that lints a generated corpus with only this rule enabled, over three shapes: many ordinary calls with few registrations, registrations whose callback the parser resolves precisely, and registrations behind an unresolved wrapper. The two variants alternate within one session, five rounds of three samples each with the execution order swapped every round, compared with `benchstat` (n=15):

| Shape | `sec/op` vs `main` | `allocs/op` vs `main` |
| --- | --- | --- |
| Ordinary calls | -2.70% (p=0.009) | -4.48% (p=0.000) |
| Direct callbacks | -2.15% (p=0.000) | -0.37% (p=0.000) |
| Wrapped callbacks | -1.72% (p=0.007) | -0.40% (p=0.000) |

Bytes allocated fall by 1.47% on the ordinary-call shape and about 0.3% on the other two. These figures cover a full lint run including shared Rstest call analysis, which dominates the measurement, so the reduction attributable to the rule's own listener work is larger than the totals suggest.

The temporary benchmark probe is not included in the production diff.
