### PR TITLE
fix: align no-cond-assign with ESLint

### DIFF
--- a/internal/rules/no_cond_assign/no_cond_assign.go
+++ b/internal/rules/no_cond_assign/no_cond_assign.go
@@ -128,7 +128,11 @@ func findConditionalAncestor(node *ast.Node) *ast.Node {
 		if test, _ := conditionalTest(parent); test == current {
 			return parent
 		}
-		if ast.IsFunctionLikeDeclaration(parent) {
+		// ts-go combines ESTree's MethodDefinition and FunctionExpression into
+		// one node. Its computed name and member decorators remain outside the
+		// function boundary; parameters, types, and the body remain inside it.
+		if ast.IsFunctionLikeDeclaration(parent) &&
+			current != parent.Name() && current.Kind != ast.KindDecorator {
 			return nil
 		}
 		current = parent

--- a/internal/rules/no_cond_assign/no_cond_assign.md
+++ b/internal/rules/no_cond_assign/no_cond_assign.md
@@ -38,4 +38,4 @@ var branchResult = x ? (y = 1) : z; // assignment is in a branch, not the test
 ## Original Documentation
 
 - [ESLint: no-cond-assign](https://eslint.org/docs/latest/rules/no-cond-assign)
-- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-cond-assign.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-cond-assign.js)

--- a/internal/rules/no_cond_assign/no_cond_assign_test.go
+++ b/internal/rules/no_cond_assign/no_cond_assign_test.go
@@ -352,6 +352,44 @@ func TestNoCondAssignAlwaysMessageData(t *testing.T) {
 	assert.Equal(t, diagnostics[0].Message.Data["type"], "an 'if' statement")
 }
 
+func TestNoCondAssignAlwaysFunctionBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want int
+	}{
+		// ESTree represents each method as a MethodDefinition whose computed
+		// name and decorators sit outside the nested FunctionExpression.
+		{name: "class computed method", code: `if (class { [value = next()]() {} }) {}`, want: 1},
+		{name: "object computed method", code: `if ({ [value = next()]() {} }) {}`, want: 1},
+		{name: "computed getter", code: `if (class { get [value = next()]() { return 1 } }) {}`, want: 1},
+		{name: "computed setter", code: `if (class { set [value = next()](nextValue) {} }) {}`, want: 1},
+		{name: "static async generator name", code: `if (class { static async *[value = next()]() {} }) {}`, want: 1},
+		{name: "method decorator", code: `if (class { @dec(value = next()) method() {} }) {}`, want: 1},
+		{name: "field initializer", code: `if (class { field = (value = next()) }) {}`, want: 1},
+		{name: "static block", code: `if (class { static { value = next() } }) {}`, want: 1},
+
+		// These positions belong to the method's FunctionExpression and must
+		// continue to shield their assignments from an outer condition.
+		{name: "method body", code: `if (class { method() { value = next() } }) {}`},
+		{name: "method parameter", code: `if (class { method(parameter = value = next()) {} }) {}`},
+		{name: "parameter decorator", code: `if (class { method(@dec(value = next()) parameter: unknown) {} }) {}`},
+		{name: "function in computed name", code: `if (class { [() => value = next()]() {} }) {}`},
+		{name: "function in method decorator", code: `if (class { @dec(() => value = next()) method() {} }) {}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := runNoCondAssign(t, test.code, []any{"always"}, rule.EditDemandNone)
+			assert.Equal(t, len(diagnostics), test.want)
+			for _, diagnostic := range diagnostics {
+				assert.Equal(t, diagnostic.Message.Id, "unexpected")
+				assert.Equal(t, diagnostic.Message.Data["type"], "an 'if' statement")
+			}
+		})
+	}
+}
+
 func runNoCondAssign(t *testing.T, code string, options []any, demand rule.EditDemand) []rule.RuleDiagnostic {
 	t.Helper()
 

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -82,6 +82,7 @@ define.test({
     './tests/eslint/rules/func-style.test.ts',
     './tests/eslint/rules/grouped-accessor-pairs.test.ts',
     './tests/eslint/rules/no-case-declarations.test.ts',
+    './tests/eslint/rules/no-cond-assign.test.ts',
     './tests/eslint/rules/no-console.test.ts',
     './tests/eslint/rules/no-continue.test.ts',
     './tests/eslint/rules/no-div-regex.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-cond-assign.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-cond-assign.test.ts.snap
@@ -1,0 +1,677 @@
+// Rstest Snapshot v1
+
+exports[`no-cond-assign > invalid 1`] = `
+{
+  "code": "var x; if (x = 0) { var b = 1; }",
+  "diagnostics": [
+    {
+      "message": "Expected a conditional expression and instead saw an assignment.",
+      "messageId": "missing",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 2`] = `
+{
+  "code": "var x; while (x = 0) { var b = 1; }",
+  "diagnostics": [
+    {
+      "message": "Expected a conditional expression and instead saw an assignment.",
+      "messageId": "missing",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 3`] = `
+{
+  "code": "var x = 0, y; do { y = x; } while (x = x + 1);",
+  "diagnostics": [
+    {
+      "message": "Expected a conditional expression and instead saw an assignment.",
+      "messageId": "missing",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 4`] = `
+{
+  "code": "var x; for(; x+=1 ;){};",
+  "diagnostics": [
+    {
+      "message": "Expected a conditional expression and instead saw an assignment.",
+      "messageId": "missing",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 5`] = `
+{
+  "code": "var x; if ((x) = (0));",
+  "diagnostics": [
+    {
+      "message": "Expected a conditional expression and instead saw an assignment.",
+      "messageId": "missing",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 6`] = `
+{
+  "code": "if (someNode || (someNode = parentNode)) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 7`] = `
+{
+  "code": "while (someNode || (someNode = parentNode)) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'while' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 8`] = `
+{
+  "code": "do { } while (someNode || (someNode = parentNode));",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'do...while' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 9`] = `
+{
+  "code": "for (; (typeof l === 'undefined' ? (l = 0) : l); i++) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'for' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 10`] = `
+{
+  "code": "if (x = 0) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 11`] = `
+{
+  "code": "while (x = 0) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'while' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 12`] = `
+{
+  "code": "do { } while (x = x + 1);",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'do...while' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 13`] = `
+{
+  "code": "for(; x = y; ) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'for' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 14`] = `
+{
+  "code": "if ((x = 0)) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 15`] = `
+{
+  "code": "while ((x = 0)) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'while' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 16`] = `
+{
+  "code": "do { } while ((x = x + 1));",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'do...while' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 17`] = `
+{
+  "code": "for(; (x = y); ) { }",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within a 'for' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 18`] = `
+{
+  "code": "var x; var b = (x = 0) ? 1 : 0;",
+  "diagnostics": [
+    {
+      "message": "Expected a conditional expression and instead saw an assignment.",
+      "messageId": "missing",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 19`] = `
+{
+  "code": "var x; var b = x && (y = 0) ? 1 : 0;",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within ConditionalExpression.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 20`] = `
+{
+  "code": "(((3496.29)).bkufyydt = 2e308) ? foo : bar;",
+  "diagnostics": [
+    {
+      "message": "Expected a conditional expression and instead saw an assignment.",
+      "messageId": "missing",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 21`] = `
+{
+  "code": "if (class { [value = next()]() {} }) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 22`] = `
+{
+  "code": "if ({ [value = next()]() {} }) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 23`] = `
+{
+  "code": "if (class { get [value = next()]() { return 1 } }) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 24`] = `
+{
+  "code": "if (class { set [value = next()](nextValue) {} }) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 25`] = `
+{
+  "code": "if (class { static async *[value = next()]() {} }) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-cond-assign > invalid 26`] = `
+{
+  "code": "if (class { @dec(value = next()) method() {} }) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected assignment within an 'if' statement.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-cond-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-cond-assign.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-cond-assign.test.ts
@@ -1,0 +1,224 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-cond-assign', {
+  valid: [
+    // Upstream ESLint v10.9.1 suite.
+    `var x = 0; if (x == 0) { var b = 1; }`,
+    {
+      code: `var x = 0; if (x == 0) { var b = 1; }`,
+      options: ['always'] as any,
+    },
+    `var x = 5; while (x < 5) { x = x + 1; }`,
+    `if ((someNode = someNode.parentNode) !== null) { }`,
+    {
+      code: `if ((someNode = someNode.parentNode) !== null) { }`,
+      options: ['except-parens'] as any,
+    },
+    `if ((a = b));`,
+    `while ((a = b));`,
+    `do {} while ((a = b));`,
+    `for (;(a = b););`,
+    `for (;;) {}`,
+    `if (someNode || (someNode = parentNode)) { }`,
+    `while (someNode || (someNode = parentNode)) { }`,
+    `do { } while (someNode || (someNode = parentNode));`,
+    `for (;someNode || (someNode = parentNode););`,
+    {
+      code: `if ((function(node) { return node = parentNode; })(someNode)) { }`,
+      options: ['except-parens'] as any,
+    },
+    {
+      code: `if ((function(node) { return node = parentNode; })(someNode)) { }`,
+      options: ['always'] as any,
+    },
+    {
+      code: `if ((node => node = parentNode)(someNode)) { }`,
+      options: ['except-parens'] as any,
+      languageOptions: { ecmaVersion: 6 },
+    },
+    {
+      code: `if ((node => node = parentNode)(someNode)) { }`,
+      options: ['always'] as any,
+      languageOptions: { ecmaVersion: 6 },
+    },
+    {
+      code: `if (function(node) { return node = parentNode; }) { }`,
+      options: ['except-parens'] as any,
+    },
+    {
+      code: `if (function(node) { return node = parentNode; }) { }`,
+      options: ['always'] as any,
+    },
+    { code: `x = 0;`, options: ['always'] as any },
+    `var x; var b = (x === 0) ? 1 : 0;`,
+    {
+      code: `switch (foo) { case a = b: bar(); }`,
+      options: ['except-parens'] as any,
+    },
+    {
+      code: `switch (foo) { case a = b: bar(); }`,
+      options: ['always'] as any,
+    },
+    {
+      code: `switch (foo) { case baz + (a = b): bar(); }`,
+      options: ['always'] as any,
+    },
+
+    // A method's FunctionExpression still shields its own executable slots.
+    {
+      code: `if (class { method() { value = next() } }) {}`,
+      options: ['always'] as any,
+    },
+    {
+      code: `if (class { method(parameter = value = next()) {} }) {}`,
+      options: ['always'] as any,
+    },
+    {
+      code: `if (class { [() => value = next()]() {} }) {}`,
+      options: ['always'] as any,
+    },
+    {
+      code: `if (class { @dec(() => value = next()) method() {} }) {}`,
+      options: ['always'] as any,
+    },
+  ],
+  invalid: [
+    // Upstream ESLint v10.9.1 suite.
+    {
+      code: `var x; if (x = 0) { var b = 1; }`,
+      errors: [
+        {
+          messageId: 'missing',
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      code: `var x; while (x = 0) { var b = 1; }`,
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: `var x = 0, y; do { y = x; } while (x = x + 1);`,
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: `var x; for(; x+=1 ;){};`,
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: `var x; if ((x) = (0));`,
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: `if (someNode || (someNode = parentNode)) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected', column: 18, endColumn: 39 }],
+    },
+    {
+      code: `while (someNode || (someNode = parentNode)) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `do { } while (someNode || (someNode = parentNode));`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `for (; (typeof l === 'undefined' ? (l = 0) : l); i++) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `if (x = 0) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `while (x = 0) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `do { } while (x = x + 1);`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `for(; x = y; ) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `if ((x = 0)) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `while ((x = 0)) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `do { } while ((x = x + 1));`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `for(; (x = y); ) { }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `var x; var b = (x = 0) ? 1 : 0;`,
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: `var x; var b = x && (y = 0) ? 1 : 0;`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `(((3496.29)).bkufyydt = 2e308) ? foo : bar;`,
+      errors: [{ messageId: 'missing' }],
+    },
+
+    // ts-go combines MethodDefinition and FunctionExpression, but these
+    // member-level slots remain outside the function boundary in ESTree.
+    {
+      code: `if (class { [value = next()]() {} }) {}`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected', line: 1, column: 14 }],
+    },
+    {
+      code: `if ({ [value = next()]() {} }) {}`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected', line: 1, column: 8 }],
+    },
+    {
+      code: `if (class { get [value = next()]() { return 1 } }) {}`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected', line: 1, column: 18 }],
+    },
+    {
+      code: `if (class { set [value = next()](nextValue) {} }) {}`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected', line: 1, column: 18 }],
+    },
+    {
+      code: `if (class { static async *[value = next()]() {} }) {}`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected', line: 1, column: 28 }],
+    },
+    {
+      code: `if (class { @dec(value = next()) method() {} }) {}`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'unexpected', line: 1, column: 18 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Align no-cond-assign always mode with ESLint v10.9.1 for assignments in computed method/accessor names and member decorators.
- Preserve function boundaries for method bodies, parameters, and nested functions.
- Add the latest upstream RuleTester cases, focused boundary attacks, and 26 JS diagnostic snapshots.
- Keep the rule allocation-free; fixed-workload native listener time measured 9.9 ms -> 9.5 ms across 10,500 files.

## Related Links

- https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-cond-assign.js
- https://github.com/eslint/eslint/blob/v10.9.1/tests/lib/rules/no-cond-assign.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).