### PR TITLE
refactor: remove configured rule compatibility alias

### DIFF
--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1659,7 +1659,7 @@ func TestCLIRuleOverlayDoesNotAlterTargetDiscovery(t *testing.T) {
 		Programs:         binding.Programs,
 		TargetsByProgram: targetsByProgram,
 		SingleThreaded:   true,
-		GetRulesForFile: func(sf *ast.SourceFile) []linter.ConfiguredRule {
+		GetRulesForFile: func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			return fileConfigResolver.EnabledRulesForSourcePath(sf.FileName())
 		},
 	})

--- a/cmd/rslint/program_test.go
+++ b/cmd/rslint/program_test.go
@@ -58,7 +58,7 @@ func TestGate_LinterFiltersTypeAwareRuleOnSourceOnlyProgram(t *testing.T) {
 	lintPlan, err := linter.PrepareLintPlan(linter.PrepareLintPlanOptions{
 		Programs:         loaded.Programs,
 		TargetsByProgram: loaded.TargetsByProgram,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			return configuredRules
 		},
 	})

--- a/internal/config/all_rules_test.go
+++ b/internal/config/all_rules_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
-	"github.com/web-infra-dev/rslint/internal/linter"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/testutil"
@@ -470,7 +469,7 @@ func countDiagnosticsForRule(t *testing.T, fileName, source string, impl rule.Ru
 		t.Fatalf("create program: %v", err)
 	}
 
-	configured := linter.ConfiguredRule{
+	configured := rule.ConfiguredRule{
 		Name:     impl.Name,
 		Severity: rule.SeverityWarning,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -494,11 +493,11 @@ func countDiagnosticsForRule(t *testing.T, fileName, source string, impl rule.Ru
 	testutil.LintProgram(t, testutil.LintProgramOptions{
 		Program:                sourceProgram,
 		ExcludedPathSubstrings: testutil.DefaultExcludedPathSubstrings,
-		GetRulesForFile: func(sf *tsast.SourceFile) []linter.ConfiguredRule {
+		GetRulesForFile: func(sf *tsast.SourceFile) []rule.ConfiguredRule {
 			if sf.FileName() != filePath {
 				return nil
 			}
-			return []linter.ConfiguredRule{configured}
+			return []rule.ConfiguredRule{configured}
 		},
 		OnDiagnostic: func(d rule.RuleDiagnostic) { count++ },
 	})
@@ -596,7 +595,7 @@ func TestGapFile_OptionalTypeCheckerRules_DoNotPanic(t *testing.T) {
 	}
 
 	var sawNilChecker, sawAnyListener bool
-	probe := linter.ConfiguredRule{
+	probe := rule.ConfiguredRule{
 		Name:     "gap-probe",
 		Severity: rule.SeverityWarning,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -615,7 +614,7 @@ func TestGapFile_OptionalTypeCheckerRules_DoNotPanic(t *testing.T) {
 	testutil.LintProgram(t, testutil.LintProgramOptions{
 		Program:                sourceProgram,
 		ExcludedPathSubstrings: testutil.DefaultExcludedPathSubstrings,
-		GetRulesForFile:        func(sf *tsast.SourceFile) []linter.ConfiguredRule { return configured },
+		GetRulesForFile:        func(sf *tsast.SourceFile) []rule.ConfiguredRule { return configured },
 		OnDiagnostic:           func(d rule.RuleDiagnostic) {},
 	})
 
@@ -631,16 +630,16 @@ func TestGapFile_OptionalTypeCheckerRules_DoNotPanic(t *testing.T) {
 // that does not set RequiresTypeInfo: true. Each rule is run with nil
 // options — the point is to exercise the listener / TypeChecker plumbing,
 // not to test correctness of the report payloads.
-func collectNonTypeAwareRules(t *testing.T) []linter.ConfiguredRule {
+func collectNonTypeAwareRules(t *testing.T) []rule.ConfiguredRule {
 	t.Helper()
 	all := baseRuleCatalog().AllRules()
-	out := make([]linter.ConfiguredRule, 0, len(all))
+	out := make([]rule.ConfiguredRule, 0, len(all))
 	for name, impl := range all {
 		if impl.RequiresTypeInfo {
 			continue
 		}
 		ruleImpl := impl
-		out = append(out, linter.ConfiguredRule{
+		out = append(out, rule.ConfiguredRule{
 			Name:     name,
 			Severity: rule.SeverityWarning,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/config/file_match_path_test.go
+++ b/internal/config/file_match_path_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -493,7 +493,7 @@ type configuredRuleView struct {
 	hasRun             bool
 }
 
-func configuredRuleViews(rules []linter.ConfiguredRule) []configuredRuleView {
+func configuredRuleViews(rules []rule.ConfiguredRule) []configuredRuleView {
 	views := make([]configuredRuleView, len(rules))
 	for index, configuredRule := range rules {
 		views[index] = configuredRuleView{

--- a/internal/linter/eslint_plugin_test.go
+++ b/internal/linter/eslint_plugin_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-func pluginRule(name string, opts []any, sev rule.DiagnosticSeverity) ConfiguredRule {
-	return ConfiguredRule{Name: name, Options: opts, Severity: sev, IsEslintPluginRule: true}
+func pluginRule(name string, opts []any, sev rule.DiagnosticSeverity) rule.ConfiguredRule {
+	return rule.ConfiguredRule{Name: name, Options: opts, Severity: sev, IsEslintPluginRule: true}
 }
 
 func TestDispatchEslintPluginRulesAsyncPublishesAfterCompletionObserver(t *testing.T) {
@@ -85,7 +85,7 @@ func TestBuildEslintPluginFileInput_EffectiveLanguageOptions(t *testing.T) {
 	raw := map[string]any{
 		"parserOptions": map[string]any{"ecmaFeatures": map[string]any{"jsx": true}},
 	}
-	rules := []ConfiguredRule{{
+	rules := []rule.ConfiguredRule{{
 		Name:               "plugin/rule",
 		IsEslintPluginRule: true,
 		Environment:        &rule.RuleEnvironment{},
@@ -145,10 +145,10 @@ func TestDispatchEslintPlugin_GroupsBySignature(t *testing.T) {
 	// A,B share (configKey + rule + options) → one batch; C differs in
 	// options → another; D differs in configKey → another. 3 batches total.
 	files := []EslintPluginFileInput{
-		{Path: "/a.ts", ConfigKey: "/cfg", Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
-		{Path: "/b.ts", ConfigKey: "/cfg", Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
-		{Path: "/c.ts", ConfigKey: "/cfg", Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o2"}, rule.SeverityError)}},
-		{Path: "/d.ts", ConfigKey: "/other", Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
+		{Path: "/a.ts", ConfigKey: "/cfg", Rules: []rule.ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
+		{Path: "/b.ts", ConfigKey: "/cfg", Rules: []rule.ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
+		{Path: "/c.ts", ConfigKey: "/cfg", Rules: []rule.ConfiguredRule{pluginRule("uc/x", []any{"o2"}, rule.SeverityError)}},
+		{Path: "/d.ts", ConfigKey: "/other", Rules: []rule.ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
 	}
 	var (
 		mu      sync.Mutex
@@ -192,8 +192,8 @@ func TestDispatchEslintPlugin_SeverityDoesNotFragmentBatches(t *testing.T) {
 	// so these must share exactly ONE batch — yet each file keeps its severity.
 	ta, tb := "a\n", "b\n"
 	files := []EslintPluginFileInput{
-		{Path: "/a.ts", ConfigKey: "/cfg", Text: &ta, Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
-		{Path: "/b.ts", ConfigKey: "/cfg", Text: &tb, Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityWarning)}},
+		{Path: "/a.ts", ConfigKey: "/cfg", Text: &ta, Rules: []rule.ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
+		{Path: "/b.ts", ConfigKey: "/cfg", Text: &tb, Rules: []rule.ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityWarning)}},
 	}
 	var (
 		mu         sync.Mutex
@@ -244,7 +244,7 @@ func TestDispatchEslintPlugin_ConcurrentBatchesAllEmitted(t *testing.T) {
 			Path:      fmt.Sprintf("/f%d.ts", i),
 			ConfigKey: "/cfg",
 			Text:      &texts[i],
-			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct options → distinct batch
+			Rules:     []rule.ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct options → distinct batch
 		}
 	}
 	var (
@@ -297,7 +297,7 @@ func TestDispatchEslintPlugin_BatchFailureDoesNotAbortOthers(t *testing.T) {
 			Path:      fmt.Sprintf("/f%d.ts", i),
 			ConfigKey: "/cfg",
 			Text:      &texts[i],
-			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)},
+			Rules:     []rule.ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)},
 		}
 	}
 	wantErr := errors.New("boom")
@@ -340,7 +340,7 @@ func TestDispatchEslintPlugin_FirstBatchErrorWins(t *testing.T) {
 			Path:      fmt.Sprintf("/f%d.ts", i),
 			ConfigKey: "/cfg",
 			Text:      &texts[i],
-			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct options → own batch, order f0..f5
+			Rules:     []rule.ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct options → own batch, order f0..f5
 		}
 	}
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
@@ -362,7 +362,7 @@ func TestDispatchEslintPlugin_FirstBatchErrorWins(t *testing.T) {
 func TestDispatchEslintPlugin_SeverityReattachAndClamp(t *testing.T) {
 	text := "abc\n" // len 4 bytes
 	files := []EslintPluginFileInput{
-		{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityWarning)}},
+		{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityWarning)}},
 	}
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 		return &EslintPluginLintResult{Results: []EslintPluginFileResult{{
@@ -408,7 +408,7 @@ func TestDispatchEslintPlugin_SeverityReattachAndClamp(t *testing.T) {
 func TestDispatchEslintPlugin_ParseErrorClasses(t *testing.T) {
 	text := "x"
 	mkFiles := func() []EslintPluginFileInput {
-		return []EslintPluginFileInput{{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}}}
+		return []EslintPluginFileInput{{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}}}
 	}
 	run := func(fr EslintPluginFileResult) []rule.RuleDiagnostic {
 		dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
@@ -482,7 +482,7 @@ func TestDispatchEslintPlugin_ParseErrorClasses(t *testing.T) {
 
 func TestDispatchEslintPlugin_Cancelled(t *testing.T) {
 	text := "x"
-	files := []EslintPluginFileInput{{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}}}
+	files := []EslintPluginFileInput{{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}}}
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 		return &EslintPluginLintResult{Results: []EslintPluginFileResult{{FilePath: "/a.ts", Cancelled: true}}}, nil
 	}
@@ -494,7 +494,7 @@ func TestDispatchEslintPlugin_Cancelled(t *testing.T) {
 
 func TestDispatchEslintPlugin_MissingResultNoPanic(t *testing.T) {
 	text := "x"
-	files := []EslintPluginFileInput{{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}}}
+	files := []EslintPluginFileInput{{Path: "/a.ts", ConfigKey: "/cfg", Text: &text, Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}}}
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 		return &EslintPluginLintResult{Results: nil}, nil // no result for /a.ts
 	}
@@ -564,7 +564,7 @@ func TestDispatchEslintPlugin_FrameReuseOverlayAndNoFrame(t *testing.T) {
 	// bytes 6..12 (two 3-byte runes), so a [6,12] worker offset must land on them.
 	sf := newTextSourceFile("const 变量 = 1;")
 	files := []EslintPluginFileInput{
-		{Path: "/a.ts", ConfigKey: "/cfg", SourceFile: sf, Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}},
+		{Path: "/a.ts", ConfigKey: "/cfg", SourceFile: sf, Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}},
 	}
 	dispatch := func(_ context.Context, _ EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 		return &EslintPluginLintResult{Results: []EslintPluginFileResult{{
@@ -595,7 +595,7 @@ func TestDispatchEslintPlugin_FrameReuseOverlayAndNoFrame(t *testing.T) {
 	const code = "const x = 1;"
 	bomText := "\ufeff" + code
 	files2 := []EslintPluginFileInput{
-		{Path: "/b.ts", ConfigKey: "/cfg", Text: &bomText, Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}},
+		{Path: "/b.ts", ConfigKey: "/cfg", Text: &bomText, Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}},
 	}
 	dispatch2 := func(_ context.Context, _ EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 		return &EslintPluginLintResult{Results: []EslintPluginFileResult{{
@@ -631,7 +631,7 @@ func TestDispatchEslintPlugin_FrameReuseOverlayAndNoFrame(t *testing.T) {
 
 	// (c) Neither SourceFile nor Text -> surface a 'no source frame' error.
 	files3 := []EslintPluginFileInput{
-		{Path: "/c.ts", ConfigKey: "/cfg", Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}},
+		{Path: "/c.ts", ConfigKey: "/cfg", Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)}},
 	}
 	dispatch3 := func(_ context.Context, _ EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 		return &EslintPluginLintResult{Results: []EslintPluginFileResult{{
@@ -740,7 +740,7 @@ func TestDispatchEslintPlugin_MultipleRulesPerFile(t *testing.T) {
 	text := "x\n"
 	files := []EslintPluginFileInput{{
 		Path: "/a.ts", ConfigKey: "/cfg", Text: &text,
-		Rules: []ConfiguredRule{
+		Rules: []rule.ConfiguredRule{
 			pluginRule("uc/a", []any{"o"}, rule.SeverityError),
 			pluginRule("uc/b", nil, rule.SeverityWarning),
 		},
@@ -797,7 +797,7 @@ func TestDispatchEslintPlugin_DeadlineExceededSurfaces(t *testing.T) {
 			Path:      fmt.Sprintf("/f%d.ts", i),
 			ConfigKey: "/cfg",
 			Text:      &texts[i],
-			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct option → distinct batch
+			Rules:     []rule.ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct option → distinct batch
 		}
 	}
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
@@ -833,7 +833,7 @@ func TestDispatchEslintPlugin_FixAndSuggestionsRebuilt(t *testing.T) {
 	text := "const x = 1;\n"
 	files := []EslintPluginFileInput{{
 		Path: "/a.ts", ConfigKey: "/cfg", Text: &text,
-		Rules: []ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)},
+		Rules: []rule.ConfiguredRule{pluginRule("uc/x", nil, rule.SeverityError)},
 	}}
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 		return &EslintPluginLintResult{Results: []EslintPluginFileResult{{
@@ -889,7 +889,7 @@ func TestDispatchEslintPlugin_EmitsInBatchOrderDespiteOutOfOrderCompletion(t *te
 			Path:      fmt.Sprintf("/f%d.ts", i),
 			ConfigKey: "/cfg",
 			Text:      &texts[i],
-			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct option → own batch
+			Rules:     []rule.ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct option → own batch
 		}
 	}
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
@@ -924,7 +924,7 @@ func TestDispatchEslintPlugin_RealErrorOutranksCanceled(t *testing.T) {
 			Path:      fmt.Sprintf("/f%d.ts", i),
 			ConfigKey: "/cfg",
 			Text:      &txt,
-			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)},
+			Rules:     []rule.ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)},
 		}
 	}
 	files := []EslintPluginFileInput{mkFile(0), mkFile(1)}
@@ -952,11 +952,11 @@ func TestBuildEslintPluginFileInputsUsesPreparedPlan(t *testing.T) {
 	if nativeFile == nil || pluginFile == nil {
 		t.Fatalf("prepared plan fixtures are missing: native=%v plugin=%v", nativeFile != nil, pluginFile != nil)
 	}
-	nativeRule := ConfiguredRule{Name: "native/rule", Severity: rule.SeverityError}
+	nativeRule := rule.ConfiguredRule{Name: "native/rule", Severity: rule.SeverityError}
 	pluginConfiguredRule := pluginRule("external/rule", []any{"option"}, rule.SeverityWarning)
 	plan := &LintPlan{programs: []programLintPlan{{files: []lintFilePlan{
-		{file: nativeFile, rules: []ConfiguredRule{nativeRule}},
-		{file: pluginFile, rules: []ConfiguredRule{nativeRule, pluginConfiguredRule}},
+		{file: nativeFile, rules: []rule.ConfiguredRule{nativeRule}},
+		{file: pluginFile, rules: []rule.ConfiguredRule{nativeRule, pluginConfiguredRule}},
 	}}}}
 
 	resolveCalls := 0
@@ -1003,13 +1003,13 @@ func TestDispatchEslintPluginRulesWithOutcomeSurfacesFailure(t *testing.T) {
 			Path:      "/repo/good.ts",
 			ConfigKey: "/repo",
 			Text:      &goodText,
-			Rules:     []ConfiguredRule{pluginRule("external/rule", []any{"good"}, rule.SeverityWarning)},
+			Rules:     []rule.ConfiguredRule{pluginRule("external/rule", []any{"good"}, rule.SeverityWarning)},
 		},
 		{
 			Path:      "/repo/bad.ts",
 			ConfigKey: "/repo",
 			Text:      &badText,
-			Rules:     []ConfiguredRule{pluginRule("external/rule", []any{"bad"}, rule.SeverityError)},
+			Rules:     []rule.ConfiguredRule{pluginRule("external/rule", []any{"bad"}, rule.SeverityError)},
 		},
 	}
 	dispatchError := errors.New("WorkerPool: closed")
@@ -1068,7 +1068,7 @@ func TestDispatchEslintPluginRulesWithOutcomePreservesCancellation(t *testing.T)
 		[]EslintPluginFileInput{{
 			Path:      "/repo/a.ts",
 			ConfigKey: "/repo",
-			Rules:     []ConfiguredRule{pluginRule("external/rule", nil, rule.SeverityError)},
+			Rules:     []rule.ConfiguredRule{pluginRule("external/rule", nil, rule.SeverityError)},
 		}},
 		false,
 		SuggestionsModeOff,

--- a/internal/linter/lint_plan_test.go
+++ b/internal/linter/lint_plan_test.go
@@ -76,12 +76,12 @@ func TestPreparedLintPlanPreservesNativeSemanticsAndIsReused(t *testing.T) {
 	}
 
 	newRuleHandler := func(calls map[string]int) RuleHandler {
-		return func(file *ast.SourceFile) []ConfiguredRule {
+		return func(file *ast.SourceFile) []rule.ConfiguredRule {
 			calls[file.FileName()]++
 			switch file.FileName() {
 			case paths["a.ts"]:
 				rules := noopRule()
-				return append(rules, ConfiguredRule{
+				return append(rules, rule.ConfiguredRule{
 					Name:               "community/plugin-rule",
 					Severity:           rule.SeverityWarning,
 					IsEslintPluginRule: true,
@@ -90,7 +90,7 @@ func TestPreparedLintPlanPreservesNativeSemanticsAndIsReused(t *testing.T) {
 				typeAwareRule := noopRule()[0]
 				typeAwareRule.Name = "type-aware-rule"
 				typeAwareRule.RequiresTypeInfo = true
-				return []ConfiguredRule{typeAwareRule}
+				return []rule.ConfiguredRule{typeAwareRule}
 			default:
 				return nil
 			}
@@ -150,8 +150,8 @@ func TestLintPlanRunsSourceOnlyProgramWithoutChecker(t *testing.T) {
 		Programs:         programs,
 		TargetsByProgram: [][]string{{file.FileName()}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{
 				{
 					Name:     "source-only-native",
 					Severity: rule.SeverityError,
@@ -237,12 +237,12 @@ func TestSourceOnlyPlanSeparatesUniverseFromExecutionProjection(t *testing.T) {
 		Programs:         programs,
 		TargetsByProgram: [][]string{{a.FileName()}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(file *ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(file *ast.SourceFile) []rule.ConfiguredRule {
 			resolved.Add(1)
 			if file != a {
 				t.Fatalf("resolved rules for %q, want only a.ts", file.FileName())
 			}
-			return []ConfiguredRule{{
+			return []rule.ConfiguredRule{{
 				Name:     "source-only-projection",
 				Severity: rule.SeverityError,
 				Run: func(rule.RuleContext) rule.RuleListeners {
@@ -300,8 +300,8 @@ func TestSourceOnlyProgramSharesModuleGraphAndDerivedCache(t *testing.T) {
 		Programs:         programs,
 		TargetsByProgram: [][]string{{files[0].FileName(), files[1].FileName()}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "source-only-modules",
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -365,8 +365,8 @@ func TestSourceOnlyProgramRunsProgramIndexedImportRule(t *testing.T) {
 		Programs:         programs,
 		TargetsByProgram: [][]string{{files[0].FileName()}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     no_cycle.NoCycleRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -430,8 +430,8 @@ func checkerFreeExecutionTestOptions(
 		Programs:         programs,
 		TargetsByProgram: [][]string{targets},
 		SingleThreaded:   singleThreaded,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "checker-free-concurrency",
 				Severity: rule.SeverityError,
 				Run:      run,
@@ -565,7 +565,7 @@ func TestPrepareLintPlanParallelizesRuleResolution(t *testing.T) {
 	opts := PrepareLintPlanOptions{
 		Programs:         wrapTestPrograms(program),
 		TargetsByProgram: [][]string{{paths["a.ts"], paths["b.ts"], paths["c.ts"], paths["d.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			if active.Add(1) >= 2 && signaled.CompareAndSwap(false, true) {
 				close(twoActive)
 			}
@@ -608,7 +608,7 @@ func TestPrepareLintPlanHonorsSingleThreadedOrder(t *testing.T) {
 		Programs:         wrapTestPrograms(program),
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{wantOrder},
-		GetRulesForFile: func(file *ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(file *ast.SourceFile) []rule.ConfiguredRule {
 			gotOrder = append(gotOrder, file.FileName())
 			return noopRule()
 		},
@@ -630,7 +630,7 @@ func TestPreparedLintPlanPreservesSameFileAcrossProgramsInParallel(t *testing.T)
 	plan := mustPrepareLintPlan(t, PrepareLintPlanOptions{
 		Programs:         programs,
 		TargetsByProgram: [][]string{{paths["shared.ts"]}, {paths["shared.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			calls.Add(1)
 			return noopRule()
 		},
@@ -661,7 +661,7 @@ func TestPrepareLintPlanDeduplicatesTargetsInFirstOccurrenceOrder(t *testing.T) 
 		Programs:         wrapTestPrograms(raw),
 		TargetsByProgram: [][]string{{paths["b.ts"], paths["a.ts"], paths["b.ts"]}},
 		SingleThreaded:   true,
-		GetRulesForFile:  func(*ast.SourceFile) []ConfiguredRule { return noopRule() },
+		GetRulesForFile:  func(*ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 	})
 	targets := plan.Targets()
 	if len(targets) != 2 || targets[0].File.FileName() != paths["b.ts"] || targets[1].File.FileName() != paths["a.ts"] {
@@ -689,7 +689,7 @@ func TestRunLinterRejectsTypeCheckOnlyProgramsWithLintPlan(t *testing.T) {
 		Programs:         wrapTestPrograms(programA),
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{pathsA["a.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			configured := noopRule()
 			configured[0].Run = func(rule.RuleContext) rule.RuleListeners {
 				runs.Add(1)
@@ -718,7 +718,7 @@ func TestPrepareLintPlanRequiresTargetsForEveryProgram(t *testing.T) {
 		_, err := PrepareLintPlan(PrepareLintPlanOptions{
 			Programs:         programs,
 			TargetsByProgram: targetsByProgram,
-			GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 				ruleCalls.Add(1)
 				return noopRule()
 			},
@@ -754,7 +754,7 @@ func TestPrepareLintPlanRejectsTargetOutsideBoundProgramBeforeRuleResolution(t *
 	_, err := PrepareLintPlan(PrepareLintPlanOptions{
 		Programs:         wrapTestPrograms(raw),
 		TargetsByProgram: [][]string{{paths["a.ts"], missing}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			ruleCalls.Add(1)
 			return noopRule()
 		},
@@ -780,7 +780,7 @@ func TestPrepareLintPlanDoesNotReapplyDefaultExclusions(t *testing.T) {
 		Programs:         wrapTestPrograms(raw),
 		TargetsByProgram: [][]string{{target}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			ruleCalls.Add(1)
 			return noopRule()
 		},
@@ -804,7 +804,7 @@ func TestSyntaxErrorTargetIsCountedWithoutResolvingOrRunningRules(t *testing.T) 
 		Programs:         wrapTestPrograms(raw),
 		TargetsByProgram: [][]string{{target}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			ruleCalls.Add(1)
 			return noopRule()
 		},
@@ -831,7 +831,7 @@ func TestRunLinterRejectsNilProgramBeforeLintSideEffects(t *testing.T) {
 	planOpts := PrepareLintPlanOptions{
 		Programs:         append(wrapTestPrograms(raw), nil),
 		TargetsByProgram: [][]string{{paths["a.ts"]}, nil},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			ruleCalls.Add(1)
 			return noopRule()
 		},
@@ -859,7 +859,7 @@ func TestRunLinterRejectsNilProgramBeforeLintSideEffects(t *testing.T) {
 	invalidOpts := PrepareLintPlanOptions{
 		Programs:         []*lintprogram.Program{invalid},
 		TargetsByProgram: [][]string{nil},
-		GetRulesForFile:  func(*ast.SourceFile) []ConfiguredRule { return noopRule() },
+		GetRulesForFile:  func(*ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 	}
 	if _, err := PrepareLintPlan(invalidOpts); !errors.Is(err, errInvalidProgram) {
 		t.Fatalf("PrepareLintPlan zero Program error = %v", err)
@@ -895,8 +895,8 @@ func TestPreparedLintPlanFreezesProgramTypeCapability(t *testing.T) {
 			plan := mustPrepareLintPlan(t, PrepareLintPlanOptions{
 				Programs:         programs,
 				TargetsByProgram: [][]string{{paths["a.ts"]}},
-				GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-					return []ConfiguredRule{{
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{
 						Name:             "type-aware-probe",
 						RequiresTypeInfo: true,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -938,7 +938,7 @@ func TestLintSingleFileRejectsFileOutsideProgram(t *testing.T) {
 	LintSingleFile(LintSingleFileOptions{
 		Program: lintprogram.NewFromCompiler(raw),
 		File:    missing,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			t.Fatal("missing single-file target resolved rules")
 			return nil
 		},

--- a/internal/linter/linter_allowdirs_test.go
+++ b/internal/linter/linter_allowdirs_test.go
@@ -19,7 +19,7 @@ func TestRunLinterInProgram_AllowDirsBasic(t *testing.T) {
 	lintedFileNames := []string{}
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{srcDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -47,7 +47,7 @@ func TestRunLinterInProgram_AllowDirsNoFalsePrefix(t *testing.T) {
 	lintedFileNames := []string{}
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{srcDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -79,7 +79,7 @@ func TestRunLinterInProgram_AllowDirsAndFilesOR(t *testing.T) {
 		[]string{paths["lib/b.ts"]}, // allowFiles
 		[]string{srcDir},            // allowDirs
 		legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -103,7 +103,7 @@ func TestRunLinterInProgram_AllowDirsEmpty(t *testing.T) {
 	})
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -120,7 +120,7 @@ func TestRunLinterInProgram_BothNilLintsAll(t *testing.T) {
 	})
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -142,7 +142,7 @@ func TestRunLinterInProgram_MultipleAllowDirs(t *testing.T) {
 	lintedFileNames := []string{}
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{srcDir, libDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -169,7 +169,7 @@ func TestRunLinterInProgram_AllowDirsWithEmptyAllowFiles(t *testing.T) {
 	srcDir := tmpDirPath(t, paths, "src/a.ts")
 
 	lintedFiles := runLinterInCompilerProgram(program, []string{}, []string{srcDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -185,7 +185,7 @@ func TestRunLinterInProgram_AllowDirsNoMatchInProgram(t *testing.T) {
 	})
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{"/nonexistent/dir"}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -206,7 +206,7 @@ func TestRunLinterInProgram_NestedAllowDirs(t *testing.T) {
 	lintedFileNames := []string{}
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{componentsDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -231,7 +231,7 @@ func TestRunLinterInProgram_AllowDirsEmptyString(t *testing.T) {
 
 	// Empty string as allowDir should not match anything
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{""}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -250,7 +250,7 @@ func TestRunLinterInProgram_AllowDirsTrailingSlash(t *testing.T) {
 	// Trailing slash should still work
 	srcDir := tmpDirPath(t, paths, "src/a.ts") + "/"
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{srcDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -268,7 +268,7 @@ func TestRunLinterInProgram_AllowDirsSameAsFilePath(t *testing.T) {
 	// Using the exact file path as allowDir should NOT match
 	// (a file is not "inside" itself)
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{paths["src/a.ts"]}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -291,7 +291,7 @@ func TestRunLinterInProgram_AllowDirsAndFilesOverlap(t *testing.T) {
 		[]string{paths["src/a.ts"]},
 		[]string{srcDir},
 		legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) { diagnosticCount++ }, nil,
 		nil,
 	)
@@ -372,7 +372,7 @@ func TestRunLinter_AllowDirsIntegration(t *testing.T) {
 
 	srcDir := tmpDirPath(t, paths, "src/a.ts")
 	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, []string{srcDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -401,7 +401,7 @@ func TestRunLinter_MultiplePrograms(t *testing.T) {
 		[]string{pathsA["a.ts"], pathsB["b.ts"]},
 		nil,
 		legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -436,7 +436,7 @@ func TestRunLinter_MultipleProgramsWithAllowDirs(t *testing.T) {
 		nil,
 		[]string{srcDirA, srcDirB},
 		legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -460,7 +460,7 @@ func TestRunLinterInProgram_SkipTakesPriorityOverAllowDirs(t *testing.T) {
 	// allowDirs would include src/a.ts, but skipFiles should take priority
 	lintedFiles := runLinterInCompilerProgram(program, nil, []string{srcDir},
 		[]string{"src"}, // skip pattern matching "src" in path
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -477,7 +477,7 @@ func TestRunLinterInProgram_SkipTakesPriorityOverAllowFiles(t *testing.T) {
 
 	lintedFiles := runLinterInCompilerProgram(program, []string{paths["src/a.ts"]}, nil,
 		[]string{"src"}, // skip pattern matching "src" in path
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -494,7 +494,7 @@ func TestRunLinterInProgram_BothEmptyNonNil(t *testing.T) {
 
 	// Both non-nil but empty → filter is active, nothing passes
 	lintedFiles := runLinterInCompilerProgram(program, []string{}, []string{}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -511,7 +511,7 @@ func TestRunLinterInProgram_EmptyNonNilRules(t *testing.T) {
 
 	diagnosticCount := 0
 	lintedFiles := runLinterInCompilerProgram(program, []string{paths["a.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return []ConfiguredRule{} }, // empty non-nil
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return []rule.ConfiguredRule{} }, // empty non-nil
 		false, func(d rule.RuleDiagnostic) { diagnosticCount++ }, nil,
 		nil,
 	)

--- a/internal/linter/linter_allowfiles_test.go
+++ b/internal/linter/linter_allowfiles_test.go
@@ -24,7 +24,7 @@ func TestRunLinterInProgram_AllowFilesNil(t *testing.T) {
 	})
 
 	lintedFiles := runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -43,7 +43,7 @@ func TestRunLinterInProgram_AllowFilesSingle(t *testing.T) {
 
 	lintedFileNames := []string{}
 	lintedFiles := runLinterInCompilerProgram(program, []string{paths["a.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -70,7 +70,7 @@ func TestRunLinterInProgram_AllowFilesMultiple(t *testing.T) {
 
 	lintedFileNames := []string{}
 	lintedFiles := runLinterInCompilerProgram(program, []string{paths["a.ts"], paths["c.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -94,7 +94,7 @@ func TestRunLinterInProgram_AllowFilesEmpty(t *testing.T) {
 	})
 
 	lintedFiles := runLinterInCompilerProgram(program, []string{}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -111,7 +111,7 @@ func TestRunLinterInProgram_AllowFilesNotInProgram(t *testing.T) {
 
 	nonexistent := tspath.NormalizePath(filepath.Join(t.TempDir(), "nonexistent.ts"))
 	lintedFiles := runLinterInCompilerProgram(program, []string{nonexistent}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -128,7 +128,7 @@ func TestRunLinterInProgram_AllowFilesNoRules(t *testing.T) {
 
 	diagnostics := []rule.RuleDiagnostic{}
 	lintedFiles := runLinterInCompilerProgram(program, []string{paths["a.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		false, func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
 	)
@@ -150,7 +150,7 @@ func TestRunLinterInProgram_AllowFilesPartialMatch(t *testing.T) {
 	nonexistent := tspath.NormalizePath(filepath.Join(t.TempDir(), "nonexistent.ts"))
 	lintedFileNames := []string{}
 	lintedFiles := runLinterInCompilerProgram(program, []string{paths["a.ts"], nonexistent}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -169,7 +169,7 @@ func TestRunLinterInProgram_AllowFilesDuplicate(t *testing.T) {
 	})
 
 	lintedFiles := runLinterInCompilerProgram(program, []string{paths["a.ts"], paths["a.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -187,7 +187,7 @@ func TestRunLinter_AllowFilesIntegration(t *testing.T) {
 
 	lintedFileNames := []string{}
 	result, err := runLinterPositional([]*compiler.Program{program}, true, []string{paths["b.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
 		},
@@ -210,7 +210,7 @@ func TestRunLinter_AllowFilesNilPassthrough(t *testing.T) {
 	})
 
 	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
 	)
@@ -234,7 +234,7 @@ func TestRunLinter_TargetFilesEmptyDoesNotScanProgram(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{nil},
-		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			called = true
 			return noopRule()
 		},
@@ -269,7 +269,7 @@ func TestRunLinter_TargetFilesCanSelectImportedNonRootFile(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{target}},
-		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			linted = append(linted, sf.FileName())
 			return noopRule()
 		},
@@ -302,7 +302,7 @@ func TestLintSingleFile_TargetsImportedNonRootFile(t *testing.T) {
 	LintSingleFile(LintSingleFileOptions{
 		Program: lintprogram.NewFromCompiler(program),
 		File:    target,
-		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			linted = append(linted, sf.FileName())
 			return noopRule()
 		},

--- a/internal/linter/linter_dedup_test.go
+++ b/internal/linter/linter_dedup_test.go
@@ -88,7 +88,7 @@ func collectLintedFiles(t *testing.T, programs []*compiler.Program) map[string]i
 	counts := make(map[string]int)
 	_, err := runLinterPositional(
 		programs, true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			counts[sf.FileName()]++
 			return noopRule()
 		},
@@ -281,7 +281,7 @@ func TestRunLinter_DiagnosticsNotDuplicated(t *testing.T) {
 	// Baseline: diagnostic count for lib.ts in single-program mode
 	singleDiags := 0
 	runLinterInCompilerProgram(programLib, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {
 			if d.FilePath == libPath {
 				singleDiags++
@@ -297,7 +297,7 @@ func TestRunLinter_DiagnosticsNotDuplicated(t *testing.T) {
 	runLinterPositional(
 		[]*compiler.Program{programLib, programApp},
 		true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {
 			if d.FilePath == libPath {
 				multiDiags++
@@ -426,7 +426,7 @@ func TestLegacySingleProgramScopeCanSelectImportedFile(t *testing.T) {
 	// The explicit compatibility scope is not constrained by root ownership.
 	lintedFiles := make(map[string]int)
 	runLinterInCompilerProgram(program, []string{libPath}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			lintedFiles[sf.FileName()]++
 			return noopRule()
 		},

--- a/internal/linter/linter_edits_test.go
+++ b/internal/linter/linter_edits_test.go
@@ -77,8 +77,8 @@ func TestRunLinterDiagnosticConsumerEditDemand(t *testing.T) {
 				Programs:         programs,
 				SingleThreaded:   true,
 				TargetsByProgram: [][]string{{paths["edits.ts"]}},
-				GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-					return []ConfiguredRule{{
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{
 						Name:     "edit-demand",
 						Severity: rule.SeverityWarning,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -177,8 +177,8 @@ func TestRunLinterDeferredFixesSkipSuppressedDiagnostic(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{paths["suppressed.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "deferred-rule",
 				Severity: rule.SeverityWarning,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -233,8 +233,8 @@ func TestRunLinterDeferredBuilderMayDeclineArtifact(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{paths["decline.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "decline-fix",
 				Severity: rule.SeverityWarning,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -308,8 +308,8 @@ func TestRunLinterLegacyReportsRespectEditDemand(t *testing.T) {
 				Programs:         programs,
 				SingleThreaded:   true,
 				TargetsByProgram: [][]string{{paths["legacy.ts"]}},
-				GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-					return []ConfiguredRule{{
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{
 						Name:     "legacy-report",
 						Severity: rule.SeverityWarning,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -361,8 +361,8 @@ func TestRunLinterDiscardingConsumerSkipsDeferredEdits(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{paths["discarded.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "discarded",
 				Severity: rule.SeverityWarning,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/linter/linter_pattern_traversal_test.go
+++ b/internal/linter/linter_pattern_traversal_test.go
@@ -18,8 +18,8 @@ func runPatternTraversalTest(t *testing.T, source string, listeners rule.RuleLis
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{paths["input.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "pattern-traversal",
 				Severity: rule.SeverityWarning,
 				Run: func(rule.RuleContext) rule.RuleListeners {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 // noopRule returns a rule that reports on every identifier (for testing file filtering).
-func noopRule() []ConfiguredRule {
-	return []ConfiguredRule{
+func noopRule() []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{
 		{
 			Name:     "test-rule",
 			Severity: rule.SeverityWarning,
@@ -123,8 +123,8 @@ const runtime = null;`,
 		Programs:         programs,
 		TargetsByProgram: [][]string{{paths["input.mjs"]}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "jsdoc-traversal-boundary",
 				Severity: rule.SeverityError,
 				Run: func(rule.RuleContext) rule.RuleListeners {
@@ -213,8 +213,8 @@ func TestRunLinter_ExecutedRules(t *testing.T) {
 	})
 
 	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{
 				{Name: "rule-a", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
 				{Name: "rule-b", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
 			}
@@ -246,8 +246,8 @@ func TestRunLinter_DoesNotExecutePluginPlaceholderInNativePass(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{paths["a.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:               "community/example",
 				IsEslintPluginRule: true,
 				Run: func(rule.RuleContext) rule.RuleListeners {
@@ -288,8 +288,8 @@ func TestRunLinter_GlobalDeclarationMetadata(t *testing.T) {
 
 	var captured *rule.RuleContext
 	result, err := runLinterPositional([]*compiler.Program{program}, true, []string{paths["globals.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name: "capture-globals",
 				Environment: &rule.RuleEnvironment{
 					LanguageOptions: languageOptions,
@@ -375,13 +375,13 @@ func TestRunLinter_ExecutedRulesPerFile(t *testing.T) {
 
 	// Different files get different rules — ExecutedRules should be the union.
 	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule {
+		func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			if sf.FileName() == paths["a.ts"] {
-				return []ConfiguredRule{
+				return []rule.ConfiguredRule{
 					{Name: "only-a", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
 				}
 			}
-			return []ConfiguredRule{
+			return []rule.ConfiguredRule{
 				{Name: "only-b", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
 			}
 		},
@@ -410,8 +410,8 @@ func TestRunLinter_ExecutedRulesAcrossPrograms(t *testing.T) {
 		"b.ts": "const b = 2;",
 	})
 
-	configuredRule := func(name string) ConfiguredRule {
-		return ConfiguredRule{
+	configuredRule := func(name string) rule.ConfiguredRule {
+		return rule.ConfiguredRule{
 			Name:     name,
 			Severity: rule.SeverityWarning,
 			Run:      func(rule.RuleContext) rule.RuleListeners { return nil },
@@ -421,11 +421,11 @@ func TestRunLinter_ExecutedRulesAcrossPrograms(t *testing.T) {
 	lintPlan := mustPrepareLintPlan(t, PrepareLintPlanOptions{
 		Programs:         programs,
 		TargetsByProgram: [][]string{{pathsA["a.ts"]}, {pathsB["b.ts"]}},
-		GetRulesForFile: func(file *ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(file *ast.SourceFile) []rule.ConfiguredRule {
 			if file.FileName() == pathsA["a.ts"] {
-				return []ConfiguredRule{configuredRule("shared"), configuredRule("only-a")}
+				return []rule.ConfiguredRule{configuredRule("shared"), configuredRule("only-a")}
 			}
-			return []ConfiguredRule{configuredRule("shared"), configuredRule("only-b")}
+			return []rule.ConfiguredRule{configuredRule("shared"), configuredRule("only-b")}
 		},
 	})
 	result, err := RunLinter(RunLinterOptions{
@@ -454,7 +454,7 @@ func TestRunLinter_ExecutedRulesEmpty(t *testing.T) {
 
 	// No rules returned → ExecutedRules should be empty.
 	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		false, func(d rule.RuleDiagnostic) {}, nil, nil,
 	)
 
@@ -515,8 +515,8 @@ func TestListenerRegistryIsolationAndRuleOrderAcrossFiles(t *testing.T) {
 		"b.ts": "const beta = 2;",
 	})
 
-	configuredListenerRule := func(kind ast.Kind, name string, severity rule.DiagnosticSeverity) ConfiguredRule {
-		return ConfiguredRule{
+	configuredListenerRule := func(kind ast.Kind, name string, severity rule.DiagnosticSeverity) rule.ConfiguredRule {
+		return rule.ConfiguredRule{
 			Name:     name,
 			Severity: severity,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -535,14 +535,14 @@ func TestListenerRegistryIsolationAndRuleOrderAcrossFiles(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{paths["a.ts"], paths["b.ts"]}},
-		GetRulesForFile: func(sourceFile *ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
 			if sourceFile.FileName() == paths["a.ts"] {
-				return []ConfiguredRule{
+				return []rule.ConfiguredRule{
 					configuredListenerRule(ast.KindIdentifier, "a-first", rule.SeverityWarning),
 					configuredListenerRule(ast.KindIdentifier, "a-second", rule.SeverityError),
 				}
 			}
-			return []ConfiguredRule{
+			return []rule.ConfiguredRule{
 				configuredListenerRule(ast.KindNumericLiteral, "b-first", rule.SeverityError),
 				configuredListenerRule(ast.KindNumericLiteral, "b-second", rule.SeverityWarning),
 			}
@@ -618,8 +618,8 @@ func TestRuleContextReporterPreservesDiagnosticSemantics(t *testing.T) {
 		Programs:         programs,
 		SingleThreaded:   true,
 		TargetsByProgram: [][]string{{paths["reporter.ts"]}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "reporter-semantics",
 				Severity: rule.SeverityWarning,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -717,8 +717,8 @@ func TestRunLinterCachesOncePerFileAcrossRules(t *testing.T) {
 	values := make(map[string][]*int)
 	builds := make(map[string]int)
 
-	makeRule := func(name string) ConfiguredRule {
-		return ConfiguredRule{
+	makeRule := func(name string) rule.ConfiguredRule {
+		return rule.ConfiguredRule{
 			Name:     name,
 			Severity: rule.SeverityWarning,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -741,8 +741,8 @@ func TestRunLinterCachesOncePerFileAcrossRules(t *testing.T) {
 			paths["first.test.ts"],
 			paths["second.test.ts"],
 		}},
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
-			return []ConfiguredRule{makeRule("first-rule"), makeRule("second-rule")}
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{makeRule("first-rule"), makeRule("second-rule")}
 		},
 	})
 	_, err := RunLinter(RunLinterOptions{

--- a/internal/linter/linter_typecheck_test.go
+++ b/internal/linter/linter_typecheck_test.go
@@ -30,7 +30,7 @@ func TestTypeCheck_ReportsSemanticErrors(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true, // typeCheck enabled
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -62,7 +62,7 @@ func TestTypeCheck_Disabled_NoSemanticErrors(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		false, // typeCheck disabled
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -82,7 +82,7 @@ func TestTypeCheck_RuleNameFormat(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -116,7 +116,7 @@ func TestTypeCheck_SeverityIsError(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -138,7 +138,7 @@ func TestTypeCheck_NoErrorsOnValidCode(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -161,7 +161,7 @@ func TestTypeCheck_CoexistsWithLintRules(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -198,7 +198,7 @@ func TestTypeCheck_NotConstrainedByAllowFiles(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, []string{paths["a.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -231,7 +231,7 @@ func TestTypeCheck_NotConstrainedByAllowDirs(t *testing.T) {
 	srcDir := tmpDirPath(t, paths, "src/a.ts")
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, []string{srcDir}, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -263,7 +263,7 @@ func TestTypeCheck_RunLinter_Integration(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	_, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -292,7 +292,7 @@ func TestTypeCheck_RunLinter_DisabledIntegration(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	_, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		false,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -322,7 +322,7 @@ const z: boolean = 'true';
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -348,7 +348,7 @@ func TestTypeCheck_MessageNotEmpty(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -370,7 +370,7 @@ func TestTypeCheck_MessageContainsAssignability(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -397,7 +397,7 @@ func TestTypeCheck_RangeIsValid(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -427,7 +427,7 @@ func TestTypeCheck_EmptyFile(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -447,7 +447,7 @@ func TestTypeCheck_OnlyComments(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -467,7 +467,7 @@ func TestTypeCheck_UndefinedVariable(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -496,7 +496,7 @@ x.foo;
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -524,7 +524,7 @@ func TestTypeCheck_MultipleFiles(t *testing.T) {
 
 	filesWithErrors := make(map[string]bool)
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) {
 			if strings.HasPrefix(d.RuleName, "TypeScript(") {
@@ -552,7 +552,7 @@ const x: Foo = { a: 'hello' };
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -706,7 +706,7 @@ func TestTypeCheck_NodeModulesIncludedWhenInProgram(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, []string{"node_modules"},
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -742,7 +742,7 @@ const x: number = 'hello';
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -765,7 +765,7 @@ const x: number = 'hello';
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -788,7 +788,7 @@ const x: number = 42;
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -820,7 +820,7 @@ func TestTypeCheck_NoFixesOrSuggestions(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -848,7 +848,7 @@ func TestTypeCheck_LintedFileCount(t *testing.T) {
 	})
 
 	count := runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) {}, nil,
 		nil,
@@ -866,7 +866,7 @@ func TestTypeCheck_LintedFileCountWithAllowFiles(t *testing.T) {
 	})
 
 	count := runLinterInCompilerProgram(program, []string{paths["a.ts"]}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) {}, nil,
 		nil,
@@ -887,7 +887,7 @@ func TestTypeCheck_SourceFileMatchesDiagnosticOrigin(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -915,7 +915,7 @@ const x: string = value;
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -945,7 +945,7 @@ greet(123);
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -980,7 +980,7 @@ function getNum(): number {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1007,7 +1007,7 @@ func TestTypeCheck_TypeSafeCodeOnlyLintDiagnostics(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1047,7 +1047,7 @@ func TestTypeCheck_MultiplePrograms(t *testing.T) {
 		[]*compiler.Program{program1, program2},
 		true,
 		nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) {
 			mu.Lock()
@@ -1085,7 +1085,7 @@ func TestTypeCheck_RangePointsToCorrectToken(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1120,7 +1120,7 @@ func TestTypeCheck_NoDuplicateDiagnostics(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1162,7 +1162,7 @@ func TestTypeCheck_AllowFilesEmptySliceBlocksLintOnly(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	count := runLinterInCompilerProgram(program, []string{}, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1191,7 +1191,7 @@ func TestTypeCheck_TS2322_TypeAssignment(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1224,7 +1224,7 @@ const x: Foo = { a: 1 };
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1258,7 +1258,7 @@ const result: string = identity<number>(42);
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1288,7 +1288,7 @@ const c: Color = 'red';
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1317,7 +1317,7 @@ const x: [number, string] = [1, 2];
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1347,7 +1347,7 @@ const x: Foo = { a: 1, b: 2 };
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1380,7 +1380,7 @@ const x: number = 'hello';
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1407,7 +1407,7 @@ func TestTypeCheck_MessageIdEmpty(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		nil,
@@ -1436,7 +1436,7 @@ func TestTypeCheck_FileFilterSuppressesLintRulesOnly(t *testing.T) {
 
 	var diagnostics []rule.RuleDiagnostic
 	count := runLinterInCompilerProgram(program, nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
 		func(fileName string) bool { return fileName != ignoredPath },
@@ -1485,7 +1485,7 @@ func TestTypeCheck_FileFilterDoesNotMaskTypeChecksAcrossPrograms(t *testing.T) {
 		[]*compiler.Program{program},
 		true,
 		nil, nil, legacyDefaultExcludedPathSubstrings,
-		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		func(sf *ast.SourceFile) []rule.ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) {
 			mu.Lock()

--- a/internal/linter/linter_typecheck_typeonly_test.go
+++ b/internal/linter/linter_typecheck_typeonly_test.go
@@ -21,8 +21,8 @@ import (
 
 // triggerOnIdentifierRule reports a warning on every identifier — used to
 // confirm rules really would have fired if Phase 1 had run.
-func triggerOnIdentifierRule() []ConfiguredRule {
-	return []ConfiguredRule{
+func triggerOnIdentifierRule() []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{
 		{
 			Name:     "would-have-fired",
 			Severity: rule.SeverityError,
@@ -168,7 +168,7 @@ func TestTypeCheckOnly_BaselineLintWouldFire(t *testing.T) {
 		Programs:         programs,
 		TargetsByProgram: [][]string{{paths["a.ts"]}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			return triggerOnIdentifierRule()
 		},
 	})
@@ -201,7 +201,7 @@ func TestTypeCheckOnly_EmptyLintPlanDoesNotConstrainTypeCheck(t *testing.T) {
 		Programs:         programs,
 		TargetsByProgram: [][]string{nil},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			t.Fatal("empty target projection resolved rules")
 			return nil
 		},
@@ -235,7 +235,7 @@ func TestTypeCheck_IncludesZeroTargetProgramFromLintPlan(t *testing.T) {
 		Programs:         programs,
 		TargetsByProgram: [][]string{{lintPaths["lint.ts"]}, nil},
 		SingleThreaded:   true,
-		GetRulesForFile:  func(*ast.SourceFile) []ConfiguredRule { return noopRule() },
+		GetRulesForFile:  func(*ast.SourceFile) []rule.ConfiguredRule { return noopRule() },
 	})
 
 	var diagnostics []rule.RuleDiagnostic

--- a/internal/linter/linter_typeinfo_test.go
+++ b/internal/linter/linter_typeinfo_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-func checkerProbeRule(checkerWasNil *bool) []ConfiguredRule {
-	return []ConfiguredRule{{
+func checkerProbeRule(checkerWasNil *bool) []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{{
 		Name:     "checker-probe",
 		Severity: rule.SeverityWarning,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -49,7 +49,7 @@ func TestCompilerCapableProgramProvidesTypeChecker(t *testing.T) {
 		"a.ts": "const x = 1;",
 	})
 	var checkerWasNil bool
-	runProgramCapabilityProbe(t, lintprogram.NewFromCompiler(raw), func(*ast.SourceFile) []ConfiguredRule {
+	runProgramCapabilityProbe(t, lintprogram.NewFromCompiler(raw), func(*ast.SourceFile) []rule.ConfiguredRule {
 		return checkerProbeRule(&checkerWasNil)
 	})
 	if checkerWasNil {
@@ -67,7 +67,7 @@ func TestSourceOnlyProgramWithholdsTypeChecker(t *testing.T) {
 	}
 	sourceOnly := mustSourceOnlyTestProgram(t, raw, []*ast.SourceFile{file})
 	var checkerWasNil bool
-	result := runProgramCapabilityProbe(t, sourceOnly, func(*ast.SourceFile) []ConfiguredRule {
+	result := runProgramCapabilityProbe(t, sourceOnly, func(*ast.SourceFile) []rule.ConfiguredRule {
 		return checkerProbeRule(&checkerWasNil)
 	})
 	if !checkerWasNil || result.LintedFileCount != 1 {
@@ -85,8 +85,8 @@ func TestSourceOnlyProgramFiltersTypeAwareRule(t *testing.T) {
 	}
 	sourceOnly := mustSourceOnlyTestProgram(t, raw, []*ast.SourceFile{file})
 	ruleRan := false
-	result := runProgramCapabilityProbe(t, sourceOnly, func(*ast.SourceFile) []ConfiguredRule {
-		return []ConfiguredRule{{
+	result := runProgramCapabilityProbe(t, sourceOnly, func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:             "type-aware-probe",
 			Severity:         rule.SeverityWarning,
 			RequiresTypeInfo: true,
@@ -109,8 +109,8 @@ func TestCompilerCapableProgramRunsTypeAwareRule(t *testing.T) {
 		"a.ts": "const x = 1;",
 	})
 	ruleRan := false
-	result := runProgramCapabilityProbe(t, lintprogram.NewFromCompiler(raw), func(*ast.SourceFile) []ConfiguredRule {
-		return []ConfiguredRule{{
+	result := runProgramCapabilityProbe(t, lintprogram.NewFromCompiler(raw), func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:             "type-aware-probe",
 			Severity:         rule.SeverityWarning,
 			RequiresTypeInfo: true,

--- a/internal/linter/parse_cache_sharing_test.go
+++ b/internal/linter/parse_cache_sharing_test.go
@@ -43,8 +43,8 @@ func setupDualRootFixture(t *testing.T) string {
 
 // varReportingRule reports every `var` keyword usage — enough to produce
 // deterministic diagnostics on every fixture file, including dual-root ones.
-func varReportingRule() []ConfiguredRule {
-	return []ConfiguredRule{{
+func varReportingRule() []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{{
 		Name:     "test/no-var",
 		Severity: rule.SeverityError,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -96,7 +96,7 @@ func collectDiags(t *testing.T, programs []*compiler.Program, singleThreaded boo
 			Programs:         lintPrograms,
 			TargetsByProgram: targetsByProgram,
 			SingleThreaded:   singleThreaded,
-			GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 				return varReportingRule()
 			},
 		})

--- a/internal/linter/timing_test.go
+++ b/internal/linter/timing_test.go
@@ -3,11 +3,13 @@ package linter
 import (
 	"testing"
 	"time"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func TestTimingCollectorAddFile(t *testing.T) {
 	c := NewTimingCollector()
-	rules := []ConfiguredRule{{Name: "x"}, {Name: "y"}}
+	rules := []rule.ConfiguredRule{{Name: "x"}, {Name: "y"}}
 	c.addFile("a.ts", rules, []time.Duration{time.Millisecond, 2 * time.Millisecond})
 	c.addFile("b.ts", rules[:1], []time.Duration{3 * time.Millisecond})
 
@@ -24,7 +26,7 @@ func TestTimingCollectorAddFileRepeated(t *testing.T) {
 	// --fix re-lint passes fold the same file into the collector again:
 	// time keeps accruing but the file must not be counted twice.
 	c := NewTimingCollector()
-	rules := []ConfiguredRule{{Name: "x"}}
+	rules := []rule.ConfiguredRule{{Name: "x"}}
 	c.addFile("a.ts", rules, []time.Duration{time.Millisecond})
 	c.addFile("a.ts", rules, []time.Duration{2 * time.Millisecond})
 

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -6,11 +6,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-// Compatibility alias keeps linter-focused callers source-compatible while
-// ownership lives in internal/rule. New framework code should name
-// rule.ConfiguredRule directly.
-type ConfiguredRule = rule.ConfiguredRule
-
 type RuleHandler = func(sourceFile *ast.SourceFile) []rule.ConfiguredRule
 type DiagnosticHandler = func(diagnostic rule.RuleDiagnostic)
 

--- a/internal/lsp/document_changes_test.go
+++ b/internal/lsp/document_changes_test.go
@@ -307,7 +307,7 @@ func lintOffTheEditorPath(program *compiler.Program, file string, resolver *conf
 	linter.LintSingleFile(linter.LintSingleFileOptions{
 		Program: lintprogram.NewFromCompiler(program),
 		File:    file,
-		GetRulesForFile: func(f *ast.SourceFile) []linter.ConfiguredRule {
+		GetRulesForFile: func(f *ast.SourceFile) []rule.ConfiguredRule {
 			rules, _ := resolver.EnabledRulesForFile(f.FileName())
 			return rules
 		},

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -1764,7 +1764,7 @@ func TestLSPActiveRulesForFile_RespectsFiles(t *testing.T) {
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    file,
-			GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+			GetRulesForFile: func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
 				targetPath := sourceFile.FileName()
 				return configuredRulesForLSPTest(
 					cfg,

--- a/internal/plugins/import/rules/first/first_test.go
+++ b/internal/plugins/import/rules/first/first_test.go
@@ -823,8 +823,8 @@ func createFirstProgram(t testing.TB, fileName string, code string) (*compiler.P
 	return program, sourceFile
 }
 
-func firstConfiguredRules(*ast.SourceFile) []linter.ConfiguredRule {
-	return []linter.ConfiguredRule{{
+func firstConfiguredRules(*ast.SourceFile) []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{{
 		Name:     first.FirstRule.Name,
 		Severity: rule.SeverityError,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
@@ -927,8 +927,8 @@ func createNoDuplicatesProgram(t testing.TB, fileName string, code string) (*com
 	return program, sourceFile
 }
 
-func noDuplicatesConfiguredRules(*ast.SourceFile) []linter.ConfiguredRule {
-	return []linter.ConfiguredRule{{
+func noDuplicatesConfiguredRules(*ast.SourceFile) []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{{
 		Name:     no_duplicates.NoDuplicatesRule.Name,
 		Severity: rule.SeverityError,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/import/rules/order/order_extras_branches_test.go
+++ b/internal/plugins/import/rules/order/order_extras_branches_test.go
@@ -498,8 +498,8 @@ func lintOrderWithDemand(program *compiler.Program, sourceFile *ast.SourceFile, 
 	var diagnostics []rule.RuleDiagnostic
 	linter.LintSingleFile(linter.LintSingleFileOptions{
 		Program: lintprogram.NewFromCompiler(program), File: sourceFile.FileName(), HasTypeInfo: true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name: order.OrderRule.Name, Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners { return order.OrderRule.Run(ctx, options) },
 			}}

--- a/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment_test.go
+++ b/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment_test.go
@@ -1759,8 +1759,8 @@ func TestDestructuringAssignmentEditDemand(t *testing.T) {
 				Programs:         programs,
 				TargetsByProgram: [][]string{{sourceFile.FileName()}},
 				SingleThreaded:   true,
-				GetRulesForFile: func(_ *ast.SourceFile) []linter.ConfiguredRule {
-					return []linter.ConfiguredRule{{
+				GetRulesForFile: func(_ *ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{
 						Name:     "test",
 						Severity: rule.SeverityError,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_cross_file_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_cross_file_test.go
@@ -220,8 +220,8 @@ declare function setTimeout(handler: () => void, timeout: number): number;
 		Programs:         programs,
 		TargetsByProgram: [][]string{{tsxPath}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(_ *ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(_ *ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "react-hooks/exhaustive-deps",
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
@@ -676,9 +676,9 @@ func createExhaustiveDepsProgram(t testing.TB, fileName string, code string) (*c
 	return program, sourceFile
 }
 
-func exhaustiveDepsConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
-	return func(*ast.SourceFile) []linter.ConfiguredRule {
-		return []linter.ConfiguredRule{{
+func exhaustiveDepsConfiguredRules(options []any) func(*ast.SourceFile) []rule.ConfiguredRule {
+	return func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:     ExhaustiveDepsRule.Name,
 			Severity: rule.SeverityError,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/rstest/rules/no_alias_methods/no_alias_methods_extras_test.go
+++ b/internal/plugins/rstest/rules/no_alias_methods/no_alias_methods_extras_test.go
@@ -414,8 +414,8 @@ expect(fn).not['toThrowError']();`,
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoAliasMethodsRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_expect_type_of/prefer_expect_type_of_extras_test.go
@@ -377,8 +377,8 @@ expect.soft(typeof other)['toEqual']("number");`,
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferExpectTypeOfRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/rstest/rules/prefer_todo/prefer_todo_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_todo/prefer_todo_extras_test.go
@@ -426,8 +426,8 @@ test("options", { timeout: 100 }, () => {});`,
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     prefer_todo.PreferTodoRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/array_type/array_type_test.go
+++ b/internal/plugins/typescript/rules/array_type/array_type_test.go
@@ -511,8 +511,8 @@ type ReadonlySimple = readonly Value[];`,
 					Program:     lintprogram.NewFromCompiler(program),
 					File:        sourceFile.FileName(),
 					HasTypeInfo: true,
-					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-						return []linter.ConfiguredRule{{
+					GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+						return []rule.ConfiguredRule{{
 							Name:     ArrayTypeRule.Name,
 							Severity: rule.SeverityError,
 							Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style_test.go
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style_test.go
@@ -393,8 +393,8 @@ type Reported = { [key: string]: unknown };`
 	linter.LintSingleFile(linter.LintSingleFileOptions{
 		Program: sourceProgram,
 		File:    sourceFile.FileName(),
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "@typescript-eslint/consistent-indexed-object-style",
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -462,8 +462,8 @@ type Suggest = Record<Key, unknown>;
 				linter.LintSingleFile(linter.LintSingleFileOptions{
 					Program: sourceProgram,
 					File:    sourceFile.FileName(),
-					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-						return []linter.ConfiguredRule{{
+					GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+						return []rule.ConfiguredRule{{
 							Name:     ConsistentIndexedObjectStyleRule.Name,
 							Severity: rule.SeverityError,
 							Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
@@ -457,8 +457,8 @@ const array = ([source]) as Array<number>;`,
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     ConsistentTypeAssertionsRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions_test.go
@@ -471,8 +471,8 @@ declare global { interface Array<T> { item: T; } }`,
 				linter.LintSingleFile(linter.LintSingleFileOptions{
 					Program: lintprogram.NewFromCompiler(program),
 					File:    sourceFile.FileName(),
-					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-						return []linter.ConfiguredRule{{
+					GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+						return []rule.ConfiguredRule{{
 							Name:     ConsistentTypeDefinitionsRule.Name,
 							Severity: rule.SeverityError,
 							Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -694,8 +694,8 @@ func lintConsistentTypeDefinitions(
 	linter.LintSingleFile(linter.LintSingleFileOptions{
 		Program: lintprogram.NewFromCompiler(program),
 		File:    sourceFile.FileName(),
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     ConsistentTypeDefinitionsRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
@@ -423,8 +423,8 @@ func TestDotNotationEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:             DotNotationRule.Name,
 					Severity:         rule.SeverityError,
 					RequiresTypeInfo: DotNotationRule.RequiresTypeInfo,

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations_extras_test.go
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations_extras_test.go
@@ -854,8 +854,8 @@ let visibleAgain: number;
 				Programs:         programs,
 				TargetsByProgram: [][]string{{sourceFile.FileName()}},
 				SingleThreaded:   true,
-				GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-					return []linter.ConfiguredRule{{
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{
 						Name:     "@typescript-eslint/init-declarations",
 						Severity: rule.SeverityWarning,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style_test.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style_test.go
@@ -872,8 +872,8 @@ declare namespace External {
 					Program:     lintprogram.NewFromCompiler(program),
 					File:        sourceFile.FileName(),
 					HasTypeInfo: true,
-					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-						return []linter.ConfiguredRule{{
+					GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+						return []rule.ConfiguredRule{{
 							Name:     MethodSignatureStyleRule.Name,
 							Severity: rule.SeverityError,
 							Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor_test.go
@@ -529,8 +529,8 @@ func TestNoArrayConstructorEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoArrayConstructorRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
@@ -250,8 +250,8 @@ func runNoDeprecatedDiagnosticsForFiles(t *testing.T, files map[string]string, e
 		Programs:         programs,
 		TargetsByProgram: [][]string{{sourceFile.FileName()}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(_ *ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(_ *ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     "test",
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
@@ -648,8 +648,8 @@ const scoped: number = 1;
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     "@typescript-eslint/no-inferrable-types",
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -1132,9 +1132,9 @@ func createNoRestrictedTypesProgram(t testing.TB, fileName string, code string) 
 	return program, sourceFile
 }
 
-func noRestrictedTypesConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
-	return func(*ast.SourceFile) []linter.ConfiguredRule {
-		return []linter.ConfiguredRule{{
+func noRestrictedTypesConfiguredRules(options []any) func(*ast.SourceFile) []rule.ConfiguredRule {
+	return func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:     NoRestrictedTypesRule.Name,
 			Severity: rule.SeverityError,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
@@ -1756,8 +1756,8 @@ func createNoUnnecessaryTypeConstraintProgram(
 	return program, sourceFile
 }
 
-func noUnnecessaryTypeConstraintConfiguredRules(*ast.SourceFile) []linter.ConfiguredRule {
-	return []linter.ConfiguredRule{{
+func noUnnecessaryTypeConstraintConfiguredRules(*ast.SourceFile) []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{{
 		Name:     NoUnnecessaryTypeConstraintRule.Name,
 		Severity: rule.SeverityError,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
@@ -1173,8 +1173,8 @@ func TestNoUnnecessaryTypeConversionEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:             NoUnnecessaryTypeConversionRule.Name,
 					Severity:         rule.SeverityError,
 					RequiresTypeInfo: NoUnnecessaryTypeConversionRule.RequiresTypeInfo,

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
@@ -1705,8 +1705,8 @@ func TestNoUnnecessaryTypeParametersEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:             NoUnnecessaryTypeParametersRule.Name,
 					Severity:         rule.SeverityError,
 					RequiresTypeInfo: NoUnnecessaryTypeParametersRule.RequiresTypeInfo,

--- a/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument_extras_test.go
@@ -56,8 +56,8 @@ func runNoUnsafeArgumentLenientProgram(
 		Programs:         programs,
 		TargetsByProgram: [][]string{{sourceFile.FileName()}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:             NoUnsafeArgumentRule.Name,
 				Severity:         rule.SeverityError,
 				RequiresTypeInfo: true,

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_imports_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_imports_test.go
@@ -442,9 +442,9 @@ func createNoUnusedVarsProgram(t testing.TB, fileName string, code string) (*com
 	return program, sourceFile
 }
 
-func noUnusedVarsConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
-	return func(*ast.SourceFile) []linter.ConfiguredRule {
-		return []linter.ConfiguredRule{{
+func noUnusedVarsConfiguredRules(options []any) func(*ast.SourceFile) []rule.ConfiguredRule {
+	return func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:             NoUnusedVarsRule.Name,
 			Severity:         rule.SeverityError,
 			RequiresTypeInfo: true,

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
@@ -1329,8 +1329,8 @@ class C {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoUselessConstructorRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
+++ b/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
@@ -584,8 +584,8 @@ const suppressed = maybe as string;
 			Programs:         programs,
 			TargetsByProgram: [][]string{{sourceFile.FileName()}},
 			SingleThreaded:   true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:             NonNullableTypeAssertionStyleRule.Name,
 					Severity:         rule.SeverityError,
 					RequiresTypeInfo: NonNullableTypeAssertionStyleRule.RequiresTypeInfo,

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring_test.go
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring_test.go
@@ -1205,8 +1205,8 @@ func TestPreferDestructuringEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:             PreferDestructuringRule.Name,
 					Severity:         rule.SeverityError,
 					RequiresTypeInfo: PreferDestructuringRule.RequiresTypeInfo,

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
@@ -1245,8 +1245,8 @@ interface ThisCallable { (): this; }`,
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferFunctionTypeRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check_extras_test.go
+++ b/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check_extras_test.go
@@ -450,8 +450,8 @@ func testSwitchExhaustivenessCheckEditDemand(t *testing.T) {
 			Program:     sourceProgram,
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:             SwitchExhaustivenessCheckRule.Name,
 					Severity:         rule.SeverityError,
 					RequiresTypeInfo: SwitchExhaustivenessCheckRule.RequiresTypeInfo,

--- a/internal/plugins/unicorn/rules/no_array_fill_with_reference_type/no_array_fill_with_reference_type_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_array_fill_with_reference_type/no_array_fill_with_reference_type_extras_test.go
@@ -234,8 +234,8 @@ func TestNoArrayFillWithReferenceTypeDoesNotResolveConstAcrossFiles(t *testing.T
 		Program:     lintprogram.NewFromCompiler(program),
 		File:        usageFile,
 		HasTypeInfo: true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     no_array_fill_with_reference_type.NoArrayFillWithReferenceTypeRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_await_in_promise_methods/no_await_in_promise_methods_extras_test.go
@@ -178,8 +178,8 @@ func TestNoAwaitInPromiseMethodsEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     no_await_in_promise_methods.NoAwaitInPromiseMethodsRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
@@ -728,8 +728,8 @@ func TestNoStaticOnlyClassEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     no_static_only_class.NoStaticOnlyClassRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
@@ -531,8 +531,8 @@ func TestPreferArrayFlatEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     prefer_array_flat.PreferArrayFlatRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
@@ -289,8 +289,8 @@ func lintPreferArraySomeWithDemand(program *compiler.Program, sourceFile *ast.So
 		Program:     lintprogram.NewFromCompiler(program),
 		File:        sourceFile.FileName(),
 		HasTypeInfo: true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     prefer_array_some.PreferArraySomeRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_extras_test.go
@@ -304,8 +304,8 @@ func lintPreferNodeProtocolWithDemand(
 		Program:     lintprogram.NewFromCompiler(program),
 		File:        sourceFile.FileName(),
 		HasTypeInfo: true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     prefer_node_protocol.PreferNodeProtocolRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
@@ -478,8 +478,8 @@ func lintPreferSetHasWithDemand(
 		Program:     lintprogram.NewFromCompiler(program),
 		File:        sourceFile.FileName(),
 		HasTypeInfo: true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     prefer_set_has.PreferSetHasRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/program/loader/root_programs_test.go
+++ b/internal/program/loader/root_programs_test.go
@@ -200,8 +200,8 @@ func TestRootProgramSupportsCrossFileImportRules(t *testing.T) {
 			plan.Files[1].Path,
 		}},
 		SingleThreaded: true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{
 				{
 					Name:     no_cycle.NoCycleRule.Name,
 					Severity: rule.SeverityError,

--- a/internal/rules/capitalized_comments/capitalized_comments_extras_test.go
+++ b/internal/rules/capitalized_comments/capitalized_comments_extras_test.go
@@ -307,8 +307,8 @@ func TestCapitalizedCommentsEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     CapitalizedCommentsRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/dot_notation/dot_notation_extras_test.go
+++ b/internal/rules/dot_notation/dot_notation_extras_test.go
@@ -266,8 +266,8 @@ const fourth = object. /* keep */ while;`,
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     DotNotationRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_div_regex/no_div_regex_extras_test.go
+++ b/internal/rules/no_div_regex/no_div_regex_extras_test.go
@@ -151,8 +151,8 @@ func TestNoDivRegexEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoDivRegexRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast_test.go
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast_test.go
@@ -363,8 +363,8 @@ func TestNoExtraBooleanCastEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoExtraBooleanCastRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_import_assign/no_import_assign_test.go
+++ b/internal/rules/no_import_assign/no_import_assign_test.go
@@ -773,8 +773,8 @@ func lintNoImportAssignForComparison(
 		Program:     lintprogram.NewFromCompiler(program),
 		File:        sourceFile.FileName(),
 		HasTypeInfo: true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     NoImportAssignRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_nonoctal_decimal_escape/no_nonoctal_decimal_escape_test.go
+++ b/internal/rules/no_nonoctal_decimal_escape/no_nonoctal_decimal_escape_test.go
@@ -1323,7 +1323,7 @@ func runRuleLeniently(t *testing.T, code string, tsx bool) []rule.RuleDiagnostic
 		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
 	}
 
-	configured := linter.ConfiguredRule{
+	configured := rule.ConfiguredRule{
 		Name:     NoNonoctalDecimalEscapeRule.Name,
 		Severity: rule.SeverityWarning,
 		Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -1335,11 +1335,11 @@ func runRuleLeniently(t *testing.T, code string, tsx bool) []rule.RuleDiagnostic
 	testutil.LintProgram(t, testutil.LintProgramOptions{
 		Program:                lintprogram.NewFromCompiler(program),
 		ExcludedPathSubstrings: testutil.DefaultExcludedPathSubstrings,
-		GetRulesForFile: func(sf *ast.SourceFile) []linter.ConfiguredRule {
+		GetRulesForFile: func(sf *ast.SourceFile) []rule.ConfiguredRule {
 			if sf.FileName() != filePath {
 				return nil
 			}
-			return []linter.ConfiguredRule{configured}
+			return []rule.ConfiguredRule{configured}
 		},
 		OnDiagnostic: func(d rule.RuleDiagnostic) { diags = append(diags, d) },
 	})

--- a/internal/rules/no_object_constructor/no_object_constructor_extras_test.go
+++ b/internal/rules/no_object_constructor/no_object_constructor_extras_test.go
@@ -482,9 +482,9 @@ func lintNoObjectConstructorWithDemand(
 	return diagnostics
 }
 
-func noObjectConstructorConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
-	return func(*ast.SourceFile) []linter.ConfiguredRule {
-		return []linter.ConfiguredRule{{
+func noObjectConstructorConfiguredRules(options []any) func(*ast.SourceFile) []rule.ConfiguredRule {
+	return func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:     NoObjectConstructorRule.Name,
 			Severity: rule.SeverityError,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_promise_executor_return/no_promise_executor_return_extras_test.go
+++ b/internal/rules/no_promise_executor_return/no_promise_executor_return_extras_test.go
@@ -927,9 +927,9 @@ func lintNoPromiseExecutorReturnWithDemand(
 	return diagnostics
 }
 
-func noPromiseExecutorReturnConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
-	return func(*ast.SourceFile) []linter.ConfiguredRule {
-		return []linter.ConfiguredRule{{
+func noPromiseExecutorReturnConfiguredRules(options []any) func(*ast.SourceFile) []rule.ConfiguredRule {
+	return func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:     NoPromiseExecutorReturnRule.Name,
 			Severity: rule.SeverityError,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary_test.go
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary_test.go
@@ -648,8 +648,8 @@ const defaultAssignment = value ? value : other ?? fallback;`,
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoUnneededTernaryRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
@@ -559,11 +559,11 @@ consume(outer);
 	testutil.LintProgram(t, testutil.LintProgramOptions{
 		Program:                sourceProgram,
 		ExcludedPathSubstrings: testutil.DefaultExcludedPathSubstrings,
-		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
 			if sourceFile.FileName() != filePath {
 				return nil
 			}
-			return []linter.ConfiguredRule{{
+			return []rule.ConfiguredRule{{
 				Name:     NoUnusedVarsRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -843,11 +843,11 @@ consume(data);`,
 				testutil.LintProgram(t, testutil.LintProgramOptions{
 					Program:                sourceProgram,
 					ExcludedPathSubstrings: testutil.DefaultExcludedPathSubstrings,
-					GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+					GetRulesForFile: func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
 						if sourceFile.FileName() != filePath {
 							return nil
 						}
-						return []linter.ConfiguredRule{{
+						return []rule.ConfiguredRule{{
 							Name:     NoUnusedVarsRule.Name,
 							Severity: rule.SeverityError,
 							Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -931,8 +931,8 @@ assigned = 2;
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        filePath,
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoUnusedVarsRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/tspath"
-	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -675,8 +674,8 @@ func TestImportedRegExpConstructorAlias(t *testing.T) {
 	testutil.LintProgram(t, testutil.LintProgramOptions{
 		Program: lintprogram.NewFromCompiler(program),
 		Files:   []string{sourceFile.FileName()},
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     NoUselessBackreferenceRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -733,8 +732,8 @@ first("\\1(a)");
 	testutil.LintProgram(t, testutil.LintProgramOptions{
 		Program: sourceProgram,
 		Files:   []string{sourceFile.FileName()},
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     NoUselessBackreferenceRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_useless_computed_key/no_useless_computed_key_test.go
+++ b/internal/rules/no_useless_computed_key/no_useless_computed_key_test.go
@@ -1044,8 +1044,8 @@ const { ['binding']: binding } = input;`,
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoUselessComputedKeyRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_useless_rename/no_useless_rename_test.go
+++ b/internal/rules/no_useless_rename/no_useless_rename_test.go
@@ -1077,8 +1077,8 @@ const { binding: binding = fallback } = input;
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoUselessRenameRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/no_useless_return/no_useless_return_extras_test.go
+++ b/internal/rules/no_useless_return/no_useless_return_extras_test.go
@@ -464,8 +464,8 @@ function third() { g(); return /* keep */; }`,
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     NoUselessReturnRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/object_shorthand/object_shorthand_test.go
+++ b/internal/rules/object_shorthand/object_shorthand_test.go
@@ -252,8 +252,8 @@ const second = {arrow: () => { return 2; }};`,
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     ObjectShorthandRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/one_var/one_var_test.go
+++ b/internal/rules/one_var/one_var_test.go
@@ -2797,8 +2797,8 @@ func TestOneVarEditDemand(t *testing.T) {
 					Program:     lintprogram.NewFromCompiler(program),
 					File:        sourceFile.FileName(),
 					HasTypeInfo: true,
-					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-						return []linter.ConfiguredRule{{
+					GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+						return []rule.ConfiguredRule{{
 							Name:     OneVarRule.Name,
 							Severity: rule.SeverityError,
 							Run: func(ctx rule.RuleContext) rule.RuleListeners {
@@ -2995,8 +2995,8 @@ func TestOneVarDisableDirectives(t *testing.T) {
 				Program:     lintprogram.NewFromCompiler(program),
 				File:        sourceFile.FileName(),
 				HasTypeInfo: true,
-				GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-					return []linter.ConfiguredRule{
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{
 						{
 							Name:     OneVarRule.Name,
 							Severity: rule.SeverityError,

--- a/internal/rules/operator_assignment/operator_assignment_extras_test.go
+++ b/internal/rules/operator_assignment/operator_assignment_extras_test.go
@@ -487,8 +487,8 @@ func TestOperatorAssignmentEditDemand(t *testing.T) {
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     OperatorAssignmentRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/prefer_destructuring/prefer_destructuring_extras_test.go
+++ b/internal/rules/prefer_destructuring/prefer_destructuring_extras_test.go
@@ -274,8 +274,8 @@ func TestPreferDestructuringEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferDestructuringRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_extras_test.go
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_extras_test.go
@@ -185,8 +185,8 @@ const kept = Math.pow(base /* keep */, exponent);`,
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferExponentiationOperatorRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/prefer_object_has_own/prefer_object_has_own_extras_test.go
+++ b/internal/rules/prefer_object_has_own/prefer_object_has_own_extras_test.go
@@ -454,8 +454,8 @@ func TestPreferObjectHasOwnEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferObjectHasOwnRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/prefer_object_spread/prefer_object_spread_extras_test.go
+++ b/internal/rules/prefer_object_spread/prefer_object_spread_extras_test.go
@@ -550,8 +550,8 @@ func TestPreferObjectSpreadEditDemand(t *testing.T) {
 			Program:     lintprogram.NewFromCompiler(program),
 			File:        sourceFile.FileName(),
 			HasTypeInfo: true,
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferObjectSpreadRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
@@ -596,9 +596,9 @@ func lintPreserveCaughtErrorWithDemand(
 	return diagnostics
 }
 
-func preserveCaughtErrorConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
-	return func(*ast.SourceFile) []linter.ConfiguredRule {
-		return []linter.ConfiguredRule{{
+func preserveCaughtErrorConfiguredRules(options []any) func(*ast.SourceFile) []rule.ConfiguredRule {
+	return func(*ast.SourceFile) []rule.ConfiguredRule {
+		return []rule.ConfiguredRule{{
 			Name:     PreserveCaughtErrorRule.Name,
 			Severity: rule.SeverityError,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/unicode_bom/unicode_bom_disk_test.go
+++ b/internal/rules/unicode_bom/unicode_bom_disk_test.go
@@ -185,11 +185,11 @@ func lintFile(t *testing.T, filePath string, fs vfs.FS) []rule.RuleDiagnostic {
 	testutil.LintProgram(t, testutil.LintProgramOptions{
 		Program:                lintprogram.NewFromCompiler(program),
 		ExcludedPathSubstrings: testutil.DefaultExcludedPathSubstrings,
-		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
 			if sourceFile.FileName() != filePath {
 				return nil
 			}
-			return []linter.ConfiguredRule{{
+			return []rule.ConfiguredRule{{
 				Name:     UnicodeBomRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/unicode_bom/unicode_bom_extras_test.go
+++ b/internal/rules/unicode_bom/unicode_bom_extras_test.go
@@ -364,8 +364,8 @@ func runUnicodeBom(t *testing.T, code string, demand rule.EditDemand) []rule.Rul
 		Programs:         programs,
 		TargetsByProgram: [][]string{{program.GetSourceFile(fileName).FileName()}},
 		SingleThreaded:   true,
-		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
 				Name:     UnicodeBomRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/tests/bench-go/linter_bench_test.go
+++ b/tests/bench-go/linter_bench_test.go
@@ -29,7 +29,7 @@ var (
 func BenchmarkLinterSyntaxRules(b *testing.B) {
 	program := lintprogram.NewFromCompiler(createBenchmarkProgramInDir(b, filepath.Join(b.TempDir(), "syntax"), 32, false))
 	rules := benchmarkSyntaxRules()
-	getRules := func(*ast.SourceFile) []linter.ConfiguredRule { return rules }
+	getRules := func(*ast.SourceFile) []rule.ConfiguredRule { return rules }
 	onDiag := func(rule.RuleDiagnostic) {}
 
 	b.ReportAllocs()
@@ -43,7 +43,7 @@ func BenchmarkLinterSyntaxRules(b *testing.B) {
 func BenchmarkLinterTypeAwareRules(b *testing.B) {
 	program := lintprogram.NewFromCompiler(createBenchmarkProgramInDir(b, filepath.Join(b.TempDir(), "type-aware"), 32, false))
 	rules := benchmarkTypeAwareRules()
-	getRules := func(*ast.SourceFile) []linter.ConfiguredRule { return rules }
+	getRules := func(*ast.SourceFile) []rule.ConfiguredRule { return rules }
 	onDiag := func(rule.RuleDiagnostic) {}
 
 	b.ReportAllocs()
@@ -105,8 +105,8 @@ func BenchmarkLinterSemanticDiagnostics(b *testing.B) {
 	}
 }
 
-func benchmarkSyntaxRules() []linter.ConfiguredRule {
-	return []linter.ConfiguredRule{
+func benchmarkSyntaxRules() []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{
 		{
 			Name:     "bench-syntax-vars",
 			Severity: rule.SeverityWarning,
@@ -150,8 +150,8 @@ func benchmarkSyntaxRules() []linter.ConfiguredRule {
 	}
 }
 
-func benchmarkTypeAwareRules() []linter.ConfiguredRule {
-	return []linter.ConfiguredRule{
+func benchmarkTypeAwareRules() []rule.ConfiguredRule {
+	return []rule.ConfiguredRule{
 		{
 			Name:             "bench-type-identifiers",
 			Severity:         rule.SeverityWarning,


### PR DESCRIPTION
## Summary

- Remove the obsolete `linter.ConfiguredRule` compatibility alias after rule descriptor ownership moved to `internal/rule`.
- Migrate tests and benchmarks to name `rule.ConfiguredRule` directly.
- Make the package boundary explicit so new callers cannot continue depending on the linter-owned alias.

## Validation

- Compiled all 83 affected Go packages with `go test -run '^$'`
- `go test ./internal/linter`
- `golangci-lint run ./internal/linter`: 0 issues
- gofmt, zero-reference search, and git diff checks