### PR TITLE
chore(deps): migrate to @rstackjs/doc-ui v1.14.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,9 @@ catalogs:
     '@rspress/plugin-sitemap':
       specifier: ^2.0.18
       version: 2.0.18
-    '@rstack-dev/doc-ui':
-      specifier: ^1.14.7
-      version: 1.14.7
+    '@rstackjs/doc-ui':
+      specifier: 1.14.9
+      version: 1.14.9
     '@rstest/core':
       specifier: ^0.11.3
       version: 0.11.3
@@ -448,7 +448,7 @@ importers:
         version: 26.2.0
       '@typescript-eslint/parser':
         specifier: 'catalog:'
-        version: 8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/rule-tester':
         specifier: workspace:*
         version: link:../rule-tester
@@ -460,7 +460,7 @@ importers:
         version: 10.9.0(jiti@2.7.0)
       eslint-plugin-cypress:
         specifier: 'catalog:'
-        version: 6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.9.0(jiti@2.7.0))
+        version: 6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.0(jiti@2.7.0))
       eslint-plugin-es-x:
         specifier: 'catalog:'
         version: 9.7.0(eslint@10.9.0(jiti@2.7.0))
@@ -515,7 +515,7 @@ importers:
         version: 4.68.0
       prebundle:
         specifier: 'catalog:'
-        version: 1.6.5(typescript@5.9.3)
+        version: 1.6.5(typescript@6.0.3)
 
   packages/rule-tester:
     dependencies:
@@ -685,9 +685,9 @@ importers:
       '@rspress/plugin-sitemap':
         specifier: 'catalog:'
         version: 2.0.18(@rspress/core@2.0.18(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
-      '@rstack-dev/doc-ui':
+      '@rstackjs/doc-ui':
         specifier: 'catalog:'
-        version: 1.14.7(@rspress/core@2.0.18(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.14.9(@rspress/core@2.0.18(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.3.3
@@ -2738,8 +2738,8 @@ packages:
   '@rspress/shared@2.0.18':
     resolution: {integrity: sha512-GJswqJQCPSxvBt5r+gJzz8Em8EEK/sOmCQjTpemTvldvxr1Lva85BGVnSQZOgofnM0nrjt18kn4mmnuuSstbpA==}
 
-  '@rstack-dev/doc-ui@1.14.7':
-    resolution: {integrity: sha512-PnY2JKleZxQTbSrxRAyG84lBKNwXwB+v05sUOFxF5qD1UPmBn/bzRmL4zNOPq1qG4d0PjTG62weetryub40M2A==}
+  '@rstackjs/doc-ui@1.14.9':
+    resolution: {integrity: sha512-Te7Wx4K9JuvluP7HsH/Dpdju5QhClUe17/9YBzHlul+x2wg63jOkngv79DlMXyYDJgHQ+11vZfz18B+bnPhttw==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
@@ -8450,7 +8450,7 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstack-dev/doc-ui@1.14.7(@rspress/core@2.0.18(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rstackjs/doc-ui@1.14.9(@rspress/core@2.0.18(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))':
     optionalDependencies:
       '@rspress/core': 2.0.18(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
@@ -8813,24 +8813,24 @@ snapshots:
 
   '@types/vscode@1.125.0': {}
 
-  '@typescript-eslint/parser@8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.9.0(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8839,24 +8839,24 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
-  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9780,12 +9780,12 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-cypress@6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.9.0(jiti@2.7.0)):
+  eslint-plugin-cypress@6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.9.0(jiti@2.7.0)
       globals: 17.9.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.9.0(jiti@2.7.0))(typescript@6.0.3)
 
   eslint-plugin-es-x@9.7.0(eslint@10.9.0(jiti@2.7.0)):
     dependencies:
@@ -11721,13 +11721,13 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
-  prebundle@1.6.5(typescript@5.9.3):
+  prebundle@1.6.5(typescript@6.0.3):
     dependencies:
       '@vercel/ncc': 0.38.4
       cac: 7.0.0
       prettier: 3.9.6
       rollup: 4.62.2
-      rollup-plugin-dts: 6.4.1(rollup@4.62.2)(typescript@5.9.3)
+      rollup-plugin-dts: 6.4.1(rollup@4.62.2)(typescript@6.0.3)
       terser: 5.49.0
     transitivePeerDependencies:
       - typescript
@@ -12083,14 +12083,14 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rollup-plugin-dts@6.4.1(rollup@4.62.2)(typescript@5.9.3):
+  rollup-plugin-dts@6.4.1(rollup@4.62.2)(typescript@6.0.3):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       convert-source-map: 2.0.0
       magic-string: 0.30.21
       rollup: 4.62.2
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       '@babel/code-frame': 7.29.7
 
@@ -12648,10 +12648,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  ts-api-utils@2.5.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,7 +83,7 @@ catalog:
   '@rsbuild/plugin-sass': ^1.5.3
   '@rspress/core': ^2.0.18
   '@rspress/plugin-sitemap': ^2.0.18
-  '@rstack-dev/doc-ui': ^1.14.7
+  '@rstackjs/doc-ui': 1.14.9
   '@tailwindcss/postcss': ^4.3.3
   '@types/dagre': ^0.7.54
   '@types/react-dom': ^19.2.3

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
     "@rslint/core": "workspace:*",
     "@rspress/core": "catalog:",
     "@rspress/plugin-sitemap": "catalog:",
-    "@rstack-dev/doc-ui": "catalog:",
+    "@rstackjs/doc-ui": "catalog:",
     "@tailwindcss/postcss": "catalog:",
     "@types/dagre": "catalog:",
     "@types/node": "catalog:",

--- a/website/theme/components/Hero.tsx
+++ b/website/theme/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { useI18n, useNavigate } from '@rspress/core/runtime';
-import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
+import { Hero as BaseHero } from '@rstackjs/doc-ui/hero';
 import { useI18nUrl } from './utils';
 import './Hero.module.scss';
 

--- a/website/theme/components/ToolStack.tsx
+++ b/website/theme/components/ToolStack.tsx
@@ -1,6 +1,6 @@
 import { useLang } from '@rspress/core/runtime';
-import { containerStyle } from '@rstack-dev/doc-ui/section-style';
-import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
+import { containerStyle } from '@rstackjs/doc-ui/section-style';
+import { ToolStack as BaseToolStack } from '@rstackjs/doc-ui/tool-stack';
 
 export function ToolStack() {
   const lang = useLang();

--- a/website/theme/index.scss
+++ b/website/theme/index.scss
@@ -1,13 +1,3 @@
 :root {
-  --rp-c-brand: #ff5e00;
-  --rp-c-brand-dark: #ff704d;
-  --rp-c-brand-darker: #ff704d;
-  --rp-c-brand-light: #ff7524;
-  --rp-c-brand-lighter: #ff7524;
   --rp-c-link: var(--rp-c-brand);
-  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
-}
-
-.dark {
-  --rp-c-link: var(--rp-c-brand-light);
 }

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,6 +1,7 @@
 import { Layout as BaseLayout } from '@rspress/core/theme-original';
-import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
+import { NavIcon } from '@rstackjs/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
+import '@rstackjs/doc-ui/theme.css';
 import './index.scss';
 
 const Layout = () => {

--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -1,4 +1,4 @@
-import { BackgroundImage } from '@rstack-dev/doc-ui/background-image';
+import { BackgroundImage } from '@rstackjs/doc-ui/background-image';
 import { CopyRight } from '../components/Copyright';
 import { Hero } from '../components/Hero';
 import { ToolStack } from '../components/ToolStack';


### PR DESCRIPTION
## Summary

`@rstackjs/doc-ui` replaces the old `@rstack-dev/doc-ui` package and exposes shared Rspress theme styles. This PR migrates the rslint website to v1.14.9, loads the shared `theme.css`, and keeps only the rslint-specific link color override locally.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8382
- https://github.com/rstackjs/rstack-doc-ui/releases/tag/v1.14.9

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).