### PR TITLE
feat(rstest): add consistent-each-for rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -1,6 +1,7 @@
 package rstest
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/consistent_each_for"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/consistent_rstest_namespace"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/expect_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/hoisted_apis_on_top"
@@ -39,6 +40,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		consistent_each_for.ConsistentEachForRule,
 		consistent_rstest_namespace.ConsistentRstestNamespaceRule,
 		expect_expect.ExpectExpectRule,
 		hoisted_apis_on_top.HoistedApisOnTopRule,

--- a/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for.go
+++ b/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for.go
@@ -1,0 +1,144 @@
+package consistent_each_for
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+//go:embed consistent_each_for.schema.json
+var schemaJSON []byte
+
+// The option keys, which are also the registration names the messages use.
+const (
+	registrationDescribe = "describe"
+	registrationIt       = "it"
+	registrationTest     = "test"
+)
+
+// preferences maps a registration name to the parameterized form required for
+// it. A name absent from the map is unconfigured, and the rule leaves every
+// registration made through it alone — which is why an empty options object,
+// the default, turns the whole rule into a no-op.
+type preferences map[string]rstestUtils.RstestParameterizedKind
+
+func parseOptions(rawOptions []any) preferences {
+	if len(rawOptions) == 0 {
+		return nil
+	}
+	optionsMap, ok := rawOptions[0].(map[string]any)
+	if !ok || len(optionsMap) == 0 {
+		return nil
+	}
+	parsed := make(preferences, len(optionsMap))
+	for _, name := range []string{registrationDescribe, registrationIt, registrationTest} {
+		value, ok := optionsMap[name].(string)
+		if !ok {
+			continue
+		}
+		switch rstestUtils.RstestParameterizedKind(value) {
+		case rstestUtils.RstestParameterizedEach:
+			parsed[name] = rstestUtils.RstestParameterizedEach
+		case rstestUtils.RstestParameterizedFor:
+			parsed[name] = rstestUtils.RstestParameterizedFor
+		}
+	}
+	if len(parsed) == 0 {
+		return nil
+	}
+	return parsed
+}
+
+// registrationName returns the option key that governs a parsed registration.
+// A suite is always governed by `describe`, including when it was reached as
+// `test.describe`, where the resolved name stays `test`; a test is governed by
+// whichever of `test` and `it` it was written with.
+func registrationName(parsed *rstestUtils.ParsedRstestFnCall) (string, bool) {
+	switch parsed.Kind {
+	case rstestUtils.RstestFnTypeDescribe:
+		return registrationDescribe, true
+	case rstestUtils.RstestFnTypeTest:
+		if parsed.Name == registrationTest || parsed.Name == registrationIt {
+			return parsed.Name, true
+		}
+	}
+	return "", false
+}
+
+// reportNode picks the accessor the diagnostic points at. The written `.each`
+// or `.for` is the honest anchor, but it is only present in MemberEntries when
+// it was written at this call site: a registration that picked up its
+// parameterized form through an alias, such as `const cases = test.for`, has
+// the semantic kind and no member node to match. The identifier that resolves
+// to the parameterized API is then what the reader can act on.
+func reportNode(
+	node *ast.Node,
+	parsed *rstestUtils.ParsedRstestFnCall,
+	actual rstestUtils.RstestParameterizedKind,
+) *ast.Node {
+	for _, entry := range parsed.MemberEntries {
+		if entry.Name == string(actual) && entry.Node != nil {
+			return entry.Node
+		}
+	}
+	if parsed.Head.Local.Node != nil {
+		return parsed.Head.Local.Node
+	}
+	return node
+}
+
+func buildConsistentMethodMessage(
+	functionName string,
+	preferred rstestUtils.RstestParameterizedKind,
+	actual rstestUtils.RstestParameterizedKind,
+) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "consistentMethod",
+		Description: "Prefer using `" + functionName + "." + string(preferred) +
+			"` over `" + functionName + "." + string(actual) + "`",
+		Data: map[string]string{
+			"functionName": functionName,
+			"preferred":    string(preferred),
+			"actual":       string(actual),
+		},
+	}
+}
+
+var ConsistentEachForRule = rule.Rule{
+	Name:   "rstest/consistent-each-for",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		configured := parseOptions(options)
+		if len(configured) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				parsed := analysis.ParseFnCall(node)
+				if parsed == nil || !parsed.IsParameterized() {
+					return
+				}
+				name, ok := registrationName(parsed)
+				if !ok {
+					return
+				}
+				preferred, ok := configured[name]
+				if !ok {
+					return
+				}
+				actual := parsed.ParameterizedKind
+				if actual == preferred {
+					return
+				}
+				ctx.ReportNode(
+					reportNode(node, parsed, actual),
+					buildConsistentMethodMessage(name, preferred, actual),
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for.md
+++ b/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for.md
@@ -1,0 +1,55 @@
+# consistent-each-for
+
+## Rule Details
+
+Rstest offers two ways to register a parameterized test or suite, and they are not interchangeable: [`.each`](https://rstest.rs/api/runtime-api/test-api/test#testeach) spreads an array case into separate callback parameters, while [`.for`](https://rstest.rs/api/runtime-api/test-api/test#testfor) passes the case through untouched and hands the callback the [TestContext](https://rstest.rs/api/runtime-api/test-api/test#testcontext) as a second argument. A file that uses both makes every parameterized block a small puzzle about which shape its callback receives. This rule picks one form per registration name and reports the other.
+
+`test`, `it`, and `describe` are configured independently, and a name that is not configured is not checked. That means the rule does nothing at all until at least one preference is set — enabling it without options is not an error, it simply never reports.
+
+Both call forms are covered: a case array, as in `test.each([1, 2])`, and a tagged template table, as in `` test.each`a | b` ``. Modifiers written between the registration and the accessor — `.skip`, `.only`, `.concurrent`, `.skipIf(…)`, `.extend({…})` — do not hide it. The registration is resolved rather than name-matched, so an import from `@rstest/core` or `@rstest/playwright`, a global, and a local alias are all recognised, while a same-named import from another test framework and a local variable that merely shares the name are left alone. A suite registered as `test.describe` is governed by the `describe` preference. The diagnostic points at the `.each` or `.for` accessor, or, when a variable holds the already-parameterized registration, at that variable.
+
+No fix is offered. Whether switching forms requires rewriting the callback depends on the shape of the cases, which is a runtime value the rule cannot inspect: `[[1, 2]]` reaches an `.each` callback as `(a, b)` and a `.for` callback as `([a, b])`, while a list of scalars or a template table reaches both the same way.
+
+## Incorrect
+
+```ts
+// { "test": "for" }
+test.each([
+  [2, 4],
+  [3, 9],
+])('squares %i', (input, expected) => {
+  expect(square(input)).toBe(expected);
+});
+```
+
+## Correct
+
+```ts
+// { "test": "for" }
+test.for([
+  [2, 4],
+  [3, 9],
+])('squares %i', ([input, expected]) => {
+  expect(square(input)).toBe(expected);
+});
+```
+
+## Options
+
+```json
+{
+  "rstest/consistent-each-for": [
+    "error",
+    {
+      "test": "for",
+      "describe": "each"
+    }
+  ]
+}
+```
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `describe` | `string` | none | Parameterized form to require for `describe`, either `"each"` or `"for"`. |
+| `it` | `string` | none | Parameterized form to require for `it`, either `"each"` or `"for"`. |
+| `test` | `string` | none | Parameterized form to require for `test`, either `"each"` or `"for"`. |

--- a/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for.schema.json
+++ b/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for.schema.json
@@ -1,0 +1,25 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "describe": {
+          "type": "string",
+          "enum": ["each", "for"]
+        },
+        "it": {
+          "type": "string",
+          "enum": ["each", "for"]
+        },
+        "test": {
+          "type": "string",
+          "enum": ["each", "for"]
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for_extras_test.go
+++ b/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for_extras_test.go
@@ -1,0 +1,172 @@
+// TestConsistentEachForExtras covers what the migrated suite does not: the
+// tagged-template form of both parameterized APIs, the source matrix
+// (`@rstest/core` and `@rstest/playwright` imports, globals, aliases, shadowed
+// and foreign names), the `test.describe` spelling whose resolved name is not
+// `describe`, and every option-parsing branch.
+package consistent_each_for
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func expectedError(message string, line int, column int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{
+		{
+			MessageId: "consistentMethod",
+			Message:   message,
+			Line:      line,
+			Column:    column,
+		},
+	}
+}
+
+func TestConsistentEachForExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ConsistentEachForRule,
+		[]rule_tester.ValidTestCase{
+			// ---- nothing is configured: the rule is a no-op ----
+			{Code: `test.for([1, 2])("adds", ([n]) => {})`},
+			{Code: `test.for([1, 2])("adds", ([n]) => {})`, Options: map[string]any{}},
+			// A key left out governs nothing, so `it` and `describe` stay free
+			// while `test` is pinned.
+			{
+				Code:    `it.for([1, 2])("adds", ([n]) => {}); describe.for([1, 2])("group", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+			},
+
+			// ---- a registration that is not parameterized is never reported ----
+			{Code: `test("adds", () => {})`, Options: map[string]any{"test": "for"}},
+			{Code: `test.skip("adds", () => {})`, Options: map[string]any{"test": "for"}},
+			{Code: `describe("group", () => {})`, Options: map[string]any{"describe": "for"}},
+			{Code: `beforeEach(() => {})`, Options: map[string]any{"test": "for"}},
+
+			// ---- the name has to resolve to a Rstest registration ----
+			{
+				Code:    `import { test } from 'vitest'; test.for([1, 2])("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+			},
+			{
+				Code:    `const test = { for: (cases: number[]) => (name: string, fn: () => void) => {} }; test.for([1, 2])("adds", () => {})`,
+				Options: map[string]any{"test": "each"},
+			},
+
+			// A bare `.for` read without invoking it is not a registration, so
+			// the alias it initializes resolves to nothing and the call made
+			// through it is left alone.
+			{
+				Code:    `const cases = test.for;` + "\n" + `cases([1, 2])("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+			},
+
+			// ---- both parameterized forms, written the preferred way ----
+			{
+				Code:    "test.each`\n  a    | b\n  ${1} | ${2}\n`(\"adds $a and $b\", ({ a, b }) => {})",
+				Options: map[string]any{"test": "each"},
+			},
+			{
+				Code:    "test.for`\n  a    | b\n  ${1} | ${2}\n`(\"adds $a and $b\", ({ a, b }) => {})",
+				Options: map[string]any{"test": "for"},
+			},
+			{
+				Code:    `import { test } from '@rstest/playwright'; test.for([1, 2])("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "for"},
+			},
+			{
+				Code:    `import { test } from '@rstest/playwright'; test.describe.each([1, 2])("group", (n) => {})`,
+				Options: map[string]any{"describe": "each", "test": "for"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- the tagged-template form is the same registration ----
+			{
+				Code:    "test.each`\n  a    | b\n  ${1} | ${2}\n`(\"adds $a and $b\", ({ a, b }) => {})",
+				Options: map[string]any{"test": "for"},
+				Errors:  expectedError("Prefer using `test.for` over `test.each`", 1, 6),
+			},
+			{
+				Code:    "describe.for`\n  a    | b\n  ${1} | ${2}\n`(\"group $a\", ({ a, b }) => {})",
+				Options: map[string]any{"describe": "each"},
+				Errors:  expectedError("Prefer using `describe.each` over `describe.for`", 1, 10),
+			},
+
+			// ---- the source matrix ----
+			{
+				Code:    `import { test } from '@rstest/core';` + "\n" + `test.for([1, 2])("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+				Errors:  expectedError("Prefer using `test.each` over `test.for`", 2, 6),
+			},
+			{
+				Code:    `import { test } from '@rstest/playwright';` + "\n" + `test.each([1, 2])("adds", (n) => {})`,
+				Options: map[string]any{"test": "for"},
+				Errors:  expectedError("Prefer using `test.for` over `test.each`", 2, 6),
+			},
+			// `test.describe` resolves to a suite while keeping the name `test`,
+			// so the `describe` preference is what governs it.
+			{
+				Code:    `import { test } from '@rstest/playwright';` + "\n" + `test.describe.for([1, 2])("group", ([n]) => {})`,
+				Options: map[string]any{"describe": "each"},
+				Errors:  expectedError("Prefer using `describe.each` over `describe.for`", 2, 15),
+			},
+
+			// ---- modifiers between the registration and the accessor ----
+			{
+				Code:    `test.concurrent.for([1, 2])("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+				Errors:  expectedError("Prefer using `test.each` over `test.for`", 1, 17),
+			},
+			{
+				Code:    `test.skipIf(process.env.CI).for([1, 2])("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+				Errors:  expectedError("Prefer using `test.each` over `test.for`", 1, 29),
+			},
+			{
+				Code:    `test.extend({}).for([1, 2])("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+				Errors:  expectedError("Prefer using `test.each` over `test.for`", 1, 17),
+			},
+
+			// ---- the accessor came in through an alias ----
+			// The written call site has no `for` to point at, so the diagnostic
+			// lands on the identifier that resolves to the parameterized API.
+			{
+				Code:    `const adds = test.for([1, 2]);` + "\n" + `adds("adds", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+				Errors:  expectedError("Prefer using `test.each` over `test.for`", 2, 1),
+			},
+
+			// ---- each key governs its own registrations ----
+			{
+				Code: `test.for([1, 2])("adds", ([n]) => {})` + "\n" +
+					`it.for([1, 2])("adds", ([n]) => {})` + "\n" +
+					`describe.each([1, 2])("group", (n) => {})`,
+				Options: map[string]any{"test": "each", "it": "each", "describe": "for"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.each` over `test.for`",
+						Line:      1,
+						Column:    6,
+					},
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `it.each` over `it.for`",
+						Line:      2,
+						Column:    4,
+					},
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `describe.for` over `describe.each`",
+						Line:      3,
+						Column:    10,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for_upstream_test.go
+++ b/internal/plugins/rstest/rules/consistent_each_for/consistent_each_for_upstream_test.go
@@ -1,0 +1,210 @@
+// TestConsistentEachForUpstream migrates the complete
+// @vitest/eslint-plugin@v1.6.27 consistent-each-for suite, minus the cases
+// built on `suite`, which Rstest does not expose. Rstest-only shapes — the
+// tagged-template form, aliases, `@rstest/playwright`, imported and shadowed
+// registrations, and the option-parsing branches — live in
+// consistent_each_for_extras_test.go.
+package consistent_each_for
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestConsistentEachForUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ConsistentEachForRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`},
+			{Code: `test.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`},
+			{Code: `describe.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })`},
+			{
+				Code:    `test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "each"},
+			},
+			{
+				Code:    `test.skip.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "each"},
+			},
+			{
+				Code:    `test.only.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "each"},
+			},
+			{
+				Code:    `test.concurrent.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "each"},
+			},
+			{
+				Code:    `test.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "for"},
+			},
+			{
+				Code:    `test.skip.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "for"},
+			},
+			{
+				Code:    `test.only.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "for"},
+			},
+			{
+				Code:    `it.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"it": "each"},
+			},
+			{
+				Code:    `it.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"it": "for"},
+			},
+			{
+				Code:    `describe.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })`,
+				Options: map[string]any{"describe": "each"},
+			},
+			{
+				Code:    `describe.skip.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })`,
+				Options: map[string]any{"describe": "each"},
+			},
+			{
+				Code:    `describe.for([1, 2, 3])("suite", ([n]) => { test("test", () => {}) })`,
+				Options: map[string]any{"describe": "for"},
+			},
+			{
+				Code: `test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })
+describe.for([1, 2, 3])("suite", ([n]) => { test("test", () => {}) })`,
+				Options: map[string]any{"test": "each", "describe": "for"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    `test.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "each"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.each` over `test.for`",
+						Line:      1,
+						Column:    6,
+					},
+				},
+			},
+			{
+				Code:    `test.skip.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "each"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.each` over `test.for`",
+						Line:      1,
+						Column:    11,
+					},
+				},
+			},
+			{
+				Code:    `test.only.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "each"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.each` over `test.for`",
+						Line:      1,
+						Column:    11,
+					},
+				},
+			},
+			{
+				Code:    `test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "for"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.for` over `test.each`",
+						Line:      1,
+						Column:    6,
+					},
+				},
+			},
+			{
+				Code:    `test.skip.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"test": "for"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.for` over `test.each`",
+						Line:      1,
+						Column:    11,
+					},
+				},
+			},
+			{
+				Code:    `it.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"it": "each"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `it.each` over `it.for`",
+						Line:      1,
+						Column:    4,
+					},
+				},
+			},
+			{
+				Code:    `it.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })`,
+				Options: map[string]any{"it": "for"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `it.for` over `it.each`",
+						Line:      1,
+						Column:    4,
+					},
+				},
+			},
+			{
+				Code:    `describe.for([1, 2, 3])("suite", ([n]) => { test("test", () => {}) })`,
+				Options: map[string]any{"describe": "each"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `describe.each` over `describe.for`",
+						Line:      1,
+						Column:    10,
+					},
+				},
+			},
+			{
+				Code:    `describe.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })`,
+				Options: map[string]any{"describe": "for"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `describe.for` over `describe.each`",
+						Line:      1,
+						Column:    10,
+					},
+				},
+			},
+			{
+				Code: `test.for([1, 2])("test1", ([n]) => {})
+test.for([3, 4])("test2", ([n]) => {})`,
+				Options: map[string]any{"test": "each"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.each` over `test.for`",
+						Line:      1,
+						Column:    6,
+					},
+					{
+						MessageId: "consistentMethod",
+						Message:   "Prefer using `test.each` over `test.for`",
+						Line:      2,
+						Column:    6,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -602,6 +602,7 @@ define.test({
     './tests/eslint-plugin-jest/rules/valid-title.test.ts',
 
     // rstest
+    './tests/rstest/rules/consistent-each-for.test.ts',
     './tests/rstest/rules/consistent-rstest-namespace.test.ts',
     './tests/rstest/rules/expect-expect.test.ts',
     './tests/rstest/rules/hoisted-apis-on-top.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/consistent-each-for.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/consistent-each-for.test.ts
@@ -1,0 +1,139 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const methodError = (
+  functionName: string,
+  preferred: string,
+  actual: string,
+  line: number,
+  column: number,
+) => ({
+  messageId: 'consistentMethod',
+  message: `Prefer using \`${functionName}.${preferred}\` over \`${functionName}.${actual}\``,
+  line,
+  column,
+});
+
+ruleTester.run('consistent-each-for', {} as never, {
+  valid: [
+    {
+      code: 'test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+    },
+    {
+      code: 'test.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+    },
+    {
+      code: 'describe.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })',
+    },
+    {
+      code: 'test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ test: 'each' }],
+    },
+    {
+      code: 'test.skip.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ test: 'each' }],
+    },
+    {
+      code: 'test.only.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ test: 'each' }],
+    },
+    {
+      code: 'test.concurrent.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ test: 'each' }],
+    },
+    {
+      code: 'test.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ test: 'for' }],
+    },
+    {
+      code: 'test.skip.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ test: 'for' }],
+    },
+    {
+      code: 'test.only.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ test: 'for' }],
+    },
+    {
+      code: 'it.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ it: 'each' }],
+    },
+    {
+      code: 'it.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ it: 'for' }],
+    },
+    {
+      code: 'describe.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })',
+      options: [{ describe: 'each' }],
+    },
+    {
+      code: 'describe.skip.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })',
+      options: [{ describe: 'each' }],
+    },
+    {
+      code: 'describe.for([1, 2, 3])("suite", ([n]) => { test("test", () => {}) })',
+      options: [{ describe: 'for' }],
+    },
+    {
+      code: `test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })
+describe.for([1, 2, 3])("suite", ([n]) => { test("test", () => {}) })`,
+      options: [{ test: 'each', describe: 'for' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'test.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ test: 'each' }],
+      errors: [methodError('test', 'each', 'for', 1, 6)],
+    },
+    {
+      code: 'test.skip.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ test: 'each' }],
+      errors: [methodError('test', 'each', 'for', 1, 11)],
+    },
+    {
+      code: 'test.only.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ test: 'each' }],
+      errors: [methodError('test', 'each', 'for', 1, 11)],
+    },
+    {
+      code: 'test.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ test: 'for' }],
+      errors: [methodError('test', 'for', 'each', 1, 6)],
+    },
+    {
+      code: 'test.skip.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ test: 'for' }],
+      errors: [methodError('test', 'for', 'each', 1, 11)],
+    },
+    {
+      code: 'it.for([1, 2, 3])("test", ([n]) => { expect(n).toBeDefined() })',
+      options: [{ it: 'each' }],
+      errors: [methodError('it', 'each', 'for', 1, 4)],
+    },
+    {
+      code: 'it.each([1, 2, 3])("test", (n) => { expect(n).toBeDefined() })',
+      options: [{ it: 'for' }],
+      errors: [methodError('it', 'for', 'each', 1, 4)],
+    },
+    {
+      code: 'describe.for([1, 2, 3])("suite", ([n]) => { test("test", () => {}) })',
+      options: [{ describe: 'each' }],
+      errors: [methodError('describe', 'each', 'for', 1, 10)],
+    },
+    {
+      code: 'describe.each([1, 2, 3])("suite", (n) => { test("test", () => {}) })',
+      options: [{ describe: 'for' }],
+      errors: [methodError('describe', 'for', 'each', 1, 10)],
+    },
+    {
+      code: `test.for([1, 2])("test1", ([n]) => {})
+test.for([3, 4])("test2", ([n]) => {})`,
+      options: [{ test: 'each' }],
+      errors: [
+        methodError('test', 'each', 'for', 1, 6),
+        methodError('test', 'each', 'for', 2, 6),
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Report a parameterized `test`, `it`, or `describe` registration written with `.each` where the project configured `.for`, or the reverse.

## Credits

Port from [`eslint-plugin-vitest`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `consistent-each-for`.

## Intentional differences from upstream

- **No `suite` option.** Rstest does not export `suite`, so the option would configure a registration that cannot exist.

- **The registration is resolved instead of name-matched.** Resolving through the shared `ParseFnCall` picks up imports from `@rstest/core` and `@rstest/playwright`, globals, and aliases, while leaving a local name that merely looks like a registration alone.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
