### PR TITLE
fix: align no-empty-object-type suggestions

### DIFF
--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
@@ -112,25 +112,45 @@ func getExtendsClause(interfaceDecl *ast.InterfaceDeclaration) *ast.HeritageClau
 	return nil
 }
 
-// isMergedWithClassDeclaration reports whether the interface's name resolves
-// to a symbol that also has a class declaration in the same scope (TypeScript
-// declaration merging). Mirrors upstream's
-// `scope.set.get(name).defs.some(def => def.type === 'ClassDeclaration')`
-// check via the tsgo TypeChecker.
-func isMergedWithClassDeclaration(ctx rule.RuleContext, nameNode *ast.Node) bool {
-	if ctx.TypeChecker == nil || nameNode == nil {
+// isMergedWithOtherDeclaration reports whether an interface participates in
+// TypeScript declaration merging with another interface or a class. Replacing
+// one declaration with a type alias would make the resulting program invalid,
+// so those diagnostics must not carry replacement suggestions.
+//
+// The binder handles ordinary same-file bindings without a checker lookup and
+// naturally distinguishes unrelated lexical bindings. The checker fallback is
+// still required for global and ambient bindings assembled across source files.
+func isMergedWithOtherDeclaration(ctx rule.RuleContext, node *ast.Node, nameNode *ast.Node) bool {
+	if node == nil || nameNode == nil {
 		return false
 	}
-	symbol := ctx.TypeChecker.GetSymbolAtLocation(nameNode)
+	binderSymbol := node.Symbol()
+	if hasOtherInterfaceOrClassDeclaration(binderSymbol, node) {
+		return true
+	}
+	if ctx.TypeChecker == nil {
+		return false
+	}
+	return hasOtherInterfaceOrClassDeclaration(ctx.TypeChecker.GetSymbolAtLocation(nameNode), node)
+}
+
+func hasOtherInterfaceOrClassDeclaration(symbol *ast.Symbol, node *ast.Node) bool {
 	if symbol == nil {
 		return false
 	}
 	for _, decl := range symbol.Declarations {
-		if decl.Kind == ast.KindClassDeclaration {
+		if decl != node && (decl.Kind == ast.KindClassDeclaration || decl.Kind == ast.KindInterfaceDeclaration) {
 			return true
 		}
 	}
 	return false
+}
+
+func canSuggestInterfaceReplacement(ctx rule.RuleContext, node *ast.Node, nameNode *ast.Node) bool {
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) && ast.HasSyntacticModifier(node, ast.ModifierFlagsDefault) {
+		return false
+	}
+	return !isMergedWithOtherDeclaration(ctx, node, nameNode)
 }
 
 // typeParametersText returns the bracketed type-parameter clause text
@@ -214,42 +234,43 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 					return
 				}
 
-				mergedWithClass := isMergedWithClassDeclaration(ctx, nameNode)
-
-				nameText := utils.TrimmedNodeText(ctx.SourceFile, nameNode)
-				typeParam := typeParametersText(ctx, interfaceDecl)
-				fixRange := interfaceFixRange(ctx, interfaceDecl, node)
-
 				if extendCount == 0 {
-					if mergedWithClass {
-						ctx.ReportNode(nameNode, buildNoEmptyInterfaceMessage("allowInterfaces"))
-						return
-					}
-					suggestions := make([]rule.RuleSuggestion, 0, 2)
-					for _, replacement := range []string{"object", "unknown"} {
-						suggestions = append(suggestions, rule.RuleSuggestion{
-							Message: buildReplaceEmptyInterfaceMessage(replacement),
-							FixesArr: []rule.RuleFix{
-								rule.RuleFixReplaceRange(fixRange, fmt.Sprintf("type %s%s = %s", nameText, typeParam, replacement)),
-							},
-						})
-					}
-					ctx.ReportNodeWithSuggestions(nameNode, buildNoEmptyInterfaceMessage("allowInterfaces"), suggestions...)
+					ctx.ReportNodeWithDeferredSuggestions(nameNode, buildNoEmptyInterfaceMessage("allowInterfaces"), func() []rule.RuleSuggestion {
+						if !canSuggestInterfaceReplacement(ctx, node, nameNode) {
+							return nil
+						}
+						nameText := utils.TrimmedNodeText(ctx.SourceFile, nameNode)
+						typeParam := typeParametersText(ctx, interfaceDecl)
+						fixRange := interfaceFixRange(ctx, interfaceDecl, node)
+						suggestions := make([]rule.RuleSuggestion, 0, 2)
+						for _, replacement := range []string{"object", "unknown"} {
+							suggestions = append(suggestions, rule.RuleSuggestion{
+								Message: buildReplaceEmptyInterfaceMessage(replacement),
+								FixesArr: []rule.RuleFix{
+									rule.RuleFixReplaceRange(fixRange, fmt.Sprintf("type %s%s = %s", nameText, typeParam, replacement)),
+								},
+							})
+						}
+						return suggestions
+					})
 					return
 				}
 
 				// extendCount == 1 here.
-				if mergedWithClass {
-					ctx.ReportNode(nameNode, buildNoEmptyInterfaceWithSuperMessage())
-					return
-				}
-
-				extendedTypeText := utils.TrimmedNodeText(ctx.SourceFile, extendClause.Types.Nodes[0])
-				ctx.ReportNodeWithSuggestions(nameNode, buildNoEmptyInterfaceWithSuperMessage(), rule.RuleSuggestion{
-					Message: buildReplaceEmptyInterfaceWithSuperMessage(),
-					FixesArr: []rule.RuleFix{
-						rule.RuleFixReplaceRange(fixRange, fmt.Sprintf("type %s%s = %s", nameText, typeParam, extendedTypeText)),
-					},
+				ctx.ReportNodeWithDeferredSuggestions(nameNode, buildNoEmptyInterfaceWithSuperMessage(), func() []rule.RuleSuggestion {
+					if !canSuggestInterfaceReplacement(ctx, node, nameNode) {
+						return nil
+					}
+					nameText := utils.TrimmedNodeText(ctx.SourceFile, nameNode)
+					typeParam := typeParametersText(ctx, interfaceDecl)
+					fixRange := interfaceFixRange(ctx, interfaceDecl, node)
+					extendedTypeText := utils.TrimmedNodeText(ctx.SourceFile, extendClause.Types.Nodes[0])
+					return []rule.RuleSuggestion{{
+						Message: buildReplaceEmptyInterfaceWithSuperMessage(),
+						FixesArr: []rule.RuleFix{
+							rule.RuleFixReplaceRange(fixRange, fmt.Sprintf("type %s%s = %s", nameText, typeParam, extendedTypeText)),
+						},
+					}}
 				})
 			}
 		}
@@ -279,16 +300,18 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 					}
 				}
 
-				suggestions := make([]rule.RuleSuggestion, 0, 2)
-				for _, replacement := range []string{"object", "unknown"} {
-					suggestions = append(suggestions, rule.RuleSuggestion{
-						Message: buildReplaceEmptyObjectTypeMessage(replacement),
-						FixesArr: []rule.RuleFix{
-							rule.RuleFixReplace(ctx.SourceFile, node, replacement),
-						},
-					})
-				}
-				ctx.ReportNodeWithSuggestions(node, buildNoEmptyObjectMessage("allowObjectTypes"), suggestions...)
+				ctx.ReportNodeWithDeferredSuggestions(node, buildNoEmptyObjectMessage("allowObjectTypes"), func() []rule.RuleSuggestion {
+					suggestions := make([]rule.RuleSuggestion, 0, 2)
+					for _, replacement := range []string{"object", "unknown"} {
+						suggestions = append(suggestions, rule.RuleSuggestion{
+							Message: buildReplaceEmptyObjectTypeMessage(replacement),
+							FixesArr: []rule.RuleFix{
+								rule.RuleFixReplace(ctx.SourceFile, node, replacement),
+							},
+						})
+					}
+					return suggestions
+				})
 			}
 		}
 

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.md
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.md
@@ -87,4 +87,4 @@ type DialogProps = {};
 ## Original Documentation
 
 - [typescript-eslint: no-empty-object-type](https://typescript-eslint.io/rules/no-empty-object-type)
-- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.67.0/packages/eslint-plugin/src/rules/no-empty-object-type.ts)
+- [Source code](https://github.com/typescript-eslint/typescript-eslint/blob/v8.69.0/packages/eslint-plugin/src/rules/no-empty-object-type.ts)

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_declaration_merge_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_declaration_merge_test.go
@@ -1,0 +1,78 @@
+package no_empty_object_type
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestNoEmptyObjectTypeCrossFileDeclarationMergeSuggestions(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		declaration string
+	}{
+		{name: "interface", declaration: `interface Shared { value: string }`},
+		{name: "class", declaration: `class Shared { value = "value" }`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := fixtures.GetRootDir()
+			interfacePath := tspath.ResolvePath(root.Dir, "merge-interface.ts")
+			otherPath := tspath.ResolvePath(root.Dir, "merge-other.ts")
+			fs := utils.NewOverlayVFS(root.FS, map[string]string{
+				interfacePath: `interface Shared {}`,
+				otherPath:     test.declaration,
+			})
+			host := utils.CreateCompilerHost(root.Dir, fs)
+			program, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", host)
+			if err != nil {
+				t.Fatalf("failed to create program: %v", err)
+			}
+			sourceFile := program.GetSourceFile(interfacePath)
+			if sourceFile == nil {
+				t.Fatalf("source file %q not found", interfacePath)
+			}
+
+			var diagnostics []rule.RuleDiagnostic
+			linter.LintSingleFile(linter.LintSingleFileOptions{
+				Program:     lintprogram.NewFromCompiler(program),
+				File:        sourceFile.FileName(),
+				HasTypeInfo: true,
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{
+						Name:     NoEmptyObjectTypeRule.Name,
+						Severity: rule.SeverityError,
+						Run: func(ctx rule.RuleContext) rule.RuleListeners {
+							return NoEmptyObjectTypeRule.Run(ctx, nil)
+						},
+					}}
+				},
+				Consumer: rule.DiagnosticConsumer{
+					Demand: rule.EditDemandSuggestion,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				},
+			})
+
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+			}
+			if diagnostics[0].Message.Id != "noEmptyInterface" {
+				t.Fatalf("message id = %q, want noEmptyInterface", diagnostics[0].Message.Id)
+			}
+			if diagnostics[0].Suggestions != nil {
+				t.Fatalf("suggestions = %d, want none for a cross-file declaration merge", len(*diagnostics[0].Suggestions))
+			}
+		})
+	}
+}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
@@ -1062,3 +1062,63 @@ func TestNoEmptyObjectTypeAllowWithNameLookbehind(t *testing.T) {
 		},
 	})
 }
+
+func TestNoEmptyObjectTypeMergedInterfaceSuggestions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoEmptyObjectTypeRule, nil, []rule_tester.InvalidTestCase{
+		{
+			Code: `
+interface Box<T> {}
+interface Box<T> {
+  value: T;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      2,
+					Column:    11,
+					EndLine:   2,
+					EndColumn: 14,
+				},
+			},
+		},
+		{
+			Code: `
+interface Box {
+  value: string;
+}
+interface Box {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      5,
+					Column:    11,
+					EndLine:   5,
+					EndColumn: 14,
+				},
+			},
+		},
+		{
+			Code: `
+namespace Box {
+  export interface Value {}
+}
+namespace Box {
+  export interface Value {
+    value: string;
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      3,
+					Column:    20,
+					EndLine:   3,
+					EndColumn: 25,
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_upstream_test.go
@@ -204,6 +204,155 @@ const derived = class Derived {};
 		},
 		{
 			Code: `
+interface Base {}
+
+interface Base {
+  name: string;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      2,
+					Column:    11,
+					EndLine:   2,
+					EndColumn: 15,
+				},
+			},
+		},
+		{
+			Code: `
+interface Base {}
+
+interface Base {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      2,
+					Column:    11,
+					EndLine:   2,
+					EndColumn: 15,
+				},
+				{
+					MessageId: "noEmptyInterface",
+					Line:      4,
+					Column:    11,
+					EndLine:   4,
+					EndColumn: 15,
+				},
+			},
+		},
+		{
+			Code: `
+interface Base {}
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      2,
+					Column:    11,
+					EndLine:   2,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterface",
+							Output: `
+type Base = object
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+`,
+						},
+						{
+							MessageId: "replaceEmptyInterface",
+							Output: `
+type Base = unknown
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+interface Derived {
+  name: string;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      6,
+					Column:    11,
+					EndLine:   6,
+					EndColumn: 18,
+				},
+			},
+		},
+		{
+			Code: `export default interface Base {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 30,
+				},
+			},
+		},
+		{
+			Code: `export default interface Derived extends Base {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 33,
+				},
+			},
+		},
+		{
+			Code: `export interface Base {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 22,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `export type Base = object`},
+						{MessageId: "replaceEmptyInterface", Output: `export type Base = unknown`},
+					},
+				},
+			},
+		},
+		{
+			Code: `
 interface Base {
   name: string;
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-empty-object-type.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-empty-object-type.test.ts.snap
@@ -163,6 +163,249 @@ const derived = class Derived {};
 exports[`no-empty-object-type > invalid 6`] = `
 {
   "code": "
+interface Base {}
+
+interface Base {
+  name: string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 7`] = `
+{
+  "code": "
+interface Base {}
+
+interface Base {}
+      ",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 4,
+        },
+        "start": {
+          "column": 11,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 8`] = `
+{
+  "code": "
+interface Base {}
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 9`] = `
+{
+  "code": "
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+interface Derived {
+  name: string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 10`] = `
+{
+  "code": "export default interface Base {}",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 11`] = `
+{
+  "code": "export default interface Derived extends Base {}",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 12`] = `
+{
+  "code": "export interface Base {}",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 13`] = `
+{
+  "code": "
 interface Base {
   name: string;
 }
@@ -192,7 +435,7 @@ interface Derived extends Base {}
 }
 `;
 
-exports[`no-empty-object-type > invalid 7`] = `
+exports[`no-empty-object-type > invalid 14`] = `
 {
   "code": "interface Base extends Array<number> {}",
   "diagnostics": [
@@ -218,7 +461,7 @@ exports[`no-empty-object-type > invalid 7`] = `
 }
 `;
 
-exports[`no-empty-object-type > invalid 8`] = `
+exports[`no-empty-object-type > invalid 15`] = `
 {
   "code": "interface Base extends Array<number | {}> {}",
   "diagnostics": [
@@ -262,7 +505,7 @@ exports[`no-empty-object-type > invalid 8`] = `
 }
 `;
 
-exports[`no-empty-object-type > invalid 9`] = `
+exports[`no-empty-object-type > invalid 16`] = `
 {
   "code": "
 interface Derived {
@@ -293,7 +536,7 @@ interface Base extends Array<Derived> {}
 }
 `;
 
-exports[`no-empty-object-type > invalid 10`] = `
+exports[`no-empty-object-type > invalid 17`] = `
 {
   "code": "
 type R = Record<string, unknown>;
@@ -322,7 +565,7 @@ interface Base extends R {}
 }
 `;
 
-exports[`no-empty-object-type > invalid 11`] = `
+exports[`no-empty-object-type > invalid 18`] = `
 {
   "code": "interface Base<T> extends Derived<T> {}",
   "diagnostics": [
@@ -348,7 +591,7 @@ exports[`no-empty-object-type > invalid 11`] = `
 }
 `;
 
-exports[`no-empty-object-type > invalid 12`] = `
+exports[`no-empty-object-type > invalid 19`] = `
 {
   "code": "
 declare namespace BaseAndDerived {
@@ -368,213 +611,6 @@ declare namespace BaseAndDerived {
         "start": {
           "column": 20,
           "line": 4,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-empty-object-type",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-empty-object-type > invalid 13`] = `
-{
-  "code": "type Base = {};",
-  "diagnostics": [
-    {
-      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
-- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
-- If you want a type meaning "any object", you probably want \`object\` instead.
-- If you want a type meaning "any value", you probably want \`unknown\` instead.",
-      "messageId": "noEmptyObject",
-      "range": {
-        "end": {
-          "column": 15,
-          "line": 1,
-        },
-        "start": {
-          "column": 13,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-empty-object-type",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-empty-object-type > invalid 14`] = `
-{
-  "code": "type Base = {};",
-  "diagnostics": [
-    {
-      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
-- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
-- If you want a type meaning "any object", you probably want \`object\` instead.
-- If you want a type meaning "any value", you probably want \`unknown\` instead.",
-      "messageId": "noEmptyObject",
-      "range": {
-        "end": {
-          "column": 15,
-          "line": 1,
-        },
-        "start": {
-          "column": 13,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-empty-object-type",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-empty-object-type > invalid 15`] = `
-{
-  "code": "let value: {};",
-  "diagnostics": [
-    {
-      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
-- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
-- If you want a type meaning "any object", you probably want \`object\` instead.
-- If you want a type meaning "any value", you probably want \`unknown\` instead.",
-      "messageId": "noEmptyObject",
-      "range": {
-        "end": {
-          "column": 14,
-          "line": 1,
-        },
-        "start": {
-          "column": 12,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-empty-object-type",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-empty-object-type > invalid 16`] = `
-{
-  "code": "let value: {};",
-  "diagnostics": [
-    {
-      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
-- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
-- If you want a type meaning "any object", you probably want \`object\` instead.
-- If you want a type meaning "any value", you probably want \`unknown\` instead.",
-      "messageId": "noEmptyObject",
-      "range": {
-        "end": {
-          "column": 14,
-          "line": 1,
-        },
-        "start": {
-          "column": 12,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-empty-object-type",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-empty-object-type > invalid 17`] = `
-{
-  "code": "
-let value: {
-  /* ... */
-};
-      ",
-  "diagnostics": [
-    {
-      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
-- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
-- If you want a type meaning "any object", you probably want \`object\` instead.
-- If you want a type meaning "any value", you probably want \`unknown\` instead.",
-      "messageId": "noEmptyObject",
-      "range": {
-        "end": {
-          "column": 2,
-          "line": 4,
-        },
-        "start": {
-          "column": 12,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-empty-object-type",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-empty-object-type > invalid 18`] = `
-{
-  "code": "type MyUnion<T> = T | {};",
-  "diagnostics": [
-    {
-      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
-- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
-- If you want a type meaning "any object", you probably want \`object\` instead.
-- If you want a type meaning "any value", you probably want \`unknown\` instead.",
-      "messageId": "noEmptyObject",
-      "range": {
-        "end": {
-          "column": 25,
-          "line": 1,
-        },
-        "start": {
-          "column": 23,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-empty-object-type",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-empty-object-type > invalid 19`] = `
-{
-  "code": "type Base = {} | null;",
-  "diagnostics": [
-    {
-      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
-- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
-- If you want a type meaning "any object", you probably want \`object\` instead.
-- If you want a type meaning "any value", you probably want \`unknown\` instead.",
-      "messageId": "noEmptyObject",
-      "range": {
-        "end": {
-          "column": 15,
-          "line": 1,
-        },
-        "start": {
-          "column": 13,
-          "line": 1,
         },
       },
       "ruleName": "@typescript-eslint/no-empty-object-type",
@@ -616,6 +652,213 @@ exports[`no-empty-object-type > invalid 20`] = `
 `;
 
 exports[`no-empty-object-type > invalid 21`] = `
+{
+  "code": "type Base = {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 22`] = `
+{
+  "code": "let value: {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 23`] = `
+{
+  "code": "let value: {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 24`] = `
+{
+  "code": "
+let value: {
+  /* ... */
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 25`] = `
+{
+  "code": "type MyUnion<T> = T | {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 26`] = `
+{
+  "code": "type Base = {} | null;",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 27`] = `
+{
+  "code": "type Base = {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 28`] = `
 {
   "code": "interface Base {}",
   "diagnostics": [

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-empty-object-type.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-empty-object-type.test.ts
@@ -204,6 +204,171 @@ const derived = class Derived {};
     },
     {
       code: `
+interface Base {}
+
+interface Base {
+  name: string;
+}
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 2,
+          line: 2,
+          messageId: 'noEmptyInterface',
+        },
+      ],
+    },
+    {
+      code: `
+interface Base {}
+
+interface Base {}
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 2,
+          line: 2,
+          messageId: 'noEmptyInterface',
+        },
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 4,
+          line: 4,
+          messageId: 'noEmptyInterface',
+        },
+      ],
+    },
+    {
+      code: `
+interface Base {}
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 2,
+          line: 2,
+          messageId: 'noEmptyInterface',
+          suggestions: [
+            {
+              data: { replacement: 'object' },
+              messageId: 'replaceEmptyInterface',
+              output: `
+type Base = object
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+      `,
+            },
+            {
+              data: { replacement: 'unknown' },
+              messageId: 'replaceEmptyInterface',
+              output: `
+type Base = unknown
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+interface Derived {
+  name: string;
+}
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 18,
+          endLine: 6,
+          line: 6,
+          messageId: 'noEmptyInterfaceWithSuper',
+        },
+      ],
+    },
+    {
+      code: 'export default interface Base {}',
+      errors: [
+        {
+          column: 26,
+          data: { option: 'allowInterfaces' },
+          endColumn: 30,
+          endLine: 1,
+          line: 1,
+          messageId: 'noEmptyInterface',
+        },
+      ],
+    },
+    {
+      code: 'export default interface Derived extends Base {}',
+      errors: [
+        {
+          column: 26,
+          endColumn: 33,
+          endLine: 1,
+          line: 1,
+          messageId: 'noEmptyInterfaceWithSuper',
+        },
+      ],
+    },
+    {
+      code: 'export interface Base {}',
+      errors: [
+        {
+          column: 18,
+          data: { option: 'allowInterfaces' },
+          endColumn: 22,
+          endLine: 1,
+          line: 1,
+          messageId: 'noEmptyInterface',
+          suggestions: [
+            {
+              data: { replacement: 'object' },
+              messageId: 'replaceEmptyInterface',
+              output: `export type Base = object`,
+            },
+            {
+              data: { replacement: 'unknown' },
+              messageId: 'replaceEmptyInterface',
+              output: `export type Base = unknown`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
 interface Base {
   name: string;
 }


### PR DESCRIPTION
## Summary

- Align no-empty-object-type with typescript-eslint 8.69.0 by withholding unsafe suggestions for declaration-merged and default-exported interfaces while preserving diagnostics.
- Use binder symbols plus a type-checker fallback so same-file, namespace, and cross-file merges are handled without regressing unrelated lexical scopes.
- Defer suggestion construction until requested; the diagnostics-only benchmark median improved from 2.62 ms to 0.80 ms for 4,000 diagnostics, with allocations reduced from 84,036 to 16,034. The suggestion-enabled path remained allocation-neutral.
- Port the latest upstream Go and JS cases, update the JS snapshots, and add adversarial generic, reversed-order, repeated-namespace, and cross-file merge coverage.
- Verify every one of the 18 reported files: all 50 diagnostics match both the documented payloads and typescript-eslint 8.69.0 exactly.

Validation:
- Targeted Go package tests
- Targeted JS rule test and stable snapshots
- check-spell
- format:check
- golangci-lint on changed Go files only

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/pull/12739
- https://typescript-eslint.io/rules/no-empty-object-type

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).