### PR TITLE
feat(rstest): add prefer-called-times rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_standalone_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_exactly_once_with"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_times"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_each"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_hooks_in_order"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_local_test_context_for_concurrent_snapshots"
@@ -42,6 +43,7 @@ func GetAllRules() []rule.Rule {
 		no_mocks_import.NoMocksImportRule,
 		no_standalone_expect.NoStandaloneExpectRule,
 		prefer_called_exactly_once_with.PreferCalledExactlyOnceWithRule,
+		prefer_called_times.PreferCalledTimesRule,
 		prefer_each.PreferEachRule,
 		prefer_hooks_in_order.PreferHooksInOrderRule,
 		require_local_test_context_for_concurrent_snapshots.RequireLocalTestContextForConcurrentSnapshotsRule,

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.go
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.go
@@ -34,7 +34,7 @@ var PreferCalledTimesRule = rule.Rule{
 		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				matcher, ok := calledOnceMatcherEntry(analysis.ParseExpectCall(node))
+				matcher, matcherCall, ok := calledOnceMatcherEntry(analysis.ParseExpectCall(node))
 				if !ok {
 					return
 				}
@@ -49,7 +49,7 @@ var PreferCalledTimesRule = rule.Rule{
 						return nil
 					}
 
-					argumentStart, ok := argumentListStart(ctx.SourceFile, matcher.Call)
+					argumentStart, ok := argumentListStart(ctx.SourceFile, matcherCall)
 					if !ok {
 						return nil
 					}
@@ -65,7 +65,7 @@ var PreferCalledTimesRule = rule.Rule{
 }
 
 // calledOnceMatcherEntry returns the matcher entry of a `toHaveBeenCalledOnce()`
-// assertion.
+// assertion together with the call expression that invokes that matcher.
 //
 // The matcher must be invoked: `expect(fn).toHaveBeenCalledOnce` asserts
 // nothing, and Chai's `calledOnce` is a property getter whose call-count
@@ -76,7 +76,9 @@ var PreferCalledTimesRule = rule.Rule{
 // and friends, where the author never passed a value to assert on; the
 // assertion is broken whichever call-count matcher it names, so rewriting the
 // matcher would only make a wrong assertion look right.
-func calledOnceMatcherEntry(parsed *rstestUtils.ParsedRstestExpectCall) (rstestUtils.ParsedRstestFnMemberEntry, bool) {
+func calledOnceMatcherEntry(
+	parsed *rstestUtils.ParsedRstestExpectCall,
+) (rstestUtils.ParsedRstestFnMemberEntry, *ast.Node, bool) {
 	if parsed == nil ||
 		parsed.Reason != rstestUtils.RstestExpectParseReasonNone ||
 		parsed.Head == nil ||
@@ -84,21 +86,54 @@ func calledOnceMatcherEntry(parsed *rstestUtils.ParsedRstestExpectCall) (rstestU
 		parsed.Matcher != calledOnceMatcher ||
 		len(parsed.Matchers) == 0 ||
 		parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall {
-		return rstestUtils.ParsedRstestFnMemberEntry{}, false
+		return rstestUtils.ParsedRstestFnMemberEntry{}, nil, false
 	}
 
-	call := parsed.MatcherEntry.Call
-	if call == nil || call.Kind != ast.KindCallExpression {
-		return rstestUtils.ParsedRstestFnMemberEntry{}, false
+	call := matcherCall(parsed.MatcherEntry)
+	if call == nil {
+		return rstestUtils.ParsedRstestFnMemberEntry{}, nil, false
 	}
 	// `toHaveBeenCalledOnce` takes no arguments, so anything already written
 	// between the parentheses means the assertion is not the shape this rule
 	// rewrites.
 	if arguments := call.AsCallExpression().Arguments; arguments != nil && len(arguments.Nodes) > 0 {
-		return rstestUtils.ParsedRstestFnMemberEntry{}, false
+		return rstestUtils.ParsedRstestFnMemberEntry{}, nil, false
 	}
 
-	return *parsed.MatcherEntry, true
+	return *parsed.MatcherEntry, call, true
+}
+
+// matcherCall returns the call expression that directly invokes entry's
+// accessor.
+//
+// MemberEntry.Call cannot be used for this. GetMemberEntries marks the last
+// entry of a callee chain as invoked, so each enclosing call overwrites the
+// field: for `expect(fn).toHaveBeenCalledOnce()()` the matcher entry ends up
+// carrying the outer call, whose parentheses hold no matcher argument list at
+// all. Inserting the count there produces
+// `expect(fn).toHaveBeenCalledTimes()(1)`, which asserts something else
+// entirely. Walking up from the accessor instead always lands on the call the
+// matcher name is the callee of, and stops at it. Parentheses around the
+// callee are transparent, matching how the chain was parsed in the first
+// place.
+func matcherCall(entry *rstestUtils.ParsedRstestFnMemberEntry) *ast.Node {
+	_, accessor := testFramework.AccessorReceiverAndParent(entry)
+	if accessor == nil {
+		return nil
+	}
+
+	child := accessor
+	parent := accessor.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		child = parent
+		parent = parent.Parent
+	}
+	if parent == nil ||
+		parent.Kind != ast.KindCallExpression ||
+		parent.AsCallExpression().Expression != child {
+		return nil
+	}
+	return parent
 }
 
 // argumentListStart returns the offset just after the matcher call's opening

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.go
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.go
@@ -1,0 +1,135 @@
+package prefer_called_times
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+// calledOnceMatcher is the only matcher this rule rewrites.
+//
+// Upstream also matches `toBeCalledOnce` and derives the replacement with
+// matcherName.replace('Once', 'Times'). Rstest's assertion library does not
+// expose `toBeCalledOnce` at all (@vitest/expect@4.1.10 dist/index.d.ts has
+// `toHaveBeenCalledOnce` at line 650 and no `toBeCalledOnce` anywhere), so
+// there is exactly one source name and exactly one target name, and the
+// derivation collapses into two constants.
+const (
+	calledOnceMatcher  = "toHaveBeenCalledOnce"
+	calledTimesMatcher = "toHaveBeenCalledTimes"
+)
+
+var preferCalledTimesMessage = rule.RuleMessage{
+	Id:          "preferCalledTimes",
+	Description: "Prefer " + calledTimesMatcher + "(1)",
+}
+
+var PreferCalledTimesRule = rule.Rule{
+	Name:   "rstest/prefer-called-times",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				matcher, ok := calledOnceMatcherEntry(analysis.ParseExpectCall(node))
+				if !ok {
+					return
+				}
+
+				ctx.ReportNodeWithDeferredFixes(matcher.Node, preferCalledTimesMessage, func() []rule.RuleFix {
+					nameRange, nameText, ok := testFramework.AccessorReplacement(
+						ctx.SourceFile,
+						matcher.Node,
+						calledTimesMatcher,
+					)
+					if !ok {
+						return nil
+					}
+
+					argumentStart, ok := argumentListStart(ctx.SourceFile, matcher.Call)
+					if !ok {
+						return nil
+					}
+
+					return []rule.RuleFix{
+						rule.RuleFixReplaceRange(nameRange, nameText),
+						rule.RuleFixReplaceRange(core.NewTextRange(argumentStart, argumentStart), "1"),
+					}
+				})
+			},
+		}
+	},
+}
+
+// calledOnceMatcherEntry returns the matcher entry of a `toHaveBeenCalledOnce()`
+// assertion.
+//
+// The matcher must be invoked: `expect(fn).toHaveBeenCalledOnce` asserts
+// nothing, and Chai's `calledOnce` is a property getter whose call-count
+// equivalent is `callCount(1)` rather than `toHaveBeenCalledTimes(1)`. Both are
+// excluded by requiring RstestExpectMatcherCall.
+//
+// An assertion factory must also have run. Head is nil for `expect.toBe(1)`
+// and friends, where the author never passed a value to assert on; the
+// assertion is broken whichever call-count matcher it names, so rewriting the
+// matcher would only make a wrong assertion look right.
+func calledOnceMatcherEntry(parsed *rstestUtils.ParsedRstestExpectCall) (rstestUtils.ParsedRstestFnMemberEntry, bool) {
+	if parsed == nil ||
+		parsed.Reason != rstestUtils.RstestExpectParseReasonNone ||
+		parsed.Head == nil ||
+		parsed.MatcherEntry == nil ||
+		parsed.Matcher != calledOnceMatcher ||
+		len(parsed.Matchers) == 0 ||
+		parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall {
+		return rstestUtils.ParsedRstestFnMemberEntry{}, false
+	}
+
+	call := parsed.MatcherEntry.Call
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return rstestUtils.ParsedRstestFnMemberEntry{}, false
+	}
+	// `toHaveBeenCalledOnce` takes no arguments, so anything already written
+	// between the parentheses means the assertion is not the shape this rule
+	// rewrites.
+	if arguments := call.AsCallExpression().Arguments; arguments != nil && len(arguments.Nodes) > 0 {
+		return rstestUtils.ParsedRstestFnMemberEntry{}, false
+	}
+
+	return *parsed.MatcherEntry, true
+}
+
+// argumentListStart returns the offset just after the matcher call's opening
+// parenthesis, which is where the `1` argument is inserted.
+//
+// Upstream computes this as `matcher.range[1] + 1`, which assumes the `(`
+// immediately follows the matcher name. That holds for `x.toBeCalledOnce()`
+// only: `x['toBeCalledOnce']()`, `x.toBeCalledOnce /* c */ ()` and a call split
+// across lines all put other characters in between. The parenthesis is scanned
+// for instead, starting after the callee so that the parentheses of the
+// receiver — `expect(fn)` — are never mistaken for the matcher's own.
+func argumentListStart(sourceFile *ast.SourceFile, call *ast.Node) (int, bool) {
+	callee := call.AsCallExpression().Expression
+	if callee == nil {
+		return 0, false
+	}
+
+	start := callee.End()
+	// A type argument list may hold parentheses of its own, as in
+	// `toHaveBeenCalledOnce<(a: string) => void>()`.
+	if typeArguments := call.AsCallExpression().TypeArguments; typeArguments != nil {
+		start = max(start, typeArguments.End())
+	}
+
+	for _, token := range utils.TokensOfNode(sourceFile, call) {
+		if token.Start < start {
+			continue
+		}
+		if token.Kind == ast.KindOpenParenToken {
+			return token.End, true
+		}
+	}
+	return 0, false
+}

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
@@ -1,0 +1,76 @@
+# prefer-called-times
+
+## Rule Details
+
+Prefer `expect(fn).toHaveBeenCalledTimes(1)` over
+`expect(fn).toHaveBeenCalledOnce()`. Both assert the same thing, and spelling
+the count out keeps a file's call-count assertions in one form, so changing an
+expected count is an edit to the number rather than a switch to a different
+matcher.
+
+Examples of **incorrect** code:
+
+```ts
+expect(fn).toHaveBeenCalledOnce();
+expect(fn).not.toHaveBeenCalledOnce();
+expect(fn).resolves.toHaveBeenCalledOnce();
+expect.soft(fn).toHaveBeenCalledOnce();
+```
+
+Examples of **correct** code:
+
+```ts
+expect(fn).toHaveBeenCalledTimes(1);
+expect(fn).not.toHaveBeenCalledTimes(1);
+expect(fn).toHaveBeenCalledTimes(2);
+```
+
+## Options
+
+This rule has no options.
+
+## Recognized assertions
+
+The matcher has to be called. `expect(fn).toHaveBeenCalledOnce` asserts
+nothing, and rewriting it would turn a no-op into a live assertion, so it is
+left alone. So is `expect.toHaveBeenCalledOnce()`, which never received a value
+to count calls on.
+
+Chai's `calledOnce` is not covered. It is a property rather than a matcher
+call, and the assertion that takes a count in that style is `callCount(1)`, so
+`expect(fn).to.have.been.calledOnce` is not reported.
+
+A matcher named by a computed key, `expect(fn)[matcherName]()`, is not
+reported: which assertion runs is only known at runtime.
+
+Every expect source is covered: globals, `@rstest/core` named imports and
+renamed imports, `require('@rstest/core')` destructuring, namespace imports,
+whole-module `require`, `import.meta.rstest`, `@rstest/playwright`, and the
+`expect` a test callback receives through its context (`({ expect })` and
+`ctx.expect`). An `expect` from another assertion library, and a local variable
+that shadows `expect`, are not reported.
+
+## Fix
+
+The fix renames the matcher and gives it the count `1`, leaving the rest of the
+assertion exactly as written. The expect root as spelled at the call site,
+`expect.soft`, the optional second `message` argument of
+`expect(actual, message)`, the modifier chain, the accessor's own quoting, and
+the surrounding line breaks and comments all survive:
+
+```ts
+expect.soft(fn, 'called once')['toHaveBeenCalledOnce']();
+// becomes
+expect.soft(fn, 'called once')['toHaveBeenCalledTimes'](1);
+```
+
+An assertion split across lines, or written with a comment between the matcher
+and its parentheses, is fixed as written. A comment already sitting between the
+parentheses is kept, with the `1` inserted before it.
+
+## Conflicting rules
+
+A rule enforcing the opposite preference — rewriting
+`toHaveBeenCalledTimes(1)` into `toHaveBeenCalledOnce()` — must not be enabled
+alongside this one, or the two fixes will rewrite each other. Choose the form
+the codebase should use and enable only the rule for it.

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
@@ -43,6 +43,9 @@ call, and the assertion that takes a count in that style is `callCount(1)`, so
 A matcher named by a computed key, `expect(fn)[matcherName]()`, is not
 reported: which assertion runs is only known at runtime.
 
+Parentheses around the assertion are transparent, including around an optional
+chain: `(expect(fn)?.toHaveBeenCalledOnce)()` is reported and fixed.
+
 Every expect source is covered: globals, `@rstest/core` named imports and
 renamed imports, `require('@rstest/core')` destructuring, namespace imports,
 whole-module `require`, `import.meta.rstest`, `@rstest/playwright`, and the
@@ -67,6 +70,10 @@ expect.soft(fn, 'called once')['toHaveBeenCalledTimes'](1);
 An assertion split across lines, or written with a comment between the matcher
 and its parentheses, is fixed as written. A comment already sitting between the
 parentheses is kept, with the `1` inserted before it.
+
+The count goes into the matcher's own argument list, never into a call that
+merely encloses the assertion, so `expect(fn).toHaveBeenCalledOnce()()` becomes
+`expect(fn).toHaveBeenCalledTimes(1)()`.
 
 ## Conflicting rules
 

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
@@ -2,82 +2,32 @@
 
 ## Rule Details
 
-Prefer `expect(fn).toHaveBeenCalledTimes(1)` over
-`expect(fn).toHaveBeenCalledOnce()`. Both assert the same thing, and spelling
-the count out keeps a file's call-count assertions in one form, so changing an
-expected count is an edit to the number rather than a switch to a different
-matcher.
+Requires call-count assertions to be spelled `expect(fn).toHaveBeenCalledTimes(1)` rather than `expect(fn).toHaveBeenCalledOnce()`. Both assert the same thing, and writing the count out keeps every call-count assertion in a file in one form, so changing an expected count becomes an edit to a number instead of a switch to a different matcher.
 
-Examples of **incorrect** code:
+The matcher has to be called. `expect(fn).toHaveBeenCalledOnce` asserts nothing, so it is left alone, and so is `expect.toHaveBeenCalledOnce()`, which never received a value to count calls on. A matcher named by a computed key, `expect(fn)[matcherName]()`, is not reported either, because which assertion runs is only known at runtime. Chai's `calledOnce` is a property rather than a matcher call, and the assertion that takes a count in that style is `callCount(1)`, so `expect(fn).to.have.been.calledOnce` is outside this rule.
 
-```ts
-expect(fn).toHaveBeenCalledOnce();
-expect(fn).not.toHaveBeenCalledOnce();
-expect(fn).resolves.toHaveBeenCalledOnce();
-expect.soft(fn).toHaveBeenCalledOnce();
-```
+Every `expect` source is recognized: globals, named and renamed imports, `require` destructuring, namespace imports, whole-module `require`, `import.meta.rstest`, Playwright integrations, and the `expect` a test callback receives through its test context. An `expect` from another assertion library, or a local variable that shadows `expect`, is not reported.
 
-Examples of **correct** code:
+## Incorrect
 
 ```ts
-expect(fn).toHaveBeenCalledTimes(1);
-expect(fn).not.toHaveBeenCalledTimes(1);
-expect(fn).toHaveBeenCalledTimes(2);
+test('notifies the listener once', () => {
+  emitter.emit('ready');
+
+  expect(listener).toHaveBeenCalledOnce();
+});
 ```
 
-## Options
-
-This rule has no options.
-
-## Recognized assertions
-
-The matcher has to be called. `expect(fn).toHaveBeenCalledOnce` asserts
-nothing, and rewriting it would turn a no-op into a live assertion, so it is
-left alone. So is `expect.toHaveBeenCalledOnce()`, which never received a value
-to count calls on.
-
-Chai's `calledOnce` is not covered. It is a property rather than a matcher
-call, and the assertion that takes a count in that style is `callCount(1)`, so
-`expect(fn).to.have.been.calledOnce` is not reported.
-
-A matcher named by a computed key, `expect(fn)[matcherName]()`, is not
-reported: which assertion runs is only known at runtime.
-
-Parentheses around the assertion are transparent, including around an optional
-chain: `(expect(fn)?.toHaveBeenCalledOnce)()` is reported and fixed.
-
-Every expect source is covered: globals, `@rstest/core` named imports and
-renamed imports, `require('@rstest/core')` destructuring, namespace imports,
-whole-module `require`, `import.meta.rstest`, `@rstest/playwright`, and the
-`expect` a test callback receives through its context (`({ expect })` and
-`ctx.expect`). An `expect` from another assertion library, and a local variable
-that shadows `expect`, are not reported.
-
-## Fix
-
-The fix renames the matcher and gives it the count `1`, leaving the rest of the
-assertion exactly as written. The expect root as spelled at the call site,
-`expect.soft`, the optional second `message` argument of
-`expect(actual, message)`, the modifier chain, the accessor's own quoting, and
-the surrounding line breaks and comments all survive:
+## Correct
 
 ```ts
-expect.soft(fn, 'called once')['toHaveBeenCalledOnce']();
-// becomes
-expect.soft(fn, 'called once')['toHaveBeenCalledTimes'](1);
+test('notifies the listener once', () => {
+  emitter.emit('ready');
+
+  expect(listener).toHaveBeenCalledTimes(1);
+});
 ```
 
-An assertion split across lines, or written with a comment between the matcher
-and its parentheses, is fixed as written. A comment already sitting between the
-parentheses is kept, with the `1` inserted before it.
+## Autofix
 
-The count goes into the matcher's own argument list, never into a call that
-merely encloses the assertion, so `expect(fn).toHaveBeenCalledOnce()()` becomes
-`expect(fn).toHaveBeenCalledTimes(1)()`.
-
-## Conflicting rules
-
-A rule enforcing the opposite preference — rewriting
-`toHaveBeenCalledTimes(1)` into `toHaveBeenCalledOnce()` — must not be enabled
-alongside this one, or the two fixes will rewrite each other. Choose the form
-the codebase should use and enable only the rule for it.
+Renames the matcher to `toHaveBeenCalledTimes` and inserts the count `1` into its argument list. Nothing else in the assertion changes: the expect root as written at the call site, `expect.soft`, the second `message` argument of `expect(actual, message)`, the modifier chain, the accessor's own quoting, and the surrounding line breaks and comments are all left as they are.

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times.md
@@ -6,7 +6,7 @@ Requires call-count assertions to be spelled `expect(fn).toHaveBeenCalledTimes(1
 
 The matcher has to be called. `expect(fn).toHaveBeenCalledOnce` asserts nothing, so it is left alone, and so is `expect.toHaveBeenCalledOnce()`, which never received a value to count calls on. A matcher named by a computed key, `expect(fn)[matcherName]()`, is not reported either, because which assertion runs is only known at runtime. Chai's `calledOnce` is a property rather than a matcher call, and the assertion that takes a count in that style is `callCount(1)`, so `expect(fn).to.have.been.calledOnce` is outside this rule.
 
-Every `expect` source is recognized: globals, named and renamed imports, `require` destructuring, namespace imports, whole-module `require`, `import.meta.rstest`, Playwright integrations, and the `expect` a test callback receives through its test context. An `expect` from another assertion library, or a local variable that shadows `expect`, is not reported.
+Every `expect` source is recognized: globals, named and renamed imports, `require` destructuring, namespace imports, whole-module `require`, `import.meta.rstest`, Playwright integrations, and the `expect` a test callback receives through its [TestContext](https://rstest.rs/api/runtime-api/test-api/test#testcontext). An `expect` from another assertion library, or a local variable that shadows `expect`, is not reported.
 
 ## Incorrect
 

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
@@ -1,0 +1,393 @@
+// TestPreferCalledTimesExtras locks in the Rstest-only augmentation required by
+// the port spec: the matcher-shape contract, every Rstest expect source, the
+// accessor and trivia matrix around both edits, and the shapes where the fix
+// is withheld while the diagnostic stands.
+package prefer_called_times
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferCalledTimesExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferCalledTimesRule,
+		[]rule_tester.ValidTestCase{
+			// ---- A. Matcher shape ----
+			// A matcher that is never called asserts nothing; rewriting it
+			// would turn a no-op into a live assertion.
+			{Code: `expect(fn).toHaveBeenCalledOnce;`},
+			{Code: `expect(fn).not.toHaveBeenCalledOnce;`},
+			// Already the target shape.
+			{Code: `expect(fn).toHaveBeenCalledTimes(1);`},
+			// `toHaveBeenCalledOnce` takes no arguments, so anything already
+			// written between the parentheses is a different assertion.
+			{Code: `expect(fn).toHaveBeenCalledOnce(1);`},
+			{Code: `expect(fn).toHaveBeenCalledOnce(...args);`},
+			// Chai's call-count property. Its `toHaveBeenCalledTimes(1)`
+			// equivalent is `callCount(1)`, so this rule leaves it alone.
+			{Code: `expect(fn).calledOnce;`},
+			{Code: `expect(fn).to.have.been.calledOnce;`},
+
+			// ---- A. Other matchers ----
+			{Code: `expect(fn).toHaveBeenCalled();`},
+			{Code: `expect(fn).toHaveReturnedOnce();`},
+			{Code: `expect(fn).toHaveBeenCalledOnceWith(1);`},
+
+			// ---- B. Matchers Rstest does not have ----
+			// `toBeCalledOnce` is absent from @vitest/expect@4.1.10, so code
+			// calling it is broken rather than improvable.
+			{Code: `expect(fn).toBeCalledOnce();`},
+			{Code: `expect(fn).rejects.not.toBeCalledOnce();`},
+
+			// ---- C. Reverse sources ----
+			{Code: `import { expect } from 'vitest'; expect(fn).toHaveBeenCalledOnce();`},
+			{Code: `import { expect } from '@jest/globals'; expect(fn).toHaveBeenCalledOnce();`},
+			{Code: `import { expect } from '@playwright/test'; expect(fn).toHaveBeenCalledOnce();`},
+			{Code: `import { expect } from 'chai'; expect(fn).toHaveBeenCalledOnce();`},
+			{Code: `const expect = createAssertionLibrary(); expect(fn).toHaveBeenCalledOnce();`},
+			{Code: `custom.expect(fn).toHaveBeenCalledOnce();`},
+
+			// ---- C. Shadowing ----
+			{Code: `import { expect } from '@rstest/core'; function f(expect: any) { expect(fn).toHaveBeenCalledOnce(); }`},
+			{Code: `import { expect as check } from '@rstest/core'; function f(check: any) { check(fn).toHaveBeenCalledOnce(); }`},
+			{Code: `import * as core from '@rstest/core'; function f() { const core = helper(); core.expect(fn).toHaveBeenCalledOnce(); }`},
+
+			// ---- D. Broken chains ----
+			// A second promise modifier makes the chain unparseable, and the
+			// rule refuses to guess what the author meant.
+			{Code: `expect(fn).resolves.rejects.toHaveBeenCalledOnce();`},
+			// No assertion factory ran, so there is no value to count calls
+			// on. The assertion is broken whichever matcher it names.
+			{Code: `expect.toHaveBeenCalledOnce();`},
+			{Code: `expect.not.toHaveBeenCalledOnce();`},
+
+			// ---- D. Computed identifier keys ----
+			// The key names the matcher only at runtime, so the alias tables
+			// cannot be consulted and rewriting it would rename a variable.
+			{Code: `expect(fn)[toHaveBeenCalledOnce]();`},
+			{Code: `const toHaveBeenCalledOnce = 'toHaveBeenCalledTimes';
+expect(fn)[toHaveBeenCalledOnce]();`},
+
+			// ---- D. TS wrappers are analysis boundaries ----
+			{Code: `expect(fn)!.toHaveBeenCalledOnce();`},
+			{Code: `(expect(fn) as any).toHaveBeenCalledOnce();`},
+			{Code: `(expect(fn) satisfies Assertion).toHaveBeenCalledOnce();`},
+
+			// ---- D. Dimension 4 / graceful degradation ----
+			{Code: `broken.expect?.(fn).toHaveBeenCalledOnce();`},
+			// N/A: declaration and container variants, function kinds, class
+			// members, and overload signatures are unrelated to this rule's
+			// single call-expression listener over analysis.ParseExpectCall.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- E. Accessor forms; the written form survives both edits ----
+			{
+				Code:   `expect(fn)['toHaveBeenCalledOnce']();`,
+				Output: []string{`expect(fn)['toHaveBeenCalledTimes'](1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   `expect(fn)["toHaveBeenCalledOnce"]();`,
+				Output: []string{`expect(fn)["toHaveBeenCalledTimes"](1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   "expect(fn)[`toHaveBeenCalledOnce`]();",
+				Output: []string{"expect(fn)[`toHaveBeenCalledTimes`](1);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   `expect(fn)?.toHaveBeenCalledOnce();`,
+				Output: []string{`expect(fn)?.toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 13}},
+			},
+			{
+				Code:   `expect(fn).toHaveBeenCalledOnce?.();`,
+				Output: []string{`expect(fn).toHaveBeenCalledTimes?.(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   `(expect(fn)).toHaveBeenCalledOnce();`,
+				Output: []string{`(expect(fn)).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 14}},
+			},
+
+			// ---- E. Trivia between the matcher name and its parentheses ----
+			// Upstream inserts at `matcher.range[1] + 1`, which lands inside
+			// the comment or on the wrong character in every case below.
+			{
+				Code:   "expect(fn).\n  toHaveBeenCalledOnce();",
+				Output: []string{"expect(fn).\n  toHaveBeenCalledTimes(1);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 3}},
+			},
+			{
+				Code:   "expect(fn). /* keep */ toHaveBeenCalledOnce();",
+				Output: []string{"expect(fn). /* keep */ toHaveBeenCalledTimes(1);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 24}},
+			},
+			{
+				Code:   "expect(fn).toHaveBeenCalledOnce /* keep */ ();",
+				Output: []string{"expect(fn).toHaveBeenCalledTimes /* keep */ (1);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   "expect(fn).toHaveBeenCalledOnce(/* keep */);",
+				Output: []string{"expect(fn).toHaveBeenCalledTimes(1/* keep */);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   "expect(fn).toHaveBeenCalledOnce(\n);",
+				Output: []string{"expect(fn).toHaveBeenCalledTimes(1\n);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   "expect(fn)[/* keep */ 'toHaveBeenCalledOnce']();",
+				Output: []string{"expect(fn)[/* keep */ 'toHaveBeenCalledTimes'](1);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 23}},
+			},
+
+			// ---- F. Assertion factories and the second expect argument ----
+			// Nothing outside the matcher is rewritten, so the factory, its
+			// message argument and the modifier chain all survive.
+			{
+				Code:   `expect.soft(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`expect.soft(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 17}},
+			},
+			{
+				Code:   `expect(fn, 'spy was called once').toHaveBeenCalledOnce();`,
+				Output: []string{`expect(fn, 'spy was called once').toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 35}},
+			},
+			{
+				Code:   `await expect(fn).resolves.not.toHaveBeenCalledOnce();`,
+				Output: []string{`await expect(fn).resolves.not.toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 31}},
+			},
+			{
+				Code:   `await expect(fn).rejects.toHaveBeenCalledOnce();`,
+				Output: []string{`await expect(fn).rejects.toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 26}},
+			},
+
+			// ---- G. Rstest expect sources ----
+			{
+				Code: `import { expect } from '@rstest/core';
+expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`import { expect } from '@rstest/core';
+expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 12}},
+			},
+			{
+				Code: `import { expect as check } from '@rstest/core';
+check(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`import { expect as check } from '@rstest/core';
+check(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 11}},
+			},
+			{
+				Code: `const { expect } = require('@rstest/core');
+expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`const { expect } = require('@rstest/core');
+expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 12}},
+			},
+			{
+				Code: `import * as core from '@rstest/core';
+core.expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`import * as core from '@rstest/core';
+core.expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 17}},
+			},
+			{
+				Code: `const core = require('@rstest/core');
+core.expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`const core = require('@rstest/core');
+core.expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 17}},
+			},
+			{
+				Code:   `import.meta.rstest.expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`import.meta.rstest.expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 31}},
+			},
+			{
+				Code: `const { expect } = import.meta.rstest;
+expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`const { expect } = import.meta.rstest;
+expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 12}},
+			},
+			{
+				Code: `const api = import.meta.rstest;
+api.expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`const api = import.meta.rstest;
+api.expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 16}},
+			},
+			{
+				Code: `import { expect } from '@rstest/playwright';
+expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`import { expect } from '@rstest/playwright';
+expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 2, Column: 12}},
+			},
+			{
+				Code:   `test('x', ctx => ctx.expect(fn).toHaveBeenCalledOnce());`,
+				Output: []string{`test('x', ctx => ctx.expect(fn).toHaveBeenCalledTimes(1));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 33}},
+			},
+			{
+				Code:   `test('x', ({ expect }) => expect(fn).toHaveBeenCalledOnce());`,
+				Output: []string{`test('x', ({ expect }) => expect(fn).toHaveBeenCalledTimes(1));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 38}},
+			},
+			{
+				Code:   `test('x', { timeout: 1 }, ({ expect: check }) => check(fn).toHaveBeenCalledOnce());`,
+				Output: []string{`test('x', { timeout: 1 }, ({ expect: check }) => check(fn).toHaveBeenCalledTimes(1));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 60}},
+			},
+
+			// ---- H. Real-user shapes ----
+			{
+				Code: `import { expect, test, rs } from '@rstest/core';
+
+test('notifies once', () => {
+  const listener = rs.fn();
+  emitter.emit('ready');
+  expect(listener).toHaveBeenCalledOnce();
+});`,
+				Output: []string{`import { expect, test, rs } from '@rstest/core';
+
+test('notifies once', () => {
+  const listener = rs.fn();
+  emitter.emit('ready');
+  expect(listener).toHaveBeenCalledTimes(1);
+});`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 6, Column: 20}},
+			},
+			{
+				Code: `test.for([1, 2])('case %i', (row, { expect }) => {
+  expect(handler)
+    .toHaveBeenCalledOnce();
+});`,
+				Output: []string{`test.for([1, 2])('case %i', (row, { expect }) => {
+  expect(handler)
+    .toHaveBeenCalledTimes(1);
+});`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 3, Column: 6}},
+			},
+		},
+	)
+}
+
+// TestPreferCalledTimesEditDemand locks in that the diagnostic is identical
+// under every edit demand and that only the fixes come and go.
+func TestPreferCalledTimesEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`expect(fn).toHaveBeenCalledOnce();
+expect(fn).not['toHaveBeenCalledOnce']();`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      lintprogram.NewFromCompiler(program),
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     PreferCalledTimesRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferCalledTimesRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		want := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d diagnostic %d changed:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+	}
+
+	for _, diagnostic := range diagnosticsOnly {
+		if diagnostic.FixesPtr != nil {
+			t.Fatal("EditDemandNone unexpectedly materialized fixes")
+		}
+	}
+	for _, diagnostic := range suggestionOnly {
+		if diagnostic.FixesPtr != nil {
+			t.Fatal("EditDemandSuggestion unexpectedly materialized fixes")
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		for _, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Fatal("prefer-called-times unexpectedly materialized suggestions")
+			}
+		}
+	}
+
+	for index := range allEdits {
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("assertion %d produced inconsistent fixes between autofix and all demands", index)
+		}
+		// The matcher rename and the inserted `1` are always one fix each.
+		if got := len(*autofixOnly[index].FixesPtr); got != 2 {
+			t.Fatalf("assertion %d produced %d fixes, want 2", index, got)
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
@@ -34,6 +34,9 @@ func TestPreferCalledTimesExtras(t *testing.T) {
 			// written between the parentheses is a different assertion.
 			{Code: `expect(fn).toHaveBeenCalledOnce(1);`},
 			{Code: `expect(fn).toHaveBeenCalledOnce(...args);`},
+			// The argument check reads the matcher's own call, so a trailing
+			// call on the assertion's result cannot hide it.
+			{Code: `expect(fn).toHaveBeenCalledOnce(1)();`},
 			// Chai's call-count property. Its `toHaveBeenCalledTimes(1)`
 			// equivalent is `callCount(1)`, so this rule leaves it alone.
 			{Code: `expect(fn).calledOnce;`},
@@ -120,6 +123,51 @@ expect(fn)[toHaveBeenCalledOnce]();`},
 			{
 				Code:   `(expect(fn)).toHaveBeenCalledOnce();`,
 				Output: []string{`(expect(fn)).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 14}},
+			},
+
+			// ---- E. Trailing calls on the assertion's result ----
+			// The count belongs to the matcher's own argument list, not to
+			// whichever call happens to enclose the assertion.
+			{
+				Code:   `expect(fn).toHaveBeenCalledOnce()();`,
+				Output: []string{`expect(fn).toHaveBeenCalledTimes(1)();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   `expect(fn).toHaveBeenCalledOnce()()();`,
+				Output: []string{`expect(fn).toHaveBeenCalledTimes(1)()();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   `expect(fn).toHaveBeenCalledOnce()(1);`,
+				Output: []string{`expect(fn).toHaveBeenCalledTimes(1)(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+			{
+				Code:   `expect(fn)['toHaveBeenCalledOnce']()();`,
+				Output: []string{`expect(fn)['toHaveBeenCalledTimes'](1)();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 12}},
+			},
+
+			// ---- E. A parenthesized optional chain is still an assertion ----
+			// ESTree wraps an optional chain in a ChainExpression, which
+			// upstream's chain walk does not enter, so upstream misses these.
+			// The matcher and its receiver are unambiguous here and the
+			// rewrite is exact, so this port reports them.
+			{
+				Code:   `(expect(fn)?.toHaveBeenCalledOnce)();`,
+				Output: []string{`(expect(fn)?.toHaveBeenCalledTimes)(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `((expect(fn)?.toHaveBeenCalledOnce))();`,
+				Output: []string{`((expect(fn)?.toHaveBeenCalledTimes))(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `(expect(fn)?.toHaveBeenCalledOnce)?.();`,
+				Output: []string{`(expect(fn)?.toHaveBeenCalledTimes)?.(1);`},
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledTimes", Line: 1, Column: 14}},
 			},
 

--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_upstream_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_upstream_test.go
@@ -1,0 +1,82 @@
+// TestPreferCalledTimesUpstream migrates the complete
+// @vitest/eslint-plugin@v1.6.27 prefer-called-times suite. The three upstream
+// invalid cases written with `toBeCalledOnce` move to the valid list because
+// Rstest's assertion library does not expose that matcher; everything else is
+// carried over 1:1. Rstest API sources, accessor forms, fix boundaries and
+// edit-demand coverage live in prefer_called_times_extras_test.go.
+package prefer_called_times
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferCalledTimesUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferCalledTimesRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect(fn).toBeCalledTimes(1);`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(1);`},
+			{Code: `expect(fn).toBeCalledTimes(2);`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(2);`},
+			{Code: `expect(fn).toBeCalledTimes(expect.anything());`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(expect.anything());`},
+			{Code: `expect(fn).not.toBeCalledTimes(2);`},
+			{Code: `expect(fn).rejects.not.toBeCalledTimes(1);`},
+			{Code: `expect(fn).not.toHaveBeenCalledTimes(1);`},
+			{Code: `expect(fn).resolves.not.toHaveBeenCalledTimes(1);`},
+			{Code: `expect(fn).toBeCalledTimes(0);`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(0);`},
+			{Code: `expect(fn);`},
+			// Upstream reports the next three. `toBeCalledOnce` does not exist
+			// in @vitest/expect@4.1.10, so Rstest code that calls it is broken
+			// rather than improvable, and this rule stays out of it.
+			{Code: `expect(fn).toBeCalledOnce();`},
+			{Code: `expect(fn).not.toBeCalledOnce();`},
+			{Code: `expect(fn).resolves.toBeCalledOnce();`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `expect(fn).toHaveBeenCalledOnce();`,
+				Output: []string{`expect(fn).toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferCalledTimes",
+					Message:   "Prefer toHaveBeenCalledTimes(1)",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 32,
+				}},
+			},
+			{
+				Code:   `expect(fn).not.toHaveBeenCalledOnce();`,
+				Output: []string{`expect(fn).not.toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferCalledTimes",
+					Message:   "Prefer toHaveBeenCalledTimes(1)",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 36,
+				}},
+			},
+			{
+				Code:   `expect(fn).resolves.toHaveBeenCalledOnce();`,
+				Output: []string{`expect(fn).resolves.toHaveBeenCalledTimes(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "preferCalledTimes",
+					Message:   "Prefer toHaveBeenCalledTimes(1)",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 41,
+				}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -597,6 +597,7 @@ export default defineConfig({
     './tests/rstest/rules/no-mocks-import.test.ts',
     './tests/rstest/rules/no-standalone-expect.test.ts',
     './tests/rstest/rules/prefer-called-exactly-once-with.test.ts',
+    './tests/rstest/rules/prefer-called-times.test.ts',
     './tests/rstest/rules/prefer-each.test.ts',
     './tests/rstest/rules/prefer-hooks-in-order.test.ts',
     './tests/rstest/rules/require-local-test-context-for-concurrent-snapshots.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/prefer-called-times.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/prefer-called-times.test.ts
@@ -1,0 +1,68 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-called-times', {} as never, {
+  valid: [
+    { code: `expect(fn).toBeCalledTimes(1);` },
+    { code: `expect(fn).toHaveBeenCalledTimes(1);` },
+    { code: `expect(fn).toBeCalledTimes(2);` },
+    { code: `expect(fn).toHaveBeenCalledTimes(2);` },
+    { code: `expect(fn).toBeCalledTimes(expect.anything());` },
+    { code: `expect(fn).toHaveBeenCalledTimes(expect.anything());` },
+    { code: `expect(fn).not.toBeCalledTimes(2);` },
+    { code: `expect(fn).rejects.not.toBeCalledTimes(1);` },
+    { code: `expect(fn).not.toHaveBeenCalledTimes(1);` },
+    { code: `expect(fn).resolves.not.toHaveBeenCalledTimes(1);` },
+    { code: `expect(fn).toBeCalledTimes(0);` },
+    { code: `expect(fn).toHaveBeenCalledTimes(0);` },
+    { code: `expect(fn);` },
+    { code: `expect(fn).toBeCalledOnce();` },
+    { code: `expect(fn).not.toBeCalledOnce();` },
+    { code: `expect(fn).resolves.toBeCalledOnce();` },
+  ],
+  invalid: [
+    {
+      code: `expect(fn).toHaveBeenCalledOnce();`,
+      output: `expect(fn).toHaveBeenCalledTimes(1);`,
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          message: 'Prefer toHaveBeenCalledTimes(1)',
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 32,
+        },
+      ],
+    },
+    {
+      code: `expect(fn).not.toHaveBeenCalledOnce();`,
+      output: `expect(fn).not.toHaveBeenCalledTimes(1);`,
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          message: 'Prefer toHaveBeenCalledTimes(1)',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 36,
+        },
+      ],
+    },
+    {
+      code: `expect(fn).resolves.toHaveBeenCalledOnce();`,
+      output: `expect(fn).resolves.toHaveBeenCalledTimes(1);`,
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          message: 'Prefer toHaveBeenCalledTimes(1)',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 41,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Report `expect(fn).toHaveBeenCalledOnce()` and point at `expect(fn).toHaveBeenCalledTimes(1)`, so that every call-count assertion in a file reads the same way and changing an expected count is an edit to the number rather than a switch to a different matcher. The rule is autofixable.

The matcher has to be called — `expect(fn).toHaveBeenCalledOnce` asserts nothing, and rewriting it would turn a no-op into a live assertion — and an assertion factory has to have run, so `expect.toHaveBeenCalledOnce()`, which never received a value to count calls on, is left alone. Chai's `calledOnce` is a property getter whose count-taking equivalent is `callCount(1)` rather than `toHaveBeenCalledTimes(1)`, so it is not covered either.

Assertions resolve through the shared `ParseExpectCall`, so globals, named and aliased imports, namespace and whole-module `require`, `import.meta.rstest`, `@rstest/playwright` and the `expect` a test callback receives through its context are all followed. Registered in the rstest plugin but left out of the `recommended` preset, matching upstream.

The fix edits two places and leaves the rest of the assertion exactly as written: it renames the matcher accessor, and inserts `1` directly after the matcher call's opening parenthesis. The expect root as spelled at the call site, `expect.soft`, the optional second `message` argument of `expect(actual, message)`, the modifier chain, the accessor's own quoting and the surrounding line breaks and comments all survive.

## Credits

Port from [`eslint-plugin-vitest`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `prefer-called-times`.

## Intentional differences from upstream

- **`toBeCalledOnce` is not reported.** Upstream matches both `toBeCalledOnce` and `toHaveBeenCalledOnce`, and derives the replacement by substituting `Times` for `Once`. `@vitest/expect@4.1.10`, which Rstest depends on, has no `toBeCalledOnce` at all, so code calling it is broken rather than improvable and the rule stays out of it. That leaves one source name and one replacement, so the derivation becomes two constants.

- **A matcher that already has arguments is not reported.** `toHaveBeenCalledOnce` takes none, so anything written between the parentheses means the assertion is not the shape this rule rewrites — and upstream's fix would insert `1` in front of it and change what the assertion checks.

- **`expect.toHaveBeenCalledOnce()` is not reported.** No value was ever passed to `expect`, so the assertion cannot run whichever call-count matcher it names. Upstream reports it and renames the matcher, which only makes a broken assertion look correct.

- **The insertion point for `1` is scanned for.** Upstream computes it as one character past the end of the matcher name, which assumes the opening parenthesis sits immediately after it. That holds for `expect(fn).toHaveBeenCalledOnce()` alone; `expect(fn)['toHaveBeenCalledOnce']()`, a call split across lines, and a comment between the name and the parentheses each put other characters in between, and upstream's fix corrupts them. This port scans for the parenthesis instead, and inserts the `1` after it so a comment already written between the parentheses is kept.

- **Element-access fixes preserve the accessor's delimiters.** `['toHaveBeenCalledOnce']` becomes `['toHaveBeenCalledTimes']` rather than being normalized to a single-quoted string, matching the rest of the plugin.

- **A parenthesized optional chain is still reported.** ESTree wraps an optional chain in a `ChainExpression`, and upstream's chain walk does not enter it, so `(expect(fn)?.toHaveBeenCalledOnce)()` goes unreported there. The matcher and its receiver are unambiguous in that shape and the rewrite is exact, so this port reports and fixes it.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

