### PR TITLE
refactor: consolidate diagnostic processing

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -494,6 +494,25 @@ type RuleFix struct {
 }
 ```
 
+`internal/linter` owns the shared producer semantics around this model. Native
+rules, TypeScript syntax/program diagnostics, and reconstructed third-party
+plugin diagnostics all enter the surfaces as `RuleDiagnostic` values. The
+single-file TypeScript syntax projection is shared by CLI/API target
+collection and LSP document linting, while TypeScript program diagnostics keep
+their richer message-chain and related-information formatting. Completed CLI
+and API diagnostic sets are stably ordered by caller-visible file path and
+start byte offset only after each surface has projected paths into its own
+identity space; equal keys retain producer emission order. LSP deliberately
+does not use that completed-set ordering because it publishes native results
+first and merges generation-stamped plugin results later.
+
+After that semantic boundary, representation remains integration-owned. CLI
+builds an `internal/output.Report`, API projects to its 1-based structured wire
+model and flat UTF-16 edit offsets, and LSP projects to 0-based LSP positions
+while retaining its stale-generation and code-action lifecycle. Counts, fix
+passes, path bases, stderr notices, and protocol empty-array rules therefore do
+not belong to a universal diagnostic pipeline.
+
 ### Severity Levels
 
 - `SeverityError`: lint error

--- a/cmd/rslint/lint_pipeline.go
+++ b/cmd/rslint/lint_pipeline.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -9,7 +8,6 @@ import (
 	"runtime/pprof"
 	"runtime/trace"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -731,21 +729,10 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 
 	allDiags = deduplicateTypeScriptDiagnostics(allDiags, fs, targetPlan.PreferredCallerPaths())
 
-	// Diagnostics arrive in completion order — programs and, within a
-	// program, file shards run in parallel — so impose a deterministic
-	// order before printing. The key is (file, start position) only,
-	// deliberately with NO end/rule tie-break: ESLint orders same-start
-	// diagnostics by emission order (parent reported before nested child),
-	// and a file's diagnostics are all emitted by a single worker, so under
-	// a STABLE sort this key is already fully deterministic. Keep this
-	// comparator in sync with the --api one in internal/api/server/lint.go (same policy over
-	// api.Diagnostic).
-	slices.SortStableFunc(allDiags, func(a, b rule.RuleDiagnostic) int {
-		if c := strings.Compare(a.FilePath, b.FilePath); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.Range.Pos(), b.Range.Pos())
-	})
+	// Paths have already been remapped into the caller-visible target space.
+	// Sort the completed set before rendering; same-start diagnostics retain
+	// emission order.
+	linter.StableSortDiagnosticsByFileAndStart(allDiags)
 
 	// Phase 3: Build one report from the final post-fix diagnostics, then let
 	// the CLI output subsystem own format dispatch, colors, and summary text.

--- a/internal/api/server/diagnostic_projection.go
+++ b/internal/api/server/diagnostic_projection.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/api"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type lintDiagnosticProjection struct {
+	diagnostics         []api.Diagnostic
+	errorCount          int
+	warningCount        int
+	fixableErrorCount   int
+	fixableWarningCount int
+}
+
+func projectLintDiagnostics(diagnostics []rule.RuleDiagnostic) lintDiagnosticProjection {
+	projection := lintDiagnosticProjection{
+		diagnostics: make([]api.Diagnostic, 0, len(diagnostics)),
+	}
+	for _, diagnostic := range diagnostics {
+		projection.diagnostics = append(projection.diagnostics, projectLintDiagnostic(diagnostic))
+
+		hasFix := diagnostic.FixesPtr != nil && len(*diagnostic.FixesPtr) > 0
+		switch diagnostic.Severity {
+		case rule.SeverityError:
+			projection.errorCount++
+			if hasFix {
+				projection.fixableErrorCount++
+			}
+		case rule.SeverityWarning:
+			projection.warningCount++
+			if hasFix {
+				projection.fixableWarningCount++
+			}
+		}
+	}
+	return projection
+}
+
+func projectLintDiagnostic(diagnostic rule.RuleDiagnostic) api.Diagnostic {
+	startLine, startColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(
+		diagnostic.SourceFile,
+		diagnostic.Range.Pos(),
+	)
+	endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(
+		diagnostic.SourceFile,
+		diagnostic.Range.End(),
+	)
+	projected := api.Diagnostic{
+		RuleName:  diagnostic.RuleName,
+		MessageId: diagnostic.Message.Id,
+		Message:   diagnostic.Message.Description,
+		FilePath:  diagnostic.FilePath,
+		Range: api.Range{
+			Start: api.Position{Line: startLine + 1, Column: int(startColumn) + 1},
+			End:   api.Position{Line: endLine + 1, Column: int(endColumn) + 1},
+		},
+		Severity: diagnostic.Severity.String(),
+	}
+
+	text := diagnostic.SourceFile.Text()
+	if diagnostic.FixesPtr != nil && len(*diagnostic.FixesPtr) > 0 {
+		projected.Fixes = projectLintFixes(text, *diagnostic.FixesPtr)
+	}
+	if diagnostic.Suggestions != nil && len(*diagnostic.Suggestions) > 0 {
+		projected.Suggestions = make([]api.Suggestion, 0, len(*diagnostic.Suggestions))
+		for _, suggestion := range *diagnostic.Suggestions {
+			projected.Suggestions = append(projected.Suggestions, api.Suggestion{
+				MessageId: suggestion.Message.Id,
+				Message:   suggestion.Message.Description,
+				Data:      suggestion.Message.Data,
+				Fixes:     projectLintFixes(text, suggestion.FixesArr),
+			})
+		}
+	}
+	return projected
+}
+
+func projectLintFixes(text string, fixes []rule.RuleFix) []api.Fix {
+	if len(fixes) == 0 {
+		return nil
+	}
+	projected := make([]api.Fix, 0, len(fixes))
+	for _, fix := range fixes {
+		projected = append(projected, api.Fix{
+			Text:     fix.Text,
+			StartPos: byteOffsetToUTF16(text, fix.Range.Pos()),
+			EndPos:   byteOffsetToUTF16(text, fix.Range.End()),
+		})
+	}
+	return projected
+}
+
+// byteOffsetToUTF16 converts a byte offset within text to a flat UTF-16 code
+// unit offset, the unit ESLint uses for fix and suggestion ranges. Diagnostic
+// line and column positions instead count UTF-16 units from the line start.
+func byteOffsetToUTF16(text string, byteOffset int) int {
+	if byteOffset < 0 {
+		// ESLint uses [-1, 0] to remove a byte order mark. The negative offset
+		// is meaningful as-is and has no prefix text to measure.
+		return byteOffset
+	}
+	if byteOffset == 0 {
+		return 0
+	}
+	if byteOffset >= len(text) {
+		return int(core.UTF16Len(text))
+	}
+	return int(core.UTF16Len(text[:byteOffset]))
+}

--- a/internal/api/server/diagnostic_projection_test.go
+++ b/internal/api/server/diagnostic_projection_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/api"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type diagnosticProjectionSource struct{ text string }
+
+func (source diagnosticProjectionSource) Text() string { return source.text }
+func (source diagnosticProjectionSource) ECMALineMap() []core.TextPos {
+	return core.ComputeECMALineStarts(source.text)
+}
+
+func TestProjectLintDiagnosticsPreservesUTF16CoordinatesAndCounts(t *testing.T) {
+	const text = "😀x\r\n中y"
+	fixes := []rule.RuleFix{{Text: "z", Range: core.NewTextRange(4, 5)}}
+	suggestions := []rule.RuleSuggestion{{
+		Message:  rule.RuleMessage{Id: "replaceCJK", Description: "Replace CJK", Data: map[string]string{"value": "中"}},
+		FixesArr: []rule.RuleFix{{Text: "z", Range: core.NewTextRange(7, 10)}},
+	}}
+	projection := projectLintDiagnostics([]rule.RuleDiagnostic{{
+		RuleName:    "test/rule",
+		Message:     rule.RuleMessage{Id: "message", Description: "message"},
+		FilePath:    "source.ts",
+		SourceFile:  diagnosticProjectionSource{text: text},
+		Range:       core.NewTextRange(4, 5),
+		Severity:    rule.SeverityWarning,
+		FixesPtr:    &fixes,
+		Suggestions: &suggestions,
+	}})
+
+	if projection.errorCount != 0 || projection.warningCount != 1 ||
+		projection.fixableErrorCount != 0 || projection.fixableWarningCount != 1 {
+		t.Fatalf("counts = errors:%d warnings:%d fixableErrors:%d fixableWarnings:%d",
+			projection.errorCount, projection.warningCount, projection.fixableErrorCount, projection.fixableWarningCount)
+	}
+	if len(projection.diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(projection.diagnostics))
+	}
+	diagnostic := projection.diagnostics[0]
+	if diagnostic.Range.Start.Line != 1 || diagnostic.Range.Start.Column != 3 ||
+		diagnostic.Range.End.Line != 1 || diagnostic.Range.End.Column != 4 {
+		t.Fatalf("diagnostic range = %+v, want line 1 columns 3..4", diagnostic.Range)
+	}
+	if len(diagnostic.Fixes) != 1 || diagnostic.Fixes[0].StartPos != 2 || diagnostic.Fixes[0].EndPos != 3 {
+		t.Fatalf("fixes = %+v, want flat UTF-16 range [2,3)", diagnostic.Fixes)
+	}
+	if len(diagnostic.Suggestions) != 1 || len(diagnostic.Suggestions[0].Fixes) != 1 ||
+		diagnostic.Suggestions[0].Fixes[0].StartPos != 5 || diagnostic.Suggestions[0].Fixes[0].EndPos != 6 {
+		t.Fatalf("suggestions = %+v, want flat UTF-16 range [5,6)", diagnostic.Suggestions)
+	}
+}
+
+func TestHandleLintSortsDiagnosticsInResponsePathSpace(t *testing.T) {
+	root := t.TempDir()
+	workingDirectory := filepath.Join(root, "a-workspace")
+	outsideDirectory := filepath.Join(root, "z-outside")
+	writeProgramTestFiles(t, root, map[string]string{
+		"a-workspace/inside.js": "debugger;\n",
+		"z-outside/outside.js":  "debugger;\n",
+	})
+	insidePath := filepath.Join(workingDirectory, "inside.js")
+	outsidePath := filepath.Join(outsideDirectory, "outside.js")
+
+	response, err := (&Handler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Files:            []string{insidePath, outsidePath},
+		WorkingDirectory: workingDirectory,
+		ConfigDirectory:  workingDirectory,
+		Config:           json.RawMessage(`[{"rules":{"no-debugger":"error"}}]`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("HandleLintWithContext: %v", err)
+	}
+	got := make([]string, 0, len(response.Diagnostics))
+	for _, diagnostic := range response.Diagnostics {
+		got = append(got, diagnostic.FilePath)
+	}
+	want := []string{
+		tspath.NormalizePath(filepath.Join("..", "z-outside", "outside.js")),
+		"inside.js",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("diagnostic order = %v, want response-path order %v", got, want)
+	}
+}

--- a/internal/api/server/lint.go
+++ b/internal/api/server/lint.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
-	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
@@ -379,13 +377,11 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 		return tspath.ConvertToRelativePath(targetPathForSourcePath(sourcePath), comparePathOptions)
 	}
 
-	// Collect diagnostics and source files
-	var diagnostics []api.Diagnostic
+	// Collect diagnostics in the shared internal model. Each diagnostic is
+	// copied into the API's caller-visible path space before the completed set
+	// is sorted and projected to wire fields below.
+	var diagnostics []rule.RuleDiagnostic
 	var diagnosticsLock sync.Mutex
-	errorsCount := 0
-	warningsCount := 0
-	fixableErrorsCount := 0
-	fixableWarningsCount := 0
 	// When Fix is requested, the original RuleDiagnostics (byte-offset fixes +
 	// their SourceFile) are retained per file for the in-band fix pass below.
 	var diagnosticsByFile map[string][]rule.RuleDiagnostic
@@ -401,105 +397,25 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 	diagnosticCollector := func(d rule.RuleDiagnostic) {
 		diagnosticsLock.Lock()
 		defer diagnosticsLock.Unlock()
+		responsePath := responsePathForSourcePath(d.FilePath)
 		if d.SourceFile != nil {
 			sourceFilesLock.Lock()
-			filePath := responsePathForSourcePath(d.FilePath)
 			if sf, ok := d.SourceFile.(*ast.SourceFile); ok {
-				sourceFiles[filePath] = sf
+				sourceFiles[responsePath] = sf
 			}
 			sourceFilesLock.Unlock()
 		}
 
-		diagnosticStart := d.Range.Pos()
-		diagnosticEnd := d.Range.End()
-
-		startLine, startColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticStart)
-		endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticEnd)
-
-		diagnostic := api.Diagnostic{
-			RuleName:  d.RuleName,
-			MessageId: d.Message.Id,
-			Message:   d.Message.Description,
-			FilePath:  responsePathForSourcePath(d.FilePath),
-			Range: api.Range{
-				Start: api.Position{
-					Line:   startLine + 1, // Convert to 1-based indexing
-					Column: int(startColumn) + 1,
-				},
-				End: api.Position{
-					Line:   endLine + 1,
-					Column: int(endColumn) + 1,
-				},
-			},
-			Severity: d.Severity.String(),
-		}
-
-		// Fix and suggestion ranges are flat UTF-16 offsets (ESLint's unit),
-		// converted from the rule's byte offsets via byteOffsetToUTF16. This is
-		// a DIFFERENT conversion than the line/column above (which counts UTF-16
-		// units from the line start, not a flat file offset).
-		fixText := d.SourceFile.Text()
-
-		// Add fixes if available.
-		if d.FixesPtr != nil && len(*d.FixesPtr) > 0 {
-			var fixes []api.Fix
-			for _, fix := range *d.FixesPtr {
-				fixes = append(fixes, api.Fix{
-					Text:     fix.Text,
-					StartPos: byteOffsetToUTF16(fixText, fix.Range.Pos()),
-					EndPos:   byteOffsetToUTF16(fixText, fix.Range.End()),
-				})
-			}
-			diagnostic.Fixes = fixes
-		}
-
-		// Add suggestions if available — optional, user-selected fixes the
-		// editor surfaces (distinct from auto-applied Fixes).
-		if d.Suggestions != nil && len(*d.Suggestions) > 0 {
-			suggestions := make([]api.Suggestion, 0, len(*d.Suggestions))
-			for _, sug := range *d.Suggestions {
-				var fixes []api.Fix
-				for _, fix := range sug.FixesArr {
-					fixes = append(fixes, api.Fix{
-						Text:     fix.Text,
-						StartPos: byteOffsetToUTF16(fixText, fix.Range.Pos()),
-						EndPos:   byteOffsetToUTF16(fixText, fix.Range.End()),
-					})
-				}
-				suggestions = append(suggestions, api.Suggestion{
-					MessageId: sug.Message.Id,
-					Message:   sug.Message.Description,
-					Data:      sug.Message.Data,
-					Fixes:     fixes,
-				})
-			}
-			diagnostic.Suggestions = suggestions
-		}
-
-		diagnostics = append(diagnostics, diagnostic)
-
-		// Split counts by severity (ESLint semantics): errorCount counts errors
-		// only, not the total. fixable*Count counts the fixable subset.
 		hasFix := d.FixesPtr != nil && len(*d.FixesPtr) > 0
-		switch d.Severity {
-		case rule.SeverityError:
-			errorsCount++
-			if hasFix {
-				fixableErrorsCount++
-			}
-		case rule.SeverityWarning:
-			warningsCount++
-			if hasFix {
-				fixableWarningsCount++
-			}
-		}
-
 		// Retain the original diagnostic (byte-offset fixes + SourceFile) for the
 		// in-band fix pass, grouped by the caller-visible target path.
 		if req.Fix && hasFix {
 			targetPath := targetPathForSourcePath(d.FilePath)
 			diagnosticsByFile[targetPath] = append(diagnosticsByFile[targetPath], d)
 		}
+
+		d.FilePath = responsePath
+		diagnostics = append(diagnostics, d)
 	}
 
 	// Every selected target is parsed even when no config entry contributes
@@ -606,26 +522,8 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 		}
 	}
 
-	if diagnostics == nil {
-		diagnostics = []api.Diagnostic{}
-	}
-	// Sort diagnostics by (file, start position) only — deliberately NO
-	// end/rule tie-break: ESLint and the upstream rule tests order
-	// same-start diagnostics by emission order (parent reported before
-	// nested child), and a file's diagnostics are all emitted by a single
-	// worker, so under a STABLE sort this key is already fully
-	// deterministic. Keep this comparator in sync with the CLI comparator
-	// over rule.RuleDiagnostic.
-	sort.SliceStable(diagnostics, func(i, j int) bool {
-		a, b := diagnostics[i], diagnostics[j]
-		if a.FilePath != b.FilePath {
-			return a.FilePath < b.FilePath
-		}
-		if a.Range.Start.Line != b.Range.Start.Line {
-			return a.Range.Start.Line < b.Range.Start.Line
-		}
-		return a.Range.Start.Column < b.Range.Start.Column
-	})
+	linter.StableSortDiagnosticsByFileAndStart(diagnostics)
+	diagnosticProjection := projectLintDiagnostics(diagnostics)
 
 	// Apply fixes in-band when requested. ApplyRuleFixes is the same pure fixer
 	// the CLI uses through applyFixPass, but here the result stays in-memory in
@@ -668,11 +566,11 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 
 	// Create response
 	response := &api.LintResponse{
-		Diagnostics:         diagnostics,
-		ErrorCount:          errorsCount,
-		WarningCount:        warningsCount,
-		FixableErrorCount:   fixableErrorsCount,
-		FixableWarningCount: fixableWarningsCount,
+		Diagnostics:         diagnosticProjection.diagnostics,
+		ErrorCount:          diagnosticProjection.errorCount,
+		WarningCount:        diagnosticProjection.warningCount,
+		FixableErrorCount:   diagnosticProjection.fixableErrorCount,
+		FixableWarningCount: diagnosticProjection.fixableWarningCount,
 		// FileCount mirrors the unique caller-visible LintedFiles result set.
 		FileCount:   len(lintedFiles),
 		RuleCount:   len(lintResult.ExecutedRules),
@@ -695,25 +593,4 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 		response.EncodedSourceFiles = encodedSourceFiles
 	}
 	return response, nil
-}
-
-// byteOffsetToUTF16 converts a byte offset within text to a flat UTF-16 code
-// unit offset — the unit ESLint uses for fix / suggestion ranges. This is a
-// DIFFERENT conversion than line/column (scanner.GetECMALineAndUTF16CharacterOfPosition,
-// which counts UTF-16 units from a line start); fix ranges are flat offsets
-// from the start of the file.
-func byteOffsetToUTF16(text string, byteOffset int) int {
-	if byteOffset < 0 {
-		// A fix reaching back before the text — ESLint's [-1, 0] for removing
-		// a byte order mark. There is nothing to measure, and the position is
-		// meaningful as it stands.
-		return byteOffset
-	}
-	if byteOffset == 0 {
-		return 0
-	}
-	if byteOffset >= len(text) {
-		return int(core.UTF16Len(text))
-	}
-	return int(core.UTF16Len(text[:byteOffset]))
 }

--- a/internal/linter/diagnostic_order.go
+++ b/internal/linter/diagnostic_order.go
@@ -1,0 +1,21 @@
+package linter
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// StableSortDiagnosticsByFileAndStart orders a completed diagnostic set by
+// caller-visible file path and start byte offset. Diagnostics with the same
+// file and start retain their emission order.
+func StableSortDiagnosticsByFileAndStart(diagnostics []rule.RuleDiagnostic) {
+	slices.SortStableFunc(diagnostics, func(a, b rule.RuleDiagnostic) int {
+		if c := strings.Compare(a.FilePath, b.FilePath); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Range.Pos(), b.Range.Pos())
+	})
+}

--- a/internal/linter/diagnostic_order_test.go
+++ b/internal/linter/diagnostic_order_test.go
@@ -1,0 +1,29 @@
+package linter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func TestStableSortDiagnosticsByFileAndStartPreservesEqualKeyOrder(t *testing.T) {
+	diagnostics := []rule.RuleDiagnostic{
+		{FilePath: "b.ts", Range: core.NewTextRange(0, 1), RuleName: "b"},
+		{FilePath: "a.ts", Range: core.NewTextRange(9, 10), RuleName: "later"},
+		{FilePath: "a.ts", Range: core.NewTextRange(2, 8), RuleName: "same-start-first"},
+		{FilePath: "a.ts", Range: core.NewTextRange(2, 3), RuleName: "same-start-second"},
+	}
+
+	StableSortDiagnosticsByFileAndStart(diagnostics)
+
+	got := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		got = append(got, diagnostic.RuleName)
+	}
+	want := []string{"same-start-first", "same-start-second", "later", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("diagnostic order = %v, want %v", got, want)
+	}
+}

--- a/internal/linter/target_syntax_diagnostics.go
+++ b/internal/linter/target_syntax_diagnostics.go
@@ -2,17 +2,16 @@ package linter
 
 import (
 	"context"
-	"fmt"
 
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 type targetSyntacticDiagnosticKey struct {
-	path string
-	code int32
-	pos  int
-	end  int
+	path     string
+	ruleName string
+	pos      int
+	end      int
 }
 
 // CollectTargetSyntacticDiagnostics returns syntax diagnostics for the exact
@@ -32,7 +31,7 @@ func CollectTargetSyntacticDiagnostics(
 	var diagnostics []rule.RuleDiagnostic
 	for i, program := range programs {
 		coveredByProgramDiagnostics := programDiagnosticsIncluded && program.CanProvideProgramDiagnostics()
-		if i >= len(targetsByProgram) || len(targetsByProgram[i]) == 0 {
+		if coveredByProgramDiagnostics || i >= len(targetsByProgram) || len(targetsByProgram[i]) == 0 {
 			continue
 		}
 		ctx := context.Background()
@@ -41,31 +40,18 @@ func CollectTargetSyntacticDiagnostics(
 			if file == nil {
 				continue
 			}
-			for _, diagnostic := range program.SyntacticDiagnostics(ctx, file) {
-				if coveredByProgramDiagnostics {
-					continue
-				}
-				loc := diagnostic.Loc()
+			for _, diagnostic := range CollectFileSyntacticDiagnostics(ctx, program, file) {
 				key := targetSyntacticDiagnosticKey{
-					path: file.FileName(),
-					code: diagnostic.Code(),
-					pos:  loc.Pos(),
-					end:  loc.End(),
+					path:     diagnostic.FilePath,
+					ruleName: diagnostic.RuleName,
+					pos:      diagnostic.Range.Pos(),
+					end:      diagnostic.Range.End(),
 				}
 				if _, ok := seen[key]; ok {
 					continue
 				}
 				seen[key] = struct{}{}
-				diagnostics = append(diagnostics, rule.RuleDiagnostic{
-					RuleName:     fmt.Sprintf("TypeScript(TS%d)", diagnostic.Code()),
-					SourceFile:   file,
-					FilePath:     file.FileName(),
-					Range:        loc,
-					Message:      rule.RuleMessage{Description: diagnostic.String()},
-					Severity:     rule.SeverityError,
-					Origin:       rule.DiagnosticOriginTypeScript,
-					PreFormatted: true,
-				})
+				diagnostics = append(diagnostics, diagnostic)
 			}
 		}
 	}

--- a/internal/linter/target_syntax_diagnostics_test.go
+++ b/internal/linter/target_syntax_diagnostics_test.go
@@ -1,11 +1,14 @@
 package linter
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func syntaxDiagnosticTestProgram(t *testing.T) (*compiler.Program, string) {
@@ -64,5 +67,34 @@ func TestCollectTargetSyntacticDiagnosticsDeduplicatesSharedTargets(t *testing.T
 	)
 	if len(diagnostics) != 1 {
 		t.Fatalf("shared syntax diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+	}
+}
+
+func TestCollectFileSyntacticDiagnosticsProjectsTypeScriptFields(t *testing.T) {
+	compilerProgram, targetPath := syntaxDiagnosticTestProgram(t)
+	sourceFile := compilerProgram.GetSourceFile(targetPath)
+	if sourceFile == nil {
+		t.Fatalf("compiler Program does not contain %q", targetPath)
+	}
+	program := lintprogram.NewFromCompiler(compilerProgram)
+	raw := program.SyntacticDiagnostics(context.Background(), sourceFile)
+	diagnostics := CollectFileSyntacticDiagnostics(context.Background(), program, sourceFile)
+	if len(raw) == 0 || len(diagnostics) != len(raw) {
+		t.Fatalf("projected diagnostics = %d, raw diagnostics = %d", len(diagnostics), len(raw))
+	}
+
+	got := diagnostics[0]
+	want := raw[0]
+	if got.SourceFile != sourceFile || got.FilePath != targetPath {
+		t.Fatalf("source identity = (%T, %q), want source file and %q", got.SourceFile, got.FilePath, targetPath)
+	}
+	if got.Range.Pos() != want.Loc().Pos() || got.Range.End() != want.Loc().End() {
+		t.Fatalf("range = [%d,%d), want [%d,%d)", got.Range.Pos(), got.Range.End(), want.Loc().Pos(), want.Loc().End())
+	}
+	if !strings.HasPrefix(got.RuleName, "TypeScript(TS") || got.Message.Description != want.String() {
+		t.Fatalf("identity/message = (%q, %q), want TypeScript code and %q", got.RuleName, got.Message.Description, want.String())
+	}
+	if got.Severity != rule.SeverityError || got.Origin != rule.DiagnosticOriginTypeScript || !got.PreFormatted {
+		t.Fatalf("severity/origin/preformatted = (%v, %v, %v)", got.Severity, got.Origin, got.PreFormatted)
 	}
 }

--- a/internal/linter/typecheck.go
+++ b/internal/linter/typecheck.go
@@ -105,19 +105,9 @@ func runTypeCheckForProgram(prog *program.Program) []collectedTypeCheckDiagnosti
 		// type-check is meant to be a transparent passthrough of tsc.
 
 		message := flattenDiagnosticMessage(d)
-		loc := d.Loc()
 		collected = append(collected, collectedTypeCheckDiagnostic{
-			key: typeCheckDedupeKeyForDiagnostic(prog, d),
-			ruleDiagnostic: rule.RuleDiagnostic{
-				RuleName:     fmt.Sprintf("TypeScript(TS%d)", d.Code()),
-				Range:        loc,
-				Message:      rule.RuleMessage{Description: message},
-				SourceFile:   file,
-				FilePath:     file.FileName(),
-				Severity:     rule.SeverityError,
-				Origin:       rule.DiagnosticOriginTypeScript,
-				PreFormatted: true,
-			},
+			key:            typeCheckDedupeKeyForDiagnostic(prog, d),
+			ruleDiagnostic: newTypeScriptDiagnostic(file, d, message),
 		})
 	}
 	return collected

--- a/internal/linter/typescript_diagnostics.go
+++ b/internal/linter/typescript_diagnostics.go
@@ -1,0 +1,42 @@
+package linter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func newTypeScriptDiagnostic(sourceFile *ast.SourceFile, diagnostic *ast.Diagnostic, description string) rule.RuleDiagnostic {
+	return rule.RuleDiagnostic{
+		RuleName:     fmt.Sprintf("TypeScript(TS%d)", diagnostic.Code()),
+		SourceFile:   sourceFile,
+		FilePath:     sourceFile.FileName(),
+		Range:        diagnostic.Loc(),
+		Message:      rule.RuleMessage{Description: description},
+		Severity:     rule.SeverityError,
+		Origin:       rule.DiagnosticOriginTypeScript,
+		PreFormatted: true,
+	}
+}
+
+// CollectFileSyntacticDiagnostics projects ts-go syntax diagnostics for one
+// source file into rslint's shared diagnostic model.
+func CollectFileSyntacticDiagnostics(
+	ctx context.Context,
+	program *lintprogram.Program,
+	sourceFile *ast.SourceFile,
+) []rule.RuleDiagnostic {
+	if program == nil || sourceFile == nil {
+		return nil
+	}
+
+	typeScriptDiagnostics := program.SyntacticDiagnostics(ctx, sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, len(typeScriptDiagnostics))
+	for _, diagnostic := range typeScriptDiagnostics {
+		diagnostics = append(diagnostics, newTypeScriptDiagnostic(sourceFile, diagnostic, diagnostic.String()))
+	}
+	return diagnostics
+}

--- a/internal/lsp/lint_execution.go
+++ b/internal/lsp/lint_execution.go
@@ -162,20 +162,7 @@ func lintSingleFile(
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}
 	}
 	sourceProgram := lintprogram.NewFromCompiler(program)
-	if syntacticDiagnostics := sourceProgram.SyntacticDiagnostics(ctx, sourceFile); len(syntacticDiagnostics) > 0 {
-		diagnostics := make([]rule.RuleDiagnostic, 0, len(syntacticDiagnostics))
-		for _, diagnostic := range syntacticDiagnostics {
-			diagnostics = append(diagnostics, rule.RuleDiagnostic{
-				RuleName:     fmt.Sprintf("TypeScript(TS%d)", diagnostic.Code()),
-				SourceFile:   sourceFile,
-				FilePath:     sourceFile.FileName(),
-				Range:        diagnostic.Loc(),
-				Message:      rule.RuleMessage{Description: diagnostic.String()},
-				Severity:     rule.SeverityError,
-				Origin:       rule.DiagnosticOriginTypeScript,
-				PreFormatted: true,
-			})
-		}
+	if diagnostics := linter.CollectFileSyntacticDiagnostics(ctx, sourceProgram, sourceFile); len(diagnostics) > 0 {
 		return lintPassResult{Diagnostics: diagnostics, HasSyntaxErrors: true}
 	}
 


### PR DESCRIPTION
## Summary

- Reuse one TypeScript syntax-diagnostic projection in CLI/API target collection and LSP document linting.
- Reuse stable final diagnostic ordering in CLI and API after each surface maps diagnostics into its caller-visible path space.
- Keep API wire conversion and counting in a focused server adapter, and document the ownership boundary.

This is a behavior-preserving refactor: CLI rendering, API 1-based UTF-16 ranges and flat UTF-16 edits/counts, and LSP native/plugin publication semantics remain unchanged.

## Validation

- `go test -count=1 ./internal/linter ./internal/api/server ./internal/lsp ./cmd/rslint ./internal/output`
- Targeted race tests for API projection/order and linter projection/order
- `golangci-lint run ./cmd/rslint ./internal/api/server ./internal/linter ./internal/lsp`
- Prettier, cspell, and `git diff --check`
- Windows/amd64 and JS/WASM builds
- 52/52 runnable real repositories passed across plain, `--type-check`, and independent explicit `--config` scenarios; all 318 paired main/PR runs had identical diagnostics, ordering, counts, rule/file summaries, and exit codes, with 0 hangs or residual processes. One repository was skipped before lint because its installed rstack 0.3.2 has no public config-loader export.

## Performance

Median of 10 alternating main/PR samples per mode after the machine reached at least 80% CPU idle. Positive deltas are slower; negative deltas are faster.

| Repository | Mode | Wall main → PR | Delta | Internal main → PR | Delta |
| --- | --- | ---: | ---: | ---: | ---: |
| rsbuild | plain | 422.5 → 426.0 ms | +0.83% | 388.5 → 390.0 ms | +0.39% |
| rsbuild | type-check | 586.5 → 581.0 ms | -0.94% | 548.5 → 545.0 ms | -0.64% |
| rsbuild | config | 409.5 → 410.0 ms | +0.12% | 371.0 → 373.5 ms | +0.67% |
| rspack | plain | 256.5 → 251.0 ms | -2.14% | 220.0 → 215.0 ms | -2.27% |
| rspack | type-check | 333.5 → 334.0 ms | +0.15% | 296.5 → 298.0 ms | +0.51% |
| rspack | config | 251.0 → 249.5 ms | -0.60% | 216.5 → 213.5 ms | -1.39% |
