### PR TITLE
fix: correct exported directive scope resolution

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -2151,23 +2151,14 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	// upstream counts the directive itself as a use. reportUsedIgnorePattern
 	// still sees it as used, which is what turns a directive on an ignored name
 	// into a usedIgnoredVar report.
-	if !varInfo.Used && ctx.IsExportedGlobalBinding(definition, name) {
+	if !varInfo.Used && ctx.IsExportedGlobalBinding(rawSym, name) {
 		varInfo.Used = true
 		varInfo.OnlyUsedAsType = false
 	}
 
 	// vars: "local" — skip top-level (global scope) variable declarations.
-	if opts.Vars == "local" && !isParameterNode(definition) && !isCaughtErrorNode(definition) {
-		if definition != nil && definition.Parent != nil {
-			parent := definition.Parent
-			// VariableDeclaration → VariableDeclarationList → VariableStatement → SourceFile
-			for parent != nil && (parent.Kind == ast.KindVariableDeclarationList || parent.Kind == ast.KindVariableStatement) {
-				parent = parent.Parent
-			}
-			if parent != nil && parent.Kind == ast.KindSourceFile {
-				return
-			}
-		}
+	if opts.Vars == "local" && ctx.IsGlobalScopeBinding(rawSym, name) {
+		return
 	}
 
 	// For type-level declarations and imports, being used in a type context
@@ -2629,12 +2620,14 @@ var NoUnusedVarsRule = rule.CreateRule(rule.Rule{
 
 			ast.KindTypeParameter: func(node *ast.Node) {
 				// Generic type parameter declarations: `<T>`, `<T = unknown>`, `<T extends U>`.
-				// Skip nodes that syntactically share KindTypeParameter in tsgo but aren't
-				// parameter declarations: `infer T`, mapped-type `[P in K]`, JSDoc @template.
+				// Skip nodes that syntactically share KindTypeParameter in tsgo but the
+				// TypeScript rule intentionally treats as used: mapped-type `[P in K]`
+				// bindings and JSDoc @template metadata. `infer T` remains an ordinary
+				// scope variable and is checked.
 				parent := node.Parent
 				if parent != nil {
 					switch parent.Kind {
-					case ast.KindInferType, ast.KindMappedType, ast.KindJSDocTemplateTag:
+					case ast.KindMappedType, ast.KindJSDocTemplateTag:
 						return
 					}
 				}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.md
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.md
@@ -83,12 +83,20 @@ var PublicValue = 1;
 type PublicType = string;
 ```
 
-The comment resolves each name against the global scope, so it applies to a
-file whose top level is that scope — one with no `import`/`export` of its own.
-A module's top-level binding, a block binding, and a function's parameters live
-in their own scopes and are still reported.
+The comment resolves each name only against the outer global scope. Whether a
+file has that scope is determined by its effective
+`languageOptions.sourceType`, not by the presence of `import` or `export`
+syntax. With flat config, omitting `sourceType` makes `.js` and `.ts` files
+modules even when they contain no module syntax, so the comment has no effect.
+Set `sourceType: "script"` for a shared script.
+
+Module bindings, bindings in a JavaScript CommonJS wrapper, block bindings,
+function parameters, and nested type bindings are still reported. An exact,
+case-sensitive `.cjs` extension defaults to the CommonJS wrapper.
+TypeScript-flavoured files configured as `commonjs` retain a global program
+scope, so their top-level bindings can be marked by the comment.
 
 ## Original Documentation
 
 - [typescript-eslint: no-unused-vars](https://typescript-eslint.io/rules/no-unused-vars)
-- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-unused-vars.ts)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/rules/no-unused-vars.ts)

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_exported_scope_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_exported_scope_test.go
@@ -1,0 +1,190 @@
+package no_unused_vars
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedVarsExportedDirectiveInternalBindings(t *testing.T) {
+	script := rule.LanguageOptions{SourceType: "script"}
+	unusedT := func(line, column int) rule_tester.InvalidTestCaseError {
+		return rule_tester.InvalidTestCaseError{MessageId: "unusedVar", Line: line, Column: column}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{
+			// The effective source goal, rather than import/export syntax, selects
+			// the global program scope.
+			{
+				Code: `/* exported T */
+type T = string;
+export {};`,
+				LanguageOptions: script,
+			},
+			{
+				Code:            `/* exported T */ export type T = string;`,
+				LanguageOptions: script,
+			},
+			// A named default export has distinct local and export symbols. The
+			// local binding still belongs to the script global scope and vars:local
+			// must skip it before reportUsedIgnorePattern is considered.
+			{
+				Code:            `export default function _f() {} consume(_f);`,
+				LanguageOptions: script,
+				Options: map[string]interface{}{
+					"vars":                    "local",
+					"varsIgnorePattern":       "^_",
+					"reportUsedIgnorePattern": true,
+				},
+			},
+			{
+				Code:            `/* exported T */ type T = string;`,
+				FileName:        "exported.ts",
+				LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"},
+			},
+			// An ignored internal binding is unused, not a directive-created use.
+			{
+				Code:            `/* exported T */ type A<T> = string; consume(null as A<number>);`,
+				LanguageOptions: script,
+				Options: map[string]interface{}{
+					"varsIgnorePattern":       "^T$",
+					"reportUsedIgnorePattern": true,
+				},
+			},
+			// These scope-manager bindings are intentionally ignored by the
+			// TypeScript rule, independently of the directive.
+			{Code: `/* exported T */ type A<U> = { [T in keyof U]: string }; consume(null as A<{ x: 1 }>);`, LanguageOptions: script},
+			{Code: `/* exported T */ enum A { T } consume(A);`, LanguageOptions: script},
+			{Code: `/* exported T */ type A = (T: number) => void; consume(null as A);`, LanguageOptions: script},
+			// vars:local skips every binding hoisted into the script global scope,
+			// including destructuring and var declarations nested in statements.
+			{
+				Code: `{ var blockVar = 1; }
+var { top } = source;
+for (var loopVar of source) { consume(); }`,
+				LanguageOptions: script,
+				Options:         map[string]interface{}{"vars": "local"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `/* exported T */
+type A<T> = string;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 8)},
+			},
+			{
+				Code: `/* exported T */
+interface A<T> { value: string }
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 13)},
+			},
+			{
+				Code: `/* exported T */
+class A<T> {}
+consume(A);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 9)},
+			},
+			{
+				Code: `/* exported T */
+function f<T>() {}
+f();`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 12)},
+			},
+			{
+				Code: `/* exported T */
+type A = <T>() => void;
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 11)},
+			},
+			{
+				Code: `/* exported T */
+interface A { <T>(): void }
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 16)},
+			},
+			{
+				Code: `/* exported T */
+interface A { new <T>(): object }
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 20)},
+			},
+			{
+				Code: `/* exported T */
+interface A { f<T>(): void }
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 17)},
+			},
+			{
+				Code: `/* exported T */
+type A<U> = U extends infer T ? U : never;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(2, 29)},
+			},
+			// The global T is exported, but the shadowing type parameter is not.
+			{
+				Code: `/* exported T */
+type T = number;
+type A<T> = string;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(3, 8)},
+			},
+			// The export facet paired with the outer default-export local must not
+			// match an internal type parameter with the same spelling.
+			{
+				Code:            `export default function T<T>() {} consume(T);`,
+				LanguageOptions: script,
+				Options:         map[string]interface{}{"vars": "local"},
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(1, 27)},
+			},
+			// Flat-config defaults make a .ts file a module without module syntax.
+			{
+				Code: `/* exported T */
+type T = string;`,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 6)},
+			},
+			// A JavaScript CommonJS file has a wrapper scope.
+			{
+				Code:     "/* exported T */\nvar T;",
+				FileName: "exported.js",
+				TSConfig: "tsconfig.allow-js.json",
+				LanguageOptions: rule.LanguageOptions{
+					SourceType: "commonjs",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 5)},
+			},
+			// vars:local skips the outer global binding, not its type parameter.
+			{
+				Code: `type A<T> = string;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Options:         map[string]interface{}{"vars": "local"},
+				Errors:          []rule_tester.InvalidTestCaseError{unusedT(1, 8)},
+			},
+			// Latest typescript-eslint treats an infer binding as an ordinary
+			// type-scope variable and reports it when the true branch never uses it.
+			{
+				Code: `type A<U> = U extends infer T ? U : never;
+consume(null as A<number>);`,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(1, 29)},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_typescript_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_typescript_test.go
@@ -379,7 +379,7 @@ func TestNoUnusedVarsTypeParameters(t *testing.T) {
 		{Code: `export type Greeting<T extends string> = ` + "`Hello ${T}`" + `;`},
 		// --- Type parameter USED in mapped type ---
 		{Code: `export type MyRecord<K extends string> = { [P in K]: number };`},
-		// --- infer type is not a declaration — P in mapped type not reported ---
+		// --- used infer type and mapped-type bindings are not reported ---
 		{Code: `export type ElementOf<T> = T extends (infer U)[] ? U : never;`},
 		// --- arrow function type parameter ---
 		{Code: `export const fn = <T,>(x: T): T => x;`},

--- a/internal/rule/context.go
+++ b/internal/rule/context.go
@@ -52,7 +52,8 @@ type RuleContext struct {
 	// Exported owns the file's `/* exported */` view: the names an inline
 	// directive marks as intentionally global for other files to consume. Rules
 	// should ask it instead of scanning comments themselves, through
-	// IsExportedGlobalBinding where they hold the declaration — see Exported.
+	// IsExportedGlobalBinding where they hold the raw binder symbol — see
+	// Exported.
 	Exported Exported
 	// Comments lazily provides every comment in SourceFile, in source order.
 	// Rules should call Comments.All instead of walking the token tree with

--- a/internal/rule/exported.go
+++ b/internal/rule/exported.go
@@ -2,7 +2,6 @@ package rule
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // Exported is the file's complete `/* exported */` view: the names an inline
@@ -19,9 +18,10 @@ import (
 // drops names bound anywhere else — a module's top-level bindings live in the
 // module scope, so the directive does nothing there. rslint has no such
 // per-variable flag, so this view answers for the raw name alone. A rule
-// holding a declaration should ask [RuleContext.IsExportedGlobalBinding],
-// which performs that lookup; Has is for the rules that have no declaration to
-// resolve, such as no-implicit-globals' assignment to a read-only global.
+// holding a binding's raw binder symbol should ask
+// [RuleContext.IsExportedGlobalBinding], which performs that lookup; Has is for
+// rules that have no binding to resolve, such as no-implicit-globals'
+// assignment to a read-only global.
 type Exported struct {
 	names        map[string]bool
 	declarations []InlineExported
@@ -47,18 +47,33 @@ func (e Exported) Declarations() []InlineExported {
 }
 
 // IsExportedGlobalBinding reports whether an `/* exported */` comment in this
-// file lists name and decl binds it in the file's global scope. Together those
-// are the lookup ESLint performs before marking a variable: it resolves each
-// listed name against the global scope, so a name bound anywhere else — a
-// module's or a CommonJS wrapper's top level, a block, a function body — is
-// silently dropped.
+// file lists name and symbol is bound in the file's global scope. Together
+// those are the lookup ESLint performs before marking a variable: it resolves
+// each listed name against the global scope, so a name bound anywhere else — a
+// module's or a CommonJS wrapper's top level, a block, a function body, or a
+// TypeScript type scope — is silently dropped.
 //
-// A rule that wants the directive's effect asks this about the declaration it
-// holds, then applies whatever the flag means for it: no-unused-vars and
-// no-useless-assignment read it as a use, prefer-const as "may be reassigned
-// from another file", no-implicit-globals as "this global is intentional".
-func (ctx *RuleContext) IsExportedGlobalBinding(decl *ast.Node, name string) bool {
-	if ctx == nil || decl == nil || ctx.SourceFile == nil || !ctx.Exported.Has(name) {
+// symbol must be the raw binder symbol attached to the declaration, not a
+// checker-merged symbol or an alias target. A rule that wants the directive's
+// effect asks this about the binding it holds, then applies whatever the flag
+// means for it: no-unused-vars and no-useless-assignment read it as a use,
+// prefer-const as "may be reassigned from another file", and
+// no-implicit-globals as "this global is intentional".
+func (ctx *RuleContext) IsExportedGlobalBinding(symbol *ast.Symbol, name string) bool {
+	return ctx != nil && ctx.Exported.Has(name) && ctx.IsGlobalScopeBinding(symbol, name)
+}
+
+// IsGlobalScopeBinding reports whether the raw binder symbol is bound directly
+// in the outer global scope selected for this file. A module program scope and a
+// JavaScript CommonJS wrapper are deliberately non-global. TypeScript-flavoured
+// CommonJS files retain the global program scope supplied by their parser.
+//
+// The symbol owner is authoritative. In particular, tsgo's generic block-scope
+// helpers do not model TypeScript's type, mapped, conditional, enum, and
+// signature scopes, so syntactic container fallbacks would turn their internal
+// bindings into globals. A missing owner therefore fails closed.
+func (ctx *RuleContext) IsGlobalScopeBinding(symbol *ast.Symbol, name string) bool {
+	if ctx == nil || symbol == nil || ctx.SourceFile == nil {
 		return false
 	}
 	if ctx.Refs != nil {
@@ -78,22 +93,17 @@ func (ctx *RuleContext) IsExportedGlobalBinding(decl *ast.Node, name string) boo
 			return false
 		}
 	}
-	return bindingScopeContainer(decl) == ctx.SourceFile.AsNode()
-}
-
-// bindingScopeContainer returns the node owning the scope decl introduces its
-// name into: a `var` binding belongs to the nearest function or file scope and
-// reaches the global scope from inside any block, while every other
-// declaration — `let`/`const`/`class`, a function declaration, a catch
-// parameter — belongs to the nearest block scope.
-func bindingScopeContainer(decl *ast.Node) *ast.Node {
-	root := ast.GetRootDeclaration(decl)
-	if root == nil {
-		root = decl
+	source := ctx.SourceFile.AsNode()
+	// The overwhelmingly common case is a source-file local. Avoid walking
+	// outward from its declaration; the fallback also covers declarations
+	// represented by a source-file export symbol.
+	if locals := source.Locals(); locals != nil {
+		local := locals[name]
+		// A named default export's export facet is stored under "default",
+		// while its paired local retains name in this table.
+		if local == symbol || (local != nil && local.ExportSymbol == symbol) {
+			return true
+		}
 	}
-	if root.Kind == ast.KindVariableDeclaration && root.Parent != nil &&
-		root.Parent.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(root.Parent) {
-		return utils.FindEnclosingScope(root)
-	}
-	return ast.GetEnclosingBlockScopeContainer(root)
+	return bindingScope(symbol, name) == source
 }

--- a/internal/rule/exported_test.go
+++ b/internal/rule/exported_test.go
@@ -1,0 +1,127 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+)
+
+func TestIsGlobalScopeBinding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		fileName    string
+		scriptKind  core.ScriptKind
+		source      string
+		sourceType  string
+		withoutRefs bool
+		want        bool
+	}{
+		{name: "script var", source: `var Target = 1;`, sourceType: "script", want: true},
+		{name: "script function", source: `function Target() {}`, sourceType: "script", want: true},
+		{name: "script lexical destructuring", source: `const { value: Target } = source;`, sourceType: "script", want: true},
+		{name: "script block hoisted var", source: `{ var Target = 1; }`, sourceType: "script", want: true},
+		{name: "script type alias", source: `type Target = string;`, sourceType: "script", want: true},
+		{name: "script exported type alias", source: `export type Target = string;`, sourceType: "script", want: true},
+		{name: "script named default export", source: `export default function Target() {}`, sourceType: "script", want: true},
+		{name: "script import equals", source: `import Target = require("target");`, sourceType: "script", want: true},
+		{name: "typescript commonjs global", source: `type Target = string;`, sourceType: "commonjs", want: true},
+
+		{name: "default module without module syntax", source: `type Target = string;`},
+		{name: "explicit module", source: `type Target = string;`, sourceType: "module"},
+		{name: "javascript commonjs wrapper", fileName: "/scope.js", scriptKind: core.ScriptKindJS, source: `var Target = 1;`, sourceType: "commonjs"},
+		{name: "fallback script", source: `var Target = 1;`, sourceType: "script", withoutRefs: true, want: true},
+		{name: "fallback module", source: `var Target = 1;`, sourceType: "module", withoutRefs: true},
+		{name: "fallback javascript commonjs", fileName: "/scope.js", scriptKind: core.ScriptKindJS, source: `var Target = 1;`, sourceType: "commonjs", withoutRefs: true},
+		{name: "fallback typescript commonjs", source: `type Target = string;`, sourceType: "commonjs", withoutRefs: true, want: true},
+		{name: "block lexical", source: `{ let Target = 1; }`, sourceType: "script"},
+		{name: "block function", source: `{ function Target() {} }`, sourceType: "script"},
+		{name: "function local", source: `function f() { let Target = 1; }`, sourceType: "script"},
+		{name: "function parameter", source: `function f(Target: number) {}`, sourceType: "script"},
+		{name: "named function expression", source: `const Alias = function Target() {};`, sourceType: "script"},
+		{name: "named class expression", source: `const Alias = class Target {};`, sourceType: "script"},
+		{name: "catch parameter", source: `try {} catch (Target) {}`, sourceType: "script"},
+		{name: "namespace member", source: `namespace N { const Target = 1; }`, sourceType: "script"},
+		{name: "static block local", source: `class C { static { let Target = 1; } }`, sourceType: "script"},
+
+		{name: "type alias parameter", source: `type Alias<Target> = string;`, sourceType: "script"},
+		{name: "interface parameter", source: `interface Alias<Target> {}`, sourceType: "script"},
+		{name: "class parameter", source: `class Alias<Target> {}`, sourceType: "script"},
+		{name: "function parameter type", source: `function f<Target>() {}`, sourceType: "script"},
+		{name: "call signature parameter", source: `interface I { <Target>(): void; }`, sourceType: "script"},
+		{name: "construct signature parameter", source: `interface I { new <Target>(): object; }`, sourceType: "script"},
+		{name: "method signature parameter", source: `interface I { f<Target>(): void; }`, sourceType: "script"},
+		{name: "signature value parameter", source: `type F = (Target: number) => void;`, sourceType: "script"},
+		{name: "mapped type key", source: `type M<K> = { [Target in keyof K]: K[Target] };`, sourceType: "script"},
+		{name: "infer type parameter", source: `type M<T> = T extends infer Target ? string : never;`, sourceType: "script"},
+		{name: "enum member", source: `enum E { Target }`, sourceType: "script"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fileName := test.fileName
+			if fileName == "" {
+				fileName = "/scope.ts"
+			}
+			scriptKind := test.scriptKind
+			if scriptKind == core.ScriptKindUnknown {
+				scriptKind = core.ScriptKindTS
+			}
+			options := LanguageOptions{SourceType: test.sourceType}
+			sourceFile, refs := newBoundRefStoreWithLanguageOptions(t, fileName, scriptKind, test.source, options)
+			_, _, normalizedOptions := ResolveLanguageDefaults(fileName, options)
+			ctx := RuleContext{
+				SourceFile:      sourceFile,
+				LanguageOptions: normalizedOptions,
+				Refs:            refs,
+				Exported:        NewExported(map[string]bool{"Target": true}, nil),
+			}
+			if test.withoutRefs {
+				ctx.Refs = nil
+			}
+			symbol := declaredIdentifierSymbol(t, sourceFile, "Target")
+
+			if got := ctx.IsGlobalScopeBinding(symbol, "Target"); got != test.want {
+				t.Errorf("IsGlobalScopeBinding() = %v, want %v", got, test.want)
+			}
+			if got := ctx.IsExportedGlobalBinding(symbol, "Target"); got != test.want {
+				t.Errorf("IsExportedGlobalBinding() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsExportedGlobalBindingRequiresListedName(t *testing.T) {
+	t.Parallel()
+
+	sourceFile, refs := newBoundRefStoreWithLanguageOptions(
+		t,
+		"/scope.ts",
+		core.ScriptKindTS,
+		`var Target = 1;`,
+		LanguageOptions{SourceType: "script"},
+	)
+	ctx := RuleContext{SourceFile: sourceFile, Refs: refs}
+	if ctx.IsExportedGlobalBinding(declaredIdentifierSymbol(t, sourceFile, "Target"), "Target") {
+		t.Fatal("an unlisted global binding must not be treated as exported")
+	}
+}
+
+func declaredIdentifierSymbol(t *testing.T, sourceFile *ast.SourceFile, name string) *ast.Symbol {
+	t.Helper()
+	occurrences := identifiers(sourceFile.AsNode(), name)
+	if len(occurrences) == 0 {
+		t.Fatalf("no %q identifier found", name)
+	}
+	declaration := ast.GetDeclarationFromName(occurrences[0])
+	if declaration == nil {
+		declaration = occurrences[0].Parent
+	}
+	if declaration == nil || declaration.Symbol() == nil {
+		t.Fatalf("%q declaration has no raw binder symbol", name)
+	}
+	return declaration.Symbol()
+}

--- a/internal/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/rules/no_unused_vars/no_unused_vars.go
@@ -2002,28 +2002,6 @@ func coreTypeDeclarationSelfReferenceCounts(definition *ast.Node) bool {
 		(definition.Kind == ast.KindInterfaceDeclaration || definition.Kind == ast.KindTypeAliasDeclaration)
 }
 
-// isScriptGlobalDefinition models ESLint's global scope for vars:"local".
-// RefStore carries sourceType overrides; parser module syntax is only a
-// fallback for callers that do not provide one.
-// `var` uses its enclosing variable scope even when nested in a block or loop;
-// lexical declarations use tsgo's block-scope container.
-func isScriptGlobalDefinition(sourceFile *ast.SourceFile, refs *rule.RefStore, definition *ast.Node) bool {
-	if sourceFile == nil || definition == nil ||
-		(refs != nil && refs.HasNonGlobalProgramScope()) ||
-		(refs == nil && ast.IsExternalModule(sourceFile)) {
-		return false
-	}
-	root := ast.GetRootDeclaration(definition)
-	if root == nil {
-		return false
-	}
-	if root.Kind == ast.KindVariableDeclaration && root.Parent != nil &&
-		root.Parent.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(root.Parent) {
-		return utils.FindEnclosingScope(root) == sourceFile.AsNode()
-	}
-	return ast.GetEnclosingBlockScopeContainer(root) == sourceFile.AsNode()
-}
-
 // processVariable determines whether a single declared variable/parameter/import
 // is unused and, if so, reports it. The decision pipeline:
 //  1. Resolve the symbol and look up usages (original sym → SkipAlias → shared reference index)
@@ -2132,7 +2110,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	// upstream counts the directive itself as a use. reportUsedIgnorePattern
 	// still sees it as used, which is what turns a directive on an ignored name
 	// into a usedIgnoredVar report.
-	if !varInfo.Used && ctx.IsExportedGlobalBinding(definition, name) {
+	if !varInfo.Used && ctx.IsExportedGlobalBinding(sym, name) {
 		varInfo.Used = true
 	}
 	// A used binding cannot produce a diagnostic unless the caller asks to
@@ -2142,7 +2120,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 		return
 	}
 
-	scriptGlobal := isScriptGlobalDefinition(ctx.SourceFile, ctx.Refs, definition)
+	scriptGlobal := ctx.IsGlobalScopeBinding(sym, name)
 	// vars: "local" skips only the script global scope. ES module top-level
 	// bindings live in a module scope and must still be checked.
 	if opts.Vars == "local" && scriptGlobal {

--- a/internal/rules/no_unused_vars/no_unused_vars.md
+++ b/internal/rules/no_unused_vars/no_unused_vars.md
@@ -103,12 +103,20 @@ comment itself as a use:
 var publicValue = 1;
 ```
 
-The comment resolves each name against the global scope, so it applies to a
-file whose top level is that scope — a `.ts` script, or any file with no
-`import`/`export` of its own. A module's top-level binding, a block binding, and
-a function's locals live in their own scopes and are still reported.
+The comment resolves each name only against the outer global scope. Whether a
+file has that scope is determined by its effective
+`languageOptions.sourceType`, not by the presence of `import` or `export`
+syntax. With flat config, omitting `sourceType` makes `.js` and `.ts` files
+modules even when they contain no module syntax, so the comment has no effect.
+Set `sourceType: "script"` for a shared script.
+
+Module bindings, bindings in a JavaScript CommonJS wrapper, block bindings, and
+function locals are still reported. An exact, case-sensitive `.cjs` extension
+defaults to the CommonJS wrapper. TypeScript-flavoured files configured as
+`commonjs` retain a global program scope, so their top-level bindings can be
+marked by the comment.
 
 ## Original Documentation
 
 - [ESLint: no-unused-vars](https://eslint.org/docs/latest/rules/no-unused-vars)
-- [Source code](https://github.com/eslint/eslint/blob/v9.32.0/lib/rules/no-unused-vars.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-unused-vars.js)

--- a/internal/rules/no_unused_vars/no_unused_vars_exported_scope_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_exported_scope_test.go
@@ -1,0 +1,201 @@
+package no_unused_vars
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedVarsExportedInternalBindings(t *testing.T) {
+	script := rule.LanguageOptions{SourceType: "script"}
+	unusedT := func(line, column int, suggestionOutput string) rule_tester.InvalidTestCaseError {
+		return extraUnusedErrorWithSuggestion("T", false, line, column, column+1, suggestionOutput)
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{
+			// The effective source goal, rather than import/export syntax, selects
+			// the global program scope.
+			{
+				Code: `/* exported T */
+type T = string;
+export {};`,
+				LanguageOptions: script,
+			},
+			{
+				Code:            `/* exported T */ export type T = string;`,
+				LanguageOptions: script,
+			},
+			{
+				Code:            `/* exported T */ type T = string;`,
+				FileName:        "exported.ts",
+				LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"},
+			},
+			// An ignored internal binding is still unused. It must not become a
+			// usedIgnoredVar merely because its spelling appears in the directive.
+			{
+				Code:            `/* exported T */ type A<T> = string; consume(null as A<number>);`,
+				LanguageOptions: script,
+				Options: map[string]interface{}{
+					"varsIgnorePattern":       "^T$",
+					"reportUsedIgnorePattern": true,
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `/* exported T */
+type A<T> = string;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 8, `/* exported T */
+type A<> = string;
+consume(null as A<number>);`)},
+			},
+			{
+				Code: `/* exported T */
+interface A<T> { value: string }
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 13, `/* exported T */
+interface A<> { value: string }
+consume(null as A<number>);`)},
+			},
+			{
+				Code: `/* exported T */
+class A<T> {}
+consume(A);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 9, `/* exported T */
+class A<> {}
+consume(A);`)},
+			},
+			{
+				Code: `/* exported T */
+function f<T>() {}
+f();`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 12, `/* exported T */
+function f<>() {}
+f();`)},
+			},
+			{
+				Code: `/* exported T */
+type A = <T>() => void;
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 11, `/* exported T */
+type A = <>() => void;
+consume(null as A);`)},
+			},
+			{
+				Code: `/* exported T */
+interface A { <T>(): void }
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 16, `/* exported T */
+interface A { <>(): void }
+consume(null as A);`)},
+			},
+			{
+				Code: `/* exported T */
+interface A { new <T>(): object }
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 20, `/* exported T */
+interface A { new <>(): object }
+consume(null as A);`)},
+			},
+			{
+				Code: `/* exported T */
+interface A { f<T>(): void }
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 17, `/* exported T */
+interface A { f<>(): void }
+consume(null as A);`)},
+			},
+			{
+				Code: `/* exported T */
+type A<U> = { [T in keyof U]: string };
+consume(null as A<{ x: 1 }>);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 16, `/* exported T */
+type A<U> = { [ in keyof U]: string };
+consume(null as A<{ x: 1 }>);`)},
+			},
+			{
+				Code: `/* exported T */
+type A<U> = U extends infer T ? U : never;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 29, `/* exported T */
+type A<U> = U extends infer  ? U : never;
+consume(null as A<number>);`)},
+			},
+			{
+				Code: `/* exported T */
+enum A { T }
+consume(A);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 10, `/* exported T */
+enum A {  }
+consume(A);`)},
+			},
+			{
+				Code: `/* exported T */
+type A = (T: number) => void;
+consume(null as A);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("T", false, 2, 11, 20, `/* exported T */
+type A = () => void;
+consume(null as A);`),
+				},
+			},
+			// The global T is exported, but the shadowing type parameter is not.
+			{
+				Code: `/* exported T */
+type T = number;
+type A<T> = string;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(3, 8, `/* exported T */
+type T = number;
+type A<> = string;
+consume(null as A<number>);`)},
+			},
+			// Flat-config defaults make a .ts file a module even with no module syntax.
+			{
+				Code: `/* exported T */
+type T = string;`,
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(2, 6, `/* exported T */
+type  = string;`)},
+			},
+			// A JavaScript CommonJS file has a wrapper scope, not a global program scope.
+			{
+				Code:     "/* exported T */\nvar T;",
+				FileName: "exported.cjs",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("T", false, 2, 5, 6, "/* exported T */\n"),
+				},
+			},
+			// vars:local skips the outer global binding, not its internal type scope.
+			{
+				Code: `type A<T> = string;
+consume(null as A<number>);`,
+				LanguageOptions: script,
+				Options:         map[string]interface{}{"vars": "local"},
+				Errors: []rule_tester.InvalidTestCaseError{unusedT(1, 8, `type A<> = string;
+consume(null as A<number>);`)},
+			},
+		},
+	)
+}

--- a/internal/rules/no_useless_assignment/no_useless_assignment.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.go
@@ -285,7 +285,7 @@ func isTrackable(
 	}
 	if ctx.Exported.Has(sym.Name) {
 		for _, decl := range sym.Declarations {
-			if ctx.IsExportedGlobalBinding(decl, sym.Name) {
+			if ctx.IsExportedGlobalBinding(decl.Symbol(), sym.Name) {
 				return false
 			}
 		}

--- a/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
@@ -196,6 +196,18 @@ class C { handler(@Body(pipe) _b: unknown) {} }`},
 let v = 1;
 console.log(v);
 v = 2;`, LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			// An uninitialized declaration can reach this rule through a
+			// checker-resolved symbol. Its declaration must still recover the raw
+			// global binder symbol used by the directive's scope lookup.
+			{Code: `/* exported v */
+let v;
+v = 1;
+console.log(v);
+v = 2;`, LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+			{Code: `/* exported v */
+let { v } = source;
+console.log(v);
+v = 2;`, LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
 			{Code: `/* exported v */
 { var v = 1; console.log(v); v = 2; }`, LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
 		},

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -326,7 +326,7 @@ func (s *preferConstState) shouldReport(candidate *candidateInfo) bool {
 	// A global listed by `/* exported */` is shared with separately loaded
 	// files, any of which may reassign it, so upstream declines to judge
 	// whether it could be `const`.
-	if s.ctx.IsExportedGlobalBinding(candidate.declNode, candidate.nameNode.Text()) {
+	if s.ctx.IsExportedGlobalBinding(candidate.symbol, candidate.nameNode.Text()) {
 		return false
 	}
 	info := s.symbols[candidate.symbol]

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-basic.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-basic.test.ts
@@ -466,6 +466,8 @@ for (var i in arr2) {
     },
     {
       code: 'var a = 10;',
+      // The adapted ESLint fixture predates flat config and ran as a script.
+      languageOptions: { sourceType: 'script' },
       options: [{ vars: 'local' }],
     },
     {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-patterns.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-patterns.test.ts
@@ -577,6 +577,8 @@ function foo() {
 }
 foo();
       `,
+      // The adapted ESLint fixture predates flat config and ran as a script.
+      languageOptions: { sourceType: 'script' },
       options: [{ vars: 'local', varsIgnorePattern: '^_' }],
     },
     {


### PR DESCRIPTION
## Summary

- Resolve `/* exported */` names against the effective global scope using raw binder-symbol identity, including named default exports.
- Align core and TypeScript `vars: "local"` scope handling and report unused TypeScript `infer` bindings like the latest upstream implementations.
- Add source-goal and internal-binding regression coverage, and document effective `sourceType` and CommonJS behavior.

## Related Links

- [ESLint `no-unused-vars` source](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-unused-vars.js)
- [typescript-eslint unused-variable collector](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/util/collectUnusedVariables.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).