### PR TITLE
fix: preserve type assertion inference

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -115,42 +115,7 @@ func assertionTypeArguments(typeChecker *checker.Checker, t *checker.Type) []*ch
 	return nil
 }
 
-func assertionSignatureReturnsContainingAlias(signature *checker.Signature) bool {
-	declaration := signature.Declaration()
-	if declaration == nil || declaration.Type() == nil {
-		return false
-	}
-	var alias *ast.Node
-	for current := declaration.Parent; current != nil; current = current.Parent {
-		if current.Kind == ast.KindTypeAliasDeclaration {
-			alias = current
-			break
-		}
-	}
-	if alias == nil || alias.Name() == nil || !ast.IsIdentifier(alias.Name()) {
-		return false
-	}
-	aliasName := alias.Name().AsIdentifier().Text
-	found := false
-	var visit func(*ast.Node)
-	visit = func(node *ast.Node) {
-		if found || node == nil {
-			return
-		}
-		if ast.IsIdentifier(node) && node.AsIdentifier().Text == aliasName {
-			found = true
-			return
-		}
-		node.ForEachChild(func(child *ast.Node) bool {
-			visit(child)
-			return found
-		})
-	}
-	visit(declaration.Type())
-	return found
-}
-
-func assertionTypeContains(typeChecker *checker.Checker, root *checker.Type, predicate func(*checker.Type) bool, skipRecursiveCallReturns bool) bool {
+func assertionTypeContains(typeChecker *checker.Checker, root *checker.Type, predicate func(*checker.Type) bool) bool {
 	if root == nil {
 		return false
 	}
@@ -172,9 +137,7 @@ func assertionTypeContains(typeChecker *checker.Checker, root *checker.Type, pre
 		}
 		stack = append(stack, assertionTypeArguments(typeChecker, t)...)
 		for _, signature := range utils.GetCallSignatures(typeChecker, t) {
-			if !skipRecursiveCallReturns || !assertionSignatureReturnsContainingAlias(signature) {
-				stack = append(stack, checker.Checker_getReturnTypeOfSignature(typeChecker, signature))
-			}
+			stack = append(stack, checker.Checker_getReturnTypeOfSignature(typeChecker, signature))
 			for _, parameter := range checker.Signature_parameters(signature) {
 				stack = append(stack, checker.Checker_getTypeOfSymbol(typeChecker, parameter))
 			}
@@ -183,17 +146,131 @@ func assertionTypeContains(typeChecker *checker.Checker, root *checker.Type, pre
 	return false
 }
 
+type assertionSignatureIdentity struct {
+	declaration *ast.Node
+	signature   *checker.Signature
+}
+
+func assertionGetSignatureIdentity(signature *checker.Signature) assertionSignatureIdentity {
+	if declaration := signature.Declaration(); declaration != nil {
+		return assertionSignatureIdentity{declaration: declaration}
+	}
+	for signature.Target() != nil && signature.Target() != signature {
+		signature = signature.Target()
+		if declaration := signature.Declaration(); declaration != nil {
+			return assertionSignatureIdentity{declaration: declaration}
+		}
+	}
+	return assertionSignatureIdentity{signature: signature}
+}
+
+type assertionContainsAnyFrameKind uint8
+
+const (
+	assertionContainsAnyFrameType assertionContainsAnyFrameKind = iota
+	assertionContainsAnyFrameSignature
+	assertionContainsAnyFrameSignatureExit
+)
+
+type assertionContainsAnyFrame struct {
+	kind      assertionContainsAnyFrameKind
+	typeValue *checker.Type
+	signature *checker.Signature
+	identity  assertionSignatureIdentity
+}
+
+const assertionContainsAnySignatureLimit = 10_000
+
 func assertionTypeContainsAny(typeChecker *checker.Checker, root *checker.Type) bool {
-	// Upstream catches stack overflow from recursively instantiated call return
-	// types and treats them as not containing any. Avoid asking tsgo to expand
-	// that same unbounded return type in the first place.
-	return assertionTypeContains(typeChecker, root, utils.IsTypeAnyType, true)
+	if root == nil {
+		return false
+	}
+	seen := make(map[*checker.Type]bool)
+	activeSignatures := make(map[assertionSignatureIdentity]bool)
+	stack := []assertionContainsAnyFrame{{
+		kind:      assertionContainsAnyFrameType,
+		typeValue: root,
+	}}
+	expandedSignatures := 0
+	for len(stack) > 0 {
+		frame := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		switch frame.kind {
+		case assertionContainsAnyFrameSignatureExit:
+			delete(activeSignatures, frame.identity)
+		case assertionContainsAnyFrameSignature:
+			identity := assertionGetSignatureIdentity(frame.signature)
+			if activeSignatures[identity] {
+				// Recursive generic signatures can keep producing fresh types. A
+				// partial search cannot prove that a later instantiation excludes
+				// any, so preserve the assertion instead of offering an unsafe fix.
+				return true
+			}
+			expandedSignatures++
+			if expandedSignatures > assertionContainsAnySignatureLimit {
+				// Source-declared recursion is caught by the stable declaration
+				// identity above. This is a final guard for synthetic signatures
+				// that have neither a declaration nor a reusable target.
+				return true
+			}
+			activeSignatures[identity] = true
+			stack = append(stack, assertionContainsAnyFrame{
+				kind:     assertionContainsAnyFrameSignatureExit,
+				identity: identity,
+			})
+			parameters := checker.Signature_parameters(frame.signature)
+			for index := len(parameters) - 1; index >= 0; index-- {
+				stack = append(stack, assertionContainsAnyFrame{
+					kind:      assertionContainsAnyFrameType,
+					typeValue: checker.Checker_getTypeOfSymbol(typeChecker, parameters[index]),
+				})
+			}
+			stack = append(stack, assertionContainsAnyFrame{
+				kind:      assertionContainsAnyFrameType,
+				typeValue: checker.Checker_getReturnTypeOfSignature(typeChecker, frame.signature),
+			})
+		case assertionContainsAnyFrameType:
+			t := frame.typeValue
+			if t == nil || seen[t] {
+				continue
+			}
+			seen[t] = true
+			if utils.IsTypeAnyType(t) {
+				return true
+			}
+			if t.IsUnion() || t.IsIntersection() {
+				types := t.Types()
+				for index := len(types) - 1; index >= 0; index-- {
+					stack = append(stack, assertionContainsAnyFrame{
+						kind:      assertionContainsAnyFrameType,
+						typeValue: types[index],
+					})
+				}
+				continue
+			}
+			signatures := utils.GetCallSignatures(typeChecker, t)
+			for index := len(signatures) - 1; index >= 0; index-- {
+				stack = append(stack, assertionContainsAnyFrame{
+					kind:      assertionContainsAnyFrameSignature,
+					signature: signatures[index],
+				})
+			}
+			typeArguments := assertionTypeArguments(typeChecker, t)
+			for index := len(typeArguments) - 1; index >= 0; index-- {
+				stack = append(stack, assertionContainsAnyFrame{
+					kind:      assertionContainsAnyFrameType,
+					typeValue: typeArguments[index],
+				})
+			}
+		}
+	}
+	return false
 }
 
 func assertionTypeContainsTypeVariable(typeChecker *checker.Checker, root *checker.Type) bool {
 	return assertionTypeContains(typeChecker, root, func(t *checker.Type) bool {
 		return utils.IsTypeFlagSet(t, checker.TypeFlagsTypeVariable|checker.TypeFlagsIndex)
-	}, false)
+	})
 }
 
 func assertionIsTypeLiteral(t *checker.Type) bool {
@@ -476,7 +553,8 @@ func assertionIsEmptyObjectType(typeChecker *checker.Checker, t *checker.Type) b
 		(len(typeChecker.GetPropertiesOfType(t)) == 0 &&
 			len(utils.GetCallSignatures(typeChecker, t)) == 0 &&
 			len(utils.GetConstructSignatures(typeChecker, t)) == 0 &&
-			len(checker.Checker_getIndexInfosOfType(typeChecker, t)) == 0)
+			typeChecker.GetStringIndexType(t) == nil &&
+			typeChecker.GetNumberIndexType(t) == nil)
 }
 
 func assertionHasPhantomTypeArguments(typeChecker *checker.Checker, t *checker.Type) bool {

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_extras_test.go
@@ -265,3 +265,148 @@ inferred({ addons: [{} as Test<{ parameters: { potato: boolean } }>] });
 		},
 	)
 }
+
+func TestNoUnnecessaryTypeAssertionInferenceGuards(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnnecessaryTypeAssertionRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+namespace N { export type R = any }
+type R = () => N.R;
+declare const x: R;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type R = () => R | any;
+declare const x: R;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type R = () => [R, any];
+declare const x: R;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type R = () => [any, R];
+declare const x: R;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type R = (value: any) => R;
+declare const x: R;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type Sig<T> = () => T;
+type X = Sig<any>;
+type A = Sig<X>;
+type Root = A | X;
+declare const x: Root;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type Prev = [never, 0, 1, 2];
+type R<N extends 0 | 1 | 2 | 3> = N extends 0 ? any : () => R<Prev[N]>;
+declare const x: R<2>;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type Prev = [never, 0, 1, 2];
+type R<N extends 0 | 1 | 2 | 3> = N extends 0 ? string : () => R<Prev[N]>;
+declare const x: R<2>;
+declare function infer<T>(input: { value: T }): T;
+let y = infer({ value: x as object });
+y = {};
+`},
+			{Code: `
+type A<T> = () => B<T & { a: true }>;
+type B<T> = () => A<T & { b: true }>;
+declare const recursive: A<{}>;
+declare const value: object;
+value as unknown as typeof recursive;
+`},
+			{Code: `
+type R<T = {}> = (next: R<T & { next: true }>) => number;
+declare const recursive: R;
+declare const value: object;
+value as unknown as typeof recursive;
+`},
+			{Code: `
+type Test<T> = { [key: symbol]: never };
+declare function inferred<T extends Test<never>[]>(input: { addons?: T }): {
+  options: T[number] extends Test<infer U> ? U : unknown;
+};
+const test = inferred({ addons: [{} as Test<{ parameters: { potato: boolean } }>] });
+test.options.parameters.potato;
+`},
+			{Code: `
+type Pattern<T> = { [key: ` + "`data-${string}`" + `]: never };
+declare function inferred<T extends Pattern<never>[]>(input: { addons?: T }): {
+  options: T[number] extends Pattern<infer U> ? U : unknown;
+};
+const test = inferred({ addons: [{} as Pattern<{ parameters: { potato: boolean } }>] });
+test.options.parameters.potato;
+`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+type Wrapper<T> = () => T;
+declare const x: Wrapper<string> & Wrapper<number>;
+declare function consume(value: object): void;
+consume(x as object);
+`,
+				Output: []string{`
+type Wrapper<T> = () => T;
+declare const x: Wrapper<string> & Wrapper<number>;
+declare function consume(value: object): void;
+consume(x);
+`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "contextuallyUnnecessary"}},
+			},
+			{
+				Code: `
+type Test<T> = { [key: string]: never };
+declare function inferred<T extends Test<never>[]>(input: { addons?: T }): void;
+inferred({ addons: [{} as Test<{ parameter: boolean }>] });
+`,
+				Output: []string{`
+type Test<T> = { [key: string]: never };
+declare function inferred<T extends Test<never>[]>(input: { addons?: T }): void;
+inferred({ addons: [{}] });
+`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "contextuallyUnnecessary"}},
+			},
+			{
+				Code: `
+type Test<T> = { [key: number]: never };
+declare function inferred<T extends Test<never>[]>(input: { addons?: T }): void;
+inferred({ addons: [{} as Test<{ parameter: boolean }>] });
+`,
+				Output: []string{`
+type Test<T> = { [key: number]: never };
+declare function inferred<T extends Test<never>[]>(input: { addons?: T }): void;
+inferred({ addons: [{}] });
+`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "contextuallyUnnecessary"}},
+			},
+		},
+	)
+}


### PR DESCRIPTION
## Summary

- Preserve assertions when recursive signature traversal cannot prove that a type excludes any, while still inspecting the first return and parameters and bounding synthetic recursion.
- Match TypeScript empty-object semantics by considering only string and number index types, so symbol and template-pattern phantom arguments keep their inference.
- Add adversarial regression coverage for qualified aliases, recursive return and parameter graphs, finite recursive generics, path isolation, and index-signature controls.

## Related Links

N/A

## Testing

- go test ./internal/plugins/typescript/rules/no_unnecessary_type_assertion -count=3 -timeout=120s
- pnpm exec rstest run tests/typescript-eslint/rules/no-unnecessary-type-assertion.test.ts
- pnpm run check-spell
- pnpm run format:check
- golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_unnecessary_type_assertion/...
- Latest upstream target suite: 256 of 256 unmodified cases passed; compatible adversarial cases also passed.
- Go benchmark: ordinary paths kept their allocation counts; recursive-alias median improved from about 2.78 us to 2.62 us and from 54 to 53 allocations per operation.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).