### PR TITLE
fix: ignore hosted JSDoc syntax in rule checks

### DIFF
--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
@@ -126,7 +126,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 	}
 
 	isAllowedFunction := func(node *ast.Node) bool {
-		if opts.allowFunctionsWithoutTypeParameters && node.TypeParameters() == nil {
+		if opts.allowFunctionsWithoutTypeParameters && len(utils.ESTreeTypeParameters(node)) == 0 {
 			return true
 		}
 		if opts.allowIIFEs && isIIFE(node) {
@@ -254,7 +254,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 			if info.returnsOnlyFunctions {
 				argument := node.Expression()
 				info.returnsOnlyFunctions = argument != nil &&
-					typescriptutil.IsFunction(ast.SkipParentheses(argument))
+					typescriptutil.IsFunction(utils.ESTreeRuntimeExpression(argument))
 			}
 		},
 	}
@@ -264,7 +264,7 @@ func doesImmediatelyReturnFunctionExpression(node *ast.Node, info functionInfo) 
 	if node.Kind == ast.KindArrowFunction {
 		body := node.AsArrowFunction().Body
 		if body != nil && body.Kind != ast.KindBlock {
-			return typescriptutil.IsFunction(ast.SkipParentheses(body))
+			return typescriptutil.IsFunction(utils.ESTreeRuntimeExpression(body))
 		}
 	}
 	return info.hasReturn && info.returnsOnlyFunctions
@@ -272,14 +272,11 @@ func doesImmediatelyReturnFunctionExpression(node *ast.Node, info functionInfo) 
 
 // isIIFE checks if a function node is the callee of an immediately invoked call expression.
 func isIIFE(node *ast.Node) bool {
-	parent := node.Parent
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		parent = parent.Parent
-	}
+	parent := typescriptutil.GetEffectiveParent(node)
 	if parent == nil || parent.Kind != ast.KindCallExpression {
 		return false
 	}
-	callee := ast.SkipParentheses(parent.AsCallExpression().Expression)
+	callee := utils.ESTreeRuntimeExpression(parent.AsCallExpression().Expression)
 	return callee == node
 }
 
@@ -321,7 +318,7 @@ func isNameAllowed(sourceFile *ast.SourceFile, node *ast.Node, allowedNames []st
 			}
 		}
 		if funcName == "" {
-			parent := node.Parent
+			parent := typescriptutil.GetEffectiveParent(node)
 			if parent == nil {
 				return false
 			}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type_test.go
@@ -1687,3 +1687,114 @@ func runExplicitFunctionReturnTypeWithDemand(
 	sourceFile.AsNode().ForEachChild(visit)
 	return diagnostics
 }
+
+func TestExplicitFunctionReturnTypeIgnoresHostedJSDocSyntax(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ExplicitFunctionReturnTypeRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code:     "/** @template T */\nfunction f() {}",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: map[string]interface{}{
+					"allowFunctionsWithoutTypeParameters": true,
+				},
+			},
+			{
+				Code:     "const f = /** @type {() => void} */ (() => {});",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: map[string]interface{}{
+					"allowedNames":                  []interface{}{"f"},
+					"allowTypedFunctionExpressions": false,
+				},
+			},
+			{
+				Code:     "(/** @type {Function} */ (function () {}))();",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: map[string]interface{}{
+					"allowIIFEs":                    true,
+					"allowTypedFunctionExpressions": false,
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			hostedJSDocMissingReturnCase(
+				"const f = /** @type {() => void} */ (() => {});",
+				1,
+				41,
+				nil,
+			),
+			hostedJSDocMissingReturnCase(
+				"(/** @type {Function} */ (function () {}))();",
+				1,
+				27,
+				map[string]interface{}{"allowTypedFunctionExpressions": true},
+			),
+			hostedJSDocMissingReturnCase(
+				"const f = /** @satisfies {() => void} */ (() => {});",
+				1,
+				46,
+				nil,
+			),
+			hostedJSDocMissingReturnCase(
+				"/** @type {() => void} */\nconst f = () => {};",
+				2,
+				14,
+				nil,
+			),
+			hostedJSDocMissingReturnCase(
+				"class C {\n  /** @type {() => void} */\n  callback = () => {};\n}",
+				3,
+				3,
+				nil,
+			),
+			hostedJSDocMissingReturnCase(
+				"/** @type {{ callback: () => void }} */\nconst value = { callback: () => {} };",
+				2,
+				17,
+				nil,
+			),
+			hostedJSDocMissingReturnCase(
+				"/** @returns {() => void} */\nfunction outer() { return () => {}; }",
+				2,
+				30,
+				nil,
+			),
+			hostedJSDocMissingReturnCase(
+				"/** @param {() => void} cb */\nfunction outer(cb = () => {}) {}",
+				2,
+				24,
+				map[string]interface{}{"allowedNames": []interface{}{"outer"}},
+			),
+			hostedJSDocMissingReturnCase(
+				"function f() { return /** @type {() => void} */ (() => {}); }",
+				1,
+				53,
+				nil,
+			),
+			hostedJSDocMissingReturnCase(
+				"const f = () => /** @type {() => void} */ (() => {});",
+				1,
+				47,
+				nil,
+			),
+		},
+	)
+}
+
+func hostedJSDocMissingReturnCase(code string, line, column int, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mjs",
+		TSConfig: "tsconfig.allow-js.json",
+		Options:  options,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "missingReturnType", Line: line, Column: column},
+		},
+	}
+}

--- a/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.go
+++ b/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.go
@@ -199,21 +199,22 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		// only `foo`, not the access modifier. Mirror that by switching the
 		// report range to the binding name.
 		reportTarget := param
-		if !isRest && ast.HasSyntacticModifier(param, ast.ModifierFlagsParameterPropertyModifier) {
+		if !isRest && utils.ESTreeModifierFlags(param)&ast.ModifierFlagsParameterPropertyModifier != 0 {
 			reportTarget = nameNode
 		}
-		if pd.Type == nil {
+		paramType := utils.ESTreeType(param)
+		if paramType == nil {
 			reportParam(reportTarget, "missingArgType", "missingArgTypeUnnamed", nameNode, isRest)
 			return
 		}
-		if !opts.allowArgumentsExplicitlyTypedAsAny && pd.Type.Kind == ast.KindAnyKeyword {
+		if !opts.allowArgumentsExplicitlyTypedAsAny && paramType.Kind == ast.KindAnyKeyword {
 			reportParam(reportTarget, "anyTypedArg", "anyTypedArgUnnamed", nameNode, isRest)
 			return
 		}
 	}
 
 	checkParameters := func(node *ast.Node) {
-		for _, p := range node.Parameters() {
+		for _, p := range utils.ESTreeParameters(node) {
 			checkParameter(p)
 		}
 	}
@@ -374,7 +375,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		}
 		checkedFunctions[node] = true
 
-		if isAllowedName(node.Parent) ||
+		if isAllowedName(typescriptutil.GetEffectiveParent(node)) ||
 			typescriptutil.IsTypedFunctionExpression(node, opts.allowTypedFunctionExpressions) ||
 			typescriptutil.AncestorHasReturnType(node) {
 			return
@@ -396,7 +397,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		// check for constructors / set-accessors; always check parameters.
 		isConstructor := node.Kind == ast.KindConstructor
 		isSetAccessor := node.Kind == ast.KindSetAccessor
-		if !isConstructor && !isSetAccessor && node.Type() == nil {
+		if !isConstructor && !isSetAccessor && utils.ESTreeType(node) == nil {
 			// Upstream reports on the TSEmptyBodyFunctionExpression node,
 			// which spans from `(` to (typically) the trailing `;`. tsgo
 			// doesn't model the empty body separately — emulate the range by
@@ -413,7 +414,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		// Filter out private and #private members. AccessorProperty is a
 		// PropertyDeclaration with the `accessor` modifier in tsgo, so the
 		// same handling applies.
-		if ast.HasSyntacticModifier(node, ast.ModifierFlagsPrivate) {
+		if utils.ESTreeModifierFlags(node)&ast.ModifierFlagsPrivate != 0 {
 			return
 		}
 		name := node.Name()
@@ -445,6 +446,13 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 			return
 		}
 		alreadyVisited[node] = true
+		if utils.IsJSDocSyntaxNode(node) {
+			return
+		}
+		if expression := utils.ESTreeRuntimeExpression(node); expression != node {
+			checkNode(expression)
+			return
+		}
 
 		switch node.Kind {
 		case ast.KindArrowFunction, ast.KindFunctionExpression:
@@ -522,7 +530,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		return false
 	}
 	isExportedHigherOrderFunction := func(node *ast.Node) bool {
-		current := node.Parent
+		current := typescriptutil.GetEffectiveParent(node)
 		for current != nil {
 			if current.Kind == ast.KindReturnStatement {
 				// upstream skips the wrapping Block — `current.parent.parent`.
@@ -542,7 +550,7 @@ func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 			if checkedFunctions[current] {
 				return true
 			}
-			current = current.Parent
+			current = typescriptutil.GetEffectiveParent(current)
 		}
 		return false
 	}
@@ -654,7 +662,7 @@ func isValidFunctionReturnType(node *ast.Node, returns []*ast.Node, opts options
 	if opts.allowHigherOrderFunctions && typescriptutil.DoesImmediatelyReturnFunctionExpression(node, returns) {
 		return true
 	}
-	if node.Type() != nil {
+	if utils.ESTreeType(node) != nil {
 		return true
 	}
 	// Constructor / set-accessor never need a return type.
@@ -758,7 +766,11 @@ func collectMetadata(
 	assignmentsMap map[*ast.Symbol][]*ast.Node,
 	currentFn *ast.Node,
 ) {
-	if node == nil {
+	if node == nil || utils.IsJSDocSyntaxNode(node) {
+		return
+	}
+	if expression := utils.ESTreeRuntimeExpression(node); expression != node {
+		collectMetadata(ctx, expression, returnsMap, assignmentsMap, currentFn)
 		return
 	}
 	switch node.Kind {

--- a/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types_extras_test.go
+++ b/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types_extras_test.go
@@ -299,3 +299,85 @@ export default Foo;
 		},
 	})
 }
+
+func TestExplicitModuleBoundaryTypesIgnoresHostedJSDocSyntax(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ExplicitModuleBoundaryTypesRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code:     "export const f = /** @type {() => void} */ (() => {});",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options: map[string]interface{}{
+					"allowedNames":                  []interface{}{"f"},
+					"allowTypedFunctionExpressions": false,
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     "/** @param {number} value\n * @returns {number} */\nexport function f(value) { return value; }",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingReturnType"},
+					{MessageId: "missingArgType"},
+				},
+			},
+			hostedJSDocBoundaryMissingReturnCase(
+				"export const f = /** @type {() => void} */ (() => {});",
+				1,
+				48,
+			),
+			hostedJSDocBoundaryMissingReturnCase(
+				"export const f = /** @satisfies {() => void} */ (() => {});",
+				1,
+				53,
+			),
+			hostedJSDocBoundaryMissingReturnCase(
+				"/** @type {() => void} */\nconst f = () => {};\nexport { f };",
+				2,
+				14,
+			),
+			hostedJSDocBoundaryMissingReturnCase(
+				"export class C {\n  /** @type {() => void} */\n  callback = () => {};\n}",
+				3,
+				3,
+			),
+			hostedJSDocBoundaryMissingReturnCase(
+				"/** @type {{ callback: () => void }} */\nconst value = { callback: () => {} };\nexport { value };",
+				2,
+				17,
+			),
+			hostedJSDocBoundaryMissingReturnCase(
+				"export class C {\n  /** @private */\n  method() {}\n}",
+				3,
+				3,
+			),
+			hostedJSDocBoundaryMissingReturnCase(
+				"export function f() { return /** @type {() => void} */ (() => {}); }",
+				1,
+				60,
+			),
+			hostedJSDocBoundaryMissingReturnCase(
+				"export const f = () => /** @type {() => void} */ (() => {});",
+				1,
+				54,
+			),
+		},
+	)
+}
+
+func hostedJSDocBoundaryMissingReturnCase(code string, line, column int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mjs",
+		TSConfig: "tsconfig.allow-js.json",
+		Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "missingReturnType", Line: line, Column: column},
+		},
+	}
+}

--- a/internal/plugins/typescript/rules/max_params/max_params.go
+++ b/internal/plugins/typescript/rules/max_params/max_params.go
@@ -34,9 +34,9 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	opts := parseOptions(options)
 
 	check := func(node *ast.Node) {
-		params := node.Parameters()
+		params := utils.ESTreeParameters(node)
 		effective := len(params)
-		if !opts.countVoidThis && utils.IsThisVoidParameter(ast.GetThisParameter(node)) {
+		if !opts.countVoidThis && len(params) > 0 && utils.IsThisVoidParameter(params[0]) {
 			effective--
 		}
 		if effective <= opts.max {

--- a/internal/plugins/typescript/rules/max_params/max_params_test.go
+++ b/internal/plugins/typescript/rules/max_params/max_params_test.go
@@ -1012,3 +1012,62 @@ declare class Foo {
 		},
 	)
 }
+
+func TestMaxParamsIgnoresHostedJSDocSyntax(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxParamsRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code:     "/** @this {Foo} */\nfunction f(value) {}",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  objectOption(map[string]interface{}{"max": 1}),
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     "/** @this {void} */\nfunction f(value) {}",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  objectOption(map[string]interface{}{"max": 0}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Function 'f' has too many parameters (1). Maximum allowed is 0.",
+					},
+				},
+			},
+			{
+				Code:     "const value = { callback: /** @type {Function} */ ((arg) => {}) };",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  objectOption(map[string]interface{}{"max": 0}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Arrow function 'callback' has too many parameters (1). Maximum allowed is 0.",
+						Line:      1,
+						Column:    17,
+					},
+				},
+			},
+			{
+				Code:     "class C { static #callback = /** @type {Function} */ ((arg) => {}); }",
+				FileName: "file.mjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  objectOption(map[string]interface{}{"max": 0}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Static private arrow function '#callback' has too many parameters (1). Maximum allowed is 0.",
+						Line:      1,
+						Column:    11,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_empty_function/no_empty_function_extras_test.go
+++ b/internal/plugins/typescript/rules/no_empty_function/no_empty_function_extras_test.go
@@ -64,6 +64,50 @@ func TestNoEmptyFunctionAllowKindsStayIsolated(t *testing.T) {
 	)
 }
 
+func TestNoEmptyFunctionIgnoresHostedJSDocSyntax(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEmptyFunctionRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			hostedJSDocNoEmptyPayloadCase(
+				"class C {\n  /** @override */\n  method() {}\n}",
+				"method 'method'",
+				noEmptyAllow("overrideMethods"),
+			),
+			hostedJSDocNoEmptyPayloadCase(
+				"class C {\n  /** @private */\n  constructor() {}\n}",
+				"constructor",
+				noEmptyAllow("private-constructors"),
+			),
+			hostedJSDocNoEmptyPayloadCase(
+				"class C {\n  /** @protected */\n  constructor() {}\n}",
+				"constructor",
+				noEmptyAllow("protected-constructors"),
+			),
+			hostedJSDocNoEmptyPayloadCase(
+				"const value = { callback: /** @type {Function} */ (() => {}) };",
+				"method 'callback'",
+				nil,
+			),
+			hostedJSDocNoEmptyPayloadCase(
+				"class C { static #callback = /** @type {Function} */ (() => {}); }",
+				"static private method #callback",
+				nil,
+			),
+		},
+	)
+}
+
+func hostedJSDocNoEmptyPayloadCase(code, name string, options any) rule_tester.InvalidTestCase {
+	testCase := noEmptyPayloadCase(code, name, options)
+	testCase.FileName = "file.mjs"
+	testCase.TSConfig = "tsconfig.allow-js.json"
+	return testCase
+}
+
 func TestNormalizeConstructorOptions(t *testing.T) {
 	options := []any{map[string]any{
 		"allow": []any{"functions", "private-constructors", "protected-constructors"},

--- a/internal/plugins/typescript/typescriptutil/explicit_return_type_utils.go
+++ b/internal/plugins/typescript/typescriptutil/explicit_return_type_utils.go
@@ -9,6 +9,7 @@ package typescriptutil
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // IsFunction reports whether a node is FunctionDeclaration, FunctionExpression
@@ -21,19 +22,18 @@ func IsFunction(node *ast.Node) bool {
 	return ast.IsFunctionDeclaration(node) || ast.IsFunctionExpressionOrArrowFunction(node)
 }
 
-// IsTypeAssertion reports whether a node is `x as T` or `<T>x`.
+// IsTypeAssertion reports whether a node is an authored `x as T` or `<T>x`.
+// Wrappers synthesized from JSDoc casts are transparent in ESTree.
 func IsTypeAssertion(node *ast.Node) bool {
-	return ast.IsAsExpression(node) || ast.IsTypeAssertion(node)
+	return !utils.IsJSDocTypeCastWrapper(node) &&
+		(ast.IsAsExpression(node) || ast.IsTypeAssertion(node))
 }
 
-// GetEffectiveParent returns the first meaningful parent, skipping
-// ParenthesizedExpressions. tsgo preserves parens that ESLint strips, so this
-// bridges the gap when walking from a function to its containing context.
+// GetEffectiveParent returns the first meaningful ESTree parent, skipping
+// ParenthesizedExpressions and wrappers synthesized from JSDoc casts. tsgo
+// preserves both around the runtime expression that ESLint exposes directly.
 func GetEffectiveParent(node *ast.Node) *ast.Node {
-	if node == nil || node.Parent == nil {
-		return nil
-	}
-	return ast.WalkUpParenthesizedExpressions(node.Parent)
+	return utils.ESTreeParent(node)
 }
 
 // IsVariableDeclaratorWithTypeAnnotation reports whether a node is a
@@ -43,7 +43,7 @@ func IsVariableDeclaratorWithTypeAnnotation(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindVariableDeclaration {
 		return false
 	}
-	return node.AsVariableDeclaration().Type != nil
+	return utils.ESTreeType(node) != nil
 }
 
 // IsPropertyDefinitionWithTypeAnnotation reports whether a node is a
@@ -52,7 +52,7 @@ func IsPropertyDefinitionWithTypeAnnotation(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindPropertyDeclaration {
 		return false
 	}
-	return node.AsPropertyDeclaration().Type != nil
+	return utils.ESTreeType(node) != nil
 }
 
 // IsDefaultFunctionParameterWithTypeAnnotation reports whether a node is a
@@ -62,8 +62,7 @@ func IsDefaultFunctionParameterWithTypeAnnotation(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindParameter {
 		return false
 	}
-	param := node.AsParameterDeclaration()
-	return param.Type != nil && param.Initializer != nil
+	return utils.ESTreeType(node) != nil && node.AsParameterDeclaration().Initializer != nil
 }
 
 // IsFunctionArgument reports whether `parent` is a CallExpression and
@@ -72,7 +71,7 @@ func IsFunctionArgument(parent *ast.Node, funcNode *ast.Node) bool {
 	if parent == nil || parent.Kind != ast.KindCallExpression {
 		return false
 	}
-	callee := ast.SkipParentheses(parent.AsCallExpression().Expression)
+	callee := utils.ESTreeRuntimeExpression(parent.AsCallExpression().Expression)
 	return callee != funcNode
 }
 
@@ -199,7 +198,7 @@ func DoesImmediatelyReturnFunctionExpression(node *ast.Node, returns []*ast.Node
 	if node.Kind == ast.KindArrowFunction {
 		af := node.AsArrowFunction()
 		if af.Body != nil && af.Body.Kind != ast.KindBlock {
-			return IsFunction(ast.SkipParentheses(af.Body))
+			return IsFunction(utils.ESTreeRuntimeExpression(af.Body))
 		}
 	}
 	if len(returns) == 0 {
@@ -207,7 +206,7 @@ func DoesImmediatelyReturnFunctionExpression(node *ast.Node, returns []*ast.Node
 	}
 	for _, ret := range returns {
 		arg := ret.Expression()
-		if arg == nil || !IsFunction(ast.SkipParentheses(arg)) {
+		if arg == nil || !IsFunction(utils.ESTreeRuntimeExpression(arg)) {
 			return false
 		}
 	}
@@ -221,12 +220,7 @@ func AncestorHasReturnType(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	ancestor := node.Parent
-	// tsgo preserves ParenthesizedExpression that ESLint strips — peel them
-	// before checking the "is this a return value?" gate.
-	for ancestor != nil && ancestor.Kind == ast.KindParenthesizedExpression {
-		ancestor = ancestor.Parent
-	}
+	ancestor := GetEffectiveParent(node)
 
 	// ESLint's model: `if (ancestor.type === Property) ancestor = ancestor.value;`
 	// `Property.value` for `arrowFn: () => 'test'` is the ArrowFunction itself.
@@ -234,7 +228,7 @@ func AncestorHasReturnType(node *ast.Node) bool {
 	if ancestor != nil && ancestor.Kind == ast.KindPropertyAssignment {
 		pa := ancestor.AsPropertyAssignment()
 		if pa.Initializer != nil {
-			ancestor = ast.SkipParentheses(pa.Initializer)
+			ancestor = utils.ESTreeRuntimeExpression(pa.Initializer)
 		}
 	}
 
@@ -254,13 +248,13 @@ func AncestorHasReturnType(node *ast.Node) bool {
 			// In tsgo, methods and getters are their own node types (not
 			// FunctionExpression inside MethodDefinition like ESLint). Check
 			// their return type the same way.
-			if ancestor.Type() != nil {
+			if utils.ESTreeType(ancestor) != nil {
 				return true
 			}
 		case ast.KindVariableDeclaration:
-			return ancestor.AsVariableDeclaration().Type != nil
+			return utils.ESTreeType(ancestor) != nil
 		case ast.KindPropertyDeclaration:
-			return ancestor.AsPropertyDeclaration().Type != nil
+			return utils.ESTreeType(ancestor) != nil
 		case ast.KindExpressionStatement:
 			return false
 		}

--- a/internal/rules/no_empty_function/no_empty_function.go
+++ b/internal/rules/no_empty_function/no_empty_function.go
@@ -125,12 +125,13 @@ func isAllowedEmptyFunction(node *ast.Node, opts noEmptyFunctionOptions) bool {
 	if opts.allow[kind] {
 		return true
 	}
+	modifierFlags := utils.ESTreeModifierFlags(node)
 
 	if kind == "constructors" {
-		if ast.HasSyntacticModifier(node, ast.ModifierFlagsPrivate) && opts.allow["privateConstructors"] {
+		if modifierFlags&ast.ModifierFlagsPrivate != 0 && opts.allow["privateConstructors"] {
 			return true
 		}
-		if ast.HasSyntacticModifier(node, ast.ModifierFlagsProtected) && opts.allow["protectedConstructors"] {
+		if modifierFlags&ast.ModifierFlagsProtected != 0 && opts.allow["protectedConstructors"] {
 			return true
 		}
 		if hasParameterProperty(node) {
@@ -142,7 +143,7 @@ func isAllowedEmptyFunction(node *ast.Node, opts noEmptyFunctionOptions) bool {
 		if ast.HasDecorators(node) && opts.allow["decoratedFunctions"] {
 			return true
 		}
-		if ast.HasSyntacticModifier(node, ast.ModifierFlagsOverride) && opts.allow["overrideMethods"] {
+		if modifierFlags&ast.ModifierFlagsOverride != 0 && opts.allow["overrideMethods"] {
 			return true
 		}
 	}
@@ -270,12 +271,7 @@ func emptyFunctionDisplayName(node *ast.Node) string {
 }
 
 func parentSkippingParens(node *ast.Node) *ast.Node {
-	if node == nil || node.Parent == nil {
-		return nil
-	}
-	// tsgo keeps ParenthesizedExpression nodes that ESLint does not expose
-	// here, so recover the property/class-field container around `(fn)`.
-	return ast.WalkUpParenthesizedExpressions(node.Parent)
+	return utils.ESTreeParent(node)
 }
 
 func isClassMemberFunction(node *ast.Node) bool {

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -398,11 +398,47 @@ func IsJSDocTypeCastWrapper(node *ast.Node) bool {
 	return node.Kind == ast.KindAsExpression && node.Parent != nil && ast.IsJSDocTypeAssertion(node.Parent)
 }
 
+// ESTreeRuntimeExpression removes syntax that ESTree does not expose around a
+// runtime expression: source parentheses and wrappers synthesized from JSDoc
+// @type/@satisfies casts. Authored TypeScript assertions remain intact.
+func ESTreeRuntimeExpression(node *ast.Node) *ast.Node {
+	for node != nil {
+		node = ast.SkipParentheses(node)
+		expression := JSDocTypeCastExpression(node)
+		if expression == nil {
+			return node
+		}
+		node = expression
+	}
+	return nil
+}
+
+// ESTreeParent returns the first parent that ESTree exposes, skipping source
+// parentheses and wrappers synthesized from JSDoc casts.
+func ESTreeParent(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	parent := node.Parent
+	for parent != nil &&
+		(parent.Kind == ast.KindParenthesizedExpression || IsJSDocTypeCastWrapper(parent)) {
+		parent = parent.Parent
+	}
+	return parent
+}
+
 // ESTreeParameters returns only parameters authored in source. tsgo prepends
 // a reparsed `this` parameter for JSDoc @this, but ESTree keeps the tag solely
 // as a comment.
 func ESTreeParameters(node *ast.Node) []*ast.Node {
 	return slices.DeleteFunc(slices.Clone(node.Parameters()), IsJSDocSyntaxNode)
+}
+
+// ESTreeTypeParameters returns only type parameters authored in source. tsgo
+// materializes JSDoc @template tags on function-like nodes, while ESTree keeps
+// those tags solely as comments.
+func ESTreeTypeParameters(node *ast.Node) []*ast.Node {
+	return slices.DeleteFunc(slices.Clone(node.TypeParameters()), IsJSDocSyntaxNode)
 }
 
 // ESTreeType returns the source-authored type annotation, excluding a type

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -193,9 +193,9 @@ func GetForStatementHeadLoc(
  * - `export default function() {}` → `function`
  */
 func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
-	// ESTree exposes no node for parentheses, so a parenthesized function
-	// value still has the property that holds it as its parent.
-	parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+	// ESTree exposes neither parentheses nor hosted JSDoc cast wrappers, so the
+	// function value still has the property that holds it as its parent.
+	parent := ESTreeParent(node)
 
 	switch node.Kind {
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
@@ -547,7 +547,7 @@ func GetFunctionNameWithKind(node *ast.Node) string {
 	isAsync := flags&ast.FunctionFlagsAsync != 0
 	isGenerator := flags&ast.FunctionFlagsGenerator != 0
 
-	parent := node.Parent
+	parent := ESTreeParent(node)
 	isStatic, isPrivate := false, false
 	// Direct class member (MethodDeclaration / GetAccessor / SetAccessor):
 	// modifiers and private-key live on the function-like node itself.
@@ -827,7 +827,7 @@ func getFunctionDisplayName(node *ast.Node) string {
 			return s
 		}
 	}
-	parent := node.Parent
+	parent := ESTreeParent(node)
 	if parent == nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary

- Treat tsgo-hosted JSDoc parameters, types, type parameters, and modifiers as comments when rules inspect authored syntax.
- Make JSDoc `@type` and `@satisfies` wrappers transparent for typed contexts, IIFEs, higher-order functions, and function names.
- Add regression coverage for `max-params`, `explicit-module-boundary-types`, `explicit-function-return-type`, and `no-empty-function`, including adversarial wrapper and option combinations.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
