### PR TITLE
feat(rstest): add no-conditional-tests rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_commented_out_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_expect"
 	no_conditional_in "github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_in_test"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_focused_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_hooks"
@@ -36,6 +37,7 @@ func GetAllRules() []rule.Rule {
 		no_commented_out_tests.NoCommentedOutTestsRule,
 		no_conditional_expect.NoConditionalExpectRule,
 		no_conditional_in.NoConditionalInTestRule,
+		no_conditional_tests.NoConditionalTestsRule,
 		no_disabled_tests.NoDisabledTestsRule,
 		no_focused_tests.NoFocusedTestsRule,
 		no_hooks.NoHooksRule,

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.go
@@ -86,11 +86,11 @@ func registeredUnderIfBranch(node *ast.Node) bool {
 // controls parent's own evaluation — so a registration on the far side of it
 // is no longer conditional on anything wrapping parent.
 //
-// A function, method, constructor or accessor body, and a parameter's default
-// value, qualify: neither runs when the declaration itself is evaluated, only
-// later when the function is called. An instance field initializer
-// (`p = expr`, no `static`) qualifies too: it runs once per `new`, not when
-// the class declaration is evaluated.
+// A function, method, constructor or accessor body, and the runtime-evaluated
+// parts of a parameter, qualify: none runs when the declaration itself is
+// evaluated, only later when the function is called. An instance field
+// initializer (`p = expr`, no `static`) qualifies too: it runs once per `new`,
+// not when the class declaration is evaluated.
 //
 // A class static block, a static field initializer (`static p = expr`), a
 // computed member name (`[expr]`), and a decorator (`@dec(expr)`) do not
@@ -106,11 +106,18 @@ func isDeferredExecutionBoundary(child *ast.Node, parent *ast.Node) bool {
 	switch parent.Kind {
 	case ast.KindComputedPropertyName, ast.KindDecorator, ast.KindClassStaticBlockDeclaration:
 		return false
+	case ast.KindParameter:
+		// Parameter decorators run while the enclosing class is evaluated.
+		// Defaults and binding patterns run later, when the function is called.
+		return child.Kind != ast.KindDecorator
 	case ast.KindPropertyDeclaration:
-		return !ast.HasStaticModifier(parent)
+		// A non-static field's initializer is deferred until construction, but
+		// its computed name and decorators run while the class is evaluated.
+		property := parent.AsPropertyDeclaration()
+		return !ast.HasStaticModifier(parent) && child == property.Initializer
 	}
 	if !ast.IsFunctionLikeDeclaration(parent) {
 		return false
 	}
-	return child == parent.Body() || child.Kind == ast.KindParameter
+	return child == parent.Body()
 }

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.go
@@ -50,13 +50,13 @@ var NoConditionalTestsRule = rule.Rule{
 // registeredUnderIfBranch walks up from a registration call and reports whether
 // it is reached through the then or else branch of an `if`.
 //
-// The walk stops at the first function boundary, which is what keeps the rule
-// honest in two directions. Downwards, it means only the registration that the
-// `if` itself decides to run is reported: in
+// The walk stops at the first deferred-execution boundary, which is what keeps
+// the rule honest in two directions. Downwards, it means only the registration
+// that the `if` itself decides to run is reported: in
 // `if (x) { describe('a', () => { test('b', fn) }) }` the inner `test` walk
-// stops at the describe callback, so only the outer `describe` is reported.
-// Upwards, it means a condition inside an unrelated enclosing function never
-// leaks onto a registration that function merely contains.
+// stops at the describe callback's body, so only the outer `describe` is
+// reported. Upwards, it means a condition inside an unrelated enclosing
+// function never leaks onto a registration that function merely contains.
 //
 // Arriving through an `if`'s condition is not a conditional registration —
 // `if (test('a')) {}` runs the call unconditionally — so the walk continues
@@ -68,7 +68,7 @@ func registeredUnderIfBranch(node *ast.Node) bool {
 		if parent == nil || parent.Kind == ast.KindSourceFile {
 			return false
 		}
-		if ast.IsFunctionLikeOrClassStaticBlockDeclaration(parent) {
+		if isDeferredExecutionBoundary(child, parent) {
 			return false
 		}
 		if parent.Kind == ast.KindIfStatement {
@@ -79,4 +79,38 @@ func registeredUnderIfBranch(node *ast.Node) bool {
 		}
 		child = parent
 	}
+}
+
+// isDeferredExecutionBoundary reports whether stepping from child up to parent
+// crosses into code that runs later than, and independently of, whatever
+// controls parent's own evaluation — so a registration on the far side of it
+// is no longer conditional on anything wrapping parent.
+//
+// A function, method, constructor or accessor body, and a parameter's default
+// value, qualify: neither runs when the declaration itself is evaluated, only
+// later when the function is called. An instance field initializer
+// (`p = expr`, no `static`) qualifies too: it runs once per `new`, not when
+// the class declaration is evaluated.
+//
+// A class static block, a static field initializer (`static p = expr`), a
+// computed member name (`[expr]`), and a decorator (`@dec(expr)`) do not
+// qualify even though each sits inside a class body: all four run
+// synchronously as part of evaluating the class declaration itself, so a
+// registration inside one is exactly as conditional as the class declaration
+// that contains it. Climbing out of a computed name or a decorator lands back
+// on the method or accessor it belongs to — which is itself function-like —
+// so the boundary check below only treats that step as deferred when child is
+// specifically the declaration's body or one of its parameters, not merely
+// because parent is function-like.
+func isDeferredExecutionBoundary(child *ast.Node, parent *ast.Node) bool {
+	switch parent.Kind {
+	case ast.KindComputedPropertyName, ast.KindDecorator, ast.KindClassStaticBlockDeclaration:
+		return false
+	case ast.KindPropertyDeclaration:
+		return !ast.HasStaticModifier(parent)
+	}
+	if !ast.IsFunctionLikeDeclaration(parent) {
+		return false
+	}
+	return child == parent.Body() || child.Kind == ast.KindParameter
 }

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.go
@@ -1,0 +1,82 @@
+package no_conditional_tests
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildNoConditionalTestsMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noConditionalTests",
+		Description: "Avoid using if conditions in a test",
+	}
+}
+
+var NoConditionalTestsRule = rule.Rule{
+	Name:   "rstest/no-conditional-tests",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := analysis.ParseFnCall(node)
+				// Hooks are excluded: only test and suite registrations count,
+				// matching upstream's `test` / `it` / `describe` name list.
+				if parsed == nil ||
+					(parsed.Kind != rstestUtils.RstestFnTypeTest &&
+						parsed.Kind != rstestUtils.RstestFnTypeDescribe) {
+					return
+				}
+
+				if !registeredUnderIfBranch(node) {
+					return
+				}
+
+				reportNode := node
+				if parsed.Head.Local.Node != nil {
+					reportNode = parsed.Head.Local.Node
+				}
+				ctx.ReportRange(
+					internalUtils.TrimNodeTextRange(ctx.SourceFile, reportNode),
+					buildNoConditionalTestsMessage(),
+				)
+			},
+		}
+	},
+}
+
+// registeredUnderIfBranch walks up from a registration call and reports whether
+// it is reached through the then or else branch of an `if`.
+//
+// The walk stops at the first function boundary, which is what keeps the rule
+// honest in two directions. Downwards, it means only the registration that the
+// `if` itself decides to run is reported: in
+// `if (x) { describe('a', () => { test('b', fn) }) }` the inner `test` walk
+// stops at the describe callback, so only the outer `describe` is reported.
+// Upwards, it means a condition inside an unrelated enclosing function never
+// leaks onto a registration that function merely contains.
+//
+// Arriving through an `if`'s condition is not a conditional registration —
+// `if (test('a')) {}` runs the call unconditionally — so the walk continues
+// past it rather than reporting, and an outer `if` can still catch it.
+func registeredUnderIfBranch(node *ast.Node) bool {
+	child := node
+	for {
+		parent := child.Parent
+		if parent == nil || parent.Kind == ast.KindSourceFile {
+			return false
+		}
+		if ast.IsFunctionLikeOrClassStaticBlockDeclaration(parent) {
+			return false
+		}
+		if parent.Kind == ast.KindIfStatement {
+			ifStatement := parent.AsIfStatement()
+			if child == ifStatement.ThenStatement || child == ifStatement.ElseStatement {
+				return true
+			}
+		}
+		child = parent
+	}
+}

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
@@ -13,10 +13,17 @@ time and is not reported. Only `if` is reported — conditional expressions,
 `switch`, and the logical operators are left alone. Hooks such as
 `beforeEach` are not registrations and are not reported.
 
-The rule looks only as far as the nearest enclosing function, so a
-registration wrapped in a helper is attributed to wherever that helper is
-called, not to an unrelated `if` the helper happens to sit under; the same
-boundary means a nested pair such as
+The rule does not carry an enclosing `if` through code that runs later. A
+registration in a function or method body, a parameter default, or an instance
+field initializer is attributed to the later call or construction rather than
+to an `if` around its declaration. Class static blocks, static field
+initializers, computed member names, and decorators run while the class is
+defined, so registrations in those positions remain conditional on an
+enclosing `if`.
+
+A registration wrapped in a helper is therefore attributed to wherever that
+helper is called, not to an unrelated `if` the helper happens to sit under; the
+same boundary means a nested pair such as
 `if (x) { describe('a', () => { test('b', fn) }) }` reports only the outer
 `describe`. Conditions written inside a test body are covered separately by
 `rstest/no-conditional-in-test`.

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
@@ -15,15 +15,15 @@ time and is not reported. Only `if` is reported — conditional expressions,
 
 The rule does not carry an enclosing `if` through code that runs later. A
 registration in a function or method body, a parameter default, or an instance
-field initializer is attributed to the later call or construction rather than
-to an `if` around its declaration. Class static blocks, static field
-initializers, computed member names, and decorators run while the class is
-defined, so registrations in those positions remain conditional on an
-enclosing `if`.
+field initializer is left alone, because an `if` around the declaration does
+not decide whether that code runs — the later call or construction does. Class
+static blocks, static field initializers, computed member names, and decorators
+run while the class is defined, so registrations in those positions remain
+conditional on an enclosing `if`.
 
-A registration wrapped in a helper is therefore attributed to wherever that
-helper is called, not to an unrelated `if` the helper happens to sit under; the
-same boundary means a nested pair such as
+The rule does not follow a function to its call sites, so a registration in a
+helper is never reported, whether or not the helper is only ever called from
+inside an `if`. The same boundary means a nested pair such as
 `if (x) { describe('a', () => { test('b', fn) }) }` reports only the outer
 `describe`. Conditions written inside a test body are covered separately by
 `rstest/no-conditional-in-test`.

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
@@ -7,22 +7,24 @@ that only exists on some runs is a test that silently stops covering anything
 when the condition flips, and the report shows a shrinking suite rather than a
 failure.
 
-A registration is reported when it is reached through the `then` branch or the
-`else` branch of an `if`. Calls in the `if`'s own condition are not reported —
-they run every time. Only `if` is reported; conditional expressions, `switch`,
-and the logical operators are left alone.
+A registration is reported when it is reached through the `then` branch or
+the `else` branch of an `if`; a call in the `if`'s own condition runs every
+time and is not reported. Only `if` is reported — conditional expressions,
+`switch`, and the logical operators are left alone. Hooks such as
+`beforeEach` are not registrations and are not reported.
 
-The rule stops looking at the first enclosing function, so a registration
-wrapped in a helper function is attributed to wherever that helper is called,
-not to an `if` the helper happens to sit under. The same boundary means a
-nested pair reports only the outermost registration: in
-`if (x) { describe('a', () => { test('b', fn) }) }` only the `describe` is
-reported, because the inner `test` belongs to the suite callback.
-
-Hooks (`beforeEach`, `afterAll`, and the rest) are not reported.
-
-Conditions written *inside* a test body are a different concern, covered by
+The rule looks only as far as the nearest enclosing function, so a
+registration wrapped in a helper is attributed to wherever that helper is
+called, not to an unrelated `if` the helper happens to sit under; the same
+boundary means a nested pair such as
+`if (x) { describe('a', () => { test('b', fn) }) }` reports only the outer
+`describe`. Conditions written inside a test body are covered separately by
 `rstest/no-conditional-in-test`.
+
+A conditionally-run test should be registered with `test.skipIf(condition)`
+or `test.runIf(condition)` instead, so the suite keeps its shape and the
+runner decides at execution time whether to run it. Both modifiers are also
+available on `describe`.
 
 ## Incorrect
 
@@ -36,14 +38,8 @@ if (process.env.CI) {
 
 ## Correct
 
-Rstest registers the test either way and decides at run time whether to execute
-it, so the suite keeps its shape:
-
 ```ts
 test.skipIf(!process.env.CI)('uploads the report', async () => {
   await expect(upload()).resolves.toBe(true);
 });
 ```
-
-`test.runIf(condition)` expresses the same thing from the other side, and both
-modifiers are available on `describe` as well.

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
@@ -47,21 +47,3 @@ test.skipIf(!process.env.CI)('uploads the report', async () => {
 
 `test.runIf(condition)` expresses the same thing from the other side, and both
 modifiers are available on `describe` as well.
-
-## Options
-
-This rule has no options.
-
-## Differences from the Vitest plugin
-
-- The Vitest plugin matches any identifier literally named `test`, `it`, or
-  `describe`, so an ordinary variable with one of those names is reported even
-  when it has nothing to do with the test framework. This rule reports only
-  calls it can resolve to a Rstest registration, which covers imports from
-  `@rstest/core` and `@rstest/playwright`, `require` forms, `import.meta.rstest`
-  members, globals, and local aliases of any of those, while leaving shadowed
-  names and same-named APIs from other frameworks alone.
-- The Vitest plugin looks a fixed four levels up from the identifier, so it
-  misses `if (cond) test('a', fn)` written without braces and every other
-  spacing of the same code. This rule walks up to the enclosing function
-  instead, so the shape of the intervening statements does not matter.

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests.md
@@ -1,0 +1,67 @@
+# no-conditional-tests
+
+## Rule Details
+
+Disallows registering a test or a suite from inside an `if` statement. A test
+that only exists on some runs is a test that silently stops covering anything
+when the condition flips, and the report shows a shrinking suite rather than a
+failure.
+
+A registration is reported when it is reached through the `then` branch or the
+`else` branch of an `if`. Calls in the `if`'s own condition are not reported —
+they run every time. Only `if` is reported; conditional expressions, `switch`,
+and the logical operators are left alone.
+
+The rule stops looking at the first enclosing function, so a registration
+wrapped in a helper function is attributed to wherever that helper is called,
+not to an `if` the helper happens to sit under. The same boundary means a
+nested pair reports only the outermost registration: in
+`if (x) { describe('a', () => { test('b', fn) }) }` only the `describe` is
+reported, because the inner `test` belongs to the suite callback.
+
+Hooks (`beforeEach`, `afterAll`, and the rest) are not reported.
+
+Conditions written *inside* a test body are a different concern, covered by
+`rstest/no-conditional-in-test`.
+
+## Incorrect
+
+```ts
+if (process.env.CI) {
+  test('uploads the report', async () => {
+    await expect(upload()).resolves.toBe(true);
+  });
+}
+```
+
+## Correct
+
+Rstest registers the test either way and decides at run time whether to execute
+it, so the suite keeps its shape:
+
+```ts
+test.skipIf(!process.env.CI)('uploads the report', async () => {
+  await expect(upload()).resolves.toBe(true);
+});
+```
+
+`test.runIf(condition)` expresses the same thing from the other side, and both
+modifiers are available on `describe` as well.
+
+## Options
+
+This rule has no options.
+
+## Differences from the Vitest plugin
+
+- The Vitest plugin matches any identifier literally named `test`, `it`, or
+  `describe`, so an ordinary variable with one of those names is reported even
+  when it has nothing to do with the test framework. This rule reports only
+  calls it can resolve to a Rstest registration, which covers imports from
+  `@rstest/core` and `@rstest/playwright`, `require` forms, `import.meta.rstest`
+  members, globals, and local aliases of any of those, while leaving shadowed
+  names and same-named APIs from other frameworks alone.
+- The Vitest plugin looks a fixed four levels up from the identifier, so it
+  misses `if (cond) test('a', fn)` written without braces and every other
+  spacing of the same code. This rule walks up to the enclosing function
+  instead, so the shape of the intervening statements does not matter.

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_class_timing_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_class_timing_test.go
@@ -1,0 +1,112 @@
+// TestNoConditionalTestsExtrasClassTiming locks in which class-member
+// expressions run while a class is defined and which run later. General
+// Rstest-only edge shapes live in no_conditional_tests_extras_test.go.
+package no_conditional_tests
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConditionalTestsExtrasClassTiming(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoConditionalTestsRule,
+		[]rule_tester.ValidTestCase{
+			// Method and constructor bodies run only when called.
+			{Code: `if (x) { class C { m() { test("a", () => {}); } } }`},
+			{Code: `if (x) { class C { constructor() { test("a", () => {}); } } }`},
+			// Parameter defaults and binding patterns run only when called.
+			{Code: `if (x) { function f(t = test("a", () => {})) {} }`},
+			{Code: `if (x) { class C { m({ p = test("a", () => {}) } = {}) {} } }`},
+			// An instance field initializer runs once per construction.
+			{Code: `if (x) { class C { p = test("a", () => {}); } }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Static blocks and static initializers run while defining the class.
+			{
+				Code: `if (x) { class C { static { test("a", () => {}); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    29,
+					EndLine:   1,
+					EndColumn: 33,
+				}},
+			},
+			{
+				Code: `if (x) { class C { static p = test("a", () => {}); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    31,
+					EndLine:   1,
+					EndColumn: 35,
+				}},
+			},
+			// Computed names run while defining both methods and fields.
+			{
+				Code: `if (x) { class C { [test("a", () => {})]() {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 25,
+				}},
+			},
+			{
+				Code: `if (x) { class C { [test("a", () => {})] = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 25,
+				}},
+			},
+			// Member and parameter decorators run while defining the class.
+			{
+				Code: `if (x) { class C { @dec(test("a", () => {})) m() {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				Code: `if (x) { class C { @dec(test("a", () => {})) p = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				Code: `if (x) { class C { m(@dec(test("a", () => {})) value: unknown) {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    27,
+					EndLine:   1,
+					EndColumn: 31,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_test.go
@@ -69,14 +69,6 @@ if (x) { test("a", () => {}); }`},
 			{Code: `if (x) { function register() { test("a", () => {}); } register(); }`},
 			{Code: `if (x) { const o = { register() { test("a", () => {}); } }; }`},
 			{Code: `if (x) { const o = { get register() { test("a", () => {}); return 1; } }; }`},
-			{Code: `if (x) { class C { m() { test("a", () => {}); } } }`},
-			{Code: `if (x) { class C { constructor() { test("a", () => {}); } } }`},
-			{Code: `if (x) { function f(t = test("a", () => {})) {} }`},
-			// An instance field initializer runs once per `new`, not when the
-			// class declaration itself is evaluated, so it is its own
-			// deferred-execution boundary — the enclosing `if` does not
-			// control whether this registration ever runs.
-			{Code: `if (x) { class C { p = test("a", () => {}); } }`},
 			// The inner registration of a nested pair: its walk stops at the
 			// describe callback, so only the outer describe is reported.
 			{Code: `describe("a", () => { test("b", () => {}); });`},
@@ -511,56 +503,17 @@ if (x) { t("a", () => {}); }`,
 					EndColumn: 14,
 				}},
 			},
-
-			// ---- 8. Class member evaluation timing ----
-			// A static block, a static field initializer, a computed member
-			// name and a decorator all run synchronously as part of
-			// evaluating the class declaration itself — none of them defer
-			// execution the way a function or method body does — so a
-			// registration inside one is exactly as conditional as the class
-			// declaration that contains it.
 			{
-				Code: `if (x) { class C { static { test("a", () => {}); } } }`,
+				// A comma expression evaluates to its right operand, so this
+				// invokes the real Rstest registration.
+				Code: `if (x) { (0, test)("a", () => {}); }`,
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "noConditionalTests",
 					Message:   "Avoid using if conditions in a test",
 					Line:      1,
-					Column:    29,
+					Column:    14,
 					EndLine:   1,
-					EndColumn: 33,
-				}},
-			},
-			{
-				Code: `if (x) { class C { static p = test("a", () => {}); } }`,
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "noConditionalTests",
-					Message:   "Avoid using if conditions in a test",
-					Line:      1,
-					Column:    31,
-					EndLine:   1,
-					EndColumn: 35,
-				}},
-			},
-			{
-				Code: `if (x) { class C { [test("a", () => {})]() {} } }`,
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "noConditionalTests",
-					Message:   "Avoid using if conditions in a test",
-					Line:      1,
-					Column:    21,
-					EndLine:   1,
-					EndColumn: 25,
-				}},
-			},
-			{
-				Code: `if (x) { class C { @dec(test("a", () => {})) m() {} } }`,
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "noConditionalTests",
-					Message:   "Avoid using if conditions in a test",
-					Line:      1,
-					Column:    25,
-					EndLine:   1,
-					EndColumn: 29,
+					EndColumn: 18,
 				}},
 			},
 		},

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_test.go
@@ -69,8 +69,14 @@ if (x) { test("a", () => {}); }`},
 			{Code: `if (x) { function register() { test("a", () => {}); } register(); }`},
 			{Code: `if (x) { const o = { register() { test("a", () => {}); } }; }`},
 			{Code: `if (x) { const o = { get register() { test("a", () => {}); return 1; } }; }`},
-			{Code: `if (x) { class C { static { test("a", () => {}); } } }`},
 			{Code: `if (x) { class C { m() { test("a", () => {}); } } }`},
+			{Code: `if (x) { class C { constructor() { test("a", () => {}); } } }`},
+			{Code: `if (x) { function f(t = test("a", () => {})) {} }`},
+			// An instance field initializer runs once per `new`, not when the
+			// class declaration itself is evaluated, so it is its own
+			// deferred-execution boundary — the enclosing `if` does not
+			// control whether this registration ever runs.
+			{Code: `if (x) { class C { p = test("a", () => {}); } }`},
 			// The inner registration of a nested pair: its walk stops at the
 			// describe callback, so only the outer describe is reported.
 			{Code: `describe("a", () => { test("b", () => {}); });`},
@@ -503,6 +509,58 @@ if (x) { t("a", () => {}); }`,
 					Column:    10,
 					EndLine:   1,
 					EndColumn: 14,
+				}},
+			},
+
+			// ---- 8. Class member evaluation timing ----
+			// A static block, a static field initializer, a computed member
+			// name and a decorator all run synchronously as part of
+			// evaluating the class declaration itself — none of them defer
+			// execution the way a function or method body does — so a
+			// registration inside one is exactly as conditional as the class
+			// declaration that contains it.
+			{
+				Code: `if (x) { class C { static { test("a", () => {}); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    29,
+					EndLine:   1,
+					EndColumn: 33,
+				}},
+			},
+			{
+				Code: `if (x) { class C { static p = test("a", () => {}); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    31,
+					EndLine:   1,
+					EndColumn: 35,
+				}},
+			},
+			{
+				Code: `if (x) { class C { [test("a", () => {})]() {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 25,
+				}},
+			},
+			{
+				Code: `if (x) { class C { @dec(test("a", () => {})) m() {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 29,
 				}},
 			},
 		},

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_extras_test.go
@@ -1,0 +1,510 @@
+// TestNoConditionalTestsExtras locks in the Rstest-only augmentation the port
+// spec requires: the registration source matrix, the registration-shape matrix,
+// the parent-walk branch lock-ins that upstream's fixed four-level parent check
+// cannot express, and the graceful-degradation shapes of Dimension 4.
+package no_conditional_tests
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConditionalTestsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoConditionalTestsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- A. Not a conditional registration at all ----
+			{Code: `test("a", () => {});`},
+			{Code: `describe("a", () => { test("b", () => {}); });`},
+			// The call sits in the condition, so it runs unconditionally.
+			{Code: `if (test("a")) {}`},
+			{Code: `if (!describe("a")) {}`},
+			{Code: `if (x && test("a")) {} else {}`},
+			// A condition inside the test body belongs to no-conditional-in-test.
+			{Code: `test("a", () => { if (x) { expect(1).toBe(1); } });`},
+			{Code: `describe("a", () => { if (x) { helper(); } test("b", () => {}); });`},
+
+			// ---- B. Only `if` counts ----
+			{Code: `x ? test("a", () => {}) : null;`},
+			{Code: `x && test("a", () => {});`},
+			{Code: `x || test("a", () => {});`},
+			{Code: `x ?? test("a", () => {});`},
+			{Code: `switch (x) { case 1: test("a", () => {}); }`},
+			{Code: `for (const c of cs) { test(c, () => {}); }`},
+			{Code: `while (x) { test("a", () => {}); }`},
+			{Code: `try { test("a", () => {}); } catch {}`},
+
+			// ---- C. Hooks are excluded, matching upstream's name list ----
+			{Code: `if (x) { beforeEach(() => {}); }`},
+			{Code: `if (x) { afterAll(() => {}); }`},
+
+			// ---- D. The call is not a Rstest registration ----
+			{Code: `const test = f; if (x) { test("a", () => {}); }`},
+			{Code: `function outer(test) { if (x) { test("a", () => {}); } }`},
+			{Code: `import { test } from 'vitest';
+if (x) { test("a", () => {}); }`},
+			{Code: `import { test } from 'node:test';
+if (x) { test("a", () => {}); }`},
+			{Code: `import { test } from '@jest/globals';
+if (x) { test("a", () => {}); }`},
+			{Code: `import { test } from './helpers';
+if (x) { test("a", () => {}); }`},
+			{Code: `if (x) { expect(1).toBe(1); }`},
+			// A non-null assertion or a type assertion around the callee is not
+			// a chain the registration parser follows, so the call is not
+			// recognised as Rstest and nothing is reported.
+			{Code: `if (x) { test!("a", () => {}); }`},
+			{Code: `if (x) { (test as any)("a", () => {}); }`},
+			{Code: `if (x) { (test satisfies unknown)("a", () => {}); }`},
+
+			// ---- E. The function boundary stops the walk ----
+			// The registration is decided by the wrapper's caller, not by the
+			// `if` the wrapper happens to sit under.
+			{Code: `if (x) { const register = () => { test("a", () => {}); }; register(); }`},
+			{Code: `if (x) { function register() { test("a", () => {}); } register(); }`},
+			{Code: `if (x) { const o = { register() { test("a", () => {}); } }; }`},
+			{Code: `if (x) { const o = { get register() { test("a", () => {}); return 1; } }; }`},
+			{Code: `if (x) { class C { static { test("a", () => {}); } } }`},
+			{Code: `if (x) { class C { m() { test("a", () => {}); } } }`},
+			// The inner registration of a nested pair: its walk stops at the
+			// describe callback, so only the outer describe is reported.
+			{Code: `describe("a", () => { test("b", () => {}); });`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- 1. The two shapes upstream's fixed parent depth gets wrong ----
+			{
+				Code: `if (x) { test("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				// Braceless: upstream's four-level parent walk misses this.
+				Code: `if (x) test("a", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    8,
+					EndLine:   1,
+					EndColumn: 12,
+				}},
+			},
+
+			// ---- 2. Branch positions ----
+			{
+				Code: `if (x) {} else { describe("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 26,
+				}},
+			},
+			{
+				Code: `if (x) {} else describe("a", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 24,
+				}},
+			},
+			{
+				Code: `if (x) {} else if (y) { test("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				// The inner `if` puts the call in its condition, but the inner
+				// `if` itself is reached through the outer `if`'s then branch,
+				// so the registration really is conditional.
+				Code: `if (x) { if (test("a")) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+
+			// ---- 3. Distance between the `if` and the registration ----
+			{
+				Code: `if (x) { for (const c of cs) { test(c, () => {}); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    32,
+					EndLine:   1,
+					EndColumn: 36,
+				}},
+			},
+			{
+				Code: `class C { static { if (x) { test("a", () => {}); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    29,
+					EndLine:   1,
+					EndColumn: 33,
+				}},
+			},
+
+			// ---- 4. Nesting reports the outermost registration only ----
+			{
+				Code: `if (x) { describe("a", () => { test("b", () => {}); }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+			{
+				// Two sibling registrations under one `if` are two diagnostics.
+				Code: `if (x) { test("a", () => {}); test("b", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noConditionalTests",
+						Message:   "Avoid using if conditions in a test",
+						Line:      1,
+						Column:    10,
+						EndLine:   1,
+						EndColumn: 14,
+					},
+					{
+						MessageId: "noConditionalTests",
+						Message:   "Avoid using if conditions in a test",
+						Line:      1,
+						Column:    31,
+						EndLine:   1,
+						EndColumn: 35,
+					},
+				},
+			},
+
+			// ---- 5. The registration source matrix ----
+			{
+				Code: `import { test } from '@rstest/core';
+if (x) { test("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `import { it as check } from '@rstest/core';
+if (x) { check("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `import * as core from '@rstest/core';
+if (x) { core.describe("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `const { test } = require('@rstest/core');
+if (x) { test("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `const core = require('@rstest/core');
+if (x) { core.test("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) { import.meta.rstest.test("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 28,
+				}},
+			},
+			{
+				Code: `const { describe } = import.meta.rstest;
+if (x) { describe("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code: `import { test } from '@rstest/playwright';
+if (x) { test("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `const t = test;
+if (x) { t("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    10,
+					EndLine:   2,
+					EndColumn: 11,
+				}},
+			},
+
+			// ---- 6. The registration shape matrix ----
+			{
+				Code: `if (x) { test.skip("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) { it.only("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 12,
+				}},
+			},
+			{
+				Code: `if (x) { test.todo("a"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) { test.each([1, 2])("a %i", (n) => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: "if (x) { describe.each`a`(\"a\", () => {}); }",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code: `if (x) { test["skip"]("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) { test.concurrent.skipIf(y)("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) { test("a", { timeout: 100 }, () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) { test("a", () => {}, 100); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) {
+  test
+    // a comment between the members
+    .skip("a", () => {});
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 7,
+				}},
+			},
+
+			// ---- 7. Dimension 4: wrapped and degraded call shapes ----
+			{
+				Code: `if (x) { (test)("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
+			{
+				Code: `if (x) { ((test))("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 16,
+				}},
+			},
+			{
+				Code: `if (x) { test(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				// Optional call and optional member access still register.
+				Code: `if (x) { test?.("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			{
+				Code: `if (x) { test?.skip("a", () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+			// N/A: a malformed or unterminated call cannot be exercised here —
+			// the rule tester rejects source with syntactic errors before any
+			// rule runs.
+			{
+				Code: `if (x) { test(...args); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 14,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_source_only_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_source_only_test.go
@@ -1,0 +1,113 @@
+// TestNoConditionalTestsResolvesInSourceOnlyProgram locks in that the rule
+// keeps discriminating real Rstest registrations from same-named bindings when
+// rslint builds a Program with no TypeChecker — the generation used for files
+// no tsconfig project owns. The rule does not require type information, so it
+// runs there, and its registration resolution has to survive on the file's
+// binder scope graph alone.
+package no_conditional_tests_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_tests"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestNoConditionalTestsResolvesInSourceOnlyProgram(t *testing.T) {
+	if no_conditional_tests.NoConditionalTestsRule.RequiresTypeInfo {
+		t.Fatal("rstest/no-conditional-tests must not require type information")
+	}
+
+	code := `
+import { test } from 'vitest';
+import { test as rstestTest, describe } from '@rstest/core';
+import * as rstest from '@rstest/core';
+
+const localTest = (name: string, fn: () => void) => {};
+
+if (flag) { test('vitest lookalike', () => {}); }
+if (flag) { localTest('local lookalike', () => {}); }
+if (flag) { rstestTest('renamed import', () => {}); }
+if (flag) { rstest.test('namespace import', () => {}); }
+if (flag) { describe('plain import', () => {}); }
+`
+	// The identifier each diagnostic must anchor to, in source order. The two
+	// lookalikes are absent: neither is an Rstest registration, and reporting
+	// one would be the false positive this rule's resolution exists to avoid.
+	// A namespace registration anchors to its receiver, the same node a
+	// checker-backed run reports.
+	want := []string{"rstestTest", "rstest", "describe"}
+
+	root := fixtures.GetRootDir()
+	fileName := tspath.ResolvePath(root.Dir, "no-conditional-tests-source-only.ts")
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: code})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	sourceProgram, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
+		RootFileNames:   []string{fileName},
+		Host:            host,
+		CompilerOptions: &core.CompilerOptions{Module: core.ModuleKindESNext},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatalf("NewFromRoots: %v", err)
+	}
+	if sourceProgram.CanProvideTypeChecker(sourceProgram.SourceFiles()[0]) {
+		t.Fatal("expected a source-only Program with no TypeChecker")
+	}
+
+	lintPlan, err := linter.PrepareLintPlan(linter.PrepareLintPlanOptions{
+		Programs:         []*lintprogram.Program{sourceProgram},
+		TargetsByProgram: [][]string{{fileName}},
+		SingleThreaded:   true,
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
+				Name:     no_conditional_tests.NoConditionalTestsRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return no_conditional_tests.NoConditionalTestsRule.Run(ctx, nil)
+				},
+			}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("PrepareLintPlan: %v", err)
+	}
+
+	type reported struct {
+		pos  int
+		text string
+	}
+	var got []reported
+	if _, err := linter.RunLinter(linter.RunLinterOptions{
+		SingleThreaded: true,
+		LintPlan:       lintPlan,
+		Consumer: rule.DiagnosticConsumer{
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				got = append(got, reported{
+					pos:  diagnostic.Range.Pos(),
+					text: code[diagnostic.Range.Pos():diagnostic.Range.End()],
+				})
+			},
+		},
+	}); err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	sort.Slice(got, func(left, right int) bool { return got[left].pos < got[right].pos })
+
+	if len(got) != len(want) {
+		t.Fatalf("reported %d registrations, want %d: %v", len(got), len(want), got)
+	}
+	for index, expected := range want {
+		if got[index].text != expected {
+			t.Errorf("diagnostic %d anchored to %q, want %q", index, got[index].text, expected)
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_upstream_test.go
+++ b/internal/plugins/rstest/rules/no_conditional_tests/no_conditional_tests_upstream_test.go
@@ -1,0 +1,97 @@
+// TestNoConditionalTestsUpstream migrates the complete
+// @vitest/eslint-plugin@v1.6.27 no-conditional-tests suite. Rstest-only edge
+// cases, the source matrix and the branch lock-ins that upstream's fixed
+// four-level parent check cannot express live in
+// no_conditional_tests_extras_test.go.
+package no_conditional_tests
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConditionalTestsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoConditionalTestsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `test("shows error", () => {});`},
+			{Code: `it("foo", function () {})`},
+			{Code: `it('foo', () => {}); function myTest() { if ('bar') {} }`},
+			{Code: `function myFunc(str: string) {
+    return str;
+  }
+  describe("myTest", () => {
+     it("convert shortened equal filter", () => {
+      expect(
+      myFunc("5")
+      ).toEqual("5");
+     });
+    });`},
+			{Code: `describe("shows error", () => {
+     if (1 === 2) {
+      myFunc();
+     }
+     expect(true).toBe(false);
+    });`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `describe("shows error", () => {
+    if(true) {
+     test("shows error", () => {
+      expect(true).toBe(true);
+     })
+    }
+   })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      3,
+					Column:    6,
+					EndLine:   3,
+					EndColumn: 10,
+				}},
+			},
+			{
+				Code: `
+   describe("shows error", () => {
+    if(true) {
+     it("shows error", () => {
+      expect(true).toBe(true);
+      })
+     }
+   })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      4,
+					Column:    6,
+					EndLine:   4,
+					EndColumn: 8,
+				}},
+			},
+			{
+				Code: `describe("errors", () => {
+    if (Math.random() > 0) {
+     test("test2", () => {
+     expect(true).toBeTruthy();
+    });
+    }
+   });`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noConditionalTests",
+					Message:   "Avoid using if conditions in a test",
+					Line:      3,
+					Column:    6,
+					EndLine:   3,
+					EndColumn: 10,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_hooks/no_hooks_extras_test.go
+++ b/internal/plugins/rstest/rules/no_hooks/no_hooks_extras_test.go
@@ -59,7 +59,6 @@ func TestNoHooksExtras(t *testing.T) {
 			// ---- Locks in parser contract: non-plain-call positions ----
 			{Code: `new beforeEach()`},
 			{Code: "beforeEach`x`"},
-			{Code: `(0, beforeEach)(() => {})`},
 			{Code: `globalThis.beforeEach(() => {})`},
 			// ---- Locks in upstream create() branch: non-hook CallExpression is ignored ----
 			{Code: `notAHook(() => {})`},
@@ -98,6 +97,18 @@ func TestNoHooksExtras(t *testing.T) {
 			},
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: a comma-wrapped hook remains the called hook ----
+			{
+				Code: `(0, beforeEach)(() => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedHook",
+					Message:   "Unexpected 'beforeEach' hook",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 26,
+				}},
+			},
 			// ---- Locks in parser branch: core globals and timeout overload ----
 			{
 				Code: `beforeAll(() => {}, 1000);`,

--- a/internal/plugins/rstest/utils/call_analysis.go
+++ b/internal/plugins/rstest/utils/call_analysis.go
@@ -36,9 +36,13 @@ type rstestCallAnalysisFileCacheKey struct{}
 // lints the same file. Manually-constructed contexts without a file cache keep
 // the standalone behavior used by rule and parser tests.
 func GetRstestCallAnalysis(ctx rule.RuleContext) *RstestCallAnalysis {
+	// Refs travels with SourceFile and TypeChecker because it is file-scoped
+	// like both: the parser uses it to resolve a registration's root binding
+	// when no checker is available (see resolveRstestRootSymbol).
 	analysisCtx := rule.RuleContext{
 		SourceFile:  ctx.SourceFile,
 		TypeChecker: ctx.TypeChecker,
+		Refs:        ctx.Refs,
 	}
 	return rule.CachedByFile(
 		ctx,

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -236,6 +236,11 @@ func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool)
 		}
 		parts[len(parts)-1].invocation = rstestTagInvoked
 		return root, parts, rootInvoked, true
+	case ast.KindBinaryExpression:
+		if !internalUtils.IsCommaOperator(node) {
+			return nil, nil, false, false
+		}
+		return parseRstestChain(node.AsBinaryExpression().Right)
 	default:
 		return nil, nil, false, false
 	}
@@ -305,6 +310,11 @@ func parseImportMetaRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, b
 		}
 		parts[len(parts)-1].invocation = rstestTagInvoked
 		return root, parts, rootInvoked, true
+	case ast.KindBinaryExpression:
+		if !internalUtils.IsCommaOperator(node) {
+			return nil, nil, false, false
+		}
+		return parseImportMetaRstestChain(node.AsBinaryExpression().Right)
 	default:
 		return nil, nil, false, false
 	}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -320,6 +320,33 @@ func parseImportMetaRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, b
 	}
 }
 
+// resolveRstestRootSymbol returns the binding a registration chain's root
+// identifier refers to.
+//
+// Every discrimination this parser promises — an import from `@rstest/core`
+// against a same-named import from Vitest or Jest, a global against a local
+// declaration that shadows it, an alias against an unrelated variable — is
+// decided from this symbol's declarations. Without one,
+// [testFramework.ResolveFunctionIdentifierReferenceFromSymbol] can only fall
+// back to the identifier's spelling, which is wrong in both directions: a
+// `test` imported from Vitest is taken for an Rstest global, while a renamed
+// or namespace import from `@rstest/core` stops resolving at all.
+//
+// The TypeChecker is therefore not the only source consulted. A source-only
+// Program — the generation rslint builds for files no tsconfig project owns —
+// carries no checker, so the file's reference store answers instead. Its
+// binder scope walk resolves imports and declarations authored in this file,
+// which is everything the discriminations above need; only bindings declared
+// outside the file are beyond it, and those were never Rstest registrations.
+func resolveRstestRootSymbol(ctx rule.RuleContext, root *ast.Node) *ast.Symbol {
+	if ctx.TypeChecker != nil {
+		if symbol := ctx.TypeChecker.GetSymbolAtLocation(root); symbol != nil {
+			return symbol
+		}
+	}
+	return ctx.Refs.ResolveInFile(root)
+}
+
 func resolveRstestRoot(
 	root *ast.Node,
 	parts []rstestChainPart,
@@ -332,10 +359,7 @@ func resolveRstestRoot(
 	}
 
 	localName := root.AsIdentifier().Text
-	var symbol *ast.Symbol
-	if ctx.TypeChecker != nil {
-		symbol = ctx.TypeChecker.GetSymbolAtLocation(root)
-	}
+	symbol := resolveRstestRootSymbol(ctx, root)
 	for _, profile := range rstestAllProfiles {
 		module := profileImportModule(profile)
 		name, originalNode, mode := testFramework.ResolveFunctionIdentifierReferenceFromSymbol(

--- a/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
@@ -61,6 +61,8 @@ func TestParseRstestFnCallHooks(t *testing.T) {
 			{Code: `import { beforeAll } from 'vitest'; beforeAll(() => {});`},
 			{Code: `import { beforeEach } from '@jest/globals'; beforeEach(() => {});`},
 			{Code: `const beforeAll = createHookRegistry(); beforeAll(() => {});`},
+			// Only comma expressions are transparent callee wrappers.
+			{Code: `(flag && test)("case", () => {});`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// All four hooks as globals.
@@ -124,6 +126,12 @@ func TestParseRstestFnCallHooks(t *testing.T) {
 			// Test and describe parsing is unchanged.
 			{Code: `test("case", () => {});`, Errors: parsedHookError("test", "test")},
 			{Code: `describe("suite", () => {});`, Errors: parsedHookError("describe", "describe")},
+			// A comma expression evaluates to its right operand before the call.
+			{Code: `(0, test)("case", () => {});`, Errors: parsedHookError("test", "test")},
+			{Code: `(sideEffect(), describe.only)("suite", () => {});`, Errors: parsedHookError("describe", "describe")},
+			{Code: `(0, beforeEach)(() => {});`, Errors: parsedHookError("hook", "beforeEach")},
+			{Code: `(0, import.meta.rstest.test)("case", () => {});`, Errors: parsedHookError("test", "test")},
+			{Code: `const wrapped = (0, test); wrapped("case", () => {});`, Errors: parsedHookError("test", "test")},
 		},
 	)
 }

--- a/internal/utils/test_framework/member_chain.go
+++ b/internal/utils/test_framework/member_chain.go
@@ -190,8 +190,9 @@ func MemberEntriesRange(sourceFile *ast.SourceFile, entries []MemberEntry) (core
 	return core.NewTextRange(start.Pos(), entries[len(entries)-1].Node.End()), true
 }
 
-// ResolveFirstIdentifier walks the left side of a call/member chain and
-// returns its first identifier, if any.
+// ResolveFirstIdentifier walks the effective callee of a call/member chain and
+// returns its first identifier, if any. A comma expression contributes only
+// its right operand because that is the value JavaScript calls.
 func ResolveFirstIdentifier(node *ast.Node) *ast.Node {
 	if node == nil {
 		return nil
@@ -212,6 +213,12 @@ func ResolveFirstIdentifier(node *ast.Node) *ast.Node {
 		return ResolveFirstIdentifier(node.AsElementAccessExpression().Expression)
 	case ast.KindTaggedTemplateExpression:
 		return ResolveFirstIdentifier(node.AsTaggedTemplateExpression().Tag)
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindCommaToken {
+			return ResolveFirstIdentifier(binary.Right)
+		}
+		return nil
 	default:
 		return nil
 	}

--- a/internal/utils/test_framework/member_chain_test.go
+++ b/internal/utils/test_framework/member_chain_test.go
@@ -104,6 +104,17 @@ func TestResolveFirstIdentifier(t *testing.T) {
 	if identifier == nil || identifier.Kind != ast.KindIdentifier || identifier.AsIdentifier().Text != "test" {
 		t.Fatalf("first identifier = %#v, want test", identifier)
 	}
+
+	_, commaCall := parseFirstCall(t, "(ignored, test)()")
+	identifier = ResolveFirstIdentifier(commaCall.AsCallExpression().Expression)
+	if identifier == nil || identifier.Kind != ast.KindIdentifier || identifier.AsIdentifier().Text != "test" {
+		t.Fatalf("comma expression identifier = %#v, want test", identifier)
+	}
+
+	_, logicalCall := parseFirstCall(t, "(ignored || test)()")
+	if identifier := ResolveFirstIdentifier(logicalCall.AsCallExpression().Expression); identifier != nil {
+		t.Fatalf("logical expression identifier = %#v, want nil", identifier)
+	}
 }
 
 func TestCalleeChainName(t *testing.T) {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -594,6 +594,7 @@ export default defineConfig({
     './tests/rstest/rules/no-commented-out-tests.test.ts',
     './tests/rstest/rules/no-conditional-expect.test.ts',
     './tests/rstest/rules/no-conditional-in-test.test.ts',
+    './tests/rstest/rules/no-conditional-tests.test.ts',
     './tests/rstest/rules/no-disabled-tests.test.ts',
     './tests/rstest/rules/no-focused-tests.test.ts',
     './tests/rstest/rules/no-hooks.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/no-conditional-tests.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-conditional-tests.test.ts
@@ -1,0 +1,64 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-conditional-tests', {} as never, {
+  valid: [
+    { code: 'test("shows error", () => {});' },
+    { code: 'it("foo", function () {})' },
+    { code: "it('foo', () => {}); function myTest() { if ('bar') {} }" },
+    {
+      code: `function myFunc(str: string) {
+    return str;
+  }
+  describe("myTest", () => {
+     it("convert shortened equal filter", () => {
+      expect(
+      myFunc("5")
+      ).toEqual("5");
+     });
+    });`,
+    },
+    {
+      code: `describe("shows error", () => {
+     if (1 === 2) {
+      myFunc();
+     }
+     expect(true).toBe(false);
+    });`,
+    },
+  ],
+  invalid: [
+    {
+      code: `describe("shows error", () => {
+    if(true) {
+     test("shows error", () => {
+      expect(true).toBe(true);
+     })
+    }
+   })`,
+      errors: [{ messageId: 'noConditionalTests', line: 3, column: 6 }],
+    },
+    {
+      code: `
+   describe("shows error", () => {
+    if(true) {
+     it("shows error", () => {
+      expect(true).toBe(true);
+      })
+     }
+   })`,
+      errors: [{ messageId: 'noConditionalTests', line: 4, column: 6 }],
+    },
+    {
+      code: `describe("errors", () => {
+    if (Math.random() > 0) {
+     test("test2", () => {
+     expect(true).toBeTruthy();
+    });
+    }
+   });`,
+      errors: [{ messageId: 'noConditionalTests', line: 3, column: 6 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Report a test or suite registration that is written inside an `if` statement's `then` or `else` branch, since a registration that only runs on some executions is a test whose coverage silently shrinks instead of failing. No fix is offered.

The call resolves through the shared `ParseFnCall`, so only a real Rstest `test` or `describe` registration is reported — hooks, a same-named export from another test framework, and a local variable that merely shares the name are all left alone. The walk from the registration call up to its enclosing scope stops at the first deferred-execution boundary — a function, arrow, method, constructor, or accessor body, a parameter default, or an instance field initializer — or at the source file. It never follows a function to its call sites, so a registration wrapped in a helper is not reported at all, and a nested pair such as `if (x) { describe('a', () => { test('b', fn) }) }` reports only the outer `describe`. Positions that run while a class is defined — static blocks, static field initializers, computed member names, decorators — are not boundaries, so a registration in one stays conditional on an enclosing `if`. A call sitting in the `if`'s own condition, such as `if (test('a')) {}`, is not reported — it runs unconditionally. Registered in the rstest plugin but left out of the `recommended` preset, matching upstream.

## Credits

Port from [`eslint-plugin-vitest`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `no-conditional-tests`. `eslint-plugin-jest` has no counterpart, so there is no second baseline to cross-check against.

## Intentional differences from upstream

- **The registration is resolved instead of name-matched.** Upstream reports any `Identifier` literally spelled `test`, `it`, or `describe`, so an ordinary variable with one of those names is reported even though it has nothing to do with the test framework. This port only reports a call it can resolve to a Rstest registration through `ParseFnCall`, which also lets it follow imports from `@rstest/core` and `@rstest/playwright`, `require` forms, `import.meta.rstest` members, globals, and local aliases, while staying silent on a shadowed name or a same-named API from Vitest, Jest, or `node:test`.

- **The parent walk follows the enclosing scope instead of a fixed depth.** Upstream checks whether the identifier's parent four levels up is exactly an `IfStatement`, which assumes the registration is a direct expression statement inside a braced block. `if (cond) test('a', fn)`, written without braces, puts the call three levels below the `if` instead of four, and upstream misses it. This port walks up to the first function boundary or the source file instead, so the shape and spacing of the intervening statements no longer matter, and the same walk naturally reports only the outermost registration of a nested pair.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
