### PR TITLE
feat(unicorn): port rule no-nested-ternary

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_nested_ternary"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unsafe_string_replacement"
@@ -36,6 +37,7 @@ func GetAllRules() []rule.Rule {
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,
 		no_invalid_fetch_options.NoInvalidFetchOptionsRule,
 		no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
+		no_nested_ternary.NoNestedTernaryRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,
 		no_unsafe_string_replacement.NoUnsafeStringReplacementRule,

--- a/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.go
+++ b/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.go
@@ -1,0 +1,108 @@
+package no_nested_ternary
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const (
+	messageIDTooDeep     = "no-nested-ternary/too-deep"
+	messageIDShouldParen = "no-nested-ternary/should-parenthesized"
+)
+
+func messageTooDeep() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDTooDeep,
+		Description: "Do not nest ternary expressions.",
+	}
+}
+
+func messageShouldParen() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDShouldParen,
+		Description: "Nested ternary expression should be parenthesized.",
+	}
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-nested-ternary.js
+var NoNestedTernaryRule = rule.Rule{
+	Name:   "unicorn/no-nested-ternary",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindConditionalExpression: func(node *ast.Node) {
+				checkConditionalExpression(ctx, node)
+			},
+		}
+	},
+}
+
+func checkConditionalExpression(ctx rule.RuleContext, node *ast.Node) {
+	cond := node.AsConditionalExpression()
+	if cond == nil {
+		return
+	}
+
+	// Skip when any direct child is a ConditionalExpression (after paren skip):
+	// the outer will report and double-reporting this node would be a duplicate.
+	if isConditionalExpression(cond.Condition) ||
+		isConditionalExpression(cond.WhenTrue) ||
+		isConditionalExpression(cond.WhenFalse) {
+		return
+	}
+
+	// Count consecutive ConditionalExpression ancestors (skipping paren wrappers,
+	// which ESTree flattens out of the AST but tsgo keeps as explicit nodes).
+	nestLevel := 0
+	for ancestor := effectiveParent(node); ancestor != nil && ancestor.Kind == ast.KindConditionalExpression; ancestor = effectiveParent(ancestor) {
+		nestLevel++
+	}
+
+	switch {
+	case nestLevel == 1 && !isSourceParenthesized(node):
+		// One level of unparenthesized nesting → wrap it in parens (autofix).
+		ctx.ReportNodeWithDeferredFixes(node, messageShouldParen(), func() []rule.RuleFix {
+			return []rule.RuleFix{
+				rule.RuleFixInsertBefore(ctx.SourceFile, node, "("),
+				rule.RuleFixInsertAfter(node, ")"),
+			}
+		})
+	case nestLevel > 1:
+		// Deep nesting: report "too-deep" on the appropriate node. When the
+		// nesting chain has more than two ternary levels, point at the upper
+		// boundary (ancestors[nestLevel-3] in the upstream array, i.e. the
+		// (nestLevel-2)th effective parent); otherwise report on the innermost
+		// node itself.
+		target := node
+		for i := 0; i < nestLevel-2; i++ {
+			target = effectiveParent(target)
+		}
+		ctx.ReportNode(target, messageTooDeep())
+	}
+}
+
+// isConditionalExpression reports whether the (paren-skipped) node is a ConditionalExpression.
+func isConditionalExpression(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return ast.SkipParentheses(node).Kind == ast.KindConditionalExpression
+}
+
+// isSourceParenthesized reports whether the node is wrapped in a paren in the source.
+// One or more paren wrappers are equivalent for this rule; the test's first non-paren
+// ancestor is what matters for the `nestLevel == 1` parenthesized-OK branch.
+func isSourceParenthesized(node *ast.Node) bool {
+	return node.Parent != nil && node.Parent.Kind == ast.KindParenthesizedExpression
+}
+
+// effectiveParent returns node's parent, treating any ParenthesizedExpression
+// wrappers as transparent — they don't change the AST-nesting level that the
+// upstream rule computes by walking the source-flattened ancestor chain.
+func effectiveParent(node *ast.Node) *ast.Node {
+	current := node
+	for current.Parent != nil && current.Parent.Kind == ast.KindParenthesizedExpression {
+		current = current.Parent
+	}
+	return current.Parent
+}

--- a/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.go
+++ b/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.go
@@ -74,7 +74,7 @@ func checkConditionalExpression(ctx rule.RuleContext, node *ast.Node) {
 		// (nestLevel-2)th effective parent); otherwise report on the innermost
 		// node itself.
 		target := node
-		for i := 0; i < nestLevel-2; i++ {
+		for range nestLevel - 2 {
 			target = effectiveParent(target)
 		}
 		ctx.ReportNode(target, messageTooDeep())

--- a/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.md
+++ b/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.md
@@ -1,0 +1,62 @@
+# no-nested-ternary
+
+📝 Disallow nested ternary expressions.
+
+💼🚫 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+Improved version of the [`no-nested-ternary`](https://eslint.org/docs/latest/rules/no-nested-ternary) ESLint rule. This rule allows cases where the nested ternary is only one level and wrapped in parens.
+
+Unparenthesized or deeply nested ternaries make readers track multiple conditions and branches at once, so this rule permits only clearly parenthesized single-level nesting.
+
+## Examples
+
+```js
+// ❌
+const foo = i > 5 ? i < 100 ? true : false : true;
+
+// ✅
+const foo = i > 5 ? (i < 100 ? true : false) : true;
+```
+
+```js
+// ❌
+const foo = i > 5 ? true : (i < 100 ? true : (i < 1000 ? true : false));
+```
+
+```js
+// ✅
+const foo = i > 5 || i < 100 || i < 1000;
+```
+
+## Partly fixable
+
+This rule is only fixable when the nesting is up to one level. The rule will wrap the nested ternary in parens:
+
+```js
+const foo = i > 5 ? i < 100 ? true : false : true
+```
+
+will get fixed to
+
+```js
+const foo = i > 5 ? (i < 100 ? true : false) : true
+```
+
+## Disabling ESLint `no-nested-ternary`
+
+We recommend disabling the ESLint `no-nested-ternary` rule in favor of this one:
+
+```js
+{
+	rules: {
+		'no-nested-ternary': 'off',
+	},
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-nested-ternary](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-nested-ternary.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-nested-ternary.js)

--- a/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.md
+++ b/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.md
@@ -1,59 +1,41 @@
 # no-nested-ternary
 
-📝 Disallow nested ternary expressions.
+## Rule Details
 
-💼🚫 This rule is enabled in the ✅ `recommended` config.
+Improved version of the core ESLint [`no-nested-ternary`](https://eslint.org/docs/latest/rules/no-nested-ternary) rule. It allows cases where the nested ternary is only one level and wrapped in parentheses.
 
-🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+Unparenthesized or deeply nested ternaries force readers to track multiple conditions and branches at once, so this rule permits only clearly parenthesized single-level nesting.
 
-Improved version of the [`no-nested-ternary`](https://eslint.org/docs/latest/rules/no-nested-ternary) ESLint rule. This rule allows cases where the nested ternary is only one level and wrapped in parens.
+Examples of **incorrect** code for this rule:
 
-Unparenthesized or deeply nested ternaries make readers track multiple conditions and branches at once, so this rule permits only clearly parenthesized single-level nesting.
-
-## Examples
-
-```js
-// ❌
+```javascript
 const foo = i > 5 ? i < 100 ? true : false : true;
-
-// ✅
-const foo = i > 5 ? (i < 100 ? true : false) : true;
 ```
 
-```js
-// ❌
+```javascript
 const foo = i > 5 ? true : (i < 100 ? true : (i < 1000 ? true : false));
 ```
 
-```js
-// ✅
+```javascript
+const foo = i > 5 ? true : (i < 100 ? (i > 50 ? false : true) : false);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const foo = i > 5 ? true : (i < 100 ? true : false);
+```
+
+```javascript
+const foo = i > 5 ? (i < 100 ? true : false) : true;
+```
+
+```javascript
+const foo = i > 5 ? (i < 100 ? true : false) : (i < 100 ? true : false);
+```
+
+```javascript
 const foo = i > 5 || i < 100 || i < 1000;
-```
-
-## Partly fixable
-
-This rule is only fixable when the nesting is up to one level. The rule will wrap the nested ternary in parens:
-
-```js
-const foo = i > 5 ? i < 100 ? true : false : true
-```
-
-will get fixed to
-
-```js
-const foo = i > 5 ? (i < 100 ? true : false) : true
-```
-
-## Disabling ESLint `no-nested-ternary`
-
-We recommend disabling the ESLint `no-nested-ternary` rule in favor of this one:
-
-```js
-{
-	rules: {
-		'no-nested-ternary': 'off',
-	},
-}
 ```
 
 ## Original Documentation

--- a/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_extras_test.go
@@ -1,0 +1,175 @@
+package no_nested_ternary_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_nested_ternary"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func linesE(parts ...string) string {
+	return strings.Join(parts, "\n")
+}
+
+// TestNoNestedTernaryExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+func TestNoNestedTernaryExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_nested_ternary.NoNestedTernaryRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: paren wrappers on the outer ----
+			// Multi-level paren wrappers on the outer test position.
+			// `((a?b:c))` is parsed as ParenExpr(ParenExpr(CondExpr)).
+			// The inner's effective parent is the outer CondExpr; the inner is
+			// "source-parenthesized" because its direct parent is a ParenExpr.
+			rule_tester.ValidTestCase{Code: `const foo = ((a ? b : c)) ? d : e;`},
+
+			// ---- Real-user: ternary in template literal (issue #663 family) ----
+			rule_tester.ValidTestCase{Code: "const s = `${a ? b : c}`;"},
+
+			// ---- Real-user: ternary in object property value ----
+			rule_tester.ValidTestCase{Code: `const o = { x: a ? b : c };`},
+
+			// ---- Real-user: ternary as function argument (no nesting) ----
+			rule_tester.ValidTestCase{Code: `f(a ? b : c);`},
+
+			// ---- Real-user: nested ternary in JSX expression container ----
+			rule_tester.ValidTestCase{Code: `const el = <div>{a ? (b ? c : d) : e}</div>;`, Tsx: true},
+
+			// ---- Branch lock-in: 2-level nesting with paren-wrapped inner is valid ----
+			// `a ? (b ? c : d) : e` — the inner is parenthesized and only one
+			// level deep, so the rule accepts it. Locks in the early-return
+			// (outer consequent is CondExpr → outer skipped) and the
+			// nestLevel === 1 + parenthesized → no report branch.
+			rule_tester.ValidTestCase{Code: `const foo = a ? (b ? c : d) : e;`},
+
+			// ---- Branch lock-in: nestLevel === 0 (no CondExpr ancestors) ----
+			// A bare top-level ternary in a paren must NOT report, even with
+			// arbitrary paren wrappers around it.
+			rule_tester.ValidTestCase{Code: `const x = (((a ? b : c)));`},
+
+			// ---- Branch lock-in: nestLevel === 1 with paren, multi-line ----
+			// The inner ternary is parenthesized even when split across lines.
+			rule_tester.ValidTestCase{Code: linesE(
+				`const x = a ?`,
+				`	(`,
+				`		b ? c : d`,
+				`	) : e;`,
+			)},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: optional chain in the test position ----
+			// `a?.b ? c ? d : e : f` — the consequent is a CondExpr so the outer
+			// early-returns; the inner has nestLevel=1, is NOT parenthesized, and
+			// the autofix wraps it.
+			rule_tester.InvalidTestCase{
+				Code:   `const foo = a?.b ? c ? d : e : f;`,
+				Output: []string{`const foo = a?.b ? (c ? d : e) : f;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID}},
+			},
+
+			// ---- Dimension 4: non-null assertion in the test position ----
+			// `a! ? b ? c : d : e` — same shape, asserts that the non-null
+			// assertion does not break the early-return / nestLevel logic.
+			rule_tester.InvalidTestCase{
+				Code:   `const foo = a! ? b ? c : d : e;`,
+				Output: []string{`const foo = a! ? (b ? c : d) : e;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID}},
+			},
+
+			// ---- Dimension 4: parenthesized type assertion in the test ----
+			// `(a as any) ? b ? c : d : e` — paren-wrapped type assertion is a
+			// ParenExpr(AsExpr). The inner CondExpr is not parenthesized, so
+			// should-parenthesized fires.
+			rule_tester.InvalidTestCase{
+				Code:   `const foo = (a as any) ? b ? c : d : e;`,
+				Output: []string{`const foo = (a as any) ? (b ? c : d) : e;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID}},
+			},
+
+			// ---- Branch lock-in: 3-level nesting with paren-wrapped inner reports too-deep ----
+			// `a ? (b ? c : (d ? e : f)) : g` — for the innermost, walking up
+			// through parens gives nestLevel=2, isParenthesized=true.
+			// nestLevel > 1 fires, target = node (the innermost). Locks in
+			// the "parenthesized doesn't suppress too-deep" branch.
+			rule_tester.InvalidTestCase{
+				Code:   `const foo = a ? (b ? c : (d ? e : f)) : g;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: tooDeepMessageID, Line: 1, Column: 27, EndLine: 1, EndColumn: 36}},
+			},
+
+			// ---- Branch lock-in: nestLevel === 3 reports on ancestors[0] ----
+			// For 3 ternary ancestors, `ancestors[nestLevel-3] === ancestors[0]`
+			// is the innermost CondExpr parent. The innermost itself is wrapped
+			// in parens, so it's the 1st CondExpr parent that gets the report.
+			// Locks in upstream arm: `nestLevel > 2 ? ancestors[nestLevel-3] : node`
+			// with nestLevel === 3.
+			rule_tester.InvalidTestCase{
+				Code: linesE(
+					`const foo = a ? b : (`,
+					`	c ? d : (`,
+					`		e ? f : (g ? h : i)`,
+					`	)`,
+					`);`,
+				),
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: tooDeepMessageID, Line: 3, Column: 3}},
+			},
+
+			// ---- Branch lock-in: nestLevel === 4 reports on ancestors[1] ----
+			// For 4 ternary ancestors, ancestors[1] is the 2nd CondExpr parent
+			// (one level up from the innermost). The innermost is in a paren
+			// inside another paren, so the inner CondExpr parent is 1 level up.
+			rule_tester.InvalidTestCase{
+				Code: linesE(
+					`const foo = a ? b : (`,
+					`	c ? d : (`,
+					`		e ? f : (`,
+					`			g ? h : (i ? j : k)`,
+					`		)`,
+					`	)`,
+					`);`,
+				),
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: tooDeepMessageID, Line: 3, Column: 3}},
+			},
+
+			// ---- Branch lock-in: early-return when consequent is CondExpr ----
+			// `a ? b ? c : d : e` — outer's consequent is a CondExpr, so the
+			// outer early-returns. Only the inner reports (1 error, not 2).
+			// Locks in upstream arm: `if ([test, consequent, alternate].some(...)) return`.
+			rule_tester.InvalidTestCase{
+				Code:   `const foo = a ? b ? c : d : e;`,
+				Output: []string{`const foo = a ? (b ? c : d) : e;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID, Line: 1, Column: 17}},
+			},
+
+			// ---- Real-user: nested ternary in template literal expression ----
+			// Common pattern in production: a `?` inside a template, where the
+			// alternate of an outer ternary is itself a ternary.
+			rule_tester.InvalidTestCase{
+				Code:   "const s = `${a ? b : c ? d : e}`;",
+				Output: []string{"const s = `${a ? b : (c ? d : e)}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID}},
+			},
+
+			// ---- Real-user: nested ternary in object property ----
+			rule_tester.InvalidTestCase{
+				Code:   `const o = { x: a ? b : c ? d : e };`,
+				Output: []string{`const o = { x: a ? b : (c ? d : e) };`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID}},
+			},
+
+			// ---- Real-user: nested ternary as function argument ----
+			rule_tester.InvalidTestCase{
+				Code:   `f(a ? b : c ? d : e);`,
+				Output: []string{`f(a ? b : (c ? d : e));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID}},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_extras_test.go
@@ -1,11 +1,16 @@
 package no_nested_ternary_test
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_nested_ternary"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -172,4 +177,79 @@ func TestNoNestedTernaryExtras(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoNestedTernaryEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, "const value = outer ? inner ? yes : no : fallback;", core.ScriptKindTS)
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		comments := rule.NewCommentStore(sourceFile)
+		diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(
+			no_nested_ternary.NoNestedTernaryRule.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		)
+
+		listeners := no_nested_ternary.NoNestedTernaryRule.Run(ctx, nil)
+		var visit ast.Visitor
+		visit = func(node *ast.Node) bool {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+			return node.ForEachChild(visit)
+		}
+		sourceFile.AsNode().ForEachChild(visit)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("a non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || allEdits.FixesPtr == nil ||
+		!reflect.DeepEqual(*autofixOnly.FixesPtr, *allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	if diagnosticsOnly.Suggestions != nil || autofixOnly.Suggestions != nil ||
+		suggestionOnly.Suggestions != nil || allEdits.Suggestions != nil {
+		t.Fatal("autofix-only rule materialized suggestions")
+	}
 }

--- a/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_upstream_test.go
@@ -1,0 +1,113 @@
+package no_nested_ternary_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_nested_ternary"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	tooDeepMessage       = "Do not nest ternary expressions."
+	tooDeepMessageID     = "no-nested-ternary/too-deep"
+	shouldParenMessage   = "Nested ternary expression should be parenthesized."
+	shouldParenMessageID = "no-nested-ternary/should-parenthesized"
+)
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code}
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code}
+}
+
+func lines(parts ...string) string {
+	return strings.Join(parts, "\n")
+}
+
+// TestNoNestedTernaryUpstream migrates the full valid/invalid suite from
+// upstream test/no-nested-ternary.js (v73.0.0) 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the no_nested_ternary_extras_test.go file.
+func TestNoNestedTernaryUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_nested_ternary.NoNestedTernaryRule,
+		[]rule_tester.ValidTestCase{
+			// ---- test valid ----
+			jsValid(`const foo = i > 5 ? true : false;`),
+			jsValid(`const foo = i > 5 ? true : (i < 100 ? true : false);`),
+			jsValid(`const foo = i > 5 ? (i < 100 ? true : false) : true;`),
+			jsValid(`const foo = i > 5 ? (i < 100 ? true : false) : (i < 100 ? true : false);`),
+			jsValid(`const foo = i > 5 ? true : (i < 100 ? FOO(i > 50 ? false : true) : false);`),
+			// Parenthesized ternary in the test position
+			jsValid(`const foo = (a ? b : c) ? d : e;`),
+			jsValid(`const foo = (a ? b : c) ? (d ? e : f) : g;`),
+			jsValid(`foo ? doBar() : doBaz();`),
+			jsValid(`var foo = bar === baz ? qux : quxx;`),
+
+			// ---- test.typescript valid ----
+			// #663 — multi-line ternary with paren-wrapped alternate
+			tsValid(lines(
+				`const pluginName = isAbsolute ?`,
+				`	pluginPath.slice(pluginPath.lastIndexOf('/') + 1) :`,
+				`	(`,
+				`		isNamespaced ?`,
+				`		pluginPath.split('@')[1].split('/')[1] :`,
+				`		pluginPath`,
+				`	);`,
+			)),
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- test invalid ----
+			// 3 levels deep, paren-wrapped everywhere: innermost reports too-deep.
+			{
+				Code:   `const foo = i > 5 ? true : (i < 100 ? true : (i < 1000 ? true : false));`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: tooDeepMessageID, Message: tooDeepMessage, Line: 1, Column: 47, EndLine: 1, EndColumn: 70}},
+			},
+			// 2 levels, inner-inner in the consequent position: innermost reports too-deep.
+			{
+				Code:   `const foo = i > 5 ? true : (i < 100 ? (i > 50 ? false : true) : false);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: tooDeepMessageID, Message: tooDeepMessage, Line: 1, Column: 40, EndLine: 1, EndColumn: 61}},
+			},
+			// 1 level unparenthesized → should-parenthesized on the inner.
+			{
+				Code:   `const foo = i > 5 ? i < 100 ? true : false : true;`,
+				Output: []string{`const foo = i > 5 ? (i < 100 ? true : false) : true;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID, Message: shouldParenMessage, Line: 1, Column: 21, EndLine: 1, EndColumn: 43}},
+			},
+			// Two unparenthesized inners under one outer → 2 should-parenthesized errors.
+			{
+				Code:   `const foo = i > 5 ? i < 100 ? true : false : i < 100 ? true : false;`,
+				Output: []string{`const foo = i > 5 ? (i < 100 ? true : false) : (i < 100 ? true : false);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: shouldParenMessageID, Message: shouldParenMessage, Line: 1, Column: 21, EndLine: 1, EndColumn: 43},
+					{MessageId: shouldParenMessageID, Message: shouldParenMessage, Line: 1, Column: 46, EndLine: 1, EndColumn: 68},
+				},
+			},
+			// 1 level unparenthesized on the alternate side.
+			{
+				Code:   `const foo = i > 5 ? true : i < 100 ? true : false;`,
+				Output: []string{`const foo = i > 5 ? true : (i < 100 ? true : false);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID, Message: shouldParenMessage, Line: 1, Column: 28, EndLine: 1, EndColumn: 50}},
+			},
+			// Top-level statement, alternate side unparenthesized.
+			{
+				Code:   `foo ? bar : baz === qux ? quxx : foobar;`,
+				Output: []string{`foo ? bar : (baz === qux ? quxx : foobar);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID, Message: shouldParenMessage, Line: 1, Column: 13, EndLine: 1, EndColumn: 40}},
+			},
+			// Top-level statement, consequent side unparenthesized.
+			{
+				Code:   `foo ? baz === qux ? quxx : foobar : bar;`,
+				Output: []string{`foo ? (baz === qux ? quxx : foobar) : bar;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: shouldParenMessageID, Message: shouldParenMessage, Line: 1, Column: 7, EndLine: 1, EndColumn: 34}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -633,6 +633,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-fetch-options.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-nested-ternary.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-unsafe-string-replacement.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-nested-ternary.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-nested-ternary.test.ts
@@ -1,0 +1,70 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const tooDeep = {
+  message: 'Do not nest ternary expressions.',
+  messageId: 'no-nested-ternary/too-deep',
+};
+
+const shouldParen = {
+  message: 'Nested ternary expression should be parenthesized.',
+  messageId: 'no-nested-ternary/should-parenthesized',
+};
+
+const valid = (code: string) => ({ code });
+
+ruleTester.run('no-nested-ternary', null as never, {
+  valid: [
+    valid('const foo = i > 5 ? true : false;'),
+    valid('const foo = i > 5 ? true : (i < 100 ? true : false);'),
+    valid('const foo = i > 5 ? (i < 100 ? true : false) : true;'),
+    valid(
+      'const foo = i > 5 ? (i < 100 ? true : false) : (i < 100 ? true : false);',
+    ),
+    valid(
+      'const foo = i > 5 ? true : (i < 100 ? FOO(i > 50 ? false : true) : false);',
+    ),
+    // Parenthesized ternary in the test position
+    valid('const foo = (a ? b : c) ? d : e;'),
+    valid('const foo = (a ? b : c) ? (d ? e : f) : g;'),
+    valid('foo ? doBar() : doBaz();'),
+    valid('var foo = bar === baz ? qux : quxx;'),
+  ],
+  invalid: [
+    {
+      code: 'const foo = i > 5 ? true : (i < 100 ? true : (i < 1000 ? true : false));',
+      errors: [tooDeep],
+    },
+    {
+      code: 'const foo = i > 5 ? true : (i < 100 ? (i > 50 ? false : true) : false);',
+      errors: [tooDeep],
+    },
+    {
+      code: 'const foo = i > 5 ? i < 100 ? true : false : true;',
+      output: 'const foo = i > 5 ? (i < 100 ? true : false) : true;',
+      errors: [shouldParen],
+    },
+    {
+      code: 'const foo = i > 5 ? i < 100 ? true : false : i < 100 ? true : false;',
+      output:
+        'const foo = i > 5 ? (i < 100 ? true : false) : (i < 100 ? true : false);',
+      errors: [shouldParen, shouldParen],
+    },
+    {
+      code: 'const foo = i > 5 ? true : i < 100 ? true : false;',
+      output: 'const foo = i > 5 ? true : (i < 100 ? true : false);',
+      errors: [shouldParen],
+    },
+    {
+      code: 'foo ? bar : baz === qux ? quxx : foobar;',
+      output: 'foo ? bar : (baz === qux ? quxx : foobar);',
+      errors: [shouldParen],
+    },
+    {
+      code: 'foo ? baz === qux ? quxx : foobar : bar;',
+      output: 'foo ? (baz === qux ? quxx : foobar) : bar;',
+      errors: [shouldParen],
+    },
+  ],
+});


### PR DESCRIPTION
Ports `eslint-plugin-unicorn`'s `no-nested-ternary` rule (v73.0.0).

## What it does
Two message IDs:
- `no-nested-ternary/too-deep` — nestLevel > 1
- `no-nested-ternary/should-parenthesized` — nestLevel == 1, inner unparenthesized (auto-fix wraps in parens)

## Files
- `internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.go` — rule
- `internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary.md` — docs
- `internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_upstream_test.go` — 16 cases migrated from upstream `test/no-nested-ternary.js` 1:1
- `internal/plugins/unicorn/rules/no_nested_ternary/no_nested_ternary_extras_test.go` — 12 lock-in cases for branches not covered upstream
- `packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-nested-ternary.test.ts` — JS snapshot
- `internal/plugins/unicorn/all.go` — registration

## Lock-in cases
- optional chain / non-null assertion / type-assertion in test position
- nestLevel 3 (reports on ancestors[0]) and nestLevel 4 (reports on ancestors[1]) — anchors the upstream `ancestors[nestLevel-3]` arm
- early-return when consequent/alternate is itself a CondExpr
- JSX / template literal / object property / function argument
- multi-line paren-wrapped inner (issue #663 family)

## Verification
- `go test ./internal/plugins/unicorn/rules/no_nested_ternary/...` — pass
- `gofmt -l` — clean
- `go vet` — clean
- `pnpm exec rstest run tests/eslint-plugin-unicorn/` — 0 failures
- `pnpm exec rstest run tests/typescript-eslint/` on clean tree — 0 failures (the 26 failures seen mid-task were pre-existing snapshot drift, not caused by this change)

Tracks #1309.