### PR TITLE
fix: handle external TypeScript references in id-match

### DIFF
--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 // RefStore owns the per-file identifier-reference index for one linted source
@@ -195,13 +196,51 @@ func sharesDeclaration(a, b *ast.Symbol) bool {
 //
 // Returns nil for identifiers that aren't reference positions (declaration
 // names, property keys, import bindings, re-export/alias-label names, labels,
-// intrinsic JSX tags — see isReferencePosition) and for names that don't
+// intrinsic JSX tags — see scope.IsReferenceIdentifier) and for names that don't
 // resolve to any symbol.
 func (s *RefStore) Resolve(node *ast.Node) *ast.Symbol {
-	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
+	if s == nil || !scope.IsReferenceIdentifier(node) {
 		return nil
 	}
-	meaning := referenceMeaning(node)
+	return s.resolveReference(node, referenceMeaning(node))
+}
+
+// ResolveTypeOrNamespace returns the symbol selected by node's exact
+// TypeScript meaning only when that reference meaning, and the selected symbol
+// itself, are type- or namespace-capable. It resolves with the full meaning
+// first so a local value selected by a dual-space export cannot be bypassed by
+// a second, narrower type lookup.
+//
+// Alias capability is read through the checker when available, but the alias
+// symbol itself is returned so callers can still tell whether its declaration
+// belongs to the linted file.
+func (s *RefStore) ResolveTypeOrNamespace(node *ast.Node) *ast.Symbol {
+	if s == nil || !scope.IsReferenceIdentifier(node) {
+		return nil
+	}
+	semanticMeaning := scope.TypeScriptReferenceMeaning(node)
+	capability := typeOrNamespaceSymbolFlags(semanticMeaning)
+	if capability == 0 {
+		return nil
+	}
+	symbol := s.resolveReference(node, referenceMeaningForSemanticMeaning(node, semanticMeaning))
+	if symbol == nil {
+		return nil
+	}
+	flags := symbol.Flags
+	if flags&ast.SymbolFlagsAlias != 0 {
+		if s.tc == nil {
+			return nil
+		}
+		flags = s.tc.GetSymbolFlags(symbol)
+	}
+	if flags&capability == 0 {
+		return nil
+	}
+	return symbol
+}
+
+func (s *RefStore) resolveReference(node *ast.Node, meaning ast.SymbolFlags) *ast.Symbol {
 	if sym := s.binderReferenceSymbol(node, meaning); sym != nil {
 		return sym
 	}
@@ -219,7 +258,7 @@ func (s *RefStore) Resolve(node *ast.Node) *ast.Symbol {
 // their answer must not change merely because rslint happened to construct a
 // TypeChecker for the file.
 func (s *RefStore) ResolveInFile(node *ast.Node) *ast.Symbol {
-	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
+	if s == nil || !scope.IsReferenceIdentifier(node) {
 		return nil
 	}
 	return s.binderReferenceSymbol(node, referenceMeaning(node))
@@ -231,7 +270,7 @@ func (s *RefStore) ResolveInFile(node *ast.Node) *ast.Symbol {
 // independently be type-capable, value-capable, or both. Like ResolveInFile,
 // it never consults the TypeChecker or declarations outside this source file.
 func (s *RefStore) ResolveInFileWithMeaning(node *ast.Node, meaning ast.SymbolFlags) *ast.Symbol {
-	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
+	if s == nil || !scope.IsReferenceIdentifier(node) {
 		return nil
 	}
 	return s.binderReferenceSymbol(node, meaning)
@@ -248,7 +287,7 @@ func (s *RefStore) HasImplicitWrapperBinding(name string) bool {
 // resolved file wrapper. It never consults the TypeChecker and does not
 // manufacture an ast.Symbol for an implicit binding.
 func (s *RefStore) IsDefinedInFile(node *ast.Node) bool {
-	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
+	if s == nil || !scope.IsReferenceIdentifier(node) {
 		return false
 	}
 	if s.binderReferenceSymbol(node, referenceMeaning(node)) != nil {
@@ -565,7 +604,7 @@ func (s *RefStore) hasAuthoredProgramDefinition(name string) bool {
 // IsGlobalReference is IsGlobalNameReference using the declaration-space
 // meaning implied by node's syntactic reference position.
 func (s *RefStore) IsGlobalReference(node *ast.Node) bool {
-	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
+	if s == nil || !scope.IsReferenceIdentifier(node) {
 		return false
 	}
 	meaning := referenceMeaning(node)
@@ -705,7 +744,7 @@ func (s *RefStore) collectCandidates() {
 	s.refs = make(map[*ast.Symbol][]*ast.Node)
 	var visit func(n *ast.Node) bool
 	visit = func(n *ast.Node) bool {
-		if n.Kind == ast.KindIdentifier && isReferencePosition(n) {
+		if scope.IsReferenceIdentifier(n) {
 			text := n.Text()
 			s.candidates[text] = append(s.candidates[text], n)
 		}
@@ -715,166 +754,37 @@ func (s *RefStore) collectCandidates() {
 	s.sourceFile.AsNode().ForEachChild(visit)
 }
 
-// isReferencePosition reports whether an identifier can reference a symbol
-// declared elsewhere: not a declaration name, and not a position that names
-// something non-local (property names, import bindings, labels, intrinsic JSX
-// tags). The one exception is a local named export's real target — see the
-// ExportSpecifier case below.
-func isReferencePosition(n *ast.Node) bool {
-	p := n.Parent
-	if p != nil && p.Kind == ast.KindShorthandPropertyAssignment && p.AsShorthandPropertyAssignment().Name() == n {
-		// `{x}` reads x as an expression, and `({x} = obj)` writes to x once
-		// the object literal is reinterpreted as an assignment pattern;
-		// IsDeclarationName treats this name as a declaration (it also
-		// declares the object's property), which would otherwise discard
-		// both real uses.
-		return true
-	}
-	if p != nil && p.Kind == ast.KindExportSpecifier {
-		// `export { foo }` / `export { foo as bar }` reads its local binding
-		// through PropertyName when present (the rename target, `foo`) or
-		// Name when it isn't (no rename) — ESLint's scope-manager marks this
-		// as a read of that binding. IsDeclarationName treats this node as a
-		// declaration either way (Name() equals the node itself when there's
-		// no PropertyName, and equals the alias label `bar` when there is),
-		// which would otherwise discard the real local reference the same
-		// way it would for a shorthand property name above. A re-export
-		// (`export { foo } from 'mod'`, aliased or not) references the
-		// other module's binding instead, so neither part is a reference
-		// there.
-		if utils.IsReExportSpecifier(p) {
-			return false
-		}
-		if propertyName := p.PropertyName(); propertyName != nil {
-			return propertyName == n
-		}
-		return true
-	}
-	if ast.IsDeclarationName(n) {
-		return false
-	}
-	if p == nil {
-		return false
-	}
-	switch p.Kind {
-	case ast.KindPropertyAccessExpression:
-		return p.AsPropertyAccessExpression().Name() != n
-	case ast.KindQualifiedName:
-		return p.AsQualifiedName().Right != n
-	case ast.KindPropertyAssignment:
-		return p.AsPropertyAssignment().Name() != n
-	case ast.KindBindingElement:
-		return p.AsBindingElement().PropertyName != n
-	case ast.KindImportAttribute:
-		// Import attribute keys (`type` in `with { type: "json" }`) are
-		// syntactic names, not references to same-named variables.
-		return p.AsImportAttribute().Name() != n
-	case ast.KindImportSpecifier, ast.KindNamespaceImport,
-		ast.KindImportClause, ast.KindNamespaceExport:
-		// Import bindings and the export half of `export * as NS` resolve
-		// through module/alias machinery the checker owns; the current
-		// consumers never treat them as references.
-		return false
-	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement:
-		// Labels live in their own namespace and never reference variables.
-		return false
-	case ast.KindMetaProperty:
-		// `target`/`meta`/`defer` in `new.target`, `import.meta`, and
-		// `import.defer` are syntactic, not identifiers that can reference a
-		// variable.
-		return false
-	case ast.KindJsxNamespacedName:
-		// The namespace and name pieces of a namespaced JSX tag or attribute
-		// (`<foo:bar attr:name="v" />`) are syntactic, never variable
-		// references; the plain identifier tag name case is still handled
-		// by IsJsxTagName below.
-		return false
-	}
-	if ast.IsJsxTagName(n) {
-		// Lowercase tag names are JSX intrinsics (`<div>`), not identifier
-		// references; uppercase ones reference a component value.
-		text := n.Text()
-		return len(text) > 0 && (text[0] < 'a' || text[0] > 'z')
-	}
-	return true
-}
-
 // referenceMeaning mirrors the meaning the checker's
 // getSymbolOfNameOrPropertyAccessExpression would resolve this identifier
 // with. SymbolFlagsAlias is always included: the plain binder lookup cannot
 // resolve alias targets, so import aliases must match on the alias symbol
 // itself (which is also what the reference consumers track).
 func referenceMeaning(n *ast.Node) ast.SymbolFlags {
-	p := n.Parent
-	if p != nil && p.Kind == ast.KindTypePredicate {
+	return referenceMeaningForSemanticMeaning(n, scope.TypeScriptReferenceMeaning(n))
+}
+
+func referenceMeaningForSemanticMeaning(n *ast.Node, meaning ast.SemanticMeaning) ast.SymbolFlags {
+	if n.Parent != nil && n.Parent.Kind == ast.KindTypePredicate {
 		// `x is T` — the x names a parameter.
 		return ast.SymbolFlagsFunctionScopedVariable
 	}
-	if p != nil && p.Kind == ast.KindExportAssignment {
-		// `export = Foo` and `export default Foo` resolve entity names in all
-		// declaration spaces. In particular, TypeScript permits type-only
-		// declarations such as an interface to be consumed by `export =`.
-		// Mirror the checker's getSymbolOfNameOrPropertyAccessExpression path
-		// instead of treating the identifier as an ordinary value expression.
-		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
-	}
-	if p != nil && p.Kind == ast.KindExportSpecifier {
-		// A type-only export creates a type reference. It may bind to a type,
-		// namespace, or import alias, but never to a value-only declaration.
-		// Namespace is separate from Type in the TypeScript binder even though
-		// typescript-eslint scope-manager treats namespace definitions as
-		// type-capable variables.
-		if ast.IsTypeOnlyImportOrExportDeclaration(p) {
-			return ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
-		}
-		// A regular local export creates a dual value/type reference, so it
-		// can bind in any declaration space.
-		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
-	}
-	// `import a = b.c` — the right-hand side may name a value, type, or
-	// namespace.
-	entity := n
-	for entity.Parent != nil && entity.Parent.Kind == ast.KindQualifiedName {
-		entity = entity.Parent
-	}
-	if entity.Parent != nil && entity.Parent.Kind == ast.KindImportEqualsDeclaration &&
-		entity.Parent.AsImportEqualsDeclaration().ModuleReference == entity {
-		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
-	}
-	// Heritage clauses parse dotted names as PropertyAccessExpressions rather
-	// than QualifiedNames. In a type-only heritage position, the root of that
-	// property-access chain still names a namespace and must skip a same-named
-	// value binding. A class `extends` expression is not part of a type node, so
-	// it deliberately continues to the value-space branch below.
-	if isTypeOnlyPropertyAccessQualifier(n) {
-		return ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
-	}
-	if ast.IsExpressionNode(n) {
-		return ast.SymbolFlagsValue | ast.SymbolFlagsAlias
-	}
-	// Leftmost qualifier of a non-expression entity name (`A` in `let x: A.B`)
-	// names a namespace. Expression and typeof chains were handled above.
-	if p != nil && p.Kind == ast.KindQualifiedName && p.AsQualifiedName().Left == n {
-		return ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
-	}
-	if ast.IsPartOfTypeNode(n) {
-		return ast.SymbolFlagsType | ast.SymbolFlagsAlias
-	}
-	return ast.SymbolFlagsValue | ast.SymbolFlagsAlias
+	return symbolFlagsForSemanticMeaning(meaning) | ast.SymbolFlagsAlias
 }
 
-// isTypeOnlyPropertyAccessQualifier reports whether n is the lexical root of
-// an expression-shaped qualified name used as a type. TypeScript represents
-// `N.T` in `class C implements N.T` and `interface I extends N.T` with a
-// PropertyAccessExpression, even though N has namespace meaning there.
-func isTypeOnlyPropertyAccessQualifier(n *ast.Node) bool {
-	entity := n
-	for entity.Parent != nil && entity.Parent.Kind == ast.KindPropertyAccessExpression {
-		access := entity.Parent.AsPropertyAccessExpression()
-		if access == nil || access.Expression != entity {
-			break
-		}
-		entity = entity.Parent
+func symbolFlagsForSemanticMeaning(meaning ast.SemanticMeaning) ast.SymbolFlags {
+	var flags ast.SymbolFlags
+	if meaning&ast.SemanticMeaningValue != 0 {
+		flags |= ast.SymbolFlagsValue
 	}
-	return entity != n && ast.IsPartOfTypeNode(entity)
+	if meaning&ast.SemanticMeaningType != 0 {
+		flags |= ast.SymbolFlagsType
+	}
+	if meaning&ast.SemanticMeaningNamespace != 0 {
+		flags |= ast.SymbolFlagsNamespace
+	}
+	return flags
+}
+
+func typeOrNamespaceSymbolFlags(meaning ast.SemanticMeaning) ast.SymbolFlags {
+	return symbolFlagsForSemanticMeaning(meaning & (ast.SemanticMeaningType | ast.SemanticMeaningNamespace))
 }

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -360,6 +360,112 @@ func TestRefStoreExportAssignmentResolvesTypeOnlySymbol(t *testing.T) {
 	}
 }
 
+func TestRefStoreResolveTypeOrNamespaceUsesExactReferenceMeaning(t *testing.T) {
+	tests := []struct {
+		name         string
+		source       string
+		identifier   string
+		wantResolved bool
+	}{
+		{
+			name:         "direct export resolves type",
+			source:       `export = Record;`,
+			identifier:   "Record",
+			wantResolved: true,
+		},
+		{
+			name:       "parenthesized export is value-only",
+			source:     `export = ((Record));`,
+			identifier: "Record",
+		},
+		{
+			name:       "import equals rejects type-only target",
+			source:     `import Alias = Record;`,
+			identifier: "Record",
+		},
+		{
+			name:         "import equals resolves namespace target",
+			source:       `import Alias = Intl.Collator;`,
+			identifier:   "Intl",
+			wantResolved: true,
+		},
+		{
+			name:         "qualified type root resolves namespace",
+			source:       `type T = Intl.CollatorOptions;`,
+			identifier:   "Intl",
+			wantResolved: true,
+		},
+		{
+			name:       "type query remains value-only",
+			source:     `type T = typeof Intl;`,
+			identifier: "Intl",
+		},
+		{
+			name:       "class extends remains value-only",
+			source:     `class C extends Intl.Collator {}`,
+			identifier: "Intl",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile, refs, done := newCheckedRefStore(t, test.source)
+			defer done()
+			occurrences := identifiers(sourceFile.AsNode(), test.identifier)
+			if len(occurrences) != 1 {
+				t.Fatalf("identifier occurrences = %d, want 1", len(occurrences))
+			}
+			resolved := refs.ResolveTypeOrNamespace(occurrences[0])
+			if (resolved != nil) != test.wantResolved {
+				t.Fatalf("ResolveTypeOrNamespace(%s) = %v, wantResolved %v", test.identifier, resolved, test.wantResolved)
+			}
+		})
+	}
+}
+
+func TestRefStoreResolveTypeOrNamespaceKeepsTheExactTarget(t *testing.T) {
+	t.Run("import equals uses namespace meaning", func(t *testing.T) {
+		sourceFile, refs, done := newCheckedRefStore(t, `import Alias = Record;`)
+		defer done()
+		occurrences := identifiers(sourceFile.AsNode(), "Record")
+		if len(occurrences) != 1 {
+			t.Fatalf("identifier occurrences = %d, want 1", len(occurrences))
+		}
+		if got := refs.Resolve(occurrences[0]); got != nil {
+			t.Fatalf("Resolve(type-only import-equals root) = %v, want nil", got)
+		}
+	})
+
+	t.Run("local value shadows external type", func(t *testing.T) {
+		sourceFile, refs, done := newCheckedRefStore(t, `const Record = 1; export default Record;`)
+		defer done()
+		occurrences := identifiers(sourceFile.AsNode(), "Record")
+		if len(occurrences) != 2 {
+			t.Fatalf("identifier occurrences = %d, want 2", len(occurrences))
+		}
+		if got := refs.ResolveTypeOrNamespace(occurrences[1]); got != nil {
+			t.Fatalf("ResolveTypeOrNamespace(local value) = %v, want nil", got)
+		}
+		if got, want := refs.Resolve(occurrences[1]), occurrences[0].Parent.Symbol(); got != want {
+			t.Fatalf("Resolve(local value) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("local alias retains its authored identity", func(t *testing.T) {
+		sourceFile, refs, done := newCheckedRefStore(t, `import type { T as Alias } from "./foo"; export default Alias;`)
+		defer done()
+		occurrences := identifiers(sourceFile.AsNode(), "Alias")
+		if len(occurrences) != 2 {
+			t.Fatalf("identifier occurrences = %d, want 2", len(occurrences))
+		}
+		got := refs.ResolveTypeOrNamespace(occurrences[1])
+		want := occurrences[0].Parent.Symbol()
+		if got == nil || got != want {
+			t.Fatalf("ResolveTypeOrNamespace(local alias) = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestRefStoreExportDefaultNamedFunction(t *testing.T) {
 	// A named default export is bound to an export symbol named "default", so
 	// looking its candidates up by symbol name finds nothing: the references

--- a/internal/rules/id_match/id_match.go
+++ b/internal/rules/id_match/id_match.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	esregexp "github.com/web-infra-dev/rslint/internal/utils/ecmascript/regexp"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 //go:embed id_match.schema.json
@@ -110,7 +111,10 @@ func (r *idMatch) report(node *ast.Node, name string) {
 	if r.isReferenceToGlobalVariable(node, name) || r.isExternallyDeclaredType(node, name) {
 		return
 	}
-	r.ctx.ReportNode(node, messageNotMatch(name, r.opts.pattern))
+	r.ctx.ReportRange(
+		utils.GetESTreeBindingIdentifierRange(r.ctx.SourceFile, node),
+		messageNotMatch(name, r.opts.pattern),
+	)
 }
 
 func (r *idMatch) reportIfInvalid(node *ast.Node, name string) {
@@ -338,17 +342,32 @@ func isNonReferenceIdentifier(node *ast.Node) bool {
 	return utils.IsNonReferenceIdentifier(node)
 }
 
-// isExternallyDeclaredType reports whether a name used in a type position is
-// declared somewhere other than the linted file — `Record`, `Omit` and the
-// rest of the TypeScript standard library, an ambient declaration, a global
-// another file contributes.
+// isExternallyDeclaredType reports whether a reference that TypeScript can
+// resolve in type or namespace space is declared somewhere other than the
+// linted file — `Record`, `Omit` and the rest of the standard library, an
+// ambient declaration, or a global another file contributes.
 //
 // NOTE: Unlike ESLint, whose scope model has no types in it at all, rslint has
 // to answer this to stay usable on TypeScript: without it every `Record<K, V>`
 // in the project is reported against a pattern its author never chose. A name
 // the file itself declares or imports still counts as the author's.
 func (r *idMatch) isExternallyDeclaredType(node *ast.Node, name string) bool {
-	if r.ctx.SourceFile == nil || !ast.IsPartOfTypeNode(node) || !isTypeGlobalReference(node) {
+	if r.ctx.SourceFile == nil || ast.IsInJSFile(node) || !isTypeGlobalReference(node) {
+		return false
+	}
+	// A local export specifier has an overlaid exported-name role in ESTree.
+	// In the unaliased form that non-reference role shares the reference's
+	// source range and decides the diagnostic; keep both aliased and unaliased
+	// forms authored rather than extending the external-type policy to invalid
+	// exports of ambient globals.
+	if node.Parent != nil && node.Parent.Kind == ast.KindExportSpecifier {
+		return false
+	}
+	// Preserve the ordinary-value fast path: those references account for the
+	// overwhelming majority of identifier visits and cannot select an external
+	// type. The explicit shapes are precisely the legal references that
+	// ast.IsPartOfTypeNode does not recognize on the identifier alone.
+	if !mayReferenceExternalTypeOrNamespace(node) {
 		return false
 	}
 	// The standard library's own names are answered without asking for a
@@ -357,15 +376,38 @@ func (r *idMatch) isExternallyDeclaredType(node *ast.Node, name string) bool {
 	// tsconfig owns and stays quiet in one a tsconfig does. This list is the
 	// type-capable global scope typescript-eslint seeds, which is where its
 	// own scope model finds these names.
-	if r.isDefaultTypeGlobal(name) && !r.isDeclaredInFile(node, name) {
-		return true
+	if r.isDefaultTypeGlobal(name) {
+		semanticMeaning := scope.TypeScriptReferenceMeaning(node)
+		if semanticMeaning&ast.SemanticMeaningType != 0 && !r.isDeclaredInFile(node, name) {
+			return true
+		}
 	}
-	symbol := r.ctx.Refs.Resolve(node)
+	symbol := r.ctx.Refs.ResolveTypeOrNamespace(node)
 	if symbol == nil || len(symbol.Declarations) == 0 {
 		// A name nothing declares is still the author's to fix.
 		return false
 	}
 	return !utils.IsSymbolDeclaredInFile(symbol, r.ctx.SourceFile)
+}
+
+func mayReferenceExternalTypeOrNamespace(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	parent := node.Parent
+	switch parent.Kind {
+	case ast.KindExportAssignment:
+		return true
+	case ast.KindQualifiedName:
+		return parent.AsQualifiedName().Left == node
+	case ast.KindPropertyAccessExpression:
+		access := parent.AsPropertyAccessExpression()
+		return access != nil && access.Expression == node && scope.InTypePosition(node)
+	case ast.KindImportEqualsDeclaration:
+		return parent.AsImportEqualsDeclaration().ModuleReference == node
+	default:
+		return ast.IsPartOfTypeNode(node)
+	}
 }
 
 // isDefaultTypeGlobal reports whether name belongs to TypeScript-ESLint's

--- a/internal/rules/id_match/id_match.md
+++ b/internal/rules/id_match/id_match.md
@@ -8,7 +8,7 @@ The pattern is the rule's first option and is read as a JavaScript regular expre
 
 TypeScript names count as identifiers too: type aliases, interfaces, type parameters, enums and their members, namespaces, and the names a type annotation refers to are all held to the pattern.
 
-Names the file does not declare are left alone, because the author has no say in what they are called: a reference to a global such as `Object` or `Array`, a type the TypeScript standard library declares such as `Record` or `Partial`, the key of an import attribute (`with { type: "json" }`), and `import.meta` / `new.target`. A type the file declares or imports is the author's, and is checked.
+References to known globals such as `Object` or `Array` are left alone unless that reference resolves to a declaration in the file. In TypeScript, the same is true of a reference used as a type when its name is a recognized standard-library type such as `Record` or `Partial`. A valid type or namespace reference is likewise left alone when it resolves to a global declaration supplied by another project file. Fixed syntax names such as the key of an import attribute (`with { type: "json" }`) and `import.meta` / `new.target` are also left alone. By contrast, `Missing_NS` in `type T = Missing_NS.Member`, `Record` in the value expression `Record;`, and a type declared or imported by the current file are checked.
 
 Examples of **incorrect** code for this rule:
 
@@ -159,10 +159,9 @@ var { category_id = 1 } = query;
 
 ## Differences from ESLint
 
-- A name carrying a type annotation, a `?`, or a `!` is reported over the name alone. ESLint with a TypeScript parser reports over the name and everything the annotation adds, so on `function f(a_1: string) {}` the report ends at column 15 here and at column 26 there, and on `let a_1!: number;` at column 8 here and at column 17 there.
-- A class constructor whose `constructor` spelling contains a Unicode escape is rejected as syntax before rules run. ESLint accepts that spelling and checks the decoded name.
+- Given `External_NS` as a global namespace supplied by another TypeScript project file, rslint does not report it in `type T = External_NS.Member` when it fails the configured pattern; ESLint does. Both skip `Record` in `type U = Record<string, unknown>`.
 
 ## Original Documentation
 
 - [ESLint: id-match](https://eslint.org/docs/latest/rules/id-match)
-- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/id-match.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/id-match.js)

--- a/internal/rules/id_match/id_match_external_types_test.go
+++ b/internal/rules/id_match/id_match_external_types_test.go
@@ -1,0 +1,158 @@
+package id_match
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/testutil"
+	"github.com/web-infra-dev/rslint/internal/testutil/txtarfs"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
+)
+
+func TestMayReferenceExternalTypeOrNamespaceCoversExactMeanings(t *testing.T) {
+	for _, source := range []string{
+		`export = Subject;`,
+		`type T = Subject;`,
+		`type T = Subject.Member;`,
+		`interface I extends Subject {}`,
+		`interface I extends Subject.Member {}`,
+		`class C implements Subject {}`,
+		`class C implements Subject.Member {}`,
+		`import Alias = Subject;`,
+		`import Alias = Subject.Member;`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+				Path:     "/test.ts",
+			}, source, core.ScriptKindTS)
+			var subject *ast.Node
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if subject == nil && node.Kind == ast.KindIdentifier && node.Text() == "Subject" &&
+					scope.IsReferenceIdentifier(node) {
+					subject = node
+				}
+				node.ForEachChild(visit)
+				return false
+			}
+			sourceFile.AsNode().ForEachChild(visit)
+			if subject == nil {
+				t.Fatal("Subject reference not found")
+			}
+			meaning := scope.TypeScriptReferenceMeaning(subject)
+			if meaning&(ast.SemanticMeaningType|ast.SemanticMeaningNamespace) == 0 {
+				t.Fatalf("meaning = %v, want type or namespace capability", meaning)
+			}
+			if !mayReferenceExternalTypeOrNamespace(subject) {
+				t.Fatal("fast path rejected a type- or namespace-capable reference")
+			}
+		})
+	}
+}
+
+func TestIdMatchExternalTypeAndNamespaceReferences(t *testing.T) {
+	archive := txtarfs.MustParseFile(t, "testdata/external_references.txtar")
+	root := tspath.NormalizePath(archive.Materialize(t, "external-references"))
+	fs := bundled.WrapFS(osvfs.FS())
+	program, err := utils.CreateProgram(true, fs, root, "tsconfig.json", utils.CreateCompilerHost(root, fs))
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	sourceProgram := lintprogram.NewFromCompiler(program)
+
+	tests := []struct {
+		name       string
+		file       string
+		properties bool
+		want       []string
+	}{
+		{
+			name: "external type and namespace meanings",
+			file: "valid.ts",
+		},
+		{
+			name: "dual export of external namespace",
+			file: "namespace-export.ts",
+		},
+		{
+			name:       "external heritage roots with properties enabled",
+			file:       "valid.ts",
+			properties: true,
+		},
+		{
+			name: "dual export of external class",
+			file: "class-export.ts",
+		},
+		{
+			name: "parenthesized external type is a value",
+			file: "parenthesized.ts",
+			want: []string{"External_Interface"},
+		},
+		{
+			name: "value local and unresolved controls",
+			file: "controls.ts",
+			want: []string{
+				"External_NS",
+				"External_Value",
+				"External_Class",
+				"External_Value",
+				"External_Interface",
+				"Missing_NS",
+				"Local_Type",
+				"Local_Type",
+			},
+		},
+		{
+			name: "local value wins over external type",
+			file: "shadow.ts",
+			want: []string{"External_Interface", "External_Interface"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileName := tspath.ResolvePath(root, test.file)
+			got := make([]string, 0, len(test.want))
+			options := []any{`^[^_]+$`}
+			if test.properties {
+				options = append(options, map[string]any{"properties": true})
+			}
+			testutil.LintProgram(t, testutil.LintProgramOptions{
+				Program:                sourceProgram,
+				Files:                  []string{fileName},
+				ExcludedPathSubstrings: []string{},
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{
+						Name:        IdMatchRule.Name,
+						Environment: &rule.RuleEnvironment{},
+						Severity:    rule.SeverityError,
+						Run: func(ctx rule.RuleContext) rule.RuleListeners {
+							return IdMatchRule.Run(ctx, options)
+						},
+					}}
+				},
+				OnDiagnostic: func(diagnostic rule.RuleDiagnostic) {
+					got = append(got, diagnostic.Message.Description)
+				},
+			})
+			if len(got) != len(test.want) {
+				t.Fatalf("diagnostic names = %q, want %q", got, test.want)
+			}
+			for index, want := range test.want {
+				wantMessage := messageNotMatch(want, `^[^_]+$`).Description
+				if got[index] != wantMessage {
+					t.Errorf("diagnostic %d = %q, want %q", index+1, got[index], wantMessage)
+				}
+			}
+		})
+	}
+}

--- a/internal/rules/id_match/id_match_extras_noproject_test.go
+++ b/internal/rules/id_match/id_match_extras_noproject_test.go
@@ -45,6 +45,16 @@ func TestIdMatchExtrasNoProject(t *testing.T) {
 			options: []any{`^x$`},
 		},
 		{
+			name:    "library type in export assignment",
+			code:    "export = Record;",
+			options: []any{`^x$`},
+		},
+		{
+			name:    "library type in default export",
+			code:    "export default Record;",
+			options: []any{`^x$`},
+		},
+		{
 			// ---- A qualified member is still an authored name ----
 			name:    "library names as qualified type members",
 			code:    "type X = Foo.Record<string> | Foo.Array<string> | Foo.Partial<string>;",

--- a/internal/rules/id_match/id_match_extras_typescript_test.go
+++ b/internal/rules/id_match/id_match_extras_typescript_test.go
@@ -27,6 +27,14 @@ func TestIdMatchExtrasTypescript(t *testing.T) {
 				Options: []any{`^x$`},
 			},
 			{
+				Code:    `export = Record;`,
+				Options: []any{`^x$`},
+			},
+			{
+				Code:    `export default Record;`,
+				Options: []any{`^x$`},
+			},
+			{
 				Code:    `let x: ReadonlyArray<number>;`,
 				Options: []any{`^x$`},
 			},
@@ -72,6 +80,124 @@ func TestIdMatchExtrasTypescript(t *testing.T) {
 			},
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- Only a bare export assignment has type meaning ----
+			{
+				Code:    `export = (Record);`,
+				Options: []any{`^x$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^x$'.`,
+						Line:      1,
+						Column:    11,
+						EndLine:   1,
+						EndColumn: 17,
+					},
+				},
+			},
+			{
+				Code:    `export default ((Record));`,
+				Options: []any{`^x$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^x$'.`,
+						Line:      1,
+						Column:    18,
+						EndLine:   1,
+						EndColumn: 24,
+					},
+				},
+			},
+			{
+				Code:    `export default (Record as unknown);`,
+				Options: []any{`^x$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^x$'.`,
+						Line:      1,
+						Column:    17,
+						EndLine:   1,
+						EndColumn: 23,
+					},
+				},
+			},
+			{
+				Code:    `type X = Record.T;`,
+				Options: []any{`^(X|T)$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^(X|T)$'.`,
+						Line:      1,
+						Column:    10,
+						EndLine:   1,
+						EndColumn: 16,
+					},
+				},
+			},
+			{
+				Code:    `import X = Record;`,
+				Options: []any{`^X$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^X$'.`,
+						Line:      1,
+						Column:    12,
+						EndLine:   1,
+						EndColumn: 18,
+					},
+				},
+			},
+			{
+				Code:    `export type { Record as X };`,
+				Options: []any{`^X$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^X$'.`,
+						Line:      1,
+						Column:    15,
+						EndLine:   1,
+						EndColumn: 21,
+					},
+				},
+			},
+			{
+				Code:     `export default Record;`,
+				FileName: "export-default-global.js",
+				TSConfig: "tsconfig.allow-js.json",
+				Options:  []any{`^x$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^x$'.`,
+						Line:      1,
+						Column:    16,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+				},
+			},
+			{
+				Code:     `export default Record;`,
+				FileName: "export-default-global.jsx",
+				TSConfig: "tsconfig.allow-js.json",
+				Tsx:      true,
+				Options:  []any{`^x$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'Record' does not match the pattern '^x$'.`,
+						Line:      1,
+						Column:    16,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+				},
+			},
 			// ---- A class constructor is checked like any other name ----
 			{
 				Code:    `class foo { constructor() {} }`,
@@ -298,7 +424,7 @@ let x: Foo_1;`,
 					},
 				},
 			},
-			// ---- A parameter is reported over its name, not over its type annotation ----
+			// ---- A direct binding identifier owns its TypeScript annotation in TSESTree ----
 			{
 				Code:    `function f(a_1: string) {}`,
 				Options: []any{`^[^_]+$`},
@@ -309,7 +435,52 @@ let x: Foo_1;`,
 						Line:      1,
 						Column:    12,
 						EndLine:   1,
-						EndColumn: 15,
+						EndColumn: 23,
+					},
+				},
+			},
+			// ---- A direct binding identifier owns its optional marker in TSESTree ----
+			{
+				Code:    `function f(a_1?) {}`,
+				Options: []any{`^[^_]+$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'a_1' does not match the pattern '^[^_]+$'.`,
+						Line:      1,
+						Column:    12,
+						EndLine:   1,
+						EndColumn: 16,
+					},
+				},
+			},
+			// ---- A variable binding owns its definite marker and annotation in TSESTree ----
+			{
+				Code:    `let a_1!: number;`,
+				Options: []any{`^[^_]+$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'a_1' does not match the pattern '^[^_]+$'.`,
+						Line:      1,
+						Column:    5,
+						EndLine:   1,
+						EndColumn: 17,
+					},
+				},
+			},
+			// ---- A rest parameter's Identifier remains the name alone in TSESTree ----
+			{
+				Code:    `function f(...a_1: string[]) {}`,
+				Options: []any{`^[^_]+$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "notMatch",
+						Message:   `Identifier 'a_1' does not match the pattern '^[^_]+$'.`,
+						Line:      1,
+						Column:    15,
+						EndLine:   1,
+						EndColumn: 18,
 					},
 				},
 			},

--- a/internal/rules/id_match/testdata/external_references.txtar
+++ b/internal/rules/id_match/testdata/external_references.txtar
@@ -1,0 +1,50 @@
+-- external-references/tsconfig.json --
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext"
+  },
+  "files": ["external.d.ts", "valid.ts", "namespace-export.ts", "class-export.ts", "parenthesized.ts", "controls.ts", "shadow.ts"]
+}
+-- external-references/external.d.ts --
+declare namespace External_NS {
+  interface T {}
+  namespace Nested {
+    interface T {}
+  }
+  const value: number;
+}
+
+declare interface External_Interface {}
+declare const External_Value: number;
+declare class External_Class {}
+-- external-references/valid.ts --
+type X = External_NS.T;
+type Y = External_NS.Nested.T;
+type Z = External_Interface;
+interface I extends External_NS.T {}
+interface J extends External_Interface {}
+class C implements External_NS.T {}
+class D implements External_Interface {}
+import Alias = External_NS.T;
+export = External_Interface;
+-- external-references/namespace-export.ts --
+export = External_NS;
+-- external-references/class-export.ts --
+export default External_Class;
+-- external-references/parenthesized.ts --
+export default (External_Interface);
+-- external-references/controls.ts --
+type Query = typeof External_NS.value;
+const local = External_Value;
+class Derived extends External_Class {}
+export default External_Value;
+import Invalid = External_Interface;
+type Missing = Missing_NS.T;
+interface Local_Type {}
+type Local = Local_Type;
+-- external-references/shadow.ts --
+const External_Interface = 1;
+export default External_Interface;

--- a/internal/rules/no_undef/no_undef.go
+++ b/internal/rules/no_undef/no_undef.go
@@ -7,6 +7,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 //go:embed no_undef.schema.json
@@ -58,10 +59,10 @@ var NoUndefRule = rule.Rule{
 				if ctx.Globals.Access(name).IsDeclared() {
 					return
 				}
-				referenceSpace := typescriptESLintReferenceSpace(node)
+				referenceSpace := noUndefReferenceSpace(node)
 				// An explicit `off` removes only implicit globals. A declaration or
 				// import authored in this file still defines its references.
-				if ctx.Refs.ResolveInFileWithMeaning(node, referenceSpace.symbolMeaning()) != nil {
+				if ctx.Refs.ResolveInFileWithMeaning(node, referenceSpace.DeclarationMeaning()) != nil {
 					return
 				}
 				// CommonJS's wrapper-level `arguments` binding is lexical rather than
@@ -77,7 +78,7 @@ var NoUndefRule = rule.Rule{
 				// same-file resolution so authored declarations retain normal scope
 				// behavior, and do not consult the TypeChecker: ambient, cross-file,
 				// and host-library symbols are outside core no-undef's inputs.
-				if referenceSpace&eslintReferenceType != 0 && rule.IsDefaultTypeScriptTypeGlobal(name) {
+				if referenceSpace.IncludesType() && rule.IsDefaultTypeScriptTypeGlobal(name) {
 					return
 				}
 
@@ -88,6 +89,24 @@ var NoUndefRule = rule.Rule{
 			},
 		}
 	},
+}
+
+// noUndefReferenceSpace preserves the rule's established Espree-facing
+// behavior for JavaScript while sharing typescript-eslint's scope classifier
+// everywhere else. Main has historically treated a parenthesized JavaScript
+// default export as a value reference even though TSESTree erases the
+// parentheses and assigns both reference capabilities.
+func noUndefReferenceSpace(node *ast.Node) scope.ReferenceSpace {
+	if ast.IsInJSFile(node) && node.Parent != nil && node.Parent.Kind == ast.KindParenthesizedExpression {
+		if exportParent := ast.WalkUpParenthesizedExpressions(node.Parent); exportParent != nil &&
+			exportParent.Kind == ast.KindExportAssignment {
+			if assignment := exportParent.AsExportAssignment(); assignment != nil &&
+				ast.SkipParentheses(assignment.Expression) == node {
+				return scope.ReferenceValue
+			}
+		}
+	}
+	return scope.ESLintReferenceSpace(node)
 }
 
 // shouldSkip returns true if the identifier does not create a scope reference.
@@ -206,102 +225,6 @@ func shouldSkip(node *ast.Node, checkTypeof bool) bool {
 	}
 
 	return false
-}
-
-type eslintReferenceSpace uint8
-
-const (
-	eslintReferenceValue eslintReferenceSpace = 1 << iota
-	eslintReferenceType
-
-	eslintReferenceDual = eslintReferenceValue | eslintReferenceType
-)
-
-// symbolMeaning translates typescript-eslint's two reference capabilities to
-// TypeScript binder declaration spaces. Namespace declarations are considered
-// both type- and value-capable by scope-manager, and import aliases likewise
-// resolve in either capability regardless of `import type` spelling.
-func (space eslintReferenceSpace) symbolMeaning() ast.SymbolFlags {
-	meaning := ast.SymbolFlagsAlias
-	if space&eslintReferenceValue != 0 {
-		meaning |= ast.SymbolFlagsValue | ast.SymbolFlagsNamespace
-	}
-	if space&eslintReferenceType != 0 {
-		meaning |= ast.SymbolFlagsType | ast.SymbolFlagsNamespace
-	}
-	return meaning
-}
-
-// typescriptESLintReferenceSpace mirrors the reference kind assigned by
-// typescript-eslint's scope manager. Most type references are identified by
-// TypeScript-Go's IsPartOfTypeNode helper; the explicit cases below cover
-// dual-space exports, qualified heritage names, and value-only constructs
-// nested inside type syntax.
-func typescriptESLintReferenceSpace(node *ast.Node) eslintReferenceSpace {
-	if node == nil || node.Parent == nil {
-		return eslintReferenceValue
-	}
-
-	parent := node.Parent
-
-	// `typeof T` and the parameter name in `x is T` are value references.
-	if ast.IsPartOfTypeQuery(node) || parent.Kind == ast.KindTypePredicate {
-		return eslintReferenceValue
-	}
-
-	// TypeScript import-equals visits its module reference as a value, even
-	// though the TypeScript binder can also resolve namespaces there.
-	if isImportEqualsModuleReference(node) {
-		return eslintReferenceValue
-	}
-
-	// A bare identifier in an export assignment/default export, or in a local
-	// export specifier, can resolve either a value or a type upstream.
-	if parent.Kind == ast.KindExportAssignment {
-		return eslintReferenceDual
-	}
-	if parent.Kind == ast.KindExportSpecifier && !utils.IsReExportSpecifier(parent) {
-		if ast.IsTypeOnlyImportOrExportDeclaration(parent) {
-			return eslintReferenceType
-		}
-		return eslintReferenceDual
-	}
-
-	// Only the leftmost identifier of a qualified type name is a reference.
-	// shouldSkip has already removed every right-hand member name.
-	if parent.Kind == ast.KindQualifiedName && parent.AsQualifiedName().Left == node {
-		return eslintReferenceType
-	}
-
-	if ast.IsPartOfTypeNode(node) {
-		return eslintReferenceType
-	}
-
-	// TypeScript represents dotted heritage targets as property-access chains.
-	// Their lexical root is a type reference in `implements` and interface
-	// `extends`, but a value reference in class `extends`.
-	entity := node
-	for entity.Parent != nil && entity.Parent.Kind == ast.KindPropertyAccessExpression {
-		access := entity.Parent.AsPropertyAccessExpression()
-		if access == nil || access.Expression != entity {
-			break
-		}
-		entity = entity.Parent
-	}
-	if entity != node && ast.IsPartOfTypeNode(entity) {
-		return eslintReferenceType
-	}
-	return eslintReferenceValue
-}
-
-func isImportEqualsModuleReference(node *ast.Node) bool {
-	entity := node
-	for entity.Parent != nil && entity.Parent.Kind == ast.KindQualifiedName {
-		entity = entity.Parent
-	}
-	return entity.Parent != nil &&
-		entity.Parent.Kind == ast.KindImportEqualsDeclaration &&
-		entity.Parent.AsImportEqualsDeclaration().ModuleReference == entity
 }
 
 // isTypeOfOperand checks if the identifier is the sole operand of a typeof

--- a/internal/rules/no_undef/no_undef_test.go
+++ b/internal/rules/no_undef/no_undef_test.go
@@ -1358,6 +1358,10 @@ type C = const;`,
 				FileName: "type-global-export-assignment.ts",
 			},
 			{
+				Code:     `export default ((Record));`,
+				FileName: "parenthesized-type-global-export.ts",
+			},
+			{
 				Code:     `type Foo = {}; type T = Foo.Member;`,
 				FileName: "qualified-type-alias-reference.ts",
 			},
@@ -1430,6 +1434,23 @@ type C = const;`,
 			},
 		},
 		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `export default ((Record));`,
+				FileName: "parenthesized-type-global-export.js",
+				TSConfig: "tsconfig.allowJs.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:     `export default ((Record));`,
+				FileName: "parenthesized-type-global-export.jsx",
+				TSConfig: "tsconfig.allowJs.json",
+				Tsx:      true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 18},
+				},
+			},
 			{
 				Code:     `Record; AsyncIterator;`,
 				FileName: "type-globals-do-not-leak-into-value-space.ts",

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -29,11 +29,16 @@ func (b *builder) reference(id *ast.Node, s *Scope) {
 	if !b.collectReferences || id == nil || s == nil {
 		return
 	}
-	if !isReferenceIdentifier(id) {
+	if !IsReferenceIdentifier(id) {
 		return
 	}
-	value, isType := referenceSpaces(id)
-	ref := &Reference{Identifier: id, From: s, isValueReference: value, isTypeReference: isType}
+	space := ESLintReferenceSpace(id)
+	ref := &Reference{
+		Identifier:       id,
+		From:             s,
+		isValueReference: space.IncludesValue(),
+		isTypeReference:  space.IncludesType(),
+	}
 	s.References = append(s.References, ref)
 	b.manager.References = append(b.manager.References, ref)
 }

--- a/internal/utils/scope/references.go
+++ b/internal/utils/scope/references.go
@@ -2,9 +2,10 @@ package scope
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// isReferenceIdentifier reports whether `id` reads or writes a binding, as
+// IsReferenceIdentifier reports whether id reads or writes a binding, as
 // opposed to naming one (declarations), naming a member (`a.b`, `{ b: 1 }`),
 // or naming a label.
 //
@@ -12,7 +13,7 @@ import (
 // true` and every consumer filters those out, so treating them as non-
 // references here is equivalent — and it keeps the two representations of the
 // same identifier from disagreeing.
-func isReferenceIdentifier(id *ast.Node) bool {
+func IsReferenceIdentifier(id *ast.Node) bool {
 	if id == nil || id.Kind != ast.KindIdentifier {
 		return false
 	}
@@ -44,7 +45,11 @@ func isReferenceIdentifier(id *ast.Node) bool {
 
 	case ast.KindExportSpecifier:
 		// The local binding is `local` in `export { local as exported }`, and
-		// the sole name in `export { local }`.
+		// the sole name in `export { local }`. Re-exports name another module's
+		// binding and therefore have no local reference.
+		if utils.IsReExportSpecifier(parent) {
+			return false
+		}
 		spec := parent.AsExportSpecifier()
 		if spec == nil {
 			return false
@@ -55,14 +60,23 @@ func isReferenceIdentifier(id *ast.Node) bool {
 		}
 		return local == id
 
-	case ast.KindImportSpecifier:
-		// Neither the imported name nor the local alias reads a local binding.
+	case ast.KindImportSpecifier, ast.KindNamespaceImport,
+		ast.KindImportClause, ast.KindNamespaceExport:
+		// Import bindings and namespace-export labels do not read a local
+		// binding.
 		return false
 
+	case ast.KindPropertyAssignment:
+		return parent.AsPropertyAssignment().Name() != id
+
 	case ast.KindBindingElement:
-		// `{ prop: local = init }` — only the default initializer reads.
-		be := parent.AsBindingElement()
-		return be != nil && be.Initializer == id
+		// `{ prop: local = init }` — the property and binding names do not read;
+		// an identifier in the default initializer does.
+		binding := parent.AsBindingElement()
+		return binding != nil && binding.Initializer == id
+
+	case ast.KindImportAttribute:
+		return parent.AsImportAttribute().Name() != id
 
 	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement:
 		return false
@@ -86,10 +100,71 @@ func isReferenceIdentifier(id *ast.Node) bool {
 	return !ast.IsDeclarationName(id)
 }
 
-// referenceSpaces reports which binding spaces `id` can resolve to. Most
-// identifiers name either a value or a type depending on where they sit; the
-// export forms name whichever space the exported binding happens to live in.
-func referenceSpaces(id *ast.Node) (value bool, isType bool) {
+// ReferenceSpace is the pair of independent reference capabilities exposed by
+// typescript-eslint's scope manager. A reference can be value-only, type-only,
+// or dual-capable.
+type ReferenceSpace uint8
+
+const (
+	ReferenceValue ReferenceSpace = 1 << iota
+	ReferenceType
+
+	ReferenceDual = ReferenceValue | ReferenceType
+)
+
+// IncludesValue reports whether the reference can resolve a value definition.
+func (space ReferenceSpace) IncludesValue() bool {
+	return space&ReferenceValue != 0
+}
+
+// IncludesType reports whether the reference can resolve a type definition.
+func (space ReferenceSpace) IncludesType() bool {
+	return space&ReferenceType != 0
+}
+
+// DeclarationMeaning translates typescript-eslint's reference capabilities
+// to TypeScript binder declaration spaces. Namespace declarations are both
+// value- and type-capable in scope-manager, while import aliases can satisfy
+// either capability.
+func (space ReferenceSpace) DeclarationMeaning() ast.SymbolFlags {
+	meaning := ast.SymbolFlagsAlias
+	if space.IncludesValue() {
+		meaning |= ast.SymbolFlagsValue | ast.SymbolFlagsNamespace
+	}
+	if space.IncludesType() {
+		meaning |= ast.SymbolFlagsType | ast.SymbolFlagsNamespace
+	}
+	return meaning
+}
+
+// ReferenceSpaces keeps typescript-eslint's scope capabilities independent
+// from TypeScript's exact semantic meaning. They deliberately differ for some
+// syntax: ESTree erases parentheses around a bare export assignment, while the
+// TypeScript checker treats a parenthesized identifier as a value expression;
+// import-equals is value-only to scope-manager but its lexical root has
+// namespace meaning to the checker.
+type ReferenceSpaces struct {
+	ESLint     ReferenceSpace
+	TypeScript ast.SemanticMeaning
+}
+
+// ClassifyReferenceSpaces returns the scope-manager and checker spaces of id.
+// Callers should first use IsReferenceIdentifier when the AST position itself
+// may be a declaration, member name, label, or other non-reference.
+func ClassifyReferenceSpaces(id *ast.Node) ReferenceSpaces {
+	return ReferenceSpaces{
+		ESLint:     ESLintReferenceSpace(id),
+		TypeScript: TypeScriptReferenceMeaning(id),
+	}
+}
+
+// ESLintReferenceSpace reports which binding spaces id can resolve to in
+// typescript-eslint's scope manager. Most identifiers name either a value or a
+// type; export forms can name whichever space the exported binding occupies.
+func ESLintReferenceSpace(id *ast.Node) ReferenceSpace {
+	if id == nil || id.Parent == nil {
+		return ReferenceValue
+	}
 	parent := id.Parent
 	// TSESTree erases parentheses, so a parenthesized bare identifier remains
 	// the direct declaration of `export default (X)` / `export = (X)` there.
@@ -99,7 +174,7 @@ func referenceSpaces(id *ast.Node) (value bool, isType bool) {
 			exportParent.Kind == ast.KindExportAssignment {
 			if assignment := exportParent.AsExportAssignment(); assignment != nil &&
 				ast.SkipParentheses(assignment.Expression) == id {
-				return true, true
+				return ReferenceDual
 			}
 		}
 	}
@@ -107,24 +182,87 @@ func referenceSpaces(id *ast.Node) (value bool, isType bool) {
 	case ast.KindExportSpecifier:
 		// `export type { T }` and `export { type T }` export types only.
 		if spec := parent.AsExportSpecifier(); spec != nil && spec.IsTypeOnly {
-			return false, true
+			return ReferenceType
 		}
 		if named := parent.Parent; named != nil && named.Parent != nil {
 			if decl := named.Parent.AsExportDeclaration(); decl != nil && decl.IsTypeOnly {
-				return false, true
+				return ReferenceType
 			}
 		}
-		return true, true
+		return ReferenceDual
 	case ast.KindTypePredicate:
 		// The parameter name is a value reference even though the surrounding
 		// predicate is a type node.
-		return true, false
+		return ReferenceValue
 	}
 
 	if InTypePosition(id) {
-		return false, true
+		return ReferenceType
 	}
-	return true, false
+	return ReferenceValue
+}
+
+// TypeScriptReferenceMeaning mirrors the declaration space TypeScript uses to
+// resolve a lexical identifier reference. It stays separate from the ESLint
+// space above so neither consumer has to approximate the other's semantics.
+func TypeScriptReferenceMeaning(id *ast.Node) ast.SemanticMeaning {
+	if id == nil || id.Parent == nil {
+		return ast.SemanticMeaningValue
+	}
+	parent := id.Parent
+
+	switch parent.Kind {
+	// Only the raw direct child receives export-assignment All meaning.
+	// Parentheses turn the identifier into an ordinary value expression in the
+	// TypeScript AST even though ESTree erases them.
+	case ast.KindExportAssignment:
+		return ast.SemanticMeaningAll
+	case ast.KindExportSpecifier:
+		if ast.IsTypeOnlyImportOrExportDeclaration(parent) {
+			return ast.SemanticMeaningType | ast.SemanticMeaningNamespace
+		}
+		return ast.SemanticMeaningAll
+	case ast.KindTypePredicate:
+		// A type-predicate parameter reads a value.
+		return ast.SemanticMeaningValue
+	case ast.KindQualifiedName:
+		// Dotted type names resolve their leftmost lexical identifier as a
+		// namespace.
+		if parent.AsQualifiedName().Left == id {
+			if ast.IsPartOfTypeQuery(id) {
+				return ast.SemanticMeaningValue
+			}
+			// This is also the root of an internal import-equals module name such
+			// as `A` in `import X = A.B`. The final qualified entity can have All
+			// meaning there, but its member name is not a lexical reference.
+			return ast.SemanticMeaningNamespace
+		}
+	case ast.KindPropertyAccessExpression:
+		// Type-only heritage clauses use PropertyAccessExpression for their
+		// qualified target, while class extends and ordinary accesses are values.
+		if ast.IsPartOfTypeQuery(id) {
+			return ast.SemanticMeaningValue
+		}
+		if isTypeOnlyPropertyAccessQualifier(id) {
+			return ast.SemanticMeaningNamespace
+		}
+		return ast.SemanticMeaningValue
+	case ast.KindImportEqualsDeclaration:
+		if parent.AsImportEqualsDeclaration().ModuleReference == id {
+			return ast.SemanticMeaningNamespace
+		}
+	}
+
+	// Most identifiers are ordinary values. Only ask the more specific
+	// type-query question after establishing that the identifier is nested in
+	// type syntax; a type-query operand still reads a value there.
+	if InTypePosition(id) {
+		if ast.IsPartOfTypeQuery(id) {
+			return ast.SemanticMeaningValue
+		}
+		return ast.SemanticMeaningType
+	}
+	return ast.SemanticMeaningValue
 }
 
 // InTypePosition reports whether `id` names a type rather than a value.
@@ -136,12 +274,31 @@ func referenceSpaces(id *ast.Node) (value bool, isType bool) {
 // with property accesses even in type position (`implements A.B.C`), so both
 // shapes have to be climbed.
 func InTypePosition(id *ast.Node) bool {
+	if id == nil {
+		return false
+	}
 	entity := id
 	for entity.Parent != nil &&
 		(entity.Parent.Kind == ast.KindQualifiedName || entity.Parent.Kind == ast.KindPropertyAccessExpression) {
 		entity = entity.Parent
 	}
 	return ast.IsPartOfTypeNode(entity)
+}
+
+// isTypeOnlyPropertyAccessQualifier reports whether id is the lexical root of
+// an expression-shaped qualified name used as a type. TypeScript represents
+// `N.T` in `class C implements N.T` and `interface I extends N.T` with a
+// PropertyAccessExpression, while class `extends N.T` remains value syntax.
+func isTypeOnlyPropertyAccessQualifier(id *ast.Node) bool {
+	entity := id
+	for entity.Parent != nil && entity.Parent.Kind == ast.KindPropertyAccessExpression {
+		access := entity.Parent.AsPropertyAccessExpression()
+		if access == nil || access.Expression != entity {
+			break
+		}
+		entity = entity.Parent
+	}
+	return entity != id && ast.IsPartOfTypeNode(entity)
 }
 
 // isImportTypeQualifier reports whether `id` is part of the qualifier of an

--- a/internal/utils/scope/scope_test.go
+++ b/internal/utils/scope/scope_test.go
@@ -454,6 +454,132 @@ func TestBuildKeepsReferenceSpacesIndependent(t *testing.T) {
 	})
 }
 
+func TestClassifyReferenceSpacesKeepsESLintAndTypeScriptMeaningsIndependent(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		eslint     ReferenceSpace
+		typescript ast.SemanticMeaning
+	}{
+		{
+			name:       "direct export assignment",
+			source:     `export default Subject; interface Subject {}`,
+			eslint:     ReferenceDual,
+			typescript: ast.SemanticMeaningAll,
+		},
+		{
+			name:       "parenthesized export assignment",
+			source:     `export default ((Subject)); interface Subject {}`,
+			eslint:     ReferenceDual,
+			typescript: ast.SemanticMeaningValue,
+		},
+		{
+			name:       "direct type reference",
+			source:     `type T = Subject; interface Subject {}`,
+			eslint:     ReferenceType,
+			typescript: ast.SemanticMeaningType,
+		},
+		{
+			name:       "qualified type root",
+			source:     `type T = Subject.Member; declare namespace Subject { interface Member {} }`,
+			eslint:     ReferenceType,
+			typescript: ast.SemanticMeaningNamespace,
+		},
+		{
+			name:       "interface heritage root",
+			source:     `interface I extends Subject.Member {} declare namespace Subject { interface Member {} }`,
+			eslint:     ReferenceType,
+			typescript: ast.SemanticMeaningNamespace,
+		},
+		{
+			name:       "class implements root",
+			source:     `class C implements Subject.Member {} declare namespace Subject { interface Member {} }`,
+			eslint:     ReferenceType,
+			typescript: ast.SemanticMeaningNamespace,
+		},
+		{
+			name:       "class extends root",
+			source:     `class C extends Subject.Base {} declare namespace Subject { class Base {} }`,
+			eslint:     ReferenceValue,
+			typescript: ast.SemanticMeaningValue,
+		},
+		{
+			name:       "import equals root",
+			source:     `import Alias = Subject.Member; declare namespace Subject { interface Member {} }`,
+			eslint:     ReferenceValue,
+			typescript: ast.SemanticMeaningNamespace,
+		},
+		{
+			name:       "type query operand",
+			source:     `type T = typeof Subject; declare const Subject: unknown;`,
+			eslint:     ReferenceValue,
+			typescript: ast.SemanticMeaningValue,
+		},
+		{
+			name:       "computed type key",
+			source:     `type T = { [Subject]: unknown }; declare const Subject: unique symbol;`,
+			eslint:     ReferenceValue,
+			typescript: ast.SemanticMeaningValue,
+		},
+		{
+			name:       "type-only export specifier",
+			source:     `interface Subject {} export type { Subject };`,
+			eslint:     ReferenceType,
+			typescript: ast.SemanticMeaningType | ast.SemanticMeaningNamespace,
+		},
+		{
+			name:       "regular export specifier",
+			source:     `interface Subject {} export { Subject };`,
+			eslint:     ReferenceDual,
+			typescript: ast.SemanticMeaningAll,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reference := findReference(t, buildWithReferences(t, test.source), "Subject")
+			spaces := ClassifyReferenceSpaces(reference.Identifier)
+			if spaces.ESLint != test.eslint {
+				t.Errorf("ESLint space = %v, want %v", spaces.ESLint, test.eslint)
+			}
+			if spaces.TypeScript != test.typescript {
+				t.Errorf("TypeScript meaning = %v, want %v", spaces.TypeScript, test.typescript)
+			}
+		})
+	}
+}
+
+func TestIsReferenceIdentifierRejectsReExportAndImportTypeNames(t *testing.T) {
+	for _, source := range []string{
+		`export { Subject } from "mod";`,
+		`type T = import("mod").Subject;`,
+	} {
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/test.ts",
+			Path:     "/test.ts",
+		}, source, core.ScriptKindTS)
+		for _, identifier := range identifiersWithText(sourceFile.AsNode(), "Subject") {
+			if IsReferenceIdentifier(identifier) {
+				t.Errorf("%s: Subject unexpectedly classified as a local reference", source)
+			}
+		}
+	}
+}
+
+func identifiersWithText(root *ast.Node, text string) []*ast.Node {
+	var identifiers []*ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindIdentifier && node.Text() == text {
+			identifiers = append(identifiers, node)
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	root.ForEachChild(visit)
+	return identifiers
+}
+
 func TestBuildFunctionTypeScopeKeepsComputedMethodKeyOutside(t *testing.T) {
 	m := buildWithReferences(t, `interface I { [key](arg: Later): Result } declare const key: unique symbol; interface Later {} interface Result {}`)
 	key := findReference(t, m, "key")


### PR DESCRIPTION
## Summary

- prevent `id-match` from reporting built-in or cross-file TypeScript type and namespace references in every valid reference position while continuing to check value references, export specifiers, properties, and names declared or imported by the linted file
- preserve each reference's exact TypeScript meaning when deciding whether an external name is exempt
- align TypeScript binding diagnostic ranges with ESLint 10.9.1, expand multi-file and semantic-invariant coverage, and document the one remaining user-visible behavior difference

## Related Links

- [ESLint 10.9.1 `id-match` source](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/id-match.js)
- [typescript-eslint 8.68.0 release](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.68.0)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
