### PR TITLE
fix: align no-unused-vars removal suggestions

### DIFF
--- a/internal/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/rules/no_unused_vars/no_unused_vars.go
@@ -1247,6 +1247,47 @@ func removeNodeRange(sourceFile *ast.SourceFile, node *ast.Node) rule.RuleFix {
 	return rule.RuleFixRemoveRange(utils.TrimNodeTextRange(sourceFile, node))
 }
 
+// isClosingBraceOfBlock mirrors ESLint's distinction between a closing brace
+// that ends a statement-level block (where ASI makes adjacency safe) and one
+// that ends an expression (where removing the declaration between it and the
+// next token could change the parse).
+func isClosingBraceOfBlock(sourceFile *ast.SourceFile, token utils.SourceToken) bool {
+	if sourceFile == nil || token.Kind != ast.KindCloseBraceToken {
+		return false
+	}
+
+	// GetNodeAtPosition normally returns the innermost construct owning the
+	// brace. Walk outward defensively, but consider only constructs ending at
+	// this exact brace so an enclosing block cannot make an object/function
+	// expression brace look safe.
+	for node := ast.GetNodeAtPosition(sourceFile, token.Start, false); node != nil; node = node.Parent {
+		if node.End() != token.End {
+			continue
+		}
+		switch node.Kind {
+		case ast.KindBlock:
+			return node.Parent != nil &&
+				node.Parent.Kind != ast.KindFunctionExpression && node.Parent.Kind != ast.KindArrowFunction
+		case ast.KindClassDeclaration, ast.KindSwitchStatement:
+			return true
+		case ast.KindClassExpression, ast.KindObjectLiteralExpression:
+			return false
+		}
+	}
+	return false
+}
+
+func isDeclarationNotSafeToRemove(
+	sourceFile *ast.SourceFile,
+	next utils.SourceToken,
+	previous utils.SourceToken,
+	hasPrevious bool,
+) bool {
+	return next.Kind == ast.KindStringLiteral ||
+		(hasPrevious && previous.Kind != ast.KindSemicolonToken && previous.Kind != ast.KindOpenBraceToken &&
+			!isClosingBraceOfBlock(sourceFile, previous))
+}
+
 func isSingleStatementBody(node *ast.Node) bool {
 	if node == nil || node.Parent == nil {
 		return false
@@ -1299,6 +1340,15 @@ func fixVariableDeclaration(ctx rule.RuleContext, declaration *ast.Node, ac *ana
 	declarationRange := utils.TrimNodeTextRange(ctx.SourceFile, declaration)
 	if len(declarations) > 1 {
 		if before, ok := tokenBefore(ac.tokens, declarationRange.Pos(), 0); ok && before.Text == "," {
+			if declaration == declarations[len(declarations)-1] {
+				after, hasAfter := tokenAfter(ac.tokens, declarationRange.End(), 0)
+				if hasAfter && after.Kind != ast.KindSemicolonToken {
+					lastRemaining, hasLastRemaining := tokenBefore(ac.tokens, declarationRange.Pos(), 1)
+					if isDeclarationNotSafeToRemove(ctx.SourceFile, after, lastRemaining, hasLastRemaining) {
+						return rule.RuleFix{}, false
+					}
+				}
+			}
 			return rule.RuleFixRemoveRange(core.NewTextRange(before.Start, declarationRange.End())), true
 		}
 		if after, ok := tokenAfter(ac.tokens, declarationRange.End(), 0); ok && after.Text == "," {
@@ -1318,12 +1368,26 @@ func fixVariableDeclaration(ctx rule.RuleContext, declaration *ast.Node, ac *ana
 	next, hasNext := tokenAfter(ac.tokens, statementRange.End(), 0)
 	if hasNext {
 		previous, hasPrevious := tokenBefore(ac.tokens, statementRange.Pos(), 0)
-		if next.Kind == ast.KindStringLiteral ||
-			(hasPrevious && previous.Text != ";" && previous.Text != "{") {
+		if isDeclarationNotSafeToRemove(ctx.SourceFile, next, previous, hasPrevious) {
 			return rule.RuleFix{}, false
 		}
 	}
 	return rule.RuleFixRemoveRange(statementRange), true
+}
+
+func fixFunctionOrClassDeclaration(ctx rule.RuleContext, declaration *ast.Node, ac *analysisContext) (rule.RuleFix, bool) {
+	if declaration == nil {
+		return rule.RuleFix{}, false
+	}
+	ac.ensureTokens(ctx.SourceFile)
+	declarationRange := utils.TrimNodeTextRange(ctx.SourceFile, declaration)
+	if next, hasNext := tokenAfter(ac.tokens, declarationRange.End(), 0); hasNext {
+		previous, hasPrevious := tokenBefore(ac.tokens, declarationRange.Pos(), 0)
+		if isDeclarationNotSafeToRemove(ctx.SourceFile, next, previous, hasPrevious) {
+			return rule.RuleFix{}, false
+		}
+	}
+	return rule.RuleFixRemoveRange(declarationRange), true
 }
 
 func fixFunctionParameter(ctx rule.RuleContext, parameter *ast.Node, ac *analysisContext) (rule.RuleFix, bool) {
@@ -1531,10 +1595,10 @@ func getCoreRemoveSuggestion(ctx rule.RuleContext, nameNode *ast.Node, definitio
 			// itself as ESLint's removal range, not the whole declaration.
 			fix, ok = removeNodeRange(ctx.SourceFile, nameNode), true
 		} else {
-			fix, ok = removeNodeRange(ctx.SourceFile, definition), true
+			fix, ok = fixFunctionOrClassDeclaration(ctx, definition, ac)
 		}
 	case ast.KindClassDeclaration:
-		fix, ok = removeNodeRange(ctx.SourceFile, definition), true
+		fix, ok = fixFunctionOrClassDeclaration(ctx, definition, ac)
 	case ast.KindTypeParameter, ast.KindEnumMember:
 		ac.ensureTokens(ctx.SourceFile)
 		fix, ok = fixCommaSeparatedName(ctx, nameNode, ac), true

--- a/internal/rules/no_unused_vars/no_unused_vars_upstream_asi_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_upstream_asi_test.go
@@ -1,0 +1,235 @@
+package no_unused_vars
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func upstreamASIError(name string, assigned bool, suggestionOutput *string) rule_tester.InvalidTestCaseError {
+	action := "defined"
+	if assigned {
+		action = "assigned a value"
+	}
+	expected := rule_tester.InvalidTestCaseError{
+		MessageId: "unusedVar",
+		Message:   "'" + name + "' is " + action + " but never used.",
+	}
+	if suggestionOutput != nil {
+		expected.Suggestions = []rule_tester.InvalidTestCaseSuggestion{{
+			MessageId: "removeVar",
+			Output:    *suggestionOutput,
+		}}
+	}
+	return expected
+}
+
+func upstreamASISuggestion(output string) *string {
+	return &output
+}
+
+// TestNoUnusedVarsUpstreamASISuggestions covers the no-unused-vars cases added
+// upstream after the full v10.7.0 fixture, through ESLint v10.9.1. They pin
+// both sides of the ASI safety boundary for removal suggestions.
+func TestNoUnusedVarsUpstreamASISuggestions(t *testing.T) {
+	module := rule.LanguageOptions{SourceType: "module"}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "if (true) {}\nfunction unused() {}\n(console.log)()",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", false, upstreamASISuggestion("if (true) {}\n\n(console.log)()")),
+				},
+			},
+			{
+				Code:            "export class A {}\nfunction unused() {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", false, upstreamASISuggestion("export class A {}\n\n(console.log)()")),
+				},
+			},
+			{
+				Code: "switch (1) {}\nfunction unused() {}\n(console.log)()",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", false, upstreamASISuggestion("switch (1) {}\n\n(console.log)()")),
+				},
+			},
+			{
+				Code:            "export const f = function() {}\nfunction unused() {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors:          []rule_tester.InvalidTestCaseError{upstreamASIError("unused", false, nil)},
+			},
+			{
+				Code:            "export const obj = { a: 1 }\nfunction unused() {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors:          []rule_tester.InvalidTestCaseError{upstreamASIError("unused", false, nil)},
+			},
+			{
+				Code:            "const x = 1\nfunction unused() {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("\nfunction unused() {}\n(console.log)()")),
+					upstreamASIError("unused", false, nil),
+				},
+			},
+			{
+				Code:            "const x = 1\nfunction unused() {}\n/regex/.test('a')",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("\nfunction unused() {}\n/regex/.test('a')")),
+					upstreamASIError("unused", false, nil),
+				},
+			},
+			{
+				Code:            "const x = 1\nclass Unused {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("\nclass Unused {}\n(console.log)()")),
+					upstreamASIError("Unused", false, nil),
+				},
+			},
+			{
+				Code:            "const x = 1,\n      y = () => {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("const \n      y = () => {}\n(console.log)()")),
+					upstreamASIError("y", true, nil),
+				},
+			},
+			{
+				Code:            "const { x } = obj,\n      y = () => {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("const \n      y = () => {}\n(console.log)()")),
+					upstreamASIError("y", true, nil),
+				},
+			},
+			{
+				Code: "var x = 1;\nfunction unused() {}\nvar z = 3",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("\nfunction unused() {}\nvar z = 3")),
+					upstreamASIError("unused", false, upstreamASISuggestion("var x = 1;\n\nvar z = 3")),
+					upstreamASIError("z", true, upstreamASISuggestion("var x = 1;\nfunction unused() {}\n")),
+				},
+			},
+			{
+				Code: "{ console.log(); class Unused {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("Unused", false, upstreamASISuggestion("{ console.log();  }")),
+				},
+			},
+			{
+				Code: "console.log();\nfunction unused() {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", false, upstreamASISuggestion("console.log();\n")),
+				},
+			},
+			{
+				Code: "console.log();\nclass Unused {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("Unused", false, upstreamASISuggestion("console.log();\n")),
+				},
+			},
+			{
+				Code:   "const before = true\nfunction unused() {}\nif (before) {}",
+				Errors: []rule_tester.InvalidTestCaseError{upstreamASIError("unused", false, nil)},
+			},
+			{
+				Code:            "/* comment */\nfunction unused() {}\n(a) => {}",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", false, upstreamASISuggestion("/* comment */\n\n(a) => {}")),
+					upstreamASIError("a", false, upstreamASISuggestion("/* comment */\nfunction unused() {}\n() => {}")),
+				},
+			},
+			{
+				Code:            "const x = 1;\nfunction unused() {}\n/* comment */\n(a) => {}",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("\nfunction unused() {}\n/* comment */\n(a) => {}")),
+					upstreamASIError("unused", false, upstreamASISuggestion("const x = 1;\n\n/* comment */\n(a) => {}")),
+					upstreamASIError("a", false, upstreamASISuggestion("const x = 1;\nfunction unused() {}\n/* comment */\n() => {}")),
+				},
+			},
+			{
+				Code:            "const x = 1,\n      y = () => {}\n() => {};",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("x", true, upstreamASISuggestion("const \n      y = () => {}\n() => {};")),
+					upstreamASIError("y", true, nil),
+				},
+			},
+			{
+				Code: "var a = 1, b = 2; console.log(a)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("b", true, upstreamASISuggestion("var a = 1; console.log(a)")),
+				},
+			},
+		},
+	)
+}
+
+// TestNoUnusedVarsASIAdversarial attacks boundaries adjacent to the upstream
+// cases: the documented variable-after-function shape, expression braces,
+// string directives, EOF, and a retained semicolon in a multi-declaration.
+func TestNoUnusedVarsASIAdversarial(t *testing.T) {
+	module := rule.LanguageOptions{SourceType: "module"}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "function used() {}\nvar Type2Parser = function type2Parser() {};\nused();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("Type2Parser", true, upstreamASISuggestion("function used() {}\n\nused();")),
+				},
+			},
+			{
+				Code: "function used() {}\nfunction unused() {}\n(console.log)();\nused();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", false, upstreamASISuggestion("function used() {}\n\n(console.log)();\nused();")),
+				},
+			},
+			{
+				Code:            "export const arrow = () => {}\nfunction unused() {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors:          []rule_tester.InvalidTestCaseError{upstreamASIError("unused", false, nil)},
+			},
+			{
+				Code:            "export const Expression = class {}\nfunction unused() {}\n(console.log)()",
+				LanguageOptions: module,
+				Errors:          []rule_tester.InvalidTestCaseError{upstreamASIError("unused", false, nil)},
+			},
+			{
+				Code: "function used() {}\nvar unused = 1;\n'not a directive';\nused();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", true, nil),
+				},
+			},
+			{
+				Code:            "export const expression = function() {}\nvar unused = 1",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", true, upstreamASISuggestion("export const expression = function() {}\n")),
+				},
+			},
+			{
+				Code:            "export const arrow = () => {}\nvar used = 1, unused = 2; consume(used)",
+				LanguageOptions: module,
+				Errors: []rule_tester.InvalidTestCaseError{
+					upstreamASIError("unused", true, upstreamASISuggestion("export const arrow = () => {}\nvar used = 1; consume(used)")),
+				},
+			},
+		},
+	)
+}


### PR DESCRIPTION
## Summary

- Align Go-side `no-unused-vars` removal suggestions with ESLint v10.9.1's ASI safety checks for variables, functions, and classes.
- Restore the documented `Type2Parser` suggestion with the exact removal range `[7254, 11382]`, while keeping expression braces and directive-producing removals unsafe.
- Add all 19 upstream ASI cases introduced after the existing v10.7.0 fixture plus 7 adversarial boundary cases.
- Benchmark the documented file with and without suggestions. The diagnostics-only path kept the same allocations, and the suggestion-path delta was limited to constructing the newly restored suggestion, so no speculative performance change was added.

### Validation

- `go test ./internal/rules/no_unused_vars -run '^TestNoUnusedVars(UpstreamASISuggestions|ASIAdversarial)$' -count=1`
- `go test ./internal/rules/no_unused_vars -run '^(TestNoUnusedVarsUpstream|TestNoUnusedVarsEditDemand)$' -count=1`
- `pnpm --filter @rslint/test-tools exec rstest run tests/eslint/rules/no-unused-vars.test.ts` (2 tests passed; 0 snapshot changes)
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run internal/rules/no_unused_vars/no_unused_vars.go internal/rules/no_unused_vars/no_unused_vars_upstream_asi_test.go`

## Related Links

- https://github.com/eslint/eslint/compare/v10.7.0...v10.9.1

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
