### PR TITLE
fix: align unified-signatures with latest upstream

### DIFF
--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures.go
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures.go
@@ -252,7 +252,7 @@ func (a *overloadAnalyzer) signaturesCanBeUnified(left, right *ast.Node, outerTy
 		return false
 	}
 	return typesAreEqual(a.ctx.SourceFile, left.Type(), right.Type()) &&
-		typeParametersAreEqual(left.TypeParameters(), right.TypeParameters()) &&
+		typeParametersAreEqual(a.ctx.SourceFile, left.TypeParameters(), right.TypeParameters()) &&
 		signatureUsesOuterTypeParameter(left, outerTypeParameters) == signatureUsesOuterTypeParameter(right, outerTypeParameters)
 }
 
@@ -350,13 +350,14 @@ func signatureReportRange(sourceFile *ast.SourceFile, signature *ast.Node) core.
 			start = scanner.SkipTrivia(sourceFile.Text(), start+len("default"))
 		}
 	}
-	if (signature.Kind == ast.KindMethodDeclaration || signature.Kind == ast.KindConstructor) && signature.ParameterList() != nil {
-		start = signature.ParameterList().Pos() - 1
-	}
-	// For generic class members, typescript-eslint reports the type-parameter
-	// list rather than the member key or opening parenthesis.
-	if signature.Kind == ast.KindMethodDeclaration && len(signature.TypeParameters()) > 0 {
-		start = signature.TypeParameters()[0].Pos() - 1
+	if signature.Kind == ast.KindMethodDeclaration || signature.Kind == ast.KindConstructor {
+		if typeParameters := signature.TypeParameterList(); typeParameters != nil && len(typeParameters.Nodes) > 0 {
+			// For generic class members, typescript-eslint reports the function
+			// value, which starts at the type-parameter list's opening token.
+			start = typeParameters.Pos() - 1
+		} else if parameters := signature.ParameterList(); parameters != nil {
+			start = parameters.Pos() - 1
+		}
 	}
 	return core.NewTextRange(start, trimmed.End())
 }
@@ -527,34 +528,37 @@ func staticParameterName(parameter *ast.Node) string {
 
 func typesAreEqual(sourceFile *ast.SourceFile, left, right *ast.Node) bool {
 	left, right = skipParenthesizedType(left), skipParenthesizedType(right)
-	return left == right || left != nil && right != nil && utils.TrimmedNodeText(sourceFile, left) == utils.TrimmedNodeText(sourceFile, right)
+	if left == right {
+		return true
+	}
+	if left == nil || right == nil {
+		return false
+	}
+	// Preserve TrimNodeTextRange's scanner-based recovery and JSDoc behavior
+	// where GetTokenPosOfNode intentionally uses different trivia rules.
+	if ast.NodeIsMissing(left) || ast.NodeIsMissing(right) ||
+		ast.NodeIsSynthesized(left) || ast.NodeIsSynthesized(right) ||
+		left.Flags&ast.NodeFlagsJSDoc != 0 || right.Flags&ast.NodeFlagsJSDoc != 0 ||
+		ast.IsJSDocNode(left) || ast.IsJSDocNode(right) {
+		return utils.TrimmedNodeText(sourceFile, left) == utils.TrimmedNodeText(sourceFile, right)
+	}
+	text := sourceFile.Text()
+	leftStart := scanner.GetTokenPosOfNode(left, sourceFile, false)
+	rightStart := scanner.GetTokenPosOfNode(right, sourceFile, false)
+	return text[leftStart:left.End()] == text[rightStart:right.End()]
 }
 
-func typeParametersAreEqual(left, right []*ast.Node) bool {
+func typeParametersAreEqual(sourceFile *ast.SourceFile, left, right []*ast.Node) bool {
 	if len(left) != len(right) {
 		return false
 	}
 	for i := range left {
 		leftParam, rightParam := left[i].AsTypeParameterDeclaration(), right[i].AsTypeParameterDeclaration()
-		if left[i].Name().Text() != right[i].Name().Text() || !constraintsAreEqual(leftParam.Constraint, rightParam.Constraint) {
+		if left[i].Name().Text() != right[i].Name().Text() || !typesAreEqual(sourceFile, leftParam.Constraint, rightParam.Constraint) {
 			return false
 		}
 	}
 	return true
-}
-
-func constraintsAreEqual(left, right *ast.Node) bool {
-	left, right = skipParenthesizedType(left), skipParenthesizedType(right)
-	return left == right || left != nil && right != nil && estreeConstraintKind(left) == estreeConstraintKind(right)
-}
-
-func estreeConstraintKind(node *ast.Node) ast.Kind {
-	if node.Kind == ast.KindLiteralType {
-		if literal := node.AsLiteralTypeNode().Literal; literal != nil && literal.Kind == ast.KindNullKeyword {
-			return ast.KindNullKeyword
-		}
-	}
-	return node.Kind
 }
 
 func skipParenthesizedType(node *ast.Node) *ast.Node {

--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures.md
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures.md
@@ -60,5 +60,5 @@ combined.
 ## Original documentation
 
 - [typescript-eslint: unified-signatures](https://typescript-eslint.io/rules/unified-signatures)
-- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.68.0/packages/eslint-plugin/src/rules/unified-signatures.ts)
-- [Tests](https://github.com/typescript-eslint/typescript-eslint/blob/v8.68.0/packages/eslint-plugin/tests/rules/unified-signatures.test.ts)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/rules/unified-signatures.ts)
+- [Tests](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/tests/rules/unified-signatures.test.ts)

--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures_extras_test.go
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures_extras_test.go
@@ -83,9 +83,13 @@ function p(key: string, defaultValue?: string): Promise<string | undefined> { th
 		{Code: `interface I<T> { f(x: { [K in keyof T]: T[] }): void; f(x: string): void; }`},
 		// Locks in upstream type-parameter-name equality arm.
 		{Code: `function f<T>(x: T): void; function f<U>(x: U): void;`},
-		// Locks in upstream constraint-kind equality arm.
+		// Locks in upstream constraint-text equality arm.
 		{Code: `function f<T extends number>(x: T): void; function f<T extends string>(x: T): void;`},
-		// ESTree exposes a null constraint as TSNullKeyword rather than TSLiteralType.
+		// A missing constraint is distinct from a present constraint.
+		{Code: `function f<T>(x: T, y: string): void; function f<T extends number>(x: T): void;`},
+		// Constraint equality is textual after transparent outer parentheses.
+		{Code: `function f<T extends 1 | 2>(x: T, y: string): void; function f<T extends 1|2>(x: T): void;`},
+		// Distinct literal constraint texts remain separate.
 		{Code: `function f<T extends null>(x: string): void; function f<T extends 'x'>(x: number): void;`},
 		// Method-signature diagnostics are disabled on the method-key line, not its parameter line.
 		{Code: `interface I {
@@ -103,9 +107,43 @@ function p(key: string, defaultValue?: string): Promise<string | undefined> { th
   f<T>
   (x: string): void;
 }`},
+		// Generic constructors use the same function-value range as class methods.
+		{Code: `declare class C {
+  constructor<T>
+  (x: string);
+  // eslint-disable-next-line test
+  constructor<T>
+  (x: string);
+}`},
+		{Code: `declare class C {
+  constructor<T>
+  (x: string);
+  constructor<T> // eslint-disable-line test
+  (x: string);
+}`},
 	}
 
 	invalid := []rule_tester.InvalidTestCase{
+		// JSDoc @overload signatures reach the same type-text comparison through
+		// tsgo's reparsed declarations and retain its JSDoc trivia semantics.
+		{
+			Code: `/**
+ * @overload
+ * @param {string} value
+ * @returns {void}
+ *
+ * @overload
+ * @param {number} value
+ * @returns {void}
+ */
+function f(value) {}`,
+			FileName: "file.mjs",
+			TSConfig: "tsconfig.allow-js.json",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "singleParameterDifference",
+				Message:   "These overloads can be combined into one signature taking `string | number`.",
+			}},
+		},
 		// Upstream's anonymous default-export fallback is the raw ESTree node type,
 		// so a declaration with that exact name belongs to the same overload group.
 		{
@@ -234,6 +272,114 @@ declare function f(x: boolean): void;`,
   constructor<T>(x: number);
 }`,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "singleParameterDifference", Line: 3}},
+		},
+		// A generic constructor's function-value range starts at <T>, even when
+		// the parameter list begins on the next line.
+		{
+			Code: `declare class C {
+  constructor<T>
+  (x: string);
+  constructor<T>
+  (x: string);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "allParametersAreSame",
+				Line:      4, Column: 14, EndLine: 5, EndColumn: 15,
+			}},
+		},
+		// A quoted generic constructor-shaped member is a MethodDeclaration in
+		// tsgo and retains the upstream function-value range.
+		{
+			Code: `declare class C {
+  "constructor"<T>
+  (x: string): void;
+  "constructor"<T>
+  (x: string): void;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "allParametersAreSame",
+				Line:      4, Column: 16, EndLine: 5, EndColumn: 21,
+			}},
+		},
+		// Without type parameters, the quoted form is a Constructor and falls
+		// back to the parameter list's opening token.
+		{
+			Code: `declare class C {
+  "constructor"(x: string): void;
+  "constructor"(x: string): void;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "allParametersAreSame",
+				Line:      3, Column: 16, EndLine: 3, EndColumn: 34,
+			}},
+		},
+		// The static generic form is a Constructor in tsgo.
+		{
+			Code: `declare class C {
+  static constructor<T>
+  (x: string): void;
+  static constructor<T>
+  (x: string): void;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "allParametersAreSame",
+				Line:      4, Column: 21, EndLine: 5, EndColumn: 21,
+			}},
+		},
+		// Type-parameter trivia does not move the opening-delimiter range.
+		{
+			Code: `declare class C {
+  private constructor /* gap */ < /* inner */ T >
+  (x: string);
+  private constructor /* gap */ < /* inner */ T >
+  (x: string);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "allParametersAreSame",
+				Line:      4, Column: 33, EndLine: 5, EndColumn: 15,
+			}},
+		},
+		// Non-generic constructors continue to start at the opening parenthesis.
+		{
+			Code: `declare class C {
+  constructor
+  (x: string);
+  constructor
+  (x: string);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "allParametersAreSame",
+				Line:      5, Column: 3, EndLine: 5, EndColumn: 15,
+			}},
+		},
+		// Larger overload groups cite the line where each function value starts.
+		{
+			Code: `declare class C {
+  constructor
+  <T>
+  (x: string);
+  constructor
+  <T>
+  (x: string);
+  constructor
+  <T>
+  (x: string);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "allParametersAreSame", Message: "This overload and the one on line 3 can be combined into one signature with identical parameters.", Line: 6, Column: 3, EndLine: 7, EndColumn: 15},
+				{MessageId: "allParametersAreSame", Message: "This overload and the one on line 3 can be combined into one signature with identical parameters.", Line: 9, Column: 3, EndLine: 10, EndColumn: 15},
+				{MessageId: "allParametersAreSame", Message: "This overload and the one on line 6 can be combined into one signature with identical parameters.", Line: 9, Column: 3, EndLine: 10, EndColumn: 15},
+			},
+		},
+		// Parenthesized constraints are transparent in typescript-estree and
+		// therefore still compare equal.
+		{
+			Code: `function f<T extends (number)>(x: T, y: string): void;
+function f<T extends number>(x: T): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "omittingSingleParameter",
+				Line:      1, Column: 38, EndLine: 1, EndColumn: 47,
+			}},
 		},
 		// ---- Real-user: typescript-eslint#12504 duplicate union members ----
 		{

--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures_upstream_test.go
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures_upstream_test.go
@@ -1,7 +1,7 @@
 package unified_signatures
 
 // TestUnifiedSignaturesUpstream migrates every valid and invalid case from
-// typescript-eslint v8.68.0. Rslint-specific coverage lives in
+// typescript-eslint v8.69.0. Rslint-specific coverage lives in
 // unified_signatures_extras_test.go.
 
 import (
@@ -34,6 +34,9 @@ func TestUnifiedSignaturesUpstream(t *testing.T) {
 			{Code: "\ninterface Generic<T> {\n  x(): void;\n  x(x: T[]): void;\n}\n    "},
 			{Code: "\ninterface I {\n  f(x1: number): void;\n  f(x1: boolean, x2?: number): void;\n}\n    "},
 			{Code: "\nfunction f<T extends number>(x: T[]): void;\nfunction f<T extends string>(x: T): void;\n    "},
+			{Code: "\ntype A = 1 | 2;\ntype B = 3 | 4;\nfunction f<T extends A>(x: T, y: string): void;\nfunction f<T extends B>(x: T): void;\n    "},
+			{Code: "\nfunction f<T extends 1 | 2>(x: T, y: string): void;\nfunction f<T extends 3 | 4>(x: T): void;\n    "},
+			{Code: "\nfunction f<T extends number>(x: T[]): void;\nfunction f<R extends number>(x: R): void;\n    "},
 			{Code: "\ndeclare function foo(n: number): number;\n\ndeclare module 'hello' {\n  function foo(n: number, s: string): number;\n}\n    "},
 			{Code: "\n{\n  function block(): number;\n  function block(n: number): number;\n  function block(n?: number): number {\n    return 3;\n  }\n}\n    "},
 			{Code: "\nexport interface Foo {\n  bar(baz: string): number[];\n  bar(): string[];\n}\n    "},

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/unified-signatures.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/unified-signatures.test.ts
@@ -116,6 +116,22 @@ interface I {
 function f<T extends number>(x: T[]): void;
 function f<T extends string>(x: T): void;
     `,
+    // Type parameters with the same name but different constraints
+    `
+type A = 1 | 2;
+type B = 3 | 4;
+function f<T extends A>(x: T, y: string): void;
+function f<T extends B>(x: T): void;
+    `,
+    `
+function f<T extends 1 | 2>(x: T, y: string): void;
+function f<T extends 3 | 4>(x: T): void;
+    `,
+    // Type parameters with the same constraint but different names
+    `
+function f<T extends number>(x: T[]): void;
+function f<R extends number>(x: R): void;
+    `,
     // Same name, different scopes
     `
 declare function foo(n: number): number;


### PR DESCRIPTION
## Summary

- Align `@typescript-eslint/unified-signatures` with typescript-eslint v8.69.0: generic constructors now report from the opening `<`, and type-parameter constraints use source-text equality.
- Reuse tsgo token positions for zero-copy type-text comparisons while preserving the existing JSDoc, missing-node, and synthesized-node behavior.
- Add exact range and directive regressions for generic/non-generic, quoted, static, private, trivia-heavy, and multi-overload constructors, plus the complete constraint and JSDoc paths.
- Package benchmark medians (6 runs, 300 ms): matched constraints improved from 93.1 to 78.5 µs/op, 107,449 to 43,441 B/op, and 851 to 451 allocs/op.

## Related Links

- [typescript-eslint v8.69.0 implementation](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/rules/unified-signatures.ts)
- [typescript-eslint v8.69.0 tests](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/tests/rules/unified-signatures.test.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
