### PR TITLE
fix(wasm): remove stray debugger statement

### DIFF
--- a/packages/rslint-wasm/wasm_exec.js
+++ b/packages/rslint-wasm/wasm_exec.js
@@ -6,7 +6,6 @@
 
 (() => {
   const enosys = () => {
-    debugger;
     const err = new Error('not implemented');
     err.code = 'ENOSYS';
     return err;


### PR DESCRIPTION
## Summary

The browser playground pauses whenever Go's WASM shim reaches an unimplemented operation because `wasm_exec.js` contains a stray `debugger` statement.

Remove the statement so `ENOSYS` errors are returned without forcing DevTools to pause.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).