### PR TITLE
fix: align autofix rounds across integrations

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -201,7 +201,7 @@ and cannot observe which construction path supplied it.
 6. **AST Traversal**: The linter traverses each file once using a DFS walk. It prunes syntax that TypeScript-Go synthesized from JSDoc comments; ESLint-compatible parsers expose that text through comment APIs rather than rule AST listeners.
 7. **Rule Execution**: Listener callbacks inspect nodes and may use syntax only or syntax plus type information.
 8. **Diagnostic Collection**: Findings are reported as `RuleDiagnostic` values, with optional fixes or suggestions.
-9. **Output Generation**: `RunPipeline` returns the last successful observation plus any final in-memory file delta. CLI optionally commits that delta to disk once and builds a report from final diagnostics, API returns structured data and maps its one-round delta to `output`, and LSP maps fix-all's delta to a whole-document edit.
+9. **Output Generation**: `RunPipeline` returns the last successful observation, the final in-memory delta, and final text for every target to which a fix was applied. CLI optionally commits the net delta to disk once and builds a report from final diagnostics, API returns final structured data plus per-fixed-file `output` (including a file restored to its input), and LSP maps fix-all's net delta to a whole-document edit.
 
 ### Error Recovery Strategy
 
@@ -579,8 +579,8 @@ stages. The lifecycle is:
    fix rounds; the generation provider only projects the immutable snapshot
    needed for the next observation.
 6. Re-materialize and re-observe the new snapshot until stable, restored to the
-   initial state, or bounded by `MaxFixRounds`; an adapter that returns a stale
-   generation is rejected before execution.
+   initial state, or bounded by the linter-owned ten-round product limit; an
+   adapter that returns a stale generation is rejected before execution.
 7. After successful completion only, optionally call `FinalChangeCommitter`
    once with the net initial-to-final delta. Intermediate changes are never
    exposed as persistence commands.
@@ -621,10 +621,12 @@ Important behavior differences by integration:
 - **LSP normal diagnostics and API**: request all native edits because fixes and
   suggestions are response metadata even when they are not immediately applied
 - **LSP speculative fix-all passes**: request native autofixes only
-- **API**: `lint({ fix: true })` selects the same core autofix use case with a
-  one-round/no-verification policy and returns its final memory delta per file
-  in `output`; the JS side persists it via `Rslint.outputFixes`. Unlike CLI, it
-  does not request cross-generation re-linting.
+- **API**: `lint({ fix: true })` selects the same linter-owned ten-round autofix
+  lifecycle as CLI and requests a complete final observation. Diagnostics,
+  counts, encoded sources, and remaining edit metadata therefore describe the
+  final in-memory source; `output` includes every file to which a fix was
+  applied, even if later rounds restored its initial text. The JS side alone
+  persists that output through `Rslint.outputFixes`.
 
 ## 8. Configuration & Directives
 
@@ -1189,8 +1191,9 @@ the complete lint/fix lifecycle in `internal/linter`, and report rendering in
 The Go API mode similarly prepares one request in
 `internal/api/server/lint.go` and calls `RunPipeline` once. Its generation provider
 maps any core snapshot onto the request's existing file-content/canonical-path
-overlay; the selected one-round autofix policy maps the returned memory delta
-to the response instead of implementing a separate fix path. API-specific path
+overlay; the core-owned bounded autofix lifecycle returns a verified final
+observation plus per-fixed-file source for the response instead of requiring a
+separate API fix path. API-specific path
 bases, opaque plugin routing keys, reverse transports, structured responses,
 and the inspector cache remain in `internal/api/server`; planning, execution,
 and mutation sequencing do not.
@@ -1412,13 +1415,13 @@ goroutines remain outside that guarantee.
   generations, API requests, LSP lint passes, and config reloads never share a
   plan cache. Merged config maps and configured-rule slices returned by the
   resolver are immutable shared state.
-- **Program Loader Session Boundary**: one CLI invocation or API lint request owns one `program/loader.Session`, created only after the request's overlay/canonical VFS wrappers are complete. The session privately composes compiler construction, source snapshots, metadata caches, project loading, target binding, and fix-generation invalidation. It is never global, never shared across API requests, and is not used by LSP, whose project session has a different invalidation model.
+- **Program Loader Generation Boundary**: the initial CLI/API observation and each changed autofix observation own a `program/loader.Session`, created only after that generation's overlay/canonical VFS wrappers are complete. A session privately composes compiler construction, source snapshots, metadata caches, project loading, and target binding for one immutable filesystem view. It is never global, never shared across API requests, and is not used by LSP, whose project session has a different invalidation model.
 - **Run/Request-Scoped Program Metadata**: successful `package.json` reads and explicitly registered root, project-reference, and extended tsconfig reads are snapshotted for the context lifetime. Keys remain exact caller paths—no cleaning, case folding, resolving real paths, or symlink merging—and failed reads are retried. Per-key read single-flight avoids duplicate concurrent I/O; generation swaps make future VFS writes safe without clearing a live map. Arbitrary JSON and non-metadata reads bypass this layer.
 - **Extended Config Parse Reuse**: the context implements ts-go's `ExtendedConfigCache` shim contract and shares common `extends` parse results across Programs. Parsing occurs outside map locks and publishes with `LoadOrStore`, avoiding recursive cross-cycle lock ordering; rare concurrent misses may duplicate parsing but share the winning immutable result and still single-flight raw bytes. Root `ParsedCommandLine` values and parsed `package.json` objects are not cached.
-- **Run/Request-Scoped Source Snapshots**: CLI runs and individual API requests share immutable source text/hash snapshots across project and transient root-parser hosts. Keys are the exact compiler-host source names, never real paths, so lexical, overlay, and symlink aliases remain distinct. Concurrent misses for one key share the successful read/hash operation; failed reads are shared only by the overlapping callers and are not retained. The source layer in one cache binds to one filesystem view across its generations; compiler hosts using another view bypass this layer while retaining content-keyed AST reuse. Snapshot sharing never publishes a bound AST across rslint Program generations.
-- **Generation-Based Fix Invalidation**: after every CLI fix write attempt, the compiler host atomically installs an empty source generation before any Program rebuild. Swapping generations rather than clearing a live map prevents an older in-flight read from repopulating the new generation. The API fix path only returns output and does not mutate or rebuild its overlay, while LSP remains version/didChange-driven.
-- **Run-Scoped Parse Reuse**: CLI Program rebuilds within one invocation and Programs within one API request share the existing content-keyed AST parse cache. Concurrent misses for the same full parse key are single-flight, so bounded Program construction does not duplicate parsing. Source-generation invalidation does not clear AST entries, so unchanged bytes can reuse their `SourceFile`. The cache is discarded with its run/request and is never repository-persistent or shared across lint requests.
-- **Bounded Multi-Pass Fixing**: `--fix` and LSP `fixAll` intentionally rerun lint after applying edits, but cap the cascade at `maxFixPasses = 10`
+- **Generation-Scoped Source Snapshots**: Programs built for one CLI/API observation share immutable source text/hash snapshots across project and transient root-parser hosts. Keys are the exact compiler-host source names, never real paths, so lexical, overlay, and symlink aliases remain distinct. Concurrent misses for one key share the successful read/hash operation; failed reads are shared only by the overlapping callers and are not retained. The next changed autofix observation receives a fresh session bound to its new overlay, so no source snapshot crosses generation boundaries and no bound AST is published across rslint Programs.
+- **Core-Owned Fix Generations**: after each successful fix round, `internal/linter` advances only its private source memory. CLI/API generation providers project that snapshot onto a fresh request-local overlay and rebuild Programs without mutating the base medium; CLI alone commits the final net delta to disk once. LSP speculative generations remain isolated from its document/session state, which still advances only through versioned document events.
+- **Generation-Scoped Parse Reuse**: all Programs within one CLI/API observation share that loader session's content-keyed AST parse cache. Concurrent misses for the same full parse key are single-flight, so multi-Program construction does not duplicate parsing. A changed autofix observation starts a fresh cache for its new source generation; caches are never repository-persistent or shared across lint requests.
+- **Bounded Multi-Pass Fixing**: CLI `--fix`, API `fix: true`, and LSP `fixAll` share the linter-owned limit of ten writable rounds. CLI and API request a final observation after the tenth write so their diagnostics describe the returned source; LSP consumes only the net text delta and does not pay for that extra observation.
 
 ### Memory Management
 

--- a/cmd/rslint/lint_command.go
+++ b/cmd/rslint/lint_command.go
@@ -549,7 +549,6 @@ func handleLintCommand(args lintArgs, ctx context.Context, dispatch linter.Eslin
 			cliFinalChangeCommitter{},
 			observationPolicy,
 			linter.AutofixPolicy{
-				MaxRounds:            linter.MaxFixRounds,
 				VerifyAfterLastRound: true,
 				VerificationDemand: linter.ArtifactDemand{
 					Native: rule.EditDemandNone,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -112,11 +112,11 @@ type LintRequest struct {
 	// EslintPlugins carries the names included as Node-dispatched placeholders
 	// in this request's rule catalog. The live implementations remain in JS.
 	EslintPlugins []EslintPluginEntry `json:"eslintPlugins,omitempty"`
-	// Fix, when true, applies rule auto-fixes in-band and returns the fixed
-	// source per file in LintResponse.Output (ESLint's `fix: true`). The fix is
-	// computed but NOT written to disk — the JS side (Rslint.outputFixes) writes
-	// it. Diagnostics describe the original input; callers can lint Output again
-	// when they need post-fix diagnostics.
+	// Fix, when true, applies rule auto-fixes in-band and returns the final source
+	// for each file to which a fix was applied in LintResponse.Output (ESLint's
+	// `fix: true`). The fix is computed but NOT written to disk — the JS side
+	// (Rslint.outputFixes) writes it. Diagnostics and encoded sources describe the
+	// final post-fix generation.
 	Fix                       bool `json:"fix,omitempty"`
 	IncludeEncodedSourceFiles bool `json:"includeEncodedSourceFiles,omitempty"` // Whether to include encoded source files in response
 }

--- a/internal/api/server/lint.go
+++ b/internal/api/server/lint.go
@@ -455,9 +455,8 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 			provider,
 			policy,
 			linter.AutofixPolicy{
-				MaxRounds:            1,
-				VerifyAfterLastRound: false,
-				VerificationDemand:   linter.ArtifactDemand{},
+				VerifyAfterLastRound: true,
+				VerificationDemand:   demand,
 			},
 			dispatch,
 		)
@@ -500,19 +499,20 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 	linter.StableSortDiagnosticsByFileAndStart(diagnostics)
 	diagnosticProjection := projectLintDiagnostics(diagnostics)
 
-	// The core applies one bounded round to request-local memory. This adapter
-	// only maps the resulting net whole-file delta into Output; the JS API keeps
-	// ownership of any later physical persistence.
+	// The core applies every bounded round to request-local memory and returns a
+	// final observation over the resulting source. This adapter maps every
+	// successfully fixed file's complete final source into Output; the JS API
+	// keeps ownership of any later physical persistence.
 	var output map[string]string
 	if req.Fix {
 		applied, ok := pipelineResult.AppliedFixes()
 		if !ok {
 			return nil, errors.New("error running linter: API fix did not return an in-memory result")
 		}
-		if len(applied.FinalChanges) > 0 {
-			output = make(map[string]string, len(applied.FinalChanges))
-			for _, change := range applied.FinalChanges {
-				output[tspath.ConvertToRelativePath(change.Path, comparePathOptions)] = change.After
+		if len(applied.FinalSources) > 0 {
+			output = make(map[string]string, len(applied.FinalSources))
+			for _, source := range applied.FinalSources {
+				output[tspath.ConvertToRelativePath(source.Path, comparePathOptions)] = source.Text
 			}
 		}
 		if len(output) == 0 {

--- a/internal/api/server/lint_fix_test.go
+++ b/internal/api/server/lint_fix_test.go
@@ -1,0 +1,506 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/api"
+	"github.com/web-infra-dev/rslint/internal/ipc"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestHandleLint_FixReturnsFinalGeneration(t *testing.T) {
+	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "..", "packages", "rslint", "fixtures"))
+	if err != nil {
+		t.Fatalf("resolve fixtures dir: %v", err)
+	}
+	config := json.RawMessage(`[{
+		"files": ["**/*.ts"],
+		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
+		"rules": { "@typescript-eslint/array-type": "error" },
+		"plugins": ["@typescript-eslint"]
+	}]`)
+	target := filepath.Join(fixturesDir, "gap-fix.ts")
+
+	response, err := (&Handler{}).HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  fixturesDir,
+		WorkingDirectory: fixturesDir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: "let a: Array<string> = [];\n"},
+		Fix:              true,
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.ErrorCount != 0 || response.FixableErrorCount != 0 || response.FixableWarningCount != 0 {
+		t.Fatalf(
+			"final counts = errors:%d fixable:%d/%d, want zero",
+			response.ErrorCount,
+			response.FixableErrorCount,
+			response.FixableWarningCount,
+		)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("final diagnostics = %+v, want none", response.Diagnostics)
+	}
+	if got := response.Output["gap-fix.ts"]; got != "let a: string[] = [];\n" {
+		t.Fatalf("fixed output = %q", got)
+	}
+}
+
+func TestHandleLint_FixOutputPreservesOverlayBOM(t *testing.T) {
+	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "..", "packages", "rslint", "fixtures"))
+	if err != nil {
+		t.Fatalf("resolve fixtures dir: %v", err)
+	}
+	config := json.RawMessage(`[{
+		"files": ["**/*.ts"],
+		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
+		"rules": { "@typescript-eslint/array-type": "error" },
+		"plugins": ["@typescript-eslint"]
+	}]`)
+	target := filepath.Join(fixturesDir, "gap-fix-bom.ts")
+	response, err := (&Handler{}).HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  fixturesDir,
+		WorkingDirectory: fixturesDir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: utils.BOM + "let a: Array<string> = [];\n"},
+		Fix:              true,
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	want := utils.BOM + "let a: string[] = [];\n"
+	if got := response.Output["gap-fix-bom.ts"]; got != want {
+		t.Fatalf("fixed BOM output = %q, want %q", got, want)
+	}
+}
+
+func TestHandleLint_FixRunsNativeCascadesWithoutWritingDisk(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "input.ts")
+	const source = "const value: Number = 1;\n"
+	if err := os.WriteFile(target, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{"files":["input.ts"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	config := json.RawMessage(`[{
+		"files": ["**/*.ts"],
+		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
+		"plugins": ["@typescript-eslint"],
+		"rules": {
+			"@typescript-eslint/no-wrapper-object-types": "error",
+			"@typescript-eslint/no-inferrable-types": "error"
+		}
+	}]`)
+
+	response, err := (&Handler{}).HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		Fix:              true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := response.Output["input.ts"]; got != "const value = 1;\n" {
+		t.Fatalf("cascade output = %q, want the second-round fix", got)
+	}
+	if len(response.Diagnostics) != 0 || response.ErrorCount != 0 || response.FixableErrorCount != 0 {
+		t.Fatalf(
+			"final diagnostics/counts are stale: %+v, errors=%d fixable=%d",
+			response.Diagnostics,
+			response.ErrorCount,
+			response.FixableErrorCount,
+		)
+	}
+	diskContent, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(diskContent) != source {
+		t.Fatalf("API wrote fixes to disk: got %q, want %q", diskContent, source)
+	}
+}
+
+func TestHandleLint_FixKeepsFilesIsolatedAcrossRounds(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.js")
+	second := filepath.Join(dir, "second.js")
+	clean := filepath.Join(dir, "clean.js")
+	response, err := (&Handler{}).HandleLint(api.LintRequest{
+		Config:           json.RawMessage(`[{"rules":{"no-var":"error"}}]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{first, second, clean},
+		FileContents: map[string]string{
+			first:  "var first = 1;\n",
+			second: "var second = 2;\n",
+			clean:  "const clean = 3;\n",
+		},
+		Fix: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Output) != 2 {
+		t.Fatalf("output files = %+v, want only the two changed files", response.Output)
+	}
+	if got := response.Output["first.js"]; strings.Contains(got, "var") || !strings.Contains(got, "first") {
+		t.Fatalf("first output was lost or contaminated: %q", got)
+	}
+	if got := response.Output["second.js"]; strings.Contains(got, "var") || !strings.Contains(got, "second") {
+		t.Fatalf("second output was lost or contaminated: %q", got)
+	}
+	if _, exists := response.Output["clean.js"]; exists {
+		t.Fatalf("unchanged file unexpectedly has output: %+v", response.Output)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("final diagnostics = %+v, want none", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_FixVerifiesAfterTenRounds(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "input.js")
+	config := json.RawMessage(`[{"plugins":["community"],"rules":{"community/increment":"error"}}]`)
+
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		if kind != api.KindPluginLint {
+			return nil, fmt.Errorf("unexpected reverse request kind %q", kind)
+		}
+		request := payload.(linter.EslintPluginLintRequest)
+		call := int(calls.Add(1))
+		if len(request.Files) != 1 || request.Files[0].Text == nil {
+			t.Fatalf("missing plugin source on call %d", call)
+		}
+		text := *request.Files[0].Text
+		value, err := strconv.Atoi(strings.TrimSpace(text))
+		if err != nil {
+			t.Fatalf("parse generation %q: %v", text, err)
+		}
+		if value != call-1 {
+			t.Fatalf("plugin call %d saw generation %d", call, value)
+		}
+		return ipc.NewMessage(ipc.KindResponse, 1, linter.EslintPluginLintResult{
+			Results: []linter.EslintPluginFileResult{{
+				FilePath: request.Files[0].Path,
+				Diagnostics: []linter.EslintPluginDiagnostic{{
+					RuleName: "community/increment",
+					Message:  "increment",
+					StartPos: 0,
+					EndPos:   len(strings.TrimSpace(text)),
+					Fixes: []linter.EslintPluginFix{{
+						Range: [2]int{0, len(strings.TrimSpace(text))},
+						Text:  strconv.Itoa(value + 1),
+					}},
+				}},
+			}},
+		})
+	})
+
+	response, err := (&Handler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: "0\n"},
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "community",
+			RuleNames: []string{"increment"},
+		}},
+		Fix: true,
+	}, requester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 11 {
+		t.Fatalf("plugin calls = %d, want ten writable rounds plus final verification", calls.Load())
+	}
+	if got := response.Output["input.js"]; got != "10\n" {
+		t.Fatalf("output = %q, want tenth write", got)
+	}
+	if len(response.Diagnostics) != 1 || response.ErrorCount != 1 || response.FixableErrorCount != 1 {
+		t.Fatalf(
+			"final verification was not projected: diagnostics=%+v errors=%d fixable=%d",
+			response.Diagnostics,
+			response.ErrorCount,
+			response.FixableErrorCount,
+		)
+	}
+	fixes := response.Diagnostics[0].Fixes
+	if len(fixes) != 1 || fixes[0].StartPos != 0 || fixes[0].EndPos != 2 || fixes[0].Text != "11" {
+		t.Fatalf("final diagnostic fix = %+v, want range [0,2] replacement 11", fixes)
+	}
+}
+
+func TestHandleLint_FixReportsOutputAfterNetRestoration(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "input.js")
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		if kind != api.KindPluginLint {
+			return nil, fmt.Errorf("unexpected reverse request kind %q", kind)
+		}
+		request := payload.(linter.EslintPluginLintRequest)
+		call := calls.Add(1)
+		if len(request.Files) != 1 || request.Files[0].Text == nil {
+			t.Fatalf("plugin call %d has no source", call)
+		}
+		text := *request.Files[0].Text
+		replacement := "b"
+		if text == "b" {
+			replacement = "a"
+		}
+		return ipc.NewMessage(ipc.KindResponse, 1, linter.EslintPluginLintResult{
+			Results: []linter.EslintPluginFileResult{{
+				FilePath: request.Files[0].Path,
+				Diagnostics: []linter.EslintPluginDiagnostic{{
+					RuleName: "community/toggle",
+					Message:  "toggle",
+					StartPos: 0,
+					EndPos:   1,
+					Fixes:    []linter.EslintPluginFix{{Range: [2]int{0, 1}, Text: replacement}},
+				}},
+			}},
+		})
+	})
+
+	response, err := (&Handler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Config:           json.RawMessage(`[{"plugins":["community"],"rules":{"community/toggle":"error"}}]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: "a"},
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "community",
+			RuleNames: []string{"toggle"},
+		}},
+		Fix: true,
+	}, requester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("plugin calls = %d, want two rounds ending at the initial source", calls.Load())
+	}
+	output, present := response.Output["input.js"]
+	if !present || output != "a" {
+		t.Fatalf("restored output = %q (present=%t), want original text reported", output, present)
+	}
+	if len(response.Diagnostics) != 1 || response.FixableErrorCount != 1 {
+		t.Fatalf("restored final diagnostics = %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_FixReportsEmptyOutput(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "input.js")
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		if kind != api.KindPluginLint {
+			return nil, fmt.Errorf("unexpected reverse request kind %q", kind)
+		}
+		request := payload.(linter.EslintPluginLintRequest)
+		call := calls.Add(1)
+		if len(request.Files) != 1 || request.Files[0].Text == nil {
+			t.Fatalf("plugin call %d has no source", call)
+		}
+		text := *request.Files[0].Text
+		result := linter.EslintPluginFileResult{FilePath: request.Files[0].Path}
+		if text != "" {
+			result.Diagnostics = []linter.EslintPluginDiagnostic{{
+				RuleName: "community/empty",
+				Message:  "empty",
+				StartPos: 0,
+				EndPos:   len(text),
+				Fixes:    []linter.EslintPluginFix{{Range: [2]int{0, len(text)}, Text: ""}},
+			}}
+		}
+		return ipc.NewMessage(ipc.KindResponse, 1, linter.EslintPluginLintResult{
+			Results: []linter.EslintPluginFileResult{result},
+		})
+	})
+
+	response, err := (&Handler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Config:           json.RawMessage(`[{"plugins":["community"],"rules":{"community/empty":"error"}}]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: "removeMe();"},
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "community",
+			RuleNames: []string{"empty"},
+		}},
+		Fix: true,
+	}, requester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("plugin calls = %d, want fix plus final verification", calls.Load())
+	}
+	output, present := response.Output["input.js"]
+	if !present || output != "" {
+		t.Fatalf("empty output = %q (present=%t), want an explicit empty string", output, present)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("final diagnostics = %+v, want none", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_FixProjectsOutputToRequestedAlias(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real.ts")
+	aliasPath := filepath.Join(dir, "alias.ts")
+	const source = "const bad = 1;\n"
+	if err := os.WriteFile(realPath, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "tsconfig.json"),
+		[]byte(`{"compilerOptions":{"noLib":true},"files":["real.ts"]}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realPath, aliasPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	var calls atomic.Int32
+	dispatch := func(_ context.Context, request linter.EslintPluginLintRequest) (*linter.EslintPluginLintResult, error) {
+		call := calls.Add(1)
+		if len(request.Files) != 1 || request.Files[0].Text == nil {
+			t.Fatalf("plugin call %d has no source", call)
+		}
+		text := *request.Files[0].Text
+		result := linter.EslintPluginFileResult{FilePath: request.Files[0].Path}
+		if strings.Contains(text, "bad") {
+			result.Diagnostics = []linter.EslintPluginDiagnostic{{
+				RuleName: "community/rename",
+				Message:  "rename",
+				StartPos: 6,
+				EndPos:   9,
+				Fixes:    []linter.EslintPluginFix{{Range: [2]int{6, 9}, Text: "good"}},
+			}}
+		}
+		return &linter.EslintPluginLintResult{
+			Results: []linter.EslintPluginFileResult{result},
+		}, nil
+	}
+
+	response, err := (&Handler{}).handleLint(context.Background(), api.LintRequest{
+		Files:          []string{aliasPath},
+		CanonicalFiles: []string{realPath},
+		Config: json.RawMessage(`[{
+			"files":["**/*.ts"],
+			"plugins":["community"],
+			"languageOptions":{"parserOptions":{"project":["./tsconfig.json"]}},
+			"rules":{"community/rename":"error"}
+		}]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "community",
+			RuleNames: []string{"rename"},
+		}},
+		Fix: true,
+	}, dispatch, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("plugin calls = %d, want fix plus final verification", calls.Load())
+	}
+	if got := response.Output["alias.ts"]; got != "const good = 1;\n" {
+		t.Fatalf("alias output = %q", got)
+	}
+	if _, present := response.Output["real.ts"]; present {
+		t.Fatalf("output leaked the Program identity: %+v", response.Output)
+	}
+	if len(response.LintedFiles) != 1 || response.LintedFiles[0] != "alias.ts" {
+		t.Fatalf("linted files = %+v, want requested alias", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("final diagnostics = %+v, want none", response.Diagnostics)
+	}
+	disk, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(disk) != source {
+		t.Fatalf("API wrote alias output to disk: %q", disk)
+	}
+}
+
+func TestHandleLint_FixCancellationDuringFinalVerificationReturnsNoResponse(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "input.js")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		if kind != api.KindPluginLint {
+			return nil, fmt.Errorf("unexpected reverse request kind %q", kind)
+		}
+		request := payload.(linter.EslintPluginLintRequest)
+		call := calls.Add(1)
+		if len(request.Files) != 1 || request.Files[0].Text == nil {
+			t.Fatalf("plugin call %d has no source", call)
+		}
+		if call == 2 {
+			cancel()
+			return nil, context.Canceled
+		}
+		return ipc.NewMessage(ipc.KindResponse, 1, linter.EslintPluginLintResult{
+			Results: []linter.EslintPluginFileResult{{
+				FilePath: request.Files[0].Path,
+				Diagnostics: []linter.EslintPluginDiagnostic{{
+					RuleName: "community/rename",
+					Message:  "rename",
+					StartPos: 6,
+					EndPos:   9,
+					Fixes:    []linter.EslintPluginFix{{Range: [2]int{6, 9}, Text: "good"}},
+				}},
+			}},
+		})
+	})
+
+	response, err := (&Handler{}).HandleLintWithContext(ctx, api.LintRequest{
+		Config:           json.RawMessage(`[{"plugins":["community"],"rules":{"community/rename":"error"}}]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: "const bad = 1;\n"},
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "community",
+			RuleNames: []string{"rename"},
+		}},
+		Fix: true,
+	}, requester)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if response != nil {
+		t.Fatalf("canceled final verification exposed a partial response: %+v", response)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("plugin calls = %d, want cancellation during final verification", calls.Load())
+	}
+}

--- a/internal/api/server/lint_test.go
+++ b/internal/api/server/lint_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/config/discovery"
 	"github.com/web-infra-dev/rslint/internal/ipc"
 	"github.com/web-infra-dev/rslint/internal/linter"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 type canonicalPathBaseFS struct {
@@ -1452,77 +1451,6 @@ func TestHandleLint_SuggestionDataConverted(t *testing.T) {
 	}
 }
 
-// ⑥: fix:true applies fixes in-band and returns the fixed source per file in
-// Output (not written to disk), plus fixable*Count split by severity.
-func TestHandleLint_FixProducesInBandOutput(t *testing.T) {
-	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "..", "packages", "rslint", "fixtures"))
-	if err != nil {
-		t.Fatalf("resolve fixtures dir: %v", err)
-	}
-	config := json.RawMessage(`[{
-		"files": ["**/*.ts"],
-		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
-		"rules": { "@typescript-eslint/array-type": "error" },
-		"plugins": ["@typescript-eslint"]
-	}]`)
-	gapFile := filepath.Join(fixturesDir, "gap-fix.ts")
-
-	handler := &Handler{}
-	resp, err := handler.HandleLint(api.LintRequest{
-		Config:           config,
-		ConfigDirectory:  fixturesDir,
-		WorkingDirectory: fixturesDir,
-		Files:            []string{gapFile},
-		FileContents:     map[string]string{gapFile: "let a: Array<string> = [];\n"},
-		Fix:              true,
-	})
-	if err != nil {
-		t.Fatalf("HandleLint returned error: %v", err)
-	}
-	if resp.FixableErrorCount != 1 || resp.FixableWarningCount != 0 {
-		t.Fatalf("expected fixableErrorCount=1 fixableWarningCount=0, got %d/%d", resp.FixableErrorCount, resp.FixableWarningCount)
-	}
-	if resp.Output == nil {
-		t.Fatal("expected non-nil Output for fix:true")
-	}
-	got, ok := resp.Output["gap-fix.ts"]
-	if !ok {
-		t.Fatalf("expected in-band output keyed \"gap-fix.ts\", got %d entries", len(resp.Output))
-	}
-	if want := "let a: string[] = [];\n"; got != want {
-		t.Fatalf("expected fixed output %q, got %q", want, got)
-	}
-}
-
-func TestHandleLint_FixOutputPreservesOverlayBOM(t *testing.T) {
-	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "..", "packages", "rslint", "fixtures"))
-	if err != nil {
-		t.Fatalf("resolve fixtures dir: %v", err)
-	}
-	config := json.RawMessage(`[{
-		"files": ["**/*.ts"],
-		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
-		"rules": { "@typescript-eslint/array-type": "error" },
-		"plugins": ["@typescript-eslint"]
-	}]`)
-	targetPath := filepath.Join(fixturesDir, "gap-fix-bom.ts")
-	response, err := (&Handler{}).HandleLint(api.LintRequest{
-		Config:           config,
-		ConfigDirectory:  fixturesDir,
-		WorkingDirectory: fixturesDir,
-		Files:            []string{targetPath},
-		FileContents:     map[string]string{targetPath: utils.BOM + "let a: Array<string> = [];\n"},
-		Fix:              true,
-	})
-	if err != nil {
-		t.Fatalf("HandleLint returned error: %v", err)
-	}
-	want := utils.BOM + "let a: string[] = [];\n"
-	if got := response.Output["gap-fix-bom.ts"]; got != want {
-		t.Fatalf("fixed BOM output = %q, want %q", got, want)
-	}
-}
-
 // ⑥: fix/suggestion ranges are flat UTF-16 offsets, not byte offsets. A CJK
 // char before the fix (1 UTF-16 unit but 3 UTF-8 bytes) makes the two diverge.
 func TestHandleLint_FixRangeIsUTF16(t *testing.T) {
@@ -2403,7 +2331,7 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 
 	var calls atomic.Int32
 	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
-		calls.Add(1)
+		call := calls.Add(1)
 		if kind != api.KindPluginLint {
 			t.Fatalf("expected pluginLint reverse request, got %q", kind)
 		}
@@ -2414,8 +2342,15 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 		if !req.Fix || req.SuggestionsMode != linter.SuggestionsModeEager {
 			t.Fatalf("unexpected fix settings: fix=%v suggestions=%q", req.Fix, req.SuggestionsMode)
 		}
-		if len(req.Files) != 1 || req.Files[0].Text == nil || *req.Files[0].Text != source {
+		if len(req.Files) != 1 || req.Files[0].Text == nil {
 			t.Fatalf("plugin request must carry the exact overlay text, got %+v", req.Files)
+		}
+		wantText := source
+		if call == 2 {
+			wantText = "const good = 1;\n"
+		}
+		if *req.Files[0].Text != wantText {
+			t.Fatalf("plugin request %d text = %q, want %q", call, *req.Files[0].Text, wantText)
 		}
 		if req.Files[0].ConfigKey != pluginConfigDirectory {
 			t.Fatalf("expected configKey %q, got %q", pluginConfigDirectory, req.Files[0].ConfigKey)
@@ -2425,9 +2360,9 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 			t.Fatalf("missing normalized plugin rule options: %+v", req.Rules)
 		}
 
-		result := linter.EslintPluginLintResult{Results: []linter.EslintPluginFileResult{{
-			FilePath: req.Files[0].Path,
-			Diagnostics: []linter.EslintPluginDiagnostic{{
+		result := linter.EslintPluginLintResult{Results: []linter.EslintPluginFileResult{{FilePath: req.Files[0].Path}}}
+		if call == 1 {
+			result.Results[0].Diagnostics = []linter.EslintPluginDiagnostic{{
 				RuleName:  "community/rename",
 				MessageId: "rename",
 				Message:   "rename bad",
@@ -2437,8 +2372,8 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 					Range: [2]int{6, 9},
 					Text:  "good",
 				}},
-			}},
-		}}}
+			}}
+		}
 		return ipc.NewMessage(ipc.KindResponse, 1, result)
 	})
 
@@ -2458,24 +2393,13 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandleLintWithContext returned error: %v", err)
 	}
-	if calls.Load() != 1 {
-		t.Fatalf("expected one pluginLint request, got %d", calls.Load())
+	if calls.Load() != 2 {
+		t.Fatalf("pluginLint requests = %d, want fixing and final observations", calls.Load())
 	}
-	if len(response.Diagnostics) != 1 {
-		t.Fatalf("expected one plugin diagnostic, got %+v", response.Diagnostics)
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("final plugin diagnostics = %+v, want none", response.Diagnostics)
 	}
-	diagnostic := response.Diagnostics[0]
-	if diagnostic.RuleName != "community/rename" || diagnostic.MessageId != "rename" || diagnostic.FilePath != "input.js" {
-		t.Fatalf("unexpected plugin diagnostic: %+v", diagnostic)
-	}
-	if diagnostic.Range.Start.Line != 1 || diagnostic.Range.Start.Column != 7 ||
-		diagnostic.Range.End.Line != 1 || diagnostic.Range.End.Column != 10 {
-		t.Fatalf("unexpected plugin diagnostic range: %+v", diagnostic.Range)
-	}
-	if len(diagnostic.Fixes) != 1 || diagnostic.Fixes[0].StartPos != 6 || diagnostic.Fixes[0].EndPos != 9 {
-		t.Fatalf("unexpected plugin fix: %+v", diagnostic.Fixes)
-	}
-	if response.ErrorCount != 1 || response.FixableErrorCount != 1 || response.RuleCount != 1 {
+	if response.ErrorCount != 0 || response.FixableErrorCount != 0 || response.RuleCount != 1 {
 		t.Fatalf("unexpected plugin counts: errors=%d fixable=%d rules=%d", response.ErrorCount, response.FixableErrorCount, response.RuleCount)
 	}
 	if got := response.Output["input.js"]; got != "const good = 1;\n" {

--- a/internal/linter/pipeline_autofix.go
+++ b/internal/linter/pipeline_autofix.go
@@ -33,7 +33,7 @@ func runAutofixPipeline(
 		return commitFinalChanges(ctx, request, result, state)
 	}
 
-	for roundIndex := range request.autofix.MaxRounds {
+	for roundIndex := range request.autofix.maxRounds {
 		if err := ctx.Err(); err != nil {
 			return result, err
 		}
@@ -59,6 +59,7 @@ func runAutofixPipeline(
 		result.fix.verified = false
 		result.fix.rounds = append(result.fix.rounds, round)
 		result.fix.finalChanges = state.finalChanges()
+		result.fix.finalSources = state.finalSources()
 		if round.RestoredInitial {
 			result.Observation = initialObservation
 			result.fix.verified = true
@@ -71,7 +72,7 @@ func runAutofixPipeline(
 			return result, err
 		}
 
-		lastAllowedRound := roundIndex+1 == request.autofix.MaxRounds
+		lastAllowedRound := roundIndex+1 == request.autofix.maxRounds
 		if lastAllowedRound && !request.autofix.VerifyAfterLastRound {
 			return commitFinalChanges(ctx, request, result, state)
 		}
@@ -116,6 +117,7 @@ func commitFinalChanges(
 	state *autofixState,
 ) (PipelineResult, error) {
 	result.fix.finalChanges = state.finalChanges()
+	result.fix.finalSources = state.finalSources()
 	if request.commit == nil {
 		return result, ctx.Err()
 	}

--- a/internal/linter/pipeline_autofix_state.go
+++ b/internal/linter/pipeline_autofix_state.go
@@ -106,3 +106,20 @@ func (s *autofixState) finalChanges() []FileChange {
 	}
 	return changes
 }
+
+func (s *autofixState) finalSources() []SourceFileSnapshot {
+	paths := make([]string, 0, len(s.appliedDiagnostics))
+	for path := range s.appliedDiagnostics {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	files := make([]SourceFileSnapshot, 0, len(paths))
+	for _, path := range paths {
+		text, known := s.text(path)
+		if !known {
+			continue
+		}
+		files = append(files, SourceFileSnapshot{Path: path, Text: text})
+	}
+	return files
+}

--- a/internal/linter/pipeline_autofix_test.go
+++ b/internal/linter/pipeline_autofix_test.go
@@ -28,7 +28,7 @@ func TestAutofixPipelineOwnsMemoryRoundsAndReobservesSnapshots(t *testing.T) {
 	result, err := RunPipeline(context.Background(), NewAutofixRequest(
 		provider,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: MaxFixRounds},
+		AutofixPolicy{},
 		nil,
 	))
 	if err != nil {
@@ -70,7 +70,7 @@ func TestAutofixSyntaxGateStopsBeforeAfterNativePluginDispatch(t *testing.T) {
 			Plugin:        PluginAfterNativeJoined,
 			PluginFailure: PluginDiscardOnFailure,
 		},
-		AutofixPolicy{MaxRounds: MaxFixRounds, StopOnTargetSyntaxErrors: true},
+		AutofixPolicy{StopOnTargetSyntaxErrors: true},
 		func(context.Context, EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 			dispatches++
 			return &EslintPluginLintResult{}, nil
@@ -119,7 +119,7 @@ func TestAutofixSyntaxGateStopsConcurrentPluginBeforeDispatch(t *testing.T) {
 			Demand: ArtifactDemand{Plugin: rule.EditDemandAutofix},
 			Plugin: PluginConcurrentJoined,
 		},
-		AutofixPolicy{MaxRounds: 1, StopOnTargetSyntaxErrors: true},
+		autofixPolicyForTest(1, AutofixPolicy{StopOnTargetSyntaxErrors: true}),
 		func(context.Context, EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 			dispatches++
 			return &EslintPluginLintResult{}, nil
@@ -137,8 +137,8 @@ func TestAutofixSyntaxGateStopsConcurrentPluginBeforeDispatch(t *testing.T) {
 
 func TestAutofixUsesProductRoundLimitThenVerifiesOnce(t *testing.T) {
 	root := tspath.NormalizePath(t.TempDir())
-	next := make(map[string]string, MaxFixRounds)
-	for round := range MaxFixRounds {
+	next := make(map[string]string, maxFixRounds)
+	for round := range maxFixRounds {
 		next[strconv.Itoa(round)] = strconv.Itoa(round + 1)
 	}
 	var fixArtifactBuilds atomic.Int32
@@ -170,7 +170,6 @@ func TestAutofixUsesProductRoundLimitThenVerifiesOnce(t *testing.T) {
 		provider,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
 		AutofixPolicy{
-			MaxRounds:            MaxFixRounds,
 			VerifyAfterLastRound: true,
 			VerificationDemand: ArtifactDemand{
 				Native:      rule.EditDemandSuggestion,
@@ -183,7 +182,7 @@ func TestAutofixUsesProductRoundLimitThenVerifiesOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	applied, ok := result.AppliedFixes()
-	if !ok || !applied.Verified || len(applied.Rounds) != MaxFixRounds || applied.Last.Index != MaxFixRounds {
+	if !ok || !applied.Verified || len(applied.Rounds) != maxFixRounds || applied.Last.Index != maxFixRounds {
 		t.Fatalf("applied result = %+v", applied)
 	}
 	if applied.Initial.Native.Files != nil || len(applied.Last.Native.Files) != 1 {
@@ -193,11 +192,11 @@ func TestAutofixUsesProductRoundLimitThenVerifiesOnce(t *testing.T) {
 			applied.Last.Native.Files,
 		)
 	}
-	if provider.acquisitions != MaxFixRounds+1 || provider.observed[len(provider.observed)-1] != strconv.Itoa(MaxFixRounds) {
+	if provider.acquisitions != maxFixRounds+1 || provider.observed[len(provider.observed)-1] != strconv.Itoa(maxFixRounds) {
 		t.Fatalf("provider acquisitions/observations = %d/%+v", provider.acquisitions, provider.observed)
 	}
-	if fixArtifactBuilds.Load() != MaxFixRounds {
-		t.Fatalf("autofix artifact builds = %d, want %d; final verification demand was not isolated", fixArtifactBuilds.Load(), MaxFixRounds)
+	if fixArtifactBuilds.Load() != maxFixRounds {
+		t.Fatalf("autofix artifact builds = %d, want %d; final verification demand was not isolated", fixArtifactBuilds.Load(), maxFixRounds)
 	}
 }
 
@@ -213,7 +212,7 @@ func TestAutofixCanStopAtRoundLimitWithoutVerification(t *testing.T) {
 	result, err := RunPipeline(context.Background(), NewAutofixRequest(
 		provider,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 2},
+		autofixPolicyForTest(2, AutofixPolicy{}),
 		nil,
 	))
 	if err != nil {
@@ -241,7 +240,7 @@ func TestAutofixRestoredInitialReusesInitialObservation(t *testing.T) {
 	result, err := RunPipeline(context.Background(), NewAutofixRequest(
 		provider,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 3},
+		autofixPolicyForTest(3, AutofixPolicy{}),
 		nil,
 	))
 	if err != nil {
@@ -249,7 +248,8 @@ func TestAutofixRestoredInitialReusesInitialObservation(t *testing.T) {
 	}
 	applied, ok := result.AppliedFixes()
 	if !ok || !applied.Verified || len(applied.Rounds) != 2 || !applied.Rounds[1].RestoredInitial ||
-		applied.Last.Index != applied.Initial.Index || result.Observation.Index != 0 || len(applied.FinalChanges) != 0 {
+		applied.Last.Index != applied.Initial.Index || result.Observation.Index != 0 || len(applied.FinalChanges) != 0 ||
+		len(applied.FinalSources) != 1 || applied.FinalSources[0].Path != provider.fileName || applied.FinalSources[0].Text != "a" {
 		t.Fatalf("restored applied result/provider = %+v / %+v", applied, provider)
 	}
 	if provider.acquisitions != 2 || strings.Join(provider.observed, ",") != "a,b" {
@@ -269,7 +269,7 @@ func TestAutofixSameTextFixConsumesRound(t *testing.T) {
 	result, err := RunPipeline(context.Background(), NewAutofixRequest(
 		provider,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		nil,
 	))
 	if err != nil {
@@ -277,8 +277,38 @@ func TestAutofixSameTextFixConsumesRound(t *testing.T) {
 	}
 	applied, ok := result.AppliedFixes()
 	if !ok || !applied.Verified || len(applied.Rounds) != 1 || len(applied.FinalChanges) != 0 ||
+		len(applied.FinalSources) != 1 || applied.FinalSources[0].Text != "a" ||
 		len(applied.Rounds[0].ChangedPaths) != 1 || applied.Rounds[0].AppliedDiagnostics != 1 {
 		t.Fatalf("same-text applied result/provider = %+v / %+v", applied, provider)
+	}
+}
+
+func TestAutofixFinalSourcesIncludePartiallyRestoredFiles(t *testing.T) {
+	state := newAutofixState()
+	if _, err := state.apply([]FileChange{
+		{Path: "a.js", Before: "a", After: "b", AppliedDiagnostics: 1},
+		{Path: "b.js", Before: "x", After: "y", AppliedDiagnostics: 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	round, err := state.apply([]FileChange{
+		{Path: "a.js", Before: "b", After: "a", AppliedDiagnostics: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if round.RestoredInitial {
+		t.Fatal("one restored file must not hide another file's remaining change")
+	}
+	changes := state.finalChanges()
+	if len(changes) != 1 || changes[0].Path != "b.js" || changes[0].After != "y" {
+		t.Fatalf("net changes = %+v, want only b.js", changes)
+	}
+	sources := state.finalSources()
+	if len(sources) != 2 ||
+		sources[0] != (SourceFileSnapshot{Path: "a.js", Text: "a"}) ||
+		sources[1] != (SourceFileSnapshot{Path: "b.js", Text: "y"}) {
+		t.Fatalf("final fixed sources = %+v", sources)
 	}
 }
 
@@ -287,7 +317,7 @@ func TestAutofixRejectsRoundLimitAboveProductBound(t *testing.T) {
 	_, err := RunPipeline(context.Background(), NewAutofixRequest(
 		provider,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: MaxFixRounds + 1},
+		autofixPolicyForTest(maxFixRounds+1, AutofixPolicy{}),
 		nil,
 	))
 	if err == nil || !strings.Contains(err.Error(), "product safety bound") {
@@ -336,7 +366,7 @@ func TestAutofixReobserveFailurePreservesLastSuccessfulObservation(t *testing.T)
 			Plugin:        PluginConcurrentJoined,
 			PluginFailure: PluginDiscardOnFailure,
 		},
-		AutofixPolicy{MaxRounds: 1, VerifyAfterLastRound: true},
+		autofixPolicyForTest(1, AutofixPolicy{VerifyAfterLastRound: true}),
 		func(dispatchCtx context.Context, request EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 			if dispatches.Add(1) == 2 {
 				<-nativeFinished
@@ -384,7 +414,7 @@ func TestAutofixRejectsProviderThatIgnoresMemorySnapshot(t *testing.T) {
 	result, err := RunPipeline(context.Background(), NewAutofixRequest(
 		provider,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 2},
+		autofixPolicyForTest(2, AutofixPolicy{}),
 		nil,
 	))
 	if err == nil || !strings.Contains(err.Error(), "did not materialize in-memory target") {

--- a/internal/linter/pipeline_commit_test.go
+++ b/internal/linter/pipeline_commit_test.go
@@ -34,7 +34,7 @@ func TestCommittedAutofixCommitsOnlyFinalDeltaOnce(t *testing.T) {
 		provider,
 		committer,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: MaxFixRounds},
+		AutofixPolicy{},
 		nil,
 	))
 	if err != nil {
@@ -93,7 +93,7 @@ func TestAutofixTerminalCommitErrorReturnsConfirmedExternalState(t *testing.T) {
 		provider,
 		committer,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		nil,
 	))
 	if err == nil || !strings.Contains(err.Error(), "partial commit") {
@@ -126,7 +126,7 @@ func TestAutofixPropagatesCancellationFromTerminalCommitter(t *testing.T) {
 		provider,
 		committer,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		nil,
 	))
 	if !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), commitErr.Error()) {
@@ -144,7 +144,7 @@ func TestCommittedAutofixRejectsNilCommitterBeforeAcquisition(t *testing.T) {
 		provider,
 		nil,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		nil,
 	))
 	if err == nil || !strings.Contains(err.Error(), "committer must not be nil") {
@@ -167,7 +167,7 @@ func TestAutofixPipelineRejectsFalseTerminalCommitConfirmation(t *testing.T) {
 		provider,
 		committer,
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		nil,
 	))
 	if err == nil || !strings.Contains(err.Error(), "confirmed 0 of 1") {

--- a/internal/linter/pipeline_contract.go
+++ b/internal/linter/pipeline_contract.go
@@ -9,10 +9,11 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-// MaxFixRounds is the product-wide safety bound. A round is one non-empty
+// maxFixRounds is the product-wide safety bound. A round is one non-empty
 // in-memory change-set application; a final verification observation and the
-// optional external commit are not rounds.
-const MaxFixRounds = 10
+// optional external commit are not rounds. The bound stays private so
+// integrations cannot independently select a pass count and drift apart.
+const maxFixRounds = 10
 
 // ReleaseFunc ends the producer lease for one acquired generation. The
 // pipeline wraps it with exact-once semantics immediately after acquisition;
@@ -225,12 +226,17 @@ type ProgressiveDiagnostics interface {
 	Submit(parentCtx context.Context, run DeferredPluginRun)
 }
 
-// AutofixPolicy configures bounded apply-and-observe behavior.
+// AutofixPolicy configures the observable result and syntax behavior of the
+// product-owned bounded apply-and-observe operation.
 type AutofixPolicy struct {
-	MaxRounds                int
 	VerifyAfterLastRound     bool
 	VerificationDemand       ArtifactDemand
 	StopOnTargetSyntaxErrors bool
+
+	// maxRounds is fixed by the constructors for production requests. Keeping
+	// it private prevents CLI, API, and LSP from acquiring separate fix limits;
+	// package tests may lower it to exercise boundary behavior economically.
+	maxRounds int
 }
 
 type pipelineRequestKind uint8
@@ -303,6 +309,9 @@ func NewAutofixRequest(
 	autofix AutofixPolicy,
 	dispatcher EslintPluginDispatcher,
 ) PipelineRequest {
+	if autofix.maxRounds == 0 {
+		autofix.maxRounds = maxFixRounds
+	}
 	return PipelineRequest{
 		kind:       pipelineRequestAutofix,
 		provider:   provider,
@@ -371,11 +380,11 @@ func (r PipelineRequest) validate() error {
 		if !r.policy.Demand.plansAutofixes() {
 			return errors.New("linter pipeline: autofix observations must request autofix artifacts")
 		}
-		if r.autofix.MaxRounds <= 0 {
-			return errors.New("linter pipeline: autofix MaxRounds must be positive")
+		if r.autofix.maxRounds <= 0 {
+			return errors.New("linter pipeline: autofix round limit must be positive")
 		}
-		if r.autofix.MaxRounds > MaxFixRounds {
-			return errors.New("linter pipeline: autofix MaxRounds exceeds the product safety bound")
+		if r.autofix.maxRounds > maxFixRounds {
+			return errors.New("linter pipeline: autofix round limit exceeds the product safety bound")
 		}
 		if !r.autofix.VerificationDemand.valid() {
 			return errors.New("linter pipeline: verification artifact demand is invalid")

--- a/internal/linter/pipeline_fix_test.go
+++ b/internal/linter/pipeline_fix_test.go
@@ -73,7 +73,7 @@ func TestPipelineFreezesTextOnlyForFixableTargets(t *testing.T) {
 	result, err := RunPipeline(context.Background(), NewAutofixRequest(
 		pipelineTestProvider(generation, nil),
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		nil,
 	))
 	if err != nil {

--- a/internal/linter/pipeline_plugin_test.go
+++ b/internal/linter/pipeline_plugin_test.go
@@ -57,7 +57,7 @@ func TestPipelineConcurrentPluginStartsBeforeNativeAndPlansProjectedFix(t *testi
 			Demand: ArtifactDemand{Native: rule.EditDemandAutofix, Plugin: rule.EditDemandAutofix},
 			Plugin: PluginConcurrentJoined,
 		},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		func(_ context.Context, request EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 			if request.Files[0].Path != fileName {
 				t.Fatalf("plugin wire path = %q, want Program source path %q", request.Files[0].Path, fileName)
@@ -252,7 +252,7 @@ func TestPipelineFreezesCompletePluginInputAfterMemoryChanges(t *testing.T) {
 			Demand: ArtifactDemand{Native: rule.EditDemandAutofix},
 			Plugin: PluginConcurrentJoined,
 		},
-		AutofixPolicy{MaxRounds: 1, VerifyAfterLastRound: true},
+		autofixPolicyForTest(1, AutofixPolicy{VerifyAfterLastRound: true}),
 		func(_ context.Context, request EslintPluginLintRequest) (*EslintPluginLintResult, error) {
 			dispatches++
 			if len(request.Files) != 2 {
@@ -357,7 +357,7 @@ func TestPipelineRejectsDuplicateProjectedTargetBeforeExecution(t *testing.T) {
 	_, err := RunPipeline(context.Background(), NewAutofixRequest(
 		pipelineTestProvider(generation, nil),
 		ObservationPolicy{Demand: ArtifactDemand{Native: rule.EditDemandAutofix}},
-		AutofixPolicy{MaxRounds: 1},
+		autofixPolicyForTest(1, AutofixPolicy{}),
 		nil,
 	))
 	if err == nil || !strings.Contains(err.Error(), "duplicate projected target") || ruleRan {

--- a/internal/linter/pipeline_result.go
+++ b/internal/linter/pipeline_result.go
@@ -88,8 +88,14 @@ type AppliedFixResult struct {
 	Last         ObservationResult
 	Rounds       []FixRoundResult
 	FinalChanges []FileChange
-	// Verified means Last observes the same text represented by FinalChanges.
-	// It does not promise that another fix round would produce no edits.
+	// FinalSources contains the complete final text for every path to which at
+	// least one fix was applied in a successful round. Unlike FinalChanges, it
+	// retains paths whose fixes restored the initial text so in-memory consumers
+	// can still report that fixes were applied.
+	FinalSources []SourceFileSnapshot
+	// Verified means Last observes the final in-memory source represented by
+	// FinalSources (and its net delta in FinalChanges). It does not promise that
+	// another fix round would produce no edits.
 	Verified       bool
 	Committed      bool
 	CommittedPaths []string
@@ -102,6 +108,7 @@ type fixResult struct {
 	initial        ObservationResult
 	rounds         []FixRoundResult
 	finalChanges   []FileChange
+	finalSources   []SourceFileSnapshot
 	verified       bool
 	committed      bool
 	committedPaths []string
@@ -116,6 +123,7 @@ func (r fixResult) applied(last ObservationResult) (AppliedFixResult, bool) {
 		Last:           last,
 		Rounds:         cloneFixRounds(r.rounds),
 		FinalChanges:   cloneFileChanges(r.finalChanges),
+		FinalSources:   cloneSourceFileSnapshots(r.finalSources),
 		Verified:       r.verified,
 		Committed:      r.committed,
 		CommittedPaths: append([]string(nil), r.committedPaths...),
@@ -177,6 +185,10 @@ func clonePluginOutcome(outcome EslintPluginDispatchOutcome) EslintPluginDispatc
 
 func cloneFileChanges(changes []FileChange) []FileChange {
 	return append([]FileChange(nil), changes...)
+}
+
+func cloneSourceFileSnapshots(files []SourceFileSnapshot) []SourceFileSnapshot {
+	return append([]SourceFileSnapshot(nil), files...)
 }
 
 func cloneFixRounds(rounds []FixRoundResult) []FixRoundResult {

--- a/internal/linter/pipeline_support_test.go
+++ b/internal/linter/pipeline_support_test.go
@@ -72,6 +72,11 @@ func pipelineTestProvider(generation Generation, release ReleaseFunc) Generation
 	})
 }
 
+func autofixPolicyForTest(maxRounds int, policy AutofixPolicy) AutofixPolicy {
+	policy.maxRounds = maxRounds
+	return policy
+}
+
 func runPipelineWithParallelRuleResolver(
 	t *testing.T,
 	resolver func(*ast.SourceFile) []rule.ConfiguredRule,

--- a/internal/lsp/code_action.go
+++ b/internal/lsp/code_action.go
@@ -106,13 +106,10 @@ func isFixAllRequest(ctx *lsproto.CodeActionContext) bool {
 	return false
 }
 
-// maxFixRounds is the maximum number of non-empty change-set commits when two
-// rules produce fixes that undo each other.
-const maxFixRounds = linter.MaxFixRounds
-
 // handleFixAllCodeAction computes all auto-fixes for the given URI using
 // bounded rounds: each observation lints an isolated overlay and each non-empty
-// planned change set advances it by one round, until stable or maxFixRounds.
+// planned change set advances it by one round, until stable or the linter-owned
+// product limit.
 // This handles cascading fixes (e.g. no-wrapper-object-types fix triggers no-inferrable-types).
 // It does NOT push diagnostics or update s.diagnostics — that is left to the
 // subsequent didSave handler in the normal save flow.
@@ -152,9 +149,6 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 			PluginFailure: linter.PluginDiscardOnFailure,
 		},
 		linter.AutofixPolicy{
-			MaxRounds:                maxFixRounds,
-			VerifyAfterLastRound:     false,
-			VerificationDemand:       linter.ArtifactDemand{},
 			StopOnTargetSyntaxErrors: true,
 		},
 		budgetedDispatch,

--- a/internal/lsp/lint_test_support_test.go
+++ b/internal/lsp/lint_test_support_test.go
@@ -127,7 +127,6 @@ func runSpeculativeFixAllForTest(
 			PluginFailure: linter.PluginDiscardOnFailure,
 		},
 		linter.AutofixPolicy{
-			MaxRounds:                maxFixRounds,
 			StopOnTargetSyntaxErrors: true,
 		},
 		dispatch,

--- a/internal/lsp/service_fixall_test.go
+++ b/internal/lsp/service_fixall_test.go
@@ -549,11 +549,3 @@ func TestHandleFixAllCodeAction_DocumentNotInMap(t *testing.T) {
 		t.Error("expected empty code actions for document not in map")
 	}
 }
-
-// ======== maxFixRounds constant test ========
-
-func TestMaxFixRounds_IsReasonable(t *testing.T) {
-	if maxFixRounds < 1 || maxFixRounds > 100 {
-		t.Errorf("maxFixRounds = %d, should be between 1 and 100", maxFixRounds)
-	}
-}

--- a/internal/program/loader/session.go
+++ b/internal/program/loader/session.go
@@ -12,9 +12,11 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
-// Session owns Program-construction services for one CLI invocation or API
-// request. It is reused across fix generations but never shared between
-// requests or with the LSP session lifecycle.
+// Session owns Program-construction services for one immutable CLI/API source
+// generation. A caller may explicitly invalidate its source snapshots before
+// reusing it, but the lint pipeline's overlay providers use a fresh Session per
+// fix generation. Sessions are never shared between requests or with the LSP
+// lifecycle.
 type Session struct {
 	context            *buildContext
 	initialPrograms    []*compiler.Program

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -113,7 +113,7 @@ export interface LintResult {
   warningCount: number;
   fixableErrorCount: number;
   fixableWarningCount: number;
-  output?: string; // present only when fix:true changed the file
+  output?: string; // present when fix:true applied at least one fix to the file
 }
 
 interface PluginLintSession {
@@ -448,6 +448,7 @@ export class Rslint {
       : null;
     try {
       const files = selectedFiles.map((file) => file.lexicalPath);
+      const overlay = this.#resolveOverlay();
       const response = await this.#service.lint(
         {
           config: usesNativeDiscovery ? undefined : overrideConfig,
@@ -467,12 +468,18 @@ export class Rslint {
           files,
           canonicalFiles: selectedFiles.map((file) => file.canonicalPath),
           // Overlay (e.g. an in-memory tsconfig) for the program over disk files.
-          fileContents: this.#resolveOverlay(),
+          fileContents: overlay,
           fix: this.#fix,
         },
         discoverySession?.handlers ?? {},
       );
-      const contents = await this.#readDiagnosticContents(response, this.#cwd);
+      const multiEditSources = await this.#resolveMultiEditSources(
+        response,
+        this.#cwd,
+        pathResolver,
+        overlay,
+        selectedFiles,
+      );
       // The multi-config native path returns absolute identities. Relative
       // values remain accepted for low-level/older implementations.
       const linted = response.lintedFiles
@@ -482,9 +489,12 @@ export class Rslint {
               : path.resolve(this.#cwd, file),
           )
         : files;
-      return this.#toLintResults(response, this.#cwd, linted, contents).sort(
-        (a, b) => nativePathIdentity.compare(a.filePath, b.filePath),
-      );
+      return this.#toLintResults(
+        response,
+        this.#cwd,
+        linted,
+        multiEditSources,
+      ).sort((a, b) => nativePathIdentity.compare(a.filePath, b.filePath));
     } finally {
       await discoverySession?.shutdown();
     }
@@ -634,28 +644,87 @@ export class Rslint {
     return this.#normalizedOverrideConfig;
   }
 
-  async #readDiagnosticContents(
+  async #resolveMultiEditSources(
     response: LintResponse,
     configDirectory: string,
+    pathResolver: RunPathResolver,
+    overlay?: Record<string, string>,
+    resolvedFiles: readonly ResolvedFilesystemPath[] = [],
   ): Promise<Record<string, string>> {
-    // Read source for each file that produced a diagnostic so mergeFixes can
-    // gap-fill multi-edit fixes (parity with lintText, which has the source
-    // in-hand). Only diagnosed files are read; a lint with no findings reads
-    // nothing.
+    // Read only sources required to gap-fill multi-edit fixes or suggestions.
+    // Single edits need no source text, and an Output entry already carries the
+    // authoritative final generation.
+    const toAbs = (filePath: string): string =>
+      path.isAbsolute(filePath)
+        ? path.normalize(filePath)
+        : path.resolve(configDirectory, filePath);
+    const outputPaths = new Set(
+      Object.keys(response.output ?? {}).map((filePath) =>
+        nativePathIdentity.key(toAbs(filePath)),
+      ),
+    );
+    const diagnostics = (response.diagnostics ?? []).filter((diagnostic) => {
+      const needsSource =
+        (diagnostic.fixes?.length ?? 0) > 1 ||
+        diagnostic.suggestions?.some(
+          (suggestion) => (suggestion.fixes?.length ?? 0) > 1,
+        );
+      return (
+        needsSource &&
+        !outputPaths.has(nativePathIdentity.key(toAbs(diagnostic.filePath)))
+      );
+    });
+    if (diagnostics.length === 0) return {};
+
+    const overlayEntries = Object.entries(overlay ?? {});
+    const resolvedOverlayFiles = await pathResolver.resolveAll(
+      overlayEntries.map(([filePath]) => toAbs(filePath)),
+    );
+    const overlayByPath = new Map<string, string>();
+    for (const [index, [, source]] of overlayEntries.entries()) {
+      overlayByPath.set(resolvedOverlayFiles[index].lexicalKey, source);
+    }
+    for (const [index, [, source]] of overlayEntries.entries()) {
+      const canonicalKey = resolvedOverlayFiles[index].canonicalKey;
+      if (!overlayByPath.has(canonicalKey)) {
+        overlayByPath.set(canonicalKey, source);
+      }
+    }
+    // Go materializes each selected lexical path through its canonical identity.
+    // Mirror that request-known equivalence here so a diagnostic projected back
+    // to a symlink alias still finds the exact virtual source that was linted.
+    // Canonical content wins when callers supplied conflicting alias entries,
+    // matching the Program's physical source identity.
+    for (const file of resolvedFiles) {
+      const source =
+        overlayByPath.get(file.canonicalKey) ??
+        overlayByPath.get(file.lexicalKey);
+      if (source !== undefined) {
+        overlayByPath.set(file.canonicalKey, source);
+        overlayByPath.set(file.lexicalKey, source);
+      }
+    }
     const contents: Record<string, string> = {};
-    for (const d of response.diagnostics ?? []) {
-      const abs = path.isAbsolute(d.filePath)
-        ? path.normalize(d.filePath)
-        : path.resolve(configDirectory, d.filePath);
-      if (!(abs in contents)) {
-        try {
-          // A BOM is never part of the text a fix range indexes — Go strips it
-          // and reports it separately, matching ESLint's SourceCode — so strip
-          // it here too and the gap-fill slices line up.
-          contents[abs] = stripBOM(await readFile(abs, 'utf8'));
-        } catch {
-          // Unreadable (e.g. virtual/deleted) — mergeFixes degrades to first edit.
-        }
+    const contentPaths = new Set<string>();
+    for (const d of diagnostics) {
+      const abs = toAbs(d.filePath);
+      const key = nativePathIdentity.key(abs);
+      if (contentPaths.has(key)) continue;
+
+      const overlaySource = overlayByPath.get(key);
+      if (overlaySource !== undefined) {
+        contents[abs] = stripBOM(overlaySource);
+        contentPaths.add(key);
+        continue;
+      }
+      try {
+        // A BOM is never part of the text a fix range indexes — Go strips it
+        // and reports it separately, matching ESLint's SourceCode — so strip
+        // it here too and the gap-fill slices line up.
+        contents[abs] = stripBOM(await readFile(abs, 'utf8'));
+        contentPaths.add(key);
+      } catch {
+        // Unreadable (e.g. virtual/deleted) — mergeFixes degrades to first edit.
       }
     }
     return contents;
@@ -673,6 +742,16 @@ export class Rslint {
     const contentByPath = new Map<string, string>();
     for (const [filePath, source] of Object.entries(contents ?? {})) {
       contentByPath.set(nativePathIdentity.key(filePath), source);
+    }
+
+    // Remaining diagnostics after a multi-round fix refer to the final source
+    // generation. Use that exact text (without its optional BOM) when merging
+    // multi-edit fixes and suggestions; never gap-fill from stale disk/input.
+    const outputByPath = new Map<string, string>();
+    for (const [filePath, fixed] of Object.entries(response.output ?? {})) {
+      const key = nativePathIdentity.key(toAbs(filePath));
+      outputByPath.set(key, fixed);
+      contentByPath.set(key, stripBOM(fixed));
     }
 
     // Every linted file gets a result, even with zero messages (ESLint shape).
@@ -696,12 +775,6 @@ export class Rslint {
         byFile.set(key, bucket);
       }
       bucket.messages.push(toLintMessage(d, contentByPath.get(key)));
-    }
-
-    // Wire `output` is keyed by relative path; remap to absolute.
-    const outputByPath = new Map<string, string>();
-    for (const [rel, fixed] of Object.entries(response.output ?? {})) {
-      outputByPath.set(nativePathIdentity.key(toAbs(rel)), fixed);
     }
 
     const results: LintResult[] = [];

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -59,7 +59,7 @@ export interface LintResponse {
   // discovery requests use workingDirectory. Present for lintFiles so the
   // Rslint class seeds one result per linted file.
   lintedFiles?: string[];
-  output?: Record<string, string>; // Per-file fixed source, present when fix:true applied a fix
+  output?: Record<string, string>; // Per-file final source, present when fix:true applied at least one fix
   encodedSourceFiles?: Record<string, string>; // Binary encoded source files as base64-encoded strings
 }
 
@@ -108,9 +108,10 @@ export interface LintOptions {
   fileContents?: Record<string, string>; // Map of file paths to their contents for VFS
   includeEncodedSourceFiles?: boolean; // Whether to include encoded source files in response
   // Apply rule auto-fixes in-band (ESLint's `fix: true`); the fixed source per
-  // file is returned in LintResponse.output and is NOT written to disk. Rules
-  // and languageOptions live in the config entries — there is no separate
-  // ruleOptions / languageOptions override surface.
+  // file is returned in LintResponse.output and is NOT written to disk.
+  // Diagnostics and encoded sources describe the final post-fix generation.
+  // Rules and languageOptions live in the config entries — there is no
+  // separate ruleOptions / languageOptions override surface.
   fix?: boolean;
 }
 

--- a/packages/rslint/tests/api.test.mjs
+++ b/packages/rslint/tests/api.test.mjs
@@ -91,13 +91,21 @@ describe('lint fix:true', async (t) => {
         [virtual_entry]: fileContent,
       },
       fix: true,
+      includeEncodedSourceFiles: true,
     });
 
     // fix:true applies fixes in-band and returns the fixed source per file in
     // `output` (array-type rewrites `Array<string>` → `string[]`); the fix is
     // not written to disk.
     expect(diags.output).toBeDefined();
-    expect(diags.fixableErrorCount).toBe(1);
+    expect(diags.diagnostics).toEqual([]);
+    expect(diags.errorCount).toBe(0);
+    expect(diags.fixableErrorCount).toBe(0);
+    const encoded = diags.encodedSourceFiles['src/virtual.ts'];
+    const buffer = Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0));
+    expect(new RemoteSourceFile(buffer, new TextDecoder()).text).toBe(
+      'let a: string[] = [];',
+    );
     expect({
       input: fileContent,
       output: diags.output,

--- a/packages/rslint/tests/autofix.test.mjs
+++ b/packages/rslint/tests/autofix.test.mjs
@@ -1,0 +1,265 @@
+import { Rslint } from '@rslint/core';
+import { describe, test, expect } from '@rstest/core';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+describe('Rslint autofix', () => {
+  test('remaining multi-edit metadata targets the final output', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-fix-limit-'));
+    const pluginPath = path.join(tmp, 'blocking-plugin.mjs');
+    await writeFile(
+      pluginPath,
+      `export default {
+		rules: {
+			block: {
+				meta: {
+					fixable: 'code',
+					schema: [],
+					messages: { block: 'block' },
+				},
+				create(context) {
+					return { Program(node) {
+						context.report({
+								node,
+								messageId: 'block',
+								fix(fixer) {
+									const text = context.sourceCode.text;
+									const offset = text.indexOf('if (value)');
+									return fixer.replaceTextRange(
+										[0, text.length],
+										text.slice(0, offset) + ' ' + text.slice(offset),
+									);
+								},
+							});
+						} };
+					},
+				},
+			},
+		};\n`,
+    );
+    await writeFile(
+      path.join(tmp, 'rslint.config.mjs'),
+      `import blocking from ${JSON.stringify(pathToFileURL(pluginPath).href)};
+		export default [{
+			plugins: { blocking },
+			rules: {
+				'blocking/block': 'error',
+				'no-else-return': 'error',
+				'no-prototype-builtins': 'error',
+			},
+		}];\n`,
+    );
+
+    const rslint = new Rslint({ cwd: tmp, fix: true });
+    const nativeFixer = new Rslint({
+      cwd: tmp,
+      overrideConfigFile: true,
+      overrideConfig: [{ rules: { 'no-else-return': 'error' } }],
+      fix: true,
+    });
+    const BOM = String.fromCharCode(0xfeff);
+    const source =
+      BOM +
+      `const prefix = 0;
+function f(value) {
+  const ownsKey = value.hasOwnProperty('key');
+  if (value) {
+    return 1;
+  } else {
+    return 2;
+  }
+}\n`;
+    try {
+      const [result] = await rslint.lintText(source, { filePath: 'probe.js' });
+      let finalSource = source;
+      for (let round = 0; round < 10; round++) {
+        finalSource = finalSource.replace('if (value)', ' if (value)');
+      }
+      expect(result.output).toBe(finalSource);
+      const finalText = finalSource.slice(BOM.length);
+      const message = result.messages.find(
+        (candidate) => candidate.ruleId === 'no-else-return',
+      );
+      expect(message).toBeDefined();
+      expect(message.fix).toBeDefined();
+      const [expected] = await nativeFixer.lintText(finalSource, {
+        filePath: 'expected.js',
+      });
+      const applied =
+        finalText.slice(0, message.fix.range[0]) +
+        message.fix.text +
+        finalText.slice(message.fix.range[1]);
+      expect(applied).toBe(expected.output.slice(BOM.length));
+
+      const suggestionMessage = result.messages.find(
+        (candidate) => candidate.ruleId === 'no-prototype-builtins',
+      );
+      const suggestion = suggestionMessage?.suggestions?.[0]?.fix;
+      expect(suggestion).toBeDefined();
+      const suggestionApplied =
+        finalText.slice(0, suggestion.range[0]) +
+        suggestion.text +
+        finalText.slice(suggestion.range[1]);
+      expect(suggestionApplied).toBe(
+        finalText.replace(
+          "value.hasOwnProperty('key')",
+          "Object.prototype.hasOwnProperty.call(value, 'key')",
+        ),
+      );
+    } finally {
+      await Promise.all([rslint.close(), nativeFixer.close()]);
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('fix:true preserves an explicitly empty output', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-empty-fix-'));
+    const pluginPath = path.join(tmp, 'empty-plugin.mjs');
+    await writeFile(
+      pluginPath,
+      `export default {
+			rules: {
+				empty: {
+					meta: { fixable: 'code', schema: [], messages: { empty: 'empty' } },
+					create(context) {
+						return { Program(node) {
+							if (context.sourceCode.text.length === 0) return;
+							context.report({
+								node,
+								messageId: 'empty',
+								fix: (fixer) => fixer.removeRange([0, context.sourceCode.text.length]),
+							});
+						} };
+					},
+				},
+			},
+		};\n`,
+    );
+    await writeFile(
+      path.join(tmp, 'rslint.config.mjs'),
+      `import empty from ${JSON.stringify(pathToFileURL(pluginPath).href)};
+		export default [{ plugins: { empty }, rules: { 'empty/empty': 'error' } }];\n`,
+    );
+
+    const rslint = new Rslint({ cwd: tmp, fix: true });
+    try {
+      const [result] = await rslint.lintText('removeMe();', {
+        filePath: 'probe.js',
+      });
+      expect(result.output).toBe('');
+      expect(result.messages).toEqual([]);
+    } finally {
+      await rslint.close();
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles merges aliased multi-edits from the canonical virtual source', async () => {
+    // Both native rules emit two wire edits spanning source text. Their gap
+    // text must come from the canonical-path overlay because the ranges
+    // describe that source generation, even when lintFiles selected an alias
+    // whose physical file contains different text.
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-overlay-fix-'));
+    const realTarget = path.join(tmp, 'real.js');
+    const aliasTarget = path.join(tmp, 'alias.js');
+    const source = (marker, callGap, eol) =>
+      [
+        'function choose(value) {',
+        `  const marker = ${JSON.stringify(marker)};`,
+        `  const ownsKey = value.hasOwnProperty${callGap}('key');`,
+        '  if (value) {',
+        '    return 1;',
+        '  } else {',
+        '    return 2;',
+        '  }',
+        '}',
+        '',
+      ].join(eol);
+    const diskSource = source('diskMarker', ' /* disk gap */ ', '\n');
+    const overlaySource = source(
+      'overlayMarker🧪',
+      ' /* overlay gap 🧪 */ ',
+      '\r\n',
+    );
+    await writeFile(realTarget, diskSource);
+    try {
+      await symlink(realTarget, aliasTarget);
+    } catch {
+      await rm(tmp, { recursive: true, force: true });
+      return;
+    }
+
+    const fixInspector = new Rslint({
+      cwd: tmp,
+      overrideConfigFile: true,
+      overrideConfig: [{ rules: { 'no-else-return': 'error' } }],
+      virtualFiles: { [realTarget]: overlaySource },
+    });
+    // This request deliberately has no other multi-edit diagnostic: source
+    // loading therefore depends on the suggestion branch itself.
+    const suggestionInspector = new Rslint({
+      cwd: tmp,
+      overrideConfigFile: true,
+      overrideConfig: [{ rules: { 'no-prototype-builtins': 'error' } }],
+      virtualFiles: { [realTarget]: overlaySource },
+    });
+    const fixer = new Rslint({
+      cwd: tmp,
+      overrideConfigFile: true,
+      overrideConfig: [{ rules: { 'no-else-return': 'error' } }],
+      fix: true,
+    });
+    try {
+      const [fixResult] = await fixInspector.lintFiles('alias.js');
+      expect(fixResult.filePath).toBe(path.normalize(aliasTarget));
+      const message = fixResult.messages.find(
+        (candidate) => candidate.ruleId === 'no-else-return',
+      );
+      expect(message).toBeDefined();
+      expect(message.fix).toBeDefined();
+
+      const [fixed] = await fixer.lintText(overlaySource, {
+        filePath: 'probe.js',
+      });
+      const applied =
+        overlaySource.slice(0, message.fix.range[0]) +
+        message.fix.text +
+        overlaySource.slice(message.fix.range[1]);
+      expect(applied).toBe(fixed.output);
+      expect(applied).toContain('overlayMarker🧪');
+      expect(applied).not.toContain('diskMarker');
+
+      const [suggestionResult] =
+        await suggestionInspector.lintFiles('alias.js');
+      expect(suggestionResult.output).toBeUndefined();
+      const suggestionMessage = suggestionResult.messages.find(
+        (candidate) => candidate.ruleId === 'no-prototype-builtins',
+      );
+      const suggestion = suggestionMessage?.suggestions?.[0]?.fix;
+      expect(suggestion).toBeDefined();
+      const suggestionApplied =
+        overlaySource.slice(0, suggestion.range[0]) +
+        suggestion.text +
+        overlaySource.slice(suggestion.range[1]);
+      expect(suggestionApplied).toBe(
+        overlaySource.replace(
+          "value.hasOwnProperty /* overlay gap 🧪 */ ('key')",
+          "Object.prototype.hasOwnProperty.call /* overlay gap 🧪 */ (value, 'key')",
+        ),
+      );
+      expect(suggestionApplied).toContain('overlayMarker🧪');
+      expect(suggestionApplied).toContain('overlay gap 🧪');
+      expect(suggestionApplied).not.toContain('disk gap');
+      expect(suggestionApplied).not.toContain('diskMarker');
+    } finally {
+      await Promise.all([
+        fixInspector.close(),
+        suggestionInspector.close(),
+        fixer.close(),
+      ]);
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -229,11 +229,10 @@ describe('Rslint class', () => {
         'const found = [1].filter(Boolean);\n',
         { filePath: 'probe.ts' },
       );
-      expect(result.messages.map((message) => message.ruleId).sort()).toEqual([
-        'local/prefer-array-some',
+      expect(result.messages.map((message) => message.ruleId)).toEqual([
         'local/program-listener',
       ]);
-      expect(result.fixableErrorCount).toBe(1);
+      expect(result.fixableErrorCount).toBe(0);
       expect(result.output).toBe('const found = [1].some(Boolean);\n');
     } finally {
       await rslint.close();
@@ -371,7 +370,7 @@ describe('Rslint class', () => {
     }
   });
 
-  test('fix:true returns per-result output + fixable count', async () => {
+  test('fix:true returns output with final post-fix diagnostics', async () => {
     const rslint = new Rslint({
       cwd: fixturesDir,
       overrideConfigFile: true,
@@ -384,12 +383,9 @@ describe('Rslint class', () => {
       });
       const r = results[0];
       expect(r.output).toBe('let a: string[] = [];');
-      expect(r.fixableErrorCount).toBe(1);
-      // Single-pass (design §8): messages still report the pre-fix diagnostics
-      // — the fixable error is in `output` AND still listed, unlike ESLint's
-      // post-fix re-lint. Pinned so this reverse-of-ESLint behavior is explicit.
-      expect(r.messages).toHaveLength(1);
-      expect(r.errorCount).toBe(1);
+      expect(r.fixableErrorCount).toBe(0);
+      expect(r.messages).toHaveLength(0);
+      expect(r.errorCount).toBe(0);
     } finally {
       await rslint.close();
     }
@@ -1962,7 +1958,7 @@ module.exports = config;`
     // the source must equal Go's in-band output — exercises both the multi-edit
     // merge branch and JS↔Go fix agreement.
     const code = 'const f = (function () { return 1; }).bind(this);';
-    const rslint = new Rslint({
+    const options = {
       cwd: fixturesDir,
       overrideConfigFile: true,
       overrideConfig: [
@@ -1972,20 +1968,24 @@ module.exports = config;`
           rules: { 'no-extra-bind': 'error' },
         },
       ],
-      fix: true,
-    });
+    };
+    const inspector = new Rslint(options);
+    const fixer = new Rslint({ ...options, fix: true });
     try {
-      const results = await rslint.lintText(code, { filePath: 'gap-bind.ts' });
-      const r = results[0];
-      const m = r.messages.find((x) => x.ruleId === 'no-extra-bind');
+      const [inspected] = await inspector.lintText(code, {
+        filePath: 'gap-bind.ts',
+      });
+      const [fixed] = await fixer.lintText(code, { filePath: 'gap-bind.ts' });
+      const m = inspected.messages.find((x) => x.ruleId === 'no-extra-bind');
       expect(m).toBeDefined();
       expect(m.fix).toBeDefined();
       expect(m.fix.range).toHaveLength(2);
       const applied =
         code.slice(0, m.fix.range[0]) + m.fix.text + code.slice(m.fix.range[1]);
-      expect(applied).toBe(r.output);
+      expect(applied).toBe(fixed.output);
+      expect(fixed.messages).toEqual([]);
     } finally {
-      await rslint.close();
+      await Promise.all([inspector.close(), fixer.close()]);
     }
   });
 
@@ -2039,10 +2039,8 @@ module.exports = config;`
     }
   });
 
-  test('lintFiles keeps fix.range BOM-stripped and keeps the BOM in output', async () => {
-    // A BOM is never part of the text a fix range indexes, so fix.range stays
-    // BOM-stripped — matching ESLint v10 and the message column. `output` is
-    // the whole file, so it keeps the mark a fix did not ask to remove.
+  test('lintFiles keeps the BOM in fixed output', async () => {
+    // `output` is the whole file, so it keeps a mark the fix did not remove.
     const BOM = String.fromCharCode(0xfeff);
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-bom-'));
     try {
@@ -2060,11 +2058,7 @@ module.exports = config;`
       try {
         const results = await rslint.lintFiles('bom.ts');
         expect(results).toHaveLength(1);
-        const m = results[0].messages[0];
-        // Identical to the no-BOM lintText case (line 47): BOM-stripped [7, 20].
-        expect(m.fix.range).toEqual([7, 20]);
-        expect(m.fix.text).toBe('string[]');
-        // Only output carries the BOM.
+        expect(results[0].messages).toEqual([]);
         expect(results[0].output).toBe(BOM + 'let a: string[] = [];\n');
       } finally {
         await rslint.close();
@@ -2074,11 +2068,8 @@ module.exports = config;`
     }
   });
 
-  test('lintFiles multi-edit fix on a BOM-prefixed file: merged range BOM-stripped, output keeps BOM', async () => {
-    // no-extra-bind emits a multi-edit fix; on a BOM-prefixed disk file the
-    // merged range must stay BOM-stripped (Go's coordinate space) so applying it
-    // to the BOM-stripped body reproduces output minus its BOM. Exercises the
-    // multi-edit merge branch on a file that carries a mark.
+  test('lintFiles multi-edit fix on a BOM-prefixed file keeps BOM', async () => {
+    // no-extra-bind emits a multi-edit fix; final output keeps the mark.
     const BOM = String.fromCharCode(0xfeff);
     const body = 'const f = (function () { return 1; }).bind(this);\n';
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-bom-multi-'));
@@ -2101,16 +2092,10 @@ module.exports = config;`
       });
       try {
         const results = await rslint.lintFiles('bind.ts');
-        const m = results[0].messages.find((x) => x.ruleId === 'no-extra-bind');
-        expect(m).toBeDefined();
-        expect(m.fix).toBeDefined();
-        // BOM-stripped range: applying it to the BOM-stripped body equals output
-        // minus its re-prepended BOM.
-        const applied =
-          body.slice(0, m.fix.range[0]) +
-          m.fix.text +
-          body.slice(m.fix.range[1]);
-        expect(results[0].output).toBe(BOM + applied);
+        expect(results[0].messages).toEqual([]);
+        expect(results[0].output).toBe(
+          BOM + 'const f = (function () { return 1; });\n',
+        );
       } finally {
         await rslint.close();
       }
@@ -2138,9 +2123,7 @@ module.exports = config;`
       });
       try {
         const results = await rslint.lintFiles('bom.ts');
-        expect(results[0].messages[0].ruleId).toBe('unicode-bom');
-        expect(results[0].messages[0].fix.range).toEqual([-1, 0]);
-        expect(results[0].messages[0].fix.text).toBe('');
+        expect(results[0].messages).toEqual([]);
         expect(results[0].output).toBe('let a = 1;\n');
       } finally {
         await rslint.close();
@@ -2170,10 +2153,7 @@ module.exports = config;`
         const results = await rslint.lintText(BOM + 'let a = 1;\n', {
           filePath: path.join(tmp, 'buffer.ts'),
         });
-        expect(results[0].messages[0].ruleId).toBe('unicode-bom');
-        // Line 1, column 1 — the mark's own position, as ESLint reports it.
-        expect(results[0].messages[0].line).toBe(1);
-        expect(results[0].messages[0].column).toBe(1);
+        expect(results[0].messages).toEqual([]);
         expect(results[0].output).toBe('let a = 1;\n');
       } finally {
         await rslint.close();

--- a/website/docs/en/api/rslint.md
+++ b/website/docs/en/api/rslint.md
@@ -151,6 +151,8 @@ static outputFixes(results: LintResult[]): Promise<void>
 
 Writes the `output` of fixed results back to disk.
 
+With `fix: true`, rslint runs up to ten lint-fix rounds. Result messages and counts describe the final in-memory source; findings removed by applied fixes do not remain in `messages`.
+
 ```ts
 const rslint = new Rslint({ fix: true });
 const results = await rslint.lintFiles(['src/**/*.ts']);

--- a/website/docs/en/guide/js-api.md
+++ b/website/docs/en/guide/js-api.md
@@ -94,7 +94,9 @@ const [result] = await rslint.lintText(
 
 ## Auto-fixing
 
-Pass `fix: true`. A result whose file a fix changed then carries an `output` string — the full fixed source; results with no applied fix have no `output`.
+Pass `fix: true`. A result whose file received at least one applied fix carries an `output` string — the full final source, even if later fixes restored the input; results with no applied fix have no `output`.
+
+Rslint repeats linting and fixing until no fix is produced, a fix cycle restores the input, or ten writable rounds have run. `messages` and all diagnostic counts describe the final source in `output`, so successfully fixed findings are no longer reported. If the round limit leaves a fixable finding, its `message.fix` range also targets that final source.
 
 **Write fixes to disk** with the static [`Rslint.outputFixes`](/api/rslint#outputfixes):
 
@@ -154,7 +156,7 @@ Both methods resolve to `LintResult[]`:
 | `warningCount`        | `number`        | Number of warning-severity messages                                 |
 | `fixableErrorCount`   | `number`        | Errors that have an auto-fix                                        |
 | `fixableWarningCount` | `number`        | Warnings that have an auto-fix                                      |
-| `output`              | `string?`       | Fixed source — present only when `fix: true` changed the file       |
+| `output`              | `string?`       | Final source — present when `fix: true` applied at least one fix    |
 
 Each `LintMessage`:
 


### PR DESCRIPTION
## Summary

- make the linter own the product-wide ten-round autofix limit so CLI, API, and LSP cannot drift
- make API fix responses observe the final in-memory generation while preserving output for every file that received a fix
- merge remaining multi-edit fixes and suggestions against the authoritative final or virtual source, including BOM, empty-output, and symlink-alias cases
- document the unified lifecycle and organize focused autofix regressions

## Related Links

- Follow-up to #1892

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).