### PR TITLE
fix: align plugin edits with ESLint API

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -618,8 +618,9 @@ Important behavior differences by integration:
 - **LSP quick fix**: returns direct text edits for one diagnostic
 - **LSP fix-all**: materializes isolated speculative generations for repeated
   core-owned memory rounds, then returns one whole-document replacement edit
-- **LSP normal diagnostics and API**: request all native edits because fixes and
-  suggestions are response metadata even when they are not immediately applied
+- **LSP normal diagnostics and API**: request all native and third-party plugin
+  edits because fixes and suggestions are response metadata even when they are
+  not immediately applied
 - **LSP speculative fix-all passes**: request native autofixes only
 - **API**: `lint({ fix: true })` selects the same linter-owned ten-round autofix
   lifecycle as CLI and requests a complete final observation. Diagnostics,
@@ -1458,7 +1459,7 @@ JSON config supports only bundled plugin names because it cannot represent live 
 ### Integration Points
 
 - **Language Server**: `internal/lsp` exposes diagnostics and code actions
-- **JavaScript API**: `packages/rslint` talks to the `internal/api/server` handler composed by `cmd/rslint --api` through the versioned `2.0.0` protocol; the handshake negotiates reverse `pluginLint` support before third-party rules run
+- **JavaScript API**: `packages/rslint` talks to the `internal/api/server` handler composed by `cmd/rslint --api` through the versioned `3.0.0` protocol; the handshake negotiates reverse `pluginLint` support before third-party rules run
 - **WASM Playground**: `packages/rslint-wasm` runs the API server in a browser worker
 - **Rust Client**: `crates/tsgo-client` consumes `cmd/tsgo`
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -64,7 +64,7 @@ const (
 )
 
 // Version is the IPC protocol version.
-const Version = "2.0.0"
+const Version = "3.0.0"
 
 const CapabilityReversePluginLint = "reversePluginLint"
 const CapabilityReverseConfigLoad = "reverseConfigLoadV1"

--- a/internal/api/server/lint.go
+++ b/internal/api/server/lint.go
@@ -439,10 +439,8 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 	}
 	demand := linter.ArtifactDemand{
 		Native:      rule.EditDemandAll,
+		Plugin:      rule.EditDemandAll,
 		LintedFiles: true,
-	}
-	if req.Fix {
-		demand.Plugin = rule.EditDemandAll
 	}
 	policy := linter.ObservationPolicy{
 		Demand:        demand,

--- a/internal/api/server/lint_test.go
+++ b/internal/api/server/lint_test.go
@@ -2339,8 +2339,8 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 		if !ok {
 			t.Fatalf("unexpected pluginLint payload type %T", payload)
 		}
-		if !req.Fix || req.SuggestionsMode != linter.SuggestionsModeEager {
-			t.Fatalf("unexpected fix settings: fix=%v suggestions=%q", req.Fix, req.SuggestionsMode)
+		if !req.CollectFixes || req.SuggestionsMode != linter.SuggestionsModeEager {
+			t.Fatalf("unexpected edit settings: collectFixes=%v suggestions=%q", req.CollectFixes, req.SuggestionsMode)
 		}
 		if len(req.Files) != 1 || req.Files[0].Text == nil {
 			t.Fatalf("plugin request must carry the exact overlay text, got %+v", req.Files)
@@ -2404,6 +2404,95 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 	}
 	if got := response.Output["input.js"]; got != "const good = 1;\n" {
 		t.Fatalf("expected plugin fix in Output, got %q", got)
+	}
+}
+
+func TestHandleLint_EslintPluginEditsWithoutAutofix(t *testing.T) {
+	dir := t.TempDir()
+	pluginConfigDirectory := filepath.Join(dir, "authored-config")
+	target := filepath.Join(dir, "input.js")
+	const source = "const bad = 1;\n"
+	config := json.RawMessage(`[{
+		"plugins": ["community"],
+		"rules": { "community/rename": "warn" }
+	}]`)
+
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		calls.Add(1)
+		if kind != api.KindPluginLint {
+			t.Fatalf("expected pluginLint reverse request, got %q", kind)
+		}
+		req, ok := payload.(linter.EslintPluginLintRequest)
+		if !ok {
+			t.Fatalf("unexpected pluginLint payload type %T", payload)
+		}
+		if !req.CollectFixes || req.SuggestionsMode != linter.SuggestionsModeEager {
+			t.Fatalf("unexpected edit settings: collectFixes=%v suggestions=%q", req.CollectFixes, req.SuggestionsMode)
+		}
+		if len(req.Files) != 1 || req.Files[0].Text == nil || *req.Files[0].Text != source {
+			t.Fatalf("plugin request must carry the exact overlay text, got %+v", req.Files)
+		}
+		result := linter.EslintPluginLintResult{Results: []linter.EslintPluginFileResult{{
+			FilePath: req.Files[0].Path,
+			Diagnostics: []linter.EslintPluginDiagnostic{{
+				RuleName:  "community/rename",
+				MessageId: "rename",
+				Message:   "rename bad",
+				StartPos:  6,
+				EndPos:    9,
+				Fixes: []linter.EslintPluginFix{{
+					Range: [2]int{6, 9},
+					Text:  "good",
+				}},
+				Suggestions: []linter.EslintPluginSuggestion{{
+					MessageId: "suggestRename",
+					Desc:      "Rename to better",
+					Fixes: []linter.EslintPluginFix{{
+						Range: [2]int{6, 9},
+						Text:  "better",
+					}},
+				}},
+			}},
+		}}}
+		return ipc.NewMessage(ipc.KindResponse, 1, result)
+	})
+
+	response, err := (&Handler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Config:                config,
+		ConfigDirectory:       dir,
+		PluginConfigDirectory: pluginConfigDirectory,
+		WorkingDirectory:      dir,
+		Files:                 []string{target},
+		FileContents:          map[string]string{target: source},
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "community",
+			RuleNames: []string{"rename"},
+		}},
+	}, requester)
+	if err != nil {
+		t.Fatalf("HandleLintWithContext returned error: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("pluginLint requests = %d, want one non-mutating observation", calls.Load())
+	}
+	if len(response.Diagnostics) != 1 {
+		t.Fatalf("plugin diagnostics = %+v, want one", response.Diagnostics)
+	}
+	diagnostic := response.Diagnostics[0]
+	if len(diagnostic.Fixes) != 1 || diagnostic.Fixes[0].Text != "good" {
+		t.Fatalf("plugin autofix payload = %+v, want replacement good", diagnostic.Fixes)
+	}
+	if len(diagnostic.Suggestions) != 1 || len(diagnostic.Suggestions[0].Fixes) != 1 ||
+		diagnostic.Suggestions[0].Fixes[0].Text != "better" {
+		t.Fatalf("plugin suggestion payload = %+v, want replacement better", diagnostic.Suggestions)
+	}
+	if response.WarningCount != 1 || response.FixableWarningCount != 1 || response.ErrorCount != 0 {
+		t.Fatalf("unexpected plugin counts: warnings=%d fixableWarnings=%d errors=%d",
+			response.WarningCount, response.FixableWarningCount, response.ErrorCount)
+	}
+	if len(response.Output) != 0 {
+		t.Fatalf("non-autofix request unexpectedly produced output: %+v", response.Output)
 	}
 }
 

--- a/internal/linter/eslint_plugin.go
+++ b/internal/linter/eslint_plugin.go
@@ -42,15 +42,16 @@ type EslintPluginLintRequest struct {
 	Generation      string                            `json:"generation,omitempty"`
 	Files           []EslintPluginLintFile            `json:"files"`
 	Rules           map[string]EslintPluginRuleConfig `json:"rules"`
-	Fix             bool                              `json:"fix"`
+	CollectFixes    bool                              `json:"collectFixes"`
 	SuggestionsMode string                            `json:"suggestionsMode"`
 	CollectTiming   bool                              `json:"collectTiming,omitempty"`
 }
 
 // SuggestionsMode values for EslintPluginLintRequest.SuggestionsMode — the wire
 // contract the Node worker interprets. "eager" materializes each suggestion's
-// fix (the CLI/LSP --fix path applies them like fixes); "off" records only the
-// suggestion descriptors without running their fixers.
+// fix for consumers such as Node API and LSP code actions; suggestions are never
+// applied by the autofix pipeline. "off" records only their descriptors without
+// running their fixers.
 const (
 	SuggestionsModeOff   = "off"
 	SuggestionsModeEager = "eager"
@@ -256,7 +257,7 @@ func DispatchEslintPluginRules(
 	ctx context.Context,
 	dispatch EslintPluginDispatcher,
 	files []EslintPluginFileInput,
-	fix bool,
+	collectFixes bool,
 	suggestionsMode string,
 	timing *TimingCollector,
 	onDiagnostic DiagnosticHandler,
@@ -265,7 +266,7 @@ func DispatchEslintPluginRules(
 		ctx,
 		dispatch,
 		files,
-		fix,
+		collectFixes,
 		suggestionsMode,
 		timing,
 		onDiagnostic,
@@ -277,7 +278,7 @@ func dispatchEslintPluginRules(
 	ctx context.Context,
 	dispatch EslintPluginDispatcher,
 	files []EslintPluginFileInput,
-	fix bool,
+	collectFixes bool,
 	suggestionsMode string,
 	timing *TimingCollector,
 	onDiagnostic DiagnosticHandler,
@@ -302,7 +303,7 @@ func dispatchEslintPluginRules(
 				ctx,
 				dispatch,
 				batch,
-				fix,
+				collectFixes,
 				suggestionsMode,
 				timing,
 				func(d rule.RuleDiagnostic) { batchDiags[i] = append(batchDiags[i], d) },
@@ -379,7 +380,7 @@ func DispatchEslintPluginRulesAsync(
 	ctx context.Context,
 	dispatch EslintPluginDispatcher,
 	inputs []EslintPluginFileInput,
-	fix bool,
+	collectFixes bool,
 	suggestionsMode string,
 	timing *TimingCollector,
 ) <-chan EslintPluginDispatchOutcome {
@@ -389,7 +390,7 @@ func DispatchEslintPluginRulesAsync(
 			ctx,
 			dispatch,
 			inputs,
-			fix,
+			collectFixes,
 			suggestionsMode,
 			timing,
 		)
@@ -405,7 +406,7 @@ func DispatchEslintPluginRulesWithOutcome(
 	ctx context.Context,
 	dispatch EslintPluginDispatcher,
 	inputs []EslintPluginFileInput,
-	fix bool,
+	collectFixes bool,
 	suggestionsMode string,
 	timing *TimingCollector,
 ) EslintPluginDispatchOutcome {
@@ -414,7 +415,7 @@ func DispatchEslintPluginRulesWithOutcome(
 		ctx,
 		dispatch,
 		inputs,
-		fix,
+		collectFixes,
 		suggestionsMode,
 		timing,
 		func(diagnostic rule.RuleDiagnostic) {
@@ -450,7 +451,7 @@ func dispatchOneBatch(
 	ctx context.Context,
 	dispatch EslintPluginDispatcher,
 	batch []EslintPluginFileInput,
-	fix bool,
+	collectFixes bool,
 	suggestionsMode string,
 	timing *TimingCollector,
 	onDiagnostic DiagnosticHandler,
@@ -461,7 +462,7 @@ func dispatchOneBatch(
 			err = fmt.Errorf("eslint-plugin dispatch panicked: %v", r)
 		}
 	}()
-	req := buildEslintPluginRequest(batch, fix, suggestionsMode, timing != nil)
+	req := buildEslintPluginRequest(batch, collectFixes, suggestionsMode, timing != nil)
 	res, dispatchErr := dispatch(ctx, req)
 	if dispatchErr != nil {
 		return dispatchErr
@@ -538,7 +539,7 @@ func eslintPluginBatchKey(f EslintPluginFileInput) string {
 	return string(b)
 }
 
-func buildEslintPluginRequest(batch []EslintPluginFileInput, fix bool, suggestionsMode string, collectTiming bool) EslintPluginLintRequest {
+func buildEslintPluginRequest(batch []EslintPluginFileInput, collectFixes bool, suggestionsMode string, collectTiming bool) EslintPluginLintRequest {
 	rules := map[string]EslintPluginRuleConfig{}
 	for _, r := range batch[0].Rules {
 		rules[r.Name] = EslintPluginRuleConfig{Options: r.Options}
@@ -556,7 +557,7 @@ func buildEslintPluginRequest(batch []EslintPluginFileInput, fix bool, suggestio
 	return EslintPluginLintRequest{
 		Files:           wireFiles,
 		Rules:           rules,
-		Fix:             fix,
+		CollectFixes:    collectFixes,
 		SuggestionsMode: suggestionsMode,
 		CollectTiming:   collectTiming,
 	}

--- a/internal/linter/eslint_plugin_test.go
+++ b/internal/linter/eslint_plugin_test.go
@@ -641,7 +641,7 @@ func TestEslintPluginWire_RoundTrip(t *testing.T) {
 			Settings:        map[string]any{"foo": "bar"},
 		}},
 		Rules:           map[string]EslintPluginRuleConfig{"p/r": {Options: []any{"opt"}}},
-		Fix:             true,
+		CollectFixes:    true,
 		SuggestionsMode: "eager",
 	}
 	data, err := json.Marshal(req)
@@ -652,10 +652,13 @@ func TestEslintPluginWire_RoundTrip(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal request: %v", err)
 	}
-	for _, k := range []string{"files", "rules", "fix", "suggestionsMode"} {
+	for _, k := range []string{"files", "rules", "collectFixes", "suggestionsMode"} {
 		if _, ok := got[k]; !ok {
 			t.Errorf("request JSON missing top-level key %q", k)
 		}
+	}
+	if _, ok := got["fix"]; ok {
+		t.Error(`request JSON unexpectedly contains obsolete key "fix"`)
 	}
 	f0 := got["files"].([]any)[0].(map[string]any)
 	for _, k := range []string{"path", "text", "configKey", "languageOptions", "settings"} {

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -724,7 +724,7 @@ export class Rslint {
         contents[abs] = stripBOM(await readFile(abs, 'utf8'));
         contentPaths.add(key);
       } catch {
-        // Unreadable (e.g. virtual/deleted) — mergeFixes degrades to first edit.
+        // Unreadable (e.g. deleted) — mergeFixes omits the atomic multi-edit.
       }
     }
     return contents;
@@ -828,17 +828,19 @@ function toLintMessage(d: Diagnostic, sourceText?: string): LintMessage {
   const fix = mergeFixes(d.fixes, sourceText);
   if (fix) message.fix = fix;
   if (d.suggestions && d.suggestions.length > 0) {
-    message.suggestions = d.suggestions.map((s) => {
+    const suggestions: LintSuggestion[] = [];
+    for (const s of d.suggestions) {
       const sFix = mergeFixes(s.fixes, sourceText);
-      return {
-        messageId: s.messageId,
-        ...(s.data ? { data: s.data } : {}),
+      if (!sFix) continue;
+      const suggestion: LintSuggestion = {
         desc: s.message,
-        // A suggestion always carries a fix; fall back to an empty edit if a
-        // rule somehow emitted none (keeps the ESLint shape non-optional).
-        fix: sFix ?? { range: [0, 0], text: '' },
+        fix: sFix,
       };
-    });
+      if (s.messageId) suggestion.messageId = s.messageId;
+      if (s.data) suggestion.data = s.data;
+      suggestions.push(suggestion);
+    }
+    if (suggestions.length > 0) message.suggestions = suggestions;
   }
   return message;
 }
@@ -847,8 +849,9 @@ function toLintMessage(d: Diagnostic, sourceText?: string): LintMessage {
  * Collapse rslint's per-diagnostic fix edits (possibly several) into ESLint's
  * single `{ range, text }`. A lone edit maps directly; multiple edits merge
  * into one span, filling gaps from sourceText (ESLint's mergeFixes). Without
- * sourceText (e.g. a diagnosed file whose source could not be read), a
- * multi-edit fix degrades to its first edit rather than guessing across a gap.
+ * sourceText (e.g. a diagnosed file whose source could not be read), omit the
+ * whole atomic multi-edit rather than exposing a partial edit the rule never
+ * returned.
  *
  * Offsets are flat UTF-16, in the same byte-order-mark-free space as Go's fix
  * ranges (matching ESLint v10, whose `fix.range` is relative to BOM-stripped
@@ -870,10 +873,7 @@ function mergeFixes(
   const start = sorted[0].startPos;
   const end = sorted[sorted.length - 1].endPos;
   if (sourceText === undefined) {
-    return {
-      range: [sorted[0].startPos, sorted[0].endPos],
-      text: sorted[0].text,
-    };
+    return undefined;
   }
   let text = '';
   let lastPos = start;

--- a/packages/rslint/src/eslint-plugin/linter/diagnostic-builder.ts
+++ b/packages/rslint/src/eslint-plugin/linter/diagnostic-builder.ts
@@ -51,9 +51,10 @@ function interpolateMessage(
 // ─────────────────────────────────────────────────────────────────────
 
 /**
- * Suggestion descriptor as returned to Go. `fixes` is null in `'off'`
- * mode (we record the descriptor but didn't run `fix(fixer)`); a
- * populated array in `'eager'` mode.
+ * Suggestion descriptor as returned to Go. `fixes` is null only in `'off'`
+ * mode, where the descriptor is retained without invoking `fix(fixer)`.
+ * In `'eager'` mode suggestions whose fixer produces no edit are omitted,
+ * matching ESLint's `FileReport.mapSuggestions()` behavior.
  */
 export interface SuggestionDescriptor {
   messageId?: string;
@@ -321,12 +322,11 @@ export function buildDiagnostic(args: BuildDiagnosticArgs): Diagnostic | null {
     );
   }
 
-  // ── fix(fixer) — only when the caller asked us to collect fixes. ──
+  // ── fix(fixer) — only when the consumer requested the edit payload. ──
   //
-  // collectFixes is true when the consumer (CLI --fix, LSP code-actions)
-  // intends to surface the fix payload to the user. `false` skips the
-  // descriptor.fix(fixer) call entirely so a plugin whose fix() is
-  // expensive doesn't pay the cost on plain lint passes.
+  // Applying edits is a separate pipeline decision. For example, the
+  // ESLint-compatible Node API collects this payload even with `fix:false`.
+  // `false` skips descriptor.fix(fixer) for consumers that do not expose edits.
   let fixes: Fix[] | undefined;
   if (collectFixes && typeof descriptor.fix === 'function') {
     try {
@@ -380,7 +380,7 @@ export function buildDiagnostic(args: BuildDiagnosticArgs): Diagnostic | null {
         );
       }
     }
-    suggestions = descriptor.suggest.map((s) => {
+    const builtSuggestions = descriptor.suggest.map((s) => {
       let suggestionMessage = s.desc;
       if (!suggestionMessage && s.messageId) {
         suggestionMessage = messages[s.messageId] ?? `(${s.messageId})`;
@@ -401,6 +401,16 @@ export function buildDiagnostic(args: BuildDiagnosticArgs): Diagnostic | null {
       }
       return { messageId: s.messageId, desc: suggestionMessage, fixes: sFixes };
     });
+    if (suggestionsMode === 'eager') {
+      const materializedSuggestions = builtSuggestions.filter(
+        (suggestion) => suggestion.fixes !== null,
+      );
+      if (materializedSuggestions.length > 0) {
+        suggestions = materializedSuggestions;
+      }
+    } else {
+      suggestions = builtSuggestions;
+    }
   }
 
   return {

--- a/packages/rslint/src/eslint-plugin/plugin/plugin-lint-protocol.ts
+++ b/packages/rslint/src/eslint-plugin/plugin/plugin-lint-protocol.ts
@@ -60,8 +60,8 @@ export interface EslintPluginLintRequest {
     configKey?: string;
   }>;
   rules?: Record<string, { options?: readonly unknown[] }>;
-  /** Collect autofixes (driven by Go's `--fix`). */
-  fix?: boolean;
+  /** Materialize each diagnostic's autofix payload without applying it. */
+  collectFixes: boolean;
   suggestionsMode?: 'off' | 'eager';
   /** Collect per-rule execution times (driven by Go's `--timing`). */
   collectTiming?: boolean;
@@ -107,9 +107,7 @@ export function buildPluginLintTasks(
       { options: v.options ?? [], meta: undefined },
     ]),
   );
-  // `fix` is the wire-level name (mirrors Go's `EslintPluginLintRequest.Fix`);
-  // the worker's per-task field stays `collectFixes`.
-  const collectFixes = input.fix ?? false;
+  const { collectFixes } = input;
   const suggestionsMode: 'off' | 'eager' = input.suggestionsMode ?? 'off';
   const collectTiming = input.collectTiming ?? false;
 

--- a/packages/rslint/src/service/protocol.ts
+++ b/packages/rslint/src/service/protocol.ts
@@ -1,3 +1,3 @@
-export const API_PROTOCOL_VERSION = '2.0.0';
+export const API_PROTOCOL_VERSION = '3.0.0';
 export const API_REVERSE_PLUGIN_LINT_CAPABILITY = 'reversePluginLint';
 export const API_REVERSE_CONFIG_LOAD_CAPABILITY = 'reverseConfigLoadV1';

--- a/packages/rslint/tests/autofix.test.mjs
+++ b/packages/rslint/tests/autofix.test.mjs
@@ -156,6 +156,191 @@ function f(value) {
     }
   });
 
+  test('fix:false returns community-plugin edits without applying them', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-edit-info-'));
+    const pluginPath = path.join(tmp, 'edit-info-plugin.mjs');
+    await writeFile(
+      pluginPath,
+      `export default {
+        rules: {
+          rename: {
+            meta: {
+              type: 'suggestion',
+              fixable: 'code',
+              schema: [],
+              messages: { rename: 'Rename bad' },
+            },
+            create(context) {
+              return {
+                Identifier(node) {
+                  if (node.name !== 'bad') return;
+                  context.report({
+                    node,
+                    messageId: 'rename',
+                    fix: (fixer) => fixer.replaceText(node, 'good'),
+                  });
+                },
+              };
+            },
+          },
+          choices: {
+            meta: {
+              type: 'suggestion',
+              hasSuggestions: true,
+              schema: [],
+              messages: {
+                choose: 'Choose uppercase names',
+                uppercase: 'Uppercase {{ first }} and {{ second }}',
+                empty: 'Empty suggestion',
+              },
+            },
+            create(context) {
+              let left;
+              let right;
+              return {
+                Identifier(node) {
+                  if (node.name === 'left') left = node;
+                  if (node.name === 'right') right = node;
+                },
+                'Program:exit'() {
+                  if (!left || !right) return;
+                  context.report({
+                    node: left,
+                    messageId: 'choose',
+                    suggest: [
+                      {
+                        messageId: 'uppercase',
+                        data: { first: 'left', second: 'right' },
+                        fix: (fixer) => [
+                          fixer.replaceText(left, 'LEFT'),
+                          fixer.replaceText(right, 'RIGHT'),
+                        ],
+                      },
+                      {
+                        messageId: 'empty',
+                        fix: () => null,
+                      },
+                    ],
+                  });
+                },
+              };
+            },
+          },
+        },
+      };\n`,
+    );
+    await writeFile(
+      path.join(tmp, 'rslint.config.mjs'),
+      `import editInfo from ${JSON.stringify(pathToFileURL(pluginPath).href)};
+      export default [{
+        plugins: { probe: editInfo },
+        rules: {
+          'probe/rename': 'error',
+          'probe/choices': 'warn',
+        },
+      }];\n`,
+    );
+
+    const source = 'const bad = 1;\nconst choice = left + right;\n';
+    const rslint = new Rslint({ cwd: tmp, fix: false });
+    try {
+      const [result] = await rslint.lintText(source, {
+        filePath: 'probe.js',
+      });
+      const rename = result.messages.find(
+        (message) => message.ruleId === 'probe/rename',
+      );
+      expect(rename?.fix).toBeDefined();
+      expect(
+        source.slice(0, rename.fix.range[0]) +
+          rename.fix.text +
+          source.slice(rename.fix.range[1]),
+      ).toBe('const good = 1;\nconst choice = left + right;\n');
+
+      const choices = result.messages.find(
+        (message) => message.ruleId === 'probe/choices',
+      );
+      expect(choices?.suggestions).toHaveLength(1);
+      expect(choices.suggestions[0].messageId).toBe('uppercase');
+      expect(choices.suggestions[0].desc).toBe('Uppercase left and right');
+      const suggestion = choices.suggestions[0].fix;
+      expect(
+        source.slice(0, suggestion.range[0]) +
+          suggestion.text +
+          source.slice(suggestion.range[1]),
+      ).toBe('const bad = 1;\nconst choice = LEFT + RIGHT;\n');
+
+      expect(result.errorCount).toBe(1);
+      expect(result.warningCount).toBe(1);
+      expect(result.fixableErrorCount).toBe(1);
+      expect(result.fixableWarningCount).toBe(0);
+      expect(result.output).toBeUndefined();
+    } finally {
+      await rslint.close();
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles omits atomic multi-edits when their source disappears', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-edit-source-'),
+    );
+    const target = path.join(tmp, 'probe.js');
+    const pluginPath = path.join(tmp, 'delete-source-plugin.mjs');
+    const source = [
+      'const f = (function () { return 1; }).bind(this);',
+      "value.hasOwnProperty('key');",
+      '',
+    ].join('\n');
+    await writeFile(target, source);
+    await writeFile(
+      pluginPath,
+      `import { unlinkSync } from 'node:fs';
+      export default {
+        rules: {
+          source: {
+            meta: { schema: [] },
+            create() {
+              return { Program() { unlinkSync(${JSON.stringify(target)}); } };
+            },
+          },
+        },
+      };\n`,
+    );
+    await writeFile(
+      path.join(tmp, 'rslint.config.mjs'),
+      `import deleteSource from ${JSON.stringify(pathToFileURL(pluginPath).href)};
+      export default [{
+        plugins: { destroy: deleteSource },
+        rules: {
+          'destroy/source': 'error',
+          'no-extra-bind': 'error',
+          'no-prototype-builtins': 'error',
+        },
+      }];\n`,
+    );
+
+    const rslint = new Rslint({ cwd: tmp, fix: false });
+    try {
+      const [result] = await rslint.lintFiles(target);
+      const autofix = result.messages.find(
+        (message) => message.ruleId === 'no-extra-bind',
+      );
+      const suggestion = result.messages.find(
+        (message) => message.ruleId === 'no-prototype-builtins',
+      );
+      expect(autofix).toBeDefined();
+      expect(autofix.fix).toBeUndefined();
+      expect(suggestion).toBeDefined();
+      expect(suggestion.suggestions).toBeUndefined();
+      expect(result.fixableErrorCount).toBe(0);
+      expect(result.output).toBeUndefined();
+    } finally {
+      await rslint.close();
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('lintFiles merges aliased multi-edits from the canonical virtual source', async () => {
     // Both native rules emit two wire edits spanning source text. Their gap
     // text must come from the canonical-path overlay because the ranges

--- a/packages/rslint/tests/eslint-plugin/host-cancel.test.ts
+++ b/packages/rslint/tests/eslint-plugin/host-cancel.test.ts
@@ -24,7 +24,7 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
         { path: 'a.ts', text: 'const x = null;', configKey: LOCAL_CONFIG_DIR },
       ],
       rules: { 'local/no-null': { options: [] } },
-      fix: false,
+      collectFixes: false,
       suggestionsMode: 'off',
     };
 

--- a/packages/rslint/tests/eslint-plugin/linter/report-validation.test.ts
+++ b/packages/rslint/tests/eslint-plugin/linter/report-validation.test.ts
@@ -73,7 +73,11 @@ function unknownSuggestIdMsg(
 // from the loc/node-range branches.
 const NODE = { type: 'Identifier', range: [0, 3] as [number, number] } as never;
 
-function build(descriptor: unknown, messages: Record<string, string>) {
+function build(
+  descriptor: unknown,
+  messages: Record<string, string>,
+  suggestionsMode: 'off' | 'eager' = 'off',
+) {
   return buildDiagnostic({
     ruleName: 'test/rule',
     // descriptor is an `unknown` test input projected onto the typed
@@ -83,7 +87,7 @@ function build(descriptor: unknown, messages: Record<string, string>) {
     messages,
     fixer: makeFixer(),
     collectFixes: false,
-    suggestionsMode: 'off',
+    suggestionsMode,
   });
 }
 
@@ -292,6 +296,43 @@ describe('#2 suggest[] validation matches ESLint validateSuggestions', () => {
     expect(diag).not.toBeNull();
     expect(diag!.suggestions).toHaveLength(1);
     expect(diag!.suggestions![0].desc).toBe('inline desc');
+  });
+
+  test('eager mode omits a suggestion whose fixer produces no edit', () => {
+    const diag = build(
+      {
+        node: NODE,
+        message: 'm',
+        suggest: [{ messageId: 'real', fix: () => null }],
+      },
+      messages,
+      'eager',
+    );
+    expect(diag).not.toBeNull();
+    expect(diag!.suggestions).toBeUndefined();
+  });
+
+  test('eager mode retains a suggestion with a materialized edit', () => {
+    const diag = build(
+      {
+        node: NODE,
+        message: 'm',
+        suggest: [
+          {
+            messageId: 'real',
+            fix: (fixer: ReturnType<typeof makeFixer>) =>
+              fixer.replaceTextRange([0, 3], 'bar'),
+          },
+        ],
+      },
+      messages,
+      'eager',
+    );
+    expect(diag).not.toBeNull();
+    expect(diag!.suggestions).toHaveLength(1);
+    expect(diag!.suggestions![0].fixes).toEqual([
+      { range: [0, 3], text: 'bar' },
+    ]);
   });
 });
 

--- a/packages/rslint/tests/eslint-plugin/packaged-isolation.test.ts
+++ b/packages/rslint/tests/eslint-plugin/packaged-isolation.test.ts
@@ -77,7 +77,7 @@ const host = await createPluginLintHost([
 const res = await host.lint({
   files: [{ path: 'a.ts', text: 'const x = null;', configKey: cfgDir }],
   rules: { 'pkg/no-null': { options: [] } },
-  fix: false,
+  collectFixes: false,
   suggestionsMode: 'off',
 });
 await host.shutdown();

--- a/packages/rslint/tests/eslint-plugin/plugin/plugin-lint-protocol.test.ts
+++ b/packages/rslint/tests/eslint-plugin/plugin/plugin-lint-protocol.test.ts
@@ -9,8 +9,8 @@
  *   - emitting `configKey` on every task (empty string when absent),
  *   - firing `onUnknownConfigKey` for hosts that want a clearer log
  *     before the worker's internal-error parseError lands,
- *   - propagating the shared `rules` / `fix` / `suggestionsMode` block to
- *     every task (wire `fix` maps to the worker's `collectFixes`),
+ *   - propagating the shared `rules` / `collectFixes` / `suggestionsMode`
+ *     block to every task,
  *   - forwarding `languageOptions` / `settings` opaquely to the worker.
  */
 
@@ -30,7 +30,7 @@ function input(
   return {
     files,
     rules: opts.rules ?? { 'uc/no-null': { options: [] } },
-    fix: opts.fix,
+    collectFixes: opts.collectFixes ?? false,
     suggestionsMode: opts.suggestionsMode,
   };
 }
@@ -80,7 +80,7 @@ describe('buildPluginLintTasks', () => {
     expect(tasks[0].configKey).toBe('/nowhere');
   });
 
-  test('shared rules / fix / suggestionsMode propagate to every task', () => {
+  test('shared rules / collectFixes / suggestionsMode propagate to every task', () => {
     const tasks = buildPluginLintTasks(
       input(
         [
@@ -92,7 +92,7 @@ describe('buildPluginLintTasks', () => {
             'uc/no-null': { options: [{ checkStrictEquality: true }] },
             'uc/prefer-array-some': { options: [] },
           },
-          fix: true,
+          collectFixes: true,
           suggestionsMode: 'eager',
         },
       ),
@@ -100,7 +100,6 @@ describe('buildPluginLintTasks', () => {
     );
     expect(tasks).toHaveLength(2);
     for (const t of tasks) {
-      // wire `fix:true` maps to the worker's per-task `collectFixes`.
       expect(t.collectFixes).toBe(true);
       expect(t.suggestionsMode).toBe('eager');
       expect(Object.keys(t.rules).sort()).toEqual([
@@ -113,9 +112,9 @@ describe('buildPluginLintTasks', () => {
     }
   });
 
-  test('rules / fix / suggestionsMode defaults are sensible', () => {
+  test('rules / collectFixes / suggestionsMode defaults are sensible', () => {
     const tasks = buildPluginLintTasks(
-      { files: [{ path: '/a.ts', text: '' }] },
+      { files: [{ path: '/a.ts', text: '' }], collectFixes: false },
       { configDirSet: new Set() },
     );
     expect(tasks[0].collectFixes).toBe(false);

--- a/packages/rslint/tests/fixtures/fake-api-binary.cjs
+++ b/packages/rslint/tests/fixtures/fake-api-binary.cjs
@@ -25,7 +25,7 @@ function onMessage(msg) {
       kind: 'response',
       id: msg.id,
       data: {
-        version: '2.0.0',
+        version: '3.0.0',
         ok: true,
         capabilities: ['reversePluginLint'],
       },

--- a/packages/rslint/tests/node-service.test.ts
+++ b/packages/rslint/tests/node-service.test.ts
@@ -82,9 +82,9 @@ suite('NodeRslintService reject-all-pending on crash/terminate', () => {
   test('does not harm a normal request/response round-trip', async () => {
     const svc = new NodeRslintService({ rslintPath: FAKE });
     await expect(
-      svc.sendMessage('handshake', { version: '2.0.0' }),
+      svc.sendMessage('handshake', { version: '3.0.0' }),
     ).resolves.toEqual({
-      version: '2.0.0',
+      version: '3.0.0',
       ok: true,
       capabilities: ['reversePluginLint'],
     });
@@ -109,7 +109,7 @@ suite('NodeRslintService reject-all-pending on crash/terminate', () => {
     process.env.RSLINT_FAKE_EXIT_SILENT = '1';
     try {
       const svc = new NodeRslintService({ rslintPath: FAKE });
-      await svc.sendMessage('handshake', { version: '2.0.0' });
+      await svc.sendMessage('handshake', { version: '3.0.0' });
       await expect(svc.sendMessage('exit', {})).resolves.toBeNull();
     } finally {
       delete process.env.RSLINT_FAKE_EXIT_SILENT;

--- a/packages/rslint/tests/service.test.ts
+++ b/packages/rslint/tests/service.test.ts
@@ -23,7 +23,7 @@ class ReverseLintBackend implements RslintServiceInterface {
   async sendMessage(kind: string, data: any): Promise<any> {
     if (kind === 'handshake')
       return {
-        version: '2.0.0',
+        version: '3.0.0',
         ok: true,
         capabilities: ['reversePluginLint'],
       };
@@ -200,7 +200,7 @@ class ReverseConfigBackend extends ReverseLintBackend {
     if (kind === 'handshake') {
       this.handshakeCapabilities = [...(data.capabilities ?? [])];
       return {
-        version: '2.0.0',
+        version: '3.0.0',
         ok: true,
         capabilities: [API_REVERSE_CONFIG_LOAD_CAPABILITY],
       };
@@ -291,7 +291,7 @@ describe('RSLintService reverse lint request scoping', () => {
     };
     const service = new RSLintService(backend);
     await expect(service.lint({ files: ['a.ts'] })).rejects.toThrow(
-      /protocol mismatch.*2\.0\.0.*1\.0\.0/,
+      /protocol mismatch.*3\.0\.0.*1\.0\.0/,
     );
     await service.close();
   });
@@ -300,7 +300,7 @@ describe('RSLintService reverse lint request scoping', () => {
     const backend = new ReverseLintBackend();
     backend.sendMessage = async (kind: string, data: any): Promise<any> => {
       if (kind === 'handshake') {
-        return { version: '2.0.0', ok: true, capabilities: [] };
+        return { version: '3.0.0', ok: true, capabilities: [] };
       }
       return ReverseLintBackend.prototype.sendMessage.call(backend, kind, data);
     };

--- a/packages/vscode-extension/__tests__/suite-eslint-plugins/plugin-pool.test.ts
+++ b/packages/vscode-extension/__tests__/suite-eslint-plugins/plugin-pool.test.ts
@@ -49,7 +49,7 @@ function request(generation: string): EslintPluginLintRequest {
     generation,
     files: [],
     rules: {},
-    fix: false,
+    collectFixes: false,
     suggestionsMode: 'off',
   };
 }


### PR DESCRIPTION
## Summary

- Return community-plugin autofix and suggestion edits from the JavaScript API when fix is false, without applying them.
- Separate edit collection from autofix application in reverse plugin IPC and bump the API protocol to 3.0.0 so incompatible peers fail fast.
- Omit suggestions without usable edits and fail closed for atomic multi-edits when the source snapshot is unavailable.

## Related Links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).