### PR TITLE
feat: port rule unicorn/consistent-date-clone

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -2,6 +2,7 @@ package unicorn_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/catch_error_name"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_date_clone"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/error_message"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
@@ -38,6 +39,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		catch_error_name.CatchErrorNameRule,
+		consistent_date_clone.ConsistentDateCloneRule,
 		error_message.ErrorMessageRule,
 		filename_case.FilenameCaseRule,
 		new_for_builtins.NewForBuiltinsRule,

--- a/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone.go
+++ b/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone.go
@@ -43,6 +43,9 @@ var ConsistentDateCloneRule = rule.Rule{
 				}
 
 				argument := ast.SkipParentheses(node.Arguments()[0])
+				if argument == nil || ast.IsOptionalChain(argument) {
+					return
+				}
 				getTimeCall, ok := unicornutil.MatchDotMethodCall(argument, unicornutil.DotMethodCallOptions{
 					Method:          "getTime",
 					ArgumentsLength: &zeroArguments,

--- a/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone.go
+++ b/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone.go
@@ -1,0 +1,62 @@
+package consistent_date_clone
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "consistent-date-clone/error"
+
+var unnecessaryGetTimeMessage = rule.RuleMessage{
+	Id:          messageID,
+	Description: "Unnecessary `.getTime()` call.",
+}
+
+func isSingleArgumentDateConstruction(node *ast.Node) bool {
+	if node == nil || !ast.IsNewExpression(node) {
+		return false
+	}
+
+	arguments := node.Arguments()
+	if len(arguments) != 1 || ast.IsSpreadElement(arguments[0]) {
+		return false
+	}
+
+	callee := ast.SkipParentheses(node.Expression())
+	return callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "Date"
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/consistent-date-clone.md
+var ConsistentDateCloneRule = rule.Rule{
+	Name:   "unicorn/consistent-date-clone",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		zeroArguments := 0
+		return rule.RuleListeners{
+			// Exit order reports a nested clone before its enclosing clone, matching
+			// the source-ordered diagnostics exposed by ESLint.
+			rule.ListenerOnExit(ast.KindNewExpression): func(node *ast.Node) {
+				if !isSingleArgumentDateConstruction(node) {
+					return
+				}
+
+				argument := ast.SkipParentheses(node.Arguments()[0])
+				getTimeCall, ok := unicornutil.MatchDotMethodCall(argument, unicornutil.DotMethodCallOptions{
+					Method:          "getTime",
+					ArgumentsLength: &zeroArguments,
+				})
+				if !ok {
+					return
+				}
+
+				reportRange := utils.TrimNodeTextRange(ctx.SourceFile, getTimeCall.Property).
+					WithEnd(getTimeCall.Call.End())
+				ctx.ReportRangeWithDeferredFixes(reportRange, unnecessaryGetTimeMessage, func() []rule.RuleFix {
+					return unicornutil.RemoveMethodCallFixes(getTimeCall)
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone.md
+++ b/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone.md
@@ -1,0 +1,41 @@
+# consistent-date-clone
+
+## Rule Details
+
+Prefer passing an existing `Date` directly to the `Date` constructor when
+cloning it. Since ECMAScript 2015, `new Date(date)` copies the original date's
+time value without requiring an intermediate number.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const copy = new Date(date.getTime());
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const copy = new Date(date);
+```
+
+The rule only reports the direct `new Date(date.getTime())` shape. Calls with
+additional constructor arguments or component-wise date construction are left
+unchanged:
+
+```javascript
+new Date(date.getTime(), extraArgument);
+
+new Date(
+  date.getFullYear(),
+  date.getMonth(),
+  date.getDate(),
+  date.getHours(),
+  date.getMinutes(),
+  date.getSeconds(),
+);
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: consistent-date-clone](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/consistent-date-clone.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/consistent-date-clone.js)

--- a/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone_extras_test.go
+++ b/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone_extras_test.go
@@ -40,6 +40,10 @@ func TestConsistentDateCloneExtras(t *testing.T) {
 			// non-optional, non-computed, zero-argument getTime method call.
 			{Code: `new Date(date.getTime?.())`, FileName: "file.js"},
 			{Code: `new Date((date?.getTime)())`, FileName: "file.js"},
+			// An optional chain may start below the final getTime call. ESTree wraps
+			// the complete argument in ChainExpression, so upstream ignores it.
+			{Code: `new Date(date?.value.getTime())`, FileName: "file.js"},
+			{Code: `new Date((date?.value.getTime)())`, FileName: "file.js"},
 			{Code: `new Date(date["getTime"]())`, FileName: "file.js"},
 			{Code: `new Date(date.getTime(...[]))`, FileName: "file.js"},
 			{Code: `new Date(date.getTime)`, FileName: "file.js"},
@@ -91,6 +95,14 @@ func TestConsistentDateCloneExtras(t *testing.T) {
 				FileName: "file.js",
 				Output:   []string{`new Date(((date)))`},
 				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(((date)).getTime /* call */ ())`, `getTime /* call */ ()`, 0)},
+			},
+			// Parentheses end the optional chain, so the outer getTime call is an
+			// ordinary call that upstream reports and fixes.
+			{
+				Code:     `new Date((date?.value).getTime())`,
+				FileName: "file.js",
+				Output:   []string{`new Date((date?.value))`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date((date?.value).getTime())`, `getTime()`, 0)},
 			},
 
 			// The property diagnostic starts after receiver-side comments, while the

--- a/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone_extras_test.go
+++ b/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone_extras_test.go
@@ -1,0 +1,271 @@
+// TestConsistentDateCloneExtras locks in tsgo-specific AST shapes, every
+// reachable upstream gate, and edit-demand behavior. The direct v74.0.0
+// migration lives in the sibling consistent_date_clone_upstream_test.go file.
+package consistent_date_clone_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	consistent_date_clone "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_date_clone"
+	"github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestConsistentDateCloneExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&consistent_date_clone.ConsistentDateCloneRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream isNewExpression() arm 1: the callee must be the
+			// exact identifier Date rather than a same-named member.
+			{Code: `new globalThis.Date(date.getTime())`, FileName: "file.js"},
+
+			// Locks in upstream isNewExpression() arms 2 and 3: exactly one
+			// non-spread argument is required.
+			{Code: `new Date()`, FileName: "file.js"},
+			{Code: `new Date(date.getTime(), other)`, FileName: "file.js"},
+			{Code: `new Date(...[date.getTime()])`, FileName: "file.js"},
+
+			// Locks in upstream isMethodCall() arms 1-4: the inner call must be a
+			// non-optional, non-computed, zero-argument getTime method call.
+			{Code: `new Date(date.getTime?.())`, FileName: "file.js"},
+			{Code: `new Date((date?.getTime)())`, FileName: "file.js"},
+			{Code: `new Date(date["getTime"]())`, FileName: "file.js"},
+			{Code: `new Date(date.getTime(...[]))`, FileName: "file.js"},
+			{Code: `new Date(date.getTime)`, FileName: "file.js"},
+
+			// Dimension 4: wrappers around the argument or Date callee remain visible
+			// to TSESTree and therefore prevent the direct shape from matching.
+			{Code: `new Date((date.getTime() as number))`, FileName: "file.ts", Tsx: false},
+			{Code: `new (Date as DateConstructor)(date.getTime())`, FileName: "file.ts", Tsx: false},
+
+			// Dimension 4: a private method name is not an Identifier property.
+			{
+				Code:     `class Clock { #getTime() { return 0 } clone(date) { return new Date(date.#getTime()) } }`,
+				FileName: "file.js",
+			},
+
+			// ---- Real-user: upstream #2437 component construction without milliseconds ----
+			{Code: `new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds())`, FileName: "file.js"},
+			// ---- Real-user: upstream #2437 component construction with milliseconds ----
+			{Code: `new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds())`, FileName: "file.js"},
+
+			// N/A: JSX tag names and object-member key equivalence classes are not
+			// expression shapes consumed by this rule.
+			// N/A: the rule has an empty options schema, so defaults and option
+			// combinations do not apply.
+		},
+		[]rule_tester.InvalidTestCase{
+			// Dimension 4: parentheses around the Date callee and argument call are
+			// transparent for detection but preserved by the fixer.
+			{
+				Code:     `new (Date)(date.getTime())`,
+				FileName: "file.js",
+				Output:   []string{`new (Date)(date)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new (Date)(date.getTime())`, `getTime()`, 0)},
+			},
+			{
+				Code:     `new Date((date.getTime()))`,
+				FileName: "file.js",
+				Output:   []string{`new Date((date))`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date((date.getTime()))`, `getTime()`, 0)},
+			},
+			{
+				Code:     `new Date((date.getTime)())`,
+				FileName: "file.js",
+				Output:   []string{`new Date((date))`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date((date.getTime)())`, `getTime)()`, 0)},
+			},
+			{
+				Code:     `new Date(((date)).getTime /* call */ ())`,
+				FileName: "file.js",
+				Output:   []string{`new Date(((date)))`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(((date)).getTime /* call */ ())`, `getTime /* call */ ()`, 0)},
+			},
+
+			// The property diagnostic starts after receiver-side comments, while the
+			// fix removes those comments together with the redundant method call.
+			{
+				Code:     `new Date(date /* receiver */ .getTime())`,
+				FileName: "file.js",
+				Output:   []string{`new Date(date)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(date /* receiver */ .getTime())`, `getTime()`, 0)},
+			},
+			{
+				Code: `new Date(
+	date
+		.getTime(
+			/* comment */
+		),
+)`,
+				FileName: "file.js",
+				Output: []string{`new Date(
+	date,
+)`},
+				Errors: []rule_tester.InvalidTestCaseError{expectedError(`new Date(
+	date
+		.getTime(
+			/* comment */
+		),
+)`, `getTime(
+			/* comment */
+		)`, 0)},
+			},
+
+			// Dimension 4: TypeScript wrappers on the receiver are part of the value
+			// being cloned and must survive the rewrite.
+			{
+				Code:     `new Date(date!.getTime())`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`new Date(date!)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(date!.getTime())`, `getTime()`, 0)},
+			},
+			{
+				Code:     `new Date((date satisfies Date).getTime())`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`new Date((date satisfies Date))`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date((date satisfies Date).getTime())`, `getTime()`, 0)},
+			},
+
+			// Type arguments do not change either call-expression shape.
+			{
+				Code:     `new Date<string>(date.getTime<number>())`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`new Date<string>(date)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date<string>(date.getTime<number>())`, `getTime<number>()`, 0)},
+			},
+
+			// The rule is syntax-based: a local declaration named Date still matches.
+			{
+				Code:     `class Date { constructor(value) {} } new Date(date.getTime())`,
+				FileName: "file.js",
+				Output:   []string{`class Date { constructor(value) {} } new Date(date)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`class Date { constructor(value) {} } new Date(date.getTime())`, `getTime()`, 0)},
+			},
+
+			// Same-kind siblings report in source order and both fixes apply in one pass.
+			{
+				Code:     `const first = new Date(a.getTime()); const second = new Date(b.getTime());`,
+				FileName: "file.js",
+				Output:   []string{`const first = new Date(a); const second = new Date(b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(`const first = new Date(a.getTime()); const second = new Date(b.getTime());`, `getTime()`, 0),
+					expectedError(`const first = new Date(a.getTime()); const second = new Date(b.getTime());`, `getTime()`, 1),
+				},
+			},
+		},
+	)
+}
+
+func TestConsistentDateCloneEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const fileName = "edit-demand.ts"
+	const source = `const clone = new Date(date.getTime());`
+	const fixedSource = `const clone = new Date(date);`
+
+	compilerProgram, sourceFile := createConsistentDateCloneProgram(t, fileName, source)
+	diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		got := lintConsistentDateCloneWithDemand(compilerProgram, sourceFile, demand)
+		if len(got) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+		}
+		diagnostics[demand] = got[0]
+	}
+
+	base := diagnostics[rule.EditDemandNone]
+	for demand, diagnostic := range diagnostics {
+		want := base
+		want.FixesPtr = nil
+		want.Suggestions = nil
+		got := diagnostic
+		got.FixesPtr = nil
+		got.Suggestions = nil
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, got, want)
+		}
+		if diagnostic.Suggestions != nil {
+			t.Errorf("demand %d unexpectedly materialized suggestions", demand)
+		}
+	}
+
+	if diagnostics[rule.EditDemandNone].FixesPtr != nil {
+		t.Errorf("none demand unexpectedly materialized fixes")
+	}
+	if diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+		t.Errorf("suggestion-only demand unexpectedly materialized fixes")
+	}
+	autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+	allFixes := diagnostics[rule.EditDemandAll].FixesPtr
+	if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
+		t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+	}
+	output, unapplied, fixed := linter.ApplyRuleFixes(source, []rule.RuleDiagnostic{diagnostics[rule.EditDemandAll]})
+	if !fixed || len(unapplied) != 0 || output != fixedSource {
+		t.Fatalf("autofix result = %q, unapplied = %d, fixed = %v; want %q", output, len(unapplied), fixed, fixedSource)
+	}
+}
+
+func createConsistentDateCloneProgram(t testing.TB, fileName, source string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFS(rootDir.FS, map[string]string{tspath.ResolvePath(rootDir.Dir, fileName): source})
+	host := utils.CreateCompilerHost(rootDir.Dir, fs)
+	compilerProgram, err := utils.CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := compilerProgram.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return compilerProgram, sourceFile
+}
+
+func lintConsistentDateCloneWithDemand(
+	compilerProgram *compiler.Program,
+	sourceFile *ast.SourceFile,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:     program.NewFromCompiler(compilerProgram),
+		File:        sourceFile.FileName(),
+		HasTypeInfo: true,
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
+				Name:     consistent_date_clone.ConsistentDateCloneRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return consistent_date_clone.ConsistentDateCloneRule.Run(ctx, nil)
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}

--- a/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone_upstream_test.go
+++ b/internal/plugins/unicorn/rules/consistent_date_clone/consistent_date_clone_upstream_test.go
@@ -1,0 +1,141 @@
+// TestConsistentDateCloneUpstream migrates the complete valid/invalid suite
+// from eslint-plugin-unicorn v74.0.0. rslint-specific edge-shape and branch
+// lock-in cases live in consistent_date_clone_extras_test.go.
+package consistent_date_clone_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	consistent_date_clone "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_date_clone"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID = "consistent-date-clone/error"
+	message   = "Unnecessary `.getTime()` call."
+)
+
+func expectedError(code, target string, occurrence int) rule_tester.InvalidTestCaseError {
+	searchFrom := 0
+	start := -1
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], target)
+		if relative < 0 {
+			panic("target not found in test input: " + target)
+		}
+		start = searchFrom + relative
+		searchFrom = start + 1
+	}
+
+	lineStart := strings.LastIndex(code[:start], "\n") + 1
+	line := strings.Count(code[:start], "\n") + 1
+	column := start - lineStart + 1
+	end := start + len(target)
+	endLineStart := strings.LastIndex(code[:end], "\n") + 1
+	endLine := strings.Count(code[:end], "\n") + 1
+	endColumn := end - endLineStart + 1
+
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestConsistentDateCloneUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&consistent_date_clone.ConsistentDateCloneRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `new Date(date)`, FileName: "file.js"},
+			{Code: `date.getTime()`, FileName: "file.js"},
+			{Code: `new Date(...date.getTime())`, FileName: "file.js"},
+			{Code: `new Date(getTime())`, FileName: "file.js"},
+			{Code: `new Date(date.getTime(), extraArgument)`, FileName: "file.js"},
+			{Code: `new Date(date.not_getTime())`, FileName: "file.js"},
+			{Code: `new Date(date?.getTime())`, FileName: "file.js"},
+			{Code: `new NotDate(date.getTime())`, FileName: "file.js"},
+			{Code: `new Date(date[getTime]())`, FileName: "file.js"},
+			{Code: `new Date(date.getTime(extraArgument))`, FileName: "file.js"},
+			{Code: `Date(date.getTime())`, FileName: "file.js"},
+			{
+				Code: `new Date(
+	date.getFullYear(),
+	date.getMonth(),
+	date.getDate(),
+	date.getHours(),
+	date.getMinutes(),
+	date.getSeconds(),
+	date.getMilliseconds(),
+);`,
+				FileName: "file.js",
+			},
+			{
+				Code: `new Date(
+	date.getFullYear(),
+	date.getMonth(),
+	date.getDate(),
+	date.getHours(),
+	date.getMinutes(),
+	date.getSeconds(),
+);`,
+				FileName: "file.js",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `new Date(date.getTime())`,
+				FileName: "file.js",
+				Output:   []string{`new Date(date)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(date.getTime())`, `getTime()`, 0)},
+			},
+			{
+				Code:     `new Date(date.getTime(),)`,
+				FileName: "file.js",
+				Output:   []string{`new Date(date,)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(date.getTime(),)`, `getTime()`, 0)},
+			},
+			{
+				Code:     `new Date(new Date(date.getTime()).getTime())`,
+				FileName: "file.js",
+				Output:   []string{`new Date(new Date(date))`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(`new Date(new Date(date.getTime()).getTime())`, `getTime()`, 0),
+					expectedError(`new Date(new Date(date.getTime()).getTime())`, `getTime()`, 1),
+				},
+			},
+			{
+				Code:     `new Date((0, date).getTime())`,
+				FileName: "file.js",
+				Output:   []string{`new Date((0, date))`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date((0, date).getTime())`, `getTime()`, 0)},
+			},
+			{
+				Code:     `new Date(date.getTime(/* comment */))`,
+				FileName: "file.js",
+				Output:   []string{`new Date(date)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(date.getTime(/* comment */))`, `getTime(/* comment */)`, 0)},
+			},
+			{
+				Code:     `new Date(date./* comment */getTime())`,
+				FileName: "file.js",
+				Output:   []string{`new Date(date)`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date(date./* comment */getTime())`, `getTime()`, 0)},
+			},
+			{
+				Code:     `new Date((date as Date).getTime())`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`new Date((date as Date))`},
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError(`new Date((date as Date).getTime())`, `getTime()`, 0)},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
@@ -2,7 +2,6 @@ package prefer_array_flat_map
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -52,15 +51,10 @@ func isIgnoredMapObject(node *ast.Node) bool {
 
 func buildFixes(sf *ast.SourceFile, flatCall dotMethodCall, mapCall dotMethodCall) []rule.RuleFix {
 	mapPropertyRange := utils.TrimNodeTextRange(sf, mapCall.Property)
-	// Remove the .flat member and the following call separately, preserving any
-	// parentheses around the callee: (foo.map(cb).flat)() -> (foo.flatMap(cb)).
-	removeFlatPropertyRange := core.NewTextRange(flatCall.Object.End(), flatCall.Callee.End())
-	removeFlatArgumentsRange := core.NewTextRange(flatCall.RawCallee.End(), flatCall.Call.End())
-	return []rule.RuleFix{
+	fixes := []rule.RuleFix{
 		rule.RuleFixReplaceRange(mapPropertyRange, "flatMap"),
-		rule.RuleFixRemoveRange(removeFlatPropertyRange),
-		rule.RuleFixRemoveRange(removeFlatArgumentsRange),
 	}
+	return append(fixes, unicornutil.RemoveMethodCallFixes(flatCall)...)
 }
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-array-flat-map.md

--- a/internal/plugins/unicorn/unicornutil/fix_method_call.go
+++ b/internal/plugins/unicorn/unicornutil/fix_method_call.go
@@ -1,0 +1,16 @@
+package unicornutil
+
+import (
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// RemoveMethodCallFixes mirrors Unicorn's removeMethodCall fixer. It removes
+// the dotted property and the following argument list separately so explicit
+// parentheses around the receiver or callee remain intact.
+func RemoveMethodCallFixes(call DotMethodCall) []rule.RuleFix {
+	return []rule.RuleFix{
+		rule.RuleFixRemoveRange(core.NewTextRange(call.Object.End(), call.Callee.End())),
+		rule.RuleFixRemoveRange(core.NewTextRange(call.RawCallee.End(), call.Call.End())),
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -654,6 +654,7 @@ define.test({
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/catch-error-name.test.ts',
+    './tests/eslint-plugin-unicorn/rules/consistent-date-clone.test.ts',
     './tests/eslint-plugin-unicorn/rules/error-message.test.ts',
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/consistent-date-clone.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/consistent-date-clone.test.ts
@@ -1,0 +1,70 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string, filename = 'file.js') => ({ code, filename });
+const invalid = (
+  code: string,
+  output: string,
+  errorCount = 1,
+  filename = 'file.js',
+) => ({
+  code,
+  filename,
+  output,
+  errors: Array.from({ length: errorCount }, () => ({
+    messageId: 'consistent-date-clone/error',
+    message: 'Unnecessary `.getTime()` call.',
+  })),
+});
+
+ruleTester.run('consistent-date-clone', null as never, {
+  valid: [
+    valid('new Date(date)'),
+    valid('date.getTime()'),
+    valid('new Date(...date.getTime())'),
+    valid('new Date(getTime())'),
+    valid('new Date(date.getTime(), extraArgument)'),
+    valid('new Date(date.not_getTime())'),
+    valid('new Date(date?.getTime())'),
+    valid('new NotDate(date.getTime())'),
+    valid('new Date(date[getTime]())'),
+    valid('new Date(date.getTime(extraArgument))'),
+    valid('Date(date.getTime())'),
+    valid(`new Date(
+  date.getFullYear(),
+  date.getMonth(),
+  date.getDate(),
+  date.getHours(),
+  date.getMinutes(),
+  date.getSeconds(),
+  date.getMilliseconds(),
+);`),
+    valid(`new Date(
+  date.getFullYear(),
+  date.getMonth(),
+  date.getDate(),
+  date.getHours(),
+  date.getMinutes(),
+  date.getSeconds(),
+);`),
+  ],
+  invalid: [
+    invalid('new Date(date.getTime())', 'new Date(date)'),
+    invalid('new Date(date.getTime(),)', 'new Date(date,)'),
+    invalid(
+      'new Date(new Date(date.getTime()).getTime())',
+      'new Date(new Date(date))',
+      2,
+    ),
+    invalid('new Date((0, date).getTime())', 'new Date((0, date))'),
+    invalid('new Date(date.getTime(/* comment */))', 'new Date(date)'),
+    invalid('new Date(date./* comment */getTime())', 'new Date(date)'),
+    invalid(
+      'new Date((date as Date).getTime())',
+      'new Date((date as Date))',
+      1,
+      'file.ts',
+    ),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -26,7 +26,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/consistent-class-member-order': 'error', // not implemented
     // 'unicorn/consistent-compound-words': 'error', // not implemented
     // 'unicorn/consistent-conditional-object-spread': 'error', // not implemented
-    // 'unicorn/consistent-date-clone': 'error', // not implemented
+    'unicorn/consistent-date-clone': 'error',
     // 'unicorn/consistent-destructuring': 'off', // not implemented
     // 'unicorn/consistent-empty-array-spread': 'error', // not implemented
     // 'unicorn/consistent-existence-index-check': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/consistent-date-clone` from
`eslint-plugin-unicorn@v74.0.0` to rslint.

The rule reports redundant `Date#getTime()` calls when cloning an existing
`Date`:

```js
// Before
const cloned = new Date(date.getTime());

// After
const cloned = new Date(date);
```

## Implementation

- Matches `new Date(date.getTime())` with exactly one constructor argument.
- Preserves parentheses and TypeScript expression wrappers during autofix.
- Excludes optional calls, computed properties, spread arguments, and
  additional constructor arguments.
- Preserves upstream syntax-based behavior when `Date` is locally shadowed.
- Extracts the existing `removeMethodCall` behavior into a shared Unicorn
  fixer.
- Registers the rule and enables it in the Unicorn recommended preset.

## Tests

- Migrated the complete upstream v74.0.0 test suite.
- Added Go coverage for TypeScript syntax, parentheses, optional chains,
  comments, nested calls, diagnostic ranges, and edit-demand behavior.
- Added the JS end-to-end RuleTester suite.
- Differentially verified diagnostic messages, positions, and autofixes
  against `eslint-plugin-unicorn@v74.0.0`.

Verification completed:

- `go test -count=1 ./internal/plugins/unicorn/rules/consistent_date_clone`
- `go test -count=1 ./internal/plugins/unicorn/rules/prefer_array_flat_map`
- `go test -count=1 ./internal/plugins/unicorn/unicornutil`
- `go test -count=1 ./internal/plugins/unicorn/...`
- `pnpm build`
- `pnpm exec rstest run --testTimeout=10000 consistent-date-clone`
- `pnpm exec rstest run --testTimeout=10000 presets`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint`: 0 issues

## Related Links

- [Documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/consistent-date-clone.md)
- [Source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/consistent-date-clone.js)
- [Upstream tests](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/consistent-date-clone.js)

Tracks #1309.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Rule registered in the Unicorn catalog.
- [x] Unicorn recommended preset updated.
