### PR TITLE
fix: handle async imports from missing project outputs

### DIFF
--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -6,6 +6,8 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -456,6 +458,172 @@ func isThenableType(typeChecker *checker.Checker, node *ast.Node, t *checker.Typ
 	return isThenableTypePart(typeChecker, node, t)
 }
 
+type unloadedAsyncExportsCacheKey struct{}
+
+type unloadedAsyncExportsCache struct {
+	files utils.LazyMap[string, map[string]struct{}]
+}
+
+func isThenableExpression(ctx rule.RuleContext, node *ast.Node, t *checker.Type) bool {
+	if !utils.IsTypeAnyType(t) {
+		return isThenableType(ctx.TypeChecker, node, t)
+	}
+	return isUnloadedImportedAsyncCall(ctx, node)
+}
+
+// isUnloadedImportedAsyncCall recovers the one piece of type information
+// require-await needs when a project reference redirects an imported
+// source file to a missing declaration output. TypeScript-eslint constructs
+// its lint Program without that redirect and sees the inferred Promise return;
+// tsgo keeps the import alias but gives the call `any` because the source is
+// outside this Program's universe.
+//
+// The fallback is deliberately narrower than treating `any` as thenable. It
+// accepts only a direct named-import call whose resolved module is unloaded and
+// whose TypeScript source directly exports an unannotated async function.
+// An explicit `any`, a synchronous export, a local `any`, or an async generator
+// therefore retains the upstream missing-await diagnostic.
+func isUnloadedImportedAsyncCall(ctx rule.RuleContext, node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(node.Expression())
+	if callee == nil || callee.Kind != ast.KindIdentifier {
+		return false
+	}
+
+	symbol := ctx.TypeChecker.GetSymbolAtLocation(callee)
+	if symbol == nil || symbol.Flags&ast.SymbolFlagsAlias == 0 {
+		return false
+	}
+
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil ||
+			declaration.Kind != ast.KindImportSpecifier ||
+			ast.GetSourceFileOfNode(declaration) != ctx.SourceFile {
+			continue
+		}
+		specifier := declaration.AsImportSpecifier()
+		if specifier == nil || specifier.IsTypeOnly {
+			return false
+		}
+		importDeclarationNode := ast.FindAncestorKind(declaration.Parent, ast.KindImportDeclaration)
+		if importDeclarationNode == nil {
+			return false
+		}
+		importDeclaration := importDeclarationNode.AsImportDeclaration()
+		if importDeclaration == nil || importDeclaration.ImportClause == nil || importDeclaration.ImportClause.IsTypeOnly() {
+			return false
+		}
+
+		resolvedPath, target, ok := ctx.Program().ResolveModule(ctx.SourceFile, importDeclaration.ModuleSpecifier)
+		if !ok || target != nil {
+			return false
+		}
+		importedName := specifier.PropertyName
+		if importedName == nil {
+			importedName = specifier.Name()
+		}
+		if importedName == nil || importedName.Kind != ast.KindIdentifier {
+			return false
+		}
+		_, ok = unloadedAsyncExports(ctx, resolvedPath)[importedName.Text()]
+		return ok
+	}
+	return false
+}
+
+func unloadedAsyncExports(ctx rule.RuleContext, fileName string) map[string]struct{} {
+	cache := rule.CachedByProgram(ctx, unloadedAsyncExportsCacheKey{}, func() *unloadedAsyncExportsCache {
+		return &unloadedAsyncExportsCache{}
+	})
+	return cache.files.Get(fileName, func() map[string]struct{} {
+		return collectUnannotatedAsyncExports(ctx, fileName)
+	})
+}
+
+func collectUnannotatedAsyncExports(ctx rule.RuleContext, fileName string) map[string]struct{} {
+	fileSystem := ctx.Program().FS()
+	if fileSystem == nil {
+		return nil
+	}
+	text, ok := fileSystem.ReadFile(fileName)
+	if !ok {
+		return nil
+	}
+	scriptKind := core.GetScriptKindFromFileName(fileName)
+	if scriptKind != core.ScriptKindTS && scriptKind != core.ScriptKindTSX {
+		return nil
+	}
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: fileName,
+		Path: tspath.ToPath(
+			fileName,
+			ctx.Program().CurrentDirectory(),
+			fileSystem.UseCaseSensitiveFileNames(),
+		),
+	}, text, scriptKind)
+	if len(sourceFile.Diagnostics()) != 0 {
+		return nil
+	}
+
+	var exports map[string]struct{}
+	for _, statement := range sourceFile.Statements.Nodes {
+		if statement == nil || !ast.HasSyntacticModifier(statement, ast.ModifierFlagsExport) {
+			continue
+		}
+
+		switch statement.Kind {
+		case ast.KindVariableStatement:
+			declarationList := statement.AsVariableStatement().DeclarationList.AsVariableDeclarationList()
+			for _, declarationNode := range declarationList.Declarations.Nodes {
+				declaration := declarationNode.AsVariableDeclaration()
+				if declaration == nil || declaration.Type != nil || declaration.Initializer == nil {
+					continue
+				}
+				name := declaration.Name()
+				initializer := ast.SkipParentheses(declaration.Initializer)
+				if name == nil || name.Kind != ast.KindIdentifier ||
+					!isUnannotatedAsyncFunction(initializer) {
+					continue
+				}
+				if exports == nil {
+					exports = make(map[string]struct{})
+				}
+				exports[name.Text()] = struct{}{}
+			}
+
+		case ast.KindFunctionDeclaration:
+			if ast.HasSyntacticModifier(statement, ast.ModifierFlagsDefault) ||
+				!isUnannotatedAsyncFunction(statement) {
+				continue
+			}
+			name := statement.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				continue
+			}
+			if exports == nil {
+				exports = make(map[string]struct{})
+			}
+			exports[name.Text()] = struct{}{}
+		}
+	}
+	return exports
+}
+
+func isUnannotatedAsyncFunction(node *ast.Node) bool {
+	if node == nil || node.Type() != nil {
+		return false
+	}
+	if node.Kind != ast.KindArrowFunction &&
+		node.Kind != ast.KindFunctionExpression &&
+		node.Kind != ast.KindFunctionDeclaration {
+		return false
+	}
+	flags := ast.GetFunctionFlags(node)
+	return flags&ast.FunctionFlagsAsync != 0 && flags&ast.FunctionFlagsGenerator == 0
+}
+
 func hasAsyncIterator(typeChecker *checker.Checker, t *checker.Type) bool {
 	if utils.IsTypeFlagSet(t, checker.TypeFlagsUnionOrIntersection) {
 		for _, typePart := range t.Types() {
@@ -515,7 +683,7 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 				body := ast.SkipParentheses(node.Body())
 				if !ast.IsBlock(body) &&
 					!ast.IsAwaitExpression(body) &&
-					isThenableType(ctx.TypeChecker, body, ctx.TypeChecker.GetTypeAtLocation(body)) {
+					isThenableExpression(ctx, body, ctx.TypeChecker.GetTypeAtLocation(body)) {
 					scope.hasAwait = true
 				}
 			}
@@ -576,7 +744,7 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 				}
 
 				if node.AsYieldExpression().AsteriskToken == nil {
-					if isThenableType(ctx.TypeChecker, argument, ctx.TypeChecker.GetTypeAtLocation(argument)) {
+					if isThenableExpression(ctx, argument, ctx.TypeChecker.GetTypeAtLocation(argument)) {
 						scope.isAsyncYield = true
 					}
 					return
@@ -597,7 +765,7 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 				}
 
 				expr := node.Expression()
-				if expr != nil && isThenableType(ctx.TypeChecker, expr, ctx.TypeChecker.GetTypeAtLocation(expr)) {
+				if expr != nil && isThenableExpression(ctx, expr, ctx.TypeChecker.GetTypeAtLocation(expr)) {
 					scope.hasAwait = true
 				}
 			},

--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -567,6 +567,17 @@ func collectUnannotatedAsyncExports(ctx rule.RuleContext, fileName string) map[s
 		return nil
 	}
 
+	functionDeclarationCounts := make(map[string]int)
+	for _, statement := range sourceFile.Statements.Nodes {
+		if statement == nil || statement.Kind != ast.KindFunctionDeclaration {
+			continue
+		}
+		name := statement.Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			functionDeclarationCounts[name.Text()]++
+		}
+	}
+
 	var exports map[string]struct{}
 	for _, statement := range sourceFile.Statements.Nodes {
 		if statement == nil || !ast.HasSyntacticModifier(statement, ast.ModifierFlagsExport) {
@@ -600,6 +611,12 @@ func collectUnannotatedAsyncExports(ctx rule.RuleContext, fileName string) map[s
 			}
 			name := statement.Name()
 			if name == nil || name.Kind != ast.KindIdentifier {
+				continue
+			}
+			// Overload signatures determine the imported call type. Do not infer
+			// a thenable return from the async implementation when another declaration
+			// for the same binding may expose `any` or a non-thenable return.
+			if functionDeclarationCounts[name.Text()] != 1 {
 				continue
 			}
 			if exports == nil {

--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -568,13 +568,32 @@ func collectUnannotatedAsyncExports(ctx rule.RuleContext, fileName string) map[s
 	}
 
 	functionDeclarationCounts := make(map[string]int)
+	firstVariableDeclarations := make(map[string]*ast.Node)
 	for _, statement := range sourceFile.Statements.Nodes {
-		if statement == nil || statement.Kind != ast.KindFunctionDeclaration {
+		if statement == nil {
 			continue
 		}
-		name := statement.Name()
-		if name != nil && name.Kind == ast.KindIdentifier {
-			functionDeclarationCounts[name.Text()]++
+		switch statement.Kind {
+		case ast.KindFunctionDeclaration:
+			name := statement.Name()
+			if name != nil && name.Kind == ast.KindIdentifier {
+				functionDeclarationCounts[name.Text()]++
+			}
+		case ast.KindVariableStatement:
+			declarationList := statement.AsVariableStatement().DeclarationList.AsVariableDeclarationList()
+			for _, declarationNode := range declarationList.Declarations.Nodes {
+				declaration := declarationNode.AsVariableDeclaration()
+				if declaration == nil {
+					continue
+				}
+				name := declaration.Name()
+				if name == nil || name.Kind != ast.KindIdentifier {
+					continue
+				}
+				if _, seen := firstVariableDeclarations[name.Text()]; !seen {
+					firstVariableDeclarations[name.Text()] = declarationNode
+				}
+			}
 		}
 	}
 
@@ -594,7 +613,11 @@ func collectUnannotatedAsyncExports(ctx rule.RuleContext, fileName string) map[s
 				}
 				name := declaration.Name()
 				initializer := ast.SkipParentheses(declaration.Initializer)
-				if name == nil || name.Kind != ast.KindIdentifier ||
+				if name == nil || name.Kind != ast.KindIdentifier {
+					continue
+				}
+				if firstVariableDeclarations[name.Text()] != declarationNode ||
+					functionDeclarationCounts[name.Text()] != 0 ||
 					!isUnannotatedAsyncFunction(initializer) {
 					continue
 				}
@@ -616,7 +639,7 @@ func collectUnannotatedAsyncExports(ctx rule.RuleContext, fileName string) map[s
 			// Overload signatures determine the imported call type. Do not infer
 			// a thenable return from the async implementation when another declaration
 			// for the same binding may expose `any` or a non-thenable return.
-			if functionDeclarationCounts[name.Text()] != 1 {
+			if functionDeclarationCounts[name.Text()] != 1 || firstVariableDeclarations[name.Text()] != nil {
 				continue
 			}
 			if exports == nil {

--- a/internal/plugins/typescript/rules/require_await/require_await_extras_test.go
+++ b/internal/plugins/typescript/rules/require_await/require_await_extras_test.go
@@ -868,7 +868,7 @@ func TestRequireAwaitMissingProjectReferenceOutput(t *testing.T) {
 		},
 	})
 
-	wantLines := []int{21, 22, 23, 24, 25, 27, 29}
+	wantLines := []int{22, 23, 24, 25, 26, 27, 29, 31}
 	if len(diagnostics) != len(wantLines) {
 		t.Fatalf("diagnostics = %d (%v), want %d at lines %v", len(diagnostics), diagnostics, len(wantLines), wantLines)
 	}

--- a/internal/plugins/typescript/rules/require_await/require_await_extras_test.go
+++ b/internal/plugins/typescript/rules/require_await/require_await_extras_test.go
@@ -10,14 +10,19 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/testutil"
+	"github.com/web-infra-dev/rslint/internal/testutil/txtarfs"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -816,6 +821,61 @@ const caseIntersection = null as GoodThenable & { tag: string };
 	for name := range expected {
 		if !seen[name] {
 			t.Errorf("test case %s was not visited", name)
+		}
+	}
+}
+
+func TestRequireAwaitMissingProjectReferenceOutput(t *testing.T) {
+	archive := txtarfs.MustParseFile(t, "testdata/missing_project_reference_output.txtar")
+	root := tspath.NormalizePath(archive.Materialize(t, "missing-project-reference-output"))
+	appRoot := tspath.ResolvePath(root, "app")
+	entryPath := tspath.ResolvePath(appRoot, "src/main.ts")
+	dependencyPath := tspath.ResolvePath(root, "fixture-lib/src/index.ts")
+	fs := bundled.WrapFS(osvfs.FS())
+	compilerProgram, err := utils.CreateProgram(
+		true,
+		fs,
+		appRoot,
+		"tsconfig.json",
+		utils.CreateCompilerHost(appRoot, fs),
+	)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	if compilerProgram.GetSourceFile(dependencyPath) != nil {
+		t.Fatalf("fixture precondition failed: project-reference source %q was loaded despite its missing declaration output", dependencyPath)
+	}
+
+	sourceProgram := lintprogram.NewFromCompiler(compilerProgram)
+	var diagnostics []rule.RuleDiagnostic
+	testutil.LintProgram(t, testutil.LintProgramOptions{
+		Program:                sourceProgram,
+		Files:                  []string{entryPath},
+		ExcludedPathSubstrings: []string{},
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
+				Name:             RequireAwaitRule.Name,
+				Environment:      &rule.RuleEnvironment{},
+				Severity:         rule.SeverityError,
+				RequiresTypeInfo: true,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return RequireAwaitRule.Run(ctx, nil)
+				},
+			}}
+		},
+		OnDiagnostic: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+
+	wantLines := []int{21, 22, 23, 24, 25, 27, 29}
+	if len(diagnostics) != len(wantLines) {
+		t.Fatalf("diagnostics = %d (%v), want %d at lines %v", len(diagnostics), diagnostics, len(wantLines), wantLines)
+	}
+	for index, diagnostic := range diagnostics {
+		line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(diagnostic.SourceFile, diagnostic.Range.Pos())
+		if line+1 != wantLines[index] {
+			t.Errorf("diagnostic %d line = %d, want %d", index+1, line+1, wantLines[index])
 		}
 	}
 }

--- a/internal/plugins/typescript/rules/require_await/require_await_extras_test.go
+++ b/internal/plugins/typescript/rules/require_await/require_await_extras_test.go
@@ -868,7 +868,7 @@ func TestRequireAwaitMissingProjectReferenceOutput(t *testing.T) {
 		},
 	})
 
-	wantLines := []int{22, 23, 24, 25, 26, 27, 29, 31}
+	wantLines := []int{25, 26, 27, 28, 29, 30, 31, 33, 35}
 	if len(diagnostics) != len(wantLines) {
 		t.Fatalf("diagnostics = %d (%v), want %d at lines %v", len(diagnostics), diagnostics, len(wantLines), wantLines)
 	}

--- a/internal/plugins/typescript/rules/require_await/testdata/missing_project_reference_output.txtar
+++ b/internal/plugins/typescript/rules/require_await/testdata/missing_project_reference_output.txtar
@@ -20,6 +20,7 @@ import {
   asyncGenerator,
   asyncValue,
   asyncValue as renamedAsyncValue,
+  overloaded,
   returnAny,
   returnAnyDeclaration,
   syncValue,
@@ -38,6 +39,7 @@ async function* generated() {
 const explicitAny = async () => typedAny();
 const returnAnnotatedAny = async () => returnAny();
 const declarationReturnAnnotatedAny = async () => returnAnyDeclaration();
+const overloadedResult = async () => overloaded();
 const synchronous = async () => syncValue();
 const generatorResult = async () => asyncGenerator();
 declare const localAny: any;
@@ -68,6 +70,10 @@ export async function asyncDeclaration() {
 export const typedAny: any = async () => "ok";
 export const returnAny = async (): any => "ok";
 export async function returnAnyDeclaration(): any {
+  return "ok";
+}
+export function overloaded(): any;
+export async function overloaded() {
   return "ok";
 }
 export const syncValue = () => "ok";

--- a/internal/plugins/typescript/rules/require_await/testdata/missing_project_reference_output.txtar
+++ b/internal/plugins/typescript/rules/require_await/testdata/missing_project_reference_output.txtar
@@ -18,8 +18,10 @@
 import {
   asyncDeclaration,
   asyncGenerator,
+  asyncThenAny,
   asyncValue,
   asyncValue as renamedAsyncValue,
+  anyThenAsync,
   overloaded,
   returnAny,
   returnAnyDeclaration,
@@ -29,6 +31,7 @@ import {
 
 const concise = async () => asyncValue();
 const declaration = async () => asyncDeclaration();
+const redeclared = async () => asyncThenAny();
 const block = async () => {
   return renamedAsyncValue();
 };
@@ -40,6 +43,7 @@ const explicitAny = async () => typedAny();
 const returnAnnotatedAny = async () => returnAny();
 const declarationReturnAnnotatedAny = async () => returnAnyDeclaration();
 const overloadedResult = async () => overloaded();
+const redeclaredAny = async () => anyThenAsync();
 const synchronous = async () => syncValue();
 const generatorResult = async () => asyncGenerator();
 declare const localAny: any;
@@ -64,6 +68,10 @@ function shadow(asyncValue: any) {
 }
 -- missing-project-reference-output/fixture-lib/src/index.ts --
 export const asyncValue = async () => "ok";
+export var asyncThenAny = async () => "ok";
+export var asyncThenAny: any;
+export var anyThenAsync: any;
+export var anyThenAsync = async () => "ok";
 export async function asyncDeclaration() {
   return "ok";
 }

--- a/internal/plugins/typescript/rules/require_await/testdata/missing_project_reference_output.txtar
+++ b/internal/plugins/typescript/rules/require_await/testdata/missing_project_reference_output.txtar
@@ -1,0 +1,76 @@
+-- missing-project-reference-output/app/tsconfig.json --
+{
+  "compilerOptions": {
+    "disableSourceOfProjectReferenceRedirect": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "fixture-lib": ["../fixture-lib/src/index.ts"]
+    },
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../fixture-lib" }]
+}
+-- missing-project-reference-output/app/src/main.ts --
+import {
+  asyncDeclaration,
+  asyncGenerator,
+  asyncValue,
+  asyncValue as renamedAsyncValue,
+  returnAny,
+  returnAnyDeclaration,
+  syncValue,
+  typedAny,
+} from "fixture-lib";
+
+const concise = async () => asyncValue();
+const declaration = async () => asyncDeclaration();
+const block = async () => {
+  return renamedAsyncValue();
+};
+async function* generated() {
+  yield asyncValue();
+}
+
+const explicitAny = async () => typedAny();
+const returnAnnotatedAny = async () => returnAny();
+const declarationReturnAnnotatedAny = async () => returnAnyDeclaration();
+const synchronous = async () => syncValue();
+const generatorResult = async () => asyncGenerator();
+declare const localAny: any;
+const unresolvedLocal = async () => localAny();
+function shadow(asyncValue: any) {
+  return async () => asyncValue();
+}
+-- missing-project-reference-output/fixture-lib/tsconfig.json --
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "target": "ESNext"
+  },
+  "include": ["src"]
+}
+-- missing-project-reference-output/fixture-lib/src/index.ts --
+export const asyncValue = async () => "ok";
+export async function asyncDeclaration() {
+  return "ok";
+}
+export const typedAny: any = async () => "ok";
+export const returnAny = async (): any => "ok";
+export async function returnAnyDeclaration(): any {
+  return "ok";
+}
+export const syncValue = () => "ok";
+export const asyncGenerator = async function* () {
+  yield "ok";
+};


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/require-await` with upstream when an imported project-reference source is redirected to a missing declaration output and tsgo consequently exposes the call as `any`.
- Recover only direct, unannotated async named exports from unloaded TypeScript sources, while preserving diagnostics for explicit `any`, overloaded or redeclared bindings, synchronous exports, async generators, local values, and shadowed imports.
- Add a missing-output project-reference fixture covering concise returns, block returns, async-generator yields, renamed imports, async variable exports, async function declarations, and adversarial controls including an `any` overload and both variable-redeclaration orders.
- Verify the reported TSX file against the final binary with no diagnostics; targeted Go and JS rule tests pass with no snapshot changes. Benchmarks show unchanged allocations and no listener-time regression, so no benchmark file or performance-only change is included.

## Related Links

- [typescript-eslint require-await rule](https://typescript-eslint.io/rules/require-await/)
- [Latest upstream implementation](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/require-await.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
