### PR TITLE
fix: preserve JSDoc class field names

### DIFF
--- a/internal/rules/class_methods_use_this/class_methods_use_this_extras_test.go
+++ b/internal/rules/class_methods_use_this/class_methods_use_this_extras_test.go
@@ -112,6 +112,10 @@ func TestClassMethodsUseThisExtras(t *testing.T) {
 			// ---- Dimension 4: class-field function wrappers ----
 			{Code: `class C { foo = (() => { this.value; }); }`},
 			{Code: `class C { foo = (function () { this.value; }); }`},
+			// Authored TypeScript wrappers remain visible in ESTree and therefore
+			// keep the function from being a direct class-field value.
+			{Code: `class C { foo = ((() => {}) as unknown); }`},
+			{Code: `class C { foo = ((() => {}) satisfies unknown); }`},
 
 			// ---- Real-user: eslint/eslint#17976 — explicit override opt-out ----
 			{
@@ -161,19 +165,118 @@ func TestClassMethodsUseThisExtras(t *testing.T) {
 				Code:     `class A { field = /** @type {() => void} */ (() => {}); }`,
 				FileName: "jsdoc-cast-arrow.js",
 				TSConfig: "tsconfig.allow-js.json",
-				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "missingThis"}},
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 46,
+				)},
 			},
 			{
 				Code:     `class A { field = /** @type {() => void} */ (function () {}); }`,
 				FileName: "jsdoc-cast-function.js",
 				TSConfig: "tsconfig.allow-js.json",
-				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "missingThis"}},
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 55,
+				)},
 			},
 			{
 				Code:     `class A { field = /** @satisfies {() => void} */ (() => {}); }`,
 				FileName: "jsdoc-satisfies-arrow.js",
 				TSConfig: "tsconfig.allow-js.json",
-				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "missingThis"}},
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 51,
+				)},
+			},
+			{
+				Code:     `class A { #field = /** @type {Function} */ (async () => {}); }`,
+				FileName: "jsdoc-private-async-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class private async method #field.",
+					1, 11, 1, 51,
+				)},
+			},
+			{
+				Code:     `class A { field = /** @type {Function} */ (/** @satisfies {Function} */ (() => {})); }`,
+				FileName: "nested-jsdoc-casts.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 74,
+				)},
+			},
+			{
+				Code:     `class A { field = /** @type {(value: unknown) => void} */ (value => {}); }`,
+				FileName: "jsdoc-single-param-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 59,
+				)},
+			},
+			{
+				Code:     `class A { field = /** @satisfies {(value: unknown) => void} */ (value => {}); }`,
+				FileName: "jsdoc-satisfies-single-param-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 64,
+				)},
+			},
+			{
+				Code:     `class A { field = /** @type {(value: unknown) => void} */ ((value => {})); }`,
+				FileName: "jsdoc-parenthesized-single-param-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 60,
+				)},
+			},
+			{
+				Code:     `class A { field = /** @type {(value: unknown) => Promise<void>} */ (async value => {}); }`,
+				FileName: "jsdoc-async-single-param-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class async method 'field'.",
+					1, 11, 1, 75,
+				)},
+			},
+			{
+				Code:     `class A { @dec field = /** @type {Function} */ (value => {}); }`,
+				FileName: "decorated-jsdoc-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 48,
+				)},
+			},
+			{
+				Code:     `class A { @dec field = /** @type {Function} */ (() => {}); }`,
+				FileName: "decorated-jsdoc-zero-param-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 49,
+				)},
+			},
+			{
+				Code:     `class A { @dec field = /** @type {Function} */ (function () {}); }`,
+				FileName: "decorated-jsdoc-function-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class method 'field'.",
+					1, 11, 1, 58,
+				)},
+			},
+			{
+				Code:     `class A { accessor field = /** @type {Function} */ (value => {}); }`,
+				FileName: "jsdoc-auto-accessor.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{missingThisAt(
+					"Expected 'this' to be used by class arrow function.",
+					1, 59, 1, 61,
+				)},
 			},
 
 			// Abstract properties do not create a frame, but the following

--- a/internal/rules/max_params/max_params_extras_test.go
+++ b/internal/rules/max_params/max_params_extras_test.go
@@ -88,6 +88,34 @@ func TestMaxParamsExtras(t *testing.T) {
 			{Code: "function f(a, b, c, d) {} // eslint-disable-line test"},
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- JSDoc casts are transparent to the shared ESTree function owner ----
+			{
+				Code:     "const value = { field: /** @type {Function} */ ((a, b, c, d) => {}) };",
+				FileName: "jsdoc-object-property.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "exceed",
+					Message:   exceedMessage("Method 'field'", 4, 3),
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 49,
+				}},
+			},
+			{
+				Code:     "class A { static #field = /** @type {Function} */ ((a, b, c, d) => {}); }",
+				FileName: "jsdoc-static-private-field.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "exceed",
+					Message:   exceedMessage("Static private method #field", 4, 3),
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 52,
+				}},
+			},
+
 			// ---- Dimension 4: declaration/container forms ----
 			{
 				Code:   "async function f(a, b, c, d) {}",

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -404,6 +404,9 @@ func IsJSDocTypeCastWrapper(node *ast.Node) bool {
 func ESTreeRuntimeExpression(node *ast.Node) *ast.Node {
 	for node != nil {
 		node = ast.SkipParentheses(node)
+		if node.Kind != ast.KindAsExpression && node.Kind != ast.KindSatisfiesExpression {
+			return node
+		}
 		expression := JSDocTypeCastExpression(node)
 		if expression == nil {
 			return node
@@ -420,11 +423,20 @@ func ESTreeParent(node *ast.Node) *ast.Node {
 		return nil
 	}
 	parent := node.Parent
-	for parent != nil &&
-		(parent.Kind == ast.KindParenthesizedExpression || IsJSDocTypeCastWrapper(parent)) {
-		parent = parent.Parent
+	for parent != nil {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+			parent = parent.Parent
+		case ast.KindAsExpression, ast.KindSatisfiesExpression:
+			if !IsJSDocTypeCastWrapper(parent) {
+				return parent
+			}
+			parent = parent.Parent
+		default:
+			return parent
+		}
 	}
-	return parent
+	return nil
 }
 
 // ESTreeParameters returns only parameters authored in source. tsgo prepends

--- a/internal/utils/function_head_range.go
+++ b/internal/utils/function_head_range.go
@@ -23,9 +23,9 @@ func NewFunctionHeadRangeLocator(sourceFile *ast.SourceFile) *FunctionHeadRangeL
 // Range returns the report range for node's function head.
 func (l *FunctionHeadRangeLocator) Range(node *ast.Node) core.TextRange {
 	// GetFunctionHeadLoc has to reproduce SourceCode.getTokenBefore() for a
-	// single-parameter field arrow. Its general implementation scans from the
-	// start of the source file, which becomes quadratic when a rule reports many
-	// such fields. The owning field gives us a narrow, local token boundary.
+	// single-parameter field arrow. Its general implementation lazily builds a
+	// token index for the whole file; the owning field gives rules that only
+	// need these report ranges a narrower, local token boundary.
 	if loc, ok := l.singleParameterFieldArrowHeadRange(node); ok {
 		return loc
 	}
@@ -35,7 +35,7 @@ func (l *FunctionHeadRangeLocator) Range(node *ast.Node) core.TextRange {
 	switch {
 	case isFunctionHeadMember(node):
 	case node.Kind == ast.KindArrowFunction || node.Kind == ast.KindFunctionExpression:
-		owner := ast.WalkUpParenthesizedExpressions(node.Parent)
+		owner := ESTreeParent(node)
 		if owner == nil || owner.Kind != ast.KindPropertyDeclaration ||
 			ast.HasSyntacticModifier(owner, ast.ModifierFlagsAccessor) {
 			return loc
@@ -60,7 +60,7 @@ func (l *FunctionHeadRangeLocator) singleParameterFieldArrowHeadRange(node *ast.
 		return core.TextRange{}, false
 	}
 
-	owner := ast.WalkUpParenthesizedExpressions(node.Parent)
+	owner := ESTreeParent(node)
 	if owner == nil {
 		return core.TextRange{}, false
 	}
@@ -73,14 +73,18 @@ func (l *FunctionHeadRangeLocator) singleParameterFieldArrowHeadRange(node *ast.
 	default:
 		return core.TextRange{}, false
 	}
+	initializer := owner.Initializer()
+	if initializer == nil ||
+		(initializer != node && ESTreeRuntimeExpression(initializer) != node) {
+		return core.TextRange{}, false
+	}
 
 	parameterStart := TrimNodeTextRange(l.sourceFile, arrow.Parameters.Nodes[0]).Pos()
-	scanStart := TrimNodeTextRange(l.sourceFile, node).Pos()
-	if parent := node.Parent; parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		// A parenless arrow can itself be wrapped: `field = (value => {})`.
-		// ESLint sees no wrapper node, so that `(` is the token before `value`.
-		scanStart = TrimNodeTextRange(l.sourceFile, parent).Pos()
-	}
+	// Start at the owning property's initializer. This is the narrowest source
+	// boundary that includes every ESTree-elided parenthesis and JSDoc cast
+	// around the arrow, so the scan still observes a `(` immediately before a
+	// single parameter without falling back to a file-wide token lookup.
+	scanStart := TrimNodeTextRange(l.sourceFile, initializer).Pos()
 
 	end := parameterStart
 	var previousKind ast.Kind
@@ -89,8 +93,7 @@ func (l *FunctionHeadRangeLocator) singleParameterFieldArrowHeadRange(node *ast.
 	if l.tokens == nil {
 		l.tokens = scanner.NewScanner()
 	}
-	// Reuse one scanner per file: constructing one for every report would trade
-	// the quadratic scan for avoidable per-diagnostic allocations.
+	// Reuse one scanner per file to avoid per-diagnostic allocations.
 	l.tokens.SetText(l.sourceFile.Text())
 	l.tokens.SetLanguageVariant(l.sourceFile.LanguageVariant)
 	l.tokens.ResetTokenState(scanStart)

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -689,9 +689,10 @@ func GetFunctionNameWithKindCore(node *ast.Node) string {
 		return strings.Join(append(tokens, "method", "'constructor'"), " ")
 	}
 
-	// ESTree does not expose parentheses as nodes, so a function value wrapped
-	// only in parentheses still has the surrounding property as its parent.
-	parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+	// ESTree exposes neither parentheses nor wrappers synthesized from JSDoc
+	// casts, so a function wrapped only in those nodes still has the surrounding
+	// property as its parent.
+	parent := ESTreeParent(node)
 	if parent == nil {
 		return "function"
 	}
@@ -807,7 +808,8 @@ func isCoreClassFieldInitializer(node *ast.Node, parent *ast.Node) bool {
 	switch node.Kind {
 	case ast.KindArrowFunction, ast.KindFunctionExpression:
 		initializer := parent.AsPropertyDeclaration().Initializer
-		return initializer != nil && ast.SkipParentheses(initializer) == node
+		return initializer != nil &&
+			(initializer == node || ESTreeRuntimeExpression(initializer) == node)
 	}
 	return false
 }

--- a/internal/utils/ts_eslint_test.go
+++ b/internal/utils/ts_eslint_test.go
@@ -217,3 +217,65 @@ func TestGetFunctionNameWithKindCore(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFunctionNameWithKindCoreJSDocCasts(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		kind ast.Kind
+		want string
+	}{
+		{
+			name: "class field arrow",
+			code: "class C { field = /** @type {Function} */ (() => {}) }",
+			kind: ast.KindArrowFunction,
+			want: "method 'field'",
+		},
+		{
+			name: "static private async class field arrow",
+			code: "class C { static #field = /** @type {Function} */ (async () => {}) }",
+			kind: ast.KindArrowFunction,
+			want: "static private async method #field",
+		},
+		{
+			name: "class field async generator function prefers owner name",
+			code: "class C { field = /** @type {Function} */ (async function* named() {}) }",
+			kind: ast.KindFunctionExpression,
+			want: "async generator method 'field'",
+		},
+		{
+			name: "object property arrow",
+			code: "const value = { field: /** @type {Function} */ (() => {}) };",
+			kind: ast.KindArrowFunction,
+			want: "method 'field'",
+		},
+		{
+			name: "dynamic class field falls back to function name",
+			code: "class C { [key] = /** @type {Function} */ (function named() {}) }",
+			kind: ast.KindFunctionExpression,
+			want: "method 'named'",
+		},
+		{
+			name: "nested type and satisfies casts",
+			code: "class C { field = /** @type {Function} */ (/** @satisfies {Function} */ (() => {})) }",
+			kind: ast.KindArrowFunction,
+			want: "method 'field'",
+		},
+		{
+			name: "auto accessor remains a plain arrow function",
+			code: "class C { static accessor #field = /** @type {Function} */ (async () => {}) }",
+			kind: ast.KindArrowFunction,
+			want: "async arrow function",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceFile := parseJSFile(t, tt.code)
+			node := findFirstNodeOfKind(t, sourceFile, tt.kind)
+			if got := GetFunctionNameWithKindCore(node); got != tt.want {
+				t.Fatalf("GetFunctionNameWithKindCore() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve the ESTree-visible property owner for functions behind JSDoc @type and @satisfies wrappers, so core diagnostics retain field names and modifiers.
- Align function-head ranges for JSDoc-wrapped and decorated fields while keeping authored TypeScript wrappers and auto-accessors unchanged.
- Add exact ESLint 10.9.0 regression coverage for class-methods-use-this and max-params.

## Related Links

- https://eslint.org/docs/latest/rules/class-methods-use-this
- https://eslint.org/docs/latest/rules/max-params

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).