### PR TITLE
feat: port rule unicorn/prefer-add-event-listener-options

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -21,6 +21,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unsafe_string_replacement"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_xor_as_exponentiation"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_add_event_listener_options"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_some"
@@ -57,6 +58,7 @@ func GetAllRules() []rule.Rule {
 		no_unsafe_string_replacement.NoUnsafeStringReplacementRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		no_xor_as_exponentiation.NoXorAsExponentiationRule,
+		prefer_add_event_listener_options.PreferAddEventListenerOptionsRule,
 		prefer_array_flat.PreferArrayFlatRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,
 		prefer_array_some.PreferArraySomeRule,

--- a/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options.go
+++ b/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options.go
@@ -1,0 +1,67 @@
+package prefer_add_event_listener_options
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "prefer-add-event-listener-options"
+
+func preferOptionsMessage(value, replacement string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageID,
+		Description: "Prefer `" + replacement + "` over `" + value + "`.",
+		Data: map[string]string{
+			"replacement": replacement,
+			"value":       value,
+		},
+	}
+}
+
+// PreferAddEventListenerOptionsRule prefers the options-object form of
+// addEventListener over its legacy boolean useCapture argument.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-add-event-listener-options.js
+var PreferAddEventListenerOptionsRule = rule.Rule{
+	Name:   "unicorn/prefer-add-event-listener-options",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		argumentCount := 3
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Method:              "addEventListener",
+					ArgumentsLength:     &argumentCount,
+					RejectSpreadElement: true,
+				})
+				if !ok {
+					return
+				}
+
+				// ESTree removes source parentheses and JavaScript JSDoc casts,
+				// while authored TypeScript assertions remain visible to upstream.
+				option := utils.ESTreeRuntimeExpression(call.Call.Arguments()[2])
+				if option == nil {
+					return
+				}
+
+				value := ""
+				switch option.Kind {
+				case ast.KindTrueKeyword:
+					value = "true"
+				case ast.KindFalseKeyword:
+					value = "false"
+				default:
+					return
+				}
+
+				replacement := "{capture: " + value + "}"
+				ctx.ReportNodeWithDeferredFixes(option, preferOptionsMessage(value, replacement), func() []rule.RuleFix {
+					return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, option, replacement)}
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options.md
+++ b/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options.md
@@ -1,0 +1,32 @@
+# prefer-add-event-listener-options
+
+## Rule Details
+
+Prefer the options-object form of `.addEventListener()` over the legacy boolean
+`useCapture` argument.
+
+The object form makes the capture behavior explicit and leaves room for other
+listener options such as `passive`, `once`, and `signal`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+element.addEventListener('click', handleClick, true);
+element.addEventListener('scroll', handleScroll, false);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+element.addEventListener('click', handleClick, { capture: true });
+element.addEventListener('scroll', handleScroll, { capture: false });
+element.addEventListener('scroll', handleScroll, {
+  passive: true,
+  capture: true,
+});
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: prefer-add-event-listener-options](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-add-event-listener-options.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-add-event-listener-options.js)

--- a/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options_extras_test.go
@@ -1,0 +1,261 @@
+// TestPreferAddEventListenerOptionsExtras covers tsgo-specific edge shapes,
+// real-user examples, and every reachable upstream branch. The complete
+// upstream suite remains isolated in the sibling upstream test file.
+package prefer_add_event_listener_options_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	prefer_add_event_listener_options "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_add_event_listener_options"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferAddEventListenerOptionsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_add_event_listener_options.PreferAddEventListenerOptionsRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream isMethodCall() arm 1: a bare call is not a method call.
+			{Code: `addEventListener("click", listener, true)`, FileName: "file.js"},
+			// Locks in upstream isMethodCall() name constraint.
+			{Code: `window.notAddEventListener("click", listener, true)`, FileName: "file.js"},
+			// Locks in upstream argumentsLength === 3.
+			{Code: `window.addEventListener()`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, true, extra)`, FileName: "file.js"},
+
+			// ---- Dimension 4: element and private access keys are excluded ----
+			{Code: `window['addEventListener']("click", listener, true)`, FileName: "file.js"},
+			{Code: "window[`addEventListener`](\"click\", listener, true)", FileName: "file.js"},
+			{Code: `window[0]("click", listener, true)`, FileName: "file.js"},
+			{Code: `window[Symbol.addEventListener]("click", listener, true)`, FileName: "file.js"},
+			{Code: `class C { #addEventListener() {} method() { this.#addEventListener("click", listener, true) } }`, FileName: "file.js"},
+
+			// ---- Dimension 4: optional member and optional call forms are excluded ----
+			{Code: `((window))?.addEventListener("click", listener, true)`, FileName: "file.ts", Tsx: false},
+			{Code: `(window.addEventListener)?.("click", listener, true)`, FileName: "file.ts", Tsx: false},
+
+			// ---- Dimension 4: TypeScript wrappers around the inspected boolean remain visible upstream ----
+			{Code: `window.addEventListener("click", listener, true as boolean)`, FileName: "file.ts", Tsx: false},
+			{Code: `window.addEventListener("click", listener, true satisfies boolean)`, FileName: "file.ts", Tsx: false},
+			{Code: `window.addEventListener("click", listener, true!)`, FileName: "file.ts", Tsx: false},
+
+			// ---- Graceful degradation: spread arguments disqualify the call ----
+			{Code: `window.addEventListener(...args, listener, true)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, ...options)`, FileName: "file.js"},
+
+			// Locks in upstream boolean-literal gate: other literal kinds are ignored.
+			{Code: `window.addEventListener("click", listener, 1)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, "true")`, FileName: "file.js"},
+
+			// ---- Real-user: #2067 already uses the preferred extensible object form ----
+			{Code: `el.addEventListener('click', () => {}, {capture: true})`, FileName: "file.js"},
+
+			// N/A: declaration/container variants; the rule only inspects calls.
+			// N/A: object-literal spread/rest and body-less declarations; neither is traversed specially.
+			// N/A: ancestor walks; the rule does not inspect parents or enclosing scopes.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: single- and multi-level parenthesized receivers are transparent ----
+			{
+				Code:     `((window)).addEventListener("click", listener, true)`,
+				FileName: "file.js",
+				Output:   []string{`((window)).addEventListener("click", listener, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+
+			// ---- Dimension 4: TypeScript receiver wrappers do not affect the method match ----
+			{
+				Code:     `window!.addEventListener("click", listener, false)`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`window!.addEventListener("click", listener, {capture: false})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+			{
+				Code:     `(window as Window).addEventListener("click", listener, true)`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`(window as Window).addEventListener("click", listener, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+			{
+				Code:     `(window satisfies Window).addEventListener("click", listener, true)`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`(window satisfies Window).addEventListener("click", listener, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+
+			// ---- Dimension 4: parenthesized callee is transparent in ESTree ----
+			{
+				Code:     `(window.addEventListener)("click", listener, true)`,
+				FileName: "file.js",
+				Output:   []string{`(window.addEventListener)("click", listener, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+
+			// ---- Dimension 4: JavaScript JSDoc casts are invisible to ESTree ----
+			{
+				Code:     `window.addEventListener("click", listener, /** @type {boolean} */ (true))`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", listener, /** @type {boolean} */ ({capture: true}))`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+			{
+				Code:     `/** @type {any} */ (window.addEventListener)("click", listener, true)`,
+				FileName: "file.js",
+				Output:   []string{`/** @type {any} */ (window.addEventListener)("click", listener, {capture: true})`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   expectedMessage("true"),
+					Line:      1,
+					Column:    65,
+					EndLine:   1,
+					EndColumn: 69,
+				}},
+			},
+			{
+				Code:     `/** @satisfies {any} */ (window.addEventListener)("click", listener, false)`,
+				FileName: "file.js",
+				Output:   []string{`/** @satisfies {any} */ (window.addEventListener)("click", listener, {capture: false})`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   expectedMessage("false"),
+					Line:      1,
+					Column:    70,
+					EndLine:   1,
+					EndColumn: 75,
+				}},
+			},
+
+			// Locks in upstream CallExpression handling with TypeScript type arguments.
+			{
+				Code:     `window.addEventListener<Event>("click", listener, true)`,
+				FileName: "file.ts",
+				Tsx:      false,
+				Output:   []string{`window.addEventListener<Event>("click", listener, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+
+			// Locks in upstream replacement branch 1: true maps to capture: true.
+			{
+				Code:     `target.addEventListener("x", handler, true)`,
+				FileName: "file.js",
+				Output:   []string{`target.addEventListener("x", handler, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID, Message: expectedMessage("true")}},
+			},
+			// Locks in upstream replacement branch 2: false maps to capture: false.
+			{
+				Code:     `target.addEventListener("x", handler, false)`,
+				FileName: "file.js",
+				Output:   []string{`target.addEventListener("x", handler, {capture: false})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID, Message: expectedMessage("false")}},
+			},
+
+			// ---- Dimension 4: same-kind nesting reports each matching call independently ----
+			{
+				Code:     `window.addEventListener("outer", () => window.addEventListener("inner", listener, false), true)`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("outer", () => window.addEventListener("inner", listener, {capture: false}), {capture: true})`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID},
+					{MessageId: messageID},
+				},
+			},
+
+			// ---- Real-user: #2067 legacy boolean signature with an inline listener ----
+			{
+				Code:     `el.addEventListener('click', () => {}, true)`,
+				FileName: "file.js",
+				Output:   []string{`el.addEventListener('click', () => {}, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: messageID}},
+			},
+		},
+	)
+}
+
+// TestPreferAddEventListenerOptionsEditDemand verifies that the deferred
+// autofix never changes the diagnostic identity and is only materialized for
+// consumers that request autofixes.
+func TestPreferAddEventListenerOptionsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `window.addEventListener("click", listener, true);`, core.ScriptKindTS)
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		comments := rule.NewCommentStore(sourceFile)
+		diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(
+			prefer_add_event_listener_options.PreferAddEventListenerOptionsRule.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		)
+
+		listeners := prefer_add_event_listener_options.PreferAddEventListenerOptionsRule.Run(ctx, nil)
+		var visit ast.Visitor
+		visit = func(node *ast.Node) bool {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+			return node.ForEachChild(visit)
+		}
+		sourceFile.AsNode().ForEachChild(visit)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("a non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || allEdits.FixesPtr == nil ||
+		!reflect.DeepEqual(*autofixOnly.FixesPtr, *allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	if diagnosticsOnly.Suggestions != nil || autofixOnly.Suggestions != nil ||
+		suggestionOnly.Suggestions != nil || allEdits.Suggestions != nil {
+		t.Fatal("autofix-only rule materialized suggestions")
+	}
+}

--- a/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_add_event_listener_options/prefer_add_event_listener_options_upstream_test.go
@@ -1,0 +1,118 @@
+// TestPreferAddEventListenerOptionsUpstream migrates the complete v74.0.0
+// upstream test/prefer-add-event-listener-options.js suite. rslint-specific
+// edge shapes and branch lock-ins live in the sibling extras test file.
+package prefer_add_event_listener_options_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	prefer_add_event_listener_options "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_add_event_listener_options"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const messageID = "prefer-add-event-listener-options"
+
+func expectedMessage(value string) string {
+	return "Prefer `{capture: " + value + "}` over `" + value + "`."
+}
+
+func upstreamError(value string, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   expectedMessage(value),
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestPreferAddEventListenerOptionsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_add_event_listener_options.PreferAddEventListenerOptionsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `window.addEventListener("click", listener)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, {capture: true})`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, {capture: false})`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, {passive: true})`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, {once: true})`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, {signal})`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, options)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, capture)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, Boolean(value))`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, condition ? true : false)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, undefined)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", listener, null)`, FileName: "file.js"},
+			{Code: `window["addEventListener"]("click", listener, true)`, FileName: "file.js"},
+			{Code: `window?.addEventListener("click", listener, true)`, FileName: "file.js"},
+			{Code: `window.addEventListener?.("click", listener, true)`, FileName: "file.js"},
+			{Code: `window.addEventListener("click", ...arguments_, true)`, FileName: "file.js"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `window.addEventListener("click", listener, true)`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", listener, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("true", 1, 44, 1, 48)},
+			},
+			{
+				Code:     `window.addEventListener("click", listener, false)`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", listener, {capture: false})`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("false", 1, 44, 1, 49)},
+			},
+			{
+				Code:     `window.addEventListener("click", listener, (true))`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", listener, ({capture: true}))`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("true", 1, 45, 1, 49)},
+			},
+			{
+				Code:     `window.addEventListener("click", () => {}, true)`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", () => {}, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("true", 1, 44, 1, 48)},
+			},
+			{
+				Code:     `window.addEventListener("click", function () {}, false)`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", function () {}, {capture: false})`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("false", 1, 50, 1, 55)},
+			},
+			{
+				Code:     `document.body.addEventListener("click", listener, true)`,
+				FileName: "file.js",
+				Output:   []string{`document.body.addEventListener("click", listener, {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("true", 1, 51, 1, 55)},
+			},
+			{
+				Code:     `(window).addEventListener("click", listener, false)`,
+				FileName: "file.js",
+				Output:   []string{`(window).addEventListener("click", listener, {capture: false})`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("false", 1, 46, 1, 51)},
+			},
+			{
+				Code:     `window.addEventListener("click", listener, /* useCapture */ true)`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", listener, /* useCapture */ {capture: true})`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("true", 1, 61, 1, 65)},
+			},
+			{
+				Code:     `window.addEventListener("click", listener, true /* useCapture */)`,
+				FileName: "file.js",
+				Output:   []string{`window.addEventListener("click", listener, {capture: true} /* useCapture */)`},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("true", 1, 44, 1, 48)},
+			},
+			{
+				Code:     "window.addEventListener(\n\t\"click\",\n\tlistener,\n\ttrue\n)",
+				FileName: "file.js",
+				Output:   []string{"window.addEventListener(\n\t\"click\",\n\tlistener,\n\t{capture: true}\n)"},
+				Errors:   []rule_tester.InvalidTestCaseError{upstreamError("true", 4, 2, 4, 6)},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/unicornutil/method_call.go
+++ b/internal/plugins/unicorn/unicornutil/method_call.go
@@ -1,6 +1,9 @@
 package unicornutil
 
-import "github.com/microsoft/typescript-go/shim/ast"
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
 
 // DotMethodCall is a non-computed method call matched by MatchDotMethodCall.
 type DotMethodCall struct {
@@ -32,8 +35,9 @@ type DotMethodCallOptions struct {
 
 // MatchDotMethodCall matches a dot-property CallExpression. Static bracket
 // access is intentionally excluded because unicorn's isMethodCall defaults to
-// computed:false. Parentheses are transparent except around optional-chain
-// callees, matching the upstream helper's semantics.
+// computed:false. Parentheses and JavaScript JSDoc casts are transparent
+// except around optional-chain callees, matching the ESTree view upstream.
+// Authored TypeScript assertions remain visible and therefore unmatched.
 func MatchDotMethodCall(node *ast.Node, options DotMethodCallOptions) (DotMethodCall, bool) {
 	if node == nil || !ast.IsCallExpression(node) {
 		return DotMethodCall{}, false
@@ -74,7 +78,7 @@ func MatchDotMethodCall(node *ast.Node, options DotMethodCallOptions) (DotMethod
 	}
 
 	rawCallee := call.Expression
-	callee := ast.SkipParentheses(rawCallee)
+	callee := utils.ESTreeRuntimeExpression(rawCallee)
 	if callee == nil || (rawCallee != callee && ast.IsOptionalChain(callee)) ||
 		!ast.IsPropertyAccessExpression(callee) {
 		return DotMethodCall{}, false

--- a/internal/plugins/unicorn/unicornutil/method_call_test.go
+++ b/internal/plugins/unicorn/unicornutil/method_call_test.go
@@ -1,0 +1,106 @@
+package unicornutil
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
+)
+
+func parseMethodCallTestSource(fileName, code string, scriptKind core.ScriptKind) *ast.SourceFile {
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: fileName,
+		Path:     tspath.Path(fileName),
+	}, code, scriptKind)
+}
+
+func firstMethodCallTestCall(t *testing.T, sourceFile *ast.SourceFile) *ast.Node {
+	t.Helper()
+	var found *ast.Node
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if found != nil {
+			return true
+		}
+		if ast.IsCallExpression(node) {
+			found = node
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if found == nil {
+		t.Fatal("expected a call expression")
+	}
+	return found
+}
+
+func TestMatchDotMethodCallESTreeCalleeWrappers(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileName   string
+		code       string
+		scriptKind core.ScriptKind
+		want       bool
+	}{
+		{
+			name:       "plain method",
+			fileName:   "/test.js",
+			code:       `object.method("value")`,
+			scriptKind: core.ScriptKindJS,
+			want:       true,
+		},
+		{
+			name:       "parenthesized callee",
+			fileName:   "/test.js",
+			code:       `(object.method)("value")`,
+			scriptKind: core.ScriptKindJS,
+			want:       true,
+		},
+		{
+			name:       "JSDoc type cast callee",
+			fileName:   "/test.js",
+			code:       `/** @type {any} */ (object.method)("value")`,
+			scriptKind: core.ScriptKindJS,
+			want:       true,
+		},
+		{
+			name:       "JSDoc satisfies cast callee",
+			fileName:   "/test.js",
+			code:       `/** @satisfies {any} */ (object.method)("value")`,
+			scriptKind: core.ScriptKindJS,
+			want:       true,
+		},
+		{
+			name:       "JSDoc cast does not hide optional member",
+			fileName:   "/test.js",
+			code:       `/** @type {any} */ (object?.method)("value")`,
+			scriptKind: core.ScriptKindJS,
+		},
+		{
+			name:       "authored TypeScript as expression",
+			fileName:   "/test.ts",
+			code:       `(object.method as any)("value")`,
+			scriptKind: core.ScriptKindTS,
+		},
+		{
+			name:       "authored TypeScript satisfies expression",
+			fileName:   "/test.ts",
+			code:       `(object.method satisfies any)("value")`,
+			scriptKind: core.ScriptKindTS,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parseMethodCallTestSource(test.fileName, test.code, test.scriptKind)
+			call := firstMethodCallTestCall(t, sourceFile)
+			_, got := MatchDotMethodCall(call, DotMethodCallOptions{Method: "method"})
+			if got != test.want {
+				t.Fatalf("MatchDotMethodCall(%q) = %v, want %v", test.code, got, test.want)
+			}
+		})
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -673,6 +673,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/no-unsafe-string-replacement.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-xor-as-exponentiation.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-add-event-listener-options.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-some.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-add-event-listener-options.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-add-event-listener-options.test.ts
@@ -1,0 +1,58 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code, filename: 'file.js' });
+const invalid = (code: string, value: 'true' | 'false') => ({
+  code,
+  filename: 'file.js',
+  errors: [
+    {
+      message: `Prefer \`{capture: ${value}}\` over \`${value}\`.`,
+    },
+  ],
+});
+
+ruleTester.run('prefer-add-event-listener-options', null as never, {
+  valid: [
+    valid('window.addEventListener("click", listener)'),
+    valid('window.addEventListener("click", listener, {capture: true})'),
+    valid('window.addEventListener("click", listener, {capture: false})'),
+    valid('window.addEventListener("click", listener, {passive: true})'),
+    valid('window.addEventListener("click", listener, {once: true})'),
+    valid('window.addEventListener("click", listener, {signal})'),
+    valid('window.addEventListener("click", listener, options)'),
+    valid('window.addEventListener("click", listener, capture)'),
+    valid('window.addEventListener("click", listener, Boolean(value))'),
+    valid(
+      'window.addEventListener("click", listener, condition ? true : false)',
+    ),
+    valid('window.addEventListener("click", listener, undefined)'),
+    valid('window.addEventListener("click", listener, null)'),
+    valid('window["addEventListener"]("click", listener, true)'),
+    valid('window?.addEventListener("click", listener, true)'),
+    valid('window.addEventListener?.("click", listener, true)'),
+    valid('window.addEventListener("click", ...arguments_, true)'),
+  ],
+  invalid: [
+    invalid('window.addEventListener("click", listener, true)', 'true'),
+    invalid('window.addEventListener("click", listener, false)', 'false'),
+    invalid('window.addEventListener("click", listener, (true))', 'true'),
+    invalid('window.addEventListener("click", () => {}, true)', 'true'),
+    invalid('window.addEventListener("click", function () {}, false)', 'false'),
+    invalid('document.body.addEventListener("click", listener, true)', 'true'),
+    invalid('(window).addEventListener("click", listener, false)', 'false'),
+    invalid(
+      'window.addEventListener("click", listener, /* useCapture */ true)',
+      'true',
+    ),
+    invalid(
+      'window.addEventListener("click", listener, true /* useCapture */)',
+      'true',
+    ),
+    invalid(
+      'window.addEventListener(\n\t"click",\n\tlistener,\n\ttrue\n)',
+      'true',
+    ),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -206,7 +206,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-abort-signal-any': 'error', // not implemented
     // 'unicorn/prefer-abort-signal-timeout': 'error', // not implemented
     // 'unicorn/prefer-add-event-listener': 'error', // not implemented
-    // 'unicorn/prefer-add-event-listener-options': 'error', // not implemented
+    'unicorn/prefer-add-event-listener-options': 'error',
     // 'unicorn/prefer-aggregate-error': 'error', // not implemented
     // 'unicorn/prefer-array-find': 'error', // not implemented
     'unicorn/prefer-array-flat': 'error',


### PR DESCRIPTION
## Summary

Port the `unicorn/prefer-add-event-listener-options` rule from ESLint to rslint.

The rule prefers an options object over the legacy boolean argument passed to `addEventListener`.

```js
// Incorrect
element.addEventListener('click', listener, true);

// Correct
element.addEventListener('click', listener, {capture: true});
```

This also updates the shared method-call matcher to handle JavaScript callees wrapped in JSDoc casts consistently with ESTree.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-add-event-listener-options.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-add-event-listener-options.js
- Tracking issue: #1309

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
