### PR TITLE
feat: port rule unicorn/no-magic-array-flat-depth

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_magic_array_flat_depth"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_nested_ternary"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
@@ -41,6 +42,7 @@ func GetAllRules() []rule.Rule {
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,
 		no_invalid_fetch_options.NoInvalidFetchOptionsRule,
 		no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
+		no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
 		no_nested_ternary.NoNestedTernaryRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/helpers_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/helpers_test.go
@@ -1,0 +1,176 @@
+// Test helpers shared by the upstream and extras test files. Kept in a
+// separate _test.go file so each suite can be compiled and run independently
+// while still agreeing on a single source of truth for the depth-token
+// position arithmetic and the InvalidTestCase builder.
+package no_magic_array_flat_depth_test
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID     = "no-magic-array-flat-depth"
+	messageString = "Magic number as depth is not allowed."
+)
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.mjs"}
+}
+
+// depthInvalid reports the depth-argument position (line/column 1-based) of
+// the only numeric-literal argument in `code` and asserts the error fires on
+// the depth token.
+func depthInvalid(code string) rule_tester.InvalidTestCase {
+	offset, length := findDepthLiteral(code)
+	if offset < 0 {
+		panic("no numeric literal found in no-magic-array-flat-depth test: " + code)
+	}
+
+	line, column := lineColumnForOffset(code, offset)
+	endLine, endColumn := lineColumnForOffset(code, offset+length)
+
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mjs",
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: messageID,
+			Message:   messageString,
+			Line:      line,
+			Column:    column,
+			EndLine:   endLine,
+			EndColumn: endColumn,
+		}},
+	}
+}
+
+// findDepthLiteral returns the byte offset and length of the numeric
+// argument passed to the only `.flat(` call in `code`. The upstream test
+// cases always use a single literal depth (no expressions), so a simple scan
+// for the first numeric-literal-shaped token after the last `.flat(` opener
+// is enough.
+func findDepthLiteral(code string) (int, int) {
+	// Locate the call's opening paren — `.flat(` — and search after it.
+	openIdx := strings.LastIndex(code, ".flat(")
+	if openIdx < 0 {
+		// Optional-member form: `?.flat(`.
+		openIdx = strings.LastIndex(code, "?.flat(")
+		if openIdx < 0 {
+			return -1, 0
+		}
+		openIdx++ // skip the leading `?` and use `.flat(`.
+	}
+	after := openIdx + len(".flat(")
+	// Skip whitespace.
+	i := after
+	for i < len(code) && (code[i] == ' ' || code[i] == '\t') {
+		i++
+	}
+	if i >= len(code) {
+		return -1, 0
+	}
+	start := i
+	// A numeric literal must start with a digit (or a digit-prefix `0`).
+	if !isDigit(code[i]) {
+		return -1, 0
+	}
+	// Detect 0x/0b/0o/0X/0B/0O prefix; consume the prefix and switch the
+	// character set for the rest of the literal.
+	hexDigits := false
+	binDigits := false
+	octDigits := false
+	if code[i] == '0' && i+1 < len(code) {
+		switch code[i+1] {
+		case 'x', 'X':
+			i += 2
+			hexDigits = true
+		case 'b', 'B':
+			i += 2
+			binDigits = true
+		case 'o', 'O':
+			i += 2
+			octDigits = true
+		}
+	}
+	// Consume integer part digits (and `_` separators).
+	for i < len(code) {
+		c := code[i]
+		if c == '_' {
+			i++
+			continue
+		}
+		if isDigit(c) {
+			i++
+			continue
+		}
+		if hexDigits && isHexLetter(c) {
+			i++
+			continue
+		}
+		if binDigits && (c == '0' || c == '1') {
+			i++
+			continue
+		}
+		if octDigits && c >= '0' && c <= '7' {
+			i++
+			continue
+		}
+		break
+	}
+	// Decimal fraction and exponent (e.g. `1.5`, `1e2`, `1.5e-3`). These only
+	// apply to plain decimal literals, not hex/binary/octal.
+	if !hexDigits && !binDigits && !octDigits {
+		if i < len(code) && code[i] == '.' && i+1 < len(code) && isDigit(code[i+1]) {
+			i++
+			for i < len(code) {
+				c := code[i]
+				if c == '_' || isDigit(c) {
+					i++
+					continue
+				}
+				break
+			}
+		}
+		if i < len(code) && (code[i] == 'e' || code[i] == 'E') {
+			i++
+			if i < len(code) && (code[i] == '+' || code[i] == '-') {
+				i++
+			}
+			for i < len(code) {
+				c := code[i]
+				if c == '_' || isDigit(c) {
+					i++
+					continue
+				}
+				break
+			}
+		}
+	}
+	if i == start {
+		return -1, 0
+	}
+	return start, i - start
+}
+
+func isDigit(b byte) bool     { return b >= '0' && b <= '9' }
+func isHexLetter(b byte) bool { return (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F') }
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for index := 0; index < offset; {
+		r, size := utf8.DecodeRuneInString(code[index:])
+		if r == '\n' {
+			line++
+			column = 1
+		} else if r > 0xFFFF {
+			column += 2
+		} else {
+			column++
+		}
+		index += size
+	}
+	return line, column
+}

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
@@ -63,10 +63,12 @@ var NoMagicArrayFlatDepthRule = rule.Rule{
 				}
 
 				// Skip when the receiver is statically known NOT to be an array
-				// (e.g. a typed `Set`). Type-aware check; without the type checker
-				// this branch is a no-op, matching upstream's behavior on JS / gap
-				// files.
-				if unicornutil.IsKnownNonArray(ctx, call.Object) {
+				// (e.g. a typed `Set`). Mirrors upstream's
+				// `shouldSkipKnownNonArrayReceiver`: typed arrays stay
+				// reportable, but receivers like `new Set()` are skipped, and
+				// directly-visible mismatches like `"x".flat(2)` or
+				// `({flat(){}}).flat(2)` are always reported.
+				if unicornutil.ShouldSkipKnownNonArrayReceiver(ctx, call.Object) {
 					return
 				}
 

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
@@ -1,0 +1,108 @@
+package no_magic_array_flat_depth
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "no-magic-array-flat-depth"
+
+var message = rule.RuleMessage{
+	Id:          messageID,
+	Description: "Magic number as depth is not allowed.",
+}
+
+// NoMagicArrayFlatDepthRule flags `Array#flat(<numeric literal>)` calls where
+// the depth argument is any numeric literal other than `1` (the default). A
+// "magic" depth such as `flat(2)` or `flat(99)` is almost always a sign that
+// the caller doesn't know the array's structure; preferring `flat(Infinity)`
+// or restructuring the data is usually clearer.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-magic-array-flat-depth.md
+var NoMagicArrayFlatDepthRule = rule.Rule{
+	Name:   "unicorn/no-magic-array-flat-depth",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Method:              "flat",
+					ArgumentsLength:     &[]int{1}[0],
+					AllowOptionalMember: true,
+				})
+				if !ok {
+					return
+				}
+
+				depth := call.Call.Arguments()[0]
+				// ESTree / upstream transparently unwraps parens around the
+				// argument; tsgo keeps ParenthesizedExpression nodes, so the
+				// depth may be wrapped. SkipParentheses matches the upstream
+				// semantic.
+				depth = ast.SkipParentheses(depth)
+				if !isNumericLiteral(depth) {
+					return
+				}
+				// `depth.value === 1` in upstream. tsgo's NumericLiteral exposes
+				// the raw text rather than a typed value; NormalizeNumericLiteral
+				// decimal-canonicalises the text so `1`, `1.0`, and `0x01` all
+				// round-trip to the string `"1"` and reject this branch.
+				if utils.NormalizeNumericLiteral(depth.AsNumericLiteral().Text) == "1" {
+					return
+				}
+
+				// Skip if any comment sits between the callee end (= the `(`) and
+				// the closing paren — a commented explanation is exactly the kind
+				// of context upstream wants to preserve. Upstream checks
+				// `commentsExistBetween(openingParenthesisToken, closingParenthesisToken)`,
+				// which covers both sides of the depth argument.
+				if hasCommentBetweenParens(ctx, call.Call, depth) {
+					return
+				}
+
+				// Skip when the receiver is statically known NOT to be an array
+				// (e.g. a typed `Set`). Type-aware check; without the type checker
+				// this branch is a no-op, matching upstream's behavior on JS / gap
+				// files.
+				if unicornutil.IsKnownNonArray(ctx, call.Object) {
+					return
+				}
+
+				ctx.ReportNode(depth, message)
+			},
+		}
+	},
+}
+
+// isNumericLiteral reports whether node is a numeric literal. Mirrors
+// upstream's `isNumericLiteral` helper.
+func isNumericLiteral(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindNumericLiteral
+}
+
+// hasCommentBetweenParens reports whether any comment lives in the source
+// span from the end of the callee (right after `flat`, i.e. the position of
+// the opening `(`) up to the end of the call expression. Mirrors upstream's
+// `sourceCode.commentsExistBetween(openingParenthesisToken, closingParenthesisToken)`.
+func hasCommentBetweenParens(ctx rule.RuleContext, call *ast.Node, depth *ast.Node) bool {
+	callee := call.AsCallExpression().Expression
+	if callee == nil {
+		return false
+	}
+	openParenPos := utils.TrimNodeTextRange(ctx.SourceFile, callee).End()
+	callEnd := utils.TrimNodeTextRange(ctx.SourceFile, call).End()
+	depthStart := utils.TrimNodeTextRange(ctx.SourceFile, depth).Pos()
+	if openParenPos >= callEnd {
+		return false
+	}
+	// Avoid wasting a comment scan on the trivial case where the depth is the
+	// only thing in the parens.
+	if depthStart == openParenPos+1 || depthStart == openParenPos+2 {
+		// depth is immediately after `(`, optionally with whitespace.
+		depthEnd := depth.End()
+		return utils.HasCommentInSpan(ctx.Comments.All(), depthEnd, callEnd)
+	}
+	return utils.HasCommentInSpan(ctx.Comments.All(), openParenPos, callEnd)
+}

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.md
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.md
@@ -1,0 +1,34 @@
+# no-magic-array-flat-depth
+
+## Rule Details
+
+Disallow a magic number as the `depth` argument in `Array#flat(…)`.
+
+`Array#flat()` is often used to flatten deeply nested arrays, but using a
+hard-coded depth like `flat(2)` or `flat(99)` is usually a sign the caller
+doesn't know the array's structure. Prefer `flat(Infinity)` for "fully flatten"
+or restructure the data so the depth is implicit.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const array = [1, [2, [3]]];
+array.flat(2);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const array = [1, [2, [3]]];
+array.flat(Infinity);
+```
+
+```javascript
+const array = [1, 2, 3];
+array.flat();
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-magic-array-flat-depth](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/no-magic-array-flat-depth.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-magic-array-flat-depth.js)

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_extras_test.go
@@ -1,0 +1,103 @@
+// TestNoMagicArrayFlatDepthExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch it covers, so future refactors can't
+// silently regress them without breaking a named lock-in.
+package no_magic_array_flat_depth_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_magic_array_flat_depth"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// tsValid is the in-package alias for jsValid — the rule is mostly
+// syntactic and the TS-only valid case is exercised in upstream.
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.mjs"}
+}
+
+// tsDepthInvalid mirrors the upstream helper, but routes through the same
+// depthInvalid builder.
+func tsDepthInvalid(code string) rule_tester.InvalidTestCase {
+	return depthInvalid(code)
+}
+
+func TestNoMagicArrayFlatDepthExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Branch: not a CallExpression ----
+			tsValid(`2;`),
+			tsValid(`let x = 2;`),
+
+			// ---- Branch: CallExpression with a non-`flat` method name ----
+			tsValid(`array.map(2)`),
+			tsValid(`array.forEach(2)`),
+			tsValid(`array.slice(2)`),
+			tsValid(`array.flatMap(2)`),
+			// Computed member access disqualifies the call.
+			tsValid(`array["flat"](2)`),
+			tsValid(`arr()["flat"](2)`),
+			// Bare `flat(2)` is not a dot-method call.
+			tsValid(`flat(2)`),
+
+			// ---- Branch: special non-numeric tokens that look numeric-ish ----
+			tsValid(`array.flat(NaN)`),
+			tsValid(`array.flat(Number.MAX_SAFE_INTEGER)`),
+			tsValid(`array.flat(BigInt(1))`),
+			tsValid(`array.flat(depthVar)`),
+			// BigInt literal — different kind in tsgo.
+			tsValid(`array.flat(2n)`),
+
+			// ---- Branch: depth is `1` in any normalized shape ----
+			tsValid(`array.flat(1.0)`),
+			tsValid(`array.flat(0x01)`),
+			tsValid(`array.flat((1))`),
+
+			// ---- Branch: optional chain on the call disqualifies it ----
+			tsValid(`array.flat?.(2)`),
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Branch lock-in: every non-1 numeric literal shape ----
+			tsDepthInvalid(`array.flat(0)`),
+			tsDepthInvalid(`array.flat(2)`),
+			tsDepthInvalid(`array.flat(99)`),
+			tsDepthInvalid(`array.flat(0xff)`),
+			tsDepthInvalid(`array.flat(0b10)`),
+			tsDepthInvalid(`array.flat(0o10)`),
+			tsDepthInvalid(`array.flat(1e2)`),
+			tsDepthInvalid(`array.flat(1.5)`),
+			tsDepthInvalid(`array.flat(0b10_0000)`), // numeric separators
+
+			// ---- Branch lock-in: parenthesized depth ----
+			// `(2)` is a ParenthesizedExpression wrapping a NumericLiteral;
+			// MatchDotMethodCall returns the NumericLiteral as the argument.
+			{
+				Code:     `array.flat((2))`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+
+			// ---- Branch lock-in: receiver in unusual positions ----
+			tsDepthInvalid(`arr.map(x).flat(2)`),
+			// `arr()?.flat(2)` — optional member on a parenthesized call
+			// still matches the dot-method-call shape.
+			{
+				Code:     `arr()?.flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
@@ -1,0 +1,69 @@
+// TestNoMagicArrayFlatDepthUpstream migrates the full valid/invalid suite from
+// upstream test/no-magic-array-flat-depth.js 1:1. Position assertions cover
+// line/column for the depth argument reported in every invalid case.
+// rslint-specific lock-in cases live in no_magic_array_flat_depth_extras_test.go.
+package no_magic_array_flat_depth_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_magic_array_flat_depth"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Known non-array receiver (type information) ----
+			{
+				Code:     `function f(foo: {flat(depth: number): void}) { foo.flat(2); }`,
+				FileName: "file.ts",
+			},
+
+			// ---- depth is 1 (the default) ----
+			jsValid(`array.flat(1)`),
+			jsValid(`array.flat(1.0)`),
+			jsValid(`array.flat(0x01)`),
+
+			// ---- depth is not a numeric literal ----
+			jsValid(`array.flat(unknown)`),
+			jsValid(`array.flat(Number.POSITIVE_INFINITY)`),
+			jsValid(`array.flat(Infinity)`),
+
+			// ---- comments around the depth explain the magic number ----
+			jsValid(`array.flat(/* explanation */2)`),
+			jsValid(`array.flat(2/* explanation */)`),
+
+			// ---- no argument or wrong number of arguments ----
+			jsValid(`array.flat()`),
+			jsValid(`array.flat(2, extraArgument)`),
+
+			// ---- not a CallExpression of `.flat` ----
+			jsValid(`new array.flat(2)`),
+			jsValid(`array.flat?.(2)`),
+			jsValid(`array.notFlat(2)`),
+			jsValid(`flat(2)`),
+		},
+		[]rule_tester.InvalidTestCase{
+			depthInvalid(`array.flat(2)`),
+			depthInvalid(`array?.flat(2)`),
+			depthInvalid(`array.flat(99,)`),
+			depthInvalid(`array.flat(0b10,)`),
+
+			// A receiver that is known to be an array must still be reported.
+			{
+				Code:     `function f(foo: number[][]) { foo.flat(2); }`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
@@ -24,6 +24,12 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 				Code:     `function f(foo: {flat(depth: number): void}) { foo.flat(2); }`,
 				FileName: "file.ts",
 			},
+			// `shouldSkipKnownNonArrayReceiver` skip case — a typed `Set` is
+			// known not to be an array, so the rule legitimately skips it.
+			{
+				Code:     `function f(foo: Set<number>) { foo.flat(2); }`,
+				FileName: "file.ts",
+			},
 
 			// ---- depth is 1 (the default) ----
 			jsValid(`array.flat(1)`),
@@ -59,6 +65,38 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			{
 				Code:     `function f(foo: number[][]) { foo.flat(2); }`,
 				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+
+			// `shouldSkipKnownNonArrayReceiver` regression cases — these
+			// receivers are directly visible (mismatch is at the call site)
+			// so the rule MUST still report them, even though
+			// `isKnownNonIndexedCollection` would otherwise skip them.
+			{
+				Code:     `({flat(){}}).flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `"x".flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			// Typed array — shares most of Array's method surface, but
+			// `flat()` isn't on its prototype, so reporting the broken call
+			// is the right call.
+			{
+				Code:     `new Uint8Array().flat(2)`,
+				FileName: "file.mjs",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: messageID,
 					Message:   messageString,

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
@@ -55,6 +55,23 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			jsValid(`Boolean(0).flat(2)`),
 			jsValid(`BigInt(1).flat(2)`),
 
+			// Globals whose call results are folded by upstream's static
+			// evaluator to a known non-array value. Lock in so the helper
+			// continues to handle them and doesn't over-report.
+			jsValid(`Math.abs(-2).flat(2)`),
+			jsValid(`Math.max(1, 2).flat(2)`),
+			jsValid(`Array.isArray([]).flat(2)`),
+			jsValid(`parseInt("2", 10).flat(2)`),
+			jsValid(`parseFloat("2").flat(2)`),
+			jsValid(`Object().flat(2)`),
+			// String.fromCharCode is folded by the shared static evaluator.
+			jsValid(`String.fromCharCode(65).flat(2)`),
+			// Optional-member access on a global receiver still resolves.
+			jsValid(`Math?.abs(-2).flat(2)`),
+			jsValid(`Math?.max(1, 2)?.flat(2)`),
+			// Parenthesized form must not defeat the static resolution.
+			jsValid(`(Number(1)).flat(2)`),
+
 			// ---- depth is 1 (the default) ----
 			jsValid(`array.flat(1)`),
 			jsValid(`array.flat(1.0)`),
@@ -183,6 +200,44 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			},
 			{
 				Code:     `Symbol().flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+
+			// Local bindings where upstream keeps the source-only
+			// "unknown" classification: `let` / `var` / destructuring
+			// don't follow the `const IDENT = EXPR` resolution path, and
+			// `const IDENT = Math.PI` is still unknown because Math.PI
+			// itself is a MemberExpression. Lock in that rslint matches.
+			{
+				Code:     `let value = 1; value.flat(2);`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `var value = 1; value.flat(2);`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `const {value = 1} = {}; value.flat(2);`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `const value = Math.PI; value.flat(2);`,
 				FileName: "file.mjs",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: messageID,

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
@@ -31,6 +31,30 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 				FileName: "file.ts",
 			},
 
+			// Arrow / class expressions are deliberately NOT in the
+			// `directlyReportableReceiverTypes` set; they fall through to
+			// `isKnownNonIndexedCollection`, which classifies both as
+			// non-array expressions and skips them. Lock in every shape
+			// upstream marks as "skip" so future refactors don't promote
+			// them to the reportable set.
+			jsValid(`(() => {}).flat(2)`),
+			jsValid(`(async () => {}).flat(2)`),
+			jsValid(`(class {}).flat(2)`),
+			jsValid(`(class extends Array {}).flat(2)`),
+			jsValid(`(class { flat() {} }).flat(2)`),
+			jsValid(`(() => {})?.flat(2)`),
+			jsValid(`(class {})?.flat(2)`),
+			jsValid(`(((() => {}))).flat(2)`),
+			jsValid(`(((class {}))).flat(2)`),
+
+			// Constructor calls that the static evaluator resolves to a
+			// known non-array value — upstream (and rslint) legitimately
+			// skip these.
+			jsValid(`Number(1).flat(2)`),
+			jsValid(`String("x").flat(2)`),
+			jsValid(`Boolean(0).flat(2)`),
+			jsValid(`BigInt(1).flat(2)`),
+
 			// ---- depth is 1 (the default) ----
 			jsValid(`array.flat(1)`),
 			jsValid(`array.flat(1.0)`),
@@ -96,6 +120,69 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			// is the right call.
 			{
 				Code:     `new Uint8Array().flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+
+			// Source-only unknown receivers — upstream's `getStaticType`
+			// returns "unknown" for bare identifiers and member expressions
+			// without an evaluable static value, so the rule reports. These
+			// exercise the source-only branch of
+			// `ShouldSkipKnownNonArrayReceiver`, which would otherwise lean
+			// on the type checker and over-classify globals.
+			{
+				Code:     `undefined.flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `NaN.flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Infinity.flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Number.NaN.flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Math.PI.flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Symbol.iterator.flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Symbol().flat(2)`,
 				FileName: "file.mjs",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: messageID,

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
@@ -54,23 +54,13 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			jsValid(`String("x").flat(2)`),
 			jsValid(`Boolean(0).flat(2)`),
 			jsValid(`BigInt(1).flat(2)`),
-
-			// Globals whose call results are folded by upstream's static
-			// evaluator to a known non-array value. Lock in so the helper
-			// continues to handle them and doesn't over-report.
-			jsValid(`Math.abs(-2).flat(2)`),
-			jsValid(`Math.max(1, 2).flat(2)`),
-			jsValid(`Array.isArray([]).flat(2)`),
-			jsValid(`parseInt("2", 10).flat(2)`),
-			jsValid(`parseFloat("2").flat(2)`),
-			jsValid(`Object().flat(2)`),
-			// String.fromCharCode is folded by the shared static evaluator.
-			jsValid(`String.fromCharCode(65).flat(2)`),
-			// Optional-member access on a global receiver still resolves.
-			jsValid(`Math?.abs(-2).flat(2)`),
-			jsValid(`Math?.max(1, 2)?.flat(2)`),
-			// Parenthesized form must not defeat the static resolution.
+			// Parenthesized form of a coercion constructor must still
+			// be skipped.
 			jsValid(`(Number(1)).flat(2)`),
+
+			// `String.fromCharCode` is folded by the shared static
+			// evaluator to a string value, so the rule skips it.
+			jsValid(`String.fromCharCode(65).flat(2)`),
 
 			// ---- depth is 1 (the default) ----
 			jsValid(`array.flat(1)`),
@@ -238,6 +228,91 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			},
 			{
 				Code:     `const value = Math.PI; value.flat(2);`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+
+			// Source-only unknown receivers: calls the rslint static
+			// evaluator cannot fold. The rslint type checker would
+			// over-classify their return type as a known non-array
+			// primitive, so the source-only path bypasses it.
+			{
+				Code:     `Math.abs(-2).flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Math.max(1, 2).flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Math.random().flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Array.from([1]).flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Object.keys({a: 1}).flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `JSON.parse("[]").flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Array.isArray([]).flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `parseInt("2", 10).flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `parseFloat("2").flat(2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+			{
+				Code:     `Object().flat(2)`,
 				FileName: "file.mjs",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: messageID,

--- a/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
@@ -48,22 +48,18 @@ func isDirectlyReportableReceiver(node *ast.Node) bool {
 }
 
 // isSourceOnlyUnknownShape reports whether node is a shape that upstream's
-// `getTypeFromStaticValue` classifies as "unknown" without a resolvable
-// static value. For these shapes upstream reports the rule rather than
-// skipping, even when the type checker would have a definitive answer
-// (because a `TypeChecker` typically has global type information that
-// over-classifies a source-only file's bare `undefined` / `NaN` /
-// `Math.PI` / `Symbol()` as a known non-array).
+// `getTypeFromStaticValue` / `getTypeFromVariable` classify as "unknown"
+// without a resolvable static value. For these shapes upstream reports the
+// rule rather than skipping, even when the type checker would have a
+// definitive answer (because a `TypeChecker` typically has global type
+// information that over-classifies a source-only file's bare `undefined` /
+// `NaN` / `Math.PI` / `Symbol()` as a known non-array).
 //
-// The Identifier branch checks `ctx.Refs`: a local binding resolves to a
-// `const` array declaration and the outer `IsKnownNonIndexedCollection` will
-// correctly return false. A global identifier that fails to resolve gets
-// the upstream-style "unknown" treatment here so the rule fires. The
+// The Identifier branch checks `ctx.Refs`: a non-`const` binding or a
+// `const IDENT = MEMBER` initializer recursively fall through to
+// "unknown" exactly the way upstream's `getTypeFromVariable` does. The
 // MemberExpression and unresolved CallExpression branches follow the
-// upstream source-only rule directly, since the static evaluator rarely
-// resolves a member chain or constructor-style call to a known array
-// shape and the type checker would over-classify built-in members like
-// `Math.PI` or `Symbol()`.
+// upstream source-only rule directly.
 func isSourceOnlyUnknownShape(ctx rule.RuleContext, node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -73,61 +69,182 @@ func isSourceOnlyUnknownShape(ctx rule.RuleContext, node *ast.Node) bool {
 		return false
 	}
 	if ast.IsIdentifier(node) {
-		if ctx.Refs == nil {
-			return true
-		}
-		if ctx.Refs.ResolveInFile(node) == nil {
-			return true
-		}
-		return false
+		return isSourceOnlyUnknownIdentifier(ctx, node)
 	}
 	if ast.IsAccessExpression(node) {
 		return true
 	}
 	if ast.IsCallExpression(node) {
-		// `Number(1)` / `String("x")` / `Boolean(0)` / `BigInt(1)` /
-		// `Symbol()` — these constructor calls are folded by upstream's
-		// static evaluator into a known non-array value. The rslint static
-		// evaluator only handles method calls (e.g. `String.fromCharCode`,
-		// `Array.of`), not bare constructor calls, so replicate the upstream
-		// shape here: a bare Identifier callee that is a non-array
-		// constructor resolves to a known non-array value, and the rule
-		// legitimately skips. `Symbol()` returns a unique Symbol each call
-		// and therefore does NOT resolve — keep reporting it.
-		if isNonArrayConstructorCall(ctx, node) {
-			return false
-		}
-		// For unknown call results like `Symbol()`, upstream reports; match
-		// that by treating the unresolvable case as source-only unknown.
-		return true
+		return isSourceOnlyUnknownCall(ctx, node)
 	}
 	return false
 }
 
-// isNonArrayConstructorCall reports whether node is a bare constructor call
-// (`Number(1)`, `String("x")`, `Boolean(0)`, `BigInt(1)`) that upstream's
-// static evaluator folds to a known non-array value. `Symbol()` is excluded
-// because every call returns a unique Symbol and the static evaluator cannot
-// fold it.
-func isNonArrayConstructorCall(ctx rule.RuleContext, node *ast.Node) bool {
+// isSourceOnlyUnknownIdentifier mirrors upstream's `getTypeFromVariable`
+// path: only `const IDENT = EXPR` resolves the binding to EXPR's type.
+// Anything else (no binding, `let`, `var`, destructuring patterns,
+// non-ident binding) stays "unknown" for source-only purposes.
+func isSourceOnlyUnknownIdentifier(ctx rule.RuleContext, idNode *ast.Node) bool {
+	if ctx.Refs == nil {
+		return true
+	}
+	symbol := ctx.Refs.ResolveInFile(idNode)
+	if symbol == nil {
+		return true
+	}
+	if len(symbol.Declarations) != 1 {
+		return true
+	}
+	declaration := symbol.Declarations[0]
+	if declaration == nil {
+		return true
+	}
+	// Type annotation, if present, would let the type checker resolve the
+	// binding definitively; defer to the outer IsKnownNonIndexedCollection
+	// path by reporting "not source-only unknown" here.
+	if arrayBindingTypeAnnotation(declaration) != nil {
+		return false
+	}
+	if !ast.IsVariableDeclaration(declaration) {
+		return true
+	}
+	variable := declaration.AsVariableDeclaration()
+	if variable == nil {
+		return true
+	}
+	declarationList := declaration.Parent
+	if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) {
+		return true
+	}
+	if declarationList.Flags&ast.NodeFlagsConst == 0 {
+		return true
+	}
+	if !ast.IsIdentifier(variable.Name()) {
+		// Destructuring binding like `const {value = 1} = {};` — the
+		// binding name is a pattern, not an Identifier. Upstream keeps this
+		// "unknown".
+		return true
+	}
+	if variable.Initializer == nil {
+		return true
+	}
+	// `const value = EXPR` — recurse into EXPR to mirror upstream's
+	// `getTypeFromVariable` recursive call to `getType(init, ...)`. If EXPR
+	// is itself an Identifier or MemberExpression, upstream classifies it
+	// as "unknown" and so do we.
+	initializer := variable.Initializer
+	if ast.IsIdentifier(initializer) || ast.IsAccessExpression(initializer) {
+		return true
+	}
+	// For other initializer shapes (call expressions, literals, etc.),
+	// fall through to the type checker / static evaluator via
+	// IsKnownNonIndexedCollection, which can correctly handle
+	// `const value = Number(1)`, `const value = [1, 2]`, etc.
+	return false
+}
+
+// isSourceOnlyUnknownCall handles CallExpression receivers. Upstream
+// resolves a number of common builtin call patterns to a known non-array
+// value via its static evaluator; the rslint evaluator only handles a
+// subset, so we replicate the upstream shape explicitly here. Calls that
+// don't match any known pattern are treated as source-only unknown and
+// reported — matching upstream's behavior for `Symbol()`, which returns a
+// unique Symbol each call and therefore cannot be folded.
+func isSourceOnlyUnknownCall(ctx rule.RuleContext, node *ast.Node) bool {
 	call := node.AsCallExpression()
 	if call == nil {
 		return false
 	}
 	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
-	if callee == nil || !ast.IsIdentifier(callee) {
-		return false
+	if callee == nil {
+		return true
 	}
-	// If the identifier shadows a local binding, defer to the
-	// type-checker / reference resolver path so the user's declaration wins.
+	if ast.IsIdentifier(callee) {
+		return isSourceOnlyUnknownIdentifierCall(ctx, node, callee)
+	}
+	if ast.IsAccessExpression(callee) {
+		return isSourceOnlyUnknownMemberCall(ctx, node, callee)
+	}
+	// Other callee shapes (IIFEs, optional call chains, …): upstream
+	// leaves them unknown.
+	return true
+}
+
+// isSourceOnlyUnknownIdentifierCall handles calls of the form
+// `FUNC(args)` where `FUNC` is a bare Identifier. The rslint static
+// evaluator does not fold these, but the shape is enough to decide:
+// globals the user can't shadow (`parseInt`, `parseFloat`, `Object`, …)
+// and the four coercion constructors return a known non-array value.
+// `Symbol()` is excluded because every call returns a unique Symbol.
+func isSourceOnlyUnknownIdentifierCall(ctx rule.RuleContext, call *ast.Node, callee *ast.Node) bool {
+	// If the callee resolves to a local binding, the user's declaration
+	// wins; fall through to IsKnownNonIndexedCollection.
 	if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
 		return false
 	}
 	switch callee.AsIdentifier().Text {
-	case "Number", "String", "Boolean", "BigInt":
+	case "Number", "String", "Boolean", "BigInt",
+		"parseInt", "parseFloat", "Object":
+		return false
+	}
+	return true
+}
+
+// isSourceOnlyUnknownMemberCall handles calls of the form
+// `RECEIVER.METHOD(args)`. `String.fromCharCode` is already handled by the
+// static evaluator; the rest of the upstream-resolved set (Math.abs,
+// Math.max, Array.isArray, …) is too large to enumerate, so we use a
+// receiver-name heuristic. A receiver that is a known global with a
+// method that returns a primitive resolves to a known non-array value
+// and the rule legitimately skips.
+func isSourceOnlyUnknownMemberCall(ctx rule.RuleContext, call *ast.Node, callee *ast.Node) bool {
+	// First let the shared static evaluator take a swing: it knows how to
+	// fold `String.fromCharCode`, `Array.of`, and a few string methods.
+	// Anything it resolves falls through to IsKnownNonIndexedCollection.
+	staticEvaluator := arrayReceiverStaticEvaluator(ctx)
+	if _, known := staticEvaluator.EvalArrayValue(call); known {
+		// Resolved to a known value: let the outer
+		// IsKnownNonIndexedCollection path decide.
+		return false
+	}
+	receiver := accessExpressionObject(callee)
+	if receiver == nil {
 		return true
 	}
-	return false
+	if !ast.IsIdentifier(receiver) {
+		// Nested member access like `Foo.Bar.baz()`; upstream can't
+		// statically resolve these.
+		return true
+	}
+	// If the receiver resolves to a local binding, the user's
+	// declaration wins; fall through.
+	if ctx.Refs != nil && ctx.Refs.ResolveInFile(receiver) != nil {
+		return false
+	}
+	// Known global receivers that return non-array values for any
+	// well-known method call. `Symbol` is excluded because Symbol values
+	// cannot be folded.
+	switch receiver.AsIdentifier().Text {
+	case "Math", "Number", "String", "Boolean", "BigInt", "Array", "Object", "JSON":
+		return false
+	}
+	return true
+}
+
+// accessExpressionObject returns the object of a PropertyAccessExpression
+// or ElementAccessExpression, with parentheses stripped. Returns nil for
+// other access shapes.
+func accessExpressionObject(callee *ast.Node) *ast.Node {
+	if callee == nil {
+		return nil
+	}
+	if ast.IsPropertyAccessExpression(callee) {
+		return ast.SkipParentheses(callee.AsPropertyAccessExpression().Expression)
+	}
+	if ast.IsElementAccessExpression(callee) {
+		return ast.SkipParentheses(callee.AsElementAccessExpression().Expression)
+	}
+	return nil
 }
 
 // ShouldSkipKnownNonArrayReceiver mirrors the upstream helper of the same
@@ -145,13 +262,82 @@ func ShouldSkipKnownNonArrayReceiver(ctx rule.RuleContext, node *ast.Node) bool 
 	if isDirectlyReportableReceiver(node) {
 		return false
 	}
-	// Source-only JS: identifiers without a local binding (e.g. `undefined`,
-	// `NaN`) and bare member expressions are "unknown" in upstream's
-	// classification. Skipping the type checker for these avoids
-	// over-classifying them via global type info that the user's source
-	// doesn't actually carry.
+	// Calls that the source-only path recognizes as folding to a known
+	// non-array value skip the rule, mirroring upstream's static
+	// evaluator. The type checker would over-classify or under-classify
+	// these in source-only files, so we short-circuit here.
+	if ast.IsCallExpression(node) {
+		if isNonArrayResolvingCall(ctx, node) {
+			return true
+		}
+	}
+	// Source-only JS: identifiers without a local binding, identifiers
+	// bound via `let`/`var`/destructuring, bare member expressions, and
+	// call expressions the static evaluator cannot fold are "unknown" in
+	// upstream's classification. Skipping the type checker for these
+	// avoids over-classifying them via global type info that the user's
+	// source doesn't actually carry.
 	if isSourceOnlyUnknownShape(ctx, node) {
 		return false
 	}
 	return IsKnownNonIndexedCollection(ctx, node)
+}
+
+// isNonArrayResolvingCall reports whether node is a CallExpression that
+// upstream's static evaluator folds to a known non-array value, including
+// the four coercion constructors (`Number`, `String`, `Boolean`, `BigInt`),
+// the `parseInt` / `parseFloat` / `Object` global functions, and the
+// well-known global method receivers (`Math.*`, `Array.isArray`, etc.).
+// `Symbol()` is excluded because every call returns a unique Symbol and
+// the static evaluator cannot fold it.
+func isNonArrayResolvingCall(ctx rule.RuleContext, node *ast.Node) bool {
+	call := node.AsCallExpression()
+	if call == nil {
+		return false
+	}
+	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	if callee == nil {
+		return false
+	}
+	if ast.IsIdentifier(callee) {
+		// If the callee resolves to a local binding, the user's
+		// declaration wins; fall through to IsKnownNonIndexedCollection.
+		if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
+			return false
+		}
+		switch callee.AsIdentifier().Text {
+		case "Number", "String", "Boolean", "BigInt",
+			"parseInt", "parseFloat", "Object":
+			return true
+		}
+		return false
+	}
+	if ast.IsAccessExpression(callee) {
+		// First let the shared static evaluator take a swing: it knows
+		// how to fold `String.fromCharCode`, `Array.of`, and a few
+		// string methods.
+		staticEvaluator := arrayReceiverStaticEvaluator(ctx)
+		if _, known := staticEvaluator.EvalArrayValue(node); known {
+			// Resolved: let the outer IsKnownNonIndexedCollection path
+			// decide.
+			return false
+		}
+		receiver := accessExpressionObject(callee)
+		if receiver == nil || !ast.IsIdentifier(receiver) {
+			return false
+		}
+		// If the receiver resolves to a local binding, the user's
+		// declaration wins; fall through.
+		if ctx.Refs != nil && ctx.Refs.ResolveInFile(receiver) != nil {
+			return false
+		}
+		// Known global receivers that return non-array values for any
+		// well-known method call. `Symbol` is excluded because Symbol
+		// values cannot be folded.
+		switch receiver.AsIdentifier().Text {
+		case "Math", "Number", "String", "Boolean", "BigInt", "Array", "Object", "JSON":
+			return true
+		}
+	}
+	return false
 }

--- a/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
@@ -14,7 +14,11 @@ import (
 // This mirrors the upstream `shouldSkipKnownNonArrayReceiver` helper in
 // eslint-plugin-unicorn. The kinds listed here correspond to ESTree's
 // "directly visible" syntactic node categories: array / object / function
-// literals and template literals.
+// literals and template literals. Critically, `ArrowFunctionExpression` and
+// `ClassExpression` are NOT in the set — they fall through to
+// `isKnownNonIndexedCollection`, which classifies them as non-array
+// expressions and therefore skips them. That mirrors upstream's deliberate
+// `nonArrayExpressionTypes` set in `is-array.js`.
 func isDirectlyReportableReceiver(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -29,8 +33,6 @@ func isDirectlyReportableReceiver(node *ast.Node) bool {
 	case ast.KindArrayLiteralExpression,
 		ast.KindObjectLiteralExpression,
 		ast.KindFunctionExpression,
-		ast.KindArrowFunction,
-		ast.KindClassExpression,
 		ast.KindTemplateExpression,
 		ast.KindNoSubstitutionTemplateLiteral,
 		ast.KindStringLiteral,
@@ -40,6 +42,89 @@ func isDirectlyReportableReceiver(node *ast.Node) bool {
 		ast.KindFalseKeyword,
 		ast.KindNullKeyword,
 		ast.KindRegularExpressionLiteral:
+		return true
+	}
+	return false
+}
+
+// isSourceOnlyUnknownShape reports whether node is a shape that upstream's
+// `getTypeFromStaticValue` classifies as "unknown" without a resolvable
+// static value. For these shapes upstream reports the rule rather than
+// skipping, even when the type checker would have a definitive answer
+// (because a `TypeChecker` typically has global type information that
+// over-classifies a source-only file's bare `undefined` / `NaN` /
+// `Math.PI` / `Symbol()` as a known non-array).
+//
+// The Identifier branch checks `ctx.Refs`: a local binding resolves to a
+// `const` array declaration and the outer `IsKnownNonIndexedCollection` will
+// correctly return false. A global identifier that fails to resolve gets
+// the upstream-style "unknown" treatment here so the rule fires. The
+// MemberExpression and unresolved CallExpression branches follow the
+// upstream source-only rule directly, since the static evaluator rarely
+// resolves a member chain or constructor-style call to a known array
+// shape and the type checker would over-classify built-in members like
+// `Math.PI` or `Symbol()`.
+func isSourceOnlyUnknownShape(ctx rule.RuleContext, node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	if ast.IsIdentifier(node) {
+		if ctx.Refs == nil {
+			return true
+		}
+		if ctx.Refs.ResolveInFile(node) == nil {
+			return true
+		}
+		return false
+	}
+	if ast.IsAccessExpression(node) {
+		return true
+	}
+	if ast.IsCallExpression(node) {
+		// `Number(1)` / `String("x")` / `Boolean(0)` / `BigInt(1)` /
+		// `Symbol()` — these constructor calls are folded by upstream's
+		// static evaluator into a known non-array value. The rslint static
+		// evaluator only handles method calls (e.g. `String.fromCharCode`,
+		// `Array.of`), not bare constructor calls, so replicate the upstream
+		// shape here: a bare Identifier callee that is a non-array
+		// constructor resolves to a known non-array value, and the rule
+		// legitimately skips. `Symbol()` returns a unique Symbol each call
+		// and therefore does NOT resolve — keep reporting it.
+		if isNonArrayConstructorCall(ctx, node) {
+			return false
+		}
+		// For unknown call results like `Symbol()`, upstream reports; match
+		// that by treating the unresolvable case as source-only unknown.
+		return true
+	}
+	return false
+}
+
+// isNonArrayConstructorCall reports whether node is a bare constructor call
+// (`Number(1)`, `String("x")`, `Boolean(0)`, `BigInt(1)`) that upstream's
+// static evaluator folds to a known non-array value. `Symbol()` is excluded
+// because every call returns a unique Symbol and the static evaluator cannot
+// fold it.
+func isNonArrayConstructorCall(ctx rule.RuleContext, node *ast.Node) bool {
+	call := node.AsCallExpression()
+	if call == nil {
+		return false
+	}
+	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	if callee == nil || !ast.IsIdentifier(callee) {
+		return false
+	}
+	// If the identifier shadows a local binding, defer to the
+	// type-checker / reference resolver path so the user's declaration wins.
+	if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
+		return false
+	}
+	switch callee.AsIdentifier().Text {
+	case "Number", "String", "Boolean", "BigInt":
 		return true
 	}
 	return false
@@ -58,6 +143,14 @@ func isDirectlyReportableReceiver(node *ast.Node) bool {
 // should call `IsKnownNonArray` directly instead.
 func ShouldSkipKnownNonArrayReceiver(ctx rule.RuleContext, node *ast.Node) bool {
 	if isDirectlyReportableReceiver(node) {
+		return false
+	}
+	// Source-only JS: identifiers without a local binding (e.g. `undefined`,
+	// `NaN`) and bare member expressions are "unknown" in upstream's
+	// classification. Skipping the type checker for these avoids
+	// over-classifying them via global type info that the user's source
+	// doesn't actually carry.
+	if isSourceOnlyUnknownShape(ctx, node) {
 		return false
 	}
 	return IsKnownNonIndexedCollection(ctx, node)

--- a/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
@@ -1,0 +1,64 @@
+package unicornutil
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// directlyReportableReceiverTypes is the set of ESTree node kinds that
+// should be reported even when the receiver is "statically known not to be
+// an array" (a string literal, a literal object, a function expression, …).
+// The mismatch is visible at the call site, so reporting it is the right
+// thing to do.
+//
+// This mirrors the upstream `shouldSkipKnownNonArrayReceiver` helper in
+// eslint-plugin-unicorn. The kinds listed here correspond to ESTree's
+// "directly visible" syntactic node categories: array / object / function
+// literals and template literals.
+func isDirectlyReportableReceiver(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	// ESTree / upstream transparently unwraps parens; tsgo keeps
+	// ParenthesizedExpression nodes, so strip them before classifying.
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindArrayLiteralExpression,
+		ast.KindObjectLiteralExpression,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindClassExpression,
+		ast.KindTemplateExpression,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+		ast.KindRegularExpressionLiteral:
+		return true
+	}
+	return false
+}
+
+// ShouldSkipKnownNonArrayReceiver mirrors the upstream helper of the same
+// name. A receiver that is statically known to be a non-array (a typed Set,
+// a custom class with a same-named method, etc.) should be skipped UNLESS
+// the receiver is one of the directly-reportable kinds above, in which case
+// the mismatch between the receiver and `Array#flat()` is visible at the
+// call site and worth reporting.
+//
+// A typed-array receiver is still reported, since it shares most of
+// `Array`'s method surface and `flat()` is not on its prototype at all.
+// `require-array-sort-compare` (which needs typed arrays to be skipped)
+// should call `IsKnownNonArray` directly instead.
+func ShouldSkipKnownNonArrayReceiver(ctx rule.RuleContext, node *ast.Node) bool {
+	if isDirectlyReportableReceiver(node) {
+		return false
+	}
+	return IsKnownNonIndexedCollection(ctx, node)
+}

--- a/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
@@ -2,10 +2,10 @@ package unicornutil
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 // directlyReportableReceiverTypes is the set of ESTree node kinds that
@@ -63,7 +63,7 @@ func isSourceOnlyFile(ctx rule.RuleContext) bool {
 	if name == "" {
 		return true
 	}
-	ext := strings.ToLower(filepath.Ext(name))
+	ext := ecmascript.StringToLowerCase(filepath.Ext(name))
 	return ext != ".ts" && ext != ".tsx" && ext != ".mts" && ext != ".cts"
 }
 

--- a/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
@@ -1,6 +1,9 @@
 package unicornutil
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -47,204 +50,21 @@ func isDirectlyReportableReceiver(node *ast.Node) bool {
 	return false
 }
 
-// isSourceOnlyUnknownShape reports whether node is a shape that upstream's
-// `getTypeFromStaticValue` / `getTypeFromVariable` classify as "unknown"
-// without a resolvable static value. For these shapes upstream reports the
-// rule rather than skipping, even when the type checker would have a
-// definitive answer (because a `TypeChecker` typically has global type
-// information that over-classifies a source-only file's bare `undefined` /
-// `NaN` / `Math.PI` / `Symbol()` as a known non-array).
-//
-// The Identifier branch checks `ctx.Refs`: a non-`const` binding or a
-// `const IDENT = MEMBER` initializer recursively fall through to
-// "unknown" exactly the way upstream's `getTypeFromVariable` does. The
-// MemberExpression and unresolved CallExpression branches follow the
-// upstream source-only rule directly.
-func isSourceOnlyUnknownShape(ctx rule.RuleContext, node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	node = ast.SkipParentheses(node)
-	if node == nil {
-		return false
-	}
-	if ast.IsIdentifier(node) {
-		return isSourceOnlyUnknownIdentifier(ctx, node)
-	}
-	if ast.IsAccessExpression(node) {
+// isSourceOnlyFile reports whether the file is a non-TypeScript source
+// (`.mjs`, `.js`, `.cjs`, …) where the type checker's global type
+// information would over-classify a bare identifier / member / call
+// receiver that the upstream parser would leave "unknown". When the file
+// is TypeScript, the type annotation / type-service path stays in charge.
+func isSourceOnlyFile(ctx rule.RuleContext) bool {
+	if ctx.SourceFile == nil {
 		return true
 	}
-	if ast.IsCallExpression(node) {
-		return isSourceOnlyUnknownCall(ctx, node)
-	}
-	return false
-}
-
-// isSourceOnlyUnknownIdentifier mirrors upstream's `getTypeFromVariable`
-// path: only `const IDENT = EXPR` resolves the binding to EXPR's type.
-// Anything else (no binding, `let`, `var`, destructuring patterns,
-// non-ident binding) stays "unknown" for source-only purposes.
-func isSourceOnlyUnknownIdentifier(ctx rule.RuleContext, idNode *ast.Node) bool {
-	if ctx.Refs == nil {
+	name := ctx.SourceFile.FileName()
+	if name == "" {
 		return true
 	}
-	symbol := ctx.Refs.ResolveInFile(idNode)
-	if symbol == nil {
-		return true
-	}
-	if len(symbol.Declarations) != 1 {
-		return true
-	}
-	declaration := symbol.Declarations[0]
-	if declaration == nil {
-		return true
-	}
-	// Type annotation, if present, would let the type checker resolve the
-	// binding definitively; defer to the outer IsKnownNonIndexedCollection
-	// path by reporting "not source-only unknown" here.
-	if arrayBindingTypeAnnotation(declaration) != nil {
-		return false
-	}
-	if !ast.IsVariableDeclaration(declaration) {
-		return true
-	}
-	variable := declaration.AsVariableDeclaration()
-	if variable == nil {
-		return true
-	}
-	declarationList := declaration.Parent
-	if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) {
-		return true
-	}
-	if declarationList.Flags&ast.NodeFlagsConst == 0 {
-		return true
-	}
-	if !ast.IsIdentifier(variable.Name()) {
-		// Destructuring binding like `const {value = 1} = {};` — the
-		// binding name is a pattern, not an Identifier. Upstream keeps this
-		// "unknown".
-		return true
-	}
-	if variable.Initializer == nil {
-		return true
-	}
-	// `const value = EXPR` — recurse into EXPR to mirror upstream's
-	// `getTypeFromVariable` recursive call to `getType(init, ...)`. If EXPR
-	// is itself an Identifier or MemberExpression, upstream classifies it
-	// as "unknown" and so do we.
-	initializer := variable.Initializer
-	if ast.IsIdentifier(initializer) || ast.IsAccessExpression(initializer) {
-		return true
-	}
-	// For other initializer shapes (call expressions, literals, etc.),
-	// fall through to the type checker / static evaluator via
-	// IsKnownNonIndexedCollection, which can correctly handle
-	// `const value = Number(1)`, `const value = [1, 2]`, etc.
-	return false
-}
-
-// isSourceOnlyUnknownCall handles CallExpression receivers. Upstream
-// resolves a number of common builtin call patterns to a known non-array
-// value via its static evaluator; the rslint evaluator only handles a
-// subset, so we replicate the upstream shape explicitly here. Calls that
-// don't match any known pattern are treated as source-only unknown and
-// reported — matching upstream's behavior for `Symbol()`, which returns a
-// unique Symbol each call and therefore cannot be folded.
-func isSourceOnlyUnknownCall(ctx rule.RuleContext, node *ast.Node) bool {
-	call := node.AsCallExpression()
-	if call == nil {
-		return false
-	}
-	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
-	if callee == nil {
-		return true
-	}
-	if ast.IsIdentifier(callee) {
-		return isSourceOnlyUnknownIdentifierCall(ctx, node, callee)
-	}
-	if ast.IsAccessExpression(callee) {
-		return isSourceOnlyUnknownMemberCall(ctx, node, callee)
-	}
-	// Other callee shapes (IIFEs, optional call chains, …): upstream
-	// leaves them unknown.
-	return true
-}
-
-// isSourceOnlyUnknownIdentifierCall handles calls of the form
-// `FUNC(args)` where `FUNC` is a bare Identifier. The rslint static
-// evaluator does not fold these, but the shape is enough to decide:
-// globals the user can't shadow (`parseInt`, `parseFloat`, `Object`, …)
-// and the four coercion constructors return a known non-array value.
-// `Symbol()` is excluded because every call returns a unique Symbol.
-func isSourceOnlyUnknownIdentifierCall(ctx rule.RuleContext, call *ast.Node, callee *ast.Node) bool {
-	// If the callee resolves to a local binding, the user's declaration
-	// wins; fall through to IsKnownNonIndexedCollection.
-	if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
-		return false
-	}
-	switch callee.AsIdentifier().Text {
-	case "Number", "String", "Boolean", "BigInt",
-		"parseInt", "parseFloat", "Object":
-		return false
-	}
-	return true
-}
-
-// isSourceOnlyUnknownMemberCall handles calls of the form
-// `RECEIVER.METHOD(args)`. `String.fromCharCode` is already handled by the
-// static evaluator; the rest of the upstream-resolved set (Math.abs,
-// Math.max, Array.isArray, …) is too large to enumerate, so we use a
-// receiver-name heuristic. A receiver that is a known global with a
-// method that returns a primitive resolves to a known non-array value
-// and the rule legitimately skips.
-func isSourceOnlyUnknownMemberCall(ctx rule.RuleContext, call *ast.Node, callee *ast.Node) bool {
-	// First let the shared static evaluator take a swing: it knows how to
-	// fold `String.fromCharCode`, `Array.of`, and a few string methods.
-	// Anything it resolves falls through to IsKnownNonIndexedCollection.
-	staticEvaluator := arrayReceiverStaticEvaluator(ctx)
-	if _, known := staticEvaluator.EvalArrayValue(call); known {
-		// Resolved to a known value: let the outer
-		// IsKnownNonIndexedCollection path decide.
-		return false
-	}
-	receiver := accessExpressionObject(callee)
-	if receiver == nil {
-		return true
-	}
-	if !ast.IsIdentifier(receiver) {
-		// Nested member access like `Foo.Bar.baz()`; upstream can't
-		// statically resolve these.
-		return true
-	}
-	// If the receiver resolves to a local binding, the user's
-	// declaration wins; fall through.
-	if ctx.Refs != nil && ctx.Refs.ResolveInFile(receiver) != nil {
-		return false
-	}
-	// Known global receivers that return non-array values for any
-	// well-known method call. `Symbol` is excluded because Symbol values
-	// cannot be folded.
-	switch receiver.AsIdentifier().Text {
-	case "Math", "Number", "String", "Boolean", "BigInt", "Array", "Object", "JSON":
-		return false
-	}
-	return true
-}
-
-// accessExpressionObject returns the object of a PropertyAccessExpression
-// or ElementAccessExpression, with parentheses stripped. Returns nil for
-// other access shapes.
-func accessExpressionObject(callee *ast.Node) *ast.Node {
-	if callee == nil {
-		return nil
-	}
-	if ast.IsPropertyAccessExpression(callee) {
-		return ast.SkipParentheses(callee.AsPropertyAccessExpression().Expression)
-	}
-	if ast.IsElementAccessExpression(callee) {
-		return ast.SkipParentheses(callee.AsElementAccessExpression().Expression)
-	}
-	return nil
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext != ".ts" && ext != ".tsx" && ext != ".mts" && ext != ".cts"
 }
 
 // ShouldSkipKnownNonArrayReceiver mirrors the upstream helper of the same
@@ -258,86 +78,111 @@ func accessExpressionObject(callee *ast.Node) *ast.Node {
 // `Array`'s method surface and `flat()` is not on its prototype at all.
 // `require-array-sort-compare` (which needs typed arrays to be skipped)
 // should call `IsKnownNonArray` directly instead.
+//
+// The rslint tsgo type checker has global type information for built-in
+// identifiers (e.g. `undefined` → Undefined, `Symbol` → Symbol,
+// `Math.random()` → number) that the upstream parser does NOT have. For a
+// source-only `.mjs` input, the type checker would over-classify these as
+// known non-arrays and silence reports that upstream emits. The helper
+// therefore takes a source-only path that mirrors upstream's
+// `getTypeFromStaticValue` returning "unknown" for those shapes, and only
+// falls back to `IsKnownNonIndexedCollection` (and therefore the type
+// checker) for `.ts` inputs where type annotations make the classification
+// defensible.
 func ShouldSkipKnownNonArrayReceiver(ctx rule.RuleContext, node *ast.Node) bool {
 	if isDirectlyReportableReceiver(node) {
 		return false
 	}
-	// Calls that the source-only path recognizes as folding to a known
-	// non-array value skip the rule, mirroring upstream's static
-	// evaluator. The type checker would over-classify or under-classify
-	// these in source-only files, so we short-circuit here.
-	if ast.IsCallExpression(node) {
-		if isNonArrayResolvingCall(ctx, node) {
+
+	// Coercion constructors: the only CallExpression callees upstream's
+	// `getStaticValueForControlFlow` reliably folds to a known non-array
+	// value (a number, string, boolean, or bigint). `Symbol()` is
+	// deliberately excluded because every call returns a unique Symbol
+	// and cannot be folded.
+	if isNonArrayCoercionConstructorCall(ctx, node) {
+		return true
+	}
+
+	// For CallExpression, the shared static evaluator folds a handful
+	// of cases like `String.fromCharCode(65)` and `Array.of(...)`. If
+	// it resolves to a non-array value, trust that result.
+	if isSourceOnlyFile(ctx) && ast.IsCallExpression(node) {
+		staticEvaluator := arrayReceiverStaticEvaluator(ctx)
+		if _, known := staticEvaluator.EvalArrayValue(node); known {
 			return true
 		}
 	}
-	// Source-only JS: identifiers without a local binding, identifiers
-	// bound via `let`/`var`/destructuring, bare member expressions, and
-	// call expressions the static evaluator cannot fold are "unknown" in
-	// upstream's classification. Skipping the type checker for these
-	// avoids over-classifying them via global type info that the user's
-	// source doesn't actually carry.
-	if isSourceOnlyUnknownShape(ctx, node) {
-		return false
+
+	// Source-only path: trust upstream's "unknown" classification for
+	// identifier / member / call receivers. We deliberately skip the
+	// shared static evaluator for those shapes because it folds
+	// identifiers like `undefined` to a known non-array value that the
+	// upstream parser does NOT fold.
+	if isSourceOnlyFile(ctx) {
+		if isShapeUpstreamUnknown(node) {
+			return false
+		}
 	}
+
 	return IsKnownNonIndexedCollection(ctx, node)
 }
 
-// isNonArrayResolvingCall reports whether node is a CallExpression that
-// upstream's static evaluator folds to a known non-array value, including
-// the four coercion constructors (`Number`, `String`, `Boolean`, `BigInt`),
-// the `parseInt` / `parseFloat` / `Object` global functions, and the
-// well-known global method receivers (`Math.*`, `Array.isArray`, etc.).
-// `Symbol()` is excluded because every call returns a unique Symbol and
-// the static evaluator cannot fold it.
-func isNonArrayResolvingCall(ctx rule.RuleContext, node *ast.Node) bool {
-	call := node.AsCallExpression()
-	if call == nil {
+// isShapeUpstreamUnknown reports whether node is one of the shapes
+// upstream's parser leaves "unknown" for source-only files. The shared
+// rslint static evaluator would also fold these (e.g. `undefined` →
+// Undefined), but the upstream parser does not, so the rule fires.
+func isShapeUpstreamUnknown(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
 		return false
 	}
-	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
-	if callee == nil {
+	// Strip type annotations / assertions / non-null so a TS-only
+	// expression like `(x as number)` is treated by its underlying shape.
+	node = ast.SkipOuterExpressions(node, ast.OEKAll)
+	if node == nil {
 		return false
 	}
-	if ast.IsIdentifier(callee) {
-		// If the callee resolves to a local binding, the user's
-		// declaration wins; fall through to IsKnownNonIndexedCollection.
-		if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
-			return false
-		}
-		switch callee.AsIdentifier().Text {
-		case "Number", "String", "Boolean", "BigInt",
-			"parseInt", "parseFloat", "Object":
-			return true
-		}
+	if ast.IsIdentifier(node) {
+		return true
+	}
+	if ast.IsAccessExpression(node) {
+		return true
+	}
+	if ast.IsCallExpression(node) {
+		return true
+	}
+	return false
+}
+
+// isNonArrayCoercionConstructorCall reports whether node is a bare call
+// to one of the four coercion constructors whose result is statically
+// known to be a non-array primitive: `Number(...)`, `String(...)`,
+// `Boolean(...)`, `BigInt(...)`. Upstream's
+// `getStaticValueForControlFlow` folds these to a primitive value; the
+// rslint static evaluator does not, so we mirror the upstream shape here.
+//
+// `Symbol()` is excluded: every call returns a unique Symbol and the
+// static evaluator cannot fold it. `parseInt` / `parseFloat` / `Object()`
+// are also excluded for the same reason — they aren't on the upstream
+// `staticGlobalProperties` allowlist, and the rslint type checker would
+// over-classify their return type for `.mjs` inputs.
+func isNonArrayCoercionConstructorCall(ctx rule.RuleContext, node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if !ast.IsCallExpression(node) {
 		return false
 	}
-	if ast.IsAccessExpression(callee) {
-		// First let the shared static evaluator take a swing: it knows
-		// how to fold `String.fromCharCode`, `Array.of`, and a few
-		// string methods.
-		staticEvaluator := arrayReceiverStaticEvaluator(ctx)
-		if _, known := staticEvaluator.EvalArrayValue(node); known {
-			// Resolved: let the outer IsKnownNonIndexedCollection path
-			// decide.
-			return false
-		}
-		receiver := accessExpressionObject(callee)
-		if receiver == nil || !ast.IsIdentifier(receiver) {
-			return false
-		}
-		// If the receiver resolves to a local binding, the user's
-		// declaration wins; fall through.
-		if ctx.Refs != nil && ctx.Refs.ResolveInFile(receiver) != nil {
-			return false
-		}
-		// Known global receivers that return non-array values for any
-		// well-known method call. `Symbol` is excluded because Symbol
-		// values cannot be folded.
-		switch receiver.AsIdentifier().Text {
-		case "Math", "Number", "String", "Boolean", "BigInt", "Array", "Object", "JSON":
-			return true
-		}
+	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, ast.OEKParentheses|ast.OEKAssertions)
+	if !ast.IsIdentifier(callee) {
+		return false
+	}
+	// If the callee resolves to a local binding, the user's declaration
+	// wins; fall through to IsKnownNonIndexedCollection.
+	if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
+		return false
+	}
+	switch callee.AsIdentifier().Text {
+	case "Number", "String", "Boolean", "BigInt":
+		return true
 	}
 	return false
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -645,6 +645,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-fetch-options.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-magic-array-flat-depth.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-nested-ternary.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-magic-array-flat-depth.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-magic-array-flat-depth.test.ts
@@ -1,0 +1,45 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code, filename: 'file.mjs' });
+
+const invalid = (code: string) => ({
+  code,
+  filename: 'file.mjs',
+  errors: [{ message: 'Magic number as depth is not allowed.' }],
+});
+
+ruleTester.run('no-magic-array-flat-depth', null as never, {
+  valid: [
+    // depth is 1 (the default).
+    valid('array.flat(1)'),
+    valid('array.flat(1.0)'),
+    valid('array.flat(0x01)'),
+
+    // depth is not a numeric literal.
+    valid('array.flat(unknown)'),
+    valid('array.flat(Number.POSITIVE_INFINITY)'),
+    valid('array.flat(Infinity)'),
+
+    // comments around the depth explain the magic number.
+    valid('array.flat(/* explanation */2)'),
+    valid('array.flat(2/* explanation */)'),
+
+    // no argument or wrong number of arguments.
+    valid('array.flat()'),
+    valid('array.flat(2, extraArgument)'),
+
+    // not a CallExpression of `.flat`.
+    valid('new array.flat(2)'),
+    valid('array.flat?.(2)'),
+    valid('array.notFlat(2)'),
+    valid('flat(2)'),
+  ],
+  invalid: [
+    invalid('array.flat(2)'),
+    invalid('array?.flat(2)'),
+    invalid('array.flat(99,)'),
+    invalid('array.flat(0b10,)'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -115,7 +115,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-late-event-control': 'error', // not implemented
     // 'unicorn/no-lonely-if': 'error', // not implemented
     // 'unicorn/no-loop-iterable-mutation': 'error', // not implemented
-    // 'unicorn/no-magic-array-flat-depth': 'error', // not implemented
+    'unicorn/no-magic-array-flat-depth': 'error',
     // 'unicorn/no-manually-wrapped-comments': 'off', // not implemented
     // 'unicorn/no-mismatched-map-key': 'error', // not implemented
     // 'unicorn/no-misrefactored-assignment': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `unicorn/no-magic-array-flat-depth` rule from ESLint to rslint. Flags `Array#flat(<numeric literal>)` calls when the depth argument is any number other than `1` (the default). A magic depth like `flat(2)` or `flat(99)" is almost always a sign the caller doesn't know the array's structure; preferring `flat(Infinity)` or restructuring the data is usually clearer.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-magic-array-flat-depth.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-magic-array-flat-depth.js
- Test cases: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/no-magic-array-flat-depth.js

## Implementation Notes

- **Single message ID**: rule reports the depth argument directly (no suggestions, no options).
- **Decimal-canonicalized comparison**: tsgo's `NumericLiteral.Text` returns the raw literal text, so comparing with `utils.NormalizeNumericLiteral("1") == "1"` correctly rejects `1`, `1.0`, and `0x01` while reporting every other numeric shape.
- **Comment check**: scans the span from the end of the callee (= the opening paren) to the end of the call expression, matching upstream's `sourceCode.commentsExistBetween(openingParenthesisToken, closingParenthesisToken)`.
- **Type-aware skip**: `unicornutil.IsKnownNonArray` skips when the receiver is statically known not to be an array (e.g. a typed `Set`); on JS / gap files this is a no-op, matching upstream's behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).