### PR TITLE
fix: respect effective source type in no-unused-vars

### DIFF
--- a/internal/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/rules/no_unused_vars/no_unused_vars.go
@@ -1939,10 +1939,14 @@ func coreTypeDeclarationSelfReferenceCounts(definition *ast.Node) bool {
 }
 
 // isScriptGlobalDefinition models ESLint's global scope for vars:"local".
+// RefStore carries sourceType overrides; parser module syntax is only a
+// fallback for callers that do not provide one.
 // `var` uses its enclosing variable scope even when nested in a block or loop;
 // lexical declarations use tsgo's block-scope container.
-func isScriptGlobalDefinition(sourceFile *ast.SourceFile, definition *ast.Node) bool {
-	if sourceFile == nil || definition == nil || ast.IsExternalModule(sourceFile) {
+func isScriptGlobalDefinition(sourceFile *ast.SourceFile, refs *rule.RefStore, definition *ast.Node) bool {
+	if sourceFile == nil || definition == nil ||
+		(refs != nil && refs.HasNonGlobalProgramScope()) ||
+		(refs == nil && ast.IsExternalModule(sourceFile)) {
 		return false
 	}
 	root := ast.GetRootDeclaration(definition)
@@ -2067,7 +2071,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 		return
 	}
 
-	scriptGlobal := isScriptGlobalDefinition(ctx.SourceFile, definition)
+	scriptGlobal := isScriptGlobalDefinition(ctx.SourceFile, ctx.Refs, definition)
 	// vars: "local" skips only the script global scope. ES module top-level
 	// bindings live in a module scope and must still be checked.
 	if opts.Vars == "local" && scriptGlobal {

--- a/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
@@ -429,6 +429,98 @@ func TestNoUnusedVarsExtrasScopes(t *testing.T) {
 	)
 }
 
+func TestNoUnusedVarsSourceTypeScopes(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{
+			// vars:"local" ignores program-level bindings only when the effective
+			// source type gives the file a global program scope.
+			{
+				Code:            `var foo;`,
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			{
+				Code:            `export {}; var foo; let bar; const baz = 1; function fn() {} class C {}`,
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			{
+				Code:            `import "./foo"; var foo;`,
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			{
+				Code:            `var foo;`,
+				FileName:        "file.ts",
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// The default source type is module even when no import or export
+			// makes the parser classify the file as an external module.
+			{
+				Code:    `var foo;`,
+				Options: map[string]interface{}{"vars": "local"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("foo", false, 1, 5, 8, ""),
+				},
+			},
+			{
+				Code:     `var foo;`,
+				FileName: "source-type.tsx",
+				Options:  map[string]interface{}{"vars": "local"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("foo", false, 1, 5, 8, ""),
+				},
+			},
+			{
+				Code:     `var foo;`,
+				FileName: "source-type.jsx",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  map[string]interface{}{"vars": "local"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("foo", false, 1, 5, 8, ""),
+				},
+			},
+			{
+				Code:            `var foo;`,
+				FileName:        "file.cjs",
+				TSConfig:        "tsconfig.allow-js.json",
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "module"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("foo", false, 1, 5, 8, ""),
+				},
+			},
+			{
+				Code:            `var foo;`,
+				FileName:        "source-type-commonjs.jsx",
+				TSConfig:        "tsconfig.allow-js.json",
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("foo", false, 1, 5, 8, ""),
+				},
+			},
+			// A nested variable remains local even when script overrides module
+			// syntax at the program boundary.
+			{
+				Code:            "import \"./foo\";\nfunction outer() {\n  var nested;\n  nested = 1;\n}\nouter();",
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedError("nested", true, 4, 3, 9, ""),
+				},
+			},
+		},
+	)
+}
+
 func TestNoUnusedVarsGapJavaScriptUsesBinderScopes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/no_unused_vars/no_unused_vars_extras_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_extras_test.go
@@ -30,16 +30,32 @@ func TestNoUnusedVarsExtras(t *testing.T) {
 			{Code: `let captured; const read = () => captured; read();`},
 
 			// String-form options skip only the global scope.
-			{Code: `const globalOnly = 1;`, Options: []interface{}{"local"}},
+			{
+				Code:            `const globalOnly = 1;`,
+				Options:         []interface{}{"local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
 
 			// JavaScript-compatible regexp syntax uses regexp2.
 			{Code: `const _unused = 1;`, Options: map[string]interface{}{"varsIgnorePattern": `(?<=_)unused`}},
 
 			// Locks in upstream collectUnusedVariables() global-scope branch:
 			// `local` ignores a script global but not an ES module binding.
-			{Code: `const scriptGlobal = 1;`, Options: map[string]interface{}{"vars": "local"}},
-			{Code: `const { x, nested: [y] } = source;`, Options: map[string]interface{}{"vars": "local"}},
-			{Code: `{ var blockVar = 1; } for (var loopVar of source) { consume(); }`, Options: map[string]interface{}{"vars": "local"}},
+			{
+				Code:            `const scriptGlobal = 1;`,
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			{
+				Code:            `const { x, nested: [y] } = source;`,
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			{
+				Code:            `{ var blockVar = 1; } for (var loopVar of source) { consume(); }`,
+				Options:         map[string]interface{}{"vars": "local"},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
 
 			// Locks in upstream array-pattern precedence: only an identifier that
 			// is a direct ArrayPattern child matches this option.

--- a/internal/rules/no_unused_vars/no_unused_vars_upstream.json
+++ b/internal/rules/no_unused_vars/no_unused_vars_upstream.json
@@ -67,7 +67,8 @@
     },
     {
       "code": "var a=10;",
-      "options": ["local"]
+      "options": ["local"],
+      "languageOptions": { "sourceType": "script" }
     },
     {
       "code": "var min = \"min\"; Math[min];",
@@ -142,7 +143,8 @@
           "vars": "local",
           "args": "all"
         }
-      ]
+      ],
+      "languageOptions": { "sourceType": "script" }
     },
     {
       "code": "var g = function(bar, baz) { return 2; }; g();",
@@ -321,7 +323,8 @@
           "vars": "local",
           "varsIgnorePattern": "^_"
         }
-      ]
+      ],
+      "languageOptions": { "sourceType": "script" }
     },
     {
       "code": "function foo(_a) { } foo();",
@@ -1596,6 +1599,7 @@
           "varsIgnorePattern": "^_"
         }
       ],
+      "languageOptions": { "sourceType": "script" },
       "errors": [
         {
           "messageId": "unusedVar",

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unused-vars.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unused-vars.test.ts
@@ -7,6 +7,9 @@ interface FixtureCase {
   code: string;
   options?: unknown;
   globals?: Record<string, boolean>;
+  languageOptions?: {
+    sourceType?: 'module' | 'script' | 'commonjs';
+  };
   skip?: boolean;
   tsx?: boolean;
 }
@@ -34,15 +37,20 @@ const fixture = JSON.parse(
   fs.readFileSync(fixturePath, 'utf8'),
 ) as FixtureSuite;
 
-function languageOptions(globals?: Record<string, boolean>) {
-  if (!globals) return undefined;
+function languageOptions(testCase: FixtureCase) {
+  if (!testCase.globals && !testCase.languageOptions) return undefined;
   return {
-    globals: Object.fromEntries(
-      Object.entries(globals).map(([name, enabled]) => [
-        name,
-        enabled ? 'readonly' : 'off',
-      ]),
-    ),
+    ...testCase.languageOptions,
+    ...(testCase.globals
+      ? {
+          globals: Object.fromEntries(
+            Object.entries(testCase.globals).map(([name, enabled]) => [
+              name,
+              enabled ? 'readonly' : 'off',
+            ]),
+          ),
+        }
+      : {}),
   };
 }
 
@@ -56,7 +64,7 @@ ruleTester.run('no-unused-vars', {
   valid: fixture.valid.map((testCase) => ({
     code: integrationCode(testCase.code),
     options: testCase.options,
-    languageOptions: languageOptions(testCase.globals),
+    languageOptions: languageOptions(testCase),
     filename: testCase.tsx ? 'src/virtual.tsx' : undefined,
     skip: testCase.skip,
   })) as any,
@@ -64,7 +72,7 @@ ruleTester.run('no-unused-vars', {
     code: integrationCode(testCase.code),
     errors: testCase.errors,
     options: testCase.options,
-    languageOptions: languageOptions(testCase.globals),
+    languageOptions: languageOptions(testCase),
     filename: testCase.tsx ? 'src/virtual.tsx' : undefined,
     skip: testCase.skip,
   })) as any,


### PR DESCRIPTION
## Summary

- Make `no-unused-vars` with `vars: "local"` classify program bindings from the effective `languageOptions.sourceType` instead of import/export syntax alone.
- Add regression coverage for default module behavior and explicit script/commonjs behavior across TS, TSX, JSX, module syntax, declaration kinds, and nested scopes.
- Preserve the script environment of migrated upstream cases explicitly.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).