### PR TITLE
fix: define regex class set punctuators

### DIFF
--- a/internal/utils/regex_capture_groups.go
+++ b/internal/utils/regex_capture_groups.go
@@ -258,6 +258,11 @@ func isUnicodeSetsStringProperty(escape string) bool {
 	}
 }
 
+// reservedClassSetPunctuators are the characters ECMAScript reserves inside a
+// v-flag class when they appear doubled (`!!`, `##`, `..`, …). `&` is in the
+// set because `&&` is only legal as the intersection operator.
+const reservedClassSetPunctuators = "&!#$%*+,.:;<=>?@^`~"
+
 // classHasInvalidUnicodeEscape validates the strict escape forms ClassEnd
 // deliberately treats permissively to find a closing bracket. In u/v classes,
 // an identity escape is not a fallback: incomplete hex escapes, legacy octal


### PR DESCRIPTION
## Summary

- Define the missing `reservedClassSetPunctuators` used by regex capture-group validation.
- Restore Go compilation on the latest main branch.
- Verify with `go test ./internal/utils`, spell checking, formatting, and changed-code Go lint.

## Related Links

- https://github.com/web-infra-dev/rslint/actions/runs/33478329501/job/99763545420?pr=1976

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).