### PR TITLE
fix: preserve destructuring writes in no-global-assign

### DIFF
--- a/internal/rules/no_global_assign/no_global_assign.go
+++ b/internal/rules/no_global_assign/no_global_assign.go
@@ -35,17 +35,12 @@ func parseOptions(rawOptions []any) options {
 	return opts
 }
 
-// hasStackedTypeWrappers reports whether the identifier reaches a direct
-// assignment or update target through more than one TypeScript expression
-// wrapper. ESLint's scope analysis unwraps such a target exactly once — an
-// AsExpression, TypeAssertionExpression or NonNullExpression — so
-// `(Object as any) = 1` is a write while `((Object as any) as any) = 1` is not.
-// Parentheses never count because the ESTree AST has no node for them.
-// Destructuring defaults are AssignmentPattern nodes in ESTree rather than
-// direct assignment targets, so their inner `=` must not stop this walk. A
-// `satisfies` target is not a write at any depth, which IsWriteReference already
-// answers.
-func hasStackedTypeWrappers(node *ast.Node) bool {
+// stackedTypeWrapperWriteExpression returns the direct assignment or update
+// expression reached through more than one TypeScript target wrapper. ESLint's
+// scope analysis unwraps one AsExpression, TypeAssertionExpression, or
+// NonNullExpression from direct targets; parentheses do not count because
+// ESTree does not preserve them.
+func stackedTypeWrapperWriteExpression(node *ast.Node) *ast.Node {
 	wrappers := 0
 	current := node
 	for parent := current.Parent; parent != nil; parent = current.Parent {
@@ -56,70 +51,122 @@ func hasStackedTypeWrappers(node *ast.Node) bool {
 		case ast.KindBinaryExpression:
 			binary := parent.AsBinaryExpression()
 			if binary == nil || binary.OperatorToken == nil || binary.Left != current {
-				return false
+				return nil
 			}
-			if isDefaultValueInDestructuringAssignment(parent) {
-				return false
+			if wrappers > 1 && ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
+				return parent
 			}
-			return wrappers > 1 && ast.IsAssignmentOperator(binary.OperatorToken.Kind)
+			return nil
 		case ast.KindPrefixUnaryExpression:
 			prefix := parent.AsPrefixUnaryExpression()
-			return wrappers > 1 && prefix != nil && prefix.Operand == current &&
-				(prefix.Operator == ast.KindPlusPlusToken || prefix.Operator == ast.KindMinusMinusToken)
+			if wrappers > 1 && prefix != nil && prefix.Operand == current &&
+				(prefix.Operator == ast.KindPlusPlusToken || prefix.Operator == ast.KindMinusMinusToken) {
+				return parent
+			}
+			return nil
 		case ast.KindPostfixUnaryExpression:
 			postfix := parent.AsPostfixUnaryExpression()
-			return wrappers > 1 && postfix != nil && postfix.Operand == current &&
-				(postfix.Operator == ast.KindPlusPlusToken || postfix.Operator == ast.KindMinusMinusToken)
+			if wrappers > 1 && postfix != nil && postfix.Operand == current &&
+				(postfix.Operator == ast.KindPlusPlusToken || postfix.Operator == ast.KindMinusMinusToken) {
+				return parent
+			}
+			return nil
 		default:
-			return false
+			return nil
 		}
 		current = parent
 	}
-	return false
+	return nil
 }
 
-// isDefaultValueInDestructuringAssignment extends the shared assignment-pattern
-// check only for this rule's scope-reference emulation. ESLint's scope walk
-// sees the TypeScript wrappers here before it reaches the enclosing pattern;
-// other rules inspect ESTree AssignmentExpression nodes and must not treat the
-// same wrappers as transparent.
-func isDefaultValueInDestructuringAssignment(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindBinaryExpression {
-		return false
-	}
-	binary := node.AsBinaryExpression()
-	if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken {
-		return false
-	}
-
-	assignmentTargetNode := node
-	for parent := assignmentTargetNode.Parent; parent != nil; parent = assignmentTargetNode.Parent {
+// isVisitedByEnclosingWritePattern mirrors the child edges followed by
+// typescript-eslint's PatternVisitor. A stacked direct write is still a write
+// when an enclosing destructuring pattern visits it. Right-hand values,
+// computed keys, member expressions, and call arguments are evaluation-only
+// boundaries; a call callee and nodes handled by PatternVisitor's default
+// visitor remain reachable.
+func isVisitedByEnclosingWritePattern(node *ast.Node) bool {
+	current := node
+	for parent := current.Parent; parent != nil; parent = current.Parent {
 		switch parent.Kind {
-		case ast.KindParenthesizedExpression,
-			ast.KindAsExpression,
-			ast.KindTypeAssertionExpression,
-			ast.KindNonNullExpression,
-			ast.KindSatisfiesExpression:
-			assignmentTargetNode = parent
-		default:
-			target := ast.GetAssignmentTarget(assignmentTargetNode)
-			if target == nil {
+		case ast.KindBinaryExpression:
+			binary := parent.AsBinaryExpression()
+			if binary == nil || binary.OperatorToken == nil {
 				return false
 			}
-			if ast.IsDestructuringAssignment(target) {
-				return true
+			if binary.OperatorToken.Kind == ast.KindEqualsToken && binary.Left == current {
+				// Do not skip parentheses: typescript-eslint converts a parenthesized
+				// array or object on the left to an expression, not a pattern.
+				if current.Kind == ast.KindArrayLiteralExpression || current.Kind == ast.KindObjectLiteralExpression {
+					return true
+				}
 			}
-			if !ast.IsForInOrOfStatement(target) {
+			if ast.IsAssignmentOperator(binary.OperatorToken.Kind) && binary.Left != current {
 				return false
 			}
-			statement := target.AsForInOrOfStatement()
-			if statement == nil || statement.Initializer == nil {
+
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			statement := parent.AsForInOrOfStatement()
+			if statement == nil || statement.Initializer != current {
 				return false
 			}
-			initializer := ast.SkipParentheses(statement.Initializer)
-			return initializer != nil &&
-				(initializer.Kind == ast.KindArrayLiteralExpression || initializer.Kind == ast.KindObjectLiteralExpression)
+			return current.Kind == ast.KindArrayLiteralExpression || current.Kind == ast.KindObjectLiteralExpression
+
+		case ast.KindParenthesizedExpression:
+			paren := parent.AsParenthesizedExpression()
+			if paren == nil || paren.Expression != current {
+				return false
+			}
+
+		case ast.KindAsExpression:
+			asExpression := parent.AsAsExpression()
+			if asExpression == nil || asExpression.Expression != current {
+				return false
+			}
+
+		case ast.KindTypeAssertionExpression:
+			assertion := parent.AsTypeAssertion()
+			if assertion == nil || assertion.Expression != current {
+				return false
+			}
+
+		case ast.KindNonNullExpression:
+			nonNull := parent.AsNonNullExpression()
+			if nonNull == nil || nonNull.Expression != current {
+				return false
+			}
+
+		case ast.KindSatisfiesExpression:
+			satisfies := parent.AsSatisfiesExpression()
+			if satisfies == nil || satisfies.Expression != current {
+				return false
+			}
+
+		case ast.KindCallExpression:
+			call := parent.AsCallExpression()
+			if call == nil || call.Expression != current {
+				return false
+			}
+
+		case ast.KindPropertyAssignment:
+			property := parent.AsPropertyAssignment()
+			if property == nil || property.Initializer != current {
+				return false
+			}
+
+		case ast.KindShorthandPropertyAssignment:
+			shorthand := parent.AsShorthandPropertyAssignment()
+			if shorthand == nil || shorthand.Name() != current {
+				return false
+			}
+
+		case ast.KindPropertyAccessExpression,
+			ast.KindElementAccessExpression,
+			ast.KindComputedPropertyName,
+			ast.KindDecorator:
+			return false
 		}
+		current = parent
 	}
 	return false
 }
@@ -166,7 +213,8 @@ var NoGlobalAssignRule = rule.Rule{
 					return
 				}
 
-				if hasStackedTypeWrappers(node) {
+				if write := stackedTypeWrapperWriteExpression(node); write != nil &&
+					!isVisitedByEnclosingWritePattern(write) {
 					return
 				}
 

--- a/internal/rules/no_global_assign/no_global_assign_test.go
+++ b/internal/rules/no_global_assign/no_global_assign_test.go
@@ -144,6 +144,20 @@ func TestNoGlobalAssignRule(t *testing.T) {
 			{Code: `Object!! = 1;`},
 			{Code: `((Object as any) as any) += 1;`},
 			{Code: `((Object as any) as any)++;`},
+			{Code: `Object!! += 1;`},
+			{Code: `++(Object!!);`},
+
+			// An outer destructuring pattern does not turn evaluation-only children
+			// into writes, and wrapping the pattern root prevents PatternVisitor
+			// from recognizing it as a pattern.
+			{Code: `[x = (Object!! += 1)] = arr;`},
+			{Code: `({[(Object!! += 1)]: x} = src);`},
+			{Code: `[foo(Object!! += 1)] = arr;`},
+			{Code: `[((Object!! += 1).x)] = arr;`},
+			{Code: `([(Object!! += 1)] as any) = arr;`},
+			{Code: `([(Object!! += 1)]) = arr;`},
+			{Code: `(([(Object!! += 1)])) = arr;`},
+			{Code: `(({x: (Object!! += 1)})) = src;`},
 
 			// Satisfies expression write is NOT detected by ESLint scope analysis
 			{Code: `(Object satisfies any) = 1;`},
@@ -642,8 +656,52 @@ func TestNoGlobalAssignRule(t *testing.T) {
 					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 8},
 				},
 			},
+			// Compound assignments and updates remain writes when an enclosing
+			// destructuring pattern visits them.
+			{
+				Code: `[(Object!! += 1)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `[(Object!!)++] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `[++(Object!!)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `({x: (Object!! += 1)} = src);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code: `[{x: [(Object!! += 1)]}] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `for ([(Object!! += 1)] of rows) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `for ([(Object!! += 1)] in rows) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 8},
+				},
+			},
 			// TypeScript wrappers around a destructuring default are transparent
-			// when finding the enclosing pattern.
+			// throughout the path to the enclosing pattern.
 			{
 				Code: `[(Object!! = 0) as any] = arr;`,
 				Errors: []rule_tester.InvalidTestCaseError{
@@ -666,6 +724,75 @@ func TestNoGlobalAssignRule(t *testing.T) {
 				Code: `[(Object!! = 0) satisfies any] = arr;`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `[[Object!! = 0] as any] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `[[Object!! = 0] satisfies any] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `[...([Object!! = 0] as any)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code: `[((Object as any)! += 1)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 4},
+				},
+			},
+
+			// PatternVisitor-specific child edges remain distinct from ordinary
+			// assignment-target edges.
+			{
+				Code: `[((Object!! += 1)())] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code: `[new foo(Object!! += 1)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `[((Object!! += 1) ? x : y)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code: `[(0, Object!! += 1)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `[void (Object!! += 1)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `[((Object!! += 1) = x)] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code: `[(([(Object!! += 1)] as any) as any) = rhs] = top;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 6},
 				},
 			},
 			{


### PR DESCRIPTION
## Summary

- Preserve no-global-assign reports when stacked TypeScript wrapper writes are reached through an enclosing destructuring pattern.
- Match typescript-eslint PatternVisitor boundaries for nested patterns, evaluation-only children, and parenthesized pattern roots.
- Add regression coverage for compound assignments, updates, defaults, rest elements, for-in/of targets, and generic visitor paths.

## Related Links

- [ESLint no-global-assign](https://eslint.org/docs/latest/rules/no-global-assign)
- [typescript-eslint PatternVisitor](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/scope-manager/src/referencer/PatternVisitor.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
