### PR TITLE
fix: align no-var autofix safety

### DIFF
--- a/internal/rules/no_var/no_var.go
+++ b/internal/rules/no_var/no_var.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 // https://eslint.org/docs/latest/rules/no-var
@@ -84,7 +85,8 @@ func isInDeclareGlobal(node *ast.Node) bool {
 
 // ---------- canFix: determines if var→let is safe ----------
 
-// canFix checks all 10 ESLint conditions to determine if var→let is safe.
+// canFix applies ESLint's safety conditions plus TypeScript/runtime cases where
+// upstream's scope approximation would change behavior.
 func canFix(node *ast.Node, ctx *rule.RuleContext) bool {
 	if ctx.Refs == nil {
 		return false
@@ -116,32 +118,39 @@ func canFix(node *ast.Node, ctx *rule.RuleContext) bool {
 		return false
 	}
 
-	// Collect all variable names declared in this var statement
+	// Collect all variable names declared in this var statement.
 	var vars []varInfo
+	hasUnresolvedBinding := false
 	for _, decl := range declList.Declarations.Nodes {
 		varDecl := decl.AsVariableDeclaration()
 		if varDecl == nil || varDecl.Name() == nil {
 			continue
 		}
 		utils.CollectBindingNames(varDecl.Name(), func(ident *ast.Node, _ string) {
-			if sym := utils.BindingNameSymbol(ident); sym != nil {
-				vars = append(vars, varInfo{nameNode: ident, sym: sym})
+			sym := utils.BindingNameSymbol(ident)
+			if sym == nil {
+				hasUnresolvedBinding = true
+				return
 			}
+			vars = append(vars, varInfo{
+				nameNode: ident,
+				sym:      sym,
+			})
 		})
 	}
-
-	if len(vars) == 0 {
+	if hasUnresolvedBinding {
 		return false
 	}
 
 	for _, v := range vars {
+		varScope := findEnclosingScope(v.nameNode)
 		// Condition 3: global scope variable (script mode, not module)
-		if isGlobalVar(v.nameNode, ctx) {
+		if isGlobalVar(varScope, ctx) {
 			return false
 		}
 
 		// Condition 4: redeclared variable
-		if isRedeclared(v.sym) {
+		if isRedeclared(v.sym) || isRedeclaredByFunction(v.nameNode, v.sym, varScope) {
 			return false
 		}
 
@@ -149,46 +158,51 @@ func canFix(node *ast.Node, ctx *rule.RuleContext) bool {
 		if v.nameNode.Text() == "let" {
 			return false
 		}
+
+		// A var may reuse a simple catch parameter, but let may not. In a
+		// nested block let would instead create a different binding.
+		if isShadowedByCatchParameter(v.nameNode, varScope) {
+			return false
+		}
 	}
 
-	// Collect references only after the cheap blockers above. A reference can
-	// only resolve to these symbols from within its scope, so the file-wide
-	// lists are identical to what a bounded scope walk would find.
-	refs := make(map[*ast.Symbol][]*ast.Node, len(vars))
+	inLoop := isInLoop(node)
 	for _, v := range vars {
-		refs[v.sym] = ctx.Refs.References(v.sym)
-	}
+		// Collect references only after the cheap blockers above. A reference
+		// can only resolve to this symbol from within its variable scope, so the
+		// file-wide list is identical to a bounded scope walk.
+		refs := filterSafeAmbientNamespaceReferences(v.nameNode, ctx.Refs.References(v.sym))
 
-	// Condition 2: self-reference in TDZ
-	// Uses positional range checks (matching ESLint's approach).
-	if hasTDZIssue(declList, vars, refs) {
-		return false
-	}
-
-	for _, v := range vars {
-		varRefs := refs[v.sym]
+		// Condition 2: self-reference in TDZ
+		if hasTDZIssue(v.nameNode, refs) {
+			return false
+		}
 
 		// Condition 5: used from outside the block scope
-		if isUsedFromOutsideScope(node, varRefs) {
+		if isUsedFromOutsideScope(node, refs) {
 			return false
 		}
 
 		// Condition 7: referenced before declaration (hoisting)
-		if hasReferenceBeforeDeclaration(v.nameNode, varRefs) {
+		if hasReferenceBeforeDeclaration(v.nameNode, refs) {
+			return false
+		}
+
+		// A hoisted function declaration can execute a later var reference
+		// before let would be initialized, even when the reference itself is
+		// textually after the declaration.
+		if hasUnsafeHoistedFunctionReference(v.nameNode, refs, ctx) {
+			return false
+		}
+
+		// Condition 8: referenced in a closure within the loop
+		if inLoop && isReferencedInClosure(node, refs) {
 			return false
 		}
 	}
 
-	// Conditions 8 & 9: loop-specific checks
-	if isInLoop(node) {
-		for _, v := range vars {
-			// Condition 8: referenced in a closure within the loop
-			if isReferencedInClosure(node, refs[v.sym]) {
-				return false
-			}
-		}
-
-		// Condition 9: uninitialized declaration in a loop
+	// Condition 9: uninitialized declaration in a loop
+	if inLoop {
 		if !isLoopAssignee(node) && !isDeclarationFullyInitialized(declList) {
 			return false
 		}
@@ -199,98 +213,197 @@ func canFix(node *ast.Node, ctx *rule.RuleContext) bool {
 
 // ---------- Condition helpers ----------
 
-// Condition 2: hasTDZIssue uses positional range checks (matching ESLint) to detect
-// references that would cause a Temporal Dead Zone error with `let`.
-func hasTDZIssue(declList *ast.VariableDeclarationList, vars []varInfo, refs map[*ast.Symbol][]*ast.Node) bool {
-	for _, declaration := range declList.Declarations.Nodes {
-		varDecl := declaration.AsVariableDeclaration()
-		if varDecl == nil || varDecl.Initializer == nil {
+// Condition 2: hasTDZIssue reuses the shared initializer walk to detect
+// references that would enter the temporal dead zone with `let`.
+func hasTDZIssue(nameNode *ast.Node, refs []*ast.Node) bool {
+	var declaration *ast.VariableDeclaration
+	for _, ref := range refs {
+		if isTypeOnlyReferenceLocation(ref) ||
+			!scope.IsInsideOwnInitializer(nameNode, ref.End()) {
 			continue
 		}
-		name := varDecl.Name()
-		if name == nil {
+
+		// A function expression used directly as the declarator's value is
+		// evaluated only after the binding has been initialized. Defaults in
+		// the binding pattern itself are still immediate and stay unsafe.
+		if declaration == nil {
+			root := ast.GetRootDeclaration(nameNode.Parent)
+			if root != nil {
+				declaration = root.AsVariableDeclaration()
+			}
+		}
+		if isInDirectFunctionInitializer(declaration, ref) {
 			continue
 		}
-		nameStart := name.Pos()
-		nameEnd := name.End()
-
-		for _, v := range vars {
-			if v.nameNode.Pos() < nameStart || v.nameNode.End() > nameEnd {
-				continue
-			}
-
-			// A non-function initializer executes while its own bindings are in
-			// TDZ. Bindings from earlier declarators are already initialized.
-			if !isFunctionNode(varDecl.Initializer) {
-				initStart := varDecl.Initializer.Pos()
-				initEnd := varDecl.Initializer.End()
-				for _, ref := range refs[v.sym] {
-					if ref.Pos() >= initStart && ref.End() <= initEnd {
-						return true
-					}
-				}
-			}
-
-			// A reference to a binding within its own default value is also a TDZ
-			// issue, e.g. `var {a = a} = {}`.
-			defaultRange := getDefaultValueRange(v.nameNode)
-			if defaultRange == nil {
-				continue
-			}
-			defStart := defaultRange.Pos()
-			defEnd := defaultRange.End()
-			for _, ref := range refs[v.sym] {
-				if ref.Pos() >= defStart && ref.End() <= defEnd {
-					return true
-				}
-			}
-		}
+		return true
 	}
 
 	return false
 }
 
-// getDefaultValueRange returns the default value initializer node for a binding
-// inside a destructuring pattern, or nil if there is no default.
-func getDefaultValueRange(nameNode *ast.Node) *ast.Node {
-	if nameNode.Parent == nil {
-		return nil
-	}
-	if nameNode.Parent.Kind == ast.KindBindingElement {
-		be := nameNode.Parent.AsBindingElement()
-		if be != nil && be.Initializer != nil {
-			return be.Initializer
-		}
-	}
-	return nil
+func isInDirectFunctionInitializer(declaration *ast.VariableDeclaration, reference *ast.Node) bool {
+	return declaration != nil && declaration.Initializer != nil && isFunctionNode(declaration.Initializer) &&
+		reference.Pos() >= declaration.Initializer.Pos() && reference.End() <= declaration.Initializer.End()
 }
 
-// isFunctionNode checks if the node is a function/arrow expression (deferred execution).
+// isFunctionNode checks if the runtime expression is a function/arrow
+// expression (deferred execution). Parentheses and TypeScript assertions do
+// not change when the function body runs.
 func isFunctionNode(node *ast.Node) bool {
+	node = ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
+	if node == nil {
+		return false
+	}
 	return node.Kind == ast.KindFunctionExpression || node.Kind == ast.KindArrowFunction
 }
 
 // Condition 3: isGlobalVar checks if a variable is in the global scope (script mode).
-func isGlobalVar(nameNode *ast.Node, ctx *rule.RuleContext) bool {
+func isGlobalVar(varScope *ast.Node, ctx *rule.RuleContext) bool {
 	// A syntactic module or a file with module/CommonJS language defaults has a
 	// non-global top-level scope. Omitted sourceType gets ESLint's module default
 	// even when the file contains no import/export marker.
 	if ctx.Refs.HasNonGlobalProgramScope() {
 		return false
 	}
-	// Check if the declaration is at the source file top level (no enclosing function)
-	enclosing := findEnclosingScope(nameNode)
-	return enclosing != nil && enclosing.Kind == ast.KindSourceFile
+	return varScope != nil && varScope.Kind == ast.KindSourceFile
 }
 
 // Condition 4: isRedeclared checks if a symbol has multiple declarations.
 func isRedeclared(sym *ast.Symbol) bool {
-	return len(sym.Declarations) >= 2
+	return sym != nil && len(sym.Declarations) >= 2
+}
+
+// isRedeclaredByFunction covers the one legal value-space redeclaration that
+// tsgo's binder keeps as a separate symbol: a var sharing its variable scope
+// with a function declaration. Replacing the var with let would either be a
+// syntax error or introduce a new binding. The binder-owned scope tables let
+// us detect it without reconstructing the file's scopes.
+func isRedeclaredByFunction(nameNode *ast.Node, ownSymbol *ast.Symbol, scopeNode *ast.Node) bool {
+	if nameNode == nil {
+		return false
+	}
+	if scopeNode == nil {
+		return false
+	}
+	last := scopeNode
+	if scopeNode.Kind == ast.KindModuleBlock && scopeNode.Parent != nil &&
+		scopeNode.Parent.Kind == ast.KindModuleDeclaration {
+		last = scopeNode.Parent
+	}
+
+	name := nameNode.Text()
+	for current := nameNode.Parent; current != nil; current = current.Parent {
+		if symbolDeclaresFunction(current.Locals()[name], ownSymbol) {
+			return true
+		}
+		if owner := current.Symbol(); owner != nil &&
+			symbolDeclaresFunction(owner.Exports[name], ownSymbol) {
+			return true
+		}
+		if current == last {
+			break
+		}
+	}
+	return false
+}
+
+func symbolDeclaresFunction(symbol *ast.Symbol, ownSymbol *ast.Symbol) bool {
+	if symbol == nil || symbol == ownSymbol {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration.Kind == ast.KindFunctionDeclaration {
+			return true
+		}
+	}
+	return false
+}
+
+// isShadowedByCatchParameter checks only as far as the var's own variable
+// scope. A nested function or class static block owns a different var, so a
+// catch parameter outside that boundary cannot conflict with the replacement.
+func isShadowedByCatchParameter(nameNode *ast.Node, boundary *ast.Node) bool {
+	if nameNode == nil {
+		return false
+	}
+	name := nameNode.Text()
+	for current := nameNode.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindCatchClause {
+			catchClause := current.AsCatchClause()
+			if catchClause != nil && catchClause.VariableDeclaration != nil {
+				declaration := catchClause.VariableDeclaration.AsVariableDeclaration()
+				if declaration != nil && bindingContainsName(declaration.Name(), name) {
+					return true
+				}
+			}
+		}
+		if current == boundary {
+			break
+		}
+	}
+	return false
+}
+
+func bindingContainsName(binding *ast.Node, target string) bool {
+	found := false
+	utils.CollectBindingNames(binding, func(_ *ast.Node, name string) {
+		if name == target {
+			found = true
+		}
+	})
+	return found
+}
+
+// filterSafeAmbientNamespaceReferences removes type-only reads contributed by
+// another declaration that reopens the same ambient namespace. Those reads
+// remain valid after var becomes let, while keeping them would incorrectly
+// look like uses outside the declaration's ModuleBlock. Duplicate ambient var
+// declarations are still rejected earlier by the binder symbol check.
+func filterSafeAmbientNamespaceReferences(nameNode *ast.Node, refs []*ast.Node) []*ast.Node {
+	if len(refs) == 0 || !utils.IsInAmbientContext(nameNode) {
+		return refs
+	}
+	var filtered []*ast.Node
+	for i, ref := range refs {
+		if !isTypeOnlyReferenceLocation(ref) || !isInReopenedNamespace(nameNode, ref) {
+			if filtered != nil {
+				filtered = append(filtered, ref)
+			}
+			continue
+		}
+		if filtered == nil {
+			filtered = make([]*ast.Node, 0, len(refs)-1)
+			filtered = append(filtered, refs[:i]...)
+		}
+	}
+	if filtered == nil {
+		return refs
+	}
+	return filtered
+}
+
+func isInReopenedNamespace(declaration *ast.Node, reference *ast.Node) bool {
+	for declarationAncestor := declaration.Parent; declarationAncestor != nil; declarationAncestor = declarationAncestor.Parent {
+		if declarationAncestor.Kind != ast.KindModuleDeclaration || declarationAncestor.Symbol() == nil {
+			continue
+		}
+		for referenceAncestor := reference.Parent; referenceAncestor != nil; referenceAncestor = referenceAncestor.Parent {
+			if referenceAncestor.Kind == ast.KindModuleDeclaration &&
+				referenceAncestor != declarationAncestor &&
+				referenceAncestor.Symbol() == declarationAncestor.Symbol() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Condition 5: isUsedFromOutsideScope checks if any reference is positionally
 // outside the block scope containing the declaration.
 func isUsedFromOutsideScope(declListNode *ast.Node, refs []*ast.Node) bool {
+	if len(refs) == 0 {
+		return false
+	}
 	scopeNode := findBlockScope(declListNode)
 	if scopeNode == nil {
 		return false
@@ -311,24 +424,162 @@ func isUsedFromOutsideScope(declListNode *ast.Node, refs []*ast.Node) bool {
 func hasReferenceBeforeDeclaration(nameNode *ast.Node, refs []*ast.Node) bool {
 	declPos := nameNode.Pos()
 	for _, ref := range refs {
-		if ref.Pos() < declPos && ref != nameNode {
+		if ref.Pos() < declPos && ref != nameNode && !isTypeOnlyReferenceLocation(ref) {
 			return true
 		}
 	}
 	return false
 }
 
+// hasUnsafeHoistedFunctionReference detects a later textual reference that is
+// evaluated by a hoisted function declaration called before the var. With let,
+// that call would enter the temporal dead zone. Calls through parentheses and
+// TypeScript expression wrappers, constructor calls, and tagged templates all
+// execute the declaration and are therefore unsafe.
+func hasUnsafeHoistedFunctionReference(nameNode *ast.Node, refs []*ast.Node, ctx *rule.RuleContext) bool {
+	if len(refs) == 0 {
+		return false
+	}
+	declarationScope := findEnclosingExecutionScope(nameNode)
+	declarationStart := nameNode.Pos()
+	for _, ref := range refs {
+		if ref.Pos() < declarationStart || isTypeOnlyReferenceLocation(ref) {
+			continue
+		}
+		for currentScope := findEnclosingExecutionScope(ref); currentScope != nil && currentScope != declarationScope; currentScope = findEnclosingExecutionScope(currentScope) {
+			if currentScope.Kind != ast.KindFunctionDeclaration || currentScope.Name() == nil {
+				continue
+			}
+			functionSymbol := utils.BindingNameSymbol(currentScope.Name())
+			for _, functionRef := range ctx.Refs.References(functionSymbol) {
+				if isImmediateInvocation(functionRef) &&
+					(functionRef.Pos() < declarationStart || isInvocationInOwnInitializer(nameNode, functionRef)) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isInvocationInOwnInitializer catches calls such as
+// `var value = readValue(); function readValue() { return value; }`. The call
+// is textually after the binding name but still runs before let initializes
+// it. A function/arrow used directly as the initializer stays deferred.
+func isInvocationInOwnInitializer(nameNode *ast.Node, invocation *ast.Node) bool {
+	if !scope.IsInsideOwnInitializer(nameNode, invocation.End()) {
+		return false
+	}
+	root := ast.GetRootDeclaration(nameNode.Parent)
+	return root == nil || !isInDirectFunctionInitializer(root.AsVariableDeclaration(), invocation)
+}
+
+func isImmediateInvocation(reference *ast.Node) bool {
+	current := invocationResultExpression(reference)
+	if utils.IsCallee(current) || isTaggedTemplateTag(current) {
+		return true
+	}
+
+	// Function.prototype.call/apply invoke their receiver immediately. Reuse
+	// the shared access helpers so dotted, computed, optional, and asserted
+	// member expressions agree with the rest of the rules.
+	parent := current.Parent
+	if parent == nil || !ast.IsAccessExpression(parent) ||
+		utils.AccessExpressionObject(parent) != current {
+		return false
+	}
+	name, ok := utils.AccessExpressionStaticName(parent)
+	return ok && (name == "call" || name == "apply") && utils.IsCallee(parent)
+}
+
+// invocationResultExpression walks only expressions whose result can be the
+// referenced function itself. This covers the right-most operand of a comma
+// expression and the value-producing arms of logical and conditional
+// expressions without treating an ordinary member access as a function call.
+func invocationResultExpression(reference *ast.Node) *ast.Node {
+	current := reference
+	for current != nil && current.Parent != nil {
+		parent := current.Parent
+		if ast.IsOuterExpression(parent, ast.OEKParentheses|ast.OEKAssertions) {
+			current = parent
+			continue
+		}
+		if parent.Kind == ast.KindBinaryExpression {
+			binary := parent.AsBinaryExpression()
+			if binary != nil && binary.OperatorToken != nil &&
+				((binary.OperatorToken.Kind == ast.KindCommaToken && binary.Right == current) ||
+					ast.IsLogicalOrCoalescingBinaryOperator(binary.OperatorToken.Kind)) {
+				current = parent
+				continue
+			}
+		}
+		if parent.Kind == ast.KindConditionalExpression {
+			conditional := parent.AsConditionalExpression()
+			if conditional != nil && (conditional.WhenTrue == current || conditional.WhenFalse == current) {
+				current = parent
+				continue
+			}
+		}
+		break
+	}
+	return current
+}
+
+func isTaggedTemplateTag(node *ast.Node) bool {
+	current := node
+	parent := current.Parent
+	for parent != nil && ast.IsOuterExpression(parent, ast.OEKParentheses|ast.OEKAssertions) {
+		current = parent
+		parent = current.Parent
+	}
+	if parent == nil || parent.Kind != ast.KindTaggedTemplateExpression {
+		return false
+	}
+	tagged := parent.AsTaggedTemplateExpression()
+	return tagged != nil && tagged.Tag == current
+}
+
 // Condition 8: isReferencedInClosure checks if any reference is from a different
 // function scope than the variable (closure captures in a loop).
 func isReferencedInClosure(declNode *ast.Node, refs []*ast.Node) bool {
-	declFuncScope := findEnclosingScope(declNode)
+	if len(refs) == 0 {
+		return false
+	}
+	declFuncScope := findEnclosingExecutionScope(declNode)
 	for _, ref := range refs {
-		refFuncScope := findEnclosingScope(ref)
+		// Type syntax is erased and cannot observe per-iteration bindings.
+		if isTypeOnlyReferenceLocation(ref) {
+			continue
+		}
+		refFuncScope := findEnclosingExecutionScope(ref)
 		if refFuncScope != declFuncScope {
 			return true
 		}
 	}
 	return false
+}
+
+func isTypeOnlyReferenceLocation(node *ast.Node) bool {
+	return ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node)
+}
+
+// findEnclosingExecutionScope uses tsgo's container walk, which already keeps
+// computed keys and member/parameter decorators outside their method body.
+// Static blocks and static fields run while their class is evaluated and are
+// folded into the surrounding execution context. Instance field initializers
+// run later, when an instance is constructed, and remain a boundary.
+func findEnclosingExecutionScope(node *ast.Node) *ast.Node {
+	for node != nil && node.Parent != nil {
+		container := ast.GetThisContainer(node, true, false)
+		if container.Kind == ast.KindSourceFile || utils.IsFunctionLikeContainer(container) {
+			return container
+		}
+		if container.Kind == ast.KindPropertyDeclaration && !ast.HasStaticModifier(container) {
+			return container
+		}
+		node = container
+	}
+	return nil
 }
 
 // Condition 9: isDeclarationFullyInitialized checks if every declarator has an initializer.
@@ -379,28 +630,20 @@ func isInValidLetPosition(node *ast.Node) bool {
 
 // isInLoop checks if a node is inside a loop body.
 func isInLoop(node *ast.Node) bool {
-	current := node.Parent
-	for current != nil {
-		switch current.Kind {
-		case ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement,
-			ast.KindWhileStatement, ast.KindDoStatement:
+	for current := node.Parent; current != nil; current = current.Parent {
+		if ast.IsIterationStatement(current, false) {
 			return true
-		case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
-			ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor,
-			ast.KindSourceFile:
+		}
+		if ast.IsFunctionLikeOrClassStaticBlockDeclaration(current) || current.Kind == ast.KindSourceFile {
 			return false
 		}
-		current = current.Parent
 	}
 	return false
 }
 
 // isLoopAssignee checks if a VariableDeclarationList is the left side of for-in/for-of.
 func isLoopAssignee(node *ast.Node) bool {
-	if node.Parent == nil {
-		return false
-	}
-	return node.Parent.Kind == ast.KindForInStatement || node.Parent.Kind == ast.KindForOfStatement
+	return node.Parent != nil && ast.IsForInOrOfStatement(node.Parent)
 }
 
 // findEnclosingScope delegates to the public utils.FindEnclosingScope.

--- a/internal/rules/no_var/no_var.md
+++ b/internal/rules/no_var/no_var.md
@@ -21,4 +21,4 @@ const CONFIG = {};
 ## Original Documentation
 
 - [ESLint: no-var](https://eslint.org/docs/latest/rules/no-var)
-- [Source code](https://github.com/eslint/eslint/blob/v10.8.1/lib/rules/no-var.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-var.js)

--- a/internal/rules/no_var/no_var_test.go
+++ b/internal/rules/no_var/no_var_test.go
@@ -151,6 +151,15 @@ func TestNoVarRule(t *testing.T) {
 					{MessageId: "unexpectedVar"},
 				},
 			},
+			// A UMD namespace export names the module as a whole; it is not a
+			// runtime read of a same-named local binding.
+			{
+				Code:   `export as namespace API; var API = 1; export = API;`,
+				Output: []string{`export as namespace API; let API = 1; export = API;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedVar"},
+				},
+			},
 			// Import attribute keys are syntax names, not variable references.
 			{
 				Code:   `import data from "pkg" with { type: "json" }; var type = 1;`,
@@ -601,6 +610,243 @@ func TestNoVarRule(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpectedVar"},
 				},
+			},
+		},
+	)
+}
+
+func TestNoVarAutofixSafetyAndScopeParity(t *testing.T) {
+	oneError := []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedVar"}}
+	twoErrors := []rule_tester.InvalidTestCaseError{
+		{MessageId: "unexpectedVar"},
+		{MessageId: "unexpectedVar"},
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoVarRule,
+		nil,
+		[]rule_tester.InvalidTestCase{
+			// A catch parameter and var are distinct in scope analysis, but var
+			// still writes that parameter. Let is either invalid or changes the
+			// binding being assigned.
+			{Code: `function f() { try {} catch (e) { var e = 1; } }`, Errors: oneError},
+			{Code: `function f() { try {} catch (e) { var e; } }`, Errors: oneError},
+			{Code: `function f() { try {} catch (e) { { var e = 1; } } }`, Errors: oneError},
+			{Code: `function f() { try {} catch (e) { try {} catch (x) { var e = 1; } } }`, Errors: oneError},
+			{Code: `function f() { try {} catch (e) { for (var e of []) {} } }`, Errors: oneError},
+			{
+				Code:   `function f() { try {} catch (e) { var x = 1; } }`,
+				Output: []string{`function f() { try {} catch (e) { let x = 1; } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f() { try {} catch (e) {} var e = 1; }`,
+				Output: []string{`function f() { try {} catch (e) {} let e = 1; }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f() { try {} catch (e) { function g() { var e = 1; } } }`,
+				Output: []string{`function f() { try {} catch (e) { function g() { let e = 1; } } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f() { try {} catch (e) { class C { static { var e = 1; } } } }`,
+				Output: []string{`function f() { try {} catch (e) { class C { static { let e = 1; } } } }`},
+				Errors: oneError,
+			},
+
+			// Calling a hoisted declaration before the var would enter the TDZ
+			// after the replacement, even if its read is textually later.
+			{Code: `function wrap() { foo(); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{
+				Code:   `function wrap() { var a = 1; foo(); function foo() { console.log(a); } }`,
+				Output: []string{`function wrap() { let a = 1; foo(); function foo() { console.log(a); } }`},
+				Errors: oneError,
+			},
+			{Code: `function wrap() { bar(); var a = 1; function bar() { function inner() { console.log(a); } inner(); } }`, Errors: oneError},
+			{
+				Code:   `function wrap() { foo(); var a = 1; var b = 2; function foo() { console.log(a); } }`,
+				Output: []string{`function wrap() { foo(); var a = 1; let b = 2; function foo() { console.log(a); } }`},
+				Errors: twoErrors,
+			},
+			{
+				Code:   `function wrap() { function foo() {} foo(); if (bar) { var a = 1; function foo() { console.log(a); } foo(); } }`,
+				Output: []string{`function wrap() { function foo() {} foo(); if (bar) { let a = 1; function foo() { console.log(a); } foo(); } }`},
+				Errors: oneError,
+			},
+			{Code: `function wrap() { new Foo(); var a = 1; function Foo() { console.log(a); } }`, Errors: oneError},
+			{Code: "function wrap() { tag``; var a = 1; function tag() { console.log(a); } }", Errors: oneError},
+			{Code: `function wrap() { (foo)(); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{Code: `function wrap() { foo.call(null); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{Code: `function wrap() { foo.apply(null, []); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{Code: `function wrap() { foo["call"](null); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{Code: `function wrap() { (0, foo)(); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{Code: `function wrap(flag) { (flag ? foo : other)(); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{Code: `function wrap() { (foo || other)(); var a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{Code: `function wrap() { var a = foo(); function foo() { return a; } }`, Errors: oneError},
+			{Code: `function wrap(values) { for (var a of foo()) {} function foo() { return [a]; } }`, Errors: oneError},
+			{Code: `function wrap() { var b = foo(), a = 1; function foo() { console.log(a); } }`, Errors: oneError},
+			{
+				Code:   `function wrap() { var a = 1, b = foo(); function foo() { console.log(a); } }`,
+				Output: []string{`function wrap() { let a = 1, b = foo(); function foo() { console.log(a); } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function wrap() { foo(); var a = 1; function foo(): typeof a { return 1; } }`,
+				Output: []string{`function wrap() { foo(); let a = 1; function foo(): typeof a { return 1; } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function wrap() { var a = () => foo(); function foo() { return a; } }`,
+				Output: []string{`function wrap() { let a = () => foo(); function foo() { return a; } }`},
+				Errors: oneError,
+			},
+
+			// Parentheses are not an execution boundary in ESTree. Empty binding
+			// patterns declare no variable whose scope could make the fix unsafe.
+			{
+				Code:   `var foo = ((function () { foo(); }));`,
+				Output: []string{`let foo = ((function () { foo(); }));`},
+				Errors: oneError,
+			},
+			{
+				Code:   `var foo = (((() => foo())));`,
+				Output: []string{`let foo = (((() => foo())));`},
+				Errors: oneError,
+			},
+			{
+				Code:   `var foo = ((function () { foo(); }) as () => void);`,
+				Output: []string{`let foo = ((function () { foo(); }) as () => void);`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f() { type T = typeof value; var value = null as typeof value; }`,
+				Output: []string{`function f() { type T = typeof value; let value = null as typeof value; }`},
+				Errors: oneError,
+			},
+			{Code: `function f() { var value = value as number; }`, Errors: oneError},
+			{Code: `function f() { var value = typeof value; }`, Errors: oneError},
+			{
+				Code:   `function f() { var {} = {}; var [] = []; }`,
+				Output: []string{`function f() { let {} = {}; let [] = []; }`},
+				Errors: twoErrors,
+			},
+			{
+				Code:   `function f(values) { for (var {} of values) {} }`,
+				Output: []string{`function f(values) { for (let {} of values) {} }`},
+				Errors: oneError,
+			},
+			{Code: `function f() { for (var x of x) {} }`, Errors: oneError},
+			{Code: `function f() { for (var x in x) {} }`, Errors: oneError},
+			{Code: `function f(values) { for (var [x = x] of values) {} }`, Errors: oneError},
+			{Code: `function f(values) { for (var {x = x} of values) {} }`, Errors: oneError},
+
+			// Function declarations and vars may legally share a binding, but a
+			// let replacement may not. A nested function owns a separate binding.
+			{Code: `function X() {} var X = 1;`, Errors: oneError},
+			{Code: `var X = 1; function X() {}`, Errors: oneError},
+			{Code: `function outer() { function X() {} var X = 1; }`, Errors: oneError},
+			{Code: `function outer() { var X = 1; function X() {} }`, Errors: oneError},
+			{Code: `function f(value: number) { var value = 1; }`, Errors: oneError},
+			{Code: `function outer() { function X() {} { var X = 1; } }`, Errors: oneError},
+			{Code: `declare namespace N { function X(): void; var X: unknown; }`, Errors: oneError},
+			{
+				Code:   `function outer() { function X() {} function inner() { var X = 1; } }`,
+				Output: []string{`function outer() { function X() {} function inner() { let X = 1; } }`},
+				Errors: oneError,
+			},
+
+			// These class/object/type positions execute in the current iteration.
+			// Instance fields and methods are deferred and must keep var.
+			{
+				Code:   `function f(values) { for (var x of values) { class C { static { use(x); } } } }`,
+				Output: []string{`function f(values) { for (let x of values) { class C { static { use(x); } } } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f(values) { for (var x of values) { class C { [x]() {} } } }`,
+				Output: []string{`function f(values) { for (let x of values) { class C { [x]() {} } } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f(values) { for (var x of values) { class C { static field = x; } } }`,
+				Output: []string{`function f(values) { for (let x of values) { class C { static field = x; } } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f(values) { for (var x of values) { ({ [x]: true }); } }`,
+				Output: []string{`function f(values) { for (let x of values) { ({ [x]: true }); } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f(values) { for (var x of values) { type T = () => typeof x; } }`,
+				Output: []string{`function f(values) { for (let x of values) { type T = () => typeof x; } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f(values) { for (var x of values) { @decorate(x) class C {} } }`,
+				Output: []string{`function f(values) { for (let x of values) { @decorate(x) class C {} } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f(values) { for (var x of values) { class C { @decorate(x) method() {} } } }`,
+				Output: []string{`function f(values) { for (let x of values) { class C { @decorate(x) method() {} } } }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `function f(values) { for (var x of values) { class C { method(@decorate(x) value: unknown) {} } } }`,
+				Output: []string{`function f(values) { for (let x of values) { class C { method(@decorate(x) value: unknown) {} } } }`},
+				Errors: oneError,
+			},
+			{Code: `function f(values) { for (var x of values) { class C { method(@decorate(() => x) value: unknown) {} } } }`, Errors: oneError},
+			{
+				Code:   `function f(values) { for (var x of values) { class C { field: typeof x; } } }`,
+				Output: []string{`function f(values) { for (let x of values) { class C { field: typeof x; } } }`},
+				Errors: oneError,
+			},
+			{Code: `function f(values) { for (var x of values) { class C { field = x; } consume(C); } }`, Errors: oneError},
+			{Code: `function f(values) { for (var x of values) { class C { accessor field = x; } consume(C); } }`, Errors: oneError},
+			{
+				Code:   `function f(values) { for (var x of values) { class C { static accessor field = x; } } }`,
+				Output: []string{`function f(values) { for (let x of values) { class C { static accessor field = x; } } }`},
+				Errors: oneError,
+			},
+			{Code: `function f(values) { for (var x of values) { class C { method() { return x; } } } }`, Errors: oneError},
+			{Code: `function f(values) { for (var x of values) { class C { static { consume(() => x); } } } }`, Errors: oneError},
+			{
+				Code:   `function f(values) { for (const value of values) { class C { static { var x = value; consume(() => x); } } } }`,
+				Output: []string{`function f(values) { for (const value of values) { class C { static { let x = value; consume(() => x); } } } }`},
+				Errors: oneError,
+			},
+			{Code: `class C { static { for (var x of values) { consume(() => x); } } }`, Errors: oneError},
+
+			// Ambient namespace declarations merge across separate ModuleBlocks.
+			{
+				Code:   `declare namespace N { var x: number; } declare namespace N { const y: typeof x; }`,
+				Output: []string{`declare namespace N { let x: number; } declare namespace N { const y: typeof x; }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `declare namespace N { const y: typeof x; } declare namespace N { var x: number; }`,
+				Output: []string{`declare namespace N { const y: typeof x; } declare namespace N { let x: number; }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `declare namespace N.M { var x: number; } declare namespace N.M { type Y = typeof x; }`,
+				Output: []string{`declare namespace N.M { let x: number; } declare namespace N.M { type Y = typeof x; }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `declare module "pkg" { var x: number; } declare module "pkg" { type Y = typeof x; }`,
+				Output: []string{`declare module "pkg" { let x: number; } declare module "pkg" { type Y = typeof x; }`},
+				Errors: oneError,
+			},
+			{
+				Code:   `declare namespace N { var x: number; } declare namespace N { var x: number; }`,
+				Errors: twoErrors,
 			},
 		},
 	)


### PR DESCRIPTION
## Summary

- Align `no-var` autofix safety with the correct catch-parameter and called-hoisted-function behavior in ESLint v10.9.1.
- Preserve runtime semantics across TDZ initializers and loop RHS/defaults, function/var redeclarations, loop closure execution boundaries, type-only references, and reopened ambient namespaces. Unsafe upstream fixes are intentionally not reproduced.
- Reuse the existing `RefStore`, tsgo AST/container helpers, and shared scope initializer analysis. A temporary Go benchmark exposed avoidable per-binding retained state, which was removed; benchmark code is not included.
- Verified with the targeted Go rule tests (three consecutive runs), the targeted JS `no-var` test (snapshots unchanged), `check-spell`, `format:check`, and changed-package Go lint.

## Related Links

- [ESLint no-var v10.9.1 source](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-var.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).