### PR TITLE
feat: port rule react/jsx-props-no-spreading

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -32,6 +32,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_pascal_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_multi_spaces"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_spread_multi"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_spreading"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_sort_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
@@ -113,6 +114,7 @@ func GetAllRules() []rule.Rule {
 		jsx_no_undef.JsxNoUndefRule,
 		jsx_pascal_case.JsxPascalCaseRule,
 		jsx_props_no_multi_spaces.JsxPropsNoMultiSpacesRule,
+		jsx_props_no_spreading.JsxPropsNoSpreadingRule,
 		jsx_props_no_spread_multi.JsxPropsNoSpreadMultiRule,
 		jsx_sort_props.JsxSortPropsRule,
 		jsx_uses_react.JsxUsesReactRule,

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
@@ -1,0 +1,152 @@
+package jsx_props_no_spreading
+
+import (
+	_ "embed"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+//go:embed jsx_props_no_spreading.schema.json
+var schemaJSON []byte
+
+type options struct {
+	html, custom, explicitSpread string
+	exceptions                   []string
+}
+
+var defaultOptions = options{
+	html:           "enforce",
+	custom:         "enforce",
+	explicitSpread: "enforce",
+}
+
+// JsxPropsNoSpreadingRule disallows JSX prop spreading, with separate
+// controls for intrinsic elements, custom components, and explicit object
+// spreads.
+var JsxPropsNoSpreadingRule = rule.Rule{
+	Name:   "react/jsx-props-no-spreading",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		return rule.RuleListeners{
+			ast.KindJsxSpreadAttribute: func(node *ast.Node) {
+				parent := reactutil.GetJsxParentElement(node)
+				tagName, hasTagName := jsxTagName(parent)
+
+				if hasTagName {
+					first, _ := utf8.DecodeRuneInString(tagName)
+					firstString := string(first)
+					startsWithUpper := firstString == ecmascript.StringToUpperCase(firstString)
+					isHTMLTag := !startsWithUpper
+					isCustomTag := startsWithUpper || containsDot(tagName)
+					isException := contains(opts.exceptions, tagName)
+
+					if isHTMLTag && ((opts.html == "ignore" && !isException) || (opts.html != "ignore" && isException)) {
+						return
+					}
+					if isCustomTag && ((opts.custom == "ignore" && !isException) || (opts.custom != "ignore" && isException)) {
+						return
+					}
+				}
+
+				if opts.explicitSpread == "ignore" {
+					argument := node.AsJsxSpreadAttribute().Expression
+					argument = ast.SkipParentheses(argument)
+					if argument != nil && argument.Kind == ast.KindObjectLiteralExpression && allObjectProperties(argument) {
+						return
+					}
+				}
+
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "noSpreading",
+					Description: "Prop spreading is forbidden",
+				})
+			},
+		}
+	},
+}
+
+func parseOptions(raw []any) options {
+	opts := defaultOptions
+	if len(raw) == 0 {
+		return opts
+	}
+	config, _ := raw[0].(map[string]any)
+	if config == nil {
+		return opts
+	}
+	if value, ok := config["html"].(string); ok {
+		opts.html = value
+	}
+	if value, ok := config["custom"].(string); ok {
+		opts.custom = value
+	}
+	if value, ok := config["explicitSpread"].(string); ok {
+		opts.explicitSpread = value
+	}
+	if values, ok := config["exceptions"].([]any); ok {
+		opts.exceptions = make([]string, 0, len(values))
+		for _, value := range values {
+			if exception, ok := value.(string); ok {
+				opts.exceptions = append(opts.exceptions, exception)
+			}
+		}
+	}
+	return opts
+}
+
+func jsxTagName(element *ast.Node) (string, bool) {
+	tagName := reactutil.GetJsxTagName(element)
+	if tagName == nil {
+		return "", false
+	}
+	switch tagName.Kind {
+	case ast.KindIdentifier:
+		return tagName.AsIdentifier().Text, true
+	case ast.KindPropertyAccessExpression:
+		return reactutil.GetJsxElementTypeString(tagName), true
+	default:
+		// JSXNamespacedName and other tag forms are not JSXIdentifier or
+		// JSXMemberExpression in ESTree, so upstream leaves tagName undefined.
+		return "", false
+	}
+}
+
+func allObjectProperties(object *ast.Node) bool {
+	properties := object.AsObjectLiteralExpression().Properties
+	if properties == nil {
+		return true
+	}
+	for _, property := range properties.Nodes {
+		switch property.Kind {
+		case ast.KindPropertyAssignment, ast.KindMethodDeclaration,
+			ast.KindShorthandPropertyAssignment, ast.KindGetAccessor, ast.KindSetAccessor:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsDot(value string) bool {
+	for _, char := range value {
+		if char == '.' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
@@ -2,7 +2,6 @@ package jsx_props_no_spreading
 
 import (
 	_ "embed"
-	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
@@ -39,18 +38,23 @@ var JsxPropsNoSpreadingRule = rule.Rule{
 				tagName, hasTagName := jsxTagName(parent)
 
 				if hasTagName {
-					first, _ := utf8.DecodeRuneInString(tagName)
-					firstString := string(first)
-					startsWithUpper := firstString == ecmascript.StringToUpperCase(firstString)
-					isHTMLTag := !startsWithUpper
-					isCustomTag := startsWithUpper || containsDot(tagName)
-					isException := contains(opts.exceptions, tagName)
+					codeUnits := ecmascript.StringCodeUnits(tagName)
+					if len(codeUnits) > 0 {
+						// ESLint indexes the first UTF-16 code unit, rather than the
+						// first Unicode code point. This matters for astral JSX names,
+						// whose high surrogate has no case mapping.
+						firstString := ecmascript.StringFromCodeUnits(codeUnits[:1])
+						startsWithUpper := firstString == ecmascript.StringToUpperCase(firstString)
+						isHTMLTag := !startsWithUpper
+						isCustomTag := startsWithUpper || containsDot(tagName)
+						isException := contains(opts.exceptions, tagName)
 
-					if isHTMLTag && ((opts.html == "ignore" && !isException) || (opts.html != "ignore" && isException)) {
-						return
-					}
-					if isCustomTag && ((opts.custom == "ignore" && !isException) || (opts.custom != "ignore" && isException)) {
-						return
+						if isHTMLTag && ((opts.html == "ignore" && !isException) || (opts.html != "ignore" && isException)) {
+							return
+						}
+						if isCustomTag && ((opts.custom == "ignore" && !isException) || (opts.custom != "ignore" && isException)) {
+							return
+						}
 					}
 				}
 

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
@@ -112,6 +112,10 @@ func jsxTagName(element *ast.Node) (string, bool) {
 	switch tagName.Kind {
 	case ast.KindIdentifier:
 		return tagName.AsIdentifier().Text, true
+	case ast.KindThisKeyword:
+		// ts-go parses a bare JSX `this` tag as ThisKeyword, while ESTree
+		// exposes it as a JSXIdentifier named "this".
+		return "this", true
 	case ast.KindPropertyAccessExpression:
 		propertyAccess := tagName.AsPropertyAccessExpression()
 		property := propertyAccess.Name()

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.go
@@ -109,7 +109,25 @@ func jsxTagName(element *ast.Node) (string, bool) {
 	case ast.KindIdentifier:
 		return tagName.AsIdentifier().Text, true
 	case ast.KindPropertyAccessExpression:
-		return reactutil.GetJsxElementTypeString(tagName), true
+		propertyAccess := tagName.AsPropertyAccessExpression()
+		property := propertyAccess.Name()
+		if property == nil || property.Kind != ast.KindIdentifier {
+			return "", false
+		}
+
+		// eslint-plugin-react v7.37.5 reads only the immediate object's
+		// `name` when handling JSXMemberExpression. This preserves that
+		// behavior for nested member tags, whose object has no `name`.
+		objectName := "undefined"
+		if object := propertyAccess.Expression; object != nil {
+			switch object.Kind {
+			case ast.KindIdentifier:
+				objectName = object.AsIdentifier().Text
+			case ast.KindThisKeyword:
+				objectName = "this"
+			}
+		}
+		return objectName + "." + property.AsIdentifier().Text, true
 	default:
 		// JSXNamespacedName and other tag forms are not JSXIdentifier or
 		// JSXMemberExpression in ESTree, so upstream leaves tagName undefined.

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.md
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.md
@@ -91,8 +91,9 @@ non-object expression is still reported.
 ### `exceptions`
 
 `exceptions` is an array of tag names whose HTML or custom-component setting is
-inverted. Exceptions use the complete JSX tag name, including member
-components such as `components.Group`.
+inverted. Exceptions use the JSX tag name, including two-part member components
+such as `components.Group`. This follows the upstream rule's member-expression
+handling; deeper member chains are not matched by their full authored name.
 
 ```json
 { "react/jsx-props-no-spreading": ["error", { "exceptions": ["Image", "img"] }] }

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.md
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.md
@@ -1,0 +1,123 @@
+# jsx-props-no-spreading
+
+Disallow JSX prop spreading.
+
+## Rule Details
+
+Enforces that JSX props are passed explicitly. This improves readability and
+helps avoid passing unintended props to components and HTML elements.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<App {...props} />
+<MyCustomComponent {...props} some_other_prop={some_other_prop} />
+<img {...props} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+const {src, alt} = props;
+<MyCustomComponent src={src} alt={alt} />
+<img src={src} alt={alt} />
+```
+
+## Rule Options
+
+The default configuration enforces prop spreading on HTML tags, custom
+components, and non-explicit object spreads.
+
+### `html`
+
+`"ignore"` allows prop spreading on lowercase HTML tags. The default is
+`"enforce"`.
+
+Examples of **correct** code for this rule with `{ "html": "ignore" }`:
+
+```json
+{ "react/jsx-props-no-spreading": ["error", { "html": "ignore" }] }
+```
+
+```jsx
+<img {...props} />
+```
+
+Examples of **incorrect** code for this rule with `{ "html": "ignore" }`:
+
+```jsx
+<App {...props} />
+```
+
+### `custom`
+
+`"ignore"` allows prop spreading on custom components. The default is
+`"enforce"`.
+
+Examples of **correct** code for this rule with `{ "custom": "ignore" }`:
+
+```json
+{ "react/jsx-props-no-spreading": ["error", { "custom": "ignore" }] }
+```
+
+```jsx
+<MyComponent {...props} />
+```
+
+Examples of **incorrect** code for this rule with `{ "custom": "ignore" }`:
+
+```jsx
+<img {...props} />
+```
+
+### `explicitSpread`
+
+`"ignore"` allows a spread of an object containing only explicitly listed
+properties. The default is `"enforce"`.
+
+Examples of **correct** code for this rule with `{ "explicitSpread": "ignore" }`:
+
+```json
+{ "react/jsx-props-no-spreading": ["error", { "explicitSpread": "ignore" }] }
+```
+
+```jsx
+<App {...{ prop1, prop2, prop3 }} />
+```
+
+An object containing another spread, a conditional expression, or any other
+non-object expression is still reported.
+
+### `exceptions`
+
+`exceptions` is an array of tag names whose HTML or custom-component setting is
+inverted. Exceptions use the complete JSX tag name, including member
+components such as `components.Group`.
+
+```json
+{ "react/jsx-props-no-spreading": ["error", { "exceptions": ["Image", "img"] }] }
+```
+
+```jsx
+<Image {...props} />
+<img {...props} />
+```
+
+Examples of **incorrect** code for this rule with `{ "exceptions": ["Image", "img"] }`:
+
+```jsx
+<MyComponent {...props} />
+```
+
+The `html` and `custom` options cannot both be `"ignore"` when `exceptions` is
+empty, matching the upstream schema.
+
+## When Not To Use It
+
+If your project intentionally uses prop spreading, or if spreading is the
+preferred interface for higher-order components, leave this rule disabled.
+
+## Original Documentation
+
+- [eslint-plugin-react: jsx-props-no-spreading](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-props-no-spreading.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-props-no-spreading.js)

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.schema.json
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading.schema.json
@@ -1,0 +1,34 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "html": { "enum": ["enforce", "ignore"] },
+            "custom": { "enum": ["enforce", "ignore"] },
+            "explicitSpread": { "enum": ["enforce", "ignore"] },
+            "exceptions": {
+              "type": "array",
+              "items": { "type": "string", "uniqueItems": true }
+            }
+          }
+        },
+        {
+          "not": {
+            "type": "object",
+            "required": ["html", "custom"],
+            "properties": {
+              "html": { "enum": ["ignore"] },
+              "custom": { "enum": ["ignore"] },
+              "exceptions": { "type": "array", "minItems": 0, "maxItems": 0 }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
@@ -1,0 +1,83 @@
+// TestJsxPropsNoSpreadingExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// N/A: receiver wrappers, element-access keys, class/function containers, and
+// ancestor scope walks do not apply because this rule only inspects JSX spread
+// attributes and their immediate tag / object-literal argument.
+package jsx_props_no_spreading
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxPropsNoSpreadingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxPropsNoSpreadingRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parenthesized and TypeScript-wrapped arguments ----
+		{Code: `<App {...({ value: 1 })} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+
+		// ---- Dimension 4: object member forms all count as Property ----
+		{Code: `<App {...{ shorthand }} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+		{Code: `<App {...{ "quoted": 1, 0: 2, [key]: 3 }} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+		{Code: `<App {...{ method() {}, get value() { return 1; }, set value(next) {} }} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+		{Code: `<App {...{}} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+		// ---- Dimension 4: SpreadAssignment does not mask sibling properties ----
+
+		// Locks in upstream create() tag-name fallback: JSXNamespacedName has
+		// no tagName, so only explicitSpread can suppress this diagnostic.
+		{Code: `<svg:path {...{ value: 1 }} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+
+		// Locks in upstream JSXMemberExpression handling for nested components.
+		{Code: `<components.Group.Inner {...props} />`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
+		{Code: `<components.Group.Inner {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.Group.Inner"}}},
+
+		// ---- Real-user: explicit inline object props ----
+		{Code: `<Foo {...{ prop1, prop2, prop3 }} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+		// ---- Real-user: sub-component exceptions ----
+		{Code: `<components.DropdownIndicator {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.DropdownIndicator"}}},
+		{Code: `<components.ClearIndicator {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.ClearIndicator"}}},
+
+		// Locks in upstream html ignore branch with no exception.
+		{Code: `<div {...props} />`, Tsx: true, Options: map[string]any{"html": "ignore"}},
+		// Locks in upstream html enforce branch with an exception.
+		{Code: `<div {...props} />`, Tsx: true, Options: map[string]any{"html": "enforce", "exceptions": []any{"div"}}},
+		// Locks in upstream custom ignore branch with no exception.
+		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
+		// Locks in upstream custom enforce branch with an exception.
+		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{"custom": "enforce", "exceptions": []any{"App"}}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: multiline diagnostic range ----
+		{
+			Code: "<App\n  {...props}\n  other\n/>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noSpreading", Message: noSpreadingMessage,
+				Line: 2, Column: 3, EndLine: 2, EndColumn: 13,
+			}},
+		},
+		// Locks in upstream explicitSpread fallback: a non-object expression
+		// remains reportable when explicitSpread is ignored.
+		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 16)}},
+		// Locks in upstream explicitSpread all-property predicate: any spread
+		// member makes every(isProperty) false.
+		{Code: `<App {...props!} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 17)}},
+		{Code: `type Props = {}; <App {...(props as Props)} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 23, 44)}},
+		{Code: `type Props = {}; <App {...(props satisfies Props)} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 23, 51)}},
+		{Code: `<App {...props?.bag} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 21)}},
+		{Code: `<App {...{ value: 1, ...rest }} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 32)}},
+		// ---- Real-user: conditional explicit props remain enforced ----
+		{Code: `<div {...(actAsBanner && { role: "banner" })} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 46)}},
+		// A namespaced tag has no tagName and therefore reaches the report.
+		{Code: `<svg:path {...props} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 11, 21)}},
+		// ---- Real-user: unlisted sub-component remains enforced ----
+		{Code: `<components.DropdownIndicator {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.Group"}}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 31, 41)}},
+		// Locks in defaults: an explicitly empty option object is equivalent to
+		// omitting options entirely.
+		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 16)}},
+	})
+}

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
@@ -34,7 +34,8 @@ func TestJsxPropsNoSpreadingExtras(t *testing.T) {
 
 		// Locks in upstream JSXMemberExpression handling for nested components.
 		{Code: `<components.Group.Inner {...props} />`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
-		{Code: `<components.Group.Inner {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.Group.Inner"}}},
+		// Upstream's JSXMemberExpression helper does not preserve the full
+		// name for member chains deeper than one property.
 
 		// ---- Real-user: explicit inline object props ----
 		{Code: `<Foo {...{ prop1, prop2, prop3 }} />`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
@@ -76,6 +77,7 @@ func TestJsxPropsNoSpreadingExtras(t *testing.T) {
 		{Code: `<svg:path {...props} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 11, 21)}},
 		// ---- Real-user: unlisted sub-component remains enforced ----
 		{Code: `<components.DropdownIndicator {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.Group"}}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 31, 41)}},
+		{Code: `<components.Group.Inner {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.Group.Inner"}}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 25, 35)}},
 		// Locks in defaults: an explicitly empty option object is equivalent to
 		// omitting options entirely.
 		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 16)}},

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
@@ -51,6 +51,10 @@ func TestJsxPropsNoSpreadingExtras(t *testing.T) {
 		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
 		// Locks in upstream custom enforce branch with an exception.
 		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{"custom": "enforce", "exceptions": []any{"App"}}},
+		// ts-go represents a bare JSX `this` tag as ThisKeyword, while upstream
+		// exposes it as JSXIdentifier("this").
+		{Code: `<this {...props} />`, Tsx: true, Options: map[string]any{"html": "ignore"}},
+		{Code: `<this {...props} />`, Tsx: true, Options: map[string]any{"exceptions": []any{"this"}}},
 		// ESLint classifies an astral name by its first UTF-16 code unit, whose
 		// surrogate has no case mapping, so this is a custom tag.
 		{Code: `<𐐨 {...props} />`, Tsx: true, Options: map[string]any{"custom": "ignore"}},

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_extras_test.go
@@ -51,6 +51,9 @@ func TestJsxPropsNoSpreadingExtras(t *testing.T) {
 		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
 		// Locks in upstream custom enforce branch with an exception.
 		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{"custom": "enforce", "exceptions": []any{"App"}}},
+		// ESLint classifies an astral name by its first UTF-16 code unit, whose
+		// surrogate has no case mapping, so this is a custom tag.
+		{Code: `<𐐨 {...props} />`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Dimension 4: multiline diagnostic range ----
 		{
@@ -81,5 +84,6 @@ func TestJsxPropsNoSpreadingExtras(t *testing.T) {
 		// Locks in defaults: an explicitly empty option object is equivalent to
 		// omitting options entirely.
 		{Code: `<App {...props} />`, Tsx: true, Options: map[string]any{}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 16)}},
+		{Code: `<𐐨 {...props} />`, Tsx: true, Options: map[string]any{"html": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 5, 15)}},
 	})
 }

--- a/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_upstream_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_spreading/jsx_props_no_spreading_upstream_test.go
@@ -1,0 +1,57 @@
+// TestJsxPropsNoSpreadingUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/jsx-props-no-spreading.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in the jsx_props_no_spreading_extras_test.go file.
+package jsx_props_no_spreading
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const noSpreadingMessage = "Prop spreading is forbidden"
+
+func noSpreadingError(line, column, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "noSpreading",
+		Message:   noSpreadingMessage,
+		Line:      line,
+		Column:    column,
+		EndLine:   line,
+		EndColumn: endColumn,
+	}
+}
+
+func TestJsxPropsNoSpreadingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxPropsNoSpreadingRule, []rule_tester.ValidTestCase{
+		// ---- valid ----
+		{Code: `<App one_prop={one_prop} two_prop={two_prop} />`, Tsx: true},
+		{Code: `<div one_prop={one_prop} two_prop={two_prop}></div>`, Tsx: true},
+		{Code: `const newProps = {...props}; <App one_prop={newProps.one_prop} two_prop={newProps.two_prop} style={{...styles}} />`, Tsx: true},
+		{Code: `<App><Image {...props} /><img {...props} /></App>`, Tsx: true, Options: map[string]any{"exceptions": []any{"Image", "img"}}},
+		{Code: `<App><Image {...props} /><img src={src} alt={alt} /></App>`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
+		{Code: `<App><Image {...props} /><img {...props} /></App>`, Tsx: true, Options: map[string]any{"custom": "enforce", "html": "ignore", "exceptions": []any{"Image"}}},
+		{Code: `<App><img {...props} /><Image src={src} alt={alt} /><div {...someOtherProps} /></App>`, Tsx: true, Options: map[string]any{"html": "ignore"}},
+		{Code: `<App><Foo {...{ prop1, prop2, prop3 }} /></App>`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}},
+		{Code: `<App><components.Group {...props} /><Nav.Item {...props} /></App>`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.Group", "Nav.Item"}}},
+		{Code: `<App><components.Group {...props} /><Nav.Item {...props} /></App>`, Tsx: true, Options: map[string]any{"custom": "ignore"}},
+		{Code: `<App><components.Group {...props} /><Nav.Item {...props} /></App>`, Tsx: true, Options: map[string]any{"custom": "enforce", "html": "ignore", "exceptions": []any{"components.Group", "Nav.Item"}}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- invalid ----
+		{Code: `<App {...props} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 16)}},
+		{Code: `<div {...props}></div>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 16)}},
+		{Code: `<App {...props} some_other_prop={some_other_prop} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 6, 16)}},
+		{Code: `<App><Image {...props} /><span {...props} /></App>`, Tsx: true, Options: map[string]any{"exceptions": []any{"Image", "img"}}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 32, 42)}},
+		{Code: `<App><Image {...props} /><img {...props} /></App>`, Tsx: true, Options: map[string]any{"custom": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 31, 41)}},
+		{Code: `<App><Image {...props} /><img {...props} /></App>`, Tsx: true, Options: map[string]any{"html": "ignore", "exceptions": []any{"Image", "img"}}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 31, 41)}},
+		{Code: `<App><Image {...props} /><img {...props} /><div {...props} /></App>`, Tsx: true, Options: map[string]any{"custom": "ignore", "html": "ignore", "exceptions": []any{"Image", "img"}}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 13, 23), noSpreadingError(1, 31, 41)}},
+		{Code: `<App><img {...props} /><Image {...props} /></App>`, Tsx: true, Options: map[string]any{"html": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 31, 41)}},
+		{Code: `<App><Foo {...{ prop1, prop2, prop3 }} /></App>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 11, 39)}},
+		{Code: `<App><Foo {...{ prop1, ...rest }} /></App>`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 11, 34)}},
+		{Code: `<App><Foo {...{ ...props }} /></App>`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 11, 28)}},
+		{Code: `<App><Foo {...props} /></App>`, Tsx: true, Options: map[string]any{"explicitSpread": "ignore"}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 11, 21)}},
+		{Code: `<App><components.Group {...props} /><Nav.Item {...props} /></App>`, Tsx: true, Options: map[string]any{"exceptions": []any{"components.DropdownIndicator", "Nav.Item"}}, Errors: []rule_tester.InvalidTestCaseError{noSpreadingError(1, 24, 34)}},
+	})
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -214,6 +214,7 @@ define.test({
     './tests/eslint-plugin-react/rules/jsx-no-useless-fragment.test.ts',
     './tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-props-no-spreading.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-spread-multi.test.ts',
     './tests/eslint-plugin-react/rules/jsx-sort-props.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-bracket-location.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-props-no-spreading.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-props-no-spreading.test.ts
@@ -1,0 +1,110 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-props-no-spreading', {} as never, {
+  valid: [
+    { code: '<App one_prop={one_prop} two_prop={two_prop} />' },
+    { code: '<div one_prop={one_prop} two_prop={two_prop}></div>' },
+    {
+      code: 'const newProps = {...props}; <App one_prop={newProps.one_prop} two_prop={newProps.two_prop} style={{...styles}} />',
+    },
+    {
+      code: '<App><Image {...props} /><img {...props} /></App>',
+      options: [{ exceptions: ['Image', 'img'] }],
+    },
+    {
+      code: '<App><Image {...props} /><img src={src} alt={alt} /></App>',
+      options: [{ custom: 'ignore' }],
+    },
+    {
+      code: '<App><Image {...props} /><img {...props} /></App>',
+      options: [{ custom: 'enforce', html: 'ignore', exceptions: ['Image'] }],
+    },
+    {
+      code: '<App><img {...props} /><Image src={src} alt={alt} /><div {...someOtherProps} /></App>',
+      options: [{ html: 'ignore' }],
+    },
+    {
+      code: '<App><Foo {...{ prop1, prop2, prop3 }} /></App>',
+      options: [{ explicitSpread: 'ignore' }],
+    },
+    {
+      code: '<App><components.Group {...props} /><Nav.Item {...props} /></App>',
+      options: [{ exceptions: ['components.Group', 'Nav.Item'] }],
+    },
+    {
+      code: '<App><components.Group {...props} /><Nav.Item {...props} /></App>',
+      options: [{ custom: 'ignore' }],
+    },
+    {
+      code: '<App><components.Group {...props} /><Nav.Item {...props} /></App>',
+      options: [
+        {
+          custom: 'enforce',
+          html: 'ignore',
+          exceptions: ['components.Group', 'Nav.Item'],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    { code: '<App {...props} />', errors: [{ messageId: 'noSpreading' }] },
+    { code: '<div {...props}></div>', errors: [{ messageId: 'noSpreading' }] },
+    {
+      code: '<App {...props} some_other_prop={some_other_prop} />',
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Image {...props} /><span {...props} /></App>',
+      options: [{ exceptions: ['Image', 'img'] }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Image {...props} /><img {...props} /></App>',
+      options: [{ custom: 'ignore' }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Image {...props} /><img {...props} /></App>',
+      options: [{ html: 'ignore', exceptions: ['Image', 'img'] }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Image {...props} /><img {...props} /><div {...props} /></App>',
+      options: [
+        { custom: 'ignore', html: 'ignore', exceptions: ['Image', 'img'] },
+      ],
+      errors: [{ messageId: 'noSpreading' }, { messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><img {...props} /><Image {...props} /></App>',
+      options: [{ html: 'ignore' }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Foo {...{ prop1, prop2, prop3 }} /></App>',
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Foo {...{ prop1, ...rest }} /></App>',
+      options: [{ explicitSpread: 'ignore' }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Foo {...{ ...props }} /></App>',
+      options: [{ explicitSpread: 'ignore' }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><Foo {...props} /></App>',
+      options: [{ explicitSpread: 'ignore' }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+    {
+      code: '<App><components.Group {...props} /><Nav.Item {...props} /></App>',
+      options: [{ exceptions: ['components.DropdownIndicator', 'Nav.Item'] }],
+      errors: [{ messageId: 'noSpreading' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-props-no-spreading` rule from ESLint to rslint.

Disallow JSX prop spreading, with options for HTML tags, custom components, explicit object spreads, and exceptions.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-props-no-spreading.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-props-no-spreading.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).