### PR TITLE
fix: align no-implicit-globals TypeScript pattern writes

### DIFF
--- a/internal/rules/no_implicit_globals/no_implicit_globals.go
+++ b/internal/rules/no_implicit_globals/no_implicit_globals.go
@@ -76,9 +76,10 @@ var NoImplicitGlobalsRule = rule.Rule{
 		// code, so top-level strictness decides whether a leak is reportable.
 		// It comes from the resolved source goal rather than syntax alone:
 		// CommonJS stays sloppy even when the parser accepts import/export.
+		writeContext := writeContextCache{}
 		listeners := rule.RuleListeners{
 			ast.KindIdentifier: func(node *ast.Node) {
-				checkImplicitGlobalWrite(ctx, node)
+				checkImplicitGlobalWrite(ctx, node, &writeContext)
 			},
 		}
 
@@ -237,38 +238,17 @@ func checkClassDeclaration(ctx rule.RuleContext, node *ast.Node, sourceFileNode 
 	reportDeclaration(ctx, node, nameNode.Text(), "class", true)
 }
 
-// checkImplicitGlobalWrite handles the two reference-driven diagnostics that
-// apply file-wide, independently of module-ness: an assignment to a read-only
-// global (assignmentToReadonlyGlobal) and an assignment to a name that is
-// neither declared anywhere in the file nor a known global at all, outside
-// strict-mode code (globalVariableLeak). Both only ever consider a pure `=`
-// assignment or bare for-in/for-of loop variable — the same shape ESLint's
-// own reference.isWrite() && !reference.isRead() filter selects, which
-// excludes compound assignments (foo += 1) and update expressions (foo++).
-//
-// The two diagnostics differ on `/* exported */`: upstream skips an exported
-// variable before reaching its reference loop, so the readonly assignment goes
-// unreported, while the leak is collected from the global scope's implicit
-// variables, which the directive never touches.
-//
-// Both stop at any name the file itself defines, which in a global script means
-// any top-level declaration whatsoever: ESLint keeps that file's declarations
-// and the configured globals in one global-scope variable, so a type-only
-// `interface foo {}` gives `foo` a definition and neither an implicit variable
-// (the leak) nor a definition-less read-only global (the assignment) remains.
-// Inner scopes hold separate variables that a value reference never resolves
-// to, so the same declaration inside a function or namespace leaves the name
-// global — the distinction IsGlobalNameReference draws.
-func checkImplicitGlobalWrite(ctx rule.RuleContext, node *ast.Node) {
-	root, writes := findPureAssignmentRoot(node)
+// checkImplicitGlobalWrite reports pure runtime writes to undeclared names and
+// read-only globals. TypeScript type syntax is deliberately excluded: an
+// assertion around a value can be an assignment target after erasure, but the
+// identifiers inside the assertion's type never are.
+func checkImplicitGlobalWrite(ctx rule.RuleContext, node *ast.Node, writeContext *writeContextCache) {
+	root, writes := findPureAssignmentRoot(node, writeContext)
 	if root == nil {
 		return
 	}
 	name := node.Text()
-	// PatternVisitor records target writes in the scope containing the outer
-	// assignment, including identifiers reached through TypeScript wrappers.
-	// Resolve from that same location.
-	if ctx.Refs != nil && !ctx.Refs.IsGlobalNameReference(root, name, ast.SymbolFlagsValue|ast.SymbolFlagsAlias) {
+	if ctx.Refs != nil && !ctx.Refs.IsGlobalNameReference(node, name, ast.SymbolFlagsValue|ast.SymbolFlagsAlias) {
 		return
 	}
 	switch ctx.Globals.Access(name) {
@@ -290,157 +270,215 @@ func checkImplicitGlobalWrite(ctx rule.RuleContext, node *ast.Node) {
 	}
 }
 
-// findPureAssignmentRoot walks from a candidate write-target identifier up
-// through destructuring containers and transparent TS wrappers (parens,
-// non-null assertions, `as` and `<T>` assertions) to the enclosing pure `=`
-// assignment or for-in/for-of statement, mirroring upstream's ASSIGNMENT_NODES
-// walk of reference.identifier.parent. Alongside the root it returns how many
-// write references the scope manager records for the identifier: the assignment
-// itself, plus one for every destructuring default the identifier sits under,
-// since eslint-scope adds a write per enclosing AssignmentPattern before the
-// one for the assignment. `[[foo = 1] = []] = arr` therefore reports three
-// times over the whole assignment. It returns nil for anything that isn't a pure
-// write target: compound/logical assignment operators and update expressions
-// read as well as write, so ESLint's ordinary reference analysis does not treat
-// them as leak/readonly-assignment candidates.
-//
-// TypeScript expression wrappers are where the walk stops mirroring the AST and
-// starts mirroring the scope manager. An AssignmentExpression's Left is
-// unwrapped exactly once — a TSAsExpression, TSTypeAssertion or
-// TSNonNullExpression, never a TSSatisfiesExpression — and what remains has to
-// be a pattern, so `(foo as any) = 1` is a write while `(foo as any)! = 1`,
-// `foo!! = 1` and `(foo satisfies any) = 1` are not. A wrapper around a
-// destructuring target does not survive that test either: `[foo]` is no longer a
-// destructuring pattern once an assertion wraps it, so `([foo] as any) = arr` is
-// no write at all. Every other path — a for-in/for-of head, anything nested
-// inside a pattern — visits the pattern directly and accepts a wrapped target
-// however deeply it is nested, `satisfies` included: `[foo satisfies any] = arr`
-// is a write.
-func findPureAssignmentRoot(node *ast.Node) (*ast.Node, int) {
-	current := node
-	writes := 1
-	// wrappers counts the TS expression wrappers the walk has climbed since the
-	// last pattern node, which is what an AssignmentExpression's Left has to
-	// shed in its single unwrap; satisfies records whether any of them is the
-	// one wrapper that unwrap never sheds.
-	wrappers := 0
-	satisfies := false
-	// enterPattern moves the walk onto a pattern node. Only the wrappers
-	// between the last pattern node and the assignment have to survive that
-	// single unwrap, so reaching one clears the wrapper state.
-	enterPattern := func(pattern *ast.Node) {
-		wrappers = 0
-		satisfies = false
-		current = pattern
+// findPureAssignmentRoot delegates assignment-target discovery to tsgo. The
+// only bridge needed is for erased TypeScript assertions, which
+// GetAssignmentTarget intentionally does not cross. Default values retain the
+// existing ESLint-compatible diagnostic multiplicity.
+func findPureAssignmentRoot(node *ast.Node, writeContext *writeContextCache) (*ast.Node, int) {
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return nil, 0
 	}
-	for current != nil && current.Parent != nil {
-		parent := current.Parent
-		switch parent.Kind {
-		case ast.KindBinaryExpression:
-			binary := parent.AsBinaryExpression()
-			if binary == nil || binary.OperatorToken == nil {
-				return nil, 0
-			}
-			if binary.OperatorToken.Kind != ast.KindEqualsToken {
-				return nil, 0
-			}
-			if binary.Left != current {
-				return nil, 0
-			}
-			if utils.IsInDestructuringAssignment(parent) {
-				writes++
-				enterPattern(parent)
-				continue
-			}
-			if wrappers > 1 || satisfies {
-				return nil, 0
-			}
-			return parent, writes
 
-		case ast.KindForInStatement, ast.KindForOfStatement:
-			stmt := parent.AsForInOrOfStatement()
-			if stmt == nil || stmt.Initializer != current {
-				return nil, 0
-			}
-			return parent, writes
-
-		case ast.KindObjectLiteralExpression, ast.KindArrayLiteralExpression:
-			if !utils.IsInDestructuringAssignment(parent) {
-				return nil, 0
-			}
-			enterPattern(parent)
-
-		case ast.KindShorthandPropertyAssignment:
-			shorthand := parent.AsShorthandPropertyAssignment()
-			if shorthand == nil || shorthand.Name() != current {
-				return nil, 0
-			}
-			// `{ foo = 1 } = obj` keeps its default on the shorthand rather
-			// than in a nested assignment, but the scope manager still sees an
-			// AssignmentPattern and records its extra write.
-			if shorthand.ObjectAssignmentInitializer != nil {
-				writes++
-			}
-			enterPattern(parent)
-
-		case ast.KindPropertyAssignment:
-			propAssignment := parent.AsPropertyAssignment()
-			if propAssignment == nil || propAssignment.Initializer != current {
-				return nil, 0
-			}
-			enterPattern(parent)
-
-		case ast.KindSpreadElement, ast.KindSpreadAssignment:
-			enterPattern(parent)
-
-		case ast.KindNonNullExpression, ast.KindAsExpression, ast.KindTypeAssertionExpression:
-			wrappers++
-			current = parent
-
-		case ast.KindSatisfiesExpression:
-			satisfies = true
-			current = parent
-
-		case ast.KindParenthesizedExpression:
-			// ESTree erases parentheses around an identifier, but preserves
-			// parentheses around an array/object target as a recovered invalid
-			// assignment. Do not turn that recovered container into a pattern.
-			if current.Kind == ast.KindArrayLiteralExpression || current.Kind == ast.KindObjectLiteralExpression {
-				return nil, 0
-			}
-			current = parent
-
-		case ast.KindExpressionWithTypeArguments:
-			instantiation := parent.AsExpressionWithTypeArguments()
-			if instantiation != nil && instantiation.Expression == current {
-				// TypeScript erases the type arguments, leaving this runtime
-				// expression as the assignment-pattern target.
-				current = parent
-				continue
-			}
-			// Preserve PatternVisitor's existing traversal into type arguments.
-			if (!ast.IsPartOfTypeNode(current) && !ast.IsPartOfTypeNode(parent)) ||
-				!utils.IsInDestructuringAssignment(parent) {
-				return nil, 0
-			}
-			current = parent
-
-		case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
-			// A member expression writes its property, not either identifier
-			// inside the expression. PatternVisitor records both as reads.
+	root := assignmentTargetThroughAssertions(node)
+	if root == nil || writeContext.isErasedSyntax(node, root) || writeContext.isInsideWrappedPattern(node, root) ||
+		isRestAssignmentRoot(root) {
+		return nil, 0
+	}
+	writes := 1
+	for utils.IsDefaultValueInDestructuringAssignment(root) {
+		writes++
+		root = assignmentTargetThroughAssertions(root)
+		if root == nil {
 			return nil, 0
-
-		default:
-			// TypeScript assertion and satisfies wrappers expose their type syntax
-			// to PatternVisitor. Preserve that traversal for otherwise valid
-			// assignment targets, but do not emulate recovery-only expression
-			// targets whose emitted JavaScript is not executable.
-			if (!ast.IsPartOfTypeNode(current) && !ast.IsPartOfTypeNode(parent)) ||
-				!utils.IsInDestructuringAssignment(parent) {
-				return nil, 0
-			}
-			current = parent
 		}
 	}
-	return nil, 0
+	// A standalone `=` recovered inside an invalid pattern element is not an
+	// executable assignment. Valid default initializers have already been
+	// lifted to their enclosing assignment; IsInDestructuringAssignment stops
+	// at default right-hand sides and computed property names, which remain
+	// ordinary runtime expressions.
+	if isRecoveredInvalidPatternRoot(root) {
+		return nil, 0
+	}
+	switch root.Kind {
+	case ast.KindBinaryExpression:
+		binary := root.AsBinaryExpression()
+		if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken {
+			return nil, 0
+		}
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		// A non-declaration loop initializer is a pure write target.
+	default:
+		return nil, 0
+	}
+
+	for current := node.Parent; current != nil && current != root; current = current.Parent {
+		if current.Kind == ast.KindShorthandPropertyAssignment {
+			shorthand := current.AsShorthandPropertyAssignment()
+			if shorthand != nil && shorthand.ObjectAssignmentInitializer != nil {
+				writes++
+			}
+		}
+	}
+	return root, writes
+}
+
+// assignmentTargetThroughAssertions delegates the assignment-target walk to
+// tsgo and only steps across its erased assertion outer expressions. In
+// particular, it does not cross an instantiation expression: TypeScript rejects
+// one used as an assignment target.
+func assignmentTargetThroughAssertions(node *ast.Node) *ast.Node {
+	for current := node; current != nil; {
+		if target := ast.GetAssignmentTarget(current); target != nil {
+			return target
+		}
+		parent := current.Parent
+		if parent == nil || !ast.IsOuterExpression(parent, ast.OEKAssertions|ast.OEKParentheses) || parent.Expression() != current {
+			return nil
+		}
+		current = parent
+	}
+	return nil
+}
+
+// isInsideWrappedPattern rejects every write nested in an array/object pattern
+// that is itself wrapped in parentheses or a TypeScript assertion. The target
+// check keeps ordinary parenthesized array/object values inside a member
+// receiver or index expression out of this recovery-only boundary.
+func (c *writeContextCache) isInsideWrappedPattern(node *ast.Node, root *ast.Node) bool {
+	for current := node.Parent; current != nil; current = current.Parent {
+		if current == c.wrappedKey {
+			if c.wrapped {
+				// A positive result belongs to the wrapped container, not the
+				// assignment root: a sibling pattern may remain executable.
+				return true
+			}
+			return c.rememberWrapped(root, false)
+		}
+		if !ast.IsAssignmentPattern(current) {
+			continue
+		}
+		if isWrappedPatternContainer(current) {
+			return c.rememberWrapped(current, true)
+		}
+	}
+	return c.rememberWrapped(root, false)
+}
+
+func isWrappedPatternContainer(node *ast.Node) bool {
+	current := node
+	wrapped := false
+	for current.Parent != nil {
+		parent := current.Parent
+		if !ast.IsOuterExpression(parent, ast.OEKAssertions|ast.OEKParentheses|ast.OEKExpressionsWithTypeArguments) {
+			break
+		}
+		if parent.Expression() != current {
+			break
+		}
+		wrapped = true
+		current = parent
+	}
+	return wrapped && ast.GetAssignmentTarget(current) != nil
+}
+
+// isRestAssignmentRoot rejects a recovered default/assignment used directly
+// as an array or object rest target. Assignments evaluated inside a valid
+// member target stop at that member expression and remain reportable.
+func isRestAssignmentRoot(node *ast.Node) bool {
+	current := node
+	for current.Parent != nil &&
+		ast.IsOuterExpression(current.Parent, ast.OEKAssertions|ast.OEKParentheses) &&
+		current.Parent.Expression() == current {
+		current = current.Parent
+	}
+	parent := current.Parent
+	return parent != nil && (parent.Kind == ast.KindSpreadElement || parent.Kind == ast.KindSpreadAssignment) &&
+		parent.Expression() == current && ast.GetAssignmentTarget(current) != nil
+}
+
+// isRecoveredInvalidPatternRoot distinguishes a standalone assignment buried
+// in an invalid pattern element from one evaluated while resolving a valid
+// member target. Default right-hand sides and computed property names already
+// return false from IsInDestructuringAssignment.
+func isRecoveredInvalidPatternRoot(node *ast.Node) bool {
+	if !utils.IsInDestructuringAssignment(node) {
+		return false
+	}
+	for current := node.Parent; current != nil; current = current.Parent {
+		if ast.IsArrayLiteralOrObjectLiteralDestructuringPattern(current) {
+			// Do not let a member expression outside this pattern container make
+			// its invalid contents look executable.
+			return true
+		}
+		if ast.IsAccessExpression(current) &&
+			!ast.IsOptionalChain(current) && assignmentTargetThroughAssertions(current) != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// writeContextCache excludes identifiers in syntax that cannot contribute a
+// runtime write. NodeFlagsAmbient is propagated by the parser to descendants
+// of declaration files and `declare` declarations. Interfaces, bodyless
+// function-like declarations, and abstract properties need explicit checks
+// because recovery expressions may still appear beneath their AST nodes.
+type writeContextCache struct {
+	erasedRoot, wrappedKey *ast.Node
+	erased, wrapped        bool
+}
+
+// isErasedSyntax checks whether the path from a target identifier through its
+// assignment root is erased TypeScript syntax, then classifies the root's
+// surrounding context. Remembering only the previous root makes nested
+// assignment chains linear without allocating a per-file node map: preorder
+// traversal visits the enclosing root before the roots nested inside it.
+func (c *writeContextCache) isErasedSyntax(node *ast.Node, root *ast.Node) bool {
+	for current := node; current != nil && current != root; current = current.Parent {
+		if ast.IsPartOfTypeNode(current) {
+			return true
+		}
+	}
+
+	ambient := false
+	emittedPropertyPart := false
+	for current := root; current != nil; current = current.Parent {
+		if current == c.erasedRoot {
+			return c.rememberErased(root, c.erased)
+		}
+		ambient = ambient || utils.IsInAmbientContext(current)
+		if current.Kind == ast.KindDecorator || current.Kind == ast.KindComputedPropertyName {
+			emittedPropertyPart = true
+		}
+		if ast.IsPartOfTypeNode(current) ||
+			current.Kind == ast.KindInterfaceDeclaration ||
+			(ast.IsFunctionLike(current) && current.Body() == nil) {
+			return c.rememberErased(root, true)
+		}
+		if current.Kind != ast.KindPropertyDeclaration || (!ambient && !ast.HasAbstractModifier(current)) {
+			continue
+		}
+		owner := current.Parent
+		if emittedPropertyPart && ast.HasDecorators(current) && owner != nil && ast.IsClassLike(owner) &&
+			!utils.IsInAmbientContext(owner) {
+			// With legacy decorators enabled, TypeScript emits the decorator
+			// expression and computed name even though the property is erased.
+			return c.rememberErased(root, false)
+		}
+		return c.rememberErased(root, true)
+	}
+	return c.rememberErased(root, ambient)
+}
+
+func (c *writeContextCache) rememberErased(root *ast.Node, erased bool) bool {
+	c.erasedRoot = root
+	c.erased = erased
+	return erased
+}
+
+func (c *writeContextCache) rememberWrapped(key *ast.Node, wrapped bool) bool {
+	c.wrappedKey = key
+	c.wrapped = wrapped
+	return wrapped
 }

--- a/internal/rules/no_implicit_globals/no_implicit_globals.md
+++ b/internal/rules/no_implicit_globals/no_implicit_globals.md
@@ -130,13 +130,15 @@ Examples of **correct** code for this rule with `{ "lexicalBindings": true }`:
 
 ## Differences from ESLint
 
-- ESLint's `parserOptions.ecmaFeatures.globalReturn` is not configurable, so rslint cannot place a script's top-level declarations inside the synthetic function scope that option creates.
-- ESLint's `env` config (which supplies environment globals such as `browser`'s `window`) is not supported. Declare the same names through `languageOptions.globals` or a `/*global */` comment instead.
-- TypeScript declaration forms that bind no runtime variable of their own are not reported: ambient declarations (`declare var foo: number;`, `declare function foo(): void;`, `declare class Foo {}`) and overload signatures. ESLint reports the ambient forms, and counts one declaration per overload signature, so it reports an overload pair twice where this rule reports only the implementation.
-- `/* exported __proto__ */` treats `__proto__` like any other exported name. ESLint 10.8.1 accidentally loses that entry because its directive parser stores names in an ordinary JavaScript object, where assigning `__proto__` invokes the inherited prototype setter instead of creating an own property.
-- Rslint does not reproduce `@typescript-eslint/parser`'s recovered `PatternVisitor` diagnostics for assignment targets that remain invalid after TypeScript syntax is erased, such as `[foo + bar] = value`. This rule limits assignment-target parity to code whose generated JavaScript is executable.
+- For a script parsed by ESLint with `languageOptions.parserOptions.ecmaFeatures.globalReturn: true`, ESLint treats the top level as a function scope and does not report its `var` or function declarations. Rslint treats the same source as a global script and reports those declarations.
+- In TypeScript scripts, ESLint reports ambient `var` and function declarations and, with `lexicalBindings: true`, ambient `let`, `const`, and class declarations. Rslint does not report these declarations.
+- For an overloaded global function in a TypeScript script, ESLint reports every overload signature and the implementation. Rslint reports only the implementation.
+- In TypeScript assignment targets, rslint reports only runtime value targets. For `[foo as (x: T) => U] = value`, rslint reports `foo`; ESLint also reports the function-type parameter name `x`.
+- Rslint recognizes value writes through nested erased assertions. For `(foo satisfies T) = value`, rslint reports `foo`, while ESLint does not.
+- With `/* exported __proto__ */`, rslint suppresses the global-declaration diagnostic just as it does for other exported names. ESLint 10.9.1 still reports `__proto__` because of an upstream directive-parser bug.
+- On invalid TypeScript accepted through parser recovery, such as `[foo<T>] = value` or `[foo + bar] = value`, ESLint may emit assignment diagnostics that rslint does not.
 
 ## Original Documentation
 
 - [ESLint: no-implicit-globals](https://eslint.org/docs/latest/rules/no-implicit-globals)
-- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-implicit-globals.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-implicit-globals.js)

--- a/internal/rules/no_implicit_globals/no_implicit_globals_extras_test.go
+++ b/internal/rules/no_implicit_globals/no_implicit_globals_extras_test.go
@@ -25,32 +25,102 @@ func TestNoImplicitGlobalsExtras(t *testing.T) {
 		withScriptDefaults([]rule_tester.ValidTestCase{
 			// ---- Dimension 4: receiver wrappers, opaque TS wrappers ----
 
-			// The single unwrap an AssignmentExpression's Left gets sheds an
-			// `as`/`<T>`/`!` wrapper but never a `satisfies`, so a directly
-			// wrapped target is no pattern at all (see findPureAssignmentRoot
-			// doc comment). Inside a real pattern the same wrapper is
-			// transparent — see the invalid cases.
-			{Code: `(foo satisfies any) = 1;`},
-			{Code: `(Array satisfies any) = 1;`},
-			{Code: `(foo satisfies any as any) = 1;`},
-			{Code: `((foo as any) satisfies any) = 1;`},
-
-			// An AssignmentExpression's Left is unwrapped exactly once, so a
-			// second wrapper leaves something that is no longer a pattern.
-			{Code: `(foo as any)! = 1;`},
-			{Code: `foo!! = 1;`},
-			{Code: `((foo as any) as any) = 1;`},
-			{Code: `(Array as any)! = 1;`},
-			// A wrapper around the destructuring target fails the same test:
-			// `[foo]` is no longer a destructuring pattern once an assertion
-			// wraps it.
+			// Instantiation expressions and assertions around an entire pattern
+			// are not valid TypeScript assignment targets.
+			{Code: `foo<T> = 1;`},
+			{Code: `Array<T> = 1;`},
+			{Code: `[foo<T>] = arr;`},
+			{Code: `for ((foo<T>) of arr) {}`},
 			{Code: `([foo] as any) = arr;`},
+			{Code: `([foo]!) = arr;`},
+			{Code: `({x: foo}!) = obj;`},
+			{Code: `([obj[bar = value]]!) = rhs;`},
+			{Code: `([obj[bar = value]]) = rhs;`},
+			{Code: `(({[bar = value]: foo})) = rhs;`},
+			{Code: `({[bar = value]: foo} as T) = rhs;`},
+			{Code: `([foo = (bar = value)] as T) = rhs;`},
+			{Code: `([obj[bar = value]])<T> = rhs;`},
+			{Code: `({[bar = value]: foo})<T> = rhs;`},
+			{Code: `([foo = (bar = value)])<T> = rhs;`},
+			{Code: `for (([obj[bar = value]]!) in rhs) {}`},
+			{Code: `for (({[bar = value]: foo} as T) of rhs) {}`},
 			// Parentheses around the destructuring container survive as a
 			// recovery-only invalid target; unlike parentheses around a bare
 			// identifier, they must not make the inner names writable.
 			{Code: `([foo]) = arr;`},
 			{Code: `(({foo})) = obj;`},
 			{Code: `(([foo, bar])) = arr;`},
+
+			// Only the value expression of an erased assertion can be written.
+			// Names occurring solely in its type remain type-only.
+			{Code: `[foo as T] = arr;`, Globals: map[string]any{"foo": "writable", "T": "readonly"}},
+			{Code: `[foo satisfies T] = arr;`, Globals: map[string]any{"foo": "writable", "T": "readonly"}},
+			{
+				Code:    `[foo as (x: T) => U] = arr;`,
+				Globals: map[string]any{"foo": "writable", "x": "readonly", "T": "readonly", "U": "readonly"},
+			},
+			{
+				Code:    `for ((foo as T) in obj) {}`,
+				Globals: map[string]any{"foo": "writable", "T": "readonly"},
+			},
+			{Code: `type X = { [bar = value]: T };`, Globals: map[string]any{"bar": "readonly"}},
+			{Code: `interface I { [bar = value]: T }`, Globals: map[string]any{"bar": "readonly"}},
+			{Code: `declare class C { [bar = value]: T }`, Globals: map[string]any{"bar": "readonly"}},
+			{
+				Code:    `declare function f(x = (bar = value)): void;`,
+				Globals: map[string]any{"bar": "readonly"},
+			},
+			{
+				Code:    `function f(x = (bar = value)): void; function f(): void {}`,
+				Globals: map[string]any{"f": "writable", "bar": "readonly"},
+			},
+			{
+				Code:    `abstract class C { abstract [bar = value]: T }`,
+				Globals: map[string]any{"bar": "readonly"},
+			},
+			{
+				Code:    `class C { declare [bar = value]: T }`,
+				Globals: map[string]any{"bar": "readonly"},
+			},
+			{
+				Code:    `declare class C { @dec(foo = 1) p: any }`,
+				Globals: map[string]any{"foo": "readonly"},
+			},
+			{
+				Code:    `@dec(foo = 1) declare class C {}`,
+				Globals: map[string]any{"foo": "readonly"},
+			},
+			{
+				Code:    `class C { @dec(foo = 1) m(x: string): void; m(x: any) {} }`,
+				Globals: map[string]any{"foo": "readonly"},
+			},
+			{
+				Code:    `abstract class C { @dec(foo = 1) abstract m(): void }`,
+				Globals: map[string]any{"foo": "readonly"},
+			},
+			{
+				Code:    `class C { m(@dec(foo = 1) x: string): void; m(x: any) {} }`,
+				Globals: map[string]any{"foo": "readonly"},
+			},
+			{
+				Code:    `abstract class C { @dec abstract [bar = value](): void }`,
+				Globals: map[string]any{"bar": "readonly"},
+			},
+			{
+				Code:    `abstract class C { abstract [bar = value](): void }`,
+				Globals: map[string]any{"bar": "readonly"},
+			},
+
+			// A nested assignment does not become executable merely because the
+			// parser recovered it inside an invalid pattern element.
+			{Code: `[foo += (bar = value)] = arr;`},
+			{Code: `[foo + (bar = value)] = arr;`},
+			{Code: `[call(bar = value)] = arr;`},
+			{Code: `[...(bar = value)] = rhs;`},
+			{Code: `({... (bar = value)} = rhs);`},
+			{Code: `for ([...(bar = value)] of rhs) {}`},
+			{Code: `[...foo = value] = rhs;`},
+			{Code: `target[([foo + (bar = 1)] = value)] = next;`},
 
 			// ---- Dimension 4: declaration vs expression forms ----
 
@@ -205,8 +275,16 @@ func TestNoImplicitGlobalsExtras(t *testing.T) {
 				Code:   `((foo)) = 1;`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
 			},
-			// Non-null and type assertions are transparent too (unlike
-			// `satisfies`).
+			{
+				Code:   `[([foo]), bar] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([foo]) = (bar = 1);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			// Erased TypeScript assertions are transparent around a value target,
+			// including when they are nested.
 			{
 				Code:   `foo! = 1;`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
@@ -225,6 +303,26 @@ func TestNoImplicitGlobalsExtras(t *testing.T) {
 			},
 			{
 				Code:   `(Array as any) = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+			},
+			{
+				Code:   `(foo satisfies any) = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `(Array as any)! = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+			},
+			{
+				Code:   `((foo as any) satisfies any) = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `class C extends (Array = Base) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+			},
+			{
+				Code:   `declare function fn<T>(): void; /*global foo:readonly*/ (foo = fn)<string>;`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
 			},
 			// Inside a pattern, and in a for-in/for-of head, the target is
@@ -247,6 +345,14 @@ func TestNoImplicitGlobalsExtras(t *testing.T) {
 			},
 			{
 				Code:   `for (foo! in obj) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `for ([foo] in obj) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `for ({x: foo} in obj) {}`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
 			},
 
@@ -474,20 +580,95 @@ func TestNoImplicitGlobalsExtras(t *testing.T) {
 				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
 			},
 
-			// ---- Dimension 4: `satisfies` inside a real pattern ----
-			//
-			// A pattern element is visited directly, so the wrapper the
-			// AssignmentExpression unwrap would have rejected is transparent
-			// here.
+			// ---- Dimension 4: erased assertions inside a real pattern ----
+			// Assignments in a computed key or a default right-hand side are
+			// runtime expressions, not recovered target syntax.
+			{
+				Code:    `({[bar = value]: foo} = obj);`,
+				Globals: map[string]any{"foo": "writable"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:    `[foo = (bar = value)] = arr;`,
+				Globals: map[string]any{"foo": "writable"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `({x: obj[foo = 1]} = value);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([obj[bar = 1]] = value);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `({x: (baz = obj).p} = value);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([obj[foo + (bar = 1)]] = value);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([obj[key && (bar = value)]] = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([(bar = value, obj).p] = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([([bar = value]).p] = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([obj[[bar = value]]] = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `({x: ({a: bar = value}).p} = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([obj[{a: bar = value}]] = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([...obj[bar = value]] = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `([...(bar = value).p] = rhs);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `const x = [...(foo = iterable)];`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `const x = { ...(foo = value) };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `fn(...(foo = iterable));`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `[([...(foo = iterable)]).p] = rhs;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `[({ ...(foo = value) }).p] = rhs;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `[obj[fn(...(foo = iterable))]] = rhs;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+
 			{
 				Code:   `[foo satisfies any] = arr;`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak", Line: 1, Column: 1, EndLine: 1, EndColumn: 26}},
-			},
-			// An instantiation expression erases to its runtime expression, so
-			// its expression child remains a real assignment-pattern target.
-			{
-				Code:   `[foo<string>] = arr;`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
 			},
 			{
 				Code:   `[[foo satisfies any]] = arr;`,
@@ -510,22 +691,21 @@ func TestNoImplicitGlobalsExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
 			},
 
-			// PatternVisitor traverses identifiers in TypeScript type positions
-			// when a runnable assignment target uses an assertion wrapper.
 			{
-				Code:    `[foo as T] = arr;`,
-				Globals: map[string]any{"foo": "writable", "T": "readonly"},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+				Code:   `[foo as T] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
 			},
 			{
-				Code:    `[foo<T>] = arr;`,
-				Globals: map[string]any{"foo": "writable", "T": "readonly"},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+				Code:   `[foo satisfies T] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
 			},
 			{
-				Code:    `[foo satisfies T] = arr;`,
-				Globals: map[string]any{"foo": "writable", "T": "readonly"},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+				Code:   `[foo as (x: T) => U] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:   `for ((foo as T) in obj) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
 			},
 			// ---- Only a global script's own top level defines the
 			// global-scope variable ----
@@ -554,6 +734,31 @@ func TestNoImplicitGlobalsExtras(t *testing.T) {
 			{
 				Code:   `const C = @dec(foo = 1) class {};`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "globalVariableLeak"}},
+			},
+			{
+				Code:    `class C { @dec(foo = 1) declare p: any }`,
+				Globals: map[string]any{"foo": "readonly"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+			},
+			{
+				Code:    `class C { @dec<T>(foo = 1) declare p: any }`,
+				Globals: map[string]any{"foo": "readonly", "T": "readonly"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+			},
+			{
+				Code:    `abstract class C { @dec(foo = 1) abstract p: any }`,
+				Globals: map[string]any{"foo": "readonly"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+			},
+			{
+				Code:    `abstract class C { @dec abstract [bar = value]: any }`,
+				Globals: map[string]any{"bar": "readonly"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
+			},
+			{
+				Code:    `class C { @dec declare [bar = value]: any }`,
+				Globals: map[string]any{"bar": "readonly"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "assignmentToReadonlyGlobal"}},
 			},
 
 			// The outer declaration remains global at ES5; the nested declaration


### PR DESCRIPTION
## Summary

- Reuse tsgo's assignment-target APIs and the existing reference/global resolution to classify runtime writes without a rule-local pattern visitor.
- Fix false positives for direct TypeScript instantiation expressions, exclude identifiers that occur only in type annotations, and handle assertion-wrapped assignment and for-in/of targets.
- Preserve rslint's runtime-only ambient and overload behavior, and document the remaining differences for invalid parser-recovery input.
- Add adversarial regressions for defaults, rest/spread boundaries, member-target side effects, decorators, computed names, and cache isolation.

## Benchmark

Temporary overlay benchmark on Apple M5 Max; `go test -benchmem -count=5 -benchtime=100ms`. The benchmark source is not committed.

| Case | `main` | This PR | Result |
| --- | ---: | ---: | ---: |
| 2,048-name wrapped pattern | 171.09 µs | 24.06 µs | -85.94% |
| 2,048-level deferred chain with references | 33.04 ms | 74.42 µs | -99.77% |
| 2,048-level plain assignment chain | 8.98 ms | 9.54 ms | statistically unchanged |
| 2,048-identifier read-only input | 36.96 µs | 41.07 µs | +11.11% |

Across the adversarial suite, the time geomean decreased 75.93%, bytes/op decreased 88.53%, and allocations/op decreased 84.46%. Rule initialization adds one 32-byte allocation per file.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
