### PR TITLE
fix: align no-undef with upstream reference semantics

### DIFF
--- a/internal/rule/typescript_type_globals.go
+++ b/internal/rule/typescript_type_globals.go
@@ -4,7 +4,8 @@ package rule
 import "slices"
 
 // defaultTypeScriptTypeGlobals matches the type-capable implicit variables
-// seeded by @typescript-eslint/scope-manager 8.68's default esnext library.
+// seeded by @typescript-eslint/scope-manager 8.69's default esnext library,
+// plus its special implicit `const` type used for const assertions.
 // Keep it aligned when that dependency is upgraded.
 var defaultTypeScriptTypeGlobals = [...]string{
 	"AggregateError",

--- a/internal/rule/typescript_type_globals_test.go
+++ b/internal/rule/typescript_type_globals_test.go
@@ -18,7 +18,7 @@ func TestDefaultTypeScriptTypeGlobals(t *testing.T) {
 		t.Fatal("defaultTypeScriptTypeGlobals must be sorted for binary search")
 	}
 	if got, want := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(defaultTypeScriptTypeGlobals[:], "\n")))), "ed4f69d96156ce34f2d1e402a13f234744bb9e26fdb3eec2eda444bfa2272745"; got != want {
-		t.Fatalf("defaultTypeScriptTypeGlobals SHA-256 = %s, want @typescript-eslint/scope-manager 8.68 esnext set %s", got, want)
+		t.Fatalf("defaultTypeScriptTypeGlobals SHA-256 = %s, want @typescript-eslint/scope-manager 8.69 esnext set %s", got, want)
 	}
 
 	for _, name := range []string{

--- a/internal/rules/no_undef/no_undef.go
+++ b/internal/rules/no_undef/no_undef.go
@@ -2,11 +2,10 @@ package no_undef
 
 import (
 	_ "embed"
-	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
@@ -48,47 +47,60 @@ var NoUndefRule = rule.Rule{
 			return rule.RuleListeners{}
 		}
 
-		return rule.RuleListeners{
+		listeners := rule.RuleListeners{
 			ast.KindIdentifier: func(node *ast.Node) {
-				// Skip identifiers that do not create scope references.
-				if shouldSkip(node, opts.checkTypeof) {
+				if !scope.IsReferenceIdentifier(node) || (!opts.checkTypeof && isTypeOfOperand(node)) {
 					return
 				}
-
-				name := node.Text()
-				if ctx.Globals.Access(name).IsDeclared() {
-					return
-				}
-				referenceSpace := noUndefReferenceSpace(node)
-				// An explicit `off` removes only implicit globals. A declaration or
-				// import authored in this file still defines its references.
-				if ctx.Refs.ResolveInFileWithMeaning(node, referenceSpace.DeclarationMeaning()) != nil {
-					return
-				}
-				// CommonJS's wrapper-level `arguments` binding is lexical rather than
-				// a configurable global, so it remains defined even when a same-named
-				// global is disabled.
-				if ctx.Refs.HasImplicitWrapperBinding(name) {
-					return
-				}
-				// typescript-eslint's scope manager seeds its default `esnext`
-				// library in a separate type namespace. A name such as `Record`
-				// therefore resolves in `type T = Record<string, unknown>`, but the
-				// same spelling in `Record;` remains undefined. Keep this check after
-				// same-file resolution so authored declarations retain normal scope
-				// behavior, and do not consult the TypeChecker: ambient, cross-file,
-				// and host-library symbols are outside core no-undef's inputs.
-				if referenceSpace.IncludesType() && rule.IsDefaultTypeScriptTypeGlobal(name) {
-					return
-				}
-
-				ctx.ReportNode(node, rule.RuleMessage{
-					Id:          "undef",
-					Description: fmt.Sprintf("'%s' is not defined.", name),
-				})
+				reportUndefinedReference(&ctx, node, node.Text())
 			},
 		}
+		// TSESTree represents bare `<this>` tag names as JSXIdentifiers and
+		// records them as references. tsgo preserves `this` as a keyword, so it
+		// needs its own listener; member tags such as `<this.Component>` are not
+		// references and are rejected by the shared scope classifier.
+		if ctx.SourceFile.ScriptKind == core.ScriptKindTSX {
+			listeners[ast.KindThisKeyword] = func(node *ast.Node) {
+				if scope.IsTypeScriptJsxThisReference(node) {
+					reportUndefinedReference(&ctx, node, "this")
+				}
+			}
+		}
+		return listeners
 	},
+}
+
+func reportUndefinedReference(ctx *rule.RuleContext, node *ast.Node, name string) {
+	if ctx.Globals.Access(name).IsDeclared() {
+		return
+	}
+	referenceSpace := noUndefReferenceSpace(node)
+	// An explicit `off` removes only implicit globals. A declaration or
+	// import authored in this file still defines its references.
+	if ctx.Refs.ResolveInFileWithMeaning(node, referenceSpace.DeclarationMeaning()) != nil {
+		return
+	}
+	// CommonJS's wrapper-level `arguments` binding is lexical rather than
+	// a configurable global, so it remains defined even when a same-named
+	// global is disabled.
+	if ctx.Refs.HasImplicitWrapperBinding(name) {
+		return
+	}
+	// typescript-eslint's scope manager seeds its default `esnext`
+	// library in a separate type namespace. A name such as `Record`
+	// therefore resolves in `type T = Record<string, unknown>`, but the
+	// same spelling in `Record;` remains undefined. Keep this check after
+	// same-file resolution so authored declarations retain normal scope
+	// behavior, and do not consult the TypeChecker: ambient, cross-file,
+	// and host-library symbols are outside core no-undef's inputs.
+	if referenceSpace.IncludesType() && rule.IsDefaultTypeScriptTypeGlobal(name) {
+		return
+	}
+
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "undef",
+		Description: "'" + name + "' is not defined.",
+	})
 }
 
 // noUndefReferenceSpace preserves the rule's established Espree-facing
@@ -107,124 +119,6 @@ func noUndefReferenceSpace(node *ast.Node) scope.ReferenceSpace {
 		}
 	}
 	return scope.ESLintReferenceSpace(node)
-}
-
-// shouldSkip returns true if the identifier does not create a scope reference.
-// This includes property/declaration names, labels, ImportType metadata,
-// synthetic JSDoc syntax, and typeof operands (when checkTypeof is false).
-func shouldSkip(node *ast.Node, checkTypeof bool) bool {
-	if node.Parent == nil {
-		return true
-	}
-
-	parent := node.Parent
-
-	// Skip declaration names (var x, function x, class x, import x, etc.)
-	// Exceptions: ShorthandPropertyAssignment names ({x}) and the name of a
-	// non-aliased local export (export { x }) are declaration names but also
-	// value references, so they must NOT be skipped. Re-exports
-	// (export { x } from 'mod') reference the other module's binding instead,
-	// and the alias label of export { x as y } is only a label.
-	if ast.IsDeclarationName(node) && parent.Kind != ast.KindShorthandPropertyAssignment {
-		if parent.Kind != ast.KindExportSpecifier || parent.PropertyName() != nil || utils.IsReExportSpecifier(parent) {
-			return true
-		}
-	}
-
-	// Skip property names in member access (obj.prop -> skip "prop")
-	if parent.Kind == ast.KindPropertyAccessExpression &&
-		parent.AsPropertyAccessExpression().Name() == node {
-		return true
-	}
-
-	// Skip property names in object literals ({key: value} -> skip "key")
-	if parent.Kind == ast.KindPropertyAssignment && parent.Name() == node {
-		return true
-	}
-
-	// Skip property names in binding patterns ({key: newName} destructuring -> skip "key")
-	if parent.Kind == ast.KindBindingElement && parent.PropertyName() == node {
-		return true
-	}
-
-	// Skip the original name in aliased imports (import { Original as Alias } -> skip "Original")
-	// The propertyName of an ImportSpecifier is the module's export name, not a local reference.
-	if parent.Kind == ast.KindImportSpecifier && parent.PropertyName() == node {
-		return true
-	}
-
-	// Skip the original name in re-export aliases (export { Original as Alias } from 'module')
-	// The propertyName of an ExportSpecifier in a re-export is the source module's export name.
-	// Note: without `from`, export { X as Y } refers to local X, so only skip when moduleSpecifier exists.
-	if parent.Kind == ast.KindExportSpecifier && parent.PropertyName() == node {
-		if utils.IsReExportSpecifier(parent) {
-			return true
-		}
-	}
-
-	// Skip label identifiers
-	if parent.Kind == ast.KindLabeledStatement ||
-		parent.Kind == ast.KindBreakStatement ||
-		parent.Kind == ast.KindContinueStatement {
-		return true
-	}
-
-	// Skip typeof operands (typeof x -> skip "x" unless checkTypeof is true).
-	// Walk through ParenthesizedExpression nodes because typeof (x) and
-	// typeof ((x)) are semantically identical to typeof x, but TypeScript's
-	// AST inserts ParenthesizedExpression nodes unlike ESTree.
-	if !checkTypeof && isTypeOfOperand(node) {
-		return true
-	}
-
-	// `import("pkg").Name` treats both the module argument and qualifier as
-	// module syntax rather than references. Its type arguments remain normal
-	// type references and are deliberately not skipped.
-	if utils.IsImportTypeSyntax(node) {
-		return true
-	}
-
-	// In a qualified type name (`Namespace.Name`), only the leftmost root is a
-	// reference. Every right-hand identifier names a member of that root.
-	if parent.Kind == ast.KindQualifiedName && parent.AsQualifiedName().Right == node {
-		return true
-	}
-
-	// Skip enum member names
-	if parent.Kind == ast.KindEnumMember && parent.Name() == node {
-		return true
-	}
-
-	// Skip meta-property names (`target` in `new.target`, `meta` in
-	// `import.meta`, `defer` in `import.defer`) — syntactic, not identifiers
-	// that reference a variable.
-	if parent.Kind == ast.KindMetaProperty {
-		return true
-	}
-
-	// Skip import attribute keys (`type` in `with { type: "json" }`) —
-	// syntactic names, not references to same-named variables.
-	if parent.Kind == ast.KindImportAttribute && parent.AsImportAttribute().Name() == node {
-		return true
-	}
-
-	// Skip the namespace/name parts of a namespaced JSX tag or attribute
-	// (`<foo:bar attr:name="v" />`) — syntactic, never variable references.
-	if parent.Kind == ast.KindJsxNamespacedName {
-		return true
-	}
-
-	// Skip lowercase JSX tag names (`<div>`): these are JSX intrinsics, not
-	// identifier references. Uppercase tag names (`<Foo>`) reference a
-	// component value and are checked normally.
-	if ast.IsJsxTagName(node) {
-		text := node.Text()
-		if len(text) == 0 || (text[0] >= 'a' && text[0] <= 'z') {
-			return true
-		}
-	}
-
-	return false
 }
 
 // isTypeOfOperand checks if the identifier is the sole operand of a typeof

--- a/internal/rules/no_undef/no_undef.md
+++ b/internal/rules/no_undef/no_undef.md
@@ -47,7 +47,16 @@ f();
 typeof maybeUndefined === 'string';
 ```
 
+## Differences from ESLint
+
+- In TypeScript files, rslint applies `languageOptions.ecmaVersion` to runtime
+  ECMAScript globals. ESLint with `@typescript-eslint/parser` uses that parser's
+  default ESNext library instead. For example, with `ecmaVersion: 2019`, rslint
+  reports `BigInt(1)` unless `BigInt` is configured as a global, while ESLint
+  does not. With the default parser library, type-only ESNext names such as
+  `Record` remain available in both.
+
 ## Original Documentation
 
 - [ESLint: no-undef](https://eslint.org/docs/latest/rules/no-undef)
-- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-undef.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-undef.js)

--- a/internal/rules/no_undef/no_undef_alignment_test.go
+++ b/internal/rules/no_undef/no_undef_alignment_test.go
@@ -1,0 +1,113 @@
+package no_undef
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUndefLatestParserReferenceParity(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUndefRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code:     `const el = <éclair />; const other = <Missing:Part />;`,
+				FileName: "jsx-intrinsic-and-namespaced.jsx",
+				TSConfig: "tsconfig.allowJs.json",
+				Tsx:      true,
+			},
+			{
+				Code:     `const Éclair = null; const el = <Éclair></Éclair>;`,
+				FileName: "jsx-declared-unicode.jsx",
+				TSConfig: "tsconfig.allowJs.json",
+				Tsx:      true,
+			},
+			{
+				Code:     `type T = typeof this; type U = typeof this.member;`,
+				FileName: "type-query-this.ts",
+			},
+			{
+				Code:     `const foo = null, bar = null; const el = <foo:bar />;`,
+				FileName: "declared-namespaced-tag.tsx",
+				Tsx:      true,
+			},
+			{
+				Code:     `const el = <this.Member />;`,
+				FileName: "jsx-this-member.tsx",
+				Tsx:      true,
+			},
+			{
+				Code:     `const el = <this />;`,
+				FileName: "configured-jsx-this.tsx",
+				Tsx:      true,
+				Globals:  map[string]any{"this": "readonly"},
+			},
+			{
+				Code:     `const Missing = {}; export as namespace Missing;`,
+				FileName: "declared-namespace-export.ts",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `const el = <Missing></Missing>;`,
+				FileName: "jsx-closing-tag.jsx",
+				TSConfig: "tsconfig.allowJs.json",
+				Tsx:      true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:     `const el = <Éclair />;`,
+				FileName: "jsx-unicode-component.jsx",
+				TSConfig: "tsconfig.allowJs.json",
+				Tsx:      true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:     `const el = <foo:bar></foo:bar>;`,
+				FileName: "tsx-namespaced-tag.tsx",
+				Tsx:      true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
+					{MessageId: "undef", Line: 1, Column: 17},
+					{MessageId: "undef", Line: 1, Column: 23},
+					{MessageId: "undef", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:     `const el = <this></this>;`,
+				FileName: "tsx-this-tag.tsx",
+				Tsx:      true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
+					{MessageId: "undef", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code:     `const el = <this:Foo></this:Foo>;`,
+				FileName: "tsx-this-namespaced-tag.tsx",
+				Tsx:      true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
+					{MessageId: "undef", Line: 1, Column: 18},
+					{MessageId: "undef", Line: 1, Column: 24},
+					{MessageId: "undef", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code:     `export as namespace Missing;`,
+				FileName: "missing-namespace-export.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 21},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_undef/no_undef_test.go
+++ b/internal/rules/no_undef/no_undef_test.go
@@ -577,7 +577,7 @@ function f(x = new Foo()) { function Foo() {} }`},
 				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2025},
 				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "undef", Line: 1, Column: 1}},
 			},
-			// TypeScript exposes AsyncIterator only as a type; ESLint 10.8
+			// TypeScript exposes AsyncIterator only as a type; ESLint 10.9
 			// does not provide it as a runtime language global.
 			{
 				Code:   `AsyncIterator;`,

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -637,6 +637,22 @@ func IsInJSDocSyntax(node *ast.Node) bool {
 // attributes, or qualifier of an ImportType. Type arguments are siblings of
 // those fields and remain references.
 func IsImportTypeSyntax(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	if node.Kind == ast.KindIdentifier {
+		// Ordinary value identifiers are the dominant caller path. An
+		// ImportType can contain an identifier only through a type node, a
+		// qualified name, or its attributes, so avoid walking to SourceFile for
+		// every expression reference.
+		parentKind := node.Parent.Kind
+		if (parentKind < ast.KindFirstTypeNode || parentKind > ast.KindLastTypeNode) &&
+			parentKind != ast.KindQualifiedName &&
+			parentKind != ast.KindImportAttribute &&
+			parentKind != ast.KindImportAttributes {
+			return false
+		}
+	}
 	current := node
 	for current.Parent != nil && current.Parent.Kind != ast.KindImportType {
 		current = current.Parent

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -448,6 +448,11 @@ func (b *builder) visitStatement(stmt *ast.Node, parent *Scope) {
 		}
 	case ast.KindExportDeclaration:
 		b.visitExportDeclaration(stmt, parent)
+	case ast.KindNamespaceExportDeclaration:
+		// `export as namespace Name` reads the exported value. Keep the
+		// scope-manager view consistent with IsReferenceIdentifier instead of
+		// letting the generic statement walk discard its identifier child.
+		b.reference(stmt.Name(), parent)
 	case ast.KindImportDeclaration:
 		// Bindings only; nothing to reference and no new scopes.
 	case ast.KindImportEqualsDeclaration:

--- a/internal/utils/scope/references.go
+++ b/internal/utils/scope/references.go
@@ -23,9 +23,10 @@ func IsReferenceIdentifier(id *ast.Node) bool {
 		return false
 	}
 
-	// `typeof import('m').a.b` names exports of another module, not bindings
-	// in this file.
-	if isImportTypeQualifier(id) {
+	// The argument, attributes, and qualifier of `import('m').a` are module
+	// syntax rather than bindings in this file. Type arguments remain normal
+	// references.
+	if utils.IsImportTypeSyntax(id) {
 		return false
 	}
 	// eslint-scope's JSXElement visitor only visits the opening tag. The
@@ -45,7 +46,12 @@ func IsReferenceIdentifier(id *ast.Node) bool {
 	case ast.KindQualifiedName:
 		// Same shape in type position: `A.B.C` references `A`.
 		qn := parent.AsQualifiedName()
-		return qn != nil && qn.Left == id
+		if qn == nil || qn.Left != id {
+			return false
+		}
+		// TSESTree represents the root of `typeof this.member` as a
+		// TSThisType, which its type visitor deliberately does not reference.
+		return id.Text() != "this" || !ast.IsPartOfTypeQuery(id)
 
 	case ast.KindShorthandPropertyAssignment:
 		// `{ a }` and `({ a = b } = c)` — the name is the value.
@@ -98,6 +104,17 @@ func IsReferenceIdentifier(id *ast.Node) bool {
 		// the predicate. `this is T` uses a ThisType node, not an Identifier.
 		return true
 
+	case ast.KindTypeQuery:
+		// TSESTree exposes bare `typeof this` as TSThisType rather than an
+		// Identifier, so scope-manager creates no reference for it.
+		return id.Text() != "this"
+
+	case ast.KindNamespaceExportDeclaration:
+		// `export as namespace Name` references the exported value. This is
+		// distinct from `export * as Name from`, whose NamespaceExport is only
+		// an external export label.
+		return true
+
 	case ast.KindJsxAttribute:
 		return false
 
@@ -115,6 +132,16 @@ func IsReferenceIdentifier(id *ast.Node) bool {
 	}
 
 	return !ast.IsDeclarationName(id)
+}
+
+// IsTypeScriptJsxThisReference reports the one scope-manager reference that
+// tsgo cannot represent as an Identifier: bare `this` in a TSX tag name.
+// TSESTree emits a JSXIdentifier there. It deliberately excludes
+// `<this.Member>`, whose `this` object is skipped by scope-manager, and every
+// JavaScript/JSX file, where Espree does not reference `this` tag names.
+func IsTypeScriptJsxThisReference(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindThisKeyword &&
+		!ast.IsInJSFile(node) && ast.IsJsxTagName(node)
 }
 
 // isPartOfJsxClosingTagName climbs a tag-name chain from any identifier piece
@@ -342,21 +369,6 @@ func isTypeOnlyPropertyAccessQualifier(id *ast.Node) bool {
 		entity = entity.Parent
 	}
 	return entity != id && ast.IsPartOfTypeNode(entity)
-}
-
-// isImportTypeQualifier reports whether `id` is part of the qualifier of an
-// `import(...)` type — the `a` or `b` in `typeof import('m').a.b`.
-func isImportTypeQualifier(id *ast.Node) bool {
-	current := id
-	for current.Parent != nil && current.Parent.Kind == ast.KindQualifiedName {
-		current = current.Parent
-	}
-	parent := current.Parent
-	if parent == nil || parent.Kind != ast.KindImportType {
-		return false
-	}
-	importType := parent.AsImportTypeNode()
-	return importType != nil && importType.Qualifier == current
 }
 
 // IsJsxComponentName reports whether a bare JSXIdentifier passes the shared

--- a/internal/utils/scope/scope_test.go
+++ b/internal/utils/scope/scope_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
 )
 
 func build(t *testing.T, source string) *Manager {
@@ -332,6 +333,9 @@ func TestBuildReferenceIdentifierPositions(t *testing.T) {
 	assertReferences(t, `let x: typeof Foo.Bar;`, "Foo->?")
 	// ...but an `import(...)` type names another module's exports.
 	assertReferences(t, `type T = typeof import('./m').a.b;`)
+	assertReferences(t, `export as namespace Missing;`, "Missing->?")
+	assertReferences(t, `const Present = {}; export as namespace Present;`, "Present->declared")
+	assertReferences(t, `interface TypeOnly {}; export as namespace TypeOnly;`, "TypeOnly->?")
 	// JSX: a lower-case tag is an intrinsic element, not a binding.
 	assertReferences(t, `<div />;`)
 	assertReferences(t, `<App />;`, "App->?")
@@ -639,6 +643,79 @@ func TestIsReferenceIdentifierRejectsReExportAndImportTypeNames(t *testing.T) {
 				t.Errorf("%s: Subject unexpectedly classified as a local reference", source)
 			}
 		}
+	}
+}
+
+func TestIsReferenceIdentifierMatchesTypeScriptParserEdges(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		identifier string
+		want       bool
+	}{
+		{name: "type query this", source: `type T = typeof this;`, identifier: "this"},
+		{name: "qualified type query this", source: `type T = typeof this.member;`, identifier: "this"},
+		{name: "namespace export", source: `export as namespace Missing;`, identifier: "Missing", want: true},
+		{name: "import type source", source: `type T = import(Missing).Box;`, identifier: "Missing"},
+		{name: "import type qualifier", source: `type T = typeof import("pkg").Missing;`, identifier: "Missing"},
+		{name: "import type attributes", source: `type T = import("pkg", { with: { type: Missing } }).Box;`, identifier: "Missing"},
+		{name: "import type argument", source: `type T = import("pkg").Box<Missing>;`, identifier: "Missing", want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+				Path:     "/test.ts",
+			}, test.source, core.ScriptKindTS)
+			identifiers := identifiersWithText(sourceFile.AsNode(), test.identifier)
+			if len(identifiers) != 1 {
+				t.Fatalf("found %d %q identifiers, want 1", len(identifiers), test.identifier)
+			}
+			if got := IsReferenceIdentifier(identifiers[0]); got != test.want {
+				t.Errorf("IsReferenceIdentifier(%q) = %t, want %t", test.identifier, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsTypeScriptJsxThisReference(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileName   string
+		scriptKind core.ScriptKind
+		source     string
+		want       []bool
+	}{
+		{name: "self closing TSX", fileName: "/test.tsx", scriptKind: core.ScriptKindTSX, source: `<this />`, want: []bool{true}},
+		{name: "paired TSX", fileName: "/test.tsx", scriptKind: core.ScriptKindTSX, source: `<this></this>`, want: []bool{true, true}},
+		{name: "member TSX", fileName: "/test.tsx", scriptKind: core.ScriptKindTSX, source: `<this.Member />`, want: []bool{false}},
+		{name: "expression TSX", fileName: "/test.tsx", scriptKind: core.ScriptKindTSX, source: `const value = this;`, want: []bool{false}},
+		{name: "Espree JSX", fileName: "/test.jsx", scriptKind: core.ScriptKindJSX, source: `<this />`, want: []bool{false}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: test.fileName,
+				Path:     tspath.Path(test.fileName),
+			}, test.source, test.scriptKind)
+			var got []bool
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindThisKeyword {
+					got = append(got, IsTypeScriptJsxThisReference(node))
+				}
+				return node.ForEachChild(visit)
+			}
+			sourceFile.AsNode().ForEachChild(visit)
+			if len(got) != len(test.want) {
+				t.Fatalf("found %d this nodes, want %d", len(got), len(test.want))
+			}
+			for i := range test.want {
+				if got[i] != test.want[i] {
+					t.Errorf("this node %d = %t, want %t", i, got[i], test.want[i])
+				}
+			}
+		})
 	}
 }
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-undef.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-undef.test.ts.snap
@@ -2177,6 +2177,267 @@ exports[`no-undef > invalid 82`] = `
 }
 `;
 
+exports[`no-undef > invalid 83`] = `
+{
+  "code": "const el = <Missing></Missing>;",
+  "diagnostics": [
+    {
+      "message": "'Missing' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-undef > invalid 84`] = `
+{
+  "code": "const el = <Éclair />;",
+  "diagnostics": [
+    {
+      "message": "'Éclair' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-undef > invalid 85`] = `
+{
+  "code": "const el = <foo:bar></foo:bar>;",
+  "diagnostics": [
+    {
+      "message": "'foo' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+    {
+      "message": "'bar' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+    {
+      "message": "'foo' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+    {
+      "message": "'bar' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-undef > invalid 86`] = `
+{
+  "code": "const el = <this></this>;",
+  "diagnostics": [
+    {
+      "message": "'this' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+    {
+      "message": "'this' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-undef > invalid 87`] = `
+{
+  "code": "const el = <this:Foo></this:Foo>;",
+  "diagnostics": [
+    {
+      "message": "'this' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+    {
+      "message": "'Foo' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+    {
+      "message": "'this' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+    {
+      "message": "'Foo' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-undef > invalid 88`] = `
+{
+  "code": "export as namespace Missing;",
+  "diagnostics": [
+    {
+      "message": "'Missing' is not defined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-undef",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
 exports[`no-undef languageOptions merge > invalid 1`] = `
 {
   "code": "defaultGlobal; caseGlobal; Promise;",

--- a/packages/rslint-test-tools/tests/eslint/rules/no-undef.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-undef.test.ts
@@ -241,6 +241,24 @@ ruleTester.run('no-undef', {
 
     // === Class static block with declared ===
     'var staticInit = 42; class C { static { var v = staticInit; } }',
+
+    // === Parser-specific reference shapes ===
+    {
+      code: 'const el = <éclair />; const other = <Missing:Part />;',
+      filename: 'src/virtual.jsx',
+    },
+    {
+      code: 'type T = typeof this; type U = typeof this.member;',
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'const el = <this.Member />;',
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: 'const Missing = {}; export as namespace Missing;',
+      filename: 'src/virtual.ts',
+    },
   ],
   invalid: [
     // === Basic undeclared references ===
@@ -729,6 +747,51 @@ ruleTester.run('no-undef', {
       code: 'Temporal;',
       languageOptions: { ecmaVersion: 2025 },
       errors: [{ messageId: 'undef' }],
+    },
+
+    // === Parser-specific reference shapes ===
+    {
+      code: 'const el = <Missing></Missing>;',
+      filename: 'src/virtual.jsx',
+      errors: [{ messageId: 'undef', line: 1, column: 13 }],
+    },
+    {
+      code: 'const el = <Éclair />;',
+      filename: 'src/virtual.jsx',
+      errors: [{ messageId: 'undef', line: 1, column: 13 }],
+    },
+    {
+      code: 'const el = <foo:bar></foo:bar>;',
+      filename: 'src/virtual.tsx',
+      errors: [
+        { messageId: 'undef', line: 1, column: 13 },
+        { messageId: 'undef', line: 1, column: 17 },
+        { messageId: 'undef', line: 1, column: 23 },
+        { messageId: 'undef', line: 1, column: 27 },
+      ],
+    },
+    {
+      code: 'const el = <this></this>;',
+      filename: 'src/virtual.tsx',
+      errors: [
+        { messageId: 'undef', line: 1, column: 13 },
+        { messageId: 'undef', line: 1, column: 20 },
+      ],
+    },
+    {
+      code: 'const el = <this:Foo></this:Foo>;',
+      filename: 'src/virtual.tsx',
+      errors: [
+        { messageId: 'undef', line: 1, column: 13 },
+        { messageId: 'undef', line: 1, column: 18 },
+        { messageId: 'undef', line: 1, column: 24 },
+        { messageId: 'undef', line: 1, column: 29 },
+      ],
+    },
+    {
+      code: 'export as namespace Missing;',
+      filename: 'src/virtual.ts',
+      errors: [{ messageId: 'undef', line: 1, column: 21 }],
     },
   ],
 });


### PR DESCRIPTION
## Summary

- Align native `no-undef` reference behavior with ESLint 10.9.1 and `@typescript-eslint/scope-manager` 8.69 for JSX closing tags and casing, TSX namespaced/`this` tags, type-query `this`, ImportType syntax, and namespace exports.
- Reuse the shared scope classifier and RefStore boundary, removing the rule-local reference classifier; keep parser-shape adaptation in `internal/utils/scope`.
- Document the remaining user-visible TypeScript `ecmaVersion` runtime-global difference.
- Reduce diagnostic-path allocations and add an ImportType fast path; the 1,000-diagnostic benchmark drops from 3,032 to 2,032 allocs/op, and the fixed real-repository rule time improves from 1307.4 ms to 1295.4 ms.

## Related Links

- https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-undef.js
- https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.69.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).