### PR TITLE
perf: avoid unnecessary directive checks

### DIFF
--- a/internal/rules/no_unused_expressions/no_unused_expressions.go
+++ b/internal/rules/no_unused_expressions/no_unused_expressions.go
@@ -32,12 +32,13 @@ var NoUnusedExpressionsRule = rule.Rule{
 					return
 				}
 
+				if !utils.IsDisallowedUnusedExpression(stmt.Expression, opts) {
+					return
+				}
 				if utils.IsDirectivePrologueStatement(node) {
 					return
 				}
-				if utils.IsDisallowedUnusedExpression(stmt.Expression, opts) {
-					ctx.ReportNode(node, messageUnusedExpression())
-				}
+				ctx.ReportNode(node, messageUnusedExpression())
 			},
 		}
 	},


### PR DESCRIPTION
## Summary

- Check whether an expression is disallowed before checking whether its statement is a directive, matching ESLint's checker-first evaluation order.
- Avoid directive-prologue work for already-valid expressions such as calls, assignments, updates, and allowed short-circuit/ternary forms.
- Preserve the reported `deployment.ts:1151` behavior: the default core rule reports the short-circuit expression, while `@typescript-eslint/no-unused-expressions` with `allowShortCircuit: true` does not. ESLint v10.9.1 and typescript-eslint v8.69.0 retain those semantics.

### Go benchmark

Command:

```sh
go test ./internal/rules/no_unused_expressions -run '^$' -bench '^BenchmarkNoUnusedExpressions$' -benchmem -benchtime=1s -count=5
```

The table shows medians from `benchstat`; bytes and allocations were unchanged in every case.

| Case | Time before → after | Result | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Report default logical expression | `29.92 → 29.44 µs/op` | no significant change | `41568 → 41568` | `264 → 264` |
| Report default logical expression, all edit demand | `29.48 → 29.36 µs/op` | no significant change | `41568 → 41568` | `264 → 264` |
| Allow plain call | `8.058 → 7.714 µs/op` | `-4.27%` | `608 → 608` | `8 → 8` |
| Report identifier | `21.28 → 19.01 µs/op` | no significant change | `41568 → 41568` | `264 → 264` |
| Allow short-circuit call | `14.33 → 14.34 µs/op` | no significant change | `608 → 608` | `8 → 8` |
| Report disallowed short-circuit right side | `27.46 → 26.60 µs/op` | no significant change | `41568 → 41568` | `264 → 264` |
| Allow ternary calls | `21.23 → 20.47 µs/op` | `-3.58%` | `608 → 608` | `8 → 8` |
| Report disallowed ternary branch | `33.59 → 33.24 µs/op` | no significant change | `41568 → 41568` | `264 → 264` |
| Allow TypeScript-wrapped call | `12.07 → 11.58 µs/op` | `-3.99%` | `608 → 608` | `8 → 8` |
| Report TypeScript-wrapped identifier | `24.20 → 23.81 µs/op` | no significant change | `41568 → 41568` | `264 → 264` |
| Geomean | `20.38 → 19.76 µs/op` | `-3.07%` | unchanged | unchanged |

Correctness verification:

- `go test ./internal/rules/no_unused_expressions ./internal/plugins/typescript/rules/no_unused_expressions -count=3`
- Targeted core and typescript-eslint JS rule tests; all snapshots matched with no additions or updates
- The reported source file was tested with both rules, core disabled, and TypeScript extension disabled to verify diagnostic ownership and exact range
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/no_unused_expressions/...`
- `git diff --check`

## Related Links

- [ESLint v10.9.1 implementation](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-unused-expressions.js)
- [typescript-eslint v8.69.0 implementation](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/rules/no-unused-expressions.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
