### PR TITLE
fix: align prefer-optional-chain suggestion message

### DIFF
--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -71,7 +71,7 @@ func buildPreferOptionalChainMessage() rule.RuleMessage {
 func buildOptionalChainSuggestMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "optionalChainSuggest",
-		Description: "Change to an optional chain expression. This may change the return type of the expression and some TypeScript errors may occur.",
+		Description: "Change to an optional chain.",
 	}
 }
 

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.md
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.md
@@ -89,4 +89,4 @@ When set to `true`, the rule will only report on expressions where at least one 
 ## Original Documentation
 
 - [typescript-eslint: prefer-optional-chain](https://typescript-eslint.io/rules/prefer-optional-chain)
-- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/prefer-optional-chain.ts)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.68.0/packages/eslint-plugin/src/rules/prefer-optional-chain.ts)

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -1988,3 +1988,10 @@ func TestPreferOptionalChainOptionalComparisonBoundaries(t *testing.T) {
 			},
 		})
 }
+
+func TestPreferOptionalChainSuggestionMessage(t *testing.T) {
+	const want = "Change to an optional chain."
+	if got := buildOptionalChainSuggestMessage().Description; got != want {
+		t.Fatalf("suggestion message = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Align the `prefer-optional-chain` suggestion message with typescript-eslint 8.68.0.
- Update the rule documentation to reference the matching upstream source version.
- Add focused regression coverage for the exact suggestion message.

## Related Links

- [typescript-eslint 8.68.0 source](https://github.com/typescript-eslint/typescript-eslint/blob/v8.68.0/packages/eslint-plugin/src/rules/prefer-optional-chain.ts)

## Verification

- Validated all 34 files and 51 differences from the comparison report; the two apparent missing diagnostics were caused by the report's project-config mapping and reproduce correctly with each package's `tsconfig.tsserver.json`.
- Ran the Go rule package tests and the 26 targeted JS rule tests; no snapshot changes were required.
- Ran `check-spell`, `format:check`, and changed-code-scoped `lint:go`.
- Benchmarked diagnostics and suggestion generation; no performance change was retained because the candidate did not show a compelling net improvement.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
