### PR TITLE
chore: release npm 0.9.0

### DIFF
--- a/npm/rslint/darwin-arm64/package.json
+++ b/npm/rslint/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-arm64",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for darwin-arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/darwin-x64/package.json
+++ b/npm/rslint/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-x64",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for darwin-x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-gnu/package.json
+++ b/npm/rslint/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-gnu",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-musl/package.json
+++ b/npm/rslint/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-musl",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-gnu/package.json
+++ b/npm/rslint/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-gnu",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-musl/package.json
+++ b/npm/rslint/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-musl",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-arm64-msvc/package.json
+++ b/npm/rslint/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-arm64-msvc",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for win32-arm64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-x64-msvc/package.json
+++ b/npm/rslint/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-x64-msvc",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "rslint native binaries for win32-x64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rslint-monorepo",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "private": true,
   "description": "Rslint Monorepo",
   "homepage": "https://github.com/web-infra-dev/rslint#readme",

--- a/packages/rslint-api/package.json
+++ b/packages/rslint-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/api",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Rslint AST library",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/test-tools",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "main": "src/index.ts",
   "private": true,

--- a/packages/rslint-wasm/package.json
+++ b/packages/rslint-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/wasm",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "rslint wasm package",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/core",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "exports": {
     ".": {
       "@typescript/source": "./src/index.ts",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/rule-tester",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/utils",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "",
   "main": "index.ts",
   "private": true,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "rslint",
   "displayName": "Rslint",
   "description": "Language support for Rslint",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "icon": "images/icon.png",
   "private": true,
   "publisher": "rstack",

--- a/website/rule-releases.json
+++ b/website/rule-releases.json
@@ -747,5 +747,30 @@
       "rstest:prefer-todo",
       "rstest:require-local-test-context-for-concurrent-snapshots"
     ]
+  },
+  {
+    "version": "0.9.0",
+    "rules": [
+      "eslint-plugin-jest:prefer-importing-jest-globals",
+      "eslint-plugin-react:jsx-no-useless-fragment",
+      "eslint-plugin-unicorn:no-array-concat-in-loop",
+      "eslint-plugin-unicorn:no-exports-in-scripts",
+      "eslint-plugin-unicorn:no-magic-array-flat-depth",
+      "eslint-plugin-unicorn:prefer-ternary",
+      "eslint-plugin-unicorn:throw-new-error",
+      "eslint:accessorutil",
+      "eslint:class-methods-use-this",
+      "eslint:grouped-accessor-pairs",
+      "eslint:id-denylist",
+      "eslint:id-match",
+      "eslint:logical-assignment-operators",
+      "eslint:no-invalid-this",
+      "eslint:yoda",
+      "rstest:hoisted-apis-on-top",
+      "rstest:prefer-called-once",
+      "rstest:prefer-import-in-mock",
+      "rstest:require-test-timeout",
+      "rstest:warn-todo"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- npm packages: `0.8.2` → `0.9.0`
- add rule release metadata for 20 newly added rules
- keep the independently released tsgo packages unchanged

## Testing

- `pnpm run format:check`
- full test validation is left to CI for this version-only change

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).