### PR TITLE
feat: port rule unicorn/no-xor-as-exponentiation

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unsafe_string_replacement"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_xor_as_exponentiation"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_some"
@@ -40,6 +41,7 @@ func GetAllRules() []rule.Rule {
 		no_thenable.NoThenableRule,
 		no_unsafe_string_replacement.NoUnsafeStringReplacementRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,
+		no_xor_as_exponentiation.NoXorAsExponentiationRule,
 		prefer_array_flat.PreferArrayFlatRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,
 		prefer_array_some.PreferArraySomeRule,

--- a/internal/plugins/unicorn/rules/no_xor_as_exponentiation/helpers_test.go
+++ b/internal/plugins/unicorn/rules/no_xor_as_exponentiation/helpers_test.go
@@ -1,0 +1,84 @@
+// Test helpers shared by the upstream and extras test files. Kept in a
+// separate _test.go file so each suite can be compiled and run independently
+// while still agreeing on a single source of truth for the operator-token
+// position arithmetic and the InvalidTestCase builder.
+package no_xor_as_exponentiation_test
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageIDError      = "no-xor-as-exponentiation/error"
+	messageIDSuggestion = "no-xor-as-exponentiation/suggestion"
+
+	messageErrorText      = "Unexpected bitwise XOR operator `^`. Did you mean the exponentiation operator `**`?"
+	messageSuggestionText = "Replace `^` with `**`."
+)
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.mjs"}
+}
+
+// xorInvalid reports the operator-token position of the first `^` in `code`
+// and asserts the suggestion rewrites it to `**`.
+func xorInvalid(code string) rule_tester.InvalidTestCase {
+	offset := strings.Index(code, "^")
+	if offset < 0 {
+		panic("no `^` found in no-xor-as-exponentiation test: " + code)
+	}
+	return xorAtInvalid(code, offset)
+}
+
+// xorAtInvalid reports the operator-token position of the `^` at
+// `indexOfCaret` (0-based byte offset) in `code`, asserting the suggestion
+// replaces that one specific token with `**`. Use this for cases where the
+// code contains multiple `^` and the rule fires on a non-first one.
+func xorAtInvalid(code string, indexOfCaret int) rule_tester.InvalidTestCase {
+	if indexOfCaret < 0 || indexOfCaret >= len(code) || code[indexOfCaret] != '^' {
+		panic("indexOfCaret does not point at `^` in: " + code)
+	}
+
+	line, column := lineColumnForOffset(code, indexOfCaret)
+	endLine, endColumn := lineColumnForOffset(code, indexOfCaret+len("^"))
+
+	replaced := code[:indexOfCaret] + "**" + code[indexOfCaret+len("^"):]
+
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mjs",
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: messageIDError,
+			Message:   messageErrorText,
+			Line:      line,
+			Column:    column,
+			EndLine:   endLine,
+			EndColumn: endColumn,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+				MessageId: messageIDSuggestion,
+				Output:    replaced,
+			}},
+		}},
+	}
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for index := 0; index < offset; {
+		r, size := utf8.DecodeRuneInString(code[index:])
+		if r == '\n' {
+			line++
+			column = 1
+		} else if r > 0xFFFF {
+			column += 2
+		} else {
+			column++
+		}
+		index += size
+	}
+	return line, column
+}

--- a/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation.go
+++ b/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation.go
@@ -1,0 +1,83 @@
+package no_xor_as_exponentiation
+
+import (
+	"regexp"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const (
+	messageIDError      = "no-xor-as-exponentiation/error"
+	messageIDSuggestion = "no-xor-as-exponentiation/suggestion"
+)
+
+var messageError = rule.RuleMessage{
+	Id:          messageIDError,
+	Description: "Unexpected bitwise XOR operator `^`. Did you mean the exponentiation operator `**`?",
+}
+
+var messageSuggestion = rule.RuleMessage{
+	Id:          messageIDSuggestion,
+	Description: "Replace `^` with `**`.",
+}
+
+// decimalIntegerPattern mirrors the upstream
+// eslint-plugin-unicorn `isDecimalInteger` helper. It accepts:
+//   - `0`
+//   - legacy octal that happens to be a decimal integer shape (`0[0-7]*[89]\d*`)
+//   - a non-zero digit followed by digits with optional numeric separators
+var decimalIntegerPattern = regexp.MustCompile(`^(?:0|0[0-7]*[89]\d*|[1-9](?:_?\d)*)$`)
+
+// isDecimalIntegerNumeric reports whether the given node is a numeric literal
+// whose raw source text matches the upstream decimal-integer pattern. Mirrors
+// `isDecimalIntegerNode` in the upstream plugin. Uses the raw source text
+// (e.g. `0xFF` stays `0xFF`) rather than tsgo's decimal-normalized `Text`
+// field, since the upstream regex is anchored to a literal-shape classification
+// that the normalized value would silently fold into a decimal integer.
+func isDecimalIntegerNumeric(ctx rule.RuleContext, node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindNumericLiteral {
+		return false
+	}
+	raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, node, false)
+	return decimalIntegerPattern.MatchString(raw)
+}
+
+// NoXorAsExponentiationRule flags `^` between two decimal integer literals. In
+// JavaScript `^` is bitwise XOR, not exponentiation; the rule mirrors the
+// behavior of eslint-plugin-unicorn's `no-xor-as-exponentiation`. It attaches a
+// single suggestion that rewrites the `^` token as `**`.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-xor-as-exponentiation.md
+var NoXorAsExponentiationRule = rule.Rule{
+	Name:   "unicorn/no-xor-as-exponentiation",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				binary := node.AsBinaryExpression()
+				if binary == nil || binary.OperatorToken == nil ||
+					binary.OperatorToken.Kind != ast.KindCaretToken {
+					return
+				}
+
+				left := ast.SkipParentheses(binary.Left)
+				right := ast.SkipParentheses(binary.Right)
+				if !isDecimalIntegerNumeric(ctx, left) || !isDecimalIntegerNumeric(ctx, right) {
+					return
+				}
+
+				operator := binary.OperatorToken
+				ctx.ReportNodeWithDeferredSuggestions(operator, messageError, func() []rule.RuleSuggestion {
+					return []rule.RuleSuggestion{{
+						Message: messageSuggestion,
+						FixesArr: []rule.RuleFix{
+							rule.RuleFixReplace(ctx.SourceFile, operator, "**"),
+						},
+					}}
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation.md
+++ b/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation.md
@@ -1,0 +1,21 @@
+# no-xor-as-exponentiation
+
+## Rule Details
+
+In JavaScript, `^` is the [bitwise XOR](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR) operator, not exponentiation. Developers coming from languages like Lua, Julia, R, or MATLAB, or from math notation, often expect `^` to mean "to the power of", so `2 ^ 32` silently evaluates to `34` instead of `4294967296`. The actual exponentiation operator is [`**`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation).
+
+This rule flags `^` between two decimal integer literals, which is almost always this mistake. Hexadecimal, octal, and binary literals (such as `0xFF ^ 8`) and any non-literal operands (such as `flags ^ MASK`) are ignored, since those are far more likely to be intentional bitwise XOR.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const bytes = 2 ^ 10; // 8, not 1024
+const cube = 3 ^ 3; // 0, not 27
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const bytes = 2 ** 10;
+const cube = 3 ** 3;
+```

--- a/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation.md
+++ b/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation.md
@@ -19,3 +19,8 @@ Examples of **correct** code for this rule:
 const bytes = 2 ** 10;
 const cube = 3 ** 3;
 ```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-xor-as-exponentiation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-xor-as-exponentiation.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-xor-as-exponentiation.js)

--- a/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation_extras_test.go
@@ -1,0 +1,133 @@
+// TestNoXorAsExponentiationExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch it covers, so future refactors can't silently
+// regress them without breaking a named lock-in.
+package no_xor_as_exponentiation_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_xor_as_exponentiation"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// tsValid is the in-package alias for jsValid — the rule is fully syntactic
+// and has no type-aware branches, so .ts and .mjs fixtures exercise the same
+// path.
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.mjs"}
+}
+
+func TestNoXorAsExponentiationExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_xor_as_exponentiation.NoXorAsExponentiationRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Branch: not a BinaryExpression ----
+			tsValid(`2;`),
+			tsValid(`let x = 2;`),
+
+			// ---- Branch: BinaryExpression with a non-CaretToken operator ----
+			tsValid(`2 + 8`),
+			tsValid(`2 - 8`),
+			tsValid(`2 * 8`),
+			tsValid(`2 / 8`),
+			tsValid(`2 % 8`),
+			tsValid(`2 & 8`),
+			tsValid(`2 | 8`),
+			tsValid(`2 << 8`),
+			tsValid(`2 >> 8`),
+			tsValid(`2 >>> 8`),
+
+			// ---- Branch: only one operand is a decimal-integer literal ----
+			// Right side is not a literal.
+			tsValid(`2 ^ identifier`),
+			tsValid(`2 ^ functionCall()`),
+			// Left side is not a literal.
+			tsValid(`identifier ^ 2`),
+			tsValid(`(a + b) ^ 2`),
+
+			// ---- Branch: left is decimal-integer, right is some other numeric literal shape ----
+			// Hex
+			tsValid(`2 ^ 0xFF`),
+			// Octal
+			tsValid(`2 ^ 0o10`),
+			// Binary
+			tsValid(`2 ^ 0b10`),
+			// Float
+			tsValid(`2 ^ 1.5`),
+			// Scientific
+			tsValid(`2 ^ 1e2`),
+			// BigInt — different literal kind entirely.
+			tsValid(`2 ^ 8n`),
+			// TypeScript rejects legacy octal (`01`, `007`) and decimal-with-leading-zero
+			// (`08`, `09`) at parse time, so they don't reach the rule. The decimal-integer
+			// regex intentionally accepts `0[0-7]*[89]\d*` to mirror ESLint's
+			// legacy-octal-but-decimal classification; see the upstream test suite's
+			// "Non-decimal literals are likely intentional bitwise XOR" block.
+
+			// ---- Branch: literal is wrapped in a non-parenthesis expression ----
+			// In tsgo (and ESTree) `-2` and `+2` are PrefixUnaryExpression, not NumericLiteral;
+			// the raw-text check rejects them. Parens don't change the AST shape here.
+			tsValid(`-2 ^ 3`),
+			tsValid(`2 ^ -3`),
+			tsValid(`+2 ^ 3`),
+			tsValid(`2 ^ +3`),
+			tsValid(`(-2) ^ 8`),
+			tsValid(`2 ^ (-8)`),
+
+			// ---- Branch: empty / comment-only files ----
+			tsValid(``),
+			tsValid(`// just a comment`),
+
+			// ---- Branch: `^` inside a non-binary context (e.g. template literal, regex) ----
+			tsValid("const r = /a^b/;"),
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: ESTree-transparent parentheses around operands ----
+			// SkipParentheses unwraps to the inner NumericLiteral, so these still fire.
+			xorInvalid(`(2) ^ 8`),
+			xorInvalid(`2 ^ (8)`),
+			xorInvalid(`((2)) ^ ((8))`),
+			xorInvalid(`(((2 ^ 8)))`),
+
+			// ---- Dimension 4: comments on either side of the operator survive the suggestion ----
+			// The suggestion replaces only the `^` token, leaving surrounding whitespace and
+			// comments in place.
+			xorInvalid(`2/**/^ 8`),
+			xorInvalid(`2 ^/**/ 8`),
+			xorInvalid(`2/*a*/^/*b*/8`),
+
+			// ---- Branch lock-in: single-digit pairs at both ends of the regex ----
+			xorInvalid(`0 ^ 1`),
+			xorInvalid(`9 ^ 9`),
+			// Numeric separators — the regex `(?:_?\d)*` allows them.
+			xorInvalid(`1_2 ^ 3_4`),
+			xorInvalid(`1_000_000 ^ 2`),
+
+			// ---- Branch lock-in: deeply nested binary expressions ----
+			// Only the innermost `2 ^ 8` fires; the outer `^ a` operands are not both literals.
+			// For `((2 ^ 8)) ^ a` the only caret the rule reports is the inner one.
+			// `((2 ^ 8)) ^ a`:
+			//   char 0: (  1: (  2: 2  3:   4: ^  5:   6: 8  7: )  8: )  9:   10: ^  11:   12: a
+			xorAtInvalid(`((2 ^ 8)) ^ a`, 4),
+			// `a ^ (2 ^ 8)`:
+			//   char 0: a  1:   2: ^  3:   4: (  5: 2  6:   7: ^  8:   9: 8  10: )
+			xorAtInvalid(`a ^ (2 ^ 8)`, 7),
+			// `1 ^ (2 ^ 3) ^ 4` (left-associative: `(1 ^ (2 ^ 3)) ^ 4`):
+			//   char 0: 1  1:   2: ^  3:   4: (  5: 2  6:   7: ^  8:   9: 3  10: )  11:   12: ^  13:   14: 4
+			// Only the inner `2 ^ 3` matches; the outer `^` operands include a non-literal.
+			xorAtInvalid(`1 ^ (2 ^ 3) ^ 4`, 7),
+
+			// ---- Branch lock-in: XOR at unusual positions in an expression ----
+			xorInvalid(`2 ^ 8 ? 1 : 0`),
+			xorInvalid(`[2 ^ 8]`),
+			xorInvalid(`({x: 2 ^ 8})`),
+			xorInvalid(`function f() { return 2 ^ 8; }`),
+			xorInvalid(`2 ^ 8;`),
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation_upstream_test.go
@@ -55,9 +55,10 @@ func TestNoXorAsExponentiationUpstream(t *testing.T) {
 			jsValid(`2 ** 8`),
 
 			// ---- TypeScript: operand is a `TSAsExpression`, not a literal ----
-			// rslint does not differentiate AsExpression from its operand at the
-			// rule layer; Skip: the upstream parser boundary is not relevant here.
-			{Code: `(2 as number) ^ 8`, Skip: true},
+			// rslint preserves the AsExpression wrapper after SkipParentheses, so the
+			// inner literal doesn't match `isDecimalIntegerNumeric`. Run as `.ts` to
+			// exercise the TypeScript parser path.
+			{Code: `(2 as number) ^ 8`, FileName: "file.ts"},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Plain decimal-integer pairs ----

--- a/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_xor_as_exponentiation/no_xor_as_exponentiation_upstream_test.go
@@ -1,0 +1,90 @@
+// TestNoXorAsExponentiationUpstream migrates the full valid/invalid suite from
+// upstream test/no-xor-as-exponentiation.js 1:1. Position assertions cover
+// line/column for the operator token reported in every invalid case.
+// rslint-specific lock-in cases live in no_xor_as_exponentiation_extras_test.go.
+package no_xor_as_exponentiation_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_xor_as_exponentiation"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoXorAsExponentiationUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_xor_as_exponentiation.NoXorAsExponentiationRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Already correct exponentiation ----
+			jsValid(`2 ** 32`),
+
+			// ---- Non-decimal literals are likely intentional bitwise XOR ----
+			jsValid(`0xFF ^ 8`),
+			jsValid(`2 ^ 0x10`),
+			jsValid(`0b100 ^ 2`),
+			jsValid(`0o20 ^ 2`),
+			jsValid(`2 ^ 0o20`),
+
+			// ---- Non-literal operands ----
+			jsValid(`a ^ b`),
+			jsValid(`x ^ 2`),
+			jsValid(`2 ^ y`),
+			jsValid(`flags ^ MASK`),
+
+			// ---- Floats ----
+			jsValid(`2.5 ^ 3`),
+			jsValid(`2 ^ 3.5`),
+			jsValid(`2e3 ^ 2`),
+
+			// ---- BigInt ----
+			jsValid(`2n ^ 32n`),
+
+			// ---- Unary operand is not a literal ----
+			jsValid(`2 ^ -3`),
+			jsValid(`-2 ^ 3`),
+			jsValid(`2 ^ +3`),
+
+			// ---- Other operators ----
+			jsValid(`2 | 8`),
+			jsValid(`2 & 8`),
+			jsValid(`2 << 8`),
+			jsValid(`2 ** 8`),
+
+			// ---- TypeScript: operand is a `TSAsExpression`, not a literal ----
+			// rslint does not differentiate AsExpression from its operand at the
+			// rule layer; Skip: the upstream parser boundary is not relevant here.
+			{Code: `(2 as number) ^ 8`, Skip: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Plain decimal-integer pairs ----
+			xorInvalid(`2 ^ 32`),
+			xorInvalid(`3 ^ 3`),
+			xorInvalid(`10 ^ 6`),
+			xorInvalid(`0 ^ 0`),
+			xorInvalid(`2 ^ 8`),
+
+			// ---- Surrounding whitespace preserved by the suggestion ----
+			xorInvalid(`2  ^  8`),
+
+			// ---- Inside an expression ----
+			xorInvalid(`const x = 2 ^ 8;`),
+			xorInvalid(`foo(2 ^ 8)`),
+
+			// ---- Numeric separators are still decimal integers ----
+			xorInvalid(`10 ^ 1_000`),
+
+			// ---- Nested: only the inner literal pair fires (the outer ^ has a non-literal operand) ----
+			xorInvalid(`2 ^ 8 ^ 2`),
+
+			// ---- Comment between operands must be preserved by the suggestion ----
+			xorInvalid(`2 /* comment */ ^ 8`),
+
+			// ---- TypeScript parser, plain literal pair still fires ----
+			xorInvalid(`2 ^ 8`),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -638,6 +638,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-unsafe-string-replacement.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-xor-as-exponentiation.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-some.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-xor-as-exponentiation.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-xor-as-exponentiation.test.ts
@@ -1,0 +1,86 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code, filename: 'file.mjs' });
+
+const invalid = (code: string, output: string) => ({
+  code,
+  filename: 'file.mjs',
+  errors: [
+    {
+      message:
+        'Unexpected bitwise XOR operator `^`. Did you mean the exponentiation operator `**`?',
+      suggestions: [
+        {
+          messageId: 'no-xor-as-exponentiation/suggestion',
+          desc: 'Replace `^` with `**`.',
+          output,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('no-xor-as-exponentiation', null as never, {
+  valid: [
+    // Already correct exponentiation.
+    valid('2 ** 32'),
+
+    // Non-decimal literals are likely intentional bitwise XOR.
+    valid('0xFF ^ 8'),
+    valid('2 ^ 0x10'),
+    valid('0b100 ^ 2'),
+    valid('0o20 ^ 2'),
+    valid('2 ^ 0o20'),
+
+    // Non-literal operands.
+    valid('a ^ b'),
+    valid('x ^ 2'),
+    valid('2 ^ y'),
+    valid('flags ^ MASK'),
+
+    // Floats.
+    valid('2.5 ^ 3'),
+    valid('2 ^ 3.5'),
+    valid('2e3 ^ 2'),
+
+    // BigInt.
+    valid('2n ^ 32n'),
+
+    // Unary operand is not a literal.
+    valid('2 ^ -3'),
+    valid('-2 ^ 3'),
+    valid('2 ^ +3'),
+
+    // Other operators.
+    valid('2 | 8'),
+    valid('2 & 8'),
+    valid('2 << 8'),
+    valid('2 ** 8'),
+  ],
+  invalid: [
+    // Plain decimal-integer pairs.
+    invalid('2 ^ 32', '2 ** 32'),
+    invalid('3 ^ 3', '3 ** 3'),
+    invalid('10 ^ 6', '10 ** 6'),
+    invalid('0 ^ 0', '0 ** 0'),
+    invalid('2 ^ 8', '2 ** 8'),
+
+    // Surrounding whitespace preserved by the suggestion.
+    invalid('2  ^  8', '2  **  8'),
+
+    // Inside an expression.
+    invalid('const x = 2 ^ 8;', 'const x = 2 ** 8;'),
+    invalid('foo(2 ^ 8)', 'foo(2 ** 8)'),
+
+    // Numeric separators are still decimal integers.
+    invalid('10 ^ 1_000', '10 ** 1_000'),
+
+    // Nested: only the inner literal pair fires.
+    invalid('2 ^ 8 ^ 2', '2 ^ 8 ** 2'),
+
+    // Comment between operands must be preserved by the suggestion.
+    invalid('2 /* comment */ ^ 8', '2 /* comment */ ** 8'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -198,7 +198,7 @@ const recommended: RslintConfigEntry = {
     'unicorn/no-useless-switch-case': 'error',
     // 'unicorn/no-useless-template-literals': 'error', // not implemented
     // 'unicorn/no-useless-undefined': 'error', // not implemented
-    // 'unicorn/no-xor-as-exponentiation': 'error', // not implemented
+    'unicorn/no-xor-as-exponentiation': 'error',
     // 'unicorn/no-zero-fractions': 'error', // not implemented
     // 'unicorn/number-literal-case': 'error', // not implemented
     // 'unicorn/numeric-separators-style': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `unicorn/no-xor-as-exponentiation` rule from ESLint to rslint.

Flags `^` between two decimal integer literals (a common typo when developers expect exponentiation, but JavaScript `^` is bitwise XOR). Suggests replacing `^` with `**`.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-xor-as-exponentiation.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-xor-as-exponentiation.js
- Test cases: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/no-xor-as-exponentiation.js

## Implementation Notes

- **Raw text match**: tsgo's `NumericLiteral.Text` is decimal-normalized (e.g. `0xFF` → `255`), which would fold the upstream regex's literal-shape classification. Uses `scanner.GetSourceTextOfNodeFromSourceFile` to read the raw source form before testing the decimal-integer regex.
- **Single suggestion**: only the `^` token is replaced; surrounding whitespace and comments are preserved (covered by the `2 /* comment */ ^ 8` test).
- **Suggestions are deferred**: detection, message construction, and the report range are eager; the suggestion's fix is built lazily via `ReportNodeWithDeferredSuggestions`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).