### PR TITLE
docs: refresh TypeScript compiler wording and package README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 
 Rslint is a high-performance, ESLint-compatible linter for JavaScript and TypeScript.
 
-Powered by [typescript-go](https://github.com/microsoft/typescript-go), it delivers a faster drop-in experience with type-aware rules and optional type checking in the same run.
+Powered by [TypeScript's native compiler](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/), it delivers a faster drop-in experience with type-aware rules and optional type checking in the same run.
 
 ## ✨ Goals
 
-- 🚀 **Lightning Fast**: Powered by typescript-go, delivering 20-40x faster linting performance compared to traditional ESLint setups.
+- 🚀 **Lightning Fast**: Powered by TypeScript's native compiler, delivering 20-40x faster linting performance compared to traditional ESLint setups.
 - ⚡ **Minimal Configuration**: Typed linting enabled by default with minimal setup required — no complex configuration needed.
 - 📦 **Best Effort ESLint Compatible**: Compatible with most ESLint and TypeScript-ESLint configurations, significantly reducing migration costs.
 - 🎯 **TypeScript First**: Uses TypeScript Compiler semantics as the single source of truth, ensuring 100% consistency and eliminating edge-case bugs.

--- a/packages/rslint/README.md
+++ b/packages/rslint/README.md
@@ -1,33 +1,19 @@
 # Rslint
 
-🚀 Rocket Speed Linter - A high-performance TypeScript/JavaScript linter written in Go.
+<p>
+  <a href="https://npmjs.com/package/@rslint/core?activeTab=readme"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>
+  <a href="https://npmcharts.com/compare/@rslint/core?minimal=true"><img src="https://img.shields.io/npm/dm/@rslint/core.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
+  <a href="https://github.com/web-infra-dev/rslint/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
+</p>
 
-## Features
+Rslint is a high-performance, ESLint-compatible linter for JavaScript and TypeScript.
 
-- ⚡ **Ultra-fast**: 10x+ faster than ESLint through Go-powered parallel processing
-- 🎯 **Typed linting first**: Enables typed linting by default for advanced semantic analysis
-- 🔧 **Easy migration**: Compatible with ESLint and TypeScript-ESLint rule configurations
-- 🏗️ **Project-level analysis**: Performs cross-module analysis for better linting results
-- 📦 **Monorepo support**: First-class support for large-scale TypeScript monorepos
-- 🔋 **Batteries included**: Ships with all TypeScript-ESLint rules out of the box
-
-## Installation
-
-```bash
-npm install -D @rslint/core
-```
-
-## Quick Start
-
-```bash
-
-# Lint your project
-npx rslint
-
-# See available options
-npx rslint --help
-```
+Powered by [TypeScript's native compiler](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/), it delivers a faster drop-in experience with type-aware rules and optional type checking in the same run.
 
 ## Documentation
 
-See the [main repository](https://github.com/web-infra-dev/rslint) for complete documentation and examples.
+Visit <https://rslint.rs/> to view the full documentation.
+
+## License
+
+MIT License.

--- a/website/docs/en/guide/index.mdx
+++ b/website/docs/en/guide/index.mdx
@@ -4,7 +4,7 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 Rslint is a high-performance, ESLint-compatible linter for JavaScript and TypeScript.
 
-Powered by [typescript-go](https://github.com/microsoft/typescript-go), it delivers a faster drop-in experience with type-aware rules and optional type checking in the same run.
+Powered by [TypeScript's native compiler](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/), it delivers a faster drop-in experience with type-aware rules and optional type checking in the same run.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

TypeScript 7 now presents the Go implementation as TypeScript's native compiler, while Rslint's public docs still referred to the `typescript-go` staging project.

This PR updates the root README and getting-started guide to use the current terminology, and simplifies the `@rslint/core` package README to direct users to the maintained documentation.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).