### PR TITLE
feat(website): support JS config in playground

### DIFF
--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -76,7 +76,8 @@ const Playground: React.FC = () => {
       const service = await ensureWasmService(version);
       if (!isCurrentLintRun(runId, version)) return;
       const code = editorRef.current?.getValue() ?? '';
-      const rslintConfig = editorRef.current?.getRslintConfig();
+      const rslintConfig = await editorRef.current?.getRslintConfig(version);
+      if (!isCurrentLintRun(runId, version)) return;
       const tsConfig = editorRef.current?.getTsConfig();
 
       // Build fileContents with code and config files
@@ -97,9 +98,7 @@ const Playground: React.FC = () => {
       const result = await service.lint({
         includeEncodedSourceFiles: true,
         fileContents,
-        config: Array.isArray(rslintConfig)
-          ? (rslintConfig as Record<string, unknown>[])
-          : undefined,
+        config: rslintConfig,
         configDirectory: '/',
       });
       if (!isCurrentLintRun(runId, version)) return;

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -12,6 +12,7 @@ import { jsonDefaults } from 'monaco-editor/languages/features/json/register';
 import { type Diagnostic } from '@rslint/core/service';
 import { useDark } from '@rspress/core/runtime';
 import { Button } from '@components/ui/button';
+import { evaluateConfig, type PlaygroundConfig } from './config';
 // Monaco-specific styles only (ast-node-highlight)
 import './EditorTabs.css';
 
@@ -38,7 +39,7 @@ export type EditorTabType = 'code' | 'rslint' | 'tsconfig';
 export interface EditorTabsRef {
   getValue: () => string | undefined;
   getCodeValue: () => string | undefined;
-  getRslintConfig: () => any | null;
+  getRslintConfig: (wasmVersion: string) => Promise<PlaygroundConfig>;
   getTsConfig: () => any | null;
   attachDiag: (diags: Diagnostic[]) => void;
   revealRangeByOffset: (start: number, end: number) => void;
@@ -56,19 +57,22 @@ interface EditorTabsProps {
   toolbarEnd?: ReactNode;
 }
 
-const DEFAULT_RSLINT_CONFIG = `[
+const DEFAULT_RSLINT_CONFIG = `import { defineConfig, js, ts } from '@rslint/core';
+
+export default defineConfig([
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
   {
-    "languageOptions": {
-      "parserOptions": {
-        "project": ["./tsconfig.json"]
-      }
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
     },
-    "rules": {
-      "@typescript-eslint/no-unsafe-member-access": "error"
+    rules: {
+      '@typescript-eslint/no-unsafe-member-access': 'error',
     },
-    "plugins": ["@typescript-eslint"]
-  }
-]`;
+  },
+]);`;
 
 const DEFAULT_TSCONFIG = `{
   "compilerOptions": {
@@ -127,8 +131,6 @@ export const EditorTabs = ({
   const onSelectionChangeRef = useRef(onSelectionChange);
   const onConfigChangeRef = useRef(onConfigChange);
 
-  // Store last valid parsed configs
-  const lastValidRslintConfig = useRef<any>(null);
   const lastValidTsConfig = useRef<any>(null);
 
   // Monaco keeps these subscriptions for the editor lifetime, so forward them
@@ -175,23 +177,19 @@ export const EditorTabs = ({
     }, 300);
   }
 
-  // Initialize last valid configs
+  // Initialize the last valid tsconfig.
   useEffect(() => {
-    lastValidRslintConfig.current = parseJsonc(DEFAULT_RSLINT_CONFIG);
     lastValidTsConfig.current = parseJsonc(DEFAULT_TSCONFIG);
   }, []);
 
   useImperativeHandle(ref, () => ({
     getValue: () => codeEditorRef.current?.getValue(),
     getCodeValue: () => codeEditorRef.current?.getValue(),
-    getRslintConfig: () => {
-      const content = rslintEditorRef.current?.getValue() || '';
-      const parsed = parseJsonc(content);
-      if (parsed !== null) {
-        lastValidRslintConfig.current = parsed;
-      }
-      return lastValidRslintConfig.current;
-    },
+    getRslintConfig: async (wasmVersion) =>
+      evaluateConfig(
+        rslintEditorRef.current?.getValue() ?? DEFAULT_RSLINT_CONFIG,
+        wasmVersion,
+      ),
     getTsConfig: () => {
       const content = tsconfigEditorRef.current?.getValue() || '';
       const parsed = parseJsonc(content);
@@ -398,13 +396,13 @@ export const EditorTabs = ({
     });
   }, []);
 
-  // Create the serialized config editor used by the low-level API.
+  // Create rslint.config.js editor.
   useEffect(() => {
     if (!rslintContainerRef.current) return;
 
     const editor = monaco.editor.create(rslintContainerRef.current, {
       value: DEFAULT_RSLINT_CONFIG,
-      language: 'json',
+      language: 'javascript',
       theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
@@ -450,7 +448,7 @@ export const EditorTabs = ({
 
   const tabs: { key: EditorTabType; label: string }[] = [
     { key: 'code', label: 'Code' },
-    { key: 'rslint', label: 'Config (JSON)' },
+    { key: 'rslint', label: 'rslint.config.js' },
     { key: 'tsconfig', label: 'tsconfig' },
   ];
 

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -9,10 +9,17 @@ import {
 } from 'react';
 import * as monaco from 'monaco-editor';
 import { jsonDefaults } from 'monaco-editor/languages/features/json/register';
+import {
+  javascriptDefaults,
+  ModuleKind,
+  ModuleResolutionKind,
+  ScriptTarget,
+} from 'monaco-editor/languages/features/typescript/register';
 import { type Diagnostic } from '@rslint/core/service';
 import { useDark } from '@rspress/core/runtime';
 import { Button } from '@components/ui/button';
 import { evaluateConfig, type PlaygroundConfig } from './config';
+import { installRslintCoreTypes } from './config-types';
 // Monaco-specific styles only (ast-node-highlight)
 import './EditorTabs.css';
 
@@ -185,11 +192,13 @@ export const EditorTabs = ({
   useImperativeHandle(ref, () => ({
     getValue: () => codeEditorRef.current?.getValue(),
     getCodeValue: () => codeEditorRef.current?.getValue(),
-    getRslintConfig: async (wasmVersion) =>
-      evaluateConfig(
+    getRslintConfig: async (wasmVersion) => {
+      await installRslintCoreTypes(wasmVersion);
+      return evaluateConfig(
         rslintEditorRef.current?.getValue() ?? DEFAULT_RSLINT_CONFIG,
         wasmVersion,
-      ),
+      );
+    },
     getTsConfig: () => {
       const content = tsconfigEditorRef.current?.getValue() || '';
       const parsed = parseJsonc(content);
@@ -400,9 +409,24 @@ export const EditorTabs = ({
   useEffect(() => {
     if (!rslintContainerRef.current) return;
 
+    javascriptDefaults.setCompilerOptions({
+      allowJs: true,
+      checkJs: true,
+      module: ModuleKind.ESNext,
+      moduleResolution: ModuleResolutionKind.NodeJs,
+      target: ScriptTarget.ESNext,
+    });
+    javascriptDefaults.setDiagnosticsOptions({
+      noSemanticValidation: false,
+      noSyntaxValidation: false,
+    });
+    const model = monaco.editor.createModel(
+      DEFAULT_RSLINT_CONFIG,
+      'javascript',
+      monaco.Uri.parse('file:///rslint.config.js'),
+    );
     const editor = monaco.editor.create(rslintContainerRef.current, {
-      value: DEFAULT_RSLINT_CONFIG,
-      language: 'javascript',
+      model,
       theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
@@ -416,6 +440,7 @@ export const EditorTabs = ({
 
     return () => {
       editor.dispose();
+      model.dispose();
     };
   }, []);
 

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -474,7 +474,7 @@ export const EditorTabs = ({
   const tabs: { key: EditorTabType; label: string }[] = [
     { key: 'code', label: 'Code' },
     { key: 'rslint', label: 'rslint.config.js' },
-    { key: 'tsconfig', label: 'tsconfig' },
+    { key: 'tsconfig', label: 'tsconfig.json' },
   ];
 
   return (

--- a/website/theme/components/Playground/config-types.ts
+++ b/website/theme/components/Playground/config-types.ts
@@ -38,9 +38,9 @@ async function loadTypeLibraries(
 
 /** Install exact-version @rslint/core declarations for rslint.config.js. */
 export async function installRslintCoreTypes(version: string) {
+  const currentRequestId = ++requestId;
   if (installedVersion === version) return;
 
-  const currentRequestId = ++requestId;
   const libraries: Array<{ content: string; path: string }> = [];
   await loadTypeLibraries(typeUrl(version), CORE_TYPES_PATH, libraries);
   if (currentRequestId !== requestId) return;

--- a/website/theme/components/Playground/config-types.ts
+++ b/website/theme/components/Playground/config-types.ts
@@ -1,0 +1,53 @@
+import type * as monaco from 'monaco-editor';
+import { javascriptDefaults } from 'monaco-editor/languages/features/typescript/register';
+
+const CORE_URL = 'https://esm.sh/@rslint/core@';
+const CORE_TYPES_PATH = 'file:///node_modules/@rslint/core/index.d.ts';
+const TYPE_IMPORT = /(?:import\(|from\s+)["'](\.{1,2}\/[^"']+\.d\.ts)["']/g;
+
+let installedVersion: string | undefined;
+let installedLibraries: monaco.IDisposable[] = [];
+let requestId = 0;
+
+function typeUrl(version: string) {
+  return `${CORE_URL}${encodeURIComponent(version)}/dist/index.d.ts`;
+}
+
+async function loadTypeLibraries(
+  url: string,
+  path: string,
+  libraries: Array<{ content: string; path: string }>,
+) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`unable to load @rslint/core types: ${response.status}`);
+  }
+
+  const content = await response.text();
+  libraries.push({ content, path });
+
+  const imports = [...content.matchAll(TYPE_IMPORT)].map((match) => match[1]);
+  await Promise.all(
+    imports.map((specifier) => {
+      const dependencyUrl = new URL(specifier, url).href;
+      const dependencyPath = new URL(specifier, path).href;
+      return loadTypeLibraries(dependencyUrl, dependencyPath, libraries);
+    }),
+  );
+}
+
+/** Install exact-version @rslint/core declarations for rslint.config.js. */
+export async function installRslintCoreTypes(version: string) {
+  if (installedVersion === version) return;
+
+  const currentRequestId = ++requestId;
+  const libraries: Array<{ content: string; path: string }> = [];
+  await loadTypeLibraries(typeUrl(version), CORE_TYPES_PATH, libraries);
+  if (currentRequestId !== requestId) return;
+
+  for (const library of installedLibraries) library.dispose();
+  installedLibraries = libraries.map(({ content, path }) =>
+    javascriptDefaults.addExtraLib(content, path),
+  );
+  installedVersion = version;
+}

--- a/website/theme/components/Playground/config.ts
+++ b/website/theme/components/Playground/config.ts
@@ -9,16 +9,16 @@ function prepareModule(source: string, wasmVersion: string): string {
 
 function normalizeConfig(value: unknown): PlaygroundConfig {
   if (!Array.isArray(value)) {
-    throw new Error("rslint.config.js must default-export an array.");
+    throw new Error('rslint.config.js must default-export an array.');
   }
   const entries = value.flat();
   if (
     entries.some(
       (entry) =>
-        entry === null || typeof entry !== "object" || Array.isArray(entry),
+        entry === null || typeof entry !== 'object' || Array.isArray(entry),
     )
   ) {
-    throw new Error("rslint.config.js must contain only config objects.");
+    throw new Error('rslint.config.js must contain only config objects.');
   }
   return entries as PlaygroundConfig;
 }
@@ -30,7 +30,7 @@ export async function evaluateConfig(
 ): Promise<PlaygroundConfig> {
   const moduleUrl = URL.createObjectURL(
     new Blob([prepareModule(source, wasmVersion)], {
-      type: "text/javascript",
+      type: 'text/javascript',
     }),
   );
   try {

--- a/website/theme/components/Playground/config.ts
+++ b/website/theme/components/Playground/config.ts
@@ -1,0 +1,42 @@
+export type PlaygroundConfig = Record<string, unknown>[];
+
+const CORE_IMPORT = /from ['"]@rslint\/core['"]/g;
+
+function prepareModule(source: string, wasmVersion: string): string {
+  const coreUrl = `https://esm.sh/@rslint/core@${encodeURIComponent(wasmVersion)}?target=es2022`;
+  return source.replace(CORE_IMPORT, `from ${JSON.stringify(coreUrl)}`);
+}
+
+function normalizeConfig(value: unknown): PlaygroundConfig {
+  if (!Array.isArray(value)) {
+    throw new Error("rslint.config.js must default-export an array.");
+  }
+  const entries = value.flat();
+  if (
+    entries.some(
+      (entry) =>
+        entry === null || typeof entry !== "object" || Array.isArray(entry),
+    )
+  ) {
+    throw new Error("rslint.config.js must contain only config objects.");
+  }
+  return entries as PlaygroundConfig;
+}
+
+/** Execute a config against the selected @rslint/wasm release's core package. */
+export async function evaluateConfig(
+  source: string,
+  wasmVersion: string,
+): Promise<PlaygroundConfig> {
+  const moduleUrl = URL.createObjectURL(
+    new Blob([prepareModule(source, wasmVersion)], {
+      type: "text/javascript",
+    }),
+  );
+  try {
+    const module = await import(/* rspackIgnore: true */ moduleUrl);
+    return normalizeConfig(module.default);
+  } finally {
+    URL.revokeObjectURL(moduleUrl);
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `rslint.config.js` editor to Playground.
- Rewrite `@rslint/core` imports to the exact selected release on esm.sh.
- Enable `js.configs.recommended` in the default Playground config.
- Load matching `@rslint/core` declarations so configuration type errors are reported.

## Testing

- `pnpm --filter @rslint/website exec tsc -p tsconfig.json --noEmit` (no errors in the touched Playground files)