### PR TITLE
feat(rstest): add prefer-expect-type-of rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -17,6 +17,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_standalone_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_exactly_once_with"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_each"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_expect_type_of"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_hooks_in_order"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_local_test_context_for_concurrent_snapshots"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_expect"
@@ -43,6 +44,7 @@ func GetAllRules() []rule.Rule {
 		no_standalone_expect.NoStandaloneExpectRule,
 		prefer_called_exactly_once_with.PreferCalledExactlyOnceWithRule,
 		prefer_each.PreferEachRule,
+		prefer_expect_type_of.PreferExpectTypeOfRule,
 		prefer_hooks_in_order.PreferHooksInOrderRule,
 		require_local_test_context_for_concurrent_snapshots.RequireLocalTestContextForConcurrentSnapshotsRule,
 		valid_expect.ValidExpectRule,

--- a/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.go
+++ b/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.go
@@ -1,0 +1,160 @@
+package prefer_expect_type_of
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+func buildPreferExpectTypeOfMessage(value string, typeText string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "preferExpectTypeOf",
+		Description: fmt.Sprintf(
+			"Use `expect(%s).toBeTypeOf(%s)` instead of `expect(typeof %s).toBe(%s)`",
+			value,
+			typeText,
+			value,
+			typeText,
+		),
+	}
+}
+
+// typeofAssertion describes one matched `expect(typeof value).toBe(type)`
+// chain. The rule keeps the nodes rather than their text so that the eager
+// pass stays free of source slicing beyond the two message placeholders.
+type typeofAssertion struct {
+	// typeofNode is the `typeof value` expression inside the expect head.
+	typeofNode *ast.Node
+	// operand is what `typeof` is applied to, as written.
+	operand *ast.Node
+	// matcherNode is the matcher accessor to rewrite to `toBeTypeOf`.
+	matcherNode *ast.Node
+	// matcherArgument is the single argument the matcher was called with.
+	matcherArgument *ast.Node
+}
+
+var PreferExpectTypeOfRule = rule.Rule{
+	Name:   "rstest/prefer-expect-type-of",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				assertion, ok := matchTypeofAssertion(analysis.ParseExpectCall(node))
+				if !ok {
+					return
+				}
+
+				message := buildPreferExpectTypeOfMessage(
+					utils.TrimmedNodeText(ctx.SourceFile, assertion.operand),
+					utils.TrimmedNodeText(ctx.SourceFile, assertion.matcherArgument),
+				)
+				ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
+					return buildFixes(ctx, assertion)
+				})
+			},
+		}
+	},
+}
+
+func matchTypeofAssertion(parsed *rstestUtils.ParsedRstestExpectCall) (typeofAssertion, bool) {
+	if parsed == nil ||
+		parsed.Reason != rstestUtils.RstestExpectParseReasonNone ||
+		parsed.MatcherEntry == nil ||
+		parsed.Head == nil {
+		return typeofAssertion{}, false
+	}
+
+	// `expect.poll(fn)` takes a function and `expect.element(locator)` takes a
+	// locator, so neither can carry the `typeof value` argument this rule
+	// rewrites; static members such as `expect.assertions(1)` have no head.
+	if parsed.Entry != rstestUtils.RstestExpectEntryCall &&
+		parsed.Entry != rstestUtils.RstestExpectEntrySoft {
+		return typeofAssertion{}, false
+	}
+
+	if parsed.Matcher != "toBe" && parsed.Matcher != "toEqual" {
+		return typeofAssertion{}, false
+	}
+	if len(parsed.Matchers) == 0 || parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall {
+		return typeofAssertion{}, false
+	}
+
+	// A computed identifier key names its matcher at runtime, so `toBe` here is
+	// the name of a variable rather than of a matcher. Reporting it would flag
+	// whatever assertion that variable holds.
+	matcherNode := parsed.MatcherEntry.Node
+	if matcherNode == nil || testFramework.IsComputedIdentifierAccessor(matcherNode) {
+		return typeofAssertion{}, false
+	}
+
+	headArguments := parsed.Head.Arguments()
+	if len(headArguments) == 0 {
+		return typeofAssertion{}, false
+	}
+	typeofNode := ast.SkipParentheses(headArguments[0])
+	if typeofNode == nil || typeofNode.Kind != ast.KindTypeOfExpression {
+		return typeofAssertion{}, false
+	}
+	operand := typeofNode.AsTypeOfExpression().Expression
+	if operand == nil {
+		return typeofAssertion{}, false
+	}
+
+	matcherArg := matcherArgument(parsed.MatcherEntry.Call)
+	if matcherArg == nil {
+		return typeofAssertion{}, false
+	}
+
+	return typeofAssertion{
+		typeofNode:      typeofNode,
+		operand:         operand,
+		matcherNode:     matcherNode,
+		matcherArgument: matcherArg,
+	}, true
+}
+
+// matcherArgument returns the matcher's single argument, or nil when the
+// matcher takes a different number of arguments or spreads them — neither maps
+// onto `toBeTypeOf(type)`.
+func matcherArgument(call *ast.Node) *ast.Node {
+	if call == nil {
+		return nil
+	}
+	arguments := call.Arguments()
+	if len(arguments) != 1 || arguments[0].Kind == ast.KindSpreadElement {
+		return nil
+	}
+	return arguments[0]
+}
+
+// buildFixes rewrites the two places that differ from the desired form and
+// leaves the rest of the call untouched, so `expect(actual, message)`, the
+// `expect.soft` factory, a renamed or `import.meta.rstest` expect root, the
+// modifier chain and the matcher argument all survive the fix.
+func buildFixes(ctx rule.RuleContext, assertion typeofAssertion) []rule.RuleFix {
+	typeofStart := utils.TrimNodeTextRange(ctx.SourceFile, assertion.typeofNode).Pos()
+	operandStart := utils.TrimNodeTextRange(ctx.SourceFile, assertion.operand).Pos()
+	if operandStart <= typeofStart {
+		return nil
+	}
+
+	matcherRange, matcherText, ok := testFramework.AccessorReplacement(
+		ctx.SourceFile,
+		assertion.matcherNode,
+		"toBeTypeOf",
+	)
+	if !ok {
+		return nil
+	}
+
+	return []rule.RuleFix{
+		rule.RuleFixRemoveRange(core.NewTextRange(typeofStart, operandStart)),
+		rule.RuleFixReplaceRange(matcherRange, matcherText),
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.md
+++ b/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.md
@@ -1,0 +1,90 @@
+# prefer-expect-type-of
+
+## Rule Details
+
+Prefer `expect(value).toBeTypeOf(type)` over `expect(typeof value).toBe(type)`.
+The dedicated matcher states the intent directly and, when it fails, reports
+the value's actual type instead of a plain string comparison.
+
+Examples of **incorrect** code:
+
+```ts
+expect(typeof value).toBe('string');
+expect(typeof value).toEqual('number');
+expect(typeof value).not.toBe('function');
+expect.soft(typeof value).toBe('object');
+```
+
+Examples of **correct** code:
+
+```ts
+expect(value).toBeTypeOf('string');
+expect(value).not.toBeTypeOf('function');
+expect.soft(value).toBeTypeOf('object');
+expect(typeof value === 'string').toBe(true);
+```
+
+The rule reports only a matcher that is actually called with exactly one
+argument. A broken chain such as `expect(typeof value).toBe`, a spread argument
+such as `expect(typeof value).toBe(...types)`, and a Chai property assertion
+such as `expect(typeof value).to.be.ok` are all left alone.
+
+## Fix
+
+The fix edits two places and leaves the rest of the call exactly as written: it
+removes the `typeof` operator from the assertion's argument, and renames the
+matcher accessor to `toBeTypeOf`. Everything else survives — the expect root as
+spelled at the call site, `expect.soft`, the optional second `message` argument
+of `expect(actual, message)`, the modifier chain, the matcher argument, the
+accessor's own quoting, and the surrounding line breaks and comments:
+
+```ts
+expect.soft(typeof value, 'should be a string')['toBe']('string');
+// becomes
+expect.soft(value, 'should be a string')['toBeTypeOf']('string');
+```
+
+A comment written between `typeof` and its operand sits inside the removed span
+and is removed with it. Every comment outside those two spans is preserved.
+
+## Rstest specifics
+
+The assertion is recognised through Rstest's shared expect parser, so every
+expect source is covered: globals, `@rstest/core` named imports and renamed
+imports, `require('@rstest/core')` destructuring, namespace imports, whole-module
+`require`, `import.meta.rstest`, `@rstest/playwright`, and the `expect` a test
+callback receives through its context (`({ expect })` and `ctx.expect`). An
+`expect` imported from Vitest, Jest, Playwright or Chai, and a local variable
+that shadows `expect`, are not reported.
+
+`expect.poll(fn)` and `expect.element(locator)` are excluded: the first takes a
+callback and the second a locator, so neither carries the value being type
+checked.
+
+## Differences from ESLint
+
+`@vitest/eslint-plugin` rewrites the whole assertion to
+`expect(<value>)<modifiers>.toBeTypeOf(<type>)`. On Rstest that rewrite loses
+information, so this port edits only the `typeof` operator and the matcher name.
+Three shapes come out differently:
+
+- `expect(actual, message)` keeps its message. Rstest's `expect` takes an
+  optional second argument, which upstream's whole-call rewrite drops.
+- `expect.soft(typeof value).toBe('string')` stays soft. Upstream rewrites it to
+  a plain `expect(...)`, which turns a soft assertion into one that aborts the
+  test.
+- The expect root keeps its spelling. `import.meta.rstest.expect(...)`, a
+  renamed import, and a test context's `expect` are all rewritten to a bare
+  `expect` by upstream, which may not even be bound in that scope.
+
+The port also narrows one shape:
+
+- A computed identifier key, `expect(typeof value)[matcherName]('string')`, is
+  not reported. The matcher is chosen at runtime, so `toBe` there is the name of
+  a variable rather than of a matcher, and neither the report nor a rename of
+  that variable would be correct.
+
+## Original Documentation
+
+- [@vitest/eslint-plugin: prefer-expect-type-of](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/docs/rules/prefer-expect-type-of.md)
+- [Source code](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/src/rules/prefer-expect-type-of.ts)

--- a/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.md
+++ b/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.md
@@ -24,10 +24,25 @@ expect.soft(value).toBeTypeOf('object');
 expect(typeof value === 'string').toBe(true);
 ```
 
+## Recognized assertions
+
 The rule reports only a matcher that is actually called with exactly one
 argument. A broken chain such as `expect(typeof value).toBe`, a spread argument
 such as `expect(typeof value).toBe(...types)`, and a Chai property assertion
-such as `expect(typeof value).to.be.ok` are all left alone.
+such as `expect(typeof value).to.be.ok` are all left alone. So is a matcher
+named by a computed key, `expect(typeof value)[matcherName]('string')`, because
+which assertion runs is only known at runtime.
+
+Every expect source is covered: globals, `@rstest/core` named imports and
+renamed imports, `require('@rstest/core')` destructuring, namespace imports,
+whole-module `require`, `import.meta.rstest`, `@rstest/playwright`, and the
+`expect` a test callback receives through its context (`({ expect })` and
+`ctx.expect`). An `expect` from another assertion library, and a local variable
+that shadows `expect`, are not reported.
+
+`expect.poll(fn)` and `expect.element(locator)` are excluded: the first takes a
+callback and the second a locator, so neither carries the value being type
+checked.
 
 ## Fix
 
@@ -46,45 +61,3 @@ expect.soft(value, 'should be a string')['toBeTypeOf']('string');
 
 A comment written between `typeof` and its operand sits inside the removed span
 and is removed with it. Every comment outside those two spans is preserved.
-
-## Rstest specifics
-
-The assertion is recognised through Rstest's shared expect parser, so every
-expect source is covered: globals, `@rstest/core` named imports and renamed
-imports, `require('@rstest/core')` destructuring, namespace imports, whole-module
-`require`, `import.meta.rstest`, `@rstest/playwright`, and the `expect` a test
-callback receives through its context (`({ expect })` and `ctx.expect`). An
-`expect` imported from Vitest, Jest, Playwright or Chai, and a local variable
-that shadows `expect`, are not reported.
-
-`expect.poll(fn)` and `expect.element(locator)` are excluded: the first takes a
-callback and the second a locator, so neither carries the value being type
-checked.
-
-## Differences from ESLint
-
-`@vitest/eslint-plugin` rewrites the whole assertion to
-`expect(<value>)<modifiers>.toBeTypeOf(<type>)`. On Rstest that rewrite loses
-information, so this port edits only the `typeof` operator and the matcher name.
-Three shapes come out differently:
-
-- `expect(actual, message)` keeps its message. Rstest's `expect` takes an
-  optional second argument, which upstream's whole-call rewrite drops.
-- `expect.soft(typeof value).toBe('string')` stays soft. Upstream rewrites it to
-  a plain `expect(...)`, which turns a soft assertion into one that aborts the
-  test.
-- The expect root keeps its spelling. `import.meta.rstest.expect(...)`, a
-  renamed import, and a test context's `expect` are all rewritten to a bare
-  `expect` by upstream, which may not even be bound in that scope.
-
-The port also narrows one shape:
-
-- A computed identifier key, `expect(typeof value)[matcherName]('string')`, is
-  not reported. The matcher is chosen at runtime, so `toBe` there is the name of
-  a variable rather than of a matcher, and neither the report nor a rename of
-  that variable would be correct.
-
-## Original Documentation
-
-- [@vitest/eslint-plugin: prefer-expect-type-of](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/docs/rules/prefer-expect-type-of.md)
-- [Source code](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/src/rules/prefer-expect-type-of.ts)

--- a/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of_extras_test.go
@@ -1,0 +1,444 @@
+// TestPreferExpectTypeOfExtras locks in the Rstest-only augmentation the port
+// spec requires: the expect source matrix, the assertion-factory boundary, the
+// matcher-argument contract, trivia-preserving surgical fixes, real-user
+// shapes, and graceful degradation. Edit-demand parity lives in
+// TestPreferExpectTypeOfEditDemand.
+package prefer_expect_type_of
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferExpectTypeOfExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferExpectTypeOfRule,
+		[]rule_tester.ValidTestCase{
+			// ---- A. The target form already in use ----
+			{Code: `expect(value).toBeTypeOf("string");`},
+			{Code: `expect.soft(value).toBeTypeOf("string");`},
+			{Code: `expect(typeof value).toBeTypeOf("string");`},
+
+			// ---- B. The head argument is not a typeof expression ----
+			{Code: `expect(typeof value === "string").toBe(true);`},
+			{Code: `expect(!(typeof value)).toBe(true);`},
+			{Code: `expect(value).toBe("string");`},
+			{Code: `expect().toBe("string");`},
+			{Code: `expect(...args).toBe("string");`},
+			// SkipParentheses is the spec's unwrap: a TypeScript assertion
+			// around the argument is left to the assertion-aware rules.
+			{Code: `expect(typeof value as unknown).toBe("string");`},
+			{Code: `expect((typeof value)! ).toBe("string");`},
+
+			// ---- C. Assertion factories that cannot carry a typeof value ----
+			// poll takes a callback and element takes a locator, so neither
+			// shape is a typeof assertion even when written like one.
+			{Code: `expect.poll(() => typeof value).toBe("string");`},
+			{Code: `expect.element(typeof value).toBe("string");`},
+			{Code: `expect.assertions(typeof value);`},
+			{Code: `expect.unreachable(typeof value);`},
+
+			// ---- D. Matcher contract ----
+			{Code: `expect(typeof value).toMatch("string");`},
+			{Code: `expect(typeof value).toStrictEqual("string");`},
+			{Code: `expect(typeof value).toBe();`},
+			{Code: `expect(typeof value).toBe("string", "extra");`},
+			{Code: `expect(typeof value).toBe(...types);`},
+			{Code: `expect(typeof value).toEqual(...types);`},
+			// Broken chains belong to rstest/valid-expect, which owns Reason.
+			{Code: `expect(typeof value).toBe;`},
+			{Code: `expect(typeof value);`},
+			{Code: `expect(typeof value).resolves.resolves.toBe("string");`},
+			// Chai property assertions never execute toBe.
+			{Code: `expect(typeof value).to.be.ok;`},
+			{Code: `expect(typeof value).to.be.a("string");`},
+
+			// ---- E. A computed identifier key names its matcher at runtime ----
+			// The parser records the variable's own text as the member name, so
+			// matching it here would report whatever assertion the variable
+			// holds. Fixing is impossible for the same reason, and the fix
+			// would have to rewrite the variable name.
+			{Code: `const toBe = "toStrictEqual";
+expect(typeof value)[toBe]("string");`},
+			{Code: `const toEqual = "toMatch";
+expect(typeof value)[toEqual]("string");`},
+			{Code: `expect(typeof value)[matcherName]("string");`},
+			{Code: `expect(typeof value)[matchers.toBe]("string");`},
+
+			// ---- F. Reverse sources: foreign and local expects ----
+			{Code: `import { expect } from 'vitest';
+expect(typeof value).toBe("string");`},
+			{Code: `import { expect } from '@jest/globals';
+expect(typeof value).toBe("string");`},
+			{Code: `import { expect } from '@playwright/test';
+expect(typeof value).toBe("string");`},
+			{Code: `import { expect } from 'chai';
+expect(typeof value).toBe("string");`},
+			{Code: `const expect = createAssertionLibrary();
+expect(typeof value).toBe("string");`},
+			{Code: `custom.expect(typeof value).toBe("string");`},
+			// A same-file alias of expect is not followed by the parser, so the
+			// call is not a recognised Rstest expect.
+			{Code: `import { expect } from '@rstest/core';
+const check = expect;
+check(typeof value).toBe("string");`},
+
+			// ---- F. Shadowing ----
+			{Code: `import { expect } from '@rstest/core';
+function run(expect: any) { expect(typeof value).toBe("string"); }`},
+			{Code: `import { expect as check } from '@rstest/core';
+function run(check: any) { check(typeof value).toBe("string"); }`},
+			{Code: `import * as core from '@rstest/core';
+function run() { const core = helper(); core.expect(typeof value).toBe("string"); }`},
+
+			// ---- G. Dimension 4: shapes the shared parser declines ----
+			// The rule reports only what analysis.ParseExpectCall resolves, so
+			// an unrecognised root, a chain that reads a property of the
+			// assertion's own result, and an unknown member before the matcher
+			// are all silent rather than guessed at.
+			{Code: `broken.expect?.(typeof value).toBe("string");`},
+			{Code: `expect(typeof value).toBe("string")[0];`},
+			{Code: `expect(typeof value).unknownMember.toBe("string");`},
+
+			// N/A: declaration and container variants, function kinds, class
+			// members, and overload signatures are unrelated to this rule's
+			// single call-expression listener over analysis.ParseExpectCall.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- H. Expect source matrix ----
+			{
+				Code: `import { expect } from '@rstest/core';
+expect(typeof value).toBe("string");`,
+				Output: []string{`import { expect } from '@rstest/core';
+expect(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Line:      2,
+					Column:    1,
+					EndLine:   2,
+					EndColumn: 36,
+				}},
+			},
+			{
+				Code: `import { expect as check } from '@rstest/core';
+check(typeof value).toEqual("string");`,
+				Output: []string{`import { expect as check } from '@rstest/core';
+check(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 2, Column: 1}},
+			},
+			{
+				Code: `import * as core from '@rstest/core';
+core.expect(typeof value).toBe("string");`,
+				Output: []string{`import * as core from '@rstest/core';
+core.expect(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 2, Column: 1}},
+			},
+			{
+				Code: `const { expect } = require('@rstest/core');
+expect(typeof value).toBe("string");`,
+				Output: []string{`const { expect } = require('@rstest/core');
+expect(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 2, Column: 1}},
+			},
+			{
+				Code: `const core = require('@rstest/core');
+core.expect(typeof value).toBe("string");`,
+				Output: []string{`const core = require('@rstest/core');
+core.expect(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 2, Column: 1}},
+			},
+			{
+				Code:   `import.meta.rstest.expect(typeof value).toBe("string");`,
+				Output: []string{`import.meta.rstest.expect(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code: `const { expect } = import.meta.rstest;
+expect(typeof value).toBe("string");`,
+				Output: []string{`const { expect } = import.meta.rstest;
+expect(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 2, Column: 1}},
+			},
+			{
+				Code: `import { expect } from '@rstest/playwright';
+expect(typeof value).toBe("string");`,
+				Output: []string{`import { expect } from '@rstest/playwright';
+expect(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 2, Column: 1}},
+			},
+			{
+				Code:   `test('x', ({ expect }) => expect(typeof value).toBe("string"));`,
+				Output: []string{`test('x', ({ expect }) => expect(value).toBeTypeOf("string"));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 27}},
+			},
+			{
+				Code:   `test('x', ctx => ctx.expect(typeof value).toBe("string"));`,
+				Output: []string{`test('x', ctx => ctx.expect(value).toBeTypeOf("string"));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 18}},
+			},
+
+			// ---- I. The parts of the call the surgical fix must preserve ----
+			{
+				// The message argument only expect(...) accepts survives.
+				Code:   `expect(typeof value, "value should be a string").toBe("string");`,
+				Output: []string{`expect(value, "value should be a string").toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(value).toBeTypeOf(\"string\")` instead of `expect(typeof value).toBe(\"string\")`",
+					Line:      1,
+					Column:    1,
+				}},
+			},
+			{
+				// expect.soft stays soft rather than being rewritten to expect.
+				Code:   `expect.soft(typeof value).toBe("string");`,
+				Output: []string{`expect.soft(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `expect(typeof value).not.toBe("string");`,
+				Output: []string{`expect(value).not.toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `await expect(typeof value).resolves.toBe("string");`,
+				Output: []string{`await expect(value).resolves.toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 7}},
+			},
+			{
+				Code:   `expect(typeof value).toEqual(expectedType);`,
+				Output: []string{`expect(value).toBeTypeOf(expectedType);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				// The operand keeps its own parentheses.
+				Code:   `expect(typeof (value)).toBe("string");`,
+				Output: []string{`expect((value)).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect((value)).toBeTypeOf(\"string\")` instead of `expect(typeof (value)).toBe(\"string\")`",
+					Line:      1,
+					Column:    1,
+				}},
+			},
+			{
+				// Parentheses around the typeof expression are the argument, so
+				// only the operator is removed.
+				Code:   `expect((typeof value)).toBe("string");`,
+				Output: []string{`expect((value)).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `expect(typeof value.deep.property).toBe("function");`,
+				Output: []string{`expect(value.deep.property).toBeTypeOf("function");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `expect(typeof value).toBe(` + "`string`" + `);`,
+				Output: []string{`expect(value).toBeTypeOf(` + "`string`" + `);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+
+			// ---- J. Accessor spellings are preserved ----
+			{
+				Code:   `expect(typeof value)['toBe']("string");`,
+				Output: []string{`expect(value)['toBeTypeOf']("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code:   "expect(typeof value)[`toEqual`](\"string\");",
+				Output: []string{"expect(value)[`toBeTypeOf`](\"string\");"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `expect(typeof value).not["toBe"]("string");`,
+				Output: []string{`expect(value).not["toBeTypeOf"]("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+
+			// ---- K. Trivia ----
+			{
+				// A comment between the operator and the operand sits inside the
+				// removed span and goes with it; every other comment stays.
+				Code: `expect(
+  typeof /* why */ value, // reason
+).toBe(
+  "string", // the type
+);`,
+				Output: []string{`expect(
+  value, // reason
+).toBeTypeOf(
+  "string", // the type
+);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				// A comment between the matcher accessor and its argument list
+				// is outside both edits.
+				Code:   `expect(typeof value).toBe /* here */ ("string");`,
+				Output: []string{`expect(value).toBeTypeOf /* here */ ("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code: `expect(typeof value)
+  .not
+  .toBe("string");`,
+				Output: []string{`expect(value)
+  .not
+  .toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+
+			// ---- L. Optional call and optional chain links ----
+			{
+				Code:   `expect?.(typeof value).toBe("string");`,
+				Output: []string{`expect?.(value).toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `expect(typeof value)?.toBe("string");`,
+				Output: []string{`expect(value)?.toBeTypeOf("string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 1, Column: 1}},
+			},
+
+			// ---- M. Real-user shapes ----
+			{
+				Code: `import { expect, test } from '@rstest/core';
+
+test('exposes a string id', () => {
+  const user = createUser();
+  expect(typeof user.id).toBe('string');
+  expect(user.name).toBe('ada');
+});`,
+				Output: []string{`import { expect, test } from '@rstest/core';
+
+test('exposes a string id', () => {
+  const user = createUser();
+  expect(user.id).toBeTypeOf('string');
+  expect(user.name).toBe('ada');
+});`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 5, Column: 3}},
+			},
+			{
+				Code: `test.each(['a', 1])('checks %s', (value) => {
+  expect(typeof value).toEqual(typeof value);
+});`,
+				Output: []string{`test.each(['a', 1])('checks %s', (value) => {
+  expect(value).toBeTypeOf(typeof value);
+});`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferExpectTypeOf", Line: 2, Column: 3}},
+			},
+			{
+				// Two assertions in one file are reported and fixed independently.
+				Code: `expect(typeof first).toBe("string");
+expect(typeof second).toEqual("number");`,
+				Output: []string{`expect(first).toBeTypeOf("string");
+expect(second).toBeTypeOf("number");`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferExpectTypeOf", Line: 1, Column: 1},
+					{MessageId: "preferExpectTypeOf", Line: 2, Column: 1},
+				},
+			},
+		},
+	)
+}
+
+// TestPreferExpectTypeOfEditDemand locks in that the diagnostic is identical
+// under every edit demand and that only the autofix demands materialize fixes.
+func TestPreferExpectTypeOfEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`expect(typeof value).toBe("string");
+expect.soft(typeof other)['toEqual']("number");`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      lintprogram.NewFromCompiler(program),
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     PreferExpectTypeOfRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferExpectTypeOfRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		want := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d diagnostic %d changed:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+	}
+
+	if diagnosticsOnly[0].FixesPtr != nil || diagnosticsOnly[1].FixesPtr != nil {
+		t.Fatal("EditDemandNone unexpectedly materialized fixes")
+	}
+	if suggestionOnly[0].FixesPtr != nil || suggestionOnly[1].FixesPtr != nil {
+		t.Fatal("EditDemandSuggestion unexpectedly materialized fixes")
+	}
+	for index, diagnostic := range allEdits {
+		if diagnostic.Suggestions != nil {
+			t.Fatalf("diagnostic %d unexpectedly materialized suggestions", index)
+		}
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, diagnostic.FixesPtr) {
+			t.Fatalf("diagnostic %d produced inconsistent fixes between autofix and all demands", index)
+		}
+		if fixes := *autofixOnly[index].FixesPtr; len(fixes) != 2 {
+			t.Fatalf("diagnostic %d produced %d fixes, want 2", index, len(fixes))
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of_upstream_test.go
+++ b/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of_upstream_test.go
@@ -1,0 +1,180 @@
+// TestPreferExpectTypeOfUpstream migrates the complete
+// @vitest/eslint-plugin@v1.6.27 prefer-expect-type-of suite. Rstest-only edge
+// cases, source matrices, fix-trivia coverage and edit-demand parity live in
+// prefer_expect_type_of_extras_test.go.
+package prefer_expect_type_of
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferExpectTypeOfUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferExpectTypeOfRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect("name").toBeTypeOf("string")`},
+			{Code: `expect("name").not.toBeTypeOf("string")`},
+			{Code: `expect(12).toBeTypeOf("number")`},
+			{Code: `expect(true).toBeTypeOf("boolean")`},
+			{Code: `expect({a: 1}).toBeTypeOf("object")`},
+			{Code: `expect(() => {}).toBeTypeOf("function")`},
+			{Code: `expect(sym).toBeTypeOf("symbol")`},
+			{Code: `expect(BigInt(123)).toBeTypeOf("bigint")`},
+			{Code: `expect(undefined).toBeTypeOf("undefined")`},
+			{Code: `expect(value).not.toBe(42)`},
+			{Code: `expect(value).not.toEqual(42)`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `expect(typeof 12).toBe("number")`,
+				Output: []string{`expect(12).toBeTypeOf("number")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(12).toBeTypeOf(\"number\")` instead of `expect(typeof 12).toBe(\"number\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 33,
+				}},
+			},
+			{
+				Code:   `expect(typeof "name").toBe("string")`,
+				Output: []string{`expect("name").toBeTypeOf("string")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(\"name\").toBeTypeOf(\"string\")` instead of `expect(typeof \"name\").toBe(\"string\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 37,
+				}},
+			},
+			{
+				Code:   `expect(typeof true).toBe("boolean")`,
+				Output: []string{`expect(true).toBeTypeOf("boolean")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(true).toBeTypeOf(\"boolean\")` instead of `expect(typeof true).toBe(\"boolean\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 36,
+				}},
+			},
+			{
+				Code:   `expect(typeof variable).toBe("object")`,
+				Output: []string{`expect(variable).toBeTypeOf("object")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(variable).toBeTypeOf(\"object\")` instead of `expect(typeof variable).toBe(\"object\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 39,
+				}},
+			},
+			{
+				Code:   `expect(typeof fn).toBe("function")`,
+				Output: []string{`expect(fn).toBeTypeOf("function")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(fn).toBeTypeOf(\"function\")` instead of `expect(typeof fn).toBe(\"function\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 35,
+				}},
+			},
+			{
+				Code:   `expect(typeof sym).toBe("symbol")`,
+				Output: []string{`expect(sym).toBeTypeOf("symbol")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(sym).toBeTypeOf(\"symbol\")` instead of `expect(typeof sym).toBe(\"symbol\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 34,
+				}},
+			},
+			{
+				Code:   `expect(typeof big).toBe("bigint")`,
+				Output: []string{`expect(big).toBeTypeOf("bigint")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(big).toBeTypeOf(\"bigint\")` instead of `expect(typeof big).toBe(\"bigint\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 34,
+				}},
+			},
+			{
+				Code:   `expect(typeof value).toBe("undefined")`,
+				Output: []string{`expect(value).toBeTypeOf("undefined")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(value).toBeTypeOf(\"undefined\")` instead of `expect(typeof value).toBe(\"undefined\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 39,
+				}},
+			},
+			{
+				Code:   `expect(typeof value).toEqual("string")`,
+				Output: []string{`expect(value).toBeTypeOf("string")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(value).toBeTypeOf(\"string\")` instead of `expect(typeof value).toBe(\"string\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 39,
+				}},
+			},
+			{
+				Code:   `expect(typeof value).not.toBe("string")`,
+				Output: []string{`expect(value).not.toBeTypeOf("string")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(value).toBeTypeOf(\"string\")` instead of `expect(typeof value).toBe(\"string\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 40,
+				}},
+			},
+			{
+				Code:   `expect(typeof value).toBe("unknown")`,
+				Output: []string{`expect(value).toBeTypeOf("unknown")`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(value).toBeTypeOf(\"unknown\")` instead of `expect(typeof value).toBe(\"unknown\")`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 37,
+				}},
+			},
+			{
+				Code:   `expect(typeof value).toBe(typeName)`,
+				Output: []string{`expect(value).toBeTypeOf(typeName)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferExpectTypeOf",
+					Message:   "Use `expect(value).toBeTypeOf(typeName)` instead of `expect(typeof value).toBe(typeName)`",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 36,
+				}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -596,6 +596,7 @@ export default defineConfig({
     './tests/rstest/rules/no-standalone-expect.test.ts',
     './tests/rstest/rules/prefer-called-exactly-once-with.test.ts',
     './tests/rstest/rules/prefer-each.test.ts',
+    './tests/rstest/rules/prefer-expect-type-of.test.ts',
     './tests/rstest/rules/prefer-hooks-in-order.test.ts',
     './tests/rstest/rules/require-local-test-context-for-concurrent-snapshots.test.ts',
     './tests/rstest/rules/valid-expect-in-promise.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/prefer-expect-type-of.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/prefer-expect-type-of.test.ts
@@ -1,0 +1,189 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-expect-type-of', {} as never, {
+  valid: [
+    { code: `expect("name").toBeTypeOf("string")` },
+    { code: `expect("name").not.toBeTypeOf("string")` },
+    { code: `expect(12).toBeTypeOf("number")` },
+    { code: `expect(true).toBeTypeOf("boolean")` },
+    { code: `expect({a: 1}).toBeTypeOf("object")` },
+    { code: `expect(() => {}).toBeTypeOf("function")` },
+    { code: `expect(sym).toBeTypeOf("symbol")` },
+    { code: `expect(BigInt(123)).toBeTypeOf("bigint")` },
+    { code: `expect(undefined).toBeTypeOf("undefined")` },
+    { code: `expect(value).not.toBe(42)` },
+    { code: `expect(value).not.toEqual(42)` },
+  ],
+  invalid: [
+    {
+      code: `expect(typeof 12).toBe("number")`,
+      output: `expect(12).toBeTypeOf("number")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(12).toBeTypeOf("number")\` instead of \`expect(typeof 12).toBe("number")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 33,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof "name").toBe("string")`,
+      output: `expect("name").toBeTypeOf("string")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect("name").toBeTypeOf("string")\` instead of \`expect(typeof "name").toBe("string")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 37,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof true).toBe("boolean")`,
+      output: `expect(true).toBeTypeOf("boolean")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(true).toBeTypeOf("boolean")\` instead of \`expect(typeof true).toBe("boolean")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 36,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof variable).toBe("object")`,
+      output: `expect(variable).toBeTypeOf("object")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(variable).toBeTypeOf("object")\` instead of \`expect(typeof variable).toBe("object")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 39,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof fn).toBe("function")`,
+      output: `expect(fn).toBeTypeOf("function")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(fn).toBeTypeOf("function")\` instead of \`expect(typeof fn).toBe("function")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 35,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof sym).toBe("symbol")`,
+      output: `expect(sym).toBeTypeOf("symbol")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(sym).toBeTypeOf("symbol")\` instead of \`expect(typeof sym).toBe("symbol")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 34,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof big).toBe("bigint")`,
+      output: `expect(big).toBeTypeOf("bigint")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(big).toBeTypeOf("bigint")\` instead of \`expect(typeof big).toBe("bigint")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 34,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof value).toBe("undefined")`,
+      output: `expect(value).toBeTypeOf("undefined")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(value).toBeTypeOf("undefined")\` instead of \`expect(typeof value).toBe("undefined")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 39,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof value).toEqual("string")`,
+      output: `expect(value).toBeTypeOf("string")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(value).toBeTypeOf("string")\` instead of \`expect(typeof value).toBe("string")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 39,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof value).not.toBe("string")`,
+      output: `expect(value).not.toBeTypeOf("string")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(value).toBeTypeOf("string")\` instead of \`expect(typeof value).toBe("string")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 40,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof value).toBe("unknown")`,
+      output: `expect(value).toBeTypeOf("unknown")`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(value).toBeTypeOf("unknown")\` instead of \`expect(typeof value).toBe("unknown")\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 37,
+        },
+      ],
+    },
+    {
+      code: `expect(typeof value).toBe(typeName)`,
+      output: `expect(value).toBeTypeOf(typeName)`,
+      errors: [
+        {
+          messageId: 'preferExpectTypeOf',
+          message: `Use \`expect(value).toBeTypeOf(typeName)\` instead of \`expect(typeof value).toBe(typeName)\``,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 36,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Report `expect(typeof value).toBe(type)` and its `toEqual` form and rewrite them to `expect(value).toBeTypeOf(type)`, which states the intent directly and, when it fails, reports the value's actual type instead of comparing two strings. Only a matcher that is really called, with exactly one non-spread argument, is reported: a broken chain such as `expect(typeof value).toBe`, a spread argument, and a Chai property assertion such as `expect(typeof value).to.be.ok` are all left alone.

The assertion resolves through the shared `ParseExpectCall`, so globals, named and renamed imports, namespace and whole-module `require`, `import.meta.rstest`, `@rstest/playwright` and the `expect` a test callback receives through its context are all covered, and an `expect` from Vitest, Jest, Playwright or Chai is not. `expect.poll(fn)` and `expect.element(locator)` are excluded: the first takes a callback and the second a locator, so neither carries the value being type checked. The fix is deferred. Registered in the rstest plugin but left out of the `recommended` preset, matching upstream.

## Credits

Port from [`@vitest/eslint-plugin`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `prefer-expect-type-of`. `eslint-plugin-jest` has no counterpart, so there is no second baseline to cross-check against.

## Intentional differences from upstream

- **The fix is two surgical edits rather than a whole-call rewrite.** Upstream replaces the entire assertion with `` `expect(${value})${modifiers}.toBeTypeOf(${type})` ``. This port removes the `typeof` operator from the assertion's argument and renames the matcher accessor, leaving everything else as written. Three shapes come out differently: `expect(actual, message)` keeps the second argument Rstest's `expect` accepts and upstream's rewrite drops; `expect.soft(...)` stays soft instead of becoming an assertion that aborts the test; and the expect root keeps its spelling, so `import.meta.rstest.expect(...)`, a renamed import and a test context's `expect` are not replaced by a bare `expect` that may not be bound in that scope. The accessor's own quoting is preserved for the same reason, so `expect(typeof x)['toBe']('string')` comes back as `['toBeTypeOf']`.

- **A computed identifier matcher key is not reported.** `expect(typeof value)[matcherName]('string')` chooses its matcher at runtime, so a key that happens to be spelled `toBe` names a variable rather than a matcher. Reporting it would flag whatever assertion that variable holds, and the fix would have to rewrite the variable's name; the rule stays silent instead. Upstream reads the key's own text and both reports and fixes it.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
