### PR TITLE
fix: update LintSingleFile test call sites to rule.ConfiguredRule

### DIFF
--- a/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_times/prefer_called_times_extras_test.go
@@ -361,12 +361,11 @@ expect(fn).not['toHaveBeenCalledOnce']();`,
 
 		var diagnostics []rule.RuleDiagnostic
 		linter.LintSingleFile(linter.LintSingleFileOptions{
-			Program:      lintprogram.NewFromCompiler(program),
-			File:         sourceFile.FileName(),
-			HasTypeInfo:  true,
-			ExcludePaths: []string{},
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
 					Name:     PreferCalledTimesRule.Name,
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {

--- a/internal/rules/sort_imports/sort_imports_extras_test.go
+++ b/internal/rules/sort_imports/sort_imports_extras_test.go
@@ -94,8 +94,8 @@ func TestSortImportsEditDemand(t *testing.T) {
 		linter.LintSingleFile(linter.LintSingleFileOptions{
 			Program: lintprogram.NewFromCompiler(program),
 			File:    sourceFile.FileName(),
-			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-				return []linter.ConfiguredRule{{Name: SortImportsRule.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners { return SortImportsRule.Run(ctx, nil) }}}
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{Name: SortImportsRule.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners { return SortImportsRule.Run(ctx, nil) }}}
 			},
 			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) { diagnostics = append(diagnostics, diagnostic) }},
 		})


### PR DESCRIPTION
## Summary

#1893 moved `ConfiguredRule` into the `rule` package and dropped `ExcludePaths` from `LintSingleFileOptions`. Two rule test files merged around the same time still use the old API, so `main` no longer builds. This updates those call sites; behavior is unchanged.

## Related Links

- #1893
- #1890
- #1868

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
