### PR TITLE
fix: preserve logical assignment semantics

### DIFF
--- a/internal/rules/logical_assignment_operators/logical_assignment_operators.md
+++ b/internal/rules/logical_assignment_operators/logical_assignment_operators.md
@@ -90,4 +90,4 @@ A TypeScript assertion makes the two sides count as different values, so `a = a!
 ## Original Documentation
 
 - [ESLint: logical-assignment-operators](https://eslint.org/docs/latest/rules/logical-assignment-operators)
-- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/logical-assignment-operators.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/logical-assignment-operators.js)

--- a/internal/rules/logical_assignment_operators/logical_assignment_operators_extras_test.go
+++ b/internal/rules/logical_assignment_operators/logical_assignment_operators_extras_test.go
@@ -56,6 +56,14 @@ func TestLogicalAssignmentOperatorsExtras(t *testing.T) {
 			{Code: `[a = a || b] = array`},
 			{Code: `({ x: { a = a || b } } = object)`},
 			{Code: `for ([a = a || b] of arrays) {}`},
+			{Code: `[...[a = a || b]] = array`},
+			{Code: `[...[...[a = a && b]]] = array`},
+			{Code: `({ x: [...[a = a ?? b]] } = object)`},
+			{Code: `[...{ x: a = a || b }] = array`},
+			{Code: `for ([...[a = a || b]] of arrays) {}`},
+			{Code: `for ([...[a = a || b]] in objects) {}`},
+			{Code: `for ({ x: a = a || b } of objects) {}`},
+			{Code: `for ({ x: a = a || b } in objects) {}`},
 			// ---- Dimension 4: options coverage ----
 			{Options: []any{`always`, map[string]any{`enforceForIfStatements`: false}}, Code: `if (a) a = b`},
 			{Options: []any{`always`}, Code: `if (a) a = b`},
@@ -552,6 +560,34 @@ a ??= b`},
 				},
 			},
 			{
+				Code:   `[...[x = a || (a = b)]] = arr;`,
+				Output: []string{`[...[x = (a ||= b)]] = arr;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: `logical`, Message: `Logical expression can be replaced with an assignment (||=).`, Line: 1, Column: 10, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code:   `[...[x = (a = a || b)]] = arr;`,
+				Output: []string{`[...[x = (a ||= b)]] = arr;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: `assignment`, Message: `Assignment (=) can be replaced with operator assignment (||=).`, Line: 1, Column: 11, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code:   `[object[a = a || b] = value] = array;`,
+				Output: []string{`[object[a ||= b] = value] = array;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: `assignment`, Message: `Assignment (=) can be replaced with operator assignment (||=).`, Line: 1, Column: 9, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:   `({ [a = a || b]: value } = object);`,
+				Output: []string{`({ [a ||= b]: value } = object);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: `assignment`, Message: `Assignment (=) can be replaced with operator assignment (||=).`, Line: 1, Column: 5, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
 				Code:   `[a || (a = 0)]`,
 				Output: []string{`[(a ||= 0)]`},
 				Errors: []rule_tester.InvalidTestCaseError{
@@ -774,6 +810,18 @@ this.a &&= b`},
 				},
 			},
 			{
+				Code:            `"use\x20strict"; with (object) a = a || b`,
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: `assignment`, Message: `Assignment (=) can be replaced with operator assignment (||=).`, Line: 1, Column: 32, EndLine: 1, EndColumn: 42,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: `useLogicalOperator`, Output: `"use\x20strict"; with (object) a ||= b`},
+						},
+					},
+				},
+			},
+			{
 				Code:   `with (object) { a || (a = b) }`,
 				Output: []string{`with (object) { a ||= b }`},
 				Errors: []rule_tester.InvalidTestCaseError{
@@ -809,6 +857,27 @@ this.a &&= b`},
 							{MessageId: `separate`, Output: `with (object) { a = a || b }`},
 						},
 					},
+				},
+			},
+			{
+				Code:            `"use\x20strict"; with (object) a ||= b`,
+				Options:         []any{`never`},
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: `unexpected`, Message: `Unexpected logical operator assignment (||=) shorthand.`, Line: 1, Column: 32, EndLine: 1, EndColumn: 39,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: `separate`, Output: `"use\x20strict"; with (object) a = a || b`},
+						},
+					},
+				},
+			},
+			{
+				Code:    "\"use strict\";\nwith (object) { a ||= b }",
+				Options: []any{`never`},
+				Output:  []string{"\"use strict\";\nwith (object) { a = a || b }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: `unexpected`, Message: `Unexpected logical operator assignment (||=) shorthand.`, Line: 2, Column: 17, EndLine: 2, EndColumn: 24},
 				},
 			},
 			// ---- Real-user: eslint#19672 (if-statement autofix kept as an autofix) ----

--- a/internal/rules/logical_assignment_operators/logical_assignment_operators_upstream_test.go
+++ b/internal/rules/logical_assignment_operators/logical_assignment_operators_upstream_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestLogicalAssignmentOperatorsUpstream migrates the full valid/invalid suite
 // from upstream tests/lib/rules/logical-assignment-operators.js (eslint
-// v10.8.1) 1:1. Position assertions cover line/column for every invalid case.
+// v10.9.1) 1:1. Position assertions cover line/column for every invalid case.
 // rslint-specific lock-in cases live in
 // logical_assignment_operators_extras_test.go.
 func TestLogicalAssignmentOperatorsUpstream(t *testing.T) {

--- a/internal/utils/strict_mode.go
+++ b/internal/utils/strict_mode.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/binder"
 )
 
 // IsInStrictMode checks whether a node is in strict mode code.
@@ -52,16 +53,16 @@ func IsInStrictMode(node *ast.Node, sourceFile *ast.SourceFile) bool {
 	return false
 }
 
-// HasUseStrictDirective checks if a block or source file starts with a "use strict" directive.
+// HasUseStrictDirective checks if a source-backed block or source file starts
+// with an exact "use strict" directive. Escaped lookalikes do not enable strict
+// mode, even when their decoded string value is "use strict".
 func HasUseStrictDirective(block *ast.Node) bool {
-	for _, stmt := range block.Statements() {
-		if !ast.IsPrologueDirective(stmt) {
-			break
-		}
-		expr := stmt.Expression()
-		if expr != nil && expr.Text() == "use strict" {
-			return true
-		}
+	if block == nil {
+		return false
 	}
-	return false
+	sourceFile := ast.GetSourceFileOfNode(block)
+	if sourceFile == nil {
+		return false
+	}
+	return binder.FindUseStrictPrologue(sourceFile, block.Statements()) != nil
 }

--- a/internal/utils/strict_mode_test.go
+++ b/internal/utils/strict_mode_test.go
@@ -78,6 +78,12 @@ func TestIsInStrictMode(t *testing.T) {
 			kind:     ast.KindFunctionDeclaration,
 			expected: true,
 		},
+		{
+			name:     "escaped use strict at file level",
+			code:     `"use\x20strict"; if (true) function f() {}`,
+			kind:     ast.KindFunctionDeclaration,
+			expected: false,
+		},
 
 		// === "use strict" in function body → strict inside that function ===
 		{
@@ -85,6 +91,12 @@ func TestIsInStrictMode(t *testing.T) {
 			code:     `function outer() { "use strict"; if (true) { var x = 1; } }`,
 			kind:     ast.KindVariableStatement,
 			expected: true,
+		},
+		{
+			name:     "escaped use strict in enclosing function",
+			code:     `function outer() { "use\x20strict"; if (true) { var x = 1; } }`,
+			kind:     ast.KindVariableStatement,
+			expected: false,
 		},
 
 		// === Class body (implicit strict) ===
@@ -151,19 +163,86 @@ func TestHasUseStrictDirective(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "file with use strict",
+			name:     "double-quoted directive",
 			code:     `"use strict"; var x = 1;`,
 			expected: true,
 		},
 		{
-			name:     "file without use strict",
+			name:     "single-quoted directive",
+			code:     `'use strict'; var x = 1;`,
+			expected: true,
+		},
+		{
+			name:     "directive after another prologue directive",
+			code:     `"use asm"; "use strict"; var x = 1;`,
+			expected: true,
+		},
+		{
+			name: "directive after comments",
+			code: `/* before */ // still before
+"use strict"; var x = 1;`,
+			expected: true,
+		},
+		{
+			name:     "directive after byte order mark",
+			code:     "\ufeff\"use strict\"; var x = 1;",
+			expected: true,
+		},
+		{
+			name:     "directive after hashbang",
+			code:     "#!/usr/bin/env node\n\"use strict\"; var x = 1;",
+			expected: true,
+		},
+		{
+			name:     "no directive",
 			code:     `var x = 1;`,
 			expected: false,
 		},
 		{
-			name:     "file with other string directive",
+			name:     "other directive only",
 			code:     `"use asm"; var x = 1;`,
 			expected: false,
+		},
+		{
+			name:     "directive after prologue ends",
+			code:     `0; "use strict"; var x = 1;`,
+			expected: false,
+		},
+		{
+			name:     "parenthesized string is not a directive",
+			code:     `("use strict"); var x = 1;`,
+			expected: false,
+		},
+		{
+			name:     "hex escape",
+			code:     `"use\x20strict"; var x = 1;`,
+			expected: false,
+		},
+		{
+			name:     "unicode escape",
+			code:     `"use\u0020strict"; var x = 1;`,
+			expected: false,
+		},
+		{
+			name:     "escaped first character",
+			code:     `"\x75se strict"; var x = 1;`,
+			expected: false,
+		},
+		{
+			name:     "identity escape",
+			code:     `"use\ strict"; var x = 1;`,
+			expected: false,
+		},
+		{
+			name: "line continuation",
+			code: `"use\
+ strict"; var x = 1;`,
+			expected: false,
+		},
+		{
+			name:     "exact directive after escaped lookalike",
+			code:     `"use\x20strict"; "use strict"; var x = 1;`,
+			expected: true,
 		},
 		{
 			name:     "empty file",
@@ -184,5 +263,48 @@ func TestHasUseStrictDirective(t *testing.T) {
 			result := HasUseStrictDirective(sourceFile.AsNode())
 			assert.Equal(t, result, tt.expected, "HasUseStrictDirective mismatch for: %s", tt.code)
 		})
+	}
+}
+
+func TestHasUseStrictDirectiveInFunctionBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{
+			name:     "exact directive",
+			code:     `function f() { "use strict"; work(); }`,
+			expected: true,
+		},
+		{
+			name:     "escaped lookalike",
+			code:     `function f() { "use\x20strict"; work(); }`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body, _ := parseAndFindNode(t, tt.code, ast.KindBlock)
+			assert.Equal(t, HasUseStrictDirective(body), tt.expected)
+		})
+	}
+}
+
+func TestHasUseStrictDirectiveWithoutSourceFile(t *testing.T) {
+	t.Parallel()
+
+	if HasUseStrictDirective(nil) {
+		t.Fatal("HasUseStrictDirective(nil) = true, want false")
+	}
+
+	body, _ := parseAndFindNode(t, `function f() { "use strict"; }`, ast.KindBlock)
+	body.Parent = nil
+	if HasUseStrictDirective(body) {
+		t.Fatal("HasUseStrictDirective(detached block) = true, want false")
 	}
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -51,6 +51,132 @@ func TestIsSameReferenceNumericLiteralUsesJavaScriptValue(t *testing.T) {
 	}
 }
 
+func TestIsDefaultValueInDestructuringAssignment(t *testing.T) {
+	t.Parallel()
+
+	if IsDefaultValueInDestructuringAssignment(nil) {
+		t.Fatal("IsDefaultValueInDestructuringAssignment(nil) = true, want false")
+	}
+
+	tests := []struct {
+		name     string
+		code     string
+		nodeText string
+		want     bool
+	}{
+		{
+			name:     "direct array default",
+			code:     `[a = a || b] = array`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "array default inside rest pattern",
+			code:     `[...[a = a || b]] = array`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "array default inside nested rest patterns",
+			code:     `[...[...[a = a || b]]] = array`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "nested object and array default",
+			code:     `({ x: [...[a = a || b]] } = object)`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "array rest containing object pattern",
+			code:     `[...{ x: a = a || b }] = array`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "object shorthand default is not a binary expression",
+			code:     `({ a = a || b } = object)`,
+			nodeText: `a = a || b`,
+			want:     false,
+		},
+		{
+			name:     "for-of rest pattern",
+			code:     `for ([...[a = a || b]] of arrays) {}`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "for-in rest pattern",
+			code:     `for ([...[a = a || b]] in objects) {}`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "for-of object pattern",
+			code:     `for ({ x: a = a || b } of objects) {}`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "for-in object pattern",
+			code:     `for ({ x: a = a || b } in objects) {}`,
+			nodeText: `a = a || b`,
+			want:     true,
+		},
+		{
+			name:     "ordinary assignment",
+			code:     `a = a || b`,
+			nodeText: `a = a || b`,
+			want:     false,
+		},
+		{
+			name:     "compound assignment",
+			code:     `[a += a || b] = array`,
+			nodeText: `a += a || b`,
+			want:     false,
+		},
+		{
+			name:     "assignment in default right-hand side",
+			code:     `[x = (a = a || b)] = array`,
+			nodeText: `a = a || b`,
+			want:     false,
+		},
+		{
+			name:     "assignment in computed element",
+			code:     `[object[a = a || b] = value] = array`,
+			nodeText: `a = a || b`,
+			want:     false,
+		},
+		{
+			name:     "assignment in computed property",
+			code:     `({ [a = a || b]: value } = object)`,
+			nodeText: `a = a || b`,
+			want:     false,
+		},
+		{
+			name:     "array expression rather than assignment target",
+			code:     `consume([a = a || b])`,
+			nodeText: `a = a || b`,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+				Path:     "/test.ts",
+			}, tt.code, core.ScriptKindTS)
+			node := findNodeWithText(t, sourceFile, tt.nodeText)
+			if got := IsDefaultValueInDestructuringAssignment(node); got != tt.want {
+				t.Errorf("IsDefaultValueInDestructuringAssignment(%q) = %v, want %v", tt.nodeText, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsESTreeLiteralKind(t *testing.T) {
 	literals := []ast.Kind{
 		ast.KindStringLiteral,

--- a/internal/utils/write_reference.go
+++ b/internal/utils/write_reference.go
@@ -251,43 +251,29 @@ func IsDefaultValueInDestructuringAssignment(node *ast.Node) bool {
 	if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken {
 		return false
 	}
-	parent := node.Parent
-	if parent == nil {
+	// GetAssignmentTarget follows only assignment-target edges. In particular,
+	// it crosses nested array/object patterns and rest elements, but stops at a
+	// computed key or at the right-hand side of another default. That is the
+	// same boundary ESTree uses when deciding whether this `=` is represented
+	// as an AssignmentPattern rather than an AssignmentExpression.
+	if node.Parent == nil {
 		return false
 	}
-	switch parent.Kind {
-	case ast.KindArrayLiteralExpression:
-		return isArrayOrObjectDestructuringAssignmentPattern(parent)
-	case ast.KindPropertyAssignment:
-		assignment := parent.AsPropertyAssignment()
-		return assignment != nil &&
-			assignment.Initializer == node &&
-			isArrayOrObjectDestructuringAssignmentPattern(parent.Parent)
-	case ast.KindSpreadElement:
-		return isArrayOrObjectDestructuringAssignmentPattern(parent.Parent)
-	}
-	return false
-}
-
-func isArrayOrObjectDestructuringAssignmentPattern(node *ast.Node) bool {
-	if node == nil || (node.Kind != ast.KindArrayLiteralExpression && node.Kind != ast.KindObjectLiteralExpression) {
+	target := ast.GetAssignmentTarget(node)
+	if target == nil {
 		return false
 	}
-	parent := node.Parent
-	if parent == nil {
+	if ast.IsDestructuringAssignment(target) {
+		return true
+	}
+	if !ast.IsForInOrOfStatement(target) {
 		return false
 	}
-	if parent.Kind == ast.KindBinaryExpression {
-		binary := parent.AsBinaryExpression()
-		return binary != nil && binary.OperatorToken != nil &&
-			binary.OperatorToken.Kind == ast.KindEqualsToken && binary.Left == node
+	statement := target.AsForInOrOfStatement()
+	if statement == nil || statement.Initializer == nil {
+		return false
 	}
-	if parent.Kind == ast.KindForInStatement || parent.Kind == ast.KindForOfStatement {
-		statement := parent.AsForInOrOfStatement()
-		return statement != nil && statement.Initializer == node
-	}
-	if parent.Kind == ast.KindPropertyAssignment {
-		return isArrayOrObjectDestructuringAssignmentPattern(parent.Parent)
-	}
-	return isArrayOrObjectDestructuringAssignmentPattern(parent)
+	initializer := ast.SkipParentheses(statement.Initializer)
+	return initializer != nil &&
+		(initializer.Kind == ast.KindArrayLiteralExpression || initializer.Kind == ast.KindObjectLiteralExpression)
 }


### PR DESCRIPTION
## Summary

- Reuse tsgo's assignment-target traversal to recognize defaults nested through rest patterns, while preserving reports inside computed keys, element accesses, and default-value right-hand sides.
- Reuse tsgo's raw-source strict-prologue detector so escaped `"use strict"` lookalikes keep sloppy-mode `with` fixes suggestion-only.
- Add focused utility and rule regressions for nested array/object patterns, `for-in`/`for-of`, fixer parentheses, strict-directive spellings, and `always`/`never` fix safety.
- Verify diagnostics, ranges, fix boundaries, and outputs against ESLint 10.9.1 across a 29-case differential corpus.
- Confirm no targeted benchmark regression: 1.478 µs/op to 1.443 µs/op geomean (-2.37%), with bytes and allocations unchanged.

## Related Links

- [ESLint rule documentation](https://eslint.org/docs/latest/rules/logical-assignment-operators)
- [ESLint 10.9.1 rule source](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/logical-assignment-operators.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
