### PR TITLE
fix: preserve config roots for scoped ignores

### DIFF
--- a/internal/config/base_path_test.go
+++ b/internal/config/base_path_test.go
@@ -164,6 +164,44 @@ func TestBasePathDoesNotChangeFilesystemFreeMatcherCoordinates(t *testing.T) {
 	}
 }
 
+func TestBasePathDotPreservesFilesystemFreeDirectoryIgnoreCoordinates(t *testing.T) {
+	basePath := "."
+	for _, test := range []struct {
+		name   string
+		root   string
+		target string
+	}{
+		{name: "drive", root: "C:/Top/Repo", target: "c:/top/repo/sub/visible.js"},
+		{name: "UNC", root: "//SERVER/share/Top/Repo", target: "//server/SHARE/top/repo/sub/visible.js"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			plain := ConfigWithResolvedBasePaths(RslintConfig{
+				{Ignores: []string{"**/repo"}},
+				{Rules: Rules{"no-debugger": "error"}},
+			}, test.root)
+			dot := ConfigWithResolvedBasePaths(RslintConfig{
+				{BasePath: &basePath, Ignores: []string{"**/repo"}},
+				{Rules: Rules{"no-debugger": "error"}},
+			}, test.root)
+
+			assert.Assert(t, plain.GetConfigForFile(test.target, test.root) == nil)
+			assert.Equal(
+				t,
+				dot.GetConfigForFile(test.target, test.root) != nil,
+				plain.GetConfigForFile(test.target, test.root) != nil,
+			)
+			parent := tspath.GetDirectoryPath(test.target)
+			plainPrunes := newConfigTargetResolver(plain, test.root, nil).canPruneDirectory(parent, "")
+			assert.Assert(t, plainPrunes)
+			assert.Equal(
+				t,
+				newConfigTargetResolver(dot, test.root, nil).canPruneDirectory(parent, ""),
+				plainPrunes,
+			)
+		})
+	}
+}
+
 func TestBasePathIsLiteralNotGlob(t *testing.T) {
 	basePath := "pkg*"
 	config := ConfigWithResolvedBasePaths(RslintConfig{{
@@ -190,15 +228,141 @@ func TestBasePathScopesGlobalIgnores(t *testing.T) {
 }
 
 func TestBasePathGlobalIgnoreKeepsConfigArrayRootReachable(t *testing.T) {
-	basePath := ".."
-	config := ConfigWithResolvedBasePaths(RslintConfig{
-		{BasePath: &basePath, Ignores: []string{"*"}},
-		{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
-	}, "/repo")
-	resolver := newConfigTargetResolver(config, "/repo", nil)
+	t.Run("one segment below basePath", func(t *testing.T) {
+		basePath := ".."
+		config := ConfigWithResolvedBasePaths(RslintConfig{
+			{BasePath: &basePath, Ignores: []string{"*"}},
+			{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
+		}, "/repo")
+		resolver := newConfigTargetResolver(config, "/repo", nil)
 
-	assert.Assert(t, config.GetConfigForFile("/repo/visible.js", "/repo") != nil)
-	assert.Assert(t, !resolver.canPruneDirectory("/repo", ""))
+		assert.Assert(t, config.GetConfigForFile("/repo/visible.js", "/repo") != nil)
+		assert.Assert(t, config.GetConfigForFile("/repo/sub/visible.js", "/repo") != nil)
+		assert.Assert(t, !resolver.canPruneDirectory("/repo", ""))
+		assert.Assert(t, !resolver.canPruneDirectory("/repo/sub", ""))
+	})
+
+	t.Run("multiple segments keep descendant matching", func(t *testing.T) {
+		basePath := "../.."
+		config := ConfigWithResolvedBasePaths(RslintConfig{
+			{BasePath: &basePath, Ignores: []string{"workspace", "workspace/repo/blocked/**"}},
+			{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
+		}, "/workspace/repo")
+		resolver := newConfigTargetResolver(config, "/workspace/repo", nil)
+
+		assert.Assert(t, config.GetConfigForFile("/workspace/repo/nested/visible.js", "/workspace/repo") != nil)
+		assert.Assert(t, config.GetConfigForFile("/workspace/repo/blocked/ignored.js", "/workspace/repo") == nil)
+		assert.Assert(t, !resolver.canPruneDirectory("/workspace", ""))
+		assert.Assert(t, !resolver.canPruneDirectory("/workspace/repo/nested", ""))
+		assert.Assert(t, resolver.canPruneDirectory("/workspace/repo/blocked", ""))
+	})
+}
+
+func TestBasePathGlobalIgnoreKeepsFilesystemFreeConfigArrayRootReachable(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		root   string
+		target string
+	}{
+		{
+			name:   "drive",
+			root:   "C:/Top/Repo",
+			target: "c:/top/repo/sub/visible.js",
+		},
+		{
+			name:   "UNC",
+			root:   "//SERVER/share/Top/Repo",
+			target: "//server/SHARE/top/repo/sub/visible.js",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			basePath := ".."
+			config := ConfigWithResolvedBasePaths(RslintConfig{
+				{BasePath: &basePath, Ignores: []string{"**/top/repo"}},
+				{Rules: Rules{"no-debugger": "error"}},
+			}, test.root)
+			resolver := newConfigTargetResolver(config, test.root, nil)
+
+			assert.Assert(t, config.GetConfigForFile(test.target, test.root) != nil)
+			assert.Assert(t, !resolver.canPruneDirectory(tspath.GetDirectoryPath(test.target), ""))
+		})
+	}
+}
+
+func TestBasePathGlobalIgnoreKeepsAliasedConfigArrayRootReachable(t *testing.T) {
+	root := t.TempDir()
+	physicalBase := filepath.Join(root, "physical")
+	physicalConfig := filepath.Join(physicalBase, "x", "y")
+	workspace := filepath.Join(root, "workspace")
+	configRoot := filepath.Join(workspace, "repo")
+	if err := os.MkdirAll(physicalConfig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalConfig, filepath.Join(physicalBase, "repo")); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(physicalBase, workspace); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+	lexicalVisible := filepath.Join(configRoot, "nested", "visible.js")
+	lexicalBlocked := filepath.Join(configRoot, "blocked", "ignored.js")
+	physicalVisible := filepath.Join(physicalConfig, "nested", "visible.js")
+	physicalBlocked := filepath.Join(physicalConfig, "blocked", "ignored.js")
+	writeBasePathTestFiles(t, physicalVisible, physicalBlocked)
+
+	basePath := ".."
+	configRoot = tspath.NormalizePath(configRoot)
+	config := ConfigWithResolvedBasePaths(RslintConfig{
+		{BasePath: &basePath, Ignores: []string{
+			"repo",
+			"x/y",
+			"repo/blocked",
+			"x/y/blocked",
+		}},
+		{Files: []string{"**/*.js"}, Rules: Rules{"no-debugger": "error"}},
+	}, configRoot)
+	fsys := osvfs.FS()
+	snapshot := NewPathSpaceSnapshot(map[string]RslintConfig{configRoot: config}, fsys)
+	matcher, err := NewTargetMatcherWithPathSpaces(config, configRoot, fsys, snapshot)
+	assert.NilError(t, err)
+	matchFile := func(file string) TargetMatch {
+		file = tspath.NormalizePath(file)
+		return matcher.MatchFile(PathIdentity{
+			Path:                file,
+			CanonicalPath:       tspath.NormalizePath(fsys.Realpath(file)),
+			CanonicalParentPath: tspath.NormalizePath(fsys.Realpath(tspath.GetDirectoryPath(file))),
+		})
+	}
+
+	for _, file := range []string{lexicalVisible, physicalVisible} {
+		decision := matchFile(file)
+		assert.Assert(t, decision.Selected)
+		assert.Assert(t, !decision.GloballyIgnored)
+		assert.Assert(t, !matcher.CanPruneDirectory(DirectoryIdentity{
+			LexicalPath:   tspath.NormalizePath(filepath.Dir(file)),
+			CanonicalPath: tspath.NormalizePath(fsys.Realpath(filepath.Dir(file))),
+		}))
+	}
+	for _, file := range []string{lexicalBlocked, physicalBlocked} {
+		decision := matchFile(file)
+		assert.Assert(t, decision.GloballyIgnored)
+		assert.Assert(t, matcher.CanPruneDirectory(DirectoryIdentity{
+			LexicalPath:   tspath.NormalizePath(filepath.Dir(file)),
+			CanonicalPath: tspath.NormalizePath(fsys.Realpath(filepath.Dir(file))),
+		}))
+	}
+}
+
+func writeBasePathTestFiles(t *testing.T, files ...string) {
+	t.Helper()
+	for _, file := range files {
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(file, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func TestBasePathNegationKeepsReachableSubtreeOpen(t *testing.T) {

--- a/internal/config/config_target_resolver.go
+++ b/internal/config/config_target_resolver.go
@@ -80,6 +80,47 @@ func (resolver *configTargetResolver) entryMatchesScope(
 	return true
 }
 
+// entryDirectoryCandidateDepthFloor locates the ConfigArray root in the exact
+// path spelling received by the existing ignore matcher. Subtracting the
+// directory's depth below that root from the matcher path's depth gives the
+// root's depth in the entry's path space. This remains valid across aliases and
+// filesystem-free case variants without replacing the original matcher.
+func (resolver *configTargetResolver) entryDirectoryCandidateDepthFloor(
+	matcherPath string,
+	entryMatch *configTargetMatch,
+	configArrayMatch *configTargetMatch,
+) int {
+	entryRelative, withinEntry := RelativePathWithinConfigRoot(
+		entryMatch.path,
+		entryMatch.directory,
+		resolver.scopeUseCaseSensitive(entryMatch.directory),
+	)
+	configArrayRelative, withinConfigArray := RelativePathWithinConfigRoot(
+		configArrayMatch.path,
+		configArrayMatch.directory,
+		resolver.scopeUseCaseSensitive(configArrayMatch.directory),
+	)
+	if !withinEntry || !withinConfigArray {
+		return 0
+	}
+	configArrayDepth := relativePathDepth(configArrayRelative)
+	if relativePathDepth(entryRelative) <= configArrayDepth {
+		return 0
+	}
+	matcherDepth := relativePathDepth(matcherPath)
+	if matcherDepth <= configArrayDepth {
+		return 0
+	}
+	return matcherDepth - configArrayDepth
+}
+
+func relativePathDepth(path string) int {
+	if path == "" {
+		return 0
+	}
+	return 1 + strings.Count(path, "/")
+}
+
 type scopedDirectoryRelation uint8
 
 const (
@@ -101,30 +142,46 @@ func (resolver *configTargetResolver) entryDirectoryRelation(
 		if atBase {
 			return scopedDirectoryDescendantsOnly
 		}
-		_, atConfigArrayBase := resolver.configTargetMatchWithinBase(&matches[entry.configArrayBaseIndex])
-		if atConfigArrayBase {
+		configArrayMatch := &matches[entry.configArrayBaseIndex]
+		withinConfigArray, atConfigArrayBase := resolver.configTargetMatchWithinBase(configArrayMatch)
+		if atConfigArrayBase || (!withinConfigArray && resolver.targetContainsBase(
+			configArrayMatch,
+			entry.configArrayBaseIndex,
+			target,
+		)) {
 			return scopedDirectoryDescendantsOnly
 		}
 		return scopedDirectoryInside
 	}
+	if resolver.targetContainsBase(match, entry.baseIndex, target) {
+		return scopedDirectoryDescendantsOnly
+	}
+	return scopedDirectoryOutside
+}
+
+func (resolver *configTargetResolver) targetContainsBase(
+	match *configTargetMatch,
+	baseIndex int,
+	target configTargetIdentity,
+) bool {
 	if _, containsBase := RelativePathWithinConfigRoot(
 		match.directory,
 		match.path,
 		resolver.scopeUseCaseSensitive(match.directory),
 	); containsBase {
-		return scopedDirectoryDescendantsOnly
+		return true
 	}
 	if target.canonicalMatchPath != "" {
-		physicalBase := resolver.bases[entry.baseIndex].physicalDirectory
+		physicalBase := resolver.bases[baseIndex].physicalDirectory
 		if _, containsPhysicalBase := RelativePathWithinConfigRoot(
 			physicalBase,
 			target.canonicalMatchPath,
 			true,
 		); containsPhysicalBase {
-			return scopedDirectoryDescendantsOnly
+			return true
 		}
 	}
-	return scopedDirectoryOutside
+	return false
 }
 
 // configTargetIdentity is the immutable caller-visible/canonical pair for one
@@ -589,8 +646,10 @@ func (resolver *configTargetResolver) hasAbsoluteDirectoryBlockForDirectory(
 				matcher:   newFileMatchPath(path, match.directory),
 			}
 		}
+		minimumDirectoryDepth := 0
+		configArrayMatch := configTargetMatch{}
 		if entry.configArrayBaseIndex >= 0 {
-			configArrayMatch := matches[entry.configArrayBaseIndex]
+			configArrayMatch = matches[entry.configArrayBaseIndex]
 			if fileTarget {
 				configArrayMatch.path = tspath.GetDirectoryPath(configArrayMatch.path)
 			}
@@ -605,7 +664,23 @@ func (resolver *configTargetResolver) hasAbsoluteDirectoryBlockForDirectory(
 				group.patterns,
 				selectedGitScope,
 			)
-			if ok && isDirAbsolutelyBlocked(relative, group.patterns) {
+			if !ok {
+				continue
+			}
+			if entry.configArrayBaseIndex >= 0 {
+				minimumDirectoryDepth = resolver.entryDirectoryCandidateDepthFloor(
+					relative,
+					directoryMatch,
+					&configArrayMatch,
+				)
+			}
+			if minimumDirectoryDepth == 0 {
+				if isDirAbsolutelyBlocked(relative, group.patterns) {
+					return true
+				}
+				continue
+			}
+			if isDirAbsolutelyBlockedAboveFloor(relative, group.patterns, minimumDirectoryDepth) {
 				return true
 			}
 		}
@@ -649,7 +724,23 @@ func (resolver *configTargetResolver) canPruneDirectory(path string, canonicalPa
 			if !ok {
 				continue
 			}
-			if isDirAbsolutelyBlocked(relative, group.patterns) {
+			minimumDirectoryDepth := 0
+			if entry.configArrayBaseIndex >= 0 {
+				minimumDirectoryDepth = resolver.entryDirectoryCandidateDepthFloor(
+					relative,
+					match,
+					&matches[entry.configArrayBaseIndex],
+				)
+			}
+			if minimumDirectoryDepth == 0 {
+				if isDirAbsolutelyBlocked(relative, group.patterns) {
+					return true
+				}
+			} else if isDirAbsolutelyBlockedAboveFloor(
+				relative,
+				group.patterns,
+				minimumDirectoryDepth,
+			) {
 				return true
 			}
 			if !negationCanReach && group.negationReach.overlaps(relative) {

--- a/internal/config/ignore_pattern.go
+++ b/internal/config/ignore_pattern.go
@@ -772,6 +772,42 @@ func directoryPatternAbsolutelyBlocks(pattern IgnorePattern, dirPath string) boo
 	return false
 }
 
+// isDirAbsolutelyBlockedAboveFloor applies the existing matcher with an
+// exclusive lower bound for ancestor candidates. It is used only when an
+// entry's base is above its ConfigArray root.
+func isDirAbsolutelyBlockedAboveFloor(
+	dirPath string,
+	patterns []IgnorePattern,
+	minimumDepth int,
+) bool {
+	for i := range patterns {
+		pattern := patterns[i]
+		if pattern.Negated || pattern.Kind != dirAbsoluteBlock {
+			continue
+		}
+		if depth := 1 + strings.Count(dirPath, "/"); depth > minimumDepth &&
+			(ignorePatternMatches(pattern, dirPath) || ignorePatternMatches(pattern, dirPath+"/x")) {
+			return true
+		}
+		depth := 1
+		for slash := strings.IndexByte(dirPath, '/'); slash >= 0; {
+			if depth > minimumDepth {
+				partial := dirPath[:slash]
+				if ignorePatternMatches(pattern, partial) || ignorePatternMatches(pattern, partial+"/x") {
+					return true
+				}
+			}
+			next := strings.IndexByte(dirPath[slash+1:], '/')
+			if next < 0 {
+				break
+			}
+			slash += next + 1
+			depth++
+		}
+	}
+	return false
+}
+
 func directoryBlockCandidates(dirPath string) []string {
 	candidates := make([]string, 0, 2+2*strings.Count(dirPath, "/"))
 	candidates = append(candidates, dirPath, dirPath+"/x")

--- a/packages/rslint/tests/lint-targets.test.mjs
+++ b/packages/rslint/tests/lint-targets.test.mjs
@@ -251,6 +251,38 @@ describe('CLI basePath product contract', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  test('ancestor basePath does not let a global ignore prune the config root', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'rslint-cli-base-path-'));
+    try {
+      await writeFixture(root, {
+        'app/rslint.config.mjs': `export default [
+  { basePath: '..', ignores: ['*'] },
+  { files: ['**/*.js'], rules: { 'no-debugger': 'error' } },
+];\n`,
+        'app/root.js': 'debugger;\n',
+        'app/nested/child.js': 'debugger;\n',
+      });
+
+      const result = await runCLI(root, ['app']);
+      const expected = [
+        path.join(root, 'app', 'root.js'),
+        path.join(root, 'app', 'nested', 'child.js'),
+      ].sort();
+
+      expect(result.code).toBe(1);
+      expect(
+        absoluteDiagnosticPaths(
+          root,
+          parseDiagnostics(result.stdout),
+          'no-debugger',
+        ),
+      ).toEqual(expected);
+      expect(result.stderr).not.toContain('warning:');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('CLI lint target contracts', () => {

--- a/website/docs/en/api/rslint.md
+++ b/website/docs/en/api/rslint.md
@@ -56,7 +56,7 @@ const rslint = new Rslint(options);
 
 With automatic discovery, Go selects each file's nearest config and owns ignore and target-admission semantics. The JavaScript host evaluates and normalizes the JS or TS config modules selected for that run.
 
-See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath) for automatic, explicit-file, and inline-override behavior.
+See the [`basePath` configuration reference](/config/base-path) for automatic, explicit-file, and inline-override behavior.
 
 :::warning
 Object-form community plugins are not supported in `overrideConfig`, because a plugin worker cannot re-import an in-memory plugin object. Put community plugin declarations in a JS or TS config file. Array-form built-in plugins work in `overrideConfig`.

--- a/website/docs/en/config/_meta.json
+++ b/website/docs/en/config/_meta.json
@@ -24,6 +24,11 @@
   },
   {
     "type": "file",
+    "name": "base-path",
+    "label": "basePath"
+  },
+  {
+    "type": "file",
     "name": "files",
     "label": "files"
   },

--- a/website/docs/en/config/base-path.md
+++ b/website/docs/en/config/base-path.md
@@ -1,0 +1,67 @@
+# basePath
+
+- **Type:** `string`
+
+`basePath` sets the directory from which one flat-config entry is matched. It is a literal directory path, not a glob. Its per-file configuration is inactive outside that directory; explicit TypeScript projects retain the [owner-wide behavior](#typescript-projects) described below.
+
+```ts
+{
+  basePath: 'packages/app',
+  files: ['src/**/*.ts'],
+  ignores: ['src/generated/**'],
+  languageOptions: {
+    parserOptions: { project: ['./tsconfig.json'] },
+  },
+  rules: {
+    'no-debugger': 'error',
+  },
+}
+```
+
+In this example, `files`, `ignores`, and the explicit `project` path all start from `packages/app`. `basePath` changes only their starting directory; `files` and `ignores` keep the same glob syntax and matching behavior as entries without `basePath`.
+
+An entry containing only `basePath`, `ignores`, and an optional `name` is still a [global ignore entry](/config/ignoring-files#global-and-entry-level-ignores). Its patterns are scoped to the effective base directory and participate in normal lint-target and config-candidate traversal.
+
+## Resolution base
+
+A relative `basePath` resolves from the ConfigArray base. That base depends on how the config was selected:
+
+| Config entry source                                                | `basePath` resolves from    | Relative paths when `basePath` is absent           |
+| ------------------------------------------------------------------ | --------------------------- | -------------------------------------------------- |
+| Automatically discovered config module                             | Config module directory     | Config module directory                            |
+| Explicit `--config`, API `overrideConfigFile`, or fixed LSP config | Invocation/workspace cwd    | Config module directory (existing Rslint behavior) |
+| API inline `overrideConfig` in automatic-discovery mode            | Discovered config directory | API `cwd`                                          |
+| API inline `overrideConfig` with an explicit config or no config   | API `cwd`                   | API `cwd`                                          |
+
+An inline override therefore uses the discovered module directory for `basePath` in automatic mode, and API `cwd` with an explicit config or `overrideConfigFile: true`. This matches how ESLint appends `overrideConfig` to the selected ConfigArray. Relative fields in an inline entry without `basePath` keep Rslint's existing API-`cwd` behavior.
+
+For example, if `/project` invokes an external config:
+
+```bash
+cd /project
+rslint --config /configs/rslint.config.ts
+```
+
+Then `basePath: 'app'` means `/project/app`, not `/configs/app`.
+
+Absolute paths are used as written. An empty string is also valid and still counts as an authored `basePath`; this matters when an inline override's ordinary path origin differs from its ConfigArray base. Glob characters are literal in `basePath`, so `basePath: 'packages/*'` names a directory containing `*` rather than selecting every package.
+
+## TypeScript projects
+
+`basePath` moves explicit `languageOptions.parserOptions.project` literals and globs. It does not move the governing config's implicit `tsconfig.json` fallback or change Rslint's owner-wide project collection. An explicit `project: []` still disables the fallback.
+
+Because explicit projects are collected for the governing config, a missing project can still report an error even when the entry's `files` patterns select no lint target. See [`languageOptions.parserOptions.project`](/config/language-options#languageoptionsparseroptionsproject) for the complete project behavior.
+
+## Directory and ignore boundaries
+
+For directory-ignore decisions, a scoped global ignore does not match the effective base directory itself. When `basePath` points above the selected ConfigArray base, a scoped global ignore cannot prune that base itself. Descendants still match normally relative to `basePath`.
+
+`basePath` does not move:
+
+- The config owner or requested scan root
+- The root used to collect `.gitignore` files
+- The existing `files` or `ignores` matcher and glob grammar
+
+See [`.gitignore` integration](/config/ignoring-files#gitignore-integration) for its independent collection rules.
+
+The directory named by `basePath` does not need to exist when the config loads. Non-string values are rejected immediately; a missing explicit TypeScript project is validated separately.

--- a/website/docs/en/config/configuration-file.md
+++ b/website/docs/en/config/configuration-file.md
@@ -64,37 +64,7 @@ rslint --config path/to/rslint.config.ts .
 
 ## Path resolution and `basePath`
 
-`basePath` is a directory path, not a glob. It scopes one flat-config entry to that directory. The entry's `files`, `ignores`, and explicit `languageOptions.parserOptions.project` paths resolve from the resulting directory. It changes only that starting directory; `files` and `ignores` keep exactly the same glob syntax and matching behavior as entries without `basePath`.
-
-```ts
-{
-  basePath: 'packages/app',
-  files: ['src/**/*.ts'],
-  ignores: ['src/generated/**'],
-  languageOptions: {
-    parserOptions: { project: ['./tsconfig.json'] },
-  },
-}
-```
-
-The base used to resolve `basePath` depends on how the config was selected:
-
-| Config entry source                                                | `basePath` resolves from    | Relative paths when `basePath` is absent           |
-| ------------------------------------------------------------------ | --------------------------- | -------------------------------------------------- |
-| Automatically discovered config module                             | Config module directory     | Config module directory                            |
-| Explicit `--config`, API `overrideConfigFile`, or fixed LSP config | Invocation/workspace cwd    | Config module directory (existing Rslint behavior) |
-| API inline `overrideConfig` in automatic-discovery mode            | Discovered config directory | API `cwd`                                          |
-| API inline `overrideConfig` with an explicit config or no config   | API `cwd`                   | API `cwd`                                          |
-
-An inline override therefore uses the discovered module directory for
-`basePath` in automatic mode, and API `cwd` with an explicit config or
-`overrideConfigFile: true`. This is how ESLint appends `overrideConfig` to the
-selected ConfigArray. Relative fields in an inline entry without `basePath`
-keep Rslint's existing API-`cwd` behavior.
-
-The explicit-config rule matches ESLint: if `/project` invokes `--config /configs/rslint.config.ts`, then `basePath: 'app'` means `/project/app`, not `/configs/app`. An empty string is valid and still scopes the entry. Invalid values are rejected when the config loads, even if the entry matches no target.
-
-`basePath` does not change the config owner, scan root, or `.gitignore` collection root. See [`.gitignore` integration](/config/ignoring-files#gitignore-integration).
+Relative config paths normally resolve from the config entry's authored directory. Use `basePath` to give one entry a different starting directory. See the [`basePath` configuration reference](/config/base-path) for its complete matching, TypeScript project, config-source, and `.gitignore` behavior.
 
 To generate a default config, run:
 

--- a/website/docs/en/config/files.md
+++ b/website/docs/en/config/files.md
@@ -42,4 +42,4 @@ File selection is independent of a tsconfig's `include`. A file in tsconfig but 
 Selected files not covered by a tsconfig declared by their governing config automatically receive a reduced rule set: only rules that do not require type information run. To enable type-aware rules, add the file to one of that config's tsconfigs. See [`languageOptions.parserOptions.project`](/config/language-options#languageoptionsparseroptionsproject).
 :::
 
-When an entry has `basePath`, its `files` patterns resolve from that directory and the whole entry is inactive outside it. Without `basePath`, config-module patterns keep Rslint's existing module-directory base, while API inline `overrideConfig` patterns use the API `cwd`. See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath).
+When an entry has `basePath`, its `files` patterns resolve from that directory, and its per-file configuration is inactive outside it. See the [`basePath` configuration reference](/config/base-path) for the path-origin and TypeScript project rules.

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -102,7 +102,7 @@ For directory-level patterns (`dir/**`), `!` negation cannot re-include files be
 
 The CLI, JavaScript API, and LSP automatically read `.gitignore` files and treat their patterns as additional global ignores. Automatically discovered configs and ordinary LSP files start collection at the governing config directory. An explicitly selected invocation-wide config (`--config`, API `overrideConfigFile`, or the LSP `configPath` setting) starts at the invocation or workspace-folder `cwd`, even when the config file is elsewhere. A requested directory outside `cwd` gets its own independent Git scope. Collection never searches a scope's parents. In the editor, saved `.gitignore` changes refresh diagnostics for open files.
 
-An entry's `basePath` does not move these `.gitignore` roots. It only scopes that authored entry and rebases its own `ignores` patterns.
+An entry's [`basePath`](/config/base-path) does not move these `.gitignore` roots. It only scopes that authored entry and rebases its own `ignores` patterns.
 
 - **Nested `.gitignore` files** inside one Git scope are supported — each one only affects its own directory subtree
 - **Parent patterns cascade** to child directories within that scope (e.g., root `dist/` also ignores `packages/app/dist/`)

--- a/website/docs/en/config/language-options.md
+++ b/website/docs/en/config/language-options.md
@@ -75,9 +75,9 @@ Files outside all tsconfigs are still linted, but only rules that do not require
 }
 ```
 
-When an entry has `basePath`, its explicit project literals and globs resolve from that directory. This changes only their path origin: Rslint's existing governing-config project collection remains owner-wide, so `files` and `ignores` do not filter which declared projects the loader considers. Without `basePath`, config-module project paths keep Rslint's existing module-directory base, while API inline `overrideConfig` paths use the API `cwd`.
+When an entry has `basePath`, its explicit project literals and globs resolve from that directory. This changes only their path origin: Rslint's existing governing-config project collection remains owner-wide, so `files` and `ignores` do not filter which declared projects the loader considers.
 
-Omit `project` to use the governing config directory's default `tsconfig.json`; `basePath` alone does not move that fallback. An explicit `project: []` disables that fallback for the governing config. See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath).
+Omit `project` to use the governing config directory's default `tsconfig.json`; `basePath` alone does not move that fallback. An explicit `project: []` disables that fallback for the governing config. See the [`basePath` configuration reference](/config/base-path) for the path-origin rules.
 
 ## languageOptions.globals
 

--- a/website/docs/en/guide/js-api.md
+++ b/website/docs/en/guide/js-api.md
@@ -184,4 +184,4 @@ Each `LintMessage`:
 | `fix`                | `boolean`                                   | `false`     | Apply rule auto-fixes; results carry `output`                                                                                                                                  |
 | `virtualFiles`       | `Record<string, string>`                    | —           | In-memory file overlay (path → content); unresolved reads may fall back to disk                                                                                                |
 
-See [Path resolution and `basePath`](/config/configuration-file#path-resolution-and-basepath) for the full source matrix.
+See the [`basePath` configuration reference](/config/base-path) for the full source matrix.

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -30,7 +30,7 @@ rslint --type-check-only .    # type-check only
 
 When `parserOptions.project` is omitted, rslint uses `tsconfig.json` in the governing config directory when present. An explicit `project: []` disables that fallback for the governing config. If neither configured projects nor that fallback tsconfig exist, no real TypeScript Program is built and type-check produces no diagnostics for that config.
 
-An entry's `basePath` becomes the anchor for its explicit project literals or globs. It does not move the implicit governing-directory `tsconfig.json` fallback or change Rslint's existing owner-wide project collection. Program-wide type checking still builds every explicit project declaration in the effective config catalog; `files`, `ignores`, `.gitignore`, and CLI target scope do not reduce that Program's TypeScript diagnostics.
+An entry's [`basePath`](/config/base-path) becomes the anchor for its explicit project literals or globs. It does not move the implicit governing-directory `tsconfig.json` fallback or change Rslint's existing owner-wide project collection. Program-wide type checking still builds every explicit project declaration in the effective config catalog; `files`, `ignores`, `.gitignore`, and CLI target scope do not reduce that Program's TypeScript diagnostics.
 
 ## What gets type-checked
 

--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -42,6 +42,7 @@ interface Group {
 // Keep the documented, user-facing options tied to @rslint/core's config
 // types while intentionally omitting metadata-only fields.
 const CONFIG_OPTION_LINKS = {
+  basePath: '/config/base-path',
   files: '/config/files',
   ignores: '/config/ignoring-files',
   rules: '/config/rules',
@@ -66,7 +67,7 @@ const OVERVIEW_GROUPS: Group[] = [
   {
     name: 'matching',
     icon: FilesIcon,
-    items: [option('files'), option('ignores')],
+    items: [option('basePath'), option('files'), option('ignores')],
   },
   {
     name: 'linting',


### PR DESCRIPTION
## Summary

- Match ESLint directory-ignore behavior when a scoped global ignore uses an ancestor `basePath`: the selected config root remains reachable, while descendants still match relative to `basePath`.
- Keep the boundary calculation inside `internal/config`, reuse the existing `files` and `ignores` matcher, and leave project resolution, `.gitignore` collection, target planning, Program, and LSP responsibilities unchanged.
- Add multi-depth, Windows/UNC, and symlink regression coverage, a CLI product-contract test, and a standalone `basePath` configuration reference.

## Related Links

- Closes https://github.com/web-infra-dev/rslint/issues/1201
- Follow-up to https://github.com/web-infra-dev/rslint/pull/1945
- Related to https://github.com/web-infra-dev/rslint/pull/1471

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).