### PR TITLE
fix: classify Node builtins before resolution

### DIFF
--- a/internal/plugins/import/fixtures/tsconfig.order-core-local.json
+++ b/internal/plugins/import/fixtures/tsconfig.order-core-local.json
@@ -5,7 +5,11 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "fs": ["order-internal-modules/api/service.ts"]
+      "buffer": ["order-internal-modules/api/service.ts"],
+      "fs": ["order-internal-modules/api/service.ts"],
+      "fs/not-a-builtin": ["order-internal-modules/api/service.ts"],
+      "local-api": ["order-internal-modules/api/service.ts"],
+      "virtual": ["order-internal-modules/api/service.ts"]
     },
     "lib": ["es2015", "es2017", "esnext", "DOM"]
   },

--- a/internal/plugins/import/rules/order/order.go
+++ b/internal/plugins/import/rules/order/order.go
@@ -446,6 +446,10 @@ func (queue *reportQueue) add(node *ast.Node, msg rule.RuleMessage, fixes func()
 	queue.reports = append(queue.reports, pendingReport{node: node, msg: msg, fixes: fixes})
 }
 
+func (queue *reportQueue) grow(count int) {
+	queue.reports = slices.Grow(queue.reports, count)
+}
+
 func (queue *reportQueue) flush(ctx rule.RuleContext) {
 	if len(queue.reports) > 1 {
 		slices.SortStableFunc(queue.reports, func(left, right pendingReport) int {
@@ -592,10 +596,14 @@ func (classifier *importClassifier) classify(name string, specifier *ast.Node) s
 	if tspath.IsRootedDiskPath(name) {
 		return "absolute"
 	}
+	if import_utils.IsNodeBuiltinSpecifier(name) {
+		return "builtin"
+	}
 
 	// Relative spellings have a fixed public group and normally need no module
-	// resolution. A deliberately configured core-module name is the exception:
-	// a successful resolution suppresses builtin classification.
+	// resolution. A non-exact builtin subpath or deliberately configured
+	// core-module name is the exception: a successful resolution suppresses
+	// builtin classification.
 	builtinCandidate := classifier.settings.IsCoreModuleSpecifier(name)
 	if !builtinCandidate {
 		if relativeType, ok := relativeImportType(name); ok {
@@ -754,21 +762,8 @@ func findOutOfOrder(imports []*importEntry) []*importEntry {
 	return out
 }
 
-// reverseRanks duplicates the slice and negates every rank, making the normal
-// forward scan equivalent to scanning the original sequence from the end.
-func reverseRanks(in []*importEntry) []*importEntry {
-	out := make([]*importEntry, len(in))
-	for i, v := range in {
-		dup := *v
-		dup.rank = -v.rank
-		out[len(in)-1-i] = &dup
-	}
-	return out
-}
-
-// countReverseOutOfOrder counts what findOutOfOrder(reverseRanks(imports))
-// would return without allocating the reversed entries. The actual reversed
-// slice is needed only when that direction produces fewer diagnostics.
+// countReverseOutOfOrder counts the entries that a scan from the end would
+// report, without allocating a reversed copy of every import.
 func countReverseOutOfOrder(imports []*importEntry) int {
 	if len(imports) == 0 {
 		return 0
@@ -787,33 +782,41 @@ func countReverseOutOfOrder(imports []*importEntry) int {
 	return count
 }
 
+// findReverseOutOfOrder returns the reverse-scan violations in source order.
+// Its capacity is exact because the selection pass already counted them.
+func findReverseOutOfOrder(imports []*importEntry, count int) []*importEntry {
+	minSeen := imports[len(imports)-1].rank
+	out := make([]*importEntry, 0, count)
+	for i := len(imports) - 1; i >= 0; i-- {
+		entry := imports[i]
+		if entry.rank > minSeen {
+			out = append(out, entry)
+		}
+		if entry.rank < minSeen {
+			minSeen = entry.rank
+		}
+	}
+	slices.Reverse(out)
+	return out
+}
+
 func makeOutOfOrderReports(reports *reportQueue, imported []*importEntry, source *sourceInfo) {
 	out := findOutOfOrder(imported)
 	if len(out) == 0 {
 		return
 	}
-	if countReverseOutOfOrder(imported) < len(out) {
-		rev := reverseRanks(imported)
-		revOut := findOutOfOrder(rev)
-		// Use the reversed list (with negated ranks) as the search space — the
-		// `found = imp.rank > X` predicate works against negated ranks too.
-		// The entries in `rev` carry the same node identity as the originals,
-		// so report positions still come from the original AST.
-		reportOutOfOrder(reports, rev, revOut, "after", source, true)
+	reverseCount := countReverseOutOfOrder(imported)
+	if reverseCount < len(out) {
+		reports.grow(reverseCount)
+		reportReverseOutOfOrder(reports, imported, findReverseOutOfOrder(imported, reverseCount), source)
 		return
 	}
-	reportOutOfOrder(reports, imported, out, "before", source, false)
+	reports.grow(len(out))
+	reportOutOfOrder(reports, imported, out, "before", source)
 }
 
-func reportOutOfOrder(reports *reportQueue, imported []*importEntry, outOfOrder []*importEntry, order string, source *sourceInfo, restoreSourceOrder bool) {
-	ordered := outOfOrder
-	if restoreSourceOrder && len(outOfOrder) > 1 {
-		ordered = append([]*importEntry(nil), outOfOrder...)
-		sort.SliceStable(ordered, func(i, j int) bool {
-			return ast.CompareNodePositions(ordered[i].node, ordered[j].node) < 0
-		})
-	}
-	for _, imp := range ordered {
+func reportOutOfOrder(reports *reportQueue, imported []*importEntry, outOfOrder []*importEntry, order string, source *sourceInfo) {
+	for _, imp := range outOfOrder {
 		var found *importEntry
 		for _, ii := range imported {
 			if ii.rank > imp.rank {
@@ -825,6 +828,21 @@ func reportOutOfOrder(reports *reportQueue, imported []*importEntry, outOfOrder 
 			continue
 		}
 		makeOutOfOrderReport(reports, found, imp, order, source)
+	}
+}
+
+func reportReverseOutOfOrder(reports *reportQueue, imported []*importEntry, outOfOrder []*importEntry, source *sourceInfo) {
+	for _, imp := range outOfOrder {
+		var found *importEntry
+		for i := len(imported) - 1; i >= 0; i-- {
+			if imported[i].rank < imp.rank {
+				found = imported[i]
+				break
+			}
+		}
+		if found != nil {
+			makeOutOfOrderReport(reports, found, imp, "after", source)
+		}
 	}
 }
 
@@ -1551,32 +1569,23 @@ func makeNamedOrderReport(reports *reportQueue, named []*namedEntry, opts option
 		mutateRanksToAlphabetize(imps, opts.alphabetize)
 	}
 
-	// Out-of-order detection (named flavour). When the reverse direction
-	// yields fewer reports we use the reversed (negated-rank) list as the
-	// search space, so the `found.rank > imp.rank` predicate still picks the
-	// right partner.
+	// Out-of-order detection (named flavour).
 	out := findOutOfOrder(imps)
 	if len(out) == 0 {
 		return
 	}
-	if countReverseOutOfOrder(imps) < len(out) {
-		rev := reverseRanks(imps)
-		revOut := findOutOfOrder(rev)
-		reportNamedOutOfOrder(reports, rev, revOut, "after", source, true)
+	reverseCount := countReverseOutOfOrder(imps)
+	if reverseCount < len(out) {
+		reports.grow(reverseCount)
+		reportNamedReverseOutOfOrder(reports, imps, findReverseOutOfOrder(imps, reverseCount), source)
 		return
 	}
-	reportNamedOutOfOrder(reports, imps, out, "before", source, false)
+	reports.grow(len(out))
+	reportNamedOutOfOrder(reports, imps, out, "before", source)
 }
 
-func reportNamedOutOfOrder(reports *reportQueue, all []*importEntry, outOfOrder []*importEntry, order string, source *sourceInfo, restoreSourceOrder bool) {
-	ordered := outOfOrder
-	if restoreSourceOrder && len(outOfOrder) > 1 {
-		ordered = append([]*importEntry(nil), outOfOrder...)
-		sort.SliceStable(ordered, func(i, j int) bool {
-			return ordered[i].node.Pos() < ordered[j].node.Pos()
-		})
-	}
-	for _, imp := range ordered {
+func reportNamedOutOfOrder(reports *reportQueue, all []*importEntry, outOfOrder []*importEntry, order string, source *sourceInfo) {
+	for _, imp := range outOfOrder {
 		var found *importEntry
 		for _, ii := range all {
 			if ii.rank > imp.rank {
@@ -1587,25 +1596,42 @@ func reportNamedOutOfOrder(reports *reportQueue, all []*importEntry, outOfOrder 
 		if found == nil {
 			continue
 		}
-		first := found
-		second := imp
-		disambiguateDisplayNames(first, second)
-		firstDisplay := first.displayName
-		secondDisplay := second.displayName
-		msg := rule.RuleMessage{
-			Id: "order",
-			Description: fmt.Sprintf(
-				"`%s` %s should occur %s %s of `%s`",
-				secondDisplay, makeImportDescription(second),
-				order,
-				makeImportDescription(first),
-				firstDisplay,
-			),
-		}
-		reports.add(second.node, msg, func() []rule.RuleFix {
-			return buildNamedSwapFix(source.file, source.text, first, second, order)
-		})
+		makeNamedOutOfOrderReport(reports, found, imp, order, source)
 	}
+}
+
+func reportNamedReverseOutOfOrder(reports *reportQueue, all []*importEntry, outOfOrder []*importEntry, source *sourceInfo) {
+	for _, imp := range outOfOrder {
+		var found *importEntry
+		for i := len(all) - 1; i >= 0; i-- {
+			if all[i].rank < imp.rank {
+				found = all[i]
+				break
+			}
+		}
+		if found != nil {
+			makeNamedOutOfOrderReport(reports, found, imp, "after", source)
+		}
+	}
+}
+
+func makeNamedOutOfOrderReport(reports *reportQueue, first, second *importEntry, order string, source *sourceInfo) {
+	disambiguateDisplayNames(first, second)
+	firstDisplay := first.displayName
+	secondDisplay := second.displayName
+	msg := rule.RuleMessage{
+		Id: "order",
+		Description: fmt.Sprintf(
+			"`%s` %s should occur %s %s of `%s`",
+			secondDisplay, makeImportDescription(second),
+			order,
+			makeImportDescription(first),
+			firstDisplay,
+		),
+	}
+	reports.add(second.node, msg, func() []rule.RuleFix {
+		return buildNamedSwapFix(source.file, source.text, first, second, order)
+	})
 }
 
 func buildNamedSwapFix(sourceFile *ast.SourceFile, sourceText string, first, second *importEntry, order string) []rule.RuleFix {

--- a/internal/plugins/import/rules/order/order.md
+++ b/internal/plugins/import/rules/order/order.md
@@ -194,6 +194,10 @@ together. Only meaningful with `"always-and-inside-groups"` newline modes.
 | `import/core-modules` | Extra names treated as `builtin`. |
 | `import/external-module-folders` | Resolved paths outside the importing package, or under one of these package-relative folders, classify as `external` (default `["node_modules"]`). An explicit `[]` disables the folder check; `""` denotes the package root. |
 
+Exact Node.js builtin specifiers take precedence over TypeScript filesystem
+resolution. Non-exact builtin subpath specifiers and names from
+`import/core-modules` remain resolution-sensitive.
+
 ## Differences from ESLint
 
 Compared with eslint-plugin-import 2.32.0, users may observe:

--- a/internal/plugins/import/rules/order/order_extras_branches_test.go
+++ b/internal/plugins/import/rules/order/order_extras_branches_test.go
@@ -28,9 +28,9 @@ func TestOrderBranchCoverage(t *testing.T) {
 		&order.OrderRule,
 		[]rule_tester.ValidTestCase{
 			// Node resolves an empty external-module folder to the package root,
-			// making the local `fs` path alias external just like `async`.
+			// making a local path alias external just like `async`.
 			{
-				Code:     "import external from 'async';\nimport local from 'fs';",
+				Code:     "import external from 'async';\nimport local from 'local-api';",
 				TSConfig: "tsconfig.order-core-local.json",
 				Options: map[string]any{
 					"groups":      []any{"internal", "external"},
@@ -66,11 +66,33 @@ func TestOrderBranchCoverage(t *testing.T) {
 				Code:    "import {} from './z';\nimport a from './a';",
 				Options: map[string]any{"alphabetize": map[string]any{"order": "asc"}},
 			},
-			// A project module named `fs` resolves locally and is internal, not builtin.
+			// A Node builtin remains builtin even when TypeScript paths maps the
+			// exact specifier to a project file. The configured TypeScript resolver
+			// checks Node builtins before attempting filesystem resolution.
 			{
-				Code:     "import external from 'async';\nimport local from 'fs';",
+				Code:     "import builtin from 'buffer';\nimport external from 'async';",
 				TSConfig: "tsconfig.order-core-local.json",
-				Options:  map[string]any{"groups": []any{"external", "internal", "builtin"}},
+				Options:  map[string]any{"groups": []any{"builtin", "external", "internal"}},
+			},
+			// import/internal-regex retains the upstream precedence over builtins.
+			{
+				Code:     "import overridden from 'buffer';\nimport external from 'async';",
+				TSConfig: "tsconfig.order-core-local.json",
+				Options:  map[string]any{"groups": []any{"internal", "external", "builtin"}},
+				Settings: map[string]any{"import/internal-regex": "^buffer$"},
+			},
+			// Non-exact builtin subpath specifiers remain resolution-sensitive.
+			{
+				Code:     "import local from 'fs/not-a-builtin';\nimport external from 'async';",
+				TSConfig: "tsconfig.order-core-local.json",
+				Options:  map[string]any{"groups": []any{"internal", "external", "builtin"}},
+			},
+			// Configured core modules also remain resolution-sensitive.
+			{
+				Code:     "import local from 'virtual';\nimport external from 'async';",
+				TSConfig: "tsconfig.order-core-local.json",
+				Options:  map[string]any{"groups": []any{"internal", "external", "builtin"}},
+				Settings: map[string]any{"import/core-modules": []any{"virtual"}},
 			},
 			// CommonJS export assignments are not sorted when alphabetize is ignored.
 			{

--- a/internal/plugins/import/rules/order/order_reverse_test.go
+++ b/internal/plugins/import/rules/order/order_reverse_test.go
@@ -1,0 +1,86 @@
+package order
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestReverseOutOfOrderMatchesNegatedCopy(t *testing.T) {
+	t.Parallel()
+
+	for length := 1; length <= 7; length++ {
+		ranks := make([]float64, length)
+		var visit func(int)
+		visit = func(index int) {
+			if index != length {
+				for rank := range 3 {
+					ranks[index] = float64(rank)
+					visit(index + 1)
+				}
+				return
+			}
+
+			imports := make([]*importEntry, length)
+			positions := make(map[*importEntry]int, length)
+			for position, rank := range ranks {
+				imports[position] = &importEntry{rank: rank}
+				positions[imports[position]] = position
+			}
+
+			want := referenceReversePairs(ranks)
+			count := countReverseOutOfOrder(imports)
+			out := findReverseOutOfOrder(imports, count)
+			got := make([][2]int, 0, len(out))
+			for _, entry := range out {
+				for position := len(imports) - 1; position >= 0; position-- {
+					if imports[position].rank < entry.rank {
+						got = append(got, [2]int{position, positions[entry]})
+						break
+					}
+				}
+			}
+
+			if count != len(want) || !reflect.DeepEqual(got, want) {
+				t.Fatalf("ranks %v: count/pairs = %d/%v, want %d/%v", ranks, count, got, len(want), want)
+			}
+		}
+		visit(0)
+	}
+}
+
+func referenceReversePairs(ranks []float64) [][2]int {
+	type entry struct {
+		position int
+		rank     float64
+	}
+
+	reversed := make([]entry, len(ranks))
+	for position, rank := range ranks {
+		reversed[len(ranks)-1-position] = entry{position: position, rank: -rank}
+	}
+	maxSeen := reversed[0].rank
+	var out []entry
+	for _, current := range reversed {
+		if current.rank < maxSeen {
+			out = append(out, current)
+		}
+		if current.rank > maxSeen {
+			maxSeen = current.rank
+		}
+	}
+	slices.SortFunc(out, func(left, right entry) int {
+		return left.position - right.position
+	})
+
+	pairs := make([][2]int, 0, len(out))
+	for _, current := range out {
+		for _, candidate := range reversed {
+			if candidate.rank > current.rank {
+				pairs = append(pairs, [2]int{candidate.position, current.position})
+				break
+			}
+		}
+	}
+	return pairs
+}

--- a/internal/plugins/import/utils/settings.go
+++ b/internal/plugins/import/utils/settings.go
@@ -125,9 +125,18 @@ func (compiled *ModuleSettings) IsInternalSpecifier(specifier string) bool {
 	return compiled != nil && compiled.internalRegex != nil && compiled.internalRegex.TestOrTimeout(specifier)
 }
 
+// IsNodeBuiltinSpecifier reports whether the complete written specifier is a
+// Node.js builtin. TypeScript-aware ESLint resolvers perform this exact check
+// before filesystem resolution, so an installed package or paths mapping with
+// the same name cannot shadow the builtin.
+func IsNodeBuiltinSpecifier(specifier string) bool {
+	return specifier != "" && core.NodeCoreModules()[specifier]
+}
+
 // IsCoreModuleSpecifier reports whether the specifier's package root is a
 // Node.js builtin or is listed by `import/core-modules`. Resolution remains a
-// caller concern because a resolved project module can override this lexical
+// caller concern for non-exact builtin subpath specifiers and configured core
+// modules, because a resolved project module can override their lexical
 // classification.
 func (compiled *ModuleSettings) IsCoreModuleSpecifier(specifier string) bool {
 	if specifier == "" {

--- a/internal/plugins/import/utils/settings_test.go
+++ b/internal/plugins/import/utils/settings_test.go
@@ -194,6 +194,30 @@ func TestModuleSettingsIsCoreModuleSpecifier(t *testing.T) {
 	}
 }
 
+func TestIsNodeBuiltinSpecifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		specifier string
+		want      bool
+	}{
+		{specifier: "buffer", want: true},
+		{specifier: "node:buffer", want: true},
+		{specifier: "fs/promises", want: true},
+		{specifier: "node:sqlite", want: true},
+		{specifier: "buffer/"},
+		{specifier: "fs/not-a-builtin"},
+		{specifier: "node:sqlite/database"},
+		{specifier: ""},
+	}
+
+	for _, test := range tests {
+		if got := import_utils.IsNodeBuiltinSpecifier(test.specifier); got != test.want {
+			t.Errorf("IsNodeBuiltinSpecifier(%q) = %v, want %v", test.specifier, got, test.want)
+		}
+	}
+}
+
 func TestIsScopedModuleSpecifier(t *testing.T) {
 	t.Parallel()
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/order.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/order.test.ts
@@ -2135,6 +2135,20 @@ ruleTester.run('order', rule, {
 
 ruleTester.run('order', rule, {
   valid: [
+    // Exact Node builtins take precedence over TypeScript paths resolution.
+    {
+      code: "import { Buffer } from 'buffer';\n\nimport { includes, isUndefined } from 'lodash-es';",
+      options: [
+        {
+          groups: ['builtin', 'external', 'internal'],
+          alphabetize: { order: 'desc', caseInsensitive: true },
+          'newlines-between': 'always',
+        },
+      ],
+      settings: {
+        'import/external-module-folders': ['src/order-internal-modules'],
+      },
+    },
     // Upstream regression: https://github.com/import-js/eslint-plugin-import/issues/3235
     {
       code: "import checkpoint from '../../checkpoint/models';\nimport common from '../common/files';\nimport avatar from './adapters/avatar';\nimport execution from './adapters/execution';\nimport config from './config';",

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.virtual.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/order-internal-modules/*"]
+      "@/*": ["src/order-internal-modules/*"],
+      "buffer": ["src/order-internal-modules/api/service.ts"]
     },
     "lib": ["es2015", "es2017", "esnext"],
     "experimentalDecorators": true


### PR DESCRIPTION
## Summary

- Classify exact Node.js builtin specifiers before TypeScript filesystem resolution, matching `eslint-import-resolver-typescript` when a package or paths mapping shadows names such as `buffer`.
- Preserve `import/internal-regex` precedence and resolution-sensitive behavior for non-exact builtin subpath specifiers and configured core modules.
- Avoid copying every import entry when reverse-direction diagnostics are cheaper. On the targeted 256-import benchmark this reduced allocations from 394,929 B/op and 3,556 allocs/op to 351,283 B/op and 3,291 allocs/op; median runtime improved by 5.8%–11.6% across both benchmark execution orders.
- Replayed every one of the 2,173 unique files referenced by the investigation report: the two obsolete `buffer`/`lodash-es` diagnostics disappeared, no diagnostics were added, and the remaining comparator differences were unchanged. Targeted Go and JS tests pass, with no JS snapshot changes.

## Related Links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
