### PR TITLE
fix: preserve enum comparison semantics

### DIFF
--- a/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison.go
+++ b/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison.go
@@ -2,7 +2,6 @@ package no_unsafe_enum_comparison
 
 import (
 	"slices"
-	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -21,86 +20,6 @@ func buildMismatchedConditionMessage() rule.RuleMessage {
 		Id:          "mismatchedCondition",
 		Description: "The two values in this comparison do not have a shared enum type.",
 	}
-}
-
-func buildReplaceValueWithEnumMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "replaceValueWithEnum",
-		Description: "Replace with an enum value comparison.",
-	}
-}
-
-type staticNumber interface {
-	IsNaN() bool
-}
-
-func enumLiteralMatchesStaticValue(
-	enumLiteral *checker.Type,
-	staticValue any,
-	staticValueText string,
-) bool {
-	literalValue := enumLiteral.AsLiteralType().Value()
-	if utils.IsTypeFlagSet(enumLiteral, checker.TypeFlagsStringLiteral) {
-		enumString, enumStringOK := literalValue.(string)
-		staticString, staticStringOK := staticValue.(string)
-		return enumStringOK && staticStringOK && enumString == staticString
-	}
-	if utils.IsTypeFlagSet(enumLiteral, checker.TypeFlagsNumberLiteral) {
-		staticNumber, staticNumberOK := staticValue.(staticNumber)
-		return staticNumberOK && !staticNumber.IsNaN() && checker.ValueToString(literalValue) == staticValueText
-	}
-	return false
-}
-
-func getEnumKeyForLiteral(
-	sourceFile *ast.SourceFile,
-	enumLiterals []*checker.Type,
-	literal *ast.Node,
-	staticEvaluator *utils.StaticStringEvaluator,
-) (string, bool) {
-	staticValue, ok := staticEvaluator.EvalValue(literal)
-	if !ok {
-		return "", false
-	}
-
-	staticValueText := ""
-	if _, isNumber := staticValue.(staticNumber); isNumber {
-		staticValueText, ok = staticEvaluator.EvalToString(literal)
-		if !ok {
-			return "", false
-		}
-	}
-
-	for _, enumLiteral := range enumLiterals {
-		if !enumLiteralMatchesStaticValue(enumLiteral, staticValue, staticValueText) {
-			continue
-		}
-
-		symbol := checker.Type_symbol(enumLiteral)
-		if symbol == nil || symbol.ValueDeclaration == nil || !ast.IsEnumMember(symbol.ValueDeclaration) {
-			continue
-		}
-		enumMember := symbol.ValueDeclaration
-		enumDeclaration := enumMember.Parent
-		if enumDeclaration == nil || !ast.IsEnumDeclaration(enumDeclaration) {
-			continue
-		}
-
-		enumName := enumDeclaration.Name().Text()
-		memberName := enumMember.Name()
-		switch memberName.Kind {
-		case ast.KindIdentifier:
-			return enumName + "." + memberName.Text(), true
-		case ast.KindStringLiteral:
-			escapedName := strings.ReplaceAll(memberName.Text(), "'", "\\'")
-			return enumName + "['" + escapedName + "']", true
-		case ast.KindComputedPropertyName:
-			expression := memberName.AsComputedPropertyName().Expression
-			return enumName + "[" + utils.TrimmedNodeText(sourceFile, expression) + "]", true
-		}
-	}
-
-	return "", false
 }
 
 /**
@@ -155,7 +74,6 @@ var NoUnsafeEnumComparisonRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		staticEvaluator := utils.NewStaticStringEvaluatorWithoutScope()
 		isMismatchedComparison := func(
 			leftType *checker.Type,
 			rightType *checker.Type,
@@ -221,35 +139,9 @@ var NoUnsafeEnumComparisonRule = rule.CreateRule(rule.Rule{
 				rightType := ctx.TypeChecker.GetTypeAtLocation(expr.Right)
 
 				if isMismatchedComparison(leftType, rightType) {
-					ctx.ReportNodeWithDeferredSuggestions(node, buildMismatchedConditionMessage(), func() []rule.RuleSuggestion {
-						leftEnumKey, ok := getEnumKeyForLiteral(
-							ctx.SourceFile,
-							utils.GetEnumLiterals(leftType),
-							expr.Right,
-							staticEvaluator,
-						)
-						if ok {
-							return []rule.RuleSuggestion{{
-								Message:  buildReplaceValueWithEnumMessage(),
-								FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, ast.SkipParentheses(expr.Right), leftEnumKey)},
-							}}
-						}
-
-						rightEnumKey, ok := getEnumKeyForLiteral(
-							ctx.SourceFile,
-							utils.GetEnumLiterals(rightType),
-							expr.Left,
-							staticEvaluator,
-						)
-						if ok {
-							return []rule.RuleSuggestion{{
-								Message:  buildReplaceValueWithEnumMessage(),
-								FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, ast.SkipParentheses(expr.Left), rightEnumKey)},
-							}}
-						}
-
-						return nil
-					})
+					// Even apparently direct enum member reads can observe mutation,
+					// initialization order, or import elision at runtime.
+					ctx.ReportNode(node, buildMismatchedConditionMessage())
 				}
 			},
 

--- a/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_extras_test.go
@@ -12,8 +12,126 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+func TestNoUnsafeEnumComparisonExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeEnumComparisonRule, nil, []rule_tester.InvalidTestCase{
+		{
+			Code: `
+enum Num {
+  A = 1,
+}
+declare const num: Num;
+num === (1);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			Code: `
+enum Num {
+  A = 1,
+}
+declare const num: Num;
+((1)) === num;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			// Sequence expressions still produce the diagnostic without
+			// offering a replacement that could discard an operand.
+			Code: `
+enum Num {
+  A = 2,
+}
+declare const num: Num;
+num === (1, 2);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			Code: `
+enum Num {
+  A = 2,
+}
+declare const num: Num;
+num === 'ab'.length;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			Code: `
+enum Num {
+  A = 1,
+}
+declare const num: Num;
+num === 'ab'.indexOf('b');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			// NaN is not equal to itself and must not produce a replacement.
+			Code: `
+enum Num {
+  A = 0 / 0,
+}
+declare const num: Num;
+num === 0 / 0;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			Code: `
+enum ComputedKey {
+  ['test-key' /* with comment */] = 1,
+}
+declare const computedKey: ComputedKey;
+computedKey === 1;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			Code: `
+enum ComputedKey {
+  [` + "`" + `test-key` + "`" + ` /* with comment */] = 1,
+}
+declare const computedKey: ComputedKey;
+computedKey === 1;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+		{
+			Code: `
+enum ComputedKey {
+  [` + "`" + `test-
+  key` + "`" + ` /* with comment */] = 1,
+}
+declare const computedKey: ComputedKey;
+computedKey === 1;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mismatchedCondition",
+			}},
+		},
+	})
+}
 
 func TestNoUnsafeEnumComparisonDoesNotOfferUnsafeSuggestions(t *testing.T) {
 	tests := []struct {

--- a/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_extras_test.go
@@ -3,208 +3,176 @@
 package no_unsafe_enum_comparison
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
-	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func TestNoUnsafeEnumComparisonExtras(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeEnumComparisonRule, nil, []rule_tester.InvalidTestCase{
+func TestNoUnsafeEnumComparisonDoesNotOfferUnsafeSuggestions(t *testing.T) {
+	tests := []struct {
+		name   string
+		files  map[string]string
+		target string
+	}{
 		{
-			Code: `
-enum Num {
-  A = 1,
-}
-declare const num: Num;
-num === (1);
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum Num {
-  A = 1,
-}
-declare const num: Num;
-num === (Num.A);
-`,
-				}},
-			}},
+			name: "plain literal",
+			files: map[string]string{
+				"use.ts": `enum E { A = 1 }
+const value = 1 as E;
+value === 1;`,
+			},
+			target: "use.ts",
 		},
 		{
-			Code: `
-enum Num {
-  A = 1,
-}
-declare const num: Num;
-((1)) === num;
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum Num {
-  A = 1,
-}
-declare const num: Num;
-((Num.A)) === num;
-`,
-				}},
-			}},
+			name: "computed member declared in another file",
+			files: map[string]string{
+				"enum.ts": strings.Repeat("// padding\n", 100) + `export enum E { ['x'] = 1 }`,
+				"use.ts": `import { E } from './enum.js';
+const value = 1 as E;
+value === 1;`,
+			},
+			target: "use.ts",
 		},
 		{
-			// Sequence expressions fold to their final value, while preserving
-			// their outer parentheses in the replacement.
-			Code: `
-enum Num {
-  A = 2,
-}
-declare const num: Num;
-num === (1, 2);
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum Num {
-  A = 2,
-}
-declare const num: Num;
-num === (Num.A);
-`,
-				}},
-			}},
+			name: "aliased import",
+			files: map[string]string{
+				"enum.ts": `export enum Original { A = 1 }`,
+				"use.ts": `import { Original as Alias } from './enum.js';
+const value = 1 as Alias;
+value === 1;`,
+			},
+			target: "use.ts",
 		},
 		{
-			Code: `
-enum Num {
-  A = 2,
-}
-declare const num: Num;
-num === 'ab'.length;
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum Num {
-  A = 2,
-}
-declare const num: Num;
-num === Num.A;
-`,
-				}},
-			}},
+			name: "namespace import",
+			files: map[string]string{
+				"enum.ts": `export enum E { A = 1 }`,
+				"use.ts": `import * as N from './enum.js';
+const value = 1 as N.E;
+value === 1;`,
+			},
+			target: "use.ts",
 		},
 		{
-			Code: `
-enum Num {
-  A = 1,
-}
-declare const num: Num;
-num === 'ab'.indexOf('b');
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum Num {
-  A = 1,
-}
-declare const num: Num;
-num === Num.A;
-`,
-				}},
-			}},
+			name: "type-only import",
+			files: map[string]string{
+				"enum.ts": `export enum E { A = 1 }`,
+				"use.ts": `import type { E } from './enum.js';
+declare const value: E;
+value === 1;`,
+			},
+			target: "use.ts",
 		},
 		{
-			// NaN is not equal to itself, so a textual NaN match must not offer
-			// an enum replacement suggestion.
-			Code: `
-enum Num {
-  A = 0 / 0,
-}
-declare const num: Num;
-num === 0 / 0;
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-			}},
+			name: "escaped string member",
+			files: map[string]string{
+				"use.ts": `enum E { 'a\\b' = 1 }
+const value = 1 as E;
+value === 1;`,
+			},
+			target: "use.ts",
 		},
 		{
-			Code: `
-enum ComputedKey {
-  ['test-key' /* with comment */] = 1,
-}
-declare const computedKey: ComputedKey;
-computedKey === 1;
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum ComputedKey {
-  ['test-key' /* with comment */] = 1,
-}
-declare const computedKey: ComputedKey;
-computedKey === ComputedKey['test-key'];
-`,
-				}},
-			}},
+			name: "assignment result",
+			files: map[string]string{
+				"use.ts": `enum E { A = 1 }
+declare const value: E;
+let written = 0;
+value === (written = 1);`,
+			},
+			target: "use.ts",
 		},
 		{
-			Code: `
-enum ComputedKey {
-  [` + "`" + `test-key` + "`" + ` /* with comment */] = 1,
-}
-declare const computedKey: ComputedKey;
-computedKey === 1;
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum ComputedKey {
-  [` + "`" + `test-key` + "`" + ` /* with comment */] = 1,
-}
-declare const computedKey: ComputedKey;
-computedKey === ComputedKey[` + "`" + `test-key` + "`" + `];
-`,
-				}},
-			}},
+			name: "sequence with call",
+			files: map[string]string{
+				"use.ts": `enum E { A = 1 }
+declare const value: E;
+declare function log(): void;
+value === (log(), 1);`,
+			},
+			target: "use.ts",
 		},
 		{
-			Code: `
-enum ComputedKey {
-  [` + "`" + `test-
-  key` + "`" + ` /* with comment */] = 1,
+			name: "mutated enum object",
+			files: map[string]string{
+				"use.ts": `enum E { A = 1 }
+(E as any).A = 2;
+const value = 1 as E;
+value === 1;`,
+			},
+			target: "use.ts",
+		},
+		{
+			name: "cyclic initialization",
+			files: map[string]string{
+				"enum.ts": `import './use.js';
+export enum E { A = 1 }`,
+				"use.ts": `import { E } from './enum.js';
+const value = 1 as E;
+value === 1;`,
+			},
+			target: "use.ts",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diagnostics := lintNoUnsafeEnumComparisonFiles(t, tt.files, tt.target)
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+			}
+			if diagnostics[0].Suggestions != nil {
+				t.Fatalf("suggestions = %#v, want nil", *diagnostics[0].Suggestions)
+			}
+		})
+	}
 }
-declare const computedKey: ComputedKey;
-computedKey === 1;
-`,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "mismatchedCondition",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
-					MessageId: "replaceValueWithEnum",
-					Output: `
-enum ComputedKey {
-  [` + "`" + `test-
-  key` + "`" + ` /* with comment */] = 1,
-}
-declare const computedKey: ComputedKey;
-computedKey === ComputedKey[` + "`" + `test-
-  key` + "`" + `];
-`,
-				}},
-			}},
+
+func lintNoUnsafeEnumComparisonFiles(t testing.TB, files map[string]string, target string) []rule.RuleDiagnostic {
+	t.Helper()
+	root := fixtures.GetRootDir()
+	overlay := make(map[string]string, len(files))
+	for name, code := range files {
+		overlay[tspath.ResolvePath(root.Dir, name)] = code
+	}
+	fs := utils.NewOverlayVFS(root.FS, overlay)
+	compilerProgram, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", utils.CreateCompilerHost(root.Dir, fs))
+	if err != nil {
+		t.Fatalf("create program: %v", err)
+	}
+	sourceFile := compilerProgram.GetSourceFile(target)
+	if sourceFile == nil {
+		t.Fatalf("missing target %q", target)
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:     lintprogram.NewFromCompiler(compilerProgram),
+		File:        sourceFile.FileName(),
+		HasTypeInfo: true,
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
+				Name:             NoUnsafeEnumComparisonRule.Name,
+				Severity:         rule.SeverityError,
+				RequiresTypeInfo: true,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return NoUnsafeEnumComparisonRule.Run(ctx, nil)
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandSuggestion,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
 		},
 	})
+	return diagnostics
 }

--- a/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_upstream_test.go
@@ -420,18 +420,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Fruit {
-          Apple = 0,
-          Banana = 'banana',
-        }
-        Fruit.Apple === Fruit.Apple;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -654,123 +642,15 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Str {
-          A = 'a',
-        }
-        enum Num {
-          B = 1,
-        }
-        enum Mixed {
-          A = 'a',
-          B = 1,
-        }
-
-        declare const str: Str;
-        declare const num: Num;
-        declare const mixed: Mixed;
-
-        // following are all errors because the value might be an enum value
-        str === Str.A;
-        num === 1;
-        mixed === 'a';
-        mixed === 1;
-      `,
-						},
-					},
 				},
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Str {
-          A = 'a',
-        }
-        enum Num {
-          B = 1,
-        }
-        enum Mixed {
-          A = 'a',
-          B = 1,
-        }
-
-        declare const str: Str;
-        declare const num: Num;
-        declare const mixed: Mixed;
-
-        // following are all errors because the value might be an enum value
-        str === 'a';
-        num === Num.B;
-        mixed === 'a';
-        mixed === 1;
-      `,
-						},
-					},
 				},
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Str {
-          A = 'a',
-        }
-        enum Num {
-          B = 1,
-        }
-        enum Mixed {
-          A = 'a',
-          B = 1,
-        }
-
-        declare const str: Str;
-        declare const num: Num;
-        declare const mixed: Mixed;
-
-        // following are all errors because the value might be an enum value
-        str === 'a';
-        num === 1;
-        mixed === Mixed.A;
-        mixed === 1;
-      `,
-						},
-					},
 				},
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Str {
-          A = 'a',
-        }
-        enum Num {
-          B = 1,
-        }
-        enum Mixed {
-          A = 'a',
-          B = 1,
-        }
-
-        declare const str: Str;
-        declare const num: Num;
-        declare const mixed: Mixed;
-
-        // following are all errors because the value might be an enum value
-        str === 'a';
-        num === 1;
-        mixed === 'a';
-        mixed === Mixed.B;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -919,19 +799,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Str {
-          A = 'a',
-          B = 'b',
-        }
-        declare const str: Str;
-        str === Str.B;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -947,19 +814,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Str {
-          A = 'a',
-          AB = 'ab',
-        }
-        declare const str: Str;
-        str === Str.AB;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -975,19 +829,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Num {
-          A = 1,
-          B = 2,
-        }
-        declare const num: Num;
-        Num.A === num;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1003,19 +844,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Num {
-          A = 1,
-          B = 2,
-        }
-        declare const num: Num;
-        Num.A /* with */ === /* comment */ num;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1031,19 +859,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Num {
-          A = 1,
-          B = 2,
-        }
-        declare const num: Num;
-        Num.B === num;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1059,19 +874,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Mixed {
-          A = 1,
-          B = 'b',
-        }
-        declare const mixed: Mixed;
-        mixed === Mixed.A;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1087,19 +889,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum Mixed {
-          A = 1,
-          B = 'b',
-        }
-        declare const mixed: Mixed;
-        mixed === Mixed.B;
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1114,18 +903,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum StringKey {
-          'test-key' /* with comment */ = 1,
-        }
-        declare const stringKey: StringKey;
-        stringKey === StringKey['test-key'];
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1140,18 +917,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum StringKey {
-          "key-'with-single'-quotes" = 1,
-        }
-        declare const stringKey: StringKey;
-        stringKey === StringKey['key-\'with-single\'-quotes'];
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1166,18 +931,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum StringKey {
-          'key-"with-double"-quotes' = 1,
-        }
-        declare const stringKey: StringKey;
-        stringKey === StringKey['key-"with-double"-quotes'];
-      `,
-						},
-					},
 				},
 			},
 		},
@@ -1192,18 +945,6 @@ func TestNoUnsafeEnumComparisonUpstream(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatchedCondition",
-					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{
-							MessageId: "replaceValueWithEnum",
-							Output: `
-        enum StringKey {
-          'key-` + "`" + `with-backticks` + "`" + `-quotes' = 1,
-        }
-        declare const stringKey: StringKey;
-        stringKey === StringKey['key-` + "`" + `with-backticks` + "`" + `-quotes'];
-      `,
-						},
-					},
 				},
 			},
 		},

--- a/internal/utils/ecmascript/code_units.go
+++ b/internal/utils/ecmascript/code_units.go
@@ -25,6 +25,59 @@ func StringCodeUnits(s string) []uint16 {
 	return units
 }
 
+// StringFromCodeUnits writes the UTF-16 code units JavaScript stores as a
+// string. Adjacent surrogate pairs use their ordinary UTF-8 spelling; an
+// unpaired surrogate uses the WTF-8 spelling the compiler uses to preserve it.
+func StringFromCodeUnits(units []uint16) string {
+	var result strings.Builder
+	result.Grow(len(units))
+	for i := 0; i < len(units); i++ {
+		unit := units[i]
+		if unit >= 0xD800 && unit <= 0xDBFF && i+1 < len(units) {
+			next := units[i+1]
+			if next >= 0xDC00 && next <= 0xDFFF {
+				result.WriteRune(utf16.DecodeRune(rune(unit), rune(next)))
+				i++
+				continue
+			}
+		}
+		if unit >= 0xD800 && unit <= 0xDFFF {
+			result.WriteByte(byte(0xE0 | unit>>12))
+			result.WriteByte(byte(0x80 | unit>>6&0x3F))
+			result.WriteByte(byte(0x80 | unit&0x3F))
+			continue
+		}
+		result.WriteRune(rune(unit))
+	}
+	return result.String()
+}
+
+// CombineSurrogatePairs canonicalizes a JavaScript string assembled from
+// separately scanned pieces. A high surrogate at the end of one piece and a
+// low surrogate at the start of the next become one ordinary supplementary
+// code point, while every unpaired surrogate keeps its compiler WTF-8 bytes.
+func CombineSurrogatePairs(s string) string {
+	if strings.IndexByte(s, 0xED) < 0 {
+		return s
+	}
+	var result strings.Builder
+	result.Grow(len(s))
+	for i := 0; i < len(s); {
+		r, size := decodeStringRune(s[i:])
+		if r >= 0xD800 && r <= 0xDBFF {
+			low, lowSize := decodeStringRune(s[i+size:])
+			if low >= 0xDC00 && low <= 0xDFFF {
+				result.WriteRune(utf16.DecodeRune(r, low))
+				i += size + lowSize
+				continue
+			}
+		}
+		result.WriteString(s[i : i+size])
+		i += size
+	}
+	return result.String()
+}
+
 // StringCodeUnitCount reports s's length in the UTF-16 code units counted by
 // JavaScript String#length. Unlike core.UTF16Len, it also preserves lone
 // surrogates in the WTF-8 form used by compiler string values.

--- a/internal/utils/ecmascript/code_units_test.go
+++ b/internal/utils/ecmascript/code_units_test.go
@@ -49,6 +49,62 @@ func TestStringCodeUnits(t *testing.T) {
 	}
 }
 
+func TestStringFromCodeUnits(t *testing.T) {
+	tests := []struct {
+		name  string
+		units []uint16
+	}{
+		{name: "empty", units: []uint16{}},
+		{name: "ascii and nul", units: []uint16{'a', 0, 'b'}},
+		{name: "basic plane boundaries", units: []uint16{0xD7FF, 0xE000, 0xFFFF}},
+		{name: "surrogate pair", units: []uint16{0xD83D, 0xDE00}},
+		{name: "lone high", units: []uint16{0xD800}},
+		{name: "lone low", units: []uint16{0xDFFF}},
+		{name: "reversed pair", units: []uint16{0xDC00, 0xD800}},
+		{name: "high high low", units: []uint16{0xD800, 0xD801, 0xDC00}},
+		{name: "high low low", units: []uint16{0xD800, 0xDC00, 0xDFFF}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := StringFromCodeUnits(tt.units)
+			if got := StringCodeUnits(encoded); !slices.Equal(got, tt.units) {
+				t.Fatalf("StringCodeUnits(StringFromCodeUnits(%v)) = %v", tt.units, got)
+			}
+		})
+	}
+
+	if got := StringFromCodeUnits([]uint16{0xD83D, 0xDE00}); got != "😀" {
+		t.Fatalf("surrogate pair = %q, want emoji", got)
+	}
+	if got := StringFromCodeUnits([]uint16{0xD800}); got != loneSurrogate(0xD800) {
+		t.Fatalf("lone surrogate = %q, want compiler WTF-8", got)
+	}
+}
+
+func TestCombineSurrogatePairs(t *testing.T) {
+	high := loneSurrogate(0xD83D)
+	low := loneSurrogate(0xDE00)
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "ascii", value: "plain", want: "plain"},
+		{name: "pair", value: high + low, want: "😀"},
+		{name: "lone high", value: high, want: high},
+		{name: "lone low", value: low, want: low},
+		{name: "reversed", value: low + high, want: low + high},
+		{name: "pair between text", value: "a" + high + low + "b", want: "a😀b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CombineSurrogatePairs(tt.value); got != tt.want {
+				t.Fatalf("CombineSurrogatePairs(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 // Every expectation here is what `a < b` and `a > b` answer in JavaScript.
 func TestCompareStrings(t *testing.T) {
 	tests := []struct {
@@ -77,6 +133,7 @@ func TestCompareStrings(t *testing.T) {
 		{name: "lone low surrogate against astral", a: loneSurrogate(0xDFFF), b: "\U00010000", want: 1},
 		{name: "astral against a lone low surrogate", a: "\U00010000", b: loneSurrogate(0xDFFF), want: -1},
 		{name: "lone high surrogate against astral", a: loneSurrogate(0xD800), b: "\U00010000", want: -1},
+		{name: "separate surrogate halves equal astral", a: loneSurrogate(0xD83D) + loneSurrogate(0xDE00), b: "😀", want: 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"unicode/utf16"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -421,7 +420,7 @@ func (staticEvaluator *StaticStringEvaluator) evalTemplateExpression(node *ast.N
 			}
 		}
 	}
-	return staticEvalResult{value: builder.String(), ok: true}
+	return staticEvalResult{value: ecmascript.CombineSurrogatePairs(builder.String()), ok: true}
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Node) staticEvalResult {
@@ -519,7 +518,7 @@ func (staticEvaluator *StaticStringEvaluator) concatStaticValues(left any, right
 	if !ok {
 		return staticEvalResult{}
 	}
-	return staticEvalResult{value: leftString + rightString, ok: true}
+	return staticEvalResult{value: ecmascript.CombineSurrogatePairs(leftString + rightString), ok: true}
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalPrefixUnaryExpression(node *ast.Node) staticEvalResult {
@@ -715,7 +714,7 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteralMember(node *ast.
 		if !value.ok {
 			return staticEvalResult{}
 		}
-		if propertyKey == key {
+		if ecmascript.CompareStrings(propertyKey, key) == 0 {
 			ownValue = value
 			ownFound = true
 		}
@@ -825,7 +824,7 @@ func (staticEvaluator *StaticStringEvaluator) evalMemberAccess(node *ast.Node) s
 	}
 	if key == "length" {
 		if text, ok := staticValueAsString(object.value); ok {
-			return staticEvalResult{value: staticNumberValue(len(utf16.Encode([]rune(text)))), ok: true}
+			return staticEvalResult{value: staticNumberValue(ecmascript.StringCodeUnitCount(text)), ok: true}
 		}
 	}
 	return staticMemberValue(object.value, key)
@@ -878,11 +877,11 @@ func staticMemberValue(object any, key string) staticEvalResult {
 
 func staticObjectOwnProperty(object *staticObjectValue, key string) (any, bool) {
 	for i := len(object.extraProperties) - 1; i >= 0; i-- {
-		if object.extraProperties[i].name == key {
+		if ecmascript.CompareStrings(object.extraProperties[i].name, key) == 0 {
 			return object.extraProperties[i].value, true
 		}
 	}
-	if object.propertyCount > 0 && object.property.name == key {
+	if object.propertyCount > 0 && ecmascript.CompareStrings(object.property.name, key) == 0 {
 		return object.property.value, true
 	}
 	return nil, false
@@ -1159,34 +1158,65 @@ func (staticEvaluator *StaticStringEvaluator) evalBuiltinStaticCall(node *ast.No
 }
 
 func staticStringIndexOf(text string, arguments []any) staticEvalResult {
-	if len(arguments) == 0 {
-		return staticEvalResult{}
+	needle := "undefined"
+	if len(arguments) > 0 {
+		var ok bool
+		needle, ok = staticValueToString(arguments[0])
+		if !ok {
+			return staticEvalResult{}
+		}
 	}
-	needle, ok := staticValueToString(arguments[0])
+
+	start, ok := staticArgumentInteger(arguments, 1, 0)
 	if !ok {
 		return staticEvalResult{}
 	}
 
-	start := 0
-	if len(arguments) > 1 {
-		number, ok := staticValueToNumber(arguments[1])
-		if !ok {
-			return staticEvalResult{}
+	textUnits := ecmascript.StringCodeUnits(text)
+	needleUnits := ecmascript.StringCodeUnits(needle)
+	start = min(max(start, 0), len(textUnits))
+	index := indexOfCodeUnits(textUnits, needleUnits, start)
+	return staticEvalResult{value: staticNumberValue(index), ok: true}
+}
+
+func indexOfCodeUnits(text, needle []uint16, start int) int {
+	if len(needle) == 0 {
+		return start
+	}
+	if start >= len(text) || len(needle) > len(text)-start {
+		return -1
+	}
+	if len(needle) == 1 {
+		index := slices.Index(text[start:], needle[0])
+		if index < 0 {
+			return -1
 		}
-		if !math.IsNaN(number) {
-			start = int(math.Trunc(number))
-		}
+		return start + index
 	}
 
-	textUnits := utf16.Encode([]rune(text))
-	needleUnits := utf16.Encode([]rune(needle))
-	start = min(max(start, 0), len(textUnits))
-	for i := start; i+len(needleUnits) <= len(textUnits); i++ {
-		if slices.Equal(textUnits[i:i+len(needleUnits)], needleUnits) {
-			return staticEvalResult{value: staticNumberValue(i), ok: true}
+	prefixLength := make([]int, len(needle))
+	for i, matched := 1, 0; i < len(needle); i++ {
+		for matched > 0 && needle[i] != needle[matched] {
+			matched = prefixLength[matched-1]
+		}
+		if needle[i] == needle[matched] {
+			matched++
+		}
+		prefixLength[i] = matched
+	}
+
+	for i, matched := start, 0; i < len(text); i++ {
+		for matched > 0 && text[i] != needle[matched] {
+			matched = prefixLength[matched-1]
+		}
+		if text[i] == needle[matched] {
+			matched++
+			if matched == len(needle) {
+				return i - len(needle) + 1
+			}
 		}
 	}
-	return staticEvalResult{value: staticNumberValue(-1), ok: true}
+	return -1
 }
 
 func (staticEvaluator *StaticStringEvaluator) evalCallArguments(node *ast.Node) ([]any, bool) {
@@ -1232,7 +1262,7 @@ func staticStringFromCharCode(arguments []any) staticEvalResult {
 		}
 		units = append(units, uint16(toUint32(number)))
 	}
-	return staticEvalResult{value: string(utf16.Decode(units)), ok: true}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units), ok: true}
 }
 
 func staticStringSlice(text string, arguments []any) staticEvalResult {
@@ -1244,14 +1274,14 @@ func staticStringSlice(text string, arguments []any) staticEvalResult {
 	if !ok {
 		return staticEvalResult{}
 	}
-	units := utf16.Encode([]rune(text))
+	units := ecmascript.StringCodeUnits(text)
 	length := len(units)
 	from := normalizeSliceIndex(start, length)
 	to := normalizeSliceIndex(end, length)
 	if to < from {
 		to = from
 	}
-	return staticEvalResult{value: string(utf16.Decode(units[from:to])), ok: true}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[from:to]), ok: true}
 }
 
 func staticStringSubstring(text string, arguments []any) staticEvalResult {
@@ -1263,14 +1293,14 @@ func staticStringSubstring(text string, arguments []any) staticEvalResult {
 	if !ok {
 		return staticEvalResult{}
 	}
-	units := utf16.Encode([]rune(text))
+	units := ecmascript.StringCodeUnits(text)
 	length := len(units)
 	from := clampSubstringIndex(start, length)
 	to := clampSubstringIndex(end, length)
 	if from > to {
 		from, to = to, from
 	}
-	return staticEvalResult{value: string(utf16.Decode(units[from:to])), ok: true}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[from:to]), ok: true}
 }
 
 // staticStringSubstr implements the Annex B String#substr, whose second
@@ -1284,7 +1314,7 @@ func staticStringSubstr(text string, arguments []any) staticEvalResult {
 	if !ok {
 		return staticEvalResult{}
 	}
-	units := utf16.Encode([]rune(text))
+	units := ecmascript.StringCodeUnits(text)
 	length := len(units)
 	from := normalizeSliceIndex(start, length)
 	if count <= 0 {
@@ -1294,7 +1324,7 @@ func staticStringSubstr(text string, arguments []any) staticEvalResult {
 	if count < length-from {
 		to = from + count
 	}
-	return staticEvalResult{value: string(utf16.Decode(units[from:to])), ok: true}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[from:to]), ok: true}
 }
 
 func staticStringCharAt(text string, arguments []any) staticEvalResult {
@@ -1302,11 +1332,11 @@ func staticStringCharAt(text string, arguments []any) staticEvalResult {
 	if !ok {
 		return staticEvalResult{}
 	}
-	units := utf16.Encode([]rune(text))
+	units := ecmascript.StringCodeUnits(text)
 	if index < 0 || index >= len(units) {
 		return staticEvalResult{value: "", ok: true}
 	}
-	return staticEvalResult{value: string(utf16.Decode(units[index : index+1])), ok: true}
+	return staticEvalResult{value: ecmascript.StringFromCodeUnits(units[index : index+1]), ok: true}
 }
 
 func staticStringConcat(text string, arguments []any) staticEvalResult {
@@ -1322,7 +1352,7 @@ func staticStringConcat(text string, arguments []any) staticEvalResult {
 		}
 		builder.WriteString(part)
 	}
-	return staticEvalResult{value: builder.String(), ok: true}
+	return staticEvalResult{value: ecmascript.CombineSurrogatePairs(builder.String()), ok: true}
 }
 
 func staticArgumentInteger(arguments []any, index int, defaultValue int) (int, bool) {
@@ -1727,7 +1757,7 @@ func staticValuesStrictEqual(left any, right any) (equal bool, ok bool) {
 	case staticKindString:
 		leftText, _ := staticValueAsString(left)
 		rightText, _ := staticValueAsString(right)
-		return leftText == rightText, true
+		return ecmascript.CompareStrings(leftText, rightText) == 0, true
 	case staticKindNumber:
 		leftNumber, leftOk := staticValueToNumber(left)
 		rightNumber, rightOk := staticValueToNumber(right)
@@ -1866,7 +1896,7 @@ func staticArrayJoin(value *staticArrayValue, separator string) (string, bool) {
 		}
 		builder.WriteString(part)
 	}
-	return builder.String(), true
+	return ecmascript.CombineSurrogatePairs(builder.String()), true
 }
 
 func evaluatorBool(fn func() bool) (value bool, ok bool) {

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -3,12 +3,14 @@
 package utils
 
 import (
+	"math"
 	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 	"gotest.tools/v3/assert"
 )
 
@@ -324,6 +326,101 @@ func TestStaticArrayJoinRejectsExcessiveOutput(t *testing.T) {
 	}
 	if _, ok := staticArrayJoin(value, strings.Repeat("x", 1024)); ok {
 		t.Fatal("staticArrayJoin accepted output above the static string limit")
+	}
+}
+
+func TestStaticStringEvaluatorUTF16Semantics(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir.Dir, "utf16.ts")
+	code := `
+const loneLength = String('\uD800'.length);
+const indexAfterLone = String('\uD800x'.indexOf('x'));
+const astralHighIndex = String('😀'.indexOf('\uD83D'));
+const astralLowIndex = String('😀'.indexOf('\uDE00'));
+const positiveInfinityStart = String('abc'.indexOf('a', 1 / 0));
+const negativeInfinityStart = String('abc'.indexOf('a', -1 / 0));
+const hugePositiveStart = String('abc'.indexOf('a', 1e100));
+const nanStart = String('abc'.indexOf('a', 0 / 0));
+const missingNeedle = String('undefined!'.indexOf());
+const missingNeedleAbsent = String('abc'.indexOf());
+const emptyNeedleInfinity = String('abc'.indexOf('', 1 / 0));
+const emptyNeedleMidPair = String('😀'.indexOf('', 1));
+const sliceHigh = '😀'.slice(0, 1);
+const sliceLow = '😀'.slice(1, 2);
+const substringHigh = '😀'.substring(0, 1);
+const substrLow = '😀'.substr(1, 1);
+const charAtHigh = '😀'.charAt(0);
+const charAtLow = '😀'.charAt(1);
+const fromCharCodeHigh = String.fromCharCode(0xD83D);
+const fromCharCodePair = String.fromCharCode(0xD83D, 0xDE00);
+const concatPair = '\uD83D' + '\uDE00';
+` + "const templatePair = `${'\\uD83D'}${'\\uDE00'}`;\n" + `
+const joinPair = ['\uD83D', '\uDE00'].join('');
+const astralUpper = ('\uD801' + '\uDC28').toUpperCase();
+const astralLower = ('\uD801' + '\uDC00').toLowerCase();
+const strictPair = ('\uD83D' + '\uDE00') === '😀' ? 'yes' : 'no';
+const objectPair = ({['\uD83D' + '\uDE00']: 'yes'})['😀'];
+`
+	fs := NewOverlayVFS(rootDir.FS, map[string]string{filePath: code})
+	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
+	assert.NilError(t, err, "couldn't create program")
+	sourceFile := program.GetSourceFile(filePath)
+	assert.Assert(t, sourceFile != nil)
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+	staticEvaluator := NewStaticStringEvaluatorWithSourceFile(typeChecker, sourceFile)
+
+	high := ecmascript.StringFromCodeUnits([]uint16{0xD83D})
+	low := ecmascript.StringFromCodeUnits([]uint16{0xDE00})
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "loneLength", want: "1"},
+		{name: "indexAfterLone", want: "1"},
+		{name: "astralHighIndex", want: "0"},
+		{name: "astralLowIndex", want: "1"},
+		{name: "positiveInfinityStart", want: "-1"},
+		{name: "negativeInfinityStart", want: "0"},
+		{name: "hugePositiveStart", want: "-1"},
+		{name: "nanStart", want: "0"},
+		{name: "missingNeedle", want: "0"},
+		{name: "missingNeedleAbsent", want: "-1"},
+		{name: "emptyNeedleInfinity", want: "3"},
+		{name: "emptyNeedleMidPair", want: "1"},
+		{name: "sliceHigh", want: high},
+		{name: "sliceLow", want: low},
+		{name: "substringHigh", want: high},
+		{name: "substrLow", want: low},
+		{name: "charAtHigh", want: high},
+		{name: "charAtLow", want: low},
+		{name: "fromCharCodeHigh", want: high},
+		{name: "fromCharCodePair", want: "😀"},
+		{name: "concatPair", want: "😀"},
+		{name: "templatePair", want: "😀"},
+		{name: "joinPair", want: "😀"},
+		{name: "astralUpper", want: "𐐀"},
+		{name: "astralLower", want: "𐐨"},
+		{name: "strictPair", want: "yes"},
+		{name: "objectPair", want: "yes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := staticEvaluator.Eval(findVariableInitializer(t, sourceFile, tt.name))
+			if !ok || got != tt.want {
+				t.Fatalf("Eval(%s) = (%q, %v), want code units %v", tt.name, got, ok, ecmascript.StringCodeUnits(tt.want))
+			}
+		})
+	}
+}
+
+func TestStaticStringIndexOfCommonPrefix(t *testing.T) {
+	text := strings.Repeat("a", 100_000)
+	needle := strings.Repeat("a", 50_000) + "b"
+	result := staticStringIndexOf(text, []any{needle, staticNumberValue(math.Inf(-1))})
+	value, ok := staticValueToNumber(result.value)
+	if !result.ok || !ok || value != -1 {
+		t.Fatalf("staticStringIndexOf common prefix = (%v, %v), want -1", result.value, result.ok)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Keep `no-unsafe-enum-comparison` diagnostics unchanged while withholding enum-member replacement suggestions that cannot preserve runtime semantics across mutable enum objects, initialization order, import elision, aliases, and cycles.
- Evaluate static JavaScript strings as UTF-16 code units, including lone surrogates and surrogate pairs assembled across concatenation, templates, and joins.
- Make static `String#indexOf` match JavaScript for omitted arguments and infinite positions, and replace the quadratic scan with O(n+m) KMP search.

### Verification

- `go test ./internal/plugins/typescript/rules/no_unsafe_enum_comparison -count=3`
- `go test ./internal/utils -count=3`
- `go test ./internal/utils/ecmascript -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_unsafe_enum_comparison ./internal/utils ./internal/utils/ecmascript`

### Go benchmark

Command: `go test ./internal/plugins/typescript/rules/no_unsafe_enum_comparison -run '^$' -bench '^BenchmarkNoUnsafeEnumComparison$' -benchmem -count=6`

Values below are six-sample means; the temporary benchmark source is not included in this PR.

| Case | Time before → after | Change | Bytes before → after | Allocs before → after |
| --- | ---: | ---: | ---: | ---: |
| Diagnostics only | 1764.8 → 1548.7 ns/op | -12.25% | 3080 → 2888 B/op | 46 → 41 |
| Suggestion demand | 2097.8 → 1520.7 ns/op | -27.51% | 3720 → 2888 B/op | 56 → 41 |
| Autofix demand | 1758.0 → 1555.2 ns/op | -11.54% | 3080 → 2888 B/op | 46 → 41 |
| No matching member | 1893.3 → 1582.2 ns/op | -16.43% | 3112 → 2888 B/op | 50 → 41 |
| Common-prefix `indexOf` suggestion | 588274.7 → 1840.0 ns/op | -99.69% | 42470 → 2888 B/op | 64 → 41 |
| No diagnostic | 1367.5 → 1199.3 ns/op | -12.30% | 2880 → 2688 B/op | 40 → 35 |

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
