### PR TITLE
fix(website): keep playground editor hover from being clipped

### DIFF
--- a/website/theme/components/Playground/EditorTabs.css
+++ b/website/theme/components/Playground/EditorTabs.css
@@ -1,4 +1,15 @@
 /* Monaco Editor specific styles - cannot be done with Tailwind */
+
+/* Body-level host for Monaco hover/suggest widgets, above the site nav bar */
+.playground-overflow-widgets {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  z-index: 100000;
+}
+
 .monaco-editor .ast-node-highlight {
   background: rgba(198, 228, 255, 0.65);
   outline: 1px solid #0969da;

--- a/website/theme/components/Playground/EditorTabs.css
+++ b/website/theme/components/Playground/EditorTabs.css
@@ -1,13 +1,12 @@
 /* Monaco Editor specific styles - cannot be done with Tailwind */
 
-/* Body-level host for Monaco hover/suggest widgets, above the site nav bar */
-.playground-overflow-widgets {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 0;
-  height: 0;
-  z-index: 100000;
+/*
+ * Monaco gives the hover widget an inline `z-index: 50`, which sits below the
+ * Rspress header's `z-index: 60`, so the header paints over any hover opened
+ * near the top of the page.
+ */
+.monaco-resizable-hover {
+  z-index: 1000000 !important;
 }
 
 .monaco-editor .ast-node-highlight {

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -34,6 +34,22 @@ window.MonacoEnvironment = {
 
 export type EditorTabType = 'code' | 'rslint' | 'tsconfig';
 
+/**
+ * Monaco renders hover/suggest widgets inside the editor by default, where the
+ * overflow guard clips them against the top edge and the site nav paints over
+ * them. Hosting the widgets in a body-level node escapes both.
+ */
+let overflowWidgetsNode: HTMLElement | undefined;
+function getOverflowWidgetsNode(): HTMLElement | undefined {
+  if (typeof document === 'undefined') return undefined;
+  if (!overflowWidgetsNode) {
+    overflowWidgetsNode = document.createElement('div');
+    overflowWidgetsNode.className = 'monaco-editor playground-overflow-widgets';
+    document.body.appendChild(overflowWidgetsNode);
+  }
+  return overflowWidgetsNode;
+}
+
 export interface EditorTabsRef {
   getValue: () => string | undefined;
   getCodeValue: () => string | undefined;
@@ -311,6 +327,8 @@ export const EditorTabs = ({
       theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
+      fixedOverflowWidgets: true,
+      overflowWidgetsDomNode: getOverflowWidgetsNode(),
     });
     codeEditorRef.current = editor;
 
@@ -395,6 +413,8 @@ export const EditorTabs = ({
       theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
+      fixedOverflowWidgets: true,
+      overflowWidgetsDomNode: getOverflowWidgetsNode(),
     });
     rslintEditorRef.current = editor;
 
@@ -417,6 +437,8 @@ export const EditorTabs = ({
       theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
+      fixedOverflowWidgets: true,
+      overflowWidgetsDomNode: getOverflowWidgetsNode(),
     });
     tsconfigEditorRef.current = editor;
 

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -34,22 +34,6 @@ window.MonacoEnvironment = {
 
 export type EditorTabType = 'code' | 'rslint' | 'tsconfig';
 
-/**
- * Monaco renders hover/suggest widgets inside the editor by default, where the
- * overflow guard clips them against the top edge and the site nav paints over
- * them. Hosting the widgets in a body-level node escapes both.
- */
-let overflowWidgetsNode: HTMLElement | undefined;
-function getOverflowWidgetsNode(): HTMLElement | undefined {
-  if (typeof document === 'undefined') return undefined;
-  if (!overflowWidgetsNode) {
-    overflowWidgetsNode = document.createElement('div');
-    overflowWidgetsNode.className = 'monaco-editor playground-overflow-widgets';
-    document.body.appendChild(overflowWidgetsNode);
-  }
-  return overflowWidgetsNode;
-}
-
 export interface EditorTabsRef {
   getValue: () => string | undefined;
   getCodeValue: () => string | undefined;
@@ -328,7 +312,6 @@ export const EditorTabs = ({
       automaticLayout: true,
       scrollBeyondLastLine: false,
       fixedOverflowWidgets: true,
-      overflowWidgetsDomNode: getOverflowWidgetsNode(),
     });
     codeEditorRef.current = editor;
 
@@ -414,7 +397,6 @@ export const EditorTabs = ({
       automaticLayout: true,
       scrollBeyondLastLine: false,
       fixedOverflowWidgets: true,
-      overflowWidgetsDomNode: getOverflowWidgetsNode(),
     });
     rslintEditorRef.current = editor;
 
@@ -438,7 +420,6 @@ export const EditorTabs = ({
       automaticLayout: true,
       scrollBeyondLastLine: false,
       fixedOverflowWidgets: true,
-      overflowWidgetsDomNode: getOverflowWidgetsNode(),
     });
     tsconfigEditorRef.current = editor;
 


### PR DESCRIPTION
## Summary

Hovering a symbol on the first lines of the playground editor showed a hover card that was cut off at the top and painted underneath the site nav bar; Monaco renders hover and suggest widgets inside the editor's own DOM by default, so they are clipped by the editor's overflow guard and trapped in the playground container's stacking context — this hosts them in a body-level node instead, kept above the nav.

Before:

<img width="501" height="171" alt="image" src="https://github.com/user-attachments/assets/16c1f3dd-08ff-4a12-aa41-09f2fc5dfc12" />

This PR:

<img width="519" height="188" alt="image" src="https://github.com/user-attachments/assets/7e458c34-3939-4ebe-b648-5c1c554cc268" />

