### PR TITLE
fix: align React fragment edge cases

### DIFF
--- a/internal/plugins/react/reactutil/jsx.go
+++ b/internal/plugins/react/reactutil/jsx.go
@@ -360,9 +360,13 @@ func IsFragmentTag(element *ast.Node, reactPragma, fragmentPragma string) bool {
 		return false
 	}
 
-	// <Fragment>
-	if tagName.Kind == ast.KindIdentifier {
+	// <Fragment>. tsgo preserves the otherwise JSXIdentifier-shaped `this`
+	// tag as a ThisKeyword, so it needs the same name comparison here.
+	switch tagName.Kind {
+	case ast.KindIdentifier:
 		return tagName.AsIdentifier().Text == fragmentPragma
+	case ast.KindThisKeyword:
+		return fragmentPragma == "this"
 	}
 
 	// <React.Fragment> — only a single-level member access qualifies, matching
@@ -372,10 +376,16 @@ func IsFragmentTag(element *ast.Node, reactPragma, fragmentPragma string) bool {
 		access := tagName.AsPropertyAccessExpression()
 		object := access.Expression
 		property := access.Name()
-		return object != nil && object.Kind == ast.KindIdentifier &&
-			object.AsIdentifier().Text == reactPragma &&
-			property != nil && property.Kind == ast.KindIdentifier &&
-			property.AsIdentifier().Text == fragmentPragma
+		if property == nil || property.Kind != ast.KindIdentifier ||
+			property.AsIdentifier().Text != fragmentPragma || object == nil {
+			return false
+		}
+		switch object.Kind {
+		case ast.KindIdentifier:
+			return object.AsIdentifier().Text == reactPragma
+		case ast.KindThisKeyword:
+			return reactPragma == "this"
+		}
 	}
 
 	return false

--- a/internal/plugins/react/reactutil/pragma.go
+++ b/internal/plugins/react/reactutil/pragma.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
@@ -176,17 +177,33 @@ func jsxAnnotationPragma(ctx rule.RuleContext) (string, bool) {
 		return "", false
 	}
 
+	// ESLint's SourceCode#getAllComments exposes the hashbang as its first
+	// comment. tsgo keeps it separate from ordinary comment ranges, so inspect
+	// it first to preserve both inclusion and source-order precedence.
+	if shebang := scanner.GetShebang(text); shebang != "" {
+		if name, found := jsxPragmaFromCommentValue(shebang[2:]); found {
+			return name, true
+		}
+	}
+
 	for _, comment := range ctx.Comments.All() {
-		name, found := jsxAnnotationInComment(commentValue(text, comment))
-		if found {
-			// Upstream reads `matches[1].split('.')[0]`.
-			if dot := strings.IndexByte(name, '.'); dot >= 0 {
-				name = name[:dot]
-			}
+		if name, found := jsxPragmaFromCommentValue(utils.CommentValue(text, comment)); found {
 			return name, true
 		}
 	}
 	return "", false
+}
+
+func jsxPragmaFromCommentValue(value string) (string, bool) {
+	name, found := jsxAnnotationInComment(value)
+	if !found {
+		return "", false
+	}
+	// Upstream reads `matches[1].split('.')[0]`.
+	if dot := strings.IndexByte(name, '.'); dot >= 0 {
+		name = name[:dot]
+	}
+	return name, true
 }
 
 // jsxAnnotationInComment ports `/@jsx\s+([^\s]+)/` over one comment body.
@@ -234,29 +251,6 @@ func skipNonWhitespace(text string, start int) int {
 		position += size
 	}
 	return position
-}
-
-// commentValue returns a comment's body without its delimiters, matching what
-// ESLint exposes as `comment.value` — upstream matches the annotation against
-// that, so a trailing `*/` must not become part of the captured name.
-func commentValue(text string, comment *ast.CommentRange) string {
-	if comment.Pos() < 0 || comment.End() > len(text) {
-		return ""
-	}
-	switch comment.Kind {
-	case ast.KindSingleLineCommentTrivia:
-		if comment.End() <= comment.Pos()+2 {
-			return ""
-		}
-		return text[comment.Pos()+2 : comment.End()]
-	case ast.KindMultiLineCommentTrivia:
-		if comment.End() <= comment.Pos()+4 {
-			return ""
-		}
-		return text[comment.Pos()+2 : comment.End()-2]
-	default:
-		return ""
-	}
 }
 
 // isJavaScriptIdentifier ports upstream's

--- a/internal/plugins/react/reactutil/pragma_test.go
+++ b/internal/plugins/react/reactutil/pragma_test.go
@@ -1,6 +1,13 @@
 package reactutil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
 
 // TestJsxAnnotationInComment pins the port of upstream pragmaUtil's
 // `/@jsx\s+([^\s]+)/` to the cases where a compiled RE2 pattern would answer
@@ -67,6 +74,74 @@ func TestIsJavaScriptIdentifier(t *testing.T) {
 
 			if got := isJavaScriptIdentifier(testCase.name); got != testCase.want {
 				t.Fatalf("isJavaScriptIdentifier(%q) = %v, want %v", testCase.name, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestGetReactPragmaFromContextCommentAnnotations covers annotation ordering
+// across tsgo's separately stored hashbang and ordinary comment ranges.
+func TestGetReactPragmaFromContextCommentAnnotations(t *testing.T) {
+	t.Parallel()
+
+	settingsPragma := func(pragma string) map[string]interface{} {
+		return map[string]interface{}{
+			"react": map[string]interface{}{"pragma": pragma},
+		}
+	}
+	for _, testCase := range []struct {
+		name     string
+		source   string
+		settings map[string]interface{}
+		want     string
+	}{
+		{
+			name:   "hashbang annotation",
+			source: "#!/usr/bin/env node @jsx Foo\nvalue;",
+			want:   "Foo",
+		},
+		{
+			name:   "dotted hashbang annotation",
+			source: "#!/usr/bin/env node @jsx this.h\nvalue;",
+			want:   "this",
+		},
+		{
+			name:     "hashbang wins over comments and settings",
+			source:   "#!/usr/bin/env node @jsx Foo\n/* @jsx Bar */\nvalue;",
+			settings: settingsPragma("Baz"),
+			want:     "Foo",
+		},
+		{
+			name:     "invalid hashbang annotation still wins",
+			source:   "#!/usr/bin/env node @jsx Foo-Bar\n/* @jsx Bar */\nvalue;",
+			settings: settingsPragma("Baz"),
+			want:     DefaultReactPragma,
+		},
+		{
+			name:   "non-matching hashbang falls through to comment",
+			source: "#!/usr/bin/env node @jsxFrag Foo.Fragment\n/* @jsx Bar */\nvalue;",
+			want:   "Bar",
+		},
+		{
+			name:   "unterminated block annotation",
+			source: "/* @jsx Foo",
+			want:   "Foo",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/pragma.tsx",
+				Path:     "/pragma.tsx",
+			}, testCase.source, core.ScriptKindTSX)
+			ctx := rule.RuleContext{
+				SourceFile: sourceFile,
+				Comments:   rule.NewCommentStore(sourceFile),
+				Settings:   testCase.settings,
+			}
+			if got := GetReactPragmaFromContext(ctx); got != testCase.want {
+				t.Fatalf("GetReactPragmaFromContext() = %q, want %q", got, testCase.want)
 			}
 		})
 	}

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment.go
@@ -50,32 +50,27 @@ var JsxNoUselessFragmentRule = rule.Rule{
 			return ecmascript.IsBlank(raw) && strings.Contains(raw, "\n")
 		}
 
-		nonPaddingChildren := func(node *ast.Node) []*ast.Node {
+		// nonPaddingChildSummary returns the first relevant child and a count
+		// capped at two. Every downstream question distinguishes only zero, one,
+		// or multiple children, so retaining a slice would allocate for each
+		// visited fragment with children without carrying extra information.
+		nonPaddingChildSummary := func(node *ast.Node) (int, *ast.Node) {
 			children := reactutil.GetJsxChildren(node)
-			kept := make([]*ast.Node, 0, len(children))
+			var first *ast.Node
+			count := 0
 			for _, child := range children {
-				if !isPaddingSpaces(child) {
-					kept = append(kept, child)
+				if isPaddingSpaces(child) {
+					continue
+				}
+				if count == 0 {
+					first = child
+				}
+				count++
+				if count == 2 {
+					break
 				}
 			}
-			return kept
-		}
-
-		hasLessThanTwoChildren := func(node *ast.Node) bool {
-			kept := nonPaddingChildren(node)
-			if len(kept) >= 2 {
-				return false
-			}
-			var first *ast.Node
-			if len(kept) == 1 {
-				first = kept[0]
-			}
-			return !containsCallExpression(first)
-		}
-
-		isFragmentWithSingleExpression := func(node *ast.Node) bool {
-			kept := nonPaddingChildren(node)
-			return len(kept) == 1 && isExpressionContainer(kept[0])
+			return count, first
 		}
 
 		isChildOfHtmlElement := func(node *ast.Node) bool {
@@ -84,10 +79,20 @@ var JsxNoUselessFragmentRule = rule.Rule{
 				return false
 			}
 			tagName := reactutil.GetJsxTagName(parent.AsJsxElement().OpeningElement)
-			if tagName == nil || tagName.Kind != ast.KindIdentifier {
+			if tagName == nil {
 				return false
 			}
-			return isAllLowercaseLetters(tagName.AsIdentifier().Text)
+			var name string
+			switch tagName.Kind {
+			case ast.KindIdentifier:
+				name = tagName.AsIdentifier().Text
+			case ast.KindThisKeyword:
+				// ESTree represents the legal `<this>` tag as JSXIdentifier("this").
+				name = "this"
+			default:
+				return false
+			}
+			return isAllLowercaseLetters(name)
 		}
 
 		isChildOfComponentElement := func(node *ast.Node) bool {
@@ -184,8 +189,12 @@ var JsxNoUselessFragmentRule = rule.Rule{
 				return
 			}
 
-			allowedSingleExpression := allowExpressions && isFragmentWithSingleExpression(node)
-			if hasLessThanTwoChildren(node) &&
+			nonPaddingChildCount, firstNonPaddingChild := nonPaddingChildSummary(node)
+			allowedSingleExpression := allowExpressions &&
+				nonPaddingChildCount == 1 &&
+				isExpressionContainer(firstNonPaddingChild)
+			if nonPaddingChildCount < 2 &&
+				!containsCallExpression(firstNonPaddingChild) &&
 				!isFragmentWithOnlyTextAndIsNotChild(node) &&
 				!allowedSingleExpression {
 				ctx.ReportNodeWithDeferredFixes(node, rule.RuleMessage{

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_test.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_test.go
@@ -445,7 +445,7 @@ func TestJsxNoUselessFragmentEditDemand(t *testing.T) {
 
 	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
 	program, sourceFile, err := helper.CreateTestProgram(
-		"const a = <><div /></>;\nconst b = <><span /></>;",
+		"const a = <><div /></>;\nconst b = <><span /></>;\nconst c = <this><><A/><B/></></this>;",
 		"edit-demand.tsx",
 		"tsconfig.json",
 	)
@@ -477,8 +477,8 @@ func TestJsxNoUselessFragmentEditDemand(t *testing.T) {
 				},
 			},
 		})
-		if len(diagnostics) != 2 {
-			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		if len(diagnostics) != 3 {
+			t.Fatalf("demand %d: diagnostics = %d, want 3", demand, len(diagnostics))
 		}
 		return diagnostics
 	}

--- a/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_this_test.go
+++ b/internal/plugins/react/rules/jsx_no_useless_fragment/jsx_no_useless_fragment_extras_this_test.go
@@ -1,0 +1,114 @@
+package jsx_no_useless_fragment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestJsxNoUselessFragmentExtrasThis covers the JSX positions where tsgo
+// represents ESTree's JSXIdentifier("this") as KindThisKeyword. Other
+// occurrences of `this`, including deeper members and namespace names, must
+// keep their existing behavior. General rslint-added cases live in
+// jsx_no_useless_fragment_extras_test.go; the upstream migration lives in
+// jsx_no_useless_fragment_upstream_test.go.
+func TestJsxNoUselessFragmentExtrasThis(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoUselessFragmentRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: `this` tag-name shapes that must not match ----
+		// Only a single-level pragma.Fragment member can name a fragment.
+		{Code: `<this.Namespace.Fragment>{foo}</this.Namespace.Fragment>`, Tsx: true, Settings: fragmentSettings("this", "")},
+		{Code: `<this:path>{foo}</this:path>`, Tsx: true, Settings: fragmentSettings("this", "this")},
+		// Locks in upstream isKeyedElement(): a key makes a custom fragment
+		// useful, just as it does for the default React.Fragment spelling.
+		{Code: `<this.Fragment key={item.id}>{item.value}</this.Fragment>`, Tsx: true, Settings: fragmentSettings("this", "")},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: `this` in JSXIdentifier-equivalent positions ----
+		{
+			Code: "/** @jsx this.h */\n<this.Fragment>{value}</this.Fragment>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     `<this.Fragment>{value}</this.Fragment>`,
+			Tsx:      true,
+			Settings: fragmentSettings("this", ""),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1, EndLine: 1, EndColumn: 39},
+			},
+		},
+		{
+			Code:     `<this>{value}</this>`,
+			Tsx:      true,
+			Settings: fragmentSettings("", "this"),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		// The member property remains an Identifier in tsgo; supporting the
+		// object-side keyword must not change that existing match.
+		{
+			Code:     `<this.this>{value}</this.this>`,
+			Tsx:      true,
+			Settings: fragmentSettings("this", "this"),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `<React.this>{value}</React.this>`,
+			Tsx:      true,
+			Settings: fragmentSettings("", "this"),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Regression: hashbang annotations precede comments and settings ----
+		{
+			Code: "#!/usr/bin/env node @jsx this.h\n<this.Fragment>{value}</this.Fragment>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "#!/usr/bin/env node @jsx Foo\n/* @jsx Bar */\n<Foo.Fragment>{value}</Foo.Fragment>;",
+			Tsx:      true,
+			Settings: fragmentSettings("Baz", ""),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 3, Column: 1},
+			},
+		},
+
+		// ---- Locks in upstream isChildOfHtmlElement() for bare `this` ----
+		// Member access is still a component parent: it gets no HTML-child
+		// diagnostic and intentionally blocks the autofix.
+		{
+			Code: `<this.Widget><>foo</></this.Widget>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 14},
+			},
+		},
+		{
+			Code:   `<this><><A/><B/></></this>`,
+			Tsx:    true,
+			Output: []string{`<this><A/><B/></this>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 7, EndLine: 1, EndColumn: 20},
+			},
+		},
+		{
+			Code:   `<this><>foo</></this>`,
+			Tsx:    true,
+			Output: []string{`<this>foo</this>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "NeedsMoreChildren", Message: needsMoreChildrenDescription, Line: 1, Column: 7},
+				{MessageId: "ChildOfHtmlElement", Message: childOfHtmlElementDescription, Line: 1, Column: 7},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
@@ -278,6 +278,17 @@ func TestNoDeprecatedRule(t *testing.T) {
 			}},
 		},
 
+		// ---- Regression: `@jsx Foo` in a hashbang is a pragma comment ----
+		{
+			Code: "#!/usr/bin/env node @jsx Foo\nFoo.renderComponent()",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("Foo.renderComponent", "0.12.0", "Foo.render", ""),
+				Line:      2, Column: 1,
+			}},
+		},
+
 		// ---- Upstream #4: `this.transferPropsTo()` ----
 		{
 			Code: `this.transferPropsTo()`,


### PR DESCRIPTION
## Summary

Align React pragma and Fragment edge handling with eslint-plugin-react v7.37.5.

- Recognize tsgo's `KindThisKeyword` only in JSX positions that upstream represents as `JSXIdentifier("this")`.
- Read `@jsx` annotations from hashbang comments before ordinary comments, restoring both Fragment detection and `react/no-deprecated` behavior.
- Reuse tsgo's shebang scanner and the existing comment-value utility instead of duplicating parser semantics.
- Replace temporary non-padding child slices with a one-pass 0/1/many summary while preserving diagnostics and fixes.
- Add focused regression coverage for custom `this` pragmas/fragments, hashbang precedence, HTML-child fixes, edit demands, and malformed comment resilience.

## Related Links

- [eslint-plugin-react v7.37.5](https://github.com/jsx-eslint/eslint-plugin-react/tree/v7.37.5)
- [jsx-no-useless-fragment implementation](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-no-useless-fragment.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
