### PR TITLE
docs(rstest): document preset usage for in-source tests

### DIFF
--- a/website/docs/en/api/presets/rstest-plugin.md
+++ b/website/docs/en/api/presets/rstest-plugin.md
@@ -1,6 +1,12 @@
 # rstestPlugin
 
-`rstestPlugin` is Rslint's [built-in Rstest-specific plugin](/rules/?group=rstest).
+`rstestPlugin` provides Rslint's [rules for Rstest](/rules/?group=rstest). Enable the recommended preset to catch common mistakes in test definitions, assertions, mocks, and snapshots.
+
+## Usage
+
+### Dedicated test files
+
+For projects that keep tests in dedicated test and spec files, apply the preset to those files:
 
 ```ts
 import { defineConfig, rstestPlugin } from '@rslint/core';
@@ -13,7 +19,21 @@ export default defineConfig([
 ]);
 ```
 
-`rstestPlugin.configs.recommended` does not declare `files`; the example scopes it to test and spec files.
+### In-source tests
+
+When using Rstest's [in-source testing](https://rstest.rs/config/test/include-source), tests live alongside production code and access the test API through `import.meta.rstest`. Apply the preset to every linted file to check both dedicated test files and in-source tests:
+
+```ts
+import { defineConfig, rstestPlugin } from '@rslint/core';
+
+export default defineConfig([rstestPlugin.configs.recommended]);
+```
+
+No additional Rslint globals are required for `import.meta.rstest`.
+
+### Configure test types separately
+
+To use different rule settings for dedicated test files and in-source tests, create a configuration item for each group. Use `files` to match test and spec filenames in one item, and the source patterns from Rstest's [`includeSource`](https://rstest.rs/config/test/include-source) configuration in the other.
 
 ## Presets
 


### PR DESCRIPTION
Document how to configure the recommended Rstest preset for dedicated test files, in-source tests, and separate rule settings.