### PR TITLE
test: update rule tests for configured rule move

### DIFF
--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
@@ -361,12 +361,11 @@ expect(fn).not['toHaveBeenCalledOnce']();`,
 
 		var diagnostics []rule.RuleDiagnostic
 		linter.LintSingleFile(linter.LintSingleFileOptions{
-			Program:      lintprogram.NewFromCompiler(program),
-			File:         sourceFile.FileName(),
-			HasTypeInfo:  true,
-			ExcludePaths: []string{},
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferCalledTimesRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/sort_imports/sort_imports_extras_test.go
+++ b/internal/rules/sort_imports/sort_imports_extras_test.go
@@ -94,8 +94,8 @@ func TestSortImportsEditDemand(t *testing.T) {
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{Name: SortImportsRule.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners { return SortImportsRule.Run(ctx, nil) }}}
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{Name: SortImportsRule.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners { return SortImportsRule.Run(ctx, nil) }}}
 			},
 			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) { diagnostics = append(diagnostics, diagnostic) }},
 		})


### PR DESCRIPTION
## Summary

- Update the prefer-called-times and sort-imports edit-demand tests to use rule.ConfiguredRule after the compatibility alias was removed.
- Remove the obsolete ExcludePaths field from the single-file lint test setup.

## Related Links

- Failing main CI: https://github.com/web-infra-dev/rslint/actions/runs/32988301259
- Related refactor: #1904

## Checklist

- [x] Tests updated (existing tests fixed).
- [x] Documentation updated (not required for this test-only compatibility fix).