### PR TITLE
fix: harden no-array-constructor edits

### DIFF
--- a/internal/rules/no_array_constructor/no_array_constructor.go
+++ b/internal/rules/no_array_constructor/no_array_constructor.go
@@ -2,6 +2,7 @@ package no_array_constructor
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -50,6 +51,9 @@ func calleeArgsAndTypeArgs(node *ast.Node) (callee *ast.Node, args *ast.NodeList
 // node has no parentheses at all, e.g. a bare `new Array`.
 func findOpenParen(sourceFile *ast.SourceFile, calleeEnd int, nodeEnd int) (pos int, found bool) {
 	text := sourceFile.Text()
+	if calleeEnd < 0 || nodeEnd < calleeEnd || nodeEnd > len(text) {
+		return 0, false
+	}
 	p := calleeEnd
 	for p < nodeEnd {
 		p = scanner.SkipTrivia(text, p)
@@ -75,6 +79,130 @@ func countNonSpread(args *ast.NodeList) int {
 		}
 	}
 	return count
+}
+
+func diagnosticTouchesRange(diagnostics []*ast.Diagnostic, textRange core.TextRange) bool {
+	for _, diagnostic := range diagnostics {
+		// Missing-token diagnostics are zero-width and can sit exactly at the
+		// recovered call's end, so intersection is intentionally inclusive.
+		if diagnostic != nil && diagnostic.Pos() <= textRange.End() && diagnostic.End() >= textRange.Pos() {
+			return true
+		}
+	}
+	return false
+}
+
+type arrayConstructorEditPlan struct {
+	sourceFile  *ast.SourceFile
+	comments    *rule.CommentStore
+	node        *ast.Node
+	callee      *ast.Node
+	args        *ast.NodeList
+	reportRange core.TextRange
+
+	classified    bool
+	editable      bool
+	shouldSuggest bool
+	argsStart     int
+	argsEnd       int
+}
+
+func (p *arrayConstructorEditPlan) classify() {
+	if p.classified {
+		return
+	}
+	p.classified = true
+
+	sourceText := p.sourceFile.Text()
+	start, end := p.reportRange.Pos(), p.reportRange.End()
+	calleeEnd := p.callee.End()
+	if start < 0 || start > end || end > len(sourceText) || calleeEnd < start || calleeEnd > end {
+		return
+	}
+	if p.node.Flags&(ast.NodeFlagsThisNodeHasError|ast.NodeFlagsThisNodeOrAnySubNodesHasError) != 0 ||
+		diagnosticTouchesRange(p.sourceFile.Diagnostics(), p.reportRange) ||
+		// Despite its name, JSDiagnostics contains JavaScript-file syntax
+		// diagnostics (for example, TypeScript-only syntax in a .js file).
+		// JSDocDiagnostics is intentionally excluded: malformed comment types
+		// do not recover the call AST, and the edit preserves argument text.
+		diagnosticTouchesRange(p.sourceFile.JSDiagnostics(), p.reportRange) {
+		return
+	}
+	if p.args != nil {
+		for _, arg := range p.args.Nodes {
+			if ast.NodeIsMissing(arg) || arg.Kind == ast.KindOmittedExpression {
+				return
+			}
+		}
+	}
+
+	openParen, hasParens := findOpenParen(p.sourceFile, calleeEnd, end)
+	commentBound := end
+	if hasParens {
+		closeParen := end - 1
+		if openParen >= closeParen || sourceText[closeParen] != ')' {
+			return
+		}
+		p.argsStart = openParen + 1
+		p.argsEnd = closeParen
+		commentBound = openParen
+	} else {
+		// Only NewExpression permits a valid constructor call without its own
+		// parentheses (`new Array` or `new (Array)`). A CallExpression with a
+		// nil argument list is necessarily recovered or synthetic.
+		if p.node.Kind != ast.KindNewExpression || p.args != nil {
+			return
+		}
+		p.argsStart = end
+		p.argsEnd = end
+	}
+
+	p.editable = true
+	p.shouldSuggest = ast.IsOptionalChainRoot(p.node) ||
+		(p.args != nil && len(p.args.Nodes) > 0 && countNonSpread(p.args) < 2) ||
+		utils.HasCommentInSpan(p.comments.All(), start, commentBound)
+}
+
+func (p *arrayConstructorEditPlan) replacement() (text string, addSemicolon bool) {
+	addSemicolon = utils.IsStartOfExpressionStatement(p.sourceFile, p.node) &&
+		utils.NeedsPrecedingSemicolon(p.sourceFile, p.node)
+	if p.argsStart == p.argsEnd {
+		if addSemicolon {
+			return ";[]", true
+		}
+		return "[]", false
+	}
+
+	argsText := p.sourceFile.Text()[p.argsStart:p.argsEnd]
+	if addSemicolon {
+		return ";[" + argsText + "]", true
+	}
+	return "[" + argsText + "]", false
+}
+
+func (p *arrayConstructorEditPlan) buildFixes() []rule.RuleFix {
+	p.classify()
+	if !p.editable || p.shouldSuggest {
+		return nil
+	}
+	fixText, _ := p.replacement()
+	return []rule.RuleFix{rule.RuleFixReplaceRange(p.reportRange, fixText)}
+}
+
+func (p *arrayConstructorEditPlan) buildSuggestions() []rule.RuleSuggestion {
+	p.classify()
+	if !p.editable || !p.shouldSuggest {
+		return nil
+	}
+	fixText, addSemicolon := p.replacement()
+	msg := useLiteralMessage()
+	if addSemicolon {
+		msg = useLiteralAfterSemicolonMessage()
+	}
+	return []rule.RuleSuggestion{{
+		Message:  msg,
+		FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(p.reportRange, fixText)},
+	}}
 }
 
 // https://eslint.org/docs/latest/rules/no-array-constructor
@@ -151,67 +279,32 @@ var NoArrayConstructorRule = rule.Rule{
 				return
 			}
 
-			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			openParen, hasParens := findOpenParen(ctx.SourceFile, callee.End(), nodeRange.End())
-			argsText := ""
-			commentBound := nodeRange.End()
-			if hasParens {
-				argsText = ctx.SourceFile.Text()[openParen+1 : nodeRange.End()-1]
-				commentBound = openParen
+			reportRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			plan := arrayConstructorEditPlan{
+				sourceFile:  ctx.SourceFile,
+				comments:    ctx.Comments,
+				node:        node,
+				callee:      callee,
+				args:        args,
+				reportRange: reportRange,
 			}
-			fixText := "[" + argsText + "]"
 
 			// NOTE: Unlike ESLint, utils.NeedsPrecedingSemicolon doesn't model
 			// TypeScript-only node kinds (type positions, ambient/overload
 			// function declarations, import-equals declarations), so it falls
-			// back to the conservative "needs a semicolon" answer there —
-			// e.g. after `type T = Foo` or `import Foo = Bar`. The extra `;`
-			// never changes behavior, only adds a redundant character; see
-			// the rule doc's "Differences from ESLint" section.
-			addSemicolon := utils.IsStartOfExpressionStatement(ctx.SourceFile, node) &&
-				utils.NeedsPrecedingSemicolon(ctx.SourceFile, node)
-			if addSemicolon {
-				fixText = ";" + fixText
-			}
-
-			// Replacing the call with an array literal directly (rather than
-			// as an opt-in suggestion) is only safe when doing so can't
-			// change runtime behavior or silently drop source text:
-			//   - `Array?.(...)` short-circuits to `undefined` when `Array`
-			//     is nullish; `[...]` always evaluates.
-			//   - A single spread plus at most one more argument
-			//     (`Array(5, ...args)`) is equivalent to the sparse-array
-			//     single-argument form when the spread happens to be empty
-			//     at runtime — an outcome an autofix must not risk.
-			//   - A comment between the node's start and the call's own
-			//     opening paren (`Array/*a*/()`) would be silently discarded
-			//     by the fix. Comments inside the argument list itself don't
-			//     count: the fix copies that text through verbatim.
-			shouldSuggest := ast.IsOptionalChainRoot(node) ||
-				(args != nil && len(args.Nodes) > 0 && countNonSpread(args) < 2) ||
-				utils.HasCommentInSpan(ctx.Comments.All(), nodeRange.Pos(), commentBound)
-
-			buildFixes := func() []rule.RuleFix {
-				if shouldSuggest {
-					return nil
-				}
-				return []rule.RuleFix{rule.RuleFixReplaceRange(nodeRange, fixText)}
-			}
-			buildSuggestions := func() []rule.RuleSuggestion {
-				if !shouldSuggest {
-					return nil
-				}
-				msg := useLiteralMessage()
-				if addSemicolon {
-					msg = useLiteralAfterSemicolonMessage()
-				}
-				return []rule.RuleSuggestion{{
-					Message:  msg,
-					FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(nodeRange, fixText)},
-				}}
-			}
-
-			ctx.ReportNodeWithDeferredFixesAndSuggestions(node, preferLiteralMessage(), buildFixes, buildSuggestions)
+			// back to the conservative "needs a semicolon" answer there. The
+			// edit plan keeps that existing behavior, but computes it only when
+			// the consumer requests the matching edit category.
+			//
+			// The same deferred plan classifies optional calls, risky spreads,
+			// comments, and parser-recovery boundaries. A malformed call keeps
+			// its diagnostic but never receives an edit that could drop source.
+			ctx.ReportRangeWithDeferredFixesAndSuggestions(
+				reportRange,
+				preferLiteralMessage(),
+				plan.buildFixes,
+				plan.buildSuggestions,
+			)
 		}
 
 		return rule.RuleListeners{

--- a/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
+++ b/internal/rules/no_array_constructor/no_array_constructor_extras_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
@@ -240,6 +242,10 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			// NewExpression listener is independent of the CallExpression
 			// one and doesn't cross-report.
 			directFixCase(`new Array(new Array());`, `new Array()`, `new Array([]);`),
+			// A valid sparse array nested inside the argument list is not parser
+			// recovery. Only omitted expressions directly in a malformed call's
+			// argument list make that call unsafe to edit.
+			directFixCase(`Array([,], 1);`, `Array([,], 1)`, `[[,], 1];`),
 
 			// Locks in the `nonSpreadCount` reduce (not just a length check):
 			// three arguments where two are non-spread is still safe to
@@ -602,6 +608,203 @@ func testNoArrayConstructorEditDemand(t *testing.T, source string, wantSuggestio
 			t.Errorf("demand %d: unexpected autofix %#v", demand, d.FixesPtr)
 		}
 	}
+}
+
+func TestNoArrayConstructorRecoveryAST(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "empty call", source: "Array("},
+		{name: "truncated arguments", source: "Array(a, b"},
+		{name: "new expression", source: "new Array("},
+		{name: "optional call", source: "Array?.("},
+		{name: "parenthesized callee", source: "(Array)(a, b"},
+		{name: "unclosed callee grouping", source: "new (Array"},
+		{name: "missing argument separator", source: "Array(a b)"},
+		{name: "omitted arguments", source: "Array(,,)"},
+		{name: "interior omitted argument", source: "Array(a,,b)"},
+		{name: "incomplete spread", source: "Array(...,)"},
+		{name: "comment before incomplete call", source: "Array/*keep*/("},
+		{name: "unterminated comment", source: "Array(/* keep"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			sourceFile := parseNoArrayConstructorSource(test.source)
+			if len(sourceFile.Diagnostics()) == 0 && len(sourceFile.JSDiagnostics()) == 0 {
+				t.Fatal("recovery fixture has no parser diagnostic")
+			}
+
+			diagnostics := make(map[rule.EditDemand][]rule.RuleDiagnostic, 4)
+			for _, demand := range []rule.EditDemand{
+				rule.EditDemandNone,
+				rule.EditDemandAutofix,
+				rule.EditDemandSuggestion,
+				rule.EditDemandAll,
+			} {
+				diagnostics[demand] = lintParsedNoArrayConstructor(sourceFile, demand)
+			}
+
+			want := diagnostics[rule.EditDemandNone]
+			if len(want) != 1 {
+				t.Fatalf("diagnostics-only count = %d, want 1", len(want))
+			}
+			if !reflect.DeepEqual(want[0].Message, preferLiteralMessage()) {
+				t.Fatalf("diagnostic message = %#v, want %#v", want[0].Message, preferLiteralMessage())
+			}
+			if start, end := want[0].Range.Pos(), want[0].Range.End(); start < 0 || start > end || end > len(test.source) {
+				t.Fatalf("diagnostic range = [%d,%d), source length = %d", start, end, len(test.source))
+			}
+			for demand, got := range diagnostics {
+				if len(got) != len(want) {
+					t.Fatalf("demand %d: diagnostics = %d, want %d", demand, len(got), len(want))
+				}
+				for index := range got {
+					if got[index].FixesPtr != nil || got[index].Suggestions != nil {
+						t.Errorf(
+							"demand %d diagnostic %d unexpectedly has edits: fixes=%#v suggestions=%#v",
+							demand,
+							index,
+							got[index].FixesPtr,
+							got[index].Suggestions,
+						)
+					}
+					gotIdentity, wantIdentity := got[index], want[index]
+					gotIdentity.FixesPtr, gotIdentity.Suggestions = nil, nil
+					wantIdentity.FixesPtr, wantIdentity.Suggestions = nil, nil
+					if !reflect.DeepEqual(gotIdentity, wantIdentity) {
+						t.Errorf(
+							"demand %d changed diagnostic %d:\ngot:  %#v\nwant: %#v",
+							demand,
+							index,
+							gotIdentity,
+							wantIdentity,
+						)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNoArrayConstructorRecoveryASTSuppressedDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parseNoArrayConstructorSource("/* eslint-disable no-array-constructor */ Array(")
+	if diagnostics := lintParsedNoArrayConstructor(sourceFile, rule.EditDemandAll); len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %d, want 0", len(diagnostics))
+	}
+}
+
+func TestNoArrayConstructorUnrelatedParserDiagnosticKeepsSafeEdit(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parseNoArrayConstructorSource("Array();\nconst = 1;")
+	if len(sourceFile.Diagnostics()) == 0 {
+		t.Fatal("fixture has no unrelated parser diagnostic")
+	}
+	diagnostics := lintParsedNoArrayConstructor(sourceFile, rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	fixes := diagnostics[0].Fixes()
+	if len(fixes) != 1 || fixes[0].Text != "[]" || fixes[0].Range != diagnostics[0].Range {
+		t.Fatalf("fixes = %#v, want one [] replacement", fixes)
+	}
+}
+
+func TestNoArrayConstructorJavaScriptSyntaxDiagnosticPreventsEdit(t *testing.T) {
+	t.Parallel()
+
+	source := "Array(a as number, b);"
+	sourceFile := parseNoArrayConstructorSourceWithKind("recovered.js", source, core.ScriptKindJS)
+	if len(sourceFile.Diagnostics()) != 0 || len(sourceFile.JSDiagnostics()) == 0 {
+		t.Fatalf(
+			"parser diagnostics = %d, JavaScript syntax diagnostics = %d; want only JavaScript syntax diagnostics",
+			len(sourceFile.Diagnostics()),
+			len(sourceFile.JSDiagnostics()),
+		)
+	}
+	diagnostics := lintParsedNoArrayConstructor(sourceFile, rule.EditDemandAll)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	if diagnostics[0].FixesPtr != nil || diagnostics[0].Suggestions != nil {
+		t.Fatalf(
+			"recovered JavaScript call unexpectedly has edits: fixes=%#v suggestions=%#v",
+			diagnostics[0].FixesPtr,
+			diagnostics[0].Suggestions,
+		)
+	}
+}
+
+func TestNoArrayConstructorJSDocDiagnosticKeepsPreservingEdit(t *testing.T) {
+	t.Parallel()
+
+	source := "Array(/** @param { */ function () {}, b);"
+	sourceFile := parseNoArrayConstructorSourceWithKind("malformed-jsdoc.js", source, core.ScriptKindJS)
+	if len(sourceFile.Diagnostics()) != 0 || len(sourceFile.JSDiagnostics()) != 0 {
+		t.Fatalf(
+			"parser diagnostics = %d, JavaScript syntax diagnostics = %d; want neither",
+			len(sourceFile.Diagnostics()),
+			len(sourceFile.JSDiagnostics()),
+		)
+	}
+	jsdocDiagnostics := sourceFile.JSDocDiagnostics()
+	callRange := core.NewTextRange(0, len(source)-1)
+	if len(jsdocDiagnostics) == 0 || !diagnosticTouchesRange(jsdocDiagnostics, callRange) {
+		t.Fatalf("JSDoc diagnostics = %#v, want one touching the call", jsdocDiagnostics)
+	}
+
+	diagnostics := lintParsedNoArrayConstructor(sourceFile, rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	fixes := diagnostics[0].Fixes()
+	if len(fixes) != 1 || fixes[0].Text != "[/** @param { */ function () {}, b]" || fixes[0].Range != diagnostics[0].Range {
+		t.Fatalf("fixes = %#v, want one source-preserving array-literal replacement", fixes)
+	}
+}
+
+func parseNoArrayConstructorSource(source string) *ast.SourceFile {
+	return parseNoArrayConstructorSourceWithKind("recovery.ts", source, core.ScriptKindTS)
+}
+
+func parseNoArrayConstructorSourceWithKind(fileName string, source string, scriptKind core.ScriptKind) *ast.SourceFile {
+	path := "/no-array-constructor-" + fileName
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: path,
+		Path:     tspath.Path(path),
+	}, source, scriptKind)
+}
+
+func lintParsedNoArrayConstructor(sourceFile *ast.SourceFile, demand rule.EditDemand) []rule.RuleDiagnostic {
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(NoArrayConstructorRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+		Demand: demand,
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	listeners := NoArrayConstructorRule.Run(ctx, nil)
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
 }
 
 func lintNoArrayConstructorWithDemand(


### PR DESCRIPTION
## Summary

- Keep `no-array-constructor` diagnostics on parser-recovered calls while withholding fixes and suggestions that could drop source text; valid-source diagnostics and edit artifacts remain unchanged.
- Defer edit classification, comment scanning, ASI checks, and replacement construction until the consumer requests the corresponding edit category.
- Distinguish JavaScript syntax diagnostics from JSDoc comment diagnostics, preserving safe argument text verbatim, and add focused recovery, suppression, demand, and sparse-array regressions.
- In the fixed 4,000-call Go benchmark (five runs; CPU idle 78.75% before and 94.14% after), the diagnostics-only path decreased from 20,054 to 4,054 allocs/op (-79.8%) and from 4,772,669 to 2,820,665 B/op (-40.9%).

## Related Links

- [ESLint rule documentation](https://eslint.org/docs/latest/rules/no-array-constructor)
- [ESLint 10.8.1 rule source](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-array-constructor.js)

## Validation

- `go test -count=3 ./internal/rules/no_array_constructor`
- `pnpm exec rstest run --testTimeout=10000 no-array-constructor`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/rules/no_array_constructor/...`
- `pnpm run typecheck`
- `pnpm run lint` (0 errors)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; valid-source behavior and the public API are unchanged).
