### PR TITLE
fix: refresh playground diagnostics after edits

### DIFF
--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -28,6 +28,7 @@ const Playground: React.FC = () => {
   const lastSourceTextRef = useRef<string>('');
   const [loading, setLoading] = useState(true);
   const lintTimer = useRef<number | null>(null);
+  const latestLintRunIdRef = useRef(0);
   const [selectedAstRange, setSelectedAstRange] = useState<
     { start: number; end: number; kind?: number } | undefined
   >();
@@ -61,13 +62,19 @@ const Playground: React.FC = () => {
     return () => controller.abort();
   }, []);
 
-  async function runLint(version = selectedVersion) {
-    if (!version) return;
+  function isCurrentLintRun(runId: number, version: string) {
+    return (
+      latestLintRunIdRef.current === runId &&
+      selectedVersionRef.current === version
+    );
+  }
+
+  async function runLint(version: string, runId: number) {
     try {
       setError(undefined);
       if (!initialized) setLoading(true);
       const service = await ensureWasmService(version);
-      if (selectedVersionRef.current !== version) return;
+      if (!isCurrentLintRun(runId, version)) return;
       const code = editorRef.current?.getValue() ?? '';
       const rslintConfig = editorRef.current?.getRslintConfig();
       const tsConfig = editorRef.current?.getTsConfig();
@@ -95,7 +102,7 @@ const Playground: React.FC = () => {
           : undefined,
         configDirectory: '/',
       });
-      if (selectedVersionRef.current !== version) return;
+      if (!isCurrentLintRun(runId, version)) return;
       setInitialized(true);
 
       // Convert diagnostics to the expected format
@@ -171,28 +178,33 @@ const Playground: React.FC = () => {
         await buildTypeScriptAst(lastSourceTextRef.current);
       }
     } catch (err) {
-      if (selectedVersionRef.current !== version) return;
+      if (!isCurrentLintRun(runId, version)) return;
       const errorMessage = err instanceof Error ? err.message : String(err);
       setError(`Linting failed: ${errorMessage}`);
     } finally {
-      if (selectedVersionRef.current === version) setLoading(false);
+      if (isCurrentLintRun(runId, version)) setLoading(false);
     }
   }
 
   // Debounce linting to reduce recomputation while typing (1 second delay)
   function scheduleRunLint() {
+    // Invalidate an in-flight result as soon as its input becomes stale.
+    const runId = ++latestLintRunIdRef.current;
     if (lintTimer.current) {
       window.clearTimeout(lintTimer.current);
       lintTimer.current = null;
     }
     lintTimer.current = window.setTimeout(() => {
-      runLint();
+      lintTimer.current = null;
+      const version = selectedVersionRef.current;
+      if (version) void runLint(version, runId);
     }, 1000);
   }
 
   // Cleanup any pending timers on unmount
   useEffect(() => {
     return () => {
+      latestLintRunIdRef.current++;
       if (lintTimer.current) {
         window.clearTimeout(lintTimer.current);
         lintTimer.current = null;
@@ -202,6 +214,11 @@ const Playground: React.FC = () => {
 
   useEffect(() => {
     selectedVersionRef.current = selectedVersion;
+    const runId = ++latestLintRunIdRef.current;
+    if (lintTimer.current) {
+      window.clearTimeout(lintTimer.current);
+      lintTimer.current = null;
+    }
     if (!selectedVersion) return;
     setInitialized(false);
     setDiagnostics([]);
@@ -210,7 +227,7 @@ const Playground: React.FC = () => {
     setTsAstTree(undefined);
     setAstInfo(null);
     setLoading(true);
-    void runLint(selectedVersion);
+    void runLint(selectedVersion, runId);
   }, [selectedVersion]);
 
   // Get AST info at a specific position - updates global state for main panel

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -2,6 +2,7 @@ import {
   useState,
   useRef,
   useEffect,
+  useLayoutEffect,
   useImperativeHandle,
   Ref,
   ReactNode,
@@ -122,10 +123,21 @@ export const EditorTabs = ({
   const hoverHighlightDecorationIds = useRef<string[]>([]);
   const isEditingRef = useRef<boolean>(false);
   const editingTimer = useRef<number | null>(null);
+  const onChangeRef = useRef(onChange);
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  const onConfigChangeRef = useRef(onConfigChange);
 
   // Store last valid parsed configs
   const lastValidRslintConfig = useRef<any>(null);
   const lastValidTsConfig = useRef<any>(null);
+
+  // Monaco keeps these subscriptions for the editor lifetime, so forward them
+  // through refs instead of retaining callbacks from the initial render.
+  useLayoutEffect(() => {
+    onChangeRef.current = onChange;
+    onSelectionChangeRef.current = onSelectionChange;
+    onConfigChangeRef.current = onConfigChange;
+  }, [onChange, onSelectionChange, onConfigChange]);
 
   function getInitialCode(): string {
     if (typeof window === 'undefined') {
@@ -317,12 +329,12 @@ export const EditorTabs = ({
 
     // Trigger initial onChange
     const initialVal = editor.getValue() || '';
-    onChange(initialVal);
+    onChangeRef.current(initialVal);
     scheduleSerializeToUrl(initialVal);
 
     editor.onDidChangeModelContent(() => {
       const val = editor.getValue() || '';
-      onChange(val);
+      onChangeRef.current(val);
       scheduleSerializeToUrl(val);
 
       // Mark as editing to prevent AST tree selection during typing
@@ -361,7 +373,7 @@ export const EditorTabs = ({
         lineNumber: sel.endLineNumber,
         column: sel.endColumn,
       });
-      onSelectionChange?.(
+      onSelectionChangeRef.current?.(
         Math.min(startOffset, endOffset),
         Math.max(startOffset, endOffset),
       );
@@ -401,7 +413,7 @@ export const EditorTabs = ({
     rslintEditorRef.current = editor;
 
     editor.onDidChangeModelContent(() => {
-      onConfigChange?.();
+      onConfigChangeRef.current?.();
     });
 
     return () => {
@@ -424,7 +436,7 @@ export const EditorTabs = ({
     tsconfigEditorRef.current = editor;
 
     editor.onDidChangeModelContent(() => {
-      onConfigChange?.();
+      onConfigChangeRef.current?.();
     });
 
     return () => {


### PR DESCRIPTION
## Summary

- Forward Monaco change subscriptions to the latest React callbacks so code, rslint config, and tsconfig edits schedule linting after the WASM version loads.
- Track lint run generations so rapid edits, version switches, and unmounts cannot publish stale diagnostics, markers, errors, or AST state.
- Verified the code and both config editors against the built playground with the published WASM service.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
