### PR TITLE
feat: port rule unicorn/no-object-as-default-parameter

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_magic_array_flat_depth"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_nested_ternary"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_object_as_default_parameter"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_this_assignment"
@@ -48,6 +49,7 @@ func GetAllRules() []rule.Rule {
 		no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
 		no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
 		no_nested_ternary.NoNestedTernaryRule,
+		no_object_as_default_parameter.NoObjectAsDefaultParameterRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,
 		no_this_assignment.NoThisAssignmentRule,

--- a/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter.go
+++ b/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter.go
@@ -1,0 +1,81 @@
+package no_object_as_default_parameter
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDIdentifier    = "identifier"
+	messageIDNonIdentifier = "non-identifier"
+)
+
+func identifierMessage(parameter string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDIdentifier,
+		Description: "Do not use an object literal as default for parameter `" + parameter + "`.",
+		Data:        map[string]string{"parameter": parameter},
+	}
+}
+
+var nonIdentifierMessage = rule.RuleMessage{
+	Id:          messageIDNonIdentifier,
+	Description: "Do not use an object literal as default.",
+}
+
+// NoObjectAsDefaultParameterRule disallows non-empty object literals as
+// function-parameter defaults.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-object-as-default-parameter.js
+var NoObjectAsDefaultParameterRule = rule.Rule{
+	Name:   "unicorn/no-object-as-default-parameter",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindParameter: func(node *ast.Node) {
+				parameter := node.AsParameterDeclaration()
+				if parameter == nil || parameter.Initializer == nil || node.Parent == nil ||
+					!utils.IsFunctionLikeContainer(node.Parent) || node.Parent.Body() == nil {
+					return
+				}
+
+				// typescript-eslint wraps constructor parameter properties in a
+				// TSParameterProperty, so their AssignmentPattern is not a direct
+				// child of the FunctionExpression that upstream checks.
+				if ast.IsParameterPropertyDeclaration(node, node.Parent) {
+					return
+				}
+
+				// ESTree drops parentheses around the AssignmentPattern right-hand
+				// side. TypeScript-only wrappers remain visible upstream and must not
+				// be treated as a direct ObjectExpression.
+				initializer := ast.SkipParentheses(parameter.Initializer)
+				if initializer == nil || initializer.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+
+				object := initializer.AsObjectLiteralExpression()
+				if object == nil || object.Properties == nil || len(object.Properties.Nodes) == 0 {
+					return
+				}
+
+				name := parameter.Name()
+				if name == nil {
+					return
+				}
+
+				if name.Kind == ast.KindIdentifier {
+					parameterName := name.AsIdentifier().Text
+					ctx.ReportRange(
+						utils.GetESTreeBindingIdentifierRange(ctx.SourceFile, name),
+						identifierMessage(parameterName),
+					)
+					return
+				}
+
+				ctx.ReportNode(initializer, nonIdentifierMessage)
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter.md
+++ b/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter.md
@@ -1,0 +1,43 @@
+# no-object-as-default-parameter
+
+## Rule Details
+
+Disallow non-empty object literals as function-parameter defaults. Passing a
+partial object replaces the entire default object, so individual defaulted
+properties should usually be expressed with parameter destructuring instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function read(options = { cache: true, encoding: "utf8" }) {}
+
+function connect({ secure } = { secure: true }) {}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function read({ cache = true, encoding = "utf8" } = {}) {}
+
+function read(options = {}) {}
+
+const defaults = { cache: true };
+function read(options = defaults) {}
+```
+
+The rule is syntax-based. A TypeScript annotation does not exempt a non-empty
+object literal default:
+
+```typescript
+function range(
+  options: { minimum: number; maximum: number } = {
+    minimum: 0,
+    maximum: 10,
+  },
+) {}
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-object-as-default-parameter](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-object-as-default-parameter.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-object-as-default-parameter.js)

--- a/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter_extras_test.go
@@ -1,0 +1,119 @@
+// TestNoObjectAsDefaultParameterExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+package no_object_as_default_parameter_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_object_as_default_parameter "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_object_as_default_parameter"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoObjectAsDefaultParameterExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_object_as_default_parameter.NoObjectAsDefaultParameterRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TypeScript wrappers remain visible in TSESTree ----
+			{Code: `function f(options = ({cache: true} as const)) {}`, FileName: "file.ts", Tsx: false},
+			{Code: `function f(options = ({cache: true} satisfies object)) {}`, FileName: "file.ts", Tsx: false},
+			{Code: `function f(options = ({cache: true}!)) {}`, FileName: "file.ts", Tsx: false},
+			{Code: `function f(options = source?.defaults) {}`, FileName: "file.ts", Tsx: false},
+
+			// ---- Dimension 4: TSParameterProperty is not a direct function parameter upstream ----
+			{Code: `class C { constructor(public options: object = {cache: true}) {} }`, FileName: "file.ts", Tsx: false},
+
+			// ---- Dimension 4: nested binding defaults are not top-level parameters ----
+			{Code: `function f({deep: {options = {cache: true}}}) {}`, FileName: "file.js"},
+
+			// ---- Dimension 4: graceful degradation for empty and body-less forms ----
+			{Code: `function f(options = {}) {}`, FileName: "file.js"},
+			{Code: `function f() {}`, FileName: "file.js"},
+			{Code: `abstract class C { abstract method(options?: object): void }`, FileName: "file.ts", Tsx: false},
+			{Code: `declare function f(options?: object): void;`, FileName: "file.ts", Tsx: false},
+
+			// Locks in upstream gate arm 1: a missing or non-object right-hand side is ignored.
+			{Code: `function f(options) {}`, FileName: "file.js"},
+			{Code: `function f(options = defaults) {}`, FileName: "file.js"},
+
+			// Locks in upstream gate arm 2: an empty ObjectExpression is ignored.
+			{Code: `const f = (options = {}) => {};`, FileName: "file.js"},
+
+			// Locks in upstream gate arms 3 and 4: AssignmentPatterns outside the
+			// direct function parameter list are ignored.
+			{Code: `const {options = {cache: true}} = source;`, FileName: "file.js"},
+			{Code: `const f = ({options = {cache: true}}) => {};`, FileName: "file.js"},
+			{Code: `const f = () => (options = {cache: true});`, FileName: "file.js"},
+
+			// ---- Real-user: #208 — a named defaults object is intentionally outside this syntax-only rule ----
+			{Code: `const defaults = {cache: true}; const f = (options = defaults) => {};`, FileName: "file.js"},
+
+			// N/A: element-access, dotted-member, and private-key receiver shapes do
+			// not apply; the rule only asks whether an object literal has any member.
+			// N/A: overload/abstract/declare signatures cannot legally contain a
+			// parameter initializer, so their legal body-less forms are covered above.
+			// N/A: the rule has no autofix or suggestion, so edit boundaries and
+			// edit-demand invariance do not apply.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: single- and multi-level parentheses are transparent ----
+			{Code: `function f(options = ((({cache: true})))) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 19)}},
+			{Code: `function f({cache} = ((({cache: true})))) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(1, 25, 1, 38)}},
+
+			// ---- Dimension 4: every legal object-member key/member form makes the object non-empty ----
+			{Code: `function f(options = {"cache": true}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 19)}},
+			{Code: `function f(options = {0: true}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 19)}},
+			{Code: `function f(options = {[key]: true}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 19)}},
+			{Code: `function f(options = {...defaults}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 19)}},
+			{Code: `function f(options = {cache() {}}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 19)}},
+			{Code: `function f(options = {cache}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 19)}},
+
+			// ---- Dimension 4: declaration/container forms and TSESTree identifier ranges ----
+			{Code: `function f(options: object = {cache: true}) {}`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 27)}},
+			{Code: `const f = function(options: object = {cache: true}) {};`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 20, 1, 35)}},
+			{Code: `const f = (options: object = {cache: true}) => {};`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 12, 1, 27)}},
+			{Code: `const object = {method(options: object = {cache: true}) {}};`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 24, 1, 39)}},
+			{Code: `class C { method(options: object = {cache: true}) {} }`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 18, 1, 33)}},
+			{Code: `class C { field = (options: object = {cache: true}) => {}; }`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 20, 1, 35)}},
+
+			// ---- Dimension 4: async, generator, and async-generator containers ----
+			{Code: `const f = async (options = {cache: true}) => {};`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 18, 1, 25)}},
+			{Code: `function* f(options = {cache: true}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 13, 1, 20)}},
+			{Code: `class C { static async * method(options = {cache: true}) {} }`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 33, 1, 40)}},
+
+			// ---- Dimension 4: same-kind nesting reports each direct parameter independently ----
+			{
+				Code:     `function outer(a = {x: 1}) { return function inner(b = {y: 2}) {} }`,
+				FileName: "file.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					identifierError("a", 1, 16, 1, 17),
+					identifierError("b", 1, 52, 1, 53),
+				},
+			},
+
+			// ---- Dimension 4: binding-pattern rest/empty shapes report the object default ----
+			{Code: `function f({...rest} = {...defaults}) {}`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(1, 24, 1, 37)}},
+			{Code: `function f({} = {cache: true}) {}`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(1, 17, 1, 30)}},
+
+			// Locks in upstream identifier-left branch, including the TSESTree range
+			// that folds the direct TypeScript annotation into the Identifier.
+			{Code: `function f(value: {cache: boolean} = {cache: true}) {}`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("value", 1, 12, 1, 35)}},
+			{Code: `function f(/** @type {object} */ options = {cache: true}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("options", 1, 34, 1, 41)}},
+
+			// Locks in upstream non-Identifier-left branch.
+			{Code: `function f([value] = {cache: true}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(1, 22, 1, 35)}},
+
+			// ---- Real-user: #2199 — required TypeScript properties do not exempt the literal default ----
+			{Code: `function f(range: {min: number, max: number} = {min: 0, max: 10}) {}`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{identifierError("range", 1, 12, 1, 45)}},
+
+			// ---- Real-user: #1433 — direct destructured parameters are also forbidden ----
+			{Code: `function f({cache}: {cache?: boolean} = {cache: false}) {}`, FileName: "file.ts", Tsx: false, Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(1, 41, 1, 55)}},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_object_as_default_parameter/no_object_as_default_parameter_upstream_test.go
@@ -1,0 +1,111 @@
+// TestNoObjectAsDefaultParameterUpstream migrates the full valid/invalid suite
+// from upstream test/no-object-as-default-parameter.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in no_object_as_default_parameter_extras_test.go.
+package no_object_as_default_parameter_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_object_as_default_parameter "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_object_as_default_parameter"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	identifierMessageID    = "identifier"
+	nonIdentifierMessageID = "non-identifier"
+	nonIdentifierMessage   = "Do not use an object literal as default."
+)
+
+func identifierError(parameter string, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: identifierMessageID,
+		Message:   "Do not use an object literal as default for parameter `" + parameter + "`.",
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func nonIdentifierError(line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: nonIdentifierMessageID,
+		Message:   nonIdentifierMessage,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestNoObjectAsDefaultParameterUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_object_as_default_parameter.NoObjectAsDefaultParameterRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `const abc = {};`, FileName: "file.js"},
+			{Code: `const abc = {foo: 123};`, FileName: "file.js"},
+			{Code: `function abc(foo) {}`, FileName: "file.js"},
+			{Code: `function abc(foo = null) {}`, FileName: "file.js"},
+			{Code: `function abc(foo = undefined) {}`, FileName: "file.js"},
+			{Code: `function abc(foo = 123) {}`, FileName: "file.js"},
+			{Code: `function abc(foo = true) {}`, FileName: "file.js"},
+			{Code: `function abc(foo = "bar") {}`, FileName: "file.js"},
+			{Code: `function abc(foo = 123, bar = "foo") {}`, FileName: "file.js"},
+			{Code: `function abc(foo = {}) {}`, FileName: "file.js"},
+			{Code: `function abc({foo = 123} = {}) {}`, FileName: "file.js"},
+			{Code: `(function abc() {})(foo = {a: 123})`, FileName: "file.js"},
+			{Code: `const abc = foo => {};`, FileName: "file.js"},
+			{Code: `const abc = (foo = null) => {};`, FileName: "file.js"},
+			{Code: `const abc = (foo = undefined) => {};`, FileName: "file.js"},
+			{Code: `const abc = (foo = 123) => {};`, FileName: "file.js"},
+			{Code: `const abc = (foo = true) => {};`, FileName: "file.js"},
+			{Code: `const abc = (foo = "bar") => {};`, FileName: "file.js"},
+			{Code: `const abc = (foo = 123, bar = "foo") => {};`, FileName: "file.js"},
+			{Code: `const abc = (foo = {}) => {};`, FileName: "file.js"},
+			{Code: `const abc = ({a = true, b = "foo"}) => {};`, FileName: "file.js"},
+			{Code: `const abc = function(foo = 123) {}`, FileName: "file.js"},
+			{Code: `const {abc = {foo: 123}} = bar;`, FileName: "file.js"},
+			{Code: `const {abc = {null: "baz"}} = bar;`, FileName: "file.js"},
+			{Code: `const {abc = {foo: undefined}} = undefined;`, FileName: "file.js"},
+			{Code: `const abc = ([{foo = false, bar = 123}]) => {};`, FileName: "file.js"},
+			{Code: `const abc = ({foo = {a: 123}}) => {};`, FileName: "file.js"},
+			{Code: `const abc = ([foo = {a: 123}]) => {};`, FileName: "file.js"},
+			{Code: `const abc = ({foo: bar = {a: 123}}) => {};`, FileName: "file.js"},
+			{Code: `const abc = () => (foo = {a: 123});`, FileName: "file.js"},
+			{Code: "class A {\n\t[foo = {a: 123}]() {}\n}", FileName: "file.js"},
+			{Code: "class A extends (foo = {a: 123}) {\n\ta() {}\n}", FileName: "file.js"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: `function abc(foo = {a: 123}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `async function * abc(foo = {a: 123}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 22, 1, 25)}},
+			{Code: `function abc(foo = {a: false}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `function abc(foo = {a: "bar"}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `function abc(foo = {a: "bar", b: {c: true}}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `const abc = (foo = {a: false}) => {};`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `const abc = (foo = {a: 123, b: false}) => {};`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `const abc = (foo = {a: false, b: 1, c: "test", d: null}) => {};`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `const abc = function(foo = {a: 123}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 22, 1, 25)}},
+			{Code: "class A {\n\tabc(foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 6, 2, 9)}},
+			{Code: "class A {\n\tconstructor(foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 14, 2, 17)}},
+			{Code: "class A {\n\tset abc(foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 10, 2, 13)}},
+			{Code: "class A {\n\tstatic abc(foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 13, 2, 16)}},
+			{Code: "class A {\n\t* abc(foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 8, 2, 11)}},
+			{Code: "class A {\n\tstatic async * abc(foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 21, 2, 24)}},
+			{Code: "class A {\n\t[foo = {a: 123}](foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 19, 2, 22)}},
+			{Code: "const A = class {\n\tabc(foo = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 6, 2, 9)}},
+			{Code: "object = {\n\tabc(foo = {a: 123}) {}\n};", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 2, 6, 2, 9)}},
+			{Code: "const A = class {\n\tabc({a} = {a: 123}) {}\n}", FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(2, 12, 2, 20)}},
+
+			// ---- Upstream snapshot cases ----
+			{Code: `/**/function abc(foo = {a: 123}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 18, 1, 21)}},
+			{Code: `const abc = (foo = {a: false}) => {};`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{identifierError("foo", 1, 14, 1, 17)}},
+			{Code: `function abc({a} = {a: 123}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(1, 20, 1, 28)}},
+			{Code: `function abc([a] = {a: 123}) {}`, FileName: "file.js", Errors: []rule_tester.InvalidTestCaseError{nonIdentifierError(1, 20, 1, 28)}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -661,6 +661,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-magic-array-flat-depth.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-nested-ternary.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-object-as-default-parameter.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-this-assignment.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-object-as-default-parameter.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-object-as-default-parameter.test.ts
@@ -1,0 +1,92 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const js = (code: string) => ({ code, filename: 'file.js' });
+const invalidIdentifier = (code: string, parameter = 'foo') => ({
+  code,
+  filename: 'file.js',
+  errors: [
+    {
+      messageId: 'identifier',
+      message: `Do not use an object literal as default for parameter \`${parameter}\`.`,
+      data: { parameter },
+    },
+  ],
+});
+const invalidNonIdentifier = (code: string) => ({
+  code,
+  filename: 'file.js',
+  errors: [
+    {
+      messageId: 'non-identifier',
+      message: 'Do not use an object literal as default.',
+    },
+  ],
+});
+
+ruleTester.run('no-object-as-default-parameter', null as never, {
+  valid: [
+    js('const abc = {};'),
+    js('const abc = {foo: 123};'),
+    js('function abc(foo) {}'),
+    js('function abc(foo = null) {}'),
+    js('function abc(foo = undefined) {}'),
+    js('function abc(foo = 123) {}'),
+    js('function abc(foo = true) {}'),
+    js('function abc(foo = "bar") {}'),
+    js('function abc(foo = 123, bar = "foo") {}'),
+    js('function abc(foo = {}) {}'),
+    js('function abc({foo = 123} = {}) {}'),
+    js('(function abc() {})(foo = {a: 123})'),
+    js('const abc = foo => {};'),
+    js('const abc = (foo = null) => {};'),
+    js('const abc = (foo = undefined) => {};'),
+    js('const abc = (foo = 123) => {};'),
+    js('const abc = (foo = true) => {};'),
+    js('const abc = (foo = "bar") => {};'),
+    js('const abc = (foo = 123, bar = "foo") => {};'),
+    js('const abc = (foo = {}) => {};'),
+    js('const abc = ({a = true, b = "foo"}) => {};'),
+    js('const abc = function(foo = 123) {}'),
+    js('const {abc = {foo: 123}} = bar;'),
+    js('const {abc = {null: "baz"}} = bar;'),
+    js('const {abc = {foo: undefined}} = undefined;'),
+    js('const abc = ([{foo = false, bar = 123}]) => {};'),
+    js('const abc = ({foo = {a: 123}}) => {};'),
+    js('const abc = ([foo = {a: 123}]) => {};'),
+    js('const abc = ({foo: bar = {a: 123}}) => {};'),
+    js('const abc = () => (foo = {a: 123});'),
+    js('class A {\n\t[foo = {a: 123}]() {}\n}'),
+    js('class A extends (foo = {a: 123}) {\n\ta() {}\n}'),
+  ],
+  invalid: [
+    invalidIdentifier('function abc(foo = {a: 123}) {}'),
+    invalidIdentifier('async function * abc(foo = {a: 123}) {}'),
+    invalidIdentifier('function abc(foo = {a: false}) {}'),
+    invalidIdentifier('function abc(foo = {a: "bar"}) {}'),
+    invalidIdentifier('function abc(foo = {a: "bar", b: {c: true}}) {}'),
+    invalidIdentifier('const abc = (foo = {a: false}) => {};'),
+    invalidIdentifier('const abc = (foo = {a: 123, b: false}) => {};'),
+    invalidIdentifier(
+      'const abc = (foo = {a: false, b: 1, c: "test", d: null}) => {};',
+    ),
+    invalidIdentifier('const abc = function(foo = {a: 123}) {}'),
+    invalidIdentifier('class A {\n\tabc(foo = {a: 123}) {}\n}'),
+    invalidIdentifier('class A {\n\tconstructor(foo = {a: 123}) {}\n}'),
+    invalidIdentifier('class A {\n\tset abc(foo = {a: 123}) {}\n}'),
+    invalidIdentifier('class A {\n\tstatic abc(foo = {a: 123}) {}\n}'),
+    invalidIdentifier('class A {\n\t* abc(foo = {a: 123}) {}\n}'),
+    invalidIdentifier('class A {\n\tstatic async * abc(foo = {a: 123}) {}\n}'),
+    invalidIdentifier('class A {\n\t[foo = {a: 123}](foo = {a: 123}) {}\n}'),
+    invalidIdentifier('const A = class {\n\tabc(foo = {a: 123}) {}\n}'),
+    invalidIdentifier('object = {\n\tabc(foo = {a: 123}) {}\n};'),
+    invalidNonIdentifier('const A = class {\n\tabc({a} = {a: 123}) {}\n}'),
+
+    // Upstream snapshot cases.
+    invalidIdentifier('/**/function abc(foo = {a: 123}) {}'),
+    invalidIdentifier('const abc = (foo = {a: false}) => {};'),
+    invalidNonIdentifier('function abc({a} = {a: 123}) {}'),
+    invalidNonIdentifier('function abc([a] = {a: 123}) {}'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -132,7 +132,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-non-function-verb-prefix': 'error', // not implemented
     // 'unicorn/no-nonstandard-builtin-properties': 'error', // not implemented
     // 'unicorn/no-null': 'error', // not implemented
-    // 'unicorn/no-object-as-default-parameter': 'error', // not implemented
+    'unicorn/no-object-as-default-parameter': 'error',
     // 'unicorn/no-object-methods-with-collections': 'error', // not implemented
     // 'unicorn/no-optional-chaining-on-undeclared-variable': 'error', // not implemented
     // 'unicorn/no-process-exit': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/no-object-as-default-parameter` from
`eslint-plugin-unicorn@v74.0.0` to rslint.

The rule reports non-empty object literals used as direct function parameter
defaults:

```js
function read(options = { cache: true }) {}
```

Empty object defaults and object literals outside the direct parameter position
remain allowed:

```js
function read(options = {}) {}

const defaults = { cache: true };
function read(options = defaults) {}
```

## Implementation

- Supports function declarations, function expressions, arrow functions,
  object methods, class methods, constructors, generators, and class-field
  arrows.
- Reports identifier and destructured parameters with their respective upstream
  message IDs and ranges.
- Preserves TSESTree parameter ranges for TypeScript type annotations.
- Keeps TypeScript expression wrappers such as `as`, `satisfies`, and non-null
  assertions distinct from direct object literals.
- Excludes TypeScript constructor parameter properties, matching upstream
  `TSParameterProperty` behavior.
- Registers the rule in the Unicorn catalog and enables it in the Unicorn
  recommended preset.

## Tests

- Migrated all 55 upstream valid and invalid cases.
- Added coverage for tsgo/ESTree AST differences, TypeScript syntax, container
  variants, nesting, object member forms, and diagnostic ranges.
- Added regression coverage based on upstream discussions:
  - sindresorhus/eslint-plugin-unicorn#208
  - sindresorhus/eslint-plugin-unicorn#1433
  - sindresorhus/eslint-plugin-unicorn#2199
- Added the JS end-to-end RuleTester suite.

Verification completed:

- `go test -count=1 ./internal/plugins/unicorn/rules/no_object_as_default_parameter`
- `go test -count=1 ./internal/plugins/unicorn`
- `pnpm build`
- `pnpm exec rstest run --testTimeout=10000 no-object-as-default-parameter`
- `pnpm exec rstest run --testTimeout=10000 presets`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint`: 0 issues

## Related Links

- [Documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-object-as-default-parameter.md)
- [Source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-object-as-default-parameter.js)
- [Upstream tests](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/no-object-as-default-parameter.js)

Tracks #1309.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Rule registered in the Unicorn catalog.
- [x] Unicorn recommended preset updated.
