### PR TITLE
chore: fix CI lint failure

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -59,6 +59,7 @@ golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
 golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
 golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
@@ -859,6 +859,7 @@ import type { RequireType } from "conditional-package" with { "resolution-mode":
 	sourceFile := program.GetSourceFile(filePath)
 	if sourceFile == nil {
 		t.Fatalf("source file %q not found", filePath)
+		return
 	}
 
 	var resolvedPaths []string
@@ -867,6 +868,7 @@ import type { RequireType } from "conditional-package" with { "resolution-mode":
 		resolved := program.GetResolvedModuleFromModuleSpecifier(sourceFile, moduleSpecifier)
 		if resolved == nil {
 			t.Fatalf("import on line %d did not resolve", len(resolvedPaths)+1)
+			continue
 		}
 		resolvedPaths = append(resolvedPaths, resolved.ResolvedFileName)
 	}


### PR DESCRIPTION
## Summary

- Add explicit control-flow exits after fatal nil checks so staticcheck does not report possible nil dereferences.
- Record the missing `golang.org/x/term v0.45.0` workspace checksum.

## Related Links

- https://github.com/web-infra-dev/rslint/actions/runs/32818628794/job/97711932082

## Testing

- `go test -count=1 ./internal/plugins/import/rules/no_duplicates`
- `npm run lint:go`
- `pnpm check-spell`
- `gofmt -d internal/plugins/import/rules/no_duplicates/no_duplicates_test.go`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).