### PR TITLE
feat: port rule unicorn/consistent-tuple-labels

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -3,6 +3,7 @@ package unicorn_plugin
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/catch_error_name"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_date_clone"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_tuple_labels"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/error_message"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
@@ -41,6 +42,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		catch_error_name.CatchErrorNameRule,
 		consistent_date_clone.ConsistentDateCloneRule,
+		consistent_tuple_labels.ConsistentTupleLabelsRule,
 		error_message.ErrorMessageRule,
 		filename_case.FilenameCaseRule,
 		new_for_builtins.NewForBuiltinsRule,

--- a/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels.go
+++ b/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels.go
@@ -1,0 +1,56 @@
+package consistent_tuple_labels
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const messageID = "consistent-tuple-labels"
+
+var message = rule.RuleMessage{
+	Id:          messageID,
+	Description: "This tuple element should have a label, just like the other elements.",
+}
+
+func isLabeledElement(element *ast.Node) bool {
+	// tsgo represents every labeled tuple element as NamedTupleMember,
+	// including optional and rest elements. Unlabeled optional and rest
+	// elements instead use OptionalType and RestType nodes.
+	return element != nil && element.Kind == ast.KindNamedTupleMember
+}
+
+// ConsistentTupleLabelsRule requires every element of a tuple type to have a
+// label when any element is labeled.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/consistent-tuple-labels.js
+var ConsistentTupleLabelsRule = rule.Rule{
+	Name:   "unicorn/consistent-tuple-labels",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindTupleType: func(node *ast.Node) {
+				tuple := node.AsTupleTypeNode()
+				if tuple == nil || tuple.Elements == nil || len(tuple.Elements.Nodes) < 2 {
+					return
+				}
+
+				labeledCount := 0
+				for _, element := range tuple.Elements.Nodes {
+					if isLabeledElement(element) {
+						labeledCount++
+					}
+				}
+
+				if labeledCount == 0 || labeledCount == len(tuple.Elements.Nodes) {
+					return
+				}
+
+				for _, element := range tuple.Elements.Nodes {
+					if !isLabeledElement(element) {
+						ctx.ReportNode(element, message)
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels.go
+++ b/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels.go
@@ -47,7 +47,10 @@ var ConsistentTupleLabelsRule = rule.Rule{
 
 				for _, element := range tuple.Elements.Nodes {
 					if !isLabeledElement(element) {
-						ctx.ReportNode(element, message)
+						// TSESTree omits type parentheses from the tuple element node's
+						// range. Keep the original node for label classification, but
+						// report the innermost type so diagnostic ranges match upstream.
+						ctx.ReportNode(ast.SkipTypeParentheses(element), message)
 					}
 				}
 			},

--- a/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels.md
+++ b/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels.md
@@ -1,0 +1,29 @@
+# consistent-tuple-labels
+
+## Rule Details
+
+Require every element of a tuple type to have a label when any element is
+labeled. Tuples whose elements are all labeled or all unlabeled are left
+unchanged.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+type Point = [x: number, number];
+type Route = [name: string, ...string[]];
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+type Point = [x: number, y: number];
+type Coordinates = [number, number];
+type Route = [name: string, ...segments: string[]];
+```
+
+The rule does not provide an autofix because it cannot infer meaningful labels.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: consistent-tuple-labels](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/consistent-tuple-labels.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/consistent-tuple-labels.js)

--- a/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels_extras_test.go
+++ b/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels_extras_test.go
@@ -53,15 +53,26 @@ func TestConsistentTupleLabelsExtras(t *testing.T) {
 				expectedError(`type Mixed = [label: string, number, boolean];`, `boolean`, 0),
 			),
 
-			// ---- Dimension 4: parenthesized and union element types stay
-			// unlabeled and are reported across their complete type ranges. ----
+			// ---- Dimension 4: parenthesized element types stay unlabeled, but
+			// their diagnostic ranges omit the parentheses like TSESTree. ----
 			tsInvalid(
 				`type Parenthesized = [label: string, (number)];`,
-				expectedError(`type Parenthesized = [label: string, (number)];`, `(number)`, 0),
+				expectedError(`type Parenthesized = [label: string, (number)];`, `number`, 0),
 			),
+			tsInvalid(
+				`type DeeplyParenthesized = [label: string, (((number)))];`,
+				expectedError(`type DeeplyParenthesized = [label: string, (((number)))];`, `number`, 0),
+			),
+
+			// ---- Dimension 4: compound element types are reported across their
+			// complete type ranges. ----
 			tsInvalid(
 				`type UnionElement = [label: string, number | undefined];`,
 				expectedError(`type UnionElement = [label: string, number | undefined];`, `number | undefined`, 0),
+			),
+			tsInvalid(
+				`type ParenthesizedUnion = [label: string, ((number | undefined))];`,
+				expectedError(`type ParenthesizedUnion = [label: string, ((number | undefined))];`, `number | undefined`, 0),
 			),
 
 			// ---- Dimension 4: nested mixed tuples report at both tuple levels

--- a/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels_extras_test.go
+++ b/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels_extras_test.go
@@ -1,0 +1,94 @@
+// TestConsistentTupleLabelsExtras locks in branches and edge shapes that the
+// upstream test suite does not exercise. Each case points at its branch,
+// Dimension 4 row, or representative real-user shape. The direct v74.0.0
+// migration lives in consistent_tuple_labels_upstream_test.go.
+package consistent_tuple_labels_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	consistent_tuple_labels "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_tuple_labels"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestConsistentTupleLabelsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&consistent_tuple_labels.ConsistentTupleLabelsRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream create() arm 1: tuples with fewer than two
+			// elements cannot be inconsistent.
+			tsValid(`type Empty = []; type Single = [value: string];`),
+
+			// Locks in upstream create() arm 2a: a tuple with no unlabeled
+			// elements is consistent in a declaration container.
+			tsValid(`interface API { result: [value: string, error: Error] }`),
+
+			// Locks in upstream create() arm 2b: a tuple with no labels is
+			// consistent even when nested inside a generic type argument.
+			tsValid(`type Result = Promise<[string, Error]>;`),
+
+			// Locks in upstream isLabeledElement() arms 1 and 2: tsgo represents
+			// both an ordinary labeled element and a labeled rest element as
+			// NamedTupleMember nodes.
+			tsValid(`type Params = [head: string, ...tail: number[]];`),
+
+			// ---- Dimension 4: same-kind nesting remains independent ----
+			tsValid(`type Nested = [outer: [inner: string, count: number], flag: boolean];`),
+
+			// N/A: runtime receiver wrappers, optional chains, member-key forms,
+			// class/function variants, and destructuring shapes are not tuple
+			// element forms inspected by this type-syntax-only rule.
+			// N/A: the rule has no autofix, suggestions, or options.
+		},
+		[]rule_tester.InvalidTestCase{
+			// Locks in upstream create() final arm: every unlabeled element in a
+			// mixed tuple receives its own diagnostic.
+			tsInvalid(
+				`type Mixed = [label: string, number, boolean];`,
+				expectedError(`type Mixed = [label: string, number, boolean];`, `number`, 0),
+				expectedError(`type Mixed = [label: string, number, boolean];`, `boolean`, 0),
+			),
+
+			// ---- Dimension 4: parenthesized and union element types stay
+			// unlabeled and are reported across their complete type ranges. ----
+			tsInvalid(
+				`type Parenthesized = [label: string, (number)];`,
+				expectedError(`type Parenthesized = [label: string, (number)];`, `(number)`, 0),
+			),
+			tsInvalid(
+				`type UnionElement = [label: string, number | undefined];`,
+				expectedError(`type UnionElement = [label: string, number | undefined];`, `number | undefined`, 0),
+			),
+
+			// ---- Dimension 4: nested mixed tuples report at both tuple levels
+			// without bleeding sibling state. ----
+			tsInvalid(
+				`type Nested = [outer: string, [inner: number, boolean]];`,
+				expectedError(`type Nested = [outer: string, [inner: number, boolean]];`, `[inner: number, boolean]`, 0),
+				expectedError(`type Nested = [outer: string, [inner: number, boolean]];`, `boolean`, 0),
+			),
+
+			// ---- Real-user: upstream #3382 partially labeled event-listener argument tuple ----
+			tsInvalid(
+				`type Listener = (...args: [event: string, number]) => void;`,
+				expectedError(`type Listener = (...args: [event: string, number]) => void;`, `number`, 0),
+			),
+
+			// ---- Real-user: upstream #3382 partially labeled tuple in a public declaration ----
+			tsInvalid(
+				`declare function load(): Promise<[
+	value: string,
+	Error,
+]>;`,
+				expectedError(`declare function load(): Promise<[
+	value: string,
+	Error,
+]>;`, `Error`, 0),
+			),
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels_upstream_test.go
+++ b/internal/plugins/unicorn/rules/consistent_tuple_labels/consistent_tuple_labels_upstream_test.go
@@ -1,0 +1,137 @@
+// TestConsistentTupleLabelsUpstream migrates the full valid/invalid suite from
+// upstream test/consistent-tuple-labels.js in eslint-plugin-unicorn v74.0.0
+// 1:1. Position assertions cover every invalid case. rslint-specific lock-in
+// cases live in consistent_tuple_labels_extras_test.go.
+package consistent_tuple_labels_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	consistent_tuple_labels "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_tuple_labels"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID = "consistent-tuple-labels"
+	message   = "This tuple element should have a label, just like the other elements."
+)
+
+func expectedError(code, target string, occurrence int) rule_tester.InvalidTestCaseError {
+	searchFrom := 0
+	start := -1
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], target)
+		if relative < 0 {
+			panic("target not found in test input: " + target)
+		}
+		start = searchFrom + relative
+		searchFrom = start + 1
+	}
+
+	lineStart := strings.LastIndex(code[:start], "\n") + 1
+	line := strings.Count(code[:start], "\n") + 1
+	column := start - lineStart + 1
+	end := start + len(target)
+	endLineStart := strings.LastIndex(code[:end], "\n") + 1
+	endLine := strings.Count(code[:end], "\n") + 1
+	endColumn := end - endLineStart + 1
+
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.ts", Tsx: false}
+}
+
+func tsInvalid(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{Code: code, FileName: "file.ts", Tsx: false, Errors: errors}
+}
+
+func TestConsistentTupleLabelsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&consistent_tuple_labels.ConsistentTupleLabelsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- All labeled ----
+			tsValid(`type Foo = [a: string, b: number];`),
+			tsValid(`type Foo = [a: string, b: number, c: boolean];`),
+
+			// ---- None labeled ----
+			tsValid(`type Foo = [string, number];`),
+			tsValid(`type Foo = [string, number, boolean];`),
+
+			// ---- Fewer than two elements ----
+			tsValid(`type Foo = [];`),
+			tsValid(`type Foo = [string];`),
+			tsValid(`type Foo = [a: string];`),
+
+			// ---- Optional labeled elements ----
+			tsValid(`type Foo = [a?: string, b?: number];`),
+			tsValid(`type Foo = [a: string, b?: number];`),
+
+			// ---- Optional unlabeled elements (all unlabeled) ----
+			tsValid(`type Foo = [string?, number?];`),
+
+			// ---- Labeled rest element (counts as labeled) ----
+			tsValid(`type Foo = [a: string, ...b: number[]];`),
+
+			// ---- Unlabeled rest element (all unlabeled) ----
+			tsValid(`type Foo = [string, ...number[]];`),
+
+			// ---- Nested tuples are evaluated independently ----
+			tsValid(`type Foo = [[a: number, b: number]];`),
+			tsValid(`type Foo = [a: [x: number], b: [y: number]];`),
+
+			// ---- Not a tuple ----
+			tsValid(`type Foo = string[];`),
+			tsValid(`type Foo = readonly string[];`),
+			tsValid(`type Foo = {a: string; b: number};`),
+		},
+		[]rule_tester.InvalidTestCase{
+			tsInvalid(`type Foo = [a: string, number];`, expectedError(`type Foo = [a: string, number];`, `number`, 0)),
+			tsInvalid(`type Foo = [string, b: number];`, expectedError(`type Foo = [string, b: number];`, `string`, 0)),
+			tsInvalid(`type Foo = [a: string, b: number, c: boolean, d];`, expectedError(`type Foo = [a: string, b: number, c: boolean, d];`, `d`, 0)),
+			tsInvalid(`type Foo = [a: string, number, c: boolean];`, expectedError(`type Foo = [a: string, number, c: boolean];`, `number`, 0)),
+
+			// ---- Multiple unlabeled elements are each reported ----
+			tsInvalid(
+				`type Foo = [a: string, number, boolean];`,
+				expectedError(`type Foo = [a: string, number, boolean];`, `number`, 0),
+				expectedError(`type Foo = [a: string, number, boolean];`, `boolean`, 0),
+			),
+
+			// ---- Optional unlabeled element mixed with a labeled one ----
+			tsInvalid(`type Foo = [a?: string, number?];`, expectedError(`type Foo = [a?: string, number?];`, `number?`, 0)),
+			tsInvalid(`type Foo = [string?, b: number];`, expectedError(`type Foo = [string?, b: number];`, `string?`, 0)),
+
+			// ---- Mixed via a labeled rest element ----
+			tsInvalid(`type Foo = [string, ...rest: number[]];`, expectedError(`type Foo = [string, ...rest: number[]];`, `string`, 0)),
+
+			// ---- Labeled head with an unlabeled rest element ----
+			tsInvalid(`type Foo = [a: string, ...number[]];`, expectedError(`type Foo = [a: string, ...number[]];`, `...number[]`, 0)),
+
+			// ---- Optional combined with a missing label ----
+			tsInvalid(`type Foo = [a?: string, number];`, expectedError(`type Foo = [a?: string, number];`, `number`, 0)),
+
+			// ---- Readonly tuple ----
+			tsInvalid(`type Foo = readonly [a: string, number];`, expectedError(`type Foo = readonly [a: string, number];`, `number`, 0)),
+
+			// ---- Nested tuple is inconsistent on its own ----
+			tsInvalid(`type Foo = [[a: number, number]];`, expectedError(`type Foo = [[a: number, number]];`, `number`, 1)),
+
+			// ---- Comments inside the tuple ----
+			tsInvalid(`type Foo = [a: string, /* unlabeled */ number];`, expectedError(`type Foo = [a: string, /* unlabeled */ number];`, `number`, 0)),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -657,6 +657,7 @@ define.test({
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/catch-error-name.test.ts',
     './tests/eslint-plugin-unicorn/rules/consistent-date-clone.test.ts',
+    './tests/eslint-plugin-unicorn/rules/consistent-tuple-labels.test.ts',
     './tests/eslint-plugin-unicorn/rules/error-message.test.ts',
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/consistent-tuple-labels.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/consistent-tuple-labels.test.ts
@@ -1,0 +1,51 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const messageId = 'consistent-tuple-labels';
+const message =
+  'This tuple element should have a label, just like the other elements.';
+
+const valid = (code: string) => ({ code, filename: 'file.ts' });
+const invalid = (code: string, errorCount = 1) => ({
+  code,
+  filename: 'file.ts',
+  errors: Array.from({ length: errorCount }, () => ({ messageId, message })),
+});
+
+ruleTester.run('consistent-tuple-labels', null as never, {
+  valid: [
+    valid('type Foo = [a: string, b: number];'),
+    valid('type Foo = [a: string, b: number, c: boolean];'),
+    valid('type Foo = [string, number];'),
+    valid('type Foo = [string, number, boolean];'),
+    valid('type Foo = [];'),
+    valid('type Foo = [string];'),
+    valid('type Foo = [a: string];'),
+    valid('type Foo = [a?: string, b?: number];'),
+    valid('type Foo = [a: string, b?: number];'),
+    valid('type Foo = [string?, number?];'),
+    valid('type Foo = [a: string, ...b: number[]];'),
+    valid('type Foo = [string, ...number[]];'),
+    valid('type Foo = [[a: number, b: number]];'),
+    valid('type Foo = [a: [x: number], b: [y: number]];'),
+    valid('type Foo = string[];'),
+    valid('type Foo = readonly string[];'),
+    valid('type Foo = {a: string; b: number};'),
+  ],
+  invalid: [
+    invalid('type Foo = [a: string, number];'),
+    invalid('type Foo = [string, b: number];'),
+    invalid('type Foo = [a: string, b: number, c: boolean, d];'),
+    invalid('type Foo = [a: string, number, c: boolean];'),
+    invalid('type Foo = [a: string, number, boolean];', 2),
+    invalid('type Foo = [a?: string, number?];'),
+    invalid('type Foo = [string?, b: number];'),
+    invalid('type Foo = [string, ...rest: number[]];'),
+    invalid('type Foo = [a: string, ...number[]];'),
+    invalid('type Foo = [a?: string, number];'),
+    invalid('type Foo = readonly [a: string, number];'),
+    invalid('type Foo = [[a: number, number]];'),
+    invalid('type Foo = [a: string, /* unlabeled */ number];'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -36,7 +36,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/consistent-json-file-read': 'error', // not implemented
     // 'unicorn/consistent-optional-chaining': 'error', // not implemented
     // 'unicorn/consistent-template-literal-escape': 'error', // not implemented
-    // 'unicorn/consistent-tuple-labels': 'error', // not implemented
+    'unicorn/consistent-tuple-labels': 'error',
     // 'unicorn/custom-error-definition': 'off', // not implemented
     // 'unicorn/default-export-style': 'error', // not implemented
     // 'unicorn/dom-node-dataset': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/consistent-tuple-labels` from
`eslint-plugin-unicorn@v74.0.0` to rslint.

The rule reports unlabeled tuple elements when any element in the same tuple
has a label:

```ts
// Incorrect
type Point = [x: number, number];

// Correct
type Point = [x: number, y: number];
type Coordinates = [number, number];
```

There is no autofix because meaningful tuple labels cannot be inferred.

## Implementation

- Handles ordinary, optional, rest, readonly, and nested tuple forms.
- Reports every unlabeled element in a partially labeled tuple.
- Preserves independent diagnostics for nested tuples.
- Registers the rule in the Unicorn catalog and enables it in the Unicorn
  recommended preset.

## Tests

- Migrated the complete upstream v74.0.0 suite: 17 valid and 13 invalid cases.
- Added Go coverage for tsgo tuple node shapes, nested tuples, parenthesized and
  union element types, declaration containers, and exact diagnostic ranges.
- Added the JS end-to-end RuleTester suite.
- Compared message IDs, messages, and report ranges with the upstream v74.0.0
  snapshots.

Verification completed:

- `go test -count=1 ./internal/plugins/unicorn ./internal/plugins/unicorn/rules/consistent_tuple_labels`
- `pnpm build`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 consistent-tuple-labels`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint`: 0 issues

## Related Links

- [Documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/consistent-tuple-labels.md)
- [Source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/consistent-tuple-labels.js)
- [Upstream tests](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/consistent-tuple-labels.js)

Tracks #1309.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Rule registered in the Unicorn catalog.
- [x] Unicorn recommended preset updated.
