### PR TITLE
feat(website): use published wasm binary in playground

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,9 +679,6 @@ importers:
       '@rslint/core':
         specifier: workspace:*
         version: link:../packages/rslint
-      '@rslint/wasm':
-        specifier: workspace:*
-        version: link:../packages/rslint-wasm
       '@rspress/core':
         specifier: 'catalog:'
         version: 2.0.18(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2)

--- a/website/README.md
+++ b/website/README.md
@@ -8,14 +8,6 @@ Install the dependencies:
 pnpm install
 ```
 
-Build the `@rslint/wasm` package (required for the Playground; generates `rslint.wasm.gz`):
-
-```bash
-pnpm --filter '@rslint/wasm' build
-```
-
-> **Note:** This step requires Go to be installed. The wasm build compiles the rslint CLI to WebAssembly.
-
 ## Get started
 
 Start the dev server:

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,6 @@
     "@rsbuild/plugin-sass": "catalog:",
     "@rslint/api": "workspace:*",
     "@rslint/core": "workspace:*",
-    "@rslint/wasm": "workspace:*",
     "@rspress/core": "catalog:",
     "@rspress/plugin-sitemap": "catalog:",
     "@rstack-dev/doc-ui": "catalog:",

--- a/website/theme/components/Playground/Client.css
+++ b/website/theme/components/Playground/Client.css
@@ -1,15 +1,63 @@
 .playground-container {
   height: calc(100vh - 72px);
-  background: #ffffff;
+  color: var(--rp-c-text-1);
+  background: var(--rp-c-bg);
 }
 
 .editor-panel {
   height: 100%;
-  background: #ffffff;
+  background: var(--rp-c-bg);
   position: relative;
 }
 
 .result-panel {
   height: 100%;
-  background: #ffffff;
+  background: var(--rp-c-bg);
+}
+
+/* AST inspector utilities use a compact syntax palette. Keep those colors
+ * readable when the surrounding Rspress theme switches to dark mode. */
+.dark .playground-container .text-gray-900 {
+  color: var(--rp-c-text-1);
+}
+
+.dark .playground-container .text-gray-700,
+.dark .playground-container .text-gray-600 {
+  color: var(--rp-c-text-2);
+}
+
+.dark .playground-container .text-gray-500,
+.dark .playground-container .text-gray-400 {
+  color: var(--rp-c-text-3);
+}
+
+.dark .playground-container .text-blue-900,
+.dark .playground-container .text-blue-700,
+.dark .playground-container .text-blue-600 {
+  color: #60a5fa;
+}
+
+.dark .playground-container .text-purple-600 {
+  color: #c084fc;
+}
+
+.dark .playground-container .text-cyan-600 {
+  color: #22d3ee;
+}
+
+.dark .playground-container .text-green-600 {
+  color: #4ade80;
+}
+
+.dark .playground-container .border-gray-200 {
+  border-color: var(--rp-c-divider-light);
+}
+
+.dark .playground-container .bg-gray-50 {
+  background-color: var(--rp-c-bg-soft);
+}
+
+.dark .playground-container .hover\:bg-gray-100:hover,
+.dark .playground-container .hover\:bg-gray-200:hover {
+  background-color: var(--rp-c-bg-mute);
 }

--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -362,7 +362,6 @@ const Playground: React.FC = () => {
                       {wasmVersions.map((version) => (
                         <SelectItem key={version} value={version}>
                           {version}
-                          {version === wasmVersions[0] ? ' (latest)' : ''}
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -7,7 +7,9 @@ import { ResizableSplitPane, type GetAstInfoResponse } from './ast';
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/theme/components/ui/select';
@@ -356,14 +358,19 @@ const Playground: React.FC = () => {
                       aria-label="Select @rslint/wasm version"
                       disabled={wasmVersions.length === 0}
                     >
-                      <SelectValue placeholder="Loading..." />
+                      <SelectValue placeholder="Loading...">
+                        {selectedVersion ? `v${selectedVersion}` : undefined}
+                      </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      {wasmVersions.map((version) => (
-                        <SelectItem key={version} value={version}>
-                          {version}
-                        </SelectItem>
-                      ))}
+                      <SelectGroup>
+                        <SelectLabel>Rslint Core</SelectLabel>
+                        {wasmVersions.map((version) => (
+                          <SelectItem key={version} value={version}>
+                            v{version}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
                     </SelectContent>
                   </Select>
                 </div>

--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -1,22 +1,21 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import * as Rslint from '@rslint/wasm';
 import { EditorTabs, EditorTabsRef } from './EditorTabs';
 import { ResultPanel, Diagnostic } from './ResultPanel';
 import './Client.css';
 import { RemoteSourceFile, type Node, SyntaxKind } from '@rslint/api';
 import { ResizableSplitPane, type GetAstInfoResponse } from './ast';
-
-const wasmURL = new URL('@rslint/wasm/rslint.wasm.gz', import.meta.url).href;
-let rslintService: Rslint.RSLintService | null = null;
-
-async function ensureService() {
-  if (!rslintService) {
-    rslintService = await Rslint.initialize({
-      wasmURL: wasmURL,
-    });
-  }
-  return rslintService;
-}
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/theme/components/ui/select';
+import {
+  ensureWasmService,
+  fetchWasmVersions,
+  MINIMUM_WASM_VERSION,
+} from './wasm';
 
 const Playground: React.FC = () => {
   const editorRef = useRef<EditorTabsRef | null>(null);
@@ -36,12 +35,41 @@ const Playground: React.FC = () => {
   >();
   const [astInfo, setAstInfo] = useState<GetAstInfoResponse | null>(null);
   const [astInfoLoading, setAstInfoLoading] = useState(false);
+  const [wasmVersions, setWasmVersions] = useState<string[]>([]);
+  const [selectedVersion, setSelectedVersion] = useState<string>();
+  const selectedVersionRef = useRef<string | undefined>(undefined);
 
-  async function runLint() {
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchWasmVersions(controller.signal)
+      .then((versions) => {
+        setWasmVersions(versions);
+        setSelectedVersion(versions[0]);
+      })
+      .catch((versionError) => {
+        if (
+          versionError instanceof DOMException &&
+          versionError.name === 'AbortError'
+        ) {
+          return;
+        }
+        const message =
+          versionError instanceof Error
+            ? versionError.message
+            : String(versionError);
+        setError(`Failed to load @rslint/wasm versions: ${message}`);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, []);
+
+  async function runLint(version = selectedVersion) {
+    if (!version) return;
     try {
       setError(undefined);
       if (!initialized) setLoading(true);
-      const service = await ensureService();
+      const service = await ensureWasmService(version);
+      if (selectedVersionRef.current !== version) return;
       const code = editorRef.current?.getValue() ?? '';
       const rslintConfig = editorRef.current?.getRslintConfig();
       const tsConfig = editorRef.current?.getTsConfig();
@@ -69,6 +97,7 @@ const Playground: React.FC = () => {
           : undefined,
         configDirectory: '/',
       });
+      if (selectedVersionRef.current !== version) return;
       setInitialized(true);
 
       // Convert diagnostics to the expected format
@@ -144,10 +173,11 @@ const Playground: React.FC = () => {
         await buildTypeScriptAst(lastSourceTextRef.current);
       }
     } catch (err) {
+      if (selectedVersionRef.current !== version) return;
       const errorMessage = err instanceof Error ? err.message : String(err);
       setError(`Linting failed: ${errorMessage}`);
     } finally {
-      setLoading(false);
+      if (selectedVersionRef.current === version) setLoading(false);
     }
   }
 
@@ -171,7 +201,19 @@ const Playground: React.FC = () => {
       }
     };
   }, []);
-  // Initial lint is triggered by Editor's initial onChange
+
+  useEffect(() => {
+    selectedVersionRef.current = selectedVersion;
+    if (!selectedVersion) return;
+    setInitialized(false);
+    setDiagnostics([]);
+    setAst(undefined);
+    setAstTree(undefined);
+    setTsAstTree(undefined);
+    setAstInfo(null);
+    setLoading(true);
+    void runLint(selectedVersion);
+  }, [selectedVersion]);
 
   // Get AST info at a specific position - updates global state for main panel
   const handleRequestAstInfo = useCallback(
@@ -185,7 +227,7 @@ const Playground: React.FC = () => {
 
       try {
         setAstInfoLoading(true);
-        const service = await ensureService();
+        const service = await ensureWasmService(selectedVersion!);
         const code = editorRef.current?.getValue() ?? '';
         const tsConfig = editorRef.current?.getTsConfig();
 
@@ -208,7 +250,7 @@ const Playground: React.FC = () => {
         setAstInfoLoading(false);
       }
     },
-    [initialized],
+    [initialized, selectedVersion],
   );
 
   // Fetch AST info for lazy loading - does NOT update global state
@@ -222,7 +264,7 @@ const Playground: React.FC = () => {
       if (!initialized) return null;
 
       try {
-        const service = await ensureService();
+        const service = await ensureWasmService(selectedVersion!);
         const code = editorRef.current?.getValue() ?? '';
         const tsConfig = editorRef.current?.getTsConfig();
 
@@ -241,7 +283,7 @@ const Playground: React.FC = () => {
         return null;
       }
     },
-    [initialized],
+    [initialized, selectedVersion],
   );
 
   async function buildTypeScriptAst(text: string) {
@@ -307,6 +349,32 @@ const Playground: React.FC = () => {
                 })
               }
               onConfigChange={() => scheduleRunLint()}
+              toolbarEnd={
+                <div className="flex items-center">
+                  <Select
+                    value={selectedVersion}
+                    onValueChange={setSelectedVersion}
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      aria-label="Select @rslint/wasm version"
+                      disabled={wasmVersions.length === 0}
+                    >
+                      <SelectValue
+                        placeholder={`Loading versions >= ${MINIMUM_WASM_VERSION}…`}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {wasmVersions.map((version) => (
+                        <SelectItem key={version} value={version}>
+                          {version}
+                          {version === wasmVersions[0] ? ' (latest)' : ''}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              }
             />
           </div>
         }

--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -11,11 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/theme/components/ui/select';
-import {
-  ensureWasmService,
-  fetchWasmVersions,
-  MINIMUM_WASM_VERSION,
-} from './wasm';
+import { ensureWasmService, fetchWasmVersions } from './wasm';
 
 const Playground: React.FC = () => {
   const editorRef = useRef<EditorTabsRef | null>(null);
@@ -360,9 +356,7 @@ const Playground: React.FC = () => {
                       aria-label="Select @rslint/wasm version"
                       disabled={wasmVersions.length === 0}
                     >
-                      <SelectValue
-                        placeholder={`Loading versions >= ${MINIMUM_WASM_VERSION}…`}
-                      />
+                      <SelectValue placeholder="Loading..." />
                     </SelectTrigger>
                     <SelectContent>
                       {wasmVersions.map((version) => (

--- a/website/theme/components/Playground/Editor.tsx
+++ b/website/theme/components/Playground/Editor.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, forwardRef, Ref, createRef } from 'react';
 import * as monaco from 'monaco-editor';
-import { type Diagnostic } from '@rslint/wasm';
+import { type Diagnostic } from '@rslint/core/service';
 import './Editor.css';
 
 window.MonacoEnvironment = {

--- a/website/theme/components/Playground/EditorTabs.css
+++ b/website/theme/components/Playground/EditorTabs.css
@@ -12,3 +12,14 @@
   border-radius: 3px;
   box-shadow: 0 0 0 1px rgba(245, 158, 11, 0.3);
 }
+
+.dark .monaco-editor .ast-node-highlight {
+  background: rgba(31, 111, 235, 0.35);
+  outline-color: #58a6ff;
+}
+
+.dark .monaco-editor .ast-node-hover-highlight {
+  background: rgba(187, 128, 9, 0.35);
+  outline-color: #d29922;
+  box-shadow: 0 0 0 1px rgba(210, 153, 34, 0.35);
+}

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -1,7 +1,14 @@
-import { useState, useRef, useEffect, useImperativeHandle, Ref } from 'react';
+import {
+  useState,
+  useRef,
+  useEffect,
+  useImperativeHandle,
+  Ref,
+  ReactNode,
+} from 'react';
 import * as monaco from 'monaco-editor';
 import { jsonDefaults } from 'monaco-editor/languages/features/json/register';
-import { type Diagnostic } from '@rslint/wasm';
+import { type Diagnostic } from '@rslint/core/service';
 import { Button } from '@components/ui/button';
 // Monaco-specific styles only (ast-node-highlight)
 import './EditorTabs.css';
@@ -44,6 +51,7 @@ interface EditorTabsProps {
   onChange: (value: string) => void;
   onSelectionChange?: (start: number, end: number) => void;
   onConfigChange?: () => void;
+  toolbarEnd?: ReactNode;
 }
 
 const DEFAULT_RSLINT_CONFIG = `[
@@ -88,6 +96,7 @@ export const EditorTabs = ({
   onChange,
   onSelectionChange,
   onConfigChange,
+  toolbarEnd,
 }: EditorTabsProps) => {
   const [activeTab, setActiveTab] = useState<EditorTabType>('code');
 
@@ -422,20 +431,23 @@ export const EditorTabs = ({
 
   return (
     <div className="flex flex-col h-full w-full">
-      <div className="flex items-center gap-2 bg-gray-50 p-2 flex-shrink-0">
-        {tabs.map((tab) => (
-          <Button
-            key={tab.key}
-            type="button"
-            variant={activeTab === tab.key ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => setActiveTab(tab.key)}
-            aria-pressed={activeTab === tab.key}
-            className="dark:text-accent dark:border-muted/20"
-          >
-            {tab.label}
-          </Button>
-        ))}
+      <div className="flex items-center justify-between gap-2 bg-gray-50 p-2 flex-shrink-0">
+        <div className="flex items-center gap-2">
+          {tabs.map((tab) => (
+            <Button
+              key={tab.key}
+              type="button"
+              variant={activeTab === tab.key ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setActiveTab(tab.key)}
+              aria-pressed={activeTab === tab.key}
+              className="dark:text-accent dark:border-muted/20"
+            >
+              {tab.label}
+            </Button>
+          ))}
+        </div>
+        {toolbarEnd}
       </div>
       <div className="flex-1 relative overflow-visible">
         <div

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -9,6 +9,7 @@ import {
 import * as monaco from 'monaco-editor';
 import { jsonDefaults } from 'monaco-editor/languages/features/json/register';
 import { type Diagnostic } from '@rslint/core/service';
+import { useDark } from '@rspress/core/runtime';
 import { Button } from '@components/ui/button';
 // Monaco-specific styles only (ast-node-highlight)
 import './EditorTabs.css';
@@ -99,6 +100,8 @@ export const EditorTabs = ({
   toolbarEnd,
 }: EditorTabsProps) => {
   const [activeTab, setActiveTab] = useState<EditorTabType>('code');
+  const isDark = useDark();
+  const editorTheme = isDark ? 'vs-dark' : 'vs';
 
   const codeEditorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(
     null,
@@ -305,6 +308,7 @@ export const EditorTabs = ({
     const editor = monaco.editor.create(codeContainerRef.current, {
       value: getInitialCode(),
       language: 'typescript',
+      theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
     });
@@ -388,6 +392,7 @@ export const EditorTabs = ({
     const editor = monaco.editor.create(rslintContainerRef.current, {
       value: DEFAULT_RSLINT_CONFIG,
       language: 'json',
+      theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
     });
@@ -409,6 +414,7 @@ export const EditorTabs = ({
     const editor = monaco.editor.create(tsconfigContainerRef.current, {
       value: DEFAULT_TSCONFIG,
       language: 'json',
+      theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
     });
@@ -423,6 +429,10 @@ export const EditorTabs = ({
     };
   }, []);
 
+  useEffect(() => {
+    monaco.editor.setTheme(editorTheme);
+  }, [editorTheme]);
+
   const tabs: { key: EditorTabType; label: string }[] = [
     { key: 'code', label: 'Code' },
     { key: 'rslint', label: 'rslint.json' },
@@ -431,7 +441,7 @@ export const EditorTabs = ({
 
   return (
     <div className="flex flex-col h-full w-full">
-      <div className="flex items-center justify-between gap-2 bg-gray-50 p-2 flex-shrink-0">
+      <div className="flex items-center justify-between gap-2 bg-[var(--rp-c-bg-soft)] p-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           {tabs.map((tab) => (
             <Button
@@ -441,7 +451,6 @@ export const EditorTabs = ({
               size="sm"
               onClick={() => setActiveTab(tab.key)}
               aria-pressed={activeTab === tab.key}
-              className="dark:text-accent dark:border-muted/20"
             >
               {tab.label}
             </Button>

--- a/website/theme/components/Playground/ResultPanel.css
+++ b/website/theme/components/Playground/ResultPanel.css
@@ -5,8 +5,8 @@
 }
 
 .spinner {
-  border: 2px solid #d0d7de;
-  border-top: 2px solid #0969da;
+  border: 2px solid var(--rp-c-divider-light);
+  border-top-color: var(--rp-c-brand);
   border-radius: 50%;
   width: 20px;
   height: 20px;
@@ -33,7 +33,7 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  color: #656d76;
+  color: var(--rp-c-text-2);
 }
 
 .lint-results {
@@ -52,7 +52,7 @@
 }
 
 .diagnostic-item {
-  border: 1px solid #d0d7de;
+  border: 1px solid var(--rp-c-divider-light);
   border-radius: 6px;
   font-family:
     system-ui,
@@ -106,13 +106,20 @@
   font-family:
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
+  color: #1c1d21;
   background-color: #ffebec;
   border-radius: 4px;
   border-left: 5px solid #e13238;
 }
 
+.dark .diagnostic-message {
+  color: #ffdcd7;
+  background-color: rgba(248, 81, 73, 0.15);
+  border-left-color: #f85149;
+}
+
 .diagnostic-location {
-  color: #656d76;
+  color: var(--rp-c-text-2);
   font-size: 0.75rem;
   font-family: monospace;
 }
@@ -127,7 +134,7 @@
   overflow: auto;
   /* border: 1px solid #d0d7de; */
   /* border-radius: 6px; */
-  background: #fff;
+  background: var(--rp-c-bg);
   padding: 6px 6px 10px 6px;
 }
 
@@ -152,11 +159,16 @@
   font-size: 12px;
 }
 .ast-node-row:hover {
-  background: #f3f4f6;
+  background: var(--rp-c-bg-mute);
 }
 .ast-node-row.selected {
   background: #e7f3ff;
   outline: 1px solid #96c7ff;
+}
+
+.dark .ast-node-row.selected {
+  background: rgba(31, 111, 235, 0.3);
+  outline-color: #388bfd;
 }
 
 .twisty {
@@ -179,6 +191,9 @@
   font-weight: 600;
   color: #1f6feb;
 }
+.dark .node-type {
+  color: #58a6ff;
+}
 .node-range {
   color: #8c959f;
   font-family:
@@ -196,14 +211,14 @@
 }
 
 .ast-content {
-  background: #f6f8fa;
-  border: 1px solid #d0d7de;
+  background: var(--rp-c-bg-soft);
+  border: 1px solid var(--rp-c-divider-light);
   border-radius: 6px;
   padding: 1rem;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Fira Code', monospace;
   font-size: 0.875rem;
   line-height: 1.5;
-  color: #24292f;
+  color: var(--rp-c-text-1);
   overflow: auto;
   height: 100%;
   margin: 0;
@@ -218,7 +233,7 @@
   align-items: center;
   justify-content: center;
   padding: 3rem 1rem;
-  color: #656d76;
+  color: var(--rp-c-text-2);
   text-align: center;
 }
 

--- a/website/theme/components/Playground/ResultPanel.tsx
+++ b/website/theme/components/Playground/ResultPanel.tsx
@@ -406,7 +406,7 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
 
   return (
     <div className="result-panel">
-      <div className="flex items-center justify-between bg-gray-50 p-2 flex-shrink-0">
+      <div className="flex items-center justify-between bg-[var(--rp-c-bg-soft)] p-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <Button
             type="button"
@@ -414,7 +414,6 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
             size="sm"
             onClick={() => setActiveTab('lint')}
             aria-pressed={activeTab === 'lint'}
-            className="dark:text-accent dark:border-muted/20"
           >
             Errors
             {diagnostics.length > 0 && (
@@ -429,7 +428,6 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
             size="sm"
             onClick={() => setActiveTab('ast')}
             aria-pressed={activeTab === 'ast'}
-            className="dark:text-accent dark:border-muted/20"
           >
             AST (tsgo)
           </Button>
@@ -442,7 +440,6 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
               onRequestTsAst?.();
             }}
             aria-pressed={activeTab === 'ast_ts'}
-            className="dark:text-accent dark:border-muted/20"
           >
             AST (TypeScript)
           </Button>
@@ -453,7 +450,6 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
             variant="outline"
             size="sm"
             onClick={() => copyShareUrl()}
-            className="dark:text-accent dark:border-muted/20"
             title={shareCopied ? 'Copied link' : 'Copy shareable link'}
           >
             {shareCopied ? (
@@ -487,10 +483,10 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
                 <div className="diagnostics-list">
                   {diagnostics.map((diagnostic, index) => (
                     <div key={index} className="diagnostic-item">
-                      <div className="diagnostic-header dark:text-[#1c1d21]">
+                      <div className="diagnostic-header">
                         <h4>{diagnostic.ruleName}</h4>
                       </div>
-                      <div className="diagnostic-message dark:text-[#1c1d21]">
+                      <div className="diagnostic-message">
                         {diagnostic.message} {diagnostic.range.start.line}:
                         {diagnostic.range.start.column} -{' '}
                         {diagnostic.range.end.line}:

--- a/website/theme/components/Playground/ast/AstInfoPanel.tsx
+++ b/website/theme/components/Playground/ast/AstInfoPanel.tsx
@@ -49,9 +49,9 @@ interface SectionProps {
 }
 
 const Section: React.FC<SectionProps> = ({ title, children }) => (
-  <div className="border-b border-gray-200 last:border-b-0">
-    <div className="bg-gray-50 px-3 py-2">
-      <h3 className="text-xs font-semibold tracking-wide text-gray-600">
+  <div className="border-b border-gray-200 last:border-b-0 dark:border-gray-700">
+    <div className="bg-gray-50 px-3 py-2 dark:bg-gray-900">
+      <h3 className="text-xs font-semibold tracking-wide text-gray-600 dark:text-gray-300">
         {title}
       </h3>
     </div>

--- a/website/theme/components/Playground/ast/ExpandableSection.tsx
+++ b/website/theme/components/Playground/ast/ExpandableSection.tsx
@@ -17,16 +17,20 @@ export const ExpandableSection: React.FC<ExpandableSectionProps> = ({
   return (
     <div className="my-1">
       <button
-        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-gray-100"
+        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-gray-100 dark:hover:bg-gray-800"
         onClick={() => setOpen(!open)}
       >
         <ChevronRightIcon
           className={`h-4 w-4 text-gray-500 transition-transform ${open ? 'rotate-90' : ''}`}
         />
-        <span className="font-medium text-blue-700">{title}</span>
+        <span className="font-medium text-blue-700 dark:text-blue-400">
+          {title}
+        </span>
       </button>
       {open && (
-        <div className="ml-4 border-l border-gray-200 pl-2">{children}</div>
+        <div className="ml-4 border-l border-gray-200 pl-2 dark:border-gray-700">
+          {children}
+        </div>
       )}
     </div>
   );

--- a/website/theme/components/Playground/ast/FlagsDisplay.tsx
+++ b/website/theme/components/Playground/ast/FlagsDisplay.tsx
@@ -17,7 +17,7 @@ export const FlagsDisplay: React.FC<FlagsDisplayProps> = ({ flags, names }) => {
       onMouseLeave={() => setShowTooltip(false)}
     >
       <span
-        className={`font-medium text-blue-900 ${
+        className={`font-medium text-blue-900 dark:text-blue-300 ${
           hasNames
             ? 'cursor-help border-b border-dashed border-blue-400 hover:border-blue-600'
             : ''

--- a/website/theme/components/Playground/ast/FlowGraphView.tsx
+++ b/website/theme/components/Playground/ast/FlowGraphView.tsx
@@ -78,6 +78,16 @@ export const FlowGraphView: React.FC<FlowGraphViewProps> = ({
   onNodeClick,
 }) => {
   const [hoveredNode, setHoveredNode] = useState<FlowGraphNode | null>(null);
+  const colors = {
+    edge: 'var(--rp-c-text-2)',
+    node: 'var(--rp-c-bg)',
+    nodeHover: 'var(--rp-c-bg-mute)',
+    stroke: 'var(--rp-c-text-2)',
+    strokeHover: 'var(--rp-c-brand)',
+    text: 'var(--rp-c-text-1)',
+    mutedText: 'var(--rp-c-text-2)',
+    separator: 'var(--rp-c-divider-light)',
+  };
 
   // Build layout using dagre
   const layout = useMemo(() => {
@@ -189,7 +199,7 @@ export const FlowGraphView: React.FC<FlowGraphViewProps> = ({
             refY="3"
             orient="auto"
           >
-            <polygon points="0 0, 8 3, 0 6" fill="#666" />
+            <polygon points="0 0, 8 3, 0 6" fill={colors.edge} />
           </marker>
         </defs>
 
@@ -204,7 +214,7 @@ export const FlowGraphView: React.FC<FlowGraphViewProps> = ({
               key={i}
               d={pathData}
               fill="none"
-              stroke="#666"
+              stroke={colors.edge}
               strokeWidth="1"
               markerEnd="url(#flow-arrowhead)"
             />
@@ -233,8 +243,8 @@ export const FlowGraphView: React.FC<FlowGraphViewProps> = ({
                 width={width}
                 height={NODE_HEIGHT}
                 rx="3"
-                fill={isHovered ? '#f0f9ff' : '#fff'}
-                stroke={isHovered ? '#3b82f6' : '#333'}
+                fill={isHovered ? colors.nodeHover : colors.node}
+                stroke={isHovered ? colors.strokeHover : colors.stroke}
                 strokeWidth={isHovered ? 1.5 : 1}
               />
               {/* Text/expression label (top) */}
@@ -243,7 +253,7 @@ export const FlowGraphView: React.FC<FlowGraphViewProps> = ({
                   x={width / 2}
                   y={18}
                   textAnchor="middle"
-                  fill="#111"
+                  fill={colors.text}
                   fontSize="12"
                   fontWeight="500"
                 >
@@ -257,7 +267,7 @@ export const FlowGraphView: React.FC<FlowGraphViewProps> = ({
                   y1={NODE_HEIGHT / 2}
                   x2={width - 8}
                   y2={NODE_HEIGHT / 2}
-                  stroke="#ddd"
+                  stroke={colors.separator}
                   strokeWidth="1"
                 />
               )}
@@ -267,7 +277,7 @@ export const FlowGraphView: React.FC<FlowGraphViewProps> = ({
                 y={hasText ? NODE_HEIGHT - 12 : NODE_HEIGHT / 2}
                 textAnchor="middle"
                 dominantBaseline={hasText ? 'auto' : 'middle'}
-                fill="#666"
+                fill={colors.mutedText}
                 fontSize="11"
               >
                 {flowType}

--- a/website/theme/components/Playground/ast/FlowInfoView.tsx
+++ b/website/theme/components/Playground/ast/FlowInfoView.tsx
@@ -90,11 +90,11 @@ export const FlowGraphSection: React.FC<FlowGraphSectionProps> = ({ info }) => {
   };
 
   return (
-    <div className="mt-3 pt-3 border-t border-gray-200">
+    <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
       <div className="text-gray-500 text-[10px] mb-2">
         Graph: {info.graph.nodes.length} nodes, {info.graph.edges.length} edges
       </div>
-      <div className="border border-gray-200 rounded bg-gray-50 p-2">
+      <div className="border border-gray-200 rounded bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-900">
         <FlowGraphView graph={info.graph} onNodeHover={handleNodeHover} />
       </div>
     </div>
@@ -144,13 +144,13 @@ const FlowInfoArray: React.FC<FlowInfoArrayProps> = ({ label, items }) => {
     <div className="font-mono text-xs leading-relaxed">
       <div className="flex items-center py-0.5">
         <span
-          className="text-[10px] text-gray-500 w-4 flex-shrink-0 text-center cursor-pointer hover:bg-gray-200 rounded"
+          className="text-[10px] text-gray-500 w-4 flex-shrink-0 text-center cursor-pointer hover:bg-gray-200 rounded dark:hover:bg-gray-700"
           onClick={handleToggle}
         >
           {expanded ? '▼' : '▶'}
         </span>
         <span
-          className="text-purple-600 cursor-pointer hover:underline"
+          className="text-purple-600 cursor-pointer hover:underline dark:text-purple-400"
           onClick={handleToggle}
         >
           {label}
@@ -163,7 +163,7 @@ const FlowInfoArray: React.FC<FlowInfoArrayProps> = ({ label, items }) => {
       </div>
       {expanded && (
         <>
-          <div className="ml-4 border-l border-gray-200 pl-2">
+          <div className="ml-4 border-l border-gray-200 pl-2 dark:border-gray-700">
             {items.map((item, index) =>
               item ? (
                 <FlowInfoLazy

--- a/website/theme/components/Playground/ast/KindDisplay.tsx
+++ b/website/theme/components/Playground/ast/KindDisplay.tsx
@@ -16,7 +16,7 @@ export const KindDisplay: React.FC<KindDisplayProps> = ({ kind, kindName }) => {
       onMouseLeave={() => setShowTooltip(false)}
     >
       <span
-        className={`font-medium text-blue-900 ${
+        className={`font-medium text-blue-900 dark:text-blue-300 ${
           hasKindName
             ? 'cursor-help border-b border-dashed border-blue-400 hover:border-blue-600'
             : ''

--- a/website/theme/components/Playground/ast/PropRow.tsx
+++ b/website/theme/components/Playground/ast/PropRow.tsx
@@ -8,8 +8,10 @@ interface PropRowProps {
 export const PropRow: React.FC<PropRowProps> = ({ label, value }) => (
   <div className="flex items-center py-0.5 font-mono text-xs">
     <span className="w-4 flex-shrink-0" />
-    <span className="text-purple-600">{label}</span>
-    <span className="text-gray-500">:</span>
-    <span className="ml-1 break-words text-gray-900">{value}</span>
+    <span className="text-purple-600 dark:text-purple-400">{label}</span>
+    <span className="text-gray-500 dark:text-gray-400">:</span>
+    <span className="ml-1 break-words text-gray-900 dark:text-gray-100">
+      {value}
+    </span>
   </div>
 );

--- a/website/theme/components/Playground/ast/ResizableSplitPane.tsx
+++ b/website/theme/components/Playground/ast/ResizableSplitPane.tsx
@@ -103,7 +103,7 @@ export const ResizableSplitPane: React.FC<ResizableSplitPaneProps> = ({
 
       {/* Divider */}
       <div
-        className={`relative h-full cursor-col-resize bg-gray-200 hover:bg-blue-400 ${
+        className={`relative h-full cursor-col-resize bg-gray-200 hover:bg-blue-400 dark:bg-gray-700 dark:hover:bg-blue-500 ${
           isDragging ? 'bg-blue-500' : ''
         }`}
         style={{ width: '4px', flexShrink: 0 }}

--- a/website/theme/components/Playground/index.tsx
+++ b/website/theme/components/Playground/index.tsx
@@ -1,3 +1,4 @@
+import { useHead } from '@rspress/core/runtime';
 import React, { useEffect, useState } from 'react';
 
 type PlaygroundComponent = React.ComponentType;
@@ -11,6 +12,8 @@ Open this page in a browser to use the editor and result panels.
 `;
 
 const Playground: React.FC = () => {
+  useHead({ title: 'Playground - Rslint' });
+
   if (import.meta.env.SSG_MD) {
     return PLAYGROUND_SSG_MARKDOWN;
   }

--- a/website/theme/components/Playground/wasm.ts
+++ b/website/theme/components/Playground/wasm.ts
@@ -1,0 +1,80 @@
+import type { RSLintService } from '@rslint/core/service';
+
+export const MINIMUM_WASM_VERSION = '0.8.0';
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@rslint%2Fwasm';
+const UNPKG_BASE_URL = 'https://unpkg.com/@rslint/wasm';
+
+interface WasmModule {
+  initialize(options: { wasmURL: string }): Promise<RSLintService>;
+}
+
+interface NpmPackageMetadata {
+  versions?: Record<string, unknown>;
+}
+
+let activeService:
+  { version: string; promise: Promise<RSLintService> } | undefined;
+
+function parseStableVersion(version: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = parseStableVersion(left)!;
+  const rightParts = parseStableVersion(right)!;
+  for (let index = 0; index < leftParts.length; index++) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+export async function fetchWasmVersions(
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const response = await fetch(NPM_REGISTRY_URL, { signal });
+  if (!response.ok) {
+    throw new Error(`npm registry returned ${response.status}`);
+  }
+
+  const metadata = (await response.json()) as NpmPackageMetadata;
+  const versions = Object.keys(metadata.versions ?? {})
+    .filter((version) => parseStableVersion(version) !== null)
+    .filter((version) => compareVersions(version, MINIMUM_WASM_VERSION) >= 0)
+    .sort((left, right) => compareVersions(right, left));
+
+  if (versions.length === 0) {
+    throw new Error(
+      `no stable version at or above ${MINIMUM_WASM_VERSION} was found`,
+    );
+  }
+  return versions;
+}
+
+export async function ensureWasmService(
+  version: string,
+): Promise<RSLintService> {
+  if (activeService?.version === version) return activeService.promise;
+
+  const previousService = activeService?.promise;
+  const packageUrl = `${UNPKG_BASE_URL}@${version}`;
+  const promise = (async () => {
+    const previous = await previousService?.catch(() => undefined);
+    await previous?.close();
+    const wasmModule = (await import(
+      /* rspackIgnore: true */ `${packageUrl}/dist/index.mjs`
+    )) as WasmModule;
+    return wasmModule.initialize({ wasmURL: `${packageUrl}/rslint.wasm` });
+  })();
+
+  activeService = { version, promise };
+  try {
+    return await promise;
+  } catch (error) {
+    if (activeService?.promise === promise) activeService = undefined;
+    throw error;
+  }
+}

--- a/website/theme/components/Playground/wasm.ts
+++ b/website/theme/components/Playground/wasm.ts
@@ -1,6 +1,6 @@
 import type { RSLintService } from '@rslint/core/service';
 
-export const MINIMUM_WASM_VERSION = '0.8.0';
+const MINIMUM_WASM_VERSION = '0.8.0';
 
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@rslint%2Fwasm';
 const UNPKG_BASE_URL = 'https://unpkg.com/@rslint/wasm';


### PR DESCRIPTION
## Summary

- Fetch stable `@rslint/wasm` versions at or above `0.8.0` from the npm registry.
- Load the selected published package at runtime and default the Playground to the latest version.
- Add the version selector to the editor tab bar and remove the website's local WASM dependency.
- Add dark mode for playground

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
