### PR TITLE
feat: port rule unicorn/prefer-blob-reading-methods

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -26,6 +26,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_some"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_blob_reading_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_set_has"
@@ -64,6 +65,7 @@ func GetAllRules() []rule.Rule {
 		prefer_array_flat.PreferArrayFlatRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,
 		prefer_array_some.PreferArraySomeRule,
+		prefer_blob_reading_methods.PreferBlobReadingMethodsRule,
 		prefer_node_protocol.PreferNodeProtocolRule,
 		prefer_number_properties.PreferNumberPropertiesRule,
 		prefer_set_has.PreferSetHasRule,

--- a/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods.go
+++ b/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods.go
@@ -1,0 +1,59 @@
+// Package prefer_blob_reading_methods ports eslint-plugin-unicorn's
+// `prefer-blob-reading-methods` rule.
+package prefer_blob_reading_methods
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const messageID = "error"
+
+var fileReaderMethods = []string{"readAsText", "readAsArrayBuffer"}
+
+func preferBlobMethodMessage(method string) rule.RuleMessage {
+	replacement := "text"
+	if method == "readAsArrayBuffer" {
+		replacement = "arrayBuffer"
+	}
+
+	return rule.RuleMessage{
+		Id:          messageID,
+		Description: fmt.Sprintf("Prefer `Blob#%s()` over `FileReader#%s(blob)`.", replacement, method),
+		Data: map[string]string{
+			"method":      method,
+			"replacement": replacement,
+		},
+	}
+}
+
+// PreferBlobReadingMethodsRule prefers Blob's promise-based reading methods
+// over the callback-based FileReader methods with equivalent results.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-blob-reading-methods.js
+var PreferBlobReadingMethodsRule = rule.Rule{
+	Name:   "unicorn/prefer-blob-reading-methods",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		oneArgument := 1
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Methods:             fileReaderMethods,
+					ArgumentsLength:     &oneArgument,
+					RejectSpreadElement: true,
+				})
+				if !ok {
+					return
+				}
+
+				method := call.Property.AsIdentifier().Text
+				ctx.ReportNode(call.Property, preferBlobMethodMessage(method))
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods.md
+++ b/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods.md
@@ -1,0 +1,34 @@
+# prefer-blob-reading-methods
+
+## Rule Details
+
+Prefer the promise-based `Blob#arrayBuffer()` and `Blob#text()` methods over
+the corresponding callback-based `FileReader` methods.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+fileReader.readAsArrayBuffer(blob);
+fileReader.readAsText(blob);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const arrayBuffer = await blob.arrayBuffer();
+const text = await blob.text();
+```
+
+Calls that pass an encoding to `FileReader#readAsText()` are allowed because
+`Blob#text()` always decodes as UTF-8. Other `FileReader` methods are also left
+unchanged:
+
+```javascript
+fileReader.readAsText(blob, "ascii");
+fileReader.readAsDataURL(blob);
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: prefer-blob-reading-methods](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-blob-reading-methods.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-blob-reading-methods.js)

--- a/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods_extras_test.go
@@ -1,0 +1,116 @@
+// TestPreferBlobReadingMethodsExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case identifies the upstream
+// branch, Dimension 4 row, or real-user scenario it covers.
+package prefer_blob_reading_methods_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_blob_reading_methods"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func extrasInvalid(code, fileName string, methods ...string) rule_tester.InvalidTestCase {
+	seen := map[string]int{}
+	errors := make([]rule_tester.InvalidTestCaseError, 0, len(methods))
+	for _, method := range methods {
+		errors = append(errors, methodError(code, method, seen[method]))
+		seen[method]++
+	}
+	return rule_tester.InvalidTestCase{Code: code, FileName: fileName, Errors: errors}
+}
+
+func TestPreferBlobReadingMethodsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_blob_reading_methods.PreferBlobReadingMethodsRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream isMethodCall() argument-count branches.
+			{Code: `fileReader.readAsText()`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsArrayBuffer(blob, extra)`, FileName: "file.mjs"},
+
+			// Locks in upstream isMethodCall() default allowSpreadElement: false.
+			{Code: `fileReader.readAsText(...blobs)`, FileName: "file.mjs"},
+
+			// ---- Dimension 4: element-access key forms are excluded ----
+			{Code: `fileReader['readAsText'](blob)`, FileName: "file.mjs"},
+			{Code: "fileReader[`readAsText`](blob)", FileName: "file.mjs"},
+			{Code: `fileReader[0](blob)`, FileName: "file.mjs"},
+			{Code: `fileReader[Symbol.readAsText](blob)`, FileName: "file.mjs"},
+
+			// ---- Dimension 4: optional calls and members are excluded ----
+			{Code: `(fileReader.readAsText)?.(blob)`, FileName: "file.mjs"},
+			{Code: `(fileReader?.readAsText)(blob)`, FileName: "file.mjs"},
+			{Code: `/** @type {any} */ (fileReader?.readAsText)(blob)`, FileName: "file.js"},
+
+			// ---- Dimension 4: authored TypeScript callee wrappers stay visible ----
+			{Code: `(fileReader.readAsText as any)(blob)`, FileName: "file.ts"},
+			{Code: `(fileReader.readAsArrayBuffer satisfies any)(blob)`, FileName: "file.ts"},
+
+			// Locks in upstream listener/method-name rejection branches.
+			{Code: `new fileReader.readAsText(blob)`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsText`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsDataURL(blob)`, FileName: "file.mjs"},
+
+			// ---- Dimension 4: private member names are excluded ----
+			{Code: `class Reader { #readAsText(blob) {} read(blob) { this.#readAsText(blob); } }`, FileName: "file.mjs"},
+
+			// ---- Real-user: file preview flows may still use readAsDataURL ----
+			{Code: `const reader = new FileReader(); reader.readAsDataURL(file);`, FileName: "file.mjs"},
+
+			// N/A: declaration/container forms; the rule only targets call expressions.
+			// N/A: declaration key forms; the rule inspects only a call's member name.
+			// N/A: ancestor walks and body-absent declarations; the rule performs no ancestor traversal.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver and callee wrappers ----
+			extrasInvalid(`(fileReader).readAsArrayBuffer(blob)`, "file.mjs", "readAsArrayBuffer"),
+			extrasInvalid(`((fileReader)).readAsText(blob)`, "file.mjs", "readAsText"),
+			extrasInvalid(`(fileReader.readAsText)(blob)`, "file.mjs", "readAsText"),
+
+			// ---- Dimension 4: JavaScript JSDoc callee wrappers are transparent ----
+			extrasInvalid(`/** @type {any} */ (fileReader.readAsText)(blob)`, "file.js", "readAsText"),
+			extrasInvalid(
+				`/** @satisfies {any} */ (fileReader.readAsArrayBuffer)(blob)`,
+				"file.js",
+				"readAsArrayBuffer",
+			),
+
+			// ---- Dimension 4: TypeScript receiver wrappers ----
+			extrasInvalid(`fileReader!.readAsText(blob)`, "file.ts", "readAsText"),
+			extrasInvalid(`(fileReader as FileReader).readAsArrayBuffer(blob)`, "file.ts", "readAsArrayBuffer"),
+			extrasInvalid(`(fileReader satisfies FileReader).readAsText(blob)`, "file.ts", "readAsText"),
+
+			// Locks in upstream isMethodCall() handling of type arguments.
+			extrasInvalid(`fileReader.readAsText<string>(blob)`, "file.ts", "readAsText"),
+
+			// ---- Dimension 4: same-kind nesting reports both calls ----
+			extrasInvalid(
+				`fileReader.readAsText(other.readAsArrayBuffer(blob))`,
+				"file.mjs",
+				"readAsText",
+				"readAsArrayBuffer",
+			),
+
+			// Locks in comments and multiline whitespace around the call boundary.
+			extrasInvalid("fileReader\n\t.readAsText /* keep */ (\n\t\tblob\n\t)", "file.mjs", "readAsText"),
+
+			// ---- Real-user: issue #1269 Promise-wrapped FileReader flow ----
+			extrasInvalid(
+				"const arrayBuffer = await new Promise((resolve, reject) => {\n\tconst reader = new FileReader();\n\treader.onload = () => resolve(reader.result);\n\treader.onerror = () => reject(reader.error);\n\treader.readAsArrayBuffer(blob);\n});",
+				"file.mjs",
+				"readAsArrayBuffer",
+			),
+
+			// ---- Real-user: FileReader calls commonly appear in input handlers ----
+			extrasInvalid(
+				"input.addEventListener('change', () => {\n\tconst reader = new FileReader();\n\treader.readAsText(input.files[0]);\n});",
+				"file.mjs",
+				"readAsText",
+			),
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_blob_reading_methods/prefer_blob_reading_methods_upstream_test.go
@@ -1,0 +1,92 @@
+// TestPreferBlobReadingMethodsUpstream migrates the full valid/invalid suite
+// from upstream test/prefer-blob-reading-methods.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in prefer_blob_reading_methods_extras_test.go.
+package prefer_blob_reading_methods_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_blob_reading_methods"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const messageID = "error"
+
+func expectedMessage(method string) string {
+	replacement := "text"
+	if method == "readAsArrayBuffer" {
+		replacement = "arrayBuffer"
+	}
+	return fmt.Sprintf("Prefer `Blob#%s()` over `FileReader#%s(blob)`.", replacement, method)
+}
+
+func methodError(code, method string, occurrence int) rule_tester.InvalidTestCaseError {
+	offset := -1
+	searchFrom := 0
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], method)
+		if relative < 0 {
+			panic("method not found in prefer-blob-reading-methods test: " + method)
+		}
+		offset = searchFrom + relative
+		searchFrom = offset + len(method)
+	}
+
+	prefix := code[:offset]
+	line := strings.Count(prefix, "\n") + 1
+	lastNewline := strings.LastIndex(prefix, "\n")
+	column := offset + 1
+	if lastNewline >= 0 {
+		column = offset - lastNewline
+	}
+
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   expectedMessage(method),
+		Line:      line,
+		Column:    column,
+		EndLine:   line,
+		EndColumn: column + len(method),
+	}
+}
+
+func TestPreferBlobReadingMethodsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_blob_reading_methods.PreferBlobReadingMethodsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `blob.arrayBuffer()`, FileName: "file.mjs"},
+			{Code: `blob.text()`, FileName: "file.mjs"},
+			{Code: `new Response(blob).arrayBuffer()`, FileName: "file.mjs"},
+			{Code: `new Response(blob).text()`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsDataURL(blob)`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsBinaryString(blob)`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsText(blob, "ascii")`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsArrayBuffer(blob, extraArg)`, FileName: "file.mjs"},
+			{Code: `fileReader?.readAsArrayBuffer(blob)`, FileName: "file.mjs"},
+			{Code: `fileReader.readAsText?.(blob)`, FileName: "file.mjs"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `fileReader.readAsArrayBuffer(blob)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					methodError(`fileReader.readAsArrayBuffer(blob)`, "readAsArrayBuffer", 0),
+				},
+			},
+			{
+				Code:     `fileReader.readAsText(blob)`,
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					methodError(`fileReader.readAsText(blob)`, "readAsText", 0),
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -680,6 +680,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-some.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-blob-reading-methods.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-blob-reading-methods.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-blob-reading-methods.test.ts
@@ -1,0 +1,39 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code, filename: 'file.mjs' });
+const invalid = (code: string, method: string, replacement: string) => ({
+  code,
+  filename: 'file.mjs',
+  errors: [
+    {
+      messageId: 'error',
+      message: `Prefer \`Blob#${replacement}()\` over \`FileReader#${method}(blob)\`.`,
+      data: { method, replacement },
+    },
+  ],
+});
+
+ruleTester.run('prefer-blob-reading-methods', null as never, {
+  valid: [
+    valid('blob.arrayBuffer()'),
+    valid('blob.text()'),
+    valid('new Response(blob).arrayBuffer()'),
+    valid('new Response(blob).text()'),
+    valid('fileReader.readAsDataURL(blob)'),
+    valid('fileReader.readAsBinaryString(blob)'),
+    valid('fileReader.readAsText(blob, "ascii")'),
+    valid('fileReader.readAsArrayBuffer(blob, extraArg)'),
+    valid('fileReader?.readAsArrayBuffer(blob)'),
+    valid('fileReader.readAsText?.(blob)'),
+  ],
+  invalid: [
+    invalid(
+      'fileReader.readAsArrayBuffer(blob)',
+      'readAsArrayBuffer',
+      'arrayBuffer',
+    ),
+    invalid('fileReader.readAsText(blob)', 'readAsText', 'text'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -222,7 +222,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-at': 'error', // not implemented
     // 'unicorn/prefer-await': 'error', // not implemented
     // 'unicorn/prefer-bigint-literals': 'error', // not implemented
-    // 'unicorn/prefer-blob-reading-methods': 'error', // not implemented
+    'unicorn/prefer-blob-reading-methods': 'error',
     // 'unicorn/prefer-block-statement-over-iife': 'error', // not implemented
     // 'unicorn/prefer-boolean-return': 'error', // not implemented
     // 'unicorn/prefer-class-fields': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/prefer-blob-reading-methods` from
`eslint-plugin-unicorn@v74.0.0` to rslint.

The rule reports one-argument calls to `readAsArrayBuffer()` and
`readAsText()`, preferring the corresponding promise-based `Blob` methods:

```js
// Incorrect
fileReader.readAsArrayBuffer(blob);
fileReader.readAsText(blob);

// Preferred
await blob.arrayBuffer();
await blob.text();
```

The implementation matches upstream behavior for argument counts, spread
arguments, computed access, optional members, and optional calls.

This change also:

- Registers the rule in the Unicorn catalog.
- Enables it in the Unicorn recommended preset.
- Migrates the complete upstream test suite.
- Adds coverage for parentheses, JavaScript JSDoc casts, TypeScript expression
  wrappers, nested calls, and real-world `FileReader` usage.
- Adds an end-to-end RuleTester suite.

## Related Links

- [Documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-blob-reading-methods.md)
- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-blob-reading-methods.js)
- [Upstream tests](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/prefer-blob-reading-methods.js)

Tracks #1309.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
