### PR TITLE
fix: align no-magic-array-flat-depth with Unicorn v73

### DIFF
--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth.go
@@ -58,7 +58,7 @@ var NoMagicArrayFlatDepthRule = rule.Rule{
 				// of context upstream wants to preserve. Upstream checks
 				// `commentsExistBetween(openingParenthesisToken, closingParenthesisToken)`,
 				// which covers both sides of the depth argument.
-				if hasCommentBetweenParens(ctx, call.Call, depth) {
+				if hasCommentBetweenParens(ctx, call.Call) {
 					return
 				}
 
@@ -84,27 +84,45 @@ func isNumericLiteral(node *ast.Node) bool {
 	return node != nil && node.Kind == ast.KindNumericLiteral
 }
 
-// hasCommentBetweenParens reports whether any comment lives in the source
-// span from the end of the callee (right after `flat`, i.e. the position of
-// the opening `(`) up to the end of the call expression. Mirrors upstream's
-// `sourceCode.commentsExistBetween(openingParenthesisToken, closingParenthesisToken)`.
-func hasCommentBetweenParens(ctx rule.RuleContext, call *ast.Node, depth *ast.Node) bool {
-	callee := call.AsCallExpression().Expression
-	if callee == nil {
+// hasCommentBetweenParens mirrors commentsExistBetween on the call's actual
+// parentheses. A comment between the callee and `(` is outside that range.
+func hasCommentBetweenParens(ctx rule.RuleContext, call *ast.Node) bool {
+	callExpression := call.AsCallExpression()
+	if callExpression == nil || callExpression.Arguments == nil {
 		return false
 	}
-	openParenPos := utils.TrimNodeTextRange(ctx.SourceFile, callee).End()
-	callEnd := utils.TrimNodeTextRange(ctx.SourceFile, call).End()
-	depthStart := utils.TrimNodeTextRange(ctx.SourceFile, depth).Pos()
-	if openParenPos >= callEnd {
+	callEnd := call.End()
+	argumentsStart := callExpression.Arguments.Pos()
+	text := ctx.SourceFile.Text()
+	if argumentsStart > 0 && callEnd > argumentsStart && callEnd <= len(text) &&
+		text[argumentsStart-1] == '(' && text[callEnd-1] == ')' {
+		// The listener has already proved this call has one numeric-literal
+		// argument (possibly parenthesized). A comment delimiter is therefore
+		// unambiguous here; no string, regexp, or second expression can contain it.
+		return mayContainCommentDelimiter(text, argumentsStart, callEnd-1)
+	}
+
+	comments := ctx.Comments.All()
+	if len(comments) == 0 {
 		return false
 	}
-	// Avoid wasting a comment scan on the trivial case where the depth is the
-	// only thing in the parens.
-	if depthStart == openParenPos+1 || depthStart == openParenPos+2 {
-		// depth is immediately after `(`, optionally with whitespace.
-		depthEnd := depth.End()
-		return utils.HasCommentInSpan(ctx.Comments.All(), depthEnd, callEnd)
+	callEnd = utils.TrimNodeTextRange(ctx.SourceFile, call).End()
+	opening, ok := utils.TokenBeforePosition(ctx.SourceFile, callExpression.Arguments.Pos())
+	if !ok || opening.Kind != ast.KindOpenParenToken {
+		return false
 	}
-	return utils.HasCommentInSpan(ctx.Comments.All(), openParenPos, callEnd)
+	closing, ok := utils.TokenBeforePosition(ctx.SourceFile, callEnd)
+	if !ok || closing.Kind != ast.KindCloseParenToken {
+		return false
+	}
+	return utils.HasCommentInSpan(comments, opening.End, closing.Start)
+}
+
+func mayContainCommentDelimiter(text string, start, end int) bool {
+	for index := start; index+1 < end; index++ {
+		if text[index] == '/' && (text[index+1] == '/' || text[index+1] == '*') {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_extras_test.go
@@ -61,6 +61,22 @@ func TestNoMagicArrayFlatDepthExtras(t *testing.T) {
 
 			// ---- Branch: optional chain on the call disqualifies it ----
 			tsValid(`array.flat?.(2)`),
+
+			// ---- Static-call parity: known, safely evaluated non-arrays ----
+			jsValid(`Boolean({__proto__: null}).flat(2)`),
+			jsValid(`Number(1n).flat(2)`),
+			jsValid(`String(1n).flat(2)`),
+			jsValid(`parseInt(1n).flat(2)`),
+			jsValid(`Array.isArray(1n).flat(2)`),
+			jsValid(`/** @type {Array<number>} */ const value = 1; value.flat(2)`),
+			{
+				Code:     `array.flat<number>(/* explanation */ 2)`,
+				FileName: "file.ts",
+			},
+			{
+				Code:     `array.flat<number>(2 /* explanation */)`,
+				FileName: "file.ts",
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Branch lock-in: every non-1 numeric literal shape ----
@@ -93,6 +109,35 @@ func TestNoMagicArrayFlatDepthExtras(t *testing.T) {
 			{
 				Code:     `arr()?.flat(2)`,
 				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
+
+			// ---- Static-call parity: unknown or throwing evaluations report ----
+			depthInvalid(`Math.abs({__proto__: null}).flat(2)`),
+			depthInvalid(`Number({__proto__: null}).flat(2)`),
+			depthInvalid(`String({__proto__: null}).flat(2)`),
+			depthInvalid(`parseInt({__proto__: null}, 10).flat(2)`),
+			depthInvalid(`String.fromCharCode(1n).flat(2)`),
+			depthInvalid(`Object.freeze({}, value).flat(2)`),
+			depthInvalid(`/* global value */ Object.freeze({}, value).flat(2)`),
+			depthInvalid(`/* global value */ (true ? Object.freeze({}, value) : 1).flat(2)`),
+			depthInvalid(`/** @type {number} */ const value = []; value.flat(2)`),
+			depthInvalid(`/** @type {number} */ const value = unknown; value.flat(2)`),
+			depthInvalid(`(/** @type {number} */ ([])).flat(2)`),
+			depthInvalid(`(/** @type {number} */ (unknown)).flat(2)`),
+			depthInvalid(`(/** @type {number[]} */ (1)).flat(2)`),
+			depthInvalid(`(/** @type {number} */ ('x')).flat(2)`),
+			depthInvalid(`(/** @type {number} */ ({})).flat(2)`),
+			depthInvalid("(/** @type {number} */ (`x`)).flat(2)"),
+			depthInvalid(`let value = {}; value.x = 1; Boolean(value).flat(2)`),
+			depthInvalid(`await using value = {}; value.flat(2)`),
+			depthInvalid(`const Math = {abs() { return 1 }}; Math.abs(-2).flat(2)`),
+			{
+				Code:     `array.flat<number>(2)`,
+				FileName: "file.ts",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: messageID,
 					Message:   messageString,

--- a/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_magic_array_flat_depth/no_magic_array_flat_depth_upstream_test.go
@@ -61,6 +61,13 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			// `String.fromCharCode` is folded by the shared static
 			// evaluator to a string value, so the rule skips it.
 			jsValid(`String.fromCharCode(65).flat(2)`),
+			jsValid(`Math.abs(-2).flat(2)`),
+			jsValid(`Math.max(1, 2).flat(2)`),
+			jsValid(`Array.isArray([]).flat(2)`),
+			jsValid(`parseInt("2", 10).flat(2)`),
+			jsValid(`parseFloat("2").flat(2)`),
+			jsValid(`Object().flat(2)`),
+			jsValid(`const value = 1; value.flat(2);`),
 
 			// ---- depth is 1 (the default) ----
 			jsValid(`array.flat(1)`),
@@ -91,6 +98,20 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			depthInvalid(`array?.flat(2)`),
 			depthInvalid(`array.flat(99,)`),
 			depthInvalid(`array.flat(0b10,)`),
+			depthInvalid(`Array.of(1).flat(2)`),
+			depthInvalid(`Object.freeze([]).flat(2)`),
+			depthInvalid(`Number(value).flat(2)`),
+			depthInvalid(`String(value).flat(2)`),
+			depthInvalid(`BigInt().flat(2)`),
+			depthInvalid(`(flag ? Math.PI : 1).flat(2)`),
+			{
+				Code:     `array.flat /* reason */ (2)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   messageString,
+				}},
+			},
 
 			// A receiver that is known to be an array must still be reported.
 			{
@@ -240,22 +261,6 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			// over-classify their return type as a known non-array
 			// primitive, so the source-only path bypasses it.
 			{
-				Code:     `Math.abs(-2).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Math.max(1, 2).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
 				Code:     `Math.random().flat(2)`,
 				FileName: "file.mjs",
 				Errors: []rule_tester.InvalidTestCaseError{{
@@ -281,38 +286,6 @@ func TestNoMagicArrayFlatDepthUpstream(t *testing.T) {
 			},
 			{
 				Code:     `JSON.parse("[]").flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Array.isArray([]).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `parseInt("2", 10).flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `parseFloat("2").flat(2)`,
-				FileName: "file.mjs",
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: messageID,
-					Message:   messageString,
-				}},
-			},
-			{
-				Code:     `Object().flat(2)`,
 				FileName: "file.mjs",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: messageID,

--- a/internal/plugins/unicorn/unicornutil/array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/array_receiver.go
@@ -1,10 +1,13 @@
 package unicornutil
 
 import (
+	"math"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 // IsKnownNonArray reports whether node is definitely not an Array or
@@ -68,19 +71,53 @@ var typedArrayNames = []string{
 }
 
 type arrayReceiverStaticEvaluatorFileCacheKey struct{}
+type sourceOnlyArrayReceiverCacheKey struct{}
+
+type arrayReceiverWalkState struct {
+	useTypeInformation bool
+	visiting           map[*ast.Symbol]bool
+	memo               map[*ast.Symbol]arrayClass
+	depth              int
+	steps              int
+}
+
+const (
+	maxSourceOnlyArrayReceiverDepth = 1024
+	maxSourceOnlyArrayReceiverSteps = 4096
+)
 
 // classifyArrayReceiver mirrors the syntactic short-circuits of unicorn's
 // getType (array literals, Array()/new Array()/Array.from/Array.of), then falls
 // back to a type-checker classification analogous to getTypeScriptType.
 func classifyArrayReceiver(ctx rule.RuleContext, node *ast.Node, targetNames, nonTargetNames *utils.Set[string]) arrayClass {
-	return classifyArrayReceiverInner(ctx, node, targetNames, nonTargetNames, map[*ast.Symbol]bool{})
+	return classifyArrayReceiverInner(ctx, node, targetNames, nonTargetNames, &arrayReceiverWalkState{
+		useTypeInformation: true,
+		visiting:           map[*ast.Symbol]bool{},
+	})
+}
+
+// classifySourceOnlyArrayReceiver follows Unicorn's syntax and static-value
+// paths without letting tsgo's ambient JavaScript types turn an otherwise
+// unknown expression into a known non-array.
+func classifySourceOnlyArrayReceiver(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	targetNames, nonTargetNames *utils.Set[string],
+) arrayClass {
+	memo := rule.CachedByFile(ctx, sourceOnlyArrayReceiverCacheKey{}, func() map[*ast.Symbol]arrayClass {
+		return map[*ast.Symbol]arrayClass{}
+	})
+	return classifyArrayReceiverInner(ctx, node, targetNames, nonTargetNames, &arrayReceiverWalkState{
+		visiting: map[*ast.Symbol]bool{},
+		memo:     memo,
+	})
 }
 
 func classifyArrayReceiverInner(
 	ctx rule.RuleContext,
 	node *ast.Node,
 	targetNames, nonTargetNames *utils.Set[string],
-	visitedSymbols map[*ast.Symbol]bool,
+	state *arrayReceiverWalkState,
 ) arrayClass {
 	if node == nil {
 		return arrayClassUnknown
@@ -89,57 +126,82 @@ func classifyArrayReceiverInner(
 	if node == nil {
 		return arrayClassUnknown
 	}
+	if !state.useTypeInformation {
+		if state.depth >= maxSourceOnlyArrayReceiverDepth ||
+			state.steps >= maxSourceOnlyArrayReceiverSteps {
+			return arrayClassUnknown
+		}
+		state.depth++
+		state.steps++
+		defer func() { state.depth-- }()
+	}
 
 	// Unicorn deliberately ignores a satisfies annotation and classifies the
 	// expression itself. Assertions are different: an informative annotation
 	// wins, while any / unknown falls through to the wrapped expression.
 	if node.Kind == ast.KindSatisfiesExpression {
 		return classifyArrayReceiverInner(
-			ctx, node.AsSatisfiesExpression().Expression, targetNames, nonTargetNames, visitedSymbols,
+			ctx, node.AsSatisfiesExpression().Expression, targetNames, nonTargetNames, state,
 		)
 	}
 	if node.Kind == ast.KindAsExpression || node.Kind == ast.KindTypeAssertionExpression {
-		if class := classifyArrayTypeNode(ctx, node.Type(), targetNames, nonTargetNames, map[*ast.Symbol]bool{}); class != arrayClassUnknown {
-			return class
+		if state.useTypeInformation {
+			if class := classifyArrayTypeNode(ctx, node.Type(), targetNames, nonTargetNames, map[*ast.Symbol]bool{}); class != arrayClassUnknown {
+				return class
+			}
 		}
-		return classifyArrayReceiverInner(ctx, node.Expression(), targetNames, nonTargetNames, visitedSymbols)
+		return classifyArrayReceiverInner(ctx, node.Expression(), targetNames, nonTargetNames, state)
 	}
 	if node.Kind == ast.KindNonNullExpression {
-		return classifyArrayReceiverInner(ctx, node.Expression(), targetNames, nonTargetNames, visitedSymbols)
+		return classifyArrayReceiverInner(ctx, node.Expression(), targetNames, nonTargetNames, state)
 	}
 
 	if ast.IsIdentifier(node) {
-		if class := classifyArrayIdentifier(ctx, node, targetNames, nonTargetNames, visitedSymbols); class != arrayClassUnknown {
+		if class := classifyArrayIdentifier(ctx, node, targetNames, nonTargetNames, state); class != arrayClassUnknown {
 			return class
 		}
 	}
 	if node.Kind == ast.KindConditionalExpression {
 		conditional := node.AsConditionalExpression()
-		return combineArrayClassesUnion([]arrayClass{
-			classifyArrayReceiverInner(ctx, conditional.WhenTrue, targetNames, nonTargetNames, visitedSymbols),
-			classifyArrayReceiverInner(ctx, conditional.WhenFalse, targetNames, nonTargetNames, visitedSymbols),
+		class := combineArrayClassesUnion([]arrayClass{
+			classifyArrayReceiverInner(ctx, conditional.WhenTrue, targetNames, nonTargetNames, state),
+			classifyArrayReceiverInner(ctx, conditional.WhenFalse, targetNames, nonTargetNames, state),
 		})
+		if class != arrayClassUnknown || state.useTypeInformation {
+			return class
+		}
 	}
 	if ast.IsBinaryExpression(node) &&
 		node.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken {
 		return classifyArrayReceiverInner(
-			ctx, node.AsBinaryExpression().Right, targetNames, nonTargetNames, visitedSymbols,
+			ctx, node.AsBinaryExpression().Right, targetNames, nonTargetNames, state,
 		)
 	}
 
 	// getStaticValue runs before Unicorn's syntactic target/non-target checks.
 	// Identifier and member expressions are intentionally excluded even when
-	// eslint-utils can fold them; upstream keeps those shapes unknown.
-	if !ast.IsIdentifier(node) && !ast.IsAccessExpression(node) {
-		staticEvaluator := arrayReceiverStaticEvaluator(ctx)
-		if isArray, known := staticEvaluator.EvalArrayValue(node); known {
-			if isArray {
-				return arrayClassTarget
+	// eslint-utils can fold them; upstream keeps those shapes unknown. In
+	// source-only files, calls take the guarded path below so tsgo's ambient
+	// return types cannot classify arbitrary user calls.
+	if !state.useTypeInformation && ast.IsCallExpression(node) {
+		if class := classifySourceOnlyStaticCall(ctx, node); class != arrayClassUnknown {
+			return class
+		}
+	} else if !ast.IsIdentifier(node) && !ast.IsAccessExpression(node) {
+		// Keep source-only evaluation bounded. The shared evaluator is recursive;
+		// repeatedly folding the same adversarial const chain here would otherwise
+		// be both more permissive than eslint-utils and quadratic in practice.
+		if state.useTypeInformation ||
+			(!containsInvocationExpression(node) && isBoundedSourceStaticExpression(ctx, node)) {
+			staticEvaluator := arrayReceiverStaticEvaluator(ctx)
+			if isArray, known := staticEvaluator.EvalArrayValue(node); known {
+				if isArray {
+					return arrayClassTarget
+				}
+				return arrayClassNonTarget
 			}
-			return arrayClassNonTarget
 		}
 	}
-
 	if isSyntacticArrayNode(node) {
 		return arrayClassTarget
 	}
@@ -147,7 +209,7 @@ func classifyArrayReceiverInner(
 		return arrayClassTarget
 	}
 
-	if ctx.TypeChecker != nil {
+	if state.useTypeInformation && ctx.TypeChecker != nil {
 		t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)
 		if class := classifyArrayType(ctx, t, targetNames); class != arrayClassUnknown {
 			return class
@@ -168,27 +230,268 @@ func arrayReceiverStaticEvaluator(ctx rule.RuleContext) *utils.StaticStringEvalu
 	})
 }
 
+const staticCallGlobalMeaning = ast.SymbolFlagsValue | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+const maxSourceStaticNodeCount = 256
+
+// classifySourceOnlyStaticCall delegates value proofs to rslint's evaluator.
+// This function only carries eslint-utils' missing policy: which built-ins may
+// be called, which argument conversions can throw, and the result category.
+func classifySourceOnlyStaticCall(
+	ctx rule.RuleContext,
+	node *ast.Node,
+) arrayClass {
+	call := node.AsCallExpression()
+	if call == nil {
+		return arrayClassUnknown
+	}
+	evaluator := arrayReceiverStaticEvaluator(ctx)
+	bounded := isBoundedSourceStaticExpression(ctx, node)
+	root, method, builtin := staticBuiltinCall(ctx, call.Expression)
+	if !bounded && !builtin {
+		return arrayClassUnknown
+	}
+	arguments := node.Arguments()
+	if !staticCallArgumentsKnown(ctx, evaluator, arguments) {
+		return arrayClassUnknown
+	}
+	if bounded {
+		if isArray, known := evaluator.EvalArrayValue(node); known {
+			if isArray {
+				return arrayClassTarget
+			}
+			return arrayClassNonTarget
+		}
+	}
+	if builtin {
+		switch {
+		case method == "" && root == "Boolean":
+			return arrayClassNonTarget
+		case method == "" && (root == "Number" || root == "String" || root == "parseFloat"):
+			if len(arguments) == 0 || canStaticallyConvertToString(evaluator, arguments[0]) {
+				return arrayClassNonTarget
+			}
+		case method == "" && root == "parseInt":
+			if (len(arguments) == 0 || canStaticallyConvertToString(evaluator, arguments[0])) &&
+				(len(arguments) < 2 || isStaticPrimitiveArgument(evaluator, arguments[1])) {
+				return arrayClassNonTarget
+			}
+		case method == "" && (root == "isFinite" || root == "isNaN"):
+			if len(arguments) == 0 || isStaticPrimitiveArgument(evaluator, arguments[0]) {
+				return arrayClassNonTarget
+			}
+		case method == "" && root == "BigInt":
+			if len(arguments) > 0 && isStaticallyValidBigIntArgument(arguments[0]) {
+				return arrayClassNonTarget
+			}
+		case method == "" && root == "Object":
+			if len(arguments) == 0 {
+				return arrayClassNonTarget
+			}
+			if isArray, known := evaluator.EvalArrayValue(arguments[0]); known {
+				if isArray {
+					return arrayClassTarget
+				}
+				return arrayClassNonTarget
+			}
+		case root == "Array" && method == "isArray":
+			return arrayClassNonTarget
+		case root == "Math" && isStaticMathMethod(method) && staticPrimitiveArguments(evaluator, arguments):
+			return arrayClassNonTarget
+		}
+	}
+	return arrayClassUnknown
+}
+
+// isBoundedSourceStaticExpression is a resource guard around the shared
+// evaluator, not a second evaluator. Built-in globals are allowed; local value
+// references stay on the recursive classifier's memoized path.
+func isBoundedSourceStaticExpression(ctx rule.RuleContext, root *ast.Node) bool {
+	stack := []*ast.Node{root}
+	for visited := 0; len(stack) > 0; visited++ {
+		if visited >= maxSourceStaticNodeCount {
+			return false
+		}
+		last := len(stack) - 1
+		node := stack[last]
+		stack = stack[:last]
+		if ast.IsIdentifier(node) && !utils.IsNonReferenceIdentifier(node) &&
+			!isUnshadowedGlobal(ctx, node) {
+			return false
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			stack = append(stack, child)
+			return false
+		})
+	}
+	return true
+}
+
+// Calls and constructions have their own source-only policies. Do not let a
+// compound expression feed a nested invocation back into the generic
+// evaluator and bypass its argument/global checks.
+func containsInvocationExpression(root *ast.Node) bool {
+	stack := []*ast.Node{root}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		node := stack[last]
+		stack = stack[:last]
+		if ast.IsCallExpression(node) || ast.IsNewExpression(node) {
+			return true
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			stack = append(stack, child)
+			return false
+		})
+	}
+	return false
+}
+
+func staticBuiltinCall(ctx rule.RuleContext, rawCallee *ast.Node) (root, method string, ok bool) {
+	callee := ast.SkipOuterExpressions(rawCallee, ast.OEKParentheses|ast.OEKAssertions)
+	if ast.IsIdentifier(callee) && isUnshadowedGlobal(ctx, callee) {
+		return callee.AsIdentifier().Text, "", true
+	}
+	if !ast.IsAccessExpression(callee) {
+		return "", "", false
+	}
+	object := ast.SkipParentheses(utils.AccessExpressionObject(callee))
+	method, ok = utils.AccessExpressionStaticName(callee)
+	if !ok || !ast.IsIdentifier(object) || !isUnshadowedGlobal(ctx, object) {
+		return "", "", false
+	}
+	return object.AsIdentifier().Text, method, true
+}
+
+func staticCallArgumentsKnown(
+	ctx rule.RuleContext,
+	evaluator *utils.StaticStringEvaluator,
+	arguments []*ast.Node,
+) bool {
+	for _, argument := range arguments {
+		if ast.IsSpreadElement(argument) {
+			return false
+		}
+		if isBigIntLiteral(argument) {
+			continue
+		}
+		if !isBoundedSourceStaticExpression(ctx, argument) {
+			return false
+		}
+		if _, known := evaluator.EvalValue(argument); !known {
+			return false
+		}
+	}
+	return true
+}
+
+func isBigIntLiteral(node *ast.Node) bool {
+	node = ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
+	return node != nil && node.Kind == ast.KindBigIntLiteral
+}
+
+func isStaticallyValidBigIntArgument(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindBigIntLiteral, ast.KindTrueKeyword, ast.KindFalseKeyword:
+		return true
+	case ast.KindNumericLiteral:
+		value, ok := ecmascript.StringToNumber(utils.NormalizeNumericLiteral(node.Text()))
+		return ok && !math.IsInf(value, 0) && !math.IsNaN(value) && value == math.Trunc(value)
+	}
+	return false
+}
+
+func canStaticallyConvertToString(evaluator *utils.StaticStringEvaluator, node *ast.Node) bool {
+	if isBigIntLiteral(node) {
+		return true
+	}
+	_, ok := evaluator.EvalToString(node)
+	return ok
+}
+
+func isStaticPrimitiveArgument(evaluator *utils.StaticStringEvaluator, node *ast.Node) bool {
+	value, known := evaluator.EvalValue(node)
+	if known {
+		switch value.(type) {
+		case string, bool, interface{ IsNaN() bool }:
+			return true
+		}
+	}
+	node = ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindNullKeyword, ast.KindUndefinedKeyword, ast.KindVoidExpression:
+		return true
+	}
+	return false
+}
+
+func staticPrimitiveArguments(evaluator *utils.StaticStringEvaluator, arguments []*ast.Node) bool {
+	for _, argument := range arguments {
+		if !isStaticPrimitiveArgument(evaluator, argument) {
+			return false
+		}
+	}
+	return true
+}
+
+func isUnshadowedGlobal(ctx rule.RuleContext, identifier *ast.Node) bool {
+	name := identifier.AsIdentifier().Text
+	return ctx.Globals.Access(name).IsDeclared() && ctx.Refs != nil &&
+		ctx.Refs.IsGlobalNameReference(identifier, name, staticCallGlobalMeaning)
+}
+
+func isStaticMathMethod(name string) bool {
+	switch name {
+	case "abs", "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh",
+		"cbrt", "ceil", "clz32", "cos", "cosh", "exp", "expm1", "floor", "fround",
+		"hypot", "imul", "log", "log10", "log1p", "log2", "max", "min",
+		"pow", "round", "sign", "sin", "sinh", "sqrt", "tan", "tanh", "trunc":
+		return true
+	}
+	return false
+}
+
 func classifyArrayIdentifier(
 	ctx rule.RuleContext,
 	idNode *ast.Node,
 	targetNames, nonTargetNames *utils.Set[string],
-	visitedSymbols map[*ast.Symbol]bool,
+	state *arrayReceiverWalkState,
 ) arrayClass {
 	if ctx.Refs == nil || idNode == nil {
 		return arrayClassUnknown
 	}
 	symbol := ctx.Refs.ResolveInFile(idNode)
-	if symbol == nil || visitedSymbols[symbol] || len(symbol.Declarations) != 1 {
+	if symbol == nil || len(symbol.Declarations) != 1 {
 		return arrayClassUnknown
 	}
-	visitedSymbols[symbol] = true
-	defer delete(visitedSymbols, symbol)
+	if state.visiting[symbol] {
+		return arrayClassUnknown
+	}
+	if !state.useTypeInformation {
+		if class, ok := state.memo[symbol]; ok {
+			return class
+		}
+	}
+	state.visiting[symbol] = true
+	defer func() {
+		delete(state.visiting, symbol)
+	}()
 
 	declaration := symbol.Declarations[0]
 	if declaration == nil {
 		return arrayClassUnknown
 	}
-	if annotation := arrayBindingTypeAnnotation(declaration); annotation != nil {
+	if state.useTypeInformation {
+		annotation := arrayBindingTypeAnnotation(declaration)
 		if class := classifyArrayTypeNode(ctx, annotation, targetNames, nonTargetNames, map[*ast.Symbol]bool{}); class != arrayClassUnknown {
 			return class
 		}
@@ -199,11 +502,16 @@ func classifyArrayIdentifier(
 	declarationList := declaration.Parent
 	variable := declaration.AsVariableDeclaration()
 	if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) ||
+		(!state.useTypeInformation && (ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList))) ||
 		declarationList.Flags&ast.NodeFlagsConst == 0 || variable.Name() == nil ||
 		!ast.IsIdentifier(variable.Name()) || variable.Initializer == nil {
 		return arrayClassUnknown
 	}
-	return classifyArrayReceiverInner(ctx, variable.Initializer, targetNames, nonTargetNames, visitedSymbols)
+	class := classifyArrayReceiverInner(ctx, variable.Initializer, targetNames, nonTargetNames, state)
+	if !state.useTypeInformation {
+		state.memo[symbol] = class
+	}
+	return class
 }
 
 // arrayBindingTypeAnnotation mirrors definition.name?.typeAnnotation in

--- a/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/known_non_array_receiver.go
@@ -90,99 +90,19 @@ func isSourceOnlyFile(ctx rule.RuleContext) bool {
 // checker) for `.ts` inputs where type annotations make the classification
 // defensible.
 func ShouldSkipKnownNonArrayReceiver(ctx rule.RuleContext, node *ast.Node) bool {
-	if isDirectlyReportableReceiver(node) {
-		return false
-	}
-
-	// Coercion constructors: the only CallExpression callees upstream's
-	// `getStaticValueForControlFlow` reliably folds to a known non-array
-	// value (a number, string, boolean, or bigint). `Symbol()` is
-	// deliberately excluded because every call returns a unique Symbol
-	// and cannot be folded.
-	if isNonArrayCoercionConstructorCall(ctx, node) {
-		return true
-	}
-
-	// For CallExpression, the shared static evaluator folds a handful
-	// of cases like `String.fromCharCode(65)` and `Array.of(...)`. If
-	// it resolves to a non-array value, trust that result.
-	if isSourceOnlyFile(ctx) && ast.IsCallExpression(node) {
-		staticEvaluator := arrayReceiverStaticEvaluator(ctx)
-		if _, known := staticEvaluator.EvalArrayValue(node); known {
-			return true
-		}
-	}
-
-	// Source-only path: trust upstream's "unknown" classification for
-	// identifier / member / call receivers. We deliberately skip the
-	// shared static evaluator for those shapes because it folds
-	// identifiers like `undefined` to a known non-array value that the
-	// upstream parser does NOT fold.
+	directNode := node
 	if isSourceOnlyFile(ctx) {
-		if isShapeUpstreamUnknown(node) {
-			return false
-		}
+		// tsgo materializes a JSDoc cast in JavaScript as an assertion wrapper;
+		// ESTree leaves the visible expression as the receiver node.
+		directNode = ast.SkipOuterExpressions(node, ast.OEKAll)
 	}
-
+	if isDirectlyReportableReceiver(directNode) {
+		return false
+	}
+	if isSourceOnlyFile(ctx) {
+		return classifySourceOnlyArrayReceiver(
+			ctx, node, indexedCollectionTargets, keyedCollectionNames,
+		) == arrayClassNonTarget
+	}
 	return IsKnownNonIndexedCollection(ctx, node)
-}
-
-// isShapeUpstreamUnknown reports whether node is one of the shapes
-// upstream's parser leaves "unknown" for source-only files. The shared
-// rslint static evaluator would also fold these (e.g. `undefined` →
-// Undefined), but the upstream parser does not, so the rule fires.
-func isShapeUpstreamUnknown(node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
-	if node == nil {
-		return false
-	}
-	// Strip type annotations / assertions / non-null so a TS-only
-	// expression like `(x as number)` is treated by its underlying shape.
-	node = ast.SkipOuterExpressions(node, ast.OEKAll)
-	if node == nil {
-		return false
-	}
-	if ast.IsIdentifier(node) {
-		return true
-	}
-	if ast.IsAccessExpression(node) {
-		return true
-	}
-	if ast.IsCallExpression(node) {
-		return true
-	}
-	return false
-}
-
-// isNonArrayCoercionConstructorCall reports whether node is a bare call
-// to one of the four coercion constructors whose result is statically
-// known to be a non-array primitive: `Number(...)`, `String(...)`,
-// `Boolean(...)`, `BigInt(...)`. Upstream's
-// `getStaticValueForControlFlow` folds these to a primitive value; the
-// rslint static evaluator does not, so we mirror the upstream shape here.
-//
-// `Symbol()` is excluded: every call returns a unique Symbol and the
-// static evaluator cannot fold it. `parseInt` / `parseFloat` / `Object()`
-// are also excluded for the same reason — they aren't on the upstream
-// `staticGlobalProperties` allowlist, and the rslint type checker would
-// over-classify their return type for `.mjs` inputs.
-func isNonArrayCoercionConstructorCall(ctx rule.RuleContext, node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
-	if !ast.IsCallExpression(node) {
-		return false
-	}
-	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, ast.OEKParentheses|ast.OEKAssertions)
-	if !ast.IsIdentifier(callee) {
-		return false
-	}
-	// If the callee resolves to a local binding, the user's declaration
-	// wins; fall through to IsKnownNonIndexedCollection.
-	if ctx.Refs != nil && ctx.Refs.ResolveInFile(callee) != nil {
-		return false
-	}
-	switch callee.AsIdentifier().Text {
-	case "Number", "String", "Boolean", "BigInt":
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

- Align source-only array receiver classification with Unicorn v73 for statically evaluated arrays, supported built-in calls, single const initializers, and compound expressions.
- Check explanatory comments only inside the call actual parentheses.
- Keep unknown receivers conservative and bound recursive/static analysis to avoid pathological work.

## Testing

- `go test ./internal/plugins/unicorn/unicornutil ./internal/plugins/unicorn/rules/no_magic_array_flat_depth -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/unicorn/unicornutil/... ./internal/plugins/unicorn/rules/no_magic_array_flat_depth/...`
- Unicorn v73 differential matrices and adversarial receiver/comment cases

## Performance

- `Math.abs` literal receiver classification x1000: `0.720-0.863 ms`, `80.6 KB`
- `parseInt` literal receiver classification x1000: `0.410-0.446 ms`, `80.6 KB`
- 100,000 comment-span checks: `0.534-0.539 ms`, `0 B/op`
- Depth-5000 compound receiver x1000: `0.382-0.403 ms`, depth-independent

## Related Links

N/A

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required).