### PR TITLE
fix: align accessor token and range semantics

### DIFF
--- a/internal/plugins/typescript/rules/member_ordering/member_ordering.go
+++ b/internal/plugins/typescript/rules/member_ordering/member_ordering.go
@@ -985,48 +985,6 @@ func validateWithOptionality(ctx rule.RuleContext, members []*ast.Node, cfg *par
 	}
 }
 
-// isSyntacticMember returns whether a node is a real member that participates in ordering.
-// TS-Go AST includes SemicolonClassElement (standalone `;`) in Members.Nodes,
-// but ESTree parsers strip these. We filter them out to match ESLint behavior.
-func isSyntacticMember(node *ast.Node) bool {
-	return node.Kind != ast.KindSemicolonClassElement
-}
-
-// getClassMembers extracts member nodes from a class/interface/type literal,
-// filtering out non-semantic nodes like SemicolonClassElement.
-func getClassMembers(node *ast.Node) []*ast.Node {
-	var raw []*ast.Node
-	switch node.Kind {
-	case ast.KindClassDeclaration:
-		classDecl := node.AsClassDeclaration()
-		if classDecl == nil || classDecl.Members == nil {
-			return nil
-		}
-		raw = classDecl.Members.Nodes
-	case ast.KindClassExpression:
-		classExpr := node.AsClassExpression()
-		if classExpr == nil || classExpr.Members == nil {
-			return nil
-		}
-		raw = classExpr.Members.Nodes
-	case ast.KindInterfaceDeclaration:
-		interfaceDecl := node.AsInterfaceDeclaration()
-		if interfaceDecl == nil || interfaceDecl.Members == nil {
-			return nil
-		}
-		raw = interfaceDecl.Members.Nodes
-	case ast.KindTypeLiteral:
-		typeLiteral := node.AsTypeLiteralNode()
-		if typeLiteral == nil || typeLiteral.Members == nil {
-			return nil
-		}
-		raw = typeLiteral.Members.Nodes
-	default:
-		return nil
-	}
-	return utils.Filter(raw, isSyntacticMember)
-}
-
 // --- Rule definition ---
 
 var MemberOrderingRule = rule.CreateRule(rule.Rule{
@@ -1062,7 +1020,7 @@ var MemberOrderingRule = rule.CreateRule(rule.Rule{
 		}
 
 		validate := func(node *ast.Node) {
-			members := getClassMembers(node)
+			members := utils.ESTreeMembers(node.Members())
 			if members == nil {
 				return
 			}

--- a/internal/rules/accessor_pairs/accessor_pairs_test.go
+++ b/internal/rules/accessor_pairs/accessor_pairs_test.go
@@ -23,6 +23,25 @@ func TestAccessorPairsRule(t *testing.T) {
 		t,
 		&AccessorPairsRule,
 		[]rule_tester.ValidTestCase{
+			// Espree decodes JavaScript identifier/private-identifier token values,
+			// so escaped spellings still complete the same accessor pair.
+			{
+				Code:     `var o = { get [foo]() {}, set [\u0066oo](value) {} };`,
+				FileName: "accessor-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  bothOpts,
+			},
+			{
+				Code:     `class C { get #foo() {} set #\u0066oo(value) {} }`,
+				FileName: "accessor-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  classBoth,
+			},
+			// TypeScript parser tokens retain raw spelling. Identical raw escapes
+			// still pair even though escaped and unescaped spellings do not.
+			{Code: `var o = { get [\u0066oo]() {}, set [\u0066oo](value) {} };`, Options: bothOpts},
+			{Code: `class C { get #\u0066oo() {} set #\u0066oo(value) {} }`, Options: classBoth},
+
 			// Destructuring — not object literals semantically, not flagged
 			{Code: `var { get: foo } = bar; ({ set: foo } = bar);`, Options: bothOpts},
 			{Code: `var { set } = foo; ({ get } = foo);`, Options: bothOpts},
@@ -272,7 +291,6 @@ func TestAccessorPairsRule(t *testing.T) {
 
 			// `[/a/]` and string `'/a/'` both normalize to static name "/a/".
 			{Code: `var o = { get '/a/'() {}, set [/a/](v) {} };`, Options: bothOpts},
-
 		},
 		[]rule_tester.InvalidTestCase{
 			// Default — setter without getter
@@ -766,6 +784,48 @@ func TestAccessorPairsRule(t *testing.T) {
 					{MessageId: "missingSetterInType"},
 				},
 			},
+			// TypeScript token values keep escaped identifiers raw, so these are
+			// two incomplete pairs rather than one complete pair.
+			{
+				Code:    `interface I { get [foo](): string; set [\u0066oo](value: string); }`,
+				Options: tsGetAlso,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInType"},
+					{MessageId: "missingGetterInType"},
+				},
+			},
+			{
+				Code:    `class C { get #foo() {} set #\u0066oo(value) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass"},
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+			// TSMethodSignature reports end at the first real opening paren in
+			// the signature, even when that token belongs to its computed key.
+			{
+				Code:    `interface I { set [('a')](value: string); }`,
+				Options: tsOnly,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingGetterInType",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 20,
+				}},
+			},
+			{
+				Code:    `type T = { get [foo()](): string; };`,
+				Options: tsGetAlso,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingSetterInType",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 20,
+				}},
+			},
 
 			// ---- Structural mismatches (computed keys) ----
 
@@ -899,7 +959,7 @@ func TestAccessorPairsRule(t *testing.T) {
 			// Spread in descriptor: treated syntactically, only named properties are
 			// considered — so {...d, set: ...} still counts as "set without get".
 			{
-				Code:    `Object.defineProperty(o, 'k', {...d, set: function(v) {}});`,
+				Code: `Object.defineProperty(o, 'k', {...d, set: function(v) {}});`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "missingGetterInPropertyDescriptor"},
 				},
@@ -915,7 +975,7 @@ func TestAccessorPairsRule(t *testing.T) {
 			},
 			// Parenthesized Object.defineProperties callee with optional chain.
 			{
-				Code:    `(Object?.defineProperties)(obj, {foo: {set: function(v){}}});`,
+				Code: `(Object?.defineProperties)(obj, {foo: {set: function(v){}}});`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "missingGetterInPropertyDescriptor"},
 				},

--- a/internal/rules/accessorutil/accessor_key.go
+++ b/internal/rules/accessorutil/accessor_key.go
@@ -15,7 +15,7 @@ const (
 
 // Key preserves ESLint's three accessor-key equivalence classes. Static names
 // compare by their normalized property name, private names only compare with
-// private names, and dynamic computed names compare by their token streams.
+// private names, and private/dynamic names compare by their token streams.
 type Key struct {
 	Kind KeyKind
 	Text string
@@ -28,7 +28,7 @@ func MakeKey(node *ast.Node) Key {
 		return Key{Kind: KeyDynamic}
 	}
 	if nameNode.Kind == ast.KindPrivateIdentifier {
-		return Key{Kind: KeyPrivate, Text: nameNode.AsPrivateIdentifier().Text}
+		return Key{Kind: KeyPrivate, Expr: nameNode}
 	}
 	if name, ok := utils.GetStaticPropertyName(nameNode); ok {
 		return Key{Kind: KeyStatic, Text: name}
@@ -45,19 +45,19 @@ func KeysEqual(sourceFile *ast.SourceFile, left Key, right Key) bool {
 		return false
 	}
 	switch left.Kind {
-	case KeyStatic, KeyPrivate:
+	case KeyStatic:
 		return left.Text == right.Text
-	case KeyDynamic:
-		return computedKeysEqual(sourceFile, left.Expr, right.Expr)
+	case KeyPrivate, KeyDynamic:
+		return tokenKeysEqual(sourceFile, left.Expr, right.Expr)
 	default:
 		return false
 	}
 }
 
-// computedKeysEqual mirrors ESLint's token-list comparison. HasSameTokens
+// tokenKeysEqual mirrors ESLint's token-list comparison. HasSameTokens
 // removes only transparent outer parentheses, preserves nested parentheses,
 // and compares punctuation and operators that tsgo does not expose as child
 // nodes.
-func computedKeysEqual(sourceFile *ast.SourceFile, left *ast.Node, right *ast.Node) bool {
+func tokenKeysEqual(sourceFile *ast.SourceFile, left *ast.Node, right *ast.Node) bool {
 	return utils.HasSameTokens(sourceFile, left, right)
 }

--- a/internal/rules/grouped_accessor_pairs/grouped_accessor_pairs.go
+++ b/internal/rules/grouped_accessor_pairs/grouped_accessor_pairs.go
@@ -36,9 +36,11 @@ func parseOptions(options []any) Options {
 }
 
 type accessorGroup struct {
-	key     accessorutil.Key
-	getters []int
-	setters []int
+	key         accessorutil.Key
+	getterIndex int
+	setterIndex int
+	getterCount int
+	setterCount int
 }
 
 func accessorName(node *ast.Node) string {
@@ -89,18 +91,24 @@ func checkList(ctx rule.RuleContext, headLocator *utils.FunctionHeadRangeLocator
 			groupIndex = len(groups) - 1
 		}
 		if member.Kind == ast.KindGetAccessor {
-			groups[groupIndex].getters = append(groups[groupIndex].getters, index)
+			if groups[groupIndex].getterCount == 0 {
+				groups[groupIndex].getterIndex = index
+			}
+			groups[groupIndex].getterCount++
 		} else {
-			groups[groupIndex].setters = append(groups[groupIndex].setters, index)
+			if groups[groupIndex].setterCount == 0 {
+				groups[groupIndex].setterIndex = index
+			}
+			groups[groupIndex].setterCount++
 		}
 	}
 
 	for _, group := range groups {
-		if len(group.getters) != 1 || len(group.setters) != 1 {
+		if group.getterCount != 1 || group.setterCount != 1 {
 			continue
 		}
-		getterIndex := group.getters[0]
-		setterIndex := group.setters[0]
+		getterIndex := group.getterIndex
+		setterIndex := group.setterIndex
 		formerIndex, latterIndex := getterIndex, setterIndex
 		if setterIndex < getterIndex {
 			formerIndex, latterIndex = setterIndex, getterIndex
@@ -125,19 +133,6 @@ func typeAccessor(member *ast.Node) bool {
 	return member.Kind == ast.KindGetAccessor || member.Kind == ast.KindSetAccessor
 }
 
-// ESTree does not include empty class elements (`;`) in ClassBody.body, while
-// tsgo exposes them as SemicolonClassElement nodes. Remove them before using
-// member indexes to decide whether two accessors are adjacent.
-func estreeClassMembers(members []*ast.Node) []*ast.Node {
-	filtered := make([]*ast.Node, 0, len(members))
-	for _, member := range members {
-		if member.Kind != ast.KindSemicolonClassElement {
-			filtered = append(filtered, member)
-		}
-	}
-	return filtered
-}
-
 var GroupedAccessorPairsRule = rule.Rule{
 	Name:   "grouped-accessor-pairs",
 	Schema: rule.NewSchema(schemaJSON),
@@ -152,7 +147,7 @@ var GroupedAccessorPairsRule = rule.Rule{
 				}
 			},
 			ast.KindClassDeclaration: func(node *ast.Node) {
-				members := estreeClassMembers(node.Members())
+				members := utils.ESTreeMembers(node.Members())
 				checkList(ctx, headLocator, members, opts, func(member *ast.Node) bool {
 					return concreteAccessor(member) && !ast.IsStatic(member)
 				})

--- a/internal/rules/grouped_accessor_pairs/grouped_accessor_pairs_extras_test.go
+++ b/internal/rules/grouped_accessor_pairs/grouped_accessor_pairs_extras_test.go
@@ -17,6 +17,21 @@ func TestGroupedAccessorPairsExtras(t *testing.T) {
 		t,
 		&GroupedAccessorPairsRule,
 		[]rule_tester.ValidTestCase{
+			// TypeScript parser tokens retain escaped identifier spelling for
+			// computed and private keys, unlike Espree's decoded JS tokens.
+			{Code: `({ get [foo](){}, middle: true, set [\u0066oo](value){} })`},
+			{Code: `class C { #foo; get [this.#foo](){} middle(){} set [this.#\u0066oo](value){} }`},
+			{Code: `class C { get #foo(){} middle(){} set #\u0066oo(value){} }`},
+			{Code: `class C { get #\u0066oo(){} middle(){} set #\u{66}oo(value){} }`},
+			{
+				Code:    `declare const foo: unique symbol; interface I { get [foo](): string; middle: true; set [\u0066oo](value: string); }`,
+				Options: []any{"anyOrder", map[string]any{"enforceForTSTypes": true}},
+			},
+			{
+				Code:     `({ get [<div>&amp;</div>](){}, middle: true, set [<div>&</div>](value){} })`,
+				FileName: "grouped-token.tsx",
+			},
+
 			// ---- Dimension 4: receiver/expression wrappers ----
 			// Parentheses around the complete dynamic key are transparent.
 			{Code: `({ get [(key)](){}, set [key](value){} })`},
@@ -79,15 +94,46 @@ func TestGroupedAccessorPairsExtras(t *testing.T) {
 			{Code: `interface I { get a(): string; middle: true; set a(value: string); }`, Options: []any{"anyOrder", map[string]any{"enforceForTSTypes": false}}},
 		},
 		[]rule_tester.InvalidTestCase{
-			// Identifier tokens compare by their decoded value, so an escaped
-			// spelling still names the same dynamic accessor key.
+			// Espree exposes decoded Identifier/PrivateIdentifier token values.
 			{
-				Code:   `({ get [foo](){}, middle: true, set [\u0066oo](value){} })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
+				Code:     `({ get [foo](){}, middle: true, set [\u0066oo](value){} })`,
+				FileName: "grouped-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
 			},
 			{
-				Code:   `class C { #foo; get [this.#foo](){} middle(){} set [this.#\u0066oo](value){} }`,
+				Code:     `class C { #foo; get [this.#foo](){} middle(){} set [this.#\u0066oo](value){} }`,
+				FileName: "grouped-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
+			},
+			{
+				Code:     `class C { get #foo(){} middle(){} set #\u0066oo(value){} }`,
+				FileName: "grouped-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
+			},
+			// Identical raw TypeScript private spellings still form a pair.
+			{
+				Code:   `class C { get #\u0066oo(){} middle(){} set #\u0066oo(value){} }`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
+			},
+			// Non-computed property names remain statically decoded in TypeScript.
+			{
+				Code:   `class C { get foo(){} middle(){} set \u0066oo(value){} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
+			},
+			// JSX uses Espree's decoded JSXText token value; TSX retains raw text.
+			{
+				Code:     `({ get [<div>&amp;</div>](){}, middle: true, set [<div>&</div>](value){} })`,
+				FileName: "grouped-token.jsx",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
+			},
+			{
+				Code:     `({ get [<div>&amp;</div>](){}, middle: true, set [<div>&amp;</div>](value){} })`,
+				FileName: "grouped-token.tsx",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "notGrouped"}},
 			},
 			// Empty class elements do not take precedence over an order violation.
 			{
@@ -191,6 +237,30 @@ func TestGroupedAccessorPairsExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "notGrouped",
 					Message:   "Accessor pair getter 'null' and setter 'null' should be grouped.",
+				}},
+			},
+			// For TSMethodSignature, upstream ends the function head at the first
+			// real opening-paren token, including one inside a computed key.
+			{
+				Code:    `interface I { get ['a'](): string; middle: true; set [('a')](value: string); }`,
+				Options: []any{"anyOrder", map[string]any{"enforceForTSTypes": true}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "notGrouped",
+					Line:      1,
+					Column:    50,
+					EndLine:   1,
+					EndColumn: 55,
+				}},
+			},
+			{
+				Code:    `interface I { get [('a')](): string; set [('a')](value: string); }`,
+				Options: []any{"setBeforeGet", map[string]any{"enforceForTSTypes": true}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidOrder",
+					Line:      1,
+					Column:    38,
+					EndLine:   1,
+					EndColumn: 43,
 				}},
 			},
 		},

--- a/internal/rules/no_self_compare/no_self_compare_test.go
+++ b/internal/rules/no_self_compare/no_self_compare_test.go
@@ -15,6 +15,15 @@ func TestNoSelfCompareRule(t *testing.T) {
 		&NoSelfCompareRule,
 
 		[]rule_tester.ValidTestCase{
+			// @typescript-eslint/parser preserves raw identifier and JSXText token
+			// spelling, so decoded-equivalent source forms are not self-comparisons.
+			{Code: `foo === \u0066oo`},
+			{Code: `class C { #foo; compare() { return this.#foo === this.#\u0066oo; } }`},
+			{
+				Code:     `(<div>&amp;</div>) === (<div>&</div>)`,
+				FileName: "no-self-token.tsx",
+			},
+
 			// ---- Upstream ESLint suite ----
 			{Code: `if (x === y) { }`},
 			{Code: `if (1 === 2) { }`},
@@ -81,7 +90,7 @@ func TestNoSelfCompareRule(t *testing.T) {
 			{Code: `(x!) === (y!)`},
 
 			// ---- Token-form-sensitive (matches ESLint: different source tokens) ----
-			// HasSameTokens compares raw source at each leaf, so these are
+			// HasSameTokens compares literal source forms, so these are
 			// distinguished just like ESLint's token-level getTokens() would.
 			{Code: `0x1 === 1`},
 			{Code: `1n === 0x1n`},
@@ -91,6 +100,31 @@ func TestNoSelfCompareRule(t *testing.T) {
 		},
 
 		[]rule_tester.InvalidTestCase{
+			// Espree decodes JavaScript Identifier/PrivateIdentifier and JSXText
+			// token values before the rule compares them.
+			{
+				Code:     `foo === \u0066oo`,
+				FileName: "no-self-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "comparingToSelf"}},
+			},
+			{
+				Code:     `class C { #foo; compare() { return this.#foo === this.#\u0066oo; } }`,
+				FileName: "no-self-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "comparingToSelf"}},
+			},
+			{
+				Code:     `(<div>&amp;</div>) === (<div>&</div>)`,
+				FileName: "no-self-token.jsx",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "comparingToSelf"}},
+			},
+			{
+				Code:   `\u0066oo === \u0066oo`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparingToSelf"}},
+			},
+
 			// ---- Upstream ESLint suite ----
 			{
 				Code: `if (x === x) { }`,
@@ -102,12 +136,6 @@ func TestNoSelfCompareRule(t *testing.T) {
 				Code: `if (x !== x) { }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "comparingToSelf", Line: 1, Column: 5, EndLine: 1, EndColumn: 12},
-				},
-			},
-			{
-				Code: `class C { #foo; compare() { return this.#foo === this.#\u0066oo; } }`,
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "comparingToSelf"},
 				},
 			},
 			{

--- a/internal/rules/no_useless_call/no_useless_call_test.go
+++ b/internal/rules/no_useless_call/no_useless_call_test.go
@@ -14,6 +14,9 @@ func TestNoUselessCall(t *testing.T) {
 		t,
 		&NoUselessCallRule,
 		[]rule_tester.ValidTestCase{
+			// TypeScript parser tokens retain the escaped thisArg spelling.
+			{Code: `obj.foo.call(\u006fbj, 1, 2);`},
+
 			// `this` binding is different.
 			{Code: `foo.apply(obj, 1, 2);`},
 			{Code: `obj.foo.apply(null, 1, 2);`},
@@ -67,6 +70,14 @@ func TestNoUselessCall(t *testing.T) {
 			{Code: `foo.call.call(other, 1, 2);`},
 		},
 		[]rule_tester.InvalidTestCase{
+			// Espree decodes the escaped JavaScript Identifier token to `obj`.
+			{
+				Code:     `obj.foo.call(\u006fbj, 1, 2);`,
+				FileName: "no-useless-call-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "unnecessaryCall"}},
+			},
+
 			// ---- call ----
 			{
 				Code: `foo.call(undefined, 1, 2);`,

--- a/internal/rules/operator_assignment/operator_assignment.go
+++ b/internal/rules/operator_assignment/operator_assignment.go
@@ -161,7 +161,10 @@ func hasSameTypeSyntax(sourceFile *ast.SourceFile, left, right *ast.Node) bool {
 		scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, right, false) {
 		return true
 	}
-	return utils.HasSameTokens(sourceFile, left, right)
+	// Identifier escapes do not change a TypeScript type reference's meaning.
+	// Keep that semantic equivalence here even though the TS parser exposes raw
+	// identifier spellings to token-oriented ESLint rules.
+	return utils.HasSameTokensWithDecodedIdentifiers(sourceFile, left, right)
 }
 
 // hasSameAssertionStructure reports whether two already-matched references

--- a/internal/rules/operator_assignment/operator_assignment_extras_test.go
+++ b/internal/rules/operator_assignment/operator_assignment_extras_test.go
@@ -155,6 +155,23 @@ box[0 as keyof number[]] = box[0 as readonly number[]] + y;`,
 (box as { value: keyof /* lhs */ number[] }).value += y;`},
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "replaced", Line: 2, Column: 1}},
 			},
+			// Escapes do not change a TypeScript type identifier's meaning. This
+			// fixer safety check deliberately keeps decoded-identifier semantics,
+			// even though token-oriented rules observe raw TS parser values.
+			{
+				Code: `declare let box: any, y: any;
+(box as { value: Foo }).value = (box as { value: \u0046oo }).value + y;`,
+				Output: []string{`declare let box: any, y: any;
+(box as { value: Foo }).value += y;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "replaced", Line: 2, Column: 1}},
+			},
+			{
+				Code: `declare let box: any, y: any;
+(box as { value: \u0046oo }).value = (box as { value: \u0046oo }).value + y;`,
+				Output: []string{`declare let box: any, y: any;
+(box as { value: \u0046oo }).value += y;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "replaced", Line: 2, Column: 1}},
+			},
 			// ---- ... including when the mismatch is nested in the receiver of
 			// a member access rather than at the top level ----
 			{

--- a/internal/rules/prefer_spread/prefer_spread_test.go
+++ b/internal/rules/prefer_spread/prefer_spread_test.go
@@ -15,6 +15,9 @@ func TestPreferSpreadRule(t *testing.T) {
 		&PreferSpreadRule,
 		// Valid cases - ported from ESLint
 		[]rule_tester.ValidTestCase{
+			// TypeScript parser tokens retain the escaped thisArg spelling.
+			{Code: `obj.foo.apply(\u006fbj, args);`},
+
 			{Code: `foo.apply(obj, args);`},
 			{Code: `obj.foo.apply(null, args);`},
 			{Code: `obj.foo.apply(otherObj, args);`},
@@ -71,6 +74,14 @@ func TestPreferSpreadRule(t *testing.T) {
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
+			// Espree decodes the escaped JavaScript Identifier token to `obj`.
+			{
+				Code:     `obj.foo.apply(\u006fbj, args);`,
+				FileName: "prefer-spread-token.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "preferSpread"}},
+			},
+
 			// Lock in exact message text + full reported range (the rule emits
 			// a single messageId with no modifier combinations).
 			{

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -439,6 +439,27 @@ func ESTreeParent(node *ast.Node) *ast.Node {
 	return nil
 }
 
+// ESTreeMembers removes empty class elements, which tsgo exposes as
+// SemicolonClassElement nodes but ESTree omits from ClassBody.body. The common
+// no-semicolon path returns the AST-owned slice without allocating; filtering
+// clones into a separate backing array so callers cannot rewrite that list.
+func ESTreeMembers(members []*ast.Node) []*ast.Node {
+	for index, member := range members {
+		if member.Kind != ast.KindSemicolonClassElement {
+			continue
+		}
+		filtered := make([]*ast.Node, 0, len(members)-1)
+		filtered = append(filtered, members[:index]...)
+		for _, remaining := range members[index+1:] {
+			if remaining.Kind != ast.KindSemicolonClassElement {
+				filtered = append(filtered, remaining)
+			}
+		}
+		return filtered
+	}
+	return members
+}
+
 // ESTreeParameters returns only parameters authored in source. tsgo prepends
 // a reparsed `this` parameter for JSDoc @this, but ESTree keeps the tag solely
 // as a comment.

--- a/internal/utils/ast_helpers_test.go
+++ b/internal/utils/ast_helpers_test.go
@@ -31,3 +31,25 @@ func TestOutermostParenthesizedExpression(t *testing.T) {
 		t.Fatal("nil input should return nil")
 	}
 }
+
+func TestESTreeMembers(t *testing.T) {
+	t.Parallel()
+
+	first := &ast.Node{Kind: ast.KindMethodDeclaration}
+	second := &ast.Node{Kind: ast.KindPropertyDeclaration}
+	empty := &ast.Node{Kind: ast.KindSemicolonClassElement}
+
+	withoutEmpty := []*ast.Node{first, second}
+	if got := ESTreeMembers(withoutEmpty); &got[0] != &withoutEmpty[0] {
+		t.Fatal("member slice without empty elements should be returned unchanged")
+	}
+
+	withEmpty := []*ast.Node{empty, first, empty, second, empty}
+	got := ESTreeMembers(withEmpty)
+	if len(got) != 2 || got[0] != first || got[1] != second {
+		t.Fatalf("ESTreeMembers() = %v, want [%p %p]", got, first, second)
+	}
+	if len(withEmpty) != 5 || withEmpty[0] != empty || withEmpty[2] != empty || withEmpty[4] != empty {
+		t.Fatal("filtering members mutated the AST-owned input slice")
+	}
+}

--- a/internal/utils/ecmascript/jsx_text.go
+++ b/internal/utils/ecmascript/jsx_text.go
@@ -1,0 +1,134 @@
+package ecmascript
+
+import (
+	"unicode/utf16"
+
+	jsxtx "github.com/microsoft/typescript-go/shim/transformers/jsxtransforms"
+)
+
+// JSXTextTokenValuesEqual reports whether two raw JSX text spans produce the
+// same token value in Espree. acorn-jsx decodes XHTML entities and folds source
+// CRLF pairs to LF while reading JSX text. Numeric entities use
+// String.fromCharCode semantics, so comparison has to happen in UTF-16 code
+// units rather than Go runes.
+func JSXTextTokenValuesEqual(left, right string) bool {
+	if left == right {
+		return true
+	}
+
+	leftUnits := jsxTextCodeUnits{raw: left}
+	rightUnits := jsxTextCodeUnits{raw: right}
+	for {
+		leftUnit, leftOK := leftUnits.next()
+		rightUnit, rightOK := rightUnits.next()
+		if leftOK != rightOK {
+			return false
+		}
+		if !leftOK {
+			return true
+		}
+		if leftUnit != rightUnit {
+			return false
+		}
+	}
+}
+
+type jsxTextCodeUnits struct {
+	raw        string
+	pos        int
+	pending    uint16
+	hasPending bool
+}
+
+func (it *jsxTextCodeUnits) next() (uint16, bool) {
+	if it.hasPending {
+		it.hasPending = false
+		return it.pending, true
+	}
+	if it.pos >= len(it.raw) {
+		return 0, false
+	}
+
+	switch it.raw[it.pos] {
+	case '&':
+		first, second, count, next, ok := decodeJSXTextEntity(it.raw, it.pos)
+		if ok {
+			it.pos = next
+			if count == 2 {
+				it.pending = second
+				it.hasPending = true
+			}
+			return first, true
+		}
+		// acorn-jsx restores its cursor to immediately after an invalid or
+		// unterminated entity's ampersand, then reads the remaining text again.
+		it.pos++
+		return '&', true
+	case '\r':
+		if it.pos+1 < len(it.raw) && it.raw[it.pos+1] == '\n' {
+			it.pos += 2
+			return '\n', true
+		}
+	}
+
+	r, size := decodeStringRune(it.raw[it.pos:])
+	it.pos += size
+	if r > 0xFFFF {
+		high, low := utf16.EncodeRune(r)
+		it.pending = uint16(low)
+		it.hasPending = true
+		return uint16(high), true
+	}
+	return uint16(r), true
+}
+
+// decodeJSXTextEntity mirrors acorn-jsx's jsx_readEntity. The semicolon must
+// occur within ten UTF-16 code units after the ampersand, and is itself one of
+// those ten units. Invalid entities leave the caller positioned after '&'.
+func decodeJSXTextEntity(raw string, ampersand int) (first, second uint16, count, next int, ok bool) {
+	entityStart := ampersand + 1
+	pos := entityStart
+	unitsRead := 0
+	for pos < len(raw) && unitsRead < 10 {
+		r, size := decodeStringRune(raw[pos:])
+		width := 1
+		if r > 0xFFFF {
+			width = 2
+		}
+		if unitsRead+width > 10 {
+			break
+		}
+		unitsRead += width
+		pos += size
+		if r != ';' {
+			continue
+		}
+
+		first, second, count, ok = decodeJSXEntityValue(raw[entityStart : pos-size])
+		if !ok {
+			return 0, 0, 0, 0, false
+		}
+		return first, second, count, pos, true
+	}
+	return 0, 0, 0, 0, false
+}
+
+func decodeJSXEntityValue(entity string) (first, second uint16, count int, ok bool) {
+	if len(entity) == 0 {
+		return 0, 0, 0, false
+	}
+	decoded, ok := jsxtx.DecodeEntity(entity)
+	if !ok {
+		return 0, 0, 0, false
+	}
+	if entity[0] == '#' {
+		// acorn-jsx turns numeric entities into exactly one UTF-16 code unit
+		// with String.fromCharCode, including values above the BMP.
+		return uint16(decoded), 0, 1, true
+	}
+	if decoded <= 0xFFFF {
+		return uint16(decoded), 0, 1, true
+	}
+	high, low := utf16.EncodeRune(decoded)
+	return uint16(high), uint16(low), 2, true
+}

--- a/internal/utils/ecmascript/jsx_text_test.go
+++ b/internal/utils/ecmascript/jsx_text_test.go
@@ -1,0 +1,46 @@
+package ecmascript
+
+import "testing"
+
+func TestJSXTextTokenValuesEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		left, right string
+		want        bool
+	}{
+		{name: "identical raw", left: "plain text", right: "plain text", want: true},
+		{name: "named entity", left: "&amp;", right: "&", want: true},
+		{name: "decimal entity", left: "&#65;", right: "A", want: true},
+		{name: "hex entity", left: "&#x41;", right: "A", want: true},
+		{name: "uppercase hex marker is invalid", left: "&#X41;", right: "A", want: false},
+		{name: "semicolon is required", left: "&amp", right: "&", want: false},
+		{name: "tenth unit may be semicolon", left: "&#00000000;", right: "\x00", want: true},
+		{name: "largest decimal at tenth unit", left: "&#99999999;", right: "\uE0FF", want: true},
+		{name: "largest hex at tenth unit", left: "&#xFFFFFFF;", right: "\uFFFF", want: true},
+		{name: "semicolon after tenth unit is too late", left: "&#000000000;", right: "\x00", want: false},
+		{name: "invalid decimal digits stay raw", left: "&#12a;", right: "\f", want: false},
+		{name: "invalid hex digits stay raw", left: "&#x1g;", right: "\x01", want: false},
+		{name: "invalid entity resumes after ampersand", left: "&bogus;&amp;", right: "&bogus;&", want: true},
+		{name: "adjacent ampersands", left: "&&amp;", right: "&&", want: true},
+		{name: "source CRLF folds", left: "left\r\nright", right: "left\nright", want: true},
+		{name: "lone source CR remains", left: "left\rright", right: "left\nright", want: false},
+		{name: "entity CR does not fold", left: "&#13;\n", right: "\r\n", want: false},
+		{name: "fromCharCode truncates astral numeric entity", left: "&#x1F4A9;", right: "\uF4A9", want: true},
+		{name: "single astral numeric entity is not the astral character", left: "&#x1F4A9;", right: "💩", want: false},
+		{name: "surrogate entity pair equals astral character", left: "&#xD83D;&#xDCA9;", right: "💩", want: true},
+		{name: "lone surrogate preserves its code unit", left: "&#xD83D;", right: "&#55357;", want: true},
+		{name: "different lone surrogates differ", left: "&#xD83D;", right: "&#xD83E;", want: false},
+		{name: "numeric NUL", left: "a&#0;b", right: "a\x00b", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := JSXTextTokenValuesEqual(tt.left, tt.right); got != tt.want {
+				t.Errorf("JSXTextTokenValuesEqual(%q, %q) = %v, want %v", tt.left, tt.right, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/utils/function_head_loc_test.go
+++ b/internal/utils/function_head_loc_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -61,5 +63,63 @@ func TestGetFunctionHeadLocConstructorWithDecoratorFactory(t *testing.T) {
 	// keyword up to (but not including) the parameter `(`.
 	if strings.TrimSpace(got) != "constructor" {
 		t.Fatalf("unexpected head range text: %q (pos=%d end=%d)", got, r.Pos(), r.End())
+	}
+}
+
+func TestGetFunctionHeadLocTypeAccessorComputedKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+		want string
+	}{
+		{name: "interface parenthesized key", code: `interface I { set [('a')](value: string); }`, want: `set [`},
+		{name: "type literal call key", code: `type T = { get [foo()](): string; };`, want: `get [foo`},
+		{name: "optional call key", code: `interface I { set [foo?.()](value: string); }`, want: `set [foo?.`},
+		{name: "comment fake paren", code: `interface I { set [/* ( */ 'a'](value: string); }`, want: `set [/* ( */ 'a']`},
+		{name: "string fake paren", code: `interface I { set ['('](value: string); }`, want: `set ['(']`},
+		{name: "regexp fake paren", code: `interface I { set [/a(b)/](value: string); }`, want: `set [/a(b)/]`},
+		{name: "template text fake paren", code: "interface I { set [`(`](value: string); }", want: "set [`(`]"},
+		{name: "template expression call", code: "interface I { set [`${foo()}`](value: string); }", want: "set [`${foo"},
+		{name: "multiline call key", code: "interface I {\n  set [\n    foo()\n  ](value: string);\n}", want: "set [\n    foo"},
+		{name: "declare class keeps complete key", code: `declare class C { set [('a')](value: string); }`, want: `set [('a')]`},
+		{name: "class keeps complete key", code: `class C { set [('a')](value: string) {} }`, want: `set [('a')]`},
+		{name: "object keeps complete key", code: `({ set [('a')](value: string) {} })`, want: `set [('a')]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/file.ts",
+				Path:     "/file.ts",
+			}, tt.code, core.ScriptKindTS)
+
+			var accessor *ast.Node
+			var walk func(*ast.Node) bool
+			walk = func(node *ast.Node) bool {
+				if node == nil {
+					return false
+				}
+				if node.Kind == ast.KindGetAccessor || node.Kind == ast.KindSetAccessor {
+					accessor = node
+					return true
+				}
+				return node.ForEachChild(walk)
+			}
+			walk(sourceFile.AsNode())
+			if accessor == nil {
+				t.Fatal("accessor not found")
+			}
+
+			range_ := utils.GetFunctionHeadLoc(sourceFile, accessor)
+			if range_.Pos() > range_.End() {
+				t.Fatalf("inverted range: [%d,%d)", range_.Pos(), range_.End())
+			}
+			if got := strings.TrimLeft(sourceFile.Text()[range_.Pos():range_.End()], " \t"); got != tt.want {
+				t.Fatalf("head text = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"gotest.tools/v3/assert"
@@ -20,7 +22,20 @@ func parseBinaryOperands(t *testing.T, code string) (*ast.SourceFile, *ast.Node,
 	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
 	assert.NilError(t, err, "couldn't create program for code: "+code)
 	sourceFile := program.GetSourceFile(filePath)
+	return findBinaryOperands(t, sourceFile, code)
+}
 
+func parseBinaryOperandsForKind(t *testing.T, code string, scriptKind core.ScriptKind) (*ast.SourceFile, *ast.Node, *ast.Node) {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/file",
+		Path:     "/file",
+	}, code, scriptKind)
+	return findBinaryOperands(t, sourceFile, code)
+}
+
+func findBinaryOperands(t *testing.T, sourceFile *ast.SourceFile, code string) (*ast.SourceFile, *ast.Node, *ast.Node) {
+	t.Helper()
 	var bin *ast.Node
 	var find func(node *ast.Node) bool
 	find = func(node *ast.Node) bool {
@@ -56,9 +71,9 @@ func TestHasSameTokens(t *testing.T) {
 	}{
 		// ---- Basic equality / inequality ----
 		{"identifier equal", `x === x`, true},
-		{"identifier escape equal", `foo === \u0066oo`, true},
+		{"identifier escape differs in TypeScript tokens", `foo === \u0066oo`, false},
 		{"identifier differ", `x === y`, false},
-		{"private identifier escape equal", `this.#foo === this.#\u0066oo`, true},
+		{"private identifier escape differs in TypeScript tokens", `this.#foo === this.#\u0066oo`, false},
 		{"private identifier differ", `this.#foo === this.#bar`, false},
 		{"numeric equal", `1 === 1`, true},
 		{"numeric differ", `1 === 2`, false},
@@ -183,6 +198,76 @@ func TestHasSameTokens(t *testing.T) {
 	}
 }
 
+func TestHasSameTokensParserDialect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		scriptKind core.ScriptKind
+		want       bool
+	}{
+		{name: "JavaScript identifier is decoded", code: `foo === \u0066oo`, scriptKind: core.ScriptKindJS, want: true},
+		{name: "JSX identifier is decoded", code: `foo === \u0066oo`, scriptKind: core.ScriptKindJSX, want: true},
+		{name: "TypeScript identifier stays raw", code: `foo === \u0066oo`, scriptKind: core.ScriptKindTS, want: false},
+		{name: "TSX identifier stays raw", code: `foo === \u0066oo`, scriptKind: core.ScriptKindTSX, want: false},
+		{name: "same TypeScript escape stays equal", code: `\u0066oo === \u0066oo`, scriptKind: core.ScriptKindTS, want: true},
+		{name: "different TypeScript escapes with equal width differ", code: `\u0066oo === f\u006Fo`, scriptKind: core.ScriptKindTS, want: false},
+		{name: "different JavaScript escapes decode equally", code: `\u0066oo === f\u006Fo`, scriptKind: core.ScriptKindJS, want: true},
+		{name: "JavaScript private identifier is decoded", code: `this.#foo === this.#\u0066oo`, scriptKind: core.ScriptKindJS, want: true},
+		{name: "TypeScript private identifier stays raw", code: `this.#foo === this.#\u0066oo`, scriptKind: core.ScriptKindTS, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sourceFile, left, right := parseBinaryOperandsForKind(t, tt.code, tt.scriptKind)
+			if got := HasSameTokens(sourceFile, left, right); got != tt.want {
+				t.Errorf("HasSameTokens(%q) = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasSameTokensWithDecodedIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	sourceFile, left, right := parseBinaryOperandsForKind(t, `Foo === \u0046oo`, core.ScriptKindTS)
+	if !HasSameTokensWithDecodedIdentifiers(sourceFile, left, right) {
+		t.Fatal("decoded-identifier comparison treated equivalent TypeScript identifier escapes as different")
+	}
+}
+
+func TestHasSameTokensJSXTextParserDialect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		scriptKind core.ScriptKind
+		want       bool
+	}{
+		{name: "JSX decodes named entity", code: `(<div>&amp;</div>) === (<div>&</div>)`, scriptKind: core.ScriptKindJSX, want: true},
+		{name: "TSX preserves named entity", code: `(<div>&amp;</div>) === (<div>&</div>)`, scriptKind: core.ScriptKindTSX, want: false},
+		{name: "JSX folds source CRLF", code: "(<div>a\r\nb</div>) === (<div>a\nb</div>)", scriptKind: core.ScriptKindJSX, want: true},
+		{name: "TSX preserves source CRLF", code: "(<div>a\r\nb</div>) === (<div>a\nb</div>)", scriptKind: core.ScriptKindTSX, want: false},
+		{name: "JSX text kinds share one token type", code: `(<div>&#32;</div>) === (<div> </div>)`, scriptKind: core.ScriptKindJSX, want: true},
+		{name: "TSX text kinds retain raw values", code: `(<div>&#32;</div>) === (<div> </div>)`, scriptKind: core.ScriptKindTSX, want: false},
+		{name: "JSX compares surrogate pairs as code units", code: `(<div>&#xD83D;&#xDCA9;</div>) === (<div>💩</div>)`, scriptKind: core.ScriptKindJSX, want: true},
+		{name: "TSX keeps surrogate entities raw", code: `(<div>&#xD83D;&#xDCA9;</div>) === (<div>💩</div>)`, scriptKind: core.ScriptKindTSX, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sourceFile, left, right := parseBinaryOperandsForKind(t, tt.code, tt.scriptKind)
+			if got := HasSameTokens(sourceFile, left, right); got != tt.want {
+				t.Errorf("HasSameTokens(%q) = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestHasSameTokensFullAudit is a systematic sweep of every class of
 // divergence I can think of between tsgo's AST structure and ESLint's
 // token-level view. Any regression here indicates either a newly-found
@@ -234,7 +319,7 @@ func TestHasSameTokensFullAudit(t *testing.T) {
 		{`0b1 === 1`, false, "binary vs decimal"},
 		{`0o7 === 7`, false, "octal vs decimal"},
 		{`1_000 === 1000`, false, "underscore separator visible"},
-		{`foo === \u0066oo`, true, "identifier token value decodes unicode escapes"},
+		{`foo === \u0066oo`, false, "TypeScript identifier token value preserves unicode escapes"},
 
 		// Null / undefined
 		{`null === null`, true, "null keyword self"},

--- a/internal/utils/ts_api_utils.go
+++ b/internal/utils/ts_api_utils.go
@@ -321,11 +321,22 @@ func IsStrictCompilerOptionEnabled(
 // @param node The node whose tokens should be visited
 // @param callback Is called for every token contained in `node`
 func ForEachToken(node *ast.Node, callback func(token *ast.Node), sourceFile *ast.SourceFile) {
+	forEachToken(node, func(token *ast.Node) bool {
+		callback(token)
+		return false
+	}, sourceFile)
+}
+
+// forEachToken is the short-circuiting core used when a caller only needs the
+// first matching token. Returning true from callback stops the traversal.
+func forEachToken(node *ast.Node, callback func(token *ast.Node) bool, sourceFile *ast.SourceFile) bool {
 	queue := make([]*ast.Node, 0)
 
 	for {
 		if ast.IsTokenKind(node.Kind) {
-			callback(node)
+			if callback(node) {
+				return true
+			}
 		} else {
 			children := GetChildren(node, sourceFile)
 			for i := len(children) - 1; i >= 0; i-- {
@@ -334,7 +345,7 @@ func ForEachToken(node *ast.Node, callback func(token *ast.Node), sourceFile *as
 		}
 
 		if len(queue) == 0 {
-			break
+			return false
 		}
 
 		node = queue[len(queue)-1]

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -200,6 +200,17 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 	switch node.Kind {
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
 		start := NodeTextRangeSkippingDecorators(sourceFile, node)
+		// @typescript-eslint represents accessors directly owned by an
+		// interface or type literal as TSMethodSignature nodes. Its function-head
+		// helper searches the complete signature for the first real `(` token, so
+		// a parenthesized or call-expression computed key can end the range before
+		// the parameter list. Use the parsed token tree here: a raw scanner would
+		// misread `(` inside a regular-expression literal as punctuation.
+		if isTypeAccessorSignature(node) {
+			if parenPos := findFirstParsedOpenParenStart(sourceFile, node, start.Pos()); parenPos >= 0 {
+				return start.WithEnd(parenPos)
+			}
+		}
 		// Start scanning for the parameters `(` after any decorator factory
 		// (e.g. `@dec()`) and after the method name. Nameless constructors
 		// fall back to the first token after the decorators.
@@ -954,6 +965,36 @@ func findOpenParenPosFrom(sourceFile *ast.SourceFile, start int, end int) int {
 		s.Scan()
 	}
 	return -1
+}
+
+func isTypeAccessorSignature(node *ast.Node) bool {
+	if node.Kind != ast.KindGetAccessor && node.Kind != ast.KindSetAccessor {
+		return false
+	}
+	parent := node.Parent
+	return parent != nil &&
+		(parent.Kind == ast.KindInterfaceDeclaration || parent.Kind == ast.KindTypeLiteral)
+}
+
+// findFirstParsedOpenParenStart walks parser-owned children in source order. The
+// parsed tree preserves lexical context for regular expressions and templates,
+// unlike scanning an arbitrary source range from scratch.
+func findFirstParsedOpenParenStart(sourceFile *ast.SourceFile, node *ast.Node, minimum int) int {
+	sourceText := sourceFile.Text()
+	parenPos := -1
+	forEachToken(node, func(token *ast.Node) bool {
+		if token.Kind != ast.KindOpenParenToken || ast.NodeIsMissing(token) || token.Flags&ast.NodeFlagsSynthesized != 0 {
+			return false
+		}
+		trimmed := TrimNodeTextRange(sourceFile, token)
+		if trimmed.Pos() < minimum || trimmed.Pos() >= trimmed.End() ||
+			trimmed.End() > len(sourceText) || sourceText[trimmed.Pos()] != '(' {
+			return false
+		}
+		parenPos = trimmed.Pos()
+		return true
+	}, sourceFile)
+	return parenPos
 }
 
 // findFunctionKeywordPos returns the start position of the function head,
@@ -2537,10 +2578,11 @@ func AreNodesStructurallyEqual(a, b *ast.Node) bool {
 	return true
 }
 
-// HasSameTokens reports whether two nodes produce the same token stream when
-// viewed at the raw-source level — matching ESLint's
-// `sourceCode.getTokens(a)` vs `sourceCode.getTokens(b)` semantics, which
-// preserves the original source form of each literal. Unlike
+// HasSameTokens reports whether two nodes produce the same parser token stream,
+// matching ESLint's `sourceCode.getTokens(a)` vs `sourceCode.getTokens(b)`
+// semantics. Literal spellings remain source-sensitive; Identifier,
+// PrivateIdentifier, and JSXText values follow the parser dialect exposed for
+// the source file (Espree for JS/JSX, typescript-eslint for TS/TSX). Unlike
 // [AreNodesStructurallyEqual], this helper distinguishes:
 //
 //   - `'a'` vs `"a"` (different quote style)
@@ -2550,8 +2592,8 @@ func AreNodesStructurallyEqual(a, b *ast.Node) bool {
 //
 // Implementation: we recurse on the AST using [ast.SkipParentheses] and
 // [ast.Node.ForEachChild]. At leaf nodes (no children — identifiers,
-// literals, keyword tokens) we compare the raw source slice via
-// [scanner.GetSourceTextOfNodeFromSourceFile]. For composite nodes we
+// literals, keyword tokens) we compare their parser-visible token values. For
+// composite nodes we
 // recurse on children pairwise AND scan the "gaps" between children
 // (and before/after the first/last child) with [scanner.Scanner] to pick
 // up punctuation, keyword tokens, and operators that tsgo's ForEachChild
@@ -2582,16 +2624,54 @@ func HasSameTokens(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	return hasSameTokens(sourceFile, ast.SkipParentheses(a), ast.SkipParentheses(b))
+	return hasSameTokens(sourceFile, ast.SkipParentheses(a), ast.SkipParentheses(b), compareParserIdentifierValues)
 }
+
+// HasSameTokensWithDecodedIdentifiers compares the same token structure as
+// [HasSameTokens], but treats escaped Identifier and PrivateIdentifier
+// spellings with the same decoded text as equal in every script kind. It is
+// intended for semantic safety checks where an identifier escape cannot
+// change the meaning of generated code; it does not model TypeScript parser
+// token equality.
+func HasSameTokensWithDecodedIdentifiers(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return hasSameTokens(sourceFile, ast.SkipParentheses(a), ast.SkipParentheses(b), compareDecodedIdentifierValues)
+}
+
+type identifierTokenComparison uint8
+
+const (
+	compareParserIdentifierValues identifierTokenComparison = iota
+	compareDecodedIdentifierValues
+)
 
 // hasSameTokens is the recursive core. It does NOT call SkipParentheses
 // on its inputs — parens nested inside a compound expression are visible
 // tokens in ESLint's per-node getTokens view (e.g. `(x).y` has tokens
 // `[(, x, ), ., y]`), so a recursive paren strip would collapse them.
-func hasSameTokens(sf *ast.SourceFile, a, b *ast.Node) bool {
+func hasSameTokens(sf *ast.SourceFile, a, b *ast.Node, identifiers identifierTokenComparison) bool {
 	if a == nil || b == nil {
 		return a == b
+	}
+	if isJSXTextKind(a.Kind) || isJSXTextKind(b.Kind) {
+		if !isJSXTextKind(a.Kind) || !isJSXTextKind(b.Kind) {
+			return false
+		}
+		left := sf.Text()[a.Pos():a.End()]
+		right := sf.Text()[b.Pos():b.End()]
+		switch sf.ScriptKind {
+		case core.ScriptKindJS, core.ScriptKindJSX:
+			return ecmascript.JSXTextTokenValuesEqual(left, right)
+		case core.ScriptKindTS, core.ScriptKindTSX:
+			// @typescript-eslint/parser exposes the unmodified source spelling.
+			return left == right
+		default:
+			// Preserve the previous raw-text and exact-kind behavior for script
+			// kinds that do not map to either supported parser dialect.
+			return a.Kind == b.Kind && left == right
+		}
 	}
 	if a.Kind != b.Kind {
 		return false
@@ -2615,11 +2695,21 @@ func hasSameTokens(sf *ast.SourceFile, a, b *ast.Node) bool {
 		case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
 			return sameTokensInRange(sf, a.Pos(), a.End(), b.Pos(), b.End())
 		case ast.KindIdentifier:
-			// ESLint exposes the decoded token value, so escaped and unescaped
-			// spellings of the same identifier compare equal.
-			return a.AsIdentifier().Text == b.AsIdentifier().Text
+			if a.AsIdentifier().Text != b.AsIdentifier().Text {
+				return false
+			}
+			return identifiers == compareDecodedIdentifierValues ||
+				!usesRawIdentifierTokenValues(sf) ||
+				scanner.GetSourceTextOfNodeFromSourceFile(sf, a, false) ==
+					scanner.GetSourceTextOfNodeFromSourceFile(sf, b, false)
 		case ast.KindPrivateIdentifier:
-			return a.AsPrivateIdentifier().Text == b.AsPrivateIdentifier().Text
+			if a.AsPrivateIdentifier().Text != b.AsPrivateIdentifier().Text {
+				return false
+			}
+			return identifiers == compareDecodedIdentifierValues ||
+				!usesRawIdentifierTokenValues(sf) ||
+				scanner.GetSourceTextOfNodeFromSourceFile(sf, a, false) ==
+					scanner.GetSourceTextOfNodeFromSourceFile(sf, b, false)
 		}
 		return scanner.GetSourceTextOfNodeFromSourceFile(sf, a, false) ==
 			scanner.GetSourceTextOfNodeFromSourceFile(sf, b, false)
@@ -2644,12 +2734,20 @@ func hasSameTokens(sf *ast.SourceFile, a, b *ast.Node) bool {
 		if !sameTokensInRange(sf, prevA, aKids[i].Pos(), prevB, bKids[i].Pos()) {
 			return false
 		}
-		if !hasSameTokens(sf, aKids[i], bKids[i]) {
+		if !hasSameTokens(sf, aKids[i], bKids[i], identifiers) {
 			return false
 		}
 		prevA, prevB = aKids[i].End(), bKids[i].End()
 	}
 	return sameTokensInRange(sf, prevA, a.End(), prevB, b.End())
+}
+
+func usesRawIdentifierTokenValues(sourceFile *ast.SourceFile) bool {
+	return sourceFile.ScriptKind == core.ScriptKindTS || sourceFile.ScriptKind == core.ScriptKindTSX
+}
+
+func isJSXTextKind(kind ast.Kind) bool {
+	return kind == ast.KindJsxText || kind == ast.KindJsxTextAllWhiteSpaces
 }
 
 func collectKids(n *ast.Node) []*ast.Node {


### PR DESCRIPTION
## Summary

- align shared token equality with Espree for JavaScript/JSX and @typescript-eslint/parser for TypeScript/TSX, including escaped identifiers, private identifiers, and JSX text
- match ESLint function-head ranges for interface and type-literal accessors whose computed keys contain parentheses
- preserve operator-assignment fixer semantics, reduce grouped-accessor allocation overhead, and add regression coverage across every shared-helper consumer
- validate compatibility against ESLint 10.9.1, @typescript-eslint/parser 8.68.0, and TypeScript 6.0.3

## Related Links

<!-- No related issue. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).