### PR TITLE
fix: align no-control-regex with ESLint

### DIFF
--- a/internal/rules/no_control_regex/no_control_regex.go
+++ b/internal/rules/no_control_regex/no_control_regex.go
@@ -7,7 +7,16 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
+
+var controlCharNames = func() [0x20]string {
+	var names [0x20]string
+	for value := range names {
+		names[value] = fmt.Sprintf(`\x%02x`, value)
+	}
+	return names
+}()
 
 // https://eslint.org/docs/latest/rules/no-control-regex
 var NoControlRegexRule = rule.Rule{
@@ -30,17 +39,18 @@ var NoControlRegexRule = rule.Rule{
 			},
 			ast.KindCallExpression: func(node *ast.Node) {
 				callExpr := node.AsCallExpression()
-				checkRegExpConstructor(callExpr.Expression, callExpr.Arguments, report)
+				checkRegExpConstructor(ctx, callExpr.Expression, callExpr.Arguments, report)
 			},
 			ast.KindNewExpression: func(node *ast.Node) {
 				newExpr := node.AsNewExpression()
-				checkRegExpConstructor(newExpr.Expression, newExpr.Arguments, report)
+				checkRegExpConstructor(ctx, newExpr.Expression, newExpr.Arguments, report)
 			},
 		}
 	},
 }
 
 func checkRegExpConstructor(
+	ctx rule.RuleContext,
 	callee *ast.Node,
 	args *ast.NodeList,
 	report func(*ast.Node, []string),
@@ -49,26 +59,60 @@ func checkRegExpConstructor(
 	if callee == nil || callee.Kind != ast.KindIdentifier || callee.AsIdentifier().Text != "RegExp" {
 		return
 	}
+	if !ctx.Globals.Access("RegExp").IsDeclared() {
+		return
+	}
+	if ctx.Refs != nil {
+		if !ctx.Refs.IsGlobalReference(callee) {
+			return
+		}
+	} else if utils.IsShadowed(callee, "RegExp") {
+		return
+	}
 	if args == nil || len(args.Nodes) == 0 {
 		return
 	}
 
-	patternNode := args.Nodes[0]
-	if patternNode.Kind != ast.KindStringLiteral {
+	patternNode := ast.SkipParentheses(args.Nodes[0])
+	if patternNode == nil || patternNode.Kind != ast.KindStringLiteral {
 		return
 	}
-	pattern := patternNode.AsStringLiteral().Text
+	pattern, ok := stringLiteralValue(ctx, patternNode)
+	if !ok {
+		return
+	}
 
 	// ESLint only treats flags as known when the second argument is a string
 	// literal; otherwise flags default to "" (neither u nor v).
 	flags := ""
-	if len(args.Nodes) >= 2 && args.Nodes[1].Kind == ast.KindStringLiteral {
-		flags = args.Nodes[1].AsStringLiteral().Text
+	if len(args.Nodes) >= 2 {
+		flagsNode := ast.SkipParentheses(args.Nodes[1])
+		if flagsNode != nil && flagsNode.Kind == ast.KindStringLiteral {
+			if value, valueOK := stringLiteralValue(ctx, flagsNode); valueOK {
+				flags = value
+			}
+		}
 	}
 
 	if chars := collectControlChars(pattern, flags); len(chars) > 0 {
 		report(patternNode, chars)
 	}
+}
+
+func stringLiteralValue(ctx rule.RuleContext, node *ast.Node) (string, bool) {
+	if utils.IsInStrictModeWithSourceType(node, ctx.SourceFile, ctx.LanguageOptions.EffectiveSourceType()) {
+		return node.AsStringLiteral().Text, true
+	}
+	r := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	units := utils.ParseJSStringLiteralSource(ctx.SourceFile.Text()[r.Pos():r.End()])
+	if units == nil {
+		return "", false
+	}
+	values := make([]uint16, len(units))
+	for i, unit := range units {
+		values[i] = uint16(unit.Value)
+	}
+	return ecmascript.StringFromCodeUnits(values), true
 }
 
 // collectControlChars scans a regex pattern and returns each code point in
@@ -80,22 +124,32 @@ func checkRegExpConstructor(
 //
 // Each hit is formatted as `\xHH` (lowercase, 2 digits). Symbolic control
 // escapes (\t, \n, \r, \v, \f, \0, \cX) are NOT reported — matching ESLint.
-//
-// Note on syntax-invalid patterns: ESLint uses @eslint-community/regexpp's
-// validatePattern inside a try/catch, so on a syntax error it keeps the
-// characters collected before the error point and discards anything after.
-// This scanner does not reproduce that behavior — on a malformed pattern it
-// continues scanning to the end, which may over-report control characters
-// that appear after the syntax error. Syntactically-invalid patterns are
-// independently flagged by the `no-invalid-regexp` rule, so in practice a
-// user running both rules sees every issue; the rule attribution differs.
 func collectControlChars(pattern, flagsStr string) []string {
+	pattern = ecmascript.CombineSurrogatePairs(pattern)
 	flags := utils.ParseRegexFlags(flagsStr)
 	uvMode := flags.UV()
+	results, uncertainEscape := scanControlChars(pattern, uvMode)
+	if len(results) == 0 {
+		return nil
+	}
+	if (!flags.Unicode || !flags.UnicodeSets) && !uncertainEscape && !strings.ContainsAny(pattern, `^$.*+?()[]{|}`) {
+		return results
+	}
+	if errorPosition, invalid := utils.RegexPatternCharacterEventCutoff(pattern, flags); invalid {
+		if errorPosition <= 0 {
+			return nil
+		}
+		if errorPosition < len(pattern) {
+			results, _ = scanControlChars(pattern[:errorPosition], uvMode)
+		}
+	}
+	return results
+}
 
-	var results []string
+// scanControlChars performs the character-callback part of regexpp's walk.
+func scanControlChars(pattern string, uvMode bool) (results []string, uncertainEscape bool) {
 	record := func(cp uint32) {
-		results = append(results, fmt.Sprintf(`\x%02x`, cp))
+		results = append(results, controlCharNames[cp])
 	}
 
 	i := 0
@@ -103,7 +157,8 @@ func collectControlChars(pattern, flagsStr string) []string {
 		c := pattern[i]
 
 		if c == '\\' && i+1 < len(pattern) {
-			switch pattern[i+1] {
+			next := pattern[i+1]
+			switch next {
 			case 'x':
 				// \xHH — 2 hex digits required.
 				if i+3 < len(pattern) && utils.IsHexDigit(pattern[i+2]) && utils.IsHexDigit(pattern[i+3]) {
@@ -114,15 +169,19 @@ func collectControlChars(pattern, flagsStr string) []string {
 					i += 4
 					continue
 				}
+				uncertainEscape = true
 			case 'u':
 				// \u{H...} — only recognized under u / v flag.
 				if uvMode && i+2 < len(pattern) && pattern[i+2] == '{' {
 					if closeRel := strings.IndexByte(pattern[i+3:], '}'); closeRel > 0 {
 						hex := pattern[i+3 : i+3+closeRel]
 						if utils.AllHexDigits(hex) {
-							cp := utils.ParseHexUint(hex)
-							if cp <= 0x1f {
-								record(cp)
+							significant := strings.TrimLeft(hex, "0")
+							if len(significant) <= 2 {
+								cp := utils.ParseHexUint(hex)
+								if cp <= 0x1f {
+									record(cp)
+								}
 							}
 							i += 3 + closeRel + 1
 							continue
@@ -138,6 +197,21 @@ func collectControlChars(pattern, flagsStr string) []string {
 					i += 6
 					continue
 				}
+				uncertainEscape = true
+			default:
+				switch next {
+				case 'f', 'n', 'r', 't', 'v', 'd', 'D', 's', 'S', 'w', 'W',
+					'^', '$', '\\', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|', '/':
+				case '0':
+					uncertainEscape = uncertainEscape ||
+						uvMode && i+2 < len(pattern) && pattern[i+2] >= '0' && pattern[i+2] <= '9'
+				case 'c':
+					valid := i+2 < len(pattern) &&
+						((pattern[i+2] >= 'a' && pattern[i+2] <= 'z') || (pattern[i+2] >= 'A' && pattern[i+2] <= 'Z'))
+					uncertainEscape = uncertainEscape || uvMode && !valid
+				default:
+					uncertainEscape = uncertainEscape || uvMode
+				}
 			}
 			// Any other escape (\t, \n, \\, \cI, \0, \d, \p{…}, \q{…}, etc.):
 			// consume 2 bytes. Multi-byte escape bodies (e.g. `\q{…}` under v
@@ -147,12 +221,13 @@ func collectControlChars(pattern, flagsStr string) []string {
 			i += 2
 			continue
 		}
-
 		if c <= 0x1f {
 			record(uint32(c))
 		}
+		if c == '\\' {
+			uncertainEscape = true
+		}
 		i++
 	}
-
-	return results
+	return results, uncertainEscape
 }

--- a/internal/rules/no_control_regex/no_control_regex.md
+++ b/internal/rules/no_control_regex/no_control_regex.md
@@ -38,15 +38,7 @@ var pattern7 = new RegExp('\\t');
 var pattern8 = new RegExp('\\n');
 ```
 
-## Differences from ESLint
-
-ESLint's implementation delegates pattern validation to `@eslint-community/regexpp` and wraps it in `try/catch`. On a regex-syntax error, regexpp aborts parsing, so any control characters appearing after the error point are never reported.
-
-This implementation is a linear scanner without a full ES regex parser. On a **syntactically-invalid pattern** it keeps scanning past the error, which may surface control characters ESLint would have suppressed. For valid regex patterns the two implementations produce identical output.
-
-Syntactically-invalid patterns are independently flagged by the [`no-invalid-regexp`](https://eslint.org/docs/latest/rules/no-invalid-regexp) rule, so running both rules together surfaces every relevant issue; only the rule attribution differs on malformed input.
-
 ## Original Documentation
 
 - [ESLint: no-control-regex](https://eslint.org/docs/latest/rules/no-control-regex)
-- [Source code](https://github.com/eslint/eslint/blob/v10.2.1/lib/rules/no-control-regex.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-control-regex.js)

--- a/internal/rules/no_control_regex/no_control_regex_test.go
+++ b/internal/rules/no_control_regex/no_control_regex_test.go
@@ -124,11 +124,25 @@ func TestCollectControlChars(t *testing.T) {
 		{"\\p{Script=Latin} under u", `\p{Script=Latin}`, `u`, nil},
 		{"\\p next to control xHH", `\p{Letter}\x1f`, `u`, []string{`\x1f`}},
 
-		// ── Documented divergence from ESLint on syntactically-invalid patterns.
-		// ESLint's collector inherits regexpp's stop-on-error behavior; this
-		// scanner intentionally does not model that (see rule doc). The cases
-		// below pin the current over-reporting behavior so changes are loud.
-		{"malformed: \\u{...} invalid content before control", `\u{NOT_HEX}\x1f`, `u`, []string{`\x1f`}},
+		// ── Syntax errors stop regexpp's character callbacks at the error.
+		{"malformed: \\u{...} invalid content before control", `\u{NOT_HEX}\x1f`, `u`, nil},
+		{"malformed: control before invalid \\u{...}", `\x1f\u{NOT_HEX}`, `u`, []string{`\x1f`}},
+		{"malformed: invalid quantifier before control", `*\x1f`, `u`, nil},
+		{"malformed: control before invalid quantifier", `\x1f**`, `u`, []string{`\x1f`}},
+		{"malformed: invalid range before control", `[z-a\x1f]`, `u`, nil},
+		{"malformed: control before invalid range", `[\x1fz-a]`, `u`, []string{`\x1f`}},
+		{"legacy malformed: unmatched close before control", `)\x1f`, ``, nil},
+		{"legacy malformed: control before unmatched close", `\x1f)`, ``, []string{`\x1f`}},
+		{"legacy malformed: range before control", `[a--b]\x1f`, ``, nil},
+		{"legacy Annex B identity before control", `\u{NOT_HEX}\x1f`, ``, []string{`\x1f`}},
+		{"missing numeric reference before control", `\1\x1f`, `u`, nil},
+		{"missing named reference is resolved after callbacks", `(?<a>a)\k<missing>\x1f`, `u`, []string{`\x1f`}},
+		{"single ampersand in v class", `[&\x1f]`, `v`, []string{`\x1f`}},
+		{"duplicate capture before control", `(?<a>a)(?<a>a)\x1f`, `u`, nil},
+		{"malformed: mutually exclusive u and v", `\u{1F}`, `uv`, nil},
+		{"malformed: duplicate u is ignored by pattern validator", `\u{1F}`, `uu`, []string{`\x1f`}},
+		{"malformed: unknown flag is ignored by pattern validator", `\x1f`, `z`, []string{`\x1f`}},
+		{"malformed: overflowing code point escape", `\u{100000001}`, `u`, nil},
 		{"malformed: unclosed [ still collects control inside", `[\x1f`, ``, []string{`\x1f`}},
 		{"malformed: unclosed ( still collects control inside", `(\x1f`, ``, []string{`\x1f`}},
 	}
@@ -199,6 +213,16 @@ func TestNoControlRegexRule(t *testing.T) {
 			{Code: `/[\u{20}--B]/v`},
 			{Code: "new RegExp('\\x20')"},
 
+			// ── Only the environment-global RegExp constructor is checked ──
+			{Code: `function foo(RegExp) { RegExp("\x1f"); }`},
+			{Code: `function foo(RegExp) { new RegExp("\x1f"); }`},
+			{Code: `let RegExp; RegExp("\x1f");`},
+			{Code: `RegExp("\x1f")`, Globals: map[string]any{"RegExp": "off"}},
+			{Code: `/* global RegExp: off */ RegExp("\x1f")`},
+			{Code: `namespace RegExp {} RegExp("\x1f")`},
+			{Code: `class RegExp {} RegExp("\x1f")`},
+			{Code: `enum RegExp {} RegExp("\x1f")`},
+
 			// ── Symbolic escapes — all allowed ──
 			{Code: `/\t/`},
 			{Code: `/\n/`},
@@ -220,8 +244,8 @@ func TestNoControlRegexRule(t *testing.T) {
 
 			// ── Non-string first argument — constructor path skipped ──
 			{Code: "RegExp(pattern)"},
-			{Code: "RegExp(/x20/)"},      // inner regex has no controls
-			{Code: "RegExp('a' + 'b')"},  // binary expression
+			{Code: "RegExp(/x20/)"},     // inner regex has no controls
+			{Code: "RegExp('a' + 'b')"}, // binary expression
 			{Code: "RegExp(cond ? 'a' : 'b')"},
 			{Code: "RegExp(123)"},
 			{Code: "RegExp(null)"},
@@ -250,6 +274,11 @@ func TestNoControlRegexRule(t *testing.T) {
 			// ── \p{...} unicode property — not a control escape ──
 			{Code: `/\p{Letter}/u`},
 			{Code: `new RegExp("\\p{Letter}", "u")`},
+
+			// ── Syntax errors suppress controls that occur after the error ──
+			{Code: `RegExp("\\u{NOT_HEX}\\x1f", "u")`},
+			{Code: `RegExp("*\\x1f", "u")`},
+			{Code: `RegExp("\\u{1F}", "uv")`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ── Regex literals: \xHH ──
@@ -397,6 +426,61 @@ func TestNoControlRegexRule(t *testing.T) {
 				Code: `new RegExp("[\\q{\\u{1F}}]", "v")`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+
+			// Parentheses are not represented in ESLint's ESTree arguments.
+			{
+				Code: `RegExp(("\\x1f"))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `RegExp("\\u{1F}", ("u"))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+
+			// Type-only declarations do not shadow the value-space global.
+			{
+				Code: `type RegExp = string; RegExp("\x1f")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected"},
+				},
+			},
+			{
+				Code: `interface RegExp {} RegExp("\x1f")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected"},
+				},
+			},
+
+			{
+				Code: `RegExp("\t\0")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: `Unexpected control character(s) in regular expression: \x09, \x00.`, Line: 1, Column: 8},
+				},
+			},
+
+			// Controls collected before a syntax error remain reportable.
+			{
+				Code: `RegExp("\\x1f\\u{NOT_HEX}", "u")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `RegExp("\\u{1F}", "uu")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `RegExp("\\x1f", "z")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
 				},
 			},
 

--- a/internal/utils/ecmascript/regexp/escape.go
+++ b/internal/utils/ecmascript/regexp/escape.go
@@ -306,3 +306,101 @@ func countGroups(source string) (int, bool) {
 	}
 	return count, named
 }
+
+// CapturingGroupCount returns the lexical number of capturing groups and
+// whether at least one is named. RegExp parsers perform this pass before
+// interpreting numeric and named backreferences, including on patterns that
+// later fail another grammar check.
+func CapturingGroupCount(source string) (int, bool) {
+	return countGroups(source)
+}
+
+type legacyEscapeReplacement struct {
+	start int
+	end   int
+	text  string
+}
+
+// NormalizeAnnexBEscapesForParser rewrites the few Annex B escapes that the
+// TypeScript RegExp scanner diagnoses using its JavaScript-string rules. Each
+// replacement is one parser-equivalent atom, so surrounding groups,
+// quantifiers, and ranges retain their original grammar. When rewriting is
+// needed, offsets maps every output byte back to its source byte position and
+// includes one terminal entry for len(source).
+func NormalizeAnnexBEscapesForParser(source string) (normalized string, offsets []int) {
+	groupCount, named := countGroups(source)
+	var replacements []legacyEscapeReplacement
+	inClass := false
+
+	for i := 0; i < len(source); {
+		if source[i] != '\\' {
+			switch source[i] {
+			case '[':
+				inClass = true
+			case ']':
+				inClass = false
+			}
+			_, width := utf8.DecodeRuneInString(source[i:])
+			if width == 0 {
+				width = 1
+			}
+			i += width
+			continue
+		}
+		if i+1 >= len(source) {
+			break
+		}
+		if _, width, ok := namedBackreference(source[i:]); ok {
+			i += width
+			continue
+		}
+
+		escape, err := decodeEscape(source, i+1, escapeContext{
+			inClass: inClass,
+			groups:  groupCount,
+			named:   named,
+		})
+		if err != nil {
+			i++
+			continue
+		}
+		consumed := 1 + escape.width
+		if escape.width == 0 {
+			consumed = 1
+		}
+		if escape.kind == escapeRune {
+			replacements = append(replacements, legacyEscapeReplacement{
+				start: i,
+				end:   i + consumed,
+				text:  literalRune(escape.r),
+			})
+		}
+		i += consumed
+	}
+
+	if len(replacements) == 0 {
+		return source, nil
+	}
+	var result strings.Builder
+	result.Grow(len(source))
+	offsets = make([]int, 0, len(source)+1)
+	write := func(text string, offset int) {
+		result.WriteString(text)
+		for range len(text) {
+			offsets = append(offsets, offset)
+		}
+	}
+	last := 0
+	for _, replacement := range replacements {
+		for i := last; i < replacement.start; i++ {
+			write(source[i:i+1], i)
+		}
+		write(replacement.text, replacement.start)
+		last = replacement.end
+	}
+	for i := last; i < len(source); i++ {
+		write(source[i:i+1], i)
+	}
+	offsets = append(offsets, len(source))
+	return result.String(), offsets
+}

--- a/internal/utils/ecmascript/regexp/regexp_test.go
+++ b/internal/utils/ecmascript/regexp/regexp_test.go
@@ -2,10 +2,57 @@ package regexp
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestNormalizeAnnexBEscapesForParser(t *testing.T) {
+	tests := []struct {
+		source  string
+		want    string
+		offsets []int
+	}{
+		{source: "abc", want: "abc"},
+		{source: `\k<a>`, want: `\k<a>`},
+		{
+			source:  `\u{41}*\x00`,
+			want:    `u{41}*\u0000`,
+			offsets: []int{0, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 11},
+		},
+		{
+			source:  `\01a`,
+			want:    `\u0001a`,
+			offsets: []int{0, 0, 0, 0, 0, 0, 3, 4},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.source, func(t *testing.T) {
+			got, offsets := NormalizeAnnexBEscapesForParser(test.source)
+			if got != test.want || !slices.Equal(offsets, test.offsets) {
+				t.Fatalf("NormalizeAnnexBEscapesForParser(%q) = (%q, %v), want (%q, %v)", test.source, got, offsets, test.want, test.offsets)
+			}
+		})
+	}
+}
+
+func TestCapturingGroupCount(t *testing.T) {
+	for _, test := range []struct {
+		source string
+		count  int
+		named  bool
+	}{
+		{source: `(?:a)(b)[(](?<name>c)`, count: 2, named: true},
+		{source: `\((a)(?=b)`, count: 1},
+	} {
+		count, named := CapturingGroupCount(test.source)
+		if count != test.count || named != test.named {
+			t.Errorf("CapturingGroupCount(%q) = (%d, %v), want (%d, %v)", test.source, count, named, test.count, test.named)
+		}
+	}
+}
 
 // Every expectation below is what `new RegExp(source, flags).test(subject)`
 // answers in JavaScript.

--- a/internal/utils/ecmascript/regexp_literal.go
+++ b/internal/utils/ecmascript/regexp_literal.go
@@ -23,23 +23,127 @@ func IsValidRegexLiteralForVersion(literal string, ecmaVersion int) bool {
 	if !regexFeaturesAvailable(flags, literal, ecmaVersion) {
 		return false
 	}
+	result := scanRegexLiteral(literal, false, ecmaVersion)
+	return result.complete && !result.hasError
+}
+
+// RegexLiteralCharacterEventCutoff returns the byte position where a syntax
+// error stops regexpp-style character events. Semantic errors resolved after
+// the walk do not create a cutoff. Unterminated is true when the lexer could
+// not find the literal's closing slash.
+func RegexLiteralCharacterEventCutoff(literal string) (position int, unterminated bool, ok bool) {
+	result := scanRegexLiteral(literal, true, 0)
+	if !result.hasError {
+		return 0, false, false
+	}
+	return result.errorPosition, result.unterminated, true
+}
+
+type regexLiteralScanResult struct {
+	errorPosition int
+	hasError      bool
+	unterminated  bool
+	complete      bool
+}
+
+func scanRegexLiteral(literal string, ignoreDeferredEventErrors bool, ecmaVersion int) regexLiteralScanResult {
+	flags := literalFlags(literal)
 	s := scanner.NewScanner()
-	hasError := false
+	result := regexLiteralScanResult{}
+	ignoredNamedReferenceStart := -1
 	s.SetScriptTarget(scriptTargetForECMAVersion(ecmaVersion))
-	s.SetOnError(func(message *diagnostics.Message, _ int, _ int, _ ...any) {
-		if !isIgnorableRegexLiteralDiagnostic(message, flags) {
-			hasError = true
+	s.SetOnError(func(message *diagnostics.Message, start int, length int, _ ...any) {
+		if ignoreDeferredEventErrors {
+			if message == diagnostics.There_is_no_capturing_group_named_0_in_this_regular_expression {
+				ignoredNamedReferenceStart = start
+				return
+			}
+			if message == diagnostics.Did_you_mean_0 && start == ignoredNamedReferenceStart {
+				return
+			}
+		}
+		if !result.hasError &&
+			!isIgnorableRegexLiteralDiagnostic(message, flags) &&
+			!isIgnorableSingleVAmpersandDiagnostic(message, literal, flags, start) &&
+			(!ignoreDeferredEventErrors || !isIgnorableRegexEventDiagnostic(message, flags)) {
+			result.errorPosition = start
+			if ignoreDeferredEventErrors && message == diagnostics.Range_out_of_order_in_character_class {
+				// regexpp emits onCharacter for both range endpoints before it
+				// rejects their ordering. tsgo highlights the whole range, so its
+				// end is the equivalent callback cutoff.
+				result.errorPosition += length
+			}
+			result.hasError = true
+			result.unterminated = message == diagnostics.Unterminated_regular_expression_literal
 		}
 	})
 	s.SetText(literal)
 	s.ResetTokenState(0)
-	if s.Scan() != ast.KindSlashToken {
-		return false
+	firstToken := s.Scan()
+	if firstToken != ast.KindSlashToken && firstToken != ast.KindSlashEqualsToken {
+		result.hasError = true
+		return result
 	}
 	if s.ReScanSlashToken(true) != ast.KindRegularExpressionLiteral {
+		result.hasError = true
+		return result
+	}
+	result.complete = s.TokenFlags()&ast.TokenFlagsUnterminated == 0 && s.TokenEnd() == len(literal)
+	if !result.complete && !result.hasError {
+		result.errorPosition = s.TokenEnd()
+		result.hasError = true
+		result.unterminated = s.TokenFlags()&ast.TokenFlagsUnterminated != 0
+	}
+	return result
+}
+
+func isIgnorableRegexEventDiagnostic(message *diagnostics.Message, flags string) bool {
+	if !strings.ContainsAny(flags, "uv") {
+		switch message {
+		case diagnostics.Hexadecimal_digit_expected,
+			diagnostics.An_extended_Unicode_escape_value_must_be_between_0x0_and_0x10FFFF_inclusive,
+			diagnostics.Octal_escape_sequences_are_not_allowed_Use_the_syntax_0,
+			diagnostics.Unicode_escape_sequences_are_only_available_when_the_Unicode_u_flag_or_the_Unicode_Sets_v_flag_is_set,
+			diagnostics.Expected_a_Unicode_property_name,
+			diagnostics.Expected_a_Unicode_property_name_or_value,
+			diagnostics.Expected_a_Unicode_property_value,
+			diagnostics.Unknown_Unicode_property_name,
+			diagnostics.Unknown_Unicode_property_name_or_value,
+			diagnostics.Unknown_Unicode_property_value,
+			diagnostics.Unicode_property_value_expressions_are_only_available_when_the_Unicode_u_flag_or_the_Unicode_Sets_v_flag_is_set,
+			diagnostics.Any_Unicode_property_that_would_possibly_match_more_than_a_single_character_is_only_available_when_the_Unicode_Sets_v_flag_is_set,
+			diagnostics.Anything_that_would_possibly_match_more_than_a_single_character_is_invalid_inside_a_negated_character_class,
+			diagnostics.Did_you_mean_0:
+			// Annex B treats malformed fixed escapes and Unicode property
+			// spellings as identity escapes when neither u nor v is present.
+			// The bundled tsgo parser still reports its Unicode-mode diagnostics,
+			// so they do not mark the point where regexpp stops character events.
+			return true
+		}
+	}
+	return false
+}
+
+func isIgnorableSingleVAmpersandDiagnostic(message *diagnostics.Message, literal string, flags string, start int) bool {
+	if message != diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash ||
+		!strings.ContainsRune(flags, 'v') || start < 0 || start >= len(literal) || literal[start] != '&' {
 		return false
 	}
-	return !hasError && s.TokenFlags()&ast.TokenFlagsUnterminated == 0 && s.TokenEnd() == len(literal)
+	// A single ampersand is a v-mode class character. Only two adjacent,
+	// unescaped ampersands form an intersection; `\&&` is an escaped character
+	// followed by a single one. The bundled tsgo scanner diagnoses that second
+	// form even though regexpp emits both characters.
+	previousAmpersand := start > 0 && literal[start-1] == '&' && !regexLiteralCharacterIsEscaped(literal, start-1)
+	nextAmpersand := start+1 < len(literal) && literal[start+1] == '&' && !regexLiteralCharacterIsEscaped(literal, start+1)
+	return !previousAmpersand && !nextAmpersand
+}
+
+func regexLiteralCharacterIsEscaped(literal string, position int) bool {
+	backslashes := 0
+	for position--; position >= 0 && literal[position] == '\\'; position-- {
+		backslashes++
+	}
+	return backslashes%2 != 0
 }
 
 func scriptTargetForECMAVersion(ecmaVersion int) core.ScriptTarget {

--- a/internal/utils/ecmascript/regexp_literal_test.go
+++ b/internal/utils/ecmascript/regexp_literal_test.go
@@ -14,7 +14,10 @@ func TestIsValidRegexLiteral(t *testing.T) {
 		want    bool
 	}{
 		{name: "basic", literal: `/abc/g`, want: true},
+		{name: "slash equals token", literal: `/=/`, want: true},
 		{name: "unicode sets", literal: `/[[A--B]]/v`, want: true},
+		{name: "single v ampersand", literal: `/[&]/v`, want: true},
+		{name: "escaped and single v ampersands", literal: `/[\&&]/v`, want: true},
 		{name: "inline modifier", literal: `/(?i:foo)bar/`, want: true},
 		{name: "annex b decimal escape", literal: `/\78\126\5934/`, want: true},
 		{name: "invalid unicode property", literal: `/\p{NotAProperty}/u`, want: false},
@@ -42,6 +45,7 @@ func TestIsValidRegexLiteral(t *testing.T) {
 		// A backreference that does resolve stays valid under every flag.
 		{name: "resolved backreference", literal: `/(a)\1/`, want: true},
 		{name: "resolved backreference under u", literal: `/(a)\1/u`, want: true},
+		{name: "missing named backreference under u", literal: `/\k<missing>/u`, want: false},
 	}
 
 	for _, test := range tests {
@@ -76,6 +80,45 @@ func TestIsValidRegexLiteralForVersion(t *testing.T) {
 		if got := IsValidRegexLiteralForVersion(test.literal, test.version); got != test.want {
 			t.Errorf("IsValidRegexLiteralForVersion(%q, %d) = %v, want %v", test.literal, test.version, got, test.want)
 		}
+	}
+}
+
+func TestRegexLiteralCharacterEventCutoff(t *testing.T) {
+	tests := []struct {
+		literal      string
+		position     int
+		unterminated bool
+		hasError     bool
+	}{
+		{literal: `/\x1f/`},
+		{literal: `/=/`},
+		{literal: `/[.&\x1f]/v`},
+		{literal: `/\u{NOT_HEX}\x1f/`},
+		{literal: `/\u{NOT_HEX}\x1f/u`, position: 4, hasError: true},
+		{literal: `/\x1f\u{NOT_HEX}/u`, position: 8, hasError: true},
+		{literal: `/\x1f[/`, position: 0, unterminated: true, hasError: true},
+		{literal: `/\x1f/uv`, position: 7, hasError: true},
+		// regexpp resolves named backreferences after character callbacks, so
+		// this semantic error must not truncate a rule's collected events.
+		{literal: `/\k<missing>\x1f/u`},
+		{literal: `/(?<a>a)\k<missing>\x1f/u`},
+	}
+	for _, test := range tests {
+		t.Run(test.literal, func(t *testing.T) {
+			position, unterminated, hasError := RegexLiteralCharacterEventCutoff(test.literal)
+			if position != test.position || unterminated != test.unterminated || hasError != test.hasError {
+				t.Fatalf(
+					"RegexLiteralCharacterEventCutoff(%q) = (%d, %v, %v), want (%d, %v, %v)",
+					test.literal,
+					position,
+					unterminated,
+					hasError,
+					test.position,
+					test.unterminated,
+					test.hasError,
+				)
+			}
+		})
 	}
 }
 

--- a/internal/utils/regex_validate.go
+++ b/internal/utils/regex_validate.go
@@ -62,7 +62,7 @@ func validateRegexPattern(pattern string, flags RegexFlags) regexPatternValidati
 	// validation just as the RegExp parser's CodePoint operation does.
 	pattern = ecmascript.CombineSurrogatePairs(pattern)
 
-	normalized, captureNames, ok := normalizeRegexCaptureNames(pattern, flags)
+	normalized, captureNames, _, ok := normalizeRegexCaptureNames(pattern, flags, false)
 	if !ok {
 		return regexPatternValidation{
 			hasDuplicateCaptureName:             captureNames.hasDuplicate,
@@ -218,6 +218,7 @@ func hasRegexNamedCapture(pattern string, flags RegexFlags) bool {
 type regexCaptureNameAnalysis struct {
 	hasDuplicate             bool
 	hasNonExclusiveDuplicate bool
+	nonExclusivePosition     int
 }
 
 type regexBranch struct {
@@ -305,7 +306,7 @@ func (t *regexBranchTracker) separatedFrom(left int, right int) bool {
 // declarations get distinct placeholders because ES2025 permits them when
 // their Alternatives are mutually exclusive; references use the first
 // declaration's placeholder.
-func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, regexCaptureNameAnalysis, bool) {
+func normalizeRegexCaptureNames(pattern string, flags RegexFlags, trackOffsets bool) (string, regexCaptureNameAnalysis, []int, bool) {
 	var replacements []regexCaptureNameReplacement
 	var placeholders map[string]string
 	var lastDeclarationBranch map[string]int
@@ -356,6 +357,7 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, regex
 				if !analysis.hasNonExclusiveDuplicate &&
 					(!trackBranches || !branches.separatedFrom(previous, branches.current)) {
 					analysis.hasNonExclusiveDuplicate = true
+					analysis.nonExclusivePosition = nameStart
 				}
 			}
 			lastDeclarationBranch[name] = branches.current
@@ -368,21 +370,28 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, regex
 		return true
 	}
 
+scanPattern:
 	for i := 0; i < len(pattern); {
 		switch pattern[i] {
 		case '[':
 			end := 0
 			if flags.UnicodeSets {
 				var ok bool
-				end, ok = analyzeRegexVClass(pattern, i)
+				end, _, ok = analyzeRegexVClass(pattern, i)
 				if !ok {
-					return "", analysis, false
+					if trackOffsets {
+						break scanPattern
+					}
+					return "", analysis, nil, false
 				}
 			} else {
 				var ok bool
 				end, ok = ClassEnd(pattern, i, flags)
 				if !ok {
-					return "", analysis, false
+					if trackOffsets {
+						break scanPattern
+					}
+					return "", analysis, nil, false
 				}
 			}
 			i = end
@@ -390,14 +399,20 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, regex
 			if strings.HasPrefix(pattern[i:], `\k<`) {
 				_, next, ok := readAngleName(pattern, i+2)
 				if !ok || !addName(i+3, next-1, false) {
-					return "", analysis, false
+					if trackOffsets {
+						break scanPattern
+					}
+					return "", analysis, nil, false
 				}
 				i = next
 				continue
 			}
 			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
-				return "", analysis, false
+				if trackOffsets {
+					break scanPattern
+				}
+				return "", analysis, nil, false
 			}
 			i += step
 		case '(':
@@ -405,7 +420,10 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, regex
 				(i+3 >= len(pattern) || pattern[i+3] != '=' && pattern[i+3] != '!') {
 				_, next, ok := readAngleName(pattern, i+2)
 				if !ok || !addName(i+3, next-1, true) {
-					return "", analysis, false
+					if trackOffsets {
+						break scanPattern
+					}
+					return "", analysis, nil, false
 				}
 				i = next
 			} else {
@@ -434,18 +452,41 @@ func normalizeRegexCaptureNames(pattern string, flags RegexFlags) (string, regex
 	}
 
 	if len(replacements) == 0 {
-		return pattern, analysis, true
+		return pattern, analysis, nil, true
 	}
 	var result strings.Builder
 	result.Grow(len(pattern))
+	var offsets []int
+	if trackOffsets {
+		offsets = make([]int, 0, len(pattern)+1)
+	}
+	writeOriginal := func(start int, end int) {
+		result.WriteString(pattern[start:end])
+		if trackOffsets {
+			for i := start; i < end; i++ {
+				offsets = append(offsets, i)
+			}
+		}
+	}
+	writeReplacement := func(replacement regexCaptureNameReplacement) {
+		result.WriteString(replacement.placeholder)
+		if trackOffsets {
+			for range len(replacement.placeholder) {
+				offsets = append(offsets, replacement.start)
+			}
+		}
+	}
 	last := 0
 	for _, replacement := range replacements {
-		result.WriteString(pattern[last:replacement.start])
-		result.WriteString(replacement.placeholder)
+		writeOriginal(last, replacement.start)
+		writeReplacement(replacement)
 		last = replacement.end
 	}
-	result.WriteString(pattern[last:])
-	return result.String(), analysis, true
+	writeOriginal(last, len(pattern))
+	if trackOffsets {
+		offsets = append(offsets, len(pattern))
+	}
+	return result.String(), analysis, offsets, true
 }
 
 type regexVClassFrame struct {
@@ -490,9 +531,9 @@ func (f *regexVClassFrame) addOperand(mayHaveStrings bool) {
 // mirrors the ClassSetExpression MayContainStrings reduction because the
 // pinned tsgo scanner does not propagate later union operands. tsgo remains
 // the grammar authority for every other production.
-func analyzeRegexVClass(pattern string, start int) (end int, ok bool) {
+func analyzeRegexVClass(pattern string, start int) (end int, errorPosition int, ok bool) {
 	if start >= len(pattern) || pattern[start] != '[' {
-		return start, false
+		return start, start, false
 	}
 
 	flags := RegexFlags{UnicodeSets: true}
@@ -508,9 +549,9 @@ func analyzeRegexVClass(pattern string, start int) (end int, ok bool) {
 		switch pattern[i] {
 		case '\\':
 			if strings.HasPrefix(pattern[i:], `\q{`) {
-				next, mayHaveStrings, qOK := scanRegexVQString(pattern, i)
+				next, mayHaveStrings, qErrorPosition, qOK := scanRegexVQString(pattern, i)
 				if !qOK {
-					return start, false
+					return start, qErrorPosition, false
 				}
 				frame.addOperand(mayHaveStrings)
 				i = next
@@ -519,7 +560,7 @@ func analyzeRegexVClass(pattern string, start int) (end int, ok bool) {
 			mayHaveStrings := regexVPropertyMayContainStrings(pattern, i)
 			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
-				return start, false
+				return start, i, false
 			}
 			frame.addOperand(mayHaveStrings)
 			i += step
@@ -533,26 +574,26 @@ func analyzeRegexVClass(pattern string, start int) (end int, ok bool) {
 			}
 		case ']':
 			if frame.trailingHyphen {
-				return start, false
+				return start, i, false
 			}
 			if frame.negated && frame.mayHaveStrings {
-				return start, false
+				return start, i, false
 			}
 			completedMayHaveStrings := !frame.negated && frame.mayHaveStrings
 			frames = frames[:len(frames)-1]
 			i++
 			if len(frames) == 0 {
-				return i, true
+				return i, 0, true
 			}
 			parent := &frames[len(frames)-1]
 			parent.addOperand(completedMayHaveStrings)
 		case '/':
 			// `/` is a ClassSetSyntaxCharacter. Escaping it only in the
 			// carrier would make an invalid constructor pattern valid.
-			return start, false
+			return start, i, false
 		case '^', '$':
 			if i+1 < len(pattern) && pattern[i+1] == pattern[i] {
-				return start, false
+				return start, i, false
 			}
 			frame.addOperand(false)
 			i++
@@ -583,10 +624,10 @@ func analyzeRegexVClass(pattern string, start int) (end int, ok bool) {
 			i += width
 		}
 	}
-	return start, false
+	return start, len(pattern), false
 }
 
-func scanRegexVQString(pattern string, start int) (next int, mayHaveStrings bool, ok bool) {
+func scanRegexVQString(pattern string, start int) (next int, mayHaveStrings bool, errorPosition int, ok bool) {
 	flags := RegexFlags{UnicodeSets: true}
 	characterCount := 0
 	for i := start + 3; i < len(pattern); {
@@ -594,7 +635,7 @@ func scanRegexVQString(pattern string, start int) (next int, mayHaveStrings bool
 		case '\\':
 			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
-				return 0, false, false
+				return 0, false, i, false
 			}
 			characterCount++
 			if high, fixed := regexFixedUnicodeEscape(pattern, i); fixed && high >= 0xD800 && high <= 0xDBFF {
@@ -608,12 +649,12 @@ func scanRegexVQString(pattern string, start int) (next int, mayHaveStrings bool
 			characterCount = 0
 			i++
 		case '}':
-			return i + 1, mayHaveStrings || characterCount != 1, true
+			return i + 1, mayHaveStrings || characterCount != 1, 0, true
 		case '/':
-			return 0, false, false
+			return 0, false, i, false
 		case '^', '$':
 			if i+1 < len(pattern) && pattern[i+1] == pattern[i] {
-				return 0, false, false
+				return 0, false, i, false
 			}
 			characterCount++
 			i++
@@ -626,7 +667,7 @@ func scanRegexVQString(pattern string, start int) (next int, mayHaveStrings bool
 			i += width
 		}
 	}
-	return 0, false, false
+	return 0, false, len(pattern), false
 }
 
 func regexFixedUnicodeEscape(pattern string, start int) (uint32, bool) {
@@ -665,71 +706,326 @@ func regexVPropertyMayContainStrings(pattern string, start int) bool {
 // delimiters, and rejects cases where encoding a line terminator or surrogate
 // would turn an invalid identity escape into valid syntax.
 func regexPatternLiteral(pattern string, flags RegexFlags) (string, bool) {
+	literal, _, _, ok := buildRegexPatternLiteral(pattern, flags, false)
+	return literal, ok
+}
+
+// RegexPatternCharacterEventCutoff returns the byte position where a syntax
+// error stops regexpp-style character events. It transports constructor text
+// through a RegExp literal while retaining an output-to-pattern position map.
+func RegexPatternCharacterEventCutoff(pattern string, flags RegexFlags) (int, bool) {
+	referencePosition, invalidReference := firstInvalidUnicodeNumericBackreference(pattern, flags)
+	vClassPosition, invalidVClass := firstRegexVClassErrorPosition(pattern, flags)
+	duplicatePosition, invalidDuplicate := firstDuplicateCaptureNamePosition(pattern, flags)
+	position, invalid := regexPatternParserErrorPosition(pattern, flags, true)
+	if invalidReference && (!invalid || referencePosition < position) {
+		position, invalid = referencePosition, true
+	}
+	if invalidVClass && (!invalid || vClassPosition < position) {
+		position, invalid = vClassPosition, true
+	}
+	if invalidDuplicate && (!invalid || duplicatePosition < position) {
+		position, invalid = duplicatePosition, true
+	}
+	return position, invalid
+}
+
+func firstDuplicateCaptureNamePosition(pattern string, flags RegexFlags) (int, bool) {
+	if strings.Count(pattern, "(?<") < 2 {
+		return 0, false
+	}
+	_, analysis, _, _ := normalizeRegexCaptureNames(pattern, flags, false)
+	return analysis.nonExclusivePosition, analysis.hasNonExclusiveDuplicate
+}
+
+func regexPatternParserErrorPosition(pattern string, flags RegexFlags, repairUnterminated bool) (int, bool) {
+	if flags.Unicode && flags.UnicodeSets {
+		// regexpp rejects conflicting modes before entering the pattern.
+		return 0, true
+	}
+	if strings.HasPrefix(pattern, "*") {
+		// Transporting this pattern as /*.../ would make the scanner read a
+		// block comment. A quantifier cannot begin an ECMAScript pattern.
+		return 0, true
+	}
+	literal, offsets, failureOffset, ok := buildRegexPatternLiteral(pattern, flags, true)
+	if !ok {
+		if repairUnterminated {
+			if repairedPosition, found := regexPatternEarlierErrorAfterRepair(pattern, flags, failureOffset); found {
+				return repairedPosition, true
+			}
+		}
+		return failureOffset, true
+	}
+	position, unterminated, hasError := ecmascript.RegexLiteralCharacterEventCutoff(literal)
+	if !hasError {
+		return 0, false
+	}
+	if unterminated && repairUnterminated {
+		if repairedPosition, found := regexPatternEarlierErrorAfterRepair(pattern, flags, len(pattern)); found {
+			return repairedPosition, true
+		}
+		return len(pattern), true
+	}
+	if unterminated || position >= len(offsets) {
+		return offsets[len(offsets)-1], true
+	}
+	return offsets[position], true
+}
+
+func regexPatternEarlierErrorAfterRepair(pattern string, flags RegexFlags, boundary int) (int, bool) {
+	repaired := pattern
+	trailingBackslashes := 0
+	for i := len(repaired) - 1; i >= 0 && repaired[i] == '\\'; i-- {
+		trailingBackslashes++
+	}
+	if trailingBackslashes%2 != 0 {
+		repaired += `\`
+	}
+	repaired += strings.Repeat("}]", len(pattern)+1)
+	position, invalid := regexPatternParserErrorPosition(repaired, flags, false)
+	return position, invalid && position < boundary
+}
+
+func firstInvalidUnicodeNumericBackreference(pattern string, flags RegexFlags) (int, bool) {
+	if !flags.UV() {
+		return 0, false
+	}
+	groupCount, _ := esregexp.CapturingGroupCount(pattern)
+	classDepth := 0
+	for i := 0; i < len(pattern); {
+		if pattern[i] == '\\' {
+			if classDepth == 0 && i+1 < len(pattern) && pattern[i+1] >= '1' && pattern[i+1] <= '9' {
+				value := 0
+				for j := i + 1; j < len(pattern) && pattern[j] >= '0' && pattern[j] <= '9'; j++ {
+					digit := int(pattern[j] - '0')
+					if value > (groupCount-digit)/10 {
+						return i, true
+					}
+					value = value*10 + digit
+				}
+				if value > groupCount {
+					return i, true
+				}
+			}
+			step, ok := SkipPatternEscape(pattern, i, flags)
+			if !ok {
+				i++
+			} else {
+				i += step
+			}
+			continue
+		}
+		switch pattern[i] {
+		case '[':
+			if classDepth == 0 || flags.UnicodeSets {
+				classDepth++
+			}
+		case ']':
+			if classDepth > 0 {
+				classDepth--
+			}
+		}
+		_, width := utf8.DecodeRuneInString(pattern[i:])
+		if width == 0 {
+			width = 1
+		}
+		i += width
+	}
+	return 0, false
+}
+
+func firstRegexVClassErrorPosition(pattern string, flags RegexFlags) (int, bool) {
+	if !flags.UnicodeSets {
+		return 0, false
+	}
+	for i := 0; i < len(pattern); {
+		switch pattern[i] {
+		case '\\':
+			step, ok := SkipPatternEscape(pattern, i, flags)
+			if !ok {
+				return i, true
+			}
+			i += step
+		case '[':
+			end, errorPosition, ok := analyzeRegexVClass(pattern, i)
+			if !ok {
+				return errorPosition, true
+			}
+			i = end
+		default:
+			_, width := utf8.DecodeRuneInString(pattern[i:])
+			if width == 0 {
+				width = 1
+			}
+			i += width
+		}
+	}
+	return 0, false
+}
+
+func buildRegexPatternLiteral(pattern string, flags RegexFlags, trackOffsets bool) (literalText string, offsets []int, failureOffset int, ok bool) {
 	pattern = ecmascript.CombineSurrogatePairs(pattern)
+	originalLength := len(pattern)
+	var normalizedOffsets []int
+	if trackOffsets {
+		if normalized, _, nameOffsets, namesOK := normalizeRegexCaptureNames(pattern, flags, true); namesOK {
+			pattern = normalized
+			normalizedOffsets = nameOffsets
+		}
+		if !flags.UV() {
+			normalized, annexOffsets := esregexp.NormalizeAnnexBEscapesForParser(pattern)
+			pattern = normalized
+			if annexOffsets != nil {
+				if normalizedOffsets != nil {
+					for i, offset := range annexOffsets {
+						annexOffsets[i] = normalizedOffsets[offset]
+					}
+				}
+				normalizedOffsets = annexOffsets
+			}
+		}
+	}
+	patternOffset := func(offset int) int {
+		if normalizedOffsets != nil && offset >= 0 && offset < len(normalizedOffsets) {
+			return normalizedOffsets[offset]
+		}
+		return offset
+	}
 	units := ecmascript.StringCodeUnits(pattern)
 	if ecmascript.StringFromCodeUnits(units) != pattern {
-		return "", false
+		return "", nil, 0, false
 	}
 
 	var literal strings.Builder
 	literal.Grow(len(pattern) + 4)
-	literal.WriteByte('/')
+	if trackOffsets {
+		offsets = make([]int, 0, len(pattern)+5)
+	}
+	writeString := func(value string, patternOffset int) {
+		literal.WriteString(value)
+		if trackOffsets {
+			for range len(value) {
+				offsets = append(offsets, patternOffset)
+			}
+		}
+	}
+	writeRune := func(value rune, patternOffset int) {
+		before := literal.Len()
+		literal.WriteRune(value)
+		if trackOffsets {
+			for range literal.Len() - before {
+				offsets = append(offsets, patternOffset)
+			}
+		}
+	}
+	writeUnicodeEscape := func(unit uint16, patternOffset int) {
+		before := literal.Len()
+		writeRegexUnicodeEscape(&literal, unit)
+		if trackOffsets {
+			for range literal.Len() - before {
+				offsets = append(offsets, patternOffset)
+			}
+		}
+	}
+
+	writeString("/", 0)
 	if len(units) == 0 {
-		literal.WriteString("(?:)")
+		writeString("(?:)", 0)
 	}
 
 	escaped := false
-	for _, unit := range units {
-		if unit == '\\' {
-			literal.WriteByte('\\')
-			escaped = !escaped
+	escapeStart := -1
+	unitIndex := 0
+	for sourceStart := 0; sourceStart < len(pattern); {
+		r, size := ecmascript.DecodeStringRune(pattern[sourceStart:])
+		originalSourceStart := patternOffset(sourceStart)
+		if escaped && trackOffsets &&
+			(r == '\n' || r == '\r' || r == 0x2028 || r == 0x2029 || r >= 0xD800 && r <= 0xDFFF || r > 0xFFFF) {
+			// A constructor pattern may contain characters that cannot follow a
+			// backslash in a RegExp literal carrier. Keep an invalid one-atom
+			// escape in its place so tsgo can still reveal any earlier grammar
+			// error; the inserted byte maps back to the original escape.
+			writeString("q", escapeStart)
+			escaped = false
+			escapeStart = -1
+			unitIndex++
+			if r > 0xFFFF {
+				unitIndex++
+			}
+			sourceStart += size
 			continue
 		}
-
-		switch unit {
-		case '/':
-			if !escaped {
-				literal.WriteByte('\\')
-			}
-			literal.WriteByte('/')
-		case '\n':
-			if escaped {
-				return "", false
-			}
-			literal.WriteString(`\n`)
-		case '\r':
-			if escaped {
-				return "", false
-			}
-			literal.WriteString(`\r`)
-		case 0x2028, 0x2029:
-			if escaped {
-				return "", false
-			}
-			writeRegexUnicodeEscape(&literal, unit)
-		default:
-			if unit >= 0xD800 && unit <= 0xDFFF {
-				if escaped {
-					return "", false
-				}
-				writeRegexUnicodeEscape(&literal, unit)
-			} else {
-				literal.WriteRune(rune(unit))
-			}
+		unitCount := 1
+		if r > 0xFFFF {
+			unitCount = 2
 		}
-		escaped = false
+		for range unitCount {
+			unit := units[unitIndex]
+			unitIndex++
+			if unit == '\\' {
+				writeString("\\", originalSourceStart)
+				if escaped {
+					escaped = false
+					escapeStart = -1
+				} else {
+					escaped = true
+					escapeStart = originalSourceStart
+				}
+				continue
+			}
+
+			switch unit {
+			case '/':
+				if !escaped {
+					writeString("\\", originalSourceStart)
+				}
+				writeString("/", originalSourceStart)
+			case '\n':
+				if escaped {
+					return "", nil, escapeStart, false
+				}
+				writeString(`\n`, originalSourceStart)
+			case '\r':
+				if escaped {
+					return "", nil, escapeStart, false
+				}
+				writeString(`\r`, originalSourceStart)
+			case 0x2028, 0x2029:
+				if escaped {
+					return "", nil, escapeStart, false
+				}
+				writeUnicodeEscape(unit, originalSourceStart)
+			default:
+				if unit >= 0xD800 && unit <= 0xDFFF {
+					if escaped {
+						return "", nil, escapeStart, false
+					}
+					writeUnicodeEscape(unit, originalSourceStart)
+				} else {
+					writeRune(rune(unit), originalSourceStart)
+				}
+			}
+			escaped = false
+			escapeStart = -1
+		}
+		sourceStart += size
 	}
 	if escaped {
-		return "", false
+		return "", nil, escapeStart, false
 	}
 
-	literal.WriteByte('/')
+	writeString("/", originalLength)
 	if flags.UnicodeSets {
-		literal.WriteByte('v')
-	} else {
-		literal.WriteByte('u')
+		writeString("v", originalLength)
 	}
-	return literal.String(), true
+	if flags.Unicode {
+		writeString("u", originalLength)
+	}
+	if trackOffsets {
+		offsets = append(offsets, originalLength)
+	}
+	return literal.String(), offsets, 0, true
 }
 
 func writeRegexUnicodeEscape(builder *strings.Builder, unit uint16) {

--- a/internal/utils/regex_validate_test.go
+++ b/internal/utils/regex_validate_test.go
@@ -45,6 +45,53 @@ func TestRegexPatternLiteral(t *testing.T) {
 	}
 }
 
+func TestRegexPatternCharacterEventCutoff(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		flags    RegexFlags
+		position int
+		invalid  bool
+	}{
+		{name: "valid", pattern: `\x1f`},
+		{name: "slash equals carrier", pattern: `=\x1f`, flags: RegexFlags{Unicode: true}},
+		{name: "legacy unicode identity", pattern: `\u{NOT_HEX}\x1f`},
+		{name: "single v ampersand", pattern: `[&]\x1f`, flags: RegexFlags{UnicodeSets: true}},
+		{name: "escaped capture name", pattern: `(?<\u{1d49c}>.)\x1f`},
+		{name: "deferred named reference", pattern: `(?<a>a)\k<missing>\x1f`, flags: RegexFlags{Unicode: true}},
+		{name: "invalid escape before control", pattern: `\u{NOT_HEX}\x1f`, flags: RegexFlags{Unicode: true}, position: 3, invalid: true},
+		{name: "control before invalid escape", pattern: `\x1f\u{NOT_HEX}`, flags: RegexFlags{Unicode: true}, position: 7, invalid: true},
+		{name: "leading quantifier", pattern: `*\x1f`, position: 0, invalid: true},
+		{name: "leading unicode quantifier", pattern: `{0}\x1f\😀`, flags: RegexFlags{Unicode: true}, position: 0, invalid: true},
+		{name: "invalid unicode q escape", pattern: `\q{a}\x1f`, flags: RegexFlags{Unicode: true}, position: 0, invalid: true},
+		{name: "missing numeric reference", pattern: `\1\x1f`, flags: RegexFlags{Unicode: true}, position: 0, invalid: true},
+		{name: "invalid range before control", pattern: `[z-a\x1f]`, position: 4, invalid: true},
+		{name: "legacy invalid range before control", pattern: `[a--b]\x1f`, position: 4, invalid: true},
+		{name: "control before invalid range", pattern: `[\x1fz-a]`, position: 8, invalid: true},
+		{name: "unterminated class", pattern: `[\x1f`, position: 5, invalid: true},
+		{name: "unterminated group", pattern: `(\x1f`, position: 5, invalid: true},
+		{name: "conflicting modes", pattern: `\u{1F}`, flags: RegexFlags{Unicode: true, UnicodeSets: true}, position: 0, invalid: true},
+		{name: "duplicate capture", pattern: `(?<a>a)(?<a>a)\x1f`, flags: RegexFlags{Unicode: true}, position: 10, invalid: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			position, invalid := RegexPatternCharacterEventCutoff(test.pattern, test.flags)
+			if position != test.position || invalid != test.invalid {
+				t.Fatalf(
+					"RegexPatternCharacterEventCutoff(%q, %+v) = (%d, %v), want (%d, %v)",
+					test.pattern,
+					test.flags,
+					position,
+					invalid,
+					test.position,
+					test.invalid,
+				)
+			}
+		})
+	}
+}
+
 func TestIsValidRegexPatternUnicode(t *testing.T) {
 	high := ecmascript.StringFromCodeUnits([]uint16{0xD800})
 	low := ecmascript.StringFromCodeUnits([]uint16{0xDC00})

--- a/packages/rslint-test-tools/tests/eslint/rules/no-control-regex.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-control-regex.test.ts
@@ -20,6 +20,14 @@ ruleTester.run('no-control-regex', {
     String.raw`new RegExp("\\u{1F}", flags)`,
     String.raw`new RegExp("[\\q{\\u{20}}]", "v")`,
     String.raw`/[\u{20}--B]/v`,
+    // Only the global RegExp constructor is checked (ESLint v10.9.1).
+    String.raw`function foo(RegExp) { RegExp("\x1f"); }`,
+    String.raw`function foo(RegExp) { new RegExp("\x1f"); }`,
+    String.raw`let RegExp; RegExp("\x1f");`,
+    {
+      code: String.raw`RegExp("\x1f")`,
+      languageOptions: { globals: { RegExp: 'off' } },
+    },
     // Symbolic escapes — allowed
     String.raw`/\t/`,
     String.raw`/\n/`,


### PR DESCRIPTION
## Summary

- Align `no-control-regex` with ESLint v10.9.1 global `RegExp` resolution.
- Match regexpp control-character collection on malformed constructor patterns by reusing tsgo and existing ECMAScript helpers.
- Add upstream parity, edge-case, and snapshot coverage; keep the common hit path at one allocation.

## Related Links

- https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-control-regex.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).