### PR TITLE
fix: align no-unnecessary-condition with void semantics

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_condition/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/edge_cases_test.go
@@ -68,10 +68,16 @@ func TestEdgeCases_CheckNodeForNullish(t *testing.T) {
 		{Code: "declare const x: any;\nconst y = x ?? 1;\n"},
 		{Code: "declare const x: unknown;\nconst y = x ?? 1;\n"},
 		{Code: "function f<T>(x: T) { const y = x ?? 1; }\n"},
+		// void is possibly nullish, but not always nullish
+		{Code: "declare const x: void;\nconst y = x ?? 1;\n"},
+		{Code: "declare const x: undefined | void;\nconst y = x ?? 1;\n"},
+		{Code: "declare let x: number | void;\nx ??= 1;\n"},
 		// Optional property access — nullish because property is optional
 		{Code: "declare const obj: { a?: string };\nconst x = obj.a ?? 'default';\n"},
 		// Array index ?? — unsound without noUncheckedIndexedAccess
 		{Code: "declare const arr: string[];\nconst x = arr[0] ?? '';\n"},
+		// A dynamic tuple index is unsound, while a literal tuple index is exact
+		{Code: "declare const tuple: readonly [string, string];\ndeclare const index: number;\nconst x = tuple[index] ?? '';\n"},
 		// Chain with optional array index — should skip
 		{Code: "declare const arr: string[];\narr[0]?.length ?? 0;\n"},
 		// Nullable union with ??
@@ -85,6 +91,11 @@ func TestEdgeCases_CheckNodeForNullish(t *testing.T) {
 		// Non-nullish object in ??
 		{
 			Code:   "declare const x: { a: string };\nconst y = x ?? {};\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 11}},
+		},
+		// Literal tuple indexes are sound and remain reportable
+		{
+			Code:   "declare const tuple: readonly [string, string];\nconst x = tuple[0] ?? '';\n",
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 11}},
 		},
 		// null | undefined — always nullish

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -19,13 +19,18 @@ import (
 //go:embed no_unnecessary_condition.schema.json
 var schemaJSON []byte
 
-// strictNullishFlag matches the original typescript-eslint behavior:
-// only null and undefined are considered "nullish" for isAlwaysNullish.
-var strictNullishFlag = checker.TypeFlagsUndefined | checker.TypeFlagsNull
+// Only null and undefined are always nullish. Void is intentionally excluded:
+// it participates in possibly-nullish checks, but TypeScript permits functions
+// returning other values to satisfy a void return type.
+const alwaysNullishFlag = checker.TypeFlagsUndefined | checker.TypeFlagsNull
+
+// Upstream treats void as possibly nullish because a void-returning expression
+// can evaluate to undefined at runtime.
+const possiblyNullishFlag = alwaysNullishFlag | checker.TypeFlagsVoid
 
 // isNullishType checks if a type is strictly null or undefined.
 func isNullishType(t *checker.Type) bool {
-	return utils.IsTypeFlagSet(t, strictNullishFlag)
+	return utils.IsTypeFlagSet(t, alwaysNullishFlag)
 }
 
 // isAlwaysNullish checks if ALL union constituents are null or undefined.
@@ -35,12 +40,9 @@ func isAlwaysNullish(t *checker.Type) bool {
 	})
 }
 
-// isPossiblyNullish checks if ANY union constituent is null or undefined.
-// Matches original typescript-eslint: only Null and Undefined, not Void.
+// isPossiblyNullish checks if any union constituent is null, undefined, or void.
 func isPossiblyNullish(t *checker.Type) bool {
-	return utils.Some(utils.UnionTypeParts(t), func(part *checker.Type) bool {
-		return utils.IsTypeFlagSet(part, checker.TypeFlagsUndefined|checker.TypeFlagsNull)
-	})
+	return utils.IsTypeFlagSetWithUnion(t, possiblyNullishFlag)
 }
 
 // Sentinel types for distinguishing null and undefined in comparisons.
@@ -75,13 +77,20 @@ func toStaticValue(t *checker.Type) staticValue {
 	return staticValue{ok: false}
 }
 
-var boolOperators = map[string]bool{
-	"<": true, ">": true, "<=": true, ">=": true,
-	"==": true, "===": true, "!=": true, "!==": true,
-}
-
-func isBoolOperator(op string) bool {
-	return boolOperators[op]
+func boolOperatorText(kind ast.Kind) (string, bool) {
+	switch kind {
+	case ast.KindLessThanToken,
+		ast.KindGreaterThanToken,
+		ast.KindLessThanEqualsToken,
+		ast.KindGreaterThanEqualsToken,
+		ast.KindEqualsEqualsToken,
+		ast.KindEqualsEqualsEqualsToken,
+		ast.KindExclamationEqualsToken,
+		ast.KindExclamationEqualsEqualsToken:
+		return scanner.TokenToString(kind), true
+	default:
+		return "", false
+	}
 }
 
 // booleanComparison mimics JavaScript comparison semantics for literal types.
@@ -347,28 +356,19 @@ var NoUnnecessaryConditionRule = rule.CreateRule(rule.Rule{
 
 		// --- Helper functions ---
 
-		nodeIsArrayType := func(node *ast.Node) bool {
-			nodeType := utils.GetConstrainedTypeAtLocation(tc, node)
-			return utils.Some(utils.UnionTypeParts(nodeType), func(part *checker.Type) bool {
-				return checker.Checker_isArrayType(tc, part)
-			})
-		}
-
-		nodeIsTupleType := func(node *ast.Node) bool {
-			nodeType := utils.GetConstrainedTypeAtLocation(tc, node)
-			return utils.Some(utils.UnionTypeParts(nodeType), func(part *checker.Type) bool {
-				return checker.IsTupleType(part)
-			})
-		}
-
 		isArrayIndexExpression := func(node *ast.Node) bool {
 			if !ast.IsElementAccessExpression(node) {
 				return false
 			}
 			elem := node.AsElementAccessExpression()
-			obj := elem.Expression
-			return nodeIsArrayType(obj) ||
-				(nodeIsTupleType(obj) && !ast.IsLiteralExpression(elem.ArgumentExpression))
+			isDynamicIndex := !ast.IsLiteralExpression(elem.ArgumentExpression)
+			objectType := utils.GetConstrainedTypeAtLocation(tc, elem.Expression)
+			for _, part := range utils.UnionTypeParts(objectType) {
+				if checker.Checker_isArrayType(tc, part) || (isDynamicIndex && checker.IsTupleType(part)) {
+					return true
+				}
+			}
+			return false
 		}
 
 		// Conditional is always necessary if it involves any, unknown, or a naked type variable
@@ -484,16 +484,24 @@ var NoUnnecessaryConditionRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			isMemberExpr := ast.IsAccessExpression(node)
-			if !isPossiblyNullish(t) && (!isMemberExpr || !isNullableMemberExpression(node)) {
-				// Skip array index expressions without noUncheckedIndexedAccess
-				if isNoUncheckedIndexedAccess ||
-					(!isArrayIndexExpression(node) &&
-						!isChainExpressionWithOptionalArrayIndex(node, isArrayIndexExpression)) {
-					ctx.ReportNode(node, buildNeverNullishMessage())
+			if !isPossiblyNullish(t) {
+				// Skip unsound array index expressions before nullable-member analysis;
+				// the latter performs additional property and index-signature queries.
+				if !isNoUncheckedIndexedAccess && isArrayIndexExpression(node) {
 					return
 				}
-			} else if isAlwaysNullish(t) {
+				if ast.IsAccessExpression(node) && isNullableMemberExpression(node) {
+					return
+				}
+				if !isNoUncheckedIndexedAccess &&
+					isChainExpressionWithOptionalArrayIndex(node, isArrayIndexExpression) {
+					return
+				}
+				ctx.ReportNode(node, buildNeverNullishMessage())
+				return
+			}
+
+			if isAlwaysNullish(t) {
 				ctx.ReportNode(node, buildAlwaysNullishMessage())
 				return
 			}
@@ -850,8 +858,7 @@ var NoUnnecessaryConditionRule = rule.CreateRule(rule.Rule{
 				}
 
 				// Boolean comparison operators
-				opStr := scanner.TokenToString(op)
-				if isBoolOperator(opStr) {
+				if opStr, ok := boolOperatorText(op); ok {
 					checkIfBoolExpressionIsNecessaryConditional(node, binExpr.Left, binExpr.Right, opStr)
 					return
 				}

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.md
@@ -43,4 +43,4 @@ function foo(arg: string) {
 ## Original Documentation
 
 - [typescript-eslint: no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition)
-- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.58.1/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts)

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
@@ -35,6 +35,7 @@ func TestNoUnnecessaryCondition(t *testing.T) {
 		// === void type ===
 		{Code: "declare function foo(): number | void;\nconst r = foo() === undefined;\n"},
 		{Code: "declare function foo(): number | void;\nconst r = foo() == null;\n"},
+		{Code: "declare function foo(): number | void;\nfoo() ?? 1;\n"},
 
 		// === Generics and type parameters ===
 		{Code: "function test<T extends string>(t: T) {\n  return t ? 'yes' : 'no';\n}\n"},
@@ -122,6 +123,9 @@ func TestNoUnnecessaryCondition(t *testing.T) {
 		// void return
 		{Code: "declare function foo(): void | { key: string };\nconst bar = foo()?.key;\n"},
 		{Code: "type fn = () => void;\ndeclare function foo(): void | fn;\nconst bar = foo()?.();\n"},
+		{Code: "declare function maybe<T>(v: T): T | void;\nconst a = maybe({ key1: { key2: maybe({ i: 1 }) } })?.key1.key2?.i;\n"},
+		{Code: "type Foo = { bar: { baz: number } | void } | null;\ndeclare const foo: Foo;\nfoo?.bar?.baz;\n"},
+		{Code: "declare function maybeFn(): { fn: (() => number) | void } | undefined;\nmaybeFn()?.fn?.();\n"},
 
 		// === Array index expressions ===
 		{Code: "declare const arr: string[];\nif (arr[0]) {}\n"},
@@ -170,7 +174,6 @@ func TestNoUnnecessaryCondition(t *testing.T) {
 		{Code: "declare function isString(x: unknown): x is string;\ndeclare const a: string;\nisString(a);\n"},
 		// Literal subtype (type is 'falafel' not string, so guard still narrows)
 		{Code: "declare function assertString(x: unknown): asserts x is string;\nassertString('falafel');\n", Options: map[string]interface{}{"checkTypePredicates": true}},
-
 
 		// === exactOptionalPropertyTypes: private optional field with ??= ===
 		{

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-condition.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-condition.test.ts
@@ -80,6 +80,10 @@ const result1 = foo() === undefined;
 const result2 = foo() == null;
     `,
     `
+declare function foo(): number | void;
+foo() ?? 1;
+    `,
+    `
 declare const bigInt: 0n | 1n;
 if (bigInt) {
 }
@@ -1050,6 +1054,19 @@ const bar = foo()?.key;
 type fn = () => void;
 declare function foo(): void | fn;
 const bar = foo()?.();
+    `,
+    `
+declare function maybe<T>(v: T): T | void;
+const a = maybe({ key1: { key2: maybe({ i: 1 }) } })?.key1.key2?.i;
+    `,
+    `
+type Foo = { bar: { baz: number } | void } | null;
+declare const foo: Foo;
+foo?.bar?.baz;
+    `,
+    `
+declare function maybeFn(): { fn: (() => number) | void } | undefined;
+maybeFn()?.fn?.();
     `,
     {
       code: `


### PR DESCRIPTION
## Summary

- align `@typescript-eslint/no-unnecessary-condition` with typescript-eslint v8.69.0 by treating `void` as possibly nullish for `??` and `??=`, while keeping it out of the always-nullish classification
- preserve the existing upstream-aligned diagnostics and ranges for the three reported real-project cases
- avoid redundant member/type queries for ignored array indexes and avoid string/map work for unrelated binary operators
- add upstream `void`/nested optional-chain coverage plus adversarial `void`, tuple-index, and assignment cases

Go benchmark command (temporary benchmark source removed before commit):

```sh
go test ./internal/plugins/typescript/rules/no_unnecessary_condition -run '^$' -bench '^BenchmarkNoUnnecessaryCondition$' -benchmem -count=5
```

| Case | Time before → after | Bytes before → after | Allocs before → after |
| --- | ---: | ---: | ---: |
| Non-nullish diagnostic | `38.58µs → 37.16µs` | `27.40KiB → 27.36KiB` | `597 → 595` |
| Possibly-nullish no match | `17.89µs → 16.87µs` | `4.396KiB → 4.355KiB` | `85 → 83` |
| Ignored array index | `149.74µs → 25.95µs` | `338.440KiB → 8.359KiB` | `4053 → 595` |
| Irrelevant binary no match | `14.46µs → 12.44µs` | `4.394KiB → 4.354KiB` | `85 → 83` |
| Optional-chain suggestions | `31.55µs → 28.58µs` | `40.40KiB → 40.36KiB` | `853 → 851` |
| Allowed constant loop | `12.81µs → 12.56µs` | `4.394KiB → 4.354KiB` | `85 → 83` |

Correctness checks:

- `go test ./internal/plugins/typescript/rules/no_unnecessary_condition -count=3`
- targeted JS conformance test; no snapshot added, updated, unmatched, removed, or unchecked
- direct diagnostic/range comparison against `@typescript-eslint/eslint-plugin@8.69.0`, including every reported real-project file
- `pnpm run check-spell`
- `pnpm run format:check`
- scoped `golangci-lint` for the changed rule package

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/pull/12241
- https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.69.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
