### PR TITLE
docs: rewrite `rstest/` rules' documents

### DIFF
--- a/internal/plugins/rstest/rules/expect_expect/expect_expect.md
+++ b/internal/plugins/rstest/rules/expect_expect/expect_expect.md
@@ -2,94 +2,43 @@
 
 ## Rule Details
 
-Enforce that every Rstest test registration contains at least one assertion. A
-test with no assertion can pass without verifying anything, hiding the fact that
-its intent was never checked.
+Requires every Rstest `test` or `it` callback to contain an assertion. This prevents tests from passing after exercising code without verifying its result.
 
-Examples of incorrect code:
+By default, both `expect` and Chai's `assert` count as assertions. `test.todo` and `it.todo` are exempt because they intentionally have no callback; globals, imports, aliases, parameterized tests, fixtures, and Playwright integrations are recognized.
 
-```ts
-test("does nothing", () => {
-  doSomething();
-});
-
-it("empty", () => {});
-```
-
-Examples of correct code:
+## Incorrect
 
 ```ts
-test("asserts", () => {
-  expect(value).toBe(1);
+test('creates a user', async () => {
+  await createUser({ name: 'Ada' });
 });
-
-it("uses assert", () => {
-  assert.equal(value, 1);
-});
-
-it("in a promise callback", () => {
-  return loadUser().then((user) => {
-    expect(user).toBeDefined();
-  });
-});
-
-it("named callback", run);
-function run() {
-  expect(value).toBe(1);
-}
-
-const checkValue = () => {
-  expect(value).toBe(1);
-};
-test("variable callback", checkValue);
 ```
 
-`test.todo` / `it.todo` have no callback and are exempt:
+## Correct
 
 ```ts
-test.todo("later");
-```
+test('creates a user', async () => {
+  const user = await createUser({ name: 'Ada' });
 
-The rule recognizes Rstest test registrations from globals, `@rstest/core`
-imports and aliases, `require`, namespace access, `import.meta.rstest`,
-`test.extend(...)`, `.each` / `.for`, and `@rstest/playwright`. `describe` and
-lifecycle hooks are not test registrations and are never required to assert.
-Named function declarations and variable functions are resolved independently
-of whether they appear before or after the test registration.
+  expect(user.name).toBe('Ada');
+});
+```
 
 ## Options
 
 ```json
 {
   "rstest/expect-expect": [
-    "warn",
+    "error",
     {
-      "assertFunctionNames": ["expect", "assert"],
-      "additionalTestBlockFunctions": []
+      "assertFunctionNames": ["expect", "assert", "assertUser"],
+      "additionalTestBlockFunctions": ["scenario"]
     }
   ]
 }
 ```
 
-### `assertFunctionNames`
-
-Names of functions treated as assertions. Defaults to `["expect", "assert"]`,
-matching the two assertion entry points Rstest exposes as globals. Names support
-wildcards: `request.*.expect`, `request.**.expect`, `expect*`.
-
-Rstest's own `expect` counts whatever the callee looks like, so these names only
-need to cover assertion helpers the rule cannot resolve — a wrapper of your own,
-or a third-party assertion library. `context.expect(...)`, `rstest.expect(...)`,
-an aliased `import { expect as check }` and `import.meta.rstest.expect(...)` are
-all recognized without configuration.
-
-The list replaces the default rather than extending it, so name `assert` again if
-you still want it. Naming your own helpers cannot switch Rstest's `expect` off
-though — it is recognized whether or not the list mentions it, unlike in
-`eslint-plugin-jest`, where dropping `expect` from the list stops it counting.
-
-### `additionalTestBlockFunctions`
-
-Additional function names to treat as test blocks.
-
-The rule provides no automatic fix.
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `assertFunctionNames` | `string[]` | `["expect", "assert"]` | Function names or patterns treated as assertions. Setting it replaces the default list. |
+| `additionalTestBlockFunctions` | `string[]` | `[]` | Additional functions whose callbacks are treated as test blocks. |

--- a/internal/plugins/rstest/rules/max_expects/max_expects.md
+++ b/internal/plugins/rstest/rules/max_expects/max_expects.md
@@ -2,93 +2,48 @@
 
 ## Rule Details
 
-Enforce a maximum number of assertion calls in each Rstest test body. This
-rule counts real assertion factories such as `expect(value)`,
-`expect.soft(value)`, `expect.poll(fn)`, and `expect.element(locator)`. Once a
-test exceeds the configured maximum, each additional assertion is reported.
+Limits completed assertion chains in each Rstest test or hook callback. A smaller test is usually easier to understand because it verifies one behavior at a time.
 
-Examples of **incorrect** code for this rule:
+Each `expect(...)`, `expect.soft(...)`, `expect.poll(...)`, or `expect.element(...)` assertion counts once. Static helpers such as `expect.any()` do not count.
 
-```ts
-test("case", () => {
-  expect(a).toBe(1);
-  expect(b).toBe(2);
-  expect(c).toBe(3);
-  expect(d).toBe(4);
-  expect(e).toBe(5);
-  expect(f).toBe(6);
-});
-```
-
-Examples of **correct** code for this rule:
+## Incorrect
 
 ```ts
-test("case", () => {
-  expect(a).toBe(1);
-  expect(b).toBe(2);
-  expect(c).toBe(3);
-});
-
-test.for(rows)("case", (row, context) => {
-  context.expect(row.ok).toBe(true);
-  context.expect(row.count).toBeGreaterThan(0);
+test('returns an active user', () => {
+  expect(user.id).toBe(1);
+  expect(user.name).toBe('Ada');
+  expect(user.active).toBe(true);
+  expect(user.role).toBe('admin');
+  expect(user.email).toBe('ada@example.com');
+  expect(user.createdAt).toBeInstanceOf(Date);
 });
 ```
 
-Examples of **correct** code for this rule with `{ "max": 1 }`:
-
-```json
-{ "rstest/max-expects": ["error", { "max": 1 }] }
-```
+## Correct
 
 ```ts
-test("case", () => {
-  expect(value).toBe(1);
+test('returns the user identity', () => {
+  expect(user).toMatchObject({ id: 1, name: 'Ada' });
+});
+
+test('returns an active user', () => {
+  expect(user.active).toBe(true);
 });
 ```
-
-## Rstest specifics
-
-- `expect.assertions(2)`, `expect.hasAssertions()`, `expect.any(String)`, and
-  other static `expect` helpers do not count as assertions.
-- Broken or incomplete chains such as `expect(value)` and `expect(value).toBe`
-  do not count; those are covered by `rstest/valid-expect`.
-- Chai property and chained assertions still count once per assertion factory:
-  `expect(value).to.be.ok` and
-  `expect(value).to.be.a("string").and.not.be.empty` each count as one.
-- A test body and a lifecycle hook body each carry their own count:
-  `beforeEach`, `beforeAll`, `afterEach`, and `afterAll` are test code and are
-  limited the same way a test is.
-- A callback the rule cannot resolve is still counted when it is written inside
-  the registration's callback argument, wherever in that argument it sits:
-  `test("a", fakeAsync(() => …))`, `test("a", new Wrapper(() => …))`,
-  `test("a", wrap({ cb: () => … }))`, and `test("a", cond ? () => … : null)`
-  all count. A function held in an options object — the `{ retry: 2 }` argument
-  of the `(name, options, callback)` overload — is not a callback and is not
-  counted.
-- A callback written outside the registration and reached through a member
-  expression is not counted: in `const suite = { run: () => … };
-  test("a", suite.run)`, and likewise for a class property, nothing at the
-  registration ties the function to it.
-- Assertions at the top level of a file, or directly in a `describe` body, are
-  ignored: they do not belong to a test body.
-- A detached helper inside a test gets its own count and does not leak into
-  sibling tests.
 
 ## Options
 
 ```json
 {
-  "rstest/max-expects": ["error", { "max": 5 }]
+  "rstest/max-expects": [
+    "error",
+    {
+      "max": 2
+    }
+  ]
 }
 ```
 
-- `max` configures the maximum number of assertions allowed per test body.
-  The default is `5`.
-
-This rule does not provide an autofix.
-
-## Original Documentation
-
-- [eslint-plugin-jest: max-expects](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/max-expects.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/max-expects.ts)
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `max` | `integer` | `5` | Maximum assertion calls allowed in one test or hook callback. |

--- a/internal/plugins/rstest/rules/no_alias_methods/no_alias_methods.md
+++ b/internal/plugins/rstest/rules/no_alias_methods/no_alias_methods.md
@@ -2,44 +2,24 @@
 
 ## Rule Details
 
-This rule disallows deprecated alias matchers and prefers their canonical matcher names.
+Requires canonical matcher names so assertions use one consistent vocabulary. For example, it replaces `toBeCalled` with `toHaveBeenCalled` and `toThrowError` with `toThrow`.
 
-Examples of **incorrect** code for this rule:
+The rule checks normal dot access and static bracket access. Computed matcher names are ignored because their value is only known at runtime.
 
-```typescript
-expect(spy).toBeCalled();
-expect(spy).lastCalledWith('ready');
-expect(error).not['toThrowError']();
+## Incorrect
+
+```ts
+expect(handler).toBeCalled();
+expect(handler).lastCalledWith('ready');
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
-expect(spy).toHaveBeenCalled();
-expect(spy).toHaveBeenLastCalledWith('ready');
-expect(error).not['toThrow']();
+```ts
+expect(handler).toHaveBeenCalled();
+expect(handler).toHaveBeenLastCalledWith('ready');
 ```
-
-## Options
-
-This rule has no options.
 
 ## Autofix
 
-This rule autofixes supported accessor forms and preserves the original accessor delimiter:
-
-- `expect(spy).toBeCalled()` becomes `expect(spy).toHaveBeenCalled()`
-- `expect(spy)['toBeCalled']()` becomes `expect(spy)['toHaveBeenCalled']()`
-- `expect(spy)["toBeCalled"]()` becomes `expect(spy)["toHaveBeenCalled"]()`
-- ``expect(spy)[`toBeCalled`]()`` becomes ``expect(spy)[`toHaveBeenCalled`]()``
-
-A computed key whose name is only known at runtime, such as `expect(spy)[matcherName]()`, is never reported.
-
-## Differences from eslint-plugin-vitest
-
-Rslint uses the same matcher mapping as `eslint-plugin-vitest@v1.6.27`, but four user-visible details are different:
-
-- the diagnostic wording says `canonical name of ...`;
-- element-access fixes preserve the original quote style or template-literal delimiter instead of rewriting it to a single-quoted string;
-- computed identifier keys are never reported. Upstream treats `expect(spy)[matcherName]()` as a supported accessor, matches the *variable's own name* against the alias table, and autofixes it by rewriting the variable reference. That answer does not follow from the code: the variable's value is what names the matcher, so `const toBeCalled = 'toHaveBeenCalled'` is reported and rewritten even though it already calls the canonical matcher. This rule stays silent instead;
-- template-literal keys are compared by their cooked value, so ``expect(spy)[`toBeCall\u0065d`]()`` is reported and fixed. Upstream compares `quasis[0].value.raw` and reports nothing. The cooked value is the property name the runtime actually looks up, so this is the more accurate answer, but it does turn upstream-valid code into an error. String-literal keys agree in both implementations, which also use the cooked value.
+Replaces static dot and bracket matcher aliases with canonical names while preserving the original access style.

--- a/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests.md
+++ b/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests.md
@@ -2,64 +2,20 @@
 
 ## Rule Details
 
-Disallow commented-out Rstest test cases and `describe` blocks. Commented-out tests are easy to overlook during review and can remain disabled indefinitely. Prefer removing dead tests or using an explicit Rstest API such as `.skip` or `.todo` when a disabled test should remain visible.
+Disallows tests and suites hidden in comments. Commented-out tests are easy to miss in review and can remain stale indefinitely.
 
-The rule reconstructs consecutive line comments and parses the text inside regular line and block comments as TypeScript. It reports a comment when a line, after optional whitespace, contains a call rooted at `test`, `it`, or `describe` that ultimately registers a test or suite.
+Use `test.todo` when a test should remain visible but is not ready to run. The rule recognizes commented `test`, `it`, and `describe` registrations, including modifiers and parameterized forms.
 
-The matcher understands:
+## Incorrect
 
-- Direct registrations and static dot or bracket member access.
-- The `only`, `skip`, `todo`, `fails`, `concurrent`, and `sequential` modifiers where supported by Rstest.
-- The `runIf` and `skipIf` conditional factories.
-- Array and tagged-template forms of `each` and `for`, including explicit type arguments.
-- Fixture APIs created with `test.extend`, including repeated extension.
-- Parenthesized and optional calls.
-
-Examples of **incorrect** code for this rule:
-
-```typescript
-// test('adds two numbers', () => {});
-// it.skip('is temporarily disabled', () => {});
-
-// describe.only.concurrent('focused suite', () => {});
-// test.for([{ value: 1 }])('handles $value', ({ value }) => {});
-// test.extend(fixtures).only('uses fixtures', () => {});
-
-// test.each`
-//   value | expected
-//   ${1}  | ${2}
-// `('returns $expected', ({ value, expected }) => {});
-
-/*
-describe
-  .only
-  .concurrent('math', () => {});
-*/
+```ts
+// test('rejects an invalid email', () => {
+//   expect(validateEmail('invalid')).toBe(false);
+// });
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
-// These calls only create another API or registrar. They do not define a test.
-// test.runIf(condition)
-// test.each(rows)
-// test.for`value | expected`
-// test.extend(fixtures)
-
-// Dynamic, unknown, and non-Rstest APIs are outside this rule's scope.
-// test[modifier]('name', () => {});
-// test.unknown('name', () => {});
-// fit('name', () => {});
-// rstest.test('name', () => {});
+```ts
+test.todo('rejects an invalid email');
 ```
-
-## Limitations
-
-The code inside a comment no longer participates in the source file's symbol table. The rule therefore recognizes only the canonical `test`, `it`, and `describe` names. It does not resolve imported aliases, locally renamed APIs, variables returned from `test.extend`, or namespace and in-source forms such as `import.meta.rstest`.
-
-Documentation comments (`/** ... */`) and calls inside Markdown fenced code blocks are ignored to avoid reporting examples as disabled tests. Regular prose must still form a standalone, syntactically valid Rstest registration before it is reported.
-
-## References
-
-- [Rstest `test` API](https://rstest.rs/api/runtime-api/test-api/test)
-- [Rstest `describe` API](https://rstest.rs/api/runtime-api/test-api/describe)

--- a/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.md
+++ b/internal/plugins/rstest/rules/no_conditional_expect/no_conditional_expect.md
@@ -2,54 +2,25 @@
 
 ## Rule Details
 
-Disallow calling Rstest `expect` APIs conditionally. When an assertion only
-runs on one branch, the test can pass without executing that assertion.
+Disallows assertions that only run on some execution paths. A test can pass without checking anything when its assertion is skipped by a condition.
 
-Examples of incorrect code:
+The rule recognizes `expect` from globals, imports, the local test context, Browser Mode, and Playwright integrations.
+
+## Incorrect
 
 ```ts
-test("loads user", () => {
+test('returns the user name', () => {
   if (user) {
-    expect(user.name).toBe("Alice");
+    expect(user.name).toBe('Ada');
   }
-});
-
-test("rejects", async () => {
-  await request().catch((error) => {
-    expect(error).toBeInstanceOf(Error);
-  });
-});
-
-test("uses local expect", ({ expect }) => {
-  ready && expect(value).toBeDefined();
 });
 ```
 
-The rule recognizes Rstest APIs from globals, `@rstest/core`,
-`import.meta.rstest`, test context `expect`, Browser Mode `expect.element`,
-and `@rstest/playwright`.
-
-Examples of correct code:
+## Correct
 
 ```ts
-test("loads user", () => {
+test('returns the user name', () => {
   expect(user).toBeDefined();
-  expect(user?.name).toBe("Alice");
-});
-
-test("rejects", async () => {
-  await expect(request()).rejects.toThrow();
-});
-
-test("prepares conditionally", () => {
-  if (mode === "a") {
-    setupA();
-  } else {
-    setupB();
-  }
-
-  expect(result).toBeDefined();
+  expect(user.name).toBe('Ada');
 });
 ```
-
-The rule has no options and does not provide an automatic fix.

--- a/internal/plugins/rstest/rules/no_conditional_in_test/no_conditional_in_test.md
+++ b/internal/plugins/rstest/rules/no_conditional_in_test/no_conditional_in_test.md
@@ -2,75 +2,37 @@
 
 ## Rule Details
 
-Disallow conditional logic in Rstest test bodies. A conditional usually means
-that one test is covering multiple execution paths, which makes it harder to
-see which behavior the test is intended to verify. Prefer a separate test for
-each branch.
+Disallows conditional control flow in test bodies. Separate tests make each expected behavior and failure easier to identify.
 
-Examples of **incorrect** code for this rule:
+Reported forms are `if` and `switch` statements, conditional expressions, and the logical operators `&&`, `||`, and `??`. Optional chaining is reported as well once `allowOptionalChaining` is turned off.
+
+The rule checks test callbacks and functions declared inside them. Conditions used for suite setup or helpers declared outside a test are not reported.
+
+## Incorrect
 
 ```ts
-test('loads the user', () => {
-  if (enabled) {
-    loadUser();
-  }
-});
-
-it('renders a mode', () => {
-  switch (mode) {
-    case 'none':
-      renderNone();
-      break;
-    case 'full':
-      renderFull();
-      break;
+test('renders the selected view', () => {
+  if (mode === 'compact') {
+    expect(render(mode)).toContain('Compact');
+  } else {
+    expect(render(mode)).toContain('Full');
   }
 });
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
 ```ts
-describe('user flow', () => {
-  if (enabled) {
-    test('loads the user', () => {
-      loadUser();
-    });
-  }
+test('renders the compact view', () => {
+  expect(render('compact')).toContain('Compact');
 });
 
-beforeEach(() => {
-  switch (mode) {
-    case 'none':
-      renderNone();
-      break;
-    case 'full':
-      renderFull();
-      break;
-  }
-});
-
-function pickLabel(kind: string) {
-  return kind === 'full' ? 'Full' : 'Compact';
-}
-
-test('renders a label', () => {
-  expect(pickLabel(mode)).toBe('Full');
+test('renders the full view', () => {
+  expect(render('full')).toContain('Full');
 });
 ```
-
-Conditionals inside `describe` blocks, hooks, and helper functions declared
-outside a test are not reported. Conditionals in helper functions declared
-inside a test are reported because they are still part of that test body.
 
 ## Options
-
-- First argument (optional): object with `allowOptionalChaining`
-  - `allowOptionalChaining`: whether optional chaining (`?.`) is allowed inside
-    test bodies. Default is `true`.
-
-When `allowOptionalChaining` is `false`, optional property access, element
-access, and calls are also reported:
 
 ```json
 {
@@ -83,45 +45,6 @@ access, and calls are also reported:
 }
 ```
 
-Examples of **incorrect** code with `{ "allowOptionalChaining": false }`:
-
-```ts
-test('loads a value', () => {
-  const value = api?.result;
-});
-
-test('calls a method', () => {
-  client?.run();
-});
-```
-
-Examples of **correct** code with `{ "allowOptionalChaining": false }`:
-
-```ts
-test('loads a value', () => {
-  const value = api!.result;
-});
-```
-
-## Limitations
-
-The scope is the test registration call itself, reached through supported
-Rstest forms: global `test` / `it`, imports from `@rstest/core` and
-`@rstest/playwright`, namespace and CommonJS access, `import.meta.rstest`, and
-parameterized `.each` / `.for`. Everything written inside that call is checked,
-including the title, the options and timeout arguments, the `.each` data, and a
-callback passed through a wrapper such as `test('case', wrap(() => {}))`.
-
-A function declared outside the call is not checked, even when the call names
-it as its callback: in `test('case', callback); function callback() {}` the
-body of `callback` is outside the test call, so conditionals in it are not
-reported.
-
-Unlike the upstream rule, an inner registration exiting does not clear the
-outer test's scope, so a conditional written after a nested `test(...)` is
-still reported.
-
-## Original Documentation
-
-- [eslint-plugin-jest: no-conditional-in-test](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/no-conditional-in-test.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/no-conditional-in-test.ts)
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `allowOptionalChaining` | `boolean` | `true` | Allow optional chaining in test bodies. |

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.md
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.md
@@ -2,49 +2,23 @@
 
 ## Rule Details
 
-Disallow explicitly skipped or incomplete Rstest tests. This rule reports
-`test.skip`, `it.skip`, and `describe.skip`, including valid modifier,
-parameterized, and `test.extend()` chains. It also reports `test` and `it`
-registrations that omit the callback.
+Disallows skipped tests and registrations without a callback. Disabled tests hide coverage gaps and make the suite's real status less clear.
 
-Examples of **incorrect** code for this rule:
+`test.todo` and runtime control flow such as `context.skip()` are allowed. The rule recognizes Rstest globals, imports, aliases, and parameterized or fixture-based registrations.
+
+## Incorrect
 
 ```ts
-describe.skip('suite', () => {});
-it.skip('case', () => {});
-test.skip.each(rows)('case $value', (value) => {});
-test('missing callback');
-test('options without a callback', { timeout: 100 });
+test.skip('imports a CSV file', () => {});
+test('exports a CSV file');
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
 ```ts
-describe('suite', () => {});
-test('case', () => {});
-test.todo('future case');
-
-test('runtime condition', (context) => {
-  if (!available()) {
-    context.skip();
-  }
+test('imports a CSV file', () => {
+  expect(importCsv('name\nAda')).toEqual([{ name: 'Ada' }]);
 });
+
+test.todo('exports a CSV file');
 ```
-
-`test.todo` is an explicit, visible todo state and is not reported.
-`context.skip()` is Rstest's runtime control-flow API and is also not reported.
-Conditional `skipIf` and `runIf` expressions are not evaluated by this rule.
-
-## Limitations
-
-The rule follows Rstest APIs imported from `@rstest/core`, globals, namespace
-imports, CommonJS requires, and same-file `const` aliases. It does not trace
-custom test APIs through arbitrary cross-file re-exports.
-
-The missing-callback check covers Rstest's `(description, options, fn?)`
-overload only when the options argument is written as an object literal. An
-indirect options call such as `test('case', options)` is not reported, because
-the identifier may resolve to the callback itself.
-
-This rule does not provide an autofix because removing `skip` or inventing a
-callback would change test behavior.

--- a/internal/plugins/rstest/rules/no_focused_tests/no_focused_tests.md
+++ b/internal/plugins/rstest/rules/no_focused_tests/no_focused_tests.md
@@ -2,49 +2,26 @@
 
 ## Rule Details
 
-Disallow focused Rstest tests and `describe` blocks. The rule reports an
-explicit `.only` in a test or suite registration, including conditional,
-parameterized, and extended test APIs.
+Disallows focused tests and suites. Leaving `.only` in committed code prevents the rest of the suite from running.
 
-The rule recognizes Rstest globals, `@rstest/core`, `import.meta.rstest`, and
-`@rstest/playwright`. It follows same-file `const` aliases, including aliases
-that store an already-focused API.
+The rule recognizes `.only` on Rstest tests and suites, including aliases, parameterized registrations, fixtures, and Playwright integrations.
 
-The rule provides a suggestion that removes every `.only` contributing to the
-registration. Suggestions preserve comments and optional-chain boundaries.
+## Incorrect
 
-Examples of **incorrect** code for this rule:
-
-```typescript
-import { describe, test } from '@rstest/core';
-
-test.only('adds two numbers', () => {});
-describe.only('math', () => {});
-test.concurrent.only('runs concurrently', () => {});
-test.only.for([1, 2])('handles %s', () => {});
-test.extend({ database }).only('uses a database', () => {});
-
-const focused = test.only;
-focused('focused through an alias', () => {});
-
-import.meta.rstest.test.only('in-source test', () => {});
+```ts
+describe.only('user service', () => {
+  test('creates a user', () => {});
+});
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
-import { describe, test } from '@rstest/core';
-
-test('adds two numbers', () => {});
-describe('math', () => {});
-test.concurrent('runs concurrently', () => {});
-test.extend({ database })('uses a database', () => {});
+```ts
+describe('user service', () => {
+  test('creates a user', () => {});
+});
 ```
 
-Rstest does not expose Jest's `fit` or `fdescribe` aliases, so this rule does
-not treat those names as Rstest registrations.
+## Suggestions
 
-## References
-
-- [Rstest `test` API](https://rstest.rs/api/runtime-api/test-api/test)
-- [Rstest `describe` API](https://rstest.rs/api/runtime-api/test-api/describe)
+Offers a suggestion to remove `.only` when the focused modifier is unambiguous.

--- a/internal/plugins/rstest/rules/no_hooks/no_hooks.md
+++ b/internal/plugins/rstest/rules/no_hooks/no_hooks.md
@@ -2,107 +2,43 @@
 
 ## Rule Details
 
-Disallow Rstest setup and teardown hooks. This rule reports the four lifecycle
-hooks Rstest exposes: `beforeAll`, `beforeEach`, `afterEach`, and `afterAll`.
+Disallows lifecycle hooks when a project prefers each test to set up and clean up its own state explicitly.
 
-Examples of **incorrect** code for this rule:
+The rule covers `beforeAll`, `beforeEach`, `afterEach`, and `afterAll` from globals, imports, aliases, and Playwright test objects.
 
-```typescript
-import { beforeEach, test } from '@rstest/core';
-import { test as playwrightTest } from '@rstest/playwright';
+## Incorrect
 
+```ts
 beforeEach(() => {
   resetDatabase();
 });
 
-playwrightTest.beforeAll(async () => {
-  await seedFixtures();
-});
-
-test('reads state', () => {});
+test('creates a user', () => {});
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
-import { test } from '@rstest/core';
-import { beforeEach } from 'vitest';
+```ts
+test('creates a user', () => {
+  const database = createTestDatabase();
 
-test('reads state', () => {
-  const database = createDatabase();
-  expect(database.ready()).toBe(true);
+  expect(database.users.create({ name: 'Ada' }).name).toBe('Ada');
 });
-
-beforeEach(() => {});
 ```
 
 ## Options
 
 ```json
 {
-  "rstest/no-hooks": ["error", { "allow": ["afterEach", "afterAll"] }]
+  "rstest/no-hooks": [
+    "error",
+    {
+      "allow": ["afterEach"]
+    }
+  ]
 }
 ```
 
-### `allow`
-
-This array option controls which Rstest hooks are allowed. Supported values
-are:
-
-- `"beforeAll"`
-- `"beforeEach"`
-- `"afterAll"`
-- `"afterEach"`
-
-By default, no hook is allowed.
-
-Examples of **incorrect** code for the `{ "allow": ["afterEach"] }` option:
-
-```json
-{ "rstest/no-hooks": ["error", { "allow": ["afterEach"] }] }
-```
-
-```typescript
-import { afterEach, beforeEach } from '@rstest/core';
-
-beforeEach(() => {
-  setupDatabase();
-});
-
-afterEach(() => {
-  resetModules();
-});
-```
-
-Examples of **correct** code for the `{ "allow": ["afterEach"] }` option:
-
-```json
-{ "rstest/no-hooks": ["error", { "allow": ["afterEach"] }] }
-```
-
-```typescript
-import { afterEach, test } from '@rstest/core';
-
-afterEach(() => {
-  resetModules();
-});
-
-test('reads state', () => {
-  const database = setupDatabase();
-  expect(database.ready()).toBe(true);
-});
-```
-
-## Differences from ESLint
-
-- `@rstest/playwright` member hooks such as `test.beforeEach()` and
-  `test.extend({}).afterAll()` are reported because they are real Rstest hook
-  registrations.
-- `@rstest/core` lookalikes such as `test.beforeEach()`, invalid chains such as
-  `test.skip.beforeEach()`, and execution-time APIs like `onTestFinished()` are
-  not reported.
-
-## Original Documentation
-
-- [eslint-plugin-jest: no-hooks](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/no-hooks.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/no-hooks.ts)
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `allow` | `string[]` | `[]` | Lifecycle hooks to allow: `beforeAll`, `beforeEach`, `afterEach`, or `afterAll`. |

--- a/internal/plugins/rstest/rules/no_identical_title/no_identical_title.md
+++ b/internal/plugins/rstest/rules/no_identical_title/no_identical_title.md
@@ -2,31 +2,20 @@
 
 ## Rule Details
 
-Disallow the same static title for two tests or two `describe` blocks in the
-same scope.
+Requires unique static test and suite titles within the same scope. Distinct titles make failures and test reports unambiguous.
 
-Examples of incorrect code:
+Test titles and suite titles are tracked separately. Dynamic titles and parameterized titles are ignored because their final values are created at runtime.
 
-```ts
-test("loads user", () => {});
-test.only("loads user", () => {});
-
-describe("api", () => {});
-describe.skip("api", () => {});
-```
-
-Examples of correct code:
+## Incorrect
 
 ```ts
-describe("api", () => {
-  test("loads user", () => {});
-
-  describe("nested", () => {
-    test("loads user", () => {});
-  });
-});
+test('creates a user', () => {});
+test('creates a user', () => {});
 ```
 
-Test titles and describe titles are tracked separately. Dynamic titles are
-ignored. Parameterized `.each` and `.for` registration titles are also ignored
-because Rstest expands them at runtime.
+## Correct
+
+```ts
+test('creates a user with a name', () => {});
+test('rejects a user without a name', () => {});
+```

--- a/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
+++ b/internal/plugins/rstest/rules/no_import_node_test/no_import_node_test.md
@@ -2,25 +2,26 @@
 
 ## Rule Details
 
-This rule reports imports of Node's test runner in Rstest test files, whether through an `import` declaration, a `require()` call, or an `import ... = require(...)` declaration, and whether the module is `node:test` itself or one of its sub-paths such as `node:test/reporters`. Such imports are commonly added accidentally by editor auto-import and select Node's test runner instead of Rstest.
+Disallows importing Node's test runner in an Rstest test file. Editor auto-import can otherwise select `node:test` instead of Rstest.
 
-Named imports of `node:test` containing only `test`, `it`, and `describe` can be safely fixed by changing the module to `@rstest/core`. Everything else is still reported, but is not fixed because the two modules do not have equivalent exports.
+The rule reports static imports, `require()`, and TypeScript `import = require` forms for `node:test` and paths beneath it.
 
-Examples of **incorrect** code for this rule:
+## Incorrect
 
-```typescript
+```ts
 import { test } from 'node:test';
-import * as nodeTest from 'node:test';
-import { mock } from 'node:test';
-import { tap } from 'node:test/reporters';
-const nodeTest = require('node:test');
-import nodeTest = require('node:test');
+
+test('creates a user', () => {});
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
+```ts
 import { test } from '@rstest/core';
-import { rs } from '@rstest/core';
-const assert = require('node:assert');
+
+test('creates a user', () => {});
 ```
+
+## Autofix
+
+Changes an exact named import from `node:test` to `@rstest/core` when it imports only `test`, `it`, or `describe`.

--- a/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
+++ b/internal/plugins/rstest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
@@ -2,88 +2,28 @@
 
 ## Rule Details
 
-Disallow string interpolation inside inline snapshots. The expected value of an inline snapshot lives in the source file, and updating snapshots rewrites that literal — so the interpolation is evaluated away and silently lost. Overload dynamic properties with a property matcher instead.
+Disallows interpolation inside inline snapshots. Updating a snapshot rewrites the literal in the source file, so interpolated values can be silently lost.
 
-Examples of **incorrect** code for this rule:
+Only `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` are checked. Other snapshot matchers keep their expected value outside the source file and are not affected by snapshot updates in the same way.
 
-```javascript
-import { expect } from '@rstest/core';
+## Incorrect
 
-expect(something).toMatchInlineSnapshot(
-  `Object {
-    property: ${interpolated}
-  }`,
-);
-
-expect(something).toMatchInlineSnapshot(
-  { other: expect.any(Number) },
-  `Object {
-    other: Any<Number>,
-    property: ${interpolated}
-  }`,
-);
-
-expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
-  `${interpolated}`,
-);
+```ts
+expect(user).toMatchInlineSnapshot(`
+  {
+    "id": ${user.id},
+  }
+`);
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```javascript
-import { expect } from '@rstest/core';
+```ts
+expect(user).toMatchInlineSnapshot(`
+  {
+    "id": 1,
+  }
+`);
 
-expect(something).toMatchInlineSnapshot();
-
-expect(something).toMatchInlineSnapshot(
-  `Object {
-    property: 1
-  }`,
-);
-
-expect(something).toMatchInlineSnapshot(
-  { property: expect.any(Date) },
-  `Object {
-    property: Any<Date>
-  }`,
-);
-
-expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot();
-
-expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
-  `Error Message`,
-);
-
-// Custom messages are not snapshot content, so interpolation is allowed.
-expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
-  `Error Message`,
-  `case ${caseId}`,
-);
-
-expect(something).toMatchInlineSnapshot(
-  { property: expect.any(Date) },
-  `Object {
-    property: Any<Date>
-  }`,
-  `case ${caseId}`,
-);
+expect(user).toMatchInlineSnapshot({ id: expect.any(Number) });
 ```
-
-## Only inline snapshots are checked
-
-The rule covers `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` only. Every other snapshot matcher keeps its expected value outside the source file, so nothing rewrites its arguments and interpolation is harmless:
-
-- `toMatchSnapshot` and its Chai-style alias `matchSnapshot`
-- `toThrowErrorMatchingSnapshot`
-- `toMatchFileSnapshot`
-
-`toMatchFileSnapshot` deserves a special mention: it has no Jest counterpart, and its first argument is a **file path**, so interpolating it is the intended usage rather than a mistake.
-
-```javascript
-// correct — the argument is a path, not a snapshot
-await expect(data).toMatchFileSnapshot(`./__snapshots__/${name}.json`);
-```
-
-## Original Documentation
-
-- [jest/no-interpolation-in-snapshots](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md)

--- a/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.md
+++ b/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.md
@@ -2,20 +2,19 @@
 
 ## Rule Details
 
-When using `rs.mock`, tests should import from the original module path, not directly from a `__mocks__` directory. Directly importing a manual mock can create a separate module instance and make assertions behave unexpectedly.
+Disallows importing a manual mock directly from a `__mocks__` directory. Tests should mock the original module path so Rstest controls which module instance is used.
 
-This rule reports `import` declarations and `require()` calls whose module specifier contains a `__mocks__` path segment.
+The rule checks both `import` declarations and `require()` calls.
 
-Examples of **incorrect** code for this rule:
+## Incorrect
 
-```typescript
-import thing from './__mocks__/thing';
-require('./__mocks__/thing');
+```ts
+import userClient from './__mocks__/user-client';
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
-rs.mock('./thing');
-import thing from './thing';
+```ts
+rs.mock('./user-client');
+import userClient from './user-client';
 ```

--- a/internal/plugins/rstest/rules/no_standalone_expect/no_standalone_expect.md
+++ b/internal/plugins/rstest/rules/no_standalone_expect/no_standalone_expect.md
@@ -2,59 +2,39 @@
 
 ## Rule Details
 
-Disallow using `expect` outside of `it` or `test` blocks. This rule reports `expect` calls that sit directly in a `describe` block, at module scope, or in other places where Rstest will not run them as part of a test case. This helps catch assertions that look meaningful but never execute as part of a test.
+Disallows executable assertions outside a test callback. Assertions at module scope or directly in a suite run while the test file is registered, not as part of a test case.
 
-`expect` inside a helper function is allowed, even when the helper is defined outside the `it`/`test` callback, because the assertion still runs when the helper is invoked from a test. Static `expect` APIs such as `expect.any()` and `expect.extend()` at module scope are also allowed.
+Assertions inside helper functions are allowed because a test can call them. Static helpers such as `expect.any()` and `expect.extend()` are also allowed at module scope.
 
-Only the callback body of a registration counts as the test case. A test's name, its options object and any other argument are evaluated while Rstest collects the file, so an assertion written there runs before any case starts and is reported — including on a registration that takes no callback at all, such as `test.todo(expect(1).toBe(1))`. A tagged-template registration is the exception: `` test.each`...`(name, callback) `` counts as a test block in its entirety, so an assertion in an interpolation or in an argument of the call the tag returns is allowed.
+## Incorrect
 
-Examples of **incorrect** code for this rule:
-
-```javascript
-describe('a test', () => {
-  expect(1).toBe(1);
+```ts
+describe('user service', () => {
+  expect(createUser({ name: 'Ada' }).name).toBe('Ada');
 });
-
-describe('a test', () => {
-  test('a test case', () => {
-    expect(1).toBe(1);
-  });
-
-  expect(1).toBe(1);
-});
-
-expect(1).toBe(1);
-expect.hasAssertions();
-
-test.todo(expect(1).toBe(1));
-
-test('a test case', { timeout: expect(1).toBe(1) }, () => {});
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```javascript
-describe('a test', () => {
-  test('a test case', () => {
-    expect(1).toBe(1);
+```ts
+describe('user service', () => {
+  test('creates a user', () => {
+    expect(createUser({ name: 'Ada' }).name).toBe('Ada');
   });
 });
-
-describe('a test', () => {
-  const helper = () => {
-    expect(1).toBe(1);
-  };
-
-  test('a test case', () => {
-    helper();
-  });
-});
-
-expect.any(String);
-expect.extend({});
 ```
 
 ## Options
 
-- First argument (optional): object with `additionalTestBlockFunctions`
-  - `additionalTestBlockFunctions`: array of function names that should also be treated as test blocks (for example `each.test`).
+```json
+{
+  "rstest/no-standalone-expect": [
+    "error",
+    { "additionalTestBlockFunctions": ["scenario"] }
+  ]
+}
+```
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `additionalTestBlockFunctions` | `string[]` | `[]` | Additional functions whose callbacks are treated as test blocks. |

--- a/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with.md
+++ b/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with.md
@@ -2,74 +2,23 @@
 
 ## Rule Details
 
-This rule prefers one precise mock assertion over separate call-count and argument assertions on the same target.
+Prefers one exact mock assertion over separate call-count and argument assertions. The combined matcher states the complete expectation in one place.
 
-`toHaveBeenCalledWith` passes when *any* recorded call matches, so pairing it with `toHaveBeenCalledOnce` states "called exactly once, with these arguments" across two statements. `toHaveBeenCalledExactlyOnceWith` states it in one, and it cannot silently weaken if the call-count assertion is later removed.
+Chai-style `calledOnce` and `calledWith` assertions are supported too.
 
-Examples of **incorrect** code for this rule:
+## Incorrect
 
-```typescript
+```ts
 expect(handler).toHaveBeenCalledOnce();
 expect(handler).toHaveBeenCalledWith('ready');
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
+```ts
 expect(handler).toHaveBeenCalledExactlyOnceWith('ready');
 ```
 
-## Chai-style spellings
+## Autofix
 
-Rstest also exposes the Chai-style spellings `calledOnce`, `calledWith`, and `calledOnceWith`, which assert on the same spy as their `toHaveBeen…` counterparts. The rule reports them too, including chains that mix both spellings, and the merged assertion keeps the spelling of the argument-side call:
-
-```typescript
-expect(handler).to.have.been.calledOnce;
-expect(handler).to.have.been.calledWith('ready');
-// → expect(handler).to.have.been.calledOnceWith('ready');
-```
-
-A Chai chain can also state both halves by itself. It is reported, but not fixed, for the same reason as the chains below — the rewrite folds one matcher into another inside a single chain, and the rule does not model what else the chain asserts:
-
-```typescript
-expect(handler).to.have.been.calledOnce.and.calledWith('ready');
-// merge by hand into: expect(handler).to.have.been.calledOnceWith('ready');
-```
-
-## Reported without a fix
-
-A chain that asserts more than once is reported, but the rewrite is left to the author, because applying it would mean deleting or splicing assertions the rule does not model — and getting that wrong removes a live assertion silently:
-
-```typescript
-expect(handler).to.have.been.calledOnce.and.to.be.ok;
-expect(handler).to.have.been.calledWith('ready');
-// merge by hand into: expect(handler).to.have.been.calledOnceWith('ready').and.to.be.ok;
-```
-
-The same holds when the target is not stable under a second evaluation. The fix keeps one `expect(...)` call and deletes the other, so an argument such as a function call would go from evaluated twice to evaluated once — and may not even denote the same mock both times:
-
-```typescript
-expect(getMock()).toHaveBeenCalledOnce();
-expect(getMock()).toHaveBeenCalledWith('ready');
-```
-
-Identifiers, property accesses, and element accesses with a literal key are stable, so those pairs are still fixed.
-
-## Limits
-
-The rule does not merge two assertions when:
-
-- either carries `not` anywhere in its chain, because "not called once" and "not called with these arguments" is `¬ once ∧ ¬ with`, while the combined matcher negated is `¬(once ∧ with)`; Chai allows a modifier between matchers, so this includes `calledOnce.and.not.calledWith('ready')`;
-- they carry different modifiers, because each then claims something about a different value; matching `resolves` or `rejects` on both halves does merge, awaited or not;
-- one is awaited and the other is not, because dropping the awaited statement would leave a floating promise whose failure escapes as an unhandled rejection;
-- anything other than an inert statement sits between them. The merge claims both assertions describe one call history, so nothing in between may call the target or rebind it. Neither question is decidable from the syntax, so the rule answers a narrower one it can: a statement may sit between the two halves only if it runs nothing of the author's. That covers an assertion whose `expect(...)` and matcher calls are its only calls, where no matcher executes what it asserts on and the arguments hold no other call, no `await`, no assignment and no spread, since `[...gen]` runs the iterator protocol the way a call runs a function; a call into TypeScript's default library, such as `console.log('checkpoint')` or `JSON.parse(text)`, provided it is none of `eval`, whose source arrives as a string, and `call` and `apply`, which run their receiver rather than anything handed over — all three are declared in that library themselves — and nothing callable is handed to it; a declaration whose initializers meet the same bar, where a hoisted `var` must also declare names neither assertion reads and every declared name is a plain identifier, since a destructuring pattern runs that same protocol; and any other statement that transfers control nowhere, so a bare `obj.trigger;` keeps its place, a getter on it notwithstanding, for the same reason a property read inside an assertion does. Assertions on other mocks therefore keep their place between the two halves, while a reset, a reassignment, a further call to the target, and any call the rule cannot resolve leave the pair alone. Resolving the library call needs type information, so without a type checker such a call blocks the merge as well;
-- either is an `expect.poll(...)` or `expect.element(...)` assertion, because each half then retries on its own until it passes and the two can settle against different call histories, which is the one thing the merge claims they do not do;
-- more than two of these assertions share one target, because which pair to merge is ambiguous.
-
-Three cases are not covered. When both halves are awaited, the second `await` is itself a suspension between the call-count check and the argument check, and the merge closes it: a mock called once before the pair and once more while the second half is suspended satisfies both halves separately — one recorded call at the first, one matching call among two at the second — and fails the merged assertion. The barrier rejects an intervening assertion that awaits for exactly this reason, but the pair's own `await` is part of a half rather than a statement between them. Refusing awaited pairs would drop the shape the rule was extended to support, so this one is left open.
-
-The second: a matcher registered through `expect.extend` can invoke its subject the way `toThrow` does, and the rule has no way to know it. Recognising only the matchers Rstest ships would need a matcher table this repo does not have, and refusing an intervening assertion whose subject is callable would reject `expect(otherMock).toHaveBeenCalledWith(...)` — the assertion the barrier exists to let through.
-
-The last: an exempt default-library call may still run code the author wrote on the value it is handed, because the only thing asked of that value is whether it carries a call signature. `Array.from(gen)` iterates a generator the way `[...gen]` does; `JSON.stringify(obj)` runs `obj.toJSON()` and `` console.log(`${obj}`) `` runs `obj.toString()`; and `Object.assign(obj, src)` runs the setters on `obj`, so a write the rule disqualifies when it is spelled out in the source passes when it goes through the library. Asking more of the argument than a call signature would take plain values with it — an iterable covers arrays and strings, and every object answers to `toString` — and with them the `console.log(items)` shape the exemption exists for, so this one is left open.
-
-Where a fix is offered, it preserves the surviving call's arguments, type arguments, comments, and formatting. The folded assertion is removed with its line when it owns that line, and otherwise on its own so that neighbouring statements and comments are never disturbed.
+Merges the pair into the combined matcher, keeping the argument-side assertion and deleting the call-count one. The pair is reported without a fix when the subject cannot be evaluated once instead of twice, as in `expect(getMock())`, or when one of the two chains carries further assertions that deleting the statement would drop.

--- a/internal/plugins/rstest/rules/prefer_each/prefer_each.md
+++ b/internal/plugins/rstest/rules/prefer_each/prefer_each.md
@@ -2,144 +2,24 @@
 
 ## Rule Details
 
-Prefer `.each` over wrapping Rstest `test`, `it`, `describe`, or hooks in
-native `for`, `for...in`, and `for...of` loops. Parameterized registrations are
-clearer in reporters and keep related cases grouped under one declaration.
+Prefers parameterized Rstest registrations over manually registering tests, suites, or hooks inside a loop. `.each` keeps related cases together in test output and gives each case a clear title.
 
-Examples of **incorrect** code:
+Loops used as ordinary test logic are allowed. When a loop registers one test, the diagnostic recommends `test.each` or `it.each`; loops that register suites, hooks, or several entries recommend `describe.each`.
+
+## Incorrect
 
 ```ts
-for (const row of rows) {
-  test(row.name, () => {
-    expect(runCase(row)).toBe(true);
-  });
-}
-
-for (const row of rows) {
-  beforeEach(() => setup(row));
-  test(row.name, () => {
-    expect(doSomething()).toBe(row.expected);
+for (const input of [1, 2, 3]) {
+  test(`doubles ${input}`, () => {
+    expect(double(input)).toBe(input * 2);
   });
 }
 ```
 
-Examples of **correct** code:
+## Correct
 
 ```ts
-test.each(rows)('$name', (row) => {
-  expect(runCase(row)).toBe(true);
-});
-
-describe.each(rows)('$name', (row) => {
-  beforeEach(() => setup(row));
-  test('works', () => {
-    expect(doSomething()).toBe(row.expected);
-  });
-});
-
-test('business loop', () => {
-  for (const row of rows) {
-    consume(row);
-  }
+test.each([1, 2, 3])('doubles %i', (input) => {
+  expect(double(input)).toBe(input * 2);
 });
 ```
-
-A loop is judged by what it registers, not by where it sits. A loop whose body
-holds no registration is business logic or setup work and is never reported,
-including inside a test callback. A loop that does register is reported even
-inside a test callback, because it still registers once per iteration.
-
-This rule only reports. It does not autofix, and it never recommends `.for`.
-Rstest's `.for` callback receives `(row, context)`, which is not a mechanical
-replacement for a hand-written loop.
-
-## Rstest specifics
-
-Rstest resolves same-file aliases and supports multiple API entry points, so
-the rule follows final registrations from:
-
-- globals
-- `@rstest/core` named imports and aliases
-- `require('@rstest/core')`
-- namespace imports
-- `import.meta.rstest`
-- same-file `const` aliases
-- `@rstest/playwright`
-
-When exactly one test registration appears in the loop, the suggestion keeps
-the original API family:
-
-- `it(...)` suggests `it.each`
-- `test(...)` suggests `test.each`
-- Playwright test registrations also suggest `test.each`
-
-Any loop containing `describe`, hooks, or multiple registrations suggests
-`describe.each`.
-
-## Differences from ESLint
-
-`eslint-plugin-jest` keeps a single flat list of registrations for the whole
-file and gates it on an `inTestCaseCall` boolean that every `test(...)` sets and
-every `test(...)` exit clears. Both halves leak across scopes. This port gives
-each loop its own frame instead: a registration belongs to the innermost loop
-whose body contains it, and a loop is reported from that frame alone. Four
-observable differences follow.
-
-The message names what the loop itself registers. Upstream's flat list still
-holds the enclosing `test(...)` when a loop inside its callback is reported, so
-it recommends `describe.each` for a loop that registers one test:
-
-```ts
-test('outer', () => {
-  for (const row of rows) {
-    test(row.name, () => {}); // `test.each` here, `describe.each` upstream
-  }
-});
-```
-
-A loop in a non-callback argument position is reported. Upstream is still inside
-the open `test(...)` when the loop exits, so it stays silent:
-
-```ts
-test('a', () => {}, (function () {
-  for (const row of rows) {
-    beforeEach(() => {}); // `describe.each` here, unreported upstream
-  }
-  return 5;
-})());
-```
-
-An outer loop keeps its own registrations when it contains another loop.
-Upstream clears the shared list when the inner loop is entered, which discards
-the outer loop's registration:
-
-```ts
-for (const suite of suites) {
-  test(suite.name, () => {}); // outer loop is `test.each` here, unreported upstream
-  for (const item of suite.items) {
-    consume(item);
-  }
-}
-```
-
-A registration in a nested loop's header belongs to the enclosing loop, because
-the header is evaluated once per iteration of that enclosing loop. Upstream
-clears its shared list when the inner loop is entered, so the registration is
-discarded and nothing is reported:
-
-```ts
-for (const suite of suites) {
-  // outer loop is `test.each` here, unreported upstream
-  for (const row of getRows(test(suite.name, () => {}))) {
-    consume(row);
-  }
-}
-```
-
-The same applies to a nested classic `for` initializer, condition, or update
-expression.
-
-## Original Documentation
-
-- [eslint-plugin-jest: prefer-each](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/prefer-each.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/prefer-each.ts)

--- a/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.md
+++ b/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of.md
@@ -2,62 +2,22 @@
 
 ## Rule Details
 
-Prefer `expect(value).toBeTypeOf(type)` over `expect(typeof value).toBe(type)`.
-The dedicated matcher states the intent directly and, when it fails, reports
-the value's actual type instead of a plain string comparison.
+Prefers `toBeTypeOf` over comparing `typeof` with a string. The dedicated matcher makes the assertion's intent clearer and gives a better failure message.
 
-Examples of **incorrect** code:
+The rule supports regular and soft Rstest assertions.
+
+## Incorrect
 
 ```ts
 expect(typeof value).toBe('string');
-expect(typeof value).toEqual('number');
-expect(typeof value).not.toBe('function');
-expect.soft(typeof value).toBe('object');
 ```
 
-Examples of **correct** code:
+## Correct
 
 ```ts
 expect(value).toBeTypeOf('string');
-expect(value).not.toBeTypeOf('function');
-expect.soft(value).toBeTypeOf('object');
-expect(typeof value === 'string').toBe(true);
 ```
 
-## Recognized assertions
+## Autofix
 
-The rule reports only a matcher that is actually called with exactly one
-argument. A broken chain such as `expect(typeof value).toBe`, a spread argument
-such as `expect(typeof value).toBe(...types)`, and a Chai property assertion
-such as `expect(typeof value).to.be.ok` are all left alone. So is a matcher
-named by a computed key, `expect(typeof value)[matcherName]('string')`, because
-which assertion runs is only known at runtime.
-
-Every expect source is covered: globals, `@rstest/core` named imports and
-renamed imports, `require('@rstest/core')` destructuring, namespace imports,
-whole-module `require`, `import.meta.rstest`, `@rstest/playwright`, and the
-`expect` a test callback receives through its context (`({ expect })` and
-`ctx.expect`). An `expect` from another assertion library, and a local variable
-that shadows `expect`, are not reported.
-
-`expect.poll(fn)` and `expect.element(locator)` are excluded: the first takes a
-callback and the second a locator, so neither carries the value being type
-checked.
-
-## Fix
-
-The fix edits two places and leaves the rest of the call exactly as written: it
-removes the `typeof` operator from the assertion's argument, and renames the
-matcher accessor to `toBeTypeOf`. Everything else survives — the expect root as
-spelled at the call site, `expect.soft`, the optional second `message` argument
-of `expect(actual, message)`, the modifier chain, the matcher argument, the
-accessor's own quoting, and the surrounding line breaks and comments:
-
-```ts
-expect.soft(typeof value, 'should be a string')['toBe']('string');
-// becomes
-expect.soft(value, 'should be a string')['toBeTypeOf']('string');
-```
-
-A comment written between `typeof` and its operand sits inside the removed span
-and is removed with it. Every comment outside those two spans is preserved.
+Rewrites the assertion to `toBeTypeOf`, leaving the `expect` factory, a message argument, and the modifier chain untouched.

--- a/internal/plugins/rstest/rules/prefer_hooks_in_order/prefer_hooks_in_order.md
+++ b/internal/plugins/rstest/rules/prefer_hooks_in_order/prefer_hooks_in_order.md
@@ -2,86 +2,22 @@
 
 ## Rule Details
 
-Prefer Rstest lifecycle hooks in the same order Rstest runs them:
+Requires lifecycle hooks to appear in the order Rstest runs them: `beforeAll`, `beforeEach`, `afterEach`, then `afterAll`. Keeping declarations in runtime order makes test setup easier to read.
 
-1. `beforeAll`
-2. `beforeEach`
-3. `afterEach`
-4. `afterAll`
+The rule checks consecutive hook declarations. A non-hook call begins a new sequence, allowing separate setup groups when needed.
 
-This rule checks each consecutive run of hook calls and reports a hook that
-appears after another hook from a later runtime stage. A normal non-hook call
-starts a new run. Comments, blank lines, and statements that do not contain a
-call do not.
-
-Examples of **incorrect** code for this rule:
+## Incorrect
 
 ```ts
-afterAll(() => {});
-beforeAll(() => {});
-
-import { test } from "@rstest/playwright";
-
-test.afterEach(() => {});
-test.beforeEach(() => {});
+afterAll(() => closeDatabase());
+beforeAll(() => openDatabase());
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
 ```ts
-beforeAll(() => {});
-beforeEach(() => {});
-afterEach(() => {});
-afterAll(() => {});
-
-afterAll(() => {});
-doSomething();
-beforeAll(() => {});
+beforeAll(() => openDatabase());
+beforeEach(() => resetDatabase());
+afterEach(() => clearDatabase());
+afterAll(() => closeDatabase());
 ```
-
-The rule follows Rstest hooks imported from `@rstest/core`, globals,
-CommonJS/namespace forms, `import.meta.rstest`, same-file aliases, and
-`@rstest/playwright` member hooks such as `test.beforeEach()` and
-`test.extend({}).afterAll()`.
-
-Hooks written inside a hook callback form their own run at that nesting level.
-They are not compared against the hook that encloses them, and they do not end
-the run that surrounds it:
-
-```ts
-// reported: `beforeEach` comes after `afterAll` in the same run
-afterAll(() => {});
-beforeEach(() => {});
-
-// not reported: the inner run is ordered correctly on its own terms
-afterAll(() => {
-  beforeEach(() => {});
-  afterEach(() => {});
-});
-```
-
-## Differences from ESLint
-
-The upstream rule tracks "inside a hook" as a single boolean and ignores every
-call made while it is set. That conflates two separate scopes, and this rule
-scopes each run to its own nesting level instead. Two consequences, both of
-which this rule reports differently from upstream on hook-inside-hook shapes:
-
-- A nested hook callback no longer ends the surrounding run. After a nested hook
-  exits, an ordinary call resets upstream's run, so a later outer hook starts
-  fresh and an inversion can go unreported. Here the surrounding run survives
-  the callback, so
-  `afterAll(() => { beforeEach(() => {}); doSomething(); }); beforeAll(() => {});`
-  is reported.
-
-- A nested hook is never compared against a hook from the enclosing run.
-  Upstream lets the enclosing run's index leak in, which both reports correctly
-  ordered nested runs and attributes reports to a hook from another nesting
-  level. Here `afterAll(() => { beforeEach(() => {}); afterEach(() => {}); })`
-  is accepted, and a genuinely inverted nested run is reported against the hook
-  that precedes it at its own level.
-
-## Original Documentation
-
-- [eslint-plugin-jest: prefer-hooks-in-order](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/prefer-hooks-in-order.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/prefer-hooks-in-order.ts)

--- a/internal/plugins/rstest/rules/prefer_todo/prefer_todo.md
+++ b/internal/plugins/rstest/rules/prefer_todo/prefer_todo.md
@@ -2,96 +2,28 @@
 
 ## Rule Details
 
-Prefer `test.todo(...)` over Rstest test registrations that are present in the
-file but still have no implementation. The rule reports two cases:
+Prefers `test.todo(...)` for a test that has no implementation. A todo test states the work is intentional instead of looking like a passing test.
 
-- the callback is missing entirely;
-- the callback is an inline empty function body.
+The rule reports missing callbacks and inline empty callbacks. Existing `test.todo` registrations are allowed.
 
-Unlike Jest, Rstest accepts both `(title, fn, timeout)` and
-`(title, options, fn?)`. This rule recognizes the object-literal options form
-and keeps the options object when it rewrites the registration to `.todo`.
-
-Examples of **incorrect** code for this rule:
+## Incorrect
 
 ```ts
-test('needs implementation');
-test('empty body', () => {});
-test('retry later', { timeout: 1000 }, () => {});
-test.skip('temporarily empty', () => {});
+test('exports a CSV file');
+
+test('imports a CSV file', () => {});
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
 ```ts
-test.todo('needs implementation');
-test('implemented', () => expect(value).toBe(1));
-test('indirect callback', callback);
+test.todo('exports a CSV file');
+
+test('imports a CSV file', () => {
+  expect(importCsv('name\nAda')).toEqual([{ name: 'Ada' }]);
+});
 ```
 
-## Limitations
+## Autofix
 
-Reporting and autofixing are separate decisions, so a registration can be
-reported with no fix attached.
-
-### Reported without a fix
-
-A registration the parser has proved to be an Rstest test is always reported,
-even when no rewrite delivers a todo test:
-
-- a same-file `const` alias that hides `.skip` in its initializer, such as
-  `const skipped = test.skip; skipped('case')`, because the call site has no
-  accessor to replace;
-- a repeated `.skip` chain, such as `test.skip.skip('case', () => {})`, because
-  replacing one accessor leaves the other skip active;
-- an optional registration such as `test?.('case')`, because inserting `.todo`
-  would move the optional boundary and may change the call's runtime behavior;
-- a call with unsupported arguments whose callback is still provably empty,
-  such as `test('case', () => {}, 'not a timeout')` or
-  `test('case', () => {}, 1000, extra)`, because dropping or preserving those
-  arguments would guess at behavior outside Rstest's overloads.
-
-### Not reported at all
-
-The rule stays silent when it cannot prove the call still reaches the Rstest
-test API, or when the run mode it would have to preserve is unknown:
-
-- whole-module CommonJS namespace objects, such as
-  `const core = require('@rstest/core'); core.test('case')`. Their API
-  properties are mutable even when the namespace binding is declared with
-  `const`, so `core.test` may no longer be Rstest;
-- aliases that hide a modifier or factory other than `.skip`, such as `.fails`,
-  `.each(...)`, `.for(...)` or `.extend(...)`, whose run mode the rewrite would
-  have to reason about;
-- computed member access such as `test[skip]('case', () => {})`. The member is
-  not statically known, so the run mode may be one the rule does not report on
-  at all, such as `.only` or `.each`.
-
-Sources the rule does follow are Rstest globals, named imports, ES module
-namespace imports, `import.meta.rstest` including `const` object destructuring
-of it, and same-file `const` aliases whose every hop stays a bare test API.
-
-### Overload recognition
-
-The options overload is recognized only when the second argument is written as
-an object literal. Calls such as `test('case', options)` and
-`test('case', options, () => {})` are left unchanged because the identifier may
-still be the callback.
-
-### Rstest-specific behavior
-
-The rule intentionally differs from upstream in these cases:
-
-- interpolated template titles such as ``test(`case ${name}`)`` are reported,
-  because the dynamic title does not make a missing or empty callback ambiguous;
-- nested registrations such as `wrap(test('case'))` are reported, because the
-  inner `test(...)` call still executes and registers an Rstest test. Rewriting
-  that inner call to `test.todo(...)` preserves its registration role;
-- parentheses around an inline empty callback are removed together with the
-  callback. Upstream's fix range ends at the inner function and can leave
-  unmatched closing parentheses, while this rule keeps the fixed call parseable.
-
-## Original Documentation
-
-- [eslint-plugin-jest: prefer-todo](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/prefer-todo.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/prefer-todo.ts)
+Rewrites the registration to `test.todo`, replacing a `.skip` accessor at the call site and removing an empty callback argument. A registration whose skip comes from an alias, or that chains `.skip` twice, is reported without a fix, because rewriting one accessor would leave the other skip active.

--- a/internal/plugins/rstest/rules/require_local_test_context_for_concurrent_snapshots/require_local_test_context_for_concurrent_snapshots.md
+++ b/internal/plugins/rstest/rules/require_local_test_context_for_concurrent_snapshots/require_local_test_context_for_concurrent_snapshots.md
@@ -2,38 +2,22 @@
 
 ## Rule Details
 
-Concurrent Rstest tests must use the `expect` provided by their local Test Context for snapshot assertions. A global or imported `expect` can share snapshot state between concurrently running tests.
+Requires concurrent tests to use the `expect` from their local Test Context for snapshot assertions. A shared global or imported `expect` can mix snapshot state between tests that run at the same time.
 
-Examples of **incorrect** code for this rule:
+The rule checks snapshot matchers in concurrent tests, including concurrent suites and parameterized tests. It requires type information to identify the local Test Context.
 
-```typescript
-test.concurrent('renders', () => {
-  expect(render()).toMatchSnapshot();
+## Incorrect
+
+```ts
+test.concurrent('renders a user', () => {
+  expect(renderUser()).toMatchSnapshot();
 });
 ```
 
-Examples of **correct** code for this rule:
+## Correct
 
-```typescript
-test.concurrent('renders', ({ expect }) => {
-  expect(render()).toMatchSnapshot();
+```ts
+test.concurrent('renders a user', ({ expect }) => {
+  expect(renderUser()).toMatchSnapshot();
 });
 ```
-
-An explicit inner `sequential` or `concurrent` registration overrides the mode inherited from an enclosing describe block. The mode is read only from the chained modifiers: Rstest takes just `timeout`, `retry`, `repeats` and `meta` out of the options object of a `(name, options, fn)` registration, so `concurrent` and `sequential` written there have no effect at runtime and none here either.
-
-The rule recognizes Rstest aliases, named callbacks, `.each`, `.for`, `import.meta.rstest`, and `@rstest/playwright` registrations.
-
-Assertions written inside a closure, hook or helper declared within a concurrent body are checked too, because such a function runs as part of the concurrent test whenever it runs at all:
-
-```typescript
-test.concurrent('renders', async () => {
-  await Promise.all(items.map(async item => {
-    expect(item).toMatchSnapshot();
-  }));
-});
-```
-
-A helper declared outside every registration callback is not checked, since the rule cannot tell which tests call it. A callback passed by a name the type checker cannot resolve is only matched against a function declared at the top level of the file under that exact name, so a same-named function nested inside another callback is never blamed for a test that does not run it.
-
-Rstest's `matchSnapshot` Chai alias is also checked because it uses the same snapshot state as `toMatchSnapshot`. A Chai chain may carry several assertions, so every matcher in the chain is considered and `expect(value).to.be.a('string').and.matchSnapshot()` is reported once.

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.md
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.md
@@ -2,55 +2,29 @@
 
 ## Rule Details
 
-Enforce valid `expect()` usage in Rstest. `expect` must be called with the
-right number of arguments, must be followed by a matcher, and asynchronous
-assertions must be awaited or returned so their failures are not lost.
+Validates Rstest `expect` calls: they need the required arguments and a matcher, and asynchronous assertions must be awaited or returned so failures are not lost.
 
-Examples of incorrect code:
+Rstest supports a message as the second `expect` argument and Chai-style property assertions; both are accepted by the rule.
+
+## Incorrect
 
 ```ts
-expect();                       // notEnoughArgs
-expect(value);                  // matcherNotFound
-expect(value).toBe;             // matcherNotCalled
-expect(value).notAModifier();   // modifierUnknown
+expect(user);
 
-test("async", async () => {
-  expect(promise).resolves.toBe(1); // asyncMustBeAwaited
+test('loads a user', async () => {
+  expect(loadUser()).resolves.toMatchObject({ name: 'Ada' });
 });
 ```
 
-Examples of correct code:
+## Correct
 
 ```ts
-expect(value).toBe(1);
-expect(value).not.toBe(2);
-expect(value, "message").toBe(1);   // second message argument is allowed
+expect(user).toMatchObject({ name: 'Ada' });
 
-test("async", async () => {
-  await expect(promise).resolves.toBe(1);
-  await expect(promise).rejects.toThrow();
+test('loads a user', async () => {
+  await expect(loadUser()).resolves.toMatchObject({ name: 'Ada' });
 });
 ```
-
-## Rstest specifics
-
-rstest's `expect` comes from `@vitest/expect` + chai, so this rule follows the
-vitest behavior where it differs from jest:
-
-- **A second argument to `expect` is allowed** when it is a message string or
-  template literal (`expect(value, "msg")`), and `expect.poll(fn, options)` /
-  `expect.element(el, options)` accept an options object. These do not trigger
-  `tooManyArgs`.
-- **Chai property matchers are valid** without a call: `expect(value).to.be.ok`,
-  `expect(spy).to.have.been.called`. They are not reported as `matcherNotCalled`.
-- **Forms with no assertion factory carry no assertion**: `expect.assertions(1)`,
-  `expect.hasAssertions()`, asymmetric matchers such as `expect.any(Number)` and
-  bare chains such as `expect.resolves.toBe(1)` or `expect.toResolve()` are not
-  subject to argument or await checks.
-
-`expect` is recognized from globals, `@rstest/core` imports and aliases,
-`require`, namespace access, `import.meta.rstest`, test-context `expect`
-(`test('x', ({ expect }) => ...)`), and `@rstest/playwright`.
 
 ## Options
 
@@ -59,19 +33,21 @@ vitest behavior where it differs from jest:
   "rstest/valid-expect": [
     "error",
     {
-      "alwaysAwait": false,
-      "asyncMatchers": ["toReject", "toResolve"],
-      "minArgs": 1,
-      "maxArgs": 1
+      "alwaysAwait": true,
+      "asyncMatchers": ["toReject", "toResolve", "toSettle"],
+      "maxArgs": 2
     }
   ]
 }
 ```
 
-- **`alwaysAwait`** — require every async assertion to be awaited, disallowing
-  `return`.
-- **`asyncMatchers`** — matcher names treated as asynchronous (must be awaited).
-- **`minArgs`** / **`maxArgs`** — the required argument count for `expect`.
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `alwaysAwait` | `boolean` | `false` | Require async assertions to be awaited instead of allowing `return`. |
+| `asyncMatchers` | `string[]` | `["toReject", "toResolve"]` | Matcher names treated as asynchronous. Setting it replaces the default list. |
+| `minArgs` | `number` | `1` | Minimum number of arguments for `expect`. |
+| `maxArgs` | `number` | `1` | Maximum number of arguments for `expect`. |
 
-The rule provides an automatic fix that inserts `await` (and `async` on the
-enclosing function) for async assertions that are not awaited.
+## Autofix
+
+An async assertion that is neither awaited nor returned is fixed by adding `await`, and by marking the enclosing function `async` when it is not already. Argument-count and matcher problems are reported without a fix.

--- a/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.md
+++ b/internal/plugins/rstest/rules/valid_expect_in_promise/valid_expect_in_promise.md
@@ -1,48 +1,27 @@
 # valid-expect-in-promise
 
-Require promise chains containing Rstest assertions to be returned, awaited, or consumed by a safe promise sink.
+## Rule Details
 
-Rstest has two official assertion interfaces:
+Requires promise chains containing Rstest assertions to be returned or awaited. Otherwise the test can finish before the assertion runs or before its failure is reported.
 
-```ts
-expect(actual).toBe(expected);
-assert.equal(actual, expected);
-```
+Both Rstest `expect` and Chai `assert` calls are recognized. A promise chain may also be returned from the test callback.
 
-`expect` is Rstest's extended `@vitest/expect` and Chai interface. `assert` is Chai's function-style interface exported by `@rstest/core`. They share the Chai assertion engine but are not aliases; `assert` does not contribute to `expect.assertions()` bookkeeping. Both throw assertion errors, so both have the same floating-promise risk:
+## Incorrect
 
 ```ts
-test('loads a value', () => {
-  load().then(value => {
-    assert.equal(value, 'ready');
+test('loads a user', () => {
+  loadUser().then((user) => {
+    expect(user.name).toBe('Ada');
   });
 });
 ```
 
-Return or await the chain:
+## Correct
 
 ```ts
-test('loads a value', async ({ expect }) => {
-  await load().then(value => {
-    expect(value).toBe('ready');
+test('loads a user', async () => {
+  await loadUser().then((user) => {
+    expect(user.name).toBe('Ada');
   });
 });
 ```
-
-The rule recognizes Rstest globals, `@rstest/core` imports and requires, namespace objects, `import.meta.rstest`, TestContext `expect`, and `@rstest/playwright` `expect`. It does not treat Node, direct Chai, or locally defined `assert` functions as Rstest assertions.
-
-Rstest does not support Jest-style `done` callbacks. A regular test callback's first argument is `TestContext`; `test.for` receives context as its second callback argument, while `test.each` receives case values only. All of these callbacks are analyzed.
-
-The rule follows promises stored in local bindings, including statically mappable array and object destructuring, and requires every reachable path to consume them. `Promise.resolve` and `Promise.all` preserve assertion failure. `Promise.reject` and `Promise.allSettled` are not safe sinks.
-
-A logical assignment stores the chain like a plain assignment does, and its right-hand side is only evaluated when the store happens, so `pending ||= load().then(...)` followed by `await pending` is consumed. In the other direction a promise is truthy and non-nullish, so a later `||=` or `??=` cannot replace the promise a binding already holds, while `&&=` always does and discards it.
-
-The chain also reaches its binding through `||`, `??`, `&&`, either branch of a conditional, and the right-hand side of a comma, because each of those evaluates the chain on exactly the paths where the binding receives it. `let pending = fallback || load().then(...)` is therefore tracked, and so is the longhand `pending = pending || load().then(...)`, which keeps the promise the binding already holds for the same reason `||=` does. The preserving direction is narrower and not symmetric with this one: a write leaves the promise a binding holds in place only when every path through the right-hand side evaluates to it, so `pending = pending || other` and `pending = (setup(), pending)` preserve it while `pending = other || pending`, `pending = other ?? pending`, `pending = ready && pending` and `pending = condition ? pending : other` each drop it on one path and are reported.
-
-An array literal in a binding holds the chain, and only an element-wise consumption of that binding reaches it: `await Promise.all(pending)` and `for await (const settled of pending)` consume it, while `await pending` awaits the array itself and leaves the chain floating. A spread of the binding into another array literal carries every element with it, so `await Promise.all([...pending])` and `for await (const settled of [...pending])` consume it too, and an element access such as `await pending[0]` reaches an element rather than the array.
-
-A chain is consumed only when it is awaited, returned, wrapped in `Promise.resolve` or `Promise.all`, placed in an array literal that `Promise.all` or a `for await` consumes, consumed element-wise by `for await`, or handed to an `expect(...).resolves` / `.rejects` sink. Every other position leaves it floating: `Promise.race` and `Promise.any`, any other wrapper call such as `helper(chain)`, `void chain` and `throw chain`, a property of an object literal that is not destructured straight into a binding, an array literal that is never consumed element-wise, a tagged template interpolation, and a compound arithmetic assignment such as `count += chain`, which stores no promise at all.
-
-An awaited chain is safe only when its rejection can escape the test callback. An enclosing `catch` that may swallow the rejection, or a `finally` block that may `return`, `break`, or `continue`, does not count as safe consumption. A `catch` that always rethrows preserves the failure.
-
-This rule has no options and does not provide an autofix.

--- a/internal/plugins/rstest/rules/valid_title/valid_title.md
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.md
@@ -2,157 +2,52 @@
 
 ## Rule Details
 
-Enforce valid titles on Rstest `describe`, `test`, and `it` blocks. Titles should be informative strings, follow project conventions you configure, and use only the `printf`-style placeholders that Rstest actually expands in array-based `.each` / `.for` titles.
+Validates Rstest `describe`, `test`, and `it` titles. Clear, consistently formatted titles make test output easier to scan and project conventions easier to enforce.
 
-This rule checks that titles are:
+The rule rejects empty titles, titles that are not strings, titles with leading or trailing whitespace, and titles that repeat the registration name as their first word, such as `test('test creates a user')`. The `disallowedWords`, `mustMatch`, and `mustNotMatch` options add project-specific title conventions on top of that.
 
-- not empty (including empty template literals),
-- string literals (unless relaxed via options),
-- not accidentally prefixed with the block keyword (for example `test('test foo')`),
-- free of leading or trailing whitespace (unless `ignoreSpaces` is enabled),
-- using only valid `printf` specifiers for array-based `.each` / `.for` table names,
-- not matching `disallowedWords` (whole-word, case-insensitive) when that option is set,
-- satisfying `mustMatch` / `mustNotMatch` patterns when configured (per `describe` / `test` / `it` or a single global pattern).
+In array-based `.each` and `.for` titles the rule also checks format specifiers, accepting `%s`, `%d`, `%i`, `%f`, `%j`, `%o`, `%O`, `%c`, `%#`, `%$`, and `%%`.
 
-Auto-fix is available for accidental surrounding spaces and duplicate keyword prefixes.
-
-**`emptyTitle`**
-
-Examples of **incorrect** code:
-
-```js
-describe('', () => {});
-it('', () => {});
-test('', () => {});
-```
-
-Examples of **correct** code:
-
-```js
-describe('suite', () => {});
-it('does something', () => {});
-test('works', () => {});
-```
-
-**`titleMustBeString`**
-
-Use string literals for titles unless `ignoreTypeOfDescribeName` or `ignoreTypeOfTestName` is `true`.
-
-Examples of **incorrect** code:
-
-```js
-it(123, () => {});
-describe(myFunction, () => {});
-```
-
-Examples of **correct** code:
-
-```js
-it('is a string', () => {});
-describe('suite', () => {});
-```
-
-**`invalidEachSpecifier`**
-
-Titles of array-based `.each` and `.for` registrations are formatted at runtime. After a single `%`, only `s`, `d`, `j`, `i`, `f`, `o`, `O`, `c`, `#`, and `$` are accepted, and `%%` denotes a literal percent.
-
-Examples of **incorrect** code:
-
-```js
-test.each([[1, 2]])('.add(%I, %I)', (a, b) => {
-  expect(a + b).toBe(3);
-});
-```
-
-Examples of **correct** code:
-
-```js
-test.each([[1, 2]])('.add(%i, %i)', (a, b) => {
-  expect(a + b).toBe(3);
-});
-```
-
-Tagged-template tables are not checked, because they interpolate with `$name` rather than `printf` specifiers and a bare `%` in them is literal text:
-
-```js
-test.each`
-  a    | b
-  ${1} | ${2}
-`('returns $a and $b', ({ a, b }) => {});
-```
-
-**`duplicatePrefix`**
-
-Examples of **incorrect** code:
-
-```js
-test('test foo', () => {});
-it('it foo', () => {});
-describe('describe foo', () => {
-  it('bar', () => {});
-});
-```
-
-Examples of **correct** code:
-
-```js
-test('foo', () => {});
-it('foo', () => {});
-describe('foo', () => {
-  it('bar', () => {});
-});
-```
-
-**`accidentalSpace`**
-
-Examples of **incorrect** code:
-
-```js
-test(' foo', () => {});
-it('foo ', () => {});
-```
-
-Examples of **correct** code:
-
-```js
-test('foo', () => {});
-it('foo', () => {});
-```
-
-### Differences from `jest/valid-title`
-
-The rule is otherwise a port of `jest/valid-title`, with three differences that follow from how Rstest itself behaves.
-
-**The set of valid `printf` specifiers is Rstest's, not Jest's.** Rstest formats parameterized titles with Node's `util.format` semantics, accepting `s`, `d`, `j`, `i`, `f`, `o`, `O`, `c`, and `%` after a `%`, while Jest uses its own `pretty-format` placeholder set. So:
-
-| Title | `jest/valid-title` | `rstest/valid-title` |
-| --- | :---: | :---: |
-| `test.each([])('%p', fn)` | valid | **reported** — Rstest leaves `%p` in the title verbatim |
-| `test.each([])('%O', fn)` | reported | **valid** — Rstest expands it |
-| `test.each([])('%c', fn)` | reported | **valid** — Rstest expands it |
-
-**`.for` titles are checked too.** Rstest has both `.each` and `.for`, and both format their titles the same way. Jest has no `.for`.
-
-**There are no `f` / `x` prefixed aliases.** Rstest provides no `fit`, `xit`, `xtest`, `fdescribe`, or `xdescribe`, so the keyword compared against the title is always the API being registered — `test`, `it`, or `describe` — even when it was imported or aliased under another name. `import { it as xit } from '@rstest/core'; xit('it works', fn)` is reported, and `mustMatch: { test: … }` applies to `import { test as check } …; check(…)`.
-
-### Options
+## Incorrect
 
 ```ts
-interface Options {
-  ignoreSpaces?: boolean;
-  ignoreTypeOfDescribeName?: boolean;
-  ignoreTypeOfTestName?: boolean;
-  disallowedWords?: string[];
-  mustNotMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
-  mustMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
+test('', () => {});
+test('test creates a user', () => {});
+describe('  user service  ', () => {});
+```
+
+## Correct
+
+```ts
+test('creates a user', () => {});
+describe('user service', () => {});
+```
+
+## Options
+
+```json
+{
+  "rstest/valid-title": [
+    "error",
+    {
+      "disallowedWords": ["should"],
+      "mustMatch": "^[a-z]"
+    }
+  ]
 }
 ```
 
-- **`ignoreSpaces`** (default `false`): skip leading/trailing space checks.
-- **`ignoreTypeOfDescribeName`** / **`ignoreTypeOfTestName`** (default `false`): allow non-string first arguments for `describe` or `test`/`it` respectively.
-- **`disallowedWords`**: list of words that must not appear as whole words in titles (case-insensitive).
-- **`mustMatch`** / **`mustNotMatch`**: ECMAScript regular expressions as strings, either one pattern for all block kinds or an object keyed by `describe`, `test`, and `it`. You can pass a two-element array `[pattern, customMessage]` to surface `*Custom` message variants.
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `ignoreSpaces` | `boolean` | `false` | Allow leading and trailing whitespace. |
+| `ignoreTypeOfDescribeName` | `boolean` | `false` | Allow non-string `describe` titles. |
+| `ignoreTypeOfTestName` | `boolean` | `false` | Allow non-string `test` and `it` titles. |
+| `disallowedWords` | `string[]` | `[]` | Words that titles must not contain. |
+| `mustMatch` | matcher | none | Pattern a title must match. |
+| `mustNotMatch` | matcher | none | Pattern a title must not match. |
 
-## Original Documentation
+A matcher is a pattern string, `[pattern, message]`, or an object with separate `describe`, `test`, and `it` matchers.
 
-- [jest/valid-title](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/valid-title.md)
+## Autofix
+
+Removes literal surrounding whitespace and duplicate `test`, `it`, or `describe` prefixes from titles.


### PR DESCRIPTION
## Summary

Rewrites all 23 rule pages of the `rstest` plugin so each page describes the rule on its own terms.

## Changes

- **Rule Details** now states the behavior a user needs to know, including things that were previously only implied by an example: `valid-title`'s whitespace, non-string-title and duplicate-prefix checks, and the syntax forms `no-conditional-in-test` reports (`if`, `switch`, conditional expressions, `&&` / `||` / `??`, and optional chaining under `allowOptionalChaining`).
- **Examples** show one incorrect and one correct snippet that match what the rule is for, rather than edge cases. `valid-title` no longer leads with an invalid `.each` format specifier.
- **Options** sections follow one format everywhere: a multi-line JSON example that overrides the defaults, and a table with the option's type, default and a one-line description. Shared options such as `additionalTestBlockFunctions` are described identically across pages.
- **Autofix / Suggestions** sections state when a report is fixed and when it is only reported, instead of hedging with "supported" or "when behavior is preserved". `prefer-todo`, `prefer-called-exactly-once-with`, `prefer-expect-type-of` and `valid-expect` all name their real conditions.

No rule behavior changes; documentation only.
