### PR TITLE
fix: validate Unicode regex rule options

### DIFF
--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.schema.json
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.schema.json
@@ -15,7 +15,7 @@
         },
         "allowPattern": {
           "type": "string",
-          "format": "regex",
+          "format": "regex-u",
           "description": "Regular expression of names to allow."
         },
         "allowPrivateClassPropertyAccess": {

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.schema.json
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.schema.json
@@ -48,7 +48,7 @@
         },
         "regex": {
           "type": "string",
-          "format": "regex"
+          "format": "regex-u"
         }
       },
       "required": ["match", "regex"],
@@ -96,7 +96,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -205,7 +205,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -276,7 +276,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -329,7 +329,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -396,7 +396,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -449,7 +449,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -509,7 +509,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -573,7 +573,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -643,7 +643,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -703,7 +703,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -763,7 +763,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -823,7 +823,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -894,7 +894,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -957,7 +957,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1010,7 +1010,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1063,7 +1063,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1126,7 +1126,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1194,7 +1194,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1262,7 +1262,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1330,7 +1330,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1383,7 +1383,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1436,7 +1436,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1489,7 +1489,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1542,7 +1542,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1595,7 +1595,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1648,7 +1648,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1701,7 +1701,7 @@
               {
                 "minLength": 1,
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.schema.json
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.schema.json
@@ -17,7 +17,7 @@
         },
         "allowWithName": {
           "type": "string",
-          "format": "regex",
+          "format": "regex-u",
           "description": "A stringified regular expression to allow interfaces and object type aliases with the configured name."
         }
       }

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports.schema.json
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports.schema.json
@@ -10,7 +10,7 @@
           "description": "Patterns of import paths to allow requiring from.",
           "items": {
             "type": "string",
-            "format": "regex"
+            "format": "regex-u"
           }
         },
         "allowAsImport": {

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.schema.json
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.schema.json
@@ -19,7 +19,7 @@
             },
             "argsIgnorePattern": {
               "type": "string",
-              "format": "regex",
+              "format": "regex-u",
               "description": "Regular expressions of argument names to not check for usage."
             },
             "caughtErrors": {
@@ -29,12 +29,12 @@
             },
             "caughtErrorsIgnorePattern": {
               "type": "string",
-              "format": "regex",
+              "format": "regex-u",
               "description": "Regular expressions of catch block argument names to not check for usage."
             },
             "destructuredArrayIgnorePattern": {
               "type": "string",
-              "format": "regex",
+              "format": "regex-u",
               "description": "Regular expressions of destructured array variable names to not check for usage."
             },
             "enableAutofixRemoval": {
@@ -71,7 +71,7 @@
             },
             "varsIgnorePattern": {
               "type": "string",
-              "format": "regex",
+              "format": "regex-u",
               "description": "Regular expressions of variable names to not check for usage."
             }
           }

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.schema.json
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.schema.json
@@ -10,7 +10,7 @@
           "description": "Patterns of import paths to allow requiring from.",
           "items": {
             "type": "string",
-            "format": "regex"
+            "format": "regex-u"
           }
         }
       }

--- a/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.schema.json
+++ b/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.schema.json
@@ -15,7 +15,7 @@
         },
         "defaultCaseCommentPattern": {
           "type": "string",
-          "format": "regex",
+          "format": "regex-u",
           "description": "Regular expression for a comment that can indicate an intentionally omitted default case."
         },
         "requireDefaultForNonUnion": {

--- a/internal/plugins/unicorn/rules/catch_error_name/catch_error_name.schema.json
+++ b/internal/plugins/unicorn/rules/catch_error_name/catch_error_name.schema.json
@@ -11,7 +11,7 @@
         },
         "ignore": {
           "type": "array",
-          "items": { "type": "string", "format": "regex" },
+          "items": { "type": "string", "format": "regex-u" },
           "uniqueItems": true,
           "description": "Patterns to ignore."
         }

--- a/internal/rule/schema.go
+++ b/internal/rule/schema.go
@@ -153,6 +153,10 @@ func compileSchemaJSON(rawJSON []byte) (*jsonschema.Schema, any, error) {
 	c := jsonschema.NewCompiler()
 	c.DefaultDraft(jsonschema.Draft4)
 	c.UseRegexpEngine(jsRegexpEngine)
+	c.RegisterFormat(&jsonschema.Format{
+		Name:     "regex-u",
+		Validate: validateUnicodeRegexp,
+	})
 	// An absolute URI in a private scheme, so the schema's base URL can never
 	// be confused with (or resolve against) a real file path or another
 	// resource's URL the way a bare relative "schema.json" could.
@@ -451,6 +455,18 @@ func jsRegexpEngine(pattern string) (jsonschema.Regexp, error) {
 		return nil, err
 	}
 	return jsRegexp{re}, nil
+}
+
+// validateUnicodeRegexp verifies a rule option intended for
+// `new RegExp(pattern, "u")`. This is deliberately a separate format from
+// JSON Schema's standard "regex", whose semantics are an unflagged RegExp.
+func validateUnicodeRegexp(v any) error {
+	pattern, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	_, err := esregexp.Compile(pattern, "u")
+	return err
 }
 
 // jsRegexp adapts *esregexp.RegExp to satisfy jsonschema.Regexp, which asks

--- a/internal/rule/schema_test.go
+++ b/internal/rule/schema_test.go
@@ -216,6 +216,24 @@ func TestValidateAcceptsJavaScriptOnlyRegexAsFormatRegexValue(t *testing.T) {
 	}
 }
 
+func TestValidateUnicodeRegexFormat(t *testing.T) {
+	schema := NewSchema([]byte(`{
+		"type": "array",
+		"items": [{
+			"type": "object",
+			"properties": { "pattern": { "type": "string", "format": "regex-u" } },
+			"additionalProperties": false
+		}]
+	}`))
+
+	if err := schema.Validate([]any{map[string]any{"pattern": `\p{L}+`}}); err != nil {
+		t.Errorf("expected a Unicode property escape to satisfy format: regex-u, got: %v", err)
+	}
+	if err := schema.Validate([]any{map[string]any{"pattern": `\a`}}); err == nil {
+		t.Error("expected an invalid Unicode identity escape to fail format: regex-u, got nil error")
+	}
+}
+
 func TestValidateFillsDefaultsIntoCallerOptionsInPlace(t *testing.T) {
 	// The public Validate contract config.ValidateRuleOptions relies on:
 	// defaults land in the caller's own option maps, so the very config value

--- a/internal/rules/default_case/default_case.schema.json
+++ b/internal/rules/default_case/default_case.schema.json
@@ -6,7 +6,7 @@
       "properties": {
         "commentPattern": {
           "type": "string",
-          "format": "regex"
+          "format": "regex-u"
         }
       },
       "additionalProperties": false

--- a/internal/rules/dot_notation/dot_notation.schema.json
+++ b/internal/rules/dot_notation/dot_notation.schema.json
@@ -9,7 +9,7 @@
         },
         "allowPattern": {
           "type": "string",
-          "format": "regex"
+          "format": "regex-u"
         }
       },
       "additionalProperties": false

--- a/internal/rules/id_length/id_length.schema.json
+++ b/internal/rules/id_length/id_length.schema.json
@@ -22,7 +22,7 @@
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "format": "regex"
+            "format": "regex-u"
           }
         },
         "properties": {

--- a/internal/rules/new_cap/new_cap.schema.json
+++ b/internal/rules/new_cap/new_cap.schema.json
@@ -18,7 +18,7 @@
         },
         "newIsCapExceptionPattern": {
           "type": "string",
-          "format": "regex"
+          "format": "regex-u"
         },
         "capIsNewExceptions": {
           "type": "array",
@@ -28,7 +28,7 @@
         },
         "capIsNewExceptionPattern": {
           "type": "string",
-          "format": "regex"
+          "format": "regex-u"
         },
         "properties": {
           "type": "boolean"

--- a/internal/rules/no_fallthrough/no_fallthrough.schema.json
+++ b/internal/rules/no_fallthrough/no_fallthrough.schema.json
@@ -6,7 +6,7 @@
       "properties": {
         "commentPattern": {
           "type": "string",
-          "format": "regex"
+          "format": "regex-u"
         },
         "allowEmptyCase": {
           "type": "boolean"

--- a/internal/rules/no_inline_comments/no_inline_comments.schema.json
+++ b/internal/rules/no_inline_comments/no_inline_comments.schema.json
@@ -6,7 +6,7 @@
       "properties": {
         "ignorePattern": {
           "type": "string",
-          "format": "regex"
+          "format": "regex-u"
         }
       },
       "additionalProperties": false

--- a/internal/rules/no_param_reassign/no_param_reassign.schema.json
+++ b/internal/rules/no_param_reassign/no_param_reassign.schema.json
@@ -29,7 +29,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "format": "regex"
+                "format": "regex-u"
               },
               "uniqueItems": true
             }

--- a/internal/rules/no_restricted_exports/no_restricted_exports.schema.json
+++ b/internal/rules/no_restricted_exports/no_restricted_exports.schema.json
@@ -15,7 +15,7 @@
             },
             "restrictedNamedExportsPattern": {
               "type": "string",
-              "format": "regex"
+              "format": "regex-u"
             }
           },
           "additionalProperties": false
@@ -33,7 +33,7 @@
             },
             "restrictedNamedExportsPattern": {
               "type": "string",
-              "format": "regex"
+              "format": "regex-u"
             },
             "restrictDefaultExports": {
               "type": "object",

--- a/internal/rules/no_unused_vars/no_unused_vars.schema.json
+++ b/internal/rules/no_unused_vars/no_unused_vars.schema.json
@@ -14,7 +14,7 @@
             },
             "varsIgnorePattern": {
               "type": "string",
-              "format": "regex"
+              "format": "regex-u"
             },
             "args": {
               "enum": ["all", "after-used", "none"]
@@ -24,18 +24,18 @@
             },
             "argsIgnorePattern": {
               "type": "string",
-              "format": "regex"
+              "format": "regex-u"
             },
             "caughtErrors": {
               "enum": ["all", "none"]
             },
             "caughtErrorsIgnorePattern": {
               "type": "string",
-              "format": "regex"
+              "format": "regex-u"
             },
             "destructuredArrayIgnorePattern": {
               "type": "string",
-              "format": "regex"
+              "format": "regex-u"
             },
             "ignoreClassWithStaticInitBlock": {
               "type": "boolean"

--- a/internal/rules/object_shorthand/object_shorthand.schema.json
+++ b/internal/rules/object_shorthand/object_shorthand.schema.json
@@ -50,7 +50,7 @@
             },
             "methodsIgnorePattern": {
               "type": "string",
-              "format": "regex"
+              "format": "regex-u"
             },
             "avoidQuotes": {
               "type": "boolean"


### PR DESCRIPTION
## Summary

Add the `regex-u` schema format for options compiled with `new RegExp(pattern, "u")`, and migrate the matching core, TypeScript, and Unicorn rule schemas.

This rejects patterns accepted without `u` but discarded by their rules at runtime. Plain `regex` remains for options whose upstream rules use unflagged `RegExp`.

## Testing

- `go test ./internal/rule ./internal/rules/default_case ./internal/rules/dot_notation ./internal/rules/id_length ./internal/rules/new_cap ./internal/rules/no_fallthrough ./internal/rules/no_inline_comments ./internal/rules/no_param_reassign ./internal/rules/no_restricted_exports ./internal/rules/no_unused_vars ./internal/rules/object_shorthand ./internal/plugins/typescript/rules/dot_notation ./internal/plugins/typescript/rules/naming_convention ./internal/plugins/typescript/rules/no_empty_object_type ./internal/plugins/typescript/rules/no_require_imports ./internal/plugins/typescript/rules/no_unused_vars ./internal/plugins/typescript/rules/no_var_requires ./internal/plugins/typescript/rules/switch_exhaustiveness_check ./internal/plugins/unicorn/rules/catch_error_name`