### PR TITLE
fix: remove duplicate regex class set punctuators

### DIFF
--- a/internal/utils/regex_capture_groups.go
+++ b/internal/utils/regex_capture_groups.go
@@ -10,11 +10,6 @@ import (
 	esregexp "github.com/web-infra-dev/rslint/internal/utils/ecmascript/regexp"
 )
 
-// reservedClassSetPunctuators are the characters ECMAScript reserves inside a
-// v-flag class when they appear doubled (`!!`, `##`, `..`, …). `&` is in the
-// set because `&&` is only legal as the intersection operator.
-const reservedClassSetPunctuators = "&!#$%*+,.:;<=>?@^`~"
-
 // RegexCapturingGroup is one capturing group found by RegexCapturingGroups:
 // either a plain `(...)` group or a named `(?<name>...)` group. Start is the
 // byte offset of the group's opening `(` within the pattern; End is one past


### PR DESCRIPTION
## Summary

- Remove the duplicate reservedClassSetPunctuators declaration accidentally introduced by the Rstack CLI migration.
- Restore Go compilation and unblock the affected CI jobs across platforms.
- Verified check-spell, format:check, the changed Go package lint, and the targeted internal/utils tests.

## Related Links

- Failed main CI run: https://github.com/web-infra-dev/rslint/actions/runs/33482445538

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).