### PR TITLE
fix: align jsx-sort-props fixes and locale ordering

### DIFF
--- a/.agents/skills/port-rule/references/UTILS_REFERENCE.md
+++ b/.agents/skills/port-rule/references/UTILS_REFERENCE.md
@@ -51,13 +51,14 @@ for comment := range utils.GetCommentsInRange(ctx.SourceFile, textRange) {
 // GetCommentsInRange above — safe to call per-node.
 hasComments := utils.HasCommentsInRange(ctx.SourceFile, textRange)
 
-// Check if any comment overlaps an arbitrary [start, end) span, e.g. the gap
-// between two tokens that aren't adjacent nodes. Binary-searches the file's
+// Get a read-only view of every comment overlapping an arbitrary [start, end)
+// span, or just check whether one exists. Both binary-search the file's
 // already-collected comment list — pass ctx.Comments.All(), don't rebuild it.
 // Prefer this over GetCommentsInRange/HasCommentsInRange when you're calling
 // it once per matching AST node across the whole file (e.g. once per boolean
 // cast, once per label) — see the "Token and Comment Iteration" section below
 // for why that distinction matters.
+comments := utils.CommentsInSpan(ctx.Comments.All(), start, end)
 hasComment := utils.HasCommentInSpan(ctx.Comments.All(), start, end)
 ```
 
@@ -239,10 +240,10 @@ Rules of thumb:
 
 - Need every comment in the file → iterate `ctx.Comments.All()`. Don't call
   `ForEachComment` on `ctx.SourceFile.AsNode()` yourself.
-- Need to know whether a comment exists somewhere in a bounded, non-adjacent
-  span (e.g. between two tokens that aren't parent/child) →
-  `utils.HasCommentInSpan(ctx.Comments.All(), start, end)`. It binary-searches
-  the sorted comment list (O(log k), mirrors
+- Need the comments in a bounded, non-adjacent span (e.g. between two tokens
+  that aren't parent/child) → call `utils.CommentsInSpan` with
+  `ctx.Comments.All()`, `start`, and `end`. If only existence matters, use
+  `utils.HasCommentInSpan`. Both binary-search the sorted comment list (mirrors
   ESLint's `TokenStore#commentsExistBetween`) instead of scanning again. This
   matters most when the check runs once per matching AST node (once per
   boolean cast, once per label) — a per-node full-file scan is the

--- a/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.go
+++ b/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.go
@@ -438,7 +438,7 @@ func sortableGroups(ctx rule.RuleContext, element *ast.Node, attrs []*ast.Node) 
 		if next != nil {
 			limit = utils.TrimNodeTextRange(ctx.SourceFile, next).Pos()
 		}
-		between := commentsInSpan(comments, r.End(), limit)
+		between := utils.CommentsInSpan(comments, r.End(), limit)
 		line := scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), r.Pos())
 		absorbNext := func() {
 			nextRange := utils.TrimNodeTextRange(ctx.SourceFile, next)
@@ -449,7 +449,7 @@ func sortableGroups(ctx rule.RuleContext, element *ast.Node, attrs []*ast.Node) 
 			if index+2 < len(attrs) {
 				afterNextLimit = utils.TrimNodeTextRange(ctx.SourceFile, attrs[index+2]).Pos()
 			}
-			nextComments := commentsInSpan(comments, item.end, afterNextLimit)
+			nextComments := utils.CommentsInSpan(comments, item.end, afterNextLimit)
 			if len(nextComments) == 1 && scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), nextRange.Pos()) == scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), nextComments[0].Pos()) {
 				item.end = nextComments[0].End()
 				if nextComments[0].Kind == ast.KindSingleLineCommentTrivia {
@@ -546,13 +546,4 @@ func preservesDuplicateOrder(attrs []*ast.Node, original, sorted []sortableAttri
 		}
 	}
 	return true
-}
-
-func commentsInSpan(comments []*ast.CommentRange, start, end int) []*ast.CommentRange {
-	index := sort.Search(len(comments), func(i int) bool { return comments[i].Pos() >= start })
-	var result []*ast.CommentRange
-	for ; index < len(comments) && comments[index].Pos() < end; index++ {
-		result = append(result, comments[index])
-	}
-	return result
 }

--- a/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.go
+++ b/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.go
@@ -14,8 +14,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
-	"golang.org/x/text/collate"
-	"golang.org/x/text/language"
 )
 
 //go:embed jsx_sort_props.schema.json
@@ -29,6 +27,7 @@ var JsxSortPropsRule = rule.Rule{
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
+		nameComparer := propNameComparer{options: opts}
 		reported := map[*ast.Node]map[string]bool{}
 
 		check := func(element *ast.Node) {
@@ -95,9 +94,11 @@ var JsxSortPropsRule = rule.Rule{
 				currentValue := current.AsJsxAttribute().Initializer != nil
 				previousCallback := isCallback(previousName)
 				currentCallback := isCallback(currentName)
+				previousOrderingName := previousName
+				currentOrderingName := currentName
 				if opts.ignoreCase {
-					previousName = ecmascript.StringToLowerCase(previousName)
-					currentName = ecmascript.StringToLowerCase(currentName)
+					previousOrderingName = ecmascript.StringToLowerCase(previousOrderingName)
+					currentOrderingName = ecmascript.StringToLowerCase(currentOrderingName)
 				}
 
 				if opts.reservedFirst {
@@ -105,8 +106,8 @@ var JsxSortPropsRule = rule.Rule{
 						reportAttr(current, opts.reservedError, opts.reservedDescription, opts.reservedData, true)
 						continue
 					}
-					previousReserved := contains(reserved, previousName)
-					currentReserved := contains(reserved, currentName)
+					previousReserved := contains(reserved, previousOrderingName)
+					currentReserved := contains(reserved, currentOrderingName)
 					if previousReserved && !currentReserved {
 						memo = current
 						continue
@@ -167,7 +168,7 @@ var JsxSortPropsRule = rule.Rule{
 						continue
 					}
 				}
-				if !opts.noSortAlphabetically && compareNames(previousName, currentName, opts) > 0 {
+				if !opts.noSortAlphabetically && nameComparer.Compare(previousName, currentName) > 0 {
 					reportAttr(current, "sortPropsByAlpha", "Props should be sorted alphabetically", nil, false)
 					continue
 				}
@@ -178,6 +179,15 @@ var JsxSortPropsRule = rule.Rule{
 				right := utils.TrimNodeTextRange(ctx.SourceFile, pending[j].attr)
 				return left.Pos() < right.Pos()
 			})
+			var fixes []rule.RuleFix
+			fixesBuilt := false
+			getFixes := func() []rule.RuleFix {
+				if !fixesBuilt {
+					fixes = buildFixes(ctx, element, &nameComparer, reserved)
+					fixesBuilt = true
+				}
+				return fixes
+			}
 			for _, report := range pending {
 				reportNode := report.attr.AsJsxAttribute().Name()
 				if report.wholeAttribute {
@@ -189,7 +199,7 @@ var JsxSortPropsRule = rule.Rule{
 					continue
 				}
 				ctx.ReportNodeWithDeferredFixes(reportNode, message, func() []rule.RuleFix {
-					return buildFixes(ctx, element, opts, reserved)
+					return slices.Clone(getFixes())
 				})
 			}
 		}
@@ -267,44 +277,74 @@ func isMultiline(ctx rule.RuleContext, node *ast.Node) bool {
 	return scanner.ComputeLineOfPosition(lines, r.Pos()) != scanner.ComputeLineOfPosition(lines, r.End())
 }
 
-func compareNames(left, right string, opts options) int {
-	if opts.ignoreCase || opts.locale != "auto" {
-		locale := language.Make(opts.locale)
-		base, _ := locale.Base()
-		if base.String() == "da" && ecmascript.StringToLowerCase(left) == ecmascript.StringToLowerCase(right) {
-			return ecmascript.CompareStrings(left, right)
-		}
-		return collate.New(locale).CompareString(left, right)
+type propNameComparer struct {
+	options        options
+	localeComparer *ecmascript.LocaleComparer
+}
+
+func (c *propNameComparer) Compare(left, right string) int {
+	if c.options.ignoreCase {
+		left = ecmascript.StringToLowerCase(left)
+		right = ecmascript.StringToLowerCase(right)
 	}
-	return ecmascript.CompareStrings(left, right)
+	if !c.options.ignoreCase && c.options.locale == "auto" {
+		return ecmascript.CompareStrings(left, right)
+	}
+	if c.localeComparer == nil {
+		c.localeComparer = ecmascript.NewLocaleComparer(c.options.locale)
+	}
+	return c.localeComparer.Compare(left, right)
 }
 
 type sortableAttribute struct {
-	node       *ast.Node
-	start, end int
-	pinned     bool
+	node                   *ast.Node
+	members                []*ast.Node
+	start, end             int
+	pinned                 bool
+	trailingLineComment    bool
+	trailingLineTerminator string
 }
 
-func buildFixes(ctx rule.RuleContext, element *ast.Node, opts options, reserved []string) []rule.RuleFix {
+func buildFixes(ctx rule.RuleContext, element *ast.Node, nameComparer *propNameComparer, reserved []string) []rule.RuleFix {
 	attrs := reactutil.GetJsxElementAttributes(element)
 	groups := sortableGroups(ctx, element, attrs)
 	text := ctx.SourceFile.Text()
+	elementEnd := utils.TrimNodeTextRange(ctx.SourceFile, element).End()
 	var fixes []rule.RuleFix
 	for _, group := range groups {
 		sorted := slices.Clone(group)
-		sort.SliceStable(sorted, func(i, j int) bool { return compareAttributes(ctx, sorted[i], sorted[j], opts, reserved) < 0 })
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return compareAttributes(ctx, sorted[i], sorted[j], nameComparer, reserved) < 0
+		})
+		if !preservesDuplicateOrder(attrs, group, sorted) {
+			continue
+		}
+		groupFixes := make([]rule.RuleFix, 0, len(group))
+		fixable := true
 		for index, target := range group {
 			source := sorted[index]
 			if target.start == source.start && target.end == source.end {
 				continue
 			}
-			fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(target.start, target.end), text[source.start:source.end]))
+			replacement := text[source.start:source.end]
+			if source.trailingLineComment && !destinationHasLineTerminator(text, target.end, elementEnd) {
+				if source.trailingLineTerminator == "" {
+					fixable = false
+					break
+				}
+				replacement += source.trailingLineTerminator
+			}
+			groupFixes = append(groupFixes, rule.RuleFixReplaceRange(core.NewTextRange(target.start, target.end), replacement))
+		}
+		if fixable {
+			fixes = append(fixes, groupFixes...)
 		}
 	}
 	return fixes
 }
 
-func compareAttributes(ctx rule.RuleContext, left, right sortableAttribute, opts options, reserved []string) int {
+func compareAttributes(ctx rule.RuleContext, left, right sortableAttribute, nameComparer *propNameComparer, reserved []string) int {
+	opts := nameComparer.options
 	if left.pinned != right.pinned {
 		if left.pinned {
 			return 1
@@ -362,10 +402,7 @@ func compareAttributes(ctx rule.RuleContext, left, right sortableAttribute, opts
 	if opts.noSortAlphabetically {
 		return 0
 	}
-	if opts.ignoreCase {
-		leftName, rightName = ecmascript.StringToLowerCase(leftName), ecmascript.StringToLowerCase(rightName)
-	}
-	return compareNames(leftName, rightName, opts)
+	return nameComparer.Compare(leftName, rightName)
 }
 
 func sortableGroups(ctx rule.RuleContext, element *ast.Node, attrs []*ast.Node) [][]sortableAttribute {
@@ -378,6 +415,8 @@ func sortableGroups(ctx rule.RuleContext, element *ast.Node, attrs []*ast.Node) 
 		}
 	}
 	comments := ctx.Comments.All()
+	text := ctx.SourceFile.Text()
+	elementEnd := utils.TrimNodeTextRange(ctx.SourceFile, element).End()
 	for index := 0; index < len(attrs); index++ {
 		attr := attrs[index]
 		if attr.Kind == ast.KindJsxSpreadAttribute {
@@ -388,32 +427,53 @@ func sortableGroups(ctx rule.RuleContext, element *ast.Node, attrs []*ast.Node) 
 			continue
 		}
 		r := utils.TrimNodeTextRange(ctx.SourceFile, attr)
-		item := sortableAttribute{node: attr, start: r.Pos(), end: r.End()}
+		item := sortableAttribute{node: attr, members: []*ast.Node{attr}, start: r.Pos(), end: r.End()}
+		var terminalLineComment *ast.CommentRange
 		var next *ast.Node
 		if index+1 < len(attrs) {
 			next = attrs[index+1]
 		}
 		nextIsAttribute := next != nil && next.Kind == ast.KindJsxAttribute
-		limit := utils.TrimNodeTextRange(ctx.SourceFile, element).End()
+		limit := elementEnd
 		if next != nil {
 			limit = utils.TrimNodeTextRange(ctx.SourceFile, next).Pos()
 		}
 		between := commentsInSpan(comments, r.End(), limit)
 		line := scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), r.Pos())
+		absorbNext := func() {
+			nextRange := utils.TrimNodeTextRange(ctx.SourceFile, next)
+			item.end = nextRange.End()
+			item.members = append(item.members, next)
+			terminalLineComment = nil
+			afterNextLimit := elementEnd
+			if index+2 < len(attrs) {
+				afterNextLimit = utils.TrimNodeTextRange(ctx.SourceFile, attrs[index+2]).Pos()
+			}
+			nextComments := commentsInSpan(comments, item.end, afterNextLimit)
+			if len(nextComments) == 1 && scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), nextRange.Pos()) == scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), nextComments[0].Pos()) {
+				item.end = nextComments[0].End()
+				if nextComments[0].Kind == ast.KindSingleLineCommentTrivia {
+					terminalLineComment = nextComments[0]
+				}
+			}
+		}
 		if len(between) == 1 {
 			commentLine := scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), between[0].Pos())
 			if nextIsAttribute && line+1 == commentLine {
-				item.end = utils.TrimNodeTextRange(ctx.SourceFile, next).End()
+				absorbNext()
 				item.pinned = true
 				index++
 			} else if line == commentLine {
 				if between[0].Kind == ast.KindMultiLineCommentTrivia && nextIsAttribute {
-					item.end = utils.TrimNodeTextRange(ctx.SourceFile, next).End()
+					absorbNext()
 					item.pinned = true
 					index++
 				} else {
 					item.end = between[0].End()
 					item.pinned = between[0].Kind == ast.KindMultiLineCommentTrivia
+					if between[0].Kind == ast.KindSingleLineCommentTrivia {
+						terminalLineComment = between[0]
+					}
 				}
 			} else {
 				continue
@@ -422,23 +482,70 @@ func sortableGroups(ctx rule.RuleContext, element *ast.Node, attrs []*ast.Node) 
 			if !nextIsAttribute || line+1 != scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), between[1].Pos()) {
 				continue
 			}
-			nextRange := utils.TrimNodeTextRange(ctx.SourceFile, next)
-			item.end = nextRange.End()
-			afterNextLimit := utils.TrimNodeTextRange(ctx.SourceFile, element).End()
-			if index+2 < len(attrs) {
-				afterNextLimit = utils.TrimNodeTextRange(ctx.SourceFile, attrs[index+2]).Pos()
-			}
-			nextComments := commentsInSpan(comments, item.end, afterNextLimit)
-			if len(nextComments) == 1 && scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), nextRange.Pos()) == scanner.ComputeLineOfPosition(ctx.SourceFile.ECMALineMap(), nextComments[0].Pos()) {
-				item.end = nextComments[0].End()
-			}
+			absorbNext()
 			item.pinned = true
 			index++
+		}
+		if terminalLineComment != nil {
+			item.trailingLineComment = true
+			item.trailingLineTerminator = ecmascript.LineTerminatorSequenceAt(text, terminalLineComment.End())
 		}
 		group = append(group, item)
 	}
 	flush()
 	return groups
+}
+
+func destinationHasLineTerminator(text string, start, end int) bool {
+	whitespaceEnd := ecmascript.SkipLeadingWhitespace(text, start, end)
+	return ecmascript.ContainsLineTerminator(text, start, whitespaceEnd)
+}
+
+func preservesDuplicateOrder(attrs []*ast.Node, original, sorted []sortableAttribute) bool {
+	originalIndex := make(map[*ast.Node]int, len(attrs))
+	for index, attr := range attrs {
+		if attr.Kind == ast.KindJsxAttribute {
+			originalIndex[attr] = index
+		}
+	}
+
+	replacementByTarget := make(map[*ast.Node]sortableAttribute, len(original))
+	absorbedTargets := make(map[*ast.Node]bool)
+	for index, target := range original {
+		replacementByTarget[target.node] = sorted[index]
+		for _, member := range target.members[1:] {
+			absorbedTargets[member] = true
+		}
+	}
+
+	lastIndexByName := make(map[string]int)
+	seen := make(map[string]bool)
+	visit := func(member *ast.Node) bool {
+		if member.Kind == ast.KindJsxAttribute {
+			name := reactutil.GetJsxPropName(member)
+			memberIndex := originalIndex[member]
+			if seen[name] && memberIndex < lastIndexByName[name] {
+				return false
+			}
+			seen[name] = true
+			lastIndexByName[name] = memberIndex
+		}
+		return true
+	}
+	for _, attr := range attrs {
+		if replacement, ok := replacementByTarget[attr]; ok {
+			for _, member := range replacement.members {
+				if !visit(member) {
+					return false
+				}
+			}
+			continue
+		}
+		if !absorbedTargets[attr] && !visit(attr) {
+			return false
+		}
+	}
+	return true
 }
 
 func commentsInSpan(comments []*ast.CommentRange, start, end int) []*ast.CommentRange {

--- a/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.md
+++ b/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.md
@@ -143,10 +143,10 @@ You can instead provide a non-empty subset of the reserved prop list.
 `"auto"` (the default) uses rslint's default collation for locale-aware
 comparisons when `ignoreCase` is enabled. Provide a locale name to use
 locale-aware ordering even without `ignoreCase`. Unicode collation extensions
-used by `Intl.Collator` (`co`, `kf`, and `kn`) are recognized where the bundled
-collation data supports them. Nordic default collation for ASCII prop names
-follows the Node 24 / ICU 78 ordering used as the compatibility oracle,
-including the `aa` contraction and locale-specific case order.
+used by `Intl.Collator` (`co`, `kf`, and `kn`) are accepted; unsupported
+collations use the locale's default ordering. Nordic locales order ASCII prop
+names like Node 24, including the `aa` contraction and locale-specific case
+order.
 
 ```json
 { "react/jsx-sort-props": ["error", { "locale": "de" }] }
@@ -161,17 +161,12 @@ including the `aa` contraction and locale-specific case order.
 - With `locale: "auto"`, rslint uses a deterministic default collation instead
   of the host environment's locale. Set an explicit locale such as `"de"` when
   locale-specific ordering is required.
-- Explicit locales also use deterministic bundled collation data. ECMA-402
-  permits locale data to vary by implementation, so locales outside the
-  compatibility cases above can differ from an ESLint runtime that bundles a
-  different ICU/CLDR version.
-- Locale strings are expected to be well-formed BCP 47 tags. Invalid tags can
-  fall back deterministically instead of throwing the `RangeError` produced by
-  an ESLint JavaScript runtime.
-- Autofixes preserve the source order of duplicate props. If moving a
-  comment-bearing attribute block would reverse duplicate props and change
-  JSX's last-value-wins result, rslint reports the ordering error without
-  offering that unsafe fix.
+- With an explicit `locale`, rslint can order some Unicode or mixed-case prop
+  names differently from ESLint.
+- With a malformed `locale`, rslint continues linting with its default order;
+  ESLint stops with a `RangeError`.
+- If sorting a comment-attached block would reverse duplicate props, rslint
+  reports the order without a fix; ESLint can change which prop value wins.
 - rslint accepts only strings in a `reservedFirst` array. ESLint accepts other
   values and reports them as invalid rule options during linting; rslint rejects
   those configurations during schema validation.

--- a/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.md
+++ b/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props.md
@@ -142,7 +142,11 @@ You can instead provide a non-empty subset of the reserved prop list.
 
 `"auto"` (the default) uses rslint's default collation for locale-aware
 comparisons when `ignoreCase` is enabled. Provide a locale name to use
-locale-aware ordering even without `ignoreCase`.
+locale-aware ordering even without `ignoreCase`. Unicode collation extensions
+used by `Intl.Collator` (`co`, `kf`, and `kn`) are recognized where the bundled
+collation data supports them. Nordic default collation for ASCII prop names
+follows the Node 24 / ICU 78 ordering used as the compatibility oracle,
+including the `aa` contraction and locale-specific case order.
 
 ```json
 { "react/jsx-sort-props": ["error", { "locale": "de" }] }
@@ -157,6 +161,17 @@ locale-aware ordering even without `ignoreCase`.
 - With `locale: "auto"`, rslint uses a deterministic default collation instead
   of the host environment's locale. Set an explicit locale such as `"de"` when
   locale-specific ordering is required.
+- Explicit locales also use deterministic bundled collation data. ECMA-402
+  permits locale data to vary by implementation, so locales outside the
+  compatibility cases above can differ from an ESLint runtime that bundles a
+  different ICU/CLDR version.
+- Locale strings are expected to be well-formed BCP 47 tags. Invalid tags can
+  fall back deterministically instead of throwing the `RangeError` produced by
+  an ESLint JavaScript runtime.
+- Autofixes preserve the source order of duplicate props. If moving a
+  comment-bearing attribute block would reverse duplicate props and change
+  JSX's last-value-wins result, rslint reports the ordering error without
+  offering that unsafe fix.
 - rslint accepts only strings in a `reservedFirst` array. ESLint accepts other
   values and reports them as invalid rule options during linting; rslint rejects
   those configurations during schema validation.

--- a/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props_extras_test.go
+++ b/internal/plugins/react/rules/jsx_sort_props/jsx_sort_props_extras_test.go
@@ -3,9 +3,14 @@
 package jsx_sort_props
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -22,6 +27,40 @@ func TestJsxSortPropsExtras(t *testing.T) {
 		// ---- Real-user: issue #1632 gives reserved props precedence over callbacks. ----
 		{Code: `<App key={1} a onClick={fn} />`, Tsx: true, Options: map[string]any{"reservedFirst": true, "callbacksLast": true}},
 	}, []rule_tester.InvalidTestCase{
+		// A moved line comment carries its exact terminator when the destination
+		// slot would otherwise let it consume the closing tag.
+		{Code: "<App b={1} // c\n  a={1} />", Tsx: true, Output: []string{"<App a={1}\n  b={1} // c\n />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		// The source slot keeps its separator even with no indentation, so the
+		// replacement cannot fuse two shorthand prop names.
+		{Code: "<App b // c\na />", Tsx: true, Output: []string{"<App a\nb // c\n />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		// The same guard protects ordinary attributes and spreads later on the
+		// destination line, not just an inline closing tag.
+		{Code: "<App\n b // b\n c a\n/>", Tsx: true, Output: []string{"<App\n a\n b // b\n c\n/>"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		{Code: "<App\n b // b\n a {...p}\n/>", Tsx: true, Output: []string{"<App\n a\n b // b\n {...p}\n/>"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		{Code: "<App b // b\n a>child</App>", Tsx: true, Output: []string{"<App a\n b // b\n>child</App>"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		// CRLF and the non-ASCII ECMAScript line separators are preserved rather
+		// than normalized while moving a trailing line comment.
+		{Code: "<App b // b\r\n a />", Tsx: true, Output: []string{"<App a\r\n b // b\r\n />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		{Code: "<App b // b\r a />", Tsx: true, Output: []string{"<App a\r b // b\r />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		{Code: "<App b // b\u2028 a />", Tsx: true, Output: []string{"<App a\u2028 b // b\u2028 />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		{Code: "<App b // b\u2029 a />", Tsx: true, Output: []string{"<App a\u2029 b // b\u2029 />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		// Each moved line-comment source is checked independently; a source that
+		// remains in its own slot does not receive another terminator.
+		{Code: "<App c // c\n b // b\n a d />", Tsx: true, Output: []string{"<App a\n b // b\n c // c\n d />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}, {MessageId: "sortPropsByAlpha"}}},
+		// Sorting comment blocks must not reverse duplicate props: JSX uses the
+		// last duplicate value, so this group is reported but deliberately not fixed.
+		{Code: `<App z="z" /* c */ x="first" a x="last" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}, {MessageId: "sortPropsByAlpha"}, {MessageId: "sortPropsByAlpha"}}},
+		// Attributes excluded by a complex comment sequence are stationary but
+		// still participate in the projected duplicate order.
+		{Code: "<App z x=\"first\" /* one */ // two\n x=\"last\" />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}, {MessageId: "sortPropsByAlpha"}}},
+		// Stable duplicate order remains fixable when the projected sequence
+		// keeps the same last-value-wins attribute.
+		{Code: `<App b a="first" a="last" />`, Tsx: true, Output: []string{`<App a="first" a="last" b />`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}, {MessageId: "sortPropsByAlpha"}}},
+		// Explicit locale ordering follows localeCompare for the Nordic cases
+		// where x/text's old bundled tables disagree with Node 24 / ICU 78.
+		{Code: `<App aa b />`, Tsx: true, Options: map[string]any{"locale": "nb"}, Output: []string{`<App b aa />`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		{Code: `<App AA aA />`, Tsx: true, Options: map[string]any{"locale": "da"}, Output: []string{`<App aA AA />`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
+		{Code: `<App a A />`, Tsx: true, Options: map[string]any{"locale": "mt"}, Output: []string{`<App A a />`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}}},
 		// A comment after a spread stays outside the sortable group that follows it.
 		{Code: `<App {...p} /* gap */ d c />`, Tsx: true, Output: []string{`<App {...p} /* gap */ c d />`}, Errors: []rule_tester.InvalidTestCaseError{jsxSortError("sortPropsByAlpha", "Props should be sorted alphabetically", 1, 25)}},
 		{Code: "<App {...p}\n /* gap */\n d c />", Tsx: true, Output: []string{"<App {...p}\n /* gap */\n c d />"}, Errors: []rule_tester.InvalidTestCaseError{jsxSortError("sortPropsByAlpha", "Props should be sorted alphabetically", 3, 4)}},
@@ -50,9 +89,114 @@ func TestJsxSortPropsExtras(t *testing.T) {
 		{Code: `<App b /* b */ {...p} d c />`, Tsx: true, Output: []string{`<App b /* b */ {...p} c d />`}, Errors: []rule_tester.InvalidTestCaseError{jsxSortError("sortPropsByAlpha", "Props should be sorted alphabetically", 1, 25)}},
 		// A trailing comment on the attribute absorbed by a preceding comment stays with that attribute.
 		{Code: "<App\n b /* b */\n // leading a\n a // a\n c\n/>", Tsx: true, Output: []string{"<App\n c\n b /* b */\n // leading a\n a // a\n/>"}, Errors: []rule_tester.InvalidTestCaseError{jsxSortError("sortPropsByAlpha", "Props should be sorted alphabetically", 4, 2)}},
+		// An absorbed attribute's trailing // also receives a terminator when its
+		// block moves into an inline closing-tag slot.
+		{Code: "<App\n z /* z */\n // leading b\n b // b\n a />", Tsx: true, Output: []string{"<App\n a\n z /* z */\n // leading b\n b // b\n />"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "sortPropsByAlpha"}, {MessageId: "sortPropsByAlpha"}}},
 		// Invalid custom lists report every ordinary prop without applying the sorter.
 		{Code: `<App b a />`, Tsx: true, Options: map[string]any{"reservedFirst": []any{}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "listIsEmpty"}, {MessageId: "listIsEmpty"}}},
 		// A leading spread does not hide the following ordinary prop from validation.
 		{Code: `<App {...p} key={1} />`, Tsx: true, Options: map[string]any{"reservedFirst": []any{}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "listIsEmpty"}}},
 	})
+}
+
+func TestDestinationHasLineTerminator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		gap  string
+		want bool
+	}{
+		{name: "line feed", gap: "  \n next", want: true},
+		{name: "line separator", gap: "\u2028next", want: true},
+		{name: "same line token", gap: "  next"},
+		// A comment is a token boundary for this scan. Its internal newline
+		// cannot protect the comment opener from a moved // comment.
+		{name: "block comment containing newline", gap: " /* gap\n */ next"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := destinationHasLineTerminator(test.gap, 0, len(test.gap)); got != test.want {
+				t.Fatalf("destinationHasLineTerminator(%q) = %v, want %v", test.gap, got, test.want)
+			}
+		})
+	}
+}
+
+// TestJsxSortPropsEditDemand locks the deferred-fix contract: asking only for
+// diagnostics or suggestions must not materialize the shared element fix plan.
+func TestJsxSortPropsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(`<App c b a />`, "edit-demand.tsx", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name:     JsxSortPropsRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return JsxSortPropsRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got, want := withoutEdits(diagnostics[index]), withoutEdits(allEdits[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if len(*allEdits[index].FixesPtr) == 0 {
+			t.Fatalf("diagnostic %d: all-edits demand produced no fixes", index)
+		}
+		if allEdits[index].Suggestions != nil {
+			t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+		}
+	}
 }

--- a/internal/utils/ecmascript/locale_compare.go
+++ b/internal/utils/ecmascript/locale_compare.go
@@ -1,0 +1,144 @@
+package ecmascript
+
+import (
+	"unicode/utf8"
+
+	"github.com/web-infra-dev/rslint/internal/utils/unicode17"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
+)
+
+// LocaleComparer compares strings with the locale-sensitive semantics used by
+// String.prototype.localeCompare. A comparer owns mutable collation iterators,
+// so callers must not use one concurrently. Reusing it for one rule run avoids
+// rebuilding the collation tables for every comparison.
+//
+// ECMA-402 deliberately leaves the locale data implementation-defined. This
+// implementation uses the repository's bundled x/text data, filters Unicode
+// extension keys to the ones Intl.Collator reads (co, kf, and kn), and carries
+// the modern Nordic tailoring that x/text's old CLDR tables lack. The ASCII
+// correction and tested case-first ordering match the Node 24 /
+// ICU 78 oracle; other locale-data differences remain deterministic rather
+// than depending on the host operating system.
+type LocaleComparer struct {
+	collator       *collate.Collator
+	foldedCollator *collate.Collator
+	upperFirst     bool
+}
+
+// NewLocaleComparer constructs a reusable locale comparer. The empty locale
+// and "auto" select the deterministic root collation this port uses when the
+// JavaScript call supplies no explicit locale.
+func NewLocaleComparer(locale string) *LocaleComparer {
+	tag := language.Und
+	if locale != "" && locale != "auto" {
+		tag = language.Make(locale)
+	}
+
+	base, _ := tag.Base()
+	baseName := base.String()
+	caseFirst := tag.TypeForKey("kf")
+	cleanTag := intlCollationTag(tag)
+
+	// x/text is pinned to CLDR 23, whose Norwegian tables put "aa" with
+	// ordinary a instead of treating it like the final letter å. Danish uses
+	// the same Nordic contraction and end-of-alphabet order for the ASCII
+	// identifier domain, so it supplies the missing modern no/nb/nn tailoring.
+	// x/text advertises no alternative collation for these locales, so any co
+	// request is unsupported by this implementation and falls back to default,
+	// as Intl.Collator requires.
+	if baseName == "no" || baseName == "nb" || baseName == "nn" {
+		cleanTag = language.Danish
+		if numeric := tag.TypeForKey("kn"); numeric != "" {
+			if numeric == "true" || numeric == "false" {
+				cleanTag, _ = cleanTag.SetTypeForKey("kn", numeric)
+			}
+		}
+	}
+
+	upperFirst := caseFirst == "upper"
+	if caseFirst != "upper" && caseFirst != "lower" && caseFirst != "false" {
+		// These are the CLDR locales whose default sorting collation puts
+		// uppercase first. Keep this locale data here rather than in callers.
+		upperFirst = baseName == "da" || baseName == "mt"
+	}
+	comparer := &LocaleComparer{collator: collate.New(cleanTag), upperFirst: upperFirst}
+	if upperFirst {
+		// x/text has no kf implementation. Comparing without tertiary case
+		// weights first lets us reverse only a true case tie, without undoing
+		// locale contractions such as Danish "aa".
+		comparer.foldedCollator = collate.New(cleanTag, collate.IgnoreCase)
+	}
+	return comparer
+}
+
+// Compare returns -1, 0, or 1 according to the configured locale order.
+func (c *LocaleComparer) Compare(left, right string) int {
+	if c.upperFirst {
+		if result := c.foldedCollator.CompareString(left, right); result != 0 {
+			return result
+		}
+		if result := compareUpperFirstCase(left, right); result != 0 {
+			return result
+		}
+	}
+	return c.collator.CompareString(left, right)
+}
+
+func compareUpperFirstCase(left, right string) int {
+	leftPos, rightPos := 0, 0
+	for {
+		leftWeight, nextLeft, leftOK := nextCaseWeight(left, leftPos)
+		rightWeight, nextRight, rightOK := nextCaseWeight(right, rightPos)
+		if !leftOK || !rightOK {
+			switch {
+			case leftOK:
+				return 1
+			case rightOK:
+				return -1
+			default:
+				return 0
+			}
+		}
+		if leftWeight < rightWeight {
+			return -1
+		}
+		if leftWeight > rightWeight {
+			return 1
+		}
+		leftPos, rightPos = nextLeft, nextRight
+	}
+}
+
+func nextCaseWeight(value string, pos int) (weight, next int, ok bool) {
+	for pos < len(value) {
+		r, size := utf8.DecodeRuneInString(value[pos:])
+		pos += size
+		switch {
+		case unicode17.IsUppercase(r), unicode17.IsTitle(r):
+			return 0, pos, true
+		case unicode17.IsLowercase(r):
+			return 1, pos, true
+		}
+	}
+	return 0, pos, false
+}
+
+// intlCollationTag removes Unicode extension keys that Intl.Collator does not
+// read. x/text otherwise gives keys such as ks, kc, kb, and ka meaning even
+// though ECMA-402 only admits co, kf, and kn for collation.
+func intlCollationTag(tag language.Tag) language.Tag {
+	clean, _ := language.Compose(tag, []language.Extension{})
+	for _, key := range []string{"co", "kn"} {
+		if value := tag.TypeForKey(key); value != "" {
+			if key == "co" && (value == "default" || value == "standard") {
+				continue
+			}
+			if key == "kn" && value != "true" && value != "false" {
+				continue
+			}
+			clean, _ = clean.SetTypeForKey(key, value)
+		}
+	}
+	return clean
+}

--- a/internal/utils/ecmascript/locale_compare_test.go
+++ b/internal/utils/ecmascript/locale_compare_test.go
@@ -1,0 +1,66 @@
+package ecmascript
+
+import (
+	"slices"
+	"sort"
+	"testing"
+)
+
+func TestLocaleComparer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name, locale string
+		input        []string
+		want         []string
+	}{
+		{name: "Danish contraction", locale: "da", input: []string{"aa", "b"}, want: []string{"b", "aa"}},
+		{name: "Danish default upper first", locale: "da", input: []string{"ch", "cH", "Ch", "CH"}, want: []string{"CH", "Ch", "cH", "ch"}},
+		{name: "Danish contraction case weights", locale: "da", input: []string{"aa", "Aa", "AA", "aA"}, want: []string{"aA", "AA", "Aa", "aa"}},
+		{name: "Norwegian", locale: "nb", input: []string{"aa", "b"}, want: []string{"b", "aa"}},
+		{name: "Norwegian", locale: "no-NO", input: []string{"aa", "b"}, want: []string{"b", "aa"}},
+		{name: "Norwegian Nynorsk", locale: "nn-NO", input: []string{"aa", "b"}, want: []string{"b", "aa"}},
+		{name: "Norwegian default lower first", locale: "nb", input: []string{"CH", "Ch", "cH", "ch"}, want: []string{"ch", "cH", "Ch", "CH"}},
+		{name: "Norwegian contraction case weights", locale: "nb", input: []string{"AA", "Aa", "aa", "aA"}, want: []string{"aA", "aa", "Aa", "AA"}},
+		{name: "explicit upper first", locale: "nb-u-kf-upper", input: []string{"ch", "cH", "Ch", "CH"}, want: []string{"CH", "Ch", "cH", "ch"}},
+		{name: "explicit lower first", locale: "da-u-kf-lower", input: []string{"CH", "Ch", "cH", "ch"}, want: []string{"ch", "cH", "Ch", "CH"}},
+		{name: "unsupported case first uses locale default", locale: "da-u-kf-foobar", input: []string{"a", "A"}, want: []string{"A", "a"}},
+		{name: "valueless case first uses locale default", locale: "da-u-kf", input: []string{"a", "A"}, want: []string{"A", "a"}},
+		{name: "case first preserves non-case tertiary order", locale: "en-u-kf-upper", input: []string{"ａ", "a", "Ａ", "A"}, want: []string{"A", "Ａ", "a", "ａ"}},
+		{name: "Maltese default upper first", locale: "mt", input: []string{"a", "A"}, want: []string{"A", "a"}},
+		{name: "numeric", locale: "nb-u-kn-true", input: []string{"a10", "a2"}, want: []string{"a2", "a10"}},
+		{name: "unsupported Nordic collation falls back to default", locale: "nb-u-co-phonebk", input: []string{"aa", "b"}, want: []string{"b", "aa"}},
+		{name: "irrelevant strength key", locale: "en-u-ks-level1", input: []string{"A", "a"}, want: []string{"a", "A"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			comparer := NewLocaleComparer(test.locale)
+			got := slices.Clone(test.input)
+			sort.SliceStable(got, func(i, j int) bool {
+				return comparer.Compare(got[i], got[j]) < 0
+			})
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("locale %q sorted %q, want %q", test.locale, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLocaleComparerUpperFirstIsTransitive(t *testing.T) {
+	t.Parallel()
+
+	comparer := NewLocaleComparer("en-u-kf-upper")
+	values := []string{"A", "Ａ", "a", "ａ"}
+	for _, left := range values {
+		for _, middle := range values {
+			for _, right := range values {
+				if comparer.Compare(left, middle) < 0 && comparer.Compare(middle, right) < 0 && comparer.Compare(left, right) >= 0 {
+					t.Fatalf("non-transitive order: %q < %q < %q", left, middle, right)
+				}
+			}
+		}
+	}
+}

--- a/internal/utils/ecmascript/trivia.go
+++ b/internal/utils/ecmascript/trivia.go
@@ -99,6 +99,35 @@ func ContainsLineTerminator(text string, low, high int) bool {
 	return false
 }
 
+// LineTerminatorSequenceAt returns the exact ECMAScript LineTerminatorSequence
+// beginning at byte position pos. CRLF is returned as one sequence; the other
+// possibilities are LF, CR, LS (U+2028), and PS (U+2029). An empty result means
+// pos does not begin a line terminator.
+func LineTerminatorSequenceAt(text string, pos int) string {
+	if pos < 0 || pos >= len(text) {
+		return ""
+	}
+	switch text[pos] {
+	case '\n':
+		return "\n"
+	case '\r':
+		if pos+1 < len(text) && text[pos+1] == '\n' {
+			return "\r\n"
+		}
+		return "\r"
+	case 0xE2:
+		if pos+2 < len(text) && text[pos+1] == 0x80 {
+			switch text[pos+2] {
+			case 0xA8:
+				return "\u2028"
+			case 0xA9:
+				return "\u2029"
+			}
+		}
+	}
+	return ""
+}
+
 // SkipLeadingWhitespace walks forward from `low` through ECMAScript trivia
 // whitespace and line terminators (the union of §12.2 WhiteSpace and §12.3
 // LineTerminator), returning the position of the first non-whitespace byte

--- a/internal/utils/ecmascript/trivia_test.go
+++ b/internal/utils/ecmascript/trivia_test.go
@@ -96,6 +96,32 @@ func TestContainsLineTerminator_RangeClamping(t *testing.T) {
 	}
 }
 
+func TestLineTerminatorSequenceAt(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		pos  int
+		want string
+	}{
+		{name: "LF", text: "a\nb", pos: 1, want: "\n"},
+		{name: "CRLF", text: "a\r\nb", pos: 1, want: "\r\n"},
+		{name: "CR", text: "a\rb", pos: 1, want: "\r"},
+		{name: "LS", text: "a\u2028b", pos: 1, want: "\u2028"},
+		{name: "PS", text: "a\u2029b", pos: 1, want: "\u2029"},
+		{name: "middle of CRLF", text: "a\r\nb", pos: 2, want: "\n"},
+		{name: "ordinary byte", text: "abc", pos: 1},
+		{name: "out of bounds low", text: "abc", pos: -1},
+		{name: "out of bounds high", text: "abc", pos: 3},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := LineTerminatorSequenceAt(test.text, test.pos); got != test.want {
+				t.Fatalf("LineTerminatorSequenceAt(%q, %d) = %q, want %q", test.text, test.pos, got, test.want)
+			}
+		})
+	}
+}
+
 func TestSkipTrailingWhitespace(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/utils/ecmascript/whitespace.go
+++ b/internal/utils/ecmascript/whitespace.go
@@ -14,9 +14,9 @@
 // or, where the language spells out no name at all, the question being asked
 // ([IsBlank]).
 //
-// Everything here is a pure function of its arguments. Only
-// [IsValidRegexLiteral] reaches past the standard library, for the scanner that
-// reads a regexp literal, and a rule carries that dependency already.
+// Most helpers here are pure functions of their arguments. [LocaleComparer]
+// is the exception: it owns mutable collation scratch state so one rule run can
+// reuse the expensive tables without sharing them concurrently.
 //
 // The one larger piece of the language a rule has to reproduce lives in
 // [ecmascript/regexp], which compiles a JavaScript RegExp and closes the gaps

--- a/internal/utils/for_each_comment_test.go
+++ b/internal/utils/for_each_comment_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -154,19 +155,41 @@ func TestHasCommentInSpan(t *testing.T) {
 		comments = append(comments, comment)
 	}, sf)
 	sort.Slice(comments, func(i, j int) bool { return comments[i].Pos() < comments[j].Pos() })
+	comments = slices.CompactFunc(comments, func(left, right *ast.CommentRange) bool {
+		return left.Pos() == right.Pos() && left.End() == right.End()
+	})
 
 	commentGapStart := strings.Index(src, "1")
 	commentGapEnd := strings.Index(src, "+")
+	commentsInGap := CommentsInSpan(comments, commentGapStart, commentGapEnd)
+	if len(commentsInGap) != 1 || src[commentsInGap[0].Pos():commentsInGap[0].End()] != "/* real */" {
+		t.Fatalf("CommentsInSpan returned %#v, want the real block comment", commentsInGap)
+	}
 	if !HasCommentInSpan(comments, commentGapStart, commentGapEnd) {
 		t.Fatal("expected real block comment in numeric-expression gap")
+	}
+	if got := CommentsInSpan(comments, commentsInGap[0].Pos()+1, commentsInGap[0].End()); len(got) != 1 {
+		t.Fatalf("span beginning inside a comment returned %d comments, want 1", len(got))
+	}
+	if got := CommentsInSpan(comments, commentsInGap[0].Pos()-1, commentsInGap[0].Pos()); len(got) != 0 {
+		t.Fatalf("span ending at a comment returned %d comments, want 0", len(got))
+	}
+	if got := CommentsInSpan(comments, commentsInGap[0].End(), commentsInGap[0].End()+1); len(got) != 0 {
+		t.Fatalf("span starting after a comment returned %d comments, want 0", len(got))
 	}
 
 	stringStart := strings.Index(src, `"/*`)
 	stringEnd := strings.Index(src, `*/"`) + len(`*/"`)
+	if got := CommentsInSpan(comments, stringStart, stringEnd); len(got) != 0 {
+		t.Fatalf("string literal comment markers returned %d comments, want 0", len(got))
+	}
 	if HasCommentInSpan(comments, stringStart, stringEnd) {
 		t.Fatal("string literal comment markers must not count as comments")
 	}
 
+	if got := CommentsInSpan(comments, commentGapStart, commentGapStart); got != nil {
+		t.Fatalf("empty span returned comments: %#v", got)
+	}
 	if HasCommentInSpan(comments, commentGapStart, commentGapStart) {
 		t.Fatal("empty span must not contain comments")
 	}

--- a/internal/utils/unicode17/unicode17.go
+++ b/internal/utils/unicode17/unicode17.go
@@ -153,6 +153,26 @@ func IsLower(r rune) bool {
 	return unicode.IsLower(r) || unicode.Is(lowerAdded, r)
 }
 
+// IsUppercase reports the Unicode Uppercase derived property as Unicode 17
+// defines it. It includes uppercase letters and Other_Uppercase characters
+// such as Roman numerals.
+func IsUppercase(r rune) bool {
+	return IsUpper(r) || unicode.Is(unicode.Other_Uppercase, r)
+}
+
+// IsLowercase reports the Unicode Lowercase derived property as Unicode 17
+// defines it. It includes lowercase letters and Other_Lowercase characters.
+func IsLowercase(r rune) bool {
+	return IsLower(r) || unicode.Is(unicode.Other_Lowercase, r)
+}
+
+// IsTitle reports whether r is a title-case letter (general category Lt).
+// Unicode 16 and 17 added no characters to this category, so the toolchain's
+// table already carries the complete answer.
+func IsTitle(r rune) bool {
+	return unicode.Is(unicode.Lt, r)
+}
+
 // IsLetter says for the category L what [IsUpper] says for Lu. Most of what it
 // adds is the scripts the two editions brought in whole.
 func IsLetter(r rune) bool {

--- a/internal/utils/unicode17/unicode17_test.go
+++ b/internal/utils/unicode17/unicode17_test.go
@@ -169,6 +169,34 @@ func TestCasedLettersAreLetters(t *testing.T) {
 	}
 }
 
+func TestCaseClassification(t *testing.T) {
+	tests := []struct {
+		name                        string
+		r                           rune
+		uppercase, lowercase, title bool
+	}{
+		{name: "uppercase letter", r: 'A', uppercase: true},
+		{name: "lowercase letter", r: 'a', lowercase: true},
+		{name: "other uppercase", r: '\u2160', uppercase: true},
+		{name: "other lowercase", r: '\u2170', lowercase: true},
+		{name: "title-case letter", r: '\u01C5', title: true},
+		{name: "uncased letter", r: '\u4E2D'},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsUppercase(test.r); got != test.uppercase {
+				t.Errorf("IsUppercase(%U) = %v, want %v", test.r, got, test.uppercase)
+			}
+			if got := IsLowercase(test.r); got != test.lowercase {
+				t.Errorf("IsLowercase(%U) = %v, want %v", test.r, got, test.lowercase)
+			}
+			if got := IsTitle(test.r); got != test.title {
+				t.Errorf("IsTitle(%U) = %v, want %v", test.r, got, test.title)
+			}
+		})
+	}
+}
+
 // runesOf walks out every character a table names.
 func runesOf(table *unicode.RangeTable) []rune {
 	var runes []rune

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -201,23 +201,43 @@ func HasCommentInsideNode(sourceFile *ast.SourceFile, node *ast.Node) bool {
 	return hasComment
 }
 
-// HasCommentInSpan reports whether any comment in sourceComments overlaps the
+// CommentsInSpan returns a read-only view of the comments that overlap the
 // half-open source span [start, end). sourceComments must be sorted by
-// position — pass ctx.Comments.All(), which the linter builds lazily
-// once per file. Runs in O(log k) via binary search over the (typically
-// small) comment list, the same technique ESLint's TokenStore uses for
-// commentsExistBetween, instead of re-walking the whole file's token tree on
-// every call.
+// position — pass ctx.Comments.All(), which the linter builds lazily once per
+// file. The result aliases sourceComments and runs in O(log k + m), where m is
+// the number of returned comments.
+func CommentsInSpan(sourceComments []*ast.CommentRange, start int, end int) []*ast.CommentRange {
+	if start >= end {
+		return nil
+	}
+
+	first := firstCommentOverlappingSpan(sourceComments, start)
+	if first == len(sourceComments) || sourceComments[first].Pos() >= end {
+		return nil
+	}
+	last := first + sort.Search(len(sourceComments)-first, func(i int) bool {
+		return sourceComments[first+i].Pos() >= end
+	})
+	return sourceComments[first:last]
+}
+
+// HasCommentInSpan reports whether any comment in sourceComments overlaps the
+// half-open source span [start, end). It has the same input contract as
+// CommentsInSpan and runs in O(log k).
 func HasCommentInSpan(sourceComments []*ast.CommentRange, start int, end int) bool {
 	if start >= end {
 		return false
 	}
+	first := firstCommentOverlappingSpan(sourceComments, start)
+	return first < len(sourceComments) && sourceComments[first].Pos() < end
+}
 
-	idx := sort.Search(len(sourceComments), func(i int) bool { return sourceComments[i].Pos() >= start })
-	if idx > 0 && sourceComments[idx-1].End() > start {
-		return true
+func firstCommentOverlappingSpan(sourceComments []*ast.CommentRange, start int) int {
+	first := sort.Search(len(sourceComments), func(i int) bool { return sourceComments[i].Pos() >= start })
+	if first > 0 && sourceComments[first-1].End() > start {
+		return first - 1
 	}
-	return idx < len(sourceComments) && sourceComments[idx].Pos() < end
+	return first
 }
 
 func TypeRecurser(t *checker.Type, predicate func(t *checker.Type) /* should stop */ bool) bool {


### PR DESCRIPTION
## Summary

- Preserve exact ECMAScript line terminators when moving JSX attributes with trailing line comments, preventing fixes from swallowing closing tags, later props, or spreads.
- Centralize deterministic locale comparison in `internal/utils/ecmascript`, including Node 24 / ICU 78 compatible Nordic ASCII contractions and case-first ordering.
- Suppress fixes that would reverse duplicate prop order and change JSX last-value-wins semantics, while reusing locale and fix-planning state.

## Related Links

- https://github.com/jsx-eslint/eslint-plugin-react/tree/v7.37.5

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).