### PR TITLE
fix: handle JSDoc-wrapped array concat calls

### DIFF
--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
@@ -165,7 +165,7 @@ func matchesSpreadReducer(body *ast.Node, firstParameter *ast.Node, secondParame
 
 func matchEmptyArrayConcat(node *ast.Node) (flattenMatch, bool) {
 	oneArgument := 1
-	_, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+	call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
 		Method:          "concat",
 		ArgumentsLength: &oneArgument,
 	})
@@ -173,9 +173,7 @@ func matchEmptyArrayConcat(node *ast.Node) (flattenMatch, bool) {
 		return flattenMatch{}, false
 	}
 
-	call := node.AsCallExpression()
-	callee := ast.SkipParentheses(call.Expression)
-	object := ast.SkipParentheses(callee.AsPropertyAccessExpression().Expression)
+	object := ast.SkipParentheses(call.Object)
 	if !ast.IsEmptyArrayLiteral(object) {
 		return flattenMatch{}, false
 	}

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_regressions_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_regressions_test.go
@@ -471,6 +471,82 @@ Items.flat();`,
 	suite.run(t)
 }
 
+// TestPreferArrayFlatJSDocCalleeRegression verifies that JavaScript JSDoc
+// wrappers stay transparent like they are in ESTree without making authored
+// TypeScript wrappers or optional/computed calls transparent.
+func TestPreferArrayFlatJSDocCalleeRegression(t *testing.T) {
+	var suite upstreamSuite
+
+	for _, testCase := range []struct {
+		fileName string
+		code     string
+		target   string
+		output   string
+	}{
+		{
+			fileName: "file.js",
+			code:     `/** @type {any} */ ([].concat)(...array)`,
+			target:   `([].concat)(...array)`,
+			output:   `/** @type {any} */ array.flat()`,
+		},
+		{
+			fileName: "file.js",
+			code:     `/** @satisfies {any} */ ([].concat)(array)`,
+			target:   `([].concat)(array)`,
+			output:   `/** @satisfies {any} */ [array].flat()`,
+		},
+		{
+			fileName: "file.jsx",
+			code:     `const view = <div>{/** @type {any} */ ([].concat)(...array)}</div>;`,
+			target:   `([].concat)(...array)`,
+			output:   `const view = <div>{/** @type {any} */ array.flat()}</div>;`,
+		},
+	} {
+		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+			Code:     testCase.code,
+			FileName: testCase.fileName,
+			Output:   []string{testCase.output},
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamError(testCase.code, testCase.target, `[].concat()`, 0),
+			},
+		})
+	}
+
+	const internalJSDoc = `((/** @type {any} */ ([].concat)))(...array)`
+	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+		Code:     internalJSDoc,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			upstreamError(internalJSDoc, internalJSDoc, `[].concat()`, 0),
+		},
+	})
+
+	for _, code := range []string{
+		`/** @type {any} */ (value.concat)(...array)`,
+		`/** @type {any} */ ([]?.concat)(...array)`,
+		`/** @type {any} */ ([].concat)?.(...array)`,
+		`/** @type {any} */ ([]["concat"])(...array)`,
+	} {
+		suite.valid = append(suite.valid, rule_tester.ValidTestCase{
+			Code:     code,
+			FileName: "file.js",
+		})
+	}
+
+	for _, code := range []string{
+		`([].concat as any)(...array)`,
+		`([].concat satisfies any)(...array)`,
+		`([].concat!)(...array)`,
+	} {
+		suite.valid = append(suite.valid, rule_tester.ValidTestCase{
+			Code:     code,
+			FileName: "file.ts",
+		})
+	}
+
+	suite.run(t)
+}
+
 // TestPreferArrayFlatSchemaParity locks the public option schema to unicorn
 // v64. In particular, upstream leaves array item types unconstrained while
 // still enforcing tuple length, uniqueness, and additionalProperties.


### PR DESCRIPTION
## Summary

- Prevent `unicorn/prefer-array-flat` from panicking on JavaScript JSDoc-wrapped calls such as `/** @type {any} */ ([].concat)(...array)`.
- Reuse the normalized receiver returned by `MatchDotMethodCall`, preserving existing v64 rule semantics while avoiding duplicate AST parsing.
- Add JS/JSX regression coverage for `@type` and `@satisfies` fixes, comment-safe no-fix behavior, and optional/computed/authored-TypeScript boundaries.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
