### PR TITLE
fix: preserve class member suggestion semantics

### DIFF
--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
@@ -291,7 +291,10 @@ func needsLeadingSemicolon(sourceFile *ast.SourceFile, classNode *ast.Node, node
 		classNode,
 		node,
 		nextToken,
-		utils.ClassMemberLeadingSemicolonOptions{IncludePropertiesWithoutInitializers: true},
+		utils.ClassMemberLeadingSemicolonOptions{
+			IncludePropertiesWithoutInitializers: true,
+			IncludePostfixInitializers:           true,
+		},
 	)
 }
 

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
@@ -843,6 +843,45 @@ class A {
 		{
 			Code: `
 class A {
+  field = value++
+  constructor() {}
+  *iterator() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  field = value++\n  ;\n  *iterator() {}\n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A {
+  field = value--
+  constructor() {}
+  in() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  field = value--\n  ;\n  in() {}\n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A {
+  field = value++
+  constructor() {}
+  instanceof() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  field = value++\n  ;\n  instanceof() {}\n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A {
   method() {}
   constructor() {}
   [0]() {}

--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -205,8 +205,9 @@ func buildRemoveAsyncMessage() rule.RuleMessage {
 }
 
 type asyncKeywordInfo struct {
-	tokenRange  core.TextRange
-	removeRange core.TextRange
+	tokenRange        core.TextRange
+	removeRange       core.TextRange
+	hasAuthoredPrefix bool
 }
 
 func findAsyncKeyword(sourceFile *ast.SourceFile, node *ast.Node) (asyncKeywordInfo, bool) {
@@ -214,38 +215,71 @@ func findAsyncKeyword(sourceFile *ast.SourceFile, node *ast.Node) (asyncKeywordI
 	if modifiers == nil {
 		return asyncKeywordInfo{}, false
 	}
+	hasAuthoredPrefix := false
 	for _, modifier := range modifiers.Nodes {
-		if modifier == nil || modifier.Kind != ast.KindAsyncKeyword {
+		if modifier == nil {
+			continue
+		}
+		if modifier.Kind != ast.KindAsyncKeyword {
+			if !utils.IsJSDocSyntaxNode(modifier) {
+				hasAuthoredPrefix = true
+			}
 			continue
 		}
 		tokenRange := utils.TrimNodeTextRange(sourceFile, modifier)
 		removeEnd := ecmascript.SkipLeadingWhitespace(sourceFile.Text(), tokenRange.End(), len(sourceFile.Text()))
 		return asyncKeywordInfo{
-			tokenRange:  tokenRange,
-			removeRange: core.NewTextRange(tokenRange.Pos(), removeEnd),
+			tokenRange:        tokenRange,
+			removeRange:       core.NewTextRange(tokenRange.Pos(), removeEnd),
+			hasAuthoredPrefix: hasAuthoredPrefix,
 		}, true
 	}
 	return asyncKeywordInfo{}, false
 }
 
-func needsLeadingSemicolon(sourceFile *ast.SourceFile, node *ast.Node, asyncInfo asyncKeywordInfo) bool {
-	nextToken, ok := utils.TokenAtOrAfter(sourceFile, asyncInfo.tokenRange.End())
-	if !ok {
-		return false
-	}
-
+func needsLeadingSemicolon(sourceFile *ast.SourceFile, node *ast.Node, asyncInfo asyncKeywordInfo, nextToken utils.SourceToken) bool {
 	if node.Kind == ast.KindMethodDeclaration {
+		// Removing async cannot expose nextToken as the member's first token
+		// when a decorator or another modifier precedes it.
+		if asyncInfo.hasAuthoredPrefix {
+			return false
+		}
 		return utils.NeedsClassMemberLeadingSemicolon(
 			sourceFile,
 			ast.GetContainingClass(node),
 			node,
 			nextToken,
-			utils.ClassMemberLeadingSemicolonOptions{IncludePropertiesWithoutInitializers: true},
+			utils.ClassMemberLeadingSemicolonOptions{
+				IncludePropertiesWithoutInitializers: true,
+				IncludePostfixInitializers:           true,
+			},
 		)
 	}
 	return (nextToken.Kind == ast.KindOpenBracketToken || nextToken.Kind == ast.KindOpenParenToken) &&
 		utils.IsStartOfExpressionStatement(sourceFile, node) &&
 		utils.NeedsPrecedingSemicolon(sourceFile, node)
+}
+
+func mayContainJSDocComment(text string, start int, end int) bool {
+	return start >= 0 && start < end && end <= len(text) && strings.Contains(text[start:end], "/**")
+}
+
+func hasJSDocCommentBetween(sourceFile *ast.SourceFile, text string, start int, end int) bool {
+	if start < 0 || start >= end || end > len(text) {
+		return false
+	}
+
+	for comment := range utils.GetCommentsInRange(sourceFile, core.NewTextRange(start, end)) {
+		if comment.Kind == ast.KindMultiLineCommentTrivia &&
+			comment.Pos() >= start &&
+			comment.End() <= end &&
+			comment.Pos()+3 < comment.End() &&
+			text[comment.Pos():comment.Pos()+3] == "/**" &&
+			text[comment.Pos()+3] != '/' {
+			return true
+		}
+	}
+	return false
 }
 
 func appendReturnTypeSuggestionFixes(sourceFile *ast.SourceFile, node *ast.Node, isGenerator bool, fixes []rule.RuleFix) []rule.RuleFix {
@@ -302,15 +336,43 @@ func buildRemoveAsyncSuggestion(sourceFile *ast.SourceFile, node *ast.Node, isGe
 		return nil
 	}
 
-	replacement := ""
-	if node.Kind != ast.KindMethodDeclaration && needsLeadingSemicolon(sourceFile, node, asyncInfo) {
-		replacement = ";"
+	nextToken, hasNextToken := utils.TokenAtOrAfter(sourceFile, asyncInfo.tokenRange.End())
+	text := sourceFile.Text()
+	if hasNextToken &&
+		mayContainJSDocComment(text, asyncInfo.tokenRange.End(), nextToken.Start) &&
+		hasJSDocCommentBetween(sourceFile, text, asyncInfo.tokenRange.End(), nextToken.Start) {
+		// Removing async can turn a JSDoc-style comment inside the function
+		// header into leading JSDoc and silently add declaration metadata. There
+		// is no syntax-preserving separator that works in every function context,
+		// so omit the suggestion instead of changing program semantics.
+		return nil
 	}
-	fixes := []rule.RuleFix{rule.RuleFixReplaceRange(asyncInfo.removeRange, replacement)}
-	if node.Kind == ast.KindMethodDeclaration && needsLeadingSemicolon(sourceFile, node, asyncInfo) {
-		// Decorators and modifiers precede the async token, so the semicolon
-		// must be inserted before the entire member.
-		fixes = append(fixes, rule.RuleFixInsertBefore(sourceFile, node, ";"))
+
+	needsSemicolon := hasNextToken && needsLeadingSemicolon(sourceFile, node, asyncInfo, nextToken)
+	fixes := make([]rule.RuleFix, 0, 1)
+	if node.Kind == ast.KindMethodDeclaration && needsSemicolon {
+		memberStart := node.Pos()
+		asyncStart := asyncInfo.removeRange.Pos()
+		if memberStart >= 0 && memberStart < asyncStart &&
+			ecmascript.SkipLeadingWhitespace(text, memberStart, asyncStart) != asyncStart {
+			// Put the separator before leading comments so JSDoc stays attached
+			// to the method. Keep the insertion before the removal so the raw
+			// fixes also form legal LSP edits.
+			fixes = append(fixes,
+				rule.RuleFixReplaceRange(core.NewTextRange(memberStart, memberStart), ";"),
+				rule.RuleFixRemoveRange(asyncInfo.removeRange),
+			)
+		} else {
+			// This single edit preserves the established `;member` output and
+			// cannot conflict with the async removal at the same position.
+			fixes = append(fixes, rule.RuleFixReplaceRange(asyncInfo.removeRange, ";"))
+		}
+	} else {
+		replacement := ""
+		if needsSemicolon {
+			replacement = ";"
+		}
+		fixes = append(fixes, rule.RuleFixReplaceRange(asyncInfo.removeRange, replacement))
 	}
 	fixes = appendReturnTypeSuggestionFixes(sourceFile, node, isGenerator, fixes)
 	return []rule.RuleSuggestion{{

--- a/internal/plugins/typescript/rules/require_await/require_await_suggestions_test.go
+++ b/internal/plugins/typescript/rules/require_await/require_await_suggestions_test.go
@@ -1,6 +1,7 @@
 package require_await
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -133,6 +134,7 @@ func TestRequireAwaitSuggestionBoundaries(t *testing.T) {
 			{
 				Code: `class Example {
   plain
+  /** @deprecated */
   static async [computed]() {
     return 0;
   }
@@ -143,7 +145,8 @@ func TestRequireAwaitSuggestionBoundaries(t *testing.T) {
 						MessageId: "removeAsync",
 						Output: `class Example {
   plain
-  ;static [computed]() {
+  /** @deprecated */
+  static [computed]() {
     return 0;
   }
 }`,
@@ -153,6 +156,7 @@ func TestRequireAwaitSuggestionBoundaries(t *testing.T) {
 			{
 				Code: `class Example {
   plain
+  /** @deprecated */
   @dec
   async [computed]() {
     return 0;
@@ -164,7 +168,8 @@ func TestRequireAwaitSuggestionBoundaries(t *testing.T) {
 						MessageId: "removeAsync",
 						Output: `class Example {
   plain
-  ;@dec
+  /** @deprecated */
+  @dec
   [computed]() {
     return 0;
   }
@@ -182,8 +187,294 @@ func TestRequireAwaitSuggestionBoundaries(t *testing.T) {
 					}},
 				}},
 			},
+			{
+				Code: `async /* text containing /** is still an ordinary comment */ function ordinary() {
+  return 0;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "removeAsync",
+						Output: `/* text containing /** is still an ordinary comment */ function ordinary() {
+  return 0;
+}`,
+					}},
+				}},
+			},
+			{
+				Code: `async /**/ function emptyComment() {
+  return 0;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "missingAwait",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "removeAsync",
+						Output: `/**/ function emptyComment() {
+  return 0;
+}`,
+					}},
+				}},
+			},
 		},
 	)
+}
+
+func TestRequireAwaitSkipsSuggestionsThatCouldCreateJSDoc(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAwaitRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `class Example {
+  field = this.value++
+  async /** @deprecated */ [computed]() { return 1; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `async /* ordinary */ /** @deprecated */ function declaration() {
+  return 1;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `const expression = async /** @deprecated */ function () {
+  return 1;
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code:   `const arrow = async /** @deprecated */ () => 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `const object = {
+  async /** @deprecated */ method() { return 1; },
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `async /** @deprecated */ function* generator() {
+  yield 1;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+		},
+	)
+}
+
+func TestRequireAwaitClassSuggestionSemantics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		fileName          string
+		configName        string
+		source            string
+		want              string
+		wantFixes         int
+		wantModifierFlags ast.ModifierFlags
+	}{
+		{
+			name: "postfix-generator",
+			source: `class Example {
+  field = this.value++
+  async *method() { yield 1; }
+}`,
+			want: `class Example {
+  field = this.value++
+  ;*method() { yield 1; }
+}`,
+			wantFixes: 1,
+		},
+		{
+			name: "postfix-in",
+			source: `class Example {
+  field = this.value--
+  async in() { return 1; }
+}`,
+			want: `class Example {
+  field = this.value--
+  ;in() { return 1; }
+}`,
+			wantFixes: 1,
+		},
+		{
+			name: "postfix-instanceof",
+			source: `class Example {
+  field = this.value++
+  async instanceof() { return 1; }
+}`,
+			want: `class Example {
+  field = this.value++
+  ;instanceof() { return 1; }
+}`,
+			wantFixes: 1,
+		},
+		{
+			name: "postfix-computed",
+			source: `class Example {
+  field = this.value++
+  async [computed]() { return 1; }
+}`,
+			want: `class Example {
+  field = this.value++
+  [computed]() { return 1; }
+}`,
+			wantFixes: 1,
+		},
+		{
+			name: "leading-jsdoc-and-return-type",
+			source: `class Example {
+  field = this.value // trailing
+  /** @deprecated */
+  async [computed](): Promise<number> { return 1; }
+}`,
+			want: `class Example {
+  field = this.value; // trailing
+  /** @deprecated */
+  [computed](): number { return 1; }
+}`,
+			wantFixes: 4,
+		},
+		{
+			name:       "jsdoc-synthesized-modifier",
+			fileName:   "jsdoc-synthesized-modifier.js",
+			configName: "tsconfig.allowJs.json",
+			source: `class Example {
+  field = this.value
+  /** @public */
+  async in() { return 1; }
+}`,
+			want: `class Example {
+  field = this.value;
+  /** @public */
+  in() { return 1; }
+}`,
+			wantFixes:         2,
+			wantModifierFlags: ast.ModifierFlagsPublic,
+		},
+		{
+			name: "static-prefix",
+			source: `class Example {
+  field = this.value
+  /** @deprecated */
+  static async in(): Promise<number> { return 1; }
+}`,
+			want: `class Example {
+  field = this.value
+  /** @deprecated */
+  static in(): number { return 1; }
+}`,
+			wantFixes: 3,
+		},
+		{
+			name:      "accessibility-prefix-with-unicode-trivia",
+			source:    "class Example {\r\n  field = this.value\r\n  /** @deprecated */\r\n\u00a0\u00a0protected async instanceof() { return 1; }\r\n}",
+			want:      "class Example {\r\n  field = this.value\r\n  /** @deprecated */\r\n\u00a0\u00a0protected instanceof() { return 1; }\r\n}",
+			wantFixes: 1,
+		},
+		{
+			name: "decorator-prefix",
+			source: `class Example {
+  field = this.value
+  /** @deprecated */
+  @dec
+  async *method(): AsyncGenerator<number> { yield 1; }
+}`,
+			want: `class Example {
+  field = this.value
+  /** @deprecated */
+  @dec
+  *method(): Generator<number> { yield 1; }
+}`,
+			wantFixes: 2,
+		},
+		{
+			name: "mid-header-ordinary-comment",
+			source: `class Example {
+  field = this.value
+  async /* keep */ [computed]() { return 1; }
+}`,
+			want: `class Example {
+  field = this.value
+  ;/* keep */ [computed]() { return 1; }
+}`,
+			wantFixes: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+			fileName := test.fileName
+			if fileName == "" {
+				fileName = test.name + ".ts"
+			}
+			configName := test.configName
+			if configName == "" {
+				configName = "tsconfig.json"
+			}
+			program, sourceFile, err := helper.CreateTestProgram(test.source, fileName, configName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diagnostics := program.GetSyntacticDiagnostics(context.Background(), sourceFile); len(diagnostics) != 0 {
+				t.Fatalf("source has syntactic diagnostics: %#v", diagnostics)
+			}
+
+			classNode := sourceFile.Statements.Nodes[0]
+			members := classNode.Members()
+			method := members[len(members)-1]
+			wasDeprecated := ast.GetJSDocDeprecatedTag(method) != nil
+			modifierFlags := ast.GetCombinedModifierFlags(method) &^ ast.ModifierFlagsAsync
+			if test.wantModifierFlags != 0 && modifierFlags&test.wantModifierFlags != test.wantModifierFlags {
+				t.Fatalf("original modifier flags = %v, want at least %v", modifierFlags, test.wantModifierFlags)
+			}
+			isGenerator := ast.GetFunctionFlags(method)&ast.FunctionFlagsGenerator != 0
+			suggestions := buildRemoveAsyncSuggestion(sourceFile, method, isGenerator)
+			if len(suggestions) != 1 {
+				t.Fatalf("suggestions = %#v, want one", suggestions)
+			}
+			rawFixes := append([]rule.RuleFix(nil), suggestions[0].FixesArr...)
+			if len(rawFixes) != test.wantFixes {
+				t.Fatalf("fixes = %#v, want %d", rawFixes, test.wantFixes)
+			}
+			if len(rawFixes) > 1 && rawFixes[0].Range.Pos() == rawFixes[1].Range.Pos() &&
+				rawFixes[0].Range.Pos() != rawFixes[0].Range.End() {
+				t.Fatalf("same-position LSP edits start with a replacement: %#v", rawFixes[:2])
+			}
+
+			got, unapplied, fixed := linter.ApplyRuleFixes(test.source, suggestions)
+			if !fixed || len(unapplied) != 0 {
+				t.Fatalf("suggestion application: fixed=%v, unapplied=%#v", fixed, unapplied)
+			}
+			if got != test.want {
+				t.Fatalf("suggestion output:\ngot:\n%s\nwant:\n%s", got, test.want)
+			}
+
+			fixedProgram, fixedFile, err := helper.CreateTestProgram(got, "fixed-"+fileName, configName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diagnostics := fixedProgram.GetSyntacticDiagnostics(context.Background(), fixedFile); len(diagnostics) != 0 {
+				t.Fatalf("suggestion produced syntactic diagnostics: %#v", diagnostics)
+			}
+			fixedMembers := fixedFile.Statements.Nodes[0].Members()
+			fixedMethod := fixedMembers[len(fixedMembers)-1]
+			if gotDeprecated := ast.GetJSDocDeprecatedTag(fixedMethod) != nil; gotDeprecated != wasDeprecated {
+				t.Errorf("deprecated metadata changed from %v to %v", wasDeprecated, gotDeprecated)
+			}
+			if gotFlags := ast.GetCombinedModifierFlags(fixedMethod); gotFlags != modifierFlags {
+				t.Errorf("modifier flags = %v, want %v", gotFlags, modifierFlags)
+			}
+		})
+	}
 }
 
 func TestRequireAwaitSuggestionDemand(t *testing.T) {

--- a/internal/utils/class_member_semicolon.go
+++ b/internal/utils/class_member_semicolon.go
@@ -5,13 +5,17 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
-// ClassMemberLeadingSemicolonOptions controls how
-// NeedsClassMemberLeadingSemicolon treats class fields without initializers.
+// ClassMemberLeadingSemicolonOptions controls which preceding class fields
+// NeedsClassMemberLeadingSemicolon treats as hazards.
 type ClassMemberLeadingSemicolonOptions struct {
 	// IncludePropertiesWithoutInitializers also treats plain fields like `foo`
 	// as hazards. Type-only fields like `foo: string` are always considered
 	// because the trailing type can merge with a following computed member.
 	IncludePropertiesWithoutInitializers bool
+	// IncludePostfixInitializers treats a postfix initializer as a hazard when
+	// the next member starts with `*`, `in`, or `instanceof`. A following `[`
+	// remains safe because it starts a computed member after the update.
+	IncludePostfixInitializers bool
 }
 
 // NeedsClassMemberLeadingSemicolon reports whether an edit that removes or
@@ -61,10 +65,11 @@ func NeedsClassMemberLeadingSemicolon(
 	}
 
 	init := prop.Initializer
-	// Postfix ++/-- are restricted productions, so ASI fires before the next
-	// class member token and no explicit semicolon is needed.
+	// A computed member after postfix ++/-- is unambiguous. The other
+	// expression-continuation tokens still need a semicolon when the caller can
+	// expose them as the next member's first token.
 	if init.Kind == ast.KindPostfixUnaryExpression {
-		return false
+		return options.IncludePostfixInitializers && nextToken.Kind != ast.KindOpenBracketToken
 	}
 	// Arrow functions with block bodies terminate at their own `}`; a following
 	// `[`/`in`/`instanceof`/`*` cannot become a member access on the initializer.


### PR DESCRIPTION
## Summary

- keep TypeScript `require-await` removal suggestions syntactically valid after postfix class fields while preserving computed-member ASI behavior
- preserve JSDoc and authored modifier/decorator semantics, emit LSP-safe edits, and omit the optional removal suggestion when deleting `async` could create new JSDoc metadata
- apply the same opt-in postfix safeguard to TypeScript `no-useless-constructor` and add parser-backed regression coverage for all affected member starts

Package-local `BenchmarkRequireAwait` results (Apple M5 Max, five samples; median shown):

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| diagnostics only | 4002 → 2724 | 4128 → 4128 | 67 → 67 |
| simple suggestion | 3831 → 2948 | 4721 → 4720 | 73 → 73 |
| return-type suggestion | 4372 → 3217 | 5121 → 5120 | 76 → 76 |
| class semicolon suggestion | 4064 → 3242 | 4737 → 4736 | 73 → 73 |
| await no-match | 2735 → 2528 | 3352 → 3352 | 59 → 59 |
| thenable-return no-match | 3431 → 3294 | 3353 → 3353 | 59 → 59 |

Untouched control paths also varied, so the timing deltas are treated as environment-sensitive; the benchmark establishes that the correctness changes add no memory or allocation regression. The temporary benchmark source is not included.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; no public API or configuration change).
