### PR TITLE
fix: align no-invalid-this edge semantics

### DIFF
--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
@@ -43,7 +43,7 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// Production rslint contexts already carry an effective source type.
 		ctx.LanguageOptions.SourceType = "module"
 	}
-	engineOptions := no_invalid_this_core.CoreEngineOptions(ctx, opts)
+	engineOptions := no_invalid_this_core.TypeScriptEngineOptions(ctx, opts)
 	engineOptions.FieldFrameScopedToValue = false
 	return no_invalid_this_core.BuildListeners(ctx, engineOptions)
 }

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_extras_test.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_extras_test.go
@@ -918,3 +918,37 @@ function outer() {
 		},
 	)
 }
+
+func TestNoInvalidThisES3JavaScriptDirectives(t *testing.T) {
+	unexpected := func(line, col int) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedThis", Line: line, Column: col}}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.allow-js.json",
+		t,
+		&NoInvalidThisRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code:            `"use\x20strict"; function f(){ this; }`,
+				FileName:        "escaped-es3.js",
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 3, SourceType: "script"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:            `"use strict"; function f(){ this; }`,
+				FileName:        "double-quoted-es3.js",
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 3, SourceType: "script"},
+				Errors:          unexpected(1, 29),
+			},
+			{
+				Code:            `function outer(){ 'use strict'; function f(){ this; } }`,
+				FileName:        "ancestor-es3.js",
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 3, SourceType: "script"},
+				Errors:          unexpected(1, 47),
+			},
+		},
+	)
+}

--- a/internal/rules/no_invalid_this/no_invalid_this.go
+++ b/internal/rules/no_invalid_this/no_invalid_this.go
@@ -57,8 +57,8 @@ func ParseOptions(options []any) Options {
 	return opts
 }
 
-// EngineOptions configures BuildListeners with the policy point
-// that genuinely differs between `no-invalid-this` and
+// EngineOptions configures BuildListeners with the policy points
+// that differ between `no-invalid-this` and
 // `@typescript-eslint/no-invalid-this` (see BuildListeners doc comment).
 // Everything else — the parent-chain walker, JSDoc/this-param recognition,
 // computed-key deferral, method-decorator handling — is identical between
@@ -91,9 +91,19 @@ type EngineOptions struct {
 }
 
 // CoreEngineOptions returns the ESLint-core policy for the effective language
-// options on ctx. The TypeScript wrapper reuses this policy and changes only
-// the field-frame boundary that its upstream wrapper adds.
+// options on ctx.
 func CoreEngineOptions(ctx rule.RuleContext, opts Options) EngineOptions {
+	return engineOptions(ctx, opts, false)
+}
+
+// TypeScriptEngineOptions returns the typescript-eslint policy for the
+// effective language options on ctx. Its parser honors directive prologues in
+// JavaScript files even when ecmaVersion is 3, unlike Espree.
+func TypeScriptEngineOptions(ctx rule.RuleContext, opts Options) EngineOptions {
+	return engineOptions(ctx, opts, true)
+}
+
+func engineOptions(ctx rule.RuleContext, opts Options, honorES3JSDirectives bool) EngineOptions {
 	sourceType := ctx.LanguageOptions.SourceType
 	if sourceType == "" {
 		// Production contexts are normalized before rule execution. Keep the
@@ -110,7 +120,7 @@ func CoreEngineOptions(ctx rule.RuleContext, opts Options) EngineOptions {
 		CapIsConstructor: opts.CapIsConstructor,
 		TopLevelValid:    sourceType != "module",
 		IsStrict: func(fn *ast.Node, sf *ast.SourceFile) bool {
-			return isStrictFunction(fn, sf, ecmaVersion, sourceType == "module")
+			return isStrictFunction(fn, sf, ecmaVersion, sourceType == "module", honorES3JSDirectives)
 		},
 		FieldFrameScopedToValue: true,
 	}
@@ -119,9 +129,10 @@ func CoreEngineOptions(ctx rule.RuleContext, opts Options) EngineOptions {
 // BuildListeners is the shared `this`-validity walker behind both
 // `no-invalid-this` (this package) and `@typescript-eslint/no-invalid-this`
 // (internal/plugins/typescript/rules/no_invalid_this), which wraps this
-// function directly rather than duplicating it. The rules disagree only on
-// how much of a class field the field's own frame covers (see
-// `FieldFrameScopedToValue`).
+// function directly rather than duplicating it. The rules disagree on how
+// much of a class field the field's own frame covers and whether directive
+// prologues remain active in ES3 JavaScript (typescript-eslint parses them
+// with TypeScript rather than Espree).
 //
 // Everything else — the AST shapes recognized, the order branches are
 // checked in, computed-key and decorator handling — is identical, since
@@ -209,6 +220,12 @@ func BuildListeners(ctx rule.RuleContext, eo EngineOptions) rule.RuleListeners {
 	}
 
 	reportThis := func(node *ast.Node) {
+		// typescript-go represents `this` in a JSX tag name as a ThisKeyword,
+		// while ESTree parsers expose the authored text as JSXIdentifier. Keep
+		// real expressions such as `<X>{this}</X>` reportable.
+		if utils.IsInJsxTagName(node) {
+			return
+		}
 		// A decorator's expression is evaluated at class-definition
 		// time, in the scope surrounding the class — so `this` inside
 		// one belongs to the enclosing frame, not the decorated
@@ -372,7 +389,7 @@ func computeFunctionValid(node *ast.Node, sf *ast.SourceFile, comments []*ast.Co
 // strict" directive. Class decorators are evaluated outside their decorated
 // class body, so that class boundary is skipped while walking outward; member
 // decorators remain inside the class's strict scope.
-func isStrictFunction(fn *ast.Node, sf *ast.SourceFile, ecmaVersion int, isModule bool) bool {
+func isStrictFunction(fn *ast.Node, sf *ast.SourceFile, ecmaVersion int, isModule, honorES3JSDirectives bool) bool {
 	// Modules, classes, and TypeScript namespaces impose strict mode
 	// independently of directive prologues and therefore remain strict even
 	// when the configured language version is ES3.
@@ -397,9 +414,9 @@ func isStrictFunction(fn *ast.Node, sf *ast.SourceFile, ecmaVersion int, isModul
 			}
 			return true
 		}
-		if (ecmaVersion != 3 || !sf.IsJS()) && ast.IsFunctionLike(current) && !skipDecoratedClassBody {
+		if (honorES3JSDirectives || ecmaVersion != 3 || !sf.IsJS()) && ast.IsFunctionLike(current) && !skipDecoratedClassBody {
 			body := current.Body()
-			if body != nil && body.Kind == ast.KindBlock && utils.HasUseStrictDirective(body) {
+			if body != nil && body.Kind == ast.KindBlock && hasUseStrictDirective(body, sf) {
 				return true
 			}
 		}
@@ -409,14 +426,38 @@ func isStrictFunction(fn *ast.Node, sf *ast.SourceFile, ecmaVersion int, isModul
 	// source, only the syntax-imposed contexts handled above can make the
 	// function strict. typescript-eslint keeps directives active for TypeScript
 	// sources even when languageOptions.ecmaVersion is 3.
-	if ecmaVersion == 3 && sf.IsJS() {
+	if !honorES3JSDirectives && ecmaVersion == 3 && sf.IsJS() {
 		return false
 	}
-	if utils.HasUseStrictDirective(sf.AsNode()) {
+	if hasUseStrictDirective(sf.AsNode(), sf) {
 		return true
 	}
 	body := fn.Body()
-	return body != nil && body.Kind == ast.KindBlock && utils.HasUseStrictDirective(body)
+	return body != nil && body.Kind == ast.KindBlock && hasUseStrictDirective(body, sf)
+}
+
+// hasUseStrictDirective recognizes only the exact source spellings that form
+// a JavaScript strict-mode directive. StringLiteral.Text is cooked, so using
+// it would incorrectly accept escaped lookalikes such as "use\x20strict".
+func hasUseStrictDirective(block *ast.Node, sf *ast.SourceFile) bool {
+	text := sf.Text()
+	for _, stmt := range block.Statements() {
+		if !ast.IsPrologueDirective(stmt) {
+			break
+		}
+		expr := stmt.Expression()
+		if expr == nil {
+			continue
+		}
+		start := scanner.SkipTrivia(text, expr.Pos())
+		if start >= 0 && expr.End() <= len(text) {
+			raw := text[start:expr.End()]
+			if raw == `"use strict"` || raw == `'use strict'` {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // hasThisParameter reports whether the function's parameter list begins with
@@ -698,6 +739,11 @@ func leadingCommentSummary(node *ast.Node, comments []*ast.CommentRange, sf *ast
 // node's range. Parentheses are absent from ESTree, so a comment separated from
 // the semantic node by `(` is not a leading comment of that node itself.
 func estreeNodeStart(node *ast.Node, sf *ast.SourceFile) int {
+	if node.Kind == ast.KindExpressionStatement {
+		// ESTree retains grouping parentheses in the statement's range even
+		// though it erases them from the nested expression node.
+		return scanner.SkipTrivia(sf.Text(), node.Pos())
+	}
 	if node.Kind == ast.KindArrowFunction {
 		// A parenthesized arrow's opening `(` belongs to its ESTree range as
 		// the parameter-list token; it is not an erased grouping wrapper.
@@ -1068,7 +1114,7 @@ func enclosingFrameSkip(thisNode *ast.Node, fieldFrameScopedToValue bool) int {
 			// Lexical `this` — keep walking up.
 		case ast.KindPropertyDeclaration:
 			if isAbstractPropertyDeclaration(current) {
-				return skip
+				break
 			}
 			if !fieldFrameScopedToValue {
 				return skip
@@ -1081,11 +1127,17 @@ func enclosingFrameSkip(thisNode *ast.Node, fieldFrameScopedToValue bool) int {
 			fallthrough
 		case ast.KindMethodDeclaration, ast.KindConstructor,
 			ast.KindGetAccessor, ast.KindSetAccessor:
+			if !hasFunctionBody(current) {
+				break
+			}
 			if !hasComputedKey(current) || prev != ast.GetNameOfDeclaration(current) {
 				return skip
 			}
 		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
 			ast.KindClassStaticBlockDeclaration:
+			if ast.IsFunctionLike(current) && !hasFunctionBody(current) {
+				break
+			}
 			return skip
 		}
 		prev, current = current, current.Parent

--- a/internal/rules/no_invalid_this/no_invalid_this_extras_test.go
+++ b/internal/rules/no_invalid_this/no_invalid_this_extras_test.go
@@ -698,3 +698,83 @@ function outer() {
 		},
 	)
 }
+
+func TestNoInvalidThisParityRegressions(t *testing.T) {
+	unexpected := func(line, col int) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedThis", Line: line, Column: col}}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.allow-js.json",
+		t,
+		&NoInvalidThisRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: JSX tag names are JSXIdentifier upstream ----
+			{Code: `<this />`, FileName: "jsx-tag.tsx"},
+			{Code: `<this.Widget></this.Widget>`, FileName: "jsx-member.tsx"},
+			{Code: `<this.Widget.Deep />`, FileName: "jsx-nested-member.tsx"},
+			// ---- Raw directive spelling: cooked lookalikes are not directives ----
+			{Code: `"use\x20strict"; function f(){ this; }`, FileName: "escaped-space.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			{Code: `'use str\x69ct'; function f(){ this; }`, FileName: "escaped-letter.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			{Code: `function outer(){ "use\u0020strict"; function f(){ this; } }`, FileName: "escaped-ancestor.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			{Code: "\"use\\\n strict\"; function f(){ this; }", FileName: "continued-directive.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			// ---- JSDoc anchors: ESTree retains the ExpressionStatement range ----
+			{Code: `"use strict"; /** @this */ (x + function(){ this; });`, FileName: "parenthesized-statement.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			{Code: `"use strict"; /** @this */ (((x + function(){ this; })));`, FileName: "nested-parenthesized-statement.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			// The same overload shape is valid when its enclosing decorator is
+			// evaluated in a sloppy script.
+			{Code: `class O { @dec((()=>{ function f(x: typeof this): void; function f(x:any){} })()) m(){} }`, FileName: "decorated-overload-script.ts", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			// A bodyless declaration inside a real method inherits the method frame.
+			{Code: `class C { m(){ function f(x: typeof this): void; } }`, FileName: "overload-in-method.ts"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// JSX expressions remain ordinary ThisExpression nodes upstream.
+			{Code: `<X>{this}</X>`, FileName: "jsx-expression.tsx", Errors: unexpected(1, 5)},
+			{Code: `<this.Widget>{this}</this.Widget>`, FileName: "jsx-tag-and-expression.tsx", Errors: unexpected(1, 15)},
+			// Exact single-quoted directives remain active after raw-text matching.
+			{Code: `'use strict'; function f(){ this; }`, FileName: "single-quoted.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Errors: unexpected(1, 29)},
+			// Parenthesizing the statement must not make a nested call argument own
+			// the statement's JSDoc.
+			{Code: `"use strict"; /** @this */ (foo(function(){this;}));`, FileName: "jsdoc-call-boundary.js", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Errors: unexpected(1, 44)},
+			// Bodyless declarations never push a frame, so nested frame lookup must
+			// continue through them to the decorator's enclosing module context.
+			{Code: `class O { @dec((()=>{ function f(x: typeof this): void; function f(x:any){} })()) m(){} }`, FileName: "decorated-overload.ts", Errors: unexpected(1, 44)},
+			{Code: `class O { @dec((()=>{ abstract class A { abstract m(x: typeof this): void; } })()) m(){} }`, FileName: "decorated-abstract.ts", Errors: unexpected(1, 63)},
+			{Code: `export {}; function outer(){ function f(x: typeof this): void; }`, FileName: "overload-in-strict-function.ts", Errors: unexpected(1, 51)},
+		},
+	)
+}
+
+func BenchmarkNoInvalidThisStrictDetection(b *testing.B) {
+	cases := []struct {
+		name string
+		code string
+		want bool
+	}{
+		{name: "exact-directive", code: `"use strict"; function f(){ this; }`, want: true},
+		{name: "escaped-lookalike", code: `"use\x20strict"; function f(){ this; }`, want: false},
+		{name: "no-directive", code: `void 0; function f(){ this; }`, want: false},
+	}
+	help := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	for _, test := range cases {
+		b.Run(test.name, func(b *testing.B) {
+			_, sourceFile, err := help.CreateTestProgram(test.code, test.name+".ts", "tsconfig.json")
+			if err != nil {
+				b.Fatal(err)
+			}
+			statements := sourceFile.AsNode().Statements()
+			if len(statements) != 2 {
+				b.Fatalf("statements = %d, want 2", len(statements))
+			}
+			fn := statements[1]
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if got := isStrictFunction(fn, sourceFile, 2026, false, false); got != test.want {
+					b.Fatalf("isStrictFunction() = %t, want %t", got, test.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Align `no-invalid-this` and `@typescript-eslint/no-invalid-this` with their upstream parsers for JSX tag names, raw strict-mode directives, parenthesized JSDoc statement anchors, ES3 JavaScript, and bodyless TypeScript declarations nested in decorators.

The strict-mode hot path remains allocation-free, and focused Go, IPC, spelling, formatting, and changed-package lint checks pass.

## Related Links

- [ESLint: no-invalid-this](https://eslint.org/docs/latest/rules/no-invalid-this)
- [typescript-eslint: no-invalid-this](https://typescript-eslint.io/rules/no-invalid-this)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).