### PR TITLE
fix: align prefer-array-flat with unicorn v74

### DIFF
--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
@@ -3,6 +3,7 @@ package prefer_array_flat
 import (
 	_ "embed"
 	"fmt"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -19,18 +20,22 @@ var (
 	//go:embed prefer_array_flat.schema.json
 	schemaJSON []byte
 
-	lodashFlattenFunctions = []string{
-		"_.flatten",
-		"lodash.flatten",
-		"underscore.flatten",
+	lodashFlattenFunctions = []flattenFunction{
+		{name: "_.flatten", leaf: "flatten"},
+		{name: "lodash.flatten", leaf: "flatten"},
+		{name: "underscore.flatten", leaf: "flatten"},
 	}
 )
 
 type flattenMatch struct {
-	array         *ast.Node
-	description   string
-	switchToArray bool
-	optional      bool
+	array       *ast.Node
+	description string
+	optional    bool
+}
+
+type flattenFunction struct {
+	name string
+	leaf string
 }
 
 func message(description string) rule.RuleMessage {
@@ -56,7 +61,7 @@ func matchArrayFlatMap(node *ast.Node, ctx rule.RuleContext) (flattenMatch, bool
 	if len(arguments) != 1 || ast.IsSpreadElement(arguments[0]) {
 		return flattenMatch{}, false
 	}
-	callback := ast.SkipParentheses(arguments[0])
+	callback := utils.ESTreeRuntimeExpression(arguments[0])
 	if callback == nil || !ast.IsArrowFunction(callback) || ast.IsAsyncFunction(callback) {
 		return flattenMatch{}, false
 	}
@@ -67,8 +72,9 @@ func matchArrayFlatMap(node *ast.Node, ctx rule.RuleContext) (flattenMatch, bool
 		return flattenMatch{}, false
 	}
 	parameter := unicornutil.PlainParameterIdentifier(arrow.Parameters.Nodes[0])
-	if parameter == nil || !unicornutil.IsSameIdentifier(parameter, arrow.Body) ||
-		isObviouslyNonArrayFlatMapReceiver(call.Object, ctx) {
+	if parameter == nil ||
+		!unicornutil.IsSameIdentifier(parameter, utils.ESTreeRuntimeExpression(arrow.Body)) ||
+		isObviouslyNonArrayFlatMapReceiver(utils.ESTreeRuntimeExpression(call.Object), ctx) {
 		return flattenMatch{}, false
 	}
 
@@ -79,7 +85,7 @@ func matchArrayFlatMap(node *ast.Node, ctx rule.RuleContext) (flattenMatch, bool
 	}, true
 }
 
-func matchArrayReduce(node *ast.Node) (flattenMatch, bool) {
+func matchArrayReduce(node *ast.Node, ctx rule.RuleContext) (flattenMatch, bool) {
 	twoArguments := 2
 	call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
 		Method:              "reduce",
@@ -93,11 +99,11 @@ func matchArrayReduce(node *ast.Node) (flattenMatch, bool) {
 	arguments := node.Arguments()
 	if len(arguments) != 2 || ast.IsSpreadElement(arguments[0]) ||
 		ast.IsSpreadElement(arguments[1]) ||
-		!ast.IsEmptyArrayLiteral(ast.SkipParentheses(arguments[1])) {
+		!ast.IsEmptyArrayLiteral(utils.ESTreeRuntimeExpression(arguments[1])) {
 		return flattenMatch{}, false
 	}
 
-	callback := ast.SkipParentheses(arguments[0])
+	callback := utils.ESTreeRuntimeExpression(arguments[0])
 	if callback == nil || !ast.IsArrowFunction(callback) || ast.IsAsyncFunction(callback) {
 		return flattenMatch{}, false
 	}
@@ -113,9 +119,12 @@ func matchArrayReduce(node *ast.Node) (flattenMatch, bool) {
 		return flattenMatch{}, false
 	}
 
-	body := ast.SkipParentheses(arrow.Body)
+	body := utils.ESTreeRuntimeExpression(arrow.Body)
 	if !matchesConcatReducer(body, firstParameter, secondParameter) &&
 		!matchesSpreadReducer(body, firstParameter, secondParameter) {
+		return flattenMatch{}, false
+	}
+	if unicornutil.IsKnownNonArray(ctx, utils.ESTreeRuntimeExpression(call.Object)) {
 		return flattenMatch{}, false
 	}
 
@@ -138,8 +147,14 @@ func matchesConcatReducer(body *ast.Node, firstParameter *ast.Node, secondParame
 	arguments := body.Arguments()
 	return len(arguments) == 1 &&
 		!ast.IsSpreadElement(arguments[0]) &&
-		unicornutil.IsSameIdentifier(firstParameter, call.Object) &&
-		unicornutil.IsSameIdentifier(secondParameter, arguments[0])
+		unicornutil.IsSameIdentifier(
+			firstParameter,
+			utils.ESTreeRuntimeExpression(call.Object),
+		) &&
+		unicornutil.IsSameIdentifier(
+			secondParameter,
+			utils.ESTreeRuntimeExpression(arguments[0]),
+		)
 }
 
 func matchesSpreadReducer(body *ast.Node, firstParameter *ast.Node, secondParameter *ast.Node) bool {
@@ -156,7 +171,10 @@ func matchesSpreadReducer(body *ast.Node, firstParameter *ast.Node, secondParame
 		if element == nil || element.Kind != ast.KindSpreadElement {
 			return false
 		}
-		if !unicornutil.IsSameIdentifier(parameters[index], element.AsSpreadElement().Expression) {
+		if !unicornutil.IsSameIdentifier(
+			parameters[index],
+			utils.ESTreeRuntimeExpression(element.AsSpreadElement().Expression),
+		) {
 			return false
 		}
 	}
@@ -173,52 +191,43 @@ func matchEmptyArrayConcat(node *ast.Node) (flattenMatch, bool) {
 		return flattenMatch{}, false
 	}
 
-	object := ast.SkipParentheses(call.Object)
+	object := utils.ESTreeRuntimeExpression(call.Object)
 	if !ast.IsEmptyArrayLiteral(object) {
 		return flattenMatch{}, false
 	}
 
 	argument := node.Arguments()[0]
-	if ast.IsSpreadElement(argument) {
-		return flattenMatch{
-			array:       argument.AsSpreadElement().Expression,
-			description: "[].concat()",
-		}, true
+	if !ast.IsSpreadElement(argument) {
+		return flattenMatch{}, false
 	}
 	return flattenMatch{
-		array:         argument,
-		description:   "[].concat()",
-		switchToArray: true,
+		array:       argument.AsSpreadElement().Expression,
+		description: "[].concat()",
 	}, true
 }
 
 func matchArrayPrototypeConcat(node *ast.Node) (flattenMatch, bool) {
 	twoArguments := 2
 	call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
-		Method:          "apply",
+		Methods:         []string{"apply", "call"},
 		ArgumentsLength: &twoArguments,
 	})
-	method := "apply"
-	if !ok {
-		call, ok = unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
-			Method:          "call",
-			ArgumentsLength: &twoArguments,
-		})
-		method = "call"
-	}
 	if !ok || !unicornutil.IsArrayPrototypeProperty(call.Object, "concat") {
 		return flattenMatch{}, false
 	}
 
 	arguments := node.Arguments()
 	if len(arguments) != 2 || ast.IsSpreadElement(arguments[0]) ||
-		!ast.IsEmptyArrayLiteral(ast.SkipParentheses(arguments[0])) {
+		!ast.IsEmptyArrayLiteral(utils.ESTreeRuntimeExpression(arguments[0])) {
 		return flattenMatch{}, false
 	}
 
+	method := call.Property.AsIdentifier().Text
 	secondArgument := arguments[1]
 	isSpread := ast.IsSpreadElement(secondArgument)
-	if method == "apply" && isSpread {
+	matchesApply := method == "apply" && !isSpread
+	matchesCall := method == "call" && isSpread
+	if !matchesApply && !matchesCall {
 		return flattenMatch{}, false
 	}
 	if isSpread {
@@ -226,13 +235,12 @@ func matchArrayPrototypeConcat(node *ast.Node) (flattenMatch, bool) {
 	}
 
 	return flattenMatch{
-		array:         secondArgument,
-		description:   "Array.prototype.concat()",
-		switchToArray: method == "call" && !isSpread,
+		array:       secondArgument,
+		description: "Array.prototype.concat()",
 	}, true
 }
 
-func matchFlattenFunction(node *ast.Node, functions []string) (flattenMatch, bool) {
+func matchFlattenFunction(node *ast.Node, functions []flattenFunction) (flattenMatch, bool) {
 	if node == nil || !ast.IsCallExpression(node) {
 		return flattenMatch{}, false
 	}
@@ -243,22 +251,56 @@ func matchFlattenFunction(node *ast.Node, functions []string) (flattenMatch, boo
 		return flattenMatch{}, false
 	}
 
-	callee := ast.SkipParentheses(call.Expression)
+	callee := utils.ESTreeRuntimeExpression(call.Expression)
+	leaf := nodePathLeaf(callee)
+	if leaf == "" {
+		return flattenMatch{}, false
+	}
 	for _, function := range functions {
-		if unicornutil.NodeMatchesPath(callee, function) {
+		if leaf == function.leaf && unicornutil.NodeMatchesPath(callee, function.name) {
 			return flattenMatch{
 				array:       arguments[0],
-				description: ecmascript.StringTrim(function) + "()",
+				description: function.name + "()",
 			}, true
 		}
 	}
 	return flattenMatch{}, false
 }
 
+func nodePathLeaf(node *ast.Node) string {
+	node = utils.ESTreeRuntimeExpression(node)
+	if node == nil {
+		return ""
+	}
+	if ast.IsIdentifier(node) {
+		return node.AsIdentifier().Text
+	}
+	switch node.Kind {
+	case ast.KindThisKeyword:
+		return "this"
+	case ast.KindSuperKeyword:
+		return "super"
+	}
+	if ast.IsPropertyAccessExpression(node) {
+		name := node.AsPropertyAccessExpression().Name()
+		if name != nil && ast.IsIdentifier(name) {
+			return name.AsIdentifier().Text
+		}
+		return ""
+	}
+	if node.Kind == ast.KindMetaProperty {
+		name := node.AsMetaProperty().Name()
+		if name != nil {
+			return name.Text()
+		}
+	}
+	return ""
+}
+
 // Upstream checks only whether the first Unicode rune is an uppercase letter;
 // this is not intended to validate the rest of a PascalCase name.
 func isPascalCaseIdentifier(node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
+	node = utils.ESTreeRuntimeExpression(node)
 	if node == nil || !ast.IsIdentifier(node) {
 		return false
 	}
@@ -267,7 +309,7 @@ func isPascalCaseIdentifier(node *ast.Node) bool {
 }
 
 func isDefinitelyArrayExpression(node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
+	node = utils.ESTreeRuntimeExpression(node)
 	if node == nil {
 		return false
 	}
@@ -277,12 +319,12 @@ func isDefinitelyArrayExpression(node *ast.Node) bool {
 	if !ast.IsNewExpression(node) {
 		return false
 	}
-	callee := ast.SkipParentheses(node.AsNewExpression().Expression)
+	callee := utils.ESTreeRuntimeExpression(node.AsNewExpression().Expression)
 	return callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "Array"
 }
 
 func isDefinitelyNonArrayExpression(node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
+	node = utils.ESTreeRuntimeExpression(node)
 	if node == nil {
 		return false
 	}
@@ -303,7 +345,7 @@ func isDefinitelyNonArrayExpression(node *ast.Node) bool {
 		ast.KindClassExpression:
 		return true
 	case ast.KindNewExpression:
-		callee := ast.SkipParentheses(node.AsNewExpression().Expression)
+		callee := utils.ESTreeRuntimeExpression(node.AsNewExpression().Expression)
 		return callee != nil && ast.IsIdentifier(callee) &&
 			callee.AsIdentifier().Text != "Array"
 	default:
@@ -323,7 +365,7 @@ func isObviouslyNonArrayFlatMapReceiver(node *ast.Node, ctx rule.RuleContext) bo
 
 func canFix(node *ast.Node, array *ast.Node, ctx rule.RuleContext) bool {
 	nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-	arrayRange := utils.TrimNodeTextRange(ctx.SourceFile, ast.SkipParentheses(array))
+	arrayRange := utils.TrimNodeTextRange(ctx.SourceFile, utils.ESTreeRuntimeExpression(array))
 	comments := ctx.Comments.All()
 	// Upstream fixes only when every comment in the matched call belongs to the
 	// selected array expression. Since array is nested in node, check the two
@@ -335,9 +377,7 @@ func canFix(node *ast.Node, array *ast.Node, ctx rule.RuleContext) bool {
 func replacementText(sourceFile *ast.SourceFile, match flattenMatch) string {
 	arrayText := utils.TrimmedNodeText(sourceFile, match.array)
 	fixed := arrayText
-	if match.switchToArray {
-		fixed = "[" + fixed + "]"
-	} else if match.array.Kind != ast.KindParenthesizedExpression &&
+	if match.array.Kind != ast.KindParenthesizedExpression &&
 		unicornutil.ShouldAddParenthesesToMemberExpressionObject(sourceFile, match.array) {
 		fixed = "(" + fixed + ")"
 	}
@@ -359,16 +399,29 @@ func buildFixes(node *ast.Node, match flattenMatch, ctx rule.RuleContext) []rule
 	return append(fixes, unicornutil.SpaceAroundKeywordFixes(ctx.SourceFile, node)...)
 }
 
-func parseFunctions(options []any) []string {
-	functions := make([]string, 0, len(lodashFlattenFunctions))
+func parseFunctions(options []any) []flattenFunction {
+	var configured []string
 	if len(options) > 0 {
 		optionsMap, _ := options[0].(map[string]any)
-		functions = append(functions, utils.ToStringSlice(optionsMap["functions"])...)
+		configured = utils.ToStringSlice(optionsMap["functions"])
+	}
+	if len(configured) == 0 {
+		return lodashFlattenFunctions
+	}
+
+	functions := make([]flattenFunction, 0, len(configured)+len(lodashFlattenFunctions))
+	for _, function := range configured {
+		name := ecmascript.StringTrim(function)
+		leafStart := strings.LastIndexByte(name, '.') + 1
+		functions = append(functions, flattenFunction{
+			name: name,
+			leaf: name[leafStart:],
+		})
 	}
 	return append(functions, lodashFlattenFunctions...)
 }
 
-// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-array-flat.md
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-array-flat.md
 var PreferArrayFlatRule = rule.Rule{
 	Name:   "unicorn/prefer-array-flat",
 	Schema: rule.NewSchema(schemaJSON),
@@ -376,33 +429,32 @@ var PreferArrayFlatRule = rule.Rule{
 		functions := parseFunctions(options)
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				var matches []flattenMatch
 				if match, ok := matchArrayFlatMap(node, ctx); ok {
-					matches = append(matches, match)
+					reportMatch(node, match, ctx)
 				}
-				if match, ok := matchArrayReduce(node); ok {
-					matches = append(matches, match)
+				if match, ok := matchArrayReduce(node, ctx); ok {
+					reportMatch(node, match, ctx)
 				}
 				if match, ok := matchEmptyArrayConcat(node); ok {
-					matches = append(matches, match)
+					reportMatch(node, match, ctx)
 				}
 				if match, ok := matchArrayPrototypeConcat(node); ok {
-					matches = append(matches, match)
+					reportMatch(node, match, ctx)
 				}
 				if match, ok := matchFlattenFunction(node, functions); ok {
-					matches = append(matches, match)
-				}
-
-				for _, match := range matches {
-					ruleMessage := message(match.description)
-					ctx.ReportNodeWithDeferredFixes(node, ruleMessage, func() []rule.RuleFix {
-						if !canFix(node, match.array, ctx) {
-							return nil
-						}
-						return buildFixes(node, match, ctx)
-					})
+					reportMatch(node, match, ctx)
 				}
 			},
 		}
 	},
+}
+
+func reportMatch(node *ast.Node, match flattenMatch, ctx rule.RuleContext) {
+	ruleMessage := message(match.description)
+	ctx.ReportNodeWithDeferredFixes(node, ruleMessage, func() []rule.RuleFix {
+		if !canFix(node, match.array, ctx) {
+			return nil
+		}
+		return buildFixes(node, match, ctx)
+	})
 }

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.md
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.md
@@ -24,11 +24,16 @@ Examples of **correct** code for this rule:
 
 ```javascript
 const first = array.flat();
-const second = [maybeArray].flat();
+const second = [].concat(maybeArray);
+const third = Array.prototype.concat.call([], maybeArray);
 ```
 
-`[maybeArray].flat()` preserves the behavior of `[].concat(maybeArray)` when
-the value may be either a single item or an array.
+Plain concat normalization does not consume an array of concat arguments, so
+this rule intentionally leaves it to `prefer-spread`.
+
+A matching `reduce()` is also ignored when its receiver is known not to be an
+array, including a typed array, because the proposed `.flat()` replacement
+does not exist on that receiver. Unknown receivers are still reported.
 
 ## Options
 
@@ -62,5 +67,5 @@ const second = utils.flat(array);
 
 ## Original Documentation
 
-- [eslint-plugin-unicorn: prefer-array-flat](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-array-flat.md)
-- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/rules/prefer-array-flat.js)
+- [eslint-plugin-unicorn: prefer-array-flat](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-array-flat.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-array-flat.js)

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.schema.json
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.schema.json
@@ -7,6 +7,9 @@
       "properties": {
         "functions": {
           "type": "array",
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true,
           "description": "Additional functions to check."
         }

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_fix_boundaries_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_fix_boundaries_test.go
@@ -1,0 +1,104 @@
+package prefer_array_flat_test
+
+import "testing"
+
+// TestPreferArrayFlatExtrasFixBoundaries locks in comment ownership,
+// member-object parenthesization, and ASI-sensitive rewrites that the upstream
+// suite does not exercise. The upstream migration and other augmentation live
+// in the sibling prefer_array_flat_upstream_* and prefer_array_flat_extras_*
+// test files.
+func TestPreferArrayFlatExtrasFixBoundaries(t *testing.T) {
+	var suite upstreamSuite
+
+	// ---- Dimension 3: comment ownership and fix suppression ----
+	suite.addNoFix(
+		`array.flatMap(value /* keep */ => value)`,
+		`array.flatMap(value /* keep */ => value)`,
+		`Array#flatMap()`,
+		nil,
+	)
+	suite.addFixed(
+		`foo./* keep */bar.flatMap(value => value)`,
+		`foo./* keep */bar.flatMap(value => value)`,
+		`foo./* keep */bar.flat()`,
+		`Array#flatMap()`,
+		nil,
+	)
+
+	// ---- Dimension 3: member-object parentheses ----
+	expressionCases := []struct {
+		code        string
+		replacement string
+	}{
+		{code: `_.flatten({value: 1})`, replacement: `({value: 1}).flat()`},
+		{code: `_.flatten(class {})`, replacement: `(class {}).flat()`},
+		{code: `_.flatten(value => value)`, replacement: `(value => value).flat()`},
+		{code: `_.flatten(flag ? left : right)`, replacement: `(flag ? left : right).flat()`},
+		{code: `_.flatten(value = input)`, replacement: `(value = input).flat()`},
+		{code: `_.flatten(++value)`, replacement: `(++value).flat()`},
+		{code: `_.flatten("value")`, replacement: `"value".flat()`},
+		{code: `_.flatten(/value/)`, replacement: `/value/.flat()`},
+		{code: `_.flatten(1n)`, replacement: `1n.flat()`},
+		{code: `_.flatten(true)`, replacement: `true.flat()`},
+		{code: `_.flatten(null)`, replacement: `null.flat()`},
+		{code: "_.flatten(`value`)", replacement: "`value`.flat()"},
+	}
+	for _, testCase := range expressionCases {
+		suite.addFixed(
+			testCase.code,
+			testCase.code,
+			testCase.replacement,
+			`_.flatten()`,
+			nil,
+		)
+	}
+	suite.addFixed(
+		`function* values() { return _.flatten(yield input); }`,
+		`_.flatten(yield input)`,
+		`(yield input).flat()`,
+		`_.flatten()`,
+		nil,
+	)
+
+	// ---- Dimension 3: ASI-sensitive embedded statement bodies ----
+	embeddedCases := []string{
+		`while (condition)
+	Array.prototype.concat.call([], ...value)`,
+		`for (;;)
+	Array.prototype.concat.call([], ...value)`,
+		`for (const item of items)
+	Array.prototype.concat.call([], ...value)`,
+		`do
+	Array.prototype.concat.call([], ...value)
+while (condition)`,
+		`with (object)
+	Array.prototype.concat.call([], ...value)`,
+	}
+	for _, code := range embeddedCases {
+		suite.addFixed(
+			code,
+			`Array.prototype.concat.call([], ...value)`,
+			`value.flat()`,
+			`Array.prototype.concat()`,
+			nil,
+		)
+	}
+	suite.addFixed(
+		`before()
+Array.prototype.concat.call([], ...value)`,
+		`Array.prototype.concat.call([], ...value)`,
+		`value.flat()`,
+		`Array.prototype.concat()`,
+		nil,
+	)
+	suite.addFixed(
+		`value = {}
+Array.prototype.concat.call([], ...item)`,
+		`Array.prototype.concat.call([], ...item)`,
+		`item.flat()`,
+		`Array.prototype.concat()`,
+		nil,
+	)
+
+	suite.run(t)
+}

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_jsdoc_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_jsdoc_test.go
@@ -1,0 +1,198 @@
+package prefer_array_flat_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreferArrayFlatExtrasJSDoc locks in JavaScript JSDoc wrappers across
+// callees, receivers, configured paths, and reduce patterns while keeping
+// authored TypeScript wrappers and optional/computed calls visible. Upstream
+// cases and other augmentation live in the sibling upstream and extras files.
+func TestPreferArrayFlatExtrasJSDoc(t *testing.T) {
+	var suite upstreamSuite
+
+	for _, testCase := range []struct {
+		fileName string
+		code     string
+		target   string
+		output   string
+	}{
+		{
+			fileName: "file.js",
+			code:     `/** @type {any} */ ([].concat)(...array)`,
+			target:   `([].concat)(...array)`,
+			output:   `/** @type {any} */ array.flat()`,
+		},
+		{
+			fileName: "file.js",
+			code:     `/** @satisfies {any} */ ([].concat)(...array)`,
+			target:   `([].concat)(...array)`,
+			output:   `/** @satisfies {any} */ array.flat()`,
+		},
+		{
+			fileName: "file.jsx",
+			code:     `const view = <div>{/** @type {any} */ ([].concat)(...array)}</div>;`,
+			target:   `([].concat)(...array)`,
+			output:   `const view = <div>{/** @type {any} */ array.flat()}</div>;`,
+		},
+	} {
+		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+			Code:     testCase.code,
+			FileName: testCase.fileName,
+			Output:   []string{testCase.output},
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamError(testCase.code, testCase.target, `[].concat()`, 0),
+			},
+		})
+	}
+
+	const internalJSDoc = `((/** @type {any} */ ([].concat)))(...array)`
+	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+		Code:     internalJSDoc,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			upstreamError(internalJSDoc, internalJSDoc, `[].concat()`, 0),
+		},
+	})
+
+	// Receiver/root wrappers are transparent to ESTree matching, but their
+	// comments sit outside the selected replacement expression and suppress
+	// the fix.
+	for _, testCase := range []struct {
+		code        string
+		description string
+		options     any
+	}{
+		{
+			code:        `(/** @type {any[]} */ ([])).concat(...array)`,
+			description: `[].concat()`,
+		},
+		{
+			code:        `(/** @satisfies {any[]} */ []).concat(...array)`,
+			description: `[].concat()`,
+		},
+		{
+			code:        `(/** @type {any} */ Array.prototype.concat).apply([], array)`,
+			description: `Array.prototype.concat()`,
+		},
+		{
+			code:        `(/** @type {typeof Array} */ Array).prototype.concat.apply([], array)`,
+			description: `Array.prototype.concat()`,
+		},
+		{
+			code:        `(/** @type {any} */ _).flatten(array)`,
+			description: `_.flatten()`,
+		},
+		{
+			code:        `(/** @type {any} */ utils).flat(array)`,
+			description: `utils.flat()`,
+			options: map[string]any{
+				"functions": []any{"utils.flat"},
+			},
+		},
+		{
+			code:        `array.reduce((a,b)=>(/** @type {any[]} */ a).concat(b),[])`,
+			description: `Array#reduce()`,
+		},
+		{
+			code:        `array.reduce((a,b)=>a.concat(/** @type {any[]} */ b),[])`,
+			description: `Array#reduce()`,
+		},
+		{
+			code:        `(/** @type {Set<number[]>} */ foo).reduce((a,b)=>a.concat(b),[])`,
+			description: `Array#reduce()`,
+		},
+		{
+			code:        `(/** @type {any[]} */ []).concat.apply([], array)`,
+			description: `Array.prototype.concat()`,
+		},
+	} {
+		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+			Code:     testCase.code,
+			FileName: "file.js",
+			Options:  testCase.options,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamError(testCase.code, testCase.code, testCase.description, 0),
+			},
+		})
+	}
+
+	// A JSDoc wrapper around the whole callee/call is outside the reported
+	// CallExpression range, so the safe fix remains available.
+	for _, testCase := range []struct {
+		code        string
+		target      string
+		output      string
+		description string
+	}{
+		{
+			code:        `/** @type {any} */ (_.flatten)(array)`,
+			target:      `(_.flatten)(array)`,
+			output:      `/** @type {any} */ array.flat()`,
+			description: `_.flatten()`,
+		},
+		{
+			code:        `/** @type {any} */ (([].concat(...array)))`,
+			target:      `[].concat(...array)`,
+			output:      `/** @type {any} */ ((array.flat()))`,
+			description: `[].concat()`,
+		},
+	} {
+		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+			Code:     testCase.code,
+			FileName: "file.js",
+			Output:   []string{testCase.output},
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamError(testCase.code, testCase.target, testCase.description, 0),
+			},
+		})
+	}
+
+	// JSDoc types do not turn syntactically known flatMap non-arrays into
+	// arrays. Authored TypeScript wrappers remain visible and unmatched.
+	suite.valid = append(suite.valid,
+		rule_tester.ValidTestCase{
+			Code:     `(/** @type {any[]} */ Effects).flatMap(x => x)`,
+			FileName: "file.js",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `const value = {}; (/** @type {any[]} */ value).flatMap(x => x)`,
+			FileName: "file.js",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `([] as unknown[]).concat(...array)`,
+			FileName: "file.ts",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `(_.flatten as any)(array)`,
+			FileName: "file.ts",
+		},
+	)
+
+	for _, code := range []string{
+		`/** @type {any} */ (value.concat)(...array)`,
+		`/** @type {any} */ ([]?.concat)(...array)`,
+		`/** @type {any} */ ([].concat)?.(...array)`,
+		`/** @type {any} */ ([]["concat"])(...array)`,
+	} {
+		suite.valid = append(suite.valid, rule_tester.ValidTestCase{
+			Code:     code,
+			FileName: "file.js",
+		})
+	}
+
+	for _, code := range []string{
+		`([].concat as any)(...array)`,
+		`([].concat satisfies any)(...array)`,
+		`([].concat!)(...array)`,
+	} {
+		suite.valid = append(suite.valid, rule_tester.ValidTestCase{
+			Code:     code,
+			FileName: "file.ts",
+		})
+	}
+
+	suite.run(t)
+}

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_regressions_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_regressions_test.go
@@ -4,15 +4,14 @@ package prefer_array_flat_test
 import (
 	"testing"
 
-	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
 // TestPreferArrayFlatExtrasRegressions locks in expressions, token boundaries,
 // nested calls, and scope behavior found by comparing the Go implementation
 // with unicorn v74. The complete upstream suite lives in the
-// prefer_array_flat_upstream_*_test.go files; the general Dimension 4,
-// real-user, branch, and fix-boundary cases live in the sibling extras file.
+// prefer_array_flat_upstream_*_test.go files; other rslint-specific coverage
+// lives in the sibling prefer_array_flat_extras_*_test.go files.
 func TestPreferArrayFlatExtrasRegressions(t *testing.T) {
 	var suite upstreamSuite
 
@@ -307,6 +306,24 @@ value.flat()`,
 		`Array#flatMap()`,
 		nil,
 	)
+
+	// Locks in upstream isKnownNonArrayNode()'s source-only boundary: a let
+	// binding is not resolved in JavaScript, so its Set initializer does not
+	// suppress the reduce diagnostic.
+	const unknownSetReduce = `let foo = new Set(); foo.reduce((a, b) => a.concat(b), []);`
+	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+		Code:     unknownSetReduce,
+		FileName: "file.js",
+		Output:   []string{`let foo = new Set(); foo.flat();`},
+		Errors: []rule_tester.InvalidTestCaseError{
+			upstreamError(
+				unknownSetReduce,
+				`foo.reduce((a, b) => a.concat(b), [])`,
+				`Array#reduce()`,
+				0,
+			),
+		},
+	})
 	// U+2160 is uppercase-like but belongs to Unicode category Nl, not Lu.
 	// Upstream's /^\p{Lu}/u therefore does not suppress this receiver.
 	suite.addFixed(
@@ -359,8 +376,8 @@ Items.flat();`,
 		nil,
 	)
 
-	pathOptions := map[string]interface{}{
-		"functions": []interface{}{"utils.deep.flat", "utils.flat", "flat"},
+	pathOptions := map[string]any{
+		"functions": []any{"utils.deep.flat", "utils.flat", "flat"},
 	}
 	suite.addFixed(
 		`(utils.deep).flat(array)`,
@@ -396,7 +413,7 @@ Items.flat();`,
 	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
 		Code:    overlapCode,
 		Output:  []string{`array.flat()`},
-		Options: map[string]interface{}{"functions": []interface{}{"array.flatMap"}},
+		Options: map[string]any{"functions": []any{"array.flatMap"}},
 		Errors: []rule_tester.InvalidTestCaseError{
 			upstreamError(overlapCode, overlapCode, `Array#flatMap()`, 0),
 			upstreamError(overlapCode, overlapCode, `array.flatMap()`, 0),
@@ -469,257 +486,4 @@ Items.flat();`,
 	})
 
 	suite.run(t)
-}
-
-// TestPreferArrayFlatJSDocCalleeRegression verifies that JavaScript JSDoc
-// wrappers stay transparent like they are in ESTree without making authored
-// TypeScript wrappers or optional/computed calls transparent.
-func TestPreferArrayFlatJSDocCalleeRegression(t *testing.T) {
-	var suite upstreamSuite
-
-	for _, testCase := range []struct {
-		fileName string
-		code     string
-		target   string
-		output   string
-	}{
-		{
-			fileName: "file.js",
-			code:     `/** @type {any} */ ([].concat)(...array)`,
-			target:   `([].concat)(...array)`,
-			output:   `/** @type {any} */ array.flat()`,
-		},
-		{
-			fileName: "file.js",
-			code:     `/** @satisfies {any} */ ([].concat)(...array)`,
-			target:   `([].concat)(...array)`,
-			output:   `/** @satisfies {any} */ array.flat()`,
-		},
-		{
-			fileName: "file.jsx",
-			code:     `const view = <div>{/** @type {any} */ ([].concat)(...array)}</div>;`,
-			target:   `([].concat)(...array)`,
-			output:   `const view = <div>{/** @type {any} */ array.flat()}</div>;`,
-		},
-	} {
-		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
-			Code:     testCase.code,
-			FileName: testCase.fileName,
-			Output:   []string{testCase.output},
-			Errors: []rule_tester.InvalidTestCaseError{
-				upstreamError(testCase.code, testCase.target, `[].concat()`, 0),
-			},
-		})
-	}
-
-	const internalJSDoc = `((/** @type {any} */ ([].concat)))(...array)`
-	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
-		Code:     internalJSDoc,
-		FileName: "file.js",
-		Errors: []rule_tester.InvalidTestCaseError{
-			upstreamError(internalJSDoc, internalJSDoc, `[].concat()`, 0),
-		},
-	})
-
-	// Receiver/root wrappers are transparent to ESTree matching, but their
-	// comments sit outside the selected replacement expression and suppress
-	// the fix.
-	for _, testCase := range []struct {
-		code        string
-		description string
-		options     any
-	}{
-		{
-			code:        `(/** @type {any[]} */ ([])).concat(...array)`,
-			description: `[].concat()`,
-		},
-		{
-			code:        `(/** @satisfies {any[]} */ []).concat(...array)`,
-			description: `[].concat()`,
-		},
-		{
-			code:        `(/** @type {any} */ Array.prototype.concat).apply([], array)`,
-			description: `Array.prototype.concat()`,
-		},
-		{
-			code:        `(/** @type {typeof Array} */ Array).prototype.concat.apply([], array)`,
-			description: `Array.prototype.concat()`,
-		},
-		{
-			code:        `(/** @type {any} */ _).flatten(array)`,
-			description: `_.flatten()`,
-		},
-		{
-			code:        `(/** @type {any} */ utils).flat(array)`,
-			description: `utils.flat()`,
-			options: map[string]any{
-				"functions": []any{"utils.flat"},
-			},
-		},
-		{
-			code:        `array.reduce((a,b)=>(/** @type {any[]} */ a).concat(b),[])`,
-			description: `Array#reduce()`,
-		},
-		{
-			code:        `array.reduce((a,b)=>a.concat(/** @type {any[]} */ b),[])`,
-			description: `Array#reduce()`,
-		},
-		{
-			code:        `(/** @type {Set<number[]>} */ foo).reduce((a,b)=>a.concat(b),[])`,
-			description: `Array#reduce()`,
-		},
-		{
-			code:        `(/** @type {any[]} */ []).concat.apply([], array)`,
-			description: `Array.prototype.concat()`,
-		},
-	} {
-		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
-			Code:     testCase.code,
-			FileName: "file.js",
-			Options:  testCase.options,
-			Errors: []rule_tester.InvalidTestCaseError{
-				upstreamError(testCase.code, testCase.code, testCase.description, 0),
-			},
-		})
-	}
-
-	// A JSDoc wrapper around the whole callee/call is outside the reported
-	// CallExpression range, so the safe fix remains available.
-	for _, testCase := range []struct {
-		code        string
-		target      string
-		output      string
-		description string
-	}{
-		{
-			code:        `/** @type {any} */ (_.flatten)(array)`,
-			target:      `(_.flatten)(array)`,
-			output:      `/** @type {any} */ array.flat()`,
-			description: `_.flatten()`,
-		},
-		{
-			code:        `/** @type {any} */ (([].concat(...array)))`,
-			target:      `[].concat(...array)`,
-			output:      `/** @type {any} */ ((array.flat()))`,
-			description: `[].concat()`,
-		},
-	} {
-		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
-			Code:     testCase.code,
-			FileName: "file.js",
-			Output:   []string{testCase.output},
-			Errors: []rule_tester.InvalidTestCaseError{
-				upstreamError(testCase.code, testCase.target, testCase.description, 0),
-			},
-		})
-	}
-
-	// JSDoc types do not turn syntactically known flatMap non-arrays into
-	// arrays. Authored TypeScript wrappers remain visible and unmatched.
-	suite.valid = append(suite.valid,
-		rule_tester.ValidTestCase{
-			Code:     `(/** @type {any[]} */ Effects).flatMap(x => x)`,
-			FileName: "file.js",
-		},
-		rule_tester.ValidTestCase{
-			Code:     `const value = {}; (/** @type {any[]} */ value).flatMap(x => x)`,
-			FileName: "file.js",
-		},
-		rule_tester.ValidTestCase{
-			Code:     `([] as unknown[]).concat(...array)`,
-			FileName: "file.ts",
-		},
-		rule_tester.ValidTestCase{
-			Code:     `(_.flatten as any)(array)`,
-			FileName: "file.ts",
-		},
-	)
-
-	for _, code := range []string{
-		`/** @type {any} */ (value.concat)(...array)`,
-		`/** @type {any} */ ([]?.concat)(...array)`,
-		`/** @type {any} */ ([].concat)?.(...array)`,
-		`/** @type {any} */ ([]["concat"])(...array)`,
-	} {
-		suite.valid = append(suite.valid, rule_tester.ValidTestCase{
-			Code:     code,
-			FileName: "file.js",
-		})
-	}
-
-	for _, code := range []string{
-		`([].concat as any)(...array)`,
-		`([].concat satisfies any)(...array)`,
-		`([].concat!)(...array)`,
-	} {
-		suite.valid = append(suite.valid, rule_tester.ValidTestCase{
-			Code:     code,
-			FileName: "file.ts",
-		})
-	}
-
-	suite.run(t)
-}
-
-// TestPreferArrayFlatSchemaParity locks the public option schema to unicorn
-// v74, including string-only function entries, tuple length, uniqueness, and
-// additionalProperties.
-func TestPreferArrayFlatSchemaParity(t *testing.T) {
-	tests := []struct {
-		name    string
-		options []any
-		wantErr bool
-	}{
-		{name: "no options"},
-		{name: "empty object", options: []any{map[string]any{}}},
-		{
-			name: "string functions",
-			options: []any{map[string]any{
-				"functions": []any{"flat", "utils.flat"},
-			}},
-		},
-		{
-			name: "function items must be strings",
-			options: []any{map[string]any{
-				"functions": []any{1.0, nil, true, map[string]any{}},
-			}},
-			wantErr: true,
-		},
-		{
-			name: "duplicate functions",
-			options: []any{map[string]any{
-				"functions": []any{"flat", "flat"},
-			}},
-			wantErr: true,
-		},
-		{
-			name: "functions must be array",
-			options: []any{map[string]any{
-				"functions": "flat",
-			}},
-			wantErr: true,
-		},
-		{
-			name: "unknown property",
-			options: []any{map[string]any{
-				"unknown": true,
-			}},
-			wantErr: true,
-		},
-		{
-			name:    "only one option object",
-			options: []any{map[string]any{}, map[string]any{}},
-			wantErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := prefer_array_flat.PreferArrayFlatRule.Schema.Validate(test.options)
-			if (err != nil) != test.wantErr {
-				t.Fatalf("Schema.Validate(%#v) error = %v, wantErr %v",
-					test.options, err, test.wantErr)
-			}
-		})
-	}
 }

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_regressions_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_regressions_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestPreferArrayFlatExtrasRegressions locks in expressions, token boundaries,
 // nested calls, and scope behavior found by comparing the Go implementation
-// with unicorn v64. The complete upstream suite lives in the
+// with unicorn v74. The complete upstream suite lives in the
 // prefer_array_flat_upstream_*_test.go files; the general Dimension 4,
 // real-user, branch, and fix-boundary cases live in the sibling extras file.
 func TestPreferArrayFlatExtrasRegressions(t *testing.T) {
@@ -30,12 +30,12 @@ func TestPreferArrayFlatExtrasRegressions(t *testing.T) {
 	// ---- Differential: a standalone scanner must recover the parser's regex token ----
 	suite.addFixedOutput(
 		`/before/giu
-Array.prototype.concat.call([], value)`,
+Array.prototype.concat.call([], ...value)`,
 		`/before/giu
-;[value].flat()`,
+value.flat()`,
 		nil,
 		expectedDiagnostic{
-			target:      `Array.prototype.concat.call([], value)`,
+			target:      `Array.prototype.concat.call([], ...value)`,
 			description: `Array.prototype.concat()`,
 		},
 	)
@@ -208,44 +208,44 @@ Array.prototype.concat.call([], value)`,
 		output string
 	}{
 		{
-			code:   `function flatten() { throw[].concat(value); }`,
-			target: `[].concat(value)`,
-			output: `function flatten() { throw [value].flat(); }`,
+			code:   `function flatten() { throw[].concat(...value); }`,
+			target: `[].concat(...value)`,
+			output: `function flatten() { throw value.flat(); }`,
 		},
 		{
-			code:   `const result = typeof[].concat(value);`,
-			target: `[].concat(value)`,
-			output: `const result = typeof [value].flat();`,
+			code:   `const result = typeof[].concat(...value);`,
+			target: `[].concat(...value)`,
+			output: `const result = typeof value.flat();`,
 		},
 		{
-			code:   `const result = void[].concat(value);`,
-			target: `[].concat(value)`,
-			output: `const result = void [value].flat();`,
+			code:   `const result = void[].concat(...value);`,
+			target: `[].concat(...value)`,
+			output: `const result = void value.flat();`,
 		},
 		{
-			code:   `const result = delete[].concat(value);`,
-			target: `[].concat(value)`,
-			output: `const result = delete [value].flat();`,
+			code:   `const result = delete[].concat(...value);`,
+			target: `[].concat(...value)`,
+			output: `const result = delete value.flat();`,
 		},
 		{
-			code:   `const result = [].concat(value)in object;`,
-			target: `[].concat(value)`,
-			output: `const result = [value].flat() in object;`,
+			code:   `const result = [].concat(...value)in object;`,
+			target: `[].concat(...value)`,
+			output: `const result = value.flat() in object;`,
 		},
 		{
-			code:   `for (const item of[].concat(value)) {}`,
-			target: `[].concat(value)`,
-			output: `for (const item of [value].flat()) {}`,
+			code:   `for (const item of[].concat(...value)) {}`,
+			target: `[].concat(...value)`,
+			output: `for (const item of value.flat()) {}`,
 		},
 		{
-			code:   `async function flatten() { await[].concat(value); }`,
-			target: `[].concat(value)`,
-			output: `async function flatten() { await [value].flat(); }`,
+			code:   `async function flatten() { await[].concat(...value); }`,
+			target: `[].concat(...value)`,
+			output: `async function flatten() { await value.flat(); }`,
 		},
 		{
-			code:   `function* flatten() { yield[].concat(value); }`,
-			target: `[].concat(value)`,
-			output: `function* flatten() { yield [value].flat(); }`,
+			code:   `function* flatten() { yield[].concat(...value); }`,
+			target: `[].concat(...value)`,
+			output: `function* flatten() { yield value.flat(); }`,
 		},
 	} {
 		suite.addFixedOutput(
@@ -421,8 +421,8 @@ Items.flat();`,
 		},
 	})
 
-	// Nested member receivers, switch-to-array fixes, and direct member-object
-	// fixes all settle one non-overlapping replacement per pass, in the same
+	// Nested member receivers and direct member-object fixes settle one
+	// non-overlapping replacement per pass, in the same
 	// range order as ESLint's SourceCodeFixer.
 	nestedMemberCode := `array.flatMap(value => value).flatMap(value => value)`
 	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
@@ -442,12 +442,12 @@ Items.flat();`,
 		},
 	})
 
-	nestedSwitchCode := `[].concat(_.flatten(value))`
+	nestedSwitchCode := `[].concat(..._.flatten(value))`
 	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
 		Code: nestedSwitchCode,
 		Output: []string{
-			`[_.flatten(value)].flat()`,
-			`[value.flat()].flat()`,
+			`_.flatten(value).flat()`,
+			`value.flat().flat()`,
 		},
 		Errors: []rule_tester.InvalidTestCaseError{
 			upstreamError(nestedSwitchCode, nestedSwitchCode, `[].concat()`, 0),
@@ -455,16 +455,16 @@ Items.flat();`,
 		},
 	})
 
-	nestedDirectCode := `_.flatten([].concat(value))`
+	nestedDirectCode := `_.flatten([].concat(...value))`
 	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
 		Code: nestedDirectCode,
 		Output: []string{
-			`[].concat(value).flat()`,
-			`[value].flat().flat()`,
+			`[].concat(...value).flat()`,
+			`value.flat().flat()`,
 		},
 		Errors: []rule_tester.InvalidTestCaseError{
 			upstreamError(nestedDirectCode, nestedDirectCode, `_.flatten()`, 0),
-			upstreamError(nestedDirectCode, `[].concat(value)`, `[].concat()`, 0),
+			upstreamError(nestedDirectCode, `[].concat(...value)`, `[].concat()`, 0),
 		},
 	})
 
@@ -491,9 +491,9 @@ func TestPreferArrayFlatJSDocCalleeRegression(t *testing.T) {
 		},
 		{
 			fileName: "file.js",
-			code:     `/** @satisfies {any} */ ([].concat)(array)`,
-			target:   `([].concat)(array)`,
-			output:   `/** @satisfies {any} */ [array].flat()`,
+			code:     `/** @satisfies {any} */ ([].concat)(...array)`,
+			target:   `([].concat)(...array)`,
+			output:   `/** @satisfies {any} */ array.flat()`,
 		},
 		{
 			fileName: "file.jsx",
@@ -520,6 +520,120 @@ func TestPreferArrayFlatJSDocCalleeRegression(t *testing.T) {
 			upstreamError(internalJSDoc, internalJSDoc, `[].concat()`, 0),
 		},
 	})
+
+	// Receiver/root wrappers are transparent to ESTree matching, but their
+	// comments sit outside the selected replacement expression and suppress
+	// the fix.
+	for _, testCase := range []struct {
+		code        string
+		description string
+		options     any
+	}{
+		{
+			code:        `(/** @type {any[]} */ ([])).concat(...array)`,
+			description: `[].concat()`,
+		},
+		{
+			code:        `(/** @satisfies {any[]} */ []).concat(...array)`,
+			description: `[].concat()`,
+		},
+		{
+			code:        `(/** @type {any} */ Array.prototype.concat).apply([], array)`,
+			description: `Array.prototype.concat()`,
+		},
+		{
+			code:        `(/** @type {typeof Array} */ Array).prototype.concat.apply([], array)`,
+			description: `Array.prototype.concat()`,
+		},
+		{
+			code:        `(/** @type {any} */ _).flatten(array)`,
+			description: `_.flatten()`,
+		},
+		{
+			code:        `(/** @type {any} */ utils).flat(array)`,
+			description: `utils.flat()`,
+			options: map[string]any{
+				"functions": []any{"utils.flat"},
+			},
+		},
+		{
+			code:        `array.reduce((a,b)=>(/** @type {any[]} */ a).concat(b),[])`,
+			description: `Array#reduce()`,
+		},
+		{
+			code:        `array.reduce((a,b)=>a.concat(/** @type {any[]} */ b),[])`,
+			description: `Array#reduce()`,
+		},
+		{
+			code:        `(/** @type {Set<number[]>} */ foo).reduce((a,b)=>a.concat(b),[])`,
+			description: `Array#reduce()`,
+		},
+		{
+			code:        `(/** @type {any[]} */ []).concat.apply([], array)`,
+			description: `Array.prototype.concat()`,
+		},
+	} {
+		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+			Code:     testCase.code,
+			FileName: "file.js",
+			Options:  testCase.options,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamError(testCase.code, testCase.code, testCase.description, 0),
+			},
+		})
+	}
+
+	// A JSDoc wrapper around the whole callee/call is outside the reported
+	// CallExpression range, so the safe fix remains available.
+	for _, testCase := range []struct {
+		code        string
+		target      string
+		output      string
+		description string
+	}{
+		{
+			code:        `/** @type {any} */ (_.flatten)(array)`,
+			target:      `(_.flatten)(array)`,
+			output:      `/** @type {any} */ array.flat()`,
+			description: `_.flatten()`,
+		},
+		{
+			code:        `/** @type {any} */ (([].concat(...array)))`,
+			target:      `[].concat(...array)`,
+			output:      `/** @type {any} */ ((array.flat()))`,
+			description: `[].concat()`,
+		},
+	} {
+		suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+			Code:     testCase.code,
+			FileName: "file.js",
+			Output:   []string{testCase.output},
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamError(testCase.code, testCase.target, testCase.description, 0),
+			},
+		})
+	}
+
+	// JSDoc types do not turn syntactically known flatMap non-arrays into
+	// arrays. Authored TypeScript wrappers remain visible and unmatched.
+	suite.valid = append(suite.valid,
+		rule_tester.ValidTestCase{
+			Code:     `(/** @type {any[]} */ Effects).flatMap(x => x)`,
+			FileName: "file.js",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `const value = {}; (/** @type {any[]} */ value).flatMap(x => x)`,
+			FileName: "file.js",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `([] as unknown[]).concat(...array)`,
+			FileName: "file.ts",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `(_.flatten as any)(array)`,
+			FileName: "file.ts",
+		},
+	)
 
 	for _, code := range []string{
 		`/** @type {any} */ (value.concat)(...array)`,
@@ -548,8 +662,8 @@ func TestPreferArrayFlatJSDocCalleeRegression(t *testing.T) {
 }
 
 // TestPreferArrayFlatSchemaParity locks the public option schema to unicorn
-// v64. In particular, upstream leaves array item types unconstrained while
-// still enforcing tuple length, uniqueness, and additionalProperties.
+// v74, including string-only function entries, tuple length, uniqueness, and
+// additionalProperties.
 func TestPreferArrayFlatSchemaParity(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -565,10 +679,11 @@ func TestPreferArrayFlatSchemaParity(t *testing.T) {
 			}},
 		},
 		{
-			name: "unconstrained item types",
+			name: "function items must be strings",
 			options: []any{map[string]any{
 				"functions": []any{1.0, nil, true, map[string]any{}},
 			}},
+			wantErr: true,
 		},
 		{
 			name: "duplicate functions",

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_schema_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_schema_test.go
@@ -1,0 +1,71 @@
+package prefer_array_flat_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
+)
+
+// TestPreferArrayFlatExtrasSchema locks the public option schema to unicorn
+// v74, including string-only function entries, tuple length, uniqueness, and
+// additionalProperties. Behavioral cases live in the sibling upstream and
+// extras files.
+func TestPreferArrayFlatExtrasSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []any
+		wantErr bool
+	}{
+		{name: "no options"},
+		{name: "empty object", options: []any{map[string]any{}}},
+		{
+			name: "string functions",
+			options: []any{map[string]any{
+				"functions": []any{"flat", "utils.flat"},
+			}},
+		},
+		{
+			name: "function items must be strings",
+			options: []any{map[string]any{
+				"functions": []any{1.0, nil, true, map[string]any{}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate functions",
+			options: []any{map[string]any{
+				"functions": []any{"flat", "flat"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "functions must be array",
+			options: []any{map[string]any{
+				"functions": "flat",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "unknown property",
+			options: []any{map[string]any{
+				"unknown": true,
+			}},
+			wantErr: true,
+		},
+		{
+			name:    "only one option object",
+			options: []any{map[string]any{}, map[string]any{}},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := prefer_array_flat.PreferArrayFlatRule.Schema.Validate(test.options)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Schema.Validate(%#v) error = %v, wantErr %v",
+					test.options, err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
@@ -326,8 +326,8 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 
 	// Locks in upstream isNodeMatchesNameOrPath() roots: this, super, and meta
 	// properties all participate in configured dotted paths.
-	pathOptions := map[string]interface{}{
-		"functions": []interface{}{
+	pathOptions := map[string]any{
+		"functions": []any{
 			"this.flatten",
 			"super.flatten",
 			"import.meta.flatten",
@@ -353,14 +353,14 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		`this(array)`,
 		`array.flat()`,
 		`this()`,
-		map[string]interface{}{"functions": []interface{}{"this"}},
+		map[string]any{"functions": []any{"this"}},
 	)
 	suite.addFixed(
 		`class A extends B { constructor(array) { super(array) } }`,
 		`super(array)`,
 		`array.flat()`,
 		`super()`,
-		map[string]interface{}{"functions": []interface{}{"super"}},
+		map[string]any{"functions": []any{"super"}},
 	)
 	suite.addFixed(
 		`const values = import.meta.flatten(input);`,
@@ -405,8 +405,8 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 
 	// Locks in upstream create() traversal: nested matching calls each report,
 	// and overlapping fixes settle over two passes.
-	nestedOptions := map[string]interface{}{
-		"functions": []interface{}{"flat"},
+	nestedOptions := map[string]any{
+		"functions": []any{"flat"},
 	}
 	nestedCode := `flat(_.flatten(array))`
 	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
@@ -429,97 +429,7 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		`_.flatten(values)`,
 		`values.flat()`,
 		`_.flatten()`,
-		map[string]interface{}{},
-	)
-
-	// ---- Dimension 3: comment ownership and fix suppression ----
-	suite.addNoFix(
-		`array.flatMap(value /* keep */ => value)`,
-		`array.flatMap(value /* keep */ => value)`,
-		`Array#flatMap()`,
-		nil,
-	)
-	suite.addFixed(
-		`foo./* keep */bar.flatMap(value => value)`,
-		`foo./* keep */bar.flatMap(value => value)`,
-		`foo./* keep */bar.flat()`,
-		`Array#flatMap()`,
-		nil,
-	)
-
-	// ---- Dimension 3: member-object parentheses ----
-	expressionCases := []struct {
-		code        string
-		replacement string
-	}{
-		{code: `_.flatten({value: 1})`, replacement: `({value: 1}).flat()`},
-		{code: `_.flatten(class {})`, replacement: `(class {}).flat()`},
-		{code: `_.flatten(value => value)`, replacement: `(value => value).flat()`},
-		{code: `_.flatten(flag ? left : right)`, replacement: `(flag ? left : right).flat()`},
-		{code: `_.flatten(value = input)`, replacement: `(value = input).flat()`},
-		{code: `_.flatten(++value)`, replacement: `(++value).flat()`},
-		{code: `_.flatten("value")`, replacement: `"value".flat()`},
-		{code: `_.flatten(/value/)`, replacement: `/value/.flat()`},
-		{code: `_.flatten(1n)`, replacement: `1n.flat()`},
-		{code: `_.flatten(true)`, replacement: `true.flat()`},
-		{code: `_.flatten(null)`, replacement: `null.flat()`},
-		{code: "_.flatten(`value`)", replacement: "`value`.flat()"},
-	}
-	for _, testCase := range expressionCases {
-		suite.addFixed(
-			testCase.code,
-			testCase.code,
-			testCase.replacement,
-			`_.flatten()`,
-			nil,
-		)
-	}
-	suite.addFixed(
-		`function* values() { return _.flatten(yield input); }`,
-		`_.flatten(yield input)`,
-		`(yield input).flat()`,
-		`_.flatten()`,
-		nil,
-	)
-
-	// ---- Dimension 3: ASI-sensitive embedded statement bodies ----
-	embeddedCases := []string{
-		`while (condition)
-	Array.prototype.concat.call([], ...value)`,
-		`for (;;)
-	Array.prototype.concat.call([], ...value)`,
-		`for (const item of items)
-	Array.prototype.concat.call([], ...value)`,
-		`do
-	Array.prototype.concat.call([], ...value)
-while (condition)`,
-		`with (object)
-	Array.prototype.concat.call([], ...value)`,
-	}
-	for _, code := range embeddedCases {
-		suite.addFixed(
-			code,
-			`Array.prototype.concat.call([], ...value)`,
-			`value.flat()`,
-			`Array.prototype.concat()`,
-			nil,
-		)
-	}
-	suite.addFixed(
-		`before()
-Array.prototype.concat.call([], ...value)`,
-		`Array.prototype.concat.call([], ...value)`,
-		`value.flat()`,
-		`Array.prototype.concat()`,
-		nil,
-	)
-	suite.addFixed(
-		`value = {}
-Array.prototype.concat.call([], ...item)`,
-		`Array.prototype.concat.call([], ...item)`,
-		`item.flat()`,
-		`Array.prototype.concat()`,
-		nil,
+		map[string]any{},
 	)
 
 	// N/A: string/numeric/private object or class property keys are not rule

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
@@ -60,13 +60,7 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		`Array#flatMap()`,
 		nil,
 	)
-	suite.addFixed(
-		`[].concat((maybeArray as unknown))`,
-		`[].concat((maybeArray as unknown))`,
-		`[(maybeArray as unknown)].flat()`,
-		`[].concat()`,
-		nil,
-	)
+	suite.addValid(nil, `[].concat((maybeArray as unknown))`)
 	suite.addFixed(
 		`_.flatten(array!)`,
 		`_.flatten(array!)`,
@@ -140,8 +134,8 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		nil,
 	)
 	suite.addNoFix(
-		`[].concat(((foo /* keep */)))`,
-		`[].concat(((foo /* keep */)))`,
+		`[].concat(...((foo /* keep */)))`,
+		`[].concat(...((foo /* keep */)))`,
 		`[].concat()`,
 		nil,
 	)
@@ -162,9 +156,9 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		nil,
 	)
 	suite.addFixed(
-		`[].concat(getMaybeArray())`,
-		`[].concat(getMaybeArray())`,
-		`[getMaybeArray()].flat()`,
+		`[].concat(...getArray())`,
+		`[].concat(...getArray())`,
+		`getArray().flat()`,
 		`[].concat()`,
 		nil,
 	)
@@ -172,9 +166,9 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 	// ---- Dimension 4: ASI handling must not detach an embedded statement ----
 	suite.addFixed(
 		`if (condition)
-			Array.prototype.concat.call([], value)`,
-		`Array.prototype.concat.call([], value)`,
-		`[value].flat()`,
+			Array.prototype.concat.call([], ...value)`,
+		`Array.prototype.concat.call([], ...value)`,
+		`value.flat()`,
 		`Array.prototype.concat()`,
 		nil,
 	)
@@ -215,23 +209,11 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		(randomObject).flatMap(value => value);
 	`)
 
-	// ---- Real-user: #1316 union input must be wrapped before `.flat()` ----
-	suite.addFixed(
+	// ---- Real-user: v74 leaves plain concat normalization to prefer-spread ----
+	suite.addValid(nil,
 		`declare const subAppLoads: SubAppLoad | SubAppLoad[];
 		const loads: SubAppLoad[] = [].concat(subAppLoads);`,
-		`[].concat(subAppLoads)`,
-		`[subAppLoads].flat()`,
-		`[].concat()`,
-		nil,
-	)
-
-	// ---- Real-user: #2470 v64 still reports the first concat in a chain ----
-	suite.addFixed(
 		`const values = [].concat([1]).concat([2]);`,
-		`[].concat([1])`,
-		`[[1]].flat()`,
-		`[].concat()`,
-		nil,
 	)
 
 	// Locks in upstream arrayFlatMap.testFunction() arm 1: PascalCase unknowns
@@ -270,6 +252,46 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		nil,
 	)
 
+	// v74 skips only receivers proven non-array. An all-non-array union and an
+	// asserted Set are skipped; unknown and mixed unions remain reportable.
+	suite.addValid(nil,
+		`function f(foo: Set<number[]> | Uint8Array) { foo.reduce((a, b) => a.concat(b), []); }`,
+		`declare const foo: unknown; (foo as Set<number[]>).reduce((a, b) => a.concat(b), []);`,
+		`function f(foo: Set<number[]>) { foo!.reduce((a, b) => [...a, ...b], []); }`,
+	)
+	suite.addFixed(
+		`function f(foo: Set<number[]> | number[][]) { foo.reduce((a, b) => a.concat(b), []); }`,
+		`foo.reduce((a, b) => a.concat(b), [])`,
+		`foo.flat()`,
+		`Array#reduce()`,
+		nil,
+	)
+	suite.addFixed(
+		`declare const foo: unknown; (foo satisfies Set<number[]>).reduce((a, b) => a.concat(b), []);`,
+		`(foo satisfies Set<number[]>).reduce((a, b) => a.concat(b), [])`,
+		`(foo satisfies Set<number[]>).flat()`,
+		`Array#reduce()`,
+		nil,
+	)
+	suite.valid = append(suite.valid, rule_tester.ValidTestCase{
+		Code:     `const foo = {}; foo.reduce((a, b) => a.concat(b), []);`,
+		FileName: "file.js",
+	})
+	const unknownReduce = `let foo; foo.reduce((a, b) => a.concat(b), []);`
+	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+		Code:     unknownReduce,
+		FileName: "file.js",
+		Output:   []string{`let foo; foo.flat();`},
+		Errors: []rule_tester.InvalidTestCaseError{
+			upstreamError(
+				unknownReduce,
+				`foo.reduce((a, b) => a.concat(b), [])`,
+				`Array#reduce()`,
+				0,
+			),
+		},
+	})
+
 	// Locks in upstream arrayReduce.testFunction() arm 3: default/rest
 	// parameters are not plain identifiers.
 	suite.addValid(nil,
@@ -277,15 +299,9 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		`items.reduce((...values) => values[0].concat(values[1]), [])`,
 	)
 
-	// Locks in upstream emptyArrayConcat.getArrayNode(): non-spread arguments
-	// switch to `[argument].flat()`, spread arguments do not.
-	suite.addFixed(
-		`[].concat(value)`,
-		`[].concat(value)`,
-		`[value].flat()`,
-		`[].concat()`,
-		nil,
-	)
+	// Locks in upstream emptyArrayConcat: only a spread argument is a
+	// flattening pattern; plain concat normalization remains valid.
+	suite.addValid(nil, `[].concat(value)`)
 	suite.addFixed(
 		`[].concat(...values)`,
 		`[].concat(...values)`,
@@ -294,15 +310,11 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		nil,
 	)
 
-	// Locks in upstream arrayPrototypeConcat.testFunction() arms: apply rejects
-	// a spread second argument; call accepts both spread and non-spread forms.
-	suite.addValid(nil, `Array.prototype.concat.apply([], ...values)`)
-	suite.addFixed(
+	// Locks in upstream arrayPrototypeConcat.testFunction() arms: apply accepts
+	// only a non-spread second argument, while call accepts only spread.
+	suite.addValid(nil,
+		`Array.prototype.concat.apply([], ...values)`,
 		`Array.prototype.concat.call([], value)`,
-		`Array.prototype.concat.call([], value)`,
-		`[value].flat()`,
-		`Array.prototype.concat()`,
-		nil,
 	)
 	suite.addFixed(
 		`Array.prototype.concat.call([], ...values)`,
@@ -337,6 +349,20 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 		pathOptions,
 	)
 	suite.addFixed(
+		`function flatten(array) { this(array) }`,
+		`this(array)`,
+		`array.flat()`,
+		`this()`,
+		map[string]interface{}{"functions": []interface{}{"this"}},
+	)
+	suite.addFixed(
+		`class A extends B { constructor(array) { super(array) } }`,
+		`super(array)`,
+		`array.flat()`,
+		`super()`,
+		map[string]interface{}{"functions": []interface{}{"super"}},
+	)
+	suite.addFixed(
 		`const values = import.meta.flatten(input);`,
 		`import.meta.flatten(input)`,
 		`input.flat()`,
@@ -354,8 +380,8 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 	// Locks in upstream create() comment branch: comments outside the selected
 	// array suppress the fix, but the diagnostic remains.
 	suite.addNoFix(
-		`[] /* receiver */.concat(value)`,
-		`[] /* receiver */.concat(value)`,
+		`[] /* receiver */.concat(...value)`,
+		`[] /* receiver */.concat(...value)`,
 		`[].concat()`,
 		nil,
 	)
@@ -459,39 +485,39 @@ func TestPreferArrayFlatExtras(t *testing.T) {
 	// ---- Dimension 3: ASI-sensitive embedded statement bodies ----
 	embeddedCases := []string{
 		`while (condition)
-	Array.prototype.concat.call([], value)`,
+	Array.prototype.concat.call([], ...value)`,
 		`for (;;)
-	Array.prototype.concat.call([], value)`,
+	Array.prototype.concat.call([], ...value)`,
 		`for (const item of items)
-	Array.prototype.concat.call([], value)`,
+	Array.prototype.concat.call([], ...value)`,
 		`do
-	Array.prototype.concat.call([], value)
+	Array.prototype.concat.call([], ...value)
 while (condition)`,
 		`with (object)
-	Array.prototype.concat.call([], value)`,
+	Array.prototype.concat.call([], ...value)`,
 	}
 	for _, code := range embeddedCases {
 		suite.addFixed(
 			code,
-			`Array.prototype.concat.call([], value)`,
-			`[value].flat()`,
+			`Array.prototype.concat.call([], ...value)`,
+			`value.flat()`,
 			`Array.prototype.concat()`,
 			nil,
 		)
 	}
 	suite.addFixed(
 		`before()
-Array.prototype.concat.call([], value)`,
-		`Array.prototype.concat.call([], value)`,
-		`;[value].flat()`,
+Array.prototype.concat.call([], ...value)`,
+		`Array.prototype.concat.call([], ...value)`,
+		`value.flat()`,
 		`Array.prototype.concat()`,
 		nil,
 	)
 	suite.addFixed(
 		`value = {}
-Array.prototype.concat.call([], item)`,
-		`Array.prototype.concat.call([], item)`,
-		`;[item].flat()`,
+Array.prototype.concat.call([], ...item)`,
+		`Array.prototype.concat.call([], ...item)`,
+		`item.flat()`,
 		`Array.prototype.concat()`,
 		nil,
 	)

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_concat_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_concat_test.go
@@ -22,62 +22,13 @@ func TestPreferArrayFlatUpstreamConcat(t *testing.T) {
 		`[].concat(array, EXTRA_ARGUMENT)`,
 		`[]?.concat(array)`,
 		`[].concat?.(array)`,
+		`[].concat(maybeArray)`,
+		`[].concat( ((0, maybeArray)) )`,
+		`[].concat( ((maybeArray)) )`,
+		`[].concat( [foo] )`,
+		`[].concat( [[foo]] )`,
+		`function foo(){return[].concat(maybeArray)}`,
 	)
-	for _, testCase := range []struct {
-		code        string
-		target      string
-		replacement string
-		output      string
-	}{
-		{
-			code:        `[].concat(maybeArray)`,
-			target:      `[].concat(maybeArray)`,
-			replacement: `[maybeArray].flat()`,
-		},
-		{
-			code:        `[].concat( ((0, maybeArray)) )`,
-			target:      `[].concat( ((0, maybeArray)) )`,
-			replacement: `[((0, maybeArray))].flat()`,
-		},
-		{
-			code:        `[].concat( ((maybeArray)) )`,
-			target:      `[].concat( ((maybeArray)) )`,
-			replacement: `[((maybeArray))].flat()`,
-		},
-		{
-			code:        `[].concat( [foo] )`,
-			target:      `[].concat( [foo] )`,
-			replacement: `[[foo]].flat()`,
-		},
-		{
-			code:        `[].concat( [[foo]] )`,
-			target:      `[].concat( [[foo]] )`,
-			replacement: `[[[foo]]].flat()`,
-		},
-		{
-			code:        `function foo(){return[].concat(maybeArray)}`,
-			target:      `[].concat(maybeArray)`,
-			replacement: `[maybeArray].flat()`,
-			output:      `function foo(){return [maybeArray].flat()}`,
-		},
-	} {
-		if testCase.output == "" {
-			suite.addFixed(
-				testCase.code,
-				testCase.target,
-				testCase.replacement,
-				`[].concat()`,
-				nil,
-			)
-			continue
-		}
-		suite.addFixedOutput(
-			testCase.code,
-			testCase.output,
-			nil,
-			expectedDiagnostic{target: testCase.target, description: `[].concat()`},
-		)
-	}
 
 	// ---- `[].concat(...array)` ----
 	suite.addValid(nil,
@@ -171,6 +122,11 @@ func TestPreferArrayFlatUpstreamConcat(t *testing.T) {
 		`[].concat.apply?.([], array)`,
 		`[].concat?.apply([], array)`,
 		`[]?.concat.apply([], array)`,
+		`[].concat.call([], maybeArray)`,
+		`[].concat.call([], ((0, maybeArray)))`,
+		`[].concat.call([], ((maybeArray)))`,
+		`[].concat.call([], [foo])`,
+		`[].concat.call([], [[foo]])`,
 	)
 	for _, testCase := range []struct {
 		code        string
@@ -181,11 +137,6 @@ func TestPreferArrayFlatUpstreamConcat(t *testing.T) {
 		{`[].concat.apply([], ((array)))`, `((array)).flat()`},
 		{`[].concat.apply([], [foo])`, `[foo].flat()`},
 		{`[].concat.apply([], [[foo]])`, `[[foo]].flat()`},
-		{`[].concat.call([], maybeArray)`, `[maybeArray].flat()`},
-		{`[].concat.call([], ((0, maybeArray)))`, `[((0, maybeArray))].flat()`},
-		{`[].concat.call([], ((maybeArray)))`, `[((maybeArray))].flat()`},
-		{`[].concat.call([], [foo])`, `[[foo]].flat()`},
-		{`[].concat.call([], [[foo]])`, `[[[foo]]].flat()`},
 		{`[].concat.call([], ...array)`, `array.flat()`},
 		{`[].concat.call([], ...((0, array)))`, `((0, array)).flat()`},
 		{`[].concat.call([], ...((array)))`, `((array)).flat()`},
@@ -231,6 +182,11 @@ func TestPreferArrayFlatUpstreamConcat(t *testing.T) {
 		`Array.prototype?.concat.apply([], array)`,
 		`Array?.prototype.concat.apply([], array)`,
 		`object.Array.prototype.concat.apply([], array)`,
+		`Array.prototype.concat.call([], maybeArray)`,
+		`Array.prototype.concat.call([], ((0, maybeArray)))`,
+		`Array.prototype.concat.call([], ((maybeArray)))`,
+		`Array.prototype.concat.call([], [foo])`,
+		`Array.prototype.concat.call([], [[foo]])`,
 	)
 	for _, testCase := range []struct {
 		code        string
@@ -241,11 +197,6 @@ func TestPreferArrayFlatUpstreamConcat(t *testing.T) {
 		{`Array.prototype.concat.apply([], ((array)))`, `((array)).flat()`},
 		{`Array.prototype.concat.apply([], [foo])`, `[foo].flat()`},
 		{`Array.prototype.concat.apply([], [[foo]])`, `[[foo]].flat()`},
-		{`Array.prototype.concat.call([], maybeArray)`, `[maybeArray].flat()`},
-		{`Array.prototype.concat.call([], ((0, maybeArray)))`, `[((0, maybeArray))].flat()`},
-		{`Array.prototype.concat.call([], ((maybeArray)))`, `[((maybeArray))].flat()`},
-		{`Array.prototype.concat.call([], [foo])`, `[[foo]].flat()`},
-		{`Array.prototype.concat.call([], [[foo]])`, `[[[foo]]].flat()`},
 		{`Array.prototype.concat.call([], ...array)`, `array.flat()`},
 		{`Array.prototype.concat.call([], ...((0, array)))`, `((0, array)).flat()`},
 		{`Array.prototype.concat.call([], ...((array)))`, `((array)).flat()`},

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_functions_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_functions_test.go
@@ -177,10 +177,25 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 		)
 	}
 
-	// ---- Existing `.flat()` calls ----
+	// ---- Existing `.flat()` calls and v74 plain-concat exclusions ----
 	suite.addValid(nil,
 		`array.flat()`,
 		`array.flat(1)`,
+		`before()
+			Array.prototype.concat.call([], +1)`,
+		`Array.prototype.concat.call([], (0, array))`,
+		`async function a() { return [].concat(await getArray()); }`,
+		`before()
+			Array.prototype.concat.call([], 1)`,
+		`before()
+			Array.prototype.concat.call([], 1.)`,
+		`before()
+			Array.prototype.concat.call([], .1)`,
+		`before()
+			Array.prototype.concat.call([], 1.0)`,
+		`[].concat(some./**/array)`,
+		`[/**/].concat(some./**/array)`,
+		`[/**/].concat(some.array)`,
 	)
 
 	// ---- ASI ----
@@ -206,17 +221,6 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 			description: `Array.prototype.concat()`,
 		},
 	)
-	suite.addFixedOutput(
-		`before()
-			Array.prototype.concat.call([], +1)`,
-		`before()
-			;[+1].flat()`,
-		nil,
-		expectedDiagnostic{
-			target:      `Array.prototype.concat.call([], +1)`,
-			description: `Array.prototype.concat()`,
-		},
-	)
 
 	// ---- Parentheses and await ----
 	for _, testCase := range []struct {
@@ -230,18 +234,6 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 			`Array.prototype.concat.apply([], (0, array))`,
 			`(0, array).flat()`,
 			`Array.prototype.concat()`,
-		},
-		{
-			`Array.prototype.concat.call([], (0, array))`,
-			`Array.prototype.concat.call([], (0, array))`,
-			`[(0, array)].flat()`,
-			`Array.prototype.concat()`,
-		},
-		{
-			`async function a() { return [].concat(await getArray()); }`,
-			`[].concat(await getArray())`,
-			`[await getArray()].flat()`,
-			`[].concat()`,
 		},
 		{
 			`_.flatten((0, array))`,
@@ -284,21 +276,9 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 		},
 		{
 			`before()
-			Array.prototype.concat.call([], 1)`,
-			`before()
-			;[1].flat()`,
-		},
-		{
-			`before()
 			Array.prototype.concat.apply([], 1.)`,
 			`before()
 			1..flat()`,
-		},
-		{
-			`before()
-			Array.prototype.concat.call([], 1.)`,
-			`before()
-			;[1.].flat()`,
 		},
 		{
 			`before()
@@ -308,21 +288,9 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 		},
 		{
 			`before()
-			Array.prototype.concat.call([], .1)`,
-			`before()
-			;[.1].flat()`,
-		},
-		{
-			`before()
 			Array.prototype.concat.apply([], 1.0)`,
 			`before()
 			1.0.flat()`,
-		},
-		{
-			`before()
-			Array.prototype.concat.call([], 1.0)`,
-			`before()
-			;[1.0].flat()`,
 		},
 	} {
 		target := testCase.code[len("before()\n\t\t\t"):]
@@ -336,27 +304,6 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 			},
 		)
 	}
-
-	// ---- Comments ----
-	suite.addFixed(
-		`[].concat(some./**/array)`,
-		`[].concat(some./**/array)`,
-		`[some./**/array].flat()`,
-		`[].concat()`,
-		nil,
-	)
-	suite.addNoFix(
-		`[/**/].concat(some./**/array)`,
-		`[/**/].concat(some./**/array)`,
-		`[].concat()`,
-		nil,
-	)
-	suite.addNoFix(
-		`[/**/].concat(some.array)`,
-		`[/**/].concat(some.array)`,
-		`[].concat()`,
-		nil,
-	)
 
 	suite.run(t)
 }

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_functions_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_functions_test.go
@@ -42,8 +42,8 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 	}
 
 	// ---- `options.functions` ----
-	options := map[string]interface{}{
-		"functions": []interface{}{
+	options := map[string]any{
+		"functions": []any{
 			"flat",
 			"utils.flat",
 			"globalThis.lodash.flatten",
@@ -143,8 +143,8 @@ func TestPreferArrayFlatUpstreamFunctions(t *testing.T) {
 	)
 
 	// ---- Whitespace in `options.functions` ----
-	spacesInFunctions := []interface{}{map[string]interface{}{
-		"functions": []interface{}{
+	spacesInFunctions := []any{map[string]any{
+		"functions": []any{
 			"",
 			" ",
 			" flat1 ",

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_test.go
@@ -347,19 +347,6 @@ func TestPreferArrayFlatUpstream(t *testing.T) {
 		`Array#reduce()`,
 		nil,
 	)
-	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
-		Code:     `let foo = new Set(); foo.reduce((a, b) => a.concat(b), []);`,
-		FileName: "file.js",
-		Output:   []string{`let foo = new Set(); foo.flat();`},
-		Errors: []rule_tester.InvalidTestCaseError{
-			upstreamError(
-				`let foo = new Set(); foo.reduce((a, b) => a.concat(b), []);`,
-				`foo.reduce((a, b) => a.concat(b), [])`,
-				`Array#reduce()`,
-				0,
-			),
-		},
-	})
 
 	// ---- `array.reduce((a, b) => [...a, ...b], [])` ----
 	suite.addValid(nil,

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_upstream_test.go
@@ -253,6 +253,13 @@ func TestPreferArrayFlatUpstream(t *testing.T) {
 		nil,
 	)
 	suite.addFixed(
+		`let effects = new Set(); effects.flatMap(x => x);`,
+		`effects.flatMap(x => x)`,
+		`effects.flat()`,
+		`Array#flatMap()`,
+		nil,
+	)
+	suite.addFixed(
 		`const Items = []; Items.flatMap(x => x);`,
 		`Items.flatMap(x => x)`,
 		`Items.flat()`,
@@ -288,6 +295,25 @@ func TestPreferArrayFlatUpstream(t *testing.T) {
 		`array.reduce((a, b) => b.concat(a), [])`,
 		`array.reduce((a, b) => a.notConcat(b), [])`,
 		`array.reduce((a, b) => a.concat, [])`,
+		`array.reduce((a, b) => Iterator.concat(a, b), [])`,
+	)
+	suite.valid = append(suite.valid,
+		rule_tester.ValidTestCase{
+			Code:     `function f(foo: Set<number[]>) { foo.reduce((a, b) => a.concat(b), []); }`,
+			FileName: "file.ts",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `function f(foo: Uint8Array) { foo.reduce((a, b) => a.concat(b), []); }`,
+			FileName: "file.ts",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `const foo = new Uint8Array(); foo.reduce((a, b) => a.concat(b), []);`,
+			FileName: "file.js",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `function f(foo: string) { foo.reduce((a, b) => a.concat(b), []); }`,
+			FileName: "file.ts",
+		},
 	)
 	for _, code := range []string{
 		`array.reduce((a, b) => a.concat(b), [])`,
@@ -314,6 +340,26 @@ func TestPreferArrayFlatUpstream(t *testing.T) {
 			expectedDiagnostic{target: target, description: `Array#reduce()`},
 		)
 	}
+	suite.addFixed(
+		`function f(foo: number[][]) { foo.reduce((a, b) => a.concat(b), []); }`,
+		`foo.reduce((a, b) => a.concat(b), [])`,
+		`foo.flat()`,
+		`Array#reduce()`,
+		nil,
+	)
+	suite.invalid = append(suite.invalid, rule_tester.InvalidTestCase{
+		Code:     `let foo = new Set(); foo.reduce((a, b) => a.concat(b), []);`,
+		FileName: "file.js",
+		Output:   []string{`let foo = new Set(); foo.flat();`},
+		Errors: []rule_tester.InvalidTestCaseError{
+			upstreamError(
+				`let foo = new Set(); foo.reduce((a, b) => a.concat(b), []);`,
+				`foo.reduce((a, b) => a.concat(b), [])`,
+				`Array#reduce()`,
+				0,
+			),
+		},
+	})
 
 	// ---- `array.reduce((a, b) => [...a, ...b], [])` ----
 	suite.addValid(nil,
@@ -340,6 +386,16 @@ func TestPreferArrayFlatUpstream(t *testing.T) {
 		`array.reduce((a, b) => [, ], [])`,
 		`array.reduce((a, b) => [, ,], [])`,
 	)
+	suite.valid = append(suite.valid,
+		rule_tester.ValidTestCase{
+			Code:     `function f(foo: Set<number[]>) { foo.reduce((a, b) => [...a, ...b], []); }`,
+			FileName: "file.ts",
+		},
+		rule_tester.ValidTestCase{
+			Code:     `function f(foo: Uint8Array) { foo.reduce((a, b) => [...a, ...b], []); }`,
+			FileName: "file.ts",
+		},
+	)
 	suite.addFixed(
 		`array.reduce((a, b) => [...a, ...b], [])`,
 		`array.reduce((a, b) => [...a, ...b], [])`,
@@ -362,6 +418,13 @@ func TestPreferArrayFlatUpstream(t *testing.T) {
 			target:      `[].reduce((a, b) => [...a, ...b,], [])`,
 			description: `Array#reduce()`,
 		},
+	)
+	suite.addFixed(
+		`function f(foo: number[][]) { foo.reduce((a, b) => [...a, ...b], []); }`,
+		`foo.reduce((a, b) => [...a, ...b], [])`,
+		`foo.flat()`,
+		`Array#reduce()`,
+		nil,
 	)
 
 	suite.run(t)

--- a/internal/plugins/unicorn/unicornutil/array_prototype.go
+++ b/internal/plugins/unicorn/unicornutil/array_prototype.go
@@ -1,6 +1,9 @@
 package unicornutil
 
-import "github.com/microsoft/typescript-go/shim/ast"
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
 
 func isIdentifierNamed(node *ast.Node, name string) bool {
 	return node != nil && ast.IsIdentifier(node) && node.AsIdentifier().Text == name
@@ -8,8 +11,10 @@ func isIdentifierNamed(node *ast.Node, name string) bool {
 
 // IsArrayPrototypeProperty mirrors unicorn's isArrayPrototypeProperty helper.
 // It intentionally accepts only dotted, non-optional member access.
+// Parentheses and JavaScript JSDoc casts are transparent at every segment;
+// authored TypeScript assertions remain visible.
 func IsArrayPrototypeProperty(node *ast.Node, property string) bool {
-	node = ast.SkipParentheses(node)
+	node = utils.ESTreeRuntimeExpression(node)
 	if node == nil || !ast.IsPropertyAccessExpression(node) {
 		return false
 	}
@@ -20,7 +25,7 @@ func IsArrayPrototypeProperty(node *ast.Node, property string) bool {
 		return false
 	}
 
-	object := ast.SkipParentheses(propertyAccess.Expression)
+	object := utils.ESTreeRuntimeExpression(propertyAccess.Expression)
 	if object == nil {
 		return false
 	}
@@ -37,5 +42,5 @@ func IsArrayPrototypeProperty(node *ast.Node, property string) bool {
 		return false
 	}
 
-	return isIdentifierNamed(ast.SkipParentheses(prototypeAccess.Expression), "Array")
+	return isIdentifierNamed(utils.ESTreeRuntimeExpression(prototypeAccess.Expression), "Array")
 }

--- a/internal/plugins/unicorn/unicornutil/array_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/array_receiver.go
@@ -14,6 +14,11 @@ import (
 // ReadonlyArray. Typed arrays and keyed collections are non-arrays. Unknown
 // receivers return false so syntactic array rules can still report them.
 func IsKnownNonArray(ctx rule.RuleContext, node *ast.Node) bool {
+	if isSourceOnlyFile(ctx) {
+		return classifySourceOnlyArrayReceiver(
+			ctx, node, arrayTargets, knownNonArrayNames,
+		) == arrayClassNonTarget
+	}
 	return classifyArrayReceiver(ctx, node, arrayTargets, knownNonArrayNames) == arrayClassNonTarget
 }
 

--- a/internal/plugins/unicorn/unicornutil/node_path.go
+++ b/internal/plugins/unicorn/unicornutil/node_path.go
@@ -5,19 +5,23 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 // NodeMatchesPath mirrors unicorn's isNodeMatchesNameOrPath helper. It accepts
 // dotted, non-computed, non-optional paths rooted at an identifier, this,
-// super, or a meta property. ast.IsDottedName is intentionally not used
-// because it also accepts property accesses containing optional-chain links.
+// super, or a meta property. Parentheses and JavaScript JSDoc casts are
+// transparent at every segment; authored TypeScript assertions remain
+// visible. ast.IsDottedName is intentionally not used because it also accepts
+// property accesses containing optional-chain links.
 func NodeMatchesPath(node *ast.Node, path string) bool {
 	parts := strings.Split(ecmascript.StringTrim(path), ".")
-	return nodeMatchesPathParts(ast.SkipParentheses(node), parts)
+	return nodeMatchesPathParts(utils.ESTreeRuntimeExpression(node), parts)
 }
 
 func nodeMatchesPathParts(node *ast.Node, parts []string) bool {
+	node = utils.ESTreeRuntimeExpression(node)
 	if node == nil || len(parts) == 0 {
 		return false
 	}
@@ -57,8 +61,5 @@ func nodeMatchesPathParts(node *ast.Node, parts []string) bool {
 		return false
 	}
 
-	return nodeMatchesPathParts(
-		ast.SkipParentheses(propertyAccess.Expression),
-		parts[:len(parts)-1],
-	)
+	return nodeMatchesPathParts(propertyAccess.Expression, parts[:len(parts)-1])
 }

--- a/internal/plugins/unicorn/unicornutil/unicornutil_test.go
+++ b/internal/plugins/unicorn/unicornutil/unicornutil_test.go
@@ -16,6 +16,13 @@ func parseTestSource(code string) *ast.SourceFile {
 	}, code, core.ScriptKindTS)
 }
 
+func parseTestJavaScript(code string) *ast.SourceFile {
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.js",
+		Path:     "/test.js",
+	}, code, core.ScriptKindJS)
+}
+
 func findTestNode(t *testing.T, sourceFile *ast.SourceFile, text string) *ast.Node {
 	t.Helper()
 	var found *ast.Node
@@ -123,6 +130,36 @@ utils["deep"].flat(value);
 		if got := NodeMatchesPath(node, "utils.deep.flat"); got != test.want {
 			t.Fatalf("NodeMatchesPath(%q) = %v, want %v", test.text, got, test.want)
 		}
+	}
+}
+
+func TestJSDocWrappersAreTransparentInMemberPaths(t *testing.T) {
+	sourceFile := parseTestJavaScript(`
+(/** @type {any} */ utils).deep.flat(value);
+(/** @type {typeof Array} */ Array).prototype.concat.apply([], value);
+`)
+
+	flattenCall := findTestCall(
+		t,
+		sourceFile,
+		`(/** @type {any} */ utils).deep.flat(value)`,
+	)
+	if !NodeMatchesPath(flattenCall.AsCallExpression().Expression, "utils.deep.flat") {
+		t.Fatal("JSDoc wrapper in a configured-function path should be transparent")
+	}
+
+	applyCall := findTestCall(
+		t,
+		sourceFile,
+		`(/** @type {typeof Array} */ Array).prototype.concat.apply([], value)`,
+	)
+	twoArguments := 2
+	matched, ok := MatchDotMethodCall(applyCall, DotMethodCallOptions{
+		Method:          "apply",
+		ArgumentsLength: &twoArguments,
+	})
+	if !ok || !IsArrayPrototypeProperty(matched.Object, "concat") {
+		t.Fatal("JSDoc wrapper in Array.prototype.concat should be transparent")
 	}
 }
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts
@@ -64,6 +64,11 @@ const validCases = [
   'array.reduce((a, b) => b.concat(a), [])',
   'array.reduce((a, b) => a.notConcat(b), [])',
   'array.reduce((a, b) => a.concat, [])',
+  'array.reduce((a, b) => Iterator.concat(a, b), [])',
+  'function f(foo: Set<number[]>) { foo.reduce((a, b) => a.concat(b), []); }',
+  'function f(foo: Uint8Array) { foo.reduce((a, b) => a.concat(b), []); }',
+  'const foo = new Uint8Array(); foo.reduce((a, b) => a.concat(b), []);',
+  'function f(foo: string) { foo.reduce((a, b) => a.concat(b), []); }',
 
   // `array.reduce((a, b) => [...a, ...b], [])`
   'new array.reduce((a, b) => [...a, ...b], [])',
@@ -88,6 +93,8 @@ const validCases = [
   'array.reduce((a, b) => [,...a, ...b], [])',
   'array.reduce((a, b) => [, ], [])',
   'array.reduce((a, b) => [, ,], [])',
+  'function f(foo: Set<number[]>) { foo.reduce((a, b) => [...a, ...b], []); }',
+  'function f(foo: Uint8Array) { foo.reduce((a, b) => [...a, ...b], []); }',
 
   // `[].concat(array)`
   '[].concat',
@@ -100,6 +107,12 @@ const validCases = [
   '[].concat(array, EXTRA_ARGUMENT)',
   '[]?.concat(array)',
   '[].concat?.(array)',
+  '[].concat(maybeArray)',
+  '[].concat( ((0, maybeArray)) )',
+  '[].concat( ((maybeArray)) )',
+  '[].concat( [foo] )',
+  '[].concat( [[foo]] )',
+  'function foo(){return[].concat(maybeArray)}',
 
   // `[].concat(...array)`
   'new [].concat(...array)',
@@ -128,6 +141,11 @@ const validCases = [
   '[].concat.apply?.([], array)',
   '[].concat?.apply([], array)',
   '[]?.concat.apply([], array)',
+  '[].concat.call([], maybeArray)',
+  '[].concat.call([], ((0, maybeArray)))',
+  '[].concat.call([], ((maybeArray)))',
+  '[].concat.call([], [foo])',
+  '[].concat.call([], [[foo]])',
 
   // `Array.prototype.concat.{apply,call}`
   'new Array.prototype.concat.apply([], array)',
@@ -149,6 +167,11 @@ const validCases = [
   'Array.prototype?.concat.apply([], array)',
   'Array?.prototype.concat.apply([], array)',
   'object.Array.prototype.concat.apply([], array)',
+  'Array.prototype.concat.call([], maybeArray)',
+  'Array.prototype.concat.call([], ((0, maybeArray)))',
+  'Array.prototype.concat.call([], ((maybeArray)))',
+  'Array.prototype.concat.call([], [foo])',
+  'Array.prototype.concat.call([], [[foo]])',
 
   // `_.flatten(array)`
   'new _.flatten(array)',
@@ -164,6 +187,21 @@ const validCases = [
 
   'array.flat()',
   'array.flat(1)',
+  `before()
+  Array.prototype.concat.call([], +1)`,
+  'Array.prototype.concat.call([], (0, array))',
+  'async function a() { return [].concat(await getArray()); }',
+  `before()
+  Array.prototype.concat.call([], 1)`,
+  `before()
+  Array.prototype.concat.call([], 1.)`,
+  `before()
+  Array.prototype.concat.call([], .1)`,
+  `before()
+  Array.prototype.concat.call([], 1.0)`,
+  '[].concat(some./**/array)',
+  '[/**/].concat(some./**/array)',
+  '[/**/].concat(some.array)',
 ].map((code) => valid(code));
 
 const invalidCases = [
@@ -176,6 +214,7 @@ const invalidCases = [
   'Foo.bar.flatMap(x => x)',
   'const values = getValues(); values.flatMap(x => x);',
   'const values = []; values.flatMap(x => x);',
+  'let effects = new Set(); effects.flatMap(x => x);',
   'const Items = []; Items.flatMap(x => x);',
   `for (const value of values) {
     value.flatMap(x => x);
@@ -186,19 +225,13 @@ const invalidCases = [
   'array?.reduce((a, b) => a.concat(b), [])',
   'function foo(){return[].reduce((a, b) => a.concat(b), [])}',
   'function foo(){return[]?.reduce((a, b) => a.concat(b), [])}',
+  'function f(foo: number[][]) { foo.reduce((a, b) => a.concat(b), []); }',
 
   // `array.reduce((a, b) => [...a, ...b], [])`
   'array.reduce((a, b) => [...a, ...b], [])',
   'array.reduce((a, b) => [...a, ...b,], [])',
   'function foo(){return[].reduce((a, b) => [...a, ...b,], [])}',
-
-  // `[].concat(array)`
-  '[].concat(maybeArray)',
-  '[].concat( ((0, maybeArray)) )',
-  '[].concat( ((maybeArray)) )',
-  '[].concat( [foo] )',
-  '[].concat( [[foo]] )',
-  'function foo(){return[].concat(maybeArray)}',
+  'function f(foo: number[][]) { foo.reduce((a, b) => [...a, ...b], []); }',
 
   // `[].concat(...array)`
   '[].concat(...array)',
@@ -215,11 +248,6 @@ const invalidCases = [
   '[].concat.apply([], ((array)))',
   '[].concat.apply([], [foo])',
   '[].concat.apply([], [[foo]])',
-  '[].concat.call([], maybeArray)',
-  '[].concat.call([], ((0, maybeArray)))',
-  '[].concat.call([], ((maybeArray)))',
-  '[].concat.call([], [foo])',
-  '[].concat.call([], [[foo]])',
   '[].concat.call([], ...array)',
   '[].concat.call([], ...((0, array)))',
   '[].concat.call([], ...((array)))',
@@ -233,11 +261,6 @@ const invalidCases = [
   'Array.prototype.concat.apply([], ((array)))',
   'Array.prototype.concat.apply([], [foo])',
   'Array.prototype.concat.apply([], [[foo]])',
-  'Array.prototype.concat.call([], maybeArray)',
-  'Array.prototype.concat.call([], ((0, maybeArray)))',
-  'Array.prototype.concat.call([], ((maybeArray)))',
-  'Array.prototype.concat.call([], [foo])',
-  'Array.prototype.concat.call([], [[foo]])',
   'Array.prototype.concat.call([], ...array)',
   'Array.prototype.concat.call([], ...((0, array)))',
   'Array.prototype.concat.call([], ...((array)))',
@@ -258,33 +281,18 @@ const invalidCases = [
   Array.prototype.concat.apply([], [array].concat(array))`,
   `before()
   Array.prototype.concat.apply([], +1)`,
-  `before()
-  Array.prototype.concat.call([], +1)`,
   'Array.prototype.concat.apply([], (0, array))',
-  'Array.prototype.concat.call([], (0, array))',
-  'async function a() { return [].concat(await getArray()); }',
   '_.flatten((0, array))',
   'async function a() { return _.flatten(await getArray()); }',
   'async function a() { return _.flatten((await getArray())); }',
   `before()
   Array.prototype.concat.apply([], 1)`,
   `before()
-  Array.prototype.concat.call([], 1)`,
-  `before()
   Array.prototype.concat.apply([], 1.)`,
-  `before()
-  Array.prototype.concat.call([], 1.)`,
   `before()
   Array.prototype.concat.apply([], .1)`,
   `before()
-  Array.prototype.concat.call([], .1)`,
-  `before()
   Array.prototype.concat.apply([], 1.0)`,
-  `before()
-  Array.prototype.concat.call([], 1.0)`,
-  '[].concat(some./**/array)',
-  '[/**/].concat(some./**/array)',
-  '[/**/].concat(some.array)',
 ].map((code) => invalid(code));
 
 const options = [


### PR DESCRIPTION
## Summary

- align `unicorn/prefer-array-flat` with eslint-plugin-unicorn v74, including the spread-only concat patterns, the `apply`/`call` matrix, known-non-array `reduce` receivers, and string-only configured function entries
- make JavaScript JSDoc casts transparent across method, receiver, reducer, and configured-path matching while keeping authored TypeScript assertions visible and preserving comment-safe fix behavior
- keep official Layer 1 cases isolated in `_upstream_*` tests and split rslint-only fix-boundary, JSDoc, regression, and schema coverage into named `_extras_*` areas
- reduce listener allocations with immediate reporting, precomputed configured-function leaves, and the combined `apply`/`call` matcher

### Go benchmark

Five samples per case using the same temporary full-linter benchmark before and after. Values are medians; the temporary benchmark source was deleted and is not part of this PR.

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| matched diagnostics | 38,239 → 32,894 (-13.98%) | 46,729 → 40,534 (-13.26%) | 543 → 350 (-35.54%) |
| matched autofix | 59,342 → 54,229 (-8.62%) | 122,540 → 116,344 (-5.06%) | 1,183 → 990 (-16.31%) |
| matched suggestion demand | 38,350 → 32,706 (-14.72%) | 46,729 → 40,534 (-13.26%) | 543 → 350 (-35.54%) |
| matched comment without fix | 160,292 → 156,905 (-2.11%) | 352,913 → 346,720 (-1.75%) | 7,681 → 7,488 (-2.51%) |
| matched apply autofix | 49,103 → 49,993 (+1.81%) | 118,444 → 116,348 (-1.77%) | 1,055 → 990 (-6.16%) |
| no match | 21,020 → 14,377 (-31.60%) | 8,829 → 2,635 (-70.16%) | 223 → 30 (-86.55%) |
| ignored custom function | 17,541 → 19,100 (+8.89%) | 8,828 → 8,780 (-0.54%) | 223 → 222 (-0.45%) |
| configured function diagnostics | 26,365 → 26,150 (-0.82%) | 45,797 → 43,733 (-4.51%) | 544 → 479 (-11.95%) |
| overlapping matchers | 48,230 → 47,783 (-0.93%) | 85,745 → 81,632 (-4.80%) | 864 → 799 (-7.52%) |

The equal-weight geometric mean for `ns/op` is 7.64% lower. Every case uses fewer bytes and allocations; the two local time increases are shown explicitly above.

## Related Links

- [eslint-plugin-unicorn v74 rule source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-array-flat.js)
- [eslint-plugin-unicorn v74 documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-array-flat.md)

## Validation

- exact 132-case v74 differential: diagnostic count/order, message, UTF-16 range, fix presence, and every fix pass
- target rule, shared helpers, and direct helper consumers: `go test ... -count=3`
- targeted JS integration test for `prefer-array-flat`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run check-spell`
- `pnpm run format:check`
- changed-package `golangci-lint --new-from-rev=origin/main`
- `git diff --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
