### PR TITLE
feat: port rule unicorn/no-exports-in-scripts

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_fill_with_reference_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_exports_in_scripts"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
@@ -33,6 +34,7 @@ func GetAllRules() []rule.Rule {
 		new_for_builtins.NewForBuiltinsRule,
 		no_array_fill_with_reference_type.NoArrayFillWithReferenceTypeRule,
 		no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
+		no_exports_in_scripts.NoExportsInScriptsRule,
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,
 		no_invalid_fetch_options.NoInvalidFetchOptionsRule,
 		no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.go
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.go
@@ -8,8 +8,10 @@ package no_exports_in_scripts
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 const messageID = "no-exports-in-scripts"
@@ -28,8 +30,20 @@ func message() rule.RuleMessage {
 // `export enum ...`, `export namespace ...`, and TypeScript
 // `export import ...` declarations. `KindExportDeclaration` is already an
 // export-only node and does not need this check.
-func isExported(node *ast.Node) bool {
-	return node != nil && ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+func exportedDeclarationRange(node *ast.Node, sourceFile *ast.SourceFile) (core.TextRange, bool) {
+	if node == nil || !ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) {
+		return core.TextRange{}, false
+	}
+	modifiers := node.Modifiers()
+	if modifiers == nil {
+		return core.TextRange{}, false
+	}
+	for _, modifier := range modifiers.Nodes {
+		if modifier.Kind == ast.KindExportKeyword {
+			return core.NewTextRange(utils.TrimNodeTextRange(sourceFile, modifier).Pos(), node.End()), true
+		}
+	}
+	return core.TextRange{}, false
 }
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/rules/no-exports-in-scripts.js
@@ -49,8 +63,8 @@ var NoExportsInScriptsRule = rule.Rule{
 		}
 
 		reportIfExported := func(node *ast.Node) {
-			if isExported(node) {
-				ctx.ReportNode(node, message())
+			if reportRange, ok := exportedDeclarationRange(node, ctx.SourceFile); ok {
+				ctx.ReportRange(reportRange, message())
 			}
 		}
 

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.go
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.go
@@ -25,14 +25,14 @@ func message() rule.RuleMessage {
 // the source. The check is a syntactic modifier lookup on the node itself, so
 // it correctly handles `export const x = 1;`, `export function foo() {}`,
 // `export class Foo {}`, `export interface Foo {}`, `export type ...`,
-// `export enum ...`, and `export namespace ...`. `KindExportDeclaration`
-// and `KindExportAssignment` are *already* export-only nodes and do not
-// need this check.
+// `export enum ...`, `export namespace ...`, and TypeScript
+// `export import ...` declarations. `KindExportDeclaration` is already an
+// export-only node and does not need this check.
 func isExported(node *ast.Node) bool {
 	return node != nil && ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
 }
 
-// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-exports-in-scripts.js
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/rules/no-exports-in-scripts.js
 var NoExportsInScriptsRule = rule.Rule{
 	Name:   "unicorn/no-exports-in-scripts",
 	Schema: rule.EmptyArraySchema,
@@ -43,16 +43,6 @@ var NoExportsInScriptsRule = rule.Rule{
 		// no shebang is present; this matches ESLint's `sourceCode.lines[0]
 		// .startsWith('#!')` exactly — a shebang in a comment or string
 		// never matches because the file does not literally start with `#!`.
-		//
-		// tsgo divergence: tsgo's `SourceFile.Text()` strips a leading BOM
-		// (the BOM is exposed via `ctx.HasBOM()`), so a file written as
-		// `<BOM>#!...` looks identical to a plain `#!...` file to this
-		// check. Upstream ESLint does not strip the BOM, so
-		// `lines[0].startsWith('#!')` is false for the BOM-prefixed form
-		// and the upstream rule does not fire. We follow the rslint
-		// convention (treat the shebang as the file's first content) and
-		// fire here; a future lock-in could special-case the BOM if
-		// matching upstream becomes important.
 		text := ctx.SourceFile.Text()
 		if scanner.GetShebang(text) == "" {
 			return rule.RuleListeners{}
@@ -74,13 +64,14 @@ var NoExportsInScriptsRule = rule.Rule{
 			// underlying declaration, so each surface form is a distinct
 			// node kind with `ModifierFlagsExport` set. A single helper
 			// checks the modifier for all of them.
-			ast.KindVariableStatement:    reportIfExported,
-			ast.KindFunctionDeclaration:  reportIfExported,
-			ast.KindClassDeclaration:     reportIfExported,
-			ast.KindInterfaceDeclaration: reportIfExported,
-			ast.KindTypeAliasDeclaration: reportIfExported,
-			ast.KindEnumDeclaration:      reportIfExported,
-			ast.KindModuleDeclaration:    reportIfExported,
+			ast.KindVariableStatement:       reportIfExported,
+			ast.KindFunctionDeclaration:     reportIfExported,
+			ast.KindClassDeclaration:        reportIfExported,
+			ast.KindInterfaceDeclaration:    reportIfExported,
+			ast.KindTypeAliasDeclaration:    reportIfExported,
+			ast.KindEnumDeclaration:         reportIfExported,
+			ast.KindModuleDeclaration:       reportIfExported,
+			ast.KindImportEqualsDeclaration: reportIfExported,
 
 			// ---- tsgo divergence: ExportDeclaration keeps ESTree's
 			// shape for `export {...}`, `export * from '...'`,
@@ -91,11 +82,14 @@ var NoExportsInScriptsRule = rule.Rule{
 				ctx.ReportNode(node, message())
 			},
 
-			// ---- tsgo divergence: ExportAssignment covers `export
-			// default ...` (ESTree ExportDefaultDeclaration) and
-			// `export = ...` (TypeScript's legacy CommonJS-interop form).
+			// ---- tsgo divergence: ExportAssignment covers both `export
+			// default ...` (ESTree ExportDefaultDeclaration) and `export =
+			// ...` (ESTree TSExportAssignment). Upstream reports only the
+			// former.
 			ast.KindExportAssignment: func(node *ast.Node) {
-				ctx.ReportNode(node, message())
+				if !node.AsExportAssignment().IsExportEquals {
+					ctx.ReportNode(node, message())
+				}
 			},
 		}
 	},

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.go
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.go
@@ -1,0 +1,102 @@
+// Package no_exports_in_scripts ports eslint-plugin-unicorn's
+// `no-exports-in-scripts` rule.
+//
+// A file whose first line starts with a `#!` shebang is treated as a script
+// meant to be executed directly, not as a module. Any `export` declaration
+// inside such a file mixes module and script boundaries and is reported.
+package no_exports_in_scripts
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const messageID = "no-exports-in-scripts"
+
+func message() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageID,
+		Description: "Do not use exports in scripts.",
+	}
+}
+
+// isExported reports whether the node is preceded by an `export` keyword in
+// the source. The check is a syntactic modifier lookup on the node itself, so
+// it correctly handles `export const x = 1;`, `export function foo() {}`,
+// `export class Foo {}`, `export interface Foo {}`, `export type ...`,
+// `export enum ...`, and `export namespace ...`. `KindExportDeclaration`
+// and `KindExportAssignment` are *already* export-only nodes and do not
+// need this check.
+func isExported(node *ast.Node) bool {
+	return node != nil && ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-exports-in-scripts.js
+var NoExportsInScriptsRule = rule.Rule{
+	Name:   "unicorn/no-exports-in-scripts",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		// Mirror upstream's early-out: only run when the first line of the
+		// file starts with `#!`. `scanner.GetShebang` returns the shebang
+		// substring (consumed up to and including the newline) or empty when
+		// no shebang is present; this matches ESLint's `sourceCode.lines[0]
+		// .startsWith('#!')` exactly — a shebang in a comment or string
+		// never matches because the file does not literally start with `#!`.
+		//
+		// tsgo divergence: tsgo's `SourceFile.Text()` strips a leading BOM
+		// (the BOM is exposed via `ctx.HasBOM()`), so a file written as
+		// `<BOM>#!...` looks identical to a plain `#!...` file to this
+		// check. Upstream ESLint does not strip the BOM, so
+		// `lines[0].startsWith('#!')` is false for the BOM-prefixed form
+		// and the upstream rule does not fire. We follow the rslint
+		// convention (treat the shebang as the file's first content) and
+		// fire here; a future lock-in could special-case the BOM if
+		// matching upstream becomes important.
+		text := ctx.SourceFile.Text()
+		if scanner.GetShebang(text) == "" {
+			return rule.RuleListeners{}
+		}
+
+		reportIfExported := func(node *ast.Node) {
+			if isExported(node) {
+				ctx.ReportNode(node, message())
+			}
+		}
+
+		return rule.RuleListeners{
+			// ---- tsgo divergence: in ESTree, `export const foo = 1;`,
+			// `export function foo() {}`, `export class Foo {}`,
+			// `export interface Foo {}`, `export type ...`, `export enum
+			// Foo {}`, and `export namespace ...` all share the
+			// ExportNamedDeclaration node type. tsgo collapses the
+			// `export` keyword into a syntactic modifier on the
+			// underlying declaration, so each surface form is a distinct
+			// node kind with `ModifierFlagsExport` set. A single helper
+			// checks the modifier for all of them.
+			ast.KindVariableStatement:    reportIfExported,
+			ast.KindFunctionDeclaration:  reportIfExported,
+			ast.KindClassDeclaration:     reportIfExported,
+			ast.KindInterfaceDeclaration: reportIfExported,
+			ast.KindTypeAliasDeclaration: reportIfExported,
+			ast.KindEnumDeclaration:      reportIfExported,
+			ast.KindModuleDeclaration:    reportIfExported,
+
+			// ---- tsgo divergence: ExportDeclaration keeps ESTree's
+			// shape for `export {...}`, `export * from '...'`,
+			// `export {foo} from '...'`, `export * as ns from '...'`,
+			// and the empty `export {};`. Each of these fires the
+			// listener and is reported directly.
+			ast.KindExportDeclaration: func(node *ast.Node) {
+				ctx.ReportNode(node, message())
+			},
+
+			// ---- tsgo divergence: ExportAssignment covers `export
+			// default ...` (ESTree ExportDefaultDeclaration) and
+			// `export = ...` (TypeScript's legacy CommonJS-interop form).
+			ast.KindExportAssignment: func(node *ast.Node) {
+				ctx.ReportNode(node, message())
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.md
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.md
@@ -55,5 +55,5 @@ export const foo = 1;
 
 ## Original Documentation
 
-- [eslint-plugin-unicorn: no-exports-in-scripts](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-exports-in-scripts.md)
-- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-exports-in-scripts.js)
+- [eslint-plugin-unicorn: no-exports-in-scripts](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/docs/rules/no-exports-in-scripts.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/rules/no-exports-in-scripts.js)

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.md
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts.md
@@ -1,0 +1,59 @@
+# no-exports-in-scripts
+
+## Rule Details
+
+Scripts (files whose first line starts with `#!`) are meant to be executed
+directly, not imported as modules. Exports in a script mix module and script
+boundaries and can mislead readers about how the file is intended to run.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+#!/usr/bin/env node
+export const foo = 1;
+```
+
+```javascript
+#!/usr/bin/env node
+export default foo;
+```
+
+```javascript
+#!/usr/bin/env node
+const foo = 1;
+export {foo};
+```
+
+```javascript
+#!/usr/bin/env node
+export {};
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+#!/usr/bin/env node
+const foo = 1;
+console.log(foo);
+```
+
+```javascript
+// #!/usr/bin/env node
+export const foo = 1;
+```
+
+```javascript
+console.log('#!/usr/bin/env node');
+export const foo = 1;
+```
+
+A file without a shebang is a module, and modules are free to use exports:
+
+```javascript
+export const foo = 1;
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-exports-in-scripts](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-exports-in-scripts.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-exports-in-scripts.js)

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_extras_test.go
@@ -87,6 +87,14 @@ func TestNoExportsInScriptsExtras(t *testing.T) {
 				Code:     "#!/usr/bin/env node\nconst foo = 1;\nexport = foo;",
 				FileName: "file.ts",
 			},
+
+			// The directive applies to the authored `export` line, matching
+			// upstream's ExportNamedDeclaration wrapper rather than the
+			// decorator at the start of the flattened tsgo class node.
+			{
+				Code:     "#!/usr/bin/env node\n@dec\n// eslint-disable-next-line test\nexport class C {}",
+				FileName: "file.ts",
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 1: a CRLF shebang still trips the gate, the
@@ -188,6 +196,37 @@ func TestNoExportsInScriptsExtras(t *testing.T) {
 				FileName: "file.ts",
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 39},
+				},
+			},
+
+			// A directive before the decorator does not suppress the export
+			// on the following line; the diagnostic begins at `export`.
+			{
+				Code:     "#!/usr/bin/env node\n// eslint-disable-next-line test\n@dec\nexport class C {}",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 4, Column: 1, EndLine: 4, EndColumn: 18},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\n@dec\nexport class C {}",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 18},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\n@dec\nexport default class C {}",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 26},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport @dec class C {}",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 23},
 				},
 			},
 

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_extras_test.go
@@ -79,22 +79,16 @@ func TestNoExportsInScriptsExtras(t *testing.T) {
 				Code:     "#!/usr/bin/env node\nfunction foo() { return 1; }\nconsole.log(foo());",
 				FileName: "file.mjs",
 			},
+
+			// ---- Upstream parity: TypeScript `export =` is represented as
+			// TSExportAssignment by typescript-estree, not an ESTree export
+			// declaration, so unicorn v72 does not report it. ----
+			{
+				Code:     "#!/usr/bin/env node\nconst foo = 1;\nexport = foo;",
+				FileName: "file.ts",
+			},
 		},
 		[]rule_tester.InvalidTestCase{
-			// ---- Dimension 4: BOM-prefixed shebang is a tsgo lock-in —
-			// `SourceFile.Text()` strips a leading BOM, so the gate
-			// `text[0] == '#' && text[1] == '!'` succeeds and the rule
-			// fires. This diverges from upstream (which keeps the BOM in
-			// `lines[0]` and so does not fire), but matches how every
-			// other rslint rule that gates on `scanner.GetShebang` behaves.
-			{
-				Code:     "\uFEFF#!/usr/bin/env node\nexport const foo = 1;",
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 22},
-				},
-			},
-
 			// ---- Dimension 1: a CRLF shebang still trips the gate, the
 			// export is reported on line 2. ----
 			{
@@ -127,14 +121,30 @@ func TestNoExportsInScriptsExtras(t *testing.T) {
 				},
 			},
 
-			// ---- Branch lock-in: `export = foo` (TypeScript legacy CommonJS
-			// interop) is `KindExportAssignment` and must still be reported
-			// under a shebang. 13 chars + 1 = EndColumn 14. ----
+			// ---- Upstream parity: typescript-estree wraps an exported
+			// import-equals declaration in ExportNamedDeclaration. ----
 			{
-				Code:     "#!/usr/bin/env node\nconst foo = 1;\nexport = foo;",
+				Code:     "#!/usr/bin/env node\nexport import Alias = require('pkg');",
 				FileName: "file.ts",
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 14},
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 38},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport import Alias = Namespace.Value;",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 39},
+				},
+			},
+
+			// ---- The same import-equals node can occur inside a namespace;
+			// the listener must preserve upstream's nested-node behavior. ----
+			{
+				Code:     "#!/usr/bin/env node\nnamespace Outer {\n  export import Alias = Namespace.Value;\n}",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 3, Column: 3, EndLine: 3, EndColumn: 41},
 				},
 			},
 

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_extras_test.go
@@ -1,0 +1,198 @@
+// TestNoExportsInScriptsExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking
+// a named lock-in.
+package no_exports_in_scripts_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_exports_in_scripts "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_exports_in_scripts"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExportsInScriptsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_exports_in_scripts.NoExportsInScriptsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: a no-newline file whose only content is
+			// "export" without a shebang still parses as a module and is
+			// valid (e.g. the shebang gate must not over-fire on a file that
+			// happens to be a single export line).
+			{Code: `export const foo = 1;`},
+
+			// ---- Dimension 1: empty file with only a shebang ----
+			{Code: "#!/usr/bin/env node\n", FileName: "file.mjs"},
+
+			// ---- Dimension 1: Windows-style CRLF line endings on a
+			// shebang line still get treated as a script because the
+			// scanner's GetShebang consumes the line and the first line
+			// still begins with `#!`.
+			{
+				Code:     "#!/usr/bin/env node\r\nconst foo = 1;\r\nconsole.log(foo);\r\n",
+				FileName: "file.mjs",
+			},
+
+			// ---- Dimension 1: shebang + CommonJS — no exports, no error ----
+			{
+				Code: "#!/usr/bin/env node\n" +
+					"const fs = require('node:fs');\n" +
+					"console.log(fs.readFileSync(__filename, 'utf8'));",
+				FileName: "file.cjs",
+			},
+
+			// ---- Dimension 1: shebang + dynamic import (dynamic ESM-via-
+			// import is not an export statement, so it stays valid in a
+			// script). ----
+			{
+				Code: "#!/usr/bin/env node\n" +
+					"const mod = await import('./some-module.mjs');\n" +
+					"console.log(mod);",
+				FileName: "file.mjs",
+			},
+
+			// ---- Dimension 4: TypeScript with shebang and no exports
+			// (e.g. a TypeScript script that uses console) is valid. ----
+			{
+				Code:     "#!/usr/bin/env node\nconst x: number = 1;\nconsole.log(x);",
+				FileName: "file.ts",
+			},
+
+			// ---- Dimension 4: an interface-only file under a shebang is
+			// not reported — `export interface` is the form upstream
+			// reports, and we mirror that; a bare `interface` is not an
+			// export and never trips the listener. ----
+			{
+				Code:     "#!/usr/bin/env node\ninterface Foo { bar: string }\nconsole.log('hi');",
+				FileName: "file.ts",
+			},
+
+			// ---- Dimension 4: function declaration without the `export`
+			// modifier under a shebang is valid. The `reportIfExported`
+			// helper only fires for the modifier-bearing variant. ----
+			{
+				Code:     "#!/usr/bin/env node\nfunction foo() { return 1; }\nconsole.log(foo());",
+				FileName: "file.mjs",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: BOM-prefixed shebang is a tsgo lock-in —
+			// `SourceFile.Text()` strips a leading BOM, so the gate
+			// `text[0] == '#' && text[1] == '!'` succeeds and the rule
+			// fires. This diverges from upstream (which keeps the BOM in
+			// `lines[0]` and so does not fire), but matches how every
+			// other rslint rule that gates on `scanner.GetShebang` behaves.
+			{
+				Code:     "\uFEFF#!/usr/bin/env node\nexport const foo = 1;",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 22},
+				},
+			},
+
+			// ---- Dimension 1: a CRLF shebang still trips the gate, the
+			// export is reported on line 2. ----
+			{
+				Code:     "#!/usr/bin/env node\r\nexport const foo = 1;\r\n",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 22},
+				},
+			},
+
+			// ---- Dimension 1: shebang + TypeScript `export type` (already
+			// covered upstream, but with a different surrounding program to
+			// confirm the listener fires regardless of other top-level
+			// statements). ----
+			{
+				Code:     "#!/usr/bin/env node\nconst x = 1;\nexport type Foo = string;",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 26},
+				},
+			},
+
+			// ---- Branch lock-in: empty `export {}` is `KindExportDeclaration`
+			// with no specifier list — the listener must still fire. ----
+			{
+				Code:     "#!/usr/bin/env node\nexport {}",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 10},
+				},
+			},
+
+			// ---- Branch lock-in: `export = foo` (TypeScript legacy CommonJS
+			// interop) is `KindExportAssignment` and must still be reported
+			// under a shebang. 13 chars + 1 = EndColumn 14. ----
+			{
+				Code:     "#!/usr/bin/env node\nconst foo = 1;\nexport = foo;",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 14},
+				},
+			},
+
+			// ---- Real-user: a `#!` line that doesn't look like a typical
+			// env-node shebang still triggers the rule. The rule doesn't
+			// validate the shebang value, only that the first line begins
+			// with `#!`. ----
+			{
+				Code:     "#!wat\nconst foo = 1;\nexport default foo;",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 20},
+				},
+			},
+
+			// ---- Branch lock-in: `export function` is a
+			// KindFunctionDeclaration with ModifierFlagsExport — the
+			// `reportIfExported` helper must still fire on it. ----
+			{
+				Code:     "#!/usr/bin/env node\nexport function foo() {}\n",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 25},
+				},
+			},
+
+			// ---- Branch lock-in: `export class` is a KindClassDeclaration
+			// with ModifierFlagsExport — must still fire. ----
+			{
+				Code:     "#!/usr/bin/env node\nexport class Foo {}\n",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 20},
+				},
+			},
+
+			// ---- Branch lock-in: `export enum` is a KindEnumDeclaration
+			// with ModifierFlagsExport — must still fire. ----
+			{
+				Code:     "#!/usr/bin/env node\nexport enum Color { Red, Green, Blue }\n",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 39},
+				},
+			},
+
+			// ---- Real-user: a script that mixes a type export and an
+			// interface export on the same line under a shebang — both must
+			// be reported (this is also a lock-in that the listener fires
+			// on each top-level export, not on the script-level entity). ----
+			{
+				Code:     "#!/usr/bin/env node\nexport type A = string; export interface B {}",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 24},
+					{MessageId: messageID, Line: 2, Column: 25, EndLine: 2, EndColumn: 46},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_exports_in_scripts/no_exports_in_scripts_upstream_test.go
@@ -1,0 +1,141 @@
+// TestNoExportsInScriptsUpstream migrates the full valid/invalid suite from
+// upstream test/no-exports-in-scripts.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live
+// in no_exports_in_scripts_extras_test.go.
+package no_exports_in_scripts_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_exports_in_scripts "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_exports_in_scripts"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const messageID = "no-exports-in-scripts"
+
+func TestNoExportsInScriptsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_exports_in_scripts.NoExportsInScriptsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- No shebang: the file is a module, exports are allowed ----
+			{Code: `export const foo = 1;`, FileName: "file.mjs"},
+			{Code: `export default foo;`, FileName: "file.mjs"},
+			{Code: `export * from "./foo.js";`, FileName: "file.mjs"},
+			{Code: "const foo = 1;\nexport {foo};", FileName: "file.mjs"},
+			{Code: `export {};`, FileName: "file.mjs"},
+
+			// ---- TypeScript: type-only exports without a shebang are valid ----
+			{Code: `export type Foo = string;`, FileName: "file.ts"},
+			{Code: `export interface Foo {}`, FileName: "file.ts"},
+
+			// ---- Shebang present, no export statements ----
+			{
+				Code: "#!/usr/bin/env node\n" +
+					"import process from 'node:process';\n" +
+					"\n" +
+					"console.log(process.argv);",
+				FileName: "file.mjs",
+			},
+			{
+				Code: "#!/usr/bin/env node\n" +
+					"const foo = 1;\n" +
+					"module.exports = foo;",
+				FileName: "file.cjs",
+			},
+
+			// ---- Pseudo-shebang in a comment does not count ----
+			{
+				Code:     "// #!/usr/bin/env node\nexport const foo = 1;",
+				FileName: "file.mjs",
+			},
+
+			// ---- Pseudo-shebang in a string does not count ----
+			{
+				Code:     "console.log('#!/usr/bin/env node');\nexport const foo = 1;",
+				FileName: "file.mjs",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// All invalid cases: file starts with `#!...` and contains an
+			// export statement on a subsequent line. Line/Column point at
+			// the start of the export (after the leading newline trivia),
+			// EndColumn is one past the last character of the export.
+			{
+				Code:     "#!/usr/bin/env node\nexport const foo = 1;",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 22},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport default foo;",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 20},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport * from './foo.js';",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 26},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport * as foo from './foo.js';",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 33},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nconst foo = 1;\nexport {foo};",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 14},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport {foo} from './foo.js';",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 30},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport {};",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 11},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport const foo = 1;\nexport const bar = 2;",
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 22},
+					{MessageId: messageID, Line: 3, Column: 1, EndLine: 3, EndColumn: 22},
+				},
+			},
+			// ---- TypeScript: type-only exports under a shebang ----
+			{
+				Code:     "#!/usr/bin/env node\nexport type Foo = string;",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 26},
+				},
+			},
+			{
+				Code:     "#!/usr/bin/env node\nexport interface Foo {}",
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 2, Column: 1, EndLine: 2, EndColumn: 24},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -630,6 +630,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-fill-with-reference-type.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-exports-in-scripts.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-fetch-options.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -178,5 +178,6 @@ describe('defineConfig and config presets', () => {
     expect(rec.rules?.['unicorn/no-array-fill-with-reference-type']).toBe(
       'error',
     );
+    expect(rec.rules?.['unicorn/no-exports-in-scripts']).toBe('error');
   });
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-exports-in-scripts.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-exports-in-scripts.test.ts
@@ -1,0 +1,62 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string, filename: string = 'src/virtual.tsx') => ({
+  code,
+  filename,
+});
+
+const invalid = (
+  code: string,
+  errors: number,
+  filename: string = 'src/virtual.tsx',
+) => ({ code, filename, errors });
+
+ruleTester.run('no-exports-in-scripts', null as never, {
+  valid: [
+    // ---- No shebang: the file is a module, exports are allowed ----
+    valid('export const foo = 1;'),
+    valid('export default foo;'),
+    valid('export * from "./foo.js";'),
+    valid('const foo = 1;\nexport {foo};'),
+    valid('export {};'),
+
+    // ---- TypeScript: type-only exports without a shebang are valid ----
+    valid('export type Foo = string;', 'file.ts'),
+    valid('export interface Foo {}', 'file.ts'),
+
+    // ---- Shebang present, no export statements ----
+    valid(
+      '#!/usr/bin/env node\n' +
+        "import process from 'node:process';\n" +
+        '\n' +
+        'console.log(process.argv);',
+    ),
+    valid(
+      '#!/usr/bin/env node\n' + 'const foo = 1;\n' + 'module.exports = foo;',
+    ),
+
+    // ---- Pseudo-shebang in a comment does not count ----
+    valid('// #!/usr/bin/env node\nexport const foo = 1;'),
+
+    // ---- Pseudo-shebang in a string does not count ----
+    valid("console.log('#!/usr/bin/env node');\nexport const foo = 1;"),
+  ],
+  invalid: [
+    invalid('#!/usr/bin/env node\nexport const foo = 1;', 1),
+    invalid('#!/usr/bin/env node\nexport default foo;', 1),
+    invalid("#!/usr/bin/env node\nexport * from './foo.js';", 1),
+    invalid("#!/usr/bin/env node\nexport * as foo from './foo.js';", 1),
+    invalid('#!/usr/bin/env node\nconst foo = 1;\nexport {foo};', 1),
+    invalid("#!/usr/bin/env node\nexport {foo} from './foo.js';", 1),
+    invalid('#!/usr/bin/env node\nexport {};', 1),
+    invalid(
+      '#!/usr/bin/env node\nexport const foo = 1;\nexport const bar = 2;',
+      2,
+    ),
+    // ---- TypeScript: type-only exports under a shebang ----
+    invalid('#!/usr/bin/env node\nexport type Foo = string;', 1, 'file.ts'),
+    invalid('#!/usr/bin/env node\nexport interface Foo {}', 1, 'file.ts'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -95,7 +95,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-duplicate-set-values': 'error', // not implemented
     // 'unicorn/no-empty-file': 'error', // not implemented
     // 'unicorn/no-error-property-assignment': 'error', // not implemented
-    // 'unicorn/no-exports-in-scripts': 'error', // not implemented
+    'unicorn/no-exports-in-scripts': 'error',
     // 'unicorn/no-for-each': 'error', // not implemented
     // 'unicorn/no-for-loop': 'error', // not implemented
     // 'unicorn/no-global-object-property-assignment': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `unicorn/no-exports-in-scripts` rule from ESLint to rslint.

The rule disallows export syntax in files treated as scripts while allowing exports in modules.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-exports-in-scripts.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-exports-in-scripts.js

## Checklist

- [x] Tests updated.
- [x] Documentation updated.