### PR TITLE
fix: clarify consistent-type-assertions diagnostics

### DIFF
--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
@@ -45,6 +45,37 @@ const (
 	arraySatisfiesSuggestionTemplate   = "Use const x = [ ... ] satisfies {{cast}} instead."
 )
 
+type literalAssertionMessages struct {
+	diagnosticID                     string
+	annotationOrSatisfiesDescription string
+	satisfiesDescription             string
+	annotationSuggestionID           string
+	annotationSuggestionTemplate     string
+	satisfiesSuggestionID            string
+	satisfiesSuggestionTemplate      string
+}
+
+var (
+	objectLiteralAssertionMessages = literalAssertionMessages{
+		diagnosticID:                     "unexpectedObjectTypeAssertion",
+		annotationOrSatisfiesDescription: "Use a type annotation or the `satisfies` operator instead of a type assertion for object literals.",
+		satisfiesDescription:             "Use the `satisfies` operator instead of a type assertion for object literals.",
+		annotationSuggestionID:           objectAnnotationSuggestionID,
+		annotationSuggestionTemplate:     objectAnnotationSuggestionTemplate,
+		satisfiesSuggestionID:            objectSatisfiesSuggestionID,
+		satisfiesSuggestionTemplate:      objectSatisfiesSuggestionTemplate,
+	}
+	arrayLiteralAssertionMessages = literalAssertionMessages{
+		diagnosticID:                     "unexpectedArrayTypeAssertion",
+		annotationOrSatisfiesDescription: "Use a type annotation or the `satisfies` operator instead of a type assertion for array literals.",
+		satisfiesDescription:             "Use the `satisfies` operator instead of a type assertion for array literals.",
+		annotationSuggestionID:           arrayAnnotationSuggestionID,
+		annotationSuggestionTemplate:     arrayAnnotationSuggestionTemplate,
+		satisfiesSuggestionID:            arraySatisfiesSuggestionID,
+		satisfiesSuggestionTemplate:      arraySatisfiesSuggestionTemplate,
+	}
+)
+
 var asExpressionPrecedence = ast.GetOperatorPrecedence(
 	ast.KindAsExpression,
 	ast.KindUnknown,
@@ -63,6 +94,67 @@ func skipParensUp(node *ast.Node) *ast.Node {
 		parent = parent.Parent
 	}
 	return parent
+}
+
+// isParameterPosition mirrors upstream isAsParameter after skipParensUp has
+// reconciled tsgo's explicit parenthesis nodes with ESTree.
+func isParameterPosition(parent *ast.Node) bool {
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindNewExpression, ast.KindCallExpression, ast.KindThrowStatement,
+		ast.KindJsxExpression, ast.KindParameter, ast.KindBindingElement,
+		ast.KindShorthandPropertyAssignment:
+		// Parameter / BindingElement / ShorthandPropertyAssignment cover the
+		// ESTree AssignmentPattern default-value cases; the assertion can only
+		// be the default/initializer in those nodes.
+		return true
+	case ast.KindTemplateSpan:
+		// Only tagged templates count: the substitution's TemplateExpression
+		// must itself be the argument of a TaggedTemplateExpression.
+		return parent.Parent != nil && parent.Parent.Parent != nil &&
+			parent.Parent.Parent.Kind == ast.KindTaggedTemplateExpression
+	}
+	return false
+}
+
+// annotationTarget returns the binding after which upstream can insert a type
+// annotation. Keeping this decision outside the deferred builder lets the
+// diagnostic text describe exactly the suggestions that can be produced.
+func annotationTarget(parent *ast.Node) *ast.Node {
+	if parent == nil || parent.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	declaration := parent.AsVariableDeclaration()
+	if declaration == nil || declaration.Type != nil {
+		return nil
+	}
+	return declaration.Name()
+}
+
+func isConstType(typeNode *ast.Node) bool {
+	if typeNode == nil || typeNode.Kind != ast.KindTypeReference {
+		return false
+	}
+	typeReference := typeNode.AsTypeReferenceNode()
+	return typeReference != nil &&
+		typeReference.TypeName != nil &&
+		typeReference.TypeName.Kind == ast.KindIdentifier &&
+		typeReference.TypeName.AsIdentifier().Text == "const"
+}
+
+// shouldReportLiteralType mirrors upstream checkType: only bare any/unknown
+// keywords and const assertions are exempt.
+func shouldReportLiteralType(typeNode *ast.Node) bool {
+	switch typeNode.Kind {
+	case ast.KindAnyKeyword, ast.KindUnknownKeyword:
+		return false
+	case ast.KindTypeReference:
+		return !isConstType(typeNode)
+	default:
+		return true
+	}
 }
 
 func substituteCast(template, cast string) string {
@@ -96,35 +188,29 @@ func (e consistentTypeAssertionsEdits) literalSuggestions(
 	node *ast.Node,
 	expression *ast.Node,
 	typeNode *ast.Node,
-	annotationID string,
-	annotationTemplate string,
-	satisfiesID string,
-	satisfiesTemplate string,
+	annotationTarget *ast.Node,
+	messages *literalAssertionMessages,
 ) []rule.RuleSuggestion {
 	typeText := e.text(typeNode)
 	expressionText := e.textWithParentheses(expression)
 	suggestions := make([]rule.RuleSuggestion, 0, 2)
-	if effectiveParent := skipParensUp(node); effectiveParent != nil && effectiveParent.Kind == ast.KindVariableDeclaration {
-		if declaration := effectiveParent.AsVariableDeclaration(); declaration.Type == nil {
-			if name := declaration.Name(); name != nil {
-				suggestions = append(suggestions, rule.RuleSuggestion{
-					Message: rule.RuleMessage{
-						Id:          annotationID,
-						Description: substituteCast(annotationTemplate, typeText),
-						Data:        map[string]string{"cast": typeText},
-					},
-					FixesArr: []rule.RuleFix{
-						rule.RuleFixInsertAfter(name, ": "+typeText),
-						rule.RuleFixReplace(e.sourceFile, node, expressionText),
-					},
-				})
-			}
-		}
+	if annotationTarget != nil {
+		suggestions = append(suggestions, rule.RuleSuggestion{
+			Message: rule.RuleMessage{
+				Id:          messages.annotationSuggestionID,
+				Description: substituteCast(messages.annotationSuggestionTemplate, typeText),
+				Data:        map[string]string{"cast": typeText},
+			},
+			FixesArr: []rule.RuleFix{
+				rule.RuleFixInsertAfter(annotationTarget, ": "+typeText),
+				rule.RuleFixReplace(e.sourceFile, node, expressionText),
+			},
+		})
 	}
 	suggestions = append(suggestions, rule.RuleSuggestion{
 		Message: rule.RuleMessage{
-			Id:          satisfiesID,
-			Description: substituteCast(satisfiesTemplate, typeText),
+			Id:          messages.satisfiesSuggestionID,
+			Description: substituteCast(messages.satisfiesSuggestionTemplate, typeText),
 			Data:        map[string]string{"cast": typeText},
 		},
 		FixesArr: []rule.RuleFix{
@@ -133,38 +219,6 @@ func (e consistentTypeAssertionsEdits) literalSuggestions(
 		},
 	})
 	return suggestions
-}
-
-func (e consistentTypeAssertionsEdits) objectLiteralSuggestions(
-	node *ast.Node,
-	expression *ast.Node,
-	typeNode *ast.Node,
-) []rule.RuleSuggestion {
-	return e.literalSuggestions(
-		node,
-		expression,
-		typeNode,
-		objectAnnotationSuggestionID,
-		objectAnnotationSuggestionTemplate,
-		objectSatisfiesSuggestionID,
-		objectSatisfiesSuggestionTemplate,
-	)
-}
-
-func (e consistentTypeAssertionsEdits) arrayLiteralSuggestions(
-	node *ast.Node,
-	expression *ast.Node,
-	typeNode *ast.Node,
-) []rule.RuleSuggestion {
-	return e.literalSuggestions(
-		node,
-		expression,
-		typeNode,
-		arrayAnnotationSuggestionID,
-		arrayAnnotationSuggestionTemplate,
-		arraySatisfiesSuggestionID,
-		arraySatisfiesSuggestionTemplate,
-	)
 }
 
 // angleToAsFix converts an angle-bracket assertion into an as assertion,
@@ -216,8 +270,11 @@ func (e consistentTypeAssertionsEdits) angleToAsFix(
 
 // ConsistentTypeAssertionsRule is the rslint port of upstream
 // `@typescript-eslint/consistent-type-assertions`. It mirrors upstream v8
-// observably: the same diagnostics (message ids + texts), the same
+// observably: the same diagnostic locations and message ids, the same
 // `annotation`/`satisfies` suggestions, and the same angle-bracket→as autofix.
+// Literal-assertion descriptions intentionally name only replacements that
+// are valid in the assertion's context; upstream always recommends a const
+// declaration even when the assertion is not a variable initializer.
 //
 // AST note: upstream runs on ESTree, where parentheses are not nodes, so
 // `node.expression` / `node.parent` transparently see through them. tsgo
@@ -237,101 +294,51 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 
 	edits := consistentTypeAssertionsEdits{sourceFile: ctx.SourceFile}
 
-	// isConst reports whether the assertion target is `const` (the `as const` /
-	// `<const>` assertion). Mirrors upstream `isConst`.
-	isConst := func(typeNode *ast.Node) bool {
-		if typeNode == nil || typeNode.Kind != ast.KindTypeReference {
-			return false
+	// Upstream implements object and array literal checks separately. Selecting
+	// the literal once avoids duplicate parenthesis walks and keeps each
+	// diagnostic coupled to the exact suggestions its context permits.
+	checkLiteral := func(node, expression, typeNode *ast.Node) {
+		if opts.AssertionStyle == AssertionStyleNever ||
+			(opts.ObjectLiteralTypeAssertions == LiteralAssertionAllow &&
+				opts.ArrayLiteralTypeAssertions == LiteralAssertionAllow) {
+			return
 		}
-		tr := typeNode.AsTypeReferenceNode()
-		if tr == nil || tr.TypeName == nil || tr.TypeName.Kind != ast.KindIdentifier {
-			return false
-		}
-		return tr.TypeName.AsIdentifier().Text == "const"
-	}
 
-	// checkType reports whether a literal assertion to `typeNode` should be
-	// flagged. Mirrors upstream `checkType`: only the *bare* `any` / `unknown`
-	// keywords are exempt (a union such as `any | string` is NOT), and `as
-	// const` is exempt.
-	checkType := func(typeNode *ast.Node) bool {
-		switch typeNode.Kind {
-		case ast.KindAnyKeyword, ast.KindUnknownKeyword:
-			return false
-		case ast.KindTypeReference:
-			return !isConst(typeNode)
+		var literalOption LiteralAssertion
+		var messages *literalAssertionMessages
+		switch ast.SkipParentheses(expression).Kind {
+		case ast.KindObjectLiteralExpression:
+			literalOption = opts.ObjectLiteralTypeAssertions
+			messages = &objectLiteralAssertionMessages
+		case ast.KindArrayLiteralExpression:
+			literalOption = opts.ArrayLiteralTypeAssertions
+			messages = &arrayLiteralAssertionMessages
 		default:
-			return true
+			return
 		}
-	}
+		if literalOption == LiteralAssertionAllow {
+			return
+		}
 
-	// isAsParameter mirrors upstream `isAsParameter`: the assertion is in a
-	// position where an object/array literal is "passed" rather than assigned to
-	// a typeable binding (call / new / throw arguments, JSX expression
-	// containers, default values, tagged-template substitutions).
-	isAsParameter := func(node *ast.Node) bool {
-		p := skipParensUp(node)
-		if p == nil {
-			return false
+		parent := skipParensUp(node)
+		if literalOption == LiteralAssertionAllowAsParam && isParameterPosition(parent) {
+			return
 		}
-		switch p.Kind {
-		case ast.KindNewExpression, ast.KindCallExpression, ast.KindThrowStatement,
-			ast.KindJsxExpression, ast.KindParameter, ast.KindBindingElement,
-			ast.KindShorthandPropertyAssignment:
-			// Parameter / BindingElement / ShorthandPropertyAssignment cover the
-			// ESTree `AssignmentPattern` default-value cases; the assertion can
-			// only be the default/initializer in those nodes.
-			return true
-		case ast.KindTemplateSpan:
-			// Only tagged templates count: the substitution's TemplateExpression
-			// must itself be the argument of a TaggedTemplateExpression.
-			return p.Parent != nil && p.Parent.Parent != nil &&
-				p.Parent.Parent.Kind == ast.KindTaggedTemplateExpression
+		if !shouldReportLiteralType(typeNode) {
+			return
 		}
-		return false
-	}
 
-	// checkObject / checkArray mirror upstream's checkExpressionForObjectAssertion
-	// / checkExpressionForArrayAssertion. `exprRaw` is the assertion's raw
-	// expression; the literal check uses the paren-stripped form.
-	checkObject := func(node, exprRaw, typeNode *ast.Node) {
-		expr := ast.SkipParentheses(exprRaw)
-		if opts.AssertionStyle == AssertionStyleNever ||
-			opts.ObjectLiteralTypeAssertions == LiteralAssertionAllow ||
-			expr.Kind != ast.KindObjectLiteralExpression {
-			return
+		annotationNode := annotationTarget(parent)
+		description := messages.satisfiesDescription
+		if annotationNode != nil {
+			description = messages.annotationOrSatisfiesDescription
 		}
-		if opts.ObjectLiteralTypeAssertions == LiteralAssertionAllowAsParam && isAsParameter(node) {
-			return
-		}
-		if checkType(typeNode) {
-			ctx.ReportNodeWithDeferredSuggestions(node, rule.RuleMessage{
-				Id:          "unexpectedObjectTypeAssertion",
-				Description: "Always prefer const x: T = { ... }.",
-			}, func() []rule.RuleSuggestion {
-				return edits.objectLiteralSuggestions(node, exprRaw, typeNode)
-			})
-		}
-	}
-
-	checkArray := func(node, exprRaw, typeNode *ast.Node) {
-		expr := ast.SkipParentheses(exprRaw)
-		if opts.AssertionStyle == AssertionStyleNever ||
-			opts.ArrayLiteralTypeAssertions == LiteralAssertionAllow ||
-			expr.Kind != ast.KindArrayLiteralExpression {
-			return
-		}
-		if opts.ArrayLiteralTypeAssertions == LiteralAssertionAllowAsParam && isAsParameter(node) {
-			return
-		}
-		if checkType(typeNode) {
-			ctx.ReportNodeWithDeferredSuggestions(node, rule.RuleMessage{
-				Id:          "unexpectedArrayTypeAssertion",
-				Description: "Always prefer const x: T[] = [ ... ].",
-			}, func() []rule.RuleSuggestion {
-				return edits.arrayLiteralSuggestions(node, exprRaw, typeNode)
-			})
-		}
+		ctx.ReportNodeWithDeferredSuggestions(node, rule.RuleMessage{
+			Id:          messages.diagnosticID,
+			Description: description,
+		}, func() []rule.RuleSuggestion {
+			return edits.literalSuggestions(node, expression, typeNode, annotationNode, messages)
+		})
 	}
 
 	// reportIncorrectAssertionType handles the assertion-style mismatch reports
@@ -340,7 +347,7 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	reportIncorrectAssertionType := func(node, exprRaw, typeNode *ast.Node) {
 		style := opts.AssertionStyle
 		// `as const` / `<const>` is never reported under `never`.
-		if style == AssertionStyleNever && isConst(typeNode) {
+		if style == AssertionStyleNever && isConstType(typeNode) {
 			return
 		}
 		switch style {
@@ -378,8 +385,7 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 				reportIncorrectAssertionType(node, asExpr.Expression, asExpr.Type)
 				return
 			}
-			checkObject(node, asExpr.Expression, asExpr.Type)
-			checkArray(node, asExpr.Expression, asExpr.Type)
+			checkLiteral(node, asExpr.Expression, asExpr.Type)
 		},
 		ast.KindTypeAssertionExpression: func(node *ast.Node) {
 			typeAssertion := node.AsTypeAssertion()
@@ -390,8 +396,7 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 				reportIncorrectAssertionType(node, typeAssertion.Expression, typeAssertion.Type)
 				return
 			}
-			checkObject(node, typeAssertion.Expression, typeAssertion.Type)
-			checkArray(node, typeAssertion.Expression, typeAssertion.Type)
+			checkLiteral(node, typeAssertion.Expression, typeAssertion.Type)
 		},
 	}
 }

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.md
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.md
@@ -21,7 +21,17 @@ const y = 42 as number;
 const z = value as const;
 ```
 
+## Compatibility Notes
+
+The rule is aligned with `typescript-eslint` v8.69.0 for diagnostic selection,
+message IDs, ranges, suggestions, and autofixes. Literal-assertion diagnostics
+use context-aware descriptions: an untyped variable initializer recommends a
+type annotation or the `satisfies` operator, while other expressions recommend
+only `satisfies`. Upstream always recommends `const x: T = ...`, including in
+return expressions, class fields, and other positions where that replacement
+cannot be applied.
+
 ## Original Documentation
 
 - [typescript-eslint: consistent-type-assertions](https://typescript-eslint.io/rules/consistent-type-assertions)
-- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/consistent-type-assertions.ts)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/rules/consistent-type-assertions.ts)

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
@@ -228,6 +228,7 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 			Options: objNever,
 			Errors: []rule_tester.InvalidTestCaseError{{
 				MessageId: "unexpectedObjectTypeAssertion",
+				Message:   "Use a type annotation or the `satisfies` operator instead of a type assertion for object literals.",
 				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo = {};`},
 					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = {} satisfies Foo;`},
@@ -336,8 +337,22 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 			Options: objNever,
 			Errors: []rule_tester.InvalidTestCaseError{{
 				MessageId: "unexpectedObjectTypeAssertion",
+				Message:   "Use the `satisfies` operator instead of a type assertion for object literals.",
 				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const f = (): Foo => ({ bar: 5 }) satisfies Foo;`},
+				},
+			}},
+		},
+		// An existing annotation prevents an annotation suggestion, even though
+		// the assertion is directly inside a variable declaration.
+		{
+			Code:    `const x: Foo = {} as Foo;`,
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Message:   "Use the `satisfies` operator instead of a type assertion for object literals.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x: Foo = {} satisfies Foo;`},
 				},
 			}},
 		},
@@ -393,6 +408,7 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 			Options: arrNever,
 			Errors: []rule_tester.InvalidTestCaseError{{
 				MessageId: "unexpectedArrayTypeAssertion",
+				Message:   "Use a type annotation or the `satisfies` operator instead of a type assertion for array literals.",
 				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 					{MessageId: "replaceArrayTypeAssertionWithAnnotation", Output: `const x: Foo = [];`},
 					{MessageId: "replaceArrayTypeAssertionWithSatisfies", Output: `const x = [] satisfies Foo;`},
@@ -420,6 +436,17 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 					{MessageId: "replaceArrayTypeAssertionWithAnnotation", Output: `const x: any | string[] = [5];`},
 					{MessageId: "replaceArrayTypeAssertionWithSatisfies", Output: `const x = [5] satisfies any | string[];`},
+				},
+			}},
+		},
+		{
+			Code:    `const f = (): Foo => [] as Foo;`,
+			Options: arrNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedArrayTypeAssertion",
+				Message:   "Use the `satisfies` operator instead of a type assertion for array literals.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceArrayTypeAssertionWithSatisfies", Output: `const f = (): Foo => [] satisfies Foo;`},
 				},
 			}},
 		},

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-type-assertions.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-type-assertions.test.ts.snap
@@ -1318,7 +1318,7 @@ exports[`consistent-type-assertions > invalid 51`] = `
   "code": "const x = {} as Foo<int>;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1344,7 +1344,7 @@ exports[`consistent-type-assertions > invalid 52`] = `
   "code": "const x = {} as a | b;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1370,7 +1370,7 @@ exports[`consistent-type-assertions > invalid 53`] = `
   "code": "const x = ({} as A) + b;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1396,7 +1396,7 @@ exports[`consistent-type-assertions > invalid 54`] = `
   "code": "const x = <Foo<int>>{};",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1422,7 +1422,7 @@ exports[`consistent-type-assertions > invalid 55`] = `
   "code": "const x = <a | b>{};",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1448,7 +1448,7 @@ exports[`consistent-type-assertions > invalid 56`] = `
   "code": "const x = <A>{} + b;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1474,7 +1474,7 @@ exports[`consistent-type-assertions > invalid 57`] = `
   "code": "const x = {} as Foo<int>;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1500,7 +1500,7 @@ exports[`consistent-type-assertions > invalid 58`] = `
   "code": "const x = {} as a | b;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1526,7 +1526,7 @@ exports[`consistent-type-assertions > invalid 59`] = `
   "code": "const x = ({} as A) + b;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1552,7 +1552,7 @@ exports[`consistent-type-assertions > invalid 60`] = `
   "code": "print({ bar: 5 } as Foo);",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1578,7 +1578,7 @@ exports[`consistent-type-assertions > invalid 61`] = `
   "code": "new print({ bar: 5 } as Foo);",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1608,7 +1608,7 @@ function foo() {
       ",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1634,7 +1634,7 @@ exports[`consistent-type-assertions > invalid 63`] = `
   "code": "function b(x = {} as Foo.Bar) {}",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1660,7 +1660,7 @@ exports[`consistent-type-assertions > invalid 64`] = `
   "code": "function c(x = {} as Foo) {}",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1686,7 +1686,7 @@ exports[`consistent-type-assertions > invalid 65`] = `
   "code": "print?.({ bar: 5 } as Foo);",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1712,7 +1712,7 @@ exports[`consistent-type-assertions > invalid 66`] = `
   "code": "print?.call({ bar: 5 } as Foo);",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1738,7 +1738,7 @@ exports[`consistent-type-assertions > invalid 67`] = `
   "code": "print\`\${{ bar: 5 } as Foo}\`;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1764,7 +1764,7 @@ exports[`consistent-type-assertions > invalid 68`] = `
   "code": "const x = <Foo<int>>{};",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1790,7 +1790,7 @@ exports[`consistent-type-assertions > invalid 69`] = `
   "code": "const x = <a | b>{};",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1816,7 +1816,7 @@ exports[`consistent-type-assertions > invalid 70`] = `
   "code": "const x = <A>{} + b;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1842,7 +1842,7 @@ exports[`consistent-type-assertions > invalid 71`] = `
   "code": "print(<Foo>{ bar: 5 });",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1868,7 +1868,7 @@ exports[`consistent-type-assertions > invalid 72`] = `
   "code": "new print(<Foo>{ bar: 5 });",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1898,7 +1898,7 @@ function foo() {
       ",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1924,7 +1924,7 @@ exports[`consistent-type-assertions > invalid 74`] = `
   "code": "print?.(<Foo>{ bar: 5 });",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1950,7 +1950,7 @@ exports[`consistent-type-assertions > invalid 75`] = `
   "code": "print?.call(<Foo>{ bar: 5 });",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -1976,7 +1976,7 @@ exports[`consistent-type-assertions > invalid 76`] = `
   "code": "print\`\${<Foo>{ bar: 5 }}\`;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T = { ... }.",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for object literals.",
       "messageId": "unexpectedObjectTypeAssertion",
       "range": {
         "end": {
@@ -2337,7 +2337,7 @@ exports[`consistent-type-assertions > invalid 89`] = `
   "code": "const x = [] as string[];",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2363,7 +2363,7 @@ exports[`consistent-type-assertions > invalid 90`] = `
   "code": "const x = <string[]>[];",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2389,7 +2389,7 @@ exports[`consistent-type-assertions > invalid 91`] = `
   "code": "print([5] as Foo);",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2415,7 +2415,7 @@ exports[`consistent-type-assertions > invalid 92`] = `
   "code": "new print([5] as Foo);",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2441,7 +2441,7 @@ exports[`consistent-type-assertions > invalid 93`] = `
   "code": "function b(x = [5] as Foo.Bar) {}",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2471,7 +2471,7 @@ function foo() {
       ",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2497,7 +2497,7 @@ exports[`consistent-type-assertions > invalid 95`] = `
   "code": "print\`\${[5] as Foo}\`;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2523,7 +2523,7 @@ exports[`consistent-type-assertions > invalid 96`] = `
   "code": "const foo = () => [5] as Foo;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2549,7 +2549,7 @@ exports[`consistent-type-assertions > invalid 97`] = `
   "code": "new print(<Foo>[5]);",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2575,7 +2575,7 @@ exports[`consistent-type-assertions > invalid 98`] = `
   "code": "function b(x = <Foo.Bar>[5]) {}",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2605,7 +2605,7 @@ function foo() {
       ",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2631,7 +2631,7 @@ exports[`consistent-type-assertions > invalid 100`] = `
   "code": "print\`\${<Foo>[5]}\`;",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {
@@ -2657,7 +2657,7 @@ exports[`consistent-type-assertions > invalid 101`] = `
   "code": "const foo = <Foo>[5];",
   "diagnostics": [
     {
-      "message": "Always prefer const x: T[] = [ ... ].",
+      "message": "Use a type annotation or the \`satisfies\` operator instead of a type assertion for array literals.",
       "messageId": "unexpectedArrayTypeAssertion",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

- Align `consistent-type-assertions` diagnostic selection, IDs, ranges, suggestions, and fixes with `typescript-eslint` v8.69.0/latest main.
- Replace upstream's unconditional `const x: T = ...` diagnostic text with context-aware guidance: mention a type annotation only when that suggestion is actually available, and otherwise recommend `satisfies`.
- Centralize the object/array literal path so diagnostic wording and suggestion eligibility share one decision, and document the intentional compatibility difference.
- Update focused Go assertions and 39 JS snapshots. All 45 files (126 diagnostics) from the reported audit were checked individually; file, range, severity, and message ID remained unchanged.

### Benchmark

`GOMAXPROCS=1 go test ./internal/plugins/typescript/rules/consistent_type_assertions -run '^$' -bench '^BenchmarkConsistentTypeAssertions$' -benchmem -benchtime=300ms -count=5` (median):

| Case | Before | After | Delta | Allocations |
| --- | ---: | ---: | ---: | ---: |
| object diagnostics | 29,955 ns/op | 19,169 ns/op | -36.0% | 102 -> 100 |
| object suggestions | 80,340 ns/op | 70,109 ns/op | -12.7% | 1,126 -> 1,124 |
| array diagnostics | 18,521 ns/op | 17,040 ns/op | -8.0% | 102 -> 100 |
| array suggestions | 70,084 ns/op | 68,085 ns/op | -2.9% | 1,126 -> 1,124 |
| angle autofix | 45,892 ns/op | 45,471 ns/op | -0.9% | 678 -> 676 |
| no match | 11,132 ns/op | 10,363 ns/op | -6.9% | 38 -> 36 |
| allowed parameter | 13,739 ns/op | 12,920 ns/op | -6.0% | 38 -> 36 |

The temporary benchmark source is not included in this PR.

## Related Links

- [Latest upstream implementation used for comparison](https://github.com/typescript-eslint/typescript-eslint/blob/9a6e546823e5d8f2dc015df2aa66c0230615e209/packages/eslint-plugin/src/rules/consistent-type-assertions.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

### Verification

- `go test ./internal/plugins/typescript/rules/consistent_type_assertions -count=3`
- `pnpm --filter @rslint/test-tools exec rs test tests/typescript-eslint/rules/consistent-type-assertions.test.ts`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/consistent_type_assertions/...`
- `git diff --check`
