### PR TITLE
fix: align throw-new-error with upstream semantics

### DIFF
--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
@@ -8,6 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -425,7 +426,7 @@ func (state *ruleState) checkCallExpression(node *ast.Node) {
 
 	// An optional chain (`Array?.()` or `Intl?.DateTimeFormat()`) can't be
 	// rewritten to a `new` expression, which cannot itself be optional.
-	if hasOptionalChain(node) || hasOptionalChain(call.Expression) {
+	if call.QuestionDotToken != nil || unicornutil.HasOptionalChainElement(call.Expression) {
 		return
 	}
 
@@ -1167,32 +1168,6 @@ func (state *ruleState) isLocalNonAliasIdentifier(node *ast.Node) bool {
 	}
 
 	return utils.IsShadowed(node, name)
-}
-
-func hasOptionalChain(node *ast.Node) bool {
-	node = utils.SkipAssertionsAndParens(node)
-	if node == nil {
-		return false
-	}
-	if ast.IsOptionalChain(node) {
-		return true
-	}
-	switch node.Kind {
-	case ast.KindCallExpression:
-		call := node.AsCallExpression()
-		return call != nil && hasOptionalChain(call.Expression)
-	case ast.KindPropertyAccessExpression:
-		access := node.AsPropertyAccessExpression()
-		return access != nil && hasOptionalChain(access.Expression)
-	case ast.KindElementAccessExpression:
-		access := node.AsElementAccessExpression()
-		return access != nil && hasOptionalChain(access.Expression)
-	case ast.KindNonNullExpression:
-		expression := node.AsNonNullExpression()
-		return expression != nil && hasOptionalChain(expression.Expression)
-	default:
-		return false
-	}
 }
 
 func isStrictObjectComparison(node *ast.Node) bool {

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_extras_test.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_extras_test.go
@@ -21,6 +21,8 @@ func TestNewForBuiltinsExtras(t *testing.T) {
 		[]rule_tester.ValidTestCase{
 			// ---- Dimension 4: optional calls that would require optional `new` are ignored ----
 			jsValid("const value = (globalThis?.Array)();"),
+			// ---- Dimension 4: optional chains remain visible through TS assertions ----
+			tsValid("const value = (globalThis?.Array as any)();"),
 			// ---- Dimension 4: dynamic element access is not a static builtin reference ----
 			jsValid("const key = 'Array'; globalThis[key]();"),
 			// ---- Dimension 4: numeric element keys do not match builtin names ----
@@ -158,6 +160,8 @@ func TestNewForBuiltinsExtras(t *testing.T) {
 			enforceInvalid("const value = ((globalThis)).Array();", "((globalThis)).Array()", "Array"),
 			// ---- Dimension 4: TS type-expression wrappers on receivers are transparent ----
 			tsEnforceInvalid("const value = (globalThis as any).Array();", "(globalThis as any).Array()", "Array"),
+			// ---- Dimension 4: TS-wrapped non-optional builtin callees still report ----
+			tsEnforceInvalid("const value = (globalThis.Array as any)();", "(globalThis.Array as any)()", "Array"),
 			// ---- Dimension 4: TS non-null wrappers on receivers are transparent ----
 			tsEnforceInvalid("const value = (globalThis!).Array();", "(globalThis!).Array()", "Array"),
 			// ---- Dimension 4: TS satisfies wrappers on receivers are transparent ----

--- a/internal/plugins/unicorn/rules/throw_new_error/throw_new_error.go
+++ b/internal/plugins/unicorn/rules/throw_new_error/throw_new_error.go
@@ -6,6 +6,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 const messageID = "throw-new-error"
@@ -54,18 +55,17 @@ var ThrowNewErrorRule = rule.Rule{
 					return
 				}
 
-				// A decorator call is not a construction site.
-				if node.Parent != nil && node.Parent.Kind == ast.KindDecorator {
+				// A decorator call is not a construction site. Skip syntax that
+				// tsgo preserves or synthesizes but ESTree does not expose.
+				parent := utils.ESTreeParent(node)
+				if parent != nil && parent.Kind == ast.KindDecorator {
 					return
 				}
 
-				// ESTree unwraps parentheses transparently; tsgo keeps
-				// ParenthesizedExpression nodes, so the callee has to be
-				// unwrapped before it is classified. Only parentheses are
-				// skipped, not TS assertions, so that a callee such as
-				// `(Error as any)` stays unreported exactly as upstream
-				// leaves it.
-				callee := ast.SkipParentheses(call.Expression)
+				// ESTree omits parentheses and JavaScript JSDoc casts. Authored
+				// TypeScript assertions remain intact, so a callee such as
+				// `(Error as any)` stays unreported exactly as upstream leaves it.
+				callee := utils.ESTreeRuntimeExpression(call.Expression)
 				if callee == nil {
 					return
 				}
@@ -74,7 +74,7 @@ var ThrowNewErrorRule = rule.Rule{
 				// The optional-chain flag stops at a parenthesis — `(a?.b).c`
 				// ends the chain — but upstream's hasOptionalChainElement keeps
 				// walking through it and skips the call either way.
-				if hasOptionalChainElement(callee) {
+				if unicornutil.HasOptionalChainElement(callee) {
 					return
 				}
 
@@ -90,49 +90,6 @@ var ThrowNewErrorRule = rule.Rule{
 			},
 		}
 	},
-}
-
-// hasOptionalChainElement reports whether any link of the callee chain is
-// optional, mirroring upstream's helper of the same name.
-//
-// `new` cannot be applied to an optional-chained call, so `Error?.()`,
-// `lib?.Error()`, `lib?.foo.Error()` and `(lib?.mod).Error()` are all left
-// alone.
-func hasOptionalChainElement(node *ast.Node) bool {
-	for current := node; current != nil; {
-		if ast.IsOptionalChain(current) {
-			return true
-		}
-		switch current.Kind {
-		case ast.KindCallExpression:
-			call := current.AsCallExpression()
-			if call == nil {
-				return false
-			}
-			current = ast.SkipParentheses(call.Expression)
-		case ast.KindPropertyAccessExpression:
-			access := current.AsPropertyAccessExpression()
-			if access == nil {
-				return false
-			}
-			current = ast.SkipParentheses(access.Expression)
-		case ast.KindElementAccessExpression:
-			access := current.AsElementAccessExpression()
-			if access == nil {
-				return false
-			}
-			current = ast.SkipParentheses(access.Expression)
-		case ast.KindNonNullExpression:
-			nonNull := current.AsNonNullExpression()
-			if nonNull == nil {
-				return false
-			}
-			current = ast.SkipParentheses(nonNull.Expression)
-		default:
-			return false
-		}
-	}
-	return false
 }
 
 // isCustomErrorCallee reports whether callee names an error constructor: a bare

--- a/internal/plugins/unicorn/rules/throw_new_error/throw_new_error_extras_test.go
+++ b/internal/plugins/unicorn/rules/throw_new_error/throw_new_error_extras_test.go
@@ -1,6 +1,6 @@
-// TestThrowNewErrorExtras covers cases the upstream JavaScript suite cannot
-// express: decorator syntax, which needs a TypeScript file, and the rslint-side
-// lock-in for callees tsgo represents but ESTree does not.
+// TestThrowNewErrorExtras locks in branches and edge shapes that the upstream
+// test suite does not exercise. Each group names the AST boundary it protects;
+// the full upstream suite lives in throw_new_error_upstream_test.go.
 package throw_new_error_test
 
 import (
@@ -18,33 +18,33 @@ func TestThrowNewErrorExtras(t *testing.T) {
 		t,
 		&throw_new_error.ThrowNewErrorRule,
 		[]rule_tester.ValidTestCase{
-			// A decorator is a call expression whose name ends in `Error`, so
-			// only the decorator check keeps these quiet.
-			validIn("file.ts", `@RegisterServiceError()
+			// ---- Dimension 4: parenthesized decorator calls ----
+			// Parentheses are transparent between the call and Decorator, even
+			// when tsgo preserves several explicit wrapper nodes.
+			validIn("file.ts", `@(RegisterServiceError())
 export class SomeError extends Error {}`),
-			validIn("file.ts", `@decorators.RegisterServiceError()
+			validIn("file.ts", `@(((RegisterServiceError())))
 export class SomeError extends Error {}`),
-			validIn("file.ts", `class Service {
-	@OnQueueError()
-	handle() {}
-}`),
-			validIn("file.ts", `function RegisterServiceError() {
-	return function <T extends new (...arguments_: any[]) => Error>(constructor: T) {
-		return constructor;
-	};
-}
-
-@RegisterServiceError()
+			validIn("file.js", `@(/** @type {any} */ (RegisterServiceError()))
+export class SomeError extends Error {}`),
+			validIn("file.js", `@(/** @satisfies {Function} */ (RegisterServiceError()))
 export class SomeError extends Error {}`),
 
-			// The parenthesis ends tsgo's optional chain, but upstream keeps
-			// walking past it and skips the call.
+			// ---- Dimension 4: optional chains behind transparent wrappers ----
 			validIn("file.js", `throw (lib?.mod).Error()`),
+			validIn("file.ts", `throw (lib?.mod as any).CustomError()`),
+			validIn("file.ts", `throw (<any>lib?.mod).CustomError()`),
+			validIn("file.ts", `throw (lib?.mod satisfies any).CustomError()`),
+			validIn("file.ts", `throw (lib?.mod!).CustomError()`),
+			validIn("file.ts", `throw ((((lib?.mod as any)!) satisfies any) as any).CustomError()`),
+			validIn("file.ts", `throw (factory?.() as any).CustomError()`),
+			validIn("file.ts", `throw ((lib?.mod as any)[key]).CustomError()`),
+			validIn("file.ts", `throw (((lib?.mod))).CustomError()`),
+			validIn("file.tsx", `<Component value={(lib?.mod as any).CustomError()} />`),
 
-			// tsgo keeps assertion nodes the way a TypeScript parser sees them,
-			// so the callee is not an identifier. Upstream reads the same
-			// expression the same way.
+			// ---- Dimension 4: callee classification does not unwrap TS assertions ----
 			validIn("file.ts", `throw (Error as any)()`),
+			validIn("file.ts", `throw (lib.CustomError as any)()`),
 			validIn("file.ts", `throw lib.#Error()`),
 
 			// A bare error class is not a call.
@@ -53,10 +53,64 @@ export class SomeError extends Error {}`),
 			validIn("file.js", `throw new lib.mod.CustomError('foo')`),
 		},
 		[]rule_tester.InvalidTestCase{
-			// The decorator itself is exempt, but an argument inside it is an
-			// ordinary call expression.
-			invalidIn("file.ts", `@Decorator(Error())
+			// ESTree does not expose wrappers that tsgo synthesizes for JSDoc
+			// casts, so they do not hide an otherwise reportable callee.
+			invalidIn("file.js", `throw (/** @type {any} */ (Error))()`, `(/** @type {any} */ (Error))()`),
+			invalidIn(
+				"file.js",
+				`throw (/** @satisfies {Function} */ (Error))()`,
+				`(/** @satisfies {Function} */ (Error))()`,
+			),
+			invalidIn(
+				"file.js",
+				`throw (/** @type {any} */ (lib.CustomError))()`,
+				`(/** @type {any} */ (lib.CustomError))()`,
+			),
+
+			// Locks in upstream create() decorator-parent branch: only
+			// parentheses are transparent. Authored TS wrappers remain parents.
+			invalidIn("file.ts", `@(RegisterServiceError() as any)
+export class SomeError extends Error {}`, `RegisterServiceError()`),
+			invalidIn("file.ts", `@(RegisterServiceError() satisfies any)
+export class SomeError extends Error {}`, `RegisterServiceError()`),
+			invalidIn("file.ts", `@(RegisterServiceError()!)
+export class SomeError extends Error {}`, `RegisterServiceError()`),
+			invalidIn("file.ts", `@(<any>RegisterServiceError())
+export class SomeError extends Error {}`, `RegisterServiceError()`),
+
+			// A nested call does not inherit the outer call's decorator exemption.
+			invalidIn("file.ts", `@((OuterError(Error())))
 export class SomeError extends Error {}`, `Error()`),
+
+			// Locks in upstream hasOptionalChainElement() TS-wrapper branch:
+			// wrappers without an optional link still report.
+			invalidIn("file.ts", `throw (lib.mod as any).CustomError()`, `(lib.mod as any).CustomError()`),
+			invalidIn("file.ts", `throw (<any>lib.mod).CustomError()`, `(<any>lib.mod).CustomError()`),
+			invalidIn("file.ts", `throw (lib.mod satisfies any).CustomError()`, `(lib.mod satisfies any).CustomError()`),
+			invalidIn("file.ts", `throw (lib.mod!).CustomError()`, `(lib.mod!).CustomError()`),
+			invalidIn(
+				"file.ts",
+				`throw ((((lib.mod as any)!) satisfies any) as any).CustomError()`,
+				`((((lib.mod as any)!) satisfies any) as any).CustomError()`,
+			),
+			invalidIn("file.ts", `throw (factory() as any).CustomError()`, `(factory() as any).CustomError()`),
+			invalidIn("file.ts", `throw ((lib.mod as any)[key]).CustomError()`, `((lib.mod as any)[key]).CustomError()`),
+			invalidIn("file.ts", `throw (((lib.mod))).CustomError()`, `(((lib.mod))).CustomError()`),
+			invalidIn(
+				"file.tsx",
+				`<Component value={(lib.mod as any).CustomError()} />`,
+				`(lib.mod as any).CustomError()`,
+			),
+
+			// ---- Adversarial: optional links outside the callee/object path ----
+			invalidIn("file.ts", `throw maker(value?.member).CustomError()`, `maker(value?.member).CustomError()`),
+			invalidIn("file.ts", `throw lib[value?.member].CustomError()`, `lib[value?.member].CustomError()`),
+			invalidIn(
+				"file.ts",
+				`async function run() { throw (await lib?.mod).CustomError(); }`,
+				`(await lib?.mod).CustomError()`,
+			),
+			invalidIn("file.ts", `throw (lib?.mod<T>).CustomError()`, `(lib?.mod<T>).CustomError()`),
 
 			// Nested inside another call.
 			invalidIn("file.js", `foo(Error())`, `Error()`),
@@ -64,14 +118,4 @@ export class SomeError extends Error {}`, `Error()`),
 			invalidIn("file.js", `const error = lib.mod.CustomError()`, `lib.mod.CustomError()`),
 		},
 	)
-}
-
-func validIn(fileName string, code string) rule_tester.ValidTestCase {
-	return rule_tester.ValidTestCase{Code: code, FileName: fileName}
-}
-
-func invalidIn(fileName string, code string, target string) rule_tester.InvalidTestCase {
-	testCase := invalid(code, target)
-	testCase.FileName = fileName
-	return testCase
 }

--- a/internal/plugins/unicorn/rules/throw_new_error/throw_new_error_upstream_test.go
+++ b/internal/plugins/unicorn/rules/throw_new_error/throw_new_error_upstream_test.go
@@ -1,7 +1,7 @@
 // TestThrowNewErrorUpstream migrates the valid/invalid suite from upstream
 // test/throw-new-error.js 1:1. Position assertions cover line/column for every
-// invalid case. TypeScript-only cases (decorator syntax) and rslint-specific
-// lock-in cases live in throw_new_error_extras_test.go.
+// invalid case. rslint-specific lock-in cases live in
+// throw_new_error_extras_test.go.
 package throw_new_error_test
 
 import (
@@ -57,6 +57,20 @@ func TestThrowNewErrorUpstream(t *testing.T) {
 			// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2654
 			// `Data.TaggedError` is a factory, not a constructor.
 			{Code: `class QueryError extends Data.TaggedError('QueryError') {}`},
+			validIn("file.ts", `function RegisterServiceError() {
+	return function <T extends new (...arguments_: any[]) => Error>(constructor: T) {
+		return constructor;
+	};
+}
+
+@RegisterServiceError()
+export class SomeError extends Error {}`),
+			validIn("file.ts", `@decorators.RegisterServiceError()
+export class SomeError extends Error {}`),
+			validIn("file.ts", `class Service {
+	@OnQueueError()
+	handle() {}
+}`),
 		},
 		[]rule_tester.InvalidTestCase{
 			invalid(`throw Error()`, `Error()`),
@@ -92,8 +106,20 @@ func TestThrowNewErrorUpstream(t *testing.T) {
 				"function foo() {\n\treturn[globalThis][0].Error('message');\n}",
 				`[globalThis][0].Error('message')`,
 			),
+			invalidIn("file.ts", `@Decorator(Error())
+export class SomeError extends Error {}`, `Error()`),
 		},
 	)
+}
+
+func validIn(fileName string, code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: fileName}
+}
+
+func invalidIn(fileName string, code string, target string) rule_tester.InvalidTestCase {
+	testCase := invalid(code, target)
+	testCase.FileName = fileName
+	return testCase
 }
 
 // invalid reports the position of the single call expression named by target.

--- a/internal/plugins/unicorn/unicornutil/optional_chain.go
+++ b/internal/plugins/unicorn/unicornutil/optional_chain.go
@@ -1,0 +1,39 @@
+package unicornutil
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// HasOptionalChainElement reports whether node's callee/object path contains
+// an optional-chain link. Its transparent-node list is deliberately closed:
+// tsgo's ParenthesizedExpression plus the four TypeScript wrappers that
+// Unicorn unwraps (as, satisfies, non-null, and angle-bracket assertions).
+// Call arguments and element-access keys are deliberately outside the path.
+func HasOptionalChainElement(node *ast.Node) bool {
+	for node != nil {
+		switch node.Kind {
+		case ast.KindParenthesizedExpression,
+			ast.KindAsExpression,
+			ast.KindSatisfiesExpression,
+			ast.KindNonNullExpression,
+			ast.KindTypeAssertionExpression:
+			node = node.Expression()
+		case ast.KindCallExpression:
+			if ast.IsOptionalChain(node) {
+				return true
+			}
+			node = node.AsCallExpression().Expression
+		case ast.KindPropertyAccessExpression:
+			if ast.IsOptionalChain(node) {
+				return true
+			}
+			node = node.AsPropertyAccessExpression().Expression
+		case ast.KindElementAccessExpression:
+			if ast.IsOptionalChain(node) {
+				return true
+			}
+			node = node.AsElementAccessExpression().Expression
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/internal/plugins/unicorn/unicornutil/optional_chain_test.go
+++ b/internal/plugins/unicorn/unicornutil/optional_chain_test.go
@@ -1,0 +1,54 @@
+package unicornutil
+
+import "testing"
+
+func TestHasOptionalChainElement(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		want       bool
+	}{
+		{name: "plain property", expression: "lib.mod.CustomError"},
+		{name: "direct optional call", expression: "Error?.()", want: true},
+		{name: "optional property", expression: "lib?.mod.CustomError", want: true},
+		{name: "optional element", expression: "lib?.[key].CustomError", want: true},
+		{name: "parentheses", expression: "((lib?.mod)).CustomError", want: true},
+		{name: "as expression", expression: "(lib?.mod as any).CustomError", want: true},
+		{name: "type assertion", expression: "(<any>lib?.mod).CustomError", want: true},
+		{name: "satisfies expression", expression: "(lib?.mod satisfies any).CustomError", want: true},
+		{name: "non-null expression", expression: "(lib?.mod!).CustomError", want: true},
+		{
+			name:       "nested wrappers",
+			expression: "((((lib?.mod as any)!) satisfies any) as any).CustomError",
+			want:       true,
+		},
+		{name: "optional call receiver", expression: "(factory?.() as any).CustomError", want: true},
+		{
+			name:       "non-optional call reaches optional callee",
+			expression: "((lib?.mod as any)()).CustomError",
+			want:       true,
+		},
+		{name: "non-optional call plain callee", expression: "((lib.mod as any)()).CustomError"},
+		{name: "call argument boundary", expression: "maker(value?.member).CustomError"},
+		{name: "element key boundary", expression: "lib[value?.member].CustomError"},
+		{name: "instantiation boundary", expression: "(lib?.mod<T>).CustomError"},
+	}
+
+	if HasOptionalChainElement(nil) {
+		t.Fatal("nil must not contain an optional-chain element")
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			code := "consume(" + test.expression + ")"
+			sourceFile := parseTestSource(code)
+			call := findTestCall(t, sourceFile, code).AsCallExpression()
+			if call == nil || len(call.Arguments.Nodes) != 1 {
+				t.Fatalf("%q is not a one-argument call", code)
+			}
+			if got := HasOptionalChainElement(call.Arguments.Nodes[0]); got != test.want {
+				t.Fatalf("HasOptionalChainElement(%q) = %v, want %v", test.expression, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Align unicorn/throw-new-error decorator and callee handling with ESTree, including parenthesized decorators and JavaScript JSDoc casts.
- Detect optional chains through the exact TypeScript wrappers used by upstream and share the helper with unicorn/new-for-builtins.
- Add upstream parity and adversarial regression coverage for transparent wrappers and chain-spine boundaries.
- Preserve listener performance with unchanged allocations and no observed timing regression in paired Go benchmarks.

## Related Links

- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/throw-new-error.js
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/utils/has-optional-chain-element.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).