### PR TITLE
feat: support flat config basePath

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -685,6 +685,7 @@ Each entry in the config array supports:
 
 | Field             | Type                                       | Description                                                                          |
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `basePath`        | `string`                                   | Entry-local base for selectors, ignores, and explicit TypeScript projects            |
 | `files`           | `(string \| string[])[]`                   | Non-empty selector list; top-level selectors are ORed and nested selectors are ANDed |
 | `ignores`         | `string[]`                                 | Glob patterns excluded by this entry                                                 |
 | `languageOptions` | `object`                                   | `ecmaVersion`, globals, and parser options such as project settings                  |
@@ -947,12 +948,20 @@ single `internal/linter` pipeline, not independently stateful services.
 
 An explicit JS/TS `--config` or API `overrideConfigFile` bypasses automatic
 candidate selection and loads the exact module. Its directory remains the
-authored base for relative config content, while the invocation cwd remains the
+config owner and the existing base for entries that omit `basePath`; the
+invocation cwd anchors an explicitly authored `basePath` and remains the
 implicit scan and response-path root. The exact config path is never gated by `.gitignore`;
 only after it loads does a fixed-owner frontier freeze the invocation-scoped
 Git projection used to filter lint targets. That frontier never probes or
 activates nested config candidates. Automatic candidates instead use Git
 directory reachability while selecting ownership.
+
+Config loading resolves each authored `basePath` into the entry's existing
+internal path-origin model. The existing files/ignores matcher and explicit
+project-path resolver consume that effective directory; target planning,
+program loading, and LSP do not interpret `basePath`. Automatic configs resolve
+it from the module directory, while an explicitly selected config resolves it
+from the invocation cwd. `.gitignore` collection roots remain unchanged.
 
 No-candidate behavior is surface-specific. CLI reports that no rslint config
 was found and points to `rslint --init`. Native API discovery performs no
@@ -973,7 +982,7 @@ file lookup. The only disk JSONC parser for rslint configuration belongs to the
 
 Config merging follows flat-config-style semantics in `GetConfigForFile()`:
 
-1. entries containing only `ignores` and an optional `name` form the global-ignore set
+1. entries containing `ignores` plus optional `name` or `basePath`, and no configuration fields, form the global-ignore set
 2. the implicit default extension baseline plus effective explicit `files` selectors defines the config selector union; an entry's `ignores` prevents its selector from extending that union, top-level selectors are ORed, nested patterns are ANDed, and an explicit `files: []` is invalid
 3. entries without `files` cascade across that selector union, while entry-level `ignores` prevent only that entry from contributing configuration to an otherwise selected file
 4. later rule values override earlier values; a severity-only override retains earlier rule options
@@ -1010,17 +1019,12 @@ rules instead of independently reconstructing hierarchy on the Node side.
 
 Configuration meaning and invocation scope are separate inputs. For one
 invocation-wide config, `ConfigDirectory` is the config file's directory and is
-the authored base used by `files`, `ignores`, and `parserOptions.project`;
-`ScanRoot` is the invocation working directory used by implicit/no-argument
-target discovery and the default `.gitignore` collection scope. Supplying an external config therefore does not scan
-the config directory unless the user also targets it, and does not rebase the
-config's relative patterns onto the invocation cwd. A composed config entry may
-retain a different authored base (the native API's inline `overrideConfig` is
-the current case), so matching resolves every entry from its own origin before
-merging the matched shape, and project declarations resolve from that same
-origin before they reach the Program loader. Automatic config catalogs already
-encode one owner directory per config and do not use the invocation-wide
-`ScanRoot` to infer ownership.
+the authored base used by entries without `basePath`; `ScanRoot` is the
+invocation working directory used by implicit/no-argument target discovery and
+the default `.gitignore` collection scope. A composed config entry may retain a
+different authored base, and an entry with `basePath` receives its resolved
+effective base during config loading. Automatic config catalogs already encode
+one owner directory per config and do not use `ScanRoot` to infer ownership.
 
 `target.Request` is the lint-target boundary shared by CLI/API target
 selection. Explicit files and recursive directories form one union; omitted
@@ -1435,7 +1439,7 @@ String plugin declarations select bundled Go plugin namespaces. Live third-party
 ### Integration Points
 
 - **Language Server**: `internal/lsp` exposes diagnostics and code actions
-- **JavaScript API**: `packages/rslint` talks to the `internal/api/server` handler composed by `cmd/rslint --api` through the versioned `3.0.0` protocol; the handshake negotiates reverse `pluginLint` support before third-party rules run
+- **JavaScript API**: `packages/rslint` talks to the `internal/api/server` handler composed by `cmd/rslint --api` through the versioned `3.1.0` protocol; the handshake negotiates reverse `pluginLint` support before third-party rules run
 - **WASM Playground**: `packages/rslint-wasm` runs the API server in a browser worker
 - **Rust Client**: `crates/tsgo-client` consumes `cmd/tsgo`
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -64,7 +64,7 @@ const (
 )
 
 // Version is the IPC protocol version.
-const Version = "3.0.0"
+const Version = "3.1.0"
 
 const CapabilityReversePluginLint = "reversePluginLint"
 const CapabilityReverseConfigLoad = "reverseConfigLoadV1"
@@ -100,9 +100,10 @@ type LintRequest struct {
 	// ConfigDiscovery enables the high-level host-filesystem path. It is
 	// mutually exclusive with Config and intentionally unsupported by WASM.
 	ConfigDiscovery *ConfigDiscoveryRequest `json:"configDiscovery,omitempty"`
-	// Anchor directory for resolving relative paths in the low-level Config.
-	// High-level ConfigDiscovery entries use their owning config directory;
-	// ConfigDiscovery.OverrideConfig entries use WorkingDirectory.
+	// Owner and anchor directory for the low-level Config. In high-level
+	// discovery, module entries without basePath use their owner; inline override
+	// entries without basePath use WorkingDirectory. An authored basePath instead
+	// inherits the selected ConfigArray base.
 	ConfigDirectory string `json:"configDirectory,omitempty"`
 	// PluginConfigDirectory is the opaque worker routing key for community
 	// plugins. It is independent from the directory used to resolve config paths.
@@ -129,8 +130,9 @@ type ConfigDiscoveryRequest struct {
 	// config discovery below them to branches that can govern those files.
 	Directories   []string `json:"directories,omitempty"`
 	ExplicitFiles []bool   `json:"explicitFiles,omitempty"`
-	// OverrideConfig is appended to every selected config while retaining
-	// LintRequest.WorkingDirectory as its authored relative-path base.
+	// OverrideConfig is appended to every selected config. Entries without
+	// basePath retain LintRequest.WorkingDirectory as their authored relative-path
+	// base; an authored basePath inherits the selected ConfigArray base.
 	OverrideConfig json.RawMessage `json:"overrideConfig,omitempty"`
 }
 

--- a/internal/api/server/lint.go
+++ b/internal/api/server/lint.go
@@ -123,6 +123,12 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 		configDirectory = currentDirectory
 	}
 	configDirectory = tspath.NormalizePath(configDirectory)
+	if len(rslintConfig) > 0 {
+		rslintConfig = rslintconfig.ConfigWithResolvedBasePaths(
+			rslintConfig,
+			configDirectory,
+		)
+	}
 	if len(fileContents) > 0 {
 		addEquivalentFileContentPaths(fileContents, configDirectory, currentDirectory, fs)
 		fs = utils.NewOverlayVFS(fs, fileContents)
@@ -260,7 +266,10 @@ func (h *Handler) handleLint(ctx context.Context, req api.LintRequest, dispatch 
 		} else {
 			// No JS candidate is a valid API state: lint with override entries (or
 			// syntax-only with an empty config).
-			rslintConfig = overrideConfig
+			rslintConfig = rslintconfig.ConfigWithResolvedBasePaths(
+				overrideConfig,
+				currentDirectory,
+			)
 			configDirectory = currentDirectory
 		}
 		catalogPlugins = configCatalog.EslintPlugins

--- a/internal/api/server/lint_test.go
+++ b/internal/api/server/lint_test.go
@@ -788,6 +788,31 @@ func TestHandleLint_LowLevelResponsePathsRemainRelativeToConfigDirectory(t *test
 	}
 }
 
+func TestHandleLint_LowLevelConfigResolvesBasePathFromConfigDirectory(t *testing.T) {
+	dir := t.TempDir()
+	inside := filepath.Join(dir, "src", "inside.js")
+	outside := filepath.Join(dir, "outside.js")
+	writeProgramTestFiles(t, dir, map[string]string{
+		"src/inside.js": "debugger;\n",
+		"outside.js":    "debugger;\n",
+	})
+
+	response, err := (&Handler{}).HandleLint(api.LintRequest{
+		Config: json.RawMessage(`[
+			{"basePath":"src","files":["*.js"],"rules":{"no-debugger":"error"}}
+		]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{inside, outside},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint: %v", err)
+	}
+	if response.FileCount != 2 || len(response.Diagnostics) != 1 || response.Diagnostics[0].FilePath != "src/inside.js" {
+		t.Fatalf("basePath scope was not resolved at the config boundary: %+v", response)
+	}
+}
+
 func TestHandleLint_LowLevelExternalConfigSeparatesAuthoredAndScanRoots(t *testing.T) {
 	root := t.TempDir()
 	configDirectory := filepath.Join(root, "config")
@@ -2219,16 +2244,24 @@ func TestHandleLint_ConfigDiscoveryExplicitFilesMustMatchFiles(t *testing.T) {
 
 func TestHandleLint_ConfigDiscoveryWithoutCandidateUsesOverrideOrSyntaxOnly(t *testing.T) {
 	tests := []struct {
-		name       string
-		source     string
-		override   json.RawMessage
-		wantPrefix string
+		name           string
+		targetRelative string
+		source         string
+		override       json.RawMessage
+		wantPrefix     string
 	}{
 		{
 			name:       "override config",
 			source:     "debugger;\n",
 			override:   json.RawMessage(`[{"rules":{"no-debugger":"error"}}]`),
 			wantPrefix: "no-debugger",
+		},
+		{
+			name:           "override config basePath",
+			targetRelative: "src/input.js",
+			source:         "debugger;\n",
+			override:       json.RawMessage(`[{"basePath":"src","files":["*.js"],"rules":{"no-debugger":"error"}}]`),
+			wantPrefix:     "no-debugger",
 		},
 		{
 			name:       "syntax only",
@@ -2240,7 +2273,14 @@ func TestHandleLint_ConfigDiscoveryWithoutCandidateUsesOverrideOrSyntaxOnly(t *t
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			target := filepath.Join(dir, "input.js")
+			targetRelative := test.targetRelative
+			if targetRelative == "" {
+				targetRelative = "input.js"
+			}
+			target := filepath.Join(dir, targetRelative)
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				t.Fatalf("create target directory: %v", err)
+			}
 			if err := os.WriteFile(target, []byte(test.source), 0o644); err != nil {
 				t.Fatalf("write target: %v", err)
 			}

--- a/internal/config/base_path_test.go
+++ b/internal/config/base_path_test.go
@@ -1,0 +1,285 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"gotest.tools/v3/assert"
+)
+
+func TestBasePathScopesExistingFilesAndIgnoresMatchers(t *testing.T) {
+	basePath := "pkg"
+	config := ConfigWithResolvedBasePaths(RslintConfig{{
+		BasePath: &basePath,
+		Files:    []string{"**/*.ts"},
+		Ignores:  []string{"**/*.test.ts"},
+		Rules:    Rules{"no-debugger": "error"},
+	}}, "/repo")
+
+	for _, test := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "inside", path: "/repo/pkg/src/app.ts", want: true},
+		{name: "local ignore", path: "/repo/pkg/src/app.test.ts", want: false},
+		{name: "outside", path: "/repo/other/app.ts", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, config.GetConfigForFile(test.path, "/repo") != nil, test.want)
+		})
+	}
+
+	escape := ConfigWithResolvedBasePaths(RslintConfig{{
+		BasePath: &basePath,
+		Files:    []string{"../outside.ts"},
+		Rules:    Rules{"no-debugger": "error"},
+	}}, "/repo")
+	assert.Assert(t, escape.GetConfigForFile("/repo/outside.ts", "/repo") == nil)
+
+	wholeEntry := ConfigWithResolvedBasePaths(RslintConfig{{
+		BasePath: &basePath,
+		Rules:    Rules{"no-debugger": "error"},
+	}}, "/repo")
+	assert.Assert(t, wholeEntry.GetConfigForFile("/repo/pkg/app.ts", "/repo") != nil)
+	assert.Assert(t, wholeEntry.GetConfigForFile("/repo/app.ts", "/repo") == nil)
+
+	baseItself := ConfigWithResolvedBasePaths(RslintConfig{{
+		BasePath: &basePath,
+		Files:    []string{"**"},
+		Rules:    Rules{"no-debugger": "error"},
+	}}, "/repo")
+	assert.Assert(t, baseItself.GetConfigForFile("/repo/pkg", "/repo") != nil)
+}
+
+func TestBasePathDotReusesExistingMatchers(t *testing.T) {
+	basePath := "."
+	plain := RslintConfig{
+		{Ignores: []string{"dist/**"}},
+		{Files: []string{"**/*.ts"}, Ignores: []string{"**/*.test.ts"}, Rules: Rules{"no-debugger": "error"}},
+	}
+	scoped := ConfigWithResolvedBasePaths(RslintConfig{
+		{BasePath: &basePath, Ignores: []string{"dist/**"}},
+		{BasePath: &basePath, Files: []string{"**/*.ts"}, Ignores: []string{"**/*.test.ts"}, Rules: Rules{"no-debugger": "error"}},
+	}, "/repo")
+
+	for _, path := range []string{
+		"/repo/src/app.ts",
+		"/repo/src/app.test.ts",
+		"/repo/dist/app.ts",
+		"/repo/src/app.js",
+	} {
+		assert.Equal(
+			t,
+			scoped.GetConfigForFile(path, "/repo") != nil,
+			plain.GetConfigForFile(path, "/repo") != nil,
+			path,
+		)
+	}
+}
+
+func TestBasePathScopesFilesystemFreeWindowsCoordinates(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		root     string
+		spelling string
+	}{
+		{name: "drive", root: "C:/Repo", spelling: "c:/repo"},
+		{name: "UNC", root: "//SERVER/share/Repo", spelling: "//server/SHARE/repo"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, basePath := range []string{".", "pkg"} {
+				t.Run(basePath, func(t *testing.T) {
+					relativeTarget := "src/app.ts"
+					if basePath != "." {
+						relativeTarget = basePath + "/" + relativeTarget
+					}
+
+					files := ConfigWithResolvedBasePaths(RslintConfig{{
+						BasePath: &basePath,
+						Files:    []string{"**/*.ts"},
+						Rules:    Rules{"no-debugger": "error"},
+					}}, test.root)
+					assert.Assert(t, files.GetConfigForFile(test.spelling+"/"+relativeTarget, test.root) != nil)
+
+					globalIgnore := ConfigWithResolvedBasePaths(RslintConfig{
+						{BasePath: &basePath, Ignores: []string{"**/*.ts"}},
+						{Rules: Rules{}},
+					}, test.root)
+					assert.Assert(t, globalIgnore.IsFileIgnored(test.spelling+"/"+relativeTarget, test.root))
+				})
+			}
+		})
+	}
+}
+
+func TestBasePathDoesNotChangeFilesystemFreeMatcherCoordinates(t *testing.T) {
+	basePath := "."
+	unrelatedBasePath := "D:/other"
+	for _, test := range []struct {
+		name   string
+		root   string
+		target string
+	}{
+		{name: "drive", root: "C:/Repo", target: "c:/repo/src/app.ts"},
+		{name: "UNC", root: "//SERVER/share/Repo", target: "//server/SHARE/repo/src/app.ts"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			plainFiles := RslintConfig{{
+				Files: []string{"src/*.ts"},
+				Rules: Rules{"no-debugger": "error"},
+			}}
+			dotFiles := ConfigWithResolvedBasePaths(RslintConfig{{
+				BasePath: &basePath,
+				Files:    []string{"src/*.ts"},
+				Rules:    Rules{"no-debugger": "error"},
+			}}, test.root)
+			withUnrelatedBasePath := append(append(RslintConfig(nil), plainFiles...), ConfigEntry{
+				BasePath: &unrelatedBasePath,
+				Files:    []string{"never"},
+			})
+			wantFiles := plainFiles.GetConfigForFile(test.target, test.root) != nil
+			assert.Equal(t, dotFiles.GetConfigForFile(test.target, test.root) != nil, wantFiles)
+			assert.Equal(t, withUnrelatedBasePath.GetConfigForFile(test.target, test.root) != nil, wantFiles)
+
+			plainIgnore := RslintConfig{
+				{Ignores: []string{"src/*.ts"}},
+				{Rules: Rules{}},
+			}
+			dotIgnore := ConfigWithResolvedBasePaths(RslintConfig{
+				{BasePath: &basePath, Ignores: []string{"src/*.ts"}},
+				{Rules: Rules{}},
+			}, test.root)
+			withUnrelatedBasePath = append(append(RslintConfig(nil), plainIgnore...), ConfigEntry{
+				BasePath: &unrelatedBasePath,
+				Files:    []string{"never"},
+			})
+			wantIgnored := plainIgnore.IsFileIgnored(test.target, test.root)
+			assert.Equal(t, dotIgnore.IsFileIgnored(test.target, test.root), wantIgnored)
+			assert.Equal(t, withUnrelatedBasePath.IsFileIgnored(test.target, test.root), wantIgnored)
+		})
+	}
+}
+
+func TestBasePathIsLiteralNotGlob(t *testing.T) {
+	basePath := "pkg*"
+	config := ConfigWithResolvedBasePaths(RslintConfig{{
+		BasePath: &basePath,
+		Files:    []string{"**/*.ts"},
+		Rules:    Rules{"no-debugger": "error"},
+	}}, "/repo")
+
+	assert.Assert(t, config.GetConfigForFile("/repo/pkg*/app.ts", "/repo") != nil)
+	assert.Assert(t, config.GetConfigForFile("/repo/pkg1/app.ts", "/repo") == nil)
+}
+
+func TestBasePathScopesGlobalIgnores(t *testing.T) {
+	basePath := "pkg"
+	config := ConfigWithResolvedBasePaths(RslintConfig{
+		{BasePath: &basePath, Ignores: []string{"blocked/**"}},
+		{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
+	}, "/repo")
+
+	assert.Assert(t, config.GetConfigForFile("/repo/pkg/blocked/app.js", "/repo") == nil)
+	assert.Assert(t, config.GetConfigForFile("/repo/blocked/app.js", "/repo") != nil)
+	assert.Assert(t, config.GetConfigForFile("/repo/pkg/app.js", "/repo") != nil)
+	assert.Assert(t, !newConfigTargetResolver(config, "/repo", nil).canPruneDirectory("/repo/pkg", ""))
+}
+
+func TestBasePathGlobalIgnoreKeepsConfigArrayRootReachable(t *testing.T) {
+	basePath := ".."
+	config := ConfigWithResolvedBasePaths(RslintConfig{
+		{BasePath: &basePath, Ignores: []string{"*"}},
+		{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
+	}, "/repo")
+	resolver := newConfigTargetResolver(config, "/repo", nil)
+
+	assert.Assert(t, config.GetConfigForFile("/repo/visible.js", "/repo") != nil)
+	assert.Assert(t, !resolver.canPruneDirectory("/repo", ""))
+}
+
+func TestBasePathNegationKeepsReachableSubtreeOpen(t *testing.T) {
+	basePath := "foo/pkg"
+	config := ConfigWithResolvedBasePaths(RslintConfig{
+		{Ignores: []string{"foo/**/*"}},
+		{BasePath: &basePath, Ignores: []string{"!keep.js"}},
+		{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
+	}, "/repo")
+	resolver := newConfigTargetResolver(config, "/repo", nil)
+
+	assert.Assert(t, config.GetConfigForFile("/repo/foo/pkg/keep.js", "/repo") != nil)
+	assert.Assert(t, !resolver.canPruneDirectory("/repo/foo", ""))
+	assert.Assert(t, !resolver.canPruneDirectory("/repo/foo/pkg", ""))
+}
+
+func TestBasePathNegationReopensPhysicalAliasSubtree(t *testing.T) {
+	root := t.TempDir()
+	physical := filepath.Join(root, "physical")
+	firstAlias := filepath.Join(root, "alias-one")
+	secondAlias := filepath.Join(root, "alias-two")
+	if err := os.MkdirAll(filepath.Join(physical, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physical, firstAlias); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(physical, secondAlias); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+	target := filepath.Join(secondAlias, "pkg", "keep.js")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	basePath := filepath.Join(firstAlias, "pkg")
+	config := ConfigWithResolvedBasePaths(RslintConfig{
+		{Ignores: []string{"alias-two/**/*"}},
+		{BasePath: &basePath, Ignores: []string{"!keep.js"}},
+		{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
+	}, root)
+	fsys := osvfs.FS()
+	root = tspath.NormalizePath(root)
+	physical = tspath.NormalizePath(fsys.Realpath(physical))
+	target = tspath.NormalizePath(target)
+	snapshot := NewPathSpaceSnapshot(map[string]RslintConfig{root: config}, fsys)
+	matcher, err := NewTargetMatcherWithPathSpaces(config, root, fsys, snapshot)
+	assert.NilError(t, err)
+
+	decision := matcher.MatchFile(PathIdentity{
+		Path:                target,
+		CanonicalPath:       tspath.NormalizePath(fsys.Realpath(target)),
+		CanonicalParentPath: tspath.NormalizePath(fsys.Realpath(tspath.GetDirectoryPath(target))),
+	})
+	assert.Assert(t, decision.Selected)
+	assert.Assert(t, !decision.GloballyIgnored)
+	assert.Assert(t, !matcher.CanPruneDirectory(DirectoryIdentity{
+		LexicalPath:   tspath.NormalizePath(secondAlias),
+		CanonicalPath: physical,
+	}))
+}
+
+func TestConfigWithResolvedBasePathsUsesOneInternalPathOrigin(t *testing.T) {
+	basePath := "pkg"
+	config := ConfigWithAuthoredPathBase(RslintConfig{
+		{Rules: Rules{"cwd-rule": "error"}},
+		{BasePath: &basePath, Rules: Rules{"base-rule": "error"}},
+	}, "/cwd")
+
+	effective := ConfigWithResolvedBasePaths(config, "/configs")
+	assert.Equal(t, configEntryBaseDirectory(effective[0], "/owner"), "/cwd")
+	assert.Equal(t, configEntryBaseDirectory(effective[1], "/owner"), "/configs/pkg")
+	assert.Equal(t, configEntryPathOrigin(effective[1], "/owner").configArrayBase, "/configs")
+	assert.Assert(t, configEntryPathOrigin(effective[1], "/owner").basePathScoped)
+	assert.Assert(t, &effective[0] != &config[0])
+	again := ConfigWithResolvedBasePaths(effective, "/other")
+	assert.Assert(t, &again[0] == &effective[0])
+
+	snapshot := NewPathSpaceSnapshot(map[string]RslintConfig{"/owner": effective}, nil)
+	_, configArrayBaseFrozen := snapshot.PhysicalDirectory("/configs")
+	assert.Assert(t, configArrayBaseFrozen)
+	_, err := NewTargetMatcherWithPathSpaces(effective, "/owner", nil, snapshot)
+	assert.NilError(t, err)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,10 @@ type RslintConfig []ConfigEntry
 // ConfigEntry represents a single configuration entry in the config array
 type ConfigEntry struct {
 	Name string `json:"name,omitempty"`
+	// BasePath is ESLint flat config's entry-local matching base. A pointer
+	// preserves the distinction between omission and an explicitly authored
+	// empty string; both are valid, but only the latter scopes the entry.
+	BasePath *string `json:"basePath,omitempty"`
 	// Files retains the established Go construction API for top-level OR
 	// patterns. FilePatternGroups stores nested arrays, each of which is an AND
 	// group. JSON encoding combines both fields back into one mixed `files`
@@ -39,13 +43,9 @@ type ConfigEntry struct {
 	// matchers. Keeping the uncommon metadata behind one pointer preserves the
 	// original ConfigEntry footprint for every ordinary authored config entry.
 	collectedGitignore *collectedGitignoreMetadata
-	// authoredPathBase is present only when this entry was authored in a
-	// different directory from the config array that owns it. The native API's
-	// inline overrideConfig is the primary case: it is appended after each
-	// discovered config but keeps the invocation cwd as the base for its
-	// config-relative files, ignores, and parserOptions.project values. Target
-	// matching and project resolution consume this immutable origin instead of
-	// rebasing authored strings during composition.
+	// authoredPathBase stores the entry's effective path origin when it differs
+	// from the owning config's default path semantics. API composition and
+	// config loading populate it before downstream config consumers run.
 	authoredPathBase *configEntryPathBase
 }
 
@@ -68,6 +68,10 @@ type collectedGitignoreScope struct {
 
 type configEntryPathBase struct {
 	directory string
+	// configArrayBase records the ConfigArray root whose directory itself must
+	// remain traversable for a basePath-scoped entry.
+	configArrayBase string
+	basePathScoped  bool
 }
 
 // ConfigWithAuthoredPathBase returns a shallow config snapshot whose entries
@@ -81,21 +85,71 @@ func ConfigWithAuthoredPathBase(config RslintConfig, directory string) RslintCon
 	directory = tspath.NormalizePath(directory)
 	effective := append(RslintConfig(nil), config...)
 	for index := range effective {
-		effective[index].authoredPathBase = &configEntryPathBase{directory: directory}
+		// Entries with basePath inherit the ConfigArray root instead and are
+		// materialized by ConfigWithResolvedBasePaths.
+		if effective[index].BasePath == nil {
+			effective[index].authoredPathBase = &configEntryPathBase{directory: directory}
+		}
 	}
 	return effective
 }
 
 func configEntryBaseDirectory(entry ConfigEntry, defaultDirectory string) string {
+	return configEntryPathOrigin(entry, defaultDirectory).directory
+}
+
+func configEntryPathOrigin(entry ConfigEntry, defaultDirectory string) configEntryPathBase {
 	if entry.authoredPathBase != nil && entry.authoredPathBase.directory != "" {
-		return entry.authoredPathBase.directory
+		return *entry.authoredPathBase
 	}
-	return defaultDirectory
+	if entry.BasePath != nil {
+		return configEntryPathBase{
+			directory:       tspath.ResolvePath(defaultDirectory, *entry.BasePath),
+			configArrayBase: defaultDirectory,
+			basePathScoped:  true,
+		}
+	}
+	return configEntryPathBase{directory: defaultDirectory}
+}
+
+// ConfigWithResolvedBasePaths resolves every authored basePath once at the
+// config boundary and returns a shallow immutable snapshot. configArrayBase is
+// normally the config module directory, or the invocation cwd for an explicitly
+// selected config.
+func ConfigWithResolvedBasePaths(
+	config RslintConfig,
+	configArrayBase string,
+) RslintConfig {
+	usesBasePath := false
+	for _, entry := range config {
+		if entry.BasePath != nil && entry.authoredPathBase == nil {
+			usesBasePath = true
+			break
+		}
+	}
+	if !usesBasePath {
+		return config
+	}
+	configArrayBase = tspath.NormalizePath(configArrayBase)
+	effective := append(RslintConfig(nil), config...)
+	for index := range effective {
+		entry := &effective[index]
+		if entry.BasePath == nil || entry.authoredPathBase != nil {
+			continue
+		}
+		base := tspath.ResolvePath(configArrayBase, *entry.BasePath)
+		entry.authoredPathBase = &configEntryPathBase{
+			directory:       base,
+			configArrayBase: configArrayBase,
+			basePathScoped:  true,
+		}
+	}
+	return effective
 }
 
 func configNeedsTargetResolver(config RslintConfig) bool {
 	for _, entry := range config {
-		if entry.authoredPathBase != nil || entry.collectedGitignore != nil {
+		if entry.BasePath != nil || entry.authoredPathBase != nil || entry.collectedGitignore != nil {
 			return true
 		}
 	}
@@ -201,6 +255,15 @@ func (config *RslintConfig) UnmarshalJSON(data []byte) error {
 
 		var decoded configEntryAlias
 		entryForDecode := rawEntry
+		if rawBasePath, ok := raw["basePath"]; ok {
+			var basePath any
+			if err := json.Unmarshal(rawBasePath, &basePath); err != nil {
+				return err
+			}
+			if _, valid := basePath.(string); !valid {
+				return fmt.Errorf("config entry at index %d: key \"basePath\": expected value to be a string", index)
+			}
+		}
 		if rawFiles, ok := raw["files"]; ok {
 			files, groups, err := decodeFilesSelectors(rawFiles, index)
 			if err != nil {
@@ -232,7 +295,7 @@ func (config *RslintConfig) UnmarshalJSON(data []byte) error {
 		// neutral but remains non-nil for isGlobalIgnoreEntry.
 		hasNonGlobalKey := false
 		for key := range raw {
-			if key != "ignores" && key != "name" {
+			if key != "ignores" && key != "name" && key != "basePath" {
 				hasNonGlobalKey = true
 				break
 			}
@@ -880,9 +943,9 @@ func (config RslintConfig) getConfigForFileWithIgnores(filePath string, cwd stri
 	return config.mergeConfigEntries(key)
 }
 
-// isGlobalIgnoreEntry returns true if the entry has only ignores and an
-// optional name. Empty config objects are still present and make ignores local
-// to the entry, matching ESLint flat config semantics.
+// isGlobalIgnoreEntry returns true if the entry has only ignores plus optional
+// flat-config metadata (name and basePath). Empty config objects are still
+// present and make ignores local to the entry, matching ESLint semantics.
 func isGlobalIgnoreEntry(entry ConfigEntry) bool {
 	return entry.Files == nil &&
 		entry.FilePatternGroups == nil &&

--- a/internal/config/config_target_resolver.go
+++ b/internal/config/config_target_resolver.go
@@ -15,6 +15,7 @@ import (
 type configTargetResolver struct {
 	config             RslintConfig
 	fs                 vfs.FS
+	useCaseSensitive   bool
 	bases              []configTargetBase
 	entries            []configTargetEntry
 	globalEntryIndexes []int
@@ -28,10 +29,11 @@ type configTargetBase struct {
 }
 
 type configTargetEntry struct {
-	baseIndex           int
-	ignorePatterns      []IgnorePattern
-	gitScopes           []collectedGitignoreScope
-	ignorePatternGroups []ignorePatternCoordinateGroup
+	baseIndex            int
+	configArrayBaseIndex int
+	ignorePatterns       []IgnorePattern
+	gitScopes            []collectedGitignoreScope
+	ignorePatternGroups  []ignorePatternCoordinateGroup
 }
 
 // ignorePatternCoordinateGroup is one contiguous ignore-pattern segment whose
@@ -48,6 +50,81 @@ type configTargetMatch struct {
 	path      string
 	directory string
 	matcher   fileMatchPath
+}
+
+func (resolver *configTargetResolver) entryAppliesTo(
+	entry configTargetEntry,
+	matches []configTargetMatch,
+	directory bool,
+) bool {
+	match := &matches[entry.baseIndex]
+	configArrayMatch := &matches[entry.configArrayBaseIndex]
+	return resolver.entryMatchesScope(match, configArrayMatch, directory)
+}
+
+func (resolver *configTargetResolver) entryMatchesScope(
+	match *configTargetMatch,
+	configArrayMatch *configTargetMatch,
+	directory bool,
+) bool {
+	withinBase, atBase := resolver.configTargetMatchWithinBase(match)
+	if !withinBase || (directory && atBase) {
+		return false
+	}
+	if directory {
+		_, atConfigArrayBase := resolver.configTargetMatchWithinBase(configArrayMatch)
+		if atConfigArrayBase {
+			return false
+		}
+	}
+	return true
+}
+
+type scopedDirectoryRelation uint8
+
+const (
+	scopedDirectoryOutside scopedDirectoryRelation = iota
+	// The current directory is outside the entry, but a descendant may enter
+	// its base. Pruning must therefore account for scoped negations below it.
+	scopedDirectoryDescendantsOnly
+	scopedDirectoryInside
+)
+
+func (resolver *configTargetResolver) entryDirectoryRelation(
+	entry configTargetEntry,
+	matches []configTargetMatch,
+	target configTargetIdentity,
+) scopedDirectoryRelation {
+	match := &matches[entry.baseIndex]
+	withinBase, atBase := resolver.configTargetMatchWithinBase(match)
+	if withinBase {
+		if atBase {
+			return scopedDirectoryDescendantsOnly
+		}
+		_, atConfigArrayBase := resolver.configTargetMatchWithinBase(&matches[entry.configArrayBaseIndex])
+		if atConfigArrayBase {
+			return scopedDirectoryDescendantsOnly
+		}
+		return scopedDirectoryInside
+	}
+	if _, containsBase := RelativePathWithinConfigRoot(
+		match.directory,
+		match.path,
+		resolver.scopeUseCaseSensitive(match.directory),
+	); containsBase {
+		return scopedDirectoryDescendantsOnly
+	}
+	if target.canonicalMatchPath != "" {
+		physicalBase := resolver.bases[entry.baseIndex].physicalDirectory
+		if _, containsPhysicalBase := RelativePathWithinConfigRoot(
+			physicalBase,
+			target.canonicalMatchPath,
+			true,
+		); containsPhysicalBase {
+			return scopedDirectoryDescendantsOnly
+		}
+	}
+	return scopedDirectoryOutside
 }
 
 // configTargetIdentity is the immutable caller-visible/canonical pair for one
@@ -77,28 +154,39 @@ func newConfigTargetResolverWithBases(
 	frozenBases map[string]configTargetBase,
 ) *configTargetResolver {
 	resolver := &configTargetResolver{
-		config:  config,
-		fs:      fsys,
-		entries: make([]configTargetEntry, len(config)),
+		config:           config,
+		fs:               fsys,
+		useCaseSensitive: fsys == nil || fsys.UseCaseSensitiveFileNames(),
+		entries:          make([]configTargetEntry, len(config)),
 	}
 	baseIndexByDirectory := make(map[string]int)
-	for index, entry := range config {
-		directory := normalizeAuthoredBase(configEntryBaseDirectory(entry, defaultDirectory))
+	addBase := func(directory string) int {
+		directory = normalizeAuthoredBase(directory)
 		baseID := authoredBaseID(directory)
-		baseIndex, exists := baseIndexByDirectory[baseID]
-		if !exists {
-			base, frozen := frozenBases[baseID]
-			if !frozen {
-				base = freezeConfigTargetBase(directory, fsys)
-			}
-			baseIndex = len(resolver.bases)
-			baseIndexByDirectory[baseID] = baseIndex
-			resolver.bases = append(resolver.bases, base)
+		if baseIndex, exists := baseIndexByDirectory[baseID]; exists {
+			return baseIndex
+		}
+		frozenBase, frozen := frozenBases[baseID]
+		if !frozen {
+			frozenBase = freezeConfigTargetBase(directory, fsys)
+		}
+		baseIndex := len(resolver.bases)
+		baseIndexByDirectory[baseID] = baseIndex
+		resolver.bases = append(resolver.bases, frozenBase)
+		return baseIndex
+	}
+	for index, entry := range config {
+		origin := configEntryPathOrigin(entry, defaultDirectory)
+		baseIndex := addBase(origin.directory)
+		configArrayBaseIndex := -1
+		if origin.basePathScoped {
+			configArrayBaseIndex = addBase(origin.configArrayBase)
 		}
 		patterns := configEntryIgnorePatterns(entry)
 		resolver.entries[index] = configTargetEntry{
-			baseIndex:      baseIndex,
-			ignorePatterns: patterns,
+			baseIndex:            baseIndex,
+			configArrayBaseIndex: configArrayBaseIndex,
+			ignorePatterns:       patterns,
 		}
 		if entry.collectedGitignore != nil {
 			resolver.entries[index].gitScopes = entry.collectedGitignore.scopes
@@ -201,6 +289,9 @@ func (resolver *configTargetResolver) resolveTarget(
 		}
 		prepared := resolver.entries[index]
 		match := &matches[prepared.baseIndex]
+		if prepared.configArrayBaseIndex >= 0 && !resolver.entryAppliesTo(prepared, matches, false) {
+			continue
+		}
 		if hasFileSelectors(entry) && !match.matcher.matchesConfigEntry(entry) {
 			continue
 		}
@@ -295,6 +386,31 @@ func (resolver *configTargetResolver) resolvePathSpacesWithCanonicalParent(
 	return target, matches
 }
 
+func (resolver *configTargetResolver) configTargetMatchWithinBase(
+	match *configTargetMatch,
+) (within bool, atBase bool) {
+	relative, within := RelativePathWithinConfigRoot(
+		match.path,
+		match.directory,
+		resolver.scopeUseCaseSensitive(match.directory),
+	)
+	return within, within && relative == ""
+}
+
+func (resolver *configTargetResolver) scopeUseCaseSensitive(directory string) bool {
+	if resolver.filesystemFreeCaseInsensitivePath(directory) {
+		// Filesystem-free compatibility APIs still accept Windows drive and UNC
+		// paths on every host. Their lexical containment is case-insensitive.
+		return false
+	}
+	return resolver.useCaseSensitive
+}
+
+func (resolver *configTargetResolver) filesystemFreeCaseInsensitivePath(directory string) bool {
+	return resolver.fs == nil && (strings.HasPrefix(directory, "//") ||
+		(len(directory) >= 2 && directory[1] == ':'))
+}
+
 // needsCanonicalPath reports whether lexical containment alone cannot resolve
 // every authored config base and collected Git scope. Directory walks normally
 // stay inside both, so they avoid a redundant filesystem Realpath per node;
@@ -368,6 +484,9 @@ func (resolver *configTargetResolver) globallyIgnores(
 	for _, entryIndex := range resolver.globalEntryIndexes {
 		entry := resolver.entries[entryIndex]
 		match := &matches[entry.baseIndex]
+		if entry.configArrayBaseIndex >= 0 && !resolver.entryAppliesTo(entry, matches, true) {
+			continue
+		}
 		ignored = target.applyIgnorePatternGroups(
 			match,
 			entry.ignorePatternGroups,
@@ -470,6 +589,15 @@ func (resolver *configTargetResolver) hasAbsoluteDirectoryBlockForDirectory(
 				matcher:   newFileMatchPath(path, match.directory),
 			}
 		}
+		if entry.configArrayBaseIndex >= 0 {
+			configArrayMatch := matches[entry.configArrayBaseIndex]
+			if fileTarget {
+				configArrayMatch.path = tspath.GetDirectoryPath(configArrayMatch.path)
+			}
+			if !resolver.entryMatchesScope(directoryMatch, &configArrayMatch, true) {
+				continue
+			}
+		}
 		for _, group := range entry.ignorePatternGroups {
 			relative, ok := targetPathForPatternGroup(
 				target,
@@ -495,6 +623,21 @@ func (resolver *configTargetResolver) canPruneDirectory(path string, canonicalPa
 	for _, entryIndex := range resolver.globalEntryIndexes {
 		entry := resolver.entries[entryIndex]
 		match := &matches[entry.baseIndex]
+		if entry.configArrayBaseIndex >= 0 {
+			relation := resolver.entryDirectoryRelation(entry, matches, target)
+			if relation == scopedDirectoryOutside {
+				continue
+			}
+			if relation == scopedDirectoryDescendantsOnly {
+				for _, group := range entry.ignorePatternGroups {
+					if len(group.negationReach.prefixes) > 0 {
+						negationCanReach = true
+						break
+					}
+				}
+				continue
+			}
+		}
 		selectedGitScope := entry.selectGitScope(target)
 		for _, group := range entry.ignorePatternGroups {
 			relative, ok := targetPathForPatternGroup(
@@ -560,6 +703,9 @@ func (resolver *configTargetResolver) reopensDirectory(path string, canonicalPat
 	for _, entryIndex := range resolver.globalEntryIndexes {
 		entry := resolver.entries[entryIndex]
 		match := &matches[entry.baseIndex]
+		if entry.configArrayBaseIndex >= 0 && !resolver.entryAppliesTo(entry, matches, true) {
+			continue
+		}
 		selectedGitScope := entry.selectGitScope(target)
 		for _, group := range entry.ignorePatternGroups {
 			relativePath, ok := targetPathForPatternGroup(

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -72,6 +72,33 @@ func TestValidateConfig_RejectsEmptyFilesArrayFromJSON(t *testing.T) {
 	}
 }
 
+func TestConfigBasePathJSONRoundTripAndValidation(t *testing.T) {
+	var cfg RslintConfig
+	if err := json.Unmarshal([]byte(`[{"basePath":"packages/app","ignores":["dist/**"]}]`), &cfg); err != nil {
+		t.Fatalf("unmarshal basePath: %v", err)
+	}
+	if len(cfg) != 1 || cfg[0].BasePath == nil || *cfg[0].BasePath != "packages/app" {
+		t.Fatalf("basePath was not preserved: %+v", cfg)
+	}
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal basePath: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"basePath":"packages/app"`) {
+		t.Fatalf("basePath missing from round trip: %s", encoded)
+	}
+
+	for _, value := range []string{"null", "42", `{}`, `[]`} {
+		t.Run(value, func(t *testing.T) {
+			var invalid RslintConfig
+			err := json.Unmarshal([]byte(`[{"basePath":`+value+`}]`), &invalid)
+			if err == nil || !strings.Contains(err.Error(), `key "basePath": expected value to be a string`) {
+				t.Fatalf("invalid basePath error = %v", err)
+			}
+		})
+	}
+}
+
 func TestConfigFilesJSONSupportsMixedStringsAndAndGroups(t *testing.T) {
 	input := []byte(`[{
 		"files": ["special.ts", ["**/*.js", "!**/*.test.js"]],

--- a/internal/config/discovery/coordinator.go
+++ b/internal/config/discovery/coordinator.go
@@ -62,10 +62,9 @@ func (coordinator *discoveryCoordinator) build() (*ConfigCatalog, error) {
 	if coordinator.explicitConfigPath != "" {
 		configPath := normalizeDiscoveryPath(coordinator.explicitConfigPath, cwd)
 		candidate := configCandidate{
-			path: configPath,
-			// The invocation cwd controls the default scan scope. Relative paths
-			// authored inside the selected config use the config file's directory.
-			directory: tspath.GetDirectoryPath(configPath),
+			path:            configPath,
+			directory:       tspath.GetDirectoryPath(configPath),
+			configArrayBase: cwd,
 		}
 		if err := coordinator.modules.loadCandidates([]configCandidate{candidate}); err != nil {
 			return nil, err

--- a/internal/config/discovery/module_load.go
+++ b/internal/config/discovery/module_load.go
@@ -16,6 +16,9 @@ import (
 type configCandidate struct {
 	path      string
 	directory string
+	// configArrayBase is set only when ConfigArray A differs from the config
+	// module directory, as for an explicit config. Empty means directory.
+	configArrayBase string
 }
 
 // configLoadState binds one candidate to the raw config and authored-ignore
@@ -170,9 +173,15 @@ func (coordinator *moduleLoadCoordinator) loadCandidates(rawCandidates []configC
 		} else if err := rslintconfig.ValidateConfig(result.Entries); err != nil {
 			state.failure = &ConfigModuleError{Code: "invalid", Message: err.Error()}
 		} else {
-			state.entries = append(rslintconfig.RslintConfig(nil), result.Entries...)
-			// Keep authored-ignore semantics bound to the exact loaded candidate.
-			// Git-derived ignores are added only to the separate effective draft.
+			entries := append(rslintconfig.RslintConfig(nil), result.Entries...)
+			configArrayBase := candidate.configArrayBase
+			if configArrayBase == "" {
+				configArrayBase = candidate.directory
+			}
+			state.entries = rslintconfig.ConfigWithResolvedBasePaths(
+				entries,
+				configArrayBase,
+			)
 			state.ignoreMatcher = rslintconfig.NewGlobalIgnoreMatcher(
 				state.entries,
 				candidate.directory,

--- a/internal/config/discovery/protocol.go
+++ b/internal/config/discovery/protocol.go
@@ -6,7 +6,7 @@ import (
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 )
 
-const ConfigDiscoveryProtocolVersion = 2
+const ConfigDiscoveryProtocolVersion = 3
 
 type ConfigModuleLoadMode string
 

--- a/internal/config/path_space_snapshot.go
+++ b/internal/config/path_space_snapshot.go
@@ -30,7 +30,11 @@ func NewPathSpaceSnapshot(configMap map[string]RslintConfig, fsys vfs.FS) *PathS
 	for configDir, entries := range configMap {
 		freezeBase(configDir)
 		for _, entry := range entries {
-			freezeBase(configEntryBaseDirectory(entry, configDir))
+			origin := configEntryPathOrigin(entry, configDir)
+			freezeBase(origin.directory)
+			if origin.basePathScoped {
+				freezeBase(origin.configArrayBase)
+			}
 		}
 	}
 	return &PathSpaceSnapshot{bases: bases}

--- a/internal/config/project_paths.go
+++ b/internal/config/project_paths.go
@@ -98,8 +98,11 @@ func appendUniqueConfigPath(paths []string, seenPaths map[string]struct{}, confi
 }
 
 func expandProjectGlob(fsys vfs.FS, configDirectory string, pattern string) ([]string, error) {
-	resolvedPattern := normalizeGlobPath(tspath.ResolvePath(configDirectory, pattern))
-	searchRoot := globSearchRoot(resolvedPattern, normalizeGlobPath(configDirectory))
+	// The effective config base is a literal directory, not part of the authored glob.
+	normalizedPattern := normalizeGlobPath(pattern)
+	authoredSearchRoot := globSearchRoot(normalizedPattern, ".")
+	searchRoot := normalizeGlobPath(tspath.ResolvePath(configDirectory, authoredSearchRoot))
+	resolvedPattern := normalizeGlobPath(tspath.ResolvePath(configDirectory, normalizedPattern))
 
 	if !fsys.DirectoryExists(searchRoot) {
 		return nil, nil

--- a/internal/config/project_paths_test.go
+++ b/internal/config/project_paths_test.go
@@ -121,6 +121,37 @@ func TestResolveDeclaredProjectPaths_MixedGlobAndNonGlob(t *testing.T) {
 	})
 }
 
+func TestExpandProjectGlobTreatsBaseDirectoryAsLiteral(t *testing.T) {
+	root := t.TempDir()
+	literalBase := filepath.Join(root, "pkg[1]")
+	createTestFile(t, filepath.Join(literalBase, "child", "tsconfig.json"))
+	createTestFile(t, filepath.Join(root, "pkg1", "child", "tsconfig.json"))
+
+	paths, err := expandProjectGlob(osvfs.FS(), literalBase, "*/tsconfig.json")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, paths, []string{
+		filepath.ToSlash(filepath.Join(literalBase, "child", "tsconfig.json")),
+	})
+}
+
+func TestResolveDeclaredProjectPathsUsesResolvedBasePathOrigin(t *testing.T) {
+	root := t.TempDir()
+	configArrayBase := filepath.Join(root, "cwd")
+	projectPath := filepath.Join(configArrayBase, "pkg", "tsconfig.json")
+	createTestFile(t, projectPath)
+	basePath := "pkg"
+	config := ConfigWithResolvedBasePaths(RslintConfig{{
+		BasePath: &basePath,
+		LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+			Project: ProjectPaths{"./tsconfig.json"},
+		}},
+	}}, configArrayBase)
+
+	paths, err := resolveDeclaredProjectPaths(osvfs.FS(), config, filepath.Join(root, "configs"))
+	assert.NilError(t, err)
+	assert.DeepEqual(t, paths, []string{filepath.ToSlash(projectPath)})
+}
+
 func TestResolveDeclaredProjectPaths_DeduplicatesMatches(t *testing.T) {
 	tmpDir := t.TempDir()
 	createTestFile(t, filepath.Join(tmpDir, "packages/ui/tsconfig.json"))

--- a/internal/config/target_matcher.go
+++ b/internal/config/target_matcher.go
@@ -36,8 +36,14 @@ func NewTargetMatcherWithPathSpaces(
 		return TargetMatcher{}, err
 	}
 	for _, entry := range config {
-		if _, err := pathSpaces.requireBase(configEntryBaseDirectory(entry, configDirectory)); err != nil {
+		origin := configEntryPathOrigin(entry, configDirectory)
+		if _, err := pathSpaces.requireBase(origin.directory); err != nil {
 			return TargetMatcher{}, err
+		}
+		if origin.basePathScoped {
+			if _, err := pathSpaces.requireBase(origin.configArrayBase); err != nil {
+				return TargetMatcher{}, err
+			}
 		}
 	}
 	return TargetMatcher{resolver: newConfigTargetResolverWithBases(config, configDirectory, fsys, pathSpaces.bases)}, nil

--- a/packages/rslint-test-tools/tests/cli/type-check/helpers.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/helpers.ts
@@ -82,7 +82,7 @@ export function normalizeOutput(output: string, tempDir: string): string {
     '<TEMPDIR>',
   );
   result = result.replace(
-    /in [\d.]+m?s using \d+ threads?/g,
+    /in (?:\d+h)?(?:\d+m)?[\d.]+(?:ms|s) using \d+ threads?/g,
     'in <TIME> using <N> thread(s)',
   );
   return result;

--- a/packages/rslint-test-tools/tests/cli/type-check/type-check-snapshot.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/type-check-snapshot.test.ts
@@ -9,6 +9,22 @@ import {
   makeConfig,
 } from './helpers';
 
+describe('snapshot output normalization', () => {
+  test.each(['12ms', '1.234s', '1m2.345s', '1h2m3.456s'])(
+    'normalizes a %s duration',
+    (duration) => {
+      expect(
+        normalizeOutput(
+          `Found 0 errors and 0 warnings (linted 1 file with 1 rule in ${duration} using 2 threads)\n`,
+          '/tmp/unused',
+        ),
+      ).toBe(
+        'Found 0 errors and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> thread(s))\n',
+      );
+    },
+  );
+});
+
 // ---------------------------------------------------------------------------
 // default format
 // ---------------------------------------------------------------------------

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -45,18 +45,24 @@ import type {
 
 export interface RslintOptions {
   /**
-   * Working directory for targets and discovery; also the base of inline
-   * `overrideConfig` paths.
+   * Working directory for targets and discovery. It is also the authored path
+   * base for relative fields in inline `overrideConfig` entries that omit
+   * `basePath`.
    */
   cwd?: string;
   /**
-   * Extra config appended after the resolved/discovered config. Relative
-   * `files`, `ignores`, and `parserOptions.project` paths resolve from `cwd`.
+   * Extra config appended to the selected config array. An authored `basePath`
+   * inherits that array's base (the discovered module directory in automatic
+   * mode, or `cwd` for an explicit/override-only array), matching ESLint.
+   * Relative fields in entries without `basePath` retain Rslint's existing
+   * `cwd`-relative behavior.
    */
   overrideConfig?: RslintConfigEntry | RslintConfig | null;
   /**
-   * `string` — use this JS/TS config module (no discovery); its relative
-   *            config paths resolve from the module's directory.
+   * `string` — use this JS/TS config module (no discovery); an authored
+   *            `basePath` resolves from `cwd`, matching ESLint's explicit
+   *            config behavior. Entries without `basePath` retain rslint's
+   *            existing module-directory-relative behavior.
    * `true`   — use only `overrideConfig` (no file, no discovery).
    * `null`/absent — auto-discover the nearest config (ESLint v10 semantics; no `false`).
    */
@@ -68,14 +74,15 @@ export interface RslintOptions {
    * put the `tsconfig.json` that `parserOptions.project` names plus any
    * dependency files here, then lint a buffer with `lintText`. Keys resolve
    * against `cwd` like a linted path (relative or absolute both work); a
-   * same-path `lintText` code entry wins. Inside the tsconfig (`files`) and
-   * `parserOptions.project`, use relative paths — the TS compiler resolves
-   * those, and a bare POSIX-absolute path there has no drive letter on Windows,
-   * so it won't match the overlay. The overlay permits filesystem fallback and
-   * is not a sandbox. rslint-only — ESLint has no in-memory file map.
+   * same-path `lintText` code entry wins. `parserOptions.project` resolves from
+   * the config entry's effective base, while paths inside the tsconfig resolve
+   * from that tsconfig's directory. Prefer relative paths for portability: a
+   * bare POSIX-absolute path has no drive letter on Windows. The overlay permits
+   * filesystem fallback and is not a sandbox. rslint-only — ESLint has no
+   * in-memory file map.
    *
    * Give the tsconfig explicit `files`, not a broad `include` glob: a glob is
-   * expanded against the real filesystem and would scan `cwd` on disk.
+   * expanded against the real filesystem from the tsconfig's directory.
    */
   virtualFiles?: Record<string, string>;
 }

--- a/packages/rslint/src/config/config-discovery-protocol.ts
+++ b/packages/rslint/src/config/config-discovery-protocol.ts
@@ -11,7 +11,7 @@
  * transport boundary.
  */
 
-export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 2 as const;
+export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 3 as const;
 
 export type ConfigModuleLoadMode = 'cached' | 'fresh';
 
@@ -20,7 +20,7 @@ export interface ConfigModuleCandidate {
   id: string;
   /** Absolute path to the JS/TS config module Node must execute. */
   configPath: string;
-  /** Go-authoritative directory used for config matching and plugin routing. */
+  /** Go-authoritative config-owner and routing identity. */
   configDirectory: string;
 }
 

--- a/packages/rslint/src/config/config-file-loader.ts
+++ b/packages/rslint/src/config/config-file-loader.ts
@@ -258,6 +258,15 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
         `[rslint] Config entry at index ${index}: "name" must be a string`,
       );
     }
+    // ESLint intentionally uses property-presence semantics here. A basePath
+    // inherited from a config object's prototype is normalized and validated
+    // just like an own property.
+    const hasBasePath = 'basePath' in entry;
+    if (hasBasePath && typeof entry.basePath !== 'string') {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "basePath" must be a string`,
+      );
+    }
 
     // Extract ESLint-plugin metadata from the object-form `plugins`. Live
     // plugin objects carry functions and must NEVER reach the serializable
@@ -303,7 +312,7 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
     // authored keys, including keys whose value is undefined. Preserve that
     // distinction when normalization omits an undefined or unsupported field.
     const authoredNonGlobalKey = Object.keys(entry).some(
-      (key) => key !== 'name' && key !== 'ignores',
+      (key) => key !== 'name' && key !== 'basePath' && key !== 'ignores',
     );
     const serializesNonGlobalKey =
       hasFiles ||
@@ -316,6 +325,7 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
 
     return {
       ...(entry.name !== undefined ? { name: entry.name } : {}),
+      ...(hasBasePath ? { basePath: entry.basePath } : {}),
       ...(hasFiles ? { files: entry.files } : {}),
       ...(entry.ignores !== undefined ? { ignores: entry.ignores } : {}),
       ...(entry.languageOptions !== undefined

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -191,6 +191,13 @@ export interface RslintConfigEntry {
   /** Optional human-readable name for this config entry. */
   name?: string;
   /**
+   * Directory used as the matching and project-path base for this entry.
+   * Relative values resolve from the flat config array's base: normally the
+   * config file directory, or the invocation working directory with an
+   * explicitly selected config.
+   */
+  basePath?: string;
+  /**
    * Glob selectors for files this entry applies to. Top-level selectors are
    * ORed; strings inside one nested array are ANDed, matching ESLint flat
    * config semantics.

--- a/packages/rslint/src/service/protocol.ts
+++ b/packages/rslint/src/service/protocol.ts
@@ -1,3 +1,3 @@
-export const API_PROTOCOL_VERSION = '3.0.0';
+export const API_PROTOCOL_VERSION = '3.1.0';
 export const API_REVERSE_PLUGIN_LINT_CAPABILITY = 'reversePluginLint';
 export const API_REVERSE_CONFIG_LOAD_CAPABILITY = 'reverseConfigLoadV1';

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -89,8 +89,9 @@ export interface LintOptions {
     /** Parallel to `files`; true only for caller-literal file targets. */
     explicitFiles?: boolean[];
     /**
-     * Normalized API override entries appended to every selected config;
-     * relative paths retain workingDirectory as their authored base.
+     * Normalized API override entries appended to every selected config array.
+     * Relative fields without `basePath` retain `workingDirectory` as their
+     * authored base; `basePath` itself inherits the selected ConfigArray base.
      */
     overrideConfig?: Record<string, unknown>[];
   };
@@ -98,8 +99,8 @@ export interface LintOptions {
   // request-scoped placeholder rules from this metadata, then asks the Node
   // peer to execute them through a reverse `pluginLint` request.
   eslintPlugins?: Array<{ prefix: string; ruleNames: string[] }>;
-  // Anchor for relative paths in low-level `config`. Native discovery entries
-  // use their owning config directory; inline overrides use workingDirectory.
+  // Owner and anchor for low-level `config`. Native discovery entries without
+  // basePath use their owner; inline entries without it use workingDirectory.
   configDirectory?: string;
   // Opaque community-plugin worker identity, independent from the directory
   // used to resolve config paths.

--- a/packages/rslint/tests/config-loader.test.ts
+++ b/packages/rslint/tests/config-loader.test.ts
@@ -204,6 +204,7 @@ describe('normalizeConfig', () => {
   test('preserves all known fields', () => {
     const result = normalizeConfig([
       {
+        basePath: 'packages/app',
         files: ['**/*.ts'],
         ignores: ['dist/**'],
         languageOptions: {
@@ -215,6 +216,7 @@ describe('normalizeConfig', () => {
       },
     ]);
     const entry = result[0];
+    expect(entry.basePath).toBe('packages/app');
     expect(entry.files).toEqual(['**/*.ts']);
     expect(entry.ignores).toEqual(['dist/**']);
     expect(entry.rules).toEqual({ 'no-console': 'error' });
@@ -306,6 +308,21 @@ describe('normalizeConfig', () => {
     expect(() => normalizeConfig([{ ignores: [null], rules: {} }])).toThrow(
       '"ignores" must contain only strings',
     );
+  });
+
+  test.each([null, undefined, 42, {}, []])(
+    'rejects invalid basePath %p',
+    (basePath) => {
+      expect(() => normalizeConfig([{ basePath }])).toThrow(
+        '"basePath" must be a string',
+      );
+    },
+  );
+
+  test('preserves basePath without changing an ignores-only entry shape', () => {
+    expect(
+      normalizeConfig([{ basePath: 'packages/app', ignores: ['dist/**'] }]),
+    ).toEqual([{ basePath: 'packages/app', ignores: ['dist/**'] }]);
   });
 
   test('allows omitted files and ignores', () => {

--- a/packages/rslint/tests/fixtures/fake-api-binary.cjs
+++ b/packages/rslint/tests/fixtures/fake-api-binary.cjs
@@ -25,7 +25,7 @@ function onMessage(msg) {
       kind: 'response',
       id: msg.id,
       data: {
-        version: '3.0.0',
+        version: '3.1.0',
         ok: true,
         capabilities: ['reversePluginLint'],
       },

--- a/packages/rslint/tests/fixtures/fake-config-activation-race.cjs
+++ b/packages/rslint/tests/fixtures/fake-config-activation-race.cjs
@@ -26,7 +26,7 @@ function onMessage(msg) {
       kind: 'loadConfigs',
       id: 200,
       data: {
-        protocolVersion: 2,
+        protocolVersion: 3,
         transactionId: 'cli-prepare-race',
         loadMode: 'cached',
         candidates: [
@@ -45,7 +45,7 @@ function onMessage(msg) {
       kind: 'activateConfigs',
       id: 201,
       data: {
-        protocolVersion: 2,
+        protocolVersion: 3,
         transactionId: 'cli-prepare-race',
         effectiveConfigIds: ['root'],
       },

--- a/packages/rslint/tests/fixtures/fake-exit-during-config-activation.cjs
+++ b/packages/rslint/tests/fixtures/fake-exit-during-config-activation.cjs
@@ -42,7 +42,7 @@ function onMessage(message) {
       kind: 'loadConfigs',
       id: 300,
       data: {
-        protocolVersion: 2,
+        protocolVersion: 3,
         transactionId: 'cli-exit-during-prepare',
         loadMode: 'cached',
         candidates: [
@@ -61,7 +61,7 @@ function onMessage(message) {
       kind: 'activateConfigs',
       id: 301,
       data: {
-        protocolVersion: 2,
+        protocolVersion: 3,
         transactionId: 'cli-exit-during-prepare',
         effectiveConfigIds: ['root'],
       },

--- a/packages/rslint/tests/lint-targets.test.mjs
+++ b/packages/rslint/tests/lint-targets.test.mjs
@@ -155,6 +155,104 @@ function normalizedDiagnostics(cwd, diagnostics) {
     });
 }
 
+describe('CLI basePath product contract', () => {
+  test('automatic config scopes files, ignores, and project from its directory', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'rslint-cli-base-path-'));
+    try {
+      await writeFixture(root, {
+        'packages/app/rslint.config.mjs': `export default [
+  { basePath: 'src', ignores: ['global-ignored.ts'] },
+  {
+    basePath: 'src',
+    files: ['*.ts'],
+    ignores: ['local-ignored.ts'],
+    languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+    rules: { 'no-debugger': 'error' },
+  },
+];\n`,
+        'packages/app/.gitignore': 'src/git-ignored.ts\n',
+        'packages/app/src/tsconfig.json': JSON.stringify({
+          compilerOptions: { strict: true },
+          files: ['visible.ts'],
+        }),
+        'packages/app/src/visible.ts':
+          "debugger;\nexport const broken: number = 'value';\n",
+        'packages/app/src/global-ignored.ts': 'debugger;\n',
+        'packages/app/src/local-ignored.ts': 'debugger;\n',
+        'packages/app/src/git-ignored.ts': 'debugger;\n',
+        'packages/app/src/deep/not-matched.ts': 'debugger;\n',
+        'packages/app/outside-base.ts': 'debugger;\n',
+      });
+
+      const result = await runCLI(root, [
+        '--type-check',
+        path.join('packages', 'app'),
+      ]);
+      const visible = path.join(root, 'packages', 'app', 'src', 'visible.ts');
+
+      expect(result.code).toBe(1);
+      expect(
+        normalizedDiagnostics(root, parseDiagnostics(result.stdout)),
+      ).toEqual([
+        { filePath: visible, ruleName: 'TypeScript(TS2322)' },
+        { filePath: visible, ruleName: 'no-debugger' },
+      ]);
+      expect(result.stderr).not.toContain('warning:');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('explicit external config resolves basePath from cwd without moving gitignore', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'rslint-cli-external-'));
+    const configDir = path.join(root, 'configs');
+    const cwd = path.join(root, 'packages', 'app');
+    const configPath = path.join(configDir, 'rslint.config.mjs');
+    try {
+      await writeFixture(root, {
+        'configs/rslint.config.mjs': `export default [
+  { basePath: 'src', ignores: ['config-ignored.ts'] },
+  {
+    basePath: 'src',
+    files: ['**/*.ts'],
+    languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+    rules: { 'no-debugger': 'error' },
+  },
+];\n`,
+        'packages/app/src/tsconfig.json': JSON.stringify({
+          compilerOptions: { strict: true },
+          files: ['visible.ts'],
+        }),
+        'configs/.gitignore': 'visible.ts\n',
+        'packages/app/.gitignore': 'src/git-ignored.ts\n',
+        'packages/app/src/visible.ts':
+          "debugger;\nexport const broken: number = 'value';\n",
+        'packages/app/src/git-ignored.ts': 'debugger;\n',
+        'packages/app/src/config-ignored.ts': 'debugger;\n',
+      });
+
+      const configArgument = path.relative(cwd, configPath);
+      const result = await runCLI(cwd, [
+        '--type-check',
+        '--config',
+        configArgument,
+      ]);
+      const visible = path.join(cwd, 'src', 'visible.ts');
+
+      expect(result.code).toBe(1);
+      expect(
+        normalizedDiagnostics(cwd, parseDiagnostics(result.stdout)),
+      ).toEqual([
+        { filePath: visible, ruleName: 'TypeScript(TS2322)' },
+        { filePath: visible, ruleName: 'no-debugger' },
+      ]);
+      expect(result.stderr).not.toContain('warning:');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('CLI lint target contracts', () => {
   test('external config keeps authored paths and invocation target scope', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'rslint-cli-external-'));

--- a/packages/rslint/tests/node-service.test.ts
+++ b/packages/rslint/tests/node-service.test.ts
@@ -82,9 +82,9 @@ suite('NodeRslintService reject-all-pending on crash/terminate', () => {
   test('does not harm a normal request/response round-trip', async () => {
     const svc = new NodeRslintService({ rslintPath: FAKE });
     await expect(
-      svc.sendMessage('handshake', { version: '3.0.0' }),
+      svc.sendMessage('handshake', { version: '3.1.0' }),
     ).resolves.toEqual({
-      version: '3.0.0',
+      version: '3.1.0',
       ok: true,
       capabilities: ['reversePluginLint'],
     });
@@ -109,7 +109,7 @@ suite('NodeRslintService reject-all-pending on crash/terminate', () => {
     process.env.RSLINT_FAKE_EXIT_SILENT = '1';
     try {
       const svc = new NodeRslintService({ rslintPath: FAKE });
-      await svc.sendMessage('handshake', { version: '3.0.0' });
+      await svc.sendMessage('handshake', { version: '3.1.0' });
       await expect(svc.sendMessage('exit', {})).resolves.toBeNull();
     } finally {
       delete process.env.RSLINT_FAKE_EXIT_SILENT;

--- a/packages/rslint/tests/service.test.ts
+++ b/packages/rslint/tests/service.test.ts
@@ -23,7 +23,7 @@ class ReverseLintBackend implements RslintServiceInterface {
   async sendMessage(kind: string, data: any): Promise<any> {
     if (kind === 'handshake')
       return {
-        version: '3.0.0',
+        version: '3.1.0',
         ok: true,
         capabilities: ['reversePluginLint'],
       };
@@ -200,7 +200,7 @@ class ReverseConfigBackend extends ReverseLintBackend {
     if (kind === 'handshake') {
       this.handshakeCapabilities = [...(data.capabilities ?? [])];
       return {
-        version: '3.0.0',
+        version: '3.1.0',
         ok: true,
         capabilities: [API_REVERSE_CONFIG_LOAD_CAPABILITY],
       };
@@ -291,7 +291,7 @@ describe('RSLintService reverse lint request scoping', () => {
     };
     const service = new RSLintService(backend);
     await expect(service.lint({ files: ['a.ts'] })).rejects.toThrow(
-      /protocol mismatch.*3\.0\.0.*1\.0\.0/,
+      /protocol mismatch.*3\.1\.0.*1\.0\.0/,
     );
     await service.close();
   });
@@ -300,7 +300,7 @@ describe('RSLintService reverse lint request scoping', () => {
     const backend = new ReverseLintBackend();
     backend.sendMessage = async (kind: string, data: any): Promise<any> => {
       if (kind === 'handshake') {
-        return { version: '3.0.0', ok: true, capabilities: [] };
+        return { version: '3.1.0', ok: true, capabilities: [] };
       }
       return ReverseLintBackend.prototype.sendMessage.call(backend, kind, data);
     };

--- a/packages/vscode-extension/__tests__/suite-jsconfig/core-resolver.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/core-resolver.test.ts
@@ -105,7 +105,7 @@ suite('local core resolver', () => {
       fs.writeFile(
         path.join(packageDirectory, 'config-loader.js'),
         [
-          'export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 2;',
+          'export const CONFIG_DISCOVERY_PROTOCOL_VERSION = 3;',
           'export class ConfigModuleHost {}',
           `export function resolveRslintBinary() { return ${JSON.stringify(binaryPath)}; }`,
         ].join('\n'),

--- a/packages/vscode-extension/__tests__/suite-jsconfig/runtime-manager.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/runtime-manager.test.ts
@@ -45,7 +45,7 @@ class FakeResolver implements RuntimeCoreResolver {
       packageDirectory: `/core/${identity}`,
       version: identity,
       binaryPath: `/core/${identity}/rslint`,
-      protocolVersion: 2,
+      protocolVersion: 3,
     } as CoreInstallation;
     return {
       key: `${workspaceFolder.uri}\0${identity}`,

--- a/rslint-schema.json
+++ b/rslint-schema.json
@@ -16,6 +16,10 @@
           "type": "string",
           "description": "Optional human-readable name for this configuration entry"
         },
+        "basePath": {
+          "type": "string",
+          "description": "Entry-local matching root for files, ignores, and explicit TypeScript project paths"
+        },
         "files": {
           "type": "array",
           "description": "Non-empty file selector list. Top-level selectors are ORed; patterns inside a nested array are ANDed. Rslint unions these selectors with its default JavaScript and TypeScript extension baseline.",

--- a/website/docs/en/api/rslint.md
+++ b/website/docs/en/api/rslint.md
@@ -46,15 +46,17 @@ Both `lintFiles` and `lintText` return ESLint-shaped `LintResult[]` values.
 const rslint = new Rslint(options);
 ```
 
-| Option               | Type                                        | Default         | Description                                                                                                                                                       |
-| -------------------- | ------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cwd`                | `string`                                    | `process.cwd()` | Working directory for targets and discovery; also the base of inline `overrideConfig` paths                                                                       |
-| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —               | Extra config appended after the selected config; relative `files`, `ignores`, and `parserOptions.project` paths use `cwd`                                         |
-| `overrideConfigFile` | `string \| true \| null`                    | `null`          | A JS/TS config module path disables discovery and uses its own directory as its config path base; `true` uses only the override; otherwise configs are discovered |
-| `fix`                | `boolean`                                   | `false`         | Applies auto-fixes and includes changed source in `result.output`                                                                                                 |
-| `virtualFiles`       | `Record<string, string>`                    | —               | In-memory path-to-content overlay for project inputs; unresolved reads may still fall back to disk                                                                |
+| Option               | Type                                        | Default         | Description                                                                                                                                                                      |
+| -------------------- | ------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cwd`                | `string`                                    | `process.cwd()` | Working directory for targets and discovery; also the authored base of relative fields in inline entries without `basePath`                                                      |
+| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —               | Extra config appended after the selected config; `basePath` inherits the selected ConfigArray base, while entries without it retain Rslint's existing `cwd`-relative behavior    |
+| `overrideConfigFile` | `string \| true \| null`                    | `null`          | A module path disables discovery. Its `basePath` resolves from `cwd`; entries without `basePath` retain Rslint's module-directory behavior. `true` uses only the inline override |
+| `fix`                | `boolean`                                   | `false`         | Applies auto-fixes and includes changed source in `result.output`                                                                                                                |
+| `virtualFiles`       | `Record<string, string>`                    | —               | In-memory path-to-content overlay for project inputs; unresolved reads may still fall back to disk                                                                               |
 
 With automatic discovery, Go selects each file's nearest config and owns ignore and target-admission semantics. The JavaScript host evaluates and normalizes the JS or TS config modules selected for that run.
+
+See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath) for automatic, explicit-file, and inline-override behavior.
 
 :::warning
 Object-form community plugins are not supported in `overrideConfig`, because a plugin worker cannot re-import an in-memory plugin object. Put community plugin declarations in a JS or TS config file. Array-form built-in plugins work in `overrideConfig`.
@@ -139,7 +141,7 @@ const [result] = await rslint.lintText(
 
 `virtualFiles` is an overlay, not a filesystem sandbox. Rslint can still read from disk for `.gitignore`, module resolution, and files absent from the map.
 
-Use relative `virtualFiles` keys and relative paths inside the tsconfig and `parserOptions.project`; they are resolved against `cwd` consistently across operating systems. Prefer an explicit tsconfig `files` list because a broad `include` glob is expanded against the real filesystem.
+Use relative paths for portability. `virtualFiles` keys always resolve against `cwd`; `parserOptions.project` resolves from the config entry's effective base; paths inside a tsconfig resolve from that tsconfig's directory. In the override-only example above all three directories are `cwd`. Prefer an explicit tsconfig `files` list because a broad `include` glob is expanded against the real filesystem from the tsconfig's directory.
 
 TypeScript project data is only necessary for rules that require type information. A configuration containing only syntax-based rules does not need a tsconfig or `parserOptions.project`.
 

--- a/website/docs/en/config/configuration-file.md
+++ b/website/docs/en/config/configuration-file.md
@@ -53,7 +53,7 @@ export default defineConfig([
 With this config, a `rslint.config.ts` inside `e2e/` or any `fixtures/` directory is not used by a root directory traversal. An explicitly named file is still resolved from its nearest config.
 
 :::tip
-Only **global ignore entries** (entries containing only `ignores`) block directory target discovery. Entry-level ignores do not affect config discovery. See [`ignores`](/config/ignoring-files) for the distinction.
+Only **global ignore entries** (entries containing `ignores` plus optional `name` or `basePath`, with no configuration fields) block directory target discovery. Entry-level ignores do not affect config discovery. See [`ignores`](/config/ignoring-files) for the distinction.
 :::
 
 You can specify a config file explicitly, which overrides automatic discovery:
@@ -62,7 +62,39 @@ You can specify a config file explicitly, which overrides automatic discovery:
 rslint --config path/to/rslint.config.ts .
 ```
 
-Relative `files`, `ignores`, and `languageOptions.parserOptions.project` patterns are resolved from the config file's directory, whether the config is discovered automatically or supplied with `--config`.
+## Path resolution and `basePath`
+
+`basePath` is a directory path, not a glob. It scopes one flat-config entry to that directory. The entry's `files`, `ignores`, and explicit `languageOptions.parserOptions.project` paths resolve from the resulting directory. It changes only that starting directory; `files` and `ignores` keep exactly the same glob syntax and matching behavior as entries without `basePath`.
+
+```ts
+{
+  basePath: 'packages/app',
+  files: ['src/**/*.ts'],
+  ignores: ['src/generated/**'],
+  languageOptions: {
+    parserOptions: { project: ['./tsconfig.json'] },
+  },
+}
+```
+
+The base used to resolve `basePath` depends on how the config was selected:
+
+| Config entry source                                                | `basePath` resolves from    | Relative paths when `basePath` is absent           |
+| ------------------------------------------------------------------ | --------------------------- | -------------------------------------------------- |
+| Automatically discovered config module                             | Config module directory     | Config module directory                            |
+| Explicit `--config`, API `overrideConfigFile`, or fixed LSP config | Invocation/workspace cwd    | Config module directory (existing Rslint behavior) |
+| API inline `overrideConfig` in automatic-discovery mode            | Discovered config directory | API `cwd`                                          |
+| API inline `overrideConfig` with an explicit config or no config   | API `cwd`                   | API `cwd`                                          |
+
+An inline override therefore uses the discovered module directory for
+`basePath` in automatic mode, and API `cwd` with an explicit config or
+`overrideConfigFile: true`. This is how ESLint appends `overrideConfig` to the
+selected ConfigArray. Relative fields in an inline entry without `basePath`
+keep Rslint's existing API-`cwd` behavior.
+
+The explicit-config rule matches ESLint: if `/project` invokes `--config /configs/rslint.config.ts`, then `basePath: 'app'` means `/project/app`, not `/configs/app`. An empty string is valid and still scopes the entry. Invalid values are rejected when the config loads, even if the entry matches no target.
+
+`basePath` does not change the config owner, scan root, or `.gitignore` collection root. See [`.gitignore` integration](/config/ignoring-files#gitignore-integration).
 
 To generate a default config, run:
 
@@ -103,7 +135,7 @@ See the [Configuration overview](/config/) for every available option and [Rules
 
 When multiple config entries match a file, they are merged in array order:
 
-1. **Global ignores** — entries containing only `ignores` remove files from the target set
+1. **Global ignores** — entries containing `ignores` plus optional `name` or `basePath`, with no configuration fields, remove files from the target set
 2. **Selector union** — the implicit default baseline and effective explicit `files` entries decide whether the config selects the file
 3. **Files matching** — entries whose explicit `files` patterns don't match are skipped; entries without `files` cascade across the selector union
 4. **Entry-level ignores** — matching entries do not select or configure the file, but cannot remove a target selected elsewhere

--- a/website/docs/en/config/files.md
+++ b/website/docs/en/config/files.md
@@ -42,4 +42,4 @@ File selection is independent of a tsconfig's `include`. A file in tsconfig but 
 Selected files not covered by a tsconfig declared by their governing config automatically receive a reduced rule set: only rules that do not require type information run. To enable type-aware rules, add the file to one of that config's tsconfigs. See [`languageOptions.parserOptions.project`](/config/language-options#languageoptionsparseroptionsproject).
 :::
 
-Relative patterns in a config file are resolved from that file's directory. Relative patterns in the JavaScript API's inline `overrideConfig` are resolved from the API `cwd`.
+When an entry has `basePath`, its `files` patterns resolve from that directory and the whole entry is inactive outside it. Without `basePath`, config-module patterns keep Rslint's existing module-directory base, while API inline `overrideConfig` patterns use the API `cwd`. See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath).

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -6,7 +6,7 @@ Glob patterns for files to exclude. The behavior depends on whether `ignores` ap
 
 ## Global and entry-level ignores
 
-An entry containing **only** `ignores` acts as a global ignore: matching files are removed from the lint target set. An entry-level ignore prevents that entry's `files` selector, rules, and options from contributing. It cannot remove a path selected by the default extension baseline or another entry, so such a path may still receive configuration or a zero-rule syntax pass.
+An entry containing `ignores` and no fields other than optional `name` and `basePath` acts as a global ignore: matching files are removed from the lint target set. An entry-level ignore prevents that entry's `files` selector, rules, and options from contributing. It cannot remove a path selected by the default extension baseline or another entry, so such a path may still receive configuration or a zero-rule syntax pass.
 
 ```ts
 // Global ignore entry
@@ -24,7 +24,7 @@ An entry containing **only** `ignores` acts as a global ignore: matching files a
 
 ## The `globalIgnores` helper
 
-Writing an entry with only `ignores` is common enough that `@rslint/core` exports a `globalIgnores` helper, mirroring ESLint v10. It returns a config entry containing just the given patterns, so the global-ignore intent is explicit:
+Writing a global-ignore entry is common enough that `@rslint/core` exports a `globalIgnores` helper, mirroring ESLint v10. It returns a config entry containing the given patterns, so the global-ignore intent is explicit:
 
 ```ts
 import { defineConfig, globalIgnores } from '@rslint/core';
@@ -101,6 +101,8 @@ For directory-level patterns (`dir/**`), `!` negation cannot re-include files be
 ## .gitignore integration
 
 The CLI, JavaScript API, and LSP automatically read `.gitignore` files and treat their patterns as additional global ignores. Automatically discovered configs and ordinary LSP files start collection at the governing config directory. An explicitly selected invocation-wide config (`--config`, API `overrideConfigFile`, or the LSP `configPath` setting) starts at the invocation or workspace-folder `cwd`, even when the config file is elsewhere. A requested directory outside `cwd` gets its own independent Git scope. Collection never searches a scope's parents. In the editor, saved `.gitignore` changes refresh diagnostics for open files.
+
+An entry's `basePath` does not move these `.gitignore` roots. It only scopes that authored entry and rebases its own `ignores` patterns.
 
 - **Nested `.gitignore` files** inside one Git scope are supported — each one only affects its own directory subtree
 - **Parent patterns cascade** to child directories within that scope (e.g., root `dist/` also ignores `packages/app/dist/`)

--- a/website/docs/en/config/language-options.md
+++ b/website/docs/en/config/language-options.md
@@ -75,9 +75,9 @@ Files outside all tsconfigs are still linted, but only rules that do not require
 }
 ```
 
-Relative project patterns in a config file are resolved from that file's directory. Relative project patterns in the JavaScript API's inline `overrideConfig` are resolved from the API `cwd`.
+When an entry has `basePath`, its explicit project literals and globs resolve from that directory. This changes only their path origin: Rslint's existing governing-config project collection remains owner-wide, so `files` and `ignores` do not filter which declared projects the loader considers. Without `basePath`, config-module project paths keep Rslint's existing module-directory base, while API inline `overrideConfig` paths use the API `cwd`.
 
-Omit `project` to use the governing config directory's default `tsconfig.json`. Set `project: []` to disable that fallback explicitly.
+Omit `project` to use the governing config directory's default `tsconfig.json`; `basePath` alone does not move that fallback. An explicit `project: []` disables that fallback for the governing config. See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath).
 
 ## languageOptions.globals
 

--- a/website/docs/en/guide/js-api.md
+++ b/website/docs/en/guide/js-api.md
@@ -87,10 +87,11 @@ const [result] = await rslint.lintText(
 
 **Use relative paths** in `virtualFiles` keys and inside the tsconfig:
 
-- **`virtualFiles` keys**: prefer relative paths (`'tsconfig.json'`). Keys are resolved against `cwd`, so a relative key always lines up with `parserOptions.project` (also resolved against `cwd`). An absolute key like `'/tsconfig.json'` happens to match only when `cwd` is `/`; with any other `cwd` it lands at the filesystem root and won't match the project path.
-- **Inside the tsconfig** (`files`) and in **`parserOptions.project`**: use relative paths. The TypeScript compiler resolves these, and a bare POSIX-absolute path (such as `/a.ts`) has no drive letter on Windows, so it won't match the overlay.
+- **`virtualFiles` keys**: prefer relative paths (`'tsconfig.json'`). Keys are always resolved against `cwd`. An absolute key like `'/tsconfig.json'` happens to match only when `cwd` is `/`; with any other `cwd` it lands at the filesystem root.
+- **`parserOptions.project`**: relative paths resolve from the config entry's effective base. In this override-only example that base is `cwd`; a `basePath` changes it. For a discovered config module it is normally the module directory.
+- **Inside the tsconfig** (`files` and `include`): relative paths resolve from the tsconfig's own directory. A bare POSIX-absolute path (such as `/a.ts`) has no drive letter on Windows, so it won't match the overlay.
 
-**Pin the tsconfig to explicit `files`** — a broad `include` glob is expanded against the real filesystem and would scan `cwd` on disk.
+**Pin the tsconfig to explicit `files`** — a broad `include` glob is expanded against the real filesystem and scans from the tsconfig's directory (which is `cwd` in this example).
 
 ## Auto-fixing
 
@@ -175,10 +176,12 @@ Each `LintMessage`:
 
 [`new Rslint(options)`](/api/rslint#constructor) accepts:
 
-| Option               | Type                                        | Default     | Description                                                                                                                                            |
-| -------------------- | ------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `cwd`                | `string`                                    | current cwd | Working directory for targets and discovery; also the base of inline `overrideConfig` paths                                                            |
-| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —           | Extra config appended after the resolved/discovered config; relative `files`, `ignores`, and `parserOptions.project` paths use `cwd`                   |
-| `overrideConfigFile` | `string \| true \| null`                    | `null`      | `string`: use this JS/TS config module and resolve its config-relative paths from its directory; `true`: use only `overrideConfig`; otherwise discover |
-| `fix`                | `boolean`                                   | `false`     | Apply rule auto-fixes; results carry `output`                                                                                                          |
-| `virtualFiles`       | `Record<string, string>`                    | —           | In-memory file overlay (path → content); unresolved reads may fall back to disk                                                                        |
+| Option               | Type                                        | Default     | Description                                                                                                                                                                    |
+| -------------------- | ------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cwd`                | `string`                                    | current cwd | Working directory for targets and discovery; also the authored base of inline entries without `basePath`                                                                       |
+| `overrideConfig`     | `RslintConfigEntry \| RslintConfig \| null` | —           | Extra config appended after the resolved/discovered config; `basePath` inherits the ConfigArray base, while entries without it keep Rslint's existing `cwd`-relative behavior  |
+| `overrideConfigFile` | `string \| true \| null`                    | `null`      | `string`: use this module; `basePath` resolves from `cwd`, while entries without it retain the module-directory base. `true`: use only the inline override; otherwise discover |
+| `fix`                | `boolean`                                   | `false`     | Apply rule auto-fixes; results carry `output`                                                                                                                                  |
+| `virtualFiles`       | `Record<string, string>`                    | —           | In-memory file overlay (path → content); unresolved reads may fall back to disk                                                                                                |
+
+See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath) for the full source matrix.

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -28,7 +28,9 @@ rslint --type-check .         # lint + type-check
 rslint --type-check-only .    # type-check only
 ```
 
-When `parserOptions.project` is omitted, rslint uses `tsconfig.json` in the governing config directory when present. Set `project: []` to disable that fallback explicitly. If neither configured projects nor that fallback tsconfig exist, no real TypeScript Program is built and type-check produces no diagnostics for that config.
+When `parserOptions.project` is omitted, rslint uses `tsconfig.json` in the governing config directory when present. An explicit `project: []` disables that fallback for the governing config. If neither configured projects nor that fallback tsconfig exist, no real TypeScript Program is built and type-check produces no diagnostics for that config.
+
+An entry's `basePath` becomes the anchor for its explicit project literals or globs. It does not move the implicit governing-directory `tsconfig.json` fallback or change Rslint's existing owner-wide project collection. Program-wide type checking still builds every explicit project declaration in the effective config catalog; `files`, `ignores`, `.gitignore`, and CLI target scope do not reduce that Program's TypeScript diagnostics.
 
 ## What gets type-checked
 


### PR DESCRIPTION
## Summary

- Add ESLint-compatible flat-config `basePath` support across CLI, JavaScript API, and LSP config loading.
- Resolve each entry's effective path origin once in `internal/config`; the existing `files`/`ignores` matcher and project resolver consume that model, while target planning, Program loading, and LSP remain unaware of `basePath`.
- Keep `.gitignore` collection roots unchanged, preserve explicit-config behavior (`basePath` resolves from cwd), and cover automatic/explicit behavior plus cross-platform and symlink cases.
- Update protocol versions, schema, architecture documentation, and slow type-check snapshot duration normalization.

## Related Links

- Related to https://github.com/web-infra-dev/rslint/pull/1471
- Related to https://github.com/web-infra-dev/rslint/issues/1201

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).