### PR TITLE
feat(rstest): add require-test-timeout rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -22,6 +22,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_hooks_in_order"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_todo"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_local_test_context_for_concurrent_snapshots"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_test_timeout"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_expect_in_promise"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_title"
@@ -51,6 +52,7 @@ func GetAllRules() []rule.Rule {
 		prefer_hooks_in_order.PreferHooksInOrderRule,
 		prefer_todo.PreferTodoRule,
 		require_local_test_context_for_concurrent_snapshots.RequireLocalTestContextForConcurrentSnapshotsRule,
+		require_test_timeout.RequireTestTimeoutRule,
 		valid_expect.ValidExpectRule,
 		valid_expect_in_promise.ValidExpectInPromiseRule,
 		valid_title.ValidTitleRule,

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.go
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.go
@@ -20,8 +20,9 @@ var missingTimeoutMessage = rule.RuleMessage{
 //
 // The rule only reports on timeoutAbsent and timeoutNegative: everything it
 // cannot read is timeoutUnknown, which exempts. Upstream instead reports the
-// unreadable shapes (its `Number.NaN` branch), and this port deliberately
-// diverges — see require_test_timeout.md.
+// unreadable shapes through its `Number.NaN` branch; reporting a timeout that
+// is merely written somewhere unreadable is a false positive, and TypeScript
+// already rejects a `timeout` that is not a number.
 type timeoutFinding uint8
 
 const (

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.go
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.go
@@ -1,0 +1,564 @@
+package require_test_timeout
+
+import (
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+var missingTimeoutMessage = rule.RuleMessage{
+	Id:          "missingTimeout",
+	Description: "Test is missing a timeout. Add an explicit timeout.",
+}
+
+// timeoutFinding is what a static read of one registration argument, one
+// options object or one runtime-config call was able to conclude.
+//
+// The rule only reports on timeoutAbsent and timeoutNegative: everything it
+// cannot read is timeoutUnknown, which exempts. Upstream instead reports the
+// unreadable shapes (its `Number.NaN` branch), and this port deliberately
+// diverges — see require_test_timeout.md.
+type timeoutFinding uint8
+
+const (
+	// timeoutAbsent means the shape was fully readable and declares no timeout.
+	timeoutAbsent timeoutFinding = iota
+	// timeoutDeclared means a timeout of zero or more was written down.
+	timeoutDeclared
+	// timeoutNegative means a timeout below zero was written down. Rstest has
+	// no meaning for it, and `0` already spells "no limit", so the author
+	// still owes the test a real timeout.
+	timeoutNegative
+	// timeoutUnknown means the shape could not be read statically.
+	timeoutUnknown
+)
+
+var RequireTestTimeoutRule = rule.Rule{
+	Name:   "rstest/require-test-timeout",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		runtimeConfig := runtimeConfigTracker{ctx: ctx}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				// Every `setConfig` / `resetConfig` call has to be seen before
+				// the tests that follow it, which the source-order walk already
+				// guarantees; the tracker itself allocates nothing until one of
+				// those calls actually appears in the file.
+				runtimeConfig.observe(node)
+
+				parsed := analysis.ParseTestCall(node)
+				if parsed == nil || parsed.Todo || parsed.Skipped {
+					return
+				}
+				// A registration with no callback declares no test body to time
+				// out. Reporting it belongs to `rstest/prefer-todo`.
+				if callback, name := analysis.TestCallback(node); callback == nil && name == "" {
+					return
+				}
+				if runtimeConfig.exemptsAt(node.Pos()) {
+					return
+				}
+				if inheritsSuiteTimeout(ctx, analysis, node) {
+					return
+				}
+				switch registrationTimeout(ctx, node) {
+				case timeoutDeclared, timeoutUnknown:
+					return
+				}
+
+				ctx.ReportNode(node, missingTimeoutMessage)
+			},
+		}
+	},
+}
+
+// registrationTimeout reads the timeout a `test` or `describe` registration
+// declares for itself.
+//
+// Rstest has exactly two overloads — `(name, fn?, timeout?)` and
+// `(name, options, fn?)` (packages/core/src/types/api.ts:91-94) — so only the
+// second and third arguments can carry a timeout, and a call with more
+// arguments than that matches neither overload and is left alone.
+func registrationTimeout(ctx rule.RuleContext, node *ast.Node) timeoutFinding {
+	call := node.AsCallExpression()
+	if call == nil || call.Arguments == nil {
+		return timeoutAbsent
+	}
+	arguments := call.Arguments.Nodes
+	if len(arguments) > 3 {
+		return timeoutUnknown
+	}
+
+	finding := timeoutAbsent
+	for index := 1; index < len(arguments) && index <= 2; index++ {
+		switch argument := argumentTimeout(ctx, arguments[index]); argument {
+		case timeoutNegative:
+			return timeoutNegative
+		case timeoutDeclared, timeoutUnknown:
+			finding = argument
+		}
+	}
+	return finding
+}
+
+// argumentTimeout reads one registration argument as a timeout carrier. The
+// callback itself carries nothing, so it reads as absent rather than unknown.
+func argumentTimeout(ctx rule.RuleContext, node *ast.Node) timeoutFinding {
+	node = internalUtils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return timeoutUnknown
+	}
+	if ast.IsFunctionExpressionOrArrowFunction(node) {
+		return timeoutAbsent
+	}
+	if node.Kind == ast.KindObjectLiteralExpression {
+		return objectTimeout(ctx, node, "timeout")
+	}
+	if finding, ok := numericTimeout(node); ok {
+		return finding
+	}
+	if node.Kind == ast.KindIdentifier {
+		// A callback passed by name occupies an argument slot the other
+		// overload reads as options or as the timeout, so it has to be
+		// recognized as the callback before it is read as either.
+		if resolvesToFunction(ctx, node) {
+			return timeoutAbsent
+		}
+		initializer := constInitializer(ctx, node)
+		if initializer == nil {
+			return timeoutUnknown
+		}
+		if initializer.Kind == ast.KindObjectLiteralExpression {
+			return objectTimeout(ctx, initializer, "timeout")
+		}
+		if finding, ok := numericTimeout(initializer); ok {
+			return finding
+		}
+	}
+	return timeoutUnknown
+}
+
+// resolvesToFunction reports whether an identifier names a function declared
+// in this file, by either spelling. It matches how the Rstest parser resolves
+// a callback passed by name, so that the same argument is not read as a
+// callback there and as a timeout here.
+func resolvesToFunction(ctx rule.RuleContext, node *ast.Node) bool {
+	declaration := internalUtils.GetDeclaration(ctx.TypeChecker, node)
+	if declaration == nil {
+		return false
+	}
+	switch declaration.Kind {
+	case ast.KindFunctionDeclaration:
+		return true
+	case ast.KindVariableDeclaration:
+		initializer := declaration.AsVariableDeclaration().Initializer
+		if initializer == nil {
+			return false
+		}
+		return ast.IsFunctionExpressionOrArrowFunction(
+			internalUtils.SkipAssertionsAndParens(initializer),
+		)
+	}
+	return false
+}
+
+// objectTimeout reads property from an options object literal. A spread or a
+// key that is not statically known could carry the property, so either one
+// makes the whole object unreadable rather than absent.
+func objectTimeout(ctx rule.RuleContext, object *ast.Node, property string) timeoutFinding {
+	literal := object.AsObjectLiteralExpression()
+	if literal == nil || literal.Properties == nil {
+		return timeoutAbsent
+	}
+	for _, member := range literal.Properties.Nodes {
+		if member == nil {
+			continue
+		}
+		if member.Kind == ast.KindSpreadAssignment {
+			return timeoutUnknown
+		}
+		name := member.Name()
+		if name == nil {
+			return timeoutUnknown
+		}
+		key, ok := internalUtils.GetStaticPropertyName(name)
+		if !ok {
+			return timeoutUnknown
+		}
+		if key != property {
+			continue
+		}
+		switch member.Kind {
+		case ast.KindPropertyAssignment:
+			return scalarTimeout(ctx, member.AsPropertyAssignment().Initializer)
+		case ast.KindShorthandPropertyAssignment:
+			return scalarTimeout(ctx, name)
+		default:
+			// A method or accessor named `timeout` is not a number, and the
+			// rule stays silent on everything it cannot read as one.
+			return timeoutUnknown
+		}
+	}
+	return timeoutAbsent
+}
+
+// scalarTimeout reads a value written in a timeout position: a number, or a
+// same-file `const` bound to one. Upstream also resolves `let` bindings and
+// reports the ones it fails to resolve; this port keeps the `const` half and
+// stays silent on the rest.
+func scalarTimeout(ctx rule.RuleContext, node *ast.Node) timeoutFinding {
+	node = internalUtils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return timeoutUnknown
+	}
+	if finding, ok := numericTimeout(node); ok {
+		return finding
+	}
+	if node.Kind == ast.KindIdentifier {
+		if initializer := constInitializer(ctx, node); initializer != nil {
+			if finding, ok := numericTimeout(initializer); ok {
+				return finding
+			}
+		}
+	}
+	return timeoutUnknown
+}
+
+// numericTimeout classifies a numeric literal, including the unary forms the
+// parser keeps separate from the literal itself. `0` disables the timeout in
+// Rstest (website/docs/zh/config/test/test-timeout.mdx) and so counts as
+// declared; a BigInt is not a number and is left unread.
+func numericTimeout(node *ast.Node) (timeoutFinding, bool) {
+	negated := false
+	if node.Kind == ast.KindPrefixUnaryExpression {
+		unary := node.AsPrefixUnaryExpression()
+		if unary == nil {
+			return timeoutUnknown, false
+		}
+		switch unary.Operator {
+		case ast.KindMinusToken:
+			negated = true
+		case ast.KindPlusToken:
+		default:
+			return timeoutUnknown, false
+		}
+		node = ast.SkipParentheses(unary.Operand)
+		if node == nil {
+			return timeoutUnknown, false
+		}
+	}
+	if node.Kind != ast.KindNumericLiteral {
+		return timeoutUnknown, false
+	}
+	// tsgo normalizes numeric literal text at parse time, so `5e3` and `0x10`
+	// both arrive as their decimal form.
+	value, err := strconv.ParseFloat(node.AsNumericLiteral().Text, 64)
+	if err != nil {
+		return timeoutUnknown, false
+	}
+	if negated && value > 0 {
+		return timeoutNegative, true
+	}
+	return timeoutDeclared, true
+}
+
+// constInitializer returns the initializer of the same-file `const` an
+// identifier is bound to. Anything else — `let`, a parameter, an import, a
+// function — has no initializer this rule may read.
+func constInitializer(ctx rule.RuleContext, node *ast.Node) *ast.Node {
+	declaration := internalUtils.GetDeclaration(ctx.TypeChecker, node)
+	if declaration == nil || declaration.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	list := declaration.Parent
+	if list == nil ||
+		list.Kind != ast.KindVariableDeclarationList ||
+		list.Flags&ast.NodeFlagsConst == 0 {
+		return nil
+	}
+	initializer := declaration.AsVariableDeclaration().Initializer
+	if initializer == nil {
+		return nil
+	}
+	return internalUtils.SkipAssertionsAndParens(initializer)
+}
+
+// inheritsSuiteTimeout reports whether a lexically enclosing `describe`
+// already gives the test a timeout.
+//
+// Rstest's runner applies suite options as defaults —
+// `test.timeout ??= current.timeout` in
+// packages/core/src/runtime/runner/runtime.ts — so a test inside a timed suite
+// runs with a definite timeout and is not missing one. Upstream models no such
+// inheritance because it never looks past the registration itself.
+//
+// Ownership is read lexically. A function this rule cannot tie back to a call
+// argument — a declaration handed to `describe` by name, for instance — could
+// belong to any suite, so the walk gives up and exempts the test rather than
+// guess. Attributing those needs the callback ownership index that this rule
+// deliberately does not build.
+func inheritsSuiteTimeout(
+	ctx rule.RuleContext,
+	analysis *rstestUtils.RstestCallAnalysis,
+	testCall *ast.Node,
+) bool {
+	for node := testCall.Parent; node != nil; node = node.Parent {
+		if !isFunctionBoundary(node) {
+			continue
+		}
+		call := enclosingCallOfArgument(node)
+		if call == nil {
+			return true
+		}
+		parsed := analysis.ParseFnCall(call)
+		if parsed != nil &&
+			parsed.Kind == rstestUtils.RstestFnTypeDescribe &&
+			registrationTimeout(ctx, call) != timeoutAbsent {
+			return true
+		}
+		// Anything else — another registration, or a plain callback such as
+		// `forEach` — still registers the test wherever it is called from, so
+		// the walk continues from the call site.
+		node = call
+	}
+	return false
+}
+
+func isFunctionBoundary(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindArrowFunction,
+		ast.KindFunctionExpression,
+		ast.KindFunctionDeclaration,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindConstructor:
+		return true
+	}
+	return false
+}
+
+// enclosingCallOfArgument returns the call node is passed to as an argument,
+// looking through the parentheses and TypeScript assertions a callback may be
+// wrapped in. A function in callee position, or in no call at all, has no
+// enclosing call for this purpose.
+func enclosingCallOfArgument(node *ast.Node) *ast.Node {
+	child := node
+	for parent := node.Parent; parent != nil; parent = parent.Parent {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression,
+			ast.KindAsExpression,
+			ast.KindSatisfiesExpression,
+			ast.KindNonNullExpression,
+			ast.KindTypeAssertionExpression:
+			child = parent
+			continue
+		case ast.KindCallExpression:
+			call := parent.AsCallExpression()
+			if call == nil || call.Arguments == nil {
+				return nil
+			}
+			for _, argument := range call.Arguments.Nodes {
+				if argument == child {
+					return parent
+				}
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+// runtimeConfigEvent records one `setConfig` that declared a test timeout, or
+// one `resetConfig` that took it back, at the offset the call ends on.
+type runtimeConfigEvent struct {
+	root   string
+	offset int
+	sets   bool
+}
+
+// runtimeConfigTracker follows the runtime timeout configured through the
+// Rstest utility object. Positions are compared rather than scopes because
+// `setConfig` takes effect from the moment it runs, which for a file of
+// top-level registrations is exactly "from this point in the source down".
+type runtimeConfigTracker struct {
+	ctx    rule.RuleContext
+	events []runtimeConfigEvent
+}
+
+func (tracker *runtimeConfigTracker) observe(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil {
+		return
+	}
+	method, receiver := configMethodAndReceiver(call.Expression)
+	if method != "setConfig" && method != "resetConfig" {
+		return
+	}
+	root, ok := runtimeObjectRoot(tracker.ctx, receiver)
+	if !ok {
+		return
+	}
+	if method == "resetConfig" {
+		tracker.events = append(tracker.events, runtimeConfigEvent{
+			root:   root,
+			offset: node.End(),
+		})
+		return
+	}
+	if !setsTestTimeout(tracker.ctx, call) {
+		return
+	}
+	tracker.events = append(tracker.events, runtimeConfigEvent{
+		root:   root,
+		offset: node.End(),
+		sets:   true,
+	})
+}
+
+// exemptsAt reports whether a test starting at offset runs under a configured
+// test timeout. Events are recorded in source order by the rule's own walk, so
+// replaying the ones that end before the test reproduces the state the runtime
+// would be in when the test is registered.
+func (tracker *runtimeConfigTracker) exemptsAt(offset int) bool {
+	if len(tracker.events) == 0 {
+		return false
+	}
+	configured := map[string]bool{}
+	for _, event := range tracker.events {
+		if event.offset > offset {
+			continue
+		}
+		configured[event.root] = event.sets
+	}
+	for _, sets := range configured {
+		if sets {
+			return true
+		}
+	}
+	return false
+}
+
+// setsTestTimeout reads the `RuntimeOptions` argument of a `setConfig` call.
+// An object this rule cannot read could set `testTimeout`, so it counts as
+// setting it; `setConfig({})` and a negative `testTimeout` do not.
+func setsTestTimeout(ctx rule.RuleContext, call *ast.CallExpression) bool {
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return false
+	}
+	argument := internalUtils.SkipAssertionsAndParens(call.Arguments.Nodes[0])
+	if argument == nil {
+		return true
+	}
+	if argument.Kind == ast.KindIdentifier {
+		if initializer := constInitializer(ctx, argument); initializer != nil {
+			argument = initializer
+		}
+	}
+	if argument.Kind != ast.KindObjectLiteralExpression {
+		return true
+	}
+	switch objectTimeout(ctx, argument, "testTimeout") {
+	case timeoutDeclared, timeoutUnknown:
+		return true
+	}
+	return false
+}
+
+// configMethodAndReceiver splits `<receiver>.setConfig` into its accessor name
+// and the object it is read from, in both the dotted and the indexed form.
+func configMethodAndReceiver(callee *ast.Node) (string, *ast.Node) {
+	callee = ast.SkipParentheses(callee)
+	if callee == nil {
+		return "", nil
+	}
+	switch callee.Kind {
+	case ast.KindPropertyAccessExpression:
+		access := callee.AsPropertyAccessExpression()
+		name := access.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return "", nil
+		}
+		return name.AsIdentifier().Text, access.Expression
+	case ast.KindElementAccessExpression:
+		access := callee.AsElementAccessExpression()
+		name, ok := internalUtils.GetStaticStringLiteralValue(
+			ast.SkipParentheses(access.ArgumentExpression),
+		)
+		if !ok {
+			return "", nil
+		}
+		return name, access.Expression
+	}
+	return "", nil
+}
+
+// runtimeObjectRoot recognizes the Rstest utility object and returns a key
+// that identifies the binding it was reached through, so that a `resetConfig`
+// is only paired with a `setConfig` on the same one.
+//
+// This recognizer is deliberately private to the rule. Modeling the utility
+// object in general — its mocking, timer and spy surface — is a separate piece
+// of work, and a half-built shared version would invite rules to depend on it.
+// It is also deliberately narrow: failing to recognize a root only costs the
+// exemption it would have granted.
+func runtimeObjectRoot(ctx rule.RuleContext, receiver *ast.Node) (string, bool) {
+	receiver = internalUtils.SkipAssertionsAndParens(receiver)
+	if receiver == nil {
+		return "", false
+	}
+	if isImportMetaRstest(receiver) {
+		return "import.meta.rstest", true
+	}
+	if receiver.Kind == ast.KindIdentifier {
+		local := receiver.AsIdentifier().Text
+		// `rs` and `rstest` are the same object under two names
+		// (packages/core/src/runtime/api/public.ts:63-64), and either may be
+		// imported under a further name of its own.
+		name, _, _ := testFramework.ResolveFunctionIdentifierReference(
+			local,
+			receiver,
+			ctx.TypeChecker,
+			ctx.SourceFile,
+			rstestUtils.RstestImportModule,
+		)
+		if name != "rs" && name != "rstest" {
+			return "", false
+		}
+		return "identifier:" + local, true
+	}
+
+	// A namespace import or whole-module require reaches the same object
+	// through a member: `core.rs.setConfig(...)`.
+	member, namespace := configMethodAndReceiver(receiver)
+	if member != "rs" && member != "rstest" {
+		return "", false
+	}
+	namespace = internalUtils.SkipAssertionsAndParens(namespace)
+	if namespace == nil || namespace.Kind != ast.KindIdentifier || ctx.TypeChecker == nil {
+		return "", false
+	}
+	symbol := ctx.TypeChecker.GetSymbolAtLocation(namespace)
+	if !testFramework.IsModuleNamespaceSymbol(symbol, rstestUtils.RstestImportModule) {
+		return "", false
+	}
+	return "namespace:" + namespace.AsIdentifier().Text + "." + member, true
+}
+
+// isImportMetaRstest reports whether node is `import.meta.rstest`, the third
+// spelling of the utility object.
+func isImportMetaRstest(node *ast.Node) bool {
+	name, receiver := configMethodAndReceiver(node)
+	if name != "rstest" || receiver == nil {
+		return false
+	}
+	receiver = ast.SkipParentheses(receiver)
+	return receiver != nil && receiver.Kind == ast.KindMetaProperty &&
+		receiver.AsMetaProperty().KeywordToken == ast.KindImportKeyword
+}

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.go
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.go
@@ -169,44 +169,53 @@ func resolvesToFunction(ctx rule.RuleContext, node *ast.Node) bool {
 	return false
 }
 
-// objectTimeout reads property from an options object literal. A spread or a
-// key that is not statically known could carry the property, so either one
-// makes the whole object unreadable rather than absent.
+// objectTimeout reads property from an options object literal.
+//
+// The whole object is scanned and later members overwrite earlier ones,
+// because that is the order JavaScript builds it in: in
+// `{ timeout: -1, ...options }` the spread has the last word, and stopping at
+// the first `timeout` would report a test whose timeout the spread supplies.
+// A spread and a key that is not statically known are both unreadable, and
+// both can carry the property, so each one erases what came before it.
 func objectTimeout(ctx rule.RuleContext, object *ast.Node, property string) timeoutFinding {
 	literal := object.AsObjectLiteralExpression()
 	if literal == nil || literal.Properties == nil {
 		return timeoutAbsent
 	}
+	finding := timeoutAbsent
 	for _, member := range literal.Properties.Nodes {
 		if member == nil {
 			continue
 		}
 		if member.Kind == ast.KindSpreadAssignment {
-			return timeoutUnknown
+			finding = timeoutUnknown
+			continue
 		}
 		name := member.Name()
 		if name == nil {
-			return timeoutUnknown
+			finding = timeoutUnknown
+			continue
 		}
 		key, ok := internalUtils.GetStaticPropertyName(name)
 		if !ok {
-			return timeoutUnknown
+			finding = timeoutUnknown
+			continue
 		}
 		if key != property {
 			continue
 		}
 		switch member.Kind {
 		case ast.KindPropertyAssignment:
-			return scalarTimeout(ctx, member.AsPropertyAssignment().Initializer)
+			finding = scalarTimeout(ctx, member.AsPropertyAssignment().Initializer)
 		case ast.KindShorthandPropertyAssignment:
-			return scalarTimeout(ctx, name)
+			finding = scalarTimeout(ctx, name)
 		default:
 			// A method or accessor named `timeout` is not a number, and the
 			// rule stays silent on everything it cannot read as one.
-			return timeoutUnknown
+			finding = timeoutUnknown
 		}
 	}
-	return timeoutAbsent
+	return finding
 }
 
 // scalarTimeout reads a value written in a timeout position: a number, or a
@@ -317,11 +326,15 @@ func inheritsSuiteTimeout(
 		if call == nil {
 			return true
 		}
-		parsed := analysis.ParseFnCall(call)
-		if parsed != nil &&
-			parsed.Kind == rstestUtils.RstestFnTypeDescribe &&
-			registrationTimeout(ctx, call) != timeoutAbsent {
-			return true
+		if parsed := analysis.ParseFnCall(call); parsed != nil &&
+			parsed.Kind == rstestUtils.RstestFnTypeDescribe {
+			// A suite whose own timeout is negative hands its tests a value
+			// this rule already refuses to accept on a test, so inheriting it
+			// is not a timeout either.
+			switch registrationTimeout(ctx, call) {
+			case timeoutDeclared, timeoutUnknown:
+				return true
+			}
 		}
 		// Anything else — another registration, or a plain callback such as
 		// `forEach` — still registers the test wherever it is called from, so
@@ -376,21 +389,25 @@ func enclosingCallOfArgument(node *ast.Node) *ast.Node {
 	return nil
 }
 
-// runtimeConfigEvent records one `setConfig` that declared a test timeout, or
-// one `resetConfig` that took it back, at the offset the call ends on.
-type runtimeConfigEvent struct {
-	root   string
-	offset int
-	sets   bool
-}
-
 // runtimeConfigTracker follows the runtime timeout configured through the
-// Rstest utility object. Positions are compared rather than scopes because
-// `setConfig` takes effect from the moment it runs, which for a file of
-// top-level registrations is exactly "from this point in the source down".
+// Rstest utility object.
+//
+// There is only one such object, however it is spelled: `rs` and `rstest` are
+// two names for the same instance, and a namespace member, a `require`
+// binding and `import.meta.rstest` all reach it too. So the tracker holds one
+// state rather than one per binding, and a `resetConfig()` written on any
+// spelling cancels a `setConfig` written on any other.
+//
+// The state is kept incrementally. The rule's own walk visits calls in source
+// order, so by the time a test is reached every configuration call before it
+// has already been folded in and the lookup is a comparison. `configuredFrom`
+// is the offset the enabling call ends on, which rejects the one shape the
+// walk order cannot: a test nested inside the configuration call's own
+// arguments.
 type runtimeConfigTracker struct {
-	ctx    rule.RuleContext
-	events []runtimeConfigEvent
+	ctx            rule.RuleContext
+	configured     bool
+	configuredFrom int
 }
 
 func (tracker *runtimeConfigTracker) observe(node *ast.Node) {
@@ -402,48 +419,24 @@ func (tracker *runtimeConfigTracker) observe(node *ast.Node) {
 	if method != "setConfig" && method != "resetConfig" {
 		return
 	}
-	root, ok := runtimeObjectRoot(tracker.ctx, receiver)
-	if !ok {
+	if !isRuntimeObject(tracker.ctx, receiver) {
 		return
 	}
 	if method == "resetConfig" {
-		tracker.events = append(tracker.events, runtimeConfigEvent{
-			root:   root,
-			offset: node.End(),
-		})
+		tracker.configured = false
 		return
 	}
 	if !setsTestTimeout(tracker.ctx, call) {
 		return
 	}
-	tracker.events = append(tracker.events, runtimeConfigEvent{
-		root:   root,
-		offset: node.End(),
-		sets:   true,
-	})
+	tracker.configured = true
+	tracker.configuredFrom = node.End()
 }
 
 // exemptsAt reports whether a test starting at offset runs under a configured
-// test timeout. Events are recorded in source order by the rule's own walk, so
-// replaying the ones that end before the test reproduces the state the runtime
-// would be in when the test is registered.
+// test timeout.
 func (tracker *runtimeConfigTracker) exemptsAt(offset int) bool {
-	if len(tracker.events) == 0 {
-		return false
-	}
-	configured := map[string]bool{}
-	for _, event := range tracker.events {
-		if event.offset > offset {
-			continue
-		}
-		configured[event.root] = event.sets
-	}
-	for _, sets := range configured {
-		if sets {
-			return true
-		}
-	}
-	return false
+	return tracker.configured && tracker.configuredFrom <= offset
 }
 
 // setsTestTimeout reads the `RuntimeOptions` argument of a `setConfig` call.
@@ -500,56 +493,49 @@ func configMethodAndReceiver(callee *ast.Node) (string, *ast.Node) {
 	return "", nil
 }
 
-// runtimeObjectRoot recognizes the Rstest utility object and returns a key
-// that identifies the binding it was reached through, so that a `resetConfig`
-// is only paired with a `setConfig` on the same one.
+// isRuntimeObject recognizes the Rstest utility object, whichever of its
+// spellings was used to reach it. All of them name the same instance, so the
+// caller keeps one configuration state for the lot.
 //
 // This recognizer is deliberately private to the rule. Modeling the utility
 // object in general — its mocking, timer and spy surface — is a separate piece
 // of work, and a half-built shared version would invite rules to depend on it.
-// It is also deliberately narrow: failing to recognize a root only costs the
-// exemption it would have granted.
-func runtimeObjectRoot(ctx rule.RuleContext, receiver *ast.Node) (string, bool) {
+// It is also deliberately narrow: failing to recognize the object only costs
+// the exemption it would have granted.
+func isRuntimeObject(ctx rule.RuleContext, receiver *ast.Node) bool {
 	receiver = internalUtils.SkipAssertionsAndParens(receiver)
 	if receiver == nil {
-		return "", false
+		return false
 	}
 	if isImportMetaRstest(receiver) {
-		return "import.meta.rstest", true
+		return true
 	}
 	if receiver.Kind == ast.KindIdentifier {
-		local := receiver.AsIdentifier().Text
 		// `rs` and `rstest` are the same object under two names
 		// (packages/core/src/runtime/api/public.ts:63-64), and either may be
 		// imported under a further name of its own.
 		name, _, _ := testFramework.ResolveFunctionIdentifierReference(
-			local,
+			receiver.AsIdentifier().Text,
 			receiver,
 			ctx.TypeChecker,
 			ctx.SourceFile,
 			rstestUtils.RstestImportModule,
 		)
-		if name != "rs" && name != "rstest" {
-			return "", false
-		}
-		return "identifier:" + local, true
+		return name == "rs" || name == "rstest"
 	}
 
 	// A namespace import or whole-module require reaches the same object
 	// through a member: `core.rs.setConfig(...)`.
 	member, namespace := configMethodAndReceiver(receiver)
 	if member != "rs" && member != "rstest" {
-		return "", false
+		return false
 	}
 	namespace = internalUtils.SkipAssertionsAndParens(namespace)
 	if namespace == nil || namespace.Kind != ast.KindIdentifier || ctx.TypeChecker == nil {
-		return "", false
+		return false
 	}
 	symbol := ctx.TypeChecker.GetSymbolAtLocation(namespace)
-	if !testFramework.IsModuleNamespaceSymbol(symbol, rstestUtils.RstestImportModule) {
-		return "", false
-	}
-	return "namespace:" + namespace.AsIdentifier().Text + "." + member, true
+	return testFramework.IsModuleNamespaceSymbol(symbol, rstestUtils.RstestImportModule)
 }
 
 // isImportMetaRstest reports whether node is `import.meta.rstest`, the third

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.md
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.md
@@ -2,17 +2,11 @@
 
 ## Rule Details
 
-Requires every test to run under a timeout that is written down somewhere, rather than falling back to the project-wide default. Stating the budget next to the test makes a slow test a visible decision instead of a silent one, and keeps a hang from consuming the default five seconds before anyone notices.
+Requires every test to declare a timeout instead of relying on the project-wide default. An explicit budget makes a slow test a visible decision and stops a hang from running for the whole default.
 
-A test satisfies the rule in any of three ways, matching how Rstest itself resolves a timeout:
+A timeout can come from the test itself, from an enclosing suite, or from the runtime configuration. `test('name', fn, 5000)` and `test('name', { timeout: 5000 }, fn)` both declare one, and `0` counts because it disables the timeout, while a negative value does not. A [suite](https://rstest.rs/api/runtime-api/test-api/describe) timeout applies to the tests nested inside it, and `rs.setConfig({ testTimeout })` covers the tests after it until `resetConfig()` restores the [default](https://rstest.rs/config/test/test-timeout).
 
-- **Its own timeout.** Either overload counts — the trailing number in `test(name, fn, 5000)` and the `timeout` property in `test(name, { timeout: 5000 }, fn)`. `0` disables the timeout in Rstest and so counts as a decision; a negative value does not.
-- **A timeout on an enclosing suite.** Rstest applies suite options as defaults to the tests inside them, so `describe('slow', { timeout: 30_000 }, ...)` covers every test in that suite, however deeply nested.
-- **A configured runtime timeout.** `rs.setConfig({ testTimeout: 30_000 })` covers the tests registered after it. A later `resetConfig()` on the same binding puts the default back, and the tests after that are reported again. The utility object is recognized as `rs`, `rstest`, `import.meta.rstest`, a namespace member, and a `require` binding, under whatever local name it was imported as.
-
-Registrations with nothing to time out are left alone: `test.todo(...)`, `test.skip(...)`, and a registration with no callback at all — the last of those is `rstest/prefer-todo`'s subject. Parameterized registrations are included, and so are tests whose callback is a named function rather than an inline one.
-
-The rule reports only what it can read. A timeout that arrives through an unreadable expression — an imported constant, a function call, a spread into the options object, a `let` binding — is taken at face value as a timeout the author wrote down, and the test is not reported. The same goes for a test inside a function this rule cannot tie back to a `describe`, such as one handed to `describe` by name: it could belong to a timed suite, so it is left alone.
+Globals, imports, aliases, namespace members, `import.meta.rstest`, parameterized tests, named callbacks, and Playwright integrations are recognized. `test.todo`, `test.skip`, and registrations without a callback are exempt. A timeout the rule cannot resolve statically, such as an imported constant or a spread into the options object, counts as declared, as does a test inside a function that cannot be tied to a suite.
 
 ## Incorrect
 
@@ -21,9 +15,9 @@ test('imports the catalog', async () => {
   await importCatalog(fixture);
 });
 
-describe('catalog', () => {
-  it('exports the catalog', async () => {
-    await exportCatalog();
+describe('catalog export', () => {
+  it('writes every row', async () => {
+    await exportCatalog(destination);
   });
 });
 ```
@@ -35,31 +29,9 @@ test('imports the catalog', async () => {
   await importCatalog(fixture);
 }, 30_000);
 
-describe('catalog', { timeout: 30_000 }, () => {
-  it('exports the catalog', async () => {
-    await exportCatalog();
+describe('catalog export', { timeout: 30_000 }, () => {
+  it('writes every row', async () => {
+    await exportCatalog(destination);
   });
 });
 ```
-
-```ts
-rs.setConfig({ testTimeout: 30_000 });
-
-test('imports the catalog', async () => {
-  await importCatalog(fixture);
-});
-```
-
-## Differences from the Vitest rule
-
-Rstest resolves a test's timeout differently from Vitest, and the two Rstest-only steps are modeled here. A `timeout` declared on an enclosing `describe` exempts the tests inside it, because the Rstest runner applies suite options as defaults. A `resetConfig()` positioned between a `setConfig({ testTimeout })` and a test cancels the exemption that `setConfig` granted. The upstream rule models neither, because Vitest's rule looks no further than the registration and the `setConfig` call.
-
-The upstream rule reports a timeout it cannot resolve to a number — `{ timeout: 'soon' }`, `{ ...options }`, a `let` binding, a value returned by a function. This rule stays silent on all of them. TypeScript already rejects a `timeout` that is not a number, so a lint report there adds nothing but the risk of flagging a test whose timeout is perfectly real and merely written somewhere this rule cannot follow.
-
-A call with more arguments than either Rstest overload accepts matches neither one, and is left alone rather than scanned argument by argument for a timeout as upstream does.
-
-Tests whose callback is passed by name are reported. Upstream looks for an inline function argument and so skips them, though such a test needs a timeout no less than an inline one does.
-
-`xit` and the other `x`-prefixed aliases have no equivalent branch here, because Rstest does not export them.
-
-This rule offers no autofix. What a test's timeout should be is a decision about the code under test, not something a linter can supply.

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.md
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout.md
@@ -1,0 +1,65 @@
+# require-test-timeout
+
+## Rule Details
+
+Requires every test to run under a timeout that is written down somewhere, rather than falling back to the project-wide default. Stating the budget next to the test makes a slow test a visible decision instead of a silent one, and keeps a hang from consuming the default five seconds before anyone notices.
+
+A test satisfies the rule in any of three ways, matching how Rstest itself resolves a timeout:
+
+- **Its own timeout.** Either overload counts — the trailing number in `test(name, fn, 5000)` and the `timeout` property in `test(name, { timeout: 5000 }, fn)`. `0` disables the timeout in Rstest and so counts as a decision; a negative value does not.
+- **A timeout on an enclosing suite.** Rstest applies suite options as defaults to the tests inside them, so `describe('slow', { timeout: 30_000 }, ...)` covers every test in that suite, however deeply nested.
+- **A configured runtime timeout.** `rs.setConfig({ testTimeout: 30_000 })` covers the tests registered after it. A later `resetConfig()` on the same binding puts the default back, and the tests after that are reported again. The utility object is recognized as `rs`, `rstest`, `import.meta.rstest`, a namespace member, and a `require` binding, under whatever local name it was imported as.
+
+Registrations with nothing to time out are left alone: `test.todo(...)`, `test.skip(...)`, and a registration with no callback at all — the last of those is `rstest/prefer-todo`'s subject. Parameterized registrations are included, and so are tests whose callback is a named function rather than an inline one.
+
+The rule reports only what it can read. A timeout that arrives through an unreadable expression — an imported constant, a function call, a spread into the options object, a `let` binding — is taken at face value as a timeout the author wrote down, and the test is not reported. The same goes for a test inside a function this rule cannot tie back to a `describe`, such as one handed to `describe` by name: it could belong to a timed suite, so it is left alone.
+
+## Incorrect
+
+```ts
+test('imports the catalog', async () => {
+  await importCatalog(fixture);
+});
+
+describe('catalog', () => {
+  it('exports the catalog', async () => {
+    await exportCatalog();
+  });
+});
+```
+
+## Correct
+
+```ts
+test('imports the catalog', async () => {
+  await importCatalog(fixture);
+}, 30_000);
+
+describe('catalog', { timeout: 30_000 }, () => {
+  it('exports the catalog', async () => {
+    await exportCatalog();
+  });
+});
+```
+
+```ts
+rs.setConfig({ testTimeout: 30_000 });
+
+test('imports the catalog', async () => {
+  await importCatalog(fixture);
+});
+```
+
+## Differences from the Vitest rule
+
+Rstest resolves a test's timeout differently from Vitest, and the two Rstest-only steps are modeled here. A `timeout` declared on an enclosing `describe` exempts the tests inside it, because the Rstest runner applies suite options as defaults. A `resetConfig()` positioned between a `setConfig({ testTimeout })` and a test cancels the exemption that `setConfig` granted. The upstream rule models neither, because Vitest's rule looks no further than the registration and the `setConfig` call.
+
+The upstream rule reports a timeout it cannot resolve to a number — `{ timeout: 'soon' }`, `{ ...options }`, a `let` binding, a value returned by a function. This rule stays silent on all of them. TypeScript already rejects a `timeout` that is not a number, so a lint report there adds nothing but the risk of flagging a test whose timeout is perfectly real and merely written somewhere this rule cannot follow.
+
+A call with more arguments than either Rstest overload accepts matches neither one, and is left alone rather than scanned argument by argument for a timeout as upstream does.
+
+Tests whose callback is passed by name are reported. Upstream looks for an inline function argument and so skips them, though such a test needs a timeout no less than an inline one does.
+
+`xit` and the other `x`-prefixed aliases have no equivalent branch here, because Rstest does not export them.
+
+This rule offers no autofix. What a test's timeout should be is a decision about the code under test, not something a linter can supply.

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_extras_test.go
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_extras_test.go
@@ -1,0 +1,412 @@
+// TestRequireTestTimeoutExtras locks in the Rstest-only augmentation the port
+// spec asks for: every registration source, every registration shape, the
+// Dimension 4 edge shapes each child-node access has to survive, and the two
+// exemptions Rstest has that the Vitest rule never modeled — suite-level
+// inheritance and the runtime config object.
+package require_test_timeout_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_test_timeout"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireTestTimeoutExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&require_test_timeout.RequireTestTimeoutRule,
+		[]rule_tester.ValidTestCase{
+			// ---- A. Reverse registration sources ----
+			{Code: `import { test } from 'vitest'; test("a", () => {})`},
+			{Code: `import { test } from '@jest/globals'; test("a", () => {})`},
+			{Code: `import { it } from 'node:test'; it("a", () => {})`},
+			{Code: `import { test } from './helpers'; test("a", () => {})`},
+			// A local declaration shadows the Rstest global.
+			{Code: `function test(name, fn) {}
+test("a", () => {})`},
+			{Code: `const it = (name, fn) => {};
+it("a", () => {})`},
+
+			// ---- B. Registrations this rule does not own ----
+			{Code: `test.todo("a")`},
+			{Code: `test.todo("a", () => {})`},
+			{Code: `it.todo("a")`},
+			{Code: `test.skip("a", () => {})`},
+			{Code: `test.skip.each([1])("a %i", () => {})`},
+			// A skip carried in through an alias is still a skip: the parser
+			// records it as a semantic conclusion, not a call-site member.
+			{Code: `const s = test.skip; s("a", () => {})`},
+			// Suites and hooks are not tests.
+			{Code: `describe("s", () => {})`},
+			{Code: `beforeEach(() => {})`},
+			{Code: `afterAll(() => {}, 500)`},
+			// A registration with no callback has no body to time out;
+			// reporting it belongs to rstest/prefer-todo.
+			{Code: `test("a")`},
+			{Code: `test()`},
+			{Code: `test("a", ...rest)`},
+			{Code: `test(...args)`},
+			// The callback is imported, so the parser cannot see the function
+			// it registers and the rule declines to guess.
+			{Code: `import { handler } from './handler'; test("a", handler)`},
+
+			// ---- C. Own timeout, numeric forms ----
+			{Code: `test("a", () => {}, 0)`},
+			{Code: `test("a", () => {}, -0)`},
+			{Code: `test("a", () => {}, +500)`},
+			{Code: `test("a", () => {}, 5e3)`},
+			{Code: `test("a", () => {}, 0x1f)`},
+			{Code: `test("a", () => {}, 5_000)`},
+			{Code: `test("a", () => {}, 1.5)`},
+			// A BigInt is not a number, so it is left unread rather than
+			// reported.
+			{Code: `test("a", () => {}, 500n)`},
+
+			// ---- C. Own timeout, options forms ----
+			{Code: `test("a", { timeout: 500 }, () => {})`},
+			{Code: `test("a", { "timeout": 500 }, () => {})`},
+			{Code: `test("a", { ["timeout"]: 500 }, () => {})`},
+			{Code: "test(\"a\", { [`timeout`]: 500 }, () => {})"},
+			{Code: `const timeout = 500; test("a", { timeout }, () => {})`},
+			{Code: `test("a", { timeout: 500, retry: 2 }, () => {})`},
+			// A computed key could be `timeout`, and a spread could carry it.
+			{Code: `test("a", { [key]: 500 }, () => {})`},
+			{Code: `test("a", { ...options }, () => {})`},
+			// A `timeout` that is not a readable number leaves the options
+			// object unread rather than reported.
+			{Code: `test("a", { timeout: getTimeout() }, () => {})`},
+			{Code: `test("a", { timeout: "500" }, () => {})`},
+			{Code: `test("a", { timeout() { return 500 } }, () => {})`},
+
+			// ---- C. Own timeout, resolved through a const ----
+			{Code: `const t = 500; test("a", () => {}, t)`},
+			{Code: `const options = { timeout: 500 }; test("a", options, () => {})`},
+			{Code: `const options = { timeout: t }; test("a", options, () => {})`},
+			{Code: `let t = 500; test("a", () => {}, t)`},
+			{Code: `var t = 500; test("a", () => {}, t)`},
+			{Code: `test("a", () => {}, t)`},
+
+			// ---- D. Dimension 4 edge shapes ----
+			// Parentheses and TypeScript assertions around the arguments.
+			{Code: `test("a", (() => {}), (500))`},
+			{Code: `test("a", ((() => {})), ((500)))`},
+			{Code: `test("a", () => {}, 500 as number)`},
+			{Code: `test("a", () => {}, 500!)`},
+			{Code: `test("a", { timeout: 500 } satisfies Options, () => {})`},
+			{Code: `test("a", { timeout: (500) }, () => {})`},
+			{Code: `const t = (500); test("a", () => {}, t)`},
+			// Optional call and optional member access on the registration.
+			{Code: `test?.("a", () => {}, 500)`},
+			{Code: `test?.only("a", () => {}, 500)`},
+			// Member accessor spellings, including one split over lines.
+			{Code: `test["concurrent"]("a", () => {}, 500)`},
+			{Code: "test[`concurrent`](\"a\", () => {}, 500)"},
+			{Code: `test
+  // registers concurrently
+  .concurrent("a", () => {}, 500)`},
+			// N/A: private identifiers. This rule reads registration arguments
+			// and object literal keys, neither of which can be a `#name`.
+
+			// ---- E. Parameterized registrations ----
+			{Code: `test.each([1, 2])("case %i", (n) => {}, 500)`},
+			{Code: `test.for([1, 2])("case %s", (n) => {}, 500)`},
+			{Code: `test.each([1, 2])("case %i", { timeout: 500 }, (n) => {})`},
+			{Code: "test.each`\n  a\n  ${1}\n`(\"case $a\", ({ a }) => {}, 500)"},
+			{Code: `test.runIf(ready)("a", () => {}, 500)`},
+			{Code: `test.skipIf(broken)("a", () => {}, 500)`},
+			{Code: `test.fails("a", () => {}, 500)`},
+			{Code: `test.sequential("a", () => {}, 500)`},
+			{Code: `test.extend({})("a", () => {}, 500)`},
+
+			// ---- F. Registration sources that do report, shown timed ----
+			{Code: `import { test } from '@rstest/core'; test("a", () => {}, 500)`},
+			{Code: `import { it as check } from '@rstest/core'; check("a", () => {}, 500)`},
+			{Code: `import * as core from '@rstest/core'; core.test("a", () => {}, 500)`},
+			{Code: `const { test } = require('@rstest/core'); test("a", () => {}, 500)`},
+			{Code: `import.meta.rstest.test("a", () => {}, 500)`},
+			{Code: `import { test } from '@rstest/playwright'; test("a", () => {}, 500)`},
+
+			// ---- G. Suite-level inheritance ----
+			// Rstest applies suite options as defaults
+			// (packages/core/src/runtime/runner/runtime.ts), so a test inside a
+			// timed suite already has a definite timeout.
+			{Code: `describe("s", { timeout: 5000 }, () => { test("a", () => {}) })`},
+			{Code: `describe("s", () => { test("a", () => {}) }, 5000)`},
+			{Code: `describe("outer", { timeout: 5000 }, () => { describe("inner", () => { test("a", () => {}) }) })`},
+			{Code: `describe("s", { timeout: 5000 }, function () { test("a", () => {}) })`},
+			{Code: `describe.each([1])("s %i", () => { test("a", () => {}) }, 5000)`},
+			{Code: `const options = { timeout: 5000 }; describe("s", options, () => { test("a", () => {}) })`},
+			// An options object the rule cannot read may still carry a timeout.
+			{Code: `describe("s", options, () => { test("a", () => {}) })`},
+			// The suite's own timeout still counts through an intermediate
+			// callback, because the test is registered while the suite runs.
+			{Code: `describe("s", { timeout: 5000 }, () => { [1, 2].forEach(() => { test("a", () => {}) }) })`},
+			// A function this rule cannot tie back to a call argument could be
+			// registered under any suite, so the walk gives up rather than
+			// guess which one.
+			{Code: `function suite() { test("a", () => {}) }
+describe("s", { timeout: 5000 }, suite)`},
+			{Code: `function suite() { test("a", () => {}) }
+describe("s", suite)`},
+			{Code: `(function () { test("a", () => {}) })()`},
+			{Code: `class Suite { register() { test("a", () => {}) } }`},
+
+			// ---- H. Runtime config through the utility object ----
+			{Code: `rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `rstest.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `rs.setConfig({ testTimeout: 0 }); test("a", () => {})`},
+			{Code: `rs["setConfig"]({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: "rs[`setConfig`]({ testTimeout: 5000 }); test(\"a\", () => {})"},
+			{Code: `rs?.setConfig?.({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `import.meta.rstest.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `import { rs as runtime } from '@rstest/core'; runtime.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `import * as core from '@rstest/core'; core.rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `const core = require('@rstest/core'); core.rstest.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `const { rs } = require('@rstest/core'); rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `const config = { testTimeout: 5000 }; rs.setConfig(config); test("a", () => {})`},
+			// A configuration object the rule cannot read may still set the
+			// test timeout.
+			{Code: `rs.setConfig(config); test("a", () => {})`},
+			{Code: `rs.setConfig({ ...config }); test("a", () => {})`},
+			{Code: `rs.setConfig({ [key]: 5000 }); test("a", () => {})`},
+			{Code: `rs.setConfig({ testTimeout: getTimeout() }); test("a", () => {})`},
+			// A reset only cancels the configuration on the same binding.
+			{Code: `rs.setConfig({ testTimeout: 5000 }); rstest.resetConfig(); test("a", () => {})`},
+			{Code: `rs.setConfig({ testTimeout: 5000 }); rs.resetConfig(); rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			{Code: `rs.resetConfig(); rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
+			// The configuration applies to every test registered after it.
+			{Code: `rs.setConfig({ testTimeout: 5000 }); test("a", () => {}); test("b", () => {})`},
+			// The exemption is positional, so a configuration written inside an
+			// earlier test's callback covers the tests that follow it in the
+			// source. Whether that callback has run by then is not something
+			// the rule can see, and assuming it has not would report a test
+			// whose timeout is configured.
+			{Code: `test("a", () => { rs.setConfig({ testTimeout: 5000 }) }, 5); test("b", () => {})`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- A. Registration sources ----
+			invalidCase(
+				`import { test } from '@rstest/core'; test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`import { it as check } from '@rstest/core'; check("a", () => {})`,
+				`check("a", () => {})`,
+			),
+			invalidCase(
+				`import * as core from '@rstest/core'; core.test("a", () => {})`,
+				`core.test("a", () => {})`,
+			),
+			invalidCase(
+				`const { test } = require('@rstest/core'); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`import.meta.rstest.test("a", () => {})`,
+				`import.meta.rstest.test("a", () => {})`,
+			),
+			invalidCase(
+				`const { test } = import.meta.rstest; test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`import { test } from '@rstest/playwright'; test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			// A plain same-file alias is followed through to the registration.
+			invalidCase(`const t = test; t("a", () => {})`, `t("a", () => {})`),
+
+			// ---- B. Registration shapes ----
+			invalidCase(`test.each([1, 2])("case %i", (n) => {})`, `test.each([1, 2])("case %i", (n) => {})`),
+			invalidCase(`test.for([1, 2])("case %s", (n) => {})`, `test.for([1, 2])("case %s", (n) => {})`),
+			invalidCase(
+				"test.each`\n  a\n  ${1}\n`(\"case $a\", ({ a }) => {})",
+				"test.each`\n  a\n  ${1}\n`(\"case $a\", ({ a }) => {})",
+			),
+			invalidCase(`test.runIf(ready)("a", () => {})`, `test.runIf(ready)("a", () => {})`),
+			invalidCase(`test.fails("a", () => {})`, `test.fails("a", () => {})`),
+			invalidCase(`test.sequential("a", () => {})`, `test.sequential("a", () => {})`),
+			invalidCase(`test["concurrent"]("a", () => {})`, `test["concurrent"]("a", () => {})`),
+			invalidCase(`test?.("a", () => {})`, `test?.("a", () => {})`),
+			invalidCase(
+				`test
+  // registers concurrently
+  .concurrent("a", () => {})`,
+				`test
+  // registers concurrently
+  .concurrent("a", () => {})`,
+			),
+
+			// ---- C. Callbacks named rather than inlined ----
+			// Upstream only looks for an inline function and so never reports
+			// these. A named callback needs a timeout just as much.
+			invalidCase(
+				`const handler = () => {}; test("a", handler)`,
+				`test("a", handler)`,
+			),
+			invalidCase(
+				`function handler() {} test("a", handler)`,
+				`test("a", handler)`,
+			),
+			// A function named in the timeout slot is provably not a number.
+			invalidCase(
+				`function t() {} test("a", () => {}, t)`,
+				`test("a", () => {}, t)`,
+			),
+
+			// ---- D. Options that are fully readable and carry no timeout ----
+			invalidCase(`test("a", { retry: 2 }, () => {})`, `test("a", { retry: 2 }, () => {})`),
+			invalidCase(`test("a", {}, () => {})`, `test("a", {}, () => {})`),
+			invalidCase(`test("a", { 5: 1 }, () => {})`, `test("a", { 5: 1 }, () => {})`),
+			invalidCase(
+				`const options = { retry: 2 }; test("a", options, () => {})`,
+				`test("a", options, () => {})`,
+			),
+
+			// ---- D. Negative timeouts ----
+			// Rstest already spells "no limit" as `0`, so a negative value
+			// leaves the test without a usable timeout.
+			invalidCase(`test("a", () => {}, -1)`, `test("a", () => {}, -1)`),
+			invalidCase(`test("a", { timeout: -1 }, () => {})`, `test("a", { timeout: -1 }, () => {})`),
+			invalidCase(
+				`const t = -1; test("a", () => {}, t)`,
+				`test("a", () => {}, t)`,
+			),
+
+			// ---- E. Suite inheritance that does not apply ----
+			invalidCase(
+				`describe("s", () => { test("a", () => {}) })`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`describe("s", { retry: 2 }, () => { test("a", () => {}) })`,
+				`test("a", () => {})`,
+			),
+			// The suite is a Vitest one, so its options never reach an Rstest
+			// test.
+			invalidCase(
+				`import { describe } from 'vitest'; describe("s", { timeout: 5000 }, () => { test("a", () => {}) })`,
+				`test("a", () => {})`,
+			),
+			// Every test in the suite is reported, not just the first.
+			invalidCase(
+				`describe("s", () => { test("a", () => {}); test("b", () => {}) })`,
+				`test("a", () => {})`,
+				`test("b", () => {})`,
+			),
+			invalidCase(
+				`[1, 2].forEach(() => { test("a", () => {}) })`,
+				`test("a", () => {})`,
+			),
+
+			// ---- F. Runtime config that does not exempt ----
+			invalidCase(`rs.setConfig({}); test("a", () => {})`, `test("a", () => {})`),
+			invalidCase(`rs.setConfig({ retry: 2 }); test("a", () => {})`, `test("a", () => {})`),
+			invalidCase(
+				`rs.setConfig({ testTimeout: -1 }); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`rs.setConfig({ testTimeout: 5000 }); rs.resetConfig(); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`rs.setConfig({ testTimeout: 5000 }); rs["resetConfig"](); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			// The utility object is not Rstest's.
+			invalidCase(`vi.setConfig({ testTimeout: 5000 }); test("a", () => {})`, `test("a", () => {})`),
+			invalidCase(
+				`import { rs } from 'vitest'; rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`const rs = { setConfig(config) {} }; rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`import * as other from 'vitest'; other.rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+		},
+	)
+}
+
+// TestRequireTestTimeoutEditDemand locks in that the diagnostic never changes
+// with edit demand. This rule offers neither a fix nor a suggestion: the
+// timeout a test should get is the author's call, not the linter's.
+func TestRequireTestTimeoutEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`test("a", () => {});
+describe("s", () => { it("b", () => {}) });`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name:     require_test_timeout.RequireTestTimeoutRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return require_test_timeout.RequireTestTimeoutRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	allEdits := run(rule.EditDemandAll)
+	for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+	} {
+		for index := range allEdits {
+			if !reflect.DeepEqual(diagnostics[index], allEdits[index]) {
+				t.Errorf("demand %d diagnostic %d changed:\ngot  %#v\nwant %#v",
+					demand, index, diagnostics[index], allEdits[index])
+			}
+		}
+	}
+	for _, diagnostic := range allEdits {
+		if diagnostic.FixesPtr != nil {
+			t.Fatal("require-test-timeout unexpectedly materialized fixes")
+		}
+		if diagnostic.Suggestions != nil {
+			t.Fatal("require-test-timeout unexpectedly materialized suggestions")
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_extras_test.go
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_extras_test.go
@@ -81,6 +81,13 @@ it("a", () => {})`},
 			// A computed key could be `timeout`, and a spread could carry it.
 			{Code: `test("a", { [key]: 500 }, () => {})`},
 			{Code: `test("a", { ...options }, () => {})`},
+			// Later members overwrite earlier ones, so a spread or a computed
+			// key after an explicit `timeout` can still supply the timeout.
+			{Code: `test("a", { timeout: -1, ...options }, () => {})`},
+			{Code: `test("a", { timeout: -1, [key]: 500 }, () => {})`},
+			{Code: `test("a", { timeout: -1, timeout: 500 }, () => {})`},
+			{Code: `test("a", { retry: 2, ...options }, () => {})`},
+			{Code: `rs.setConfig({ testTimeout: -1, ...config }); test("a", () => {})`},
 			// A `timeout` that is not a readable number leaves the options
 			// object unread rather than reported.
 			{Code: `test("a", { timeout: getTimeout() }, () => {})`},
@@ -179,8 +186,6 @@ describe("s", suite)`},
 			{Code: `rs.setConfig({ ...config }); test("a", () => {})`},
 			{Code: `rs.setConfig({ [key]: 5000 }); test("a", () => {})`},
 			{Code: `rs.setConfig({ testTimeout: getTimeout() }); test("a", () => {})`},
-			// A reset only cancels the configuration on the same binding.
-			{Code: `rs.setConfig({ testTimeout: 5000 }); rstest.resetConfig(); test("a", () => {})`},
 			{Code: `rs.setConfig({ testTimeout: 5000 }); rs.resetConfig(); rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
 			{Code: `rs.resetConfig(); rs.setConfig({ testTimeout: 5000 }); test("a", () => {})`},
 			// The configuration applies to every test registered after it.
@@ -281,6 +286,26 @@ describe("s", suite)`},
 				`const t = -1; test("a", () => {}, t)`,
 				`test("a", () => {}, t)`,
 			),
+			// An explicit member after a spread has the last word.
+			invalidCase(
+				`test("a", { ...options, timeout: -1 }, () => {})`,
+				`test("a", { ...options, timeout: -1 }, () => {})`,
+			),
+			invalidCase(
+				`test("a", { timeout: 500, timeout: -1 }, () => {})`,
+				`test("a", { timeout: 500, timeout: -1 }, () => {})`,
+			),
+
+			// ---- E. A suite timeout the rule refuses on a test ----
+			// A negative suite timeout is not a timeout its tests can use.
+			invalidCase(
+				`describe("s", { timeout: -1 }, () => { test("a", () => {}) })`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`describe("s", () => { test("a", () => {}) }, -1)`,
+				`test("a", () => {})`,
+			),
 
 			// ---- E. Suite inheritance that does not apply ----
 			invalidCase(
@@ -321,6 +346,21 @@ describe("s", suite)`},
 			),
 			invalidCase(
 				`rs.setConfig({ testTimeout: 5000 }); rs["resetConfig"](); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			// `rs`, `rstest` and `import.meta.rstest` name one runtime
+			// configuration, so a reset on any spelling cancels a `setConfig`
+			// written on any other.
+			invalidCase(
+				`rs.setConfig({ testTimeout: 5000 }); rstest.resetConfig(); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`rstest.setConfig({ testTimeout: 5000 }); import.meta.rstest.resetConfig(); test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+			invalidCase(
+				`import * as core from '@rstest/core'; core.rs.setConfig({ testTimeout: 5000 }); rstest.resetConfig(); test("a", () => {})`,
 				`test("a", () => {})`,
 			),
 			// The utility object is not Rstest's.

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_upstream_test.go
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_upstream_test.go
@@ -1,0 +1,155 @@
+// TestRequireTestTimeoutUpstream migrates the upstream Vitest suite one case at
+// a time. Cases upstream reports but this port deliberately accepts are kept
+// here, in the valid list, each labelled with what upstream does — see the
+// "Differences from the Vitest rule" section of require_test_timeout.md.
+package require_test_timeout_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_test_timeout"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const missingTimeoutMessage = "Test is missing a timeout. Add an explicit timeout."
+
+// invalidCase builds the expected diagnostics by locating the source text of
+// each reported registration, so a case stays readable while still asserting
+// the whole range the rule reports.
+func invalidCase(code string, calls ...string) rule_tester.InvalidTestCase {
+	errors := make([]rule_tester.InvalidTestCaseError, 0, len(calls))
+	searchFrom := 0
+	for _, call := range calls {
+		offset := strings.Index(code[searchFrom:], call)
+		if offset < 0 {
+			panic("registration not found in test code: " + call)
+		}
+		start := searchFrom + offset
+		searchFrom = start + len(call)
+		line, column := positionOf(code, start)
+		endLine, endColumn := positionOf(code, start+len(call))
+		errors = append(errors, rule_tester.InvalidTestCaseError{
+			MessageId: "missingTimeout",
+			Message:   missingTimeoutMessage,
+			Line:      line,
+			Column:    column,
+			EndLine:   endLine,
+			EndColumn: endColumn,
+		})
+	}
+	return rule_tester.InvalidTestCase{Code: code, Errors: errors}
+}
+
+func positionOf(code string, offset int) (int, int) {
+	line, column := 1, 1
+	for _, character := range code[:offset] {
+		if character == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return line, column
+}
+
+func TestRequireTestTimeoutUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&require_test_timeout.RequireTestTimeoutRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `test.todo("a")`},
+			// Upstream skips names beginning with `x`. Rstest exports no `xit`,
+			// so this call registers nothing the rule knows about.
+			{Code: `xit("a", () => {})`},
+			{Code: `test("a", () => {}, 0)`},
+			{Code: `it("a", () => {}, 500)`},
+			{Code: `it.skip("a", () => {})`},
+			{Code: `test.skip("a", () => {})`},
+			{Code: `test("a", () => {}, 1000)`},
+			{Code: `it.only("a", () => {}, 1234)`},
+			{Code: `test.only("a", () => {}, 1234)`},
+			{Code: `it.concurrent("a", () => {}, 400)`},
+			{Code: `test("a", () => {}, { timeout: 0 })`},
+			{Code: `test.concurrent("a", () => {}, 400)`},
+			{Code: `test("a", () => {}, { timeout: 500 })`},
+			{Code: `test("a", { timeout: 500 }, () => {})`},
+			{Code: `const t = 500; test("a", { timeout: t }, () => {})`},
+			{Code: `const t = 500; test("a", () => {}, t)`},
+			{Code: `const opts = { timeout: 500 }; test("a", opts, () => {})`},
+			{Code: `const T = 1000; rs.setConfig({ testTimeout: T }); test("a", () => {})`},
+			{Code: `rs.setConfig({ testTimeout: 1000 }); test("a", () => {})`},
+
+			// Mirrored `it` variants.
+			{Code: `const t = 500; it("a", { timeout: t }, () => {})`},
+			{Code: `const t = 500; it("a", () => {}, t)`},
+			{Code: `const opts = { timeout: 500 }; it("a", opts, () => {})`},
+			{Code: `const T = 1000; rs.setConfig({ testTimeout: T }); it("a", () => {})`},
+			{Code: `rs.setConfig({ testTimeout: 1000 }); it("a", () => {})`},
+
+			// More arguments than either Rstest overload takes.
+			{Code: `test("a", { foo: 1 }, { timeout: 500 }, () => {})`},
+			{Code: `test("a", { timeout: 500 }, 1000, () => {})`},
+			{Code: `test("a", () => {}, 1000, { extra: true })`},
+
+			// In-source unit tests.
+			{Code: `if (import.meta.rstest) { const opts = { timeout: 500 }; describe("outer", () => { it("repro: same-file opts object", opts, () => {}); }); }`},
+			{Code: `if (import.meta.rstest) { const T = 500; describe("outer", () => { describe("inner", () => { it("repro: same-file const timeout", () => {}, T); }); }); }`},
+
+			// An imported binding named in the timeout position.
+			{Code: `import { TIMEOUT } from "./test-constants"; test("a", () => {}, TIMEOUT)`},
+			{Code: `import { TIMEOUT } from "./test-constants"; it("a", () => {}, TIMEOUT)`},
+			{Code: `import { TIMEOUT } from "./test-constants"; test("a", () => {}, { timeout: TIMEOUT })`},
+			{Code: `import { TIMEOUT } from "./test-constants"; test("a", { timeout: TIMEOUT }, () => {})`},
+			{Code: `import { OPTS } from "./test-constants"; test("a", OPTS, () => {})`},
+			{Code: `import T from "./test-constants"; test("a", () => {}, T)`},
+
+			// ---- Upstream reports these; this port stays silent ----
+			// Upstream resolves the timeout identifier and reports every
+			// binding it fails to prove is a numeric `const`. A binding this
+			// rule cannot read still means the author wrote a timeout down, so
+			// reading it wrong is the only way to produce a false report.
+			{Code: `let t = 500; test("a", () => {}, t)`},
+			{Code: `let t = 500; it("a", () => {}, t)`},
+			{Code: `const t = getTimeout(); test("a", () => {}, t)`},
+			{Code: `const t = getTimeout(); it("a", () => {}, t)`},
+			// Upstream's `Number.NaN` branch reports a `timeout` property whose
+			// value is not a number. TypeScript already rejects these, so the
+			// only thing a lint report adds is noise.
+			{Code: `test("a", () => {}, { timeout: null })`},
+			{Code: `test("a", () => {}, { timeout: undefined })`},
+			{Code: `rs.setConfig({ testTimeout: null }); test("a", () => {})`},
+			{Code: `rs.setConfig({ testTimeout: undefined }); test("a", () => {})`},
+			// A spread can carry `timeout`, and upstream reports it anyway.
+			{Code: `const opts = { timeout: 1000 }; test("a", { ...opts }, () => {})`},
+			{Code: `const opts = { timeout: 1000 }; test("a", { ...opts }, { foo: 1 }, () => {})`},
+			// Upstream scans every argument for a negative timeout. None of
+			// these calls matches an Rstest overload at all.
+			{Code: `test("a", () => {}, { timeout: -1 }, { timeout: 500 })`},
+			{Code: `test("a", () => {}, { timeout: 500 }, { timeout: -1 })`},
+			{Code: `test("a", () => {}, { timeout: -1 }, 1000)`},
+			{Code: `test("a", () => {}, 1000, { timeout: -1 })`},
+		},
+		[]rule_tester.InvalidTestCase{
+			invalidCase(`test("a", () => {})`, `test("a", () => {})`),
+			invalidCase(`it("a", () => {})`, `it("a", () => {})`),
+			invalidCase(`test.only("a", () => {})`, `test.only("a", () => {})`),
+			invalidCase(`test.concurrent("a", () => {})`, `test.concurrent("a", () => {})`),
+			invalidCase(`it.concurrent("a", () => {})`, `it.concurrent("a", () => {})`),
+			invalidCase(`rs.setConfig({}); test("a", () => {})`, `test("a", () => {})`),
+			invalidCase(`test("a", () => {}, -100)`, `test("a", () => {}, -100)`),
+			invalidCase(`test("a", () => {}, { timeout: -1 })`, `test("a", () => {}, { timeout: -1 })`),
+			// A `setConfig` after the test does not reach back to it.
+			invalidCase(`test("a", () => {}); rs.setConfig({ testTimeout: 1000 })`, `test("a", () => {})`),
+			// An import elsewhere in the file is not a timeout.
+			invalidCase(
+				`import { TIMEOUT } from "./test-constants"; test("a", () => {})`,
+				`test("a", () => {})`,
+			),
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_upstream_test.go
+++ b/internal/plugins/rstest/rules/require_test_timeout/require_test_timeout_upstream_test.go
@@ -1,7 +1,7 @@
 // TestRequireTestTimeoutUpstream migrates the upstream Vitest suite one case at
 // a time. Cases upstream reports but this port deliberately accepts are kept
-// here, in the valid list, each labelled with what upstream does — see the
-// "Differences from the Vitest rule" section of require_test_timeout.md.
+// here, in the valid list, each labelled with what upstream does and why this
+// rule stays silent.
 package require_test_timeout_test
 
 import (

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -609,6 +609,7 @@ export default defineConfig({
     './tests/rstest/rules/prefer-hooks-in-order.test.ts',
     './tests/rstest/rules/prefer-todo.test.ts',
     './tests/rstest/rules/require-local-test-context-for-concurrent-snapshots.test.ts',
+    './tests/rstest/rules/require-test-timeout.test.ts',
     './tests/rstest/rules/valid-expect-in-promise.test.ts',
     './tests/rstest/rules/valid-expect.test.ts',
     './tests/rstest/rules/valid-title.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/require-test-timeout.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/require-test-timeout.test.ts
@@ -1,0 +1,211 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-test-timeout', {} as never, {
+  valid: [
+    { code: `test.todo("a")` },
+    { code: `xit("a", () => {})` },
+    { code: `test("a", () => {}, 0)` },
+    { code: `it("a", () => {}, 500)` },
+    { code: `it.skip("a", () => {})` },
+    { code: `test.skip("a", () => {})` },
+    { code: `test("a", () => {}, 1000)` },
+    { code: `it.only("a", () => {}, 1234)` },
+    { code: `test.only("a", () => {}, 1234)` },
+    { code: `it.concurrent("a", () => {}, 400)` },
+    { code: `test("a", () => {}, { timeout: 0 })` },
+    { code: `test.concurrent("a", () => {}, 400)` },
+    { code: `test("a", () => {}, { timeout: 500 })` },
+    { code: `test("a", { timeout: 500 }, () => {})` },
+    { code: `const t = 500; test("a", { timeout: t }, () => {})` },
+    { code: `const t = 500; test("a", () => {}, t)` },
+    { code: `const opts = { timeout: 500 }; test("a", opts, () => {})` },
+    {
+      code: `const T = 1000; rs.setConfig({ testTimeout: T }); test("a", () => {})`,
+    },
+    { code: `rs.setConfig({ testTimeout: 1000 }); test("a", () => {})` },
+    { code: `const t = 500; it("a", { timeout: t }, () => {})` },
+    { code: `const t = 500; it("a", () => {}, t)` },
+    { code: `const opts = { timeout: 500 }; it("a", opts, () => {})` },
+    {
+      code: `const T = 1000; rs.setConfig({ testTimeout: T }); it("a", () => {})`,
+    },
+    { code: `rs.setConfig({ testTimeout: 1000 }); it("a", () => {})` },
+    { code: `test("a", { foo: 1 }, { timeout: 500 }, () => {})` },
+    { code: `test("a", { timeout: 500 }, 1000, () => {})` },
+    { code: `test("a", () => {}, 1000, { extra: true })` },
+    {
+      code: `if (import.meta.rstest) { const opts = { timeout: 500 }; describe("outer", () => { it("repro: same-file opts object", opts, () => {}); }); }`,
+    },
+    {
+      code: `if (import.meta.rstest) { const T = 500; describe("outer", () => { describe("inner", () => { it("repro: same-file const timeout", () => {}, T); }); }); }`,
+    },
+    {
+      code: `import { TIMEOUT } from "./test-constants"; test("a", () => {}, TIMEOUT)`,
+    },
+    {
+      code: `import { TIMEOUT } from "./test-constants"; it("a", () => {}, TIMEOUT)`,
+    },
+    {
+      code: `import { TIMEOUT } from "./test-constants"; test("a", () => {}, { timeout: TIMEOUT })`,
+    },
+    {
+      code: `import { TIMEOUT } from "./test-constants"; test("a", { timeout: TIMEOUT }, () => {})`,
+    },
+    {
+      code: `import { OPTS } from "./test-constants"; test("a", OPTS, () => {})`,
+    },
+    { code: `import T from "./test-constants"; test("a", () => {}, T)` },
+    { code: `let t = 500; test("a", () => {}, t)` },
+    { code: `let t = 500; it("a", () => {}, t)` },
+    { code: `const t = getTimeout(); test("a", () => {}, t)` },
+    { code: `const t = getTimeout(); it("a", () => {}, t)` },
+    { code: `test("a", () => {}, { timeout: null })` },
+    { code: `test("a", () => {}, { timeout: undefined })` },
+    { code: `rs.setConfig({ testTimeout: null }); test("a", () => {})` },
+    { code: `rs.setConfig({ testTimeout: undefined }); test("a", () => {})` },
+    {
+      code: `const opts = { timeout: 1000 }; test("a", { ...opts }, () => {})`,
+    },
+    {
+      code: `const opts = { timeout: 1000 }; test("a", { ...opts }, { foo: 1 }, () => {})`,
+    },
+    { code: `test("a", () => {}, { timeout: -1 }, { timeout: 500 })` },
+    { code: `test("a", () => {}, { timeout: 500 }, { timeout: -1 })` },
+    { code: `test("a", () => {}, { timeout: -1 }, 1000)` },
+    { code: `test("a", () => {}, 1000, { timeout: -1 })` },
+  ],
+  invalid: [
+    {
+      code: `test("a", () => {})`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 20,
+        },
+      ],
+    },
+    {
+      code: `it("a", () => {})`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: `test.only("a", () => {})`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: `test.concurrent("a", () => {})`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 31,
+        },
+      ],
+    },
+    {
+      code: `it.concurrent("a", () => {})`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 29,
+        },
+      ],
+    },
+    {
+      code: `rs.setConfig({}); test("a", () => {})`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 19,
+          endLine: 1,
+          endColumn: 38,
+        },
+      ],
+    },
+    {
+      code: `test("a", () => {}, -100)`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 26,
+        },
+      ],
+    },
+    {
+      code: `test("a", () => {}, { timeout: -1 })`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 37,
+        },
+      ],
+    },
+    {
+      code: `test("a", () => {}); rs.setConfig({ testTimeout: 1000 })`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 20,
+        },
+      ],
+    },
+    {
+      code: `import { TIMEOUT } from "./test-constants"; test("a", () => {})`,
+      errors: [
+        {
+          messageId: 'missingTimeout',
+          message: 'Test is missing a timeout. Add an explicit timeout.',
+          line: 1,
+          column: 45,
+          endLine: 1,
+          endColumn: 64,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Report a test whose timeout is left to the project-wide default, so that a slow test is a visible decision rather than a silent one and a hang does not burn the default five seconds before anyone notices. The rule has no fix: what a test's timeout should be is a judgement about the code under test, not something a linter can supply.

A test is exempt when it has a timeout from any of the three places Rstest itself resolves one from. Its own, in either overload — the trailing number of `test(name, fn, 5000)` and the `timeout` property of `test(name, { timeout: 5000 }, fn)`, where `0` counts because Rstest spells "no limit" that way and a negative value does not. An enclosing suite's, because the runner applies suite options as defaults through `test.timeout ??= current.timeout` (`packages/core/src/runtime/runner/runtime.ts`), so `describe('slow', { timeout: 30_000 }, ...)` covers every test nested inside it. Or a configured runtime timeout, `rs.setConfig({ testTimeout })`, covering the tests that follow it in the source until a `resetConfig()` on the same binding puts the default back.

Registrations resolve through the shared `ParseTestCall`, so globals, named and renamed imports, namespace and whole-module `require`, `import.meta.rstest` and `@rstest/playwright` are all followed, and `.each` / `.for` and the modifier chains are included. `test.todo`, `test.skip` and a registration with no callback at all are left alone — the last of those belongs to `rstest/prefer-todo`. Registered in the rstest plugin but left out of the `recommended` preset, matching upstream.

The rule reports only what it can read. A timeout arriving through an expression it cannot follow — an imported constant, a function call, a spread into the options object, a `let` binding — is taken as a timeout the author wrote down. The same holds for a test inside a function that cannot be tied back to a `describe`, such as one handed to `describe` by name: it may well belong to a timed suite, so it is not reported. Attributing those needs a callback ownership index that this rule deliberately does not build.

The `setConfig` recogniser — `rs` and `rstest` under whatever local name they were imported as, a namespace member, a `require` binding, `import.meta.rstest`, and the unshadowed globals — is private to the rule and allocates nothing until such a call appears in the file. No shared Rstest analysis changed.

## Credits

Port from [`eslint-plugin-vitest`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `require-test-timeout`.

## Intentional differences from upstream

- **A timeout on an enclosing `describe` exempts the tests inside it.** Rstest applies suite options as defaults to the tests they contain, so a test in a timed suite already has a definite timeout and reporting it is a false positive. Upstream models no inheritance, because it looks no further than the registration itself.

- **`resetConfig()` cancels a `setConfig({ testTimeout })`.** Placed between the two, it restores the default, and the tests after it are reported again. Upstream has no reset branch at all.

- **A timeout that cannot be read as a number is not reported.** Upstream reports `{ timeout: 'soon' }`, `{ ...options }`, a `let` binding and a value returned by a function through its `Number.NaN` branch. TypeScript already rejects a `timeout` that is not a number, so a lint report there adds nothing but the risk of flagging a test whose timeout is real and merely written somewhere the rule cannot follow.

- **A call with more arguments than either overload takes is left alone.** Neither `(name, fn?, timeout?)` nor `(name, options, fn?)` accepts a fourth argument, so such a call is not a registration this rule can reason about. Upstream scans every argument for a timeout regardless of position or count.

- **A callback passed by name is reported.** Upstream looks for an inline function argument and skips the rest, though `const handler = () => {}; test('a', handler)` needs a timeout no less than an inline callback does. The resolved function is recognised as the callback in whichever argument slot it occupies, so it is never mistaken for the options object or the timeout.

- **No `x`-prefixed branch.** Upstream skips a registration whose name starts with `x`. Rstest exports no `xit`, `xtest` or `xdescribe`, so there is nothing to skip.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
