### PR TITLE
fix: align no-magic-array-flat-depth with upstream

### DIFF
--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/comments_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/comments_test.go
@@ -1,0 +1,36 @@
+package no_magic_array_flat_depth_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_magic_array_flat_depth"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoMagicArrayFlatDepthCommentBoundary(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
+		[]rule_tester.ValidTestCase{
+			jsValid(`array.flat(/* inside */ 2)`),
+			jsValid(`array.flat((/* inside */ 2))`),
+			jsValid(`array.flat(2 /* inside */)`),
+			jsValid("array.flat((2 // inside\n))"),
+			{Code: `array.flat<number>(/* inside */ 2)`, FileName: "file.ts"},
+		},
+		[]rule_tester.InvalidTestCase{
+			depthInvalid(`array.flat /* outside */ (2)`),
+			depthInvalid("array.flat // outside\n(2)"),
+			depthInvalid(`array.flat(((2)))`),
+			depthInvalid(`array.flat(2) /* outside */`),
+			{
+				Code:     `array.flat<number> /* outside */ (2)`,
+				FileName: "file.ts",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID, Message: messageString}},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/helpers_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/helpers_test.go
@@ -49,23 +49,21 @@ func depthInvalid(code string) rule_tester.InvalidTestCase {
 // findDepthLiteral returns the byte offset and length of the numeric
 // argument passed to the only `.flat(` call in `code`. The upstream test
 // cases always use a single literal depth (no expressions), so a simple scan
-// for the first numeric-literal-shaped token after the last `.flat(` opener
+// for the first numeric-literal-shaped token after the last `.flat` call
 // is enough.
 func findDepthLiteral(code string) (int, int) {
-	// Locate the call's opening paren — `.flat(` — and search after it.
-	openIdx := strings.LastIndex(code, ".flat(")
-	if openIdx < 0 {
-		// Optional-member form: `?.flat(`.
-		openIdx = strings.LastIndex(code, "?.flat(")
-		if openIdx < 0 {
-			return -1, 0
-		}
-		openIdx++ // skip the leading `?` and use `.flat(`.
+	flatIndex := strings.LastIndex(code, ".flat")
+	if flatIndex < 0 {
+		return -1, 0
 	}
-	after := openIdx + len(".flat(")
-	// Skip whitespace.
+	openOffset := strings.IndexByte(code[flatIndex+len(".flat"):], '(')
+	if openOffset < 0 {
+		return -1, 0
+	}
+	after := flatIndex + len(".flat") + openOffset + 1
+	// Skip whitespace and parentheses around the depth literal.
 	i := after
-	for i < len(code) && (code[i] == ' ' || code[i] == '\t') {
+	for i < len(code) && (code[i] == ' ' || code[i] == '\t' || code[i] == '\n' || code[i] == '(') {
 		i++
 	}
 	if i >= len(code) {

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
@@ -1,6 +1,8 @@
 package no_magic_array_flat_depth
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -53,12 +55,12 @@ var NoMagicArrayFlatDepthRule = rule.Rule{
 					return
 				}
 
-				// Skip if any comment sits between the callee end (= the `(`) and
-				// the closing paren — a commented explanation is exactly the kind
+				// Skip if any comment sits between the call's actual parentheses —
+				// a commented explanation is exactly the kind
 				// of context upstream wants to preserve. Upstream checks
 				// `commentsExistBetween(openingParenthesisToken, closingParenthesisToken)`,
 				// which covers both sides of the depth argument.
-				if hasCommentBetweenParens(ctx, call.Call, depth) {
+				if hasCommentBetweenParens(ctx, call.Call) {
 					return
 				}
 
@@ -84,27 +86,22 @@ func isNumericLiteral(node *ast.Node) bool {
 	return node != nil && node.Kind == ast.KindNumericLiteral
 }
 
-// hasCommentBetweenParens reports whether any comment lives in the source
-// span from the end of the callee (right after `flat`, i.e. the position of
-// the opening `(`) up to the end of the call expression. Mirrors upstream's
+// hasCommentBetweenParens reports whether any comment lives between the
+// call's actual opening and closing parenthesis tokens. Mirrors upstream's
 // `sourceCode.commentsExistBetween(openingParenthesisToken, closingParenthesisToken)`.
-func hasCommentBetweenParens(ctx rule.RuleContext, call *ast.Node, depth *ast.Node) bool {
-	callee := call.AsCallExpression().Expression
-	if callee == nil {
+func hasCommentBetweenParens(ctx rule.RuleContext, call *ast.Node) bool {
+	opening, closing, ok := unicornutil.CallExpressionParenthesesRange(ctx.SourceFile, call)
+	if !ok {
 		return false
 	}
-	openParenPos := utils.TrimNodeTextRange(ctx.SourceFile, callee).End()
-	callEnd := utils.TrimNodeTextRange(ctx.SourceFile, call).End()
-	depthStart := utils.TrimNodeTextRange(ctx.SourceFile, depth).Pos()
-	if openParenPos >= callEnd {
+	start, end := opening.End(), closing.Pos()
+	if start >= end {
 		return false
 	}
-	// Avoid wasting a comment scan on the trivial case where the depth is the
-	// only thing in the parens.
-	if depthStart == openParenPos+1 || depthStart == openParenPos+2 {
-		// depth is immediately after `(`, optionally with whitespace.
-		depthEnd := depth.End()
-		return utils.HasCommentInSpan(ctx.Comments.All(), depthEnd, callEnd)
-	}
-	return utils.HasCommentInSpan(ctx.Comments.All(), openParenPos, callEnd)
+	span := ctx.SourceFile.Text()[start:end]
+	// The listener has already proved that the sole argument, after removing
+	// parentheses, is a numeric literal. Consequently this span can contain
+	// only that literal, parentheses, separators, and trivia; a comment opener
+	// cannot belong to a string, template, regular expression, or division.
+	return strings.Contains(span, "//") || strings.Contains(span, "/*")
 }

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
@@ -1,7 +1,6 @@
-// TestNoMagicArrayFlatDepthUpstream migrates the full valid/invalid suite from
-// upstream test/no-magic-array-flat-depth.js 1:1. Position assertions cover
-// line/column for the depth argument reported in every invalid case.
-// rslint-specific lock-in cases live in no_magic_array_flat_depth_extras_test.go.
+// TestNoMagicArrayFlatDepthUpstream mirrors Unicorn v73.0.0's complete
+// test/no-magic-array-flat-depth.js valid/invalid suite. rslint-only regression
+// coverage lives in the neighboring extras files.
 package no_magic_array_flat_depth_test
 
 import (
@@ -19,68 +18,20 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 		t,
 		&no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
 		[]rule_tester.ValidTestCase{
-			// ---- Known non-array receiver (type information) ----
 			{
 				Code:     `function f(foo: {flat(depth: number): void}) { foo.flat(2); }`,
 				FileName: "file.ts",
 			},
-			// `shouldSkipKnownNonArrayReceiver` skip case — a typed `Set` is
-			// known not to be an array, so the rule legitimately skips it.
-			{
-				Code:     `function f(foo: Set<number>) { foo.flat(2); }`,
-				FileName: "file.ts",
-			},
-
-			// Arrow / class expressions are deliberately NOT in the
-			// `directlyReportableReceiverTypes` set; they fall through to
-			// `isKnownNonIndexedCollection`, which classifies both as
-			// non-array expressions and skips them. Lock in every shape
-			// upstream marks as "skip" so future refactors don't promote
-			// them to the reportable set.
-			jsValid(`(() => {}).flat(2)`),
-			jsValid(`(async () => {}).flat(2)`),
-			jsValid(`(class {}).flat(2)`),
-			jsValid(`(class extends Array {}).flat(2)`),
-			jsValid(`(class { flat() {} }).flat(2)`),
-			jsValid(`(() => {})?.flat(2)`),
-			jsValid(`(class {})?.flat(2)`),
-			jsValid(`(((() => {}))).flat(2)`),
-			jsValid(`(((class {}))).flat(2)`),
-
-			// Constructor calls that the static evaluator resolves to a
-			// known non-array value — upstream (and rslint) legitimately
-			// skip these.
-			jsValid(`Number(1).flat(2)`),
-			jsValid(`String("x").flat(2)`),
-			jsValid(`Boolean(0).flat(2)`),
-			jsValid(`BigInt(1).flat(2)`),
-			// Parenthesized form of a coercion constructor must still
-			// be skipped.
-			jsValid(`(Number(1)).flat(2)`),
-
-			// `String.fromCharCode` is folded by the shared static
-			// evaluator to a string value, so the rule skips it.
-			jsValid(`String.fromCharCode(65).flat(2)`),
-
-			// ---- depth is 1 (the default) ----
 			jsValid(`array.flat(1)`),
 			jsValid(`array.flat(1.0)`),
 			jsValid(`array.flat(0x01)`),
-
-			// ---- depth is not a numeric literal ----
 			jsValid(`array.flat(unknown)`),
 			jsValid(`array.flat(Number.POSITIVE_INFINITY)`),
 			jsValid(`array.flat(Infinity)`),
-
-			// ---- comments around the depth explain the magic number ----
 			jsValid(`array.flat(/* explanation */2)`),
 			jsValid(`array.flat(2/* explanation */)`),
-
-			// ---- no argument or wrong number of arguments ----
 			jsValid(`array.flat()`),
 			jsValid(`array.flat(2, extraArgument)`),
-
-			// ---- not a CallExpression of `.flat` ----
 			jsValid(`new array.flat(2)`),
 			jsValid(`array.flat?.(2)`),
 			jsValid(`array.notFlat(2)`),
@@ -91,233 +42,10 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			depthInvalid(`array?.flat(2)`),
 			depthInvalid(`array.flat(99,)`),
 			depthInvalid(`array.flat(0b10,)`),
-
-			// A receiver that is known to be an array must still be reported.
 			{
 				Code:     `function f(foo: number[][]) { foo.flat(2); }`,
 				FileName: "file.ts",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-
-			// `shouldSkipKnownNonArrayReceiver` regression cases — these
-			// receivers are directly visible (mismatch is at the call site)
-			// so the rule MUST still report them, even though
-			// `isKnownNonIndexedCollection` would otherwise skip them.
-			{
-				Code:     `({flat(){}}).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `"x".flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			// Typed array — shares most of Array's method surface, but
-			// `flat()` isn't on its prototype, so reporting the broken call
-			// is the right call.
-			{
-				Code:     `new Uint8Array().flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-
-			// Source-only unknown receivers — upstream's `getStaticType`
-			// returns "unknown" for bare identifiers and member expressions
-			// without an evaluable static value, so the rule reports. These
-			// exercise the source-only branch of
-			// `ShouldSkipKnownNonArrayReceiver`, which would otherwise lean
-			// on the type checker and over-classify globals.
-			{
-				Code:     `undefined.flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `NaN.flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Infinity.flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Number.NaN.flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Math.PI.flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Symbol.iterator.flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Symbol().flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-
-			// Local bindings where upstream keeps the source-only
-			// "unknown" classification: `let` / `var` / destructuring
-			// don't follow the `const IDENT = EXPR` resolution path, and
-			// `const IDENT = Math.PI` is still unknown because Math.PI
-			// itself is a MemberExpression. Lock in that rslint matches.
-			{
-				Code:     `let value = 1; value.flat(2);`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `var value = 1; value.flat(2);`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `const {value = 1} = {}; value.flat(2);`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `const value = Math.PI; value.flat(2);`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-
-			// Source-only unknown receivers: calls the rslint static
-			// evaluator cannot fold. The rslint type checker would
-			// over-classify their return type as a known non-array
-			// primitive, so the source-only path bypasses it.
-			{
-				Code:     `Math.abs(-2).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Math.max(1, 2).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Math.random().flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Array.from([1]).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Object.keys({a: 1}).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `JSON.parse("[]").flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Array.isArray([]).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `parseInt("2", 10).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `parseFloat("2").flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Object().flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID, Message: messageString}},
 			},
 		},
 	)

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/receiver_classification_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/receiver_classification_test.go
@@ -1,0 +1,583 @@
+// cspell:ignore ACFB Hrkt
+
+package no_magic_array_flat_depth_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_magic_array_flat_depth"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoMagicArrayFlatDepthLargeStaticMapReceiver(t *testing.T) {
+	var source strings.Builder
+	source.WriteString("new Map([")
+	for index := range 2000 {
+		if index > 0 {
+			source.WriteByte(',')
+		}
+		source.WriteByte('[')
+		source.WriteString(strconv.Itoa(index))
+		source.WriteByte(',')
+		source.WriteString(strconv.Itoa(index))
+		source.WriteByte(']')
+	}
+	source.WriteString("]).get(-1).flat(2)")
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
+		[]rule_tester.ValidTestCase{jsValid(source.String())},
+		nil,
+	)
+}
+
+func TestNoMagicArrayFlatDepthSourceOnlyRecursionGuard(t *testing.T) {
+	conditional := func(depth int, tail func(*strings.Builder, string)) string {
+		var source strings.Builder
+		source.WriteString("const value0 = 1;\n")
+		for index := 1; index <= depth; index++ {
+			source.WriteString("const value")
+			source.WriteString(strconv.Itoa(index))
+			source.WriteString(" = true ? value")
+			source.WriteString(strconv.Itoa(index - 1))
+			source.WriteString(" : 0;\n")
+		}
+		tail(&source, "value"+strconv.Itoa(depth))
+		return source.String()
+	}
+	alias := func(depth int, tail func(*strings.Builder, string)) string {
+		var source strings.Builder
+		source.WriteString("const value0 = 1;\n")
+		for index := 1; index <= depth; index++ {
+			source.WriteString("const value")
+			source.WriteString(strconv.Itoa(index))
+			source.WriteString(" = value")
+			source.WriteString(strconv.Itoa(index - 1))
+			source.WriteString(";\n")
+		}
+		tail(&source, "value"+strconv.Itoa(depth))
+		return source.String()
+	}
+	direct := func(source *strings.Builder, value string) {
+		source.WriteString(value)
+		source.WriteString(".flat(2);\n")
+	}
+	mathAbs := func(source *strings.Builder, value string) {
+		source.WriteString("Math.abs(")
+		source.WriteString(value)
+		source.WriteString(").flat(2);\n")
+	}
+	warmArguments := func(source *strings.Builder, _ string) {
+		source.WriteString("Math.max(")
+		for index := 400; index <= 2000; index += 400 {
+			if index > 400 {
+				source.WriteByte(',')
+			}
+			source.WriteString("value")
+			source.WriteString(strconv.Itoa(index))
+		}
+		source.WriteString(").flat(2);\n")
+	}
+	warmRoots := func(source *strings.Builder, _ string) {
+		for index := 400; index <= 2000; index += 400 {
+			source.WriteString("value")
+			source.WriteString(strconv.Itoa(index))
+			source.WriteString(".flat(2);\n")
+		}
+	}
+	warmAliasRoots := func(source *strings.Builder, _ string) {
+		for index := 400; index <= 2000; index += 400 {
+			source.WriteString("Math.abs(value")
+			source.WriteString(strconv.Itoa(index))
+			source.WriteString(").flat(2);\n")
+		}
+	}
+	bigIntConditionalCache := func() string {
+		var source strings.Builder
+		source.WriteString("const closed = ")
+		for range 700 {
+			source.WriteString("true ? (")
+		}
+		source.WriteString("2n ** 16n")
+		for range 700 {
+			source.WriteString(") : 0n")
+		}
+		source.WriteString(";\nBoolean(closed).flat(2);\nconst cacheAlias0 = closed;\n")
+		for depth := 1; depth <= 700; depth++ {
+			source.WriteString("const cacheAlias")
+			source.WriteString(strconv.Itoa(depth))
+			source.WriteString(" = cacheAlias")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(";\n")
+		}
+		source.WriteString("Boolean(cacheAlias700).flat(2);\n")
+		return source.String()
+	}
+	bigIntOperatorCache := func() string {
+		var source strings.Builder
+		source.WriteString("const closed = 2n")
+		for range 700 {
+			source.WriteString(" | 0n")
+		}
+		source.WriteString(";\nBoolean(closed).flat(2);\nconst cacheAlias0 = closed;\n")
+		for depth := 1; depth <= 400; depth++ {
+			source.WriteString("const cacheAlias")
+			source.WriteString(strconv.Itoa(depth))
+			source.WriteString(" = cacheAlias")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(";\n")
+		}
+		source.WriteString("Boolean(cacheAlias400).flat(2);\n")
+		return source.String()
+	}
+	classificationCacheReplay := func() string {
+		var source strings.Builder
+		source.WriteString("const value0 = 1;\n")
+		for depth := 1; depth <= 400; depth++ {
+			source.WriteString("const value")
+			source.WriteString(strconv.Itoa(depth))
+			source.WriteString(" = value")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(";\n")
+		}
+		source.WriteString("value400.flat(2);\n")
+		for range 700 {
+			source.WriteString("(true ? ")
+		}
+		source.WriteString("value400")
+		for range 700 {
+			source.WriteString(" : 0)")
+		}
+		source.WriteString(".flat(2);\n")
+		return source.String()
+	}
+	classificationFanout := func(source *strings.Builder, value string) {
+		for range 1000 {
+			direct(source, value)
+		}
+	}
+	classificationDistinctRoots := func(source *strings.Builder, value string) {
+		for index := range 1000 {
+			source.WriteString("const root")
+			source.WriteString(strconv.Itoa(index))
+			source.WriteString(" = ")
+			source.WriteString(value)
+			source.WriteString("; root")
+			source.WriteString(strconv.Itoa(index))
+			source.WriteString(".flat(2);\n")
+		}
+	}
+	classificationDiamond := func() string {
+		var source strings.Builder
+		source.WriteString("const diamond0 = 1;\n")
+		for depth := 1; depth <= 24; depth++ {
+			source.WriteString("const diamond")
+			source.WriteString(strconv.Itoa(depth))
+			source.WriteString(" = flag ? diamond")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(" : diamond")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(";\n")
+		}
+		for range 50 {
+			source.WriteString("diamond24.flat(2);\n")
+		}
+		return source.String()
+	}
+	classificationUnknownDiamond := func() string {
+		var source strings.Builder
+		source.WriteString("const unknownDiamond0 = globalThis.flag ? 1 : [];\n")
+		for depth := 1; depth <= 24; depth++ {
+			source.WriteString("const unknownDiamond")
+			source.WriteString(strconv.Itoa(depth))
+			source.WriteString(" = globalThis.flag ? unknownDiamond")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(" : unknownDiamond")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(";\n")
+		}
+		source.WriteString("unknownDiamond24.flat(2);\n")
+		return source.String()
+	}
+	classificationTerminalPoison := func() string {
+		var source strings.Builder
+		source.WriteString("const poison0 = 1;\n")
+		for depth := 1; depth <= 400; depth++ {
+			source.WriteString("const poison")
+			source.WriteString(strconv.Itoa(depth))
+			source.WriteString(" = poison")
+			source.WriteString(strconv.Itoa(depth - 1))
+			source.WriteString(";\n")
+		}
+		for range 700 {
+			source.WriteString("(true ? ")
+		}
+		source.WriteString("poison400")
+		for range 700 {
+			source.WriteString(" : 0)")
+		}
+		source.WriteString(".flat(2);\npoison400.flat(2);\n")
+		return source.String()
+	}
+	classificationTerminalRecovery := func() string {
+		var source strings.Builder
+		source.WriteString(alias(1100, func(source *strings.Builder, value string) {
+			direct(source, value)
+			source.WriteString("value77.flat(2);\n")
+		}))
+		return source.String()
+	}
+	errors := make([]rule_tester.InvalidTestCaseError, 4)
+	for index := range errors {
+		errors[index] = rule_tester.InvalidTestCaseError{MessageId: messageID, Message: messageString}
+	}
+	aliasErrors := errors[:3]
+	cycleErrors := errors[:2]
+	fanoutErrors := make([]rule_tester.InvalidTestCaseError, 1000)
+	for index := range fanoutErrors {
+		fanoutErrors[index] = rule_tester.InvalidTestCaseError{MessageId: messageID, Message: messageString}
+	}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
+		[]rule_tester.ValidTestCase{
+			jsValid(conditional(128, mathAbs)),
+			jsValid(conditional(511, direct)),
+			jsValid(alias(128, mathAbs)),
+			jsValid(alias(512, classificationFanout)),
+			jsValid(alias(512, classificationDistinctRoots)),
+			jsValid(classificationDiamond()),
+		},
+		[]rule_tester.InvalidTestCase{
+			depthInvalid(conditional(512, direct)),
+			depthInvalid(conditional(1100, mathAbs)),
+			depthInvalid(alias(1100, mathAbs)),
+			depthInvalid(conditional(2000, warmArguments)),
+			{Code: conditional(2000, warmRoots), FileName: "file.js", Errors: errors},
+			{Code: alias(2000, warmAliasRoots), FileName: "file.js", Errors: aliasErrors},
+			depthInvalid(bigIntConditionalCache()),
+			depthInvalid(bigIntOperatorCache()),
+			depthInvalid(classificationCacheReplay()),
+			depthInvalid(classificationUnknownDiamond()),
+			{Code: alias(1100, classificationFanout), FileName: "file.js", Errors: fanoutErrors},
+			{Code: alias(1100, classificationDistinctRoots), FileName: "file.js", Errors: fanoutErrors},
+			{Code: classificationTerminalPoison(), FileName: "file.js", Errors: errors[:1]},
+			{Code: classificationTerminalRecovery(), FileName: "file.js", Errors: errors[:1]},
+			{
+				Code: "const cycleA = cycleB; const cycleB = cycleA;\n" +
+					"cycleA.flat(2); cycleB.flat(2);",
+				FileName: "file.js",
+				Errors:   cycleErrors,
+			},
+			{
+				Code: "const mixedCycleA = globalThis.flag ? 1 : mixedCycleB; const mixedCycleB = mixedCycleA;\n" +
+					"mixedCycleA.flat(2); mixedCycleB.flat(2);",
+				FileName: "file.js",
+				Errors:   cycleErrors,
+			},
+		},
+	)
+}
+
+func TestNoMagicArrayFlatDepthReceiverClassification(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		{Code: `declare const value: Set<number>; value.flat(2);`, FileName: "file.ts"},
+	}
+	for _, code := range []string{
+		`(() => {}).flat(2)`,
+		`(class {}).flat(2)`,
+		`Number(1).flat(2)`,
+		`String("x").flat(2)`,
+		`Boolean(0).flat(2)`,
+		`BigInt(1).flat(2)`,
+		`Number().flat(2)`,
+		`String().flat(2)`,
+		`Boolean().flat(2)`,
+		`String.fromCharCode(65).flat(2)`,
+		`String.fromCodePoint(65).flat(2)`,
+		`String.raw({raw: ["x"]}).flat(2)`,
+		`Math.abs(-2).flat(2)`,
+		`Math.max(1, 2).flat(2)`,
+		`Math.abs().flat(2)`,
+		`Math.max().flat(2)`,
+		`Array.isArray([]).flat(2)`,
+		`parseInt("2", 10).flat(2)`,
+		`parseFloat("2").flat(2)`,
+		`parseInt().flat(2)`,
+		`parseFloat().flat(2)`,
+		`Number.parseInt("2", 10).flat(2)`,
+		`Object().flat(2)`,
+		`Object(null).flat(2)`,
+		`Object.is(1, 1).flat(2)`,
+		`Object.isFrozen({}).flat(2)`,
+		`decodeURI("x").flat(2)`,
+		`Date(0).flat(2)`,
+		`RegExp("x").flat(2)`,
+		`RegExp("\\p{L}", "u").flat(2)`,
+		`RegExp("\\p{Script=Greek}", "u").flat(2)`,
+		`RegExp("(?<a>a)\\k<a>", "u").flat(2)`,
+		`RegExp("(?:(?<a>a))(?<b>b)", "u").flat(2)`,
+		`RegExp("(?<\\u0061>a)", "u").flat(2)`,
+		`RegExp("(?<\\u{1d49c}>a)").flat(2)`,
+		`RegExp("(?<a>a)[(?<\\u{61}>)]").flat(2)`,
+		`RegExp("\\k<a>").flat(2)`,
+		`RegExp("\\p{IsGreek}").flat(2)`,
+		`RegExp("\\p{").flat(2)`,
+		`RegExp("\\k<").flat(2)`,
+		`RegExp("\\p{Script=Garay}", "u").flat(2)`,
+		`RegExp("[[A--B]]", "v").flat(2)`,
+		`RegExp("".padEnd(98301, "(a)")).flat(2)`,
+		`RegExp("".padEnd(1000, "[") + "a" + "".padEnd(1000, "]"), "v").flat(2)`,
+		`(new RegExp(/a/g).global ? 1 : []).flat(2)`,
+		`(new RegExp(/a/g, undefined).flags === "g" ? 1 : []).flat(2)`,
+		`(new RegExp(RegExp("a", "u")).unicode ? 1 : []).flat(2)`,
+		`(new RegExp(/a/g, "i").flags === "i" ? 1 : []).flat(2)`,
+		`const re = /a/g; (RegExp(re) === re ? 1 : []).flat(2)`,
+		`RegExp({[Symbol.match]: false, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({[Symbol.match]: 0, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({[Symbol.match]: null, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({[Symbol.match]: undefined, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({source: "[", flags: "u"}).flat(2)`,
+		`(RegExp({[Symbol.match]: true, source: "x", flags: "g"}).flags === "g" ? 1 : []).flat(2)`,
+		`(RegExp({[Symbol.match]: true, source: "x", flags: "g"}, "").flags === "" ? 1 : []).flat(2)`,
+		`(RegExp({[Symbol.match]: true}).source === "(?:)" ? 1 : []).flat(2)`,
+		`(RegExp({[Symbol.match]: true, source: undefined, flags: undefined}).source === "(?:)" ? 1 : []).flat(2)`,
+		`(RegExp({__proto__: {[Symbol.match]: true, source: "x", flags: "g"}}).flags === "g" ? 1 : []).flat(2)`,
+		`(RegExp({[Symbol.match]: true, source: "x", flags: "g"}, undefined).flags === "g" ? 1 : []).flat(2)`,
+		`(RegExp({[Symbol.match]: true, source: "x", flags: "g"}, "i").flags === "i" ? 1 : []).flat(2)`,
+		`(new RegExp({[Symbol.match]: true, source: "x", flags: "g"}).flags === "g" ? 1 : []).flat(2)`,
+		`RegExp({[Symbol.match]: true, constructor: RegExp, source: "[", flags: "u"}).flat(2)`,
+		`(RegExp(RegExp.prototype) === RegExp.prototype ? 1 : []).flat(2)`,
+		`(new RegExp(RegExp.prototype).source === "(?:)" ? 1 : []).flat(2)`,
+		`const inherited = {__proto__: RegExp.prototype}; (RegExp(inherited) ? 1 : []).flat(2)`,
+		`[1].at(0).flat(2)`,
+		`[1].every(Boolean).flat(2)`,
+		`[1].find(Boolean).flat(2)`,
+		`[1].findIndex(Boolean).flat(2)`,
+		`[1].some(Boolean).flat(2)`,
+		`new Map().get("x").flat(2)`,
+		`new Set([1]).has(1).flat(2)`,
+		`Object.freeze({}).flat(2)`,
+		`Object.freeze().flat(2)`,
+		`Boolean(Symbol.iterator).flat(2)`,
+		`String(Symbol.iterator).flat(2)`,
+		`(Symbol.iterator.description === "Symbol.iterator" ? 1 : []).flat(2)`,
+		`(String(Symbol.iterator) === "Symbol(Symbol.iterator)" ? 1 : []).flat(2)`,
+		`(typeof Symbol.dispose === "symbol" ? 1 : []).flat(2)`,
+		`const value = 1; value.flat(2)`,
+		`const value = {}; value.flat(2)`,
+		`const value = "x"; value.flat(2)`,
+		`const value = function () {}; value.flat(2)`,
+		`const value = () => {}; value.flat(2)`,
+		`const value = Math.abs(-2); value.flat(2)`,
+		`(flag ? 2 : 1).flat(2)`,
+		`(flag ? Math.abs(-2) : 1).flat(2)`,
+		`(true ? 1 : []).flat(2)`,
+		`(unknown, 1).flat(2)`,
+		`(1, Math.PI).flat(2)`,
+		`(false || 1).flat(2)`,
+		`(0 && []).flat(2)`,
+		`(Math.abs(-2) && 1).flat(2)`,
+		`(Math.abs(0) && []).flat(2)`,
+		`(value = 1).flat(2)`,
+		`const M = Math; M.abs(-2).flat(2)`,
+		`let M = Math; M.abs(-2).flat(2)`,
+		`const abs = Math.abs; abs(-2).flat(2)`,
+		`const integer = parseInt; integer("2", 10).flat(2)`,
+		`const toNumber = Number; toNumber(1).flat(2)`,
+		`const A = Array; A.isArray([]).flat(2)`,
+		`const Math = {abs: Number}; Math.abs(-2).flat(2)`,
+		`const Array = {of: Number}; Array.of(1).flat(2)`,
+		`"".padStart(0, Symbol.iterator).flat(2)`,
+		`"".padEnd(Infinity, "").flat(2)`,
+		`(2n ** 1000001n).flat(2)`,
+		`(1n << 1000001n).flat(2)`,
+		`(1n >> -1000001n).flat(2)`,
+		`(Number(new Date(new String("2020-01-01"))) === 1577836800000 ? 1 : []).flat(2)`,
+		`(Object.is(Number(parseInt), NaN) ? 1 : []).flat(2)`,
+		`(BigInt([]) === 0n ? 1 : []).flat(2)`,
+		`(BigInt(new Date(0)) === 0n ? 1 : []).flat(2)`,
+		`((1e-7).toExponential(20) === "9.99999999999999954748e-8" ? 1 : []).flat(2)`,
+		`((1.5).toPrecision(1) === "2" ? 1 : []).flat(2)`,
+		`((1.25).toExponential(1) === "1.3e+0" ? 1 : []).flat(2)`,
+		`((1.25).toPrecision(2) === "1.3" ? 1 : []).flat(2)`,
+	} {
+		valid = append(valid, jsValid(code))
+	}
+
+	invalid := make([]rule_tester.InvalidTestCase, 0)
+	for _, code := range []string{
+		`Array.of(1).flat(2)`,
+		`Object.freeze([]).flat(2)`,
+		`Object([]).flat(2)`,
+		`Object.seal([]).flat(2)`,
+		`Object.preventExtensions([]).flat(2)`,
+		`Math.random().flat(2)`,
+		`Math.abs(value).flat(2)`,
+		`Array.isArray(value).flat(2)`,
+		`parseInt(value).flat(2)`,
+		`Object(value).flat(2)`,
+		`Object.freeze(value).flat(2)`,
+		`Number(value).flat(2)`,
+		`String(value).flat(2)`,
+		`Boolean(value).flat(2)`,
+		`BigInt(value).flat(2)`,
+		`BigInt().flat(2)`,
+		`BigInt("x").flat(2)`,
+		`BigInt(1.2).flat(2)`,
+		`BigInt(null).flat(2)`,
+		`Symbol().flat(2)`,
+		`Math.abs(1n).flat(2)`,
+		`Math.abs(Uint8Array.prototype).flat(2)`,
+		`Number(BigInt64Array.prototype).flat(2)`,
+		`Number(Symbol.iterator).flat(2)`,
+		`parseInt(Symbol.iterator).flat(2)`,
+		`String.fromCharCode(Symbol.iterator).flat(2)`,
+		`decodeURI("%").flat(2)`,
+		`RegExp("[").flat(2)`,
+		`RegExp("\\p{Greek}", "u").flat(2)`,
+		`RegExp("\\p{Hyphen}", "u").flat(2)`,
+		`RegExp("[\\P{Latin}]", "u").flat(2)`,
+		`RegExp("]", "u").flat(2)`,
+		`RegExp("a{2,1}").flat(2)`,
+		`RegExp("[a-\\d]", "u").flat(2)`,
+		`RegExp("(?=a)+", "u").flat(2)`,
+		`RegExp("(?i:a)").flat(2)`,
+		`RegExp("(?-i:a)").flat(2)`,
+		`RegExp("(?:(?<a>a))(?<a>b)").flat(2)`,
+		`RegExp("(?<a>a)|(?<\\u0061>b)", "u").flat(2)`,
+		`RegExp("\\k<a>", "u").flat(2)`,
+		`RegExp("(?<a>a)\\k<b>").flat(2)`,
+		`RegExp("(?>a)").flat(2)`,
+		`RegExp("[/]", "v").flat(2)`,
+		`RegExp("\\p{Script=Hrkt}", "u").flat(2)`,
+		`RegExp("\\p{", "u").flat(2)`,
+		`RegExp("".padEnd(600000, "\\p{"), "u").flat(2)`,
+		`RegExp("".padEnd(98304, "(a)")).flat(2)`,
+		`RegExp("".padEnd(4000, "[") + "a" + "".padEnd(4000, "]"), "v").flat(2)`,
+		`(new RegExp(/a/g).global ? [] : 1).flat(2)`,
+		`(new RegExp(/a/g, undefined).flags === "g" ? [] : 1).flat(2)`,
+		`(new RegExp(RegExp("a", "u")).unicode ? [] : 1).flat(2)`,
+		`const re = /a/g; (RegExp(re) === re ? [] : 1).flat(2)`,
+		`const re = /a/g; (new RegExp(re) === re ? 1 : []).flat(2)`,
+		`RegExp({[Symbol.match]: true, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({[Symbol.match]: true, source: "x", flags: "gg"}).flat(2)`,
+		`RegExp({[Symbol.match]: true, source: "x", get flags() { throw new Error(); }}).flat(2)`,
+		`RegExp({[Symbol.match]: 1, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({__proto__: {[Symbol.match]: true, source: "[", flags: "u"}}).flat(2)`,
+		`RegExp({[Symbol.match]: {}, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({[Symbol.match]: Symbol.iterator, source: "[", flags: "u"}).flat(2)`,
+		`RegExp({[Symbol.match]: true, source: Symbol.iterator, flags: ""}).flat(2)`,
+		`RegExp({[Symbol.match]: true, source: "x", flags: Symbol.iterator}).flat(2)`,
+		`(new RegExp({[Symbol.match]: true, source: "[", flags: "u"}).source ? 1 : []).flat(2)`,
+		`(new RegExp({[Symbol.match]: true, source: "x", flags: "gg"}).source ? 1 : []).flat(2)`,
+		`(RegExp(RegExp.prototype) === RegExp.prototype ? [] : 1).flat(2)`,
+		`(new RegExp(RegExp.prototype) === RegExp.prototype ? 1 : []).flat(2)`,
+		`(RegExp(RegExp.prototype, undefined) === RegExp.prototype ? [] : 1).flat(2)`,
+		`(RegExp(RegExp.prototype, "") === RegExp.prototype ? 1 : []).flat(2)`,
+		`(new RegExp(RegExp.prototype).source !== "(?:)" ? 1 : []).flat(2)`,
+		`(RegExp(RegExp.prototype, "").source !== "(?:)" ? 1 : []).flat(2)`,
+		`(new RegExp(RegExp.prototype, "g").flags !== "g" ? 1 : []).flat(2)`,
+		`const inherited = {__proto__: RegExp.prototype}; (new RegExp(inherited) ? 1 : []).flat(2)`,
+		`(Symbol.iterator.description === "iterator" ? 1 : []).flat(2)`,
+		`(String(Symbol.iterator) === "Symbol(iterator)" ? 1 : []).flat(2)`,
+		`Symbol.dispose.flat(2)`,
+		`Symbol.asyncDispose.flat(2)`,
+		`(Symbol.dispose.description === "dispose" ? 1 : []).flat(2)`,
+		`(Symbol.dispose === Symbol.for("nodejs.dispose") ? 1 : []).flat(2)`,
+		`(Symbol.dispose === Symbol.for("nodejs.dispose") ? [] : 1).flat(2)`,
+		`(Symbol.keyFor(Symbol.dispose) === undefined ? 1 : []).flat(2)`,
+		`(new Set([Symbol.dispose]).has(Symbol.for("nodejs.dispose")) ? 1 : []).flat(2)`,
+		`decodeURI("%FF").flat(2)`,
+		`(new Date(Date.prototype) ? 1 : []).flat(2)`,
+		`(new Date({[Symbol.toPrimitive]: 0}) ? 1 : []).flat(2)`,
+		`(new Date({valueOf: 0, toString: 0}) ? 1 : []).flat(2)`,
+		`[[]].at(0).flat(2)`,
+		`[1].filter(Boolean).flat(2)`,
+		`[[]].find(Boolean).flat(2)`,
+		`new Map([[1, []]]).get(1).flat(2)`,
+		`Object.keys({a: 1}).flat(2)`,
+		`Object.values({a: 1}).flat(2)`,
+		`Array.from([1]).flat(2)`,
+		`JSON.parse("[]").flat(2)`,
+		`const value = []; value.flat(2)`,
+		`const value = Array.of(1); value.flat(2)`,
+		`const A = Array; A.of(1).flat(2)`,
+		`const of = Array.of; of(1).flat(2)`,
+		`const value = Math.PI; value.flat(2)`,
+		`const a = b; const b = a; a.flat(2)`,
+		`let value = 1; value.flat(2)`,
+		`var value = 1; value.flat(2)`,
+		`const {value = 1} = {}; value.flat(2)`,
+		`(flag ? [] : []).flat(2)`,
+		`(flag ? [] : 1).flat(2)`,
+		`(flag ? Math.PI : 1).flat(2)`,
+		`(true ? [] : 1).flat(2)`,
+		`(unknown, []).flat(2)`,
+		`(true && []).flat(2)`,
+		`(flag || 1).flat(2)`,
+		`(flag && 1).flat(2)`,
+		`(flag ?? 1).flat(2)`,
+		`(value = []).flat(2)`,
+		`undefined.flat(2)`,
+		`NaN.flat(2)`,
+		`Infinity.flat(2)`,
+		`Number.NaN.flat(2)`,
+		`Math.PI.flat(2)`,
+		`Symbol.iterator.flat(2)`,
+		`new Uint8Array().flat(2)`,
+		`({flat() {}}).flat(2)`,
+		`"x".flat(2)`,
+		`let M = Math; M = other; M.abs(-2).flat(2)`,
+		`const Math = {abs(value) { return value; }}; Math.abs(-2).flat(2)`,
+		`(Object.is((-0) ** 3, -0) ? [] : 1).flat(2)`,
+		`(Object.is(Math.sin(0), 0) ? [] : 1).flat(2)`,
+		`(Object.isFrozen(Object.freeze({})) ? 1 : []).flat(2)`,
+		`(Boolean.prototype.toLocaleString === Object.prototype.toLocaleString ? [] : 1).flat(2)`,
+		`(new Set([Number.parseInt]).has(parseInt) ? [] : 1).flat(2)`,
+		`new Map([[Number.parseInt, []]]).get(parseInt).flat(2)`,
+		`(/x/.lastIndex === 0 ? [] : 1).flat(2)`,
+		`"".padStart(Infinity, "x").flat(2)`,
+		`"".padEnd(Infinity).flat(2)`,
+		`(2n ** 2147483648n).flat(2)`,
+		`(1n << 2147483648n).flat(2)`,
+		`(1n >> -2147483648n).flat(2)`,
+		`(Number(new Date(new String("2020-01-01"))) === 1577836800000 ? [] : 1).flat(2)`,
+		`(Object.is(Number(parseInt), NaN) ? [] : 1).flat(2)`,
+		`(BigInt([]) === 0n ? [] : 1).flat(2)`,
+		`(BigInt(new Date(0)) === 0n ? [] : 1).flat(2)`,
+		`((1e-7).toExponential(20) === "9.99999999999999954748e-8" ? [] : 1).flat(2)`,
+		`((1.5).toPrecision(1) === "2" ? [] : 1).flat(2)`,
+		`((1.25).toExponential(1) === "1.3e+0" ? [] : 1).flat(2)`,
+		`((1.25).toPrecision(2) === "1.3" ? [] : 1).flat(2)`,
+		`((1e21).toString(36) === "5v1j4f4ds7c000" ? [] : 1).flat(2)`,
+		`("\u{1CCD6}".normalize("NFKC") === "A" ? [] : 1).flat(2)`,
+		`("\uD800e\u0301".normalize("NFC") === "\uD800é" ? [] : 1).flat(2)`,
+		`("\uD800\u{1CCD6}".normalize("NFKC") === "\uD800A" ? [] : 1).flat(2)`,
+		`("A\u0345\u0897".normalize("NFD") === "A\u0897\u0345" ? [] : 1).flat(2)`,
+		`("\uA7CE".toLowerCase() === "\uA7CE" ? [] : 1).flat(2)`,
+		`("\uA7CF".toUpperCase() === "\uA7CF" ? [] : 1).flat(2)`,
+		`("\u0295Σ".toLowerCase() === "\u0295ς" ? [] : 1).flat(2)`,
+		`("AΣ\u1ACFB".toLowerCase() === "aς\u1ACFb" ? [] : 1).flat(2)`,
+		`using value = {}; value.flat(2)`,
+		`await using value = {}; value.flat(2)`,
+	} {
+		invalid = append(invalid, depthInvalid(code))
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
+		valid,
+		invalid,
+	)
+}

--- a/internal/plugins/unicorn/rules/require_array_join_separator/require_array_join_separator.go
+++ b/internal/plugins/unicorn/rules/require_array_join_separator/require_array_join_separator.go
@@ -15,33 +15,6 @@ var missingSeparatorMessage = rule.RuleMessage{
 	Description: "Missing the separator argument.",
 }
 
-func directCallParenthesesRange(sourceFile *ast.SourceFile, node *ast.Node) (core.TextRange, core.TextRange, bool) {
-	call := node.AsCallExpression()
-	if call == nil || call.Expression == nil {
-		return core.TextRange{}, core.TextRange{}, false
-	}
-
-	scanStart := call.Expression.End()
-	if call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 {
-		scanStart = call.TypeArguments.End()
-	}
-
-	s := scanner.GetScannerForSourceFile(sourceFile, scanStart)
-	for s.Token() != ast.KindOpenParenToken && s.TokenStart() < node.End() {
-		s.Scan()
-	}
-	if s.Token() != ast.KindOpenParenToken {
-		return core.TextRange{}, core.TextRange{}, false
-	}
-	opening := s.TokenRange()
-	s.Scan()
-	if s.Token() != ast.KindCloseParenToken || s.TokenEnd() != node.End() {
-		return core.TextRange{}, core.TextRange{}, false
-	}
-
-	return opening, s.TokenRange(), true
-}
-
 func prototypeCallSuffix(sourceFile *ast.SourceFile, node *ast.Node, argument *ast.Node) (core.TextRange, int, ast.Kind, bool) {
 	if argument == nil {
 		return core.TextRange{}, 0, ast.KindUnknown, false
@@ -118,7 +91,7 @@ var RequireArrayJoinSeparatorRule = rule.Rule{
 						return
 					}
 				} else {
-					opening, directClosing, ok := directCallParenthesesRange(ctx.SourceFile, node)
+					opening, directClosing, ok := unicornutil.CallExpressionParenthesesRange(ctx.SourceFile, node)
 					if !ok {
 						return
 					}

--- a/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
+++ b/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
@@ -3,7 +3,6 @@ package require_number_to_fixed_digits_argument
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -13,44 +12,6 @@ const messageID = "require-number-to-fixed-digits-argument"
 var missingDigitsMessage = rule.RuleMessage{
 	Id:          messageID,
 	Description: "Missing the digits argument.",
-}
-
-func callParenthesesRange(sourceFile *ast.SourceFile, node *ast.Node) (core.TextRange, core.TextRange, bool) {
-	call := node.AsCallExpression()
-	if call == nil || call.Expression == nil {
-		return core.TextRange{}, core.TextRange{}, false
-	}
-
-	scanStart := call.Expression.End()
-	if call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 {
-		scanStart = call.TypeArguments.End()
-	}
-
-	s := scanner.GetScannerForSourceFile(sourceFile, scanStart)
-	var opening core.TextRange
-	depth := 0
-	foundOpening := false
-	for s.TokenStart() < node.End() {
-		switch s.Token() {
-		case ast.KindOpenParenToken:
-			if !foundOpening {
-				opening = s.TokenRange()
-				foundOpening = true
-			}
-			depth++
-		case ast.KindCloseParenToken:
-			if !foundOpening {
-				return core.TextRange{}, core.TextRange{}, false
-			}
-			depth--
-			if depth == 0 {
-				return opening, s.TokenRange(), true
-			}
-		}
-		s.Scan()
-	}
-
-	return core.TextRange{}, core.TextRange{}, false
 }
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/require-number-to-fixed-digits-argument.md
@@ -78,7 +39,7 @@ var RequireNumberToFixedDigitsArgumentRule = rule.Rule{
 					return
 				}
 
-				opening, closing, ok := callParenthesesRange(ctx.SourceFile, node)
+				opening, closing, ok := unicornutil.CallExpressionParenthesesRange(ctx.SourceFile, node)
 				if !ok {
 					return
 				}

--- a/internal/plugins/unicorn/unicornutil/array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/array_receiver.go
@@ -68,23 +68,84 @@ var typedArrayNames = []string{
 }
 
 type arrayReceiverStaticEvaluatorFileCacheKey struct{}
+type sourceOnlyArrayReceiverStaticEvaluatorFileCacheKey struct{}
+type sourceOnlyArrayReceiverClassificationFileCacheKey struct{}
+
+type sourceOnlyArrayReceiverClassificationCache struct {
+	symbols map[*ast.Symbol]sourceOnlyArrayReceiverClassificationEntry
+}
+
+type sourceOnlyArrayReceiverClassificationEntry struct {
+	class           arrayClass
+	additionalDepth int
+	terminal        bool
+}
+
+type arrayReceiverClassifier struct {
+	ctx                  rule.RuleContext
+	targetNames          *utils.Set[string]
+	nonTargetNames       *utils.Set[string]
+	staticEvaluator      *utils.StaticStringEvaluator
+	allowTypeInformation bool
+	sourceOnlySemantics  bool
+	recursionDepth       int
+	recursionPeak        int
+	recursionExhausted   bool
+	sourceOnlyCache      *sourceOnlyArrayReceiverClassificationCache
+}
+
+const maxSourceOnlyArrayReceiverDepth = 1 << 10
 
 // classifyArrayReceiver mirrors the syntactic short-circuits of unicorn's
 // getType (array literals, Array()/new Array()/Array.from/Array.of), then falls
 // back to a type-checker classification analogous to getTypeScriptType.
 func classifyArrayReceiver(ctx rule.RuleContext, node *ast.Node, targetNames, nonTargetNames *utils.Set[string]) arrayClass {
-	return classifyArrayReceiverInner(ctx, node, targetNames, nonTargetNames, map[*ast.Symbol]bool{})
+	classifier := arrayReceiverClassifier{
+		ctx:                  ctx,
+		targetNames:          targetNames,
+		nonTargetNames:       nonTargetNames,
+		staticEvaluator:      arrayReceiverStaticEvaluator(ctx),
+		allowTypeInformation: true,
+	}
+	return classifier.classify(node, map[*ast.Symbol]bool{})
 }
 
-func classifyArrayReceiverInner(
-	ctx rule.RuleContext,
-	node *ast.Node,
-	targetNames, nonTargetNames *utils.Set[string],
-	visitedSymbols map[*ast.Symbol]bool,
-) arrayClass {
+func classifySourceOnlyIndexedCollectionReceiver(ctx rule.RuleContext, node *ast.Node) arrayClass {
+	classifier := arrayReceiverClassifier{
+		ctx:                 ctx,
+		targetNames:         indexedCollectionTargets,
+		nonTargetNames:      keyedCollectionNames,
+		staticEvaluator:     sourceOnlyArrayReceiverStaticEvaluator(ctx),
+		sourceOnlySemantics: true,
+		sourceOnlyCache:     sourceOnlyArrayReceiverClassificationCacheForFile(ctx),
+	}
+	return classifier.classify(node, map[*ast.Symbol]bool{})
+}
+
+func (classifier *arrayReceiverClassifier) classify(node *ast.Node, visitedSymbols map[*ast.Symbol]bool) arrayClass {
+	if classifier.sourceOnlySemantics {
+		if classifier.recursionExhausted {
+			return arrayClassUnknown
+		}
+		if classifier.recursionDepth >= maxSourceOnlyArrayReceiverDepth {
+			// Treat exhaustion as terminal for this receiver. Otherwise an outer
+			// conditional can retry a shorter suffix with the static evaluator
+			// while unwinding and effectively segment an unbounded chain.
+			classifier.recursionExhausted = true
+			return arrayClassUnknown
+		}
+		classifier.recursionDepth++
+		classifier.recursionPeak = max(classifier.recursionPeak, classifier.recursionDepth)
+		defer func() { classifier.recursionDepth-- }()
+	}
 	if node == nil {
 		return arrayClassUnknown
 	}
+	parenthesizedOptionalAccess := classifier.sourceOnlySemantics && node.Kind == ast.KindParenthesizedExpression &&
+		func() bool {
+			inner := ast.SkipParentheses(node)
+			return inner != nil && ast.IsAccessExpression(inner) && ast.IsOptionalChain(inner)
+		}()
 	node = ast.SkipParentheses(node)
 	if node == nil {
 		return arrayClassUnknown
@@ -94,62 +155,82 @@ func classifyArrayReceiverInner(
 	// expression itself. Assertions are different: an informative annotation
 	// wins, while any / unknown falls through to the wrapped expression.
 	if node.Kind == ast.KindSatisfiesExpression {
-		return classifyArrayReceiverInner(
-			ctx, node.AsSatisfiesExpression().Expression, targetNames, nonTargetNames, visitedSymbols,
-		)
+		return classifier.classify(node.AsSatisfiesExpression().Expression, visitedSymbols)
 	}
 	if node.Kind == ast.KindAsExpression || node.Kind == ast.KindTypeAssertionExpression {
-		if class := classifyArrayTypeNode(ctx, node.Type(), targetNames, nonTargetNames, map[*ast.Symbol]bool{}); class != arrayClassUnknown {
+		if class := classifyArrayTypeNode(
+			classifier.ctx, node.Type(), classifier.targetNames, classifier.nonTargetNames, map[*ast.Symbol]bool{},
+		); class != arrayClassUnknown {
 			return class
 		}
-		return classifyArrayReceiverInner(ctx, node.Expression(), targetNames, nonTargetNames, visitedSymbols)
+		return classifier.classify(node.Expression(), visitedSymbols)
 	}
 	if node.Kind == ast.KindNonNullExpression {
-		return classifyArrayReceiverInner(ctx, node.Expression(), targetNames, nonTargetNames, visitedSymbols)
+		return classifier.classify(node.Expression(), visitedSymbols)
+	}
+	// An array literal is a target even when one of its elements cannot be
+	// folded. Taking this shape shortcut before static evaluation also avoids
+	// rebuilding deeply nested literal aliases just to rediscover the outer
+	// array kind.
+	if classifier.sourceOnlySemantics && node.Kind == ast.KindArrayLiteralExpression {
+		return arrayClassTarget
 	}
 
 	if ast.IsIdentifier(node) {
-		if class := classifyArrayIdentifier(ctx, node, targetNames, nonTargetNames, visitedSymbols); class != arrayClassUnknown {
+		if class := classifier.classifyIdentifier(node, visitedSymbols); class != arrayClassUnknown {
 			return class
+		}
+		if classifier.recursionExhausted {
+			return arrayClassUnknown
 		}
 	}
 	if node.Kind == ast.KindConditionalExpression {
 		conditional := node.AsConditionalExpression()
-		return combineArrayClassesUnion([]arrayClass{
-			classifyArrayReceiverInner(ctx, conditional.WhenTrue, targetNames, nonTargetNames, visitedSymbols),
-			classifyArrayReceiverInner(ctx, conditional.WhenFalse, targetNames, nonTargetNames, visitedSymbols),
+		class := combineArrayClassesUnion([]arrayClass{
+			classifier.classify(conditional.WhenTrue, visitedSymbols),
+			classifier.classify(conditional.WhenFalse, visitedSymbols),
 		})
+		if classifier.recursionExhausted {
+			return arrayClassUnknown
+		}
+		if !classifier.sourceOnlySemantics || class != arrayClassUnknown {
+			return class
+		}
 	}
 	if ast.IsBinaryExpression(node) &&
 		node.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken {
-		return classifyArrayReceiverInner(
-			ctx, node.AsBinaryExpression().Right, targetNames, nonTargetNames, visitedSymbols,
-		)
+		class := classifier.classify(node.AsBinaryExpression().Right, visitedSymbols)
+		if classifier.recursionExhausted {
+			return arrayClassUnknown
+		}
+		if !classifier.sourceOnlySemantics || class != arrayClassUnknown {
+			return class
+		}
 	}
-
 	// getStaticValue runs before Unicorn's syntactic target/non-target checks.
-	// Identifier and member expressions are intentionally excluded even when
-	// eslint-utils can fold them; upstream keeps those shapes unknown.
-	if !ast.IsIdentifier(node) && !ast.IsAccessExpression(node) {
-		staticEvaluator := arrayReceiverStaticEvaluator(ctx)
-		if isArray, known := staticEvaluator.EvalArrayValue(node); known {
+	// A known array member is still a target; a known non-array member stays
+	// unknown, matching upstream's getStaticType special case.
+	if !ast.IsIdentifier(node) && (classifier.sourceOnlySemantics || !ast.IsAccessExpression(node)) {
+		if isArray, known := classifier.staticEvaluator.EvalArrayValue(node); known {
 			if isArray {
 				return arrayClassTarget
 			}
-			return arrayClassNonTarget
+			if !classifier.sourceOnlySemantics || !ast.IsAccessExpression(node) || parenthesizedOptionalAccess {
+				return arrayClassNonTarget
+			}
 		}
 	}
 
 	if isSyntacticArrayNode(node) {
 		return arrayClassTarget
 	}
-	if isSyntacticTargetConstructor(node, targetNames) {
+	if isSyntacticTargetConstructor(node, classifier.targetNames) {
 		return arrayClassTarget
 	}
 
-	if ctx.TypeChecker != nil {
-		t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)
-		if class := classifyArrayType(ctx, t, targetNames); class != arrayClassUnknown {
+	if classifier.allowTypeInformation && classifier.ctx.TypeChecker != nil {
+		t := utils.GetConstrainedTypeAtLocation(classifier.ctx.TypeChecker, node)
+		if class := classifyArrayType(classifier.ctx, t, classifier.targetNames); class != arrayClassUnknown {
 			return class
 		}
 	}
@@ -168,17 +249,90 @@ func arrayReceiverStaticEvaluator(ctx rule.RuleContext) *utils.StaticStringEvalu
 	})
 }
 
-func classifyArrayIdentifier(
+func sourceOnlyArrayReceiverStaticEvaluator(ctx rule.RuleContext) *utils.StaticStringEvaluator {
+	return rule.CachedByFile(ctx, sourceOnlyArrayReceiverStaticEvaluatorFileCacheKey{}, func() *utils.StaticStringEvaluator {
+		return utils.NewStaticStringEvaluatorForSourceOnlyStaticValue(
+			ctx.SourceFile, sourceOnlyStaticReferenceResolver{refs: ctx.Refs, globals: ctx.Globals},
+		)
+	})
+}
+
+func sourceOnlyArrayReceiverClassificationCacheForFile(
 	ctx rule.RuleContext,
+) *sourceOnlyArrayReceiverClassificationCache {
+	return rule.CachedByFile(ctx, sourceOnlyArrayReceiverClassificationFileCacheKey{}, func() *sourceOnlyArrayReceiverClassificationCache {
+		return &sourceOnlyArrayReceiverClassificationCache{
+			symbols: map[*ast.Symbol]sourceOnlyArrayReceiverClassificationEntry{},
+		}
+	})
+}
+
+type sourceOnlyStaticReferenceResolver struct {
+	refs    *rule.RefStore
+	globals rule.Globals
+}
+
+func (resolver sourceOnlyStaticReferenceResolver) Resolve(node *ast.Node) *ast.Symbol {
+	if resolver.refs == nil {
+		return nil
+	}
+	return resolver.refs.ResolveInFile(node)
+}
+
+func (resolver sourceOnlyStaticReferenceResolver) IsUnshadowedGlobal(node *ast.Node, name string) bool {
+	return resolver.refs != nil && node != nil && ast.IsIdentifier(node) &&
+		node.AsIdentifier().Text == name && resolver.globals.Access(name).IsDeclared() &&
+		!resolver.refs.IsDefinedInFile(node)
+}
+
+func (classifier *arrayReceiverClassifier) classifyIdentifier(
 	idNode *ast.Node,
-	targetNames, nonTargetNames *utils.Set[string],
 	visitedSymbols map[*ast.Symbol]bool,
-) arrayClass {
-	if ctx.Refs == nil || idNode == nil {
+) (class arrayClass) {
+	if classifier.ctx.Refs == nil || idNode == nil {
 		return arrayClassUnknown
 	}
-	symbol := ctx.Refs.ResolveInFile(idNode)
-	if symbol == nil || visitedSymbols[symbol] || len(symbol.Declarations) != 1 {
+	symbol := classifier.ctx.Refs.ResolveInFile(idNode)
+	if symbol == nil {
+		return arrayClassUnknown
+	}
+	if visitedSymbols[symbol] {
+		return arrayClassUnknown
+	}
+	memoizeClassification := classifier.sourceOnlySemantics && classifier.sourceOnlyCache != nil
+	if memoizeClassification {
+		if cached, exists := classifier.sourceOnlyCache.symbols[symbol]; exists {
+			if class, replay := classifier.replaySourceOnlyClassification(cached); replay {
+				return class
+			}
+		}
+		startDepth := classifier.recursionDepth
+		previousPeak := classifier.recursionPeak
+		classifier.recursionPeak = startDepth
+		defer func() {
+			localPeak := classifier.recursionPeak
+			classifier.recursionPeak = max(previousPeak, localPeak)
+			// Unknown is a stable, conservative result for an immutable symbol
+			// too. Publishing only after the initializer has been classified keeps
+			// cycles out of the lookup path, while memoizing unknown prevents a
+			// shared conditional dependency from expanding exponentially.
+			entry := sourceOnlyArrayReceiverClassificationEntry{
+				class:           class,
+				additionalDepth: localPeak - startDepth,
+			}
+			if classifier.recursionExhausted {
+				// The rejected next node proves that this symbol needs at least one
+				// level beyond the observed peak. Deeper contexts can replay the
+				// terminal unknown in O(1); shallower contexts recompute and replace
+				// it with either an exact result or a stronger lower bound.
+				entry.class = arrayClassUnknown
+				entry.additionalDepth++
+				entry.terminal = true
+			}
+			classifier.sourceOnlyCache.symbols[symbol] = entry
+		}()
+	}
+	if len(symbol.Declarations) != 1 {
 		return arrayClassUnknown
 	}
 	visitedSymbols[symbol] = true
@@ -189,7 +343,9 @@ func classifyArrayIdentifier(
 		return arrayClassUnknown
 	}
 	if annotation := arrayBindingTypeAnnotation(declaration); annotation != nil {
-		if class := classifyArrayTypeNode(ctx, annotation, targetNames, nonTargetNames, map[*ast.Symbol]bool{}); class != arrayClassUnknown {
+		if class := classifyArrayTypeNode(
+			classifier.ctx, annotation, classifier.targetNames, classifier.nonTargetNames, map[*ast.Symbol]bool{},
+		); class != arrayClassUnknown {
 			return class
 		}
 	}
@@ -199,11 +355,32 @@ func classifyArrayIdentifier(
 	declarationList := declaration.Parent
 	variable := declaration.AsVariableDeclaration()
 	if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) ||
-		declarationList.Flags&ast.NodeFlagsConst == 0 || variable.Name() == nil ||
+		declarationList.Flags&ast.NodeFlagsConst == 0 ||
+		classifier.sourceOnlySemantics && (ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList)) ||
+		variable.Name() == nil ||
 		!ast.IsIdentifier(variable.Name()) || variable.Initializer == nil {
 		return arrayClassUnknown
 	}
-	return classifyArrayReceiverInner(ctx, variable.Initializer, targetNames, nonTargetNames, visitedSymbols)
+	return classifier.classify(variable.Initializer, visitedSymbols)
+}
+
+func (classifier *arrayReceiverClassifier) replaySourceOnlyClassification(
+	entry sourceOnlyArrayReceiverClassificationEntry,
+) (arrayClass, bool) {
+	projectedDepth := classifier.recursionDepth + entry.additionalDepth
+	if projectedDepth > maxSourceOnlyArrayReceiverDepth {
+		// Recreate the terminal state and peak that produced this conservative
+		// result. Otherwise an outer symbol can store an undersized lower bound,
+		// or a conditional/comma expression can bypass the guard via static eval.
+		classifier.recursionPeak = max(classifier.recursionPeak, maxSourceOnlyArrayReceiverDepth)
+		classifier.recursionExhausted = true
+		return arrayClassUnknown, true
+	}
+	if entry.terminal {
+		return arrayClassUnknown, false
+	}
+	classifier.recursionPeak = max(classifier.recursionPeak, projectedDepth)
+	return entry.class, true
 }
 
 // arrayBindingTypeAnnotation mirrors definition.name?.typeAnnotation in

--- a/internal/plugins/unicorn/unicornutil/array_receiver_cache_test.go
+++ b/internal/plugins/unicorn/unicornutil/array_receiver_cache_test.go
@@ -1,0 +1,30 @@
+package unicornutil
+
+import "testing"
+
+func TestReplaySourceOnlyClassificationDepthBoundary(t *testing.T) {
+	terminal := sourceOnlyArrayReceiverClassificationEntry{
+		class: arrayClassUnknown, additionalDepth: 1, terminal: true,
+	}
+	classifier := arrayReceiverClassifier{recursionDepth: maxSourceOnlyArrayReceiverDepth - 1}
+	if _, replay := classifier.replaySourceOnlyClassification(terminal); replay || classifier.recursionExhausted {
+		t.Fatal("a terminal lower bound equal to the depth limit was replayed instead of recomputed")
+	}
+
+	classifier = arrayReceiverClassifier{recursionDepth: maxSourceOnlyArrayReceiverDepth}
+	if class, replay := classifier.replaySourceOnlyClassification(terminal); !replay || class != arrayClassUnknown || !classifier.recursionExhausted ||
+		classifier.recursionPeak != maxSourceOnlyArrayReceiverDepth {
+		t.Fatalf("terminal overflow replay = (%v, %v, exhausted=%v, peak=%d)",
+			class, replay, classifier.recursionExhausted, classifier.recursionPeak)
+	}
+
+	exact := sourceOnlyArrayReceiverClassificationEntry{
+		class: arrayClassNonTarget, additionalDepth: 2,
+	}
+	classifier = arrayReceiverClassifier{recursionDepth: maxSourceOnlyArrayReceiverDepth - 1}
+	if class, replay := classifier.replaySourceOnlyClassification(exact); !replay || class != arrayClassUnknown || !classifier.recursionExhausted ||
+		classifier.recursionPeak != maxSourceOnlyArrayReceiverDepth {
+		t.Fatalf("exact-cache overflow replay = (%v, %v, exhausted=%v, peak=%d)",
+			class, replay, classifier.recursionExhausted, classifier.recursionPeak)
+	}
+}

--- a/internal/plugins/unicorn/unicornutil/call_expression.go
+++ b/internal/plugins/unicorn/unicornutil/call_expression.go
@@ -1,0 +1,61 @@
+package unicornutil
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// CallExpressionParenthesesRange returns the actual opening and closing
+// parenthesis tokens of a call. It starts after type arguments and after the
+// final argument, so parentheses inside either cannot be mistaken for the
+// call's delimiters.
+func CallExpressionParenthesesRange(sourceFile *ast.SourceFile, node *ast.Node) (core.TextRange, core.TextRange, bool) {
+	if sourceFile == nil || node == nil {
+		return core.TextRange{}, core.TextRange{}, false
+	}
+	call := node.AsCallExpression()
+	if call == nil || call.Expression == nil {
+		return core.TextRange{}, core.TextRange{}, false
+	}
+	// The parser records the argument-list span immediately after consuming
+	// `(`, while the call node ends immediately after `)`. This is the common
+	// non-recovery path and avoids allocating two scanners per call.
+	if call.Arguments != nil {
+		text := sourceFile.Text()
+		openingPos, closingPos := call.Arguments.Pos()-1, node.End()-1
+		if openingPos >= 0 && closingPos > openingPos && closingPos < len(text) &&
+			text[openingPos] == '(' && text[closingPos] == ')' {
+			return core.NewTextRange(openingPos, openingPos+1),
+				core.NewTextRange(closingPos, closingPos+1), true
+		}
+	}
+
+	scanStart := call.Expression.End()
+	if call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 {
+		scanStart = call.TypeArguments.End()
+	}
+	s := scanner.GetScannerForSourceFile(sourceFile, scanStart)
+	for s.Token() != ast.KindOpenParenToken && s.TokenStart() < node.End() {
+		s.Scan()
+	}
+	if s.Token() != ast.KindOpenParenToken {
+		return core.TextRange{}, core.TextRange{}, false
+	}
+	opening := s.TokenRange()
+
+	suffixStart := opening.End()
+	arguments := node.Arguments()
+	if len(arguments) > 0 {
+		suffixStart = arguments[len(arguments)-1].End()
+	}
+	s = scanner.GetScannerForSourceFile(sourceFile, suffixStart)
+	if s.Token() == ast.KindCommaToken {
+		s.Scan()
+	}
+	if s.Token() != ast.KindCloseParenToken || s.TokenEnd() != node.End() {
+		return core.TextRange{}, core.TextRange{}, false
+	}
+
+	return opening, s.TokenRange(), true
+}

--- a/internal/plugins/unicorn/unicornutil/call_expression_test.go
+++ b/internal/plugins/unicorn/unicornutil/call_expression_test.go
@@ -1,0 +1,31 @@
+package unicornutil
+
+import "testing"
+
+func TestCallExpressionParenthesesRange(t *testing.T) {
+	for _, code := range []string{
+		`array.flat /* outside */ (2)`,
+		`fn?.()`,
+		`fn<(value: number) => number>()`,
+		`fn(/\)/,)`,
+		"fn(`)`,)",
+	} {
+		t.Run(code, func(t *testing.T) {
+			sourceFile := parseTestSource(code)
+			call := findTestCall(t, sourceFile, code)
+			opening, closing, ok := CallExpressionParenthesesRange(sourceFile, call)
+			if !ok {
+				t.Fatal("CallExpressionParenthesesRange returned false")
+			}
+			if got := sourceFile.Text()[opening.Pos():opening.End()]; got != "(" {
+				t.Fatalf("opening token = %q, want (", got)
+			}
+			if got := sourceFile.Text()[closing.Pos():closing.End()]; got != ")" {
+				t.Fatalf("closing token = %q, want )", got)
+			}
+			if opening.Pos() <= call.Expression().End() && code == `array.flat /* outside */ (2)` {
+				t.Fatal("opening token must start after the callee-side comment")
+			}
+		})
+	}
+}

--- a/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
@@ -1,35 +1,17 @@
 package unicornutil
 
 import (
-	"path/filepath"
-
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
-// directlyReportableReceiverTypes is the set of ESTree node kinds that
-// should be reported even when the receiver is "statically known not to be
-// an array" (a string literal, a literal object, a function expression, …).
-// The mismatch is visible at the call site, so reporting it is the right
-// thing to do.
-//
-// This mirrors the upstream `shouldSkipKnownNonArrayReceiver` helper in
-// eslint-plugin-unicorn. The kinds listed here correspond to ESTree's
-// "directly visible" syntactic node categories: array / object / function
-// literals and template literals. Critically, `ArrowFunctionExpression` and
-// `ClassExpression` are NOT in the set — they fall through to
-// `isKnownNonIndexedCollection`, which classifies them as non-array
-// expressions and therefore skips them. That mirrors upstream's deliberate
-// `nonArrayExpressionTypes` set in `is-array.js`.
+// isDirectlyReportableReceiver mirrors the ESTree node kinds Unicorn reports
+// even when the expression is visibly not an array. Arrow and class
+// expressions are deliberately absent: upstream classifies those as known
+// non-arrays and skips them.
 func isDirectlyReportableReceiver(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	// ESTree / upstream transparently unwraps parens; tsgo keeps
-	// ParenthesizedExpression nodes, so strip them before classifying.
-	node = ast.SkipParentheses(node)
-	if node == nil {
+	if node = ast.SkipParentheses(node); node == nil {
 		return false
 	}
 	switch node.Kind {
@@ -50,139 +32,26 @@ func isDirectlyReportableReceiver(node *ast.Node) bool {
 	return false
 }
 
-// isSourceOnlyFile reports whether the file is a non-TypeScript source
-// (`.mjs`, `.js`, `.cjs`, …) where the type checker's global type
-// information would over-classify a bare identifier / member / call
-// receiver that the upstream parser would leave "unknown". When the file
-// is TypeScript, the type annotation / type-service path stays in charge.
+// isSourceOnlyFile reports whether Unicorn receives the file without parser
+// type services. The source-only classifier must not use tsgo's lib.d.ts
+// knowledge, which would turn upstream-unknown JavaScript expressions into
+// known non-arrays.
 func isSourceOnlyFile(ctx rule.RuleContext) bool {
 	if ctx.SourceFile == nil {
 		return true
 	}
-	name := ctx.SourceFile.FileName()
-	if name == "" {
-		return true
-	}
-	ext := ecmascript.StringToLowerCase(filepath.Ext(name))
-	return ext != ".ts" && ext != ".tsx" && ext != ".mts" && ext != ".cts"
+	return ctx.SourceFile.ScriptKind == core.ScriptKindJS || ctx.SourceFile.ScriptKind == core.ScriptKindJSX
 }
 
-// ShouldSkipKnownNonArrayReceiver mirrors the upstream helper of the same
-// name. A receiver that is statically known to be a non-array (a typed Set,
-// a custom class with a same-named method, etc.) should be skipped UNLESS
-// the receiver is one of the directly-reportable kinds above, in which case
-// the mismatch between the receiver and `Array#flat()` is visible at the
-// call site and worth reporting.
-//
-// A typed-array receiver is still reported, since it shares most of
-// `Array`'s method surface and `flat()` is not on its prototype at all.
-// `require-array-sort-compare` (which needs typed arrays to be skipped)
-// should call `IsKnownNonArray` directly instead.
-//
-// The rslint tsgo type checker has global type information for built-in
-// identifiers (e.g. `undefined` → Undefined, `Symbol` → Symbol,
-// `Math.random()` → number) that the upstream parser does NOT have. For a
-// source-only `.mjs` input, the type checker would over-classify these as
-// known non-arrays and silence reports that upstream emits. The helper
-// therefore takes a source-only path that mirrors upstream's
-// `getTypeFromStaticValue` returning "unknown" for those shapes, and only
-// falls back to `IsKnownNonIndexedCollection` (and therefore the type
-// checker) for `.ts` inputs where type annotations make the classification
-// defensible.
+// ShouldSkipKnownNonArrayReceiver mirrors Unicorn's helper of the same name.
+// JavaScript uses the source-only recursive/static classifier; TypeScript keeps
+// the existing annotation and type-information path.
 func ShouldSkipKnownNonArrayReceiver(ctx rule.RuleContext, node *ast.Node) bool {
 	if isDirectlyReportableReceiver(node) {
 		return false
 	}
-
-	// Coercion constructors: the only CallExpression callees upstream's
-	// `getStaticValueForControlFlow` reliably folds to a known non-array
-	// value (a number, string, boolean, or bigint). `Symbol()` is
-	// deliberately excluded because every call returns a unique Symbol
-	// and cannot be folded.
-	if isNonArrayCoercionConstructorCall(ctx, node) {
-		return true
-	}
-
-	// For CallExpression, the shared static evaluator folds a handful
-	// of cases like `String.fromCharCode(65)` and `Array.of(...)`. If
-	// it resolves to a non-array value, trust that result.
-	if isSourceOnlyFile(ctx) && ast.IsCallExpression(node) {
-		staticEvaluator := arrayReceiverStaticEvaluator(ctx)
-		if _, known := staticEvaluator.EvalArrayValue(node); known {
-			return true
-		}
-	}
-
-	// Source-only path: trust upstream's "unknown" classification for
-	// identifier / member / call receivers. We deliberately skip the
-	// shared static evaluator for those shapes because it folds
-	// identifiers like `undefined` to a known non-array value that the
-	// upstream parser does NOT fold.
 	if isSourceOnlyFile(ctx) {
-		if isShapeUpstreamUnknown(node) {
-			return false
-		}
+		return classifySourceOnlyIndexedCollectionReceiver(ctx, node) == arrayClassNonTarget
 	}
-
 	return IsKnownNonIndexedCollection(ctx, node)
-}
-
-// isShapeUpstreamUnknown reports whether node is one of the shapes
-// upstream's parser leaves "unknown" for source-only files. The shared
-// rslint static evaluator would also fold these (e.g. `undefined` →
-// Undefined), but the upstream parser does not, so the rule fires.
-func isShapeUpstreamUnknown(node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
-	if node == nil {
-		return false
-	}
-	// Strip type annotations / assertions / non-null so a TS-only
-	// expression like `(x as number)` is treated by its underlying shape.
-	node = ast.SkipOuterExpressions(node, ast.OEKAll)
-	if node == nil {
-		return false
-	}
-	if ast.IsIdentifier(node) {
-		return true
-	}
-	if ast.IsAccessExpression(node) {
-		return true
-	}
-	if ast.IsCallExpression(node) {
-		return true
-	}
-	return false
-}
-
-// isNonArrayCoercionConstructorCall reports whether node is a bare call
-// to one of the four coercion constructors whose result is statically
-// known to be a non-array primitive: `Number(...)`, `String(...)`,
-// `Boolean(...)`, `BigInt(...)`. Upstream's
-// `getStaticValueForControlFlow` folds these to a primitive value; the
-// rslint static evaluator does not, so we mirror the upstream shape here.
-//
-// `Symbol()` is excluded: every call returns a unique Symbol and the
-// static evaluator cannot fold it. `parseInt` / `parseFloat` / `Object()`
-// are also excluded for the same reason — they aren't on the upstream
-// `staticGlobalProperties` allowlist, and the rslint type checker would
-// over-classify their return type for `.mjs` inputs.
-func isNonArrayCoercionConstructorCall(ctx rule.RuleContext, node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
-	if !ast.IsCallExpression(node) {
-		return false
-	}
-	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, ast.OEKParentheses|ast.OEKAssertions)
-	if !ast.IsIdentifier(callee) {
-		return false
-	}
-	// If the callee resolves to a local binding, the user's declaration
-	// wins; fall through to IsKnownNonIndexedCollection.
-	if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
-		return false
-	}
-	switch callee.AsIdentifier().Text {
-	case "Number", "String", "Boolean", "BigInt":
-		return true
-	}
-	return false
 }

--- a/internal/utils/ecmascript/code_units.go
+++ b/internal/utils/ecmascript/code_units.go
@@ -25,6 +25,34 @@ func StringCodeUnits(s string) []uint16 {
 	return units
 }
 
+// StringFromCodeUnits writes UTF-16 code units in the WTF-8 representation
+// used by compiler string values. Valid surrogate pairs become their scalar
+// value, while a lone surrogate keeps the three bytes that identify that
+// exact JavaScript code unit.
+func StringFromCodeUnits(units []uint16) string {
+	var builder strings.Builder
+	builder.Grow(len(units))
+	for index := 0; index < len(units); index++ {
+		unit := units[index]
+		if unit >= 0xD800 && unit <= 0xDBFF && index+1 < len(units) {
+			next := units[index+1]
+			if next >= 0xDC00 && next <= 0xDFFF {
+				builder.WriteRune(utf16.DecodeRune(rune(unit), rune(next)))
+				index++
+				continue
+			}
+		}
+		if unit >= 0xD800 && unit <= 0xDFFF {
+			builder.WriteByte(0xE0 | byte(unit>>12))
+			builder.WriteByte(0x80 | byte(unit>>6&0x3F))
+			builder.WriteByte(0x80 | byte(unit&0x3F))
+			continue
+		}
+		builder.WriteRune(rune(unit))
+	}
+	return builder.String()
+}
+
 // StringCodeUnitCount reports s's length in the UTF-16 code units counted by
 // JavaScript String#length. Unlike core.UTF16Len, it also preserves lone
 // surrogates in the WTF-8 form used by compiler string values.

--- a/internal/utils/ecmascript/math.go
+++ b/internal/utils/ecmascript/math.go
@@ -1,0 +1,75 @@
+// Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+//
+// Developed at SunSoft, a Sun Microsystems, Inc. business.
+// Permission to use, copy, modify, and distribute this software is freely
+// granted, provided that this notice is preserved.
+
+package ecmascript
+
+// cspell:ignore fdlibm
+
+import "math"
+
+// Acos implements the fdlibm algorithm used by V8's Math.acos. Go's
+// math.Acos differs from V8 by one ULP for some inputs, which is observable to
+// JavaScript constant evaluation through strict equality.
+func Acos(x float64) float64 {
+	const (
+		one    = 1.00000000000000000000e+00
+		pi     = 3.14159265358979311600e+00
+		pio2Hi = 1.57079632679489655800e+00
+		pio2Lo = 6.12323399573676603587e-17
+		pS0    = 1.66666666666666657415e-01
+		pS1    = -3.25565818622400915405e-01
+		pS2    = 2.01212532134862925881e-01
+		pS3    = -4.00555345006794114027e-02
+		pS4    = 7.91534994289814532176e-04
+		pS5    = 3.47933107596021167570e-05
+		qS1    = -2.40339491173441421878e+00
+		qS2    = 2.02094576023350569471e+00
+		qS3    = -6.88283971605453293030e-01
+		qS4    = 7.70381505559019352791e-02
+	)
+
+	bits := math.Float64bits(x)
+	high := int32(bits >> 32)
+	absHigh := high & 0x7fffffff
+	if absHigh >= 0x3ff00000 {
+		low := uint32(bits)
+		if (uint32(absHigh-0x3ff00000) | low) == 0 {
+			if high > 0 {
+				return 0
+			}
+			return pi + 2*pio2Lo
+		}
+		return math.NaN()
+	}
+	if absHigh < 0x3fe00000 {
+		if absHigh <= 0x3c600000 {
+			return pio2Hi + pio2Lo
+		}
+		z := x * x
+		p := z * (pS0 + z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))))
+		q := one + z*(qS1+z*(qS2+z*(qS3+z*qS4)))
+		r := p / q
+		return pio2Hi - (x - (pio2Lo - x*r))
+	}
+	if high < 0 {
+		z := (one + x) * 0.5
+		p := z * (pS0 + z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))))
+		q := one + z*(qS1+z*(qS2+z*(qS3+z*qS4)))
+		s := math.Sqrt(z)
+		r := p / q
+		w := r*s - pio2Lo
+		return pi - 2*(s+w)
+	}
+	z := (one - x) * 0.5
+	s := math.Sqrt(z)
+	df := math.Float64frombits(math.Float64bits(s) & 0xffffffff00000000)
+	c := (z - df*df) / (s + df)
+	p := z * (pS0 + z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))))
+	q := one + z*(qS1+z*(qS2+z*(qS3+z*qS4)))
+	r := p / q
+	w := r*s + c
+	return 2 * (df + w)
+}

--- a/internal/utils/ecmascript/math_test.go
+++ b/internal/utils/ecmascript/math_test.go
@@ -1,0 +1,29 @@
+package ecmascript
+
+import (
+	"math"
+	"testing"
+)
+
+func TestAcosMatchesV8(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input float64
+		bits  uint64
+	}{
+		{input: 0.60303859878331423, bits: 0x3fed8d3e1e8ab947},
+		{input: 0.5, bits: 0x3ff0c152382d7366},
+		{input: -0.5, bits: 0x4000c152382d7366},
+		{input: 1, bits: 0},
+		{input: -1, bits: 0x400921fb54442d18},
+	}
+	for _, test := range tests {
+		if got := math.Float64bits(Acos(test.input)); got != test.bits {
+			t.Errorf("Acos(%g) bits = %#x, want %#x", test.input, got, test.bits)
+		}
+	}
+	if !math.IsNaN(Acos(2)) {
+		t.Error("Acos(2) should be NaN")
+	}
+}

--- a/internal/utils/ecmascript/number.go
+++ b/internal/utils/ecmascript/number.go
@@ -64,6 +64,141 @@ func NumberToString(value float64) string {
 	return sign + digits[:1] + "." + digits[1:] + "e" + exponentText
 }
 
+// NumberToExponential implements Number.prototype.toExponential's finite
+// number formatting. A negative fractionDigits value requests the shortest
+// round-tripping representation used when the argument is omitted.
+func NumberToExponential(value float64, fractionDigits int) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return NumberToString(value)
+	}
+	sign := ""
+	if value < 0 {
+		sign = "-"
+		value = -value
+	} else if value == 0 {
+		// JavaScript suppresses the sign of negative zero in decimal formats.
+		value = 0
+	}
+	if fractionDigits < 0 {
+		scientific := strconv.FormatFloat(value, 'e', -1, 64)
+		exponentMarker := strings.LastIndexByte(scientific, 'e')
+		exponent, _ := strconv.Atoi(scientific[exponentMarker+1:])
+		return sign + scientific[:exponentMarker] + "e" + signedDecimalExponent(exponent)
+	}
+	digits, exponent := roundedSignificantDecimal(value, fractionDigits+1)
+	mantissa := digits[:1]
+	if fractionDigits > 0 {
+		mantissa += "." + digits[1:]
+	}
+	return sign + mantissa + "e" + signedDecimalExponent(exponent)
+}
+
+// NumberToPrecision implements Number.prototype.toPrecision's finite number
+// formatting for precisions in the ECMAScript range [1, 100].
+func NumberToPrecision(value float64, precision int) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return NumberToString(value)
+	}
+	sign := ""
+	if value < 0 {
+		sign = "-"
+		value = -value
+	}
+	if value == 0 {
+		if precision == 1 {
+			return "0"
+		}
+		return "0." + strings.Repeat("0", precision-1)
+	}
+
+	digits, exponent := roundedSignificantDecimal(value, precision)
+	if exponent < -6 || exponent >= precision {
+		if len(digits) == 1 {
+			return sign + digits + "e" + signedDecimalExponent(exponent)
+		}
+		return sign + digits[:1] + "." + digits[1:] + "e" + signedDecimalExponent(exponent)
+	}
+
+	decimalPosition := exponent + 1
+	switch {
+	case decimalPosition <= 0:
+		return sign + "0." + strings.Repeat("0", -decimalPosition) + digits
+	case decimalPosition >= len(digits):
+		return sign + digits + strings.Repeat("0", decimalPosition-len(digits))
+	default:
+		return sign + digits[:decimalPosition] + "." + digits[decimalPosition:]
+	}
+}
+
+// roundedSignificantDecimal implements the finite, positive-number rounding
+// step shared by ECMAScript's ToRawPrecision and ToRawExponential operations.
+// The specification chooses the larger decimal integer on an exact tie; Go's
+// strconv fixed-precision formatting uses ties-to-even and therefore cannot be
+// used for values such as 1.25 at two significant digits.
+func roundedSignificantDecimal(value float64, precision int) (digits string, exponent int) {
+	if value == 0 {
+		return strings.Repeat("0", precision), 0
+	}
+	rational := new(big.Rat).SetFloat64(value)
+	numerator := new(big.Int).Set(rational.Num())
+	denominator := new(big.Int).Set(rational.Denom())
+	scientific := strconv.FormatFloat(value, 'e', -1, 64)
+	exponentMarker := strings.LastIndexByte(scientific, 'e')
+	exponent, _ = strconv.Atoi(scientific[exponentMarker+1:])
+	// The shortest round-tripping decimal can cross a power-of-ten boundary
+	// (for example, float64(1e-7) is slightly smaller than exact 1e-7). Correct
+	// the estimate against the exact binary rational before scaling.
+	for compareRationalToPowerOfTen(numerator, denominator, exponent) < 0 {
+		exponent--
+	}
+	for compareRationalToPowerOfTen(numerator, denominator, exponent+1) >= 0 {
+		exponent++
+	}
+	scale := precision - 1 - exponent
+	if scale >= 0 {
+		numerator.Mul(numerator, decimalPowerOfTen(scale))
+	} else {
+		denominator.Mul(denominator, decimalPowerOfTen(-scale))
+	}
+
+	remainder := new(big.Int)
+	rounded := new(big.Int)
+	rounded.QuoRem(numerator, denominator, remainder)
+	if remainder.Lsh(remainder, 1).Cmp(denominator) >= 0 {
+		rounded.Add(rounded, big.NewInt(1))
+	}
+	digits = rounded.String()
+	if len(digits) > precision {
+		rounded.Quo(rounded, big.NewInt(10))
+		digits = rounded.String()
+		exponent++
+	}
+	if len(digits) < precision {
+		digits = strings.Repeat("0", precision-len(digits)) + digits
+	}
+	return digits, exponent
+}
+
+func decimalPowerOfTen(exponent int) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(exponent)), nil)
+}
+
+func compareRationalToPowerOfTen(numerator, denominator *big.Int, exponent int) int {
+	if exponent >= 0 {
+		right := new(big.Int).Mul(denominator, decimalPowerOfTen(exponent))
+		return numerator.Cmp(right)
+	}
+	left := new(big.Int).Mul(numerator, decimalPowerOfTen(-exponent))
+	return left.Cmp(denominator)
+}
+
+func signedDecimalExponent(exponent int) string {
+	if exponent >= 0 {
+		return "+" + strconv.Itoa(exponent)
+	}
+	return strconv.Itoa(exponent)
+}
+
 // StringToNumber applies JavaScript's StringToNumber operation. The boolean is
 // false exactly when JavaScript would produce NaN; infinities and signed zero
 // are valid results.

--- a/internal/utils/ecmascript/number_test.go
+++ b/internal/utils/ecmascript/number_test.go
@@ -2,6 +2,7 @@ package ecmascript
 
 import (
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -51,6 +52,54 @@ func TestNumberToString(t *testing.T) {
 				t.Errorf("NumberToString(%v) = %q, want %q", test.value, got, test.want)
 			}
 		})
+	}
+}
+
+func TestNumberToExponential(t *testing.T) {
+	tests := []struct {
+		value          float64
+		fractionDigits int
+		want           string
+	}{
+		{value: math.Copysign(0, -1), fractionDigits: -1, want: "0e+0"},
+		{value: 0, fractionDigits: 2, want: "0.00e+0"},
+		{value: math.Copysign(0, -1), fractionDigits: 2, want: "0.00e+0"},
+		{value: 1.5, fractionDigits: 0, want: "2e+0"},
+		{value: 1.25, fractionDigits: 1, want: "1.3e+0"},
+		{value: 2.25, fractionDigits: 1, want: "2.3e+0"},
+		{value: -1.25, fractionDigits: 1, want: "-1.3e+0"},
+		{value: 1.5, fractionDigits: 2, want: "1.50e+0"},
+		{value: 1e-7, fractionDigits: 20, want: "9.99999999999999954748e-8"},
+		{value: math.MaxFloat64, fractionDigits: 20, want: "1.79769313486231570815e+308"},
+	}
+	for _, test := range tests {
+		if got := NumberToExponential(test.value, test.fractionDigits); got != test.want {
+			t.Errorf("NumberToExponential(%v, %d) = %q, want %q", test.value, test.fractionDigits, got, test.want)
+		}
+	}
+}
+
+func TestNumberToPrecision(t *testing.T) {
+	tests := []struct {
+		value     float64
+		precision int
+		want      string
+	}{
+		{value: math.Copysign(0, -1), precision: 2, want: "0.0"},
+		{value: 1.5, precision: 1, want: "2"},
+		{value: 1.25, precision: 2, want: "1.3"},
+		{value: 2.25, precision: 2, want: "2.3"},
+		{value: 0.125, precision: 2, want: "0.13"},
+		{value: -1.25, precision: 2, want: "-1.3"},
+		{value: 1.5, precision: 20, want: "1.5000000000000000000"},
+		{value: 1e-7, precision: 20, want: "9.9999999999999995475e-8"},
+		{value: 1e21, precision: 100, want: "1000000000000000000000." + strings.Repeat("0", 78)},
+		{value: math.MaxFloat64, precision: 20, want: "1.7976931348623157081e+308"},
+	}
+	for _, test := range tests {
+		if got := NumberToPrecision(test.value, test.precision); got != test.want {
+			t.Errorf("NumberToPrecision(%v, %d) = %q, want %q", test.value, test.precision, got, test.want)
+		}
 	}
 }
 

--- a/internal/utils/ecmascript/whitespace.go
+++ b/internal/utils/ecmascript/whitespace.go
@@ -81,6 +81,18 @@ func StringTrim(s string) string {
 	return strings.TrimFunc(s, IsWhiteSpaceOrLineTerminator)
 }
 
+// StringTrimStart trims the leading edge the way
+// String.prototype.trimStart does.
+func StringTrimStart(s string) string {
+	return strings.TrimLeftFunc(s, IsWhiteSpaceOrLineTerminator)
+}
+
+// StringTrimEnd trims the trailing edge the way String.prototype.trimEnd
+// does.
+func StringTrimEnd(s string) string {
+	return strings.TrimRightFunc(s, IsWhiteSpaceOrLineTerminator)
+}
+
 // IsBlank reports whether s holds nothing but whitespace, which is what
 // JavaScript's `s.trim() === ""` asks.
 func IsBlank(s string) bool {

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -1,7 +1,10 @@
+// cspell:ignore Unscopables unscopables
+
 package utils
 
 import (
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 	"unicode/utf16"
@@ -25,6 +28,20 @@ type StaticStringEvaluator struct {
 	resolving              map[*ast.Symbol]bool
 	referenceFlagsComputed bool
 	referenceFlags         map[*ast.Symbol]staticReferenceFlags
+	eslintStaticCalls      bool
+	evaluationDepth        int
+	evaluationPeak         int
+	evaluationGeneration   uint64
+	evaluationStepsLeft    int
+	stringBudgetLeft       int
+	stringWorkBudgetLeft   int
+	stringWorkContext      *staticStringWorkContext
+	bigIntWorkBudgetLeft   int
+	bigIntWorkContext      *staticStringWorkContext
+	bigIntCacheBudgetLeft  int
+	bigIntExpressionCache  map[*ast.Node]staticBigIntCacheEntry
+	aggregateBudgetLeft    int
+	aggregateIdentities    map[any]struct{}
 }
 
 func NewStaticStringEvaluator(typeChecker *checker.Checker) *StaticStringEvaluator {
@@ -40,6 +57,14 @@ func NewStaticStringEvaluatorWithSourceFile(typeChecker *checker.Checker, source
 // evaluator performs its single mutation scan.
 type StaticReferenceResolver interface {
 	Resolve(node *ast.Node) *ast.Symbol
+}
+
+// StaticGlobalReferenceResolver lets a binder-only evaluator distinguish an
+// unresolved global from a local binding without falling back to a whole-file
+// syntactic shadowing scan.
+type StaticGlobalReferenceResolver interface {
+	StaticReferenceResolver
+	IsUnshadowedGlobal(node *ast.Node, name string) bool
 }
 
 func NewStaticStringEvaluatorWithReferenceResolver(
@@ -58,6 +83,24 @@ func NewStaticStringEvaluatorWithReferenceResolver(
 	return staticEvaluator
 }
 
+// NewStaticStringEvaluatorForSourceOnlyStaticValue enables the native-call
+// subset used by eslint-utils getStaticValue while deliberately omitting a
+// TypeChecker. It is opt-in so existing string-evaluator consumers retain
+// their exact evaluation surface.
+func NewStaticStringEvaluatorForSourceOnlyStaticValue(
+	sourceFile *ast.SourceFile,
+	referenceResolver StaticReferenceResolver,
+) *StaticStringEvaluator {
+	staticEvaluator := NewStaticStringEvaluatorWithReferenceResolver(nil, sourceFile, referenceResolver)
+	staticEvaluator.eslintStaticCalls = true
+	staticEvaluator.stringWorkBudgetLeft = maxStaticStringWorkBudget
+	staticEvaluator.stringWorkContext = &staticStringWorkContext{remaining: &staticEvaluator.stringWorkBudgetLeft}
+	staticEvaluator.bigIntWorkBudgetLeft = maxStaticBigIntWorkBudget
+	staticEvaluator.bigIntWorkContext = &staticStringWorkContext{remaining: &staticEvaluator.bigIntWorkBudgetLeft}
+	staticEvaluator.bigIntCacheBudgetLeft = maxStaticBigIntCacheBudget
+	return staticEvaluator
+}
+
 // NewStaticStringEvaluatorWithoutScope mirrors eslint-utils getStaticValue
 // when no initial scope is supplied: literal expressions can still be folded,
 // but identifiers (including built-in globals) cannot be resolved.
@@ -69,6 +112,81 @@ func NewStaticStringEvaluatorWithoutScope() *StaticStringEvaluator {
 
 type staticNullValue struct{}
 type staticUndefinedValue struct{}
+type staticUnknownNumberValue struct{}
+type staticUnknownStringValue struct {
+	truthy     bool
+	numericNaN bool
+}
+type staticUnknownBooleanValue struct{}
+type staticIdentity struct{ _ byte }
+type staticOpaqueObjectValue struct{ identity *staticIdentity }
+type staticIteratorValue struct {
+	values            []any
+	kind              string
+	identity          *staticIdentity
+	stringWorkContext *staticStringWorkContext
+}
+type staticOptionalChainShortCircuitValue struct{}
+type staticRegExpValue struct {
+	source            string
+	flags             string
+	identity          any
+	stringWorkContext *staticStringWorkContext
+}
+type staticDateValue struct {
+	milliseconds staticNumberValue
+	known        bool
+	identity     *staticIdentity
+}
+type staticBoxedValue struct {
+	value             any
+	identity          *staticIdentity
+	stringWorkContext *staticStringWorkContext
+}
+
+type staticCollectionValue struct {
+	kind              string
+	entries           []staticCollectionEntry
+	index             map[staticCollectionKey]int
+	identity          *staticIdentity
+	stringWorkContext *staticStringWorkContext
+}
+
+type staticCollectionEntry struct {
+	key   any
+	value any
+}
+
+type staticCollectionKey struct {
+	kind       uint8
+	numberBits uint64
+	text       string
+	identity   any
+}
+
+type staticBigIntValue struct {
+	value             *big.Int
+	truthy            bool
+	truthyKnown       bool
+	stringWorkContext *staticStringWorkContext
+	bigIntWorkContext *staticStringWorkContext
+}
+
+func staticAbstractBigInt(truthy bool) staticBigIntValue {
+	return staticBigIntValue{truthy: truthy, truthyKnown: true}
+}
+
+type staticSymbolValue struct {
+	// description is the registry key or well-known property name used for
+	// identity. staticSymbolDescription derives the observable description.
+	description   string
+	global        bool
+	wellKnown     bool
+	hostDependent bool
+}
+
+type staticBuiltinValue string
+type staticBuiltinObjectValue string
 
 // staticNumberValue is a number this evaluator computed itself. tsgo hands
 // numbers back as jsnum.Number, a type internal/utils cannot import; the IsNaN
@@ -86,22 +204,55 @@ type staticStringNode ast.Node
 // staticObjectValue and staticArrayValue hold folded object and array literals
 // so member access and JavaScript's default string coercion can be modeled.
 type staticObjectValue struct {
-	property        staticObjectProperty
-	extraProperties []staticObjectProperty
-	propertyCount   int
-	prototype       any
-	prototypeSet    bool
+	property          staticObjectProperty
+	extraProperties   []staticObjectProperty
+	propertyCount     int
+	propertyIndices   map[string]int
+	prototype         any
+	prototypeSet      bool
+	enhancedCoercion  bool
+	stringWorkContext *staticStringWorkContext
 }
 
 type staticObjectProperty struct {
-	name  string
-	value any
+	name      string
+	symbol    staticSymbolValue
+	symbolKey bool
+	value     any
 }
 
 type staticArrayValue struct {
-	length   int
-	inline   [2]any
-	overflow []any
+	length            int
+	inline            [2]any
+	overflow          []any
+	omitted           map[int]bool
+	stringWorkContext *staticStringWorkContext
+}
+
+type staticStringWorkContext struct {
+	remaining *int
+}
+
+func (context *staticStringWorkContext) reserve(cost int) bool {
+	if context == nil || context.remaining == nil || cost <= 0 {
+		return true
+	}
+	if cost > *context.remaining {
+		*context.remaining = 0
+		return false
+	}
+	*context.remaining -= cost
+	return true
+}
+
+func (context *staticStringWorkContext) exhaust() {
+	if context != nil && context.remaining != nil {
+		*context.remaining = 0
+	}
+}
+
+func (context *staticStringWorkContext) exhausted() bool {
+	return context != nil && context.remaining != nil && *context.remaining <= 0
 }
 
 type staticReferenceFlags uint8
@@ -123,10 +274,40 @@ var objectPassThroughMethods = map[string]bool{
 // allocation. The limit is deliberately much larger than a useful diagnostic
 // message while still bounding nested Array#join coercion.
 const maxStaticStringLength = 1 << 20
+const maxStaticStringBudget = maxStaticStringLength * 8
+const maxStaticStringWorkBudget = maxStaticStringBudget
+const maxJavaScriptStringLength = 1<<29 - 24
+const maxStaticAggregateElements = 1 << 14
+const maxStaticAggregateBudget = maxStaticAggregateElements * 4
+
+// BigInt results beyond 64 Ki bits are represented by the facts the evaluator
+// can still prove (currently truthiness) instead of being materialized. This
+// keeps repeated source-only receiver classification linear in source size;
+// the separate JavaScript limit below still distinguishes results that V8
+// would reject from large values that are merely abstracted locally.
+const maxStaticBigIntBits = 1 << 16
+const maxJavaScriptBigIntBits = 1 << 30
+const maxStaticBigIntWorkBudget = 1 << 23
+const maxStaticBigIntCacheBudget = 1 << 20
+const maxStaticEvaluationSteps = 1 << 16
+const maxStaticEvaluationDepth = 1 << 10
 
 type staticEvalResult struct {
-	value any
-	ok    bool
+	value                  any
+	ok                     bool
+	stringCodeUnits        int
+	stringCodeUnitsKnown   bool
+	stringBudgetGeneration uint64
+	stringWorkCharged      bool
+	bigIntWorkCharged      bool
+	bigIntWorkBytes        int
+	cacheableBigInt        bool
+}
+
+type staticBigIntCacheEntry struct {
+	result staticEvalResult
+	depth  int
+	steps  int
 }
 
 // StaticEvalValueKind classifies a static evaluation result for callers that
@@ -201,6 +382,9 @@ func (staticEvaluator *StaticStringEvaluator) EvalArrayValue(node *ast.Node) (is
 		return false, false
 	}
 	_, isArray = result.value.(*staticArrayValue)
+	if prototype, ok := result.value.(staticBuiltinObjectValue); ok && prototype == "Array.prototype" {
+		isArray = true
+	}
 	return isArray, true
 }
 
@@ -240,6 +424,336 @@ func (staticEvaluator *StaticStringEvaluator) EvalStringValue(node *ast.Node) (s
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEvalResult {
+	if !staticEvaluator.eslintStaticCalls {
+		return staticEvaluator.evalValueUnbudgeted(node)
+	}
+	if staticEvaluator.stringWorkBudgetLeft == 0 || staticEvaluator.bigIntWorkBudgetLeft == 0 {
+		return staticEvalResult{}
+	}
+	// eslint-utils evaluates through the JavaScript call stack and turns a
+	// RangeError into an unknown static value. Keep enough headroom below the
+	// tested default Node stack limits that Go's growable stack cannot prove a
+	// value in cases where upstream can fail from recursive evaluation.
+	if staticEvaluator.evaluationDepth >= maxStaticEvaluationDepth {
+		return staticEvalResult{}
+	}
+	if staticEvaluator.evaluationDepth == 0 {
+		staticEvaluator.evaluationGeneration++
+		if staticEvaluator.evaluationGeneration == 0 {
+			staticEvaluator.evaluationGeneration++
+		}
+		staticEvaluator.evaluationStepsLeft = maxStaticEvaluationSteps
+		staticEvaluator.evaluationPeak = 0
+		staticEvaluator.stringBudgetLeft = maxStaticStringBudget
+		staticEvaluator.aggregateBudgetLeft = maxStaticAggregateBudget
+		if staticEvaluator.aggregateIdentities == nil {
+			staticEvaluator.aggregateIdentities = map[any]struct{}{}
+		} else {
+			clear(staticEvaluator.aggregateIdentities)
+		}
+	}
+	if staticEvaluator.evaluationStepsLeft == 0 {
+		return staticEvalResult{}
+	}
+	stepsBefore := staticEvaluator.evaluationStepsLeft
+	staticEvaluator.evaluationStepsLeft--
+	depthBefore := staticEvaluator.evaluationDepth
+	staticEvaluator.evaluationDepth++
+	cacheNode := SkipAssertionsAndParens(node)
+	entry, cached := staticEvaluator.bigIntExpressionCache[cacheNode]
+	var result staticEvalResult
+	cacheDepth, cacheSteps := 0, 0
+	if cached {
+		additionalSteps := entry.steps - 1
+		if entry.depth > maxStaticEvaluationDepth-depthBefore ||
+			additionalSteps > staticEvaluator.evaluationStepsLeft {
+			if additionalSteps > staticEvaluator.evaluationStepsLeft {
+				staticEvaluator.evaluationStepsLeft = 0
+			}
+			staticEvaluator.evaluationDepth--
+			return staticEvalResult{}
+		}
+		staticEvaluator.evaluationStepsLeft -= additionalSteps
+		staticEvaluator.evaluationPeak = max(
+			staticEvaluator.evaluationPeak,
+			depthBefore+entry.depth,
+		)
+		result = entry.result
+	} else {
+		previousPeak := staticEvaluator.evaluationPeak
+		staticEvaluator.evaluationPeak = staticEvaluator.evaluationDepth
+		result = staticEvaluator.evalValueUnbudgeted(node)
+		cacheDepth = staticEvaluator.evaluationPeak - depthBefore
+		cacheSteps = stepsBefore - staticEvaluator.evaluationStepsLeft
+		staticEvaluator.evaluationPeak = max(previousPeak, staticEvaluator.evaluationPeak)
+	}
+	staticEvaluator.evaluationDepth--
+	if staticEvaluator.stringWorkBudgetLeft == 0 {
+		return staticEvalResult{}
+	}
+	if !result.ok {
+		return result
+	}
+	if !result.stringCodeUnitsKnown {
+		var text string
+		var isString bool
+		var derivedString bool
+		switch value := result.value.(type) {
+		case string:
+			text, isString = value, true
+			derivedString = true
+		case *staticStringNode:
+			text, isString = staticValueAsString(value)
+		}
+		if isString {
+			if len(text) > maxStaticStringLength*3 {
+				if derivedString {
+					staticEvaluator.stringWorkBudgetLeft = 0
+				}
+				return staticEvalResult{}
+			}
+			result.stringCodeUnits = ecmascript.StringCodeUnitCount(text)
+			result.stringCodeUnitsKnown = true
+		}
+	}
+	if result.stringCodeUnitsKnown && result.stringCodeUnits > maxStaticStringLength {
+		if _, derivedString := result.value.(string); derivedString {
+			staticEvaluator.stringWorkBudgetLeft = 0
+		}
+		return staticEvalResult{}
+	}
+	if !staticEvaluator.chargeStaticStringResult(&result) {
+		return staticEvalResult{}
+	}
+	if !staticEvaluator.chargeStaticBigIntResult(&result) {
+		return staticEvalResult{}
+	}
+	result.value = staticEvaluator.attachStaticResourceBudgets(result.value)
+	cost := staticAggregateShallowCost(result.value)
+	identity := staticAggregateIdentity(result.value)
+	if identity != nil {
+		if staticEvaluator.aggregateIdentities == nil {
+			staticEvaluator.aggregateIdentities = map[any]struct{}{}
+		}
+		if _, alreadyCharged := staticEvaluator.aggregateIdentities[identity]; alreadyCharged {
+			cost = 0
+		}
+	}
+	if cost > staticEvaluator.aggregateBudgetLeft {
+		return staticEvalResult{}
+	}
+	staticEvaluator.aggregateBudgetLeft -= cost
+	if identity != nil {
+		staticEvaluator.aggregateIdentities[identity] = struct{}{}
+	}
+	if !cached {
+		staticEvaluator.cacheStaticBigIntExpression(cacheNode, result, cacheDepth, cacheSteps)
+	}
+	return result
+}
+
+// chargeStaticBigIntResult bounds repeated materialization of exact BigInt
+// values across every receiver in one source file. Cache hits retain the same
+// immutable big.Int and therefore carry the charged bit with them.
+func (staticEvaluator *StaticStringEvaluator) chargeStaticBigIntResult(result *staticEvalResult) bool {
+	if result == nil || result.bigIntWorkCharged {
+		return true
+	}
+	cost := result.bigIntWorkBytes
+	value, ok := result.value.(staticBigIntValue)
+	if !ok {
+		return true
+	}
+	if value.value != nil {
+		cost = max(cost, max((value.value.BitLen()+7)/8, 32))
+	}
+	if cost <= 0 {
+		result.bigIntWorkCharged = true
+		return true
+	}
+	if cost > staticEvaluator.bigIntWorkBudgetLeft {
+		staticEvaluator.bigIntWorkBudgetLeft = 0
+		return false
+	}
+	staticEvaluator.bigIntWorkBudgetLeft -= cost
+	result.bigIntWorkCharged = true
+	return true
+}
+
+// cacheStaticBigIntExpression retains only closed BigInt literal/operator
+// trees. Identifier evaluation clears cacheableBigInt, so an alias or
+// conditional chain must still traverse every binding and cannot use cached
+// suffixes to evade the recursion and step limits.
+func (staticEvaluator *StaticStringEvaluator) cacheStaticBigIntExpression(
+	node *ast.Node,
+	result staticEvalResult,
+	depth int,
+	steps int,
+) {
+	if node == nil || !result.ok || !result.cacheableBigInt ||
+		!isCacheableBigIntExpressionNode(node) || depth <= 0 || steps <= 0 ||
+		staticEvaluator.bigIntCacheBudgetLeft <= 0 {
+		return
+	}
+	value, ok := result.value.(staticBigIntValue)
+	if !ok {
+		return
+	}
+	cost := 64
+	if value.value != nil {
+		cost += (value.value.BitLen() + 7) / 8
+	}
+	if cost > staticEvaluator.bigIntCacheBudgetLeft {
+		return
+	}
+	if staticEvaluator.bigIntExpressionCache == nil {
+		staticEvaluator.bigIntExpressionCache = map[*ast.Node]staticBigIntCacheEntry{}
+	}
+	if _, exists := staticEvaluator.bigIntExpressionCache[node]; exists {
+		return
+	}
+	staticEvaluator.bigIntCacheBudgetLeft -= cost
+	staticEvaluator.bigIntExpressionCache[node] = staticBigIntCacheEntry{
+		result: result,
+		depth:  depth,
+		steps:  steps,
+	}
+}
+
+func isCacheableBigIntExpressionNode(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindBigIntLiteral:
+		return true
+	case ast.KindPrefixUnaryExpression:
+		operator := node.AsPrefixUnaryExpression().Operator
+		return operator == ast.KindMinusToken || operator == ast.KindTildeToken
+	case ast.KindBinaryExpression:
+		operator := node.AsBinaryExpression().OperatorToken.Kind
+		switch operator {
+		case ast.KindPlusToken, ast.KindMinusToken, ast.KindAsteriskToken,
+			ast.KindSlashToken, ast.KindPercentToken, ast.KindAsteriskAsteriskToken,
+			ast.KindBarToken, ast.KindAmpersandToken, ast.KindCaretToken,
+			ast.KindLessThanLessThanToken, ast.KindGreaterThanGreaterThanToken:
+			return true
+		}
+	}
+	return false
+}
+
+// attachStaticResourceBudgets makes allocations and size-dependent operations
+// hidden inside JavaScript primitive coercion share the enhanced evaluator's
+// persistent file budgets. The legacy evaluator never calls this helper, so
+// its evaluation surface and resource policy stay unchanged.
+func (staticEvaluator *StaticStringEvaluator) attachStaticResourceBudgets(value any) any {
+	if staticEvaluator == nil || !staticEvaluator.eslintStaticCalls {
+		return value
+	}
+	work := staticEvaluator.stringWorkContext
+	switch value := value.(type) {
+	case *staticArrayValue:
+		if value == nil || value.stringWorkContext == work {
+			return value
+		}
+		value.stringWorkContext = work
+		for index := range value.length {
+			value.set(index, staticEvaluator.attachStaticResourceBudgets(value.element(index)))
+		}
+		return value
+	case *staticObjectValue:
+		if value == nil || value.stringWorkContext == work {
+			return value
+		}
+		value.stringWorkContext = work
+		if value.propertyCount > 0 {
+			value.property.value = staticEvaluator.attachStaticResourceBudgets(value.property.value)
+		}
+		for index := range value.extraProperties {
+			value.extraProperties[index].value = staticEvaluator.attachStaticResourceBudgets(
+				value.extraProperties[index].value,
+			)
+		}
+		value.prototype = staticEvaluator.attachStaticResourceBudgets(value.prototype)
+		return value
+	case staticCollectionValue:
+		if value.stringWorkContext == work {
+			return value
+		}
+		value.stringWorkContext = work
+		for index := range value.entries {
+			value.entries[index].key = staticEvaluator.attachStaticResourceBudgets(value.entries[index].key)
+			value.entries[index].value = staticEvaluator.attachStaticResourceBudgets(value.entries[index].value)
+		}
+		return value
+	case staticIteratorValue:
+		if value.stringWorkContext == work {
+			return value
+		}
+		value.stringWorkContext = work
+		for index := range value.values {
+			value.values[index] = staticEvaluator.attachStaticResourceBudgets(value.values[index])
+		}
+		return value
+	case staticBoxedValue:
+		if value.stringWorkContext == work {
+			return value
+		}
+		value.stringWorkContext = work
+		value.value = staticEvaluator.attachStaticResourceBudgets(value.value)
+		return value
+	case staticRegExpValue:
+		value.stringWorkContext = work
+		return value
+	case staticBigIntValue:
+		value.stringWorkContext = work
+		value.bigIntWorkContext = staticEvaluator.bigIntWorkContext
+		return value
+	default:
+		return value
+	}
+}
+
+func (staticEvaluator *StaticStringEvaluator) chargeStaticStringResult(result *staticEvalResult) bool {
+	if result == nil || !result.stringCodeUnitsKnown ||
+		result.stringBudgetGeneration == staticEvaluator.evaluationGeneration {
+		return true
+	}
+	if _, sourceBacked := result.value.(*staticStringNode); sourceBacked {
+		// The literal itself is backed by source text, but every static native
+		// call that consumes it can allocate a transformed copy. Charge it once
+		// per root (rather than permanently) to bound repeated transformations.
+		if result.stringCodeUnits > staticEvaluator.stringWorkBudgetLeft {
+			staticEvaluator.stringWorkBudgetLeft = 0
+			return false
+		}
+		staticEvaluator.stringWorkBudgetLeft -= result.stringCodeUnits
+		result.stringBudgetGeneration = staticEvaluator.evaluationGeneration
+		return true
+	}
+	if !result.stringWorkCharged {
+		if result.stringCodeUnits > staticEvaluator.stringWorkBudgetLeft {
+			// The value has already been materialized. Exhaust the file budget so
+			// later roots stop before repeating the same allocation.
+			staticEvaluator.stringWorkBudgetLeft = 0
+			return false
+		}
+		staticEvaluator.stringWorkBudgetLeft -= result.stringCodeUnits
+		result.stringWorkCharged = true
+	}
+	if result.stringCodeUnits > staticEvaluator.stringBudgetLeft {
+		return false
+	}
+	staticEvaluator.stringBudgetLeft -= result.stringCodeUnits
+	result.stringBudgetGeneration = staticEvaluator.evaluationGeneration
+	return true
+}
+
+// evalValueUnbudgeted performs one evaluation step. Recursive evaluation goes
+// through evalValue so aliases, calls, and nested literals share one root
+// budget in the enhanced source-only evaluator.
+func (staticEvaluator *StaticStringEvaluator) evalValueUnbudgeted(node *ast.Node) staticEvalResult {
 	node = SkipAssertionsAndParens(node)
 	if node == nil {
 		return staticEvalResult{}
@@ -254,6 +768,35 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 		return staticEvalResult{value: false, ok: true}
 	case ast.KindNullKeyword:
 		return staticEvalResult{value: staticNullValue{}, ok: true}
+	case ast.KindBigIntLiteral:
+		if !staticEvaluator.eslintStaticCalls {
+			return staticEvaluator.evalWithTsgo(node)
+		}
+		value := new(big.Int)
+		if _, ok := value.SetString(NormalizeBigIntLiteral(node.AsBigIntLiteral().Text), 10); !ok {
+			return staticEvalResult{}
+		}
+		if value.BitLen() > maxStaticBigIntBits {
+			return staticEvalResult{
+				value: staticAbstractBigInt(value.Sign() != 0), ok: true,
+				bigIntWorkBytes: (value.BitLen() + 7) / 8, cacheableBigInt: true,
+			}
+		}
+		return staticEvalResult{
+			value: staticBigIntValue{value: value}, ok: true,
+			bigIntWorkBytes: (value.BitLen() + 7) / 8, cacheableBigInt: true,
+		}
+	case ast.KindRegularExpressionLiteral:
+		if staticEvaluator.eslintStaticCalls {
+			pattern, flags := ExtractRegexPatternAndFlags(node.AsRegularExpressionLiteral().Text)
+			source, ok := staticRegExpSource(staticEvaluator.stringWorkContext, pattern)
+			if !ok {
+				return staticEvalResult{}
+			}
+			return staticEvalResult{value: staticRegExpValue{
+				source: source, flags: canonicalRegExpFlags(flags), identity: node,
+			}, ok: true}
+		}
 	case ast.KindUndefinedKeyword:
 		if !staticEvaluator.resolveIdentifiers {
 			return staticEvalResult{}
@@ -262,6 +805,12 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 	case ast.KindIdentifier:
 		if !staticEvaluator.resolveIdentifiers {
 			return staticEvalResult{}
+		}
+		if staticEvaluator.eslintStaticCalls {
+			if result := staticEvaluator.evalIdentifier(node); result.ok {
+				return result
+			}
+			return staticEvaluator.evalESLintGlobalIdentifier(node)
 		}
 		identifier := node.AsIdentifier()
 		if identifier != nil && identifier.Text == "undefined" && !IsShadowed(node, "undefined") {
@@ -276,6 +825,10 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 		return staticEvaluator.evalPrefixUnaryExpression(node)
 	case ast.KindConditionalExpression:
 		return staticEvaluator.evalConditionalExpression(node)
+	case ast.KindTypeOfExpression:
+		if staticEvaluator.eslintStaticCalls {
+			return staticEvaluator.evalESLintTypeOfExpression(node)
+		}
 	case ast.KindVoidExpression:
 		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
 	case ast.KindObjectLiteralExpression:
@@ -291,6 +844,9 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 			return result
 		}
 	case ast.KindCallExpression:
+		if staticEvaluator.eslintStaticCalls {
+			return staticEvaluator.evalESLintStaticCall(node)
+		}
 		if result := staticEvaluator.evalBuiltinStaticCall(node); result.ok {
 			return result
 		}
@@ -303,7 +859,14 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 		if result := staticEvaluator.evalObjectPassThroughCall(node); result.ok {
 			return result
 		}
+	case ast.KindNewExpression:
+		if staticEvaluator.eslintStaticCalls {
+			return staticEvaluator.evalESLintStaticNew(node)
+		}
 	case ast.KindTaggedTemplateExpression:
+		if staticEvaluator.eslintStaticCalls {
+			return staticEvaluator.evalESLintStringRawTag(node)
+		}
 		if result := staticEvaluator.evalStringRawTag(node); result.ok {
 			return result
 		}
@@ -312,27 +875,112 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 	return staticEvaluator.evalWithTsgo(node)
 }
 
-func (staticEvaluator *StaticStringEvaluator) evalIdentifier(node *ast.Node) staticEvalResult {
+func staticAggregateShallowCost(value any) int {
+	switch value := value.(type) {
+	case *staticArrayValue:
+		return value.length
+	case *staticObjectValue:
+		return value.propertyCount
+	case staticCollectionValue:
+		if len(value.entries) > maxStaticAggregateElements/2 {
+			return maxStaticAggregateElements + 1
+		}
+		return len(value.entries) * 2
+	case staticIteratorValue:
+		return len(value.values)
+	case staticBoxedValue, staticRegExpValue, staticDateValue, staticOpaqueObjectValue:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func staticAggregateIdentity(value any) any {
+	switch value := value.(type) {
+	case *staticArrayValue:
+		return value
+	case *staticObjectValue:
+		return value
+	case staticCollectionValue:
+		return value.identity
+	case staticIteratorValue:
+		return value.identity
+	case staticBoxedValue:
+		return value.identity
+	case staticRegExpValue:
+		return value.identity
+	case staticDateValue:
+		return value.identity
+	case staticOpaqueObjectValue:
+		return value.identity
+	default:
+		return nil
+	}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalIdentifier(node *ast.Node) (result staticEvalResult) {
 	if !staticEvaluator.resolveIdentifiers {
 		return staticEvalResult{}
 	}
 	initializer, symbol, ok := staticEvaluator.resolveIdentifierInitializer(node)
-	if !ok || staticEvaluator.resolving[symbol] {
+	if !ok {
+		return staticEvalResult{}
+	}
+	if staticEvaluator.resolving[symbol] {
 		return staticEvalResult{}
 	}
 
 	staticEvaluator.resolving[symbol] = true
 	defer delete(staticEvaluator.resolving, symbol)
-
 	if isAggregateLiteral(initializer) && staticEvaluator.hasPropertyMutation(symbol) {
-		return staticEvalResult{}
+		result = staticEvalResult{}
+	} else {
+		result = staticEvaluator.evalValue(initializer)
 	}
-	result := staticEvaluator.evalValue(initializer)
+	// A primitive result remains semantically reusable, but propagating this
+	// marker through a binding would let a cached alias suffix shorten a later
+	// deep evaluation. Only the closed initializer expression itself is cached.
+	result.cacheableBigInt = false
 	if result.ok && staticValueIsAggregate(result.value) &&
 		!isAggregateLiteral(initializer) && staticEvaluator.hasPropertyMutation(symbol) {
-		return staticEvalResult{}
+		result = staticEvalResult{}
 	}
 	return result
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalESLintGlobalIdentifier(node *ast.Node) staticEvalResult {
+	if node == nil || !ast.IsIdentifier(node) {
+		return staticEvalResult{}
+	}
+	name := node.AsIdentifier().Text
+	if !staticEvaluator.isUnshadowedGlobal(node, name) {
+		return staticEvalResult{}
+	}
+	switch name {
+	case "undefined":
+		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+	case "Infinity":
+		return staticEvalResult{value: staticNumberValue(math.Inf(1)), ok: true}
+	case "NaN":
+		return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+	case "Array", "ArrayBuffer", "BigInt", "BigInt64Array", "BigUint64Array",
+		"Boolean", "DataView", "Date", "decodeURI", "decodeURIComponent",
+		"encodeURI", "encodeURIComponent", "escape", "Float32Array", "Float64Array",
+		"Function", "Int16Array", "Int32Array", "Int8Array", "isFinite", "isNaN",
+		"isPrototypeOf", "JSON", "Map", "Math", "Number", "Object", "parseFloat",
+		"parseInt", "Promise", "Proxy", "Reflect", "RegExp", "Set", "String",
+		"Symbol", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray",
+		"unescape", "WeakMap", "WeakSet":
+		return staticEvalResult{value: staticBuiltinValue(name), ok: true}
+	}
+	return staticEvalResult{}
+}
+
+func (staticEvaluator *StaticStringEvaluator) isUnshadowedGlobal(node *ast.Node, name string) bool {
+	if resolver, ok := staticEvaluator.referenceResolver.(StaticGlobalReferenceResolver); ok {
+		return resolver.IsUnshadowedGlobal(node, name)
+	}
+	return !IsShadowed(node, name)
 }
 
 func isAggregateLiteral(node *ast.Node) bool {
@@ -395,10 +1043,62 @@ func (staticEvaluator *StaticStringEvaluator) evalTemplateExpression(node *ast.N
 	if template == nil {
 		return staticEvalResult{}
 	}
+	if !staticEvaluator.eslintStaticCalls {
+		var builder strings.Builder
+		if template.Head != nil {
+			builder.WriteString(template.Head.Text())
+		}
+		if template.TemplateSpans != nil {
+			for _, spanNode := range template.TemplateSpans.Nodes {
+				span := spanNode.AsTemplateSpan()
+				if span == nil {
+					return staticEvalResult{}
+				}
+				result := staticEvaluator.evalValue(span.Expression)
+				if !result.ok {
+					return staticEvalResult{}
+				}
+				value, ok := staticValueToString(result.value)
+				if !ok {
+					return staticEvalResult{}
+				}
+				builder.WriteString(value)
+				if span.Literal != nil {
+					builder.WriteString(span.Literal.Text())
+				}
+			}
+		}
+		return staticEvalResult{value: builder.String(), ok: true}
+	}
 
 	var builder strings.Builder
+	codeUnits := 0
+	appendText := func(text string, knownUnits int, unitsKnown bool) bool {
+		if !unitsKnown {
+			if len(text) > (maxStaticStringLength-codeUnits)*3 {
+				staticEvaluator.stringWorkContext.exhaust()
+				return false
+			}
+			if !staticEvaluator.stringWorkContext.reserve(max(len(text), 1)) {
+				return false
+			}
+			knownUnits = ecmascript.StringCodeUnitCount(text)
+		}
+		if knownUnits > maxStaticStringLength-codeUnits {
+			staticEvaluator.stringWorkContext.exhaust()
+			return false
+		}
+		if !staticEvaluator.stringWorkContext.reserve(len(text) * 2) {
+			return false
+		}
+		builder.WriteString(text)
+		codeUnits += knownUnits
+		return true
+	}
 	if template.Head != nil {
-		builder.WriteString(template.Head.Text())
+		if !appendText(template.Head.Text(), 0, false) {
+			return staticEvalResult{}
+		}
 	}
 	if template.TemplateSpans != nil {
 		for _, spanNode := range template.TemplateSpans.Nodes {
@@ -414,13 +1114,19 @@ func (staticEvaluator *StaticStringEvaluator) evalTemplateExpression(node *ast.N
 			if !ok {
 				return staticEvalResult{}
 			}
-			builder.WriteString(value)
+			if !appendText(value, result.stringCodeUnits, result.stringCodeUnitsKnown) {
+				return staticEvalResult{}
+			}
 			if span.Literal != nil {
-				builder.WriteString(span.Literal.Text())
+				if !appendText(span.Literal.Text(), 0, false) {
+					return staticEvalResult{}
+				}
 			}
 		}
 	}
-	return staticEvalResult{value: builder.String(), ok: true}
+	return staticEvalResult{
+		value: builder.String(), ok: true, stringCodeUnits: codeUnits, stringCodeUnitsKnown: true,
+	}
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Node) staticEvalResult {
@@ -430,9 +1136,14 @@ func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Nod
 	}
 
 	switch binary.OperatorToken.Kind {
+	case ast.KindCommaToken:
+		if staticEvaluator.eslintStaticCalls {
+			return staticEvaluator.evalValue(binary.Right)
+		}
+		return staticEvaluator.evalWithTsgo(node)
 	case ast.KindEqualsToken:
 		result := staticEvaluator.evalValue(binary.Right)
-		if result.ok && staticValueIsAggregate(result.value) {
+		if !staticEvaluator.eslintStaticCalls && result.ok && staticValueIsAggregate(result.value) {
 			// The assigned aggregate can be mutated by another operand or call
 			// argument before the containing expression consumes it.
 			return staticEvalResult{}
@@ -479,6 +1190,10 @@ func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Nod
 		if !left.ok || !right.ok {
 			return staticEvalResult{}
 		}
+		if !staticEvaluator.eslintStaticCalls &&
+			(staticValueIsAggregate(left.value) || staticValueIsAggregate(right.value)) {
+			return staticEvalResult{}
+		}
 		equal, ok := staticValuesStrictEqual(left.value, right.value)
 		if !ok {
 			return staticEvalResult{}
@@ -494,26 +1209,57 @@ func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Nod
 			return staticEvalResult{}
 		}
 		if staticValueIsString(left.value) {
-			return staticEvaluator.concatStaticValues(left.value, right.value)
+			return staticEvaluator.concatStaticValues(left, right)
 		}
 		if staticValueIsString(right.value) {
-			return staticEvaluator.concatStaticValues(left.value, right.value)
+			return staticEvaluator.concatStaticValues(left, right)
 		}
+	}
+	if staticEvaluator.eslintStaticCalls {
+		return staticEvaluator.evalESLintBinaryExpression(binary)
 	}
 
 	return staticEvaluator.evalWithTsgo(node)
 }
 
-func (staticEvaluator *StaticStringEvaluator) concatStaticValues(left any, right any) staticEvalResult {
-	leftString, ok := staticValueToString(left)
+func (staticEvaluator *StaticStringEvaluator) concatStaticValues(
+	left, right staticEvalResult,
+) staticEvalResult {
+	leftString, ok := staticValueToString(left.value)
 	if !ok {
 		return staticEvalResult{}
 	}
-	rightString, ok := staticValueToString(right)
+	rightString, ok := staticValueToString(right.value)
 	if !ok {
 		return staticEvalResult{}
 	}
-	return staticEvalResult{value: leftString + rightString, ok: true}
+	if !staticEvaluator.eslintStaticCalls {
+		return staticEvalResult{value: leftString + rightString, ok: true}
+	}
+	leftUnits := left.stringCodeUnits
+	if !left.stringCodeUnitsKnown {
+		leftUnits = ecmascript.StringCodeUnitCount(leftString)
+	}
+	rightUnits := right.stringCodeUnits
+	if !right.stringCodeUnitsKnown {
+		rightUnits = ecmascript.StringCodeUnitCount(rightString)
+	}
+	if leftUnits > maxStaticStringLength || rightUnits > maxStaticStringLength-leftUnits {
+		staticEvaluator.stringWorkContext.exhaust()
+		return staticEvalResult{}
+	}
+	if len(leftString) > maxStaticStringLength*3 ||
+		len(rightString) > maxStaticStringLength*3-len(leftString) {
+		staticEvaluator.stringWorkContext.exhaust()
+		return staticEvalResult{}
+	}
+	if !staticEvaluator.stringWorkContext.reserve((len(leftString) + len(rightString)) * 2) {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{
+		value: leftString + rightString, ok: true,
+		stringCodeUnits: leftUnits + rightUnits, stringCodeUnitsKnown: true,
+	}
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalPrefixUnaryExpression(node *ast.Node) staticEvalResult {
@@ -549,6 +1295,29 @@ func (staticEvaluator *StaticStringEvaluator) evalNumericPrefix(prefix *ast.Pref
 	operand := staticEvaluator.evalValue(prefix.Operand)
 	if !operand.ok {
 		return staticEvalResult{}
+	}
+	if staticEvaluator.eslintStaticCalls {
+		if bigint, ok := operand.value.(staticBigIntValue); ok && bigint.value != nil {
+			switch prefix.Operator {
+			case ast.KindMinusToken:
+				value := new(big.Int).Neg(bigint.value)
+				return staticEvalResult{
+					value: staticBigIntValue{value: value}, ok: true,
+					bigIntWorkBytes: (value.BitLen() + 7) / 8,
+					cacheableBigInt: operand.cacheableBigInt,
+				}
+			case ast.KindTildeToken:
+				value := new(big.Int).Not(bigint.value)
+				return staticEvalResult{
+					value: staticBigIntValue{value: value}, ok: true,
+					bigIntWorkBytes: (value.BitLen() + 7) / 8,
+					cacheableBigInt: operand.cacheableBigInt,
+				}
+			default:
+				// Unary plus throws for BigInt.
+				return staticEvalResult{}
+			}
+		}
 	}
 	number, ok := staticValueToNumber(operand.value)
 	if !ok {
@@ -591,8 +1360,15 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteral(node *ast.Node) 
 	if object == nil || object.Properties == nil {
 		return staticEvalResult{}
 	}
+	if staticEvaluator.eslintStaticCalls && len(object.Properties.Nodes) > maxStaticAggregateElements {
+		return staticEvalResult{}
+	}
+	if staticEvaluator.eslintStaticCalls &&
+		!staticEvaluator.stringWorkContext.reserve(max(len(object.Properties.Nodes)*64, 1)) {
+		return staticEvalResult{}
+	}
 
-	value := &staticObjectValue{}
+	value := &staticObjectValue{enhancedCoercion: staticEvaluator.eslintStaticCalls}
 	for _, property := range object.Properties.Nodes {
 		var valueNode *ast.Node
 		switch property.Kind {
@@ -600,6 +1376,18 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteral(node *ast.Node) 
 			valueNode = property.AsPropertyAssignment().Initializer
 		case ast.KindShorthandPropertyAssignment:
 			valueNode = property.Name()
+		case ast.KindSpreadAssignment:
+			if !staticEvaluator.eslintStaticCalls {
+				return staticEvalResult{}
+			}
+			spread := staticEvaluator.evalValue(property.AsSpreadAssignment().Expression)
+			if !spread.ok || !staticEvaluator.spreadObjectProperties(value, spread.value) {
+				return staticEvalResult{}
+			}
+			if value.propertyCount > maxStaticAggregateElements {
+				return staticEvalResult{}
+			}
+			continue
 		default:
 			return staticEvalResult{}
 		}
@@ -610,24 +1398,56 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteral(node *ast.Node) 
 				return staticEvalResult{}
 			}
 			switch propertyValue.value.(type) {
-			case *staticObjectValue, *staticArrayValue:
+			case *staticObjectValue, *staticArrayValue, staticBuiltinObjectValue:
 				value.prototype = propertyValue.value
 				value.prototypeSet = true
 			case staticNullValue:
 				value.prototype = nil
 				value.prototypeSet = true
 			default:
+				if staticValueIsAggregate(propertyValue.value) {
+					// eslint-utils does not safely invoke inherited getters on an
+					// arbitrary native object used as an object-literal prototype.
+					return staticEvalResult{}
+				}
 				// JavaScript ignores primitive prototype-setter values.
 			}
 			continue
 		}
 
-		key, ok := staticEvaluator.evalPropertyKey(property.Name())
-		if !ok {
-			return staticEvalResult{}
-		}
 		propertyValue := staticEvaluator.evalValue(valueNode)
 		if !propertyValue.ok {
+			return staticEvalResult{}
+		}
+		if staticEvaluator.eslintStaticCalls {
+			key, symbol, ok := staticEvaluator.evalESLintPropertyKey(property.Name())
+			if !ok {
+				return staticEvalResult{}
+			}
+			if symbol != nil {
+				value.addSymbolProperty(*symbol, propertyValue.value)
+			} else if key == "__proto__" {
+				// eslint-utils builds object expressions via ordinary assignment,
+				// so a computed "__proto__" key reaches the legacy setter too.
+				switch propertyValue.value.(type) {
+				case *staticObjectValue, *staticArrayValue, staticBuiltinObjectValue:
+					value.prototype = propertyValue.value
+					value.prototypeSet = true
+				case staticNullValue:
+					value.prototype = nil
+					value.prototypeSet = true
+				default:
+					if staticValueIsAggregate(propertyValue.value) {
+						return staticEvalResult{}
+					}
+				}
+			} else {
+				value.addProperty(key, propertyValue.value)
+			}
+			continue
+		}
+		key, ok := staticEvaluator.evalPropertyKey(property.Name())
+		if !ok {
 			return staticEvalResult{}
 		}
 		value.addProperty(key, propertyValue.value)
@@ -643,6 +1463,64 @@ func (value *staticObjectValue) addProperty(name string, propertyValue any) {
 		value.extraProperties = append(value.extraProperties, property)
 	}
 	value.propertyCount++
+	if value.propertyIndices == nil && value.propertyCount >= 8 {
+		value.propertyIndices = make(map[string]int, value.propertyCount)
+		if !value.property.symbolKey {
+			value.propertyIndices[value.property.name] = 0
+		}
+		for index, existing := range value.extraProperties {
+			if !existing.symbolKey {
+				value.propertyIndices[existing.name] = index + 1
+			}
+		}
+	} else if value.propertyIndices != nil {
+		value.propertyIndices[name] = value.propertyCount - 1
+	}
+}
+
+func (value *staticObjectValue) addSymbolProperty(symbol staticSymbolValue, propertyValue any) {
+	property := staticObjectProperty{symbol: symbol, symbolKey: true, value: propertyValue}
+	if value.propertyCount == 0 {
+		value.property = property
+	} else {
+		value.extraProperties = append(value.extraProperties, property)
+	}
+	value.propertyCount++
+}
+
+func (staticEvaluator *StaticStringEvaluator) spreadObjectProperties(target *staticObjectValue, source any) bool {
+	// Object spread ignores null and undefined instead of applying the
+	// throwing Object.keys conversion used by Object.entries/keys/values.
+	if staticValueNullish(source) {
+		return true
+	}
+	properties, ok := staticEnumerableOwnProperties(staticEvaluator.stringWorkContext, source)
+	if !ok {
+		return false
+	}
+	for _, property := range properties {
+		if target.propertyCount >= maxStaticAggregateElements {
+			return false
+		}
+		target.addProperty(property.name, property.value)
+	}
+	if object, ok := source.(*staticObjectValue); ok {
+		if object.propertyCount > 0 && object.property.symbolKey {
+			if target.propertyCount >= maxStaticAggregateElements {
+				return false
+			}
+			target.addSymbolProperty(object.property.symbol, object.property.value)
+		}
+		for _, property := range object.extraProperties {
+			if property.symbolKey {
+				if target.propertyCount >= maxStaticAggregateElements {
+					return false
+				}
+				target.addSymbolProperty(property.symbol, property.value)
+			}
+		}
+	}
+	return true
 }
 
 func isObjectLiteralPrototypeSetter(property *ast.Node) bool {
@@ -729,6 +1607,50 @@ func (staticEvaluator *StaticStringEvaluator) evalArrayLiteral(node *ast.Node) s
 	if array == nil || array.Elements == nil {
 		return staticEvalResult{}
 	}
+	if staticEvaluator.eslintStaticCalls {
+		if len(array.Elements.Nodes) > maxStaticAggregateElements {
+			return staticEvalResult{}
+		}
+		if !staticEvaluator.stringWorkContext.reserve(max(len(array.Elements.Nodes)*32, 1)) {
+			return staticEvalResult{}
+		}
+		elements := make([]staticArrayElement, 0, len(array.Elements.Nodes))
+		for _, element := range array.Elements.Nodes {
+			switch element.Kind {
+			case ast.KindOmittedExpression:
+				if len(elements) >= maxStaticAggregateElements {
+					return staticEvalResult{}
+				}
+				elements = append(elements, staticArrayElement{value: staticUndefinedValue{}, omitted: true})
+			case ast.KindSpreadElement:
+				spread := staticEvaluator.evalValue(element.AsSpreadElement().Expression)
+				if !spread.ok {
+					return staticEvalResult{}
+				}
+				values, ok := staticIterableValues(
+					staticEvaluator.stringWorkContext,
+					spread.value,
+					maxStaticAggregateElements-len(elements),
+				)
+				if !ok {
+					return staticEvalResult{}
+				}
+				for _, value := range values {
+					elements = append(elements, staticArrayElement{value: value})
+				}
+			default:
+				if len(elements) >= maxStaticAggregateElements {
+					return staticEvalResult{}
+				}
+				result := staticEvaluator.evalValue(element)
+				if !result.ok {
+					return staticEvalResult{}
+				}
+				elements = append(elements, staticArrayElement{value: result.value})
+			}
+		}
+		return staticEvalResult{value: staticArrayFromElements(elements), ok: true}
+	}
 
 	arrayValue := &staticArrayValue{length: len(array.Elements.Nodes)}
 	if arrayValue.length > len(arrayValue.inline) {
@@ -737,6 +1659,12 @@ func (staticEvaluator *StaticStringEvaluator) evalArrayLiteral(node *ast.Node) s
 	for i, element := range array.Elements.Nodes {
 		if element.Kind == ast.KindOmittedExpression {
 			arrayValue.set(i, staticUndefinedValue{})
+			if staticEvaluator.eslintStaticCalls {
+				if arrayValue.omitted == nil {
+					arrayValue.omitted = make(map[int]bool, 1)
+				}
+				arrayValue.omitted[i] = true
+			}
 			continue
 		}
 		if element.Kind == ast.KindSpreadElement {
@@ -800,11 +1728,69 @@ func (staticEvaluator *StaticStringEvaluator) evalPropertyKey(name *ast.Node) (s
 	return "", false
 }
 
+func (staticEvaluator *StaticStringEvaluator) evalESLintPropertyKey(name *ast.Node) (string, *staticSymbolValue, bool) {
+	if name == nil {
+		return "", nil, false
+	}
+	if name.Kind == ast.KindComputedPropertyName {
+		computed := name.AsComputedPropertyName()
+		if computed == nil {
+			return "", nil, false
+		}
+		result := staticEvaluator.evalValue(computed.Expression)
+		if !result.ok {
+			return "", nil, false
+		}
+		if symbol, ok := result.value.(staticSymbolValue); ok {
+			if symbol.hostDependent {
+				return "", nil, false
+			}
+			return "", &symbol, true
+		}
+		key, ok := staticValueToString(result.value)
+		return key, nil, ok
+	}
+	key, ok := staticEvaluator.evalPropertyKey(name)
+	return key, nil, ok
+}
+
 func (staticEvaluator *StaticStringEvaluator) evalMemberAccess(node *ast.Node) staticEvalResult {
 	objectNode := AccessExpressionObject(node)
 	if objectNode == nil {
 		return staticEvalResult{}
 	}
+	if staticEvaluator.eslintStaticCalls {
+		// eslint-utils resolves an optional receiver before a computed key.
+		// This matters for `null?.[unknown]`, which short-circuits statically.
+		object := staticEvaluator.evalValue(objectNode)
+		if !object.ok {
+			return staticEvalResult{}
+		}
+		if _, shortCircuited := object.value.(staticOptionalChainShortCircuitValue); shortCircuited {
+			if ast.IsOptionalChain(node) && !ast.IsOuterExpression(objectNode, ast.OEKParentheses) {
+				return object
+			}
+			return staticEvalResult{}
+		}
+		if staticValueNullish(object.value) {
+			if node.QuestionDotToken() != nil {
+				return staticEvalResult{value: staticOptionalChainShortCircuitValue{}, ok: true}
+			}
+			return staticEvalResult{}
+		}
+		key, symbolKey, ok := staticEvaluator.evalESLintAccessExpressionKey(node)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if symbolKey != nil {
+			return staticESLintSymbolMemberValue(object.value, *symbolKey)
+		}
+		if result := staticESLintMemberValue(object.value, key); result.ok {
+			return result
+		}
+		return staticESLintBuiltinMember(object.value, key)
+	}
+
 	key, ok := staticEvaluator.evalAccessExpressionKey(node)
 	if !ok {
 		return staticEvalResult{}
@@ -812,12 +1798,298 @@ func (staticEvaluator *StaticStringEvaluator) evalMemberAccess(node *ast.Node) s
 	if literal := SkipAssertionsAndParens(objectNode); literal != nil && literal.Kind == ast.KindObjectLiteralExpression {
 		return staticEvaluator.evalObjectLiteralMember(literal, key)
 	}
-
 	object := staticEvaluator.evalValue(objectNode)
 	if !object.ok {
 		return staticEvalResult{}
 	}
 	return staticMemberValue(object.value, key)
+}
+
+func staticESLintBuiltinMember(object any, key string) staticEvalResult {
+	if key == "__proto__" || key == "caller" || key == "arguments" {
+		return staticEvalResult{}
+	}
+	if prototype, ok := object.(staticBuiltinObjectValue); ok {
+		return staticESLintBuiltinPrototypeMember(string(prototype), key)
+	}
+	builtin, ok := object.(staticBuiltinValue)
+	if !ok {
+		return staticEvalResult{}
+	}
+	name := string(builtin)
+	if name == "RegExp" && staticRegExpLegacyGetter(key) {
+		return staticEvalResult{}
+	}
+	switch name {
+	case "Math":
+		switch key {
+		case "E":
+			return staticEvalResult{value: staticNumberValue(math.E), ok: true}
+		case "LN10":
+			return staticEvalResult{value: staticNumberValue(math.Ln10), ok: true}
+		case "LN2":
+			return staticEvalResult{value: staticNumberValue(math.Ln2), ok: true}
+		case "LOG10E":
+			return staticEvalResult{value: staticNumberValue(math.Log10E), ok: true}
+		case "LOG2E":
+			return staticEvalResult{value: staticNumberValue(math.Log2E), ok: true}
+		case "PI":
+			return staticEvalResult{value: staticNumberValue(math.Pi), ok: true}
+		case "SQRT1_2":
+			return staticEvalResult{value: staticNumberValue(math.Sqrt2 / 2), ok: true}
+		case "SQRT2":
+			return staticEvalResult{value: staticNumberValue(math.Sqrt2), ok: true}
+		}
+	case "Number":
+		switch key {
+		case "EPSILON":
+			return staticEvalResult{value: staticNumberValue(math.Nextafter(1, 2) - 1), ok: true}
+		case "MAX_SAFE_INTEGER":
+			return staticEvalResult{value: staticNumberValue(9007199254740991), ok: true}
+		case "MAX_VALUE":
+			return staticEvalResult{value: staticNumberValue(math.MaxFloat64), ok: true}
+		case "MIN_SAFE_INTEGER":
+			return staticEvalResult{value: staticNumberValue(-9007199254740991), ok: true}
+		case "MIN_VALUE":
+			return staticEvalResult{value: staticNumberValue(math.SmallestNonzeroFloat64), ok: true}
+		case "NaN":
+			return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+		case "NEGATIVE_INFINITY":
+			return staticEvalResult{value: staticNumberValue(math.Inf(-1)), ok: true}
+		case "POSITIVE_INFINITY":
+			return staticEvalResult{value: staticNumberValue(math.Inf(1)), ok: true}
+		}
+	case "Symbol":
+		if staticSymbolProperty(key) {
+			if key == "dispose" || key == "asyncDispose" {
+				// Node 22 exposes these as Symbol.for("nodejs.*"); Node 23+
+				// exposes distinct well-known symbols. Their type and identity
+				// relative to themselves are stable, but registry membership and
+				// observable descriptions are host-dependent.
+				return staticEvalResult{value: staticSymbolValue{description: key, hostDependent: true}, ok: true}
+			}
+			return staticEvalResult{value: staticSymbolValue{description: key, wellKnown: true}, ok: true}
+		}
+	}
+	if bytes, ok := staticTypedArrayBytesPerElement(name); ok && key == "BYTES_PER_ELEMENT" {
+		return staticEvalResult{value: staticNumberValue(bytes), ok: true}
+	}
+	if staticBuiltinFunctionProperty(name, key) {
+		return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+	}
+	if key == "prototype" && staticBuiltinHasPrototype(name) {
+		if name == "Function" {
+			return staticEvalResult{value: staticBuiltinValue("Function.prototype"), ok: true}
+		}
+		return staticEvalResult{value: staticBuiltinObjectValue(name + ".prototype"), ok: true}
+	}
+	if staticBuiltinIsFunction(name) {
+		switch key {
+		case "apply", "bind", "call":
+			return staticEvalResult{value: staticBuiltinValue("Function.prototype." + key), ok: true}
+		case "constructor":
+			return staticEvalResult{value: staticBuiltinValue("Function"), ok: true}
+		case "toString":
+			return staticEvalResult{value: staticBuiltinValue("Function.prototype.toString"), ok: true}
+		}
+	}
+	if key == "length" || key == "name" {
+		if strings.Contains(name, ".") || staticBuiltinIsFunction(name) {
+			if key == "name" {
+				canonicalName := staticCanonicalBuiltinFunctionName(name)
+				if canonicalName == "Function.prototype" {
+					return staticEvalResult{value: "", ok: true}
+				}
+				return staticEvalResult{
+					value: canonicalName[strings.LastIndex(canonicalName, ".")+1:], ok: true,
+				}
+			}
+			if length, ok := staticBuiltinFunctionLength(name); ok {
+				return staticEvalResult{value: staticNumberValue(length), ok: true}
+			}
+			return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+		}
+	}
+	return staticObjectPrototypeMember(key)
+}
+
+func staticBuiltinFunctionLength(name string) (int, bool) {
+	if strings.HasPrefix(name, "Math.") {
+		switch strings.TrimPrefix(name, "Math.") {
+		case "random":
+			return 0, true
+		case "atan2", "hypot", "imul", "max", "min", "pow":
+			return 2, true
+		default:
+			if staticMathMethod(strings.TrimPrefix(name, "Math.")) {
+				return 1, true
+			}
+		}
+	}
+	switch name {
+	case "Function.prototype":
+		return 0, true
+	case "parseInt", "RegExp":
+		return 2, true
+	case "Array", "ArrayBuffer", "BigInt", "Boolean", "DataView", "decodeURI",
+		"decodeURIComponent", "encodeURI", "encodeURIComponent", "escape", "Function",
+		"isFinite", "isNaN", "isPrototypeOf", "Number", "Object", "parseFloat", "Promise",
+		"String", "unescape":
+		return 1, true
+	case "Map", "Set", "Symbol", "WeakMap", "WeakSet":
+		return 0, true
+	case "Proxy":
+		return 2, true
+	case "Date":
+		return 7, true
+	}
+	if _, typedArray := staticTypedArrayBytesPerElement(name); typedArray {
+		return 3, true
+	}
+	return 0, false
+}
+
+func staticRegExpLegacyGetter(key string) bool {
+	switch key {
+	case "input", "$_", "lastMatch", "$&", "lastParen", "$+", "leftContext", "$`",
+		"rightContext", "$'", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9":
+		return true
+	}
+	return false
+}
+
+func staticESLintBuiltinPrototypeMember(name, key string) staticEvalResult {
+	if name == "Array.prototype[Symbol.unscopables]" {
+		for _, property := range staticArrayUnscopablesPropertyNames {
+			if key == property {
+				return staticEvalResult{value: true, ok: true}
+			}
+		}
+		// This special object has a null prototype, so even Object.prototype
+		// names are absent.
+		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+	}
+	if staticBuiltinPrototypeGetterDenied(name, key) {
+		return staticEvalResult{}
+	}
+	if key == "length" && (name == "Array.prototype" || name == "String.prototype") {
+		return staticEvalResult{value: staticNumberValue(0), ok: true}
+	}
+	constructor := strings.TrimSuffix(name, ".prototype")
+	if bytes, ok := staticTypedArrayBytesPerElement(constructor); ok && key == "BYTES_PER_ELEMENT" {
+		return staticEvalResult{value: staticNumberValue(bytes), ok: true}
+	}
+	if key == "constructor" {
+		return staticEvalResult{value: staticBuiltinValue(constructor), ok: true}
+	}
+	if key == "__proto__" {
+		return staticEvalResult{}
+	}
+	switch name {
+	case "Array.prototype":
+		if staticArrayPrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "Map.prototype", "Set.prototype":
+		if key == "size" {
+			return staticEvalResult{}
+		}
+		if staticCollectionPrototypeMethod(constructor, key) {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "String.prototype":
+		if staticStringPrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "Number.prototype":
+		if staticNumberPrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "Boolean.prototype":
+		if key == "toString" || key == "valueOf" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "BigInt.prototype":
+		if key == "toLocaleString" || key == "toString" || key == "valueOf" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "Date.prototype":
+		if staticDatePrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "RegExp.prototype":
+		if key == "source" || key == "flags" {
+			return staticEvalResult{}
+		}
+		if key == "compile" || key == "exec" || key == "test" || key == "toString" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "Promise.prototype":
+		if key == "catch" || key == "finally" || key == "then" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "Symbol.prototype":
+		if key == "description" {
+			// Accessing the getter on Symbol.prototype itself throws.
+			return staticEvalResult{}
+		}
+		if key == "toString" || key == "valueOf" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "ArrayBuffer.prototype":
+		if key == "resize" || key == "slice" || key == "transfer" || key == "transferToFixedLength" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "DataView.prototype":
+		if staticDataViewPrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "WeakMap.prototype":
+		if key == "delete" || key == "get" || key == "has" || key == "set" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	case "WeakSet.prototype":
+		if key == "add" || key == "delete" || key == "has" {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	default:
+		if staticTypedArrayPrototypeMethod(constructor, key) {
+			return staticEvalResult{value: staticBuiltinValue(name + "." + key), ok: true}
+		}
+	}
+	return staticObjectPrototypeMember(key)
+}
+
+func staticBuiltinPrototypeGetterDenied(name, key string) bool {
+	switch name {
+	case "ArrayBuffer.prototype":
+		switch key {
+		case "byteLength", "detached", "maxByteLength", "resizable":
+			return true
+		}
+	case "DataView.prototype":
+		switch key {
+		case "buffer", "byteLength", "byteOffset":
+			return true
+		}
+	case "Map.prototype", "Set.prototype":
+		return key == "size"
+	case "RegExp.prototype":
+		switch key {
+		case "dotAll", "flags", "global", "hasIndices", "ignoreCase", "multiline",
+			"source", "sticky", "unicode", "unicodeSets":
+			return true
+		}
+	case "Symbol.prototype":
+		return key == "description"
+	}
+	if _, typedArray := staticTypedArrayBytesPerElement(strings.TrimSuffix(name, ".prototype")); typedArray {
+		switch key {
+		case "buffer", "byteLength", "byteOffset", "length":
+			return true
+		}
+	}
+	return false
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalAccessExpressionKey(node *ast.Node) (string, bool) {
@@ -832,6 +2104,27 @@ func (staticEvaluator *StaticStringEvaluator) evalAccessExpressionKey(node *ast.
 		return "", false
 	}
 	return staticValueToString(argument.value)
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalESLintAccessExpressionKey(node *ast.Node) (string, *staticSymbolValue, bool) {
+	if key, ok := AccessExpressionStaticName(node); ok {
+		return key, nil, true
+	}
+	if node == nil || node.Kind != ast.KindElementAccessExpression {
+		return "", nil, false
+	}
+	argument := staticEvaluator.evalValue(node.AsElementAccessExpression().ArgumentExpression)
+	if !argument.ok {
+		return "", nil, false
+	}
+	if symbol, ok := argument.value.(staticSymbolValue); ok {
+		if symbol.hostDependent {
+			return "", nil, false
+		}
+		return "", &symbol, true
+	}
+	key, ok := staticValueToString(argument.value)
+	return key, nil, ok
 }
 
 // staticMemberValue reads key off a folded object or array literal. Reading a
@@ -866,12 +2159,22 @@ func staticMemberValue(object any, key string) staticEvalResult {
 }
 
 func staticObjectOwnProperty(object *staticObjectValue, key string) (any, bool) {
+	if object.propertyIndices != nil {
+		index, ok := object.propertyIndices[key]
+		if !ok {
+			return nil, false
+		}
+		if index == 0 {
+			return object.property.value, true
+		}
+		return object.extraProperties[index-1].value, true
+	}
 	for i := len(object.extraProperties) - 1; i >= 0; i-- {
-		if object.extraProperties[i].name == key {
+		if !object.extraProperties[i].symbolKey && object.extraProperties[i].name == key {
 			return object.extraProperties[i].value, true
 		}
 	}
-	if object.propertyCount > 0 && object.property.name == key {
+	if object.propertyCount > 0 && !object.property.symbolKey && object.property.name == key {
 		return object.property.value, true
 	}
 	return nil, false
@@ -1139,25 +2442,50 @@ func (staticEvaluator *StaticStringEvaluator) evalBuiltinStaticCall(node *ast.No
 	case "charAt":
 		return staticStringCharAt(text, arguments)
 	case "concat":
-		return staticStringConcat(text, arguments)
+		return staticStringConcat(nil, text, arguments)
 	}
 
 	return staticEvalResult{}
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalCallArguments(node *ast.Node) ([]any, bool) {
+	if staticEvaluator.eslintStaticCalls && len(node.Arguments()) > maxStaticAggregateElements {
+		return nil, false
+	}
+	if staticEvaluator.eslintStaticCalls &&
+		!staticEvaluator.stringWorkContext.reserve(max(len(node.Arguments())*16, 1)) {
+		return nil, false
+	}
 	values := make([]any, 0, len(node.Arguments()))
 	for _, argumentNode := range node.Arguments() {
 		if ast.IsSpreadElement(argumentNode) {
 			spread := staticEvaluator.evalValue(argumentNode.AsSpreadElement().Expression)
-			array, ok := spread.value.(*staticArrayValue)
-			if !spread.ok || !ok {
+			if !spread.ok {
 				return nil, false
 			}
-			for index := range array.length {
-				values = append(values, array.element(index))
+			var spreadValues []any
+			var ok bool
+			if staticEvaluator.eslintStaticCalls {
+				spreadValues, ok = staticIterableValues(
+					staticEvaluator.stringWorkContext,
+					spread.value,
+					maxStaticAggregateElements-len(values),
+				)
+			} else if array, isArray := spread.value.(*staticArrayValue); isArray {
+				spreadValues = make([]any, array.length)
+				for index := range array.length {
+					spreadValues[index] = array.element(index)
+				}
+				ok = true
 			}
+			if !ok {
+				return nil, false
+			}
+			values = append(values, spreadValues...)
 			continue
+		}
+		if staticEvaluator.eslintStaticCalls && len(values) >= maxStaticAggregateElements {
+			return nil, false
 		}
 		argument := staticEvaluator.evalValue(argumentNode)
 		if !argument.ok {
@@ -1265,8 +2593,15 @@ func staticStringCharAt(text string, arguments []any) staticEvalResult {
 	return staticEvalResult{value: string(utf16.Decode(units[index : index+1])), ok: true}
 }
 
-func staticStringConcat(text string, arguments []any) staticEvalResult {
+func staticStringConcat(
+	work *staticStringWorkContext,
+	text string,
+	arguments []any,
+) staticEvalResult {
 	var builder strings.Builder
+	if !work.reserve(len(text) * 2) {
+		return staticEvalResult{}
+	}
 	builder.WriteString(text)
 	for _, argument := range arguments {
 		part, ok := staticValueToString(argument)
@@ -1274,6 +2609,10 @@ func staticStringConcat(text string, arguments []any) staticEvalResult {
 			return staticEvalResult{}
 		}
 		if len(part) > maxStaticStringLength-builder.Len() {
+			work.exhaust()
+			return staticEvalResult{}
+		}
+		if !work.reserve(len(part) * 2) {
 			return staticEvalResult{}
 		}
 		builder.WriteString(part)
@@ -1337,6 +2676,42 @@ func staticValueToNumber(value any) (float64, bool) {
 	switch value := value.(type) {
 	case staticNumberValue:
 		return float64(value), true
+	case staticUnknownNumberValue, staticBigIntValue, staticSymbolValue:
+		return 0, false
+	case staticUnknownStringValue:
+		if value.numericNaN {
+			return math.NaN(), true
+		}
+		return 0, false
+	case staticDateValue:
+		if value.known {
+			return float64(value.milliseconds), true
+		}
+		return 0, false
+	case staticBoxedValue:
+		return staticValueToNumber(value.value)
+	case staticBuiltinValue:
+		// Native function source text is engine-specific, but neither it nor an
+		// ordinary built-in object's default string is a StringNumericLiteral.
+		return math.NaN(), true
+	case staticBuiltinObjectValue:
+		if _, typedArray := staticTypedArrayBytesPerElement(
+			strings.TrimSuffix(string(value), ".prototype"),
+		); typedArray {
+			// TypedArray prototypes have no backing typed-array data. Their
+			// inherited primitive conversion throws instead of producing NaN.
+			return 0, false
+		}
+		switch value {
+		case "Boolean.prototype", "Number.prototype", "String.prototype", "Array.prototype":
+			return 0, true
+		case "RegExp.prototype":
+			return math.NaN(), true
+		case "BigInt.prototype", "Date.prototype", "Symbol.prototype", "Array.prototype[Symbol.unscopables]":
+			return 0, false
+		default:
+			return math.NaN(), true
+		}
 	case bool:
 		if value {
 			return 1, true
@@ -1591,7 +2966,11 @@ func isMutatingArrayMethod(name string) bool {
 
 func staticValueIsTsgoSafe(value any) bool {
 	switch value.(type) {
-	case bool, staticNullValue, staticUndefinedValue, staticNumberValue, *staticStringNode, *staticObjectValue, *staticArrayValue:
+	case bool, staticNullValue, staticUndefinedValue, staticOptionalChainShortCircuitValue, staticNumberValue,
+		staticUnknownNumberValue, staticUnknownStringValue, staticUnknownBooleanValue,
+		staticOpaqueObjectValue, staticRegExpValue, staticDateValue, staticBoxedValue,
+		staticCollectionValue, staticBigIntValue, staticSymbolValue, staticBuiltinValue, staticBuiltinObjectValue,
+		*staticStringNode, *staticObjectValue, *staticArrayValue:
 		return false
 	default:
 		return value != nil
@@ -1621,7 +3000,7 @@ func staticValueIsString(value any) bool {
 
 func staticValueNullish(value any) bool {
 	switch value.(type) {
-	case staticNullValue, staticUndefinedValue:
+	case staticNullValue, staticUndefinedValue, staticOptionalChainShortCircuitValue:
 		return true
 	default:
 		return false
@@ -1629,8 +3008,12 @@ func staticValueNullish(value any) bool {
 }
 
 func staticValueUndefined(value any) bool {
-	_, ok := value.(staticUndefinedValue)
-	return ok
+	switch value.(type) {
+	case staticUndefinedValue, staticOptionalChainShortCircuitValue:
+		return true
+	default:
+		return false
+	}
 }
 
 // staticValueKind is the JavaScript typeof-like classification `===` needs.
@@ -1644,21 +3027,35 @@ const (
 	staticKindString
 	staticKindNumber
 	staticKindBoolean
+	staticKindBigInt
+	staticKindSymbol
 	staticKindNull
 	staticKindUndefined
 )
 
 func staticValueKindOf(value any) staticValueKind {
 	switch value.(type) {
-	case bool:
+	case bool, staticUnknownBooleanValue:
 		return staticKindBoolean
+	case staticBigIntValue:
+		return staticKindBigInt
+	case staticSymbolValue:
+		return staticKindSymbol
 	case staticNullValue:
 		return staticKindNull
 	case staticUndefinedValue:
 		return staticKindUndefined
+	case staticOptionalChainShortCircuitValue:
+		return staticKindUndefined
 	}
 	if staticValueIsString(value) {
 		return staticKindString
+	}
+	if _, ok := value.(staticUnknownStringValue); ok {
+		return staticKindString
+	}
+	if _, ok := value.(staticUnknownNumberValue); ok {
+		return staticKindNumber
 	}
 	if _, isNumber := value.(interface{ IsNaN() bool }); isNumber {
 		return staticKindNumber
@@ -1670,6 +3067,30 @@ func staticValueKindOf(value any) staticValueKind {
 // values. Comparing across kinds is always false, which keeps `1n === 1` right
 // even though bigint values themselves stay unknown.
 func staticValuesStrictEqual(left any, right any) (equal bool, ok bool) {
+	if leftBuiltin, ok := left.(staticBuiltinValue); ok {
+		rightBuiltin, rightOK := right.(staticBuiltinValue)
+		return rightOK && staticCanonicalBuiltinFunctionName(string(leftBuiltin)) ==
+			staticCanonicalBuiltinFunctionName(string(rightBuiltin)), true
+	}
+	if leftBuiltin, ok := left.(staticBuiltinObjectValue); ok {
+		rightBuiltin, rightOK := right.(staticBuiltinObjectValue)
+		return rightOK && leftBuiltin == rightBuiltin, true
+	}
+	leftAggregate := staticValueIsAggregate(left)
+	rightAggregate := staticValueIsAggregate(right)
+	if leftAggregate != rightAggregate {
+		return false, true
+	}
+	if leftAggregate {
+		leftKey, leftOK := staticCanonicalCollectionKey(left, nil)
+		rightKey, rightOK := staticCanonicalCollectionKey(right, nil)
+		if leftOK && rightOK && leftKey.kind >= 11 && rightKey.kind >= 11 {
+			return leftKey == rightKey, true
+		}
+		// Object/array initializers are reevaluated for each identifier
+		// reference, so separately materialized aggregates are never identical.
+		return false, true
+	}
 	leftKind := staticValueKindOf(left)
 	rightKind := staticValueKindOf(right)
 	if leftKind == staticKindUnknown || rightKind == staticKindUnknown {
@@ -1681,8 +3102,11 @@ func staticValuesStrictEqual(left any, right any) (equal bool, ok bool) {
 
 	switch leftKind {
 	case staticKindString:
-		leftText, _ := staticValueAsString(left)
-		rightText, _ := staticValueAsString(right)
+		leftText, leftOK := staticValueAsString(left)
+		rightText, rightOK := staticValueAsString(right)
+		if !leftOK || !rightOK {
+			return false, false
+		}
 		return leftText == rightText, true
 	case staticKindNumber:
 		leftNumber, leftOk := staticValueToNumber(left)
@@ -1698,14 +3122,71 @@ func staticValuesStrictEqual(left any, right any) (equal bool, ok bool) {
 			return false, false
 		}
 		return leftFlag == rightFlag, true
+	case staticKindBigInt:
+		leftBigInt, leftOK := left.(staticBigIntValue)
+		rightBigInt, rightOK := right.(staticBigIntValue)
+		if !leftOK || !rightOK || leftBigInt.value == nil || rightBigInt.value == nil {
+			return false, false
+		}
+		if !staticReserveBigIntComparisonWork(leftBigInt, rightBigInt) {
+			return false, false
+		}
+		return leftBigInt.value.Cmp(rightBigInt.value) == 0, true
+	case staticKindSymbol:
+		leftSymbol, leftOK := left.(staticSymbolValue)
+		rightSymbol, rightOK := right.(staticSymbolValue)
+		if !leftOK || !rightOK {
+			return false, false
+		}
+		return staticSymbolIdentityEqual(leftSymbol, rightSymbol)
 	}
 	return true, true
 }
 
+func staticCanonicalBuiltinFunctionName(name string) string {
+	if memberSeparator := strings.IndexByte(name, '.'); memberSeparator > 0 {
+		if _, typedArray := staticTypedArrayBytesPerElement(name[:memberSeparator]); typedArray {
+			switch name[memberSeparator:] {
+			case ".from", ".of":
+				return "TypedArray" + name[memberSeparator:]
+			}
+		}
+	}
+	if prototypeSeparator := strings.Index(name, ".prototype."); prototypeSeparator > 0 {
+		if _, typedArray := staticTypedArrayBytesPerElement(name[:prototypeSeparator]); typedArray {
+			canonical := "TypedArray" + name[prototypeSeparator:]
+			if canonical == "TypedArray.prototype.toString" {
+				return "Array.prototype.toString"
+			}
+			return canonical
+		}
+	}
+	switch name {
+	case "Number.parseInt":
+		return "parseInt"
+	case "Number.parseFloat":
+		return "parseFloat"
+	case "Set.prototype.keys":
+		return "Set.prototype.values"
+	case "Date.prototype.toGMTString":
+		return "Date.prototype.toUTCString"
+	case "String.prototype.trimLeft":
+		return "String.prototype.trimStart"
+	case "String.prototype.trimRight":
+		return "String.prototype.trimEnd"
+	default:
+		return name
+	}
+}
+
 func staticValueIsAggregate(value any) bool {
-	switch value.(type) {
-	case *staticObjectValue, *staticArrayValue:
+	switch value := value.(type) {
+	case *staticObjectValue, *staticArrayValue, staticOpaqueObjectValue, staticIteratorValue,
+		staticRegExpValue, staticDateValue, staticBoxedValue, staticCollectionValue,
+		staticBuiltinObjectValue:
 		return true
+	case staticBuiltinValue:
+		return !staticBuiltinIsFunction(string(value))
 	default:
 		return false
 	}
@@ -1717,12 +3198,27 @@ func staticValueTruthy(value any) (truthy bool, ok bool) {
 		return value != "", true
 	case staticNumberValue:
 		return value != 0 && !value.IsNaN(), true
+	case staticUnknownNumberValue, staticUnknownBooleanValue:
+		return false, false
+	case staticUnknownStringValue:
+		if value.truthy {
+			return true, true
+		}
+		return false, false
+	case staticBigIntValue:
+		if value.value != nil {
+			return value.value.Sign() != 0, true
+		}
+		return value.truthy, value.truthyKnown
+	case staticSymbolValue, staticBuiltinValue, staticBuiltinObjectValue, staticOpaqueObjectValue, staticIteratorValue,
+		staticRegExpValue, staticDateValue, staticBoxedValue, staticCollectionValue:
+		return true, true
 	case *staticStringNode:
 		stringValue, _ := staticValueAsString(value)
 		return stringValue != "", true
 	case bool:
 		return value, true
-	case staticNullValue, staticUndefinedValue:
+	case staticNullValue, staticUndefinedValue, staticOptionalChainShortCircuitValue:
 		return false, true
 	case *staticObjectValue, *staticArrayValue:
 		return true, true
@@ -1732,11 +3228,84 @@ func staticValueTruthy(value any) (truthy bool, ok bool) {
 }
 
 func staticValueToString(value any) (string, bool) {
+	return staticValueToStringWithWork(value, true)
+}
+
+// staticValueToStringWithWork performs JavaScript's primitive string
+// conversion. Enhanced-evaluator aggregates carry a shared file work budget;
+// charge=false is used only while a surrounding streamed conversion has
+// already reserved the complete allocation.
+func staticValueToStringWithWork(value any, charge bool) (string, bool) {
 	switch value := value.(type) {
 	case string:
 		return value, true
 	case staticNumberValue:
 		return ecmascript.NumberToString(float64(value)), true
+	case staticBigIntValue:
+		if value.value == nil {
+			return "", false
+		}
+		if charge && !value.stringWorkContext.reserve(staticBigIntStringBytesUpperBound(value.value)) {
+			return "", false
+		}
+		return value.value.String(), true
+	case staticUnknownStringValue:
+		return "", false
+	case staticUnknownNumberValue, staticUnknownBooleanValue, staticSymbolValue,
+		staticOpaqueObjectValue, staticIteratorValue:
+		return "", false
+	case staticRegExpValue:
+		length := len(value.source) + len(value.flags) + 2
+		if charge && value.stringWorkContext != nil &&
+			(length > maxStaticStringLength || !value.stringWorkContext.reserve(length)) {
+			value.stringWorkContext.exhaust()
+			return "", false
+		}
+		var builder strings.Builder
+		builder.Grow(length)
+		builder.WriteByte('/')
+		builder.WriteString(value.source)
+		builder.WriteByte('/')
+		builder.WriteString(value.flags)
+		return builder.String(), true
+	case staticDateValue:
+		return "", false
+	case staticBoxedValue:
+		if _, symbol := value.value.(staticSymbolValue); symbol {
+			return "", false
+		}
+		return staticValueToStringWithWork(value.value, charge)
+	case staticCollectionValue:
+		return "[object " + value.kind + "]", true
+	case staticBuiltinValue:
+		if !staticBuiltinIsFunction(string(value)) {
+			return "[object " + string(value) + "]", true
+		}
+		return "", false
+	case staticBuiltinObjectValue:
+		name := strings.TrimSuffix(string(value), ".prototype")
+		if value == "Array.prototype[Symbol.unscopables]" {
+			// The object has a null prototype and therefore no ordinary primitive
+			// conversion method. String/number coercion throws upstream.
+			return "", false
+		}
+		if name == "Date" || name == "Symbol" {
+			return "", false
+		}
+		if _, typedArray := staticTypedArrayBytesPerElement(name); typedArray {
+			return "", false
+		}
+		switch name {
+		case "Array", "String":
+			return "", true
+		case "Boolean":
+			return "false", true
+		case "BigInt", "Number":
+			return "0", true
+		case "RegExp":
+			return "/(?:)/", true
+		}
+		return "[object " + name + "]", true
 	case *staticStringNode:
 		return staticValueAsString(value)
 	case bool:
@@ -1746,12 +3315,21 @@ func staticValueToString(value any) (string, bool) {
 		return "false", true
 	case staticNullValue:
 		return "null", true
-	case staticUndefinedValue:
+	case staticUndefinedValue, staticOptionalChainShortCircuitValue:
 		return "undefined", true
 	case *staticArrayValue:
-		return staticArrayToString(value)
+		return staticArrayToStringWithWork(value, charge)
 	case *staticObjectValue:
-		if _, overridesToString := staticObjectOwnProperty(value, "toString"); overridesToString || value.prototypeSet {
+		_, overridesToString := staticObjectOwnProperty(value, "toString")
+		overridesValueOf := false
+		overridesToPrimitive := false
+		if value.enhancedCoercion {
+			_, overridesValueOf = staticObjectOwnProperty(value, "valueOf")
+			_, overridesToPrimitive = staticObjectOwnSymbolProperty(value, staticSymbolValue{
+				description: "toPrimitive", wellKnown: true,
+			})
+		}
+		if overridesToString || overridesValueOf || overridesToPrimitive || value.prototypeSet {
 			return "", false
 		}
 		return "[object Object]", true
@@ -1760,69 +3338,260 @@ func staticValueToString(value any) (string, bool) {
 	}
 }
 
+func staticBigIntStringBytesUpperBound(value *big.Int) int {
+	if value == nil || value.Sign() == 0 {
+		return 1
+	}
+	// ceil(bitLength * log10(2)) is an upper bound on the decimal digit
+	// count. 30103/100000 is slightly larger than log10(2).
+	digits := (value.BitLen()*30103 + 99999) / 100000
+	if value.Sign() < 0 {
+		digits++
+	}
+	return max(digits, 1)
+}
+
 // staticArrayToString implements `Array.prototype.join(',')`, which is what
 // an array coerces to via the default ToString. Nullish elements fold to "",
 // not "null"/"undefined" as a direct string conversion would give.
 func staticArrayToString(value *staticArrayValue) (string, bool) {
-	return staticArrayJoin(value, ",")
+	return staticArrayToStringWithWork(value, true)
 }
 
+func staticArrayToStringWithWork(value *staticArrayValue, charge bool) (string, bool) {
+	return staticArrayJoinWithWork(value, ",", charge)
+}
+
+type staticStringMeasure struct {
+	bytes             int
+	codeUnits         int
+	temporaryBytes    int
+	resourceExhausted bool
+}
+
+const maxStaticArrayStringDepth = 1 << 10
+
 func staticArrayJoin(value *staticArrayValue, separator string) (string, bool) {
+	return staticArrayJoinWithWork(value, separator, true)
+}
+
+func staticArrayJoinWithWork(value *staticArrayValue, separator string, charge bool) (string, bool) {
 	if value == nil || value.length < 0 {
 		return "", false
 	}
+	resourceLimited := value.stringWorkContext != nil
+	work := value.stringWorkContext
+	if !charge {
+		work = nil
+	}
+	measure, ok := measureStaticArrayJoin(
+		value,
+		separator,
+		work,
+		map[*staticArrayValue]bool{},
+		0,
+		resourceLimited,
+	)
+	if !ok {
+		if measure.resourceExhausted {
+			value.stringWorkContext.exhaust()
+		}
+		return "", false
+	}
+	allocationCost := measure.bytes + measure.temporaryBytes
+	if charge && !value.stringWorkContext.reserve(allocationCost) {
+		return "", false
+	}
+
 	var builder strings.Builder
-	capacity := 0
-	if value.length > 1 {
-		separatorCount := value.length - 1
-		if len(separator) > 0 && separatorCount > maxStaticStringLength/len(separator) {
-			return "", false
-		}
-		capacity = separatorCount * len(separator)
+	builder.Grow(measure.bytes)
+	if !appendStaticArrayJoin(
+		&builder,
+		value,
+		separator,
+		map[*staticArrayValue]bool{},
+		0,
+		resourceLimited,
+	) {
+		return "", false
 	}
-	for i := range value.length {
-		element := value.element(i)
-		elementLength := 0
-		switch element := element.(type) {
-		case string:
-			elementLength = len(element)
-		case *staticStringNode:
-			stringValue, _ := staticValueAsString(element)
-			elementLength = len(stringValue)
-		case bool:
-			if element {
-				elementLength = len("true")
-			} else {
-				elementLength = len("false")
-			}
-		}
-		if elementLength > maxStaticStringLength-capacity {
-			return "", false
-		}
-		capacity += elementLength
+	return builder.String(), true
+}
+
+func measureStaticArrayJoin(
+	value *staticArrayValue,
+	separator string,
+	work *staticStringWorkContext,
+	visiting map[*staticArrayValue]bool,
+	depth int,
+	resourceLimited bool,
+) (staticStringMeasure, bool) {
+	if value == nil || value.length < 0 || visiting[value] {
+		return staticStringMeasure{}, false
 	}
-	builder.Grow(capacity)
-	for i := range value.length {
-		element := value.element(i)
-		if i > 0 {
-			if len(separator) > maxStaticStringLength-builder.Len() {
-				return "", false
-			}
-			builder.WriteString(separator)
+	if resourceLimited && depth > maxStaticArrayStringDepth || !work.reserve(1) {
+		return staticStringMeasure{resourceExhausted: true}, false
+	}
+	visiting[value] = true
+	defer delete(visiting, value)
+
+	separatorMeasure, ok := measureStaticStringText(separator, work)
+	if !ok {
+		return staticStringMeasure{resourceExhausted: true}, false
+	}
+	var measure staticStringMeasure
+	for index := range value.length {
+		if index > 0 && !addStaticStringMeasure(&measure, separatorMeasure) {
+			return staticStringMeasure{resourceExhausted: true}, false
 		}
+		element := value.element(index)
 		if staticValueNullish(element) {
 			continue
 		}
-		part, ok := staticValueToString(element)
-		if !ok {
-			return "", false
+		part, partOK := measureStaticStringValue(
+			element,
+			work,
+			visiting,
+			depth+1,
+			resourceLimited,
+		)
+		if !partOK {
+			return part, false
 		}
-		if len(part) > maxStaticStringLength-builder.Len() {
-			return "", false
+		if !addStaticStringMeasure(&measure, part) {
+			return staticStringMeasure{resourceExhausted: true}, false
 		}
-		builder.WriteString(part)
 	}
-	return builder.String(), true
+	return measure, true
+}
+
+func measureStaticStringValue(
+	value any,
+	work *staticStringWorkContext,
+	visiting map[*staticArrayValue]bool,
+	depth int,
+	resourceLimited bool,
+) (staticStringMeasure, bool) {
+	switch value := value.(type) {
+	case string:
+		return measureStaticStringText(value, work)
+	case *staticStringNode:
+		text, ok := staticValueAsString(value)
+		if !ok {
+			return staticStringMeasure{}, false
+		}
+		return measureStaticStringText(text, work)
+	case staticBigIntValue:
+		if value.value == nil || !work.reserve(1) {
+			return staticStringMeasure{resourceExhausted: value.value != nil}, false
+		}
+		length := staticBigIntStringBytesUpperBound(value.value)
+		return staticStringMeasure{bytes: length, codeUnits: length, temporaryBytes: length}, true
+	case staticRegExpValue:
+		if !work.reserve(len(value.source) + len(value.flags) + 2) {
+			return staticStringMeasure{resourceExhausted: true}, false
+		}
+		return staticStringMeasure{
+			bytes:     len(value.source) + len(value.flags) + 2,
+			codeUnits: ecmascript.StringCodeUnitCount(value.source) + ecmascript.StringCodeUnitCount(value.flags) + 2,
+		}, true
+	case staticBoxedValue:
+		if _, symbol := value.value.(staticSymbolValue); symbol {
+			return staticStringMeasure{}, false
+		}
+		return measureStaticStringValue(value.value, work, visiting, depth, resourceLimited)
+	case *staticArrayValue:
+		return measureStaticArrayJoin(value, ",", work, visiting, depth, resourceLimited)
+	default:
+		// All remaining known conversions are bounded primitive formatting or
+		// fixed built-in object tags. Reserve their maximum practical work
+		// before asking the shared semantic conversion for the exact spelling.
+		if !work.reserve(64) {
+			return staticStringMeasure{resourceExhausted: true}, false
+		}
+		text, ok := staticValueToStringWithWork(value, false)
+		if !ok {
+			return staticStringMeasure{}, false
+		}
+		measure, ok := measureStaticStringText(text, nil)
+		if !ok {
+			return staticStringMeasure{resourceExhausted: true}, false
+		}
+		measure.temporaryBytes = len(text)
+		return measure, true
+	}
+}
+
+func measureStaticStringText(text string, work *staticStringWorkContext) (staticStringMeasure, bool) {
+	if !work.reserve(max(len(text), 1)) {
+		return staticStringMeasure{resourceExhausted: true}, false
+	}
+	measure := staticStringMeasure{bytes: len(text), codeUnits: ecmascript.StringCodeUnitCount(text)}
+	if measure.bytes > maxStaticStringLength || measure.codeUnits > maxStaticStringLength {
+		measure.resourceExhausted = true
+		return measure, false
+	}
+	return measure, true
+}
+
+func addStaticStringMeasure(total *staticStringMeasure, part staticStringMeasure) bool {
+	if total == nil || part.bytes > maxStaticStringLength-total.bytes ||
+		part.codeUnits > maxStaticStringLength-total.codeUnits {
+		return false
+	}
+	total.bytes += part.bytes
+	total.codeUnits += part.codeUnits
+	if part.temporaryBytes > maxStaticStringWorkBudget-total.temporaryBytes {
+		total.temporaryBytes = maxStaticStringWorkBudget + 1
+	} else {
+		total.temporaryBytes += part.temporaryBytes
+	}
+	return true
+}
+
+func appendStaticArrayJoin(
+	builder *strings.Builder,
+	value *staticArrayValue,
+	separator string,
+	visiting map[*staticArrayValue]bool,
+	depth int,
+	resourceLimited bool,
+) bool {
+	if builder == nil || value == nil || visiting[value] ||
+		resourceLimited && depth > maxStaticArrayStringDepth {
+		return false
+	}
+	visiting[value] = true
+	defer delete(visiting, value)
+	for index := range value.length {
+		if index > 0 {
+			builder.WriteString(separator)
+		}
+		element := value.element(index)
+		if staticValueNullish(element) {
+			continue
+		}
+		if nested, ok := element.(*staticArrayValue); ok {
+			if !appendStaticArrayJoin(builder, nested, ",", visiting, depth+1, resourceLimited) {
+				return false
+			}
+			continue
+		}
+		switch element := element.(type) {
+		case staticRegExpValue:
+			builder.WriteByte('/')
+			builder.WriteString(element.source)
+			builder.WriteByte('/')
+			builder.WriteString(element.flags)
+		default:
+			part, ok := staticValueToStringWithWork(element, false)
+			if !ok {
+				return false
+			}
+			builder.WriteString(part)
+		}
+	}
+	return true
 }
 
 func evaluatorBool(fn func() bool) (value bool, ok bool) {

--- a/internal/utils/static_string_evaluator_eslint_calls.go
+++ b/internal/utils/static_string_evaluator_eslint_calls.go
@@ -1,0 +1,5326 @@
+// cspell:ignore dgimsuvy fdlibm fontcolor fontsize Gurung Hrkt Khema Kirat libm Onal subarray Sunuwar Tigalari Todhri Tulu Unscopables unscopables
+
+package utils
+
+import (
+	"math"
+	"math/big"
+	"math/bits"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	// The capture limit is stable across the Node versions supported by Unicorn
+	// 73. V8 parses nested v-mode classes recursively, however, and its failure
+	// point varies with the host stack and current call depth. Stop with ample
+	// headroom below the tested default supported runtimes instead of pinning
+	// the guard to one runtime's exact stack limit.
+	maxStaticRegExpCaptures           = 1<<15 - 1
+	maxStaticRegExpUnicodeSetsNesting = 1024
+)
+
+// evalESLintStaticCall mirrors the safety boundary in eslint-utils:
+// every argument must be static, and only allowlisted native functions are
+// invoked. Native identity is represented explicitly so stable aliases and
+// locally composed objects such as `{abs: Number}` retain their semantics.
+func (staticEvaluator *StaticStringEvaluator) evalESLintStaticCall(node *ast.Node) staticEvalResult {
+	call := node.AsCallExpression()
+	if call == nil || call.Expression == nil {
+		return staticEvalResult{}
+	}
+	// eslint-utils resolves every argument before it inspects an optional
+	// callee, so an unknown spread/argument keeps the whole call unknown even
+	// when JavaScript itself would short-circuit it.
+	arguments, ok := staticEvaluator.evalCallArguments(node)
+	if !ok {
+		return staticEvalResult{}
+	}
+	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	if ast.IsAccessExpression(callee) {
+		receiver := staticEvaluator.evalValue(AccessExpressionObject(callee))
+		if !receiver.ok {
+			return staticEvalResult{}
+		}
+		if _, shortCircuited := receiver.value.(staticOptionalChainShortCircuitValue); shortCircuited {
+			if call.QuestionDotToken != nil {
+				return receiver
+			}
+			return staticEvalResult{}
+		}
+		if staticValueNullish(receiver.value) {
+			if call.QuestionDotToken != nil {
+				return staticEvalResult{value: staticOptionalChainShortCircuitValue{}, ok: true}
+			}
+			return staticEvalResult{}
+		}
+		method, ok := staticEvaluator.evalAccessExpressionKey(callee)
+		if !ok {
+			return staticEvalResult{}
+		}
+		calleeValue := staticESLintMemberValue(receiver.value, method)
+		if !calleeValue.ok {
+			calleeValue = staticESLintBuiltinMember(receiver.value, method)
+		}
+		if !calleeValue.ok || staticValueNullish(calleeValue.value) {
+			return staticEvalResult{}
+		}
+		if builtin, ok := calleeValue.value.(staticBuiltinValue); ok {
+			if result := evalESLintBuiltinCall(staticEvaluator.stringWorkContext, string(builtin), arguments); result.ok {
+				return result
+			}
+		}
+		return evalESLintPrototypeCall(staticEvaluator.stringWorkContext, receiver.value, method, arguments)
+	}
+
+	calleeValue := staticEvaluator.evalValue(callee)
+	if calleeValue.ok {
+		if _, shortCircuited := calleeValue.value.(staticOptionalChainShortCircuitValue); shortCircuited {
+			if ast.IsOptionalChain(node) && !ast.IsOuterExpression(call.Expression, ast.OEKParentheses) {
+				return calleeValue
+			}
+			return staticEvalResult{}
+		}
+		if staticValueNullish(calleeValue.value) {
+			if call.QuestionDotToken != nil {
+				return staticEvalResult{value: staticOptionalChainShortCircuitValue{}, ok: true}
+			}
+			return staticEvalResult{}
+		}
+	}
+	if calleeValue.ok {
+		if builtin, ok := calleeValue.value.(staticBuiltinValue); ok {
+			if result := evalESLintBuiltinCall(staticEvaluator.stringWorkContext, string(builtin), arguments); result.ok {
+				return result
+			}
+		}
+	}
+
+	return staticEvalResult{}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalESLintStaticNew(node *ast.Node) staticEvalResult {
+	newExpression := node.AsNewExpression()
+	if newExpression == nil || newExpression.Expression == nil {
+		return staticEvalResult{}
+	}
+	arguments, ok := staticEvaluator.evalCallArguments(node)
+	if !ok {
+		return staticEvalResult{}
+	}
+	callee := staticEvaluator.evalValue(newExpression.Expression)
+	if !callee.ok {
+		return staticEvalResult{}
+	}
+	builtin, ok := callee.value.(staticBuiltinValue)
+	if !ok {
+		return staticEvalResult{}
+	}
+
+	switch string(builtin) {
+	case "Boolean", "Number", "String":
+		if string(builtin) == "String" && len(arguments) > 0 {
+			if _, symbol := arguments[0].(staticSymbolValue); symbol {
+				return staticEvalResult{}
+			}
+		}
+		primitive := evalESLintBuiltinCall(staticEvaluator.stringWorkContext, string(builtin), arguments)
+		if !primitive.ok {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: staticBoxedValue{value: primitive.value, identity: &staticIdentity{}}, ok: true}
+	case "Date":
+		return staticDateConstructor(arguments)
+	case "Map", "Set":
+		return staticCollectionCall(staticEvaluator.stringWorkContext, string(builtin), arguments)
+	case "Object":
+		return staticObjectCall(arguments)
+	case "RegExp":
+		return staticRegExpCall(staticEvaluator.stringWorkContext, arguments, true)
+	}
+	return staticEvalResult{}
+}
+
+func evalESLintBuiltinCall(
+	work *staticStringWorkContext,
+	name string,
+	arguments []any,
+) staticEvalResult {
+	if !work.reserve(max(len(arguments)*8, 1)) {
+		return staticEvalResult{}
+	}
+	switch name {
+	case "Array.isArray":
+		isArray := staticValueIsArray(staticArgument(arguments, 0))
+		return staticEvalResult{value: isArray, ok: true}
+	case "Array.of":
+		return staticEvalResult{value: staticArrayFromValues(arguments), ok: true}
+	case "Boolean":
+		if len(arguments) == 0 {
+			return staticEvalResult{value: false, ok: true}
+		}
+		truthy, ok := staticValueTruthy(arguments[0])
+		if !ok {
+			return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+		}
+		return staticEvalResult{value: truthy, ok: true}
+	case "Number":
+		if len(arguments) == 0 {
+			return staticEvalResult{value: staticNumberValue(0), ok: true}
+		}
+		return staticNumberCall(arguments[0])
+	case "String":
+		if len(arguments) == 0 {
+			return staticEvalResult{value: "", ok: true}
+		}
+		return staticStringCall(arguments[0])
+	case "BigInt":
+		if len(arguments) == 0 {
+			return staticEvalResult{}
+		}
+		return staticBigIntCall(arguments[0])
+	case "Object":
+		return staticObjectCall(arguments)
+	case "Object.freeze", "Object.preventExtensions", "Object.seal":
+		// eslint-utils treats these as pass-through calls. It does not invoke
+		// the native method, so the evaluator-owned object is not mutated.
+		return staticEvalResult{value: staticArgument(arguments, 0), ok: true}
+	case "Object.entries", "Object.keys", "Object.values":
+		if len(arguments) == 0 || staticValueNullish(arguments[0]) {
+			return staticEvalResult{}
+		}
+		return staticObjectEntriesCall(work, name, arguments[0])
+	case "Object.is":
+		equal, ok := staticSameValue(staticArgument(arguments, 0), staticArgument(arguments, 1))
+		if !ok {
+			return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+		}
+		return staticEvalResult{value: equal, ok: true}
+	case "Object.isExtensible", "Object.isFrozen", "Object.isSealed":
+		argument := staticArgument(arguments, 0)
+		_, builtin := argument.(staticBuiltinValue)
+		if !staticValueIsAggregate(argument) && !builtin {
+			return staticEvalResult{value: name != "Object.isExtensible", ok: true}
+		}
+		// All objects materialized by getStaticValue are fresh/extensible. Its
+		// freeze/seal/preventExtensions allowlist is pass-through and never
+		// mutates those evaluator-owned values.
+		return staticEvalResult{value: name == "Object.isExtensible", ok: true}
+	case "Number.isFinite", "Number.isNaN":
+		return staticNumberPredicate(name, staticArgument(arguments, 0))
+	case "Number.parseFloat", "parseFloat", "Number.parseInt", "parseInt":
+		return staticParseNumber(name, arguments)
+	case "String.fromCharCode":
+		for _, argument := range arguments {
+			if !staticCanConvertToNumber(argument) {
+				return staticEvalResult{}
+			}
+			if _, exact := staticValueToNumber(argument); !exact {
+				return staticEvalResult{value: staticUnknownStringValue{}, ok: true}
+			}
+		}
+		return staticESLintStringFromCharCode(work, arguments)
+	case "String.fromCodePoint":
+		return staticStringFromCodePoint(work, arguments)
+	case "String.raw":
+		return staticStringRawCall(work, arguments)
+	case "Date":
+		// Date() always returns a non-empty string, independent of its ignored
+		// arguments. The exact wall-clock value is deliberately not fabricated.
+		return staticEvalResult{value: staticUnknownStringValue{truthy: true}, ok: true}
+	case "Date.parse":
+		return staticDateParse(staticArgument(arguments, 0))
+	case "RegExp":
+		return staticRegExpCall(work, arguments, false)
+	case "isFinite", "isNaN":
+		number, ok := staticValueToNumber(staticArgument(arguments, 0))
+		if !ok {
+			if staticCanConvertToNumber(staticArgument(arguments, 0)) {
+				return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+			}
+			return staticEvalResult{}
+		}
+		if name == "isFinite" {
+			return staticEvalResult{value: !math.IsNaN(number) && !math.IsInf(number, 0), ok: true}
+		}
+		return staticEvalResult{value: math.IsNaN(number), ok: true}
+	case "isPrototypeOf":
+		if _, isNull := staticArgument(arguments, 0).(staticNullValue); isNull {
+			return staticEvalResult{value: false, ok: true}
+		}
+		return staticEvalResult{}
+	case "decodeURI", "decodeURIComponent", "encodeURI", "encodeURIComponent", "escape", "unescape":
+		return staticURICall(work, name, arguments)
+	case "Symbol.for":
+		key, ok := staticValueToString(staticArgument(arguments, 0))
+		if !ok {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: staticSymbolValue{description: key, global: true}, ok: true}
+	case "Symbol.keyFor":
+		symbol, ok := staticArgument(arguments, 0).(staticSymbolValue)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if symbol.hostDependent {
+			return staticEvalResult{}
+		}
+		if !symbol.global {
+			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+		}
+		return staticEvalResult{value: symbol.description, ok: true}
+	}
+	if strings.HasPrefix(name, "Math.") {
+		return staticMathCall(strings.TrimPrefix(name, "Math."), arguments)
+	}
+	return staticEvalResult{}
+}
+
+func evalESLintPrototypeCall(
+	work *staticStringWorkContext,
+	receiver any,
+	method string,
+	arguments []any,
+) staticEvalResult {
+	if !work.reserve(max(len(arguments)*8, 1)) {
+		return staticEvalResult{}
+	}
+	switch value := receiver.(type) {
+	case *staticArrayValue:
+		return staticArrayPrototypeCall(work, value, method, arguments)
+	case string:
+		return staticStringPrototypeCall(work, value, method, arguments)
+	case *staticStringNode:
+		text, _ := staticValueAsString(value)
+		return staticStringPrototypeCall(work, text, method, arguments)
+	case staticNumberValue, staticUnknownNumberValue:
+		return staticNumberPrototypeCall(receiver, method, arguments)
+	case staticCollectionValue:
+		if !work.reserve(max(len(value.entries)*64, 1)) {
+			return staticEvalResult{}
+		}
+		switch method {
+		case "entries", "keys", "values":
+			values := make([]any, 0, len(value.entries))
+			for _, entry := range value.entries {
+				switch method {
+				case "entries":
+					if value.kind == "Map" {
+						values = append(values, staticArrayFromValues([]any{entry.key, entry.value}))
+					} else {
+						values = append(values, staticArrayFromValues([]any{entry.key, entry.key}))
+					}
+				case "keys":
+					values = append(values, entry.key)
+				case "values":
+					if value.kind == "Map" {
+						values = append(values, entry.value)
+					} else {
+						values = append(values, entry.key)
+					}
+				}
+			}
+			return staticEvalResult{value: staticIteratorValue{
+				values: values, kind: value.kind, identity: &staticIdentity{},
+			}, ok: true}
+		case "has":
+			return staticCollectionHas(value, staticArgument(arguments, 0))
+		case "get":
+			if value.kind == "Map" {
+				return staticMapGet(value, staticArgument(arguments, 0))
+			}
+		}
+	case staticBoxedValue:
+		switch staticValueKindOf(value.value) {
+		case staticKindString:
+			text, ok := staticValueAsString(value.value)
+			if ok {
+				return staticStringPrototypeCall(work, text, method, arguments)
+			}
+		case staticKindNumber:
+			return staticNumberPrototypeCall(value.value, method, arguments)
+		}
+	case staticBuiltinObjectValue:
+		switch value {
+		case "Array.prototype":
+			return staticArrayPrototypeCall(work, staticArrayFromValues(nil), method, arguments)
+		case "String.prototype":
+			return staticStringPrototypeCall(work, "", method, arguments)
+		case "Number.prototype":
+			return staticNumberPrototypeCall(staticNumberValue(0), method, arguments)
+		}
+	}
+	if staticValueKindOf(receiver) == staticKindNumber {
+		return staticNumberPrototypeCall(receiver, method, arguments)
+	}
+	return staticEvalResult{}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalESLintTypeOfExpression(node *ast.Node) staticEvalResult {
+	typeOf := node.AsTypeOfExpression()
+	if typeOf == nil {
+		return staticEvalResult{}
+	}
+	operand := staticEvaluator.evalValue(typeOf.Expression)
+	if !operand.ok {
+		return staticEvalResult{}
+	}
+	switch staticValueKindOf(operand.value) {
+	case staticKindString:
+		return staticEvalResult{value: "string", ok: true}
+	case staticKindNumber:
+		return staticEvalResult{value: "number", ok: true}
+	case staticKindBoolean:
+		return staticEvalResult{value: "boolean", ok: true}
+	case staticKindBigInt:
+		return staticEvalResult{value: "bigint", ok: true}
+	case staticKindSymbol:
+		return staticEvalResult{value: "symbol", ok: true}
+	case staticKindUndefined:
+		return staticEvalResult{value: "undefined", ok: true}
+	case staticKindNull:
+		return staticEvalResult{value: "object", ok: true}
+	}
+	if builtin, ok := operand.value.(staticBuiltinValue); ok && staticBuiltinIsFunction(string(builtin)) {
+		return staticEvalResult{value: "function", ok: true}
+	}
+	if staticValueIsAggregate(operand.value) || staticValueTruthyObject(operand.value) {
+		return staticEvalResult{value: "object", ok: true}
+	}
+	return staticEvalResult{}
+}
+
+func staticValueTruthyObject(value any) bool {
+	switch value.(type) {
+	case staticBuiltinValue, staticSymbolValue:
+		return true
+	}
+	return false
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalESLintBinaryExpression(binary *ast.BinaryExpression) staticEvalResult {
+	left := staticEvaluator.evalValue(binary.Left)
+	right := staticEvaluator.evalValue(binary.Right)
+	if !left.ok || !right.ok {
+		return staticEvalResult{}
+	}
+	op := binary.OperatorToken.Kind
+
+	switch op {
+	case ast.KindEqualsEqualsToken, ast.KindExclamationEqualsToken:
+		equal, ok := staticValuesLooseEqual(left.value, right.value)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if op == ast.KindExclamationEqualsToken {
+			equal = !equal
+		}
+		return staticEvalResult{value: equal, ok: true}
+	case ast.KindLessThanToken, ast.KindLessThanEqualsToken,
+		ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken:
+		comparison, ordered, ok := staticValuesCompare(left.value, right.value)
+		if !ok {
+			return staticEvalResult{}
+		}
+		var value bool
+		if ordered {
+			switch op {
+			case ast.KindLessThanToken:
+				value = comparison < 0
+			case ast.KindLessThanEqualsToken:
+				value = comparison <= 0
+			case ast.KindGreaterThanToken:
+				value = comparison > 0
+			default:
+				value = comparison >= 0
+			}
+		}
+		return staticEvalResult{value: value, ok: true}
+	}
+
+	leftBigInt, leftIsBigInt := left.value.(staticBigIntValue)
+	rightBigInt, rightIsBigInt := right.value.(staticBigIntValue)
+	if leftIsBigInt || rightIsBigInt {
+		if !leftIsBigInt || !rightIsBigInt {
+			return staticEvalResult{}
+		}
+		result := staticBigIntBinary(op, leftBigInt, rightBigInt)
+		result.cacheableBigInt = result.ok && left.cacheableBigInt && right.cacheableBigInt
+		return result
+	}
+	if op == ast.KindPlusToken {
+		leftPrimitive, leftPrimitiveOK := staticAddPrimitive(left.value)
+		rightPrimitive, rightPrimitiveOK := staticAddPrimitive(right.value)
+		if !leftPrimitiveOK || !rightPrimitiveOK {
+			return staticEvalResult{}
+		}
+		left.value, right.value = leftPrimitive, rightPrimitive
+		if _, ok := left.value.(staticUnknownStringValue); ok {
+			if staticCanConvertToString(right.value) {
+				return staticEvalResult{value: staticUnknownStringValue{}, ok: true}
+			}
+			return staticEvalResult{}
+		}
+		if _, ok := right.value.(staticUnknownStringValue); ok {
+			if staticCanConvertToString(left.value) {
+				return staticEvalResult{value: staticUnknownStringValue{}, ok: true}
+			}
+			return staticEvalResult{}
+		}
+		if staticValueIsString(left.value) || staticValueIsString(right.value) {
+			return staticEvaluator.concatStaticValues(left, right)
+		}
+	}
+
+	leftNumber, leftKnown := staticValueToNumber(left.value)
+	rightNumber, rightKnown := staticValueToNumber(right.value)
+	if !leftKnown || !rightKnown {
+		if staticCanConvertToNumber(left.value) && staticCanConvertToNumber(right.value) {
+			return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+		}
+		return staticEvalResult{}
+	}
+	var result float64
+	switch op {
+	case ast.KindPlusToken:
+		result = leftNumber + rightNumber
+	case ast.KindMinusToken:
+		result = leftNumber - rightNumber
+	case ast.KindAsteriskToken:
+		result = leftNumber * rightNumber
+	case ast.KindSlashToken:
+		result = leftNumber / rightNumber
+	case ast.KindPercentToken:
+		result = math.Mod(leftNumber, rightNumber)
+	case ast.KindAsteriskAsteriskToken:
+		var exact bool
+		result, exact = staticMathExactSpecialCase("pow", []float64{leftNumber, rightNumber})
+		if !exact {
+			return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+		}
+	case ast.KindBarToken:
+		result = float64(toInt32(leftNumber) | toInt32(rightNumber))
+	case ast.KindAmpersandToken:
+		result = float64(toInt32(leftNumber) & toInt32(rightNumber))
+	case ast.KindCaretToken:
+		result = float64(toInt32(leftNumber) ^ toInt32(rightNumber))
+	case ast.KindLessThanLessThanToken:
+		result = float64(toInt32(leftNumber) << (toUint32(rightNumber) & 31))
+	case ast.KindGreaterThanGreaterThanToken:
+		result = float64(toInt32(leftNumber) >> (toUint32(rightNumber) & 31))
+	case ast.KindGreaterThanGreaterThanGreaterThanToken:
+		result = float64(toUint32(leftNumber) >> (toUint32(rightNumber) & 31))
+	default:
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: staticNumberValue(result), ok: true}
+}
+
+func staticBigIntBinary(operator ast.Kind, left, right staticBigIntValue) staticEvalResult {
+	if left.value == nil || right.value == nil {
+		return staticEvalResult{}
+	}
+	value := new(big.Int)
+	switch operator {
+	case ast.KindPlusToken:
+		value.Add(left.value, right.value)
+	case ast.KindMinusToken:
+		value.Sub(left.value, right.value)
+	case ast.KindAsteriskToken:
+		value.Mul(left.value, right.value)
+	case ast.KindSlashToken:
+		if right.value.Sign() == 0 {
+			return staticEvalResult{}
+		}
+		value.Quo(left.value, right.value)
+	case ast.KindPercentToken:
+		if right.value.Sign() == 0 {
+			return staticEvalResult{}
+		}
+		value.Rem(left.value, right.value)
+	case ast.KindAsteriskAsteriskToken:
+		if right.value.Sign() < 0 || !right.value.IsUint64() {
+			return staticEvalResult{}
+		}
+		exponent := right.value.Uint64()
+		absolute := new(big.Int).Abs(left.value)
+		if exponent > 0 && absolute.Cmp(big.NewInt(1)) > 0 {
+			minimumBits, minimumOverflow := staticBigIntProductBits(uint64(absolute.BitLen()-1), exponent)
+			maximumBits, maximumOverflow := staticBigIntProductBits(uint64(absolute.BitLen()), exponent)
+			if minimumOverflow || minimumBits > maxJavaScriptBigIntBits {
+				return staticEvalResult{}
+			}
+			if absolute.TrailingZeroBits() == uint(absolute.BitLen()-1) {
+				maximumBits = minimumBits
+				maximumOverflow = false
+			}
+			if maximumOverflow || maximumBits > maxStaticBigIntBits {
+				if maximumOverflow || maximumBits > maxJavaScriptBigIntBits {
+					return staticEvalResult{}
+				}
+				return staticEvalResult{value: staticAbstractBigInt(true), ok: true}
+			}
+		}
+		value.Exp(left.value, right.value, nil)
+	case ast.KindBarToken:
+		value.Or(left.value, right.value)
+	case ast.KindAmpersandToken:
+		value.And(left.value, right.value)
+	case ast.KindCaretToken:
+		value.Xor(left.value, right.value)
+	case ast.KindLessThanLessThanToken, ast.KindGreaterThanGreaterThanToken:
+		if !right.value.IsInt64() {
+			return staticEvalResult{}
+		}
+		shift := right.value.Int64()
+		leftShift := operator == ast.KindLessThanLessThanToken
+		magnitude := uint64(shift)
+		if shift < 0 {
+			magnitude = uint64(-(shift + 1)) + 1
+			leftShift = !leftShift
+		}
+		if leftShift {
+			if left.value.Sign() == 0 {
+				return staticEvalResult{value: staticBigIntValue{value: new(big.Int)}, ok: true}
+			}
+			if magnitude > maxJavaScriptBigIntBits ||
+				uint64(left.value.BitLen()) > maxJavaScriptBigIntBits-magnitude {
+				return staticEvalResult{}
+			}
+			if magnitude > maxStaticBigIntBits ||
+				uint64(left.value.BitLen()) > maxStaticBigIntBits-magnitude {
+				return staticEvalResult{value: staticAbstractBigInt(true), ok: true}
+			}
+			value.Lsh(left.value, uint(magnitude))
+		} else {
+			if magnitude >= uint64(left.value.BitLen())+1 {
+				if left.value.Sign() < 0 {
+					return staticEvalResult{value: staticBigIntValue{value: big.NewInt(-1)}, ok: true}
+				}
+				return staticEvalResult{value: staticBigIntValue{value: new(big.Int)}, ok: true}
+			}
+			value.Rsh(left.value, uint(magnitude))
+		}
+	default:
+		return staticEvalResult{}
+	}
+	if value.BitLen() > maxStaticBigIntBits {
+		return staticEvalResult{
+			value: staticAbstractBigInt(value.Sign() != 0), ok: true,
+			bigIntWorkBytes: (value.BitLen() + 7) / 8,
+		}
+	}
+	return staticEvalResult{
+		value: staticBigIntValue{value: value}, ok: true,
+		bigIntWorkBytes: (value.BitLen() + 7) / 8,
+	}
+}
+
+func staticBigIntProductBits(factor, exponent uint64) (uint64, bool) {
+	if factor == 0 || exponent == 0 {
+		return 1, false
+	}
+	if factor > (^uint64(0)-1)/exponent {
+		return 0, true
+	}
+	return factor*exponent + 1, false
+}
+
+func staticValuesCompare(left, right any) (comparison int, ordered bool, ok bool) {
+	left, leftPrimitive := staticRelationalPrimitive(left)
+	right, rightPrimitive := staticRelationalPrimitive(right)
+	if !leftPrimitive || !rightPrimitive {
+		return 0, false, false
+	}
+	if staticValueIsString(left) && staticValueIsString(right) {
+		leftText, _ := staticValueAsString(left)
+		rightText, _ := staticValueAsString(right)
+		return ecmascript.CompareStrings(leftText, rightText), true, true
+	}
+	leftBigInt, leftIsBigInt := left.(staticBigIntValue)
+	rightBigInt, rightIsBigInt := right.(staticBigIntValue)
+	if leftIsBigInt && rightIsBigInt && leftBigInt.value != nil && rightBigInt.value != nil {
+		if !staticReserveBigIntComparisonWork(leftBigInt, rightBigInt) {
+			return 0, false, false
+		}
+		return leftBigInt.value.Cmp(rightBigInt.value), true, true
+	}
+	if leftIsBigInt || rightIsBigInt {
+		bigint, other, reverse := leftBigInt, right, false
+		if rightIsBigInt {
+			bigint, other, reverse = rightBigInt, left, true
+		}
+		if bigint.value == nil {
+			return 0, false, false
+		}
+		if text, isString := staticValueAsString(other); isString {
+			parsed := staticBigIntFromString(text)
+			otherBigInt, valid := parsed.value.(staticBigIntValue)
+			if !parsed.ok || !valid || otherBigInt.value == nil {
+				return 0, false, true
+			}
+			otherBigInt.bigIntWorkContext = bigint.bigIntWorkContext
+			if !staticReserveBigIntComparisonWork(bigint, otherBigInt) {
+				return 0, false, false
+			}
+			comparison = bigint.value.Cmp(otherBigInt.value)
+		} else {
+			number, numberOK := staticValueToNumber(other)
+			if !numberOK {
+				return 0, false, false
+			}
+			if math.IsNaN(number) {
+				return 0, false, true
+			}
+			if math.IsInf(number, 1) {
+				comparison = -1
+			} else if math.IsInf(number, -1) {
+				comparison = 1
+			} else {
+				integer, accuracy := new(big.Float).SetFloat64(number).Int(nil)
+				comparison = bigint.value.Cmp(integer)
+				if comparison == 0 {
+					switch accuracy {
+					case big.Below:
+						comparison = -1
+					case big.Above:
+						comparison = 1
+					}
+				}
+			}
+		}
+		if reverse {
+			comparison = -comparison
+		}
+		return comparison, true, true
+	}
+	leftNumber, leftOK := staticValueToNumber(left)
+	rightNumber, rightOK := staticValueToNumber(right)
+	if !leftOK || !rightOK {
+		return 0, false, false
+	}
+	if math.IsNaN(leftNumber) || math.IsNaN(rightNumber) {
+		return 0, false, true
+	}
+	switch {
+	case leftNumber < rightNumber:
+		return -1, true, true
+	case leftNumber > rightNumber:
+		return 1, true, true
+	default:
+		return 0, true, true
+	}
+}
+
+// BigInt comparisons can scan every machine word even though their result is
+// only a boolean. Charge the largest magnitude once per comparison so cached
+// values cannot turn a compact fanout into unbounded per-file work.
+func staticReserveBigIntComparisonWork(left, right staticBigIntValue) bool {
+	work := left.bigIntWorkContext
+	if work == nil {
+		work = right.bigIntWorkContext
+	}
+	cost := 32
+	// big.Int comparison stops after the sign, magnitude length, or highest
+	// differing word. Only equal bit lengths and signs can force a full scan.
+	if left.value != nil && right.value != nil &&
+		left.value.Sign() == right.value.Sign() && left.value.BitLen() == right.value.BitLen() {
+		cost = max(cost, (left.value.BitLen()+7)/8)
+	}
+	return work.reserve(cost)
+}
+
+// staticRelationalPrimitive implements the number-hint ToPrimitive step used
+// by Abstract Relational Comparison. It intentionally differs from addition's
+// default hint: Date values prefer valueOf here, while arrays and ordinary
+// objects still fall through to their string representation.
+func staticRelationalPrimitive(value any) (any, bool) {
+	switch value := value.(type) {
+	case staticDateValue:
+		if value.known {
+			return value.milliseconds, true
+		}
+		return staticUnknownNumberValue{}, true
+	case staticBoxedValue:
+		return value.value, true
+	case staticBuiltinObjectValue:
+		switch value {
+		case "Boolean.prototype":
+			return false, true
+		case "Number.prototype":
+			return staticNumberValue(0), true
+		case "BigInt.prototype":
+			return staticBigIntValue{value: new(big.Int)}, true
+		case "String.prototype", "Array.prototype":
+			return "", true
+		case "Date.prototype":
+			return staticNumberValue(math.NaN()), true
+		case "RegExp.prototype":
+			return "/(?:)/", true
+		case "Symbol.prototype", "Array.prototype[Symbol.unscopables]":
+			return nil, false
+		}
+		text, ok := staticValueToString(value)
+		return text, ok
+	case staticBuiltinValue:
+		if staticBuiltinIsFunction(string(value)) {
+			return nil, false
+		}
+		return "[object " + string(value) + "]", true
+	case *staticArrayValue, *staticObjectValue, staticRegExpValue, staticCollectionValue:
+		text, ok := staticValueToString(value)
+		return text, ok
+	case staticOpaqueObjectValue, staticIteratorValue:
+		return nil, false
+	}
+	return value, true
+}
+
+func staticAddPrimitive(value any) (any, bool) {
+	if builtin, ok := value.(staticBuiltinValue); ok && staticBuiltinIsFunction(string(builtin)) {
+		// A native function's source text is engine-specific. It is an object
+		// for abstract equality, but its ToPrimitive result is not fabricated.
+		return nil, false
+	}
+	if builtin, ok := value.(staticBuiltinValue); ok && !staticBuiltinIsFunction(string(builtin)) {
+		return "[object " + string(builtin) + "]", true
+	}
+	if staticValueIsAggregate(value) {
+		if prototype, ok := value.(staticBuiltinObjectValue); ok {
+			switch prototype {
+			case "Number.prototype":
+				return staticNumberValue(0), true
+			case "Boolean.prototype":
+				return false, true
+			case "String.prototype", "Array.prototype":
+				return "", true
+			case "BigInt.prototype":
+				return staticBigIntValue{value: new(big.Int)}, true
+			case "RegExp.prototype":
+				return "/(?:)/", true
+			}
+		}
+		if _, ok := value.(staticDateValue); ok {
+			return staticUnknownStringValue{truthy: true, numericNaN: true}, true
+		}
+		if boxed, ok := value.(staticBoxedValue); ok {
+			return boxed.value, true
+		}
+		text, ok := staticValueToString(value)
+		return text, ok
+	}
+	return value, true
+}
+
+func staticValuesLooseEqual(left, right any) (bool, bool) {
+	leftKind, rightKind := staticValueKindOf(left), staticValueKindOf(right)
+	if leftKind == rightKind {
+		return staticValuesStrictEqual(left, right)
+	}
+	if leftKind == staticKindNull && rightKind == staticKindUndefined ||
+		leftKind == staticKindUndefined && rightKind == staticKindNull {
+		return true, true
+	}
+	if leftKind == staticKindBoolean {
+		leftNumber, ok := staticValueToNumber(left)
+		if !ok {
+			return false, false
+		}
+		return staticValuesLooseEqual(staticNumberValue(leftNumber), right)
+	}
+	if rightKind == staticKindBoolean {
+		rightNumber, ok := staticValueToNumber(right)
+		if !ok {
+			return false, false
+		}
+		return staticValuesLooseEqual(left, staticNumberValue(rightNumber))
+	}
+	if leftKind == staticKindString && rightKind == staticKindNumber ||
+		leftKind == staticKindNumber && rightKind == staticKindString {
+		leftNumber, leftOK := staticValueToNumber(left)
+		rightNumber, rightOK := staticValueToNumber(right)
+		if !leftOK || !rightOK {
+			return false, false
+		}
+		return leftNumber == rightNumber, true
+	}
+	if leftKind == staticKindBigInt && (rightKind == staticKindString || rightKind == staticKindNumber) ||
+		rightKind == staticKindBigInt && (leftKind == staticKindString || leftKind == staticKindNumber) {
+		bigint, other := left, right
+		if rightKind == staticKindBigInt {
+			bigint, other = right, left
+		}
+		bigintValue, bigintKnown := bigint.(staticBigIntValue)
+		if !bigintKnown || bigintValue.value == nil {
+			return false, false
+		}
+		if text, isString := staticValueAsString(other); isString {
+			parsed := staticBigIntFromString(text)
+			otherBigInt, valid := parsed.value.(staticBigIntValue)
+			if !parsed.ok || !valid || otherBigInt.value == nil {
+				return false, true
+			}
+			otherBigInt.bigIntWorkContext = bigintValue.bigIntWorkContext
+			if !staticReserveBigIntComparisonWork(bigintValue, otherBigInt) {
+				return false, false
+			}
+			return bigintValue.value.Cmp(otherBigInt.value) == 0, true
+		}
+		number, ok := staticValueToNumber(other)
+		if !ok || math.IsNaN(number) || math.IsInf(number, 0) || math.Trunc(number) != number {
+			return false, ok
+		}
+		integer, accuracy := new(big.Float).SetFloat64(number).Int(nil)
+		return accuracy == big.Exact && bigintValue.value.Cmp(integer) == 0, true
+	}
+	if staticValueIsObjectForCoercion(left) && !staticValueIsObjectForCoercion(right) {
+		primitive, ok := staticAddPrimitive(left)
+		if !ok {
+			return false, false
+		}
+		return staticValuesLooseEqual(primitive, right)
+	}
+	if staticValueIsObjectForCoercion(right) && !staticValueIsObjectForCoercion(left) {
+		primitive, ok := staticAddPrimitive(right)
+		if !ok {
+			return false, false
+		}
+		return staticValuesLooseEqual(left, primitive)
+	}
+	return false, true
+}
+
+func staticValueIsObjectForCoercion(value any) bool {
+	if builtin, ok := value.(staticBuiltinValue); ok {
+		return staticBuiltinIsFunction(string(builtin))
+	}
+	return staticValueIsAggregate(value)
+}
+
+func staticArgument(arguments []any, index int) any {
+	if index >= len(arguments) {
+		return staticUndefinedValue{}
+	}
+	return arguments[index]
+}
+
+func staticNumberCall(value any) staticEvalResult {
+	if boxed, ok := value.(staticBoxedValue); ok {
+		return staticNumberCall(boxed.value)
+	}
+	if bigint, ok := value.(staticBigIntValue); ok {
+		if bigint.value == nil {
+			return staticEvalResult{}
+		}
+		if bigint.value.BitLen() > 1024 {
+			converted := math.Inf(1)
+			if bigint.value.Sign() < 0 {
+				converted = math.Inf(-1)
+			}
+			return staticEvalResult{value: staticNumberValue(converted), ok: true}
+		}
+		converted, _ := new(big.Float).SetInt(bigint.value).Float64()
+		return staticEvalResult{value: staticNumberValue(converted), ok: true}
+	}
+	if _, ok := value.(staticSymbolValue); ok {
+		return staticEvalResult{}
+	}
+	switch value.(type) {
+	case staticUnknownNumberValue:
+		return staticEvalResult{value: value, ok: true}
+	case staticUnknownStringValue, staticUnknownBooleanValue:
+		return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+	}
+	number, ok := staticValueToNumber(value)
+	if !ok {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: staticNumberValue(number), ok: true}
+}
+
+func staticStringCall(value any) staticEvalResult {
+	if symbol, ok := value.(staticSymbolValue); ok {
+		description, known := staticSymbolDescription(symbol)
+		if !known {
+			return staticEvalResult{value: staticUnknownStringValue{truthy: true, numericNaN: true}, ok: true}
+		}
+		return staticEvalResult{value: "Symbol(" + description + ")", ok: true}
+	}
+	if _, ok := value.(staticUnknownStringValue); ok {
+		return staticEvalResult{value: value, ok: true}
+	}
+	switch value.(type) {
+	case staticUnknownNumberValue, staticUnknownBooleanValue:
+		return staticEvalResult{value: staticUnknownStringValue{}, ok: true}
+	}
+	if _, ok := value.(staticDateValue); ok {
+		return staticEvalResult{value: staticUnknownStringValue{truthy: true, numericNaN: true}, ok: true}
+	}
+	if builtin, ok := value.(staticBuiltinValue); ok && staticBuiltinIsFunction(string(builtin)) {
+		return staticEvalResult{value: staticUnknownStringValue{truthy: true, numericNaN: true}, ok: true}
+	}
+	text, ok := staticValueToString(value)
+	if !ok {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: text, ok: true}
+}
+
+func staticDateConstructor(arguments []any) staticEvalResult {
+	if len(arguments) == 0 {
+		return staticEvalResult{value: staticDateValue{identity: &staticIdentity{}}, ok: true}
+	}
+	for _, argument := range arguments {
+		if _, symbol := argument.(staticSymbolValue); symbol {
+			return staticEvalResult{}
+		}
+		if _, bigint := argument.(staticBigIntValue); bigint {
+			return staticEvalResult{}
+		}
+	}
+	if len(arguments) == 1 {
+		argument := arguments[0]
+		if date, ok := argument.(staticDateValue); ok {
+			return staticEvalResult{value: staticDateValue{
+				milliseconds: date.milliseconds, known: date.known, identity: &staticIdentity{},
+			}, ok: true}
+		}
+		primitive, ok := staticAddPrimitive(argument)
+		if !ok {
+			// A failed ToPrimitive may represent an exception (for example an
+			// invalid Symbol.toPrimitive property), not merely an unknown date.
+			// Keep the whole call unknown so receiver classification cannot turn
+			// that exception into a known non-array value.
+			return staticEvalResult{}
+		}
+		if staticValueKindOf(primitive) == staticKindString {
+			parsed := staticDateParse(primitive)
+			milliseconds, known := parsed.value.(staticNumberValue)
+			return staticEvalResult{value: staticDateValue{
+				milliseconds: milliseconds, known: parsed.ok && known, identity: &staticIdentity{},
+			}, ok: true}
+		}
+		if _, symbol := primitive.(staticSymbolValue); symbol {
+			return staticEvalResult{}
+		}
+		if _, bigint := primitive.(staticBigIntValue); bigint {
+			return staticEvalResult{}
+		}
+		number, ok := staticValueToNumber(primitive)
+		if !ok {
+			if staticCanConvertToNumber(primitive) {
+				return staticEvalResult{value: staticDateValue{identity: &staticIdentity{}}, ok: true}
+			}
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: staticDateValue{milliseconds: staticNumberValue(number), known: true, identity: &staticIdentity{}}, ok: true}
+	}
+	if !staticNumericArguments(arguments, 0, len(arguments)) {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: staticDateValue{identity: &staticIdentity{}}, ok: true}
+}
+
+func staticBigIntCall(value any) staticEvalResult {
+	if staticValueIsObjectForCoercion(value) {
+		// BigInt applies ToPrimitive with the number hint. Date values therefore
+		// use valueOf (unlike addition/default-hint coercion) before parsing.
+		primitive, ok := staticRelationalPrimitive(value)
+		if !ok {
+			return staticEvalResult{}
+		}
+		return staticBigIntCall(primitive)
+	}
+	switch value := value.(type) {
+	case staticBigIntValue:
+		return staticEvalResult{value: value, ok: true}
+	case bool:
+		integer := int64(0)
+		if value {
+			integer = 1
+		}
+		return staticEvalResult{value: staticBigIntValue{value: big.NewInt(integer)}, ok: true}
+	case staticNumberValue:
+		number := float64(value)
+		if math.IsNaN(number) || math.IsInf(number, 0) || math.Trunc(number) != number {
+			return staticEvalResult{}
+		}
+		integer, _ := new(big.Float).SetFloat64(number).Int(nil)
+		return staticEvalResult{value: staticBigIntValue{value: integer}, ok: true}
+	case string:
+		return staticBigIntFromString(value)
+	case *staticStringNode:
+		text, _ := staticValueAsString(value)
+		return staticBigIntFromString(text)
+	default:
+		if staticValueKindOf(value) != staticKindNumber {
+			return staticEvalResult{}
+		}
+		number, ok := staticValueToNumber(value)
+		if !ok || math.IsNaN(number) || math.IsInf(number, 0) || math.Trunc(number) != number {
+			return staticEvalResult{}
+		}
+		integer, _ := new(big.Float).SetFloat64(number).Int(nil)
+		return staticEvalResult{value: staticBigIntValue{value: integer}, ok: true}
+	}
+}
+
+func staticBigIntFromString(text string) staticEvalResult {
+	text = ecmascript.StringTrim(text)
+	if text == "" {
+		return staticEvalResult{value: staticBigIntValue{value: new(big.Int)}, ok: true}
+	}
+	base := 10
+	digits := text
+	if len(text) > 2 && text[0] == '0' {
+		switch text[1] {
+		case 'b', 'B':
+			base, digits = 2, text[2:]
+		case 'o', 'O':
+			base, digits = 8, text[2:]
+		case 'x', 'X':
+			base, digits = 16, text[2:]
+		}
+	}
+	value := new(big.Int)
+	if _, ok := value.SetString(digits, base); !ok {
+		return staticEvalResult{}
+	}
+	if value.BitLen() > maxStaticBigIntBits {
+		return staticEvalResult{
+			value: staticAbstractBigInt(value.Sign() != 0), ok: true,
+			bigIntWorkBytes: (value.BitLen() + 7) / 8,
+		}
+	}
+	return staticEvalResult{
+		value: staticBigIntValue{value: value}, ok: true,
+		bigIntWorkBytes: (value.BitLen() + 7) / 8,
+	}
+}
+
+func staticObjectCall(arguments []any) staticEvalResult {
+	value := staticArgument(arguments, 0)
+	if staticValueNullish(value) {
+		return staticEvalResult{value: &staticObjectValue{enhancedCoercion: true}, ok: true}
+	}
+	switch value.(type) {
+	case *staticObjectValue, *staticArrayValue, staticOpaqueObjectValue,
+		staticRegExpValue, staticDateValue, staticBoxedValue, staticCollectionValue, staticIteratorValue,
+		staticBuiltinValue, staticBuiltinObjectValue:
+		return staticEvalResult{value: value, ok: true}
+	default:
+		return staticEvalResult{value: staticBoxedValue{value: value, identity: &staticIdentity{}}, ok: true}
+	}
+}
+
+func staticCollectionCall(
+	work *staticStringWorkContext,
+	kind string,
+	arguments []any,
+) staticEvalResult {
+	collection := staticCollectionValue{
+		kind: kind, identity: &staticIdentity{}, stringWorkContext: work,
+	}
+	if len(arguments) == 0 || staticValueNullish(arguments[0]) {
+		return staticEvalResult{value: collection, ok: true}
+	}
+	iterable, ok := staticIterableValues(work, arguments[0], maxStaticAggregateElements)
+	if !ok {
+		return staticEvalResult{}
+	}
+	if !work.reserve(max(len(iterable)*64, 1)) {
+		return staticEvalResult{}
+	}
+	for _, element := range iterable {
+		if kind == "Set" {
+			if !staticCollectionStore(&collection, element, nil) {
+				return staticEvalResult{}
+			}
+			continue
+		}
+		_, builtinObject := element.(staticBuiltinValue)
+		if !staticValueIsAggregate(element) && !builtinObject {
+			return staticEvalResult{}
+		}
+		key := staticESLintGetMemberValue(element, "0")
+		value := staticESLintGetMemberValue(element, "1")
+		if !key.ok || !value.ok {
+			return staticEvalResult{}
+		}
+		if !staticCollectionStore(&collection, key.value, value.value) {
+			return staticEvalResult{}
+		}
+	}
+	return staticEvalResult{value: collection, ok: true}
+}
+
+func staticESLintGetMemberValue(object any, key string) staticEvalResult {
+	if result := staticESLintMemberValue(object, key); result.ok {
+		return result
+	}
+	return staticESLintBuiltinMember(object, key)
+}
+
+func staticIterableValues(work *staticStringWorkContext, value any, limit int) ([]any, bool) {
+	if limit < 0 {
+		return nil, false
+	}
+	switch value := value.(type) {
+	case *staticArrayValue:
+		if value.length > limit || !work.reserve(max(value.length*16, 1)) {
+			return nil, false
+		}
+		values := make([]any, value.length)
+		for index := range value.length {
+			if value.omitted[index] {
+				values[index] = staticUndefinedValue{}
+			} else {
+				values[index] = value.element(index)
+			}
+		}
+		return values, true
+	case string:
+		return staticStringIteratorValues(work, value, limit)
+	case *staticStringNode:
+		text, _ := staticValueAsString(value)
+		return staticStringIteratorValues(work, text, limit)
+	case staticBoxedValue:
+		if text, ok := staticValueAsString(value.value); ok {
+			return staticStringIteratorValues(work, text, limit)
+		}
+	case staticIteratorValue:
+		if len(value.values) > limit || !work.reserve(max(len(value.values)*16, 1)) {
+			return nil, false
+		}
+		return value.values, true
+	case staticCollectionValue:
+		if len(value.entries) > limit || !work.reserve(max(len(value.entries)*48, 1)) {
+			return nil, false
+		}
+		values := make([]any, 0, len(value.entries))
+		for _, entry := range value.entries {
+			if value.kind == "Map" {
+				values = append(values, staticArrayFromValues([]any{entry.key, entry.value}))
+			} else {
+				values = append(values, entry.key)
+			}
+		}
+		return values, true
+	case staticBuiltinObjectValue:
+		if value == "Array.prototype" {
+			return []any{}, true
+		}
+	}
+	return nil, false
+}
+
+func staticCollectionStore(collection *staticCollectionValue, key, value any) bool {
+	if canonical, ok := staticCanonicalCollectionKey(key, collection.stringWorkContext); ok {
+		if collection.index == nil {
+			collection.index = make(map[staticCollectionKey]int, 8)
+		}
+		if index, exists := collection.index[canonical]; exists {
+			if collection.kind == "Map" {
+				collection.entries[index].value = value
+			}
+			return true
+		}
+		collection.index[canonical] = len(collection.entries)
+		collection.entries = append(collection.entries, staticCollectionEntry{key: key, value: value})
+		return true
+	}
+	if collection.stringWorkContext.exhausted() {
+		return false
+	}
+	for index, entry := range collection.entries {
+		equal, known := staticSameValueZero(entry.key, key)
+		if !known {
+			return false
+		}
+		if equal {
+			if collection.kind == "Map" {
+				collection.entries[index].value = value
+			}
+			return true
+		}
+	}
+	collection.entries = append(collection.entries, staticCollectionEntry{key: key, value: value})
+	return true
+}
+
+func staticCanonicalCollectionKey(
+	value any,
+	work *staticStringWorkContext,
+) (staticCollectionKey, bool) {
+	switch value := value.(type) {
+	case staticNullValue:
+		return staticCollectionKey{kind: 1}, true
+	case staticUndefinedValue, staticOptionalChainShortCircuitValue:
+		return staticCollectionKey{kind: 2}, true
+	case bool:
+		if value {
+			return staticCollectionKey{kind: 3, numberBits: 1}, true
+		}
+		return staticCollectionKey{kind: 3}, true
+	case string:
+		if !work.reserve(max(len(value), 1)) {
+			return staticCollectionKey{}, false
+		}
+		return staticCollectionKey{kind: 4, text: value}, true
+	case *staticStringNode:
+		text, ok := staticValueAsString(value)
+		if ok && !work.reserve(max(len(text), 1)) {
+			return staticCollectionKey{}, false
+		}
+		return staticCollectionKey{kind: 4, text: text}, ok
+	case staticNumberValue:
+		number := float64(value)
+		bits := math.Float64bits(number)
+		if number == 0 {
+			bits = 0
+		} else if math.IsNaN(number) {
+			bits = math.Float64bits(math.NaN())
+		}
+		return staticCollectionKey{kind: 5, numberBits: bits}, true
+	case staticBigIntValue:
+		if value.value == nil {
+			return staticCollectionKey{}, false
+		}
+		byteLength := (value.value.BitLen() + 7) / 8
+		// big.Int.Bytes and the conversion to a comparable string each allocate
+		// the magnitude once, and the map then hashes it. Charge all three passes
+		// before materializing the key so a compact fanout cannot amplify them.
+		if !work.reserve(max(byteLength*3, 1)) {
+			return staticCollectionKey{}, false
+		}
+		sign := uint64(0)
+		if value.value.Sign() < 0 {
+			sign = 1
+		}
+		return staticCollectionKey{
+			kind: 6, numberBits: sign, text: string(value.value.Bytes()),
+		}, true
+	case staticSymbolValue:
+		if value.hostDependent || !value.global && !value.wellKnown {
+			return staticCollectionKey{}, false
+		}
+		if !work.reserve(max(len(value.description), 1)) {
+			return staticCollectionKey{}, false
+		}
+		kind := uint8(7)
+		if value.wellKnown {
+			kind = 8
+		}
+		return staticCollectionKey{kind: kind, text: value.description}, true
+	case staticBuiltinValue:
+		name := string(value)
+		if staticBuiltinIsFunction(name) {
+			name = staticCanonicalBuiltinFunctionName(name)
+		}
+		return staticCollectionKey{kind: 9, text: name}, true
+	case staticBuiltinObjectValue:
+		return staticCollectionKey{kind: 10, text: string(value)}, true
+	case *staticObjectValue:
+		return staticCollectionKey{kind: 11, identity: value}, true
+	case *staticArrayValue:
+		return staticCollectionKey{kind: 12, identity: value}, true
+	case staticRegExpValue:
+		if value.identity != nil {
+			return staticCollectionKey{kind: 13, identity: value.identity}, true
+		}
+	case staticDateValue:
+		if value.identity != nil {
+			return staticCollectionKey{kind: 14, identity: value.identity}, true
+		}
+	case staticBoxedValue:
+		if value.identity != nil {
+			return staticCollectionKey{kind: 15, identity: value.identity}, true
+		}
+	case staticCollectionValue:
+		if value.identity != nil {
+			return staticCollectionKey{kind: 16, identity: value.identity}, true
+		}
+	case staticOpaqueObjectValue:
+		if value.identity != nil {
+			return staticCollectionKey{kind: 17, identity: value.identity}, true
+		}
+	case staticIteratorValue:
+		if value.identity != nil {
+			return staticCollectionKey{kind: 18, identity: value.identity}, true
+		}
+	}
+	if staticValueKindOf(value) == staticKindNumber {
+		number, ok := staticValueToNumber(value)
+		if !ok {
+			return staticCollectionKey{}, false
+		}
+		bits := math.Float64bits(number)
+		if number == 0 {
+			bits = 0
+		} else if math.IsNaN(number) {
+			bits = math.Float64bits(math.NaN())
+		}
+		return staticCollectionKey{kind: 5, numberBits: bits}, true
+	}
+	return staticCollectionKey{}, false
+}
+
+func staticStringIteratorValues(work *staticStringWorkContext, text string, limit int) ([]any, bool) {
+	unitCount := ecmascript.StringCodeUnitCount(text)
+	if unitCount > limit*2 ||
+		!work.reserve(max(len(text)*2+min(unitCount, limit)*32, 1)) {
+		return nil, false
+	}
+	units := ecmascript.StringCodeUnits(text)
+	values := make([]any, 0, min(len(units), limit))
+	for index := 0; index < len(units); index++ {
+		if len(values) >= limit {
+			return nil, false
+		}
+		end := index + 1
+		if units[index] >= 0xD800 && units[index] <= 0xDBFF && end < len(units) &&
+			units[end] >= 0xDC00 && units[end] <= 0xDFFF {
+			end++
+		}
+		values = append(values, ecmascript.StringFromCodeUnits(units[index:end]))
+		index = end - 1
+	}
+	return values, true
+}
+
+func staticCollectionHas(collection staticCollectionValue, key any) staticEvalResult {
+	if canonical, ok := staticCanonicalCollectionKey(key, collection.stringWorkContext); ok {
+		if collection.index != nil {
+			_, exists := collection.index[canonical]
+			return staticEvalResult{value: exists, ok: true}
+		}
+	} else if collection.stringWorkContext.exhausted() {
+		return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+	}
+	for _, entry := range collection.entries {
+		equal, known := staticSameValueZero(entry.key, key)
+		if !known {
+			return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+		}
+		if equal {
+			return staticEvalResult{value: true, ok: true}
+		}
+	}
+	return staticEvalResult{value: false, ok: true}
+}
+
+func staticMapGet(collection staticCollectionValue, key any) staticEvalResult {
+	if canonical, ok := staticCanonicalCollectionKey(key, collection.stringWorkContext); ok {
+		if collection.index != nil {
+			if index, exists := collection.index[canonical]; exists {
+				return staticEvalResult{value: collection.entries[index].value, ok: true}
+			}
+			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+		}
+	} else if collection.stringWorkContext.exhausted() {
+		return staticEvalResult{}
+	}
+	for _, entry := range collection.entries {
+		equal, known := staticSameValueZero(entry.key, key)
+		if !known {
+			return staticEvalResult{}
+		}
+		if equal {
+			return staticEvalResult{value: entry.value, ok: true}
+		}
+	}
+	return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+}
+
+func staticRegExpCall(
+	work *staticStringWorkContext,
+	arguments []any,
+	construct bool,
+) staticEvalResult {
+	pattern := ""
+	flags := ""
+	if len(arguments) > 0 && !staticValueUndefined(arguments[0]) {
+		switch argument := arguments[0].(type) {
+		case staticRegExpValue:
+			if !construct && (len(arguments) < 2 || staticValueUndefined(arguments[1])) {
+				return staticEvalResult{value: argument, ok: true}
+			}
+			pattern = argument.source
+			if len(arguments) < 2 || staticValueUndefined(arguments[1]) {
+				flags = argument.flags
+			}
+		case *staticObjectValue:
+			isRegExp, known := staticRegExpObjectMatch(argument)
+			if !known {
+				return staticEvalResult{}
+			}
+			if !isRegExp {
+				var ok bool
+				pattern, ok = staticValueToString(argument)
+				if !ok {
+					return staticEvalResult{}
+				}
+				break
+			}
+			if !construct && (len(arguments) < 2 || staticValueUndefined(arguments[1])) {
+				constructor := staticESLintGetMemberValue(argument, "constructor")
+				if !constructor.ok {
+					return staticEvalResult{}
+				}
+				equal, equalKnown := staticValuesStrictEqual(constructor.value, staticBuiltinValue("RegExp"))
+				if !equalKnown {
+					return staticEvalResult{}
+				}
+				if equal {
+					return staticEvalResult{value: argument, ok: true}
+				}
+			}
+			var ok bool
+			pattern, ok = staticRegExpObjectTextProperty(argument, "source")
+			if !ok {
+				return staticEvalResult{}
+			}
+			if len(arguments) < 2 || staticValueUndefined(arguments[1]) {
+				flags, ok = staticRegExpObjectTextProperty(argument, "flags")
+				if !ok {
+					return staticEvalResult{}
+				}
+			}
+		case staticBuiltinObjectValue:
+			if argument == "RegExp.prototype" {
+				if !construct && (len(arguments) < 2 || staticValueUndefined(arguments[1])) {
+					return staticEvalResult{value: argument, ok: true}
+				}
+				pattern = "(?:)"
+				break
+			}
+			var ok bool
+			pattern, ok = staticValueToString(argument)
+			if !ok {
+				return staticEvalResult{}
+			}
+		default:
+			var ok bool
+			pattern, ok = staticValueToString(argument)
+			if !ok {
+				return staticEvalResult{}
+			}
+		}
+	}
+	if len(arguments) > 1 && !staticValueUndefined(arguments[1]) {
+		var ok bool
+		flags, ok = staticValueToString(arguments[1])
+		if !ok {
+			return staticEvalResult{}
+		}
+	}
+	if !work.reserve(max((len(pattern)+len(flags))*2, 1)) {
+		return staticEvalResult{}
+	}
+	if !staticRegExpConstructorSourceValid(pattern, flags) {
+		return staticEvalResult{}
+	}
+	source, ok := staticRegExpSource(work, pattern)
+	if !ok || !staticRegExpConstructorPatternValid(source, flags) {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: staticRegExpValue{
+		source: source, flags: canonicalRegExpFlags(flags), identity: &staticIdentity{},
+	}, ok: true}
+}
+
+func staticRegExpObjectMatch(object *staticObjectValue) (bool, bool) {
+	match := staticESLintSymbolMemberValue(object, staticSymbolValue{description: "match", wellKnown: true})
+	if !match.ok {
+		return false, false
+	}
+	if staticValueUndefined(match.value) {
+		return false, true
+	}
+	return staticValueTruthy(match.value)
+}
+
+func staticRegExpObjectTextProperty(object *staticObjectValue, key string) (string, bool) {
+	property := staticESLintGetMemberValue(object, key)
+	if !property.ok {
+		return "", false
+	}
+	if staticValueUndefined(property.value) {
+		return "", true
+	}
+	return staticValueToString(property.value)
+}
+
+// A raw slash is ordinary constructor text in every grammar except a v-mode
+// character class, where it is a reserved punctuator and must be escaped.
+// Turning constructor text into a slash-delimited literal necessarily escapes
+// the delimiter, so this early error has to be checked before that conversion.
+// The two Hrkt script aliases are also a grammar-version boundary: tsgo's table
+// accepts them while every Node version supported by Unicorn 73 rejects them.
+func staticRegExpConstructorSourceValid(pattern, flags string) bool {
+	unicodeSets := strings.Contains(flags, "v")
+	unicodeMode := unicodeSets || strings.Contains(flags, "u")
+	if unicodeMode && staticRegExpHasEscapedLineTerminator(pattern) {
+		return false
+	}
+	inClass := 0
+	inClassString := false
+	captures := 0
+	for index := 0; index < len(pattern); {
+		if pattern[index] == '\\' {
+			if unicodeMode && index+2 < len(pattern) &&
+				(pattern[index+1] == 'p' || pattern[index+1] == 'P') &&
+				pattern[index+2] == '{' {
+				expressionStart := index + 3
+				expressionEnd, ok := staticRegExpPropertyExpressionEnd(pattern, expressionStart)
+				if !ok {
+					return false
+				}
+				if staticRegExpNode22RejectsProperty(pattern[expressionStart:expressionEnd]) {
+					return false
+				}
+				index = expressionEnd + 1
+				continue
+			}
+			if unicodeSets && inClass > 0 && !inClassString && index+2 < len(pattern) &&
+				pattern[index+1] == 'q' && pattern[index+2] == '{' {
+				inClassString = true
+				index += 3
+				continue
+			}
+			index += 1 + staticRegExpNextCharacterSize(pattern[index+1:])
+			continue
+		}
+		if inClassString {
+			if pattern[index] == '/' {
+				return false
+			}
+			if pattern[index] == '}' {
+				inClassString = false
+			}
+			index += staticRegExpNextCharacterSize(pattern[index:])
+			continue
+		}
+		switch pattern[index] {
+		case '[':
+			if unicodeSets {
+				inClass++
+				if inClass > maxStaticRegExpUnicodeSetsNesting {
+					return false
+				}
+			} else if inClass == 0 {
+				inClass = 1
+			}
+		case ']':
+			if inClass > 0 {
+				inClass--
+			}
+		case '/':
+			if unicodeSets && inClass > 0 {
+				return false
+			}
+		case '(':
+			if inClass == 0 && (index+1 >= len(pattern) || pattern[index+1] != '?' ||
+				index+3 < len(pattern) && pattern[index+2] == '<' &&
+					pattern[index+3] != '=' && pattern[index+3] != '!') {
+				captures++
+				if captures > maxStaticRegExpCaptures {
+					return false
+				}
+			}
+		}
+		index += staticRegExpNextCharacterSize(pattern[index:])
+	}
+	return true
+}
+
+// A Unicode property expression cannot contain another escape or opening
+// brace. Rejecting those delimiters while looking for the closing brace keeps
+// a compact sequence such as `\\p{\\p{...` linear instead of searching the
+// same suffix once per escape. The regexp parser remains the authority for the
+// property name and value grammar.
+func staticRegExpPropertyExpressionEnd(source string, start int) (int, bool) {
+	for index := start; index < len(source); index++ {
+		switch source[index] {
+		case '}':
+			return index, index > start
+		case '\\', '{':
+			return 0, false
+		}
+	}
+	return 0, false
+}
+
+func staticRegExpNode22RejectsProperty(expression string) bool {
+	separator := strings.IndexByte(expression, '=')
+	if separator < 0 {
+		return false
+	}
+	name, value := expression[:separator], expression[separator+1:]
+	if value != "Hrkt" && value != "Katakana_Or_Hiragana" {
+		return false
+	}
+	return name == "Script" || name == "sc" || name == "Script_Extensions" || name == "scx"
+}
+
+// staticRegExpConstructorPatternValid asks tsgo's ECMAScript regexp parser to
+// validate the constructor pattern after staticRegExpSource has made it safe
+// to place between literal delimiters. The regexp package intentionally accepts
+// a wider grammar in a few places and therefore cannot be used as a constructor
+// validity oracle here: treating a native SyntaxError as a RegExp object could
+// make receiver classification suppress a real diagnostic.
+//
+// tsgo implements the latest grammar. Node 22, the oldest runtime supported by
+// Unicorn 73, predates inline modifiers and the relaxation for duplicate named
+// captures in disjoint alternatives. Those two newer forms stay abstract so a
+// result is safe for every supported upstream runtime.
+func staticRegExpConstructorPatternValid(source, flags string) bool {
+	unicodeSets := strings.Contains(flags, "v")
+	source = staticRegExpNormalizeGroupNames(source, unicodeSets)
+	namedGroups, compatible := staticRegExpNode22NamedGroupProbe(source, unicodeSets)
+	if !compatible {
+		return false
+	}
+	validatorSource := staticRegExpValidatorSource(source, flags, namedGroups != "")
+	return ecmascript.IsValidRegexLiteral("/"+validatorSource+"/"+flags) &&
+		(namedGroups == "" || ecmascript.IsValidRegexLiteral("/"+namedGroups+"/"+flags))
+}
+
+// tsgo's regexp parser validates decoded group names correctly but currently
+// rejects their source-level Unicode escape spelling. Normalize only complete
+// RegExpIdentifierNames in captures and backreferences; invalid escapes or
+// decoded identifier characters are left for the validator to reject.
+func staticRegExpNormalizeGroupNames(source string, unicodeSets bool) string {
+	var builder strings.Builder
+	lastWritten := 0
+	changed := false
+	replaceName := func(start, end int) {
+		normalized, ok := staticRegExpNormalizeGroupName(source[start:end])
+		if !ok || normalized == source[start:end] {
+			return
+		}
+		if !changed {
+			builder.Grow(len(source))
+			changed = true
+		}
+		builder.WriteString(source[lastWritten:start])
+		builder.WriteString(normalized)
+		lastWritten = end
+	}
+
+	inClass := 0
+	inClassString := false
+	for index := 0; index < len(source); {
+		if source[index] == '\\' {
+			if inClass == 0 && index+3 < len(source) && source[index+1] == 'k' && source[index+2] == '<' {
+				closingOffset := strings.IndexByte(source[index+3:], '>')
+				if closingOffset < 0 {
+					break
+				}
+				closing := index + 3 + closingOffset
+				replaceName(index+3, closing)
+				index = closing + 1
+				continue
+			}
+			if unicodeSets && inClass > 0 && !inClassString && index+2 < len(source) &&
+				source[index+1] == 'q' && source[index+2] == '{' {
+				inClassString = true
+				index += 3
+				continue
+			}
+			index += 1 + staticRegExpNextCharacterSize(source[index+1:])
+			continue
+		}
+		if inClassString {
+			if source[index] == '}' {
+				inClassString = false
+			}
+			index += staticRegExpNextCharacterSize(source[index:])
+			continue
+		}
+		switch source[index] {
+		case '[':
+			if unicodeSets {
+				inClass++
+			} else if inClass == 0 {
+				inClass = 1
+			}
+			index++
+			continue
+		case ']':
+			if inClass > 0 {
+				inClass--
+			}
+			index++
+			continue
+		}
+		if inClass == 0 && index+3 < len(source) && source[index] == '(' && source[index+1] == '?' &&
+			source[index+2] == '<' && source[index+3] != '=' && source[index+3] != '!' {
+			closingOffset := strings.IndexByte(source[index+3:], '>')
+			if closingOffset < 0 {
+				break
+			}
+			closing := index + 3 + closingOffset
+			replaceName(index+3, closing)
+			index = closing + 1
+			continue
+		}
+		index += staticRegExpNextCharacterSize(source[index:])
+	}
+	if !changed {
+		return source
+	}
+	builder.WriteString(source[lastWritten:])
+	return builder.String()
+}
+
+func staticRegExpNormalizeGroupName(name string) (string, bool) {
+	if name == "" {
+		return name, false
+	}
+	var builder strings.Builder
+	builder.Grow(len(name))
+	first := true
+	for index := 0; index < len(name); {
+		character, size := utf8.DecodeRuneInString(name[index:])
+		if name[index] == '\\' {
+			var ok bool
+			character, size, ok = staticRegExpGroupNameEscape(name[index:])
+			if !ok {
+				return name, false
+			}
+		}
+		valid := character == '$' || character == '_' || scanner.IsIdentifierPart(character)
+		if first {
+			valid = character == '$' || character == '_' || scanner.IsIdentifierStart(character)
+		}
+		if character == utf8.RuneError || !valid {
+			return name, false
+		}
+		builder.WriteRune(character)
+		first = false
+		index += size
+	}
+	return builder.String(), true
+}
+
+func staticRegExpGroupNameEscape(text string) (rune, int, bool) {
+	if len(text) < 2 || text[0] != '\\' || text[1] != 'u' {
+		return 0, 0, false
+	}
+	if len(text) >= 4 && text[2] == '{' {
+		closing := strings.IndexByte(text[3:], '}')
+		if closing < 1 || closing > 6 {
+			return 0, 0, false
+		}
+		value, err := strconv.ParseUint(text[3:3+closing], 16, 32)
+		if err != nil || value > utf8.MaxRune {
+			return 0, 0, false
+		}
+		return rune(value), closing + 4, true
+	}
+	if len(text) < 6 {
+		return 0, 0, false
+	}
+	value, err := strconv.ParseUint(text[2:6], 16, 16)
+	if err != nil {
+		return 0, 0, false
+	}
+	return rune(value), 6, true
+}
+
+// staticRegExpValidatorSource bridges three conservative gaps in tsgo's
+// otherwise-strict parser without changing the RegExp value we materialize:
+// Annex B identity escapes, Unicode escapes in group names (handled above),
+// and seven Unicode 16 script values supported by Node 22 but absent from
+// tsgo's Unicode 15.1 property table. In a legacy character class, a malformed
+// braced Unicode escape is also the identity escape "u" followed by ordinary
+// class characters; spelling that identity escape without its backslash keeps
+// tsgo from treating it as a Unicode escape when the pattern has named groups.
+func staticRegExpValidatorSource(source, flags string, hasNamedGroups bool) string {
+	unicodeMode := strings.ContainsAny(flags, "uv")
+	unicodeSets := strings.Contains(flags, "v")
+	var builder strings.Builder
+	lastWritten := 0
+	changed := false
+	replace := func(start, end int, replacement string) {
+		if !changed {
+			builder.Grow(len(source))
+			changed = true
+		}
+		builder.WriteString(source[lastWritten:start])
+		builder.WriteString(replacement)
+		lastWritten = end
+	}
+
+	inClass := 0
+	inClassString := false
+	for index := 0; index < len(source); {
+		if source[index] == '\\' {
+			if unicodeSets && inClass > 0 && !inClassString && index+2 < len(source) &&
+				source[index+1] == 'q' && source[index+2] == '{' {
+				inClassString = true
+				index += 3
+				continue
+			}
+			if !inClassString && index+2 < len(source) &&
+				(source[index+1] == 'p' || source[index+1] == 'P') && source[index+2] == '{' {
+				if !unicodeMode {
+					replace(index, index+1, "")
+					index += 2
+					continue
+				}
+				expressionStart := index + 3
+				expressionEnd, ok := staticRegExpPropertyExpressionEnd(source, expressionStart)
+				if !ok {
+					return source
+				}
+				if replacement, replaceProperty := staticRegExpUnicode16PropertyReplacement(
+					source[expressionStart:expressionEnd],
+				); replaceProperty {
+					replace(expressionStart, expressionEnd, replacement)
+				}
+				index = expressionEnd + 1
+				continue
+			}
+			if !unicodeMode && inClass > 0 && index+2 < len(source) &&
+				source[index+1] == 'u' && source[index+2] == '{' {
+				replace(index, index+1, "")
+				index += 2
+				continue
+			}
+			if !unicodeMode && !hasNamedGroups && inClass == 0 && index+2 < len(source) &&
+				source[index+1] == 'k' && source[index+2] == '<' {
+				replace(index, index+1, "")
+				index += 2
+				continue
+			}
+			index += 1 + staticRegExpNextCharacterSize(source[index+1:])
+			continue
+		}
+		if inClassString {
+			if source[index] == '}' {
+				inClassString = false
+			}
+			index += staticRegExpNextCharacterSize(source[index:])
+			continue
+		}
+		switch source[index] {
+		case '[':
+			if unicodeSets {
+				inClass++
+			} else if inClass == 0 {
+				inClass = 1
+			}
+		case ']':
+			if inClass > 0 {
+				inClass--
+			}
+		}
+		index += staticRegExpNextCharacterSize(source[index:])
+	}
+	if !changed {
+		return source
+	}
+	builder.WriteString(source[lastWritten:])
+	return builder.String()
+}
+
+func staticRegExpUnicode16PropertyReplacement(expression string) (string, bool) {
+	separator := strings.IndexByte(expression, '=')
+	if separator < 0 {
+		return "", false
+	}
+	name, value := expression[:separator], expression[separator+1:]
+	if name != "Script" && name != "sc" && name != "Script_Extensions" && name != "scx" {
+		return "", false
+	}
+	switch value {
+	case "Garay", "Gurung_Khema", "Kirat_Rai", "Ol_Onal", "Sunuwar", "Todhri", "Tulu_Tigalari":
+		return name + "=Greek", true
+	}
+	return "", false
+}
+
+// staticRegExpNode22NamedGroupProbe extracts named-capture openers into one
+// flat pattern. Validating that pattern makes tsgo reject every duplicate after
+// decoding Unicode escapes in the names, including duplicates that its latest
+// grammar otherwise permits in different alternatives or nested scopes.
+func staticRegExpNode22NamedGroupProbe(source string, unicodeSets bool) (string, bool) {
+	var namedGroups strings.Builder
+	inClass := 0
+	inClassString := false
+	for index := 0; index < len(source); {
+		if source[index] == '\\' {
+			if unicodeSets && inClass > 0 && !inClassString && index+2 < len(source) &&
+				source[index+1] == 'q' && source[index+2] == '{' {
+				inClassString = true
+				index += 3
+				continue
+			}
+			index += 1 + staticRegExpNextCharacterSize(source[index+1:])
+			continue
+		}
+		if inClassString {
+			if source[index] == '}' {
+				inClassString = false
+			}
+			index += staticRegExpNextCharacterSize(source[index:])
+			continue
+		}
+		switch source[index] {
+		case '[':
+			if inClass == 0 || unicodeSets {
+				inClass++
+			}
+			index++
+			continue
+		case ']':
+			if inClass > 0 {
+				inClass--
+			}
+			index++
+			continue
+		}
+		if inClass == 0 && index+2 < len(source) && source[index] == '(' && source[index+1] == '?' {
+			switch source[index+2] {
+			case 'i', 'm', 's', '-':
+				return "", false
+			case '<':
+				if index+3 < len(source) && source[index+3] != '=' && source[index+3] != '!' {
+					closingOffset := strings.IndexByte(source[index+3:], '>')
+					if closingOffset < 0 {
+						return "", false
+					}
+					closing := index + 3 + closingOffset
+					namedGroups.WriteString(source[index : closing+1])
+					namedGroups.WriteByte(')')
+					index = closing + 1
+					continue
+				}
+			}
+		}
+		index += staticRegExpNextCharacterSize(source[index:])
+	}
+	return namedGroups.String(), true
+}
+
+func staticRegExpNextCharacterSize(text string) int {
+	_, size := utf8.DecodeRuneInString(text)
+	return max(size, 1)
+}
+
+func staticRegExpHasEscapedLineTerminator(pattern string) bool {
+	for index := 0; index < len(pattern); {
+		r, size := utf8.DecodeRuneInString(pattern[index:])
+		if ecmascript.IsLineTerminator(r) && staticRegExpPrecedingBackslashes(pattern, index)%2 != 0 {
+			return true
+		}
+		index += max(size, 1)
+	}
+	return false
+}
+
+// Without u/v, Annex B treats a backslash immediately before a raw line
+// terminator as a legacy identity escape and RegExp.prototype.source omits that
+// unmatched backslash. Constructor validation has already rejected this shape
+// in Unicode modes before the source is canonicalized.
+func staticRegExpNormalizeAnnexBLineEscapes(pattern string) string {
+	var builder strings.Builder
+	lastWritten := 0
+	changed := false
+	for index := 0; index < len(pattern); {
+		r, size := utf8.DecodeRuneInString(pattern[index:])
+		size = max(size, 1)
+		if ecmascript.IsLineTerminator(r) && staticRegExpPrecedingBackslashes(pattern, index)%2 != 0 {
+			if !changed {
+				builder.Grow(len(pattern))
+				changed = true
+			}
+			builder.WriteString(pattern[lastWritten : index-1])
+			builder.WriteString(pattern[index : index+size])
+			lastWritten = index + size
+		}
+		index += size
+	}
+	if !changed {
+		return pattern
+	}
+	builder.WriteString(pattern[lastWritten:])
+	return builder.String()
+}
+
+func staticRegExpSource(work *staticStringWorkContext, pattern string) (string, bool) {
+	if pattern == "" {
+		return "(?:)", true
+	}
+	pattern = staticRegExpNormalizeAnnexBLineEscapes(pattern)
+	if !work.reserve(max(len(pattern)*6, 1)) {
+		return "", false
+	}
+	var builder strings.Builder
+	appendText := func(text string) bool {
+		if len(text) > maxStaticStringLength-builder.Len() {
+			work.exhaust()
+			return false
+		}
+		builder.WriteString(text)
+		return true
+	}
+	for index := 0; index < len(pattern); {
+		switch pattern[index] {
+		case '\n':
+			if !appendText(`\n`) {
+				return "", false
+			}
+			index++
+		case '\r':
+			if !appendText(`\r`) {
+				return "", false
+			}
+			index++
+		case '/':
+			backslashes := 0
+			for previous := index - 1; previous >= 0 && pattern[previous] == '\\'; previous-- {
+				backslashes++
+			}
+			if backslashes%2 == 0 {
+				if !appendText(`\`) {
+					return "", false
+				}
+			}
+			if !appendText("/") {
+				return "", false
+			}
+			index++
+		default:
+			r, size := utf8.DecodeRuneInString(pattern[index:])
+			switch r {
+			case '\u2028':
+				if !appendText(`\u2028`) {
+					return "", false
+				}
+			case '\u2029':
+				if !appendText(`\u2029`) {
+					return "", false
+				}
+			default:
+				if !appendText(pattern[index : index+size]) {
+					return "", false
+				}
+			}
+			index += size
+		}
+	}
+	return builder.String(), true
+}
+
+func staticRegExpPrecedingBackslashes(pattern string, index int) int {
+	count := 0
+	for index--; index >= 0 && pattern[index] == '\\'; index-- {
+		count++
+	}
+	return count
+}
+
+func staticParseNumber(name string, arguments []any) staticEvalResult {
+	text, ok := staticValueToString(staticArgument(arguments, 0))
+	if !ok {
+		return staticEvalResult{}
+	}
+	if name == "Number.parseInt" || name == "parseInt" {
+		radix := 0
+		if len(arguments) > 1 && !staticValueUndefined(arguments[1]) {
+			number, ok := staticValueToNumber(arguments[1])
+			if !ok {
+				if staticCanConvertToNumber(arguments[1]) {
+					return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+				}
+				return staticEvalResult{}
+			}
+			radix = int(toInt32(number))
+		}
+		return staticParseInt(text, radix)
+	}
+	return staticParseFloat(text)
+}
+
+func staticParseInt(text string, radix int) staticEvalResult {
+	text = ecmascript.StringTrim(text)
+	negative := false
+	if text != "" && (text[0] == '+' || text[0] == '-') {
+		negative = text[0] == '-'
+		text = text[1:]
+	}
+	if radix != 0 && (radix < 2 || radix > 36) {
+		return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+	}
+	stripHexPrefix := radix == 0 || radix == 16
+	if radix == 0 {
+		radix = 10
+	}
+	if stripHexPrefix && len(text) >= 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X') {
+		radix = 16
+		text = text[2:]
+	}
+	digitCount := 0
+	for digitCount < len(text) {
+		digit := asciiRadixDigit(text[digitCount])
+		if digit < 0 || digit >= radix {
+			break
+		}
+		digitCount++
+	}
+	if digitCount == 0 {
+		return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+	}
+	integer := new(big.Int)
+	integer.SetString(text[:digitCount], radix)
+	value, _ := new(big.Float).SetInt(integer).Float64()
+	if negative {
+		value = -value
+		if value == 0 {
+			value = math.Copysign(0, -1)
+		}
+	}
+	return staticEvalResult{value: staticNumberValue(value), ok: true}
+}
+
+func asciiRadixDigit(value byte) int {
+	switch {
+	case value >= '0' && value <= '9':
+		return int(value - '0')
+	case value >= 'a' && value <= 'z':
+		return int(value-'a') + 10
+	case value >= 'A' && value <= 'Z':
+		return int(value-'A') + 10
+	default:
+		return -1
+	}
+}
+
+func staticParseFloat(text string) staticEvalResult {
+	text = ecmascript.StringTrim(text)
+	if strings.HasPrefix(text, "+Infinity") || strings.HasPrefix(text, "Infinity") {
+		return staticEvalResult{value: staticNumberValue(math.Inf(1)), ok: true}
+	}
+	if strings.HasPrefix(text, "-Infinity") {
+		return staticEvalResult{value: staticNumberValue(math.Inf(-1)), ok: true}
+	}
+	length := staticDecimalPrefixLength(text)
+	if length == 0 || length == 1 && (text[0] == '+' || text[0] == '-') {
+		return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+	}
+	value, err := strconv.ParseFloat(text[:length], 64)
+	if err != nil && !strings.Contains(err.Error(), "value out of range") {
+		return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+	}
+	return staticEvalResult{value: staticNumberValue(value), ok: true}
+}
+
+func staticDecimalPrefixLength(text string) int {
+	index := 0
+	if index < len(text) && (text[index] == '+' || text[index] == '-') {
+		index++
+	}
+	integerStart := index
+	for index < len(text) && text[index] >= '0' && text[index] <= '9' {
+		index++
+	}
+	hasDigits := index > integerStart
+	if index < len(text) && text[index] == '.' {
+		index++
+		fractionStart := index
+		for index < len(text) && text[index] >= '0' && text[index] <= '9' {
+			index++
+		}
+		hasDigits = hasDigits || index > fractionStart
+	}
+	if !hasDigits {
+		return 0
+	}
+	if index < len(text) && (text[index] == 'e' || text[index] == 'E') {
+		exponentMark := index
+		index++
+		if index < len(text) && (text[index] == '+' || text[index] == '-') {
+			index++
+		}
+		exponentStart := index
+		for index < len(text) && text[index] >= '0' && text[index] <= '9' {
+			index++
+		}
+		if index == exponentStart {
+			index = exponentMark
+		}
+	}
+	return index
+}
+
+func staticDateParse(value any) staticEvalResult {
+	text, ok := staticValueToString(value)
+	if !ok {
+		return staticEvalResult{}
+	}
+	if milliseconds, matched, exact := staticDateTimeStringMilliseconds(text); matched {
+		if !exact {
+			return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+		}
+		return staticEvalResult{value: staticNumberValue(milliseconds), ok: true}
+	}
+	if staticDateHasImplementationDefinedZone(text) {
+		return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+	}
+	if staticDateTextDefinitelyInvalid(text) {
+		return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+	}
+	// Date.parse accepts implementation-defined legacy formats and normalizes
+	// some out-of-range dates. A failed Go layout match therefore does not prove
+	// JavaScript would produce NaN; retain the known number type only.
+	return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+}
+
+// staticDateTimeStringMilliseconds parses ECMAScript's Date Time String
+// Format before the implementation-defined legacy formats accepted by a
+// particular JavaScript engine. A syntactically matching string with an
+// out-of-bounds field is a known NaN; calendar overflow such as February 30 is
+// normalized by MakeDay, just as the specification requires. Local date-time
+// forms are recognized but deliberately not assigned a millisecond value:
+// V8 and Go normalize DST gaps differently, so only date-only, UTC, and
+// explicit-offset forms are exact across hosts.
+func staticDateTimeStringMilliseconds(text string) (milliseconds float64, matched, exact bool) {
+	index := 0
+	year, expanded, ok := staticDateYear(text, &index)
+	if !ok {
+		return 0, false, false
+	}
+	if expanded && year == 0 && text[0] == '-' {
+		return math.NaN(), true, true
+	}
+
+	month, day := 1, 1
+	hour, minute, second, millisecond := 0, 0, 0, 0
+	dateOnly := true
+	location := time.UTC
+	localTime := false
+	if index < len(text) {
+		if text[index] != '-' {
+			return 0, false, false
+		}
+		index++
+		if month, ok = staticDateTwoDigits(text, &index); !ok {
+			return 0, false, false
+		}
+		if index < len(text) {
+			if text[index] != '-' {
+				return 0, false, false
+			}
+			index++
+			if day, ok = staticDateTwoDigits(text, &index); !ok {
+				return 0, false, false
+			}
+		}
+	}
+
+	if index < len(text) {
+		if text[index] != 'T' {
+			return 0, false, false
+		}
+		dateOnly = false
+		localTime = true
+		index++
+		if hour, ok = staticDateTwoDigits(text, &index); !ok || index >= len(text) || text[index] != ':' {
+			return 0, false, false
+		}
+		index++
+		if minute, ok = staticDateTwoDigits(text, &index); !ok {
+			return 0, false, false
+		}
+		if index < len(text) && text[index] == ':' {
+			index++
+			if second, ok = staticDateTwoDigits(text, &index); !ok {
+				return 0, false, false
+			}
+			if index < len(text) && text[index] == '.' {
+				index++
+				if millisecond, ok = staticDateThreeDigits(text, &index); !ok {
+					return 0, false, false
+				}
+			}
+		}
+
+		location = time.Local
+		if index < len(text) && text[index] == 'Z' {
+			location = time.UTC
+			localTime = false
+			index++
+		} else if index < len(text) && (text[index] == '+' || text[index] == '-') {
+			localTime = false
+			sign := 1
+			if text[index] == '-' {
+				sign = -1
+			}
+			index++
+			offsetHour, digitsOK := staticDateTwoDigits(text, &index)
+			if !digitsOK || index >= len(text) || text[index] != ':' {
+				return 0, false, false
+			}
+			index++
+			offsetMinute, digitsOK := staticDateTwoDigits(text, &index)
+			if !digitsOK {
+				return 0, false, false
+			}
+			if offsetHour > 23 || offsetMinute > 59 {
+				return math.NaN(), true, true
+			}
+			location = time.FixedZone("", sign*(offsetHour*60+offsetMinute)*60)
+		}
+	}
+
+	if index != len(text) {
+		return 0, false, false
+	}
+	if month < 1 || month > 12 || day < 1 || day > 31 ||
+		hour < 0 || hour > 24 || minute < 0 || minute > 59 ||
+		second < 0 || second > 59 || millisecond < 0 || millisecond > 999 ||
+		hour == 24 && (minute != 0 || second != 0 || millisecond != 0) {
+		return math.NaN(), true, true
+	}
+	if dateOnly {
+		location = time.UTC
+	}
+	if localTime {
+		return 0, true, false
+	}
+	parsed := time.Date(year, time.Month(month), day, hour, minute, second, millisecond*int(time.Millisecond), location)
+	milliseconds = float64(parsed.UnixMilli())
+	if math.Abs(milliseconds) > 8.64e15 {
+		return math.NaN(), true, true
+	}
+	return milliseconds, true, true
+}
+
+func staticDateYear(text string, index *int) (year int, expanded bool, ok bool) {
+	if *index >= len(text) {
+		return 0, false, false
+	}
+	sign := 1
+	digits := 4
+	if text[*index] == '+' || text[*index] == '-' {
+		expanded = true
+		digits = 6
+		if text[*index] == '-' {
+			sign = -1
+		}
+		*index++
+	}
+	start := *index
+	if start+digits > len(text) {
+		return 0, expanded, false
+	}
+	for *index < start+digits {
+		character := text[*index]
+		if character < '0' || character > '9' {
+			return 0, expanded, false
+		}
+		year = year*10 + int(character-'0')
+		*index++
+	}
+	return sign * year, expanded, true
+}
+
+func staticDateTwoDigits(text string, index *int) (int, bool) {
+	return staticDateDigits(text, index, 2)
+}
+
+func staticDateThreeDigits(text string, index *int) (int, bool) {
+	return staticDateDigits(text, index, 3)
+}
+
+func staticDateDigits(text string, index *int, count int) (int, bool) {
+	if *index+count > len(text) {
+		return 0, false
+	}
+	value := 0
+	for range count {
+		character := text[*index]
+		if character < '0' || character > '9' {
+			return 0, false
+		}
+		value = value*10 + int(character-'0')
+		*index++
+	}
+	return value, true
+}
+
+func staticDateHasImplementationDefinedZone(text string) bool {
+	fields := strings.Fields(text)
+	if len(fields) == 0 {
+		return false
+	}
+	zone := fields[len(fields)-1]
+	if zone == "GMT" || zone == "UTC" || len(zone) < 2 || len(zone) > 5 {
+		return false
+	}
+	for index := range len(zone) {
+		if zone[index] < 'A' || zone[index] > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+func staticDateTextDefinitelyInvalid(text string) bool {
+	if staticDateTextHasDigit(text) {
+		return false
+	}
+	lower := ecmascript.StringToLowerCase(text)
+	for _, month := range [...]string{
+		"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+	} {
+		if strings.Contains(lower, month) {
+			return false
+		}
+	}
+	return true
+}
+
+func staticDateTextHasDigit(text string) bool {
+	for index := range len(text) {
+		if text[index] >= '0' && text[index] <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalRegExpFlags(flags string) string {
+	var builder strings.Builder
+	for _, candidate := range "dgimsuvy" {
+		if strings.ContainsRune(flags, candidate) {
+			builder.WriteRune(candidate)
+		}
+	}
+	return builder.String()
+}
+
+func staticObjectEntriesCall(
+	work *staticStringWorkContext,
+	name string,
+	value any,
+) staticEvalResult {
+	properties, ok := staticEnumerableOwnProperties(work, value)
+	if !ok {
+		return staticEvalResult{}
+	}
+	values := make([]any, 0, len(properties))
+	for _, property := range properties {
+		switch name {
+		case "Object.keys":
+			values = append(values, property.name)
+		case "Object.values":
+			values = append(values, property.value)
+		default:
+			values = append(values, staticArrayFromValues([]any{property.name, property.value}))
+		}
+	}
+	return staticEvalResult{value: staticArrayFromValues(values), ok: true}
+}
+
+func staticEnumerableOwnProperties(
+	work *staticStringWorkContext,
+	value any,
+) ([]staticObjectProperty, bool) {
+	switch value := value.(type) {
+	case *staticObjectValue:
+		if value.propertyCount > maxStaticAggregateElements {
+			return nil, false
+		}
+		if !work.reserve(max(value.propertyCount*64, 1)) {
+			return nil, false
+		}
+		properties := make([]staticObjectProperty, 0, value.propertyCount)
+		if value.propertyCount > 0 && !value.property.symbolKey {
+			properties = append(properties, value.property)
+		}
+		for _, property := range value.extraProperties {
+			if !property.symbolKey {
+				properties = append(properties, property)
+			}
+		}
+		return staticUniqueObjectProperties(properties), true
+	case *staticArrayValue:
+		if value.length > maxStaticAggregateElements {
+			return nil, false
+		}
+		if !work.reserve(max(value.length*48, 1)) {
+			return nil, false
+		}
+		properties := make([]staticObjectProperty, 0, value.length)
+		for index := range value.length {
+			if value.omitted[index] {
+				continue
+			}
+			properties = append(properties, staticObjectProperty{
+				name: strconv.Itoa(index), value: value.element(index),
+			})
+		}
+		return properties, true
+	case string:
+		return staticStringEnumerableProperties(work, value)
+	case *staticStringNode:
+		text, _ := staticValueAsString(value)
+		return staticStringEnumerableProperties(work, text)
+	case staticBoxedValue:
+		if text, ok := staticValueAsString(value.value); ok {
+			return staticStringEnumerableProperties(work, text)
+		}
+		return nil, true
+	case staticBuiltinObjectValue:
+		if value == "Array.prototype[Symbol.unscopables]" {
+			properties := make([]staticObjectProperty, 0, len(staticArrayUnscopablesPropertyNames))
+			for _, name := range staticArrayUnscopablesPropertyNames {
+				properties = append(properties, staticObjectProperty{name: name, value: true})
+			}
+			return properties, true
+		}
+		return nil, true
+	case bool, staticNumberValue, staticBigIntValue, staticSymbolValue,
+		staticBuiltinValue, staticRegExpValue, staticDateValue,
+		staticCollectionValue, staticOpaqueObjectValue:
+		return nil, true
+	}
+	if staticValueKindOf(value) == staticKindNumber {
+		return nil, true
+	}
+	return nil, false
+}
+
+var staticArrayUnscopablesPropertyNames = [...]string{
+	"at", "copyWithin", "entries", "fill", "find", "findIndex", "findLast", "findLastIndex",
+	"flat", "flatMap", "includes", "keys", "toReversed", "toSorted", "toSpliced", "values",
+}
+
+func staticUniqueObjectProperties(properties []staticObjectProperty) []staticObjectProperty {
+	result := make([]staticObjectProperty, 0, len(properties))
+	indices := make(map[string]int, len(properties))
+	for _, property := range properties {
+		if index, exists := indices[property.name]; exists {
+			result[index].value = property.value
+			continue
+		}
+		indices[property.name] = len(result)
+		result = append(result, property)
+	}
+	sort.SliceStable(result, func(left, right int) bool {
+		leftIndex, leftOK := staticObjectArrayIndex(result[left].name)
+		rightIndex, rightOK := staticObjectArrayIndex(result[right].name)
+		if leftOK != rightOK {
+			return leftOK
+		}
+		return leftOK && leftIndex < rightIndex
+	})
+	return result
+}
+
+func staticObjectArrayIndex(value string) (uint32, bool) {
+	if value == "" || value == "4294967295" {
+		return 0, false
+	}
+	if len(value) > 1 && value[0] == '0' {
+		return 0, false
+	}
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil || parsed >= math.MaxUint32 {
+		return 0, false
+	}
+	return uint32(parsed), true
+}
+
+func staticStringEnumerableProperties(
+	work *staticStringWorkContext,
+	text string,
+) ([]staticObjectProperty, bool) {
+	if ecmascript.StringCodeUnitCount(text) > maxStaticAggregateElements {
+		return nil, false
+	}
+	if !work.reserve(max(len(text)*64, 1)) {
+		return nil, false
+	}
+	units := ecmascript.StringCodeUnits(text)
+	properties := make([]staticObjectProperty, len(units))
+	for index, unit := range units {
+		properties[index] = staticObjectProperty{
+			name: strconv.Itoa(index), value: ecmascript.StringFromCodeUnits([]uint16{unit}),
+		}
+	}
+	return properties, true
+}
+
+func staticNumberPredicate(name string, value any) staticEvalResult {
+	number, ok := staticValueToNumber(value)
+	if staticValueKindOf(value) != staticKindNumber {
+		return staticEvalResult{value: false, ok: true}
+	}
+	if !ok {
+		return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+	}
+	if name == "Number.isFinite" {
+		return staticEvalResult{value: !math.IsNaN(number) && !math.IsInf(number, 0), ok: true}
+	}
+	return staticEvalResult{value: math.IsNaN(number), ok: true}
+}
+
+func staticStringFromCodePoint(
+	work *staticStringWorkContext,
+	arguments []any,
+) staticEvalResult {
+	if !work.reserve(max(len(arguments)*8, 1)) {
+		return staticEvalResult{}
+	}
+	units := make([]uint16, 0, len(arguments))
+	for _, argument := range arguments {
+		number, ok := staticValueToNumber(argument)
+		if !ok || math.Trunc(number) != number || number < 0 || number > utf8.MaxRune {
+			return staticEvalResult{}
+		}
+		if number <= 0xFFFF {
+			units = append(units, uint16(number))
+			continue
+		}
+		codePoint := uint32(number) - 0x10000
+		units = append(units, uint16(0xD800+codePoint>>10), uint16(0xDC00+codePoint&0x3FF))
+	}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units), ok: true}
+}
+
+func staticStringRawCall(
+	work *staticStringWorkContext,
+	arguments []any,
+) staticEvalResult {
+	if len(arguments) == 0 {
+		return staticEvalResult{}
+	}
+	raw := staticESLintMemberValue(arguments[0], "raw")
+	if !raw.ok {
+		return staticEvalResult{}
+	}
+	lengthValue := staticESLintMemberValue(raw.value, "length")
+	if !lengthValue.ok {
+		return staticEvalResult{}
+	}
+	length, ok := staticToLength(lengthValue.value)
+	if !ok || length > maxStaticAggregateElements {
+		return staticEvalResult{}
+	}
+	var builder strings.Builder
+	for index := range length {
+		segmentValue := staticESLintMemberValue(raw.value, strconv.Itoa(index))
+		if !segmentValue.ok {
+			return staticEvalResult{}
+		}
+		segment, ok := staticValueToString(segmentValue.value)
+		if !ok || len(segment) > maxStaticStringLength-builder.Len() {
+			if ok {
+				work.exhaust()
+			}
+			return staticEvalResult{}
+		}
+		if !work.reserve(len(segment) * 2) {
+			return staticEvalResult{}
+		}
+		builder.WriteString(segment)
+		if index+1 >= length {
+			continue
+		}
+		substitution, ok := staticValueToString(staticArgument(arguments, index+1))
+		if !ok || len(substitution) > maxStaticStringLength-builder.Len() {
+			if ok {
+				work.exhaust()
+			}
+			return staticEvalResult{}
+		}
+		if !work.reserve(len(substitution) * 2) {
+			return staticEvalResult{}
+		}
+		builder.WriteString(substitution)
+	}
+	return staticEvalResult{value: builder.String(), ok: true}
+}
+
+func staticToLength(value any) (int, bool) {
+	number, ok := staticValueToNumber(value)
+	if !ok {
+		return 0, false
+	}
+	if math.IsNaN(number) || number <= 0 {
+		return 0, true
+	}
+	if math.IsInf(number, 1) || number > maxStaticAggregateElements {
+		return 0, false
+	}
+	return int(math.Trunc(number)), true
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalESLintStringRawTag(node *ast.Node) staticEvalResult {
+	tagged := node.AsTaggedTemplateExpression()
+	if tagged == nil || tagged.Tag == nil || tagged.Template == nil || staticEvaluator.sourceFile == nil {
+		return staticEvalResult{}
+	}
+	tag := staticEvaluator.evalValue(tagged.Tag)
+	builtin, ok := tag.value.(staticBuiltinValue)
+	if !tag.ok || !ok || builtin != "String.raw" {
+		return staticEvalResult{}
+	}
+
+	var builder strings.Builder
+	appendPart := func(part string) bool {
+		if !staticEvaluator.stringWorkContext.reserve(max(len(part)*6, 1)) {
+			return false
+		}
+		part = strings.ReplaceAll(strings.ReplaceAll(part, "\r\n", "\n"), "\r", "\n")
+		if len(part) > maxStaticStringLength-builder.Len() {
+			staticEvaluator.stringWorkContext.exhaust()
+			return false
+		}
+		builder.WriteString(part)
+		return true
+	}
+	if tagged.Template.Kind == ast.KindNoSubstitutionTemplateLiteral {
+		raw, ok := staticRawTemplateToken(staticEvaluator.sourceFile.Text(), tagged.Template)
+		if !ok || !appendPart(raw) {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: builder.String(), ok: true}
+	}
+	if tagged.Template.Kind != ast.KindTemplateExpression {
+		return staticEvalResult{}
+	}
+	template := tagged.Template.AsTemplateExpression()
+	head, ok := staticRawTemplateToken(staticEvaluator.sourceFile.Text(), template.Head)
+	if !ok || !appendPart(head) {
+		return staticEvalResult{}
+	}
+	for _, spanNode := range template.TemplateSpans.Nodes {
+		span := spanNode.AsTemplateSpan()
+		value := staticEvaluator.evalValue(span.Expression)
+		if !value.ok {
+			return staticEvalResult{}
+		}
+		text, ok := staticValueToString(value.value)
+		if !ok || !appendPart(text) {
+			return staticEvalResult{}
+		}
+		raw, ok := staticRawTemplateToken(staticEvaluator.sourceFile.Text(), span.Literal)
+		if !ok || !appendPart(raw) {
+			return staticEvalResult{}
+		}
+	}
+	return staticEvalResult{value: builder.String(), ok: true}
+}
+
+func staticRawTemplateToken(source string, node *ast.Node) (string, bool) {
+	if node == nil || node.Pos() < 0 || node.End() > len(source) || node.Pos() >= node.End() {
+		return "", false
+	}
+	text := source[node.Pos():node.End()]
+	switch node.Kind {
+	case ast.KindNoSubstitutionTemplateLiteral:
+		start, end := strings.IndexByte(text, '`'), strings.LastIndexByte(text, '`')
+		if start < 0 || end <= start {
+			return "", false
+		}
+		return text[start+1 : end], true
+	case ast.KindTemplateHead:
+		start, end := strings.IndexByte(text, '`'), strings.LastIndex(text, "${")
+		if start < 0 || end < start {
+			return "", false
+		}
+		return text[start+1 : end], true
+	case ast.KindTemplateMiddle:
+		start, end := strings.IndexByte(text, '}'), strings.LastIndex(text, "${")
+		if start < 0 || end < start {
+			return "", false
+		}
+		return text[start+1 : end], true
+	case ast.KindTemplateTail:
+		start, end := strings.IndexByte(text, '}'), strings.LastIndexByte(text, '`')
+		if start < 0 || end < start {
+			return "", false
+		}
+		return text[start+1 : end], true
+	default:
+		return "", false
+	}
+}
+
+func staticURICall(
+	work *staticStringWorkContext,
+	name string,
+	arguments []any,
+) staticEvalResult {
+	text, ok := staticValueToString(staticArgument(arguments, 0))
+	if !ok {
+		return staticEvalResult{}
+	}
+	// URI helpers can build escaped output and, for the legacy escape pair,
+	// full UTF-16 scratch buffers. Eight bytes of work per input byte is a
+	// conservative upper bound for the implemented paths.
+	if !work.reserve(max(len(text)*8, 1)) {
+		return staticEvalResult{}
+	}
+	switch name {
+	case "encodeURI", "encodeURIComponent":
+		value, ok := staticEncodeURI(text, name == "encodeURIComponent")
+		return staticEvalResult{value: value, ok: ok}
+	case "decodeURI", "decodeURIComponent":
+		value, ok := staticDecodeURI(text, name == "decodeURIComponent")
+		return staticEvalResult{value: value, ok: ok}
+	case "escape":
+		value, ok := staticEscape(text)
+		return staticEvalResult{value: value, ok: ok}
+	case "unescape":
+		return staticEvalResult{value: staticUnescape(text), ok: true}
+	}
+	return staticEvalResult{}
+}
+
+func isASCIIHex(value byte) bool {
+	return value >= '0' && value <= '9' || value >= 'a' && value <= 'f' || value >= 'A' && value <= 'F'
+}
+
+func hasUnpairedSurrogate(text string) bool {
+	units := ecmascript.StringCodeUnits(text)
+	for index := 0; index < len(units); index++ {
+		unit := units[index]
+		switch {
+		case unit >= 0xD800 && unit <= 0xDBFF:
+			if index+1 >= len(units) || units[index+1] < 0xDC00 || units[index+1] > 0xDFFF {
+				return true
+			}
+			index++
+		case unit >= 0xDC00 && unit <= 0xDFFF:
+			return true
+		}
+	}
+	return false
+}
+
+const upperHex = "0123456789ABCDEF"
+
+func staticEncodeURI(text string, component bool) (string, bool) {
+	if hasUnpairedSurrogate(text) {
+		return "", false
+	}
+	var builder strings.Builder
+	for _, value := range []byte(text) {
+		if value < utf8.RuneSelf && staticURIUnescaped(value, component) {
+			if builder.Len() >= maxStaticStringLength {
+				return "", false
+			}
+			builder.WriteByte(value)
+			continue
+		}
+		if builder.Len() > maxStaticStringLength-3 {
+			return "", false
+		}
+		builder.WriteByte('%')
+		builder.WriteByte(upperHex[value>>4])
+		builder.WriteByte(upperHex[value&0xF])
+	}
+	return builder.String(), true
+}
+
+func staticURIUnescaped(value byte, component bool) bool {
+	if value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9' ||
+		strings.ContainsRune("-_.!~*'()", rune(value)) {
+		return true
+	}
+	return !component && strings.ContainsRune(";,/?:@&=+$#", rune(value))
+}
+
+func staticDecodeURI(text string, component bool) (string, bool) {
+	var builder strings.Builder
+	for index := 0; index < len(text); {
+		if text[index] != '%' {
+			if builder.Len() >= maxStaticStringLength*3 {
+				return "", false
+			}
+			builder.WriteByte(text[index])
+			index++
+			continue
+		}
+		if index+2 >= len(text) || !isASCIIHex(text[index+1]) || !isASCIIHex(text[index+2]) {
+			return "", false
+		}
+		first := asciiHexValue(text[index+1])<<4 | asciiHexValue(text[index+2])
+		if first < utf8.RuneSelf {
+			if !component && strings.ContainsRune(";,/?:@&=+$#", rune(first)) {
+				if builder.Len() > maxStaticStringLength*3-3 {
+					return "", false
+				}
+				builder.WriteString(text[index : index+3])
+			} else {
+				if builder.Len() >= maxStaticStringLength*3 {
+					return "", false
+				}
+				builder.WriteByte(first)
+			}
+			index += 3
+			continue
+		}
+		sequenceLength := 0
+		switch {
+		case first >= 0xC2 && first <= 0xDF:
+			sequenceLength = 2
+		case first >= 0xE0 && first <= 0xEF:
+			sequenceLength = 3
+		case first >= 0xF0 && first <= 0xF4:
+			sequenceLength = 4
+		default:
+			return "", false
+		}
+		decoded := make([]byte, sequenceLength)
+		for offset := range sequenceLength {
+			position := index + offset*3
+			if position+2 >= len(text) || text[position] != '%' ||
+				!isASCIIHex(text[position+1]) || !isASCIIHex(text[position+2]) {
+				return "", false
+			}
+			decoded[offset] = asciiHexValue(text[position+1])<<4 | asciiHexValue(text[position+2])
+		}
+		if !utf8.Valid(decoded) {
+			return "", false
+		}
+		if len(decoded) > maxStaticStringLength*3-builder.Len() {
+			return "", false
+		}
+		builder.Write(decoded)
+		index += sequenceLength * 3
+	}
+	return builder.String(), true
+}
+
+func staticEscape(text string) (string, bool) {
+	var builder strings.Builder
+	for _, unit := range ecmascript.StringCodeUnits(text) {
+		if unit < utf8.RuneSelf && (unit >= 'a' && unit <= 'z' || unit >= 'A' && unit <= 'Z' ||
+			unit >= '0' && unit <= '9' || strings.ContainsRune("@*_+-./", rune(unit))) {
+			if builder.Len() >= maxStaticStringLength {
+				return "", false
+			}
+			builder.WriteByte(byte(unit))
+			continue
+		}
+		if unit < 256 {
+			if builder.Len() > maxStaticStringLength-3 {
+				return "", false
+			}
+			builder.WriteByte('%')
+			builder.WriteByte(upperHex[unit>>4])
+			builder.WriteByte(upperHex[unit&0xF])
+			continue
+		}
+		if builder.Len() > maxStaticStringLength-6 {
+			return "", false
+		}
+		builder.WriteString("%u")
+		builder.WriteByte(upperHex[unit>>12])
+		builder.WriteByte(upperHex[unit>>8&0xF])
+		builder.WriteByte(upperHex[unit>>4&0xF])
+		builder.WriteByte(upperHex[unit&0xF])
+	}
+	return builder.String(), true
+}
+
+func staticUnescape(text string) string {
+	units := ecmascript.StringCodeUnits(text)
+	result := make([]uint16, 0, len(units))
+	for index := 0; index < len(units); index++ {
+		if units[index] != '%' {
+			result = append(result, units[index])
+			continue
+		}
+		if index+5 < len(units) && units[index+1] == 'u' &&
+			staticHexUnits(units[index+2:index+6]) {
+			result = append(result, uint16(asciiHexValue(byte(units[index+2])))<<12|
+				uint16(asciiHexValue(byte(units[index+3])))<<8|
+				uint16(asciiHexValue(byte(units[index+4])))<<4|
+				uint16(asciiHexValue(byte(units[index+5]))))
+			index += 5
+			continue
+		}
+		if index+2 < len(units) && staticHexUnits(units[index+1:index+3]) {
+			result = append(result, uint16(asciiHexValue(byte(units[index+1])))<<4|
+				uint16(asciiHexValue(byte(units[index+2]))))
+			index += 2
+			continue
+		}
+		result = append(result, '%')
+	}
+	return ecmascript.StringFromCodeUnits(result)
+}
+
+func staticHexUnits(units []uint16) bool {
+	for _, unit := range units {
+		if unit > 0x7F || !isASCIIHex(byte(unit)) {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiHexValue(value byte) byte {
+	switch {
+	case value >= '0' && value <= '9':
+		return value - '0'
+	case value >= 'a' && value <= 'f':
+		return value - 'a' + 10
+	default:
+		return value - 'A' + 10
+	}
+}
+
+func staticMathCall(method string, arguments []any) staticEvalResult {
+	if method == "random" || !staticMathMethod(method) {
+		return staticEvalResult{}
+	}
+	usedArguments := 1
+	switch method {
+	case "atan2", "imul", "pow":
+		usedArguments = 2
+	case "hypot", "max", "min":
+		usedArguments = len(arguments)
+	}
+	numbers := make([]float64, min(len(arguments), usedArguments))
+	exact := true
+	for index, argument := range arguments[:len(numbers)] {
+		number, ok := staticValueToNumber(argument)
+		if !ok {
+			if !staticCanConvertToNumber(argument) {
+				return staticEvalResult{}
+			}
+			exact = false
+		}
+		numbers[index] = number
+	}
+	if !exact {
+		return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+	}
+	if method == "hypot" && len(numbers) == 0 {
+		return staticEvalResult{value: staticNumberValue(0), ok: true}
+	}
+	if staticMathRequiresRuntimeExactness(method) {
+		if result, ok := staticMathExactSpecialCase(method, numbers); ok {
+			return staticEvalResult{value: staticNumberValue(result), ok: true}
+		}
+		// V8's fdlibm/LLVM-libc results can differ from Go's libm by one or
+		// more ULPs. The return type is still certain, but using a Go result in
+		// a strict comparison could choose the wrong receiver branch.
+		return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+	}
+	argument := func(index int) float64 {
+		if index >= len(numbers) {
+			return math.NaN()
+		}
+		return numbers[index]
+	}
+	var result float64
+	switch method {
+	case "abs":
+		result = math.Abs(argument(0))
+	case "acos":
+		result = ecmascript.Acos(argument(0))
+	case "acosh":
+		result = math.Acosh(argument(0))
+	case "asin":
+		result = math.Asin(argument(0))
+	case "asinh":
+		result = math.Asinh(argument(0))
+	case "atan":
+		result = math.Atan(argument(0))
+	case "atanh":
+		result = math.Atanh(argument(0))
+	case "atan2":
+		result = math.Atan2(argument(0), argument(1))
+	case "cbrt":
+		result = math.Cbrt(argument(0))
+	case "ceil":
+		result = math.Ceil(argument(0))
+	case "clz32":
+		result = float64(bits.LeadingZeros32(toUint32(argument(0))))
+	case "cos":
+		result = math.Cos(argument(0))
+	case "cosh":
+		result = math.Cosh(argument(0))
+	case "exp":
+		result = math.Exp(argument(0))
+	case "expm1":
+		result = math.Expm1(argument(0))
+	case "floor":
+		result = math.Floor(argument(0))
+	case "fround":
+		result = float64(float32(argument(0)))
+	case "hypot":
+		result = 0
+		for _, number := range numbers {
+			result = math.Hypot(result, number)
+		}
+	case "imul":
+		result = float64(int32(toUint32(argument(0))) * int32(toUint32(argument(1))))
+	case "log":
+		result = math.Log(argument(0))
+	case "log1p":
+		result = math.Log1p(argument(0))
+	case "log2":
+		result = math.Log2(argument(0))
+	case "log10":
+		result = math.Log10(argument(0))
+	case "max":
+		result = math.Inf(-1)
+		for _, number := range numbers {
+			if math.IsNaN(number) {
+				result = math.NaN()
+				break
+			}
+			result = math.Max(result, number)
+		}
+	case "min":
+		result = math.Inf(1)
+		for _, number := range numbers {
+			if math.IsNaN(number) {
+				result = math.NaN()
+				break
+			}
+			result = math.Min(result, number)
+		}
+	case "pow":
+		result = math.Pow(argument(0), argument(1))
+	case "round":
+		value := argument(0)
+		if math.IsNaN(value) || math.IsInf(value, 0) || value == 0 || math.Abs(value) >= 1<<52 {
+			result = value
+			break
+		}
+		floor := math.Floor(value)
+		result = floor
+		if value-floor >= 0.5 {
+			result = floor + 1
+		}
+		if result == 0 && (value < 0 || math.Signbit(value)) {
+			result = math.Copysign(0, -1)
+		}
+	case "sign":
+		value := argument(0)
+		switch {
+		case math.IsNaN(value), value == 0:
+			result = value
+		case value < 0:
+			result = -1
+		default:
+			result = 1
+		}
+	case "sin":
+		result = math.Sin(argument(0))
+	case "sinh":
+		result = math.Sinh(argument(0))
+	case "sqrt":
+		result = math.Sqrt(argument(0))
+	case "tan":
+		result = math.Tan(argument(0))
+	case "tanh":
+		result = math.Tanh(argument(0))
+	case "trunc":
+		result = math.Trunc(argument(0))
+	default:
+		return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+	}
+	return staticEvalResult{value: staticNumberValue(result), ok: true}
+}
+
+// staticMathExactSpecialCase keeps results that ECMAScript defines exactly,
+// without routing general transcendental calculations through Go's libm.
+// The latter can differ from the JavaScript host by an ULP and must remain an
+// abstract number because strict comparisons can select a receiver branch.
+func staticMathExactSpecialCase(method string, numbers []float64) (float64, bool) {
+	argument := math.NaN()
+	if len(numbers) > 0 {
+		argument = numbers[0]
+	}
+	if math.IsNaN(argument) && method != "hypot" && method != "pow" {
+		return math.NaN(), true
+	}
+	if argument == 0 {
+		switch method {
+		case "asin", "asinh", "atan", "atanh", "cbrt", "expm1", "log1p", "sin", "sinh", "tan", "tanh":
+			return argument, true
+		case "cos", "cosh", "exp":
+			return 1, true
+		case "log", "log2", "log10":
+			return math.Inf(-1), true
+		}
+	}
+	switch method {
+	case "acosh":
+		if argument < 1 {
+			return math.NaN(), true
+		}
+		if argument == 1 {
+			return 0, true
+		}
+		if math.IsInf(argument, 1) {
+			return argument, true
+		}
+	case "asin":
+		if math.Abs(argument) > 1 {
+			return math.NaN(), true
+		}
+	case "asinh", "sinh":
+		if math.IsInf(argument, 0) {
+			return argument, true
+		}
+	case "atanh":
+		if argument == 1 {
+			return math.Inf(1), true
+		}
+		if argument == -1 {
+			return math.Inf(-1), true
+		}
+		if math.Abs(argument) > 1 {
+			return math.NaN(), true
+		}
+	case "atan2":
+		if len(numbers) < 2 || math.IsNaN(numbers[0]) || math.IsNaN(numbers[1]) {
+			return math.NaN(), true
+		}
+		y, x := numbers[0], numbers[1]
+		if x > 0 && y == 0 || math.IsInf(x, 1) && !math.IsInf(y, 0) {
+			return math.Copysign(0, y), true
+		}
+	case "log", "log2", "log10":
+		if argument < 0 {
+			return math.NaN(), true
+		}
+		if argument == 1 {
+			return 0, true
+		}
+		if math.IsInf(argument, 1) {
+			return argument, true
+		}
+	case "log1p":
+		if argument < -1 {
+			return math.NaN(), true
+		}
+		if argument == -1 {
+			return math.Inf(-1), true
+		}
+		if math.IsInf(argument, 1) {
+			return argument, true
+		}
+	case "cbrt":
+		if math.IsInf(argument, 0) {
+			return argument, true
+		}
+		if math.Trunc(argument) == argument && math.Abs(argument) <= 1<<53 {
+			root := math.Round(math.Cbrt(argument))
+			if root*root*root == argument {
+				return root, true
+			}
+		}
+	case "hypot":
+		allZero := true
+		hasNaN := false
+		for _, number := range numbers {
+			if math.IsInf(number, 0) {
+				return math.Inf(1), true
+			}
+			if math.IsNaN(number) {
+				hasNaN = true
+			}
+			if number != 0 {
+				allZero = false
+			}
+		}
+		if hasNaN {
+			return math.NaN(), true
+		}
+		if allZero {
+			return 0, true
+		}
+		if len(numbers) == 1 {
+			return math.Abs(numbers[0]), true
+		}
+	case "pow":
+		if len(numbers) < 2 {
+			return math.NaN(), true
+		}
+		base, exponent := numbers[0], numbers[1]
+		if exponent == 0 {
+			return 1, true
+		}
+		if math.IsNaN(exponent) || math.IsNaN(base) {
+			return math.NaN(), true
+		}
+		absoluteBase := math.Abs(base)
+		if math.IsInf(exponent, 0) {
+			if absoluteBase == 1 {
+				return math.NaN(), true
+			}
+			if (absoluteBase > 1) == math.IsInf(exponent, 1) {
+				return math.Inf(1), true
+			}
+			return 0, true
+		}
+		if math.IsInf(base, 0) || base == 0 {
+			negativeResult := math.Signbit(base) && staticOddInteger(exponent)
+			if exponent > 0 {
+				if math.IsInf(base, 0) {
+					if negativeResult {
+						return math.Inf(-1), true
+					}
+					return math.Inf(1), true
+				}
+				if negativeResult {
+					return math.Copysign(0, -1), true
+				}
+				return 0, true
+			}
+			if math.IsInf(base, 0) {
+				if negativeResult {
+					return math.Copysign(0, -1), true
+				}
+				return 0, true
+			}
+			if negativeResult {
+				return math.Inf(-1), true
+			}
+			return math.Inf(1), true
+		}
+		if base < 0 && math.Trunc(exponent) != exponent {
+			return math.NaN(), true
+		}
+		if result, ok := staticExactSafeIntegerPower(base, exponent); ok {
+			return result, true
+		}
+	case "cos":
+		if math.IsInf(argument, 0) {
+			return math.NaN(), true
+		}
+	case "cosh":
+		if math.IsInf(argument, 0) {
+			return math.Inf(1), true
+		}
+	case "exp":
+		if math.IsInf(argument, 0) {
+			if math.IsInf(argument, -1) {
+				return 0, true
+			}
+			return argument, true
+		}
+	case "expm1":
+		if math.IsInf(argument, -1) {
+			return -1, true
+		}
+		if math.IsInf(argument, 1) {
+			return argument, true
+		}
+	case "sin", "tan":
+		if math.IsInf(argument, 0) {
+			return math.NaN(), true
+		}
+	case "tanh":
+		if math.IsInf(argument, 1) {
+			return 1, true
+		}
+		if math.IsInf(argument, -1) {
+			return -1, true
+		}
+	}
+	return 0, false
+}
+
+func staticOddInteger(value float64) bool {
+	absolute := math.Abs(value)
+	return math.Trunc(value) == value && absolute < 1<<53 && int64(absolute)&1 != 0
+}
+
+func staticExactSafeIntegerPower(base, exponent float64) (float64, bool) {
+	if math.Trunc(base) != base || math.Abs(base) > 1<<53 ||
+		math.Trunc(exponent) != exponent || exponent < 0 || exponent > 1<<16 {
+		return 0, false
+	}
+	if base == 0 {
+		if math.Signbit(base) && staticOddInteger(exponent) {
+			return math.Copysign(0, -1), true
+		}
+		return 0, true
+	}
+	absoluteBase := uint64(math.Abs(base))
+	if absoluteBase > 1 {
+		minimumBits := uint64(bits.Len64(absoluteBase)-1)*uint64(exponent) + 1
+		if minimumBits > 53 {
+			return 0, false
+		}
+	}
+	baseInteger := new(big.Int)
+	baseInteger.SetInt64(int64(base))
+	exponentInteger := big.NewInt(int64(exponent))
+	result := new(big.Int).Exp(baseInteger, exponentInteger, nil)
+	if result.BitLen() > 53 || !result.IsInt64() {
+		return 0, false
+	}
+	return float64(result.Int64()), true
+}
+
+func staticMathRequiresRuntimeExactness(method string) bool {
+	switch method {
+	case "acosh", "asin", "asinh", "atan", "atanh", "atan2", "cbrt", "cos", "cosh",
+		"exp", "expm1", "hypot", "log", "log1p", "log2", "log10", "pow",
+		"sin", "sinh", "tan", "tanh":
+		return true
+	}
+	return false
+}
+
+func staticMathMethod(method string) bool {
+	switch method {
+	case "abs", "acos", "acosh", "asin", "asinh", "atan", "atanh", "atan2",
+		"cbrt", "ceil", "clz32", "cos", "cosh", "exp", "expm1", "floor",
+		"fround", "hypot", "imul", "log", "log1p", "log2", "log10", "max",
+		"min", "pow", "round", "sign", "sin", "sinh", "sqrt", "tan", "tanh", "trunc":
+		return true
+	}
+	return false
+}
+
+func staticBuiltinIsFunction(name string) bool {
+	if strings.Contains(name, ".") {
+		return true
+	}
+	switch name {
+	case "Math", "JSON", "Reflect":
+		return false
+	case "Array", "ArrayBuffer", "BigInt", "BigInt64Array", "BigUint64Array",
+		"Boolean", "DataView", "Date", "decodeURI", "decodeURIComponent",
+		"encodeURI", "encodeURIComponent", "escape", "Float32Array", "Float64Array",
+		"Function", "Int16Array", "Int32Array", "Int8Array", "isFinite", "isNaN",
+		"isPrototypeOf", "Map", "Number", "Object", "parseFloat", "parseInt",
+		"Promise", "Proxy", "RegExp", "Set", "String", "Symbol", "Uint16Array",
+		"Uint32Array", "Uint8Array", "Uint8ClampedArray", "unescape", "WeakMap", "WeakSet":
+		return true
+	}
+	return false
+}
+
+func staticValueIsArray(value any) bool {
+	if _, ok := value.(*staticArrayValue); ok {
+		return true
+	}
+	prototype, ok := value.(staticBuiltinObjectValue)
+	return ok && prototype == "Array.prototype"
+}
+
+func staticBuiltinHasPrototype(name string) bool {
+	switch name {
+	case "Array", "ArrayBuffer", "BigInt", "BigInt64Array", "BigUint64Array", "Boolean",
+		"DataView", "Date", "Float32Array", "Float64Array", "Function", "Int16Array",
+		"Int32Array", "Int8Array", "Map", "Number", "Object", "Promise", "RegExp",
+		"Set", "String", "Symbol", "Uint16Array", "Uint32Array", "Uint8Array",
+		"Uint8ClampedArray", "WeakMap", "WeakSet":
+		return true
+	}
+	return false
+}
+
+func staticBuiltinFunctionProperty(name, key string) bool {
+	switch name {
+	case "Array":
+		return key == "from" || key == "fromAsync" || key == "isArray" || key == "of"
+	case "ArrayBuffer":
+		return key == "isView"
+	case "BigInt":
+		return key == "asIntN" || key == "asUintN"
+	case "Number":
+		switch key {
+		case "isFinite", "isInteger", "isNaN", "isSafeInteger", "parseFloat", "parseInt":
+			return true
+		}
+	case "Object":
+		switch key {
+		case "assign", "create", "defineProperties", "defineProperty", "entries", "freeze",
+			"fromEntries", "getOwnPropertyDescriptor", "getOwnPropertyDescriptors",
+			"getOwnPropertyNames", "getOwnPropertySymbols", "getPrototypeOf", "groupBy",
+			"hasOwn", "is", "isExtensible", "isFrozen", "isSealed", "keys",
+			"preventExtensions", "seal", "setPrototypeOf", "values":
+			return true
+		}
+	case "String":
+		return key == "fromCharCode" || key == "fromCodePoint" || key == "raw"
+	case "Date":
+		return key == "UTC" || key == "now" || key == "parse"
+	case "Symbol":
+		return key == "for" || key == "keyFor"
+	case "JSON":
+		return key == "isRawJSON" || key == "parse" || key == "rawJSON" || key == "stringify"
+	case "Reflect":
+		switch key {
+		case "apply", "construct", "defineProperty", "deleteProperty", "get",
+			"getOwnPropertyDescriptor", "getPrototypeOf", "has", "isExtensible",
+			"ownKeys", "preventExtensions", "set", "setPrototypeOf":
+			return true
+		}
+	case "Promise":
+		switch key {
+		case "all", "allSettled", "any", "race", "reject", "resolve", "withResolvers":
+			return true
+		}
+	case "Map":
+		return key == "groupBy"
+	case "Proxy":
+		return key == "revocable"
+	case "Math":
+		return key == "random" || staticMathMethod(key)
+	case "BigInt64Array", "BigUint64Array", "Float32Array", "Float64Array", "Int16Array",
+		"Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray":
+		return key == "from" || key == "of"
+	}
+	return false
+}
+
+func staticTypedArrayBytesPerElement(name string) (int, bool) {
+	switch name {
+	case "Int8Array", "Uint8Array", "Uint8ClampedArray":
+		return 1, true
+	case "Int16Array", "Uint16Array":
+		return 2, true
+	case "Int32Array", "Uint32Array", "Float32Array":
+		return 4, true
+	case "BigInt64Array", "BigUint64Array", "Float64Array":
+		return 8, true
+	default:
+		return 0, false
+	}
+}
+
+func staticTypedArrayPrototypeMethod(name, key string) bool {
+	if _, ok := staticTypedArrayBytesPerElement(name); !ok {
+		return false
+	}
+	switch key {
+	case "at", "copyWithin", "entries", "every", "fill", "filter", "find", "findIndex",
+		"findLast", "findLastIndex", "forEach", "includes", "indexOf", "join", "keys",
+		"lastIndexOf", "map", "reduce", "reduceRight", "reverse", "set", "slice", "some",
+		"sort", "subarray", "toLocaleString", "toReversed", "toSorted", "toString", "values", "with":
+		return true
+	default:
+		return false
+	}
+}
+
+func staticSymbolProperty(key string) bool {
+	switch key {
+	case "asyncDispose", "asyncIterator", "dispose", "hasInstance", "isConcatSpreadable",
+		"iterator", "match", "matchAll", "replace", "search", "species", "split",
+		"toPrimitive", "toStringTag", "unscopables":
+		return true
+	}
+	return false
+}
+
+func staticArrayPrototypeMethod(key string) bool {
+	switch key {
+	case "at", "concat", "copyWithin", "entries", "every", "fill", "filter", "find",
+		"findIndex", "findLast", "findLastIndex", "flat", "flatMap", "forEach", "includes",
+		"indexOf", "join", "keys", "lastIndexOf", "map", "pop", "push", "reduce",
+		"reduceRight", "reverse", "shift", "slice", "some", "sort", "splice", "toLocaleString",
+		"toReversed", "toSorted", "toSpliced", "toString", "unshift", "values", "with":
+		return true
+	}
+	return false
+}
+
+func staticIteratorPrototypeMethod(key string) bool {
+	switch key {
+	case "drop", "every", "filter", "find", "flatMap", "forEach", "map", "reduce", "some", "take", "toArray":
+		return true
+	}
+	return false
+}
+
+func staticCollectionPrototypeMethod(kind, key string) bool {
+	switch key {
+	case "clear", "delete", "entries", "forEach", "has", "keys", "values":
+		return true
+	case "get", "set":
+		return kind == "Map"
+	case "add":
+		return kind == "Set"
+	case "difference", "intersection", "isDisjointFrom", "isSubsetOf", "isSupersetOf",
+		"symmetricDifference", "union":
+		return kind == "Set"
+	}
+	return false
+}
+
+func staticDataViewPrototypeMethod(key string) bool {
+	switch key {
+	case "getBigInt64", "getBigUint64", "getFloat32", "getFloat64", "getInt8", "getInt16",
+		"getInt32", "getUint8", "getUint16", "getUint32", "setBigInt64", "setBigUint64",
+		"setFloat32", "setFloat64", "setInt8", "setInt16", "setInt32", "setUint8",
+		"setUint16", "setUint32":
+		return true
+	}
+	return false
+}
+
+func staticStringPrototypeMethod(key string) bool {
+	switch key {
+	case "anchor", "at", "big", "blink", "bold", "charAt", "charCodeAt", "codePointAt",
+		"concat", "endsWith", "fixed", "fontcolor", "fontsize", "includes", "indexOf",
+		"isWellFormed", "italics", "lastIndexOf", "link", "localeCompare", "match", "matchAll",
+		"normalize", "padEnd", "padStart", "repeat", "replace", "replaceAll", "search", "slice",
+		"small", "split", "startsWith", "strike", "sub", "substr", "substring", "sup",
+		"toLocaleLowerCase", "toLocaleUpperCase", "toLowerCase", "toString", "toUpperCase",
+		"toWellFormed", "trim", "trimEnd", "trimLeft", "trimRight", "trimStart", "valueOf":
+		return true
+	}
+	return false
+}
+
+func staticStringMemberValue(value, key string) staticEvalResult {
+	if staticStringPrototypeMethod(key) {
+		return staticEvalResult{value: staticBuiltinValue("String.prototype." + key), ok: true}
+	}
+	units := ecmascript.StringCodeUnits(value)
+	if key == "length" {
+		return staticEvalResult{value: staticNumberValue(len(units)), ok: true}
+	}
+	if index, ok := staticArrayIndex(key); ok {
+		if index >= len(units) {
+			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+		}
+		return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[index : index+1]), ok: true}
+	}
+	if key == "__proto__" {
+		return staticEvalResult{value: staticBuiltinObjectValue("String.prototype"), ok: true}
+	}
+	return staticObjectPrototypeMember(key)
+}
+
+func staticESLintMemberValue(object any, key string) staticEvalResult {
+	switch object := object.(type) {
+	case *staticObjectValue:
+		if value, ok := staticObjectOwnProperty(object, key); ok {
+			return staticEvalResult{value: value, ok: true}
+		}
+		if object.prototypeSet {
+			if object.prototype == nil {
+				return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+			}
+			return staticESLintMemberValue(object.prototype, key)
+		}
+		return staticObjectPrototypeMember(key)
+	case *staticArrayValue:
+		if key == "length" {
+			return staticEvalResult{value: staticNumberValue(object.length), ok: true}
+		}
+		if index, ok := staticArrayIndex(key); ok {
+			if index >= object.length || object.omitted[index] {
+				return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+			}
+			return staticEvalResult{value: object.element(index), ok: true}
+		}
+		if staticArrayPrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue("Array.prototype." + key), ok: true}
+		}
+		if key == "constructor" {
+			return staticEvalResult{value: staticBuiltinValue("Array"), ok: true}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{}
+		}
+		return staticObjectPrototypeMember(key)
+	case string:
+		return staticStringMemberValue(object, key)
+	case *staticStringNode:
+		text, _ := staticValueAsString(object)
+		return staticStringMemberValue(text, key)
+	case staticCollectionValue:
+		if key == "size" {
+			return staticEvalResult{value: staticNumberValue(len(object.entries)), ok: true}
+		}
+		if staticCollectionPrototypeMethod(object.kind, key) {
+			return staticEvalResult{value: staticBuiltinValue(object.kind + ".prototype." + key), ok: true}
+		}
+		if key == "constructor" {
+			return staticEvalResult{value: staticBuiltinValue(object.kind), ok: true}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{}
+		}
+		return staticObjectPrototypeMember(key)
+	case staticRegExpValue:
+		return staticRegExpMemberValue(object, key)
+	case staticBoxedValue:
+		if key == "__proto__" {
+			return staticEvalResult{}
+		}
+		if _, symbol := object.value.(staticSymbolValue); symbol && key == "description" {
+			return staticEvalResult{}
+		}
+		if key == "constructor" {
+			switch staticValueKindOf(object.value) {
+			case staticKindBoolean:
+				return staticEvalResult{value: staticBuiltinValue("Boolean"), ok: true}
+			case staticKindNumber:
+				return staticEvalResult{value: staticBuiltinValue("Number"), ok: true}
+			case staticKindString:
+				return staticEvalResult{value: staticBuiltinValue("String"), ok: true}
+			case staticKindBigInt:
+				return staticEvalResult{value: staticBuiltinValue("BigInt"), ok: true}
+			case staticKindSymbol:
+				return staticEvalResult{value: staticBuiltinValue("Symbol"), ok: true}
+			}
+		}
+		switch staticValueKindOf(object.value) {
+		case staticKindString:
+			if text, ok := staticValueAsString(object.value); ok {
+				return staticStringMemberValue(text, key)
+			}
+		case staticKindNumber:
+			if staticNumberPrototypeMethod(key) {
+				return staticEvalResult{value: staticBuiltinValue("Number.prototype." + key), ok: true}
+			}
+		case staticKindBoolean:
+			if key == "toString" || key == "valueOf" {
+				return staticEvalResult{value: staticBuiltinValue("Boolean.prototype." + key), ok: true}
+			}
+		case staticKindBigInt:
+			if key == "toString" || key == "valueOf" || key == "toLocaleString" {
+				return staticEvalResult{value: staticBuiltinValue("BigInt.prototype." + key), ok: true}
+			}
+		case staticKindSymbol:
+			if key == "toString" || key == "valueOf" {
+				return staticEvalResult{value: staticBuiltinValue("Symbol.prototype." + key), ok: true}
+			}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{}
+		}
+		return staticObjectPrototypeMember(key)
+	case staticDateValue:
+		if key == "constructor" {
+			return staticEvalResult{value: staticBuiltinValue("Date"), ok: true}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{}
+		}
+		if staticDatePrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue("Date.prototype." + key), ok: true}
+		}
+		return staticObjectPrototypeMember(key)
+	case staticIteratorValue:
+		if key == "next" {
+			return staticEvalResult{value: staticBuiltinValue(object.kind + "Iterator.prototype.next"), ok: true}
+		}
+		if staticIteratorPrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue("Iterator.prototype." + key), ok: true}
+		}
+		if key == "constructor" || key == "__proto__" {
+			// Iterator.prototype.constructor and the derived iterator prototype
+			// chain are native accessors/objects that eslint-utils does not read.
+			return staticEvalResult{}
+		}
+		return staticObjectPrototypeMember(key)
+	case staticOpaqueObjectValue:
+		return staticObjectPrototypeMember(key)
+	case staticBuiltinObjectValue:
+		return staticESLintBuiltinPrototypeMember(string(object), key)
+	}
+	switch value := object.(type) {
+	case bool:
+		if key == "constructor" {
+			return staticEvalResult{value: staticBuiltinValue("Boolean"), ok: true}
+		}
+		if key == "toString" || key == "valueOf" {
+			return staticEvalResult{value: staticBuiltinValue("Boolean.prototype." + key), ok: true}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{value: staticBuiltinObjectValue("Boolean.prototype"), ok: true}
+		}
+		return staticObjectPrototypeMember(key)
+	case staticBigIntValue:
+		if key == "constructor" {
+			return staticEvalResult{value: staticBuiltinValue("BigInt"), ok: true}
+		}
+		if key == "toString" || key == "valueOf" || key == "toLocaleString" {
+			return staticEvalResult{value: staticBuiltinValue("BigInt.prototype." + key), ok: true}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{value: staticBuiltinObjectValue("BigInt.prototype"), ok: true}
+		}
+		return staticObjectPrototypeMember(key)
+	case staticSymbolValue:
+		if key == "description" {
+			description, known := staticSymbolDescription(value)
+			if !known {
+				return staticEvalResult{value: staticUnknownStringValue{truthy: true, numericNaN: true}, ok: true}
+			}
+			return staticEvalResult{value: description, ok: true}
+		}
+		if key == "constructor" {
+			return staticEvalResult{value: staticBuiltinValue("Symbol"), ok: true}
+		}
+		if key == "toString" || key == "valueOf" {
+			return staticEvalResult{value: staticBuiltinValue("Symbol.prototype." + key), ok: true}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{value: staticBuiltinObjectValue("Symbol.prototype"), ok: true}
+		}
+		return staticObjectPrototypeMember(key)
+	}
+	if staticValueKindOf(object) == staticKindNumber {
+		if staticNumberPrototypeMethod(key) {
+			return staticEvalResult{value: staticBuiltinValue("Number.prototype." + key), ok: true}
+		}
+		if key == "constructor" {
+			return staticEvalResult{value: staticBuiltinValue("Number"), ok: true}
+		}
+		if key == "__proto__" {
+			return staticEvalResult{value: staticBuiltinObjectValue("Number.prototype"), ok: true}
+		}
+		return staticObjectPrototypeMember(key)
+	}
+	return staticEvalResult{}
+}
+
+func staticESLintSymbolMemberValue(object any, key staticSymbolValue) staticEvalResult {
+	if value, ok := object.(*staticObjectValue); ok {
+		if property, found := staticObjectOwnSymbolProperty(value, key); found {
+			return staticEvalResult{value: property, ok: true}
+		}
+		if value.prototypeSet && value.prototype != nil {
+			return staticESLintSymbolMemberValue(value.prototype, key)
+		}
+		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+	}
+	if builtin, ok := object.(staticBuiltinValue); ok && key.wellKnown && key.description == "hasInstance" &&
+		staticBuiltinIsFunction(string(builtin)) {
+		return staticEvalResult{value: staticBuiltinValue("Function.prototype.[Symbol.hasInstance]"), ok: true}
+	}
+	if builtin, ok := object.(staticBuiltinValue); ok && key.wellKnown && key.description == "toStringTag" {
+		switch builtin {
+		case "Math":
+			return staticEvalResult{value: "Math", ok: true}
+		case "JSON":
+			return staticEvalResult{value: "JSON", ok: true}
+		case "Reflect":
+			return staticEvalResult{value: "Reflect", ok: true}
+		}
+	}
+	if builtin, ok := object.(staticBuiltinValue); ok && key.wellKnown && key.description == "species" &&
+		staticBuiltinHasSpeciesGetter(string(builtin)) {
+		// eslint-utils refuses to invoke native getters other than its explicit
+		// Map/Set/RegExp allowlist.
+		return staticEvalResult{}
+	}
+	if key.wellKnown && key.description == "iterator" {
+		switch value := object.(type) {
+		case *staticArrayValue:
+			return staticEvalResult{value: staticBuiltinValue("Array.prototype.values"), ok: true}
+		case string, *staticStringNode:
+			return staticEvalResult{value: staticBuiltinValue("String.prototype.[Symbol.iterator]"), ok: true}
+		case staticBoxedValue:
+			if staticValueKindOf(value.value) == staticKindString {
+				return staticEvalResult{value: staticBuiltinValue("String.prototype.[Symbol.iterator]"), ok: true}
+			}
+		case staticCollectionValue:
+			method := "values"
+			if value.kind == "Map" {
+				method = "entries"
+			}
+			return staticEvalResult{value: staticBuiltinValue(value.kind + ".prototype." + method), ok: true}
+		case staticIteratorValue:
+			return staticEvalResult{value: staticBuiltinValue("Iterator.prototype.[Symbol.iterator]"), ok: true}
+		case staticBuiltinObjectValue:
+			name := string(value)
+			switch name {
+			case "Array.prototype":
+				return staticEvalResult{value: staticBuiltinValue("Array.prototype.values"), ok: true}
+			case "String.prototype":
+				return staticEvalResult{value: staticBuiltinValue("String.prototype.[Symbol.iterator]"), ok: true}
+			case "Map.prototype":
+				return staticEvalResult{value: staticBuiltinValue("Map.prototype.entries"), ok: true}
+			case "Set.prototype":
+				return staticEvalResult{value: staticBuiltinValue("Set.prototype.values"), ok: true}
+			}
+			constructor := strings.TrimSuffix(name, ".prototype")
+			if _, ok := staticTypedArrayBytesPerElement(constructor); ok {
+				return staticEvalResult{value: staticBuiltinValue(name + ".values"), ok: true}
+			}
+		}
+	}
+	if key.wellKnown && key.description == "unscopables" {
+		if _, array := object.(*staticArrayValue); array {
+			return staticEvalResult{value: staticBuiltinObjectValue("Array.prototype[Symbol.unscopables]"), ok: true}
+		}
+	}
+	if key.wellKnown && key.description == "toStringTag" {
+		switch value := object.(type) {
+		case staticSymbolValue:
+			return staticEvalResult{value: "Symbol", ok: true}
+		case staticBigIntValue:
+			return staticEvalResult{value: "BigInt", ok: true}
+		case staticCollectionValue:
+			return staticEvalResult{value: value.kind, ok: true}
+		case staticBoxedValue:
+			switch value.value.(type) {
+			case staticSymbolValue:
+				return staticEvalResult{value: "Symbol", ok: true}
+			case staticBigIntValue:
+				return staticEvalResult{value: "BigInt", ok: true}
+			}
+		case staticIteratorValue:
+			// The derived iterator prototypes expose this through native getters;
+			// eslint-utils deliberately refuses to invoke them.
+			return staticEvalResult{}
+		}
+	}
+	if key.wellKnown && key.description == "toPrimitive" {
+		switch value := object.(type) {
+		case staticDateValue:
+			return staticEvalResult{value: staticBuiltinValue("Date.prototype.[Symbol.toPrimitive]"), ok: true}
+		case staticSymbolValue:
+			return staticEvalResult{value: staticBuiltinValue("Symbol.prototype.[Symbol.toPrimitive]"), ok: true}
+		case staticBoxedValue:
+			if _, symbol := value.value.(staticSymbolValue); symbol {
+				return staticEvalResult{value: staticBuiltinValue("Symbol.prototype.[Symbol.toPrimitive]"), ok: true}
+			}
+		}
+	}
+	if _, ok := object.(staticRegExpValue); ok && key.wellKnown {
+		switch key.description {
+		case "match", "matchAll", "replace", "search", "split":
+			return staticEvalResult{value: staticBuiltinValue("RegExp.prototype.[Symbol." + key.description + "]"), ok: true}
+		}
+	}
+	if prototype, ok := object.(staticBuiltinObjectValue); ok && key.wellKnown {
+		name := string(prototype)
+		if key.description == "toStringTag" {
+			if _, typedArray := staticTypedArrayBytesPerElement(strings.TrimSuffix(name, ".prototype")); typedArray {
+				return staticEvalResult{}
+			}
+		}
+		if name == "Array.prototype" && key.description == "unscopables" {
+			return staticEvalResult{value: staticBuiltinObjectValue("Array.prototype[Symbol.unscopables]"), ok: true}
+		}
+		if (name == "Map.prototype" || name == "Set.prototype") && key.description == "toStringTag" {
+			return staticEvalResult{value: strings.TrimSuffix(name, ".prototype"), ok: true}
+		}
+		if name == "RegExp.prototype" {
+			switch key.description {
+			case "match", "matchAll", "replace", "search", "split":
+				return staticEvalResult{value: staticBuiltinValue(name + ".[Symbol." + key.description + "]"), ok: true}
+			}
+		}
+		if name == "Symbol.prototype" && key.description == "toPrimitive" {
+			return staticEvalResult{value: staticBuiltinValue(name + ".[Symbol.toPrimitive]"), ok: true}
+		}
+		if key.description == "toStringTag" {
+			switch name {
+			case "ArrayBuffer.prototype", "BigInt.prototype", "DataView.prototype", "Promise.prototype",
+				"Symbol.prototype", "WeakMap.prototype", "WeakSet.prototype":
+				return staticEvalResult{value: strings.TrimSuffix(name, ".prototype"), ok: true}
+			}
+		}
+		if name == "Date.prototype" && key.description == "toPrimitive" {
+			return staticEvalResult{value: staticBuiltinValue(name + ".[Symbol.toPrimitive]"), ok: true}
+		}
+	}
+	return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+}
+
+func staticBuiltinHasSpeciesGetter(name string) bool {
+	switch name {
+	case "Array", "ArrayBuffer", "Map", "Promise", "RegExp", "Set":
+		return true
+	}
+	_, typedArray := staticTypedArrayBytesPerElement(name)
+	return typedArray
+}
+
+func staticObjectOwnSymbolProperty(object *staticObjectValue, key staticSymbolValue) (any, bool) {
+	for index := len(object.extraProperties) - 1; index >= 0; index-- {
+		property := object.extraProperties[index]
+		if property.symbolKey && staticSymbolsEqual(property.symbol, key) {
+			return property.value, true
+		}
+	}
+	if object.propertyCount > 0 && object.property.symbolKey && staticSymbolsEqual(object.property.symbol, key) {
+		return object.property.value, true
+	}
+	return nil, false
+}
+
+func staticSymbolsEqual(left, right staticSymbolValue) bool {
+	equal, known := staticSymbolIdentityEqual(left, right)
+	return known && equal
+}
+
+func staticSymbolIdentityEqual(left, right staticSymbolValue) (bool, bool) {
+	if left.hostDependent || right.hostDependent {
+		if left.hostDependent && right.hostDependent {
+			return left.description == right.description, true
+		}
+		return false, false
+	}
+	return (left.global && right.global || left.wellKnown && right.wellKnown) &&
+		left.description == right.description, true
+}
+
+func staticSymbolDescription(value staticSymbolValue) (string, bool) {
+	if value.hostDependent {
+		return "", false
+	}
+	if value.wellKnown {
+		return "Symbol." + value.description, true
+	}
+	return value.description, true
+}
+
+func staticObjectPrototypeMember(key string) staticEvalResult {
+	switch key {
+	case "__proto__":
+		return staticEvalResult{}
+	case "constructor":
+		return staticEvalResult{value: staticBuiltinValue("Object"), ok: true}
+	case "__defineGetter__", "__defineSetter__", "__lookupGetter__", "__lookupSetter__",
+		"hasOwnProperty", "isPrototypeOf", "propertyIsEnumerable", "toLocaleString", "toString", "valueOf":
+		return staticEvalResult{value: staticBuiltinValue("Object.prototype." + key), ok: true}
+	}
+	return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+}
+
+func staticNumberPrototypeMethod(key string) bool {
+	switch key {
+	case "toExponential", "toFixed", "toLocaleString", "toPrecision", "toString", "valueOf":
+		return true
+	default:
+		return false
+	}
+}
+
+func staticDatePrototypeMethod(key string) bool {
+	switch key {
+	case "getDate", "getDay", "getFullYear", "getHours", "getMilliseconds", "getMinutes",
+		"getMonth", "getSeconds", "getTime", "getTimezoneOffset", "getUTCDate", "getUTCDay",
+		"getUTCFullYear", "getUTCHours", "getUTCMilliseconds", "getUTCMinutes", "getUTCMonth",
+		"getUTCSeconds", "setDate", "setFullYear", "setHours", "setMilliseconds", "setMinutes",
+		"setMonth", "setSeconds", "setTime", "setUTCDate", "setUTCFullYear", "setUTCHours",
+		"setUTCMilliseconds", "setUTCMinutes", "setUTCMonth", "setUTCSeconds", "toDateString",
+		"toISOString", "toJSON", "toLocaleDateString", "toLocaleString", "toLocaleTimeString",
+		"toString", "toTimeString", "toUTCString", "toGMTString", "getYear", "setYear", "valueOf":
+		return true
+	default:
+		return false
+	}
+}
+
+func staticRegExpMemberValue(value staticRegExpValue, key string) staticEvalResult {
+	switch key {
+	case "constructor":
+		return staticEvalResult{value: staticBuiltinValue("RegExp"), ok: true}
+	case "__proto__":
+		return staticEvalResult{}
+	case "dotAll":
+		return staticEvalResult{value: strings.Contains(value.flags, "s"), ok: true}
+	case "flags":
+		return staticEvalResult{value: value.flags, ok: true}
+	case "global":
+		return staticEvalResult{value: strings.Contains(value.flags, "g"), ok: true}
+	case "hasIndices":
+		return staticEvalResult{value: strings.Contains(value.flags, "d"), ok: true}
+	case "ignoreCase":
+		return staticEvalResult{value: strings.Contains(value.flags, "i"), ok: true}
+	case "lastIndex":
+		return staticEvalResult{value: staticNumberValue(0), ok: true}
+	case "multiline":
+		return staticEvalResult{value: strings.Contains(value.flags, "m"), ok: true}
+	case "source":
+		return staticEvalResult{value: value.source, ok: true}
+	case "sticky":
+		return staticEvalResult{value: strings.Contains(value.flags, "y"), ok: true}
+	case "unicode":
+		return staticEvalResult{value: strings.Contains(value.flags, "u"), ok: true}
+	case "unicodeSets":
+		// eslint-utils intentionally does not invoke this native getter.
+		return staticEvalResult{}
+	case "compile", "exec", "test", "toString":
+		return staticEvalResult{value: staticBuiltinValue("RegExp.prototype." + key), ok: true}
+	}
+	return staticObjectPrototypeMember(key)
+}
+
+func staticArrayPrototypeCall(
+	work *staticStringWorkContext,
+	value *staticArrayValue,
+	method string,
+	arguments []any,
+) staticEvalResult {
+	if value != nil && value.stringWorkContext == nil {
+		value.stringWorkContext = work
+	}
+	if value == nil || !work.reserve(max(value.length*32, 1)) {
+		return staticEvalResult{}
+	}
+	switch method {
+	case "concat":
+		return staticArrayConcat(work, value, arguments)
+	case "flat":
+		depth, ok := staticArgumentInteger(arguments, 0, 1)
+		if !ok {
+			return staticEvalResult{}
+		}
+		return staticArrayFlat(work, value, max(depth, 0))
+	case "slice":
+		start, ok := staticArgumentInteger(arguments, 0, 0)
+		if !ok {
+			return staticEvalResult{}
+		}
+		end, ok := staticArgumentInteger(arguments, 1, value.length)
+		if !ok {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: staticArraySlice(value, start, end), ok: true}
+	case "entries", "keys", "values":
+		values := make([]any, 0, value.length)
+		for index := range value.length {
+			element := any(staticUndefinedValue{})
+			if !value.omitted[index] {
+				element = value.element(index)
+			}
+			switch method {
+			case "entries":
+				values = append(values, staticArrayFromValues([]any{staticNumberValue(index), element}))
+			case "keys":
+				values = append(values, staticNumberValue(index))
+			case "values":
+				values = append(values, element)
+			}
+		}
+		return staticEvalResult{value: staticIteratorValue{
+			values: values, kind: "Array", identity: &staticIdentity{},
+		}, ok: true}
+	case "every", "filter", "find", "findIndex", "some":
+		return staticArrayCallbackCall(work, value, method, arguments)
+	case "includes", "indexOf", "lastIndexOf":
+		return staticArraySearch(value, method, arguments)
+	case "at":
+		index, ok := staticArgumentInteger(arguments, 0, 0)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if index < 0 {
+			index += value.length
+		}
+		if index < 0 || index >= value.length || value.omitted[index] {
+			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+		}
+		return staticEvalResult{value: value.element(index), ok: true}
+	case "join", "toString":
+		separator := ","
+		if method == "join" && len(arguments) > 0 && !staticValueUndefined(arguments[0]) {
+			var ok bool
+			separator, ok = staticValueToString(arguments[0])
+			if !ok {
+				return staticEvalResult{}
+			}
+		}
+		text, ok := staticArrayJoin(value, separator)
+		return staticEvalResult{value: text, ok: ok}
+	}
+	return staticEvalResult{}
+}
+
+type staticArrayElement struct {
+	value   any
+	omitted bool
+}
+
+func staticArrayFromElements(elements []staticArrayElement) *staticArrayValue {
+	array := &staticArrayValue{length: len(elements)}
+	if array.length > len(array.inline) {
+		array.overflow = make([]any, array.length-len(array.inline))
+	}
+	for index, element := range elements {
+		array.set(index, element.value)
+		if element.omitted {
+			if array.omitted == nil {
+				array.omitted = make(map[int]bool, 1)
+			}
+			array.omitted[index] = true
+		}
+	}
+	return array
+}
+
+func staticArrayElements(value *staticArrayValue) []staticArrayElement {
+	elements := make([]staticArrayElement, value.length)
+	for index := range value.length {
+		elements[index] = staticArrayElement{
+			value: value.element(index), omitted: value.omitted[index],
+		}
+	}
+	return elements
+}
+
+func staticArrayConcat(
+	work *staticStringWorkContext,
+	receiver *staticArrayValue,
+	arguments []any,
+) staticEvalResult {
+	if receiver.length > maxStaticAggregateElements {
+		return staticEvalResult{}
+	}
+	elements := staticArrayElements(receiver)
+	for _, argument := range arguments {
+		if array, ok := argument.(*staticArrayValue); ok {
+			if array.length > maxStaticAggregateElements-len(elements) ||
+				!work.reserve(max(array.length*32, 1)) {
+				return staticEvalResult{}
+			}
+			elements = append(elements, staticArrayElements(array)...)
+			continue
+		}
+		if object, ok := argument.(*staticObjectValue); ok {
+			if object.prototypeSet {
+				return staticEvalResult{}
+			}
+			spreadable, found := staticObjectOwnSymbolProperty(object, staticSymbolValue{
+				description: "isConcatSpreadable", wellKnown: true,
+			})
+			if found {
+				truthy, known := staticValueTruthy(spreadable)
+				if !known {
+					return staticEvalResult{}
+				}
+				if truthy {
+					lengthValue, exists := staticObjectOwnProperty(object, "length")
+					if !exists {
+						lengthValue = staticUndefinedValue{}
+					}
+					length, ok := staticToLength(lengthValue)
+					if !ok || length > maxStaticAggregateElements-len(elements) ||
+						!work.reserve(max(length*32, 1)) {
+						return staticEvalResult{}
+					}
+					for index := range length {
+						value, exists := staticObjectOwnProperty(object, strconv.Itoa(index))
+						elements = append(elements, staticArrayElement{value: value, omitted: !exists})
+					}
+					continue
+				}
+			}
+		}
+		if len(elements) >= maxStaticAggregateElements {
+			return staticEvalResult{}
+		}
+		elements = append(elements, staticArrayElement{value: argument})
+	}
+	return staticEvalResult{value: staticArrayFromElements(elements), ok: true}
+}
+
+func staticArraySlice(value *staticArrayValue, start, end int) *staticArrayValue {
+	from := normalizeSliceIndex(start, value.length)
+	to := normalizeSliceIndex(end, value.length)
+	if to < from {
+		to = from
+	}
+	return staticArrayFromElements(staticArrayElements(value)[from:to])
+}
+
+func staticArrayFlat(
+	work *staticStringWorkContext,
+	value *staticArrayValue,
+	depth int,
+) staticEvalResult {
+	elements := make([]staticArrayElement, 0, value.length)
+	var appendArray func(array *staticArrayValue, currentDepth int) bool
+	appendArray = func(array *staticArrayValue, currentDepth int) bool {
+		for index := range array.length {
+			if array.omitted[index] {
+				continue
+			}
+			element := array.element(index)
+			if nested, ok := element.(*staticArrayValue); ok && currentDepth > 0 {
+				if !appendArray(nested, currentDepth-1) {
+					return false
+				}
+				continue
+			}
+			if len(elements) >= maxStaticAggregateElements {
+				return false
+			}
+			if !work.reserve(16) {
+				return false
+			}
+			elements = append(elements, staticArrayElement{value: element})
+		}
+		return true
+	}
+	if !appendArray(value, depth) {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: staticArrayFromElements(elements), ok: true}
+}
+
+func staticArraySearch(value *staticArrayValue, method string, arguments []any) staticEvalResult {
+	needle := staticArgument(arguments, 0)
+	defaultIndex := 0
+	if method == "lastIndexOf" {
+		defaultIndex = value.length - 1
+	}
+	var fromIndex int
+	var ok bool
+	if method == "lastIndexOf" && len(arguments) > 1 && staticValueUndefined(arguments[1]) {
+		// Unlike an omitted argument, an explicit undefined is converted to 0.
+		fromIndex, ok = 0, true
+	} else {
+		fromIndex, ok = staticArgumentInteger(arguments, 1, defaultIndex)
+	}
+	if !ok {
+		if len(arguments) > 1 && staticCanConvertToNumber(arguments[1]) {
+			if method == "includes" {
+				return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+			}
+			return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+		}
+		return staticEvalResult{}
+	}
+	start, end, step := fromIndex, value.length, 1
+	if method == "lastIndexOf" {
+		if start < 0 {
+			start += value.length
+		}
+		start = min(start, value.length-1)
+		end, step = -1, -1
+	} else {
+		if start < 0 {
+			start = max(value.length+start, 0)
+		}
+		if start >= value.length {
+			if method == "includes" {
+				return staticEvalResult{value: false, ok: true}
+			}
+			return staticEvalResult{value: staticNumberValue(-1), ok: true}
+		}
+	}
+	for index := start; index != end; index += step {
+		if index < 0 || index >= value.length {
+			break
+		}
+		if value.omitted[index] && method != "includes" {
+			continue
+		}
+		element := value.element(index)
+		if value.omitted[index] {
+			element = staticUndefinedValue{}
+		}
+		var equal, known bool
+		if method == "includes" {
+			equal, known = staticSameValueZero(element, needle)
+		} else {
+			equal, known = staticValuesStrictEqual(element, needle)
+		}
+		if !known {
+			if method == "includes" {
+				return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+			}
+			return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+		}
+		if equal {
+			if method == "includes" {
+				return staticEvalResult{value: true, ok: true}
+			}
+			return staticEvalResult{value: staticNumberValue(index), ok: true}
+		}
+	}
+	if method == "includes" {
+		return staticEvalResult{value: false, ok: true}
+	}
+	return staticEvalResult{value: staticNumberValue(-1), ok: true}
+}
+
+func staticArrayCallbackCall(
+	work *staticStringWorkContext,
+	value *staticArrayValue,
+	method string,
+	arguments []any,
+) staticEvalResult {
+	if len(arguments) == 0 {
+		return staticEvalResult{}
+	}
+	callback, ok := arguments[0].(staticBuiltinValue)
+	if !ok {
+		return staticEvalResult{}
+	}
+	hasUnknownPredicate := false
+	filtered := make([]any, 0, value.length)
+	for index := range value.length {
+		if value.omitted[index] && method != "find" && method != "findIndex" {
+			continue
+		}
+		element := value.element(index)
+		if value.omitted[index] {
+			element = staticUndefinedValue{}
+		}
+		predicate := evalESLintBuiltinCall(work, string(callback), []any{
+			element, staticNumberValue(index), value,
+		})
+		if !predicate.ok {
+			return staticEvalResult{}
+		}
+		truthy, known := staticValueTruthy(predicate.value)
+		if !known {
+			hasUnknownPredicate = true
+			continue
+		}
+		switch method {
+		case "filter":
+			if truthy {
+				filtered = append(filtered, element)
+			}
+		case "every":
+			if !truthy {
+				return staticEvalResult{value: false, ok: true}
+			}
+		case "some":
+			if truthy {
+				return staticEvalResult{value: true, ok: true}
+			}
+		case "find":
+			if truthy {
+				if hasUnknownPredicate {
+					return staticEvalResult{}
+				}
+				return staticEvalResult{value: element, ok: true}
+			}
+		case "findIndex":
+			if truthy {
+				if hasUnknownPredicate {
+					return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+				}
+				return staticEvalResult{value: staticNumberValue(index), ok: true}
+			}
+		}
+	}
+
+	switch method {
+	case "filter":
+		if hasUnknownPredicate {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: staticArrayFromValues(filtered), ok: true}
+	case "every":
+		if hasUnknownPredicate {
+			return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+		}
+		return staticEvalResult{value: true, ok: true}
+	case "some":
+		if hasUnknownPredicate {
+			return staticEvalResult{value: staticUnknownBooleanValue{}, ok: true}
+		}
+		return staticEvalResult{value: false, ok: true}
+	case "find":
+		if hasUnknownPredicate {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+	case "findIndex":
+		if hasUnknownPredicate {
+			return staticEvalResult{value: staticUnknownNumberValue{}, ok: true}
+		}
+		return staticEvalResult{value: staticNumberValue(-1), ok: true}
+	}
+	return staticEvalResult{}
+}
+
+func staticStringPrototypeCall(
+	work *staticStringWorkContext,
+	value, method string,
+	arguments []any,
+) staticEvalResult {
+	// String methods repeatedly materialize UTF-16 views and transformed
+	// output. Reserve the receiver scan before any method-specific allocation;
+	// builders below reserve their output separately.
+	if !work.reserve(max(len(value)*3, 1)) {
+		return staticEvalResult{}
+	}
+	for _, argument := range arguments {
+		if text, ok := staticValueAsString(argument); ok &&
+			!work.reserve(max(len(text)*8, 1)) {
+			return staticEvalResult{}
+		}
+	}
+	switch method {
+	case "at":
+		index, ok := staticArgumentInteger(arguments, 0, 0)
+		if !ok {
+			return staticEvalResult{}
+		}
+		units := ecmascript.StringCodeUnits(value)
+		if index < 0 {
+			index += len(units)
+		}
+		if index < 0 || index >= len(units) {
+			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+		}
+		return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[index : index+1]), ok: true}
+	case "charAt":
+		return staticESLintStringCharAt(value, arguments)
+	case "charCodeAt", "codePointAt":
+		index, ok := staticArgumentInteger(arguments, 0, 0)
+		if !ok {
+			return staticEvalResult{}
+		}
+		units := ecmascript.StringCodeUnits(value)
+		if index < 0 || index >= len(units) {
+			if method == "charCodeAt" {
+				return staticEvalResult{value: staticNumberValue(math.NaN()), ok: true}
+			}
+			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+		}
+		codePoint := uint32(units[index])
+		if method == "codePointAt" && units[index] >= 0xD800 && units[index] <= 0xDBFF &&
+			index+1 < len(units) && units[index+1] >= 0xDC00 && units[index+1] <= 0xDFFF {
+			codePoint = 0x10000 + uint32(units[index]-0xD800)*0x400 + uint32(units[index+1]-0xDC00)
+		}
+		return staticEvalResult{value: staticNumberValue(codePoint), ok: true}
+	case "concat":
+		return staticStringConcat(work, value, arguments)
+	case "endsWith", "includes", "startsWith":
+		return staticStringPredicate(value, method, arguments)
+	case "indexOf", "lastIndexOf":
+		return staticStringIndexOf(value, method, arguments)
+	case "normalize":
+		form := "NFC"
+		if len(arguments) > 0 && !staticValueUndefined(arguments[0]) {
+			var ok bool
+			form, ok = staticValueToString(arguments[0])
+			if !ok || form != "NFC" && form != "NFD" && form != "NFKC" && form != "NFKD" {
+				return staticEvalResult{}
+			}
+		}
+		if staticNormalizationNeedsNewerUnicodeTables(value, form, norm.Version) {
+			// Go 1.26 selects x/text's Unicode 15 normalization tables, while
+			// Node 22 (the Unicorn v73 oracle) uses Unicode 16. Preserve the
+			// known non-empty string type without fabricating a spelling for
+			// characters whose decomposition/composition was added in Unicode 16.
+			return staticEvalResult{value: staticUnknownStringValue{truthy: true}, ok: true}
+		}
+		var normalForm norm.Form
+		switch form {
+		case "NFD":
+			normalForm = norm.NFD
+		case "NFKC":
+			normalForm = norm.NFKC
+		case "NFKD":
+			normalForm = norm.NFKD
+		default:
+			normalForm = norm.NFC
+		}
+		return staticNormalizeString(work, normalForm, value)
+	case "padEnd", "padStart":
+		targetLength, ok := staticArgumentInteger(arguments, 0, 0)
+		if !ok {
+			return staticEvalResult{}
+		}
+		// StringPad returns before converting the fill string when no padding
+		// is needed. This is observable for a Symbol filler.
+		if targetLength <= ecmascript.StringCodeUnitCount(value) {
+			return staticEvalResult{value: value, ok: true}
+		}
+		filler := " "
+		if len(arguments) > 1 && !staticValueUndefined(arguments[1]) {
+			filler, ok = staticValueToString(arguments[1])
+			if !ok {
+				return staticEvalResult{}
+			}
+		}
+		return staticStringPad(work, value, method, targetLength, filler)
+	case "slice", "substr", "substring":
+		switch method {
+		case "slice":
+			return staticESLintStringSlice(value, arguments)
+		case "substr":
+			return staticESLintStringSubstr(value, arguments)
+		default:
+			return staticESLintStringSubstring(value, arguments)
+		}
+	case "toLowerCase":
+		if ecmascript.StringCodeUnitCount(value) > maxStaticStringLength/3 {
+			return staticEvalResult{}
+		}
+		if staticCaseConversionNeedsNewerRuntime(value, false) {
+			return staticEvalResult{value: staticUnknownStringValue{truthy: true}, ok: true}
+		}
+		return staticEvalResult{value: ecmascript.StringToLowerCase(value), ok: true}
+	case "toUpperCase":
+		if ecmascript.StringCodeUnitCount(value) > maxStaticStringLength/3 {
+			return staticEvalResult{}
+		}
+		if staticCaseConversionNeedsNewerRuntime(value, true) {
+			return staticEvalResult{value: staticUnknownStringValue{truthy: true}, ok: true}
+		}
+		return staticEvalResult{value: ecmascript.StringToUpperCase(value), ok: true}
+	case "toString":
+		return staticEvalResult{value: value, ok: true}
+	case "trim":
+		return staticEvalResult{value: ecmascript.StringTrim(value), ok: true}
+	case "trimEnd", "trimRight":
+		return staticEvalResult{value: ecmascript.StringTrimEnd(value), ok: true}
+	case "trimLeft", "trimStart":
+		return staticEvalResult{value: ecmascript.StringTrimStart(value), ok: true}
+	}
+	return staticEvalResult{}
+}
+
+func staticNormalizationNeedsNewerUnicodeTables(value, form, tableVersion string) bool {
+	if tableVersion != "15.0.0" {
+		// The repository is pinned to Go 1.26, which selects x/text's Unicode
+		// 15 tables. If a future toolchain selects different tables, retain exact
+		// ASCII normalization and keep every other result abstract until that
+		// table/runtime pair has been audited.
+		for _, character := range value {
+			if character >= utf8.RuneSelf {
+				return true
+			}
+		}
+		return false
+	}
+	compatibility := form == "NFKC" || form == "NFKD"
+	for _, character := range value {
+		if compatibility && character >= 0x1CCD6 && character <= 0x1CCF9 {
+			return true
+		}
+		switch character {
+		case 0x105C9, 0x105D2, 0x105DA, 0x105E4,
+			0x0897,
+			0x11382, 0x11383, 0x11384, 0x11385, 0x1138B, 0x1138E,
+			0x11390, 0x11391, 0x113B8, 0x113BB, 0x113C2, 0x113C5,
+			0x113C7, 0x113C8, 0x113C9, 0x113CE, 0x113CF, 0x113D0,
+			0x1612F,
+			0x16D63, 0x16D67, 0x16D68, 0x16D69, 0x16D6A:
+			return true
+		}
+		if character >= 0x10D69 && character <= 0x10D6D ||
+			character >= 0x1611E && character <= 0x16129 ||
+			character >= 0x1E5EE && character <= 0x1E5EF {
+			return true
+		}
+	}
+	return false
+}
+
+// staticCaseConversionNeedsNewerRuntime keeps the enhanced evaluator aligned
+// with Unicorn v73's Node 22 / Unicode 16 runtime. The shared ecmascript case
+// helpers intentionally target Node 26 / Unicode 17 for production rules, so
+// the Unicode 17-only mappings and Final_Sigma properties must stay abstract
+// here rather than choosing a receiver branch with the newer spelling.
+func staticCaseConversionNeedsNewerRuntime(value string, upper bool) bool {
+	hasFinalSigma := !upper && strings.ContainsRune(value, '\u03A3')
+	for _, character := range value {
+		if staticUnicode17CaseMappingSource(character, upper) ||
+			hasFinalSigma && staticUnicode17FinalSigmaPropertyChange(character) {
+			return true
+		}
+	}
+	return false
+}
+
+func staticUnicode17CaseMappingSource(character rune, upper bool) bool {
+	if upper {
+		return character == 0xA7CF || character == 0xA7D3 || character == 0xA7D5 ||
+			character >= 0x16EBB && character <= 0x16ED3
+	}
+	return character == 0xA7CE || character == 0xA7D2 || character == 0xA7D4 ||
+		character >= 0x16EA0 && character <= 0x16EB8
+}
+
+func staticUnicode17FinalSigmaPropertyChange(character rune) bool {
+	switch character {
+	case 0x0295,
+		0xA7CE, 0xA7CF, 0xA7D2, 0xA7D4, 0xA7F1,
+		0x10EC5, 0x11B60, 0x11B66, 0x11DD9,
+		0x1E6E3, 0x1E6E6, 0x1E6F5, 0x1E6FF:
+		return true
+	}
+	return character >= 0x1ACF && character <= 0x1ADD ||
+		character >= 0x1AE0 && character <= 0x1AEB ||
+		character >= 0x10EFA && character <= 0x10EFB ||
+		character >= 0x11B62 && character <= 0x11B64 ||
+		character >= 0x16EA0 && character <= 0x16EB8 ||
+		character >= 0x16EBB && character <= 0x16ED3 ||
+		character >= 0x16FF2 && character <= 0x16FF3 ||
+		character >= 0x1E6EE && character <= 0x1E6EF
+}
+
+func staticNormalizeString(
+	work *staticStringWorkContext,
+	form norm.Form,
+	value string,
+) staticEvalResult {
+	if !work.reserve(max(len(value)*20, 1)) {
+		return staticEvalResult{}
+	}
+	var iterator norm.Iter
+	var builder strings.Builder
+	builder.Grow(min(len(value), maxStaticStringLength*3))
+	chunkStart := 0
+	for index := 0; index+2 < len(value); index++ {
+		if value[index] != 0xED || value[index+1] < 0xA0 || value[index+1] > 0xBF ||
+			value[index+2] < 0x80 || value[index+2] > 0xBF {
+			continue
+		}
+		if !appendStaticNormalizedChunk(&builder, &iterator, form, value[chunkStart:index]) ||
+			builder.Len() > maxStaticStringLength*3-3 {
+			work.exhaust()
+			return staticEvalResult{}
+		}
+		// Compiler strings carry an unpaired UTF-16 surrogate as its three WTF-8
+		// bytes. It is a normalization barrier: preserve it verbatim, while still
+		// normalizing the well-formed chunks on either side.
+		builder.WriteString(value[index : index+3])
+		index += 2
+		chunkStart = index + 1
+	}
+	if !appendStaticNormalizedChunk(&builder, &iterator, form, value[chunkStart:]) {
+		work.exhaust()
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: builder.String(), ok: true}
+}
+
+func appendStaticNormalizedChunk(
+	builder *strings.Builder,
+	iterator *norm.Iter,
+	form norm.Form,
+	value string,
+) bool {
+	iterator.InitString(form, value)
+	for !iterator.Done() {
+		segment := iterator.Next()
+		if len(segment) > maxStaticStringLength*3-builder.Len() {
+			return false
+		}
+		builder.Write(segment)
+	}
+	return true
+}
+
+func staticESLintStringFromCharCode(
+	work *staticStringWorkContext,
+	arguments []any,
+) staticEvalResult {
+	if !work.reserve(max(len(arguments)*6, 1)) {
+		return staticEvalResult{}
+	}
+	units := make([]uint16, 0, len(arguments))
+	for _, argument := range arguments {
+		number, ok := staticValueToNumber(argument)
+		if !ok {
+			return staticEvalResult{}
+		}
+		units = append(units, uint16(toUint32(number)))
+	}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units), ok: true}
+}
+
+func staticESLintStringSlice(text string, arguments []any) staticEvalResult {
+	start, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	end, ok := staticArgumentInteger(arguments, 1, math.MaxInt)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := ecmascript.StringCodeUnits(text)
+	from, to := normalizeSliceIndex(start, len(units)), normalizeSliceIndex(end, len(units))
+	if to < from {
+		to = from
+	}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[from:to]), ok: true}
+}
+
+func staticESLintStringSubstring(text string, arguments []any) staticEvalResult {
+	start, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	end, ok := staticArgumentInteger(arguments, 1, math.MaxInt)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := ecmascript.StringCodeUnits(text)
+	from, to := clampSubstringIndex(start, len(units)), clampSubstringIndex(end, len(units))
+	if from > to {
+		from, to = to, from
+	}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[from:to]), ok: true}
+}
+
+func staticESLintStringSubstr(text string, arguments []any) staticEvalResult {
+	start, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	count, ok := staticArgumentInteger(arguments, 1, math.MaxInt)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := ecmascript.StringCodeUnits(text)
+	from := normalizeSliceIndex(start, len(units))
+	if count <= 0 {
+		return staticEvalResult{value: "", ok: true}
+	}
+	to := len(units)
+	if count < len(units)-from {
+		to = from + count
+	}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[from:to]), ok: true}
+}
+
+func staticESLintStringCharAt(text string, arguments []any) staticEvalResult {
+	index, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := ecmascript.StringCodeUnits(text)
+	if index < 0 || index >= len(units) {
+		return staticEvalResult{value: "", ok: true}
+	}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[index : index+1]), ok: true}
+}
+
+func staticStringPredicate(value, method string, arguments []any) staticEvalResult {
+	searchValue := staticArgument(arguments, 0)
+	if _, isRegExp := searchValue.(staticRegExpValue); isRegExp {
+		return staticEvalResult{}
+	}
+	if staticValueIsObjectForCoercion(searchValue) {
+		match := staticESLintSymbolMemberValue(searchValue, staticSymbolValue{
+			description: "match", wellKnown: true,
+		})
+		if !match.ok {
+			return staticEvalResult{}
+		}
+		if !staticValueUndefined(match.value) {
+			truthy, known := staticValueTruthy(match.value)
+			if !known || truthy {
+				return staticEvalResult{}
+			}
+		}
+	}
+	search, ok := staticValueToString(searchValue)
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := ecmascript.StringCodeUnits(value)
+	searchUnits := ecmascript.StringCodeUnits(search)
+	positionDefault := 0
+	if method == "endsWith" {
+		positionDefault = len(units)
+	}
+	position, ok := staticArgumentInteger(arguments, 1, positionDefault)
+	if !ok {
+		return staticEvalResult{}
+	}
+	position = min(max(position, 0), len(units))
+	var matches bool
+	switch method {
+	case "startsWith":
+		matches = staticCodeUnitsEqualAt(units, searchUnits, position)
+	case "endsWith":
+		matches = staticCodeUnitsEqualAt(units, searchUnits, position-len(searchUnits))
+	default:
+		matches = staticCodeUnitsIndex(units, searchUnits, position) >= 0
+	}
+	return staticEvalResult{value: matches, ok: true}
+}
+
+func staticStringIndexOf(value, method string, arguments []any) staticEvalResult {
+	search, ok := staticValueToString(staticArgument(arguments, 0))
+	if !ok {
+		return staticEvalResult{}
+	}
+	units := ecmascript.StringCodeUnits(value)
+	searchUnits := ecmascript.StringCodeUnits(search)
+	defaultIndex := 0
+	if method == "lastIndexOf" {
+		defaultIndex = len(units)
+	}
+	var position int
+	if method == "lastIndexOf" && len(arguments) > 1 {
+		if number, numberOK := staticValueToNumber(arguments[1]); numberOK && math.IsNaN(number) {
+			position, ok = len(units), true
+		} else {
+			position, ok = staticArgumentInteger(arguments, 1, defaultIndex)
+		}
+	} else {
+		position, ok = staticArgumentInteger(arguments, 1, defaultIndex)
+	}
+	if !ok {
+		return staticEvalResult{}
+	}
+	position = min(max(position, 0), len(units))
+	var index int
+	if method == "lastIndexOf" {
+		index = staticCodeUnitsLastIndex(units, searchUnits, position)
+	} else {
+		index = staticCodeUnitsIndex(units, searchUnits, position)
+	}
+	return staticEvalResult{value: staticNumberValue(index), ok: true}
+}
+
+func staticCodeUnitsIndex(value, search []uint16, start int) int {
+	start = max(start, 0)
+	if len(search) == 0 {
+		return min(start, len(value))
+	}
+	if start > len(value)-len(search) {
+		return -1
+	}
+	prefix := staticCodeUnitsPrefix(search)
+	matched := 0
+	for index := start; index < len(value); index++ {
+		for matched > 0 && value[index] != search[matched] {
+			matched = prefix[matched-1]
+		}
+		if value[index] == search[matched] {
+			matched++
+		}
+		if matched == len(search) {
+			return index - len(search) + 1
+		}
+	}
+	return -1
+}
+
+func staticCodeUnitsLastIndex(value, search []uint16, position int) int {
+	limit := min(max(position, 0), len(value))
+	if len(search) == 0 {
+		return limit
+	}
+	limit = min(limit, len(value)-len(search))
+	if limit < 0 {
+		return -1
+	}
+	prefix := staticCodeUnitsPrefix(search)
+	matched, last := 0, -1
+	for index, unit := range value {
+		for matched > 0 && unit != search[matched] {
+			matched = prefix[matched-1]
+		}
+		if unit == search[matched] {
+			matched++
+		}
+		if matched == len(search) {
+			start := index - len(search) + 1
+			if start > limit {
+				break
+			}
+			last = start
+			matched = prefix[matched-1]
+		}
+	}
+	return last
+}
+
+func staticCodeUnitsPrefix(pattern []uint16) []int {
+	prefix := make([]int, len(pattern))
+	for index, matched := 1, 0; index < len(pattern); index++ {
+		for matched > 0 && pattern[index] != pattern[matched] {
+			matched = prefix[matched-1]
+		}
+		if pattern[index] == pattern[matched] {
+			matched++
+		}
+		prefix[index] = matched
+	}
+	return prefix
+}
+
+func staticCodeUnitsEqualAt(value, search []uint16, index int) bool {
+	if index < 0 || index+len(search) > len(value) {
+		return false
+	}
+	for offset, unit := range search {
+		if value[index+offset] != unit {
+			return false
+		}
+	}
+	return true
+}
+
+func staticStringPad(
+	work *staticStringWorkContext,
+	value, method string,
+	targetLength int,
+	filler string,
+) staticEvalResult {
+	units := ecmascript.StringCodeUnits(value)
+	if targetLength <= len(units) || filler == "" {
+		return staticEvalResult{value: value, ok: true}
+	}
+	if targetLength > maxStaticStringLength {
+		if targetLength > maxJavaScriptStringLength {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: staticUnknownStringValue{truthy: true}, ok: true}
+	}
+	if !work.reserve(max(targetLength*8, 1)) {
+		return staticEvalResult{}
+	}
+	fillerUnits := ecmascript.StringCodeUnits(filler)
+	if len(fillerUnits) == 0 {
+		return staticEvalResult{value: value, ok: true}
+	}
+	padding := make([]uint16, targetLength-len(units))
+	for index := range padding {
+		padding[index] = fillerUnits[index%len(fillerUnits)]
+	}
+	if len(units) == 0 {
+		return staticEvalResult{value: ecmascript.StringFromCodeUnits(padding), ok: true}
+	}
+	if method == "padStart" {
+		result := make([]uint16, len(padding)+len(units))
+		copy(result, padding)
+		copy(result[len(padding):], units)
+		return staticEvalResult{value: ecmascript.StringFromCodeUnits(result), ok: true}
+	}
+	units = append(units, padding...)
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units), ok: true}
+}
+
+func staticNumberPrototypeCall(value any, method string, arguments []any) staticEvalResult {
+	if method != "toExponential" && method != "toFixed" && method != "toPrecision" && method != "toString" {
+		return staticEvalResult{}
+	}
+	receiver, receiverKnown := staticValueToNumber(value)
+	if !receiverKnown {
+		if staticValueKindOf(value) == staticKindNumber {
+			return staticEvalResult{value: staticUnknownStringValue{truthy: true}, ok: true}
+		}
+		return staticEvalResult{}
+	}
+	digits, ok := staticArgumentInteger(arguments, 0, 0)
+	if !ok {
+		return staticEvalResult{}
+	}
+	switch method {
+	case "toString":
+		radix := 10
+		if len(arguments) > 0 && !staticValueUndefined(arguments[0]) {
+			radix = digits
+		}
+		if radix < 2 || radix > 36 {
+			return staticEvalResult{}
+		}
+		if radix == 10 {
+			return staticEvalResult{value: ecmascript.NumberToString(receiver), ok: true}
+		}
+		if formatted, ok := staticNumberToRadix(receiver, radix); ok {
+			return staticEvalResult{value: formatted, ok: true}
+		}
+		return staticEvalResult{value: staticUnknownStringValue{truthy: true}, ok: true}
+	case "toPrecision":
+		if len(arguments) == 0 || staticValueUndefined(arguments[0]) {
+			return staticEvalResult{value: ecmascript.NumberToString(receiver), ok: true}
+		}
+		if math.IsNaN(receiver) || math.IsInf(receiver, 0) {
+			return staticEvalResult{value: ecmascript.NumberToString(receiver), ok: true}
+		}
+		if digits < 1 || digits > 100 {
+			return staticEvalResult{}
+		}
+		return staticEvalResult{value: ecmascript.NumberToPrecision(receiver, digits), ok: true}
+	case "toFixed":
+		if digits < 0 || digits > 100 {
+			return staticEvalResult{}
+		}
+		if math.IsNaN(receiver) || math.IsInf(receiver, 0) || math.Abs(receiver) >= 1e21 {
+			return staticEvalResult{value: ecmascript.NumberToString(receiver), ok: true}
+		}
+		return staticEvalResult{value: staticNumberToFixed(receiver, digits), ok: true}
+	case "toExponential":
+		if math.IsNaN(receiver) || math.IsInf(receiver, 0) {
+			return staticEvalResult{value: ecmascript.NumberToString(receiver), ok: true}
+		}
+		if len(arguments) > 0 && !staticValueUndefined(arguments[0]) && (digits < 0 || digits > 100) {
+			return staticEvalResult{}
+		}
+		fractionDigits := -1
+		if len(arguments) > 0 && !staticValueUndefined(arguments[0]) {
+			fractionDigits = digits
+		}
+		return staticEvalResult{value: ecmascript.NumberToExponential(receiver, fractionDigits), ok: true}
+	}
+	return staticEvalResult{}
+}
+
+func staticNumberToFixed(number float64, digits int) string {
+	negative := number < 0
+	if negative {
+		number = -number
+	}
+	rat := new(big.Rat).SetFloat64(number)
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(digits)), nil)
+	scaledNumerator := new(big.Int).Mul(new(big.Int).Set(rat.Num()), scale)
+	integer, remainder := new(big.Int), new(big.Int)
+	integer.QuoRem(scaledNumerator, rat.Denom(), remainder)
+	if new(big.Int).Lsh(remainder, 1).Cmp(rat.Denom()) >= 0 {
+		integer.Add(integer, big.NewInt(1))
+	}
+	text := integer.String()
+	if digits > 0 {
+		if len(text) <= digits {
+			text = strings.Repeat("0", digits-len(text)+1) + text
+		}
+		text = text[:len(text)-digits] + "." + text[len(text)-digits:]
+	}
+	if negative {
+		text = "-" + text
+	}
+	return text
+}
+
+func staticNumberToRadix(number float64, radix int) (string, bool) {
+	if math.IsNaN(number) || math.IsInf(number, 0) {
+		return ecmascript.NumberToString(number), true
+	}
+	if number == 0 {
+		return "0", true
+	}
+	negative := number < 0
+	if negative {
+		number = -number
+	}
+	const maxSafeInteger = 9007199254740991
+	if (math.Trunc(number) != number || number > maxSafeInteger) && radix&(radix-1) != 0 {
+		// V8 chooses a shortest round-tripping representation for non-binary
+		// radices, not the exact digits of the float's rational value. Exact
+		// conversion is portable only for safe integers and power-of-two bases.
+		return "", false
+	}
+	rat := new(big.Rat).SetFloat64(number)
+	if rat == nil {
+		return "", false
+	}
+	integer, remainder := new(big.Int), new(big.Int)
+	integer.QuoRem(rat.Num(), rat.Denom(), remainder)
+	text := integer.Text(radix)
+	if remainder.Sign() != 0 {
+		if radix%2 != 0 {
+			return "", false
+		}
+		const digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+		var fraction strings.Builder
+		base := big.NewInt(int64(radix))
+		for remainder.Sign() != 0 && fraction.Len() <= 4096 {
+			remainder.Mul(remainder, base)
+			digit := new(big.Int)
+			digit.QuoRem(remainder, rat.Denom(), remainder)
+			fraction.WriteByte(digits[digit.Int64()])
+		}
+		if remainder.Sign() != 0 {
+			return "", false
+		}
+		text += "." + fraction.String()
+	}
+	if negative {
+		text = "-" + text
+	}
+	return text, true
+}
+
+func staticCanConvertToString(value any) bool {
+	switch value.(type) {
+	case staticSymbolValue:
+		return false
+	case staticUnknownStringValue, staticUnknownNumberValue, staticUnknownBooleanValue:
+		return true
+	}
+	_, ok := staticValueToString(value)
+	return ok
+}
+
+func staticCanConvertToNumber(value any) bool {
+	switch value.(type) {
+	case staticBigIntValue, staticSymbolValue:
+		return false
+	case staticUnknownStringValue, staticUnknownNumberValue, staticUnknownBooleanValue:
+		return true
+	}
+	_, ok := staticValueToNumber(value)
+	return ok
+}
+
+func staticNumericArguments(arguments []any, start, count int) bool {
+	end := min(len(arguments), start+count)
+	for index := start; index < end; index++ {
+		if !staticValueUndefined(arguments[index]) && !staticCanConvertToNumber(arguments[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func staticSameValue(left, right any) (bool, bool) {
+	if leftNumber, leftOK := staticValueToNumber(left); leftOK && staticValueKindOf(left) == staticKindNumber {
+		rightNumber, rightOK := staticValueToNumber(right)
+		if !rightOK || staticValueKindOf(right) != staticKindNumber {
+			return false, true
+		}
+		if math.IsNaN(leftNumber) && math.IsNaN(rightNumber) {
+			return true, true
+		}
+		if leftNumber == 0 && rightNumber == 0 {
+			return math.Signbit(leftNumber) == math.Signbit(rightNumber), true
+		}
+		return leftNumber == rightNumber, true
+	}
+	return staticValuesStrictEqual(left, right)
+}
+
+func staticSameValueZero(left, right any) (bool, bool) {
+	if leftNumber, leftOK := staticValueToNumber(left); leftOK && staticValueKindOf(left) == staticKindNumber {
+		rightNumber, rightOK := staticValueToNumber(right)
+		if !rightOK || staticValueKindOf(right) != staticKindNumber {
+			return false, true
+		}
+		return leftNumber == rightNumber || math.IsNaN(leftNumber) && math.IsNaN(rightNumber), true
+	}
+	switch left := left.(type) {
+	case *staticArrayValue:
+		right, ok := right.(*staticArrayValue)
+		if !ok {
+			return false, true
+		}
+		return left == right, true
+	case *staticObjectValue:
+		right, ok := right.(*staticObjectValue)
+		if !ok {
+			return false, true
+		}
+		return left == right, true
+	}
+	return staticValuesStrictEqual(left, right)
+}

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -1,14 +1,18 @@
-// cspell:ignore truenull
+// cspell:ignore ACFB Hrkt lookaheads truenull
 
 package utils
 
 import (
+	"math"
+	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 	"gotest.tools/v3/assert"
 )
 
@@ -139,6 +143,7 @@ func TestStaticStringEvaluator(t *testing.T) {
 		"const ownProtoMessage = ({__proto__: {message: \"message\"}, message: \"\"}).message;\n" +
 		"const computedProtoMessage = ({[\"__proto__\"]: {message: \"message\"}}).message;\n" +
 		"const nullProtoString = String(({__proto__: null}));\n" +
+		"const objectValueOfString = String(({valueOf: 1}));\n" +
 		"const emptyJoin = [].join();\n" +
 		"const joined = [\"error\", \"message\"].join(\": \");\n" +
 		"const nestedEmptyJoin = [[]].join();\n" +
@@ -263,6 +268,7 @@ func TestStaticStringEvaluator(t *testing.T) {
 		{name: "ownProtoMessage", want: "", ok: true},
 		{name: "computedProtoMessage"},
 		{name: "nullProtoString"},
+		{name: "objectValueOfString", want: "[object Object]", ok: true},
 		{name: "emptyJoin", want: "", ok: true},
 		{name: "joined", want: "error: message", ok: true},
 		{name: "nestedEmptyJoin", want: "", ok: true},
@@ -288,6 +294,334 @@ func TestStaticStringEvaluator(t *testing.T) {
 	}
 	if isArray, known := staticEvaluator.EvalArrayValue(findVariableInitializer(t, sourceFile, "unknownUse")); known || isArray {
 		t.Fatalf("EvalArrayValue(unknownUse) = (%v, %v), want (false, false)", isArray, known)
+	}
+}
+
+func TestStaticEvaluatorBudgetFailureDoesNotPoisonLaterEvaluation(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir.Dir, "budget.ts")
+	code := "const small = [1]; const first = small; const second = small;"
+	fs := NewOverlayVFS(rootDir.FS, map[string]string{filePath: code})
+	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	sourceFile := program.GetSourceFile(filePath)
+	assert.Assert(t, sourceFile != nil)
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	staticEvaluator := NewStaticStringEvaluatorWithSourceFile(typeChecker, sourceFile)
+	staticEvaluator.eslintStaticCalls = true
+	staticEvaluator.stringWorkBudgetLeft = maxStaticStringWorkBudget
+	staticEvaluator.bigIntWorkBudgetLeft = maxStaticBigIntWorkBudget
+	staticEvaluator.evaluationDepth = 1
+	staticEvaluator.evaluationStepsLeft = maxStaticEvaluationSteps
+	staticEvaluator.aggregateBudgetLeft = 0
+	if _, known := staticEvaluator.EvalArrayValue(findVariableInitializer(t, sourceFile, "first")); known {
+		t.Fatal("budget-limited evaluation unexpectedly succeeded")
+	}
+
+	staticEvaluator.evaluationDepth = 0
+	if isArray, known := staticEvaluator.EvalArrayValue(findVariableInitializer(t, sourceFile, "second")); !known || !isArray {
+		t.Fatalf("fresh evaluation after a budget failure = (%v, %v), want (true, true)", isArray, known)
+	}
+}
+
+func TestStaticEvaluatorEnhancedRecursionLimitsStayIsolated(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir.Dir, "recursion.ts")
+	var code strings.Builder
+	code.WriteString("const conditional0 = 1;\n")
+	for depth := 1; depth <= maxStaticEvaluationDepth; depth++ {
+		code.WriteString("const conditional")
+		code.WriteString(strconv.Itoa(depth))
+		code.WriteString(" = true ? conditional")
+		code.WriteString(strconv.Itoa(depth - 1))
+		code.WriteString(" : 0;\n")
+	}
+	code.WriteString("const alias0 = 1;\n")
+	for depth := 1; depth <= maxStaticEvaluationDepth; depth++ {
+		code.WriteString("const alias")
+		code.WriteString(strconv.Itoa(depth))
+		code.WriteString(" = alias")
+		code.WriteString(strconv.Itoa(depth - 1))
+		code.WriteString(";\n")
+	}
+
+	fs := NewOverlayVFS(rootDir.FS, map[string]string{filePath: code.String()})
+	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	sourceFile := program.GetSourceFile(filePath)
+	assert.Assert(t, sourceFile != nil)
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	enhanced := NewStaticStringEvaluatorWithSourceFile(typeChecker, sourceFile)
+	enhanced.eslintStaticCalls = true
+	enhanced.stringWorkBudgetLeft = maxStaticStringWorkBudget
+	enhanced.stringWorkContext = &staticStringWorkContext{remaining: &enhanced.stringWorkBudgetLeft}
+	enhanced.bigIntWorkBudgetLeft = maxStaticBigIntWorkBudget
+	for _, test := range []struct {
+		name  string
+		known bool
+	}{
+		{name: "conditional" + strconv.Itoa(maxStaticEvaluationDepth/2-1), known: true},
+		{name: "conditional" + strconv.Itoa(maxStaticEvaluationDepth/2)},
+		{name: "alias" + strconv.Itoa(maxStaticEvaluationDepth-1), known: true},
+		{name: "alias" + strconv.Itoa(maxStaticEvaluationDepth)},
+	} {
+		_, known := enhanced.EvalArrayValue(findVariableInitializer(t, sourceFile, test.name))
+		if known != test.known {
+			t.Fatalf("enhanced EvalArrayValue(%s) known = %v, want %v", test.name, known, test.known)
+		}
+	}
+
+	legacy := NewStaticStringEvaluatorWithSourceFile(typeChecker, sourceFile)
+	for _, name := range []string{
+		"conditional" + strconv.Itoa(maxStaticEvaluationDepth),
+		"alias" + strconv.Itoa(maxStaticEvaluationDepth),
+	} {
+		if isArray, known := legacy.EvalArrayValue(findVariableInitializer(t, sourceFile, name)); !known || isArray {
+			t.Fatalf("legacy EvalArrayValue(%s) = (%v, %v), want (false, true)", name, isArray, known)
+		}
+	}
+}
+
+func TestStaticEvaluatorClosedBigIntCachePreservesDepthLimits(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir.Dir, "bigint-cache.ts")
+	var code strings.Builder
+	code.WriteString("const huge = 2n ** 1024n;\n")
+	code.WriteString("const dependent = huge + 1n;\n")
+	code.WriteString("const selected = true ? huge : 0n;\n")
+	code.WriteString("const logical = true && huge;\n")
+	code.WriteString("const nested = 2n")
+	for range 900 {
+		code.WriteString(" | 0n")
+	}
+	code.WriteString(";\n")
+	code.WriteString("const nestedAlias0 = nested;\n")
+	for depth := 1; depth <= 200; depth++ {
+		code.WriteString("const nestedAlias")
+		code.WriteString(strconv.Itoa(depth))
+		code.WriteString(" = nestedAlias")
+		code.WriteString(strconv.Itoa(depth - 1))
+		code.WriteString(";\n")
+	}
+	code.WriteString("const bigAlias0 = 2n ** 16n;\n")
+	for depth := 1; depth <= 1100; depth++ {
+		code.WriteString("const bigAlias")
+		code.WriteString(strconv.Itoa(depth))
+		code.WriteString(" = bigAlias")
+		code.WriteString(strconv.Itoa(depth - 1))
+		code.WriteString(";\n")
+	}
+	code.WriteString("const bigConditional0 = 2n ** 16n;\n")
+	for depth := 1; depth <= 600; depth++ {
+		code.WriteString("const bigConditional")
+		code.WriteString(strconv.Itoa(depth))
+		code.WriteString(" = true ? bigConditional")
+		code.WriteString(strconv.Itoa(depth - 1))
+		code.WriteString(" : 0n;\n")
+	}
+
+	fs := NewOverlayVFS(rootDir.FS, map[string]string{filePath: code.String()})
+	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	sourceFile := program.GetSourceFile(filePath)
+	assert.Assert(t, sourceFile != nil)
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	staticEvaluator := NewStaticStringEvaluatorWithSourceFile(typeChecker, sourceFile)
+	staticEvaluator.eslintStaticCalls = true
+	staticEvaluator.stringWorkBudgetLeft = maxStaticStringWorkBudget
+	staticEvaluator.stringWorkContext = &staticStringWorkContext{remaining: &staticEvaluator.stringWorkBudgetLeft}
+	staticEvaluator.bigIntWorkBudgetLeft = maxStaticBigIntWorkBudget
+	staticEvaluator.bigIntCacheBudgetLeft = maxStaticBigIntCacheBudget
+
+	huge := findVariableInitializer(t, sourceFile, "huge")
+	first := staticEvaluator.evalValue(huge)
+	second := staticEvaluator.evalValue(huge)
+	firstBigInt, firstOK := first.value.(staticBigIntValue)
+	secondBigInt, secondOK := second.value.(staticBigIntValue)
+	if !first.ok || !second.ok || !firstOK || !secondOK ||
+		firstBigInt.value == nil || firstBigInt.value != secondBigInt.value {
+		t.Fatal("a closed BigInt expression did not reuse its immutable result")
+	}
+	if _, cached := staticEvaluator.bigIntExpressionCache[SkipAssertionsAndParens(huge)]; !cached {
+		t.Fatal("closed BigInt expression was not cached")
+	}
+
+	dependent := findVariableInitializer(t, sourceFile, "dependent")
+	if result := staticEvaluator.evalValue(dependent); !result.ok {
+		t.Fatal("dependent BigInt expression unexpectedly became unknown")
+	}
+	if _, cached := staticEvaluator.bigIntExpressionCache[SkipAssertionsAndParens(dependent)]; cached {
+		t.Fatal("an identifier-dependent BigInt expression was cached")
+	}
+	for _, name := range []string{"selected", "logical"} {
+		initializer := findVariableInitializer(t, sourceFile, name)
+		if result := staticEvaluator.evalValue(initializer); !result.ok {
+			t.Fatalf("%s unexpectedly became unknown", name)
+		}
+		if _, cached := staticEvaluator.bigIntExpressionCache[SkipAssertionsAndParens(initializer)]; cached {
+			t.Fatalf("pass-through expression %s was cached", name)
+		}
+	}
+
+	nested := findVariableInitializer(t, sourceFile, "nested")
+	if result := staticEvaluator.evalValue(nested); !result.ok {
+		t.Fatal("bounded closed BigInt tree unexpectedly became unknown")
+	}
+	if _, cached := staticEvaluator.bigIntExpressionCache[SkipAssertionsAndParens(nested)]; !cached {
+		t.Fatal("bounded closed BigInt tree was not cached")
+	}
+	if isArray, known := staticEvaluator.EvalArrayValue(
+		findVariableInitializer(t, sourceFile, "nestedAlias200"),
+	); known || isArray {
+		t.Fatalf("cached-depth replay = (%v, %v), want (false, false)", isArray, known)
+	}
+
+	for _, name := range []string{"bigAlias400", "bigAlias800", "bigConditional400"} {
+		if isArray, known := staticEvaluator.EvalArrayValue(findVariableInitializer(t, sourceFile, name)); !known || isArray {
+			t.Fatalf("prewarmed EvalArrayValue(%s) = (%v, %v), want (false, true)", name, isArray, known)
+		}
+	}
+	for _, name := range []string{"bigAlias1100", "bigConditional600"} {
+		if isArray, known := staticEvaluator.EvalArrayValue(findVariableInitializer(t, sourceFile, name)); known || isArray {
+			t.Fatalf("deep EvalArrayValue(%s) = (%v, %v), want (false, false)", name, isArray, known)
+		}
+	}
+}
+
+func TestStaticEvaluatorBigIntWorkBudget(t *testing.T) {
+	value := new(big.Int).Lsh(big.NewInt(1), maxStaticBigIntBits-1)
+	cost := max((value.BitLen()+7)/8, 32)
+	staticEvaluator := &StaticStringEvaluator{bigIntWorkBudgetLeft: cost*2 - 1}
+	first := staticEvalResult{value: staticBigIntValue{value: value}, ok: true}
+	if !staticEvaluator.chargeStaticBigIntResult(&first) {
+		t.Fatal("first bounded BigInt result unexpectedly exhausted the work budget")
+	}
+	if !staticEvaluator.chargeStaticBigIntResult(&first) {
+		t.Fatal("the same retained BigInt result was charged twice")
+	}
+	second := staticEvalResult{value: staticBigIntValue{value: new(big.Int).Set(value)}, ok: true}
+	if staticEvaluator.chargeStaticBigIntResult(&second) {
+		t.Fatal("a fresh BigInt result exceeded the persistent work budget")
+	}
+	if staticEvaluator.bigIntWorkBudgetLeft != 0 {
+		t.Fatalf("BigInt work left after exhaustion = %d, want 0", staticEvaluator.bigIntWorkBudgetLeft)
+	}
+
+	abstract := staticBigIntBinary(
+		ast.KindAsteriskToken,
+		staticBigIntValue{value: value},
+		staticBigIntValue{value: value},
+	)
+	abstractValue, ok := abstract.value.(staticBigIntValue)
+	if !abstract.ok || !ok || abstractValue.value != nil || abstract.bigIntWorkBytes <= cost {
+		t.Fatalf("oversized multiplication metadata = %#v", abstract)
+	}
+	staticEvaluator.bigIntWorkBudgetLeft = abstract.bigIntWorkBytes - 1
+	if staticEvaluator.chargeStaticBigIntResult(&abstract) {
+		t.Fatal("an abstracted multiplication bypassed its transient BigInt work charge")
+	}
+	if staticEvaluator.bigIntWorkBudgetLeft != 0 {
+		t.Fatalf("transient BigInt work left after exhaustion = %d, want 0", staticEvaluator.bigIntWorkBudgetLeft)
+	}
+}
+
+func TestStaticBigIntComparisonWorkBudget(t *testing.T) {
+	value := new(big.Int).Lsh(big.NewInt(1), maxStaticBigIntBits-1)
+	byteLength := (value.BitLen() + 7) / 8
+	workLeft := byteLength*2 - 1
+	work := &staticStringWorkContext{remaining: &workLeft}
+	left := staticBigIntValue{value: value, bigIntWorkContext: work}
+	right := staticBigIntValue{value: new(big.Int).Set(value), bigIntWorkContext: work}
+	if equal, known := staticValuesStrictEqual(left, right); !known || !equal {
+		t.Fatal("the first exact BigInt comparison unexpectedly exhausted its work budget")
+	}
+	if equal, known := staticValuesStrictEqual(left, right); known || equal {
+		t.Fatal("a repeated exact BigInt comparison bypassed its persistent work budget")
+	}
+	if workLeft != 0 {
+		t.Fatalf("BigInt comparison work left after exhaustion = %d, want 0", workLeft)
+	}
+
+	for _, test := range []struct {
+		integer int64
+		number  float64
+		want    int
+	}{
+		{integer: 1, number: 1, want: 0},
+		{integer: 1, number: 1.5, want: -1},
+		{integer: -1, number: -1.5, want: 1},
+	} {
+		comparison, ordered, known := staticValuesCompare(
+			staticBigIntValue{value: big.NewInt(test.integer)},
+			staticNumberValue(test.number),
+		)
+		if !known || !ordered || comparison != test.want {
+			t.Fatalf("BigInt(%d) compare %v = (%d, %v, %v), want (%d, true, true)",
+				test.integer, test.number, comparison, ordered, known, test.want)
+		}
+	}
+
+	huge := new(big.Int).Lsh(big.NewInt(1), 2048)
+	for _, test := range []struct {
+		value *big.Int
+		want  float64
+	}{
+		{value: huge, want: math.Inf(1)},
+		{value: new(big.Int).Neg(huge), want: math.Inf(-1)},
+	} {
+		result := staticNumberCall(staticBigIntValue{value: test.value})
+		number, ok := result.value.(staticNumberValue)
+		if !result.ok || !ok || float64(number) != test.want {
+			t.Fatalf("Number(large BigInt) = (%#v, %v), want (%v, true)", result.value, result.ok, test.want)
+		}
+	}
+}
+
+func TestStaticEvaluatorDerivedStringBudget(t *testing.T) {
+	staticEvaluator := &StaticStringEvaluator{
+		evaluationGeneration: 1,
+		stringBudgetLeft:     maxStaticStringBudget,
+		stringWorkBudgetLeft: maxStaticStringWorkBudget,
+	}
+	result := staticEvalResult{
+		value:                strings.Repeat("x", maxStaticStringLength),
+		ok:                   true,
+		stringCodeUnits:      maxStaticStringLength,
+		stringCodeUnitsKnown: true,
+	}
+	if !staticEvaluator.chargeStaticStringResult(&result) {
+		t.Fatal("first derived string unexpectedly exhausted the budget")
+	}
+	afterFirstCharge := staticEvaluator.stringBudgetLeft
+	if !staticEvaluator.chargeStaticStringResult(&result) ||
+		staticEvaluator.stringBudgetLeft != afterFirstCharge {
+		t.Fatal("the same derived result was charged twice")
+	}
+	for range maxStaticStringBudget/maxStaticStringLength - 1 {
+		fresh := result
+		fresh.stringBudgetGeneration = 0
+		if !staticEvaluator.chargeStaticStringResult(&fresh) {
+			t.Fatal("derived string budget was exhausted too early")
+		}
+	}
+	fresh := result
+	fresh.stringBudgetGeneration = 0
+	if staticEvaluator.chargeStaticStringResult(&fresh) {
+		t.Fatal("derived string budget accepted an additional oversized result")
+	}
+
+	staticEvaluator.evaluationGeneration++
+	staticEvaluator.stringBudgetLeft = maxStaticStringBudget
+	workBudget := staticEvaluator.stringWorkBudgetLeft
+	if !staticEvaluator.chargeStaticStringResult(&result) ||
+		staticEvaluator.stringWorkBudgetLeft != workBudget {
+		t.Fatal("a retained derived string was charged to the file work budget twice")
 	}
 }
 
@@ -324,6 +658,476 @@ func TestStaticArrayJoinRejectsExcessiveOutput(t *testing.T) {
 	}
 	if _, ok := staticArrayJoin(value, strings.Repeat("x", 1024)); ok {
 		t.Fatal("staticArrayJoin accepted output above the static string limit")
+	}
+}
+
+func TestStaticArrayJoinStreamsNestedValuesWithinWorkBudget(t *testing.T) {
+	leaf := strings.Repeat("x", 16383)
+	innerValues := make([]any, 64)
+	for index := range innerValues {
+		innerValues[index] = leaf
+	}
+	inner := staticArrayFromValues(innerValues)
+
+	workLeft := maxStaticStringWorkBudget
+	work := &staticStringWorkContext{remaining: &workLeft}
+	inner.stringWorkContext = work
+	joined, ok := staticArrayJoin(inner, ",")
+	if !ok {
+		t.Fatal("staticArrayJoin rejected a nested value just below the limit")
+	}
+	if len(joined) != maxStaticStringLength-1 {
+		t.Fatalf("joined length = %d, want %d", len(joined), maxStaticStringLength-1)
+	}
+	if workLeft >= maxStaticStringWorkBudget {
+		t.Fatal("staticArrayJoin did not charge streamed output")
+	}
+
+	workLeft = maxStaticStringWorkBudget
+	inner.stringWorkContext = work
+	outer := staticArrayFromValues([]any{inner, inner})
+	outer.stringWorkContext = work
+	if _, ok := staticArrayJoin(outer, ","); ok {
+		t.Fatal("staticArrayJoin accepted repeated nested output above the limit")
+	}
+	if workLeft != 0 {
+		t.Fatalf("work left after cap failure = %d, want 0", workLeft)
+	}
+}
+
+func TestStaticArrayJoinPreservesUTF16AndNullishSemantics(t *testing.T) {
+	loneSurrogate := ecmascript.StringFromCodeUnits([]uint16{0xD800})
+	value := staticArrayFromValues([]any{"😀", staticUndefinedValue{}, loneSurrogate})
+	workLeft := maxStaticStringWorkBudget
+	value.stringWorkContext = &staticStringWorkContext{remaining: &workLeft}
+
+	got, ok := staticArrayJoin(value, "|")
+	if !ok {
+		t.Fatal("staticArrayJoin rejected valid UTF-16 input")
+	}
+	want := "😀||" + loneSurrogate
+	if got != want {
+		t.Fatalf("staticArrayJoin = %q, want %q", got, want)
+	}
+	if units := ecmascript.StringCodeUnitCount(got); units != 5 {
+		t.Fatalf("joined code units = %d, want 5", units)
+	}
+}
+
+func TestStaticArrayJoinDepthLimitIsEnhancedOnly(t *testing.T) {
+	legacy := staticArrayFromValues([]any{"x"})
+	for range maxStaticArrayStringDepth + 100 {
+		legacy = staticArrayFromValues([]any{legacy})
+	}
+	if value, ok := staticArrayJoin(legacy, ","); !ok || value != "x" {
+		t.Fatalf("legacy nested join = (%q, %v), want (x, true)", value, ok)
+	}
+
+	workLeft := maxStaticStringWorkBudget
+	enhanced := legacy
+	enhanced.stringWorkContext = &staticStringWorkContext{remaining: &workLeft}
+	if _, ok := staticArrayJoin(enhanced, ","); ok {
+		t.Fatal("enhanced nested join ignored its depth limit")
+	}
+	if workLeft != 0 {
+		t.Fatalf("enhanced nested join left %d work after its depth limit, want 0", workLeft)
+	}
+}
+
+func TestStaticPrimitiveFanoutExhaustsSharedWorkBudget(t *testing.T) {
+	segment := strings.Repeat("x", 100)
+	rawValues := make([]any, 10500)
+	for index := range rawValues {
+		rawValues[index] = segment
+	}
+	raw := staticArrayFromValues(rawValues)
+	object := &staticObjectValue{enhancedCoercion: true}
+	object.addProperty("raw", raw)
+
+	t.Run("String.raw", func(t *testing.T) {
+		workLeft := maxStaticStringWorkBudget
+		work := &staticStringWorkContext{remaining: &workLeft}
+		if result := staticStringRawCall(work, []any{object}); result.ok {
+			t.Fatal("String.raw fanout unexpectedly stayed below the output cap")
+		}
+		if workLeft != 0 {
+			t.Fatalf("work left after String.raw cap failure = %d, want 0", workLeft)
+		}
+	})
+
+	t.Run("String.concat", func(t *testing.T) {
+		workLeft := maxStaticStringWorkBudget
+		work := &staticStringWorkContext{remaining: &workLeft}
+		if result := staticStringConcat(work, "", rawValues); result.ok {
+			t.Fatal("String.concat fanout unexpectedly stayed below the output cap")
+		}
+		if workLeft != 0 {
+			t.Fatalf("work left after String.concat cap failure = %d, want 0", workLeft)
+		}
+	})
+}
+
+func TestStaticDateParseKeepsHostLocalTimeAbstract(t *testing.T) {
+	for _, text := range []string{
+		"2021-03-14T02:30:00",
+		"January 2, 2020 12:00:00",
+		"Jan 01 1970 00:00:00 GMT+0000 trailing junk",
+	} {
+		result := staticDateParse(text)
+		if !result.ok {
+			t.Fatalf("staticDateParse(%q) returned unknown", text)
+		}
+		if _, abstract := result.value.(staticUnknownNumberValue); !abstract {
+			t.Fatalf("staticDateParse(%q) = %#v, want an abstract number", text, result.value)
+		}
+	}
+
+	result := staticDateParse("2021-03-14T02:30:00Z")
+	milliseconds, exact := result.value.(staticNumberValue)
+	if !result.ok || !exact || milliseconds != 1615689000000 {
+		t.Fatalf("UTC staticDateParse = (%#v, %v), want (1615689000000, true)", result.value, result.ok)
+	}
+}
+
+func TestStaticNormalizeKeepsNewerUnicodeMappingsAbstract(t *testing.T) {
+	workLeft := maxStaticStringWorkBudget
+	work := &staticStringWorkContext{remaining: &workLeft}
+	loneSurrogate := ecmascript.StringFromCodeUnits([]uint16{0xD800})
+	for _, test := range []struct {
+		name  string
+		value string
+		form  string
+	}{
+		{name: "compatibility", value: "\U0001CCD6", form: "NFKC"},
+		{name: "decomposition", value: "\U000105C9", form: "NFD"},
+		{name: "composition", value: "\U000105D2\u0307", form: "NFC"},
+		{name: "combining class", value: "A\u0345\u0897", form: "NFD"},
+		{name: "mixed surrogate", value: loneSurrogate + "\U0001CCD6", form: "NFKC"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := staticStringPrototypeCall(work, test.value, "normalize", []any{test.form})
+			abstract, ok := result.value.(staticUnknownStringValue)
+			if !result.ok || !ok || !abstract.truthy {
+				t.Fatalf("normalize(%q, %q) = (%#v, %v), want a truthy abstract string", test.value, test.form, result.value, result.ok)
+			}
+		})
+	}
+
+	result := staticStringPrototypeCall(work, "e\u0301", "normalize", []any{"NFC"})
+	if value, ok := result.value.(string); !result.ok || !ok || value != "é" {
+		t.Fatalf("Unicode 15 normalize control = (%#v, %v), want (é, true)", result.value, result.ok)
+	}
+
+	if !staticNormalizationNeedsNewerUnicodeTables("é", "NFC", "17.0.0") {
+		t.Fatal("a future normalization table kept non-ASCII output exact")
+	}
+	if staticNormalizationNeedsNewerUnicodeTables("ASCII", "NFC", "17.0.0") {
+		t.Fatal("a future normalization table made ASCII output abstract")
+	}
+}
+
+func TestStaticNormalizePreservesSurrogateBarriers(t *testing.T) {
+	high := ecmascript.StringFromCodeUnits([]uint16{0xD800})
+	low := ecmascript.StringFromCodeUnits([]uint16{0xDC00})
+	for _, test := range []struct {
+		name  string
+		value string
+		form  string
+		want  string
+	}{
+		{name: "only surrogate", value: high, form: "NFC", want: high},
+		{name: "normalize after high", value: high + "\u212A", form: "NFC", want: high + "K"},
+		{name: "normalize before low", value: "\u212A" + low, form: "NFC", want: "K" + low},
+		{name: "compose after high", value: high + "A\u030A", form: "NFC", want: high + "Å"},
+		{name: "compose before low", value: "A\u030A" + low, form: "NFC", want: "Å" + low},
+		{name: "compatibility after high", value: high + "\uFB01", form: "NFKC", want: high + "fi"},
+		{name: "two barriers", value: "\u212A" + high + "\u212A" + low + "\u212A", form: "NFC", want: "K" + high + "K" + low + "K"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workLeft := maxStaticStringWorkBudget
+			result := staticStringPrototypeCall(
+				&staticStringWorkContext{remaining: &workLeft},
+				test.value,
+				"normalize",
+				[]any{test.form},
+			)
+			value, ok := result.value.(string)
+			if !result.ok || !ok || value != test.want {
+				t.Fatalf("normalize(%q, %q) = (%q, %v), want (%q, true)", test.value, test.form, value, result.ok, test.want)
+			}
+		})
+	}
+}
+
+func TestStaticCaseConversionKeepsNewerUnicodeSemanticsAbstract(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		value  string
+		method string
+	}{
+		{name: "lowercase mapping", value: "\uA7CE", method: "toLowerCase"},
+		{name: "uppercase mapping", value: "\uA7CF", method: "toUpperCase"},
+		{name: "Beria mapping", value: "\U00016EA0", method: "toLowerCase"},
+		{name: "cased context", value: "\u0295Σ", method: "toLowerCase"},
+		{name: "ignorable context", value: "AΣ\u1ACFB", method: "toLowerCase"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workLeft := maxStaticStringWorkBudget
+			result := staticStringPrototypeCall(
+				&staticStringWorkContext{remaining: &workLeft}, test.value, test.method, nil,
+			)
+			abstract, ok := result.value.(staticUnknownStringValue)
+			if !result.ok || !ok || !abstract.truthy {
+				t.Fatalf("%s(%q) = (%#v, %v), want a truthy abstract string", test.method, test.value, result.value, result.ok)
+			}
+		})
+	}
+
+	workLeft := maxStaticStringWorkBudget
+	result := staticStringPrototypeCall(
+		&staticStringWorkContext{remaining: &workLeft}, "\U00010D70", "toUpperCase", nil,
+	)
+	if value, ok := result.value.(string); !result.ok || !ok || value != "\U00010D50" {
+		t.Fatalf("Unicode 16 case control = (%#v, %v), want (U+10D50, true)", result.value, result.ok)
+	}
+
+	result = staticStringPrototypeCall(
+		&staticStringWorkContext{remaining: &workLeft}, "\u1ACF", "toLowerCase", nil,
+	)
+	if value, ok := result.value.(string); !result.ok || !ok || value != "\u1ACF" {
+		t.Fatalf("context-free identity control = (%#v, %v), want (U+1ACF, true)", result.value, result.ok)
+	}
+}
+
+func TestStaticRegExpConstructorPatternValidation(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		pattern string
+		flags   string
+		want    bool
+	}{
+		{name: "quantifier", pattern: `a{1,2}`, flags: "u", want: true},
+		{name: "raw closing bracket in Annex B", pattern: `]`, want: true},
+		{name: "general category", pattern: `\p{L}`, flags: "u", want: true},
+		{name: "script property", pattern: `\p{Script=Greek}`, flags: "u", want: true},
+		{name: "unicode sets", pattern: `[[A--B]]`, flags: "v", want: true},
+		{name: "named backreference", pattern: `(?<a>a)\k<a>`, flags: "u", want: true},
+		{name: "escaped named capture", pattern: `(?<\u0061>a)`, flags: "u", want: true},
+		{name: "extended escaped named capture", pattern: `(?<\u{1d49c}>a)`, want: true},
+		{name: "Annex B named identity escape", pattern: `\k<a>`, want: true},
+		{name: "Annex B property identity escape", pattern: `\p{IsGreek}`, want: true},
+		{name: "Annex B braced u identity escape in class", pattern: `(?<a>a)[(?<\u{61}>)]`, want: true},
+		{name: "Unicode 16 script", pattern: `\p{Script=Garay}`, flags: "u", want: true},
+		{name: "distinct nested names", pattern: `(?:(?<a>a))(?<b>b)`, flags: "u", want: true},
+		{name: "raw closing bracket under u", pattern: `]`, flags: "u"},
+		{name: "reversed quantifier", pattern: `a{2,1}`},
+		{name: "range bounded by class escape", pattern: `[a-\d]`, flags: "u"},
+		{name: "quantified assertion", pattern: `(?=a)+`, flags: "u"},
+		{name: "inline modifier unsupported by Node 22", pattern: `(?i:a)`},
+		{name: "negative inline modifier unsupported by Node 22", pattern: `(?-i:a)`},
+		{name: "duplicate nested name", pattern: `(?:(?<a>a))(?<a>b)`},
+		{name: "duplicate escaped name", pattern: `(?<a>a)|(?<\u0061>b)`, flags: "u"},
+		{name: "missing named backreference", pattern: `\k<a>`, flags: "u"},
+		{name: "unknown named backreference", pattern: `(?<a>a)\k<b>`},
+		{name: "dotnet atomic group", pattern: `(?>a)`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := staticRegExpConstructorPatternValid(test.pattern, test.flags); got != test.want {
+				t.Fatalf("staticRegExpConstructorPatternValid(%q, %q) = %v, want %v", test.pattern, test.flags, got, test.want)
+			}
+		})
+	}
+}
+
+func TestStaticRegExpConstructorConversionEarlyErrors(t *testing.T) {
+	workLeft := maxStaticStringWorkBudget
+	work := &staticStringWorkContext{remaining: &workLeft}
+	for _, pattern := range []string{"\\\n", "\\\r", "\\\u2028", "\\\u2029"} {
+		if staticRegExpConstructorSourceValid(pattern, "u") {
+			t.Fatalf("staticRegExpConstructorSourceValid(%q, %q) = true", pattern, "u")
+		}
+		if !staticRegExpConstructorSourceValid(pattern, "") {
+			t.Fatalf("staticRegExpConstructorSourceValid(%q, %q) = false", pattern, "")
+		}
+		if _, ok := staticRegExpSource(work, pattern); !ok {
+			t.Fatalf("staticRegExpSource(%q) unexpectedly failed in Annex B mode", pattern)
+		}
+	}
+	for _, pattern := range []string{"\n", "\\\\\n", "\r", "\\\\\u2028"} {
+		if _, ok := staticRegExpSource(work, pattern); !ok {
+			t.Fatalf("staticRegExpSource(%q) unexpectedly failed", pattern)
+		}
+	}
+	for _, pattern := range []string{"[/]", "[[/]]", `[\q{a/b}]`} {
+		if staticRegExpConstructorSourceValid(pattern, "v") {
+			t.Fatalf("staticRegExpConstructorSourceValid(%q, %q) = true", pattern, "v")
+		}
+	}
+	for _, pattern := range []string{`[\/]`, `[a/b]`, `a/b`} {
+		flags := "v"
+		want := pattern != `[a/b]`
+		if got := staticRegExpConstructorSourceValid(pattern, flags); got != want {
+			t.Fatalf("staticRegExpConstructorSourceValid(%q, %q) = %v, want %v", pattern, flags, got, want)
+		}
+	}
+	for _, flags := range []string{"u", "v"} {
+		for _, property := range []string{"Hrkt", "Katakana_Or_Hiragana"} {
+			pattern := `\p{Script=` + property + `}`
+			if staticRegExpConstructorSourceValid(pattern, flags) {
+				t.Fatalf("staticRegExpConstructorSourceValid(%q, %q) = true", pattern, flags)
+			}
+		}
+		if !staticRegExpConstructorSourceValid(`\p{Script=Greek}`, flags) {
+			t.Fatalf("staticRegExpConstructorSourceValid(%q, %q) = false", `\p{Script=Greek}`, flags)
+		}
+		for _, pattern := range []string{`\p{`, `\P{`, `\p{\p{L}`} {
+			if staticRegExpConstructorSourceValid(pattern, flags) {
+				t.Fatalf("staticRegExpConstructorSourceValid(%q, %q) = true", pattern, flags)
+			}
+		}
+	}
+	for _, pattern := range []string{`\p{`, `\P{`} {
+		if !staticRegExpConstructorSourceValid(pattern, "") {
+			t.Fatalf("legacy staticRegExpConstructorSourceValid(%q, %q) = false", pattern, "")
+		}
+	}
+	if !staticRegExpConstructorSourceValid(`\\p{`, "u") {
+		t.Fatal("an escaped backslash was mistaken for a Unicode property escape")
+	}
+	if staticRegExpConstructorSourceValid(`\\\p{Script=Hrkt}`, "u") {
+		t.Fatal("a Unicode property escape after an escaped backslash was skipped")
+	}
+}
+
+func TestStaticRegExpMalformedDelimiterScanning(t *testing.T) {
+	malformedProperties := strings.Repeat(`\p{`, 200_000)
+	if staticRegExpConstructorSourceValid(malformedProperties, "u") {
+		t.Fatal("malformed Unicode properties were accepted")
+	}
+	if !staticRegExpConstructorSourceValid(malformedProperties, "") {
+		t.Fatal("legacy property identity escapes were rejected")
+	}
+	if got := staticRegExpValidatorSource(malformedProperties, "u", false); got != malformedProperties {
+		t.Fatal("malformed Unicode properties were rewritten by the validator bridge")
+	}
+
+	malformedBackreferences := strings.Repeat(`\k<`, 200_000)
+	if got := staticRegExpNormalizeGroupNames(malformedBackreferences, false); got != malformedBackreferences {
+		t.Fatal("malformed legacy backreferences were changed during group-name normalization")
+	}
+	escapedGroupThenMalformed := `(?<\u0061>a)` + strings.Repeat(`(?<`, 200_000)
+	normalized := staticRegExpNormalizeGroupNames(escapedGroupThenMalformed, false)
+	if !strings.HasPrefix(normalized, `(?<a>a)`) ||
+		!strings.HasSuffix(normalized, strings.Repeat(`(?<`, 2)) {
+		t.Fatal("a malformed suffix discarded an earlier group-name normalization")
+	}
+}
+
+func TestStaticRegExpConstructorEngineLimits(t *testing.T) {
+	if !staticRegExpConstructorSourceValid(strings.Repeat("(a)", maxStaticRegExpCaptures), "") {
+		t.Fatal("maximum supported capture count was rejected")
+	}
+	if staticRegExpConstructorSourceValid(strings.Repeat("(a)", maxStaticRegExpCaptures+1), "") {
+		t.Fatal("capture count above the engine limit was accepted")
+	}
+	if staticRegExpConstructorSourceValid(strings.Repeat("(?<a>a)", maxStaticRegExpCaptures+1), "") {
+		t.Fatal("named captures above the engine limit were accepted")
+	}
+	for _, test := range []struct {
+		name    string
+		pattern string
+		flags   string
+	}{
+		{name: "non-capturing groups", pattern: strings.Repeat("(?:a)", maxStaticRegExpCaptures+1)},
+		{name: "lookaheads", pattern: strings.Repeat("(?=a)(?!a)", maxStaticRegExpCaptures+1)},
+		{name: "lookbehinds", pattern: strings.Repeat("(?<=a)(?<!a)", maxStaticRegExpCaptures+1)},
+		{name: "escaped parentheses", pattern: strings.Repeat(`\(`, maxStaticRegExpCaptures+1)},
+		{name: "class parentheses", pattern: strings.Repeat(`[(?<a>)]`, maxStaticRegExpCaptures+1)},
+		{name: "class strings", pattern: strings.Repeat(`[\q{\(}]`, maxStaticRegExpCaptures+1), flags: "v"},
+	} {
+		if !staticRegExpConstructorSourceValid(test.pattern, test.flags) {
+			t.Fatalf("%s were counted as captures", test.name)
+		}
+	}
+	if !staticRegExpConstructorSourceValid(
+		strings.Repeat("[", maxStaticRegExpUnicodeSetsNesting)+"a"+
+			strings.Repeat("]", maxStaticRegExpUnicodeSetsNesting),
+		"v",
+	) {
+		t.Fatal("maximum supported Unicode-sets nesting was rejected")
+	}
+	if staticRegExpConstructorSourceValid(
+		strings.Repeat("[", maxStaticRegExpUnicodeSetsNesting+1)+"a"+
+			strings.Repeat("]", maxStaticRegExpUnicodeSetsNesting+1),
+		"v",
+	) {
+		t.Fatal("Unicode-sets nesting above the engine limit was accepted")
+	}
+}
+
+func TestStaticSymbolDescriptionsAndHostDependentIdentity(t *testing.T) {
+	iterator := staticSymbolValue{description: "iterator", wellKnown: true}
+	if description, known := staticSymbolDescription(iterator); !known || description != "Symbol.iterator" {
+		t.Fatalf("well-known description = (%q, %v), want (%q, true)", description, known, "Symbol.iterator")
+	}
+	registry := staticSymbolValue{description: "iterator", global: true}
+	if description, known := staticSymbolDescription(registry); !known || description != "iterator" {
+		t.Fatalf("registry description = (%q, %v), want (%q, true)", description, known, "iterator")
+	}
+	dispose := staticSymbolValue{description: "dispose", hostDependent: true}
+	if _, known := staticSymbolDescription(dispose); known {
+		t.Fatal("Symbol.dispose unexpectedly had a host-independent description")
+	}
+	if equal, known := staticSymbolIdentityEqual(dispose, dispose); !known || !equal {
+		t.Fatalf("Symbol.dispose self identity = (%v, %v), want (true, true)", equal, known)
+	}
+	node22Dispose := staticSymbolValue{description: "nodejs.dispose", global: true}
+	if _, known := staticSymbolIdentityEqual(dispose, node22Dispose); known {
+		t.Fatal("Symbol.dispose registry identity unexpectedly ignored the host version")
+	}
+}
+
+func TestStaticCollectionBigIntKeysUseBoundedBinaryWork(t *testing.T) {
+	value := new(big.Int).Lsh(big.NewInt(1), maxStaticBigIntBits-1)
+	byteLength := (value.BitLen() + 7) / 8
+	workLeft := byteLength * 3
+	collection := staticCollectionValue{
+		kind: "Set", identity: &staticIdentity{},
+		stringWorkContext: &staticStringWorkContext{remaining: &workLeft},
+	}
+	key := staticBigIntValue{value: value}
+	if !staticCollectionStore(&collection, key, nil) {
+		t.Fatal("the first bounded bigint key was rejected")
+	}
+	if staticCollectionStore(&collection, key, nil) {
+		t.Fatal("a repeated bigint key was materialized after exhausting work")
+	}
+	if workLeft != 0 {
+		t.Fatalf("work left after bigint key cap = %d, want 0", workLeft)
+	}
+
+	equalKey, equalOK := staticCanonicalCollectionKey(
+		staticBigIntValue{value: new(big.Int).Set(value)},
+		nil,
+	)
+	originalKey, originalOK := staticCanonicalCollectionKey(key, nil)
+	negativeKey, negativeOK := staticCanonicalCollectionKey(
+		staticBigIntValue{value: new(big.Int).Neg(value)},
+		nil,
+	)
+	if !equalOK || !originalOK || equalKey != originalKey {
+		t.Fatal("separately materialized equal bigints did not share a collection key")
+	}
+	if !negativeOK || negativeKey == originalKey {
+		t.Fatal("opposite-sign bigints shared a collection key")
+	}
+
+	textWorkLeft := len("large key") - 1
+	if _, ok := staticCanonicalCollectionKey(
+		"large key",
+		&staticStringWorkContext{remaining: &textWorkLeft},
+	); ok || textWorkLeft != 0 {
+		t.Fatal("an oversized string key bypassed collection hashing work")
 	}
 }
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-magic-array-flat-depth.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-magic-array-flat-depth.test.ts
@@ -35,11 +35,29 @@ ruleTester.run('no-magic-array-flat-depth', null as never, {
     valid('array.flat?.(2)'),
     valid('array.notFlat(2)'),
     valid('flat(2)'),
+
+    // Statically known non-array receivers.
+    valid('Math.abs(-2).flat(2)'),
+    valid('Array.isArray([]).flat(2)'),
+    valid("parseInt('2', 10).flat(2)"),
+    valid('Number(1).flat(2)'),
+    valid('const value = 1; value.flat(2)'),
   ],
   invalid: [
     invalid('array.flat(2)'),
     invalid('array?.flat(2)'),
     invalid('array.flat(99,)'),
     invalid('array.flat(0b10,)'),
+
+    // Known arrays, unknown/throwing coercions, and source-only recursion.
+    invalid('Array.of(1).flat(2)'),
+    invalid('Object.freeze([]).flat(2)'),
+    invalid('Number(value).flat(2)'),
+    invalid('BigInt().flat(2)'),
+    invalid('const value = Math.PI; value.flat(2)'),
+    invalid('(flag ? Math.PI : 1).flat(2)'),
+
+    // A comment before the real opening parenthesis is outside the arguments.
+    invalid('array.flat /* explanation */ (2)'),
   ],
 });


### PR DESCRIPTION
## Summary

- Align `unicorn/no-magic-array-flat-depth` receiver classification and comment boundaries with Unicorn v73.
- Add source-only static evaluation for upstream-supported calls, variables, compound expressions, and conversions while preserving typed consumers.
- Bound recursive/static evaluation work and cache classification results; targeted benchmarks show lower allocation and runtime on common and deep inputs.
- Add upstream-parity, comment-boundary, resource, and JavaScript integration coverage.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
