### PR TITLE
feat: port rule default-param-last

### DIFF
--- a/internal/plugins/typescript/rules/default_param_last/default_param_last.go
+++ b/internal/plugins/typescript/rules/default_param_last/default_param_last.go
@@ -1,60 +1,13 @@
 package default_param_last
 
 import (
-	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
+	core "github.com/web-infra-dev/rslint/internal/rules/default_param_last"
 )
 
 // DefaultParamLastRule enforces default parameters to be last
 var DefaultParamLastRule = rule.CreateRule(rule.Rule{
 	Name:   "default-param-last",
 	Schema: rule.EmptyArraySchema,
-	Run:    run,
+	Run:    core.DefaultParamLastRule.Run,
 })
-
-var shouldBeLastMessage = rule.RuleMessage{
-	Id:          "shouldBeLast",
-	Description: "Default parameters should be last.",
-}
-
-func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
-	checkDefaultParamLast := func(node *ast.Node) {
-		params := utils.ESTreeParameters(node)
-		if len(params) < 2 {
-			return
-		}
-
-		hasSeenPlainParam := false
-		for i := len(params) - 1; i >= 0; i-- {
-			current := params[i]
-			if current == nil {
-				continue
-			}
-
-			param := current.AsParameterDeclaration()
-			if param.DotDotDotToken != nil {
-				continue
-			}
-			questionToken := param.QuestionToken
-			if utils.IsJSDocSyntaxNode(questionToken) {
-				questionToken = nil
-			}
-			if param.Initializer == nil && questionToken == nil {
-				hasSeenPlainParam = true
-				continue
-			}
-			if hasSeenPlainParam {
-				ctx.ReportNode(current, shouldBeLastMessage)
-			}
-		}
-	}
-
-	return rule.RuleListeners{
-		ast.KindFunctionDeclaration: checkDefaultParamLast,
-		ast.KindFunctionExpression:  checkDefaultParamLast,
-		ast.KindArrowFunction:       checkDefaultParamLast,
-		ast.KindMethodDeclaration:   checkDefaultParamLast,
-		ast.KindConstructor:         checkDefaultParamLast,
-	}
-}

--- a/internal/plugins/typescript/rules/default_param_last/default_param_last_test.go
+++ b/internal/plugins/typescript/rules/default_param_last/default_param_last_test.go
@@ -53,6 +53,11 @@ func TestDefaultParamLastRule(t *testing.T) {
 		{Code: `class A { constructor(a: number, b = 0) {} }`},
 		{Code: `class A { constructor(a: number, b?: number) {} }`},
 
+		// Valid: bodyless declarations are outside the upstream listeners
+		{Code: `declare function f(a?: number, b: number): void;`},
+		{Code: `abstract class A { abstract method(a?: number, b: number): void; }`},
+		{Code: `class A { constructor(a?: number, b: number); constructor(b: number) {} }`},
+
 		// Valid: parameter properties
 		{Code: `class A { constructor(public a: number, public b = 0) {} }`},
 		{Code: `class A { constructor(private a: number, public b?: number) {} }`},
@@ -130,9 +135,9 @@ func TestDefaultParamLastRule(t *testing.T) {
 
 		// Invalid: method
 		{
-			Code: `class A { method(a = 0, b: number) {} }`,
+			Code: `class A { method(@first @second a?: number, b: number) {} }`,
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "shouldBeLast"},
+				{MessageId: "shouldBeLast", Line: 1, Column: 33, EndLine: 1, EndColumn: 43},
 			},
 		},
 

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -25,6 +25,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/curly"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case_last"
+	"github.com/web-infra-dev/rslint/internal/rules/default_param_last"
 	"github.com/web-infra-dev/rslint/internal/rules/dot_notation"
 	"github.com/web-infra-dev/rslint/internal/rules/eqeqeq"
 	"github.com/web-infra-dev/rslint/internal/rules/for_direction"
@@ -236,6 +237,7 @@ func coreRules() []rule.Rule {
 		curly.CurlyRule,
 		default_case.DefaultCaseRule,
 		default_case_last.DefaultCaseLastRule,
+		default_param_last.DefaultParamLastRule,
 		dot_notation.DotNotationRule,
 		for_direction.ForDirectionRule,
 		func_names.FuncNamesRule,

--- a/internal/rules/default_param_last/default_param_last.go
+++ b/internal/rules/default_param_last/default_param_last.go
@@ -44,7 +44,11 @@ var DefaultParamLastRule = rule.Rule{
 			}
 			for i := range lastRequired {
 				if !isRequiredParameter(params[i]) {
-					ctx.ReportRange(utils.NodeTextRangeSkippingDecorators(ctx.SourceFile, params[i]), shouldBeLastMessage)
+					reportRange := utils.NodeTextRangeSkippingDecorators(ctx.SourceFile, params[i])
+					if ast.IsParameterPropertyDeclaration(params[i], node) {
+						reportRange = utils.TrimNodeTextRange(ctx.SourceFile, params[i])
+					}
+					ctx.ReportRange(reportRange, shouldBeLastMessage)
 				}
 			}
 		}

--- a/internal/rules/default_param_last/default_param_last.go
+++ b/internal/rules/default_param_last/default_param_last.go
@@ -17,6 +17,9 @@ var DefaultParamLastRule = rule.Rule{
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		check := func(node *ast.Node) {
+			if node.Body() == nil {
+				return
+			}
 			params := utils.ESTreeParameters(node)
 			isRequiredParameter := func(current *ast.Node) bool {
 				if current == nil {

--- a/internal/rules/default_param_last/default_param_last.go
+++ b/internal/rules/default_param_last/default_param_last.go
@@ -1,0 +1,61 @@
+package default_param_last
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var shouldBeLastMessage = rule.RuleMessage{
+	Id:          "shouldBeLast",
+	Description: "Default parameters should be last.",
+}
+
+// DefaultParamLastRule enforces default parameters to be last.
+var DefaultParamLastRule = rule.Rule{
+	Name:   "default-param-last",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			params := utils.ESTreeParameters(node)
+			isRequiredParameter := func(current *ast.Node) bool {
+				if current == nil {
+					return false
+				}
+				param := current.AsParameterDeclaration()
+				questionToken := param.QuestionToken
+				if utils.IsJSDocSyntaxNode(questionToken) {
+					questionToken = nil
+				}
+				return param.Initializer == nil &&
+					param.DotDotDotToken == nil &&
+					questionToken == nil
+			}
+
+			lastRequired := -1
+			for i := len(params) - 1; i >= 0; i-- {
+				if isRequiredParameter(params[i]) {
+					lastRequired = i
+					break
+				}
+			}
+			for i := range lastRequired {
+				if !isRequiredParameter(params[i]) {
+					ctx.ReportNode(params[i], shouldBeLastMessage)
+				}
+			}
+		}
+
+		// ESLint's FunctionExpression listener also reaches methods and
+		// constructors through ESTree wrapper nodes. tsgo models them directly.
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: check,
+			ast.KindFunctionExpression:  check,
+			ast.KindArrowFunction:       check,
+			ast.KindMethodDeclaration:   check,
+			ast.KindConstructor:         check,
+			ast.KindGetAccessor:         check,
+			ast.KindSetAccessor:         check,
+		}
+	},
+}

--- a/internal/rules/default_param_last/default_param_last.go
+++ b/internal/rules/default_param_last/default_param_last.go
@@ -44,7 +44,7 @@ var DefaultParamLastRule = rule.Rule{
 			}
 			for i := range lastRequired {
 				if !isRequiredParameter(params[i]) {
-					ctx.ReportNode(params[i], shouldBeLastMessage)
+					ctx.ReportRange(utils.NodeTextRangeSkippingDecorators(ctx.SourceFile, params[i]), shouldBeLastMessage)
 				}
 			}
 		}

--- a/internal/rules/default_param_last/default_param_last.md
+++ b/internal/rules/default_param_last/default_param_last.md
@@ -1,0 +1,48 @@
+# default-param-last
+
+## Rule Details
+
+Default parameters are most useful at the end of a parameter list, where callers can omit them. This rule reports default or optional parameters followed by required parameters.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function createUser(isAdmin = false, id) {}
+
+function connect(host = "localhost", port) {}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function createUser(id, isAdmin = false) {}
+
+function connect(port, host = "localhost") {}
+```
+
+The rule also supports TypeScript optional parameters and parameter properties.
+
+Examples of **incorrect** TypeScript code for this rule:
+
+```typescript
+function format(value?: string, radix: number) {}
+
+class Client {
+  constructor(public endpoint = "localhost", private retries: number) {}
+}
+```
+
+Examples of **correct** TypeScript code for this rule:
+
+```typescript
+function format(radix: number, value?: string) {}
+
+class Client {
+  constructor(private retries: number, public endpoint = "localhost") {}
+}
+```
+
+## Original Documentation
+
+- [ESLint: default-param-last](https://eslint.org/docs/latest/rules/default-param-last)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/default-param-last.js)

--- a/internal/rules/default_param_last/default_param_last_extras_test.go
+++ b/internal/rules/default_param_last/default_param_last_extras_test.go
@@ -1,0 +1,141 @@
+package default_param_last
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestDefaultParamLastExtras locks in branches and edge shapes that the upstream test suite doesn't exercise.
+// Each case carries an inline comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future refactors can't silently regress them without breaking a named lock-in.
+func TestDefaultParamLastExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&DefaultParamLastRule,
+		[]rule_tester.ValidTestCase{
+			// N/A: receiver/expression wrappers and optional chains cannot wrap a parameter declaration.
+			// N/A: member-access and property-key forms are not inspected by this rule.
+
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: "async function f(required, optional = 1) {}"},
+			{Code: "function* f(required, optional = 1) {}"},
+			{Code: "async function* f(required, optional = 1) {}"},
+			{Code: "const f = async (required, optional = 1) => {};"},
+			{Code: "const object = { method(required, optional = 1) {} };"},
+			{Code: "class C { static method(required, optional = 1) {} }"},
+			{Code: "const C = class { #method(required, optional = 1) {} };"},
+			{Code: "class C { field = (required, optional = 1) => {}; }"},
+			{Code: "class C { constructor(required, optional = 1) {} }"},
+
+			// ---- Dimension 4: nesting/traversal boundaries ----
+			{Code: "function outer(required, optional = 1) { function inner(required, optional = 1) {} }"},
+			{Code: "const outer = (required, optional = 1) => (innerRequired, innerOptional = 1) => 0;"},
+
+			// ---- Dimension 4: graceful degradation ----
+			{Code: "function empty() {}"},
+			{Code: "function destructured({value}, [fallback] = []) {}"},
+			{Code: "function rest(defaulted = 1, ...values) {}"},
+			{Code: "abstract class C { abstract method(required: number, optional?: number): void; }"},
+			{Code: "interface I { method(optional?: number, required?: number): void; }"},
+			// N/A: spread assignments and standalone rest binding elements cannot occur as function-list members.
+
+			// Locks in upstream isRequiredParameter() RestElement arm: rest does not make a preceding default invalid.
+			{Code: "function f(defaulted = 1, ...rest) {}"},
+			// Locks in upstream handleFunction() report guard false arm: no required parameter exists to the right.
+			{Code: "function f(first = 1, second = 2) {}"},
+			// Locks in the ESTree-parameter filter: a JSDoc optional tag must not become a TypeScript optional parameter.
+			{Code: "/** @param {number} [a] */\nfunction f(a, b) {}", FileName: "file.mjs", TSConfig: "tsconfig.allow-js.json"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: declaration/container forms ----
+			{
+				Code:   "async function f(defaulted = 1, required) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Message: "Default parameters should be last.", Line: 1, Column: 18, EndLine: 1, EndColumn: 31}},
+			},
+			{
+				Code:   "function* f(defaulted = 1, required) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 13, EndLine: 1, EndColumn: 26}},
+			},
+			{
+				Code:   "const f = function(defaulted = 1, required) {};",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 20, EndLine: 1, EndColumn: 33}},
+			},
+			{
+				Code:   "const f = (defaulted = 1, required) => {};",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 12, EndLine: 1, EndColumn: 25}},
+			},
+			{
+				Code:   "const object = { method(defaulted = 1, required) {} };",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 25, EndLine: 1, EndColumn: 38}},
+			},
+			{
+				Code:   "class C {\n  method(\n    defaulted = 1,\n    required,\n  ) {}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 3, Column: 5, EndLine: 3, EndColumn: 18}},
+			},
+			{
+				Code:   "class C { constructor(defaulted = 1, required) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 23, EndLine: 1, EndColumn: 36}},
+			},
+			{
+				Code:   "class C {\n  constructor(\n    public endpoint = \"localhost\",\n    private retries: number,\n  ) {}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 3, Column: 5, EndLine: 3, EndColumn: 34}},
+			},
+			{
+				Code:   "class C { field = (defaulted = 1, required) => {}; }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 20, EndLine: 1, EndColumn: 33}},
+			},
+
+			// ---- Dimension 4: nesting/traversal boundaries ----
+			{
+				Code: "function outer(defaulted = 1, required) {\n  function inner(innerDefault = 2, innerRequired) {}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "shouldBeLast", Line: 1, Column: 16, EndLine: 1, EndColumn: 29},
+					{MessageId: "shouldBeLast", Line: 2, Column: 18, EndLine: 2, EndColumn: 34},
+				},
+			},
+
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code:   "declare function overloaded(optional?: number, required: number): void;",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 29, EndLine: 1, EndColumn: 46}},
+			},
+
+			// Locks in upstream isRequiredParameter() AssignmentPattern arm and handleFunction() report-true arm.
+			{
+				Code:   "function f(defaulted = 1, required) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 12, EndLine: 1, EndColumn: 25}},
+			},
+			// Locks in upstream isRequiredParameter() optional arm.
+			{
+				Code:   "function f(optional?: number, required: number) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 12, EndLine: 1, EndColumn: 29}},
+			},
+			// Locks in upstream handleFunction() required-parameter arm before a later optional parameter.
+			{
+				Code:   "function f(first: number, optional?: number, required: number) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 27, EndLine: 1, EndColumn: 44}},
+			},
+			// Locks in upstream TSParameterProperty unwrap arm.
+			{
+				Code:   "class C { constructor(public optional?: number, private required: number) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 23, EndLine: 1, EndColumn: 47}},
+			},
+
+			// ---- Real-user: eslint/eslint#11361 optional argument before a required identifier ----
+			{
+				Code:   `function connect(host = "localhost", port) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 18, EndLine: 1, EndColumn: 36}},
+			},
+			// ---- Real-user: eslint/eslint#19431 TypeScript parameter-property support ----
+			{
+				Code:   `class Client { constructor(readonly endpoint = "localhost", retries: number) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 28, EndLine: 1, EndColumn: 59}},
+			},
+		},
+	)
+}
+
+// N/A: this rule has no options, fixes, suggestions, key comparisons, or configurable equivalence classes.

--- a/internal/rules/default_param_last/default_param_last_extras_test.go
+++ b/internal/rules/default_param_last/default_param_last_extras_test.go
@@ -90,6 +90,11 @@ func TestDefaultParamLastExtras(t *testing.T) {
 				Code:   "class C { field = (defaulted = 1, required) => {}; }",
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 20, EndLine: 1, EndColumn: 33}},
 			},
+			// ESTree parameter ranges exclude decorators, including when more than one is present.
+			{
+				Code:   "class C { method(@first @second optional?: number, required: number) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 33, EndLine: 1, EndColumn: 50}},
+			},
 
 			// ---- Dimension 4: nesting/traversal boundaries ----
 			{

--- a/internal/rules/default_param_last/default_param_last_extras_test.go
+++ b/internal/rules/default_param_last/default_param_last_extras_test.go
@@ -38,7 +38,10 @@ func TestDefaultParamLastExtras(t *testing.T) {
 			{Code: "function empty() {}"},
 			{Code: "function destructured({value}, [fallback] = []) {}"},
 			{Code: "function rest(defaulted = 1, ...values) {}"},
-			{Code: "abstract class C { abstract method(required: number, optional?: number): void; }"},
+			// typescript-eslint exposes bodyless declarations as nodes outside the upstream listeners.
+			{Code: "declare function overloaded(optional?: number, required: number): void;"},
+			{Code: "abstract class C { abstract method(optional?: number, required: number): void; }"},
+			{Code: "class C { constructor(optional?: number, required: number); constructor(required: number) {} }"},
 			{Code: "interface I { method(optional?: number, required?: number): void; }"},
 			// N/A: spread assignments and standalone rest binding elements cannot occur as function-list members.
 
@@ -95,12 +98,6 @@ func TestDefaultParamLastExtras(t *testing.T) {
 					{MessageId: "shouldBeLast", Line: 1, Column: 16, EndLine: 1, EndColumn: 29},
 					{MessageId: "shouldBeLast", Line: 2, Column: 18, EndLine: 2, EndColumn: 34},
 				},
-			},
-
-			// ---- Dimension 4: graceful degradation ----
-			{
-				Code:   "declare function overloaded(optional?: number, required: number): void;",
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 29, EndLine: 1, EndColumn: 46}},
 			},
 
 			// Locks in upstream isRequiredParameter() AssignmentPattern arm and handleFunction() report-true arm.

--- a/internal/rules/default_param_last/default_param_last_extras_test.go
+++ b/internal/rules/default_param_last/default_param_last_extras_test.go
@@ -90,10 +90,15 @@ func TestDefaultParamLastExtras(t *testing.T) {
 				Code:   "class C { field = (defaulted = 1, required) => {}; }",
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 20, EndLine: 1, EndColumn: 33}},
 			},
-			// ESTree parameter ranges exclude decorators, including when more than one is present.
+			// Ordinary ESTree parameter ranges exclude decorators, including when more than one is present.
 			{
 				Code:   "class C { method(@first @second optional?: number, required: number) {} }",
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 33, EndLine: 1, EndColumn: 50}},
+			},
+			// TSParameterProperty wrapper ranges include decorators, unlike ordinary parameters.
+			{
+				Code:   "class C { constructor(@dec public readonly optional?: number, private required: number) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "shouldBeLast", Line: 1, Column: 23, EndLine: 1, EndColumn: 61}},
 			},
 
 			// ---- Dimension 4: nesting/traversal boundaries ----

--- a/internal/rules/default_param_last/default_param_last_extras_test.go
+++ b/internal/rules/default_param_last/default_param_last_extras_test.go
@@ -37,12 +37,11 @@ func TestDefaultParamLastExtras(t *testing.T) {
 			// ---- Dimension 4: graceful degradation ----
 			{Code: "function empty() {}"},
 			{Code: "function destructured({value}, [fallback] = []) {}"},
-			{Code: "function rest(defaulted = 1, ...values) {}"},
 			// typescript-eslint exposes bodyless declarations as nodes outside the upstream listeners.
 			{Code: "declare function overloaded(optional?: number, required: number): void;"},
 			{Code: "abstract class C { abstract method(optional?: number, required: number): void; }"},
 			{Code: "class C { constructor(optional?: number, required: number); constructor(required: number) {} }"},
-			{Code: "interface I { method(optional?: number, required?: number): void; }"},
+			{Code: "interface I { method(optional?: number, required: number): void; }"},
 			// N/A: spread assignments and standalone rest binding elements cannot occur as function-list members.
 
 			// Locks in upstream isRequiredParameter() RestElement arm: rest does not make a preceding default invalid.

--- a/internal/rules/default_param_last/default_param_last_upstream_test.go
+++ b/internal/rules/default_param_last/default_param_last_upstream_test.go
@@ -1,0 +1,179 @@
+package default_param_last
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestDefaultParamLastUpstream migrates the full valid/invalid suite from upstream eslint/tests/lib/rules/default-param-last.js 1:1.
+// Position assertions cover line/column for every invalid case. rslint-specific lock-in cases live in default_param_last_extras_test.go.
+func TestDefaultParamLastUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&DefaultParamLastRule,
+		upstreamValidCases(),
+		upstreamInvalidCases(),
+	)
+}
+
+func upstreamValidCases() []rule_tester.ValidTestCase {
+	codes := []string{
+		// ---- ESLint core JavaScript valid ----
+		"function f() {}",
+		"function f(a) {}",
+		"function f(a = 5) {}",
+		"function f(a, b) {}",
+		"function f(a, b = 5) {}",
+		"function f(a, b = 5, c = 5) {}",
+		"function f(a, b = 5, ...c) {}",
+		"const f = () => {}",
+		"const f = (a) => {}",
+		"const f = (a = 5) => {}",
+		"const f = function f() {}",
+		"const f = function f(a) {}",
+		"const f = function f(a = 5) {}",
+
+		// ---- ESLint core TypeScript valid: function declarations ----
+		"function foo() {}",
+		"function foo(a: number) {}",
+		"function foo(a = 1) {}",
+		"function foo(a?: number) {}",
+		"function foo(a: number, b: number) {}",
+		"function foo(a: number, b: number, c?: number) {}",
+		"function foo(a: number, b = 1) {}",
+		"function foo(a: number, b = 1, c = 1) {}",
+		"function foo(a: number, b = 1, c?: number) {}",
+		"function foo(a: number, b?: number, c = 1) {}",
+		"function foo(a: number, b = 1, ...c) {}",
+
+		// ---- ESLint core TypeScript valid: function expressions ----
+		"const foo = function () {};",
+		"const foo = function (a: number) {};",
+		"const foo = function (a = 1) {};",
+		"const foo = function (a?: number) {};",
+		"const foo = function (a: number, b: number) {};",
+		"const foo = function (a: number, b: number, c?: number) {};",
+		"const foo = function (a: number, b = 1) {};",
+		"const foo = function (a: number, b = 1, c = 1) {};",
+		"const foo = function (a: number, b = 1, c?: number) {};",
+		"const foo = function (a: number, b?: number, c = 1) {};",
+		"const foo = function (a: number, b = 1, ...c) {};",
+
+		// ---- ESLint core TypeScript valid: arrows ----
+		"const foo = () => {};",
+		"const foo = (a: number) => {};",
+		"const foo = (a = 1) => {};",
+		"const foo = (a?: number) => {};",
+		"const foo = (a: number, b: number) => {};",
+		"const foo = (a: number, b: number, c?: number) => {};",
+		"const foo = (a: number, b = 1) => {};",
+		"const foo = (a: number, b = 1, c = 1) => {};",
+		"const foo = (a: number, b = 1, c?: number) => {};",
+		"const foo = (a: number, b?: number, c = 1) => {};",
+		"const foo = (a: number, b = 1, ...c) => {};",
+
+		// ---- ESLint core TypeScript valid: constructors and parameter properties ----
+		`class Foo { constructor(a: number, b: number, c: number) {} }`,
+		`class Foo { constructor(a: number, b?: number, c = 1) {} }`,
+		`class Foo { constructor(a: number, b = 1, c?: number) {} }`,
+		`class Foo { constructor(public a: number, protected b: number, private c: number) {} }`,
+		`class Foo { constructor(public a: number, protected b?: number, private c = 10) {} }`,
+		`class Foo { constructor(public a: number, protected b = 10, private c?: number) {} }`,
+		`class Foo { constructor(a: number, protected b?: number, private c = 0) {} }`,
+		`class Foo { constructor(a: number, b?: number, private c = 0) {} }`,
+		`class Foo { constructor(a: number, private b?: number, c = 0) {} }`,
+	}
+
+	valid := make([]rule_tester.ValidTestCase, 0, len(codes))
+	for _, code := range codes {
+		valid = append(valid, rule_tester.ValidTestCase{Code: code})
+	}
+	return valid
+}
+
+func upstreamInvalidCases() []rule_tester.InvalidTestCase {
+	return []rule_tester.InvalidTestCase{
+		// ---- ESLint core JavaScript invalid ----
+		invalidAt("function f(a = 5, b) {}", positions(1, 12, 17)),
+		invalidAt("function f(a = 5, b = 6, c) {}", positions(1, 12, 17), positions(1, 19, 24)),
+		invalidAt("function f (a = 5, b, c = 6, d) {}", positions(1, 13, 18), positions(1, 23, 28)),
+		invalidAt("function f(a = 5, b, c = 5) {}", positions(1, 12, 17)),
+		invalidAt("const f = (a = 5, b, ...c) => {}", positions(1, 12, 17)),
+		invalidAt("const f = function f (a, b = 5, c) {}", positions(1, 26, 31)),
+		invalidAt("const f = (a = 5, { b }) => {}", positions(1, 12, 17)),
+		invalidAt("const f = ({ a } = {}, b) => {}", positions(1, 12, 22)),
+		invalidAt("const f = ({ a, b } = { a: 1, b: 2 }, c) => {}", positions(1, 12, 37)),
+		invalidAt("const f = ([a] = [], b) => {}", positions(1, 12, 20)),
+		invalidAt("const f = ([a, b] = [1, 2], c) => {}", positions(1, 12, 27)),
+
+		// ---- ESLint core TypeScript invalid: function declarations ----
+		invalidAt("function foo(a = 1, b: number) {}", positions(1, 14, 19)),
+		invalidAt("function foo(a = 1, b = 2, c: number) {}", positions(1, 14, 19), positions(1, 21, 26)),
+		invalidAt("function foo(a = 1, b: number, c = 2, d: number) {}", positions(1, 14, 19), positions(1, 32, 37)),
+		invalidAt("function foo(a = 1, b: number, c = 2) {}", positions(1, 14, 19)),
+		invalidAt("function foo(a = 1, b: number, ...c) {}", positions(1, 14, 19)),
+		invalidAt("function foo(a?: number, b: number) {}", positions(1, 14, 24)),
+		invalidAt("function foo(a: number, b?: number, c: number) {}", positions(1, 25, 35)),
+		invalidAt("function foo(a = 1, b?: number, c: number) {}", positions(1, 14, 19), positions(1, 21, 31)),
+
+		// ---- ESLint core TypeScript invalid: function expressions ----
+		invalidAt("const foo = function (a = 1, b: number) {};", positions(1, 23, 28)),
+		invalidAt("const foo = function (a = 1, b = 2, c: number) {};", positions(1, 23, 28), positions(1, 30, 35)),
+		invalidAt("const foo = function (a = 1, b: number, c = 2, d: number) {};", positions(1, 23, 28), positions(1, 41, 46)),
+		invalidAt("const foo = function (a = 1, b: number, c = 2) {};", positions(1, 23, 28)),
+		invalidAt("const foo = function (a = 1, b: number, ...c) {};", positions(1, 23, 28)),
+		invalidAt("const foo = function (a?: number, b: number) {};", positions(1, 23, 33)),
+		invalidAt("const foo = function (a: number, b?: number, c: number) {};", positions(1, 34, 44)),
+		invalidAt("const foo = function (a = 1, b?: number, c: number) {};", positions(1, 23, 28), positions(1, 30, 40)),
+
+		// ---- ESLint core TypeScript invalid: arrows ----
+		invalidAt("const foo = (a = 1, b: number) => {};", positions(1, 14, 19)),
+		invalidAt("const foo = (a = 1, b = 2, c: number) => {};", positions(1, 14, 19), positions(1, 21, 26)),
+		invalidAt("const foo = (a = 1, b: number, c = 2, d: number) => {};", positions(1, 14, 19), positions(1, 32, 37)),
+		invalidAt("const foo = (a = 1, b: number, c = 2) => {};", positions(1, 14, 19)),
+		invalidAt("const foo = (a = 1, b: number, ...c) => {};", positions(1, 14, 19)),
+		invalidAt("const foo = (a?: number, b: number) => {};", positions(1, 14, 24)),
+		invalidAt("const foo = (a: number, b?: number, c: number) => {};", positions(1, 25, 35)),
+		invalidAt("const foo = (a = 1, b?: number, c: number) => {};", positions(1, 14, 19), positions(1, 21, 31)),
+
+		// ---- ESLint core TypeScript invalid: constructors and parameter properties ----
+		invalidAt("\nclass Foo {\n  constructor(\n    public a: number,\n    protected b?: number,\n    private c: number,\n  ) {}\n}", positions(5, 5, 25)),
+		invalidAt("\nclass Foo {\n  constructor(\n    public a: number,\n    protected b = 0,\n    private c: number,\n  ) {}\n}", positions(5, 5, 20)),
+		invalidAt("\nclass Foo {\n  constructor(\n    public a?: number,\n    private b: number,\n  ) {}\n}", positions(4, 5, 22)),
+		invalidAt("\nclass Foo {\n  constructor(\n    public a = 0,\n    private b: number,\n  ) {}\n}", positions(4, 5, 17)),
+		invalidAt("\nclass Foo {\n  constructor(a = 0, b: number) {}\n}", positions(3, 15, 20)),
+		invalidAt("\nclass Foo {\n  constructor(a?: number, b: number) {}\n}", positions(3, 15, 25)),
+	}
+}
+
+type expectedPosition struct {
+	line      int
+	column    int
+	endColumn int
+}
+
+func positions(line, column, endColumn int) expectedPosition {
+	return expectedPosition{line: line, column: column, endColumn: endColumn}
+}
+
+func invalidAt(code string, positions ...expectedPosition) rule_tester.InvalidTestCase {
+	errors := make([]rule_tester.InvalidTestCaseError, 0, len(positions))
+	for i, pos := range positions {
+		err := rule_tester.InvalidTestCaseError{
+			MessageId: "shouldBeLast",
+			Line:      pos.line,
+			Column:    pos.column,
+			EndLine:   pos.line,
+			EndColumn: pos.endColumn,
+		}
+		if i == 0 {
+			err.Message = "Default parameters should be last."
+		}
+		errors = append(errors, err)
+	}
+	return rule_tester.InvalidTestCase{Code: code, Errors: errors}
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -199,7 +199,7 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 
 	switch node.Kind {
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
-		start := nodeStartSkippingDecorators(sourceFile, node)
+		start := NodeTextRangeSkippingDecorators(sourceFile, node)
 		// Start scanning for the parameters `(` after any decorator factory
 		// (e.g. `@dec()`) and after the method name. Nameless constructors
 		// fall back to the first token after the decorators.
@@ -217,7 +217,7 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 
 	case ast.KindArrowFunction:
 		if holdsFunctionValue(parent) {
-			start := nodeStartSkippingDecorators(sourceFile, parent)
+			start := NodeTextRangeSkippingDecorators(sourceFile, parent)
 			return start.WithEnd(openingParenOfParamsPos(sourceFile, node))
 		}
 		af := node.AsArrowFunction()
@@ -226,7 +226,7 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 
 	case ast.KindFunctionExpression:
 		if holdsFunctionValue(parent) {
-			start := nodeStartSkippingDecorators(sourceFile, parent)
+			start := NodeTextRangeSkippingDecorators(sourceFile, parent)
 			if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
 				return start.WithEnd(parenPos)
 			}
@@ -874,11 +874,10 @@ func UpperCaseFirstASCII(s string) string {
 	return s
 }
 
-// nodeStartSkippingDecorators returns a TextRange whose start is the first
+// NodeTextRangeSkippingDecorators returns a TextRange whose start is the first
 // non-decorator token of the node. This matches ESLint's
-// getFunctionHeadLoc, which excludes leading decorators on MethodDefinition
-// and PropertyDefinition from the reported function head range.
-func nodeStartSkippingDecorators(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+// node ranges, which exclude leading decorators.
+func NodeTextRangeSkippingDecorators(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
 	fallback := TrimNodeTextRange(sourceFile, node)
 	mods := node.Modifiers()
 	if mods == nil || len(mods.Nodes) == 0 {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -107,6 +107,7 @@ export default defineConfig({
     './tests/eslint/rules/no-caller.test.ts',
 
     './tests/eslint/rules/default-case-last.test.ts',
+    './tests/eslint/rules/default-param-last.test.ts',
     './tests/eslint/rules/no-extend-native.test.ts',
     './tests/eslint/rules/no-extra-bind.test.ts',
     './tests/eslint/rules/no-extra-label.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/default-param-last.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/default-param-last.test.ts.snap
@@ -1,0 +1,1232 @@
+// Rstest Snapshot v1
+
+exports[`default-param-last > invalid 1`] = `
+{
+  "code": "function f(a = 5, b) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 2`] = `
+{
+  "code": "function f(a = 5, b = 6, c) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 3`] = `
+{
+  "code": "function f (a = 5, b, c = 6, d) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 4`] = `
+{
+  "code": "function f(a = 5, b, c = 5) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 5`] = `
+{
+  "code": "const f = (a = 5, b, ...c) => {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 6`] = `
+{
+  "code": "const f = function f (a, b = 5, c) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 7`] = `
+{
+  "code": "const f = (a = 5, { b }) => {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 8`] = `
+{
+  "code": "const f = ({ a } = {}, b) => {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 9`] = `
+{
+  "code": "const f = ({ a, b } = { a: 1, b: 2 }, c) => {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 10`] = `
+{
+  "code": "const f = ([a] = [], b) => {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 11`] = `
+{
+  "code": "const f = ([a, b] = [1, 2], c) => {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 12`] = `
+{
+  "code": "function foo(a = 1, b: number) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 13`] = `
+{
+  "code": "function foo(a = 1, b = 2, c: number) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 14`] = `
+{
+  "code": "function foo(a = 1, b: number, c = 2, d: number) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 15`] = `
+{
+  "code": "function foo(a = 1, b: number, c = 2) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 16`] = `
+{
+  "code": "function foo(a = 1, b: number, ...c) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 17`] = `
+{
+  "code": "function foo(a?: number, b: number) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 18`] = `
+{
+  "code": "function foo(a: number, b?: number, c: number) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 19`] = `
+{
+  "code": "function foo(a = 1, b?: number, c: number) {}",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 20`] = `
+{
+  "code": "const foo = function (a = 1, b: number) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 21`] = `
+{
+  "code": "const foo = function (a = 1, b = 2, c: number) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 22`] = `
+{
+  "code": "const foo = function (a = 1, b: number, c = 2, d: number) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 23`] = `
+{
+  "code": "const foo = function (a = 1, b: number, c = 2) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 24`] = `
+{
+  "code": "const foo = function (a = 1, b: number, ...c) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 25`] = `
+{
+  "code": "const foo = function (a?: number, b: number) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 26`] = `
+{
+  "code": "const foo = function (a: number, b?: number, c: number) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 27`] = `
+{
+  "code": "const foo = function (a = 1, b?: number, c: number) {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 28`] = `
+{
+  "code": "const foo = (a = 1, b: number) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 29`] = `
+{
+  "code": "const foo = (a = 1, b = 2, c: number) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 30`] = `
+{
+  "code": "const foo = (a = 1, b: number, c = 2, d: number) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 31`] = `
+{
+  "code": "const foo = (a = 1, b: number, c = 2) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 32`] = `
+{
+  "code": "const foo = (a = 1, b: number, ...c) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 33`] = `
+{
+  "code": "const foo = (a?: number, b: number) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 34`] = `
+{
+  "code": "const foo = (a: number, b?: number, c: number) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 35`] = `
+{
+  "code": "const foo = (a = 1, b?: number, c: number) => {};",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 36`] = `
+{
+  "code": "class Foo { constructor(public a: number, protected b?: number, private c: number) {} }",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 37`] = `
+{
+  "code": "class Foo { constructor(public a: number, protected b = 0, private c: number) {} }",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 38`] = `
+{
+  "code": "class Foo { constructor(public a?: number, private b: number) {} }",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 39`] = `
+{
+  "code": "class Foo { constructor(public a = 0, private b: number) {} }",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 40`] = `
+{
+  "code": "class Foo { constructor(a = 0, b: number) {} }",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`default-param-last > invalid 41`] = `
+{
+  "code": "class Foo { constructor(a?: number, b: number) {} }",
+  "diagnostics": [
+    {
+      "message": "Default parameters should be last.",
+      "messageId": "shouldBeLast",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "default-param-last",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/default-param-last.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/default-param-last.test.ts
@@ -1,0 +1,178 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+const error = { messageId: 'shouldBeLast' };
+
+ruleTester.run('default-param-last', {
+  valid: [
+    'function f() {}',
+    'function f(a) {}',
+    'function f(a = 5) {}',
+    'function f(a, b) {}',
+    'function f(a, b = 5) {}',
+    'function f(a, b = 5, c = 5) {}',
+    'function f(a, b = 5, ...c) {}',
+    'const f = () => {}',
+    'const f = (a) => {}',
+    'const f = (a = 5) => {}',
+    'const f = function f() {}',
+    'const f = function f(a) {}',
+    'const f = function f(a = 5) {}',
+
+    'function foo() {}',
+    'function foo(a: number) {}',
+    'function foo(a = 1) {}',
+    'function foo(a?: number) {}',
+    'function foo(a: number, b: number) {}',
+    'function foo(a: number, b: number, c?: number) {}',
+    'function foo(a: number, b = 1) {}',
+    'function foo(a: number, b = 1, c = 1) {}',
+    'function foo(a: number, b = 1, c?: number) {}',
+    'function foo(a: number, b?: number, c = 1) {}',
+    'function foo(a: number, b = 1, ...c) {}',
+
+    'const foo = function () {};',
+    'const foo = function (a: number) {};',
+    'const foo = function (a = 1) {};',
+    'const foo = function (a?: number) {};',
+    'const foo = function (a: number, b: number) {};',
+    'const foo = function (a: number, b: number, c?: number) {};',
+    'const foo = function (a: number, b = 1) {};',
+    'const foo = function (a: number, b = 1, c = 1) {};',
+    'const foo = function (a: number, b = 1, c?: number) {};',
+    'const foo = function (a: number, b?: number, c = 1) {};',
+    'const foo = function (a: number, b = 1, ...c) {};',
+
+    'const foo = () => {};',
+    'const foo = (a: number) => {};',
+    'const foo = (a = 1) => {};',
+    'const foo = (a?: number) => {};',
+    'const foo = (a: number, b: number) => {};',
+    'const foo = (a: number, b: number, c?: number) => {};',
+    'const foo = (a: number, b = 1) => {};',
+    'const foo = (a: number, b = 1, c = 1) => {};',
+    'const foo = (a: number, b = 1, c?: number) => {};',
+    'const foo = (a: number, b?: number, c = 1) => {};',
+    'const foo = (a: number, b = 1, ...c) => {};',
+
+    'class Foo { constructor(a: number, b: number, c: number) {} }',
+    'class Foo { constructor(a: number, b?: number, c = 1) {} }',
+    'class Foo { constructor(a: number, b = 1, c?: number) {} }',
+    'class Foo { constructor(public a: number, protected b: number, private c: number) {} }',
+    'class Foo { constructor(public a: number, protected b?: number, private c = 10) {} }',
+    'class Foo { constructor(public a: number, protected b = 10, private c?: number) {} }',
+    'class Foo { constructor(a: number, protected b?: number, private c = 0) {} }',
+    'class Foo { constructor(a: number, b?: number, private c = 0) {} }',
+    'class Foo { constructor(a: number, private b?: number, c = 0) {} }',
+  ],
+  invalid: [
+    { code: 'function f(a = 5, b) {}', errors: [error] },
+    { code: 'function f(a = 5, b = 6, c) {}', errors: [error, error] },
+    { code: 'function f (a = 5, b, c = 6, d) {}', errors: [error, error] },
+    { code: 'function f(a = 5, b, c = 5) {}', errors: [error] },
+    { code: 'const f = (a = 5, b, ...c) => {}', errors: [error] },
+    { code: 'const f = function f (a, b = 5, c) {}', errors: [error] },
+    { code: 'const f = (a = 5, { b }) => {}', errors: [error] },
+    { code: 'const f = ({ a } = {}, b) => {}', errors: [error] },
+    {
+      code: 'const f = ({ a, b } = { a: 1, b: 2 }, c) => {}',
+      errors: [error],
+    },
+    { code: 'const f = ([a] = [], b) => {}', errors: [error] },
+    { code: 'const f = ([a, b] = [1, 2], c) => {}', errors: [error] },
+
+    { code: 'function foo(a = 1, b: number) {}', errors: [error] },
+    {
+      code: 'function foo(a = 1, b = 2, c: number) {}',
+      errors: [error, error],
+    },
+    {
+      code: 'function foo(a = 1, b: number, c = 2, d: number) {}',
+      errors: [error, error],
+    },
+    { code: 'function foo(a = 1, b: number, c = 2) {}', errors: [error] },
+    { code: 'function foo(a = 1, b: number, ...c) {}', errors: [error] },
+    { code: 'function foo(a?: number, b: number) {}', errors: [error] },
+    {
+      code: 'function foo(a: number, b?: number, c: number) {}',
+      errors: [error],
+    },
+    {
+      code: 'function foo(a = 1, b?: number, c: number) {}',
+      errors: [error, error],
+    },
+
+    { code: 'const foo = function (a = 1, b: number) {};', errors: [error] },
+    {
+      code: 'const foo = function (a = 1, b = 2, c: number) {};',
+      errors: [error, error],
+    },
+    {
+      code: 'const foo = function (a = 1, b: number, c = 2, d: number) {};',
+      errors: [error, error],
+    },
+    {
+      code: 'const foo = function (a = 1, b: number, c = 2) {};',
+      errors: [error],
+    },
+    {
+      code: 'const foo = function (a = 1, b: number, ...c) {};',
+      errors: [error],
+    },
+    {
+      code: 'const foo = function (a?: number, b: number) {};',
+      errors: [error],
+    },
+    {
+      code: 'const foo = function (a: number, b?: number, c: number) {};',
+      errors: [error],
+    },
+    {
+      code: 'const foo = function (a = 1, b?: number, c: number) {};',
+      errors: [error, error],
+    },
+
+    { code: 'const foo = (a = 1, b: number) => {};', errors: [error] },
+    {
+      code: 'const foo = (a = 1, b = 2, c: number) => {};',
+      errors: [error, error],
+    },
+    {
+      code: 'const foo = (a = 1, b: number, c = 2, d: number) => {};',
+      errors: [error, error],
+    },
+    { code: 'const foo = (a = 1, b: number, c = 2) => {};', errors: [error] },
+    { code: 'const foo = (a = 1, b: number, ...c) => {};', errors: [error] },
+    { code: 'const foo = (a?: number, b: number) => {};', errors: [error] },
+    {
+      code: 'const foo = (a: number, b?: number, c: number) => {};',
+      errors: [error],
+    },
+    {
+      code: 'const foo = (a = 1, b?: number, c: number) => {};',
+      errors: [error, error],
+    },
+
+    {
+      code: 'class Foo { constructor(public a: number, protected b?: number, private c: number) {} }',
+      errors: [error],
+    },
+    {
+      code: 'class Foo { constructor(public a: number, protected b = 0, private c: number) {} }',
+      errors: [error],
+    },
+    {
+      code: 'class Foo { constructor(public a?: number, private b: number) {} }',
+      errors: [error],
+    },
+    {
+      code: 'class Foo { constructor(public a = 0, private b: number) {} }',
+      errors: [error],
+    },
+    { code: 'class Foo { constructor(a = 0, b: number) {} }', errors: [error] },
+    {
+      code: 'class Foo { constructor(a?: number, b: number) {} }',
+      errors: [error],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `default-param-last` rule from ESLint to rslint.

Enforce default and optional parameters to appear after required parameters, including TypeScript parameter properties.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/default-param-last
- Source code: https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/default-param-last.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
