### PR TITLE
docs(website): move LLMs UI to page outline

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -38,6 +38,9 @@ export default defineConfig({
     },
   },
   themeConfig: {
+    llmsUI: {
+      placement: 'outline',
+    },
     socialLinks: [
       {
         icon: 'github',


### PR DESCRIPTION
## Summary

This PR moves the LLMs UI action into the documentation page outline so it stays accessible alongside page navigation. It sets `themeConfig.llmsUI.placement` to `outline`.

## Related Links

https://github.com/rstackjs/rstack-cli/pull/414

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).