### PR TITLE
feat(react): port rule jsx-no-useless-fragment

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -77,6 +77,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_leaked_render"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_literals"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_script_url"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_useless_fragment"
 )
 
 func GetAllRules() []rule.Rule {
@@ -155,5 +156,6 @@ func GetAllRules() []rule.Rule {
 		jsx_no_leaked_render.JsxNoLeakedRenderRule,
 		jsx_no_literals.JsxNoLiteralsRule,
 		jsx_no_script_url.JsxNoScriptUrlRule,
+		jsx_no_useless_fragment.JsxNoUselessFragmentRule,
 	}
 }

--- a/internal/plugins/react/reactutil/jsx.go
+++ b/internal/plugins/react/reactutil/jsx.go
@@ -342,3 +342,41 @@ func ReturnedJSXRootTagName(fn *ast.Node) string {
 	}
 	return JSXRootTagName(body)
 }
+
+// IsFragmentTag mirrors eslint-plugin-react's `jsxUtil.isFragment(node,
+// reactPragma, fragmentPragma)`: a purely name-based test for the two long
+// fragment spellings, `<Fragment>` and `<React.Fragment>`. It deliberately
+// does NOT follow import aliases or variable initializers — upstream's shared
+// helper doesn't either, and rules that need the wider notion (jsx-fragments)
+// carry their own matcher.
+//
+// `element` may be a JsxElement, JsxSelfClosingElement, or JsxOpeningElement.
+func IsFragmentTag(element *ast.Node, reactPragma, fragmentPragma string) bool {
+	if element != nil && element.Kind == ast.KindJsxElement {
+		element = element.AsJsxElement().OpeningElement
+	}
+	tagName := GetJsxTagName(element)
+	if tagName == nil {
+		return false
+	}
+
+	// <Fragment>
+	if tagName.Kind == ast.KindIdentifier {
+		return tagName.AsIdentifier().Text == fragmentPragma
+	}
+
+	// <React.Fragment> — only a single-level member access qualifies, matching
+	// ESTree's JSXMemberExpression-with-JSXIdentifier-object shape. A deeper
+	// `<A.B.C>` chain has a member-expression object and does not match.
+	if tagName.Kind == ast.KindPropertyAccessExpression {
+		access := tagName.AsPropertyAccessExpression()
+		object := access.Expression
+		property := access.Name()
+		return object != nil && object.Kind == ast.KindIdentifier &&
+			object.AsIdentifier().Text == reactPragma &&
+			property != nil && property.Kind == ast.KindIdentifier &&
+			property.AsIdentifier().Text == fragmentPragma
+	}
+
+	return false
+}

--- a/internal/plugins/react/reactutil/pragma.go
+++ b/internal/plugins/react/reactutil/pragma.go
@@ -3,7 +3,11 @@ package reactutil
 import (
 	"regexp"
 	"strconv"
+	"strings"
+	"unicode/utf8"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
@@ -127,4 +131,151 @@ func ReactVersionLessThan(settings map[string]interface{}, major, minor, patch i
 		return b < minor
 	}
 	return c < patch
+}
+
+// GetReactPragmaFromContext mirrors eslint-plugin-react's
+// `pragmaUtil.getFromContext`, which resolves the React pragma from the file
+// itself before consulting configuration: the first comment carrying a
+// `@jsx <name>` annotation wins over `settings.react.pragma`, and only the
+// head of a dotted annotation counts (`@jsx Preact.h` yields `Preact`).
+// A name that is not a valid JavaScript identifier falls back to
+// DefaultReactPragma, matching upstream's warn-and-default path.
+//
+// Rules that classify JSX by pragma (`<React.Fragment>`, `React.createElement`,
+// deprecated `React.*` members) must go through this rather than
+// GetReactPragma, or a classic-runtime file compiled with a non-React pragma
+// both misses its own fragments and reports React's as if they were the
+// configured ones. GetReactPragma remains correct for the settings-only
+// lookups upstream performs the same way, such as `getFragmentFromContext`.
+func GetReactPragmaFromContext(ctx rule.RuleContext) string {
+	if annotated, found := jsxAnnotationPragma(ctx); found {
+		if isJavaScriptIdentifier(annotated) {
+			return annotated
+		}
+		return DefaultReactPragma
+	}
+	pragma := GetReactPragma(ctx.Settings)
+	if !isJavaScriptIdentifier(pragma) {
+		return DefaultReactPragma
+	}
+	return pragma
+}
+
+// jsxAnnotationPragma returns the head of the first `@jsx <name>` annotation
+// found in a comment, and whether any annotation was present at all. The
+// caller needs both: upstream stops looking at `settings.react.pragma` as soon
+// as an annotation exists, even one it later rejects as a non-identifier.
+func jsxAnnotationPragma(ctx rule.RuleContext) (string, bool) {
+	if ctx.SourceFile == nil {
+		return "", false
+	}
+	text := ctx.SourceFile.Text()
+	// Most files carry no classic-runtime pragma; keep the comment scan off
+	// the hot path for them.
+	if !strings.Contains(text, "@jsx") {
+		return "", false
+	}
+
+	for _, comment := range ctx.Comments.All() {
+		name, found := jsxAnnotationInComment(commentValue(text, comment))
+		if found {
+			// Upstream reads `matches[1].split('.')[0]`.
+			if dot := strings.IndexByte(name, '.'); dot >= 0 {
+				name = name[:dot]
+			}
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// jsxAnnotationInComment ports `/@jsx\s+([^\s]+)/` over one comment body.
+// It is hand-rolled rather than compiled because the character class is
+// JavaScript's `\s` — which covers more than Go's RE2 `\s` — and the pattern
+// is applied to the source under lint.
+func jsxAnnotationInComment(value string) (string, bool) {
+	const marker = "@jsx"
+	for offset := 0; ; {
+		index := strings.Index(value[offset:], marker)
+		if index < 0 {
+			return "", false
+		}
+		afterMarker := offset + index + len(marker)
+		nameStart := ecmascript.SkipLeadingWhitespace(value, afterMarker, len(value))
+		// `\s+` demands at least one whitespace character, so `@jsxFrag Foo`
+		// is not a `@jsx` annotation.
+		if nameStart > afterMarker {
+			// `[^\s]+` demands at least one character.
+			if nameEnd := skipNonWhitespace(value, nameStart); nameEnd > nameStart {
+				return value[nameStart:nameEnd], true
+			}
+		}
+		offset = afterMarker
+	}
+}
+
+// skipNonWhitespace returns the index one past the run of non-whitespace
+// characters starting at `start` — the reverse of
+// ecmascript.SkipLeadingWhitespace, over the same JavaScript `\s` definition.
+func skipNonWhitespace(text string, start int) int {
+	position := start
+	for position < len(text) {
+		if text[position] < 0x80 {
+			if ecmascript.IsTriviaWhitespaceByte(text[position]) {
+				return position
+			}
+			position++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[position:])
+		if size == 0 || ecmascript.IsTriviaWhitespaceRune(r) {
+			return position
+		}
+		position += size
+	}
+	return position
+}
+
+// commentValue returns a comment's body without its delimiters, matching what
+// ESLint exposes as `comment.value` — upstream matches the annotation against
+// that, so a trailing `*/` must not become part of the captured name.
+func commentValue(text string, comment *ast.CommentRange) string {
+	if comment.Pos() < 0 || comment.End() > len(text) {
+		return ""
+	}
+	switch comment.Kind {
+	case ast.KindSingleLineCommentTrivia:
+		if comment.End() <= comment.Pos()+2 {
+			return ""
+		}
+		return text[comment.Pos()+2 : comment.End()]
+	case ast.KindMultiLineCommentTrivia:
+		if comment.End() <= comment.Pos()+4 {
+			return ""
+		}
+		return text[comment.Pos()+2 : comment.End()-2]
+	default:
+		return ""
+	}
+}
+
+// isJavaScriptIdentifier ports upstream's
+// `/^[_$a-zA-Z][_$a-zA-Z0-9]*$/` guard. Like upstream it is deliberately
+// ASCII-only and does not reject reserved words.
+func isJavaScriptIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := range len(name) {
+		c := name[i]
+		isLetter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '$'
+		if isLetter {
+			continue
+		}
+		if i > 0 && c >= '0' && c <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/plugins/react/reactutil/pragma_test.go
+++ b/internal/plugins/react/reactutil/pragma_test.go
@@ -1,0 +1,73 @@
+package reactutil
+
+import "testing"
+
+// TestJsxAnnotationInComment pins the port of upstream pragmaUtil's
+// `/@jsx\s+([^\s]+)/` to the cases where a compiled RE2 pattern would answer
+// differently, or where the marker is only a prefix of a longer annotation.
+func TestJsxAnnotationInComment(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "plain", value: " @jsx Preact.h ", want: "Preact.h"},
+		{name: "tab separated", value: " @jsx\tPreact ", want: "Preact"},
+		{name: "newline separated", value: " @jsx\nPreact ", want: "Preact"},
+		{name: "javascript-only whitespace", value: " @jsx Preact ", want: "Preact"},
+		{name: "no whitespace after marker", value: " @jsxPreact ", want: ""},
+		{name: "longer marker is not a match", value: " @jsxFrag Preact.Fragment ", want: ""},
+		{name: "later annotation after a non-match", value: " @jsxFrag F @jsx Preact ", want: "Preact"},
+		{name: "nothing after the marker", value: " @jsx ", want: ""},
+		{name: "absent", value: " nothing to see ", want: ""},
+		{name: "non-identifier is still an annotation", value: " @jsx Foo-Bar ", want: "Foo-Bar"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, found := jsxAnnotationInComment(testCase.value)
+			if testCase.want == "" {
+				if found {
+					t.Fatalf("jsxAnnotationInComment(%q) = %q, true; want not found", testCase.value, got)
+				}
+				return
+			}
+			if !found || got != testCase.want {
+				t.Fatalf("jsxAnnotationInComment(%q) = %q, %v; want %q, true", testCase.value, got, found, testCase.want)
+			}
+		})
+	}
+}
+
+// TestIsJavaScriptIdentifier pins the port of upstream's
+// `/^[_$a-zA-Z][_$a-zA-Z0-9]*$/`, which is ASCII-only and does not exclude
+// reserved words.
+func TestIsJavaScriptIdentifier(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name string
+		want bool
+	}{
+		{name: "React", want: true},
+		{name: "_private", want: true},
+		{name: "$dollar", want: true},
+		{name: "h2", want: true},
+		{name: "class", want: true},
+		{name: "", want: false},
+		{name: "2h", want: false},
+		{name: "Foo-Bar", want: false},
+		{name: "Preact.h", want: false},
+		{name: "\u00e9lan", want: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isJavaScriptIdentifier(testCase.name); got != testCase.want {
+				t.Fatalf("isJavaScriptIdentifier(%q) = %v, want %v", testCase.name, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.go
@@ -23,7 +23,7 @@ var JsxNoUselessFragmentRule = rule.Rule{
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		allowExpressions := parseAllowExpressions(options)
-		reactPragma := reactutil.GetReactPragma(ctx.Settings)
+		reactPragma := reactutil.GetReactPragmaFromContext(ctx)
 		fragmentPragma := reactutil.GetReactFragmentPragma(ctx.Settings)
 		sourceText := ctx.SourceFile.Text()
 
@@ -75,7 +75,7 @@ var JsxNoUselessFragmentRule = rule.Rule{
 
 		isFragmentWithSingleExpression := func(node *ast.Node) bool {
 			kept := nonPaddingChildren(node)
-			return len(kept) == 1 && kept[0].Kind == ast.KindJsxExpression
+			return len(kept) == 1 && isExpressionContainer(kept[0])
 		}
 
 		isChildOfHtmlElement := func(node *ast.Node) bool {
@@ -104,7 +104,7 @@ var JsxNoUselessFragmentRule = rule.Rule{
 			if node.Kind == ast.KindJsxText {
 				return !ecmascript.IsBlank(rawText(node))
 			}
-			return node.Kind == ast.KindJsxExpression
+			return isExpressionContainer(node)
 		}
 
 		canFix := func(node *ast.Node) bool {
@@ -231,13 +231,29 @@ func parseAllowExpressions(options []any) bool {
 	return allow
 }
 
+// isExpressionContainer reports whether a JSX child is an ESTree
+// JSXExpressionContainer — `{expr}`. tsgo parses a JSX spread child
+// (`{...expr}`) into the same KindJsxExpression, distinguished only by
+// DotDotDotToken, whereas ESTree gives it a separate JSXSpreadChild type that
+// upstream's `type === 'JSXExpressionContainer'` tests all reject. Every
+// container-specific check therefore has to exclude the spread form.
+func isExpressionContainer(node *ast.Node) bool {
+	return node != nil &&
+		node.Kind == ast.KindJsxExpression &&
+		node.AsJsxExpression().DotDotDotToken == nil
+}
+
 // containsCallExpression mirrors upstream's helper: a JSX expression container
 // whose expression is a plain CallExpression. Parentheses are transparent
-// because ESTree has no ParenthesizedExpression node, while an optional call
-// (`{foo?.()}`) is NOT a match — ESTree wraps it in a ChainExpression, which
-// upstream's `type === 'CallExpression'` check rejects.
+// because ESTree has no ParenthesizedExpression node, while three call-shaped
+// forms are NOT matches, because ESTree gives each of them its own node type
+// that upstream's `type === 'CallExpression'` check rejects:
+// an optional call (`{foo?.()}`, a ChainExpression), a dynamic import
+// (`{import("x")}`, an ImportExpression), and a spread child (`{...make()}`,
+// a JSXSpreadChild). tsgo collapses the first two into KindCallExpression and
+// the third into KindJsxExpression, so each needs an explicit exclusion.
 func containsCallExpression(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindJsxExpression {
+	if !isExpressionContainer(node) {
 		return false
 	}
 	// `{}` — an empty JSX expression container — has no expression at all.
@@ -248,7 +264,9 @@ func containsCallExpression(node *ast.Node) bool {
 	if expression == nil {
 		return false
 	}
-	return expression.Kind == ast.KindCallExpression && !ast.IsOptionalChain(expression)
+	return expression.Kind == ast.KindCallExpression &&
+		!ast.IsOptionalChain(expression) &&
+		!ast.IsImportCall(expression)
 }
 
 // isFragmentWithOnlyTextAndIsNotChild mirrors upstream: a fragment like

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.go
@@ -1,0 +1,324 @@
+package jsx_no_useless_fragment
+
+import (
+	_ "embed"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+//go:embed jsx_no_useless_fragment.schema.json
+var schemaJSON []byte
+
+const (
+	needsMoreChildrenDescription  = "Fragments should contain more than one child - otherwise, there’s no need for a Fragment at all."
+	childOfHtmlElementDescription = "Passing a fragment to an HTML element is useless."
+)
+
+var JsxNoUselessFragmentRule = rule.Rule{
+	Name:   "react/jsx-no-useless-fragment",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		allowExpressions := parseAllowExpressions(options)
+		reactPragma := reactutil.GetReactPragma(ctx.Settings)
+		fragmentPragma := reactutil.GetReactFragmentPragma(ctx.Settings)
+		sourceText := ctx.SourceFile.Text()
+
+		// rawText returns a JsxText child's source spelling — upstream reads
+		// `node.raw`, so entity references and the exact whitespace run must
+		// come from the source, not from tsgo's decoded `.Text` field.
+		rawText := func(node *ast.Node) string {
+			if node == nil {
+				return ""
+			}
+			return sourceText[node.Pos():node.End()]
+		}
+
+		// isPaddingSpaces mirrors upstream's helper of the same name: a
+		// whitespace-only JSX text run that the React runtime strips, which
+		// upstream detects by the presence of a literal "\n" (not any
+		// LineTerminator — `arrayIncludes(node.raw, '\n')` compares
+		// characters).
+		isPaddingSpaces := func(node *ast.Node) bool {
+			if node == nil || node.Kind != ast.KindJsxText {
+				return false
+			}
+			raw := rawText(node)
+			return ecmascript.IsBlank(raw) && strings.Contains(raw, "\n")
+		}
+
+		nonPaddingChildren := func(node *ast.Node) []*ast.Node {
+			children := reactutil.GetJsxChildren(node)
+			kept := make([]*ast.Node, 0, len(children))
+			for _, child := range children {
+				if !isPaddingSpaces(child) {
+					kept = append(kept, child)
+				}
+			}
+			return kept
+		}
+
+		hasLessThanTwoChildren := func(node *ast.Node) bool {
+			kept := nonPaddingChildren(node)
+			if len(kept) >= 2 {
+				return false
+			}
+			var first *ast.Node
+			if len(kept) == 1 {
+				first = kept[0]
+			}
+			return !containsCallExpression(first)
+		}
+
+		isFragmentWithSingleExpression := func(node *ast.Node) bool {
+			kept := nonPaddingChildren(node)
+			return len(kept) == 1 && kept[0].Kind == ast.KindJsxExpression
+		}
+
+		isChildOfHtmlElement := func(node *ast.Node) bool {
+			parent := node.Parent
+			if parent == nil || parent.Kind != ast.KindJsxElement {
+				return false
+			}
+			tagName := reactutil.GetJsxTagName(parent.AsJsxElement().OpeningElement)
+			if tagName == nil || tagName.Kind != ast.KindIdentifier {
+				return false
+			}
+			return isAllLowercaseLetters(tagName.AsIdentifier().Text)
+		}
+
+		isChildOfComponentElement := func(node *ast.Node) bool {
+			parent := node.Parent
+			return parent != nil && parent.Kind == ast.KindJsxElement &&
+				!isChildOfHtmlElement(node) &&
+				!reactutil.IsFragmentTag(parent, reactPragma, fragmentPragma)
+		}
+
+		isNonSpaceJsxTextOrJsxCurly := func(node *ast.Node) bool {
+			if node == nil {
+				return false
+			}
+			if node.Kind == ast.KindJsxText {
+				return !ecmascript.IsBlank(rawText(node))
+			}
+			return node.Kind == ast.KindJsxExpression
+		}
+
+		canFix := func(node *ast.Node) bool {
+			parent := node.Parent
+			parentIsJsxContainer := parent != nil &&
+				(parent.Kind == ast.KindJsxElement || parent.Kind == ast.KindJsxFragment)
+
+			// Not safe to fix fragments without a jsx parent.
+			if !parentIsJsxContainer {
+				children := reactutil.GetJsxChildren(node)
+
+				// const a = <></>
+				if len(children) == 0 {
+					return false
+				}
+
+				// const a = <>cat {meow}</>
+				for _, child := range children {
+					if isNonSpaceJsxTextOrJsxCurly(child) {
+						return false
+					}
+				}
+			}
+
+			// Not safe to fix `<Eeee><>foo</></Eeee>` because `Eeee` might
+			// require its children be a ReactElement.
+			if isChildOfComponentElement(node) {
+				return false
+			}
+
+			// Upstream guards the "old TS parser" shape where a JSXFragment
+			// carries no opening / closing fragment token. tsgo always parses
+			// both, so this arm is defensive only.
+			if node.Kind == ast.KindJsxFragment {
+				fragment := node.AsJsxFragment()
+				if fragment.OpeningFragment == nil || fragment.ClosingFragment == nil {
+					return false
+				}
+			}
+
+			return true
+		}
+
+		buildFix := func(node *ast.Node) []rule.RuleFix {
+			if !canFix(node) {
+				return nil
+			}
+
+			var childrenStart, childrenEnd int
+			switch node.Kind {
+			case ast.KindJsxFragment:
+				fragment := node.AsJsxFragment()
+				childrenStart = fragment.OpeningFragment.End()
+				childrenEnd = fragment.ClosingFragment.Pos()
+			case ast.KindJsxElement:
+				element := node.AsJsxElement()
+				if element.OpeningElement == nil || element.ClosingElement == nil {
+					return nil
+				}
+				childrenStart = element.OpeningElement.End()
+				childrenEnd = element.ClosingElement.Pos()
+			case ast.KindJsxSelfClosingElement:
+				// Upstream's `opener.selfClosing ? '' : ...` arm — a
+				// self-closing fragment element has no children text.
+				return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, "")}
+			default:
+				return nil
+			}
+
+			return []rule.RuleFix{
+				rule.RuleFixReplace(ctx.SourceFile, node, trimLikeReact(sourceText[childrenStart:childrenEnd])),
+			}
+		}
+
+		checkNode := func(node *ast.Node) {
+			if isKeyedElement(node) {
+				return
+			}
+
+			allowedSingleExpression := allowExpressions && isFragmentWithSingleExpression(node)
+			if hasLessThanTwoChildren(node) &&
+				!isFragmentWithOnlyTextAndIsNotChild(node) &&
+				!allowedSingleExpression {
+				ctx.ReportNodeWithDeferredFixes(node, rule.RuleMessage{
+					Id:          "NeedsMoreChildren",
+					Description: needsMoreChildrenDescription,
+				}, func() []rule.RuleFix { return buildFix(node) })
+			}
+
+			if isChildOfHtmlElement(node) {
+				ctx.ReportNodeWithDeferredFixes(node, rule.RuleMessage{
+					Id:          "ChildOfHtmlElement",
+					Description: childOfHtmlElementDescription,
+				}, func() []rule.RuleFix { return buildFix(node) })
+			}
+		}
+
+		checkFragmentElement := func(node *ast.Node) {
+			if reactutil.IsFragmentTag(node, reactPragma, fragmentPragma) {
+				checkNode(node)
+			}
+		}
+
+		return rule.RuleListeners{
+			// ESTree models `<Fragment>…</Fragment>` and `<Fragment />` as one
+			// JSXElement kind; tsgo splits them, so both listeners are needed
+			// to cover upstream's single `JSXElement` visitor.
+			ast.KindJsxElement:            checkFragmentElement,
+			ast.KindJsxSelfClosingElement: checkFragmentElement,
+			ast.KindJsxFragment:           checkNode,
+		}
+	},
+}
+
+func parseAllowExpressions(options []any) bool {
+	if len(options) == 0 {
+		return false
+	}
+	config, ok := options[0].(map[string]any)
+	if !ok {
+		return false
+	}
+	allow, _ := config["allowExpressions"].(bool)
+	return allow
+}
+
+// containsCallExpression mirrors upstream's helper: a JSX expression container
+// whose expression is a plain CallExpression. Parentheses are transparent
+// because ESTree has no ParenthesizedExpression node, while an optional call
+// (`{foo?.()}`) is NOT a match — ESTree wraps it in a ChainExpression, which
+// upstream's `type === 'CallExpression'` check rejects.
+func containsCallExpression(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindJsxExpression {
+		return false
+	}
+	// `{}` — an empty JSX expression container — has no expression at all.
+	if node.AsJsxExpression().Expression == nil {
+		return false
+	}
+	expression := ast.SkipParentheses(node.AsJsxExpression().Expression)
+	if expression == nil {
+		return false
+	}
+	return expression.Kind == ast.KindCallExpression && !ast.IsOptionalChain(expression)
+}
+
+// isFragmentWithOnlyTextAndIsNotChild mirrors upstream: a fragment like
+// `<Foo content={<>ee eeee eeee …</>} />` is genuinely useful, so a fragment
+// holding a single text child outside of any JSX parent is left alone.
+func isFragmentWithOnlyTextAndIsNotChild(node *ast.Node) bool {
+	children := reactutil.GetJsxChildren(node)
+	if len(children) != 1 || children[0].Kind != ast.KindJsxText {
+		return false
+	}
+	parent := node.Parent
+	return parent == nil ||
+		(parent.Kind != ast.KindJsxElement && parent.Kind != ast.KindJsxFragment)
+}
+
+// isKeyedElement mirrors upstream's `<Fragment key={_}>_</Fragment>` test — a
+// keyed fragment is meaningful and never reported.
+func isKeyedElement(node *ast.Node) bool {
+	if node.Kind != ast.KindJsxElement && node.Kind != ast.KindJsxSelfClosingElement {
+		return false
+	}
+	opening := node
+	if node.Kind == ast.KindJsxElement {
+		opening = node.AsJsxElement().OpeningElement
+	}
+	for _, attribute := range reactutil.GetJsxElementAttributes(opening) {
+		if attribute.Kind == ast.KindJsxAttribute && reactutil.GetJsxPropName(attribute) == "key" {
+			return true
+		}
+	}
+	return false
+}
+
+// isAllLowercaseLetters ports upstream's `/^[a-z]+$/` tag-name test used to
+// decide whether a fragment's parent is an HTML element. JavaScript's `$`
+// anchors at the very end of the string (no trailing-newline allowance), so a
+// byte scan is exactly equivalent.
+func isAllLowercaseLetters(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := range len(name) {
+		if name[i] < 'a' || name[i] > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// trimLikeReact ports upstream's helper: a leading or trailing whitespace run
+// is dropped only when it contains a literal "\n", which is how the React
+// runtime treats JSX indentation. Note upstream tests the run for the "\n"
+// character specifically, not for any ECMAScript LineTerminator.
+func trimLikeReact(text string) string {
+	leadingEnd := ecmascript.SkipLeadingWhitespace(text, 0, len(text))
+	trailingStart := ecmascript.SkipTrailingWhitespace(text, 0, len(text))
+
+	start := 0
+	if strings.Contains(text[:leadingEnd], "\n") {
+		start = leadingEnd
+	}
+	end := len(text)
+	if strings.Contains(text[trailingStart:], "\n") {
+		end = trailingStart
+	}
+
+	// Mirrors JavaScript's `String.prototype.slice`, which yields "" when the
+	// start index runs past the end index (an all-whitespace run hits this).
+	if start >= end {
+		return ""
+	}
+	return text[start:end]
+}

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.md
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.md
@@ -1,0 +1,91 @@
+# jsx-no-useless-fragment
+
+## Rule Details
+
+Disallow unnecessary fragments. A fragment is redundant if it contains only one
+child, or if it is the child of an HTML element, and is not a
+[keyed fragment](https://react.dev/reference/react/Fragment#rendering-a-list-of-fragments).
+
+Both fragment spellings are checked: the `<>…</>` shorthand and the long form
+named by the `react` / `fragment` shared settings (`<Fragment>` and
+`<React.Fragment>` by default).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<>{foo}</>
+
+<><Foo /></>
+
+<p><>foo</></p>
+
+<></>
+
+<Fragment>foo</Fragment>
+
+<React.Fragment>foo</React.Fragment>
+
+<section>
+  <>
+    <div />
+    <div />
+  </>
+</section>
+
+{showFullName ? <>{fullName}</> : <>{firstName}</>}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+{foo}
+
+<Foo />
+
+<>
+  <Foo />
+  <Bar />
+</>
+
+<>foo {bar}</>
+
+<> {foo}</>
+
+const cat = <>meow</>
+
+<SomeComponent>
+  <>
+    <div />
+    <div />
+  </>
+</SomeComponent>
+
+<Fragment key={item.id}>{item.value}</Fragment>
+
+{showFullName ? fullName : firstName}
+```
+
+## Options
+
+- `allowExpressions` (default: `false`): when `true`, a fragment wrapping a
+  single expression is allowed. This is useful in TypeScript, where `string`
+  does not satisfy the expected `JSX.Element` return type and wrapping the
+  value in a fragment is a common workaround.
+
+Examples of **correct** code when `allowExpressions` is `true`:
+
+```jsx
+<>{foo}</>
+
+<>
+  {foo}
+</>
+```
+
+Note that `allowExpressions` only relaxes the "needs more children" check — a
+fragment passed to an HTML element is still reported.
+
+## Original Documentation
+
+- [eslint-plugin-react: jsx-no-useless-fragment](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-useless-fragment.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-useless-fragment.js)

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.md
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.md
@@ -8,7 +8,9 @@ child, or if it is the child of an HTML element, and is not a
 
 Both fragment spellings are checked: the `<>…</>` shorthand and the long form
 named by the `react` / `fragment` shared settings (`<Fragment>` and
-`<React.Fragment>` by default).
+`<React.Fragment>` by default). A `@jsx` annotation in the file — such as
+`/** @jsx Preact.h */` — renames the object half of the long form for that file
+and takes precedence over `settings.react.pragma`.
 
 Examples of **incorrect** code for this rule:
 

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.schema.json
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.schema.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowExpressions": {
+          "type": "boolean"
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_test.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_test.go
@@ -71,6 +71,22 @@ func TestJsxNoUselessFragmentExtras(t *testing.T) {
 		{Code: `<>{foo()}</>`, Tsx: true},
 		{Code: `<>{foo.bar()}</>`, Tsx: true},
 
+		// ---- Dimension 4: the `@jsx` annotation renames the pragma ----
+		// Upstream's pragmaUtil reads the annotation before `settings.react`,
+		// so under a Preact pragma `<React.Fragment>` is an ordinary component
+		// and must not be reported.
+		{Code: "/** @jsx Preact.h */\n<React.Fragment>{value}</React.Fragment>;", Tsx: true},
+		// An annotation that is not a valid identifier falls back to `React`,
+		// matching upstream's warn-and-default path, so the configured pragma
+		// is ignored once any annotation is present.
+		{Code: "/** @jsx Foo-Bar */\n<Preact.Fragment>{value}</Preact.Fragment>;", Tsx: true, Settings: fragmentSettings("Preact", "")},
+		// `@jsxFrag` is not `@jsx`: upstream's `/@jsx\s+/` needs whitespace
+		// straight after the marker, and the fragment pragma is settings-only.
+		{Code: "/** @jsxFrag Preact.Fragment */\n<Preact.Fragment>{value}</Preact.Fragment>;", Tsx: true},
+		// The annotation is read from comments, not from arbitrary source
+		// text, so a string literal cannot rename the pragma.
+		{Code: "const marker = '@jsx Preact.h';\n<Preact.Fragment>{value}</Preact.Fragment>;", Tsx: true},
+
 		// ---- Nesting / traversal boundaries ----
 		// A fragment whose parent is another fragment is never a child of an
 		// HTML element, and two children keep it useful.
@@ -133,6 +149,73 @@ func TestJsxNoUselessFragmentExtras(t *testing.T) {
 				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
 			},
 		},
+		// ---- Dimension 4: a dynamic import is not a call expression ----
+		// ESTree models `import("x")` as an ImportExpression, so upstream's
+		// call-expression exemption does not apply; tsgo parses it as a
+		// KindCallExpression with an ImportKeyword callee.
+		{
+			Code: `<>{import("x")}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: JSX spread children are not expression containers ----
+		// ESTree gives `{...value}` its own JSXSpreadChild type, which none of
+		// upstream's `type === 'JSXExpressionContainer'` tests match. So the
+		// fragment is reported, the call-expression exemption does not apply
+		// to `{...make()}`, and — because canFix's non-space-curly guard also
+		// skips it — the fix is emitted.
+		{
+			Code:   `const a = <>{...value}</>;`,
+			Tsx:    true,
+			Output: []string{`const a = {...value};`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 11},
+			},
+		},
+		{
+			Code:   `const a = <>{...make()}</>;`,
+			Tsx:    true,
+			Output: []string{`const a = {...make()};`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 11},
+			},
+		},
+		// `allowExpressions` covers `{expr}` only, so a spread child is still
+		// reported with the option on.
+		{
+			Code:    `const a = <>{...value}</>;`,
+			Tsx:     true,
+			Options: allowExpressions,
+			Output:  []string{`const a = {...value};`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 11},
+			},
+		},
+
+		// ---- Dimension 4: the `@jsx` annotation renames the pragma ----
+		// The mirror of the valid case above: the annotated pragma's fragment
+		// is the one that gets reported.
+		{
+			Code: "/** @jsx Preact.h */\n<Preact.Fragment>{value}</Preact.Fragment>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 1},
+			},
+		},
+		// A line comment carries the annotation just as well, and it wins over
+		// `settings.react.pragma`.
+		{
+			Code:     "// @jsx Preact.h\n<Preact.Fragment>{value}</Preact.Fragment>;",
+			Tsx:      true,
+			Settings: fragmentSettings("Other", ""),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 1},
+			},
+		},
+
 		// ---- Dimension 4: TS-only expression wrappers ----
 		// ESTree models these as TSAsExpression / TSNonNullExpression /
 		// TSSatisfiesExpression — none of them is a CallExpression, so the

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_test.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_test.go
@@ -1,0 +1,437 @@
+package jsx_no_useless_fragment
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestJsxNoUselessFragmentExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// naming the specific branch / Dimension 4 row / tsgo AST quirk it covers, so
+// a future refactor can't silently regress it without breaking a named
+// lock-in. The 1:1 upstream migration lives in
+// jsx_no_useless_fragment_upstream_test.go.
+//
+// Dimension walk notes for jsx-no-useless-fragment:
+//   - Dimension 2 (scoping & nesting): the rule performs no scope lookup; its
+//     only ancestor step is `node.parent`, so the relevant nesting axis is
+//     JSX containment, covered under "Nesting / traversal boundaries" below.
+//   - Dimension 4 (declaration / container forms): N/A — the rule targets JSX
+//     elements and fragments only; it never inspects a function or class.
+//   - Dimension 4 (element access `X['y']`, private names, computed keys):
+//     N/A — a JSX tag name and a JSX attribute name have no computed or
+//     private spelling.
+func TestJsxNoUselessFragmentExtras(t *testing.T) {
+	allowExpressions := []interface{}{map[string]interface{}{"allowExpressions": true}}
+	emptyOptions := []interface{}{map[string]interface{}{}}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoUselessFragmentRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: expression wrappers around the container's expression ----
+		// ESTree has no ParenthesizedExpression node, so upstream's
+		// `expression.type === 'CallExpression'` sees straight through
+		// parentheses. tsgo keeps them, so containsCallExpression must skip
+		// them to stay aligned.
+		{Code: `<>{(foos.map(foo => foo))}</>`, Tsx: true},
+		{Code: `<>{((foos.map(foo => foo)))}</>`, Tsx: true},
+		// Locks in upstream containsCallExpression() arm 2: a chain broken by
+		// parentheses is a plain CallExpression in ESTree too.
+		{Code: `<>{(foo?.bar)()}</>`, Tsx: true},
+
+		// ---- Dimension 4: fragment tag-name forms that must NOT match ----
+		{Code: `<Fragment.Foo><Bar /></Fragment.Foo>`, Tsx: true},
+		{Code: `<React.Fragment.Foo>{foo}</React.Fragment.Foo>`, Tsx: true},
+		{Code: `<A.React.Fragment>{foo}</A.React.Fragment>`, Tsx: true},
+		{Code: `<this.Fragment>{foo}</this.Fragment>`, Tsx: true},
+		{Code: `<react:Fragment>{foo}</react:Fragment>`, Tsx: true},
+
+		// ---- Locks in upstream isKeyedElement() ----
+		// A keyed fragment element is meaningful, including the self-closing
+		// and value-less attribute spellings that upstream never tests.
+		{Code: `<Fragment key="k" />`, Tsx: true},
+		{Code: `<React.Fragment key={item.id}>{item.value}</React.Fragment>`, Tsx: true},
+
+		// ---- Locks in upstream isFragmentWithOnlyTextAndIsNotChild() ----
+		// A fragment holding a single text child outside any JSX parent is
+		// useful (`<Foo content={<>text</>} />`), and stays useful when that
+		// text is whitespace only.
+		{Code: `<> </>`, Tsx: true},
+		{Code: `const a = <>meow</>;`, Tsx: true},
+		// Upstream's own `<>cat {meow}</>` comment shape: two children, so
+		// nothing is reported and canFix is never consulted.
+		{Code: `<>cat {meow}</>`, Tsx: true},
+
+		// ---- Locks in upstream hasLessThanTwoChildren() call-expression arm ----
+		{Code: `<>{foo()}</>`, Tsx: true},
+		{Code: `<>{foo.bar()}</>`, Tsx: true},
+
+		// ---- Nesting / traversal boundaries ----
+		// A fragment whose parent is another fragment is never a child of an
+		// HTML element, and two children keep it useful.
+		{Code: `<><><div /><div /></><div /></>`, Tsx: true},
+
+		// ---- Option: allowExpressions ----
+		{Code: `<Fragment>{moo}</Fragment>`, Tsx: true, Options: allowExpressions},
+		{Code: `<React.Fragment>{moo}</React.Fragment>`, Tsx: true, Options: allowExpressions},
+		// `{}` is a JSXExpressionContainer to upstream as well, so
+		// allowExpressions covers it.
+		{Code: `<>{}</>`, Tsx: true, Options: allowExpressions},
+
+		// ---- Settings: pragma / fragment resolved independently ----
+		{Code: `<Fragment>{foo}</Fragment>`, Tsx: true, Settings: fragmentSettings("", "Frag")},
+		{Code: `<React.Fragment>{foo}</React.Fragment>`, Tsx: true, Settings: fragmentSettings("Act", "")},
+
+		// ---- Real-user: keyed fragments emitted from a list render ----
+		{
+			Code: `
+        function List({ items }) {
+          return items.map((item) => (
+            <React.Fragment key={item.id}>
+              <dt>{item.term}</dt>
+              <dd>{item.description}</dd>
+            </React.Fragment>
+          ));
+        }
+      `,
+			Tsx: true,
+		},
+
+		// ---- Real-user: a string-returning component wrapped for JSX.Element ----
+		// The workaround the allowExpressions option exists for.
+		{
+			Code: `
+        const Label = ({ text }: { text: string }) => {
+          return <>{text}</>;
+        };
+      `,
+			Tsx:     true,
+			Options: allowExpressions,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: optional chains are NOT call expressions ----
+		// ESTree wraps an optional call in a ChildExpression-free
+		// ChainExpression, which upstream's `type === 'CallExpression'` test
+		// rejects; tsgo instead flags the CallExpression itself, so the rule
+		// must exclude optional chains to stay aligned.
+		{
+			Code: `<>{foo?.()}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<>{foo?.bar()}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		// ---- Dimension 4: TS-only expression wrappers ----
+		// ESTree models these as TSAsExpression / TSNonNullExpression /
+		// TSSatisfiesExpression — none of them is a CallExpression, so the
+		// fragment still needs more children.
+		{
+			Code: `<>{foo() as JSX.Element}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<>{foo()!}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		// Locks in upstream containsCallExpression() rejecting non-call
+		// expression shapes that look call-like.
+		{
+			Code: `<>{new Foo()}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: graceful degradation on empty / comment-only containers ----
+		// `{/* comment */}` parses to a container with no expression at all;
+		// it must not crash and must not be mistaken for a call.
+		{
+			Code: `<>{/* just a note */}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		// ---- Locks in upstream isKeyedElement() attribute scan ----
+		// Only a `key` attribute spares the fragment; other attributes and a
+		// spread do not.
+		{
+			Code: `<Fragment id="x">{foo}</Fragment>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<Fragment {...props}>{foo}</Fragment>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Locks in upstream isChildOfHtmlElement() `/^[a-z]+$/` ----
+		// A digit or a hyphen in the tag name takes the parent out of the
+		// HTML-element branch, so only NeedsMoreChildren fires — and, because
+		// the parent then counts as a component element, the fragment is left
+		// unfixed.
+		{
+			Code: `<h1><>foo</></h1>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 5},
+			},
+		},
+		{
+			Code: `<foo-bar><>foo</></foo-bar>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 10},
+			},
+		},
+		// A non-Identifier parent tag name (member access) also takes the
+		// HTML branch out, and additionally blocks the fix because the parent
+		// is a component element.
+		{
+			Code: `<Foo.Bar><>foo</></Foo.Bar>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 10},
+			},
+		},
+
+		// ---- Locks in upstream isChildOfComponentElement() fragment arm ----
+		// A fragment nested directly in another fragment element is fixable:
+		// the parent is a fragment, so it can't require a ReactElement child.
+		{
+			Code:   `<Fragment><>foo</></Fragment>`,
+			Tsx:    true,
+			Output: []string{`<>foo</>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 11},
+			},
+		},
+
+		// ---- Nesting / traversal boundaries ----
+		// Both the outer and the inner fragment are visited; only the outer
+		// one is short of children.
+		{
+			Code:   `<><><div /><div /></></>`,
+			Tsx:    true,
+			Output: []string{`<><div /><div /></>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Locks in upstream trimLikeReact() ----
+		// A leading / trailing whitespace run without a "\n" is preserved,
+		// because React itself preserves it.
+		{
+			Code:   `<div>  <>  <b />  </>  </div>`,
+			Tsx:    true,
+			Output: []string{`<div>    <b />    </div>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 8},
+			},
+		},
+		// An all-whitespace children run containing "\n" collapses to the
+		// empty string — the JavaScript `slice(start, end)` arm where start
+		// runs past end.
+		{
+			Code: `<div>
+<>
+</>
+</div>`,
+			Tsx: true,
+			Output: []string{`<div>
+
+</div>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 1},
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 2, Column: 1},
+			},
+		},
+
+		// ---- Locks in upstream isFragmentWithOnlyTextAndIsNotChild() ----
+		// The single child is an expression container, not text, so the
+		// "useful text fragment" escape hatch does not apply even though the
+		// fragment has no JSX parent.
+		{
+			Code: `<div p={<>{foo}</>} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 9},
+			},
+		},
+
+		// ---- Option contract: allowExpressions defaults to false ----
+		// Running with no options and with `[{}]` must produce the same
+		// diagnostic.
+		{
+			Code: `<>{moo}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<>{moo}</>`,
+			Tsx:     true,
+			Options: emptyOptions,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		// allowExpressions only silences NeedsMoreChildren — a fragment passed
+		// to an HTML element is still useless.
+		{
+			Code:    `<div><>{moo}</></div>`,
+			Tsx:     true,
+			Options: allowExpressions,
+			Output:  []string{`<div>{moo}</div>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Real-user: ternary branches wrapped in fragments ----
+		{
+			Code: `const name = showFullName ? <>{fullName}</> : <>{firstName}</>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 29},
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 47},
+			},
+		},
+		// ---- Real-user: a pass-through component wrapping its children ----
+		{
+			Code: `
+        function Wrapper({ children }) {
+          return <>{children}</>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 3, Column: 18},
+			},
+		},
+	})
+}
+
+// fragmentSettings builds a `settings.react` map with only the entries the
+// caller cares about, so a test can vary `pragma` and `fragment`
+// independently and confirm each falls back to its own default.
+func fragmentSettings(pragma, fragment string) map[string]interface{} {
+	react := map[string]interface{}{}
+	if pragma != "" {
+		react["pragma"] = pragma
+	}
+	if fragment != "" {
+		react["fragment"] = fragment
+	}
+	return map[string]interface{}{"react": react}
+}
+
+// TestJsxNoUselessFragmentEditDemand exercises Dimension 3 (autofix
+// boundaries): diagnostic count, message, and range must stay identical
+// across every edit demand, and the replacement text must materialize only
+// when an autofix is actually requested.
+func TestJsxNoUselessFragmentEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"const a = <><div /></>;\nconst b = <><span /></>;",
+		"edit-demand.tsx",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name:     JsxNoUselessFragmentRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return JsxNoUselessFragmentRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got, want := withoutEdits(diagnostics[index]), withoutEdits(allEdits[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if fixes := *allEdits[index].FixesPtr; len(fixes) == 0 {
+			t.Fatalf("diagnostic %d: all-edits demand produced no fixes", index)
+		}
+		if diagnostic := allEdits[index]; diagnostic.Suggestions != nil {
+			t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+		}
+	}
+}

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_upstream_test.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_upstream_test.go
@@ -1,0 +1,266 @@
+package jsx_no_useless_fragment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestJsxNoUselessFragmentUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/jsx-no-useless-fragment.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in jsx_no_useless_fragment_extras_test.go.
+func TestJsxNoUselessFragmentUpstream(t *testing.T) {
+	allowExpressions := []interface{}{map[string]interface{}{"allowExpressions": true}}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoUselessFragmentRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<><Foo /><Bar /></>`, Tsx: true},
+		{Code: `<>foo<div /></>`, Tsx: true},
+		{Code: `<> <div /></>`, Tsx: true},
+		{Code: `<>{"moo"} </>`, Tsx: true},
+		{Code: `<NotFragment />`, Tsx: true},
+		{Code: `<React.NotFragment />`, Tsx: true},
+		{Code: `<NotReact.Fragment />`, Tsx: true},
+		{Code: `<Foo><><div /><div /></></Foo>`, Tsx: true},
+		{Code: `<div p={<>{"a"}{"b"}</>} />`, Tsx: true},
+		{Code: `<Fragment key={item.id}>{item.value}</Fragment>`, Tsx: true},
+		{Code: `<Fooo content={<>eeee ee eeeeeee eeeeeeee</>} />`, Tsx: true},
+		{Code: `<>{foos.map(foo => foo)}</>`, Tsx: true},
+		{Code: `<>{moo}</>`, Tsx: true, Options: allowExpressions},
+		{
+			Code: `
+        <>
+          {moo}
+        </>
+      `,
+			Tsx:     true,
+			Options: allowExpressions,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `<></>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<>{}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:   `<p>moo<>foo</></p>`,
+			Tsx:    true,
+			Output: []string{`<p>moofoo</p>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 7},
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 7},
+			},
+		},
+		{
+			Code: `<>{meow}</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:   `<p><>{meow}</></p>`,
+			Tsx:    true,
+			Output: []string{`<p>{meow}</p>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 4},
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 4},
+			},
+		},
+		{
+			Code:   `<><div/></>`,
+			Tsx:    true,
+			Output: []string{`<div/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `
+        <>
+          <div/>
+        </>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <div/>
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 9},
+			},
+		},
+		{
+			Code: `<Fragment />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `
+        <React.Fragment>
+          <Foo />
+        </React.Fragment>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <Foo />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 9},
+			},
+		},
+		{
+			Code: `
+        <SomeReact.SomeFragment>
+          {foo}
+        </SomeReact.SomeFragment>
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma":   "SomeReact",
+					"fragment": "SomeFragment",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 9},
+			},
+		},
+		{
+			// Not safe to fix this case because `Eeee` might require child be ReactElement
+			Code: `<Eeee><>foo</></Eeee>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `<div><>foo</></div>`,
+			Tsx:    true,
+			Output: []string{`<div>foo</div>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 6},
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div><>{"a"}{"b"}</></div>`,
+			Tsx:    true,
+			Output: []string{`<div>{"a"}{"b"}</div>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 6},
+			},
+		},
+		{
+			// SKIP: upstream repeats the previous case for the legacy
+			// typescript-eslint parser, which reported no autofix there.
+			// rslint has a single parser, so the case above already covers it.
+			Skip: true,
+			Code: `<div><>{"a"}{"b"}</></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `
+        <section>
+          <Eeee />
+          <Eeee />
+          <>{"a"}{"b"}</>
+        </section>`,
+			Tsx: true,
+			Output: []string{`
+        <section>
+          <Eeee />
+          <Eeee />
+          {"a"}{"b"}
+        </section>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 5, Column: 11},
+			},
+		},
+		{
+			Code:   `<div><Fragment>{"a"}{"b"}</Fragment></div>`,
+			Tsx:    true,
+			Output: []string{`<div>{"a"}{"b"}</div>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 6},
+			},
+		},
+		{
+			// whitespace tricky case
+			Code: `
+        <section>
+          git<>
+            <b>hub</b>.
+          </>
+
+          git<> <b>hub</b></>
+        </section>`,
+			Tsx: true,
+			Output: []string{`
+        <section>
+          git<b>hub</b>.
+
+          git <b>hub</b>
+        </section>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 3, Column: 14},
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 7, Column: 14},
+			},
+		},
+		{
+			Code:   `<div>a <>{""}{""}</> a</div>`,
+			Tsx:    true,
+			Output: []string{`<div>a {""}{""} a</div>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 8},
+			},
+		},
+		{
+			Code: `
+        const Comp = () => (
+          <html>
+            <React.Fragment />
+          </html>
+        );
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Comp = () => (
+          <html>
+            
+          </html>
+        );
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 4, Column: 13},
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 4, Column: 13},
+			},
+		},
+		{
+			// Ensure allowExpressions still catches expected violations
+			Code:    `<><Foo>{moo}</Foo></>`,
+			Tsx:     true,
+			Options: allowExpressions,
+			Output:  []string{`<Foo>{moo}</Foo>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated.go
@@ -1,7 +1,6 @@
 package no_deprecated
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -111,27 +110,6 @@ func buildDeprecated(pragma string) map[string]deprecationInfo {
 	m["ReactDOM.unmountComponentAtNode"] = deprecationInfo{"18.0.0", "root.unmount", "https://reactjs.org/link/switch-to-createroot"}
 	m["ReactDOMServer.renderToNodeStream"] = deprecationInfo{"18.0.0", "renderToPipeableStream", "https://reactjs.org/docs/react-dom-server.html#rendertonodestream"}
 	return m
-}
-
-// jsxPragmaRe matches a `@jsx Foo` directive anywhere in source text. The
-// comment form (block vs. line) isn't constrained — upstream's pragmaUtil
-// accepts the pragma from any comment, so we scan the raw source.
-var jsxPragmaRe = regexp.MustCompile(`@jsx\s+([A-Za-z_$][\w$.]*)`)
-
-// detectJsxPragma returns the identifier following the first `@jsx` directive
-// in the source, or "" when no directive is present.
-func detectJsxPragma(sourceText string) string {
-	// Most files do not carry a classic-runtime pragma. Avoid putting the
-	// regexp engine on the hot path for every file in that overwhelmingly
-	// common case.
-	if !strings.Contains(sourceText, "@jsx") {
-		return ""
-	}
-	m := jsxPragmaRe.FindStringSubmatch(sourceText)
-	if m == nil {
-		return ""
-	}
-	return m[1]
 }
 
 // parseVersion parses a leading "major[.minor[.patch]]" numeric triple and
@@ -326,12 +304,10 @@ var NoDeprecatedRule = rule.Rule{
 	Name:   "react/no-deprecated",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// Determine pragma: `@jsx` directive in source wins over
-		// `settings.react.pragma`, matching upstream's `pragmaUtil.getFromContext`.
-		pragma := detectJsxPragma(ctx.SourceFile.Text())
-		if pragma == "" {
-			pragma = reactutil.GetReactPragma(ctx.Settings)
-		}
+		// A `@jsx` annotation in the source wins over
+		// `settings.react.pragma`, matching upstream's
+		// `pragmaUtil.getFromContext`.
+		pragma := reactutil.GetReactPragmaFromContext(ctx)
 		createClass := reactutil.GetReactCreateClass(ctx.Settings)
 		usesDefaultPragma := pragma == reactutil.DefaultReactPragma
 		deprecated := defaultDeprecated

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
@@ -25,34 +25,6 @@ func msg(oldMethod, version, newMethod, refs string) string {
 const lifecycleRefsTail = ". Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components."
 const lifecycleRefsHead = "https://reactjs.org/docs/react-component.html#"
 
-func TestDetectJsxPragmaFastPathMatchesRegexp(t *testing.T) {
-	t.Parallel()
-
-	for _, source := range []string{
-		"",
-		"const value = 'jsx';",
-		"const value = '@jsx';",
-		"/** @jsx Foo */",
-		"// prefix @jsx\t$Foo_1.Bar trailing",
-		"/* @jsx\nFoo.Bar */",
-		"@jsx Foo-Bar",
-		"@jsx9 Foo",
-		"@@jsx Foo",
-	} {
-		t.Run(source, func(t *testing.T) {
-			t.Parallel()
-
-			want := ""
-			if match := jsxPragmaRe.FindStringSubmatch(source); match != nil {
-				want = match[1]
-			}
-			if got := detectJsxPragma(source); got != want {
-				t.Fatalf("detectJsxPragma(%q) = %q, want regexp result %q", source, got, want)
-			}
-		})
-	}
-}
-
 func TestParseVersionMatchesPreviousImplementation(t *testing.T) {
 	t.Parallel()
 

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -203,6 +203,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-script-url.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-target-blank.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-undef.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-useless-fragment.test.ts',
     './tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-spread-multi.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-useless-fragment.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-useless-fragment.test.ts
@@ -1,0 +1,165 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-useless-fragment', {} as never, {
+  valid: [
+    { code: '<><Foo /><Bar /></>' },
+    { code: '<>foo<div /></>' },
+    { code: '<> <div /></>' },
+    { code: '<>{"moo"} </>' },
+    { code: '<NotFragment />' },
+    { code: '<React.NotFragment />' },
+    { code: '<NotReact.Fragment />' },
+    { code: '<Foo><><div /><div /></></Foo>' },
+    { code: '<div p={<>{"a"}{"b"}</>} />' },
+    { code: '<Fragment key={item.id}>{item.value}</Fragment>' },
+    { code: '<Fooo content={<>eeee ee eeeeeee eeeeeeee</>} />' },
+    { code: '<>{foos.map(foo => foo)}</>' },
+    {
+      code: '<>{moo}</>',
+      options: [{ allowExpressions: true }],
+    },
+    {
+      code: `
+        <>
+          {moo}
+        </>
+      `,
+      options: [{ allowExpressions: true }],
+    },
+  ],
+  invalid: [
+    {
+      code: '<></>',
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: '<>{}</>',
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: '<p>moo<>foo</></p>',
+      errors: [
+        { messageId: 'NeedsMoreChildren' },
+        { messageId: 'ChildOfHtmlElement' },
+      ],
+    },
+    {
+      code: '<>{meow}</>',
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: '<p><>{meow}</></p>',
+      errors: [
+        { messageId: 'NeedsMoreChildren' },
+        { messageId: 'ChildOfHtmlElement' },
+      ],
+    },
+    {
+      code: '<><div/></>',
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: `
+        <>
+          <div/>
+        </>
+      `,
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: '<Fragment />',
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: `
+        <React.Fragment>
+          <Foo />
+        </React.Fragment>
+      `,
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: `
+        <SomeReact.SomeFragment>
+          {foo}
+        </SomeReact.SomeFragment>
+      `,
+      settings: {
+        react: {
+          pragma: 'SomeReact',
+          fragment: 'SomeFragment',
+        },
+      },
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      // Not safe to fix this case because `Eeee` might require child be ReactElement
+      code: '<Eeee><>foo</></Eeee>',
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+    {
+      code: '<div><>foo</></div>',
+      errors: [
+        { messageId: 'NeedsMoreChildren' },
+        { messageId: 'ChildOfHtmlElement' },
+      ],
+    },
+    {
+      code: '<div><>{"a"}{"b"}</></div>',
+      errors: [{ messageId: 'ChildOfHtmlElement' }],
+    },
+    {
+      code: `
+        <section>
+          <Eeee />
+          <Eeee />
+          <>{"a"}{"b"}</>
+        </section>`,
+      errors: [{ messageId: 'ChildOfHtmlElement' }],
+    },
+    {
+      code: '<div><Fragment>{"a"}{"b"}</Fragment></div>',
+      errors: [{ messageId: 'ChildOfHtmlElement' }],
+    },
+    {
+      // whitespace tricky case
+      code: `
+        <section>
+          git<>
+            <b>hub</b>.
+          </>
+
+          git<> <b>hub</b></>
+        </section>`,
+      errors: [
+        { messageId: 'ChildOfHtmlElement', line: 3 },
+        { messageId: 'ChildOfHtmlElement', line: 7 },
+      ],
+    },
+    {
+      code: '<div>a <>{""}{""}</> a</div>',
+      errors: [{ messageId: 'ChildOfHtmlElement' }],
+    },
+    {
+      code: `
+        const Comp = () => (
+          <html>
+            <React.Fragment />
+          </html>
+        );
+      `,
+      errors: [
+        { messageId: 'NeedsMoreChildren', line: 4 },
+        { messageId: 'ChildOfHtmlElement', line: 4 },
+      ],
+    },
+    {
+      // Ensure allowExpressions still catches expected violations
+      code: '<><Foo>{moo}</Foo></>',
+      options: [{ allowExpressions: true }],
+      errors: [{ messageId: 'NeedsMoreChildren' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -346,6 +346,7 @@ mmap
 mobx
 Modns
 modns
+moofoo
 morestack
 mousein
 mouseout


### PR DESCRIPTION
## Summary

Port the `react/jsx-no-useless-fragment` rule from eslint-plugin-react to rslint.

The rule reports fragments that are redundant — a fragment with fewer than two children, or a fragment passed directly to an HTML element — while leaving keyed fragments and single-text fragments used as prop values alone. Both the `<>…</>` shorthand and the long `<Fragment>` / `<React.Fragment>` forms are checked, resolved through the `react` / `fragment` shared settings. The `allowExpressions` option (default `false`) is supported.

## Credits

Port from [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react)'s `jsx-no-useless-fragment`.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-no-useless-fragment.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-useless-fragment.js
- Closes #1937

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
