### PR TITLE
fix: align Unicode regexp semantics

### DIFF
--- a/internal/rules/no_regex_spaces/no_regex_spaces.md
+++ b/internal/rules/no_regex_spaces/no_regex_spaces.md
@@ -34,6 +34,14 @@ contains escape sequences that differ from the raw source (e.g.
 `new RegExp('\\d  ')`), the rule reports but does not autofix — the index into
 the parsed pattern would not map cleanly back to source positions.
 
+## Differences from ESLint
+
+- Pattern validation fails closed for duplicate named captures and for
+  `\q{...}` or Unicode-property operands below a negated `v` character class.
+  The rule can therefore omit a report for an ES2025 mutually exclusive
+  duplicate name or a negated single-code-point operand that ESLint proves
+  valid; this ensures a parser ambiguity never produces an unsafe autofix.
+
 ## Original Documentation
 
 - [ESLint: no-regex-spaces](https://eslint.org/docs/latest/rules/no-regex-spaces)

--- a/internal/rules/no_regex_spaces/no_regex_spaces.md
+++ b/internal/rules/no_regex_spaces/no_regex_spaces.md
@@ -36,11 +36,11 @@ the parsed pattern would not map cleanly back to source positions.
 
 ## Differences from ESLint
 
-- Pattern validation fails closed for duplicate named captures and for
-  `\q{...}` or Unicode-property operands below a negated `v` character class.
-  The rule can therefore omit a report for an ES2025 mutually exclusive
-  duplicate name or a negated single-code-point operand that ESLint proves
-  valid; this ensures a parser ambiguity never produces an unsafe autofix.
+- Constructor patterns using capture names or Unicode properties newer than
+  the bundled TypeScript parser's Unicode data can be skipped.
+- For a constructor pattern with a negated `v` class where a range is followed
+  by a string-valued operand, rslint skips a report that ESLint may emit because
+  JavaScript rejects the pattern.
 
 ## Original Documentation
 

--- a/internal/rules/no_regex_spaces/no_regex_spaces_test.go
+++ b/internal/rules/no_regex_spaces/no_regex_spaces_test.go
@@ -73,9 +73,10 @@ func TestNoRegexSpacesRule(t *testing.T) {
 			{Code: `var foo = new RegExp('{  ', 'v');`},
 			{Code: `RegExp("(?=(?<a>x))(?<a>y)  ", "u")`},
 			{Code: `RegExp("[^a\\q{bc}]  ", "v")`},
-			// The shared validator fails closed for v string-capability cases
-			// that tsgo cannot distinguish without ClassSet data flow.
-			{Code: `RegExp("[^a\\p{Letter}]  ", "v")`},
+			{Code: `RegExp("[^a-z\\q{bc}]  ", "v")`},
+			// The bundled TypeScript scanner does not yet recognize this newer
+			// Unicode script value, so shared pattern validation fails closed.
+			{Code: `RegExp("[^a\\p{Script=Gara}]  ", "v")`},
 
 			// ---- Flags cannot be determined ----
 			{Code: `new RegExp('  ', flags)`},
@@ -83,6 +84,23 @@ func TestNoRegexSpacesRule(t *testing.T) {
 			{Code: `new RegExp('[[abc]\q{  }]', flags + 'v')`},
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- Shared ECMAScript pattern validation ----
+			{
+				Code:   `var foo = /(?<a>x)|(?<a>y)  /u;`,
+				Output: []string{`var foo = /(?<a>x)|(?<a>y) {2}/u;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "multipleSpaces"}},
+			},
+			{
+				Code:   `var foo = /[^a\q{b|c}]  /v;`,
+				Output: []string{`var foo = /[^a\q{b|c}] {2}/v;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "multipleSpaces"}},
+			},
+			{
+				Code:   `var foo = /[^a\p{Letter}]  /v;`,
+				Output: []string{`var foo = /[^a\p{Letter}] {2}/v;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "multipleSpaces"}},
+			},
+
 			// ---- Regex literals ----
 			{
 				Code:   `var foo = /bar  baz/;`,

--- a/internal/rules/no_regex_spaces/no_regex_spaces_test.go
+++ b/internal/rules/no_regex_spaces/no_regex_spaces_test.go
@@ -71,6 +71,11 @@ func TestNoRegexSpacesRule(t *testing.T) {
 			{Code: `var foo = new RegExp('[  ');`},
 			{Code: `var foo = new RegExp('{  ', 'u');`},
 			{Code: `var foo = new RegExp('{  ', 'v');`},
+			{Code: `RegExp("(?=(?<a>x))(?<a>y)  ", "u")`},
+			{Code: `RegExp("[^a\\q{bc}]  ", "v")`},
+			// The shared validator fails closed for v string-capability cases
+			// that tsgo cannot distinguish without ClassSet data flow.
+			{Code: `RegExp("[^a\\p{Letter}]  ", "v")`},
 
 			// ---- Flags cannot be determined ----
 			{Code: `new RegExp('  ', flags)`},

--- a/internal/rules/require_unicode_regexp/regexp_call_tracker.go
+++ b/internal/rules/require_unicode_regexp/regexp_call_tracker.go
@@ -14,7 +14,6 @@ type regexpCallTracker struct {
 	ctx               rule.RuleContext
 	identifiersByName map[string][]*ast.Node
 	propertyEvaluator *utils.StaticStringEvaluator
-	disabledRoots     map[string]bool
 	tracedVariables   map[regexpTraceVariable]bool
 	tracedGlobals     map[regexpTraceGlobal]bool
 	calls             map[*ast.Node]bool
@@ -38,6 +37,25 @@ type regexpTraceGlobal struct {
 }
 
 var regexpGlobalObjectNames = [...]string{"globalThis", "window", "self", "global"}
+
+// sourceMayUseRegexpConstructor reports whether the file spells one of the
+// syntactic roots from which this tracker can reach the built-in constructor.
+// SourceFile.Identifiers stores normalized names, so escaped identifiers such
+// as R\u0065gExp remain observable. A nil table is treated conservatively.
+func sourceMayUseRegexpConstructor(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	if _, ok := sourceFile.Identifiers["RegExp"]; ok {
+		return true
+	}
+	for _, name := range regexpGlobalObjectNames {
+		if _, ok := sourceFile.Identifiers[name]; ok {
+			return true
+		}
+	}
+	return false
+}
 
 func newRegexpCallTracker(ctx rule.RuleContext) *regexpCallTracker {
 	tracker := &regexpCallTracker{
@@ -75,10 +93,6 @@ func (tracker *regexpCallTracker) trackGlobalRoot(name string, value regexpTrace
 	references := tracker.globalReferences(name)
 	for _, reference := range references {
 		if utils.IsWriteReference(reference) {
-			if tracker.disabledRoots == nil {
-				tracker.disabledRoots = make(map[string]bool)
-			}
-			tracker.disabledRoots[name] = true
 			return
 		}
 	}
@@ -102,9 +116,7 @@ func (tracker *regexpCallTracker) isGlobalReference(identifier *ast.Node, name s
 		return false
 	}
 	if tracker.ctx.Refs != nil {
-		if symbol := tracker.ctx.Refs.Resolve(identifier); symbol != nil {
-			return !utils.IsValueSymbolDeclaredInFile(symbol, tracker.ctx.SourceFile)
-		}
+		return tracker.ctx.Refs.IsGlobalReference(identifier)
 	}
 	return !utils.IsShadowed(identifier, name)
 }
@@ -317,7 +329,7 @@ func (tracker *regexpCallTracker) staticPropertyName(node *ast.Node) (string, bo
 }
 
 func regexpValuePassesThrough(node *ast.Node, parent *ast.Node) bool {
-	if ast.IsOuterExpression(parent, ast.OEKParentheses|ast.OEKAssertions) {
+	if ast.IsOuterExpression(parent, ast.OEKParentheses|ast.OEKAssertions|ast.OEKExpressionsWithTypeArguments) {
 		return parent.Expression() == node
 	}
 	if parent.Kind == ast.KindConditionalExpression {

--- a/internal/rules/require_unicode_regexp/require_unicode_regexp.go
+++ b/internal/rules/require_unicode_regexp/require_unicode_regexp.go
@@ -176,8 +176,36 @@ var RequireUnicodeRegexpRule = rule.Rule{
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		requireFlag := parseOptions(options)
-		evaluator := utils.NewStaticStringEvaluatorWithReferenceResolver(ctx.TypeChecker, ctx.SourceFile, ctx.Refs)
+		listeners := rule.RuleListeners{
+			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
+				pattern, flags := utils.ExtractRegexPatternAndFlags(node.Text())
+				if !checkFlags(requireFlag, flags) {
+					return
+				}
+				ctx.ReportNodeWithDeferredSuggestions(node, requireMessage(requireFlag), func() []rule.RuleSuggestion {
+					if !isValidWithUnicodeFlag(ctx.LanguageOptions.EffectiveECMAVersion(), pattern, requireFlag) {
+						return nil
+					}
+					fix, ok := buildLiteralFix(ctx, node, requireFlag)
+					if !ok {
+						return nil
+					}
+					return []rule.RuleSuggestion{{Message: addMessage(requireFlag), FixesArr: []rule.RuleFix{fix}}}
+				})
+			},
+		}
+		if !sourceMayUseRegexpConstructor(ctx.SourceFile) {
+			return listeners
+		}
+
 		callTracker := newRegexpCallTracker(ctx)
+		var evaluator *utils.StaticStringEvaluator
+		getEvaluator := func() *utils.StaticStringEvaluator {
+			if evaluator == nil {
+				evaluator = utils.NewStaticStringEvaluatorWithReferenceResolver(ctx.TypeChecker, ctx.SourceFile, ctx.Refs)
+			}
+			return evaluator
+		}
 
 		checkCall := func(node *ast.Node, argsList *ast.NodeList) {
 			if !callTracker.isCall(node) {
@@ -204,7 +232,10 @@ var RequireUnicodeRegexpRule = rule.Rule{
 			// value (not just an already-string one) is coerced to its String()
 			// form before the flag check, so e.g. a literal `false` or `1`
 			// flags argument is compared as the text "false" / "1".
-			flagsValue, flagsOk := evaluator.EvalToString(flagsNode)
+			flagsValue, flagsOk := "", false
+			if flagsNode != nil {
+				flagsValue, flagsOk = getEvaluator().EvalToString(flagsNode)
+			}
 			missingFlag := flagsNode == nil
 			if flagsOk {
 				missingFlag = checkFlags(requireFlag, flagsValue)
@@ -214,7 +245,7 @@ var RequireUnicodeRegexpRule = rule.Rule{
 			}
 
 			ctx.ReportNodeWithDeferredSuggestions(node, requireMessage(requireFlag), func() []rule.RuleSuggestion {
-				patternValue, patternOk := evaluator.EvalToString(patternNode)
+				patternValue, patternOk := getEvaluator().EvalToString(patternNode)
 				if !patternOk {
 					return nil
 				}
@@ -229,31 +260,14 @@ var RequireUnicodeRegexpRule = rule.Rule{
 			})
 		}
 
-		return rule.RuleListeners{
-			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
-				pattern, flags := utils.ExtractRegexPatternAndFlags(node.Text())
-				if !checkFlags(requireFlag, flags) {
-					return
-				}
-				ctx.ReportNodeWithDeferredSuggestions(node, requireMessage(requireFlag), func() []rule.RuleSuggestion {
-					if !isValidWithUnicodeFlag(ctx.LanguageOptions.EffectiveECMAVersion(), pattern, requireFlag) {
-						return nil
-					}
-					fix, ok := buildLiteralFix(ctx, node, requireFlag)
-					if !ok {
-						return nil
-					}
-					return []rule.RuleSuggestion{{Message: addMessage(requireFlag), FixesArr: []rule.RuleFix{fix}}}
-				})
-			},
-			ast.KindCallExpression: func(node *ast.Node) {
-				call := node.AsCallExpression()
-				checkCall(node, call.Arguments)
-			},
-			ast.KindNewExpression: func(node *ast.Node) {
-				newExpr := node.AsNewExpression()
-				checkCall(node, newExpr.Arguments)
-			},
+		listeners[ast.KindCallExpression] = func(node *ast.Node) {
+			call := node.AsCallExpression()
+			checkCall(node, call.Arguments)
 		}
+		listeners[ast.KindNewExpression] = func(node *ast.Node) {
+			newExpr := node.AsNewExpression()
+			checkCall(node, newExpr.Arguments)
+		}
+		return listeners
 	},
 }

--- a/internal/rules/require_unicode_regexp/require_unicode_regexp.md
+++ b/internal/rules/require_unicode_regexp/require_unicode_regexp.md
@@ -101,6 +101,7 @@ const fooRegexp = new RegExp("foo", "v");
   does not construct a new RegExp object while folding an expression. For
   example, `RegExp("g", "u").source` remains unknown even though ESLint can
   fold it to `"g"`.
+
 ## Original Documentation
 
 - [ESLint: require-unicode-regexp](https://eslint.org/docs/latest/rules/require-unicode-regexp)

--- a/internal/rules/require_unicode_regexp/require_unicode_regexp.md
+++ b/internal/rules/require_unicode_regexp/require_unicode_regexp.md
@@ -101,13 +101,6 @@ const fooRegexp = new RegExp("foo", "v");
   does not construct a new RegExp object while folding an expression. For
   example, `RegExp("g", "u").source` remains unknown even though ESLint can
   fold it to `"g"`.
-- A suggested flag insertion into a template literal that interpolates an
-  expression is refused whenever that template's cooked value already
-  contains the opposite flag character, even when the interpolated
-  expression's source text has no escape sequence of its own — ESLint only
-  inspects the template's literal quasis for that escape check, this rule
-  inspects the whole template source.
-
 ## Original Documentation
 
 - [ESLint: require-unicode-regexp](https://eslint.org/docs/latest/rules/require-unicode-regexp)

--- a/internal/rules/require_unicode_regexp/require_unicode_regexp.md
+++ b/internal/rules/require_unicode_regexp/require_unicode_regexp.md
@@ -88,19 +88,14 @@ const fooRegexp = new RegExp("foo", "v");
 
 ## Differences from ESLint
 
-- Suggestions are conservatively omitted for every duplicate named capture,
-  including the mutually exclusive alternatives that became valid in ES2025.
-  The diagnostic is still reported, and an added flag never depends on
-  duplicate-name control-flow acceptance.
-- When validating a `v` suggestion, a negated character class containing a
-  `\q{...}`, `\p{...}`, or `\P{...}` operand is conservatively treated as
-  unsafe, including through nested sets. This can omit suggestions for
-  single-code-point operands that ESLint proves safe, while preventing an
-  invalid suggestion for string-valued operands.
-- Static evaluation models RegExp literals and their stable properties, but it
-  does not construct a new RegExp object while folding an expression. For
-  example, `RegExp("g", "u").source` remains unknown even though ESLint can
-  fold it to `"g"`.
+- When flags come from a newly constructed RegExp object's property, such as
+  `RegExp("g", "u").source`, rslint may skip a call that ESLint reports.
+- With computed `['__proto__']` properties in constant objects, rslint follows
+  own-property semantics and can report a constructor call that ESLint skips.
+- Capture names or Unicode properties newer than the bundled TypeScript
+  parser's Unicode data can receive a diagnostic without a flag suggestion.
+- For a negated `v` class where a range is followed by a string-valued operand,
+  rslint omits ESLint's suggestion because JavaScript would reject the result.
 
 ## Original Documentation
 

--- a/internal/rules/require_unicode_regexp/require_unicode_regexp.md
+++ b/internal/rules/require_unicode_regexp/require_unicode_regexp.md
@@ -88,13 +88,19 @@ const fooRegexp = new RegExp("foo", "v");
 
 ## Differences from ESLint
 
-- A pattern is judged against `u`-flag syntax when deciding whether the
-  suggestion is safe, so one written in `v`-flag set notation — the difference
-  operator (`[\d--[3]]`), a `\q{...}` string literal — is reported without a
-  suggestion that ESLint would offer.
-- Unicode property escapes are recognized by their short aliases, so
-  `/\p{L}/` is offered the flag while `/\p{Letter}/` and
-  `/\p{Script=Greek}/` are reported without a suggestion.
+- Suggestions are conservatively omitted for every duplicate named capture,
+  including the mutually exclusive alternatives that became valid in ES2025.
+  The diagnostic is still reported, and an added flag never depends on
+  duplicate-name control-flow acceptance.
+- When validating a `v` suggestion, a negated character class containing a
+  `\q{...}`, `\p{...}`, or `\P{...}` operand is conservatively treated as
+  unsafe, including through nested sets. This can omit suggestions for
+  single-code-point operands that ESLint proves safe, while preventing an
+  invalid suggestion for string-valued operands.
+- Static evaluation models RegExp literals and their stable properties, but it
+  does not construct a new RegExp object while folding an expression. For
+  example, `RegExp("g", "u").source` remains unknown even though ESLint can
+  fold it to `"g"`.
 - A suggested flag insertion into a template literal that interpolates an
   expression is refused whenever that template's cooked value already
   contains the opposite flag character, even when the interpolated

--- a/internal/rules/require_unicode_regexp/require_unicode_regexp_extras_test.go
+++ b/internal/rules/require_unicode_regexp/require_unicode_regexp_extras_test.go
@@ -593,7 +593,18 @@ func TestRequireUnicodeRegexpExtras(t *testing.T) {
 			{
 				Code:            `/(?<a>x)|(?<a>y)/`,
 				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2025},
-				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `/(?<a>x)|(?<a>y)/u`}},
+				}},
+			},
+			{
+				Code:            `/(?:(?<a>x)|(?:y|(?<a>z)))/`,
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2025},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `/(?:(?<a>x)|(?:y|(?<a>z)))/u`}},
+				}},
 			},
 			{
 				Code:            `/(?:x|(?<a>y))(?<a>z)/`,
@@ -631,6 +642,45 @@ func TestRequireUnicodeRegexpExtras(t *testing.T) {
 			},
 			{
 				Code:            `/[^a\q{ab}]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireVFlag"}},
+			},
+			{
+				Code:            `/[^a\q{b|c}]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireVFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addVFlag", Output: `/[^a\q{b|c}]/v`}},
+				}},
+			},
+			{
+				Code:            `/[^a\p{Letter}]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireVFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addVFlag", Output: `/[^a\p{Letter}]/v`}},
+				}},
+			},
+			{
+				Code:            `/[^\q{ab}&&a]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireVFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addVFlag", Output: `/[^\q{ab}&&a]/v`}},
+				}},
+			},
+			{
+				Code:            `/[^a\p{Basic_Emoji}]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireVFlag"}},
+			},
+			{
+				Code:            `/[^a-z\q{bc}]/`,
 				Options:         []any{map[string]any{"requireFlag": "v"}},
 				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
 				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireVFlag"}},

--- a/internal/rules/require_unicode_regexp/require_unicode_regexp_extras_test.go
+++ b/internal/rules/require_unicode_regexp/require_unicode_regexp_extras_test.go
@@ -34,6 +34,25 @@ func TestRequireUnicodeRegexpExtras(t *testing.T) {
 		t,
 		&RequireUnicodeRegexpRule,
 		[]rule_tester.ValidTestCase{
+			// ReferenceTracker treats authored program-scope type declarations
+			// as modifications of a script global, but not of a module global.
+			{Code: "interface RegExp {}\nRegExp('x')", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			{Code: "type RegExp = unknown;\nRegExp('x')", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			{Code: "interface globalThis {}\nglobalThis.RegExp('x')", LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			// Namespace and type-only import declarations own their scope variable
+			// in both declaration spaces, so neither reference is the builtin.
+			{Code: "namespace RegExp {}\nRegExp('x')", LanguageOptions: rule.LanguageOptions{SourceType: "module"}},
+			{Code: "import type { RegExp } from 'x';\nRegExp('x')", LanguageOptions: rule.LanguageOptions{SourceType: "module"}},
+			// Static RegExp-literal properties that already carry u suppress the
+			// report; mutation makes an alias unknown and conservatively skipped.
+			{Code: `new RegExp("x", /u/u.source)`},
+			{Code: `new RegExp("x", /x/u.flags)`},
+			{Code: `const re = /g/u; re.lastIndex = 1; new RegExp("x", re.source)`},
+			// eslint-utils 4.10.1 does not whitelist the unicodeSets getter.
+			{Code: `new RegExp("x", /x/v.unicodeSets)`, Options: []any{map[string]any{"requireFlag": "v"}}},
+			// A RegExp used as __proto__ supplies branded getters that throw for
+			// the outer object, so its String value is not statically known.
+			{Code: `new RegExp("x", String({__proto__: /u/u}))`},
 			// ---- Locks in upstream trackMap arm: patternNode SpreadElement skips
 			// the whole call, even with further arguments present ----
 			{Code: "RegExp(...args, 'gi')"},
@@ -51,6 +70,93 @@ func TestRequireUnicodeRegexpExtras(t *testing.T) {
 			{Code: "RegExp = custom; RegExp('foo')"},
 		},
 		[]rule_tester.InvalidTestCase{
+			// A top-level type declaration in a module does not replace the
+			// runtime global, while the same declaration in script mode does.
+			{
+				Code:            "interface RegExp {}\nRegExp('x')",
+				LanguageOptions: rule.LanguageOptions{SourceType: "module"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: "interface RegExp {}\nRegExp('x', \"u\")"}},
+				}},
+			},
+			{
+				Code:            "type RegExp = unknown;\nRegExp('x')",
+				LanguageOptions: rule.LanguageOptions{SourceType: "module"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: "type RegExp = unknown;\nRegExp('x', \"u\")"}},
+				}},
+			},
+			{
+				Code:            "{ interface RegExp {} RegExp('x') }",
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: "{ interface RegExp {} RegExp('x', \"u\") }"}},
+				}},
+			},
+			{
+				Code:            "interface RegExp {}\nglobalThis.RegExp('x')",
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: "interface RegExp {}\nglobalThis.RegExp('x', \"u\")"}},
+				}},
+			},
+			{
+				Code:            "interface globalThis {}\nglobalThis.RegExp('x')",
+				LanguageOptions: rule.LanguageOptions{SourceType: "module"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: "interface globalThis {}\nglobalThis.RegExp('x', \"u\")"}},
+				}},
+			},
+			// TSInstantiationExpression is transparent in eslint-utils' tracker.
+			{
+				Code: `(RegExp<string>)("x")`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `(RegExp<string>)("x", "u")`}},
+				}},
+			},
+			{
+				Code: `const R = RegExp<string>; R("x")`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `const R = RegExp<string>; R("x", "u")`}},
+				}},
+			},
+			{
+				Code: `const R = globalThis.RegExp<string>; new R("x")`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `const R = globalThis.RegExp<string>; new R("x", "u")`}},
+				}},
+			},
+			// SourceFile.Identifiers normalizes escaped identifier spellings, so
+			// the constructor fast path cannot hide this global reference.
+			{
+				Code: `R\u0065gExp("x")`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `R\u0065gExp("x", "u")`}},
+				}},
+			},
+			// RegExp-literal properties participate in shared static evaluation.
+			// Member-expression flags are reportable but intentionally not fixed.
+			{
+				Code:   `new RegExp("x", /g/u.source)`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+			},
+			{
+				Code:   `const re = /g/u; new RegExp("x", re["source"])`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+			},
+			{
+				Code:   `new RegExp("x", ({__proto__: /g/u}).lastIndex)`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+			},
 			// ReferenceTracker follows a stable local alias of the builtin.
 			{
 				Code: "const R = RegExp; R('foo')",
@@ -438,6 +544,96 @@ func TestRequireUnicodeRegexpExtras(t *testing.T) {
 						Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: "/(?<a>x)\\k<a>/u"}},
 					},
 				},
+			},
+			// Escaped RegExpIdentifierName spellings normalize before the full
+			// ECMAScript grammar gate, including escaped references and `$`.
+			{
+				Code: `/(?<\u0061>x)\k<a>/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `/(?<\u0061>x)\k<a>/u`}},
+				}},
+			},
+			{
+				Code: `/(?<a>x)\k<\u0061>/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `/(?<a>x)\k<\u0061>/u`}},
+				}},
+			},
+			{
+				Code: `/(?<\u0024>x)\k<$>/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `/(?<\u0024>x)\k<$>/u`}},
+				}},
+			},
+			{
+				Code: `new RegExp("(?<\\u{00000061}>x)\\k<a>")`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `new RegExp("(?<\\u{00000061}>x)\\k<a>", "u")`}},
+				}},
+			},
+			// The tsgo grammar gate rejects unsafe u-mode conversions that the
+			// previous regexp2-plus-hand-scanner path accepted.
+			{Code: `new RegExp("\\q")`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}}},
+			{Code: `/[\k<a>]/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}}},
+			{Code: `/[\B]/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}}},
+			{Code: `/\1/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}}},
+			{Code: `/(a)\2/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}}},
+			{Code: `/\01/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}}},
+			{Code: `new RegExp("(?<\\u{D835}\\u{DC9C}>x)")`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}}},
+			// Relaxed duplicate names only became valid in ES2025.
+			{
+				Code:            `/(?<a>x)|(?<a>y)/`,
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+			},
+			{
+				Code:            `/(?<a>x)|(?<a>y)/`,
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2025},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+			},
+			{
+				Code:            `/(?:x|(?<a>y))(?<a>z)/`,
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2025},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+			},
+			{
+				Code:            `/(?=(?<a>x))(?<a>y)/`,
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2025},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireUFlag"}},
+			},
+			// Full positive-set v grammar and canonical property names are
+			// delegated to tsgo after the adapter's narrow safety checks.
+			{
+				Code:            `/[\q{abc}]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireVFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addVFlag", Output: `/[\q{abc}]/v`}},
+				}},
+			},
+			{
+				Code: `/\p{Script=Greek}/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "requireUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "addUFlag", Output: `/\p{Script=Greek}/u`}},
+				}},
+			},
+			{
+				Code:            `/[a^^b]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireVFlag"}},
+			},
+			{
+				Code:            `/[^a\q{ab}]/`,
+				Options:         []any{map[string]any{"requireFlag": "v"}},
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2024},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "requireVFlag"}},
 			},
 			// Group-like text inside a character class does not declare a named
 			// capture for an external backreference.

--- a/internal/utils/ecmascript/code_units.go
+++ b/internal/utils/ecmascript/code_units.go
@@ -25,6 +25,13 @@ func StringCodeUnits(s string) []uint16 {
 	return units
 }
 
+// DecodeStringRune reads the first code point from a JavaScript string value.
+// It differs from utf8.DecodeRuneInString only for the WTF-8 spelling the
+// compiler uses to preserve an unpaired UTF-16 surrogate.
+func DecodeStringRune(s string) (rune, int) {
+	return decodeStringRune(s)
+}
+
 // StringFromCodeUnits writes the UTF-16 code units JavaScript stores as a
 // string. Adjacent surrogate pairs use their ordinary UTF-8 spelling; an
 // unpaired surrogate uses the WTF-8 spelling the compiler uses to preserve it.

--- a/internal/utils/ecmascript/code_units_test.go
+++ b/internal/utils/ecmascript/code_units_test.go
@@ -49,6 +49,27 @@ func TestStringCodeUnits(t *testing.T) {
 	}
 }
 
+func TestDecodeStringRune(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+		want  rune
+		width int
+	}{
+		{name: "ASCII", value: "a", want: 'a', width: 1},
+		{name: "astral", value: "😀", want: '😀', width: 4},
+		{name: "lone high surrogate", value: loneSurrogate(0xD800), want: 0xD800, width: 3},
+		{name: "lone low surrogate", value: loneSurrogate(0xDFFF), want: 0xDFFF, width: 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, width := DecodeStringRune(test.value)
+			if got != test.want || width != test.width {
+				t.Fatalf("DecodeStringRune(%q) = (%U, %d), want (%U, %d)", test.value, got, width, test.want, test.width)
+			}
+		})
+	}
+}
+
 func TestStringFromCodeUnits(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/utils/regex_validate.go
+++ b/internal/utils/regex_validate.go
@@ -23,53 +23,78 @@ import (
 // accept every RegExpIdentifierName escape spelling. Known scanner gaps fail
 // closed so callers never turn an invalid pattern into a suggested fix.
 func IsValidRegexPattern(pattern string, flags RegexFlags) bool {
-	valid, hasDuplicateCaptureName, hasConservativeVCase := validateRegexPattern(pattern, flags)
-	return valid && !hasDuplicateCaptureName && !hasConservativeVCase
+	return isValidRegexPattern(pattern, flags, 2025)
 }
 
 // IsValidRegexPatternForECMAVersion additionally rejects pattern features
 // that had not entered the configured ECMAScript edition yet.
 func IsValidRegexPatternForECMAVersion(pattern string, flags RegexFlags, ecmaVersion int) bool {
-	valid, hasDuplicateCaptureName, hasConservativeVCase := validateRegexPattern(pattern, flags)
-	if !valid || hasDuplicateCaptureName || hasConservativeVCase {
+	if !isValidRegexPattern(pattern, flags, ecmaVersion) {
 		return false
 	}
 	return regexFeaturesAvailable(pattern, flags, ecmaVersion)
 }
 
-func validateRegexPattern(pattern string, flags RegexFlags) (
-	valid bool,
-	hasDuplicateCaptureName bool,
-	hasConservativeVCase bool,
-) {
-	if !flags.UV() {
-		_, err := esregexp.Compile(pattern, "")
-		return err == nil, false, false
+type regexPatternValidation struct {
+	valid                               bool
+	hasDuplicateCaptureName             bool
+	hasNonExclusiveDuplicateCaptureName bool
+}
+
+func isValidRegexPattern(pattern string, flags RegexFlags, ecmaVersion int) bool {
+	validation := validateRegexPattern(pattern, flags)
+	if !validation.valid || validation.hasNonExclusiveDuplicateCaptureName {
+		return false
 	}
+	return ecmaVersion >= 2025 || !validation.hasDuplicateCaptureName
+}
+
+func validateRegexPattern(pattern string, flags RegexFlags) regexPatternValidation {
 	if flags.Unicode && flags.UnicodeSets {
-		return false, false, false
+		return regexPatternValidation{}
+	}
+	if !flags.UV() && !hasRegexNamedCapture(pattern, flags) {
+		_, err := esregexp.Compile(pattern, "")
+		return regexPatternValidation{valid: err == nil}
 	}
 	// JavaScript strings are sequences of UTF-16 code units. The compiler keeps
 	// lone surrogates in WTF-8, so join an adjacent pair before identifier-name
 	// validation just as the RegExp parser's CodePoint operation does.
 	pattern = ecmascript.CombineSurrogatePairs(pattern)
 
-	normalized, hasDuplicateCaptureName, hasConservativeVCase, ok := normalizeRegexCaptureNames(pattern, flags)
+	normalized, captureNames, ok := normalizeRegexCaptureNames(pattern, flags)
 	if !ok {
-		return false, hasDuplicateCaptureName, hasConservativeVCase
+		return regexPatternValidation{
+			hasDuplicateCaptureName:             captureNames.hasDuplicate,
+			hasNonExclusiveDuplicateCaptureName: captureNames.hasNonExclusiveDuplicate,
+		}
 	}
-	literal, ok := regexPatternLiteral(normalized, flags)
-	if !ok {
-		return false, hasDuplicateCaptureName, hasConservativeVCase
+	valid := false
+	if !flags.UV() {
+		_, err := esregexp.Compile(normalized, "")
+		valid = err == nil
+	} else {
+		literal, literalOK := regexPatternLiteral(normalized, flags)
+		valid = literalOK && ecmascript.IsValidRegexLiteral(literal)
 	}
-	return ecmascript.IsValidRegexLiteral(literal), hasDuplicateCaptureName, hasConservativeVCase
+	return regexPatternValidation{
+		valid:                               valid,
+		hasDuplicateCaptureName:             captureNames.hasDuplicate,
+		hasNonExclusiveDuplicateCaptureName: captureNames.hasNonExclusiveDuplicate,
+	}
 }
 
 func regexFeaturesAvailable(pattern string, flags RegexFlags, ecmaVersion int) bool {
+	if flags.Unicode && ecmaVersion < 2015 {
+		return false
+	}
+	if flags.UnicodeSets && ecmaVersion < 2024 {
+		return false
+	}
 	for i := 0; i < len(pattern); {
 		switch pattern[i] {
 		case '\\':
-			if i+1 < len(pattern) && ecmaVersion < 2018 &&
+			if flags.UV() && i+1 < len(pattern) && ecmaVersion < 2018 &&
 				(pattern[i+1] == 'p' || pattern[i+1] == 'P' || pattern[i+1] == 'k') {
 				return false
 			}
@@ -83,8 +108,7 @@ func regexFeaturesAvailable(pattern string, flags RegexFlags, ecmaVersion int) b
 			if !ok {
 				return false
 			}
-			if ecmaVersion < 2018 && (strings.Contains(pattern[i:end], `\p`) ||
-				strings.Contains(pattern[i:end], `\P`)) {
+			if flags.UV() && ecmaVersion < 2018 && regexClassUsesUnicodeProperty(pattern, i, end, flags) {
 				return false
 			}
 			i = end
@@ -105,6 +129,28 @@ func regexFeaturesAvailable(pattern string, flags RegexFlags, ecmaVersion int) b
 		}
 	}
 	return true
+}
+
+func regexClassUsesUnicodeProperty(pattern string, start int, end int, flags RegexFlags) bool {
+	for i := start + 1; i < end-1; {
+		if pattern[i] == '\\' {
+			if i+1 < end && (pattern[i+1] == 'p' || pattern[i+1] == 'P') {
+				return true
+			}
+			step, ok := SkipPatternEscape(pattern, i, flags)
+			if !ok {
+				return false
+			}
+			i += step
+			continue
+		}
+		_, width := utf8.DecodeRuneInString(pattern[i:])
+		if width == 0 {
+			width = 1
+		}
+		i += width
+	}
+	return false
 }
 
 func isInlineModifierGroup(suffix string) bool {
@@ -134,17 +180,152 @@ type regexCaptureNameReplacement struct {
 	placeholder string
 }
 
+// hasRegexNamedCapture is a cheap legacy-mode guard. Patterns without a named
+// declaration stay on the existing regexp runtime, preserving Annex B escape
+// handling without paying for capture-name normalization.
+func hasRegexNamedCapture(pattern string, flags RegexFlags) bool {
+	for i := 0; i < len(pattern); {
+		switch pattern[i] {
+		case '[':
+			end, ok := ClassEnd(pattern, i, flags)
+			if !ok {
+				return false
+			}
+			i = end
+		case '\\':
+			step, ok := SkipPatternEscape(pattern, i, flags)
+			if !ok {
+				return false
+			}
+			i += step
+		case '(':
+			if strings.HasPrefix(pattern[i:], "(?<") &&
+				(i+3 >= len(pattern) || pattern[i+3] != '=' && pattern[i+3] != '!') {
+				return true
+			}
+			i++
+		default:
+			_, width := utf8.DecodeRuneInString(pattern[i:])
+			if width == 0 {
+				width = 1
+			}
+			i += width
+		}
+	}
+	return false
+}
+
+type regexCaptureNameAnalysis struct {
+	hasDuplicate             bool
+	hasNonExclusiveDuplicate bool
+}
+
+type regexBranch struct {
+	parent int
+	base   int
+	depth  int
+}
+
+// regexBranchTracker mirrors regexpp's ES2025 BranchID model. Every node is
+// one Alternative; siblings share a base. Two declarations are mutually
+// exclusive exactly when their ancestor paths choose different siblings of
+// the same Disjunction.
+type regexBranchTracker struct {
+	branches []regexBranch
+	current  int
+}
+
+func newRegexBranchTracker(pattern string) regexBranchTracker {
+	const (
+		minimumCapacity = 8
+		maximumCapacity = 256
+	)
+	capacity := minimumCapacity
+	if len(pattern) >= 64 {
+		estimate := 2
+		for i := 0; i < len(pattern) && estimate < maximumCapacity; i++ {
+			if pattern[i] == '(' || pattern[i] == '|' {
+				estimate++
+			}
+		}
+		if estimate > capacity {
+			capacity = estimate
+		}
+	}
+	branches := make([]regexBranch, 1, capacity)
+	branches[0] = regexBranch{parent: -1, base: 0}
+	tracker := regexBranchTracker{branches: branches}
+	tracker.enterDisjunction()
+	return tracker
+}
+
+func (t *regexBranchTracker) enterDisjunction() {
+	id := len(t.branches)
+	depth := t.branches[t.current].depth + 1
+	t.branches = append(t.branches, regexBranch{parent: t.current, base: id, depth: depth})
+	t.current = id
+}
+
+func (t *regexBranchTracker) enterAlternative() {
+	branch := t.branches[t.current]
+	id := len(t.branches)
+	t.branches = append(t.branches, branch)
+	t.current = id
+}
+
+func (t *regexBranchTracker) leaveDisjunction() {
+	if t.branches[t.current].depth > 1 {
+		t.current = t.branches[t.current].parent
+	}
+}
+
+func (t *regexBranchTracker) separatedFrom(left int, right int) bool {
+	for t.branches[left].depth > t.branches[right].depth {
+		left = t.branches[left].parent
+	}
+	for t.branches[right].depth > t.branches[left].depth {
+		right = t.branches[right].parent
+	}
+	for left >= 0 && right >= 0 {
+		leftBranch := t.branches[left]
+		rightBranch := t.branches[right]
+		if left != right && leftBranch.base == rightBranch.base {
+			return true
+		}
+		left = leftBranch.parent
+		right = rightBranch.parent
+	}
+	return false
+}
+
 // normalizeRegexCaptureNames rewrites every declaration and reference name to
 // a deterministic ASCII placeholder keyed by its decoded IdentifierName. This
-// preserves equality between raw and escaped spellings while allowing tsgo's
-// complete RegExp parser to validate the surrounding grammar. It also records
-// duplicate declarations for the fail-closed suggestion gate.
-func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool, bool, bool) {
+// preserves equality between raw and escaped spellings while allowing the
+// grammar authority to validate the surrounding pattern. Duplicate
+// declarations get distinct placeholders because ES2025 permits them when
+// their Alternatives are mutually exclusive; references use the first
+// declaration's placeholder.
+func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, regexCaptureNameAnalysis, bool) {
 	var replacements []regexCaptureNameReplacement
 	var placeholders map[string]string
-	var declarations map[string]bool
-	hasDuplicate := false
-	hasConservativeVCase := false
+	var lastDeclarationBranch map[string]int
+	analysis := regexCaptureNameAnalysis{}
+	placeholderCount := 0
+	// A duplicate declaration requires at least two declaration-looking
+	// prefixes. Avoid allocating the persistent branch tree for the common
+	// zero/one-capture case; false positives such as lookbehinds only cause the
+	// conservative tracking path to run.
+	trackBranches := strings.Count(pattern, "(?<") > 1
+	var branches regexBranchTracker
+	if trackBranches {
+		branches = newRegexBranchTracker(pattern)
+	}
+
+	newPlaceholder := func() string {
+		placeholder := "rslint" + strconv.Itoa(placeholderCount)
+		placeholderCount++
+		return placeholder
+	}
 
 	addName := func(nameStart int, nameEnd int, declaration bool) bool {
 		name, ok := normalizeRegexCaptureName(pattern[nameStart:nameEnd])
@@ -156,17 +337,28 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool,
 		}
 		placeholder, ok := placeholders[name]
 		if !ok {
-			placeholder = "rslint" + strconv.Itoa(len(placeholders))
+			placeholder = newPlaceholder()
 			placeholders[name] = placeholder
 		}
 		if declaration {
-			if declarations == nil {
-				declarations = make(map[string]bool)
+			if lastDeclarationBranch == nil {
+				lastDeclarationBranch = make(map[string]int)
 			}
-			if declarations[name] {
-				hasDuplicate = true
+			previous, exists := lastDeclarationBranch[name]
+			if exists {
+				analysis.hasDuplicate = true
+				placeholder = newPlaceholder()
+				// Declarations arrive in source/DFS order. For three ordered
+				// declarations p < q < r, separation of p/q and q/r implies
+				// separation of p/r: well-nested Disjunction intervals cannot
+				// return to p's earlier Alternative. Checking adjacent declarations
+				// is therefore equivalent to regexpp's all-pairs test.
+				if !analysis.hasNonExclusiveDuplicate &&
+					(!trackBranches || !branches.separatedFrom(previous, branches.current)) {
+					analysis.hasNonExclusiveDuplicate = true
+				}
 			}
-			declarations[name] = true
+			lastDeclarationBranch[name] = branches.current
 		}
 		replacements = append(replacements, regexCaptureNameReplacement{
 			start:       nameStart,
@@ -181,18 +373,16 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool,
 		case '[':
 			end := 0
 			if flags.UnicodeSets {
-				var content regexVClassContent
 				var ok bool
-				end, content, ok = analyzeRegexVClass(pattern, i)
+				end, ok = analyzeRegexVClass(pattern, i)
 				if !ok {
-					return "", hasDuplicate, hasConservativeVCase, false
+					return "", analysis, false
 				}
-				hasConservativeVCase = hasConservativeVCase || content.hasNegatedStringOperand
 			} else {
 				var ok bool
 				end, ok = ClassEnd(pattern, i, flags)
 				if !ok {
-					return "", hasDuplicate, hasConservativeVCase, false
+					return "", analysis, false
 				}
 			}
 			i = end
@@ -200,14 +390,14 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool,
 			if strings.HasPrefix(pattern[i:], `\k<`) {
 				_, next, ok := readAngleName(pattern, i+2)
 				if !ok || !addName(i+3, next-1, false) {
-					return "", hasDuplicate, hasConservativeVCase, false
+					return "", analysis, false
 				}
 				i = next
 				continue
 			}
 			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
-				return "", hasDuplicate, hasConservativeVCase, false
+				return "", analysis, false
 			}
 			i += step
 		case '(':
@@ -215,10 +405,23 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool,
 				(i+3 >= len(pattern) || pattern[i+3] != '=' && pattern[i+3] != '!') {
 				_, next, ok := readAngleName(pattern, i+2)
 				if !ok || !addName(i+3, next-1, true) {
-					return "", hasDuplicate, hasConservativeVCase, false
+					return "", analysis, false
 				}
 				i = next
-				continue
+			} else {
+				i++
+			}
+			if trackBranches {
+				branches.enterDisjunction()
+			}
+		case '|':
+			if trackBranches {
+				branches.enterAlternative()
+			}
+			i++
+		case ')':
+			if trackBranches {
+				branches.leaveDisjunction()
 			}
 			i++
 		default:
@@ -231,7 +434,7 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool,
 	}
 
 	if len(replacements) == 0 {
-		return pattern, hasDuplicate, hasConservativeVCase, true
+		return pattern, analysis, true
 	}
 	var result strings.Builder
 	result.Grow(len(pattern))
@@ -242,29 +445,54 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool,
 		last = replacement.end
 	}
 	result.WriteString(pattern[last:])
-	return result.String(), hasDuplicate, hasConservativeVCase, true
-}
-
-type regexVClassContent struct {
-	mayContainStrings       bool
-	hasNegatedStringOperand bool
+	return result.String(), analysis, true
 }
 
 type regexVClassFrame struct {
-	content        regexVClassContent
+	operator       regexVClassOperator
+	operandCount   int
+	mayHaveStrings bool
 	negated        bool
 	trailingHyphen bool
 }
 
+type regexVClassOperator uint8
+
+const (
+	regexVClassUnion regexVClassOperator = iota
+	regexVClassIntersection
+	regexVClassSubtraction
+)
+
+func (f *regexVClassFrame) addOperand(mayHaveStrings bool) {
+	if f.operandCount == 0 {
+		f.mayHaveStrings = mayHaveStrings
+	} else {
+		switch f.operator {
+		case regexVClassUnion:
+			// Preserve later string operands even when the union starts with a
+			// range. regexpp 4.12.2 drops that bit and can offer a v suggestion
+			// which JavaScript then rejects.
+			f.mayHaveStrings = f.mayHaveStrings || mayHaveStrings
+		case regexVClassIntersection:
+			f.mayHaveStrings = f.mayHaveStrings && mayHaveStrings
+		case regexVClassSubtraction:
+			// ClassSubtraction inherits only its left operand's value.
+		}
+	}
+	f.operandCount++
+	f.trailingHyphen = false
+}
+
 // analyzeRegexVClass performs the narrow v-mode checks needed before carrying
 // a constructor pattern through a literal. One iterative pass covers nested
-// classes, raw slashes, tsgo's trailing-hyphen and doubled-^/$ gaps, and the
-// conservative string-operand bit used only by the suggestion gate. It is a
-// lexical adapter, not a second ClassSetExpression parser; tsgo remains the
-// grammar authority for every other production.
-func analyzeRegexVClass(pattern string, start int) (end int, content regexVClassContent, ok bool) {
+// classes, raw slashes, tsgo's trailing-hyphen and doubled-^/$ gaps. It also
+// mirrors the ClassSetExpression MayContainStrings reduction because the
+// pinned tsgo scanner does not propagate later union operands. tsgo remains
+// the grammar authority for every other production.
+func analyzeRegexVClass(pattern string, start int) (end int, ok bool) {
 	if start >= len(pattern) || pattern[start] != '[' {
-		return start, regexVClassContent{}, false
+		return start, false
 	}
 
 	flags := RegexFlags{UnicodeSets: true}
@@ -280,23 +508,20 @@ func analyzeRegexVClass(pattern string, start int) (end int, content regexVClass
 		switch pattern[i] {
 		case '\\':
 			if strings.HasPrefix(pattern[i:], `\q{`) {
-				next, qOK := scanRegexVQString(pattern, i)
+				next, mayHaveStrings, qOK := scanRegexVQString(pattern, i)
 				if !qOK {
-					return start, regexVClassContent{}, false
+					return start, false
 				}
-				frame.content.mayContainStrings = true
-				frame.trailingHyphen = false
+				frame.addOperand(mayHaveStrings)
 				i = next
 				continue
 			}
-			if strings.HasPrefix(pattern[i:], `\p{`) || strings.HasPrefix(pattern[i:], `\P{`) {
-				frame.content.mayContainStrings = true
-			}
+			mayHaveStrings := regexVPropertyMayContainStrings(pattern, i)
 			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
-				return start, regexVClassContent{}, false
+				return start, false
 			}
-			frame.trailingHyphen = false
+			frame.addOperand(mayHaveStrings)
 			i += step
 		case '[':
 			frame.trailingHyphen = false
@@ -308,35 +533,49 @@ func analyzeRegexVClass(pattern string, start int) (end int, content regexVClass
 			}
 		case ']':
 			if frame.trailingHyphen {
-				return start, regexVClassContent{}, false
+				return start, false
 			}
-			frame.content.hasNegatedStringOperand = frame.content.hasNegatedStringOperand ||
-				frame.negated && frame.content.mayContainStrings
-			completed := frame.content
+			if frame.negated && frame.mayHaveStrings {
+				return start, false
+			}
+			completedMayHaveStrings := !frame.negated && frame.mayHaveStrings
 			frames = frames[:len(frames)-1]
 			i++
 			if len(frames) == 0 {
-				return i, completed, true
+				return i, true
 			}
 			parent := &frames[len(frames)-1]
-			parent.content.mayContainStrings = parent.content.mayContainStrings || completed.mayContainStrings
-			parent.content.hasNegatedStringOperand = parent.content.hasNegatedStringOperand || completed.hasNegatedStringOperand
-			parent.trailingHyphen = false
+			parent.addOperand(completedMayHaveStrings)
 		case '/':
 			// `/` is a ClassSetSyntaxCharacter. Escaping it only in the
 			// carrier would make an invalid constructor pattern valid.
-			return start, regexVClassContent{}, false
+			return start, false
 		case '^', '$':
 			if i+1 < len(pattern) && pattern[i+1] == pattern[i] {
-				return start, regexVClassContent{}, false
+				return start, false
 			}
-			frame.trailingHyphen = false
+			frame.addOperand(false)
+			i++
+		case '&':
+			if i+1 < len(pattern) && pattern[i+1] == '&' {
+				frame.operator = regexVClassIntersection
+				frame.trailingHyphen = false
+				i += 2
+				continue
+			}
+			frame.addOperand(false)
 			i++
 		case '-':
+			if i+1 < len(pattern) && pattern[i+1] == '-' {
+				frame.operator = regexVClassSubtraction
+				frame.trailingHyphen = false
+				i += 2
+				continue
+			}
 			frame.trailingHyphen = true
 			i++
 		default:
-			frame.trailingHyphen = false
+			frame.addOperand(false)
 			_, width := utf8.DecodeRuneInString(pattern[i:])
 			if width == 0 {
 				width = 1
@@ -344,37 +583,81 @@ func analyzeRegexVClass(pattern string, start int) (end int, content regexVClass
 			i += width
 		}
 	}
-	return start, regexVClassContent{}, false
+	return start, false
 }
 
-func scanRegexVQString(pattern string, start int) (next int, ok bool) {
+func scanRegexVQString(pattern string, start int) (next int, mayHaveStrings bool, ok bool) {
 	flags := RegexFlags{UnicodeSets: true}
+	characterCount := 0
 	for i := start + 3; i < len(pattern); {
 		switch pattern[i] {
 		case '\\':
 			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
-				return 0, false
+				return 0, false, false
+			}
+			characterCount++
+			if high, fixed := regexFixedUnicodeEscape(pattern, i); fixed && high >= 0xD800 && high <= 0xDBFF {
+				if low, lowFixed := regexFixedUnicodeEscape(pattern, i+step); lowFixed && low >= 0xDC00 && low <= 0xDFFF {
+					step += 6
+				}
 			}
 			i += step
+		case '|':
+			mayHaveStrings = mayHaveStrings || characterCount != 1
+			characterCount = 0
+			i++
 		case '}':
-			return i + 1, true
+			return i + 1, mayHaveStrings || characterCount != 1, true
 		case '/':
-			return 0, false
+			return 0, false, false
 		case '^', '$':
 			if i+1 < len(pattern) && pattern[i+1] == pattern[i] {
-				return 0, false
+				return 0, false, false
 			}
+			characterCount++
 			i++
 		default:
-			_, width := utf8.DecodeRuneInString(pattern[i:])
+			characterCount++
+			_, width := ecmascript.DecodeStringRune(pattern[i:])
 			if width == 0 {
 				width = 1
 			}
 			i += width
 		}
 	}
-	return 0, false
+	return 0, false, false
+}
+
+func regexFixedUnicodeEscape(pattern string, start int) (uint32, bool) {
+	if start < 0 || start+6 > len(pattern) || pattern[start] != '\\' || pattern[start+1] != 'u' ||
+		!allHexStr(pattern[start+2:start+6]) {
+		return 0, false
+	}
+	value, err := strconv.ParseUint(pattern[start+2:start+6], 16, 16)
+	return uint32(value), err == nil
+}
+
+func regexVPropertyMayContainStrings(pattern string, start int) bool {
+	if !strings.HasPrefix(pattern[start:], `\p{`) {
+		return false
+	}
+	closeRel := strings.IndexByte(pattern[start+3:], '}')
+	if closeRel < 0 {
+		return false
+	}
+	switch pattern[start+3 : start+3+closeRel] {
+	case "Basic_Emoji",
+		"Emoji_Keycap_Sequence",
+		"RGI_Emoji",
+		"RGI_Emoji_Flag_Sequence",
+		"RGI_Emoji_Modifier_Sequence",
+		"RGI_Emoji_Tag_Sequence",
+		"RGI_Emoji_ZWJ_Sequence":
+		return true
+	default:
+		return false
+	}
 }
 
 // regexPatternLiteral transports a u/v constructor pattern into a literal for

--- a/internal/utils/regex_validate.go
+++ b/internal/utils/regex_validate.go
@@ -7,112 +7,62 @@ import (
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 	esregexp "github.com/web-infra-dev/rslint/internal/utils/ecmascript/regexp"
 )
 
-// IsValidRegexPattern reports whether pattern parses cleanly under flags, the
-// way JavaScript's RegExp constructor would (a try/catch around parsing, not
-// a match attempt). Under the u/v flags this combines three checks:
+// IsValidRegexPattern reports whether pattern can be proven to parse cleanly
+// under flags, the way JavaScript's RegExp constructor would (a try/catch
+// around parsing, not a match attempt).
 //
-//   - IterateRegexCharacterClasses catches unterminated classes, including
-//     v-flag nested classes such as `[[a]` (valid `u` syntax, a SyntaxError
-//     under `v`).
-//   - regexp2 compile catches other structural errors (unclosed `(`, unmatched
-//     quantifier under Unicode mode, bad hex escapes, etc.). esregexp has no
-//     `v`-flag token, so `v` validation reuses the `u` compile — the two
-//     flags share the same non-class grammar.
-//   - A narrow u-flag identity-escape check for the handful of escapes
-//     regexp2 accepts but ES-u-mode rejects (`\a`, `\9`, …), a scan for the
-//     syntax characters regexp2 reads as literals, and a check that every
-//     `\k<name>` resolves to a group the pattern declares.
-//   - Under `v` alone, a scan of each character class for the
-//     ClassSetExpression rules that only the `v` grammar imposes — an
-//     unescaped `(`, `-`, `|`, … or a doubled reserved punctuator.
-//
-// If ANY check fails the pattern is treated as unparsable — matching
-// JavaScript's own parse-or-reject behavior.
+// Legacy patterns stay on the regexp runtime used by existing callers. Under
+// u/v, the TypeScript scanner is the grammar authority. The small adapter in
+// front of it carries constructor pattern text through a RegExp literal
+// without changing its UTF-16 semantics and replaces capture names with safe
+// ASCII placeholders because the scanner's general identifier reader does not
+// accept every RegExpIdentifierName escape spelling. Known scanner gaps fail
+// closed so callers never turn an invalid pattern into a suggested fix.
 func IsValidRegexPattern(pattern string, flags RegexFlags) bool {
-	if flags.UV() {
-		if !IterateRegexCharacterClasses(pattern, flags, func(int, int) {}) {
-			return false
-		}
-	}
-
-	compilePattern := pattern
-	compileFlags := ""
-	if flags.UV() {
-		compileFlags = "u"
-	}
-	if flags.UnicodeSets {
-		// The runtime compiler implements u grammar, where escapes such as
-		// `\&` are invalid even inside a class. In v grammar the reserved class
-		// punctuators may be escaped, so feed the compiler an equivalent hex
-		// escape and leave the original spelling to the v-specific scanner.
-		compilePattern = normalizeVClassPunctuatorEscapes(pattern)
-	}
-	if _, err := esregexp.Compile(compilePattern, compileFlags); err != nil {
-		return false
-	}
-
-	if flags.UV() {
-		if hasInvalidIdentityEscapeForUFlag(pattern) {
-			return false
-		}
-		if hasInvalidSyntaxCharForUFlag(pattern, flags) {
-			return false
-		}
-		if hasUnresolvedNamedBackreferenceForUFlag(pattern) {
-			return false
-		}
-	}
-	if flags.UnicodeSets && hasInvalidClassContentForVFlag(pattern) {
-		return false
-	}
-	return true
+	valid, hasDuplicateCaptureName, hasConservativeVCase := validateRegexPattern(pattern, flags)
+	return valid && !hasDuplicateCaptureName && !hasConservativeVCase
 }
 
 // IsValidRegexPatternForECMAVersion additionally rejects pattern features
 // that had not entered the configured ECMAScript edition yet.
 func IsValidRegexPatternForECMAVersion(pattern string, flags RegexFlags, ecmaVersion int) bool {
-	return IsValidRegexPattern(pattern, flags) && regexFeaturesAvailable(pattern, flags, ecmaVersion)
+	valid, hasDuplicateCaptureName, hasConservativeVCase := validateRegexPattern(pattern, flags)
+	if !valid || hasDuplicateCaptureName || hasConservativeVCase {
+		return false
+	}
+	return regexFeaturesAvailable(pattern, flags, ecmaVersion)
 }
 
-func normalizeVClassPunctuatorEscapes(pattern string) string {
-	var result strings.Builder
-	result.Grow(len(pattern))
-	classDepth := 0
-	for i := 0; i < len(pattern); {
-		if pattern[i] == '[' {
-			classDepth++
-			result.WriteByte(pattern[i])
-			i++
-			continue
-		}
-		if pattern[i] == ']' && classDepth > 0 {
-			classDepth--
-			result.WriteByte(pattern[i])
-			i++
-			continue
-		}
-		if pattern[i] == '\\' && i+1 < len(pattern) && classDepth > 0 &&
-			strings.IndexByte(reservedClassSetPunctuators, pattern[i+1]) >= 0 {
-			const hex = "0123456789abcdef"
-			c := pattern[i+1]
-			result.WriteString(`\x`)
-			result.WriteByte(hex[c>>4])
-			result.WriteByte(hex[c&0xf])
-			i += 2
-			continue
-		}
-		if pattern[i] == '\\' && i+1 < len(pattern) {
-			result.WriteString(pattern[i : i+2])
-			i += 2
-			continue
-		}
-		result.WriteByte(pattern[i])
-		i++
+func validateRegexPattern(pattern string, flags RegexFlags) (
+	valid bool,
+	hasDuplicateCaptureName bool,
+	hasConservativeVCase bool,
+) {
+	if !flags.UV() {
+		_, err := esregexp.Compile(pattern, "")
+		return err == nil, false, false
 	}
-	return result.String()
+	if flags.Unicode && flags.UnicodeSets {
+		return false, false, false
+	}
+	// JavaScript strings are sequences of UTF-16 code units. The compiler keeps
+	// lone surrogates in WTF-8, so join an adjacent pair before identifier-name
+	// validation just as the RegExp parser's CodePoint operation does.
+	pattern = ecmascript.CombineSurrogatePairs(pattern)
+
+	normalized, hasDuplicateCaptureName, hasConservativeVCase, ok := normalizeRegexCaptureNames(pattern, flags)
+	if !ok {
+		return false, hasDuplicateCaptureName, hasConservativeVCase
+	}
+	literal, ok := regexPatternLiteral(normalized, flags)
+	if !ok {
+		return false, hasDuplicateCaptureName, hasConservativeVCase
+	}
+	return ecmascript.IsValidRegexLiteral(literal), hasDuplicateCaptureName, hasConservativeVCase
 }
 
 func regexFeaturesAvailable(pattern string, flags RegexFlags, ecmaVersion int) bool {
@@ -133,8 +83,8 @@ func regexFeaturesAvailable(pattern string, flags RegexFlags, ecmaVersion int) b
 			if !ok {
 				return false
 			}
-			if ecmaVersion < 2018 && strings.Contains(pattern[i:end], `\p`) ||
-				ecmaVersion < 2018 && strings.Contains(pattern[i:end], `\P`) {
+			if ecmaVersion < 2018 && (strings.Contains(pattern[i:end], `\p`) ||
+				strings.Contains(pattern[i:end], `\P`)) {
 				return false
 			}
 			i = end
@@ -147,7 +97,11 @@ func regexFeaturesAvailable(pattern string, flags RegexFlags, ecmaVersion int) b
 					return false
 				}
 			}
-			i++
+			_, width := utf8.DecodeRuneInString(pattern[i:])
+			if width == 0 {
+				width = 1
+			}
+			i += width
 		}
 	}
 	return true
@@ -174,362 +128,436 @@ func isInlineModifierGroup(suffix string) bool {
 	return false
 }
 
-// hasInvalidSyntaxCharForUFlag reports whether the pattern contains an
-// unescaped `{`, `}` or `]` outside a character class. Under the u/v flag all
-// three are SyntaxCharacters and legal only in their structural roles — `{`
-// and `}` as a `{n}` / `{n,}` / `{n,m}` quantifier, `]` as a class terminator
-// — but regexp2 accepts each as a literal (its .NET lineage). Escapes and
-// character classes are skipped wholesale through the flag-aware scanners, so
-// v-flag nested classes are not mistaken for a stray `]`.
-func hasInvalidSyntaxCharForUFlag(pattern string, flags RegexFlags) bool {
-	i := 0
+type regexCaptureNameReplacement struct {
+	start       int
+	end         int
+	placeholder string
+}
+
+// normalizeRegexCaptureNames rewrites every declaration and reference name to
+// a deterministic ASCII placeholder keyed by its decoded IdentifierName. This
+// preserves equality between raw and escaped spellings while allowing tsgo's
+// complete RegExp parser to validate the surrounding grammar. It also records
+// duplicate declarations for the fail-closed suggestion gate.
+func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, bool, bool, bool) {
+	var replacements []regexCaptureNameReplacement
+	var placeholders map[string]string
+	var declarations map[string]bool
+	hasDuplicate := false
+	hasConservativeVCase := false
+
+	addName := func(nameStart int, nameEnd int, declaration bool) bool {
+		name, ok := normalizeRegexCaptureName(pattern[nameStart:nameEnd])
+		if !ok {
+			return false
+		}
+		if placeholders == nil {
+			placeholders = make(map[string]string)
+		}
+		placeholder, ok := placeholders[name]
+		if !ok {
+			placeholder = "rslint" + strconv.Itoa(len(placeholders))
+			placeholders[name] = placeholder
+		}
+		if declaration {
+			if declarations == nil {
+				declarations = make(map[string]bool)
+			}
+			if declarations[name] {
+				hasDuplicate = true
+			}
+			declarations[name] = true
+		}
+		replacements = append(replacements, regexCaptureNameReplacement{
+			start:       nameStart,
+			end:         nameEnd,
+			placeholder: placeholder,
+		})
+		return true
+	}
+
+	for i := 0; i < len(pattern); {
+		switch pattern[i] {
+		case '[':
+			end := 0
+			if flags.UnicodeSets {
+				var content regexVClassContent
+				var ok bool
+				end, content, ok = analyzeRegexVClass(pattern, i)
+				if !ok {
+					return "", hasDuplicate, hasConservativeVCase, false
+				}
+				hasConservativeVCase = hasConservativeVCase || content.hasNegatedStringOperand
+			} else {
+				var ok bool
+				end, ok = ClassEnd(pattern, i, flags)
+				if !ok {
+					return "", hasDuplicate, hasConservativeVCase, false
+				}
+			}
+			i = end
+		case '\\':
+			if strings.HasPrefix(pattern[i:], `\k<`) {
+				_, next, ok := readAngleName(pattern, i+2)
+				if !ok || !addName(i+3, next-1, false) {
+					return "", hasDuplicate, hasConservativeVCase, false
+				}
+				i = next
+				continue
+			}
+			step, ok := SkipPatternEscape(pattern, i, flags)
+			if !ok {
+				return "", hasDuplicate, hasConservativeVCase, false
+			}
+			i += step
+		case '(':
+			if strings.HasPrefix(pattern[i:], "(?<") &&
+				(i+3 >= len(pattern) || pattern[i+3] != '=' && pattern[i+3] != '!') {
+				_, next, ok := readAngleName(pattern, i+2)
+				if !ok || !addName(i+3, next-1, true) {
+					return "", hasDuplicate, hasConservativeVCase, false
+				}
+				i = next
+				continue
+			}
+			i++
+		default:
+			_, width := utf8.DecodeRuneInString(pattern[i:])
+			if width == 0 {
+				width = 1
+			}
+			i += width
+		}
+	}
+
+	if len(replacements) == 0 {
+		return pattern, hasDuplicate, hasConservativeVCase, true
+	}
+	var result strings.Builder
+	result.Grow(len(pattern))
+	last := 0
+	for _, replacement := range replacements {
+		result.WriteString(pattern[last:replacement.start])
+		result.WriteString(replacement.placeholder)
+		last = replacement.end
+	}
+	result.WriteString(pattern[last:])
+	return result.String(), hasDuplicate, hasConservativeVCase, true
+}
+
+type regexVClassContent struct {
+	mayContainStrings       bool
+	hasNegatedStringOperand bool
+}
+
+type regexVClassFrame struct {
+	content        regexVClassContent
+	negated        bool
+	trailingHyphen bool
+}
+
+// analyzeRegexVClass performs the narrow v-mode checks needed before carrying
+// a constructor pattern through a literal. One iterative pass covers nested
+// classes, raw slashes, tsgo's trailing-hyphen and doubled-^/$ gaps, and the
+// conservative string-operand bit used only by the suggestion gate. It is a
+// lexical adapter, not a second ClassSetExpression parser; tsgo remains the
+// grammar authority for every other production.
+func analyzeRegexVClass(pattern string, start int) (end int, content regexVClassContent, ok bool) {
+	if start >= len(pattern) || pattern[start] != '[' {
+		return start, regexVClassContent{}, false
+	}
+
+	flags := RegexFlags{UnicodeSets: true}
+	frames := []regexVClassFrame{{}}
+	i := start + 1
+	if i < len(pattern) && pattern[i] == '^' {
+		frames[0].negated = true
+		i++
+	}
+
 	for i < len(pattern) {
+		frame := &frames[len(frames)-1]
+		switch pattern[i] {
+		case '\\':
+			if strings.HasPrefix(pattern[i:], `\q{`) {
+				next, qOK := scanRegexVQString(pattern, i)
+				if !qOK {
+					return start, regexVClassContent{}, false
+				}
+				frame.content.mayContainStrings = true
+				frame.trailingHyphen = false
+				i = next
+				continue
+			}
+			if strings.HasPrefix(pattern[i:], `\p{`) || strings.HasPrefix(pattern[i:], `\P{`) {
+				frame.content.mayContainStrings = true
+			}
+			step, ok := SkipPatternEscape(pattern, i, flags)
+			if !ok {
+				return start, regexVClassContent{}, false
+			}
+			frame.trailingHyphen = false
+			i += step
+		case '[':
+			frame.trailingHyphen = false
+			frames = append(frames, regexVClassFrame{})
+			i++
+			if i < len(pattern) && pattern[i] == '^' {
+				frames[len(frames)-1].negated = true
+				i++
+			}
+		case ']':
+			if frame.trailingHyphen {
+				return start, regexVClassContent{}, false
+			}
+			frame.content.hasNegatedStringOperand = frame.content.hasNegatedStringOperand ||
+				frame.negated && frame.content.mayContainStrings
+			completed := frame.content
+			frames = frames[:len(frames)-1]
+			i++
+			if len(frames) == 0 {
+				return i, completed, true
+			}
+			parent := &frames[len(frames)-1]
+			parent.content.mayContainStrings = parent.content.mayContainStrings || completed.mayContainStrings
+			parent.content.hasNegatedStringOperand = parent.content.hasNegatedStringOperand || completed.hasNegatedStringOperand
+			parent.trailingHyphen = false
+		case '/':
+			// `/` is a ClassSetSyntaxCharacter. Escaping it only in the
+			// carrier would make an invalid constructor pattern valid.
+			return start, regexVClassContent{}, false
+		case '^', '$':
+			if i+1 < len(pattern) && pattern[i+1] == pattern[i] {
+				return start, regexVClassContent{}, false
+			}
+			frame.trailingHyphen = false
+			i++
+		case '-':
+			frame.trailingHyphen = true
+			i++
+		default:
+			frame.trailingHyphen = false
+			_, width := utf8.DecodeRuneInString(pattern[i:])
+			if width == 0 {
+				width = 1
+			}
+			i += width
+		}
+	}
+	return start, regexVClassContent{}, false
+}
+
+func scanRegexVQString(pattern string, start int) (next int, ok bool) {
+	flags := RegexFlags{UnicodeSets: true}
+	for i := start + 3; i < len(pattern); {
 		switch pattern[i] {
 		case '\\':
 			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
-				// Unterminated escape — let compile/scan report it.
-				return false
+				return 0, false
 			}
 			i += step
-		case '[':
-			end, ok := ClassEnd(pattern, i, flags)
-			if !ok {
-				// Unterminated class — let compile/scan report it.
-				return false
+		case '}':
+			return i + 1, true
+		case '/':
+			return 0, false
+		case '^', '$':
+			if i+1 < len(pattern) && pattern[i+1] == pattern[i] {
+				return 0, false
 			}
-			i = end
-		case '{':
-			end, ok := quantifierEnd(pattern, i)
-			if !ok {
-				return true
-			}
-			i = end
-		case '}', ']':
-			return true
+			i++
 		default:
-			i++
-		}
-	}
-	return false
-}
-
-// quantifierEnd returns the byte index just past the `}` of the
-// `{n}` / `{n,}` / `{n,m}` quantifier opening at pattern[start], or ok=false
-// when the brace does not open one.
-func quantifierEnd(pattern string, start int) (int, bool) {
-	i := start + 1
-	digits := 0
-	for i < len(pattern) && pattern[i] >= '0' && pattern[i] <= '9' {
-		i++
-		digits++
-	}
-	if digits == 0 {
-		return start, false
-	}
-	if i < len(pattern) && pattern[i] == ',' {
-		i++
-		for i < len(pattern) && pattern[i] >= '0' && pattern[i] <= '9' {
-			i++
-		}
-	}
-	if i < len(pattern) && pattern[i] == '}' {
-		return i + 1, true
-	}
-	return start, false
-}
-
-// hasInvalidIdentityEscapeForUFlag scans for escapes that ECMAScript u/v mode
-// rejects but regexp2 accepts. Conservative: on malformed input it returns
-// false (i.e. defers to regexp2's verdict) rather than inventing an error.
-func hasInvalidIdentityEscapeForUFlag(pattern string) bool {
-	i := 0
-	for i < len(pattern) {
-		c := pattern[i]
-		if c != '\\' || i+1 >= len(pattern) {
-			i++
-			continue
-		}
-		next := pattern[i+1]
-		switch next {
-		// Recognized single-letter escapes.
-		case 'd', 'D', 'w', 'W', 's', 'S', 'b', 'B', 'n', 't', 'r', 'v', 'f', '0',
-			'x', 'u', 'c', 'p', 'P', 'k', 'q',
-			// SyntaxCharacter / `/` — legal identity escapes under u.
-			'^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|', '\\', '/':
-			i += 2
-			continue
-		}
-		// Decimal backreference (\1..\9) is legal.
-		if next >= '1' && next <= '9' {
-			i += 2
-			continue
-		}
-		// Any letter/digit identity escape not recognized above is illegal under u.
-		if (next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z') {
-			return true
-		}
-		i += 2
-	}
-	return false
-}
-
-// classSetElementKind classifies one element of a v-flag class body for the
-// purposes of range validation: only a ClassSetCharacter may sit on either
-// side of a `-`.
-type classSetElementKind int
-
-const (
-	classSetPlainChar classSetElementKind = iota
-	classSetOperand
-)
-
-// reservedClassSetPunctuators are the characters ECMAScript reserves inside a
-// v-flag class when they appear doubled (`!!`, `##`, `..`, …). `&` is in the
-// set because `&&` is only legal as the intersection operator.
-const reservedClassSetPunctuators = "&!#$%*+,.:;<=>?@^`~"
-
-// hasInvalidClassContentForVFlag reports whether any character class in
-// pattern holds something the v-flag ClassSetExpression grammar rejects — an
-// unescaped ClassSetSyntaxCharacter, a doubled reserved punctuator, or a `-`
-// that isn't a range between two single characters. It is deliberately
-// conservative: set operators (`--`, and `&&` without operands on both sides)
-// count as invalid, because a pattern this scanner cannot prove legal must
-// not be offered the flag.
-func hasInvalidClassContentForVFlag(pattern string) bool {
-	flags := RegexFlags{UnicodeSets: true}
-	invalid := false
-	IterateRegexCharacterClasses(pattern, flags, func(start, end int) {
-		if !invalid && hasInvalidClassBodyForVFlag(pattern, start, end, flags) {
-			invalid = true
-		}
-	})
-	return invalid
-}
-
-// hasInvalidClassBodyForVFlag checks the body of the single class spanning
-// [start, end). Nested classes are skipped whole — IterateRegexCharacterClasses
-// hands each of them to this function in its own right.
-func hasInvalidClassBodyForVFlag(pattern string, start, end int, flags RegexFlags) bool {
-	i := start + 1
-	last := end - 1
-	if i < last && pattern[i] == '^' {
-		i++
-	}
-
-	elements := 0
-	lastWasRange := false
-	sawOperator := false
-	for i < last {
-		c := pattern[i]
-		// A `-` here has no left-hand character to open a range with.
-		if c == '-' {
-			return true
-		}
-		if strings.IndexByte(reservedClassSetPunctuators, c) >= 0 && i+1 < last && pattern[i+1] == c {
-			// `&&` is the intersection operator, legal between two operands —
-			// and a range is not an operand. Every other doubled punctuator is
-			// reserved.
-			if c != '&' || elements != 1 || lastWasRange || i+2 >= last || pattern[i+2] == '&' {
-				return true
+			_, width := utf8.DecodeRuneInString(pattern[i:])
+			if width == 0 {
+				width = 1
 			}
-			i += 2
-			elements = 0
-			sawOperator = true
+			i += width
+		}
+	}
+	return 0, false
+}
+
+// regexPatternLiteral transports a u/v constructor pattern into a literal for
+// tsgo's parser. It reads JavaScript UTF-16 code units, escapes only lexical
+// delimiters, and rejects cases where encoding a line terminator or surrogate
+// would turn an invalid identity escape into valid syntax.
+func regexPatternLiteral(pattern string, flags RegexFlags) (string, bool) {
+	pattern = ecmascript.CombineSurrogatePairs(pattern)
+	units := ecmascript.StringCodeUnits(pattern)
+	if ecmascript.StringFromCodeUnits(units) != pattern {
+		return "", false
+	}
+
+	var literal strings.Builder
+	literal.Grow(len(pattern) + 4)
+	literal.WriteByte('/')
+	if len(units) == 0 {
+		literal.WriteString("(?:)")
+	}
+
+	escaped := false
+	for _, unit := range units {
+		if unit == '\\' {
+			literal.WriteByte('\\')
+			escaped = !escaped
 			continue
 		}
 
-		kind, next, ok := classSetElement(pattern, i, last, flags)
-		if !ok {
-			return true
-		}
-		i = next
-		elements++
-		lastWasRange = false
-
-		if i < last && pattern[i] == '-' {
-			// `--` is the difference operator, which this scanner doesn't
-			// track; refuse rather than read it as a range.
-			if kind != classSetPlainChar || sawOperator || i+1 >= last || pattern[i+1] == '-' {
-				return true
+		switch unit {
+		case '/':
+			if !escaped {
+				literal.WriteByte('\\')
 			}
-			i++
-			kind, next, ok = classSetElement(pattern, i, last, flags)
-			if !ok || kind != classSetPlainChar {
-				return true
+			literal.WriteByte('/')
+		case '\n':
+			if escaped {
+				return "", false
 			}
-			i = next
-			lastWasRange = true
-		}
-	}
-	return sawOperator && elements != 1
-}
-
-// classSetElement consumes one element of a v-flag class body at pattern[i],
-// returning its kind and the index just past it. ok is false for the
-// ClassSetSyntaxCharacters that must be escaped inside a v-flag class.
-func classSetElement(pattern string, i, last int, flags RegexFlags) (classSetElementKind, int, bool) {
-	switch c := pattern[i]; c {
-	case '\\':
-		step, ok := SkipPatternEscape(pattern, i, flags)
-		if !ok || i+step > last {
-			return classSetOperand, i, false
-		}
-		switch pattern[i+1] {
-		case 'd', 'D', 'w', 'W', 's', 'S', 'p', 'P', 'q':
-			return classSetOperand, i + step, true
-		}
-		return classSetPlainChar, i + step, true
-	case '[':
-		nestedEnd, ok := ClassEnd(pattern, i, flags)
-		if !ok || nestedEnd > last {
-			return classSetOperand, i, false
-		}
-		return classSetOperand, nestedEnd, true
-	case '(', ')', '{', '}', '/', '|', ']':
-		return classSetOperand, i, false
-	}
-	_, width := utf8.DecodeRuneInString(pattern[i:])
-	if width == 0 {
-		width = 1
-	}
-	return classSetPlainChar, i + width, true
-}
-
-// hasUnresolvedNamedBackreferenceForUFlag reports whether the pattern has a
-// `\k` that no `(?<name>…)` group in the same pattern can resolve. Without the
-// u/v flag such a `\k` reads as the literal characters `k<name>`; with it, an
-// unresolved reference is a SyntaxError.
-func hasUnresolvedNamedBackreferenceForUFlag(pattern string) bool {
-	names := make(map[string]struct{})
-	var refs []string
-	for i := 0; i < len(pattern); {
-		if pattern[i] == '[' {
-			end, ok := ClassEnd(pattern, i, RegexFlags{Unicode: true})
-			if !ok {
-				return false
+			literal.WriteString(`\n`)
+		case '\r':
+			if escaped {
+				return "", false
 			}
-			i = end
-			continue
-		}
-		if pattern[i] == '\\' {
-			if i+1 >= len(pattern) {
-				return false
+			literal.WriteString(`\r`)
+		case 0x2028, 0x2029:
+			if escaped {
+				return "", false
 			}
-			if pattern[i+1] == 'k' {
-				name, next, ok := readAngleName(pattern, i+2)
-				if !ok {
-					return true
+			writeRegexUnicodeEscape(&literal, unit)
+		default:
+			if unit >= 0xD800 && unit <= 0xDFFF {
+				if escaped {
+					return "", false
 				}
-				refs = append(refs, name)
-				i = next
-				continue
+				writeRegexUnicodeEscape(&literal, unit)
+			} else {
+				literal.WriteRune(rune(unit))
 			}
-			i += 2
-			continue
 		}
-		// `(?<name>` declares a group; `(?<=` and `(?<!` are lookbehinds.
-		if strings.HasPrefix(pattern[i:], "(?<") && i+3 < len(pattern) &&
-			pattern[i+3] != '=' && pattern[i+3] != '!' {
-			name, next, ok := readAngleName(pattern, i+2)
-			normalized, valid := normalizeRegexCaptureName(name)
-			if !ok || !valid {
-				return true
-			}
-			if _, duplicate := names[normalized]; duplicate {
-				return true
-			}
-			names[normalized] = struct{}{}
-			i = next
-			continue
-		}
-		i++
+		escaped = false
 	}
-	for _, ref := range refs {
-		normalized, valid := normalizeRegexCaptureName(ref)
-		if !valid {
-			return true
-		}
-		if _, exists := names[normalized]; !exists {
-			return true
-		}
+	if escaped {
+		return "", false
 	}
-	return false
+
+	literal.WriteByte('/')
+	if flags.UnicodeSets {
+		literal.WriteByte('v')
+	} else {
+		literal.WriteByte('u')
+	}
+	return literal.String(), true
 }
 
-// normalizeRegexCaptureName validates the IdentifierName grammar used by
-// named captures and returns its decoded value so escaped and literal spellings
-// compare alike.
+func writeRegexUnicodeEscape(builder *strings.Builder, unit uint16) {
+	const hex = "0123456789ABCDEF"
+	builder.WriteString(`\u`)
+	builder.WriteByte(hex[unit>>12])
+	builder.WriteByte(hex[unit>>8&0xF])
+	builder.WriteByte(hex[unit>>4&0xF])
+	builder.WriteByte(hex[unit&0xF])
+}
+
+// normalizeRegexCaptureName validates the RegExpIdentifierName grammar and
+// returns its decoded value so escaped and literal spellings compare alike.
 func normalizeRegexCaptureName(name string) (string, bool) {
 	if name == "" {
 		return "", false
 	}
 	var result strings.Builder
+	first := true
 	for i := 0; i < len(name); {
+		var value rune
 		if name[i] != '\\' {
 			r, width := utf8.DecodeRuneInString(name[i:])
 			if r == utf8.RuneError && width == 1 {
 				return "", false
 			}
-			result.WriteRune(r)
+			value = r
 			i += width
-			continue
-		}
-		value, width, ok := decodeRegexCaptureNameEscape(name, i)
-		if !ok {
-			return "", false
-		}
-		if value >= 0xD800 && value <= 0xDBFF {
-			next, nextWidth, ok := decodeRegexCaptureNameEscape(name, i+width)
-			if !ok || next < 0xDC00 || next > 0xDFFF {
-				return "", false
-			}
-			result.WriteRune(utf16.DecodeRune(rune(value), rune(next)))
-			width += nextWidth
 		} else {
-			if value >= 0xDC00 && value <= 0xDFFF {
+			decoded, width, fixed, ok := decodeRegexCaptureNameEscape(name, i)
+			if !ok {
 				return "", false
 			}
-			result.WriteRune(rune(value))
+			i += width
+			if decoded >= 0xD800 && decoded <= 0xDBFF {
+				if !fixed {
+					return "", false
+				}
+				low, lowWidth, lowFixed, ok := decodeRegexCaptureNameEscape(name, i)
+				if !ok || !lowFixed || low < 0xDC00 || low > 0xDFFF {
+					return "", false
+				}
+				value = utf16.DecodeRune(rune(decoded), rune(low))
+				i += lowWidth
+			} else {
+				if decoded >= 0xDC00 && decoded <= 0xDFFF {
+					return "", false
+				}
+				value = rune(decoded)
+			}
 		}
-		i += width
-	}
-	normalized := result.String()
-	for i, r := range normalized {
-		if (i == 0 && !scanner.IsIdentifierStart(r)) || (i != 0 && !scanner.IsIdentifierPart(r)) {
+
+		if first {
+			if !scanner.IsIdentifierStart(value) {
+				return "", false
+			}
+			first = false
+		} else if !scanner.IsIdentifierPart(value) {
 			return "", false
 		}
+		result.WriteRune(value)
 	}
-	return normalized, true
+	return result.String(), !first
 }
 
-func decodeRegexCaptureNameEscape(name string, start int) (uint32, int, bool) {
+// decodeRegexCaptureNameEscape decodes one `\u` escape. fixed is true only
+// for the four-digit form; the grammar permits a surrogate pair only when both
+// halves use that fixed form.
+func decodeRegexCaptureNameEscape(name string, start int) (value uint32, width int, fixed bool, ok bool) {
 	if start+2 >= len(name) || name[start] != '\\' || name[start+1] != 'u' {
-		return 0, 0, false
+		return 0, 0, false, false
 	}
-	if name[start+2] == '{' {
-		closeRel := strings.IndexByte(name[start+3:], '}')
-		if closeRel < 1 {
-			return 0, 0, false
+	if name[start+2] != '{' {
+		if start+6 > len(name) || !allHexStr(name[start+2:start+6]) {
+			return 0, 0, false, false
 		}
-		digits := name[start+3 : start+3+closeRel]
-		if len(digits) > 6 || !allHexStr(digits) {
-			return 0, 0, false
+		parsed, err := strconv.ParseUint(name[start+2:start+6], 16, 16)
+		if err != nil {
+			return 0, 0, false, false
 		}
-		value, err := strconv.ParseUint(digits, 16, 32)
-		if err != nil || value > utf8.MaxRune {
-			return 0, 0, false
+		return uint32(parsed), 6, true, true
+	}
+
+	value = 0
+	digits := 0
+	for i := start + 3; i < len(name) && name[i] != '}'; i++ {
+		digit, valid := regexHexValue(name[i])
+		if !valid || value > (utf8.MaxRune-digit)/16 {
+			return 0, 0, false, false
 		}
-		return uint32(value), closeRel + 4, true
+		value = value*16 + digit
+		digits++
 	}
-	if start+6 > len(name) || !allHexStr(name[start+2:start+6]) {
-		return 0, 0, false
+	end := start + 3 + digits
+	if digits == 0 || end >= len(name) || name[end] != '}' {
+		return 0, 0, false, false
 	}
-	value, err := strconv.ParseUint(name[start+2:start+6], 16, 16)
-	if err != nil {
-		return 0, 0, false
+	return value, end - start + 1, false, true
+}
+
+func regexHexValue(value byte) (uint32, bool) {
+	switch {
+	case value >= '0' && value <= '9':
+		return uint32(value - '0'), true
+	case value >= 'a' && value <= 'f':
+		return uint32(value-'a') + 10, true
+	case value >= 'A' && value <= 'F':
+		return uint32(value-'A') + 10, true
+	default:
+		return 0, false
 	}
-	return uint32(value), 6, true
 }
 
 // readAngleName reads a `<name>` starting at pattern[start], returning the

--- a/internal/utils/regex_validate_test.go
+++ b/internal/utils/regex_validate_test.go
@@ -1,0 +1,218 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+func TestRegexPatternLiteral(t *testing.T) {
+	high := ecmascript.StringFromCodeUnits([]uint16{0xD800})
+	tests := []struct {
+		name    string
+		pattern string
+		flags   RegexFlags
+		want    string
+		ok      bool
+	}{
+		{name: "empty u", flags: RegexFlags{Unicode: true}, want: `/(?:)/u`, ok: true},
+		{name: "empty v", flags: RegexFlags{UnicodeSets: true}, want: `/(?:)/v`, ok: true},
+		{name: "unescaped slash", pattern: `/`, flags: RegexFlags{Unicode: true}, want: `/\//u`, ok: true},
+		{name: "escaped slash", pattern: `\/`, flags: RegexFlags{Unicode: true}, want: `/\//u`, ok: true},
+		{name: "two backslashes and slash", pattern: `\\/`, flags: RegexFlags{Unicode: true}, want: `/\\\//u`, ok: true},
+		{name: "three backslashes and slash", pattern: `\\\/`, flags: RegexFlags{Unicode: true}, want: `/\\\//u`, ok: true},
+		{name: "line feed", pattern: "\n", flags: RegexFlags{Unicode: true}, want: `/\n/u`, ok: true},
+		{name: "carriage return", pattern: "\r", flags: RegexFlags{Unicode: true}, want: `/\r/u`, ok: true},
+		{name: "line separator", pattern: "\u2028", flags: RegexFlags{Unicode: true}, want: `/\u2028/u`, ok: true},
+		{name: "paragraph separator", pattern: "\u2029", flags: RegexFlags{Unicode: true}, want: `/\u2029/u`, ok: true},
+		{name: "two backslashes and line feed", pattern: "\\\\\n", flags: RegexFlags{Unicode: true}, want: `/\\\n/u`, ok: true},
+		{name: "escaped line feed", pattern: "\\\n", flags: RegexFlags{Unicode: true}},
+		{name: "lone surrogate", pattern: high, flags: RegexFlags{Unicode: true}, want: `/\uD800/u`, ok: true},
+		{name: "surrogate pair", pattern: "😀", flags: RegexFlags{Unicode: true}, want: `/\uD83D\uDE00/u`, ok: true},
+		{name: "escaped surrogate", pattern: `\` + high, flags: RegexFlags{Unicode: true}},
+		{name: "trailing backslash", pattern: `\`, flags: RegexFlags{Unicode: true}},
+		{name: "invalid utf8", pattern: string([]byte{0xFF}), flags: RegexFlags{Unicode: true}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := regexPatternLiteral(test.pattern, test.flags)
+			if got != test.want || ok != test.ok {
+				t.Fatalf("regexPatternLiteral(%q) = (%q, %v), want (%q, %v)", test.pattern, got, ok, test.want, test.ok)
+			}
+		})
+	}
+}
+
+func TestIsValidRegexPatternUnicode(t *testing.T) {
+	high := ecmascript.StringFromCodeUnits([]uint16{0xD800})
+	low := ecmascript.StringFromCodeUnits([]uint16{0xDC00})
+	u := RegexFlags{Unicode: true}
+	v := RegexFlags{UnicodeSets: true}
+	tests := []struct {
+		name    string
+		pattern string
+		flags   RegexFlags
+		want    bool
+	}{
+		{name: "simple", pattern: `abc`, flags: u, want: true},
+		{name: "empty", flags: u, want: true},
+		{name: "slash", pattern: `/`, flags: u, want: true},
+		{name: "escaped slash", pattern: `\/`, flags: u, want: true},
+		{name: "two backslashes and slash", pattern: `\\/`, flags: u, want: true},
+		{name: "line feed", pattern: "\n", flags: u, want: true},
+		{name: "escaped line feed", pattern: "\\\n", flags: u},
+		{name: "two backslashes and line feed", pattern: "\\\\\n", flags: u, want: true},
+		{name: "lone high surrogate", pattern: high, flags: u, want: true},
+		{name: "lone low surrogate", pattern: low, flags: u, want: true},
+		{name: "escaped lone surrogate", pattern: `\` + high, flags: u},
+		{name: "escaped astral", pattern: `\` + "😀", flags: u},
+		{name: "invalid identity escape", pattern: `\q`, flags: u},
+		{name: "class identity escape", pattern: `[\B]`, flags: u},
+		{name: "class named-looking escape", pattern: `[\k<a>]`, flags: u},
+		{name: "missing numeric backreference", pattern: `\1`, flags: u},
+		{name: "second numeric backreference missing", pattern: `(a)\2`, flags: u},
+		{name: "legacy octal", pattern: `\01`, flags: u},
+		{name: "escaped declaration name", pattern: `(?<\u0061>x)\k<a>`, flags: u, want: true},
+		{name: "escaped reference name", pattern: `(?<a>x)\k<\u0061>`, flags: u, want: true},
+		{name: "dollar name", pattern: `(?<\u0024>x)\k<$>`, flags: u, want: true},
+		{name: "astral escaped name", pattern: `(?<\uD835\uDC9C>x)\k<\u{1D49C}>`, flags: u, want: true},
+		{name: "astral raw surrogate-pair name", pattern: "(?<" + high + low + ">x)", flags: u, want: true},
+		{name: "braced leading zeros", pattern: `(?<\u{00000061}>x)\k<a>`, flags: u, want: true},
+		{name: "forward named reference", pattern: `\k<a>(?<a>x)`, flags: u, want: true},
+		{name: "unresolved named reference", pattern: `\k<a>`, flags: u},
+		{name: "sequential duplicate name", pattern: `(?<a>x)(?<a>y)`, flags: u},
+		{name: "braced surrogate halves", pattern: `(?<\u{D835}\u{DC9C}>x)`, flags: u},
+		{name: "mixed surrogate halves", pattern: `(?<\uD835\u{DC9C}>x)`, flags: u},
+		{name: "lone high surrogate name", pattern: `(?<\uD835>x)`, flags: u},
+		{name: "lone low surrogate name", pattern: `(?<\uDC9C>x)`, flags: u},
+		{name: "group text in class", pattern: `[(?<a>x)]\k<a>`, flags: u},
+		{name: "unicode property long alias", pattern: `\p{Letter}`, flags: u, want: true},
+		{name: "unicode property script", pattern: `\p{Script=Greek}`, flags: u, want: true},
+		{name: "unicode set subtraction", pattern: `[\d--[3]]`, flags: v, want: true},
+		{name: "unicode set string", pattern: `[\q{abc}]`, flags: v, want: true},
+		{name: "raw slash in u class", pattern: `[/]`, flags: u, want: true},
+		{name: "raw slash in v class", pattern: `[/]`, flags: v},
+		{name: "escaped slash in v class", pattern: `[\/]`, flags: v, want: true},
+		{name: "raw slash in v string", pattern: `[\q{a/b}]`, flags: v},
+		{name: "escaped slash in v string", pattern: `[\q{a\/b}]`, flags: v, want: true},
+		{name: "raw slash in nested v class", pattern: `[[/]]`, flags: v},
+		{name: "trailing hyphen in u class", pattern: `[a-]`, flags: u, want: true},
+		{name: "trailing hyphen in v class", pattern: `[a-]`, flags: v},
+		{name: "trailing hyphen in negated v class", pattern: `[^a-]`, flags: v},
+		{name: "trailing hyphen in nested v class", pattern: `[[a-]]`, flags: v},
+		{name: "escaped trailing hyphen in v class", pattern: `[a\-]`, flags: v, want: true},
+		{name: "subtraction hyphens in v class", pattern: `[a--b]`, flags: v, want: true},
+		{name: "escaped hyphen in v string", pattern: `[\q{a\-}]`, flags: v, want: true},
+		{name: "leading hyphen in v class", pattern: `[-a]`, flags: v},
+		{name: "escaped leading hyphen in v class", pattern: `[\-a]`, flags: v, want: true},
+		{name: "doubled caret in v class", pattern: `[a^^b]`, flags: v},
+		{name: "doubled dollar in nested v class", pattern: `[[a$$b]]`, flags: v},
+		{name: "negation caret is not a doubled punctuator", pattern: `[^^]`, flags: v, want: true},
+		{name: "escaped doubled caret in v class", pattern: `[\^\^]`, flags: v, want: true},
+		{name: "doubled dollar in v string", pattern: `[\q{a$$b}]`, flags: v},
+		{name: "doubled caret in nested v string", pattern: `[[\q{a^^b}]]`, flags: v},
+		{name: "escaped doubled dollar in v string", pattern: `[\q{\$\$}]`, flags: v, want: true},
+		{name: "string in positive v class", pattern: `[a\q{bc}]`, flags: v, want: true},
+		{name: "property in positive v class", pattern: `[a\p{Letter}]`, flags: v, want: true},
+		{name: "both unicode modes", pattern: `a`, flags: RegexFlags{Unicode: true, UnicodeSets: true}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsValidRegexPattern(test.pattern, test.flags); got != test.want {
+				t.Fatalf("IsValidRegexPattern(%q, %+v) = %v, want %v", test.pattern, test.flags, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsValidRegexPatternUnicodeSuggestionSafety(t *testing.T) {
+	v := RegexFlags{UnicodeSets: true}
+	for _, test := range []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{name: "single-code-point string in negated class is conservative", pattern: `[^a\q{b}]`},
+		{name: "later string in negated class", pattern: `[^a\q{bc}]`},
+		{name: "property in negated class is conservative", pattern: `[^a\p{Letter}]`},
+		{name: "nested string in negated class", pattern: `[^a[\q{bc}]]`},
+		{name: "string in positive class", pattern: `[a\q{bc}]`, want: true},
+		{name: "property in positive class", pattern: `[a\p{Letter}]`, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsValidRegexPatternForECMAVersion(test.pattern, v, 2024); got != test.want {
+				t.Fatalf("IsValidRegexPatternForECMAVersion(%q) = %v, want %v", test.pattern, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsValidRegexPatternFailsClosedOnScannerGaps(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		pattern string
+		flags   RegexFlags
+	}{
+		{
+			name:    "duplicate name control flow",
+			pattern: `(?=(?<a>x))(?<a>y)`,
+			flags:   RegexFlags{Unicode: true},
+		},
+		{
+			name:    "negated multi-code-point string",
+			pattern: `[^a\q{bc}]`,
+			flags:   RegexFlags{UnicodeSets: true},
+		},
+		{
+			name:    "negated ordinary property is conservative",
+			pattern: `[^a\p{Letter}]`,
+			flags:   RegexFlags{UnicodeSets: true},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if IsValidRegexPattern(test.pattern, test.flags) {
+				t.Fatalf("IsValidRegexPattern(%q) = true, want fail-closed false", test.pattern)
+			}
+		})
+	}
+}
+
+func TestIsValidRegexPatternECMAVersion(t *testing.T) {
+	u := RegexFlags{Unicode: true}
+	for _, test := range []struct {
+		name        string
+		pattern     string
+		ecmaVersion int
+		want        bool
+	}{
+		{name: "named capture before introduction", pattern: `(?<a>x)`, ecmaVersion: 2017},
+		{name: "named capture after introduction", pattern: `(?<a>x)`, ecmaVersion: 2018, want: true},
+		{name: "duplicate alternatives before relaxation", pattern: `(?<a>x)|(?<a>y)`, ecmaVersion: 2024},
+		{name: "duplicate alternatives after relaxation are conservative", pattern: `(?<a>x)|(?<a>y)`, ecmaVersion: 2025},
+		{name: "escaped duplicate alternatives before relaxation", pattern: `(?<\u0061>x)|(?<a>y)`, ecmaVersion: 2024},
+		{name: "escaped duplicate alternatives after relaxation are conservative", pattern: `(?<\u0061>x)|(?<a>y)`, ecmaVersion: 2025},
+		{name: "unsafe nested alternative duplicate", pattern: `(?:x|(?<a>y))(?<a>z)`, ecmaVersion: 2025},
+		{name: "unsafe lookahead duplicate", pattern: `(?=(?<a>x))(?<a>y)`, ecmaVersion: 2025},
+		{name: "sequential duplicate remains invalid", pattern: `(?<a>x)(?<a>y)`, ecmaVersion: 2025},
+		{name: "inline modifiers before introduction", pattern: `(?i:a)`, ecmaVersion: 2024},
+		{name: "inline modifiers after introduction", pattern: `(?i:a)`, ecmaVersion: 2025, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsValidRegexPatternForECMAVersion(test.pattern, u, test.ecmaVersion); got != test.want {
+				t.Fatalf("IsValidRegexPatternForECMAVersion(%q, %d) = %v, want %v", test.pattern, test.ecmaVersion, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsValidRegexPatternLegacyPath(t *testing.T) {
+	// Annex B accepts escapes that u/v reject. This locks in that the tsgo
+	// literal adapter is confined to the Unicode modes.
+	for _, pattern := range []string{"\\\n", `\q`, `\01`} {
+		if !IsValidRegexPattern(pattern, RegexFlags{}) {
+			t.Errorf("legacy IsValidRegexPattern(%q) = false, want true", pattern)
+		}
+	}
+}

--- a/internal/utils/regex_validate_test.go
+++ b/internal/utils/regex_validate_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -74,6 +75,7 @@ func TestIsValidRegexPatternUnicode(t *testing.T) {
 		{name: "second numeric backreference missing", pattern: `(a)\2`, flags: u},
 		{name: "legacy octal", pattern: `\01`, flags: u},
 		{name: "escaped declaration name", pattern: `(?<\u0061>x)\k<a>`, flags: u, want: true},
+		{name: "capture name beyond bundled Unicode data", pattern: `(?<𲎰>x)`, flags: u},
 		{name: "escaped reference name", pattern: `(?<a>x)\k<\u0061>`, flags: u, want: true},
 		{name: "dollar name", pattern: `(?<\u0024>x)\k<$>`, flags: u, want: true},
 		{name: "astral escaped name", pattern: `(?<\uD835\uDC9C>x)\k<\u{1D49C}>`, flags: u, want: true},
@@ -128,18 +130,41 @@ func TestIsValidRegexPatternUnicode(t *testing.T) {
 }
 
 func TestIsValidRegexPatternUnicodeSuggestionSafety(t *testing.T) {
+	high := ecmascript.StringFromCodeUnits([]uint16{0xD800})
+	low := ecmascript.StringFromCodeUnits([]uint16{0xDFFF})
 	v := RegexFlags{UnicodeSets: true}
 	for _, test := range []struct {
 		name    string
 		pattern string
 		want    bool
 	}{
-		{name: "single-code-point string in negated class is conservative", pattern: `[^a\q{b}]`},
+		{name: "single-code-point string in negated class", pattern: `[^a\q{b}]`, want: true},
+		{name: "single-code-point string alternatives", pattern: `[^a\q{b|c}]`, want: true},
+		{name: "raw astral string", pattern: `[^a\q{😀}]`, want: true},
+		{name: "raw lone high surrogate string", pattern: `[^a\q{` + high + `}]`, want: true},
+		{name: "raw lone low surrogate string", pattern: `[^a\q{` + low + `}]`, want: true},
+		{name: "braced astral escape", pattern: `[^a\q{\u{1F600}}]`, want: true},
+		{name: "fixed surrogate pair", pattern: `[^a\q{\uD83D\uDE00}]`, want: true},
 		{name: "later string in negated class", pattern: `[^a\q{bc}]`},
-		{name: "property in negated class is conservative", pattern: `[^a\p{Letter}]`},
-		{name: "nested string in negated class", pattern: `[^a[\q{bc}]]`},
+		{name: "empty string in negated class", pattern: `[^a\q{}]`},
+		{name: "empty alternative in negated class", pattern: `[^a\q{|b}]`},
+		{name: "ordinary property in negated class", pattern: `[^a\p{Letter}]`, want: true},
+		{name: "script property in negated class", pattern: `[^a\p{Script=Greek}]`, want: true},
+		{name: "complement property in negated class", pattern: `[^a\P{Letter}]`, want: true},
+		{name: "string property in negated class", pattern: `[^a\p{Basic_Emoji}]`},
+		{name: "string after range in negated class", pattern: `[^a-z\q{bc}]`},
+		{name: "string property after range in negated class", pattern: `[^a-z\p{Basic_Emoji}]`},
+		{name: "intersection narrows strings to code points", pattern: `[^\q{ab}&&a]`, want: true},
+		{name: "intersection retains strings", pattern: `[^\q{ab}&&\q{cd}]`},
+		{name: "subtraction ignores string right operand", pattern: `[^a--\q{ab}]`, want: true},
+		{name: "subtraction retains string left operand", pattern: `[^\q{ab}--a]`},
+		{name: "nested intersection narrows strings", pattern: `[^a[\q{bc}&&a]]`, want: true},
+		{name: "nested union retains strings", pattern: `[^a[\q{bc}]]`},
 		{name: "string in positive class", pattern: `[a\q{bc}]`, want: true},
 		{name: "property in positive class", pattern: `[a\p{Letter}]`, want: true},
+		// The bundled TypeScript scanner is the grammar authority and can trail
+		// the Unicode data used by the JavaScript runtime and regexpp.
+		{name: "property from newer Unicode data", pattern: `[^a\p{Script=Gara}]`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := IsValidRegexPatternForECMAVersion(test.pattern, v, 2024); got != test.want {
@@ -159,16 +184,6 @@ func TestIsValidRegexPatternFailsClosedOnScannerGaps(t *testing.T) {
 			name:    "duplicate name control flow",
 			pattern: `(?=(?<a>x))(?<a>y)`,
 			flags:   RegexFlags{Unicode: true},
-		},
-		{
-			name:    "negated multi-code-point string",
-			pattern: `[^a\q{bc}]`,
-			flags:   RegexFlags{UnicodeSets: true},
-		},
-		{
-			name:    "negated ordinary property is conservative",
-			pattern: `[^a\p{Letter}]`,
-			flags:   RegexFlags{UnicodeSets: true},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -190,11 +205,18 @@ func TestIsValidRegexPatternECMAVersion(t *testing.T) {
 		{name: "named capture before introduction", pattern: `(?<a>x)`, ecmaVersion: 2017},
 		{name: "named capture after introduction", pattern: `(?<a>x)`, ecmaVersion: 2018, want: true},
 		{name: "duplicate alternatives before relaxation", pattern: `(?<a>x)|(?<a>y)`, ecmaVersion: 2024},
-		{name: "duplicate alternatives after relaxation are conservative", pattern: `(?<a>x)|(?<a>y)`, ecmaVersion: 2025},
+		{name: "duplicate alternatives after relaxation", pattern: `(?<a>x)|(?<a>y)`, ecmaVersion: 2025, want: true},
 		{name: "escaped duplicate alternatives before relaxation", pattern: `(?<\u0061>x)|(?<a>y)`, ecmaVersion: 2024},
-		{name: "escaped duplicate alternatives after relaxation are conservative", pattern: `(?<\u0061>x)|(?<a>y)`, ecmaVersion: 2025},
+		{name: "escaped duplicate alternatives after relaxation", pattern: `(?<\u0061>x)|(?<a>y)`, ecmaVersion: 2025, want: true},
+		{name: "nested mutually exclusive duplicates", pattern: `(?:(?<a>x)|(?:y|(?<a>z)))`, ecmaVersion: 2025, want: true},
+		{name: "three mutually exclusive duplicates", pattern: `(?<a>x)|(?<a>y)|(?<a>z)`, ecmaVersion: 2025, want: true},
+		{name: "nested three-way mutually exclusive duplicates", pattern: `(?<a>x)|(?:(?<a>y)|(?<a>z))`, ecmaVersion: 2025, want: true},
+		{name: "backreference to mutually exclusive duplicates", pattern: `(?<a>x)|(?<a>y)\k<a>`, ecmaVersion: 2025, want: true},
 		{name: "unsafe nested alternative duplicate", pattern: `(?:x|(?<a>y))(?<a>z)`, ecmaVersion: 2025},
 		{name: "unsafe lookahead duplicate", pattern: `(?=(?<a>x))(?<a>y)`, ecmaVersion: 2025},
+		{name: "unsafe duplicate after exclusive alternatives", pattern: `(?:(?<a>x)|y)(?<a>z)`, ecmaVersion: 2025},
+		{name: "third duplicate compatible with its predecessor", pattern: `(?<a>x)|(?<a>y)(?<a>z)`, ecmaVersion: 2025},
+		{name: "quantifier does not make duplicates exclusive", pattern: `(?:(?<a>x))?(?<a>y)`, ecmaVersion: 2025},
 		{name: "sequential duplicate remains invalid", pattern: `(?<a>x)(?<a>y)`, ecmaVersion: 2025},
 		{name: "inline modifiers before introduction", pattern: `(?i:a)`, ecmaVersion: 2024},
 		{name: "inline modifiers after introduction", pattern: `(?i:a)`, ecmaVersion: 2025, want: true},
@@ -204,6 +226,68 @@ func TestIsValidRegexPatternECMAVersion(t *testing.T) {
 				t.Fatalf("IsValidRegexPatternForECMAVersion(%q, %d) = %v, want %v", test.pattern, test.ecmaVersion, got, test.want)
 			}
 		})
+	}
+}
+
+func TestIsValidRegexPatternFlagECMAVersion(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		pattern     string
+		flags       RegexFlags
+		ecmaVersion int
+		want        bool
+	}{
+		{name: "u flag before introduction", pattern: `a`, flags: RegexFlags{Unicode: true}, ecmaVersion: 2014},
+		{name: "u flag at introduction", pattern: `a`, flags: RegexFlags{Unicode: true}, ecmaVersion: 2015, want: true},
+		{name: "v flag before introduction", pattern: `a`, flags: RegexFlags{UnicodeSets: true}, ecmaVersion: 2023},
+		{name: "v flag at introduction", pattern: `a`, flags: RegexFlags{UnicodeSets: true}, ecmaVersion: 2024, want: true},
+		{name: "legacy p identity escape", pattern: `\p{L}`, ecmaVersion: 2017, want: true},
+		{name: "legacy k identity escape", pattern: `\k<a>`, ecmaVersion: 2017, want: true},
+		{name: "escaped backslash before p in u class", pattern: `[\\p]`, flags: RegexFlags{Unicode: true}, ecmaVersion: 2017, want: true},
+		{name: "u property before introduction", pattern: `\p{Letter}`, flags: RegexFlags{Unicode: true}, ecmaVersion: 2017},
+		{name: "u property at introduction", pattern: `\p{Letter}`, flags: RegexFlags{Unicode: true}, ecmaVersion: 2018, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsValidRegexPatternForECMAVersion(test.pattern, test.flags, test.ecmaVersion); got != test.want {
+				t.Fatalf("IsValidRegexPatternForECMAVersion(%q, %+v, %d) = %v, want %v", test.pattern, test.flags, test.ecmaVersion, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsValidRegexPatternLegacyES2025DuplicateNames(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{name: "top-level alternatives", pattern: `(?<a>x)|(?<a>y)`, want: true},
+		{name: "escaped and raw names", pattern: `(?<\u0061>x)|(?<a>y)`, want: true},
+		{name: "forward backreference", pattern: `\k<a>(?<a>x)|(?<a>y)`, want: true},
+		{name: "sequential duplicate", pattern: `(?<a>x)(?<a>y)`},
+		{name: "lookahead duplicate", pattern: `(?=(?<a>x))(?<a>y)`},
+		{name: "group-looking text keeps legacy identity escape", pattern: `[(?<a>x)]\k<a>`, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsValidRegexPattern(test.pattern, RegexFlags{}); got != test.want {
+				t.Fatalf("IsValidRegexPattern(%q) = %v, want %v", test.pattern, got, test.want)
+			}
+		})
+	}
+
+	deepPattern := strings.Repeat("(?:", 128) + `(?<a>x)|(?<a>y)` + strings.Repeat(")", 128)
+	if !IsValidRegexPattern(deepPattern, RegexFlags{}) {
+		t.Fatal("deep mutually exclusive duplicate pattern should be valid")
+	}
+
+	var nestedAlternatives strings.Builder
+	for range 127 {
+		nestedAlternatives.WriteString(`(?<a>x)|(?:`)
+	}
+	nestedAlternatives.WriteString(`(?<a>x)`)
+	nestedAlternatives.WriteString(strings.Repeat(")", 127))
+	if !IsValidRegexPattern(nestedAlternatives.String(), RegexFlags{}) {
+		t.Fatal("nested chain of mutually exclusive duplicate patterns should be valid")
 	}
 }
 

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -83,6 +83,11 @@ func (value staticNumberValue) IsNaN() bool {
 // nested aggregate evaluation doesn't allocate an interface box per literal.
 type staticStringNode ast.Node
 
+// staticRegExpNode keeps a regular-expression literal backed by its AST node.
+// It is private because callers only observe its static properties or String
+// conversion, never a host-language regexp object.
+type staticRegExpNode ast.Node
+
 // staticObjectValue and staticArrayValue hold folded object and array literals
 // so member access and JavaScript's default string coercion can be modeled.
 type staticObjectValue struct {
@@ -248,6 +253,8 @@ func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEv
 	switch node.Kind {
 	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
 		return staticEvalResult{value: (*staticStringNode)(node), ok: true}
+	case ast.KindRegularExpressionLiteral:
+		return staticEvalResult{value: (*staticRegExpNode)(node), ok: true}
 	case ast.KindTrueKeyword:
 		return staticEvalResult{value: true, ok: true}
 	case ast.KindFalseKeyword:
@@ -337,7 +344,9 @@ func (staticEvaluator *StaticStringEvaluator) evalIdentifier(node *ast.Node) sta
 
 func isAggregateLiteral(node *ast.Node) bool {
 	node = SkipAssertionsAndParens(node)
-	return node != nil && (node.Kind == ast.KindObjectLiteralExpression || node.Kind == ast.KindArrayLiteralExpression)
+	return node != nil && (node.Kind == ast.KindObjectLiteralExpression ||
+		node.Kind == ast.KindArrayLiteralExpression ||
+		node.Kind == ast.KindRegularExpressionLiteral)
 }
 
 // ResolveIdentifierInitializer resolves an identifier to a stable variable
@@ -615,7 +624,7 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteral(node *ast.Node) 
 				return staticEvalResult{}
 			}
 			switch propertyValue.value.(type) {
-			case *staticObjectValue, *staticArrayValue:
+			case *staticRegExpNode, *staticObjectValue, *staticArrayValue:
 				value.prototype = propertyValue.value
 				value.prototypeSet = true
 			case staticNullValue:
@@ -679,9 +688,6 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteralMember(node *ast.
 			prototypeNode := SkipAssertionsAndParens(valueNode)
 			if prototypeNode != nil && prototypeNode.Kind == ast.KindObjectLiteralExpression {
 				prototypeValue = staticEvaluator.evalObjectLiteralMember(prototypeNode, key)
-				if !prototypeValue.ok {
-					return staticEvalResult{}
-				}
 				prototypeSet = true
 				continue
 			}
@@ -691,11 +697,8 @@ func (staticEvaluator *StaticStringEvaluator) evalObjectLiteralMember(node *ast.
 				return staticEvalResult{}
 			}
 			switch value.value.(type) {
-			case *staticObjectValue, *staticArrayValue:
-				prototypeValue = staticMemberValue(value.value, key)
-				if !prototypeValue.ok {
-					return staticEvalResult{}
-				}
+			case *staticRegExpNode, *staticObjectValue, *staticArrayValue:
+				prototypeValue = staticPrototypeMemberValue(value.value, key)
 				prototypeSet = true
 			case staticNullValue:
 				prototypeValue = staticEvalResult{value: staticUndefinedValue{}, ok: true}
@@ -861,12 +864,14 @@ func staticMemberValue(object any, key string) staticEvalResult {
 			return staticEvalResult{}
 		}
 		return staticStringMemberValue(str, key)
+	case *staticRegExpNode:
+		return staticRegExpMemberValue((*ast.Node)(object), key)
 	case *staticObjectValue:
 		if value, ok := staticObjectOwnProperty(object, key); ok {
 			return staticEvalResult{value: value, ok: true}
 		}
 		if object.prototypeSet && object.prototype != nil {
-			return staticMemberValue(object.prototype, key)
+			return staticPrototypeMemberValue(object.prototype, key)
 		}
 		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
 	case *staticArrayValue:
@@ -883,6 +888,54 @@ func staticMemberValue(object any, key string) staticEvalResult {
 		return staticEvalResult{value: object.element(index), ok: true}
 	}
 	return staticEvalResult{}
+}
+
+// staticPrototypeMemberValue reads a property through an authored __proto__
+// setter. RegExp's lastIndex is an own data property and is safe to inherit,
+// but its standard getters live on RegExp.prototype and brand-check the
+// original receiver. Calling one with the outer object would throw, so those
+// reads remain unknown instead of reusing direct-literal getter evaluation.
+func staticPrototypeMemberValue(prototype any, key string) staticEvalResult {
+	if _, ok := prototype.(*staticRegExpNode); ok {
+		if key == "lastIndex" {
+			return staticEvalResult{value: staticNumberValue(0), ok: true}
+		}
+		return staticEvalResult{}
+	}
+	return staticMemberValue(prototype, key)
+}
+
+// staticRegExpMemberValue models the stable own property and getter subset
+// eslint-utils exposes for a newly-created RegExp literal. `unicodeSets` is
+// deliberately absent because eslint-utils 4.10.1 does not whitelist that
+// getter yet.
+func staticRegExpMemberValue(node *ast.Node, key string) staticEvalResult {
+	pattern, flags := ExtractRegexPatternAndFlags(node.Text())
+	switch key {
+	case "source":
+		return staticEvalResult{value: pattern, ok: true}
+	case "flags":
+		_, canonicalFlags := ExtractRegexPatternAndFlags(RegExpLiteralStringValue(node.Text()))
+		return staticEvalResult{value: canonicalFlags, ok: true}
+	case "dotAll":
+		return staticEvalResult{value: strings.Contains(flags, "s"), ok: true}
+	case "global":
+		return staticEvalResult{value: strings.Contains(flags, "g"), ok: true}
+	case "hasIndices":
+		return staticEvalResult{value: strings.Contains(flags, "d"), ok: true}
+	case "ignoreCase":
+		return staticEvalResult{value: strings.Contains(flags, "i"), ok: true}
+	case "multiline":
+		return staticEvalResult{value: strings.Contains(flags, "m"), ok: true}
+	case "sticky":
+		return staticEvalResult{value: strings.Contains(flags, "y"), ok: true}
+	case "unicode":
+		return staticEvalResult{value: strings.Contains(flags, "u"), ok: true}
+	case "lastIndex":
+		return staticEvalResult{value: staticNumberValue(0), ok: true}
+	default:
+		return staticEvalResult{}
+	}
 }
 
 // staticStringMemberValue indexes a string by a canonical array-index key, the
@@ -1695,7 +1748,7 @@ func isMutatingArrayMethod(name string) bool {
 
 func staticValueIsTsgoSafe(value any) bool {
 	switch value.(type) {
-	case bool, staticNullValue, staticUndefinedValue, staticNumberValue, *staticStringNode, *staticObjectValue, *staticArrayValue:
+	case bool, staticNullValue, staticUndefinedValue, staticNumberValue, *staticStringNode, *staticRegExpNode, *staticObjectValue, *staticArrayValue:
 		return false
 	default:
 		return value != nil
@@ -1808,7 +1861,7 @@ func staticValuesStrictEqual(left any, right any) (equal bool, ok bool) {
 
 func staticValueIsAggregate(value any) bool {
 	switch value.(type) {
-	case *staticObjectValue, *staticArrayValue:
+	case *staticRegExpNode, *staticObjectValue, *staticArrayValue:
 		return true
 	default:
 		return false
@@ -1828,7 +1881,7 @@ func staticValueTruthy(value any) (truthy bool, ok bool) {
 		return value, true
 	case staticNullValue, staticUndefinedValue:
 		return false, true
-	case *staticObjectValue, *staticArrayValue:
+	case *staticRegExpNode, *staticObjectValue, *staticArrayValue:
 		return true, true
 	default:
 		return evaluatorBool(func() bool { return evaluator.IsTruthy(value) })
@@ -1843,6 +1896,8 @@ func staticValueToString(value any) (string, bool) {
 		return ecmascript.NumberToString(float64(value)), true
 	case *staticStringNode:
 		return staticValueAsString(value)
+	case *staticRegExpNode:
+		return RegExpLiteralStringValue((*ast.Node)(value).Text()), true
 	case bool:
 		if value {
 			return "true", true

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -141,6 +141,24 @@ func TestStaticStringEvaluator(t *testing.T) {
 		"const ownProtoMessage = ({__proto__: {message: \"message\"}, message: \"\"}).message;\n" +
 		"const computedProtoMessage = ({[\"__proto__\"]: {message: \"message\"}}).message;\n" +
 		"const nullProtoString = String(({__proto__: null}));\n" +
+		"const regexSource = /g/u.source;\n" +
+		"const regexComputedSource = /gi/u[\"source\"];\n" +
+		"const regexFlags = /x/mi.flags;\n" +
+		"const regexGlobal = String(/x/g.global);\n" +
+		"const regexHasIndices = String(/x/d.hasIndices);\n" +
+		"const regexUnicode = String(/x/u.unicode);\n" +
+		"const regexLastIndex = String(/x/g.lastIndex);\n" +
+		"const regexString = String(/x/mi);\n" +
+		"const regexAlias = /alias/u;\n" +
+		"const regexAliasSource = regexAlias.source;\n" +
+		"const mutatedRegex = /before/u;\n" +
+		"mutatedRegex.lastIndex = 1;\n" +
+		"const mutatedRegexSource = mutatedRegex.source;\n" +
+		"const regexUnicodeSets = /x/v.unicodeSets;\n" +
+		"const regexProtoSource = ({__proto__: /u/u}).source;\n" +
+		"const regexProtoLastIndex = String(({__proto__: /g/u}).lastIndex);\n" +
+		"const regexProtoOwnSource = ({__proto__: /u/u, source: \"own\"}).source;\n" +
+		"const regexProtoString = String({__proto__: /u/u});\n" +
 		"const emptyJoin = [].join();\n" +
 		"const joined = [\"error\", \"message\"].join(\": \");\n" +
 		"const nestedEmptyJoin = [[]].join();\n" +
@@ -265,6 +283,21 @@ func TestStaticStringEvaluator(t *testing.T) {
 		{name: "ownProtoMessage", want: "", ok: true},
 		{name: "computedProtoMessage"},
 		{name: "nullProtoString"},
+		{name: "regexSource", want: "g", ok: true},
+		{name: "regexComputedSource", want: "gi", ok: true},
+		{name: "regexFlags", want: "im", ok: true},
+		{name: "regexGlobal", want: "true", ok: true},
+		{name: "regexHasIndices", want: "true", ok: true},
+		{name: "regexUnicode", want: "true", ok: true},
+		{name: "regexLastIndex", want: "0", ok: true},
+		{name: "regexString", want: "/x/im", ok: true},
+		{name: "regexAliasSource", want: "alias", ok: true},
+		{name: "mutatedRegexSource"},
+		{name: "regexUnicodeSets"},
+		{name: "regexProtoSource"},
+		{name: "regexProtoLastIndex", want: "0", ok: true},
+		{name: "regexProtoOwnSource", want: "own", ok: true},
+		{name: "regexProtoString"},
 		{name: "emptyJoin", want: "", ok: true},
 		{name: "joined", want: "error: message", ok: true},
 		{name: "nestedEmptyJoin", want: "", ok: true},
@@ -360,6 +393,9 @@ const astralUpper = ('\uD801' + '\uDC28').toUpperCase();
 const astralLower = ('\uD801' + '\uDC00').toLowerCase();
 const strictPair = ('\uD83D' + '\uDE00') === '😀' ? 'yes' : 'no';
 const objectPair = ({['\uD83D' + '\uDE00']: 'yes'})['😀'];
+const indexedHigh = '😀'[0];
+const indexedLow = '😀'[1];
+const indexedLone = '\uD800'[0];
 `
 	fs := NewOverlayVFS(rootDir.FS, map[string]string{filePath: code})
 	program, err := CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", CreateCompilerHost(rootDir.Dir, fs))
@@ -403,6 +439,9 @@ const objectPair = ({['\uD83D' + '\uDE00']: 'yes'})['😀'];
 		{name: "astralLower", want: "𐐨"},
 		{name: "strictPair", want: "yes"},
 		{name: "objectPair", want: "yes"},
+		{name: "indexedHigh", want: high},
+		{name: "indexedLow", want: low},
+		{name: "indexedLone", want: ecmascript.StringFromCodeUnits([]uint16{0xD800})},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -225,6 +225,7 @@ fsys
 fullwidth
 funcs
 funcw
+Gara
 Garay
 gcflags
 GDSFP
@@ -294,6 +295,7 @@ jsxtransforms
 jsxtx
 justforcheck
 kase
+keycap
 keygen
 keyshortcuts
 keytar


### PR DESCRIPTION
## Summary

- Align `RegExp` constructor/reference tracking and static property evaluation with ESLint while preserving JavaScript UTF-16 code-unit semantics.
- Accept ES2025 duplicate named captures only when every same-name declaration is separated by mutually exclusive alternatives, including escaped names, nested alternatives, and backreferences.
- Model `v`-mode `MayContainStrings` through unions, intersections, subtraction, nested classes, `\q{...}`, and Unicode string properties so safe flag suggestions are restored without emitting suggestions JavaScript rejects.
- Document the remaining user-visible differences caused by conservative static evaluation, bundled Unicode data, and an unsafe upstream range-first suggestion.
- Reduce the fixed 10,500-file `require-unicode-regexp` listener timing from 708.5 ms to 601.3 ms (15.1%); the temporary benchmark source is not included.

## Related Links

N/A

## Testing

- `go test ./internal/utils/ecmascript ./internal/utils ./internal/rules/require_unicode_regexp ./internal/rules/no_regex_spaces -count=3`
- `pnpm exec rstest run tests/eslint/rules/require-unicode-regexp.test.ts tests/eslint/rules/no-regex-spaces.test.ts`
- `pnpm run build:bin`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/rules/no_regex_spaces ./internal/rules/require_unicode_regexp ./internal/utils ./internal/utils/ecmascript`
- Differential validation: 9,250 deterministic patterns plus randomized nested duplicate-capture cases, with no unexpected mismatch against regexpp.
- Three independent adversarial reviews: 3 approvals, 0 rejections.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
