### PR TITLE
feat: port rule unicorn/no-unreadable-new-expression

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -20,6 +20,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_this_assignment"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unreadable_new_expression"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unsafe_string_replacement"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_xor_as_exponentiation"
@@ -60,6 +61,7 @@ func GetAllRules() []rule.Rule {
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,
 		no_this_assignment.NoThisAssignmentRule,
+		no_unreadable_new_expression.NoUnreadableNewExpressionRule,
 		no_unsafe_string_replacement.NoUnsafeStringReplacementRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		no_xor_as_exponentiation.NoXorAsExponentiationRule,

--- a/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression.go
+++ b/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression.go
@@ -1,0 +1,100 @@
+// Package no_unreadable_new_expression ports eslint-plugin-unicorn's
+// `no-unreadable-new-expression` rule.
+package no_unreadable_new_expression
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDMemberAccess       = "member-access"
+	messageIDComplexConstructor = "complex-constructor"
+)
+
+var (
+	messageMemberAccess = rule.RuleMessage{
+		Id:          messageIDMemberAccess,
+		Description: "Do not access members directly from a `new` expression.",
+	}
+	messageComplexConstructor = rule.RuleMessage{
+		Id:          messageIDComplexConstructor,
+		Description: "Do not use a complex expression as a constructor.",
+	}
+)
+
+// isStaticMemberExpression mirrors upstream's recursive MemberExpression
+// predicate. Source parentheses and JavaScript JSDoc casts are transparent in
+// ESTree, while authored TypeScript assertions and optional chains remain
+// visible and therefore make the constructor complex.
+func isStaticMemberExpression(node *ast.Node) bool {
+	node = utils.ESTreeRuntimeExpression(node)
+	if node == nil || node.Kind != ast.KindPropertyAccessExpression || ast.IsOptionalChain(node) {
+		return false
+	}
+
+	access := node.AsPropertyAccessExpression()
+	if access == nil || access.Name() == nil || access.Name().Kind != ast.KindIdentifier {
+		return false
+	}
+
+	object := utils.ESTreeRuntimeExpression(access.Expression)
+	return object != nil && (object.Kind == ast.KindIdentifier || isStaticMemberExpression(object))
+}
+
+func isSimpleConstructor(node *ast.Node) bool {
+	node = utils.ESTreeRuntimeExpression(node)
+	return node != nil && (node.Kind == ast.KindIdentifier || isStaticMemberExpression(node))
+}
+
+func checkMemberExpression(ctx rule.RuleContext, node *ast.Node) {
+	var object, property *ast.Node
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		access := node.AsPropertyAccessExpression()
+		object = access.Expression
+		property = access.Name()
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		object = access.Expression
+		property = utils.ESTreeRuntimeExpression(access.ArgumentExpression)
+	default:
+		return
+	}
+
+	object = utils.ESTreeRuntimeExpression(object)
+	if object == nil || object.Kind != ast.KindNewExpression || property == nil {
+		return
+	}
+
+	ctx.ReportNode(property, messageMemberAccess)
+}
+
+// NoUnreadableNewExpressionRule disallows member access directly from a new
+// expression and disallows complex expressions as constructors.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-unreadable-new-expression.js
+var NoUnreadableNewExpressionRule = rule.Rule{
+	Name:   "unicorn/no-unreadable-new-expression",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				checkMemberExpression(ctx, node)
+			},
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				checkMemberExpression(ctx, node)
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				callee := utils.ESTreeRuntimeExpression(node.AsNewExpression().Expression)
+				if isSimpleConstructor(callee) {
+					return
+				}
+				if callee != nil {
+					ctx.ReportNode(callee, messageComplexConstructor)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression.md
+++ b/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression.md
@@ -1,0 +1,36 @@
+# no-unreadable-new-expression
+
+## Rule Details
+
+Disallow accessing a member directly from a `new` expression and disallow
+complex expressions as constructors. Keeping construction separate from later
+member access avoids JavaScript's precedence-sensitive `new` syntax.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const timestamp = new Date().getTime();
+const value = new (factory().Constructor)();
+const item = new constructors[Kind]();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const date = new Date();
+const timestamp = date.getTime();
+
+const { Constructor } = factory();
+const value = new Constructor();
+
+const ConstructorForKind = constructors[Kind];
+const item = new ConstructorForKind();
+```
+
+Identifier constructors and static member constructors such as
+`new Namespace.Constructor()` are allowed.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-unreadable-new-expression](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-unreadable-new-expression.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-unreadable-new-expression.js)

--- a/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression_extras_test.go
@@ -1,0 +1,102 @@
+// TestNoUnreadableNewExpressionExtras locks in tsgo/ESTree shape differences,
+// every reachable upstream branch, and representative real-world expressions
+// discussed in the upstream issue tracker. The direct v74.0.0 migration lives
+// in no_unreadable_new_expression_upstream_test.go.
+package no_unreadable_new_expression_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_unreadable_new_expression "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unreadable_new_expression"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnreadableNewExpressionExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_unreadable_new_expression.NoUnreadableNewExpressionRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream isSimpleConstructor() identifier arm. ESTree
+			// omits source parentheses around the callee.
+			{Code: `const value = new (((Foo)))();`, FileName: "file.mjs"},
+
+			// Locks in upstream isStaticMemberExpression() recursive-object arm,
+			// including parentheses that ESTree does not expose.
+			{Code: `const value = new (((namespace).models).Widget)();`, FileName: "file.mjs"},
+			{Code: `const value = new (/** @type {typeof namespace} */ (namespace).Widget)();`, FileName: "file.js"},
+
+			// Locks in upstream MemberExpression listener early-return arm: the
+			// object is not a NewExpression.
+			{Code: `const value = factory().Widget;`, FileName: "file.mjs"},
+
+			// ---- Dimension 4: authored TypeScript wrappers remain visible. ----
+			// TSESTree exposes the assertion as the member object, so this is not
+			// direct member access from a NewExpression.
+			{Code: `const value = (new Foo() as Foo).bar;`, FileName: "file.ts"},
+			{Code: `const value = (new Foo() satisfies Foo).bar;`, FileName: "file.ts"},
+
+			// Type arguments do not make an otherwise simple constructor complex.
+			{Code: `const value = new namespace.Widget<string>();`, FileName: "file.ts"},
+
+			// tsgo represents dotted JSX tag names with PropertyAccessExpression,
+			// but neither link has a NewExpression object.
+			{Code: `const value = <Namespace.Widget />;`, FileName: "file.tsx", Tsx: true},
+
+			// N/A: declaration-name/key shapes, destructuring, function/class
+			// variants, missing bodies, options, fixes, and suggestions are not
+			// inspected by this expression-only rule.
+		},
+		[]rule_tester.InvalidTestCase{
+			// Locks in upstream MemberExpression listener report arm. tsgo splits
+			// ESTree's one member kind into property and element access listeners.
+			invalid(`const value = new Foo().property;`, "file.mjs", memberAccessError(`const value = new Foo().property;`, "property", 0)),
+			invalid(`const value = new Foo()[property];`, "file.mjs", memberAccessError(`const value = new Foo()[property];`, "property", 0)),
+			invalid(`const value = new Foo()["property"];`, "file.mjs", memberAccessError(`const value = new Foo()["property"];`, `"property"`, 0)),
+			invalid(`class A { #value; method() { return new A().#value; } }`, "file.mjs", memberAccessError(`class A { #value; method() { return new A().#value; } }`, "#value", 1)),
+
+			// ---- Dimension 4: optional-chain member access still has a direct
+			// NewExpression object after ESTree removes parentheses. ----
+			invalid(`const value = (new Foo())?.property;`, "file.mjs", memberAccessError(`const value = (new Foo())?.property;`, "property", 0)),
+
+			// ---- Dimension 4: optional chains and computed access used as a
+			// constructor are complex, not static member chains. These lock in
+			// upstream isStaticMemberExpression() rejection and the NewExpression
+			// listener report arm. ----
+			invalid(`const value = new (namespace?.Widget)();`, "file.mjs", complexConstructorError(`const value = new (namespace?.Widget)();`, "namespace?.Widget", 0)),
+			invalid(`const value = new (namespace[Widget])();`, "file.mjs", complexConstructorError(`const value = new (namespace[Widget])();`, "namespace[Widget]", 0)),
+			invalid(`class A { #Ctor; method() { return new this.#Ctor(); } }`, "file.mjs", complexConstructorError(`class A { #Ctor; method() { return new this.#Ctor(); } }`, "this.#Ctor", 0)),
+
+			// ---- Dimension 4: JavaScript JSDoc casts are absent from ESTree
+			// and therefore remain transparent around a NewExpression object. ----
+			invalid(`const value = /** @type {Foo} */ (new Foo()).property;`, "file.js", memberAccessError(`const value = /** @type {Foo} */ (new Foo()).property;`, "property", 0)),
+
+			// ---- Dimension 4: authored TypeScript assertions in a constructor
+			// path remain visible and make the constructor complex. ----
+			invalid(`const value = new ((namespace as typeof other).Widget)();`, "file.ts", complexConstructorError(`const value = new ((namespace as typeof other).Widget)();`, `(namespace as typeof other).Widget`, 0)),
+			invalid(`const value = new (namespace!.Widget)();`, "file.ts", complexConstructorError(`const value = new (namespace!.Widget)();`, "namespace!.Widget", 0)),
+
+			// Same-kind nesting: only the first member directly owned by the new
+			// expression is reported, not later links in the chain.
+			invalid(`const value = new Foo().first.second.third;`, "file.mjs", memberAccessError(`const value = new Foo().first.second.third;`, "first", 0)),
+
+			// A complex outer constructor can contain another new expression
+			// whose direct member access is independently reported.
+			invalid(
+				`const value = new (new Factory().Builder)();`,
+				"file.mjs",
+				complexConstructorError(`const value = new (new Factory().Builder)();`, `new Factory().Builder`, 0),
+				memberAccessError(`const value = new (new Factory().Builder)();`, `Builder`, 0),
+			),
+
+			// Comments and line breaks do not change the direct member boundary.
+			invalid("const value = new Foo()\n\t/* keep */ .property;", "file.mjs", memberAccessError("const value = new Foo()\n\t/* keep */ .property;", "property", 0)),
+
+			// ---- Real-user: upstream #1603/#3266 examples. ----
+			invalid(`const year = new Date(commit.committedDate).getFullYear();`, "file.mjs", memberAccessError(`const year = new Date(commit.committedDate).getFullYear();`, "getFullYear", 0)),
+			invalid(`function check() { return new URL(location.href).searchParams.get('w') === '1'; }`, "file.mjs", memberAccessError(`function check() { return new URL(location.href).searchParams.get('w') === '1'; }`, "searchParams", 0)),
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_unreadable_new_expression/no_unreadable_new_expression_upstream_test.go
@@ -1,0 +1,128 @@
+// TestNoUnreadableNewExpressionUpstream migrates the complete valid/invalid
+// suite from eslint-plugin-unicorn v74.0.0. Rslint-specific edge-shape and
+// branch lock-in cases live in no_unreadable_new_expression_extras_test.go.
+package no_unreadable_new_expression_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_unreadable_new_expression "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unreadable_new_expression"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	memberAccessMessageID       = "member-access"
+	memberAccessMessage         = "Do not access members directly from a `new` expression."
+	complexConstructorMessageID = "complex-constructor"
+	complexConstructorMessage   = "Do not use a complex expression as a constructor."
+)
+
+func sourcePosition(code string, offset int) (int, int) {
+	prefix := code[:offset]
+	line := strings.Count(prefix, "\n") + 1
+	lastNewline := strings.LastIndex(prefix, "\n")
+	column := offset + 1
+	if lastNewline >= 0 {
+		column = offset - lastNewline
+	}
+	return line, column
+}
+
+func expectedError(code, target string, occurrence int, messageID, message string) rule_tester.InvalidTestCaseError {
+	searchFrom := 0
+	start := -1
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], target)
+		if relative < 0 {
+			panic("target not found in no-unreadable-new-expression test: " + target)
+		}
+		start = searchFrom + relative
+		searchFrom = start + len(target)
+	}
+
+	line, column := sourcePosition(code, start)
+	endLine, endColumn := sourcePosition(code, start+len(target))
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func memberAccessError(code, target string, occurrence int) rule_tester.InvalidTestCaseError {
+	return expectedError(code, target, occurrence, memberAccessMessageID, memberAccessMessage)
+}
+
+func complexConstructorError(code, target string, occurrence int) rule_tester.InvalidTestCaseError {
+	return expectedError(code, target, occurrence, complexConstructorMessageID, complexConstructorMessage)
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.mjs"}
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.ts"}
+}
+
+func invalid(code, fileName string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{Code: code, FileName: fileName, Errors: errors}
+}
+
+func TestNoUnreadableNewExpressionUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_unreadable_new_expression.NoUnreadableNewExpressionRule,
+		[]rule_tester.ValidTestCase{
+			jsValid(`const foo = new Foo();`),
+			jsValid(`const foo = new Foo;`),
+			jsValid(`const foo = new Foo(bar);`),
+			jsValid(`const foo = new Foo(...bar);`),
+			jsValid(`const foo = new Foo.Bar;`),
+			jsValid(`const bar = new foo.Bar();`),
+			jsValid(`const bar = new foo.bar.Baz();`),
+			jsValid(`const formatter = new Intl.ListFormat("en-US", {type: "disjunction"});`),
+			jsValid(`const foo = Foo().Bar;`),
+			jsValid(`const foo = Foo().Bar();`),
+			jsValid(`const foo = Foo.Bar();`),
+			jsValid(`const foo = new Foo(); foo.getBar();`),
+			jsValid(`const foo = new Foo(); const Bar = foo.Bar;`),
+			jsValid(`const {Bar} = foo; const bar = new Bar();`),
+			jsValid(`const Bar = foo.Bar; const bar = new Bar();`),
+			jsValid(`const bar = Foo ? new Foo() : foo.Bar;`),
+			tsValid(`const foo = new Foo<Type>();`),
+			tsValid(`const foo = new Foo<Type>;`),
+		},
+		[]rule_tester.InvalidTestCase{
+			invalid(`const bar = new Foo().getBar();`, "file.mjs", memberAccessError(`const bar = new Foo().getBar();`, "getBar", 0)),
+			invalid(`const bar = (new Foo()).getBar();`, "file.mjs", memberAccessError(`const bar = (new Foo()).getBar();`, "getBar", 0)),
+			invalid(`const Bar = new Foo().Bar;`, "file.mjs", memberAccessError(`const Bar = new Foo().Bar;`, "Bar", 1)),
+			invalid(`const Bar = (new Foo()).Bar;`, "file.mjs", memberAccessError(`const Bar = (new Foo()).Bar;`, "Bar", 1)),
+			invalid(`const Bar = (new Foo).Bar;`, "file.mjs", memberAccessError(`const Bar = (new Foo).Bar;`, "Bar", 1)),
+			invalid(`const Bar = new Foo()[Bar];`, "file.mjs", memberAccessError(`const Bar = new Foo()[Bar];`, "Bar", 1)),
+			invalid(`const Bar = (new Foo())[Bar];`, "file.mjs", memberAccessError(`const Bar = (new Foo())[Bar];`, "Bar", 1)),
+			invalid(`const bar = (new Foo)?.getBar();`, "file.mjs", memberAccessError(`const bar = (new Foo)?.getBar();`, "getBar", 0)),
+			invalid(`const baz = new Foo().bar.baz;`, "file.mjs", memberAccessError(`const baz = new Foo().bar.baz;`, "bar", 0)),
+			invalid("new Foo().bar`x`;", "file.mjs", memberAccessError("new Foo().bar`x`;", "bar", 0)),
+			invalid(`const Bar = new (Foo().Bar);`, "file.mjs", complexConstructorError(`const Bar = new (Foo().Bar);`, "Foo().Bar", 0)),
+			invalid(`const bar = new foo[Bar]();`, "file.mjs", complexConstructorError(`const bar = new foo[Bar]();`, "foo[Bar]", 0)),
+			invalid(`const bar = (new foo).Bar();`, "file.mjs", memberAccessError(`const bar = (new foo).Bar();`, "Bar", 0)),
+			invalid(`const bar = new foo().Bar();`, "file.mjs", memberAccessError(`const bar = new foo().Bar();`, "Bar", 0)),
+			invalid(`const bar = new (foo().Bar)();`, "file.mjs", complexConstructorError(`const bar = new (foo().Bar)();`, "foo().Bar", 0)),
+			invalid(`const bar = new (foo())();`, "file.mjs", complexConstructorError(`const bar = new (foo())();`, "foo()", 0)),
+			invalid(`const bar = new (foo ? Foo : Bar)();`, "file.mjs", complexConstructorError(`const bar = new (foo ? Foo : Bar)();`, "foo ? Foo : Bar", 0)),
+			invalid(`const bar = new class {}();`, "file.mjs", complexConstructorError(`const bar = new class {}();`, "class {}", 0)),
+			invalid(`const timestamp = new Date().getTime();`, "file.mjs", memberAccessError(`const timestamp = new Date().getTime();`, "getTime", 0)),
+			invalid(`const formatted = new Intl.ListFormat("en-US", {type: "disjunction"}).format(words);`, "file.mjs", memberAccessError(`const formatted = new Intl.ListFormat("en-US", {type: "disjunction"}).format(words);`, "format", 1)),
+			invalid(`const foo = new (Foo as typeof Bar)();`, "file.ts", complexConstructorError(`const foo = new (Foo as typeof Bar)();`, "Foo as typeof Bar", 0)),
+			invalid(`const bar = (new Foo<Type>()).bar;`, "file.ts", memberAccessError(`const bar = (new Foo<Type>()).bar;`, "bar", 1)),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -683,6 +683,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-this-assignment.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-unreadable-new-expression.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-unsafe-string-replacement.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-xor-as-exponentiation.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-unreadable-new-expression.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-unreadable-new-expression.test.ts
@@ -1,0 +1,78 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string, filename = 'file.mjs') => ({ code, filename });
+const invalid = (
+  code: string,
+  messageId: 'member-access' | 'complex-constructor',
+  filename = 'file.mjs',
+) => ({
+  code,
+  filename,
+  errors: [
+    {
+      messageId,
+      message:
+        messageId === 'member-access'
+          ? 'Do not access members directly from a `new` expression.'
+          : 'Do not use a complex expression as a constructor.',
+    },
+  ],
+});
+
+ruleTester.run('no-unreadable-new-expression', null as never, {
+  valid: [
+    valid('const foo = new Foo();'),
+    valid('const foo = new Foo;'),
+    valid('const foo = new Foo(bar);'),
+    valid('const foo = new Foo(...bar);'),
+    valid('const foo = new Foo.Bar;'),
+    valid('const bar = new foo.Bar();'),
+    valid('const bar = new foo.bar.Baz();'),
+    valid(
+      'const formatter = new Intl.ListFormat("en-US", {type: "disjunction"});',
+    ),
+    valid('const foo = Foo().Bar;'),
+    valid('const foo = Foo().Bar();'),
+    valid('const foo = Foo.Bar();'),
+    valid('const foo = new Foo(); foo.getBar();'),
+    valid('const foo = new Foo(); const Bar = foo.Bar;'),
+    valid('const {Bar} = foo; const bar = new Bar();'),
+    valid('const Bar = foo.Bar; const bar = new Bar();'),
+    valid('const bar = Foo ? new Foo() : foo.Bar;'),
+    valid('const foo = new Foo<Type>();', 'file.ts'),
+    valid('const foo = new Foo<Type>;', 'file.ts'),
+  ],
+  invalid: [
+    invalid('const bar = new Foo().getBar();', 'member-access'),
+    invalid('const bar = (new Foo()).getBar();', 'member-access'),
+    invalid('const Bar = new Foo().Bar;', 'member-access'),
+    invalid('const Bar = (new Foo()).Bar;', 'member-access'),
+    invalid('const Bar = (new Foo).Bar;', 'member-access'),
+    invalid('const Bar = new Foo()[Bar];', 'member-access'),
+    invalid('const Bar = (new Foo())[Bar];', 'member-access'),
+    invalid('const bar = (new Foo)?.getBar();', 'member-access'),
+    invalid('const baz = new Foo().bar.baz;', 'member-access'),
+    invalid('new Foo().bar`x`;', 'member-access'),
+    invalid('const Bar = new (Foo().Bar);', 'complex-constructor'),
+    invalid('const bar = new foo[Bar]();', 'complex-constructor'),
+    invalid('const bar = (new foo).Bar();', 'member-access'),
+    invalid('const bar = new foo().Bar();', 'member-access'),
+    invalid('const bar = new (foo().Bar)();', 'complex-constructor'),
+    invalid('const bar = new (foo())();', 'complex-constructor'),
+    invalid('const bar = new (foo ? Foo : Bar)();', 'complex-constructor'),
+    invalid('const bar = new class {}();', 'complex-constructor'),
+    invalid('const timestamp = new Date().getTime();', 'member-access'),
+    invalid(
+      'const formatted = new Intl.ListFormat("en-US", {type: "disjunction"}).format(words);',
+      'member-access',
+    ),
+    invalid(
+      'const foo = new (Foo as typeof Bar)();',
+      'complex-constructor',
+      'file.ts',
+    ),
+    invalid('const bar = (new Foo<Type>()).bar;', 'member-access', 'file.ts'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -167,7 +167,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-unreadable-array-destructuring': 'error', // not implemented
     // 'unicorn/no-unreadable-for-of-expression': 'error', // not implemented
     // 'unicorn/no-unreadable-iife': 'error', // not implemented
-    // 'unicorn/no-unreadable-new-expression': 'off', // not implemented
+    'unicorn/no-unreadable-new-expression': 'off',
     // 'unicorn/no-unreadable-object-destructuring': 'error', // not implemented
     // 'unicorn/no-unsafe-buffer-conversion': 'error', // not implemented
     // 'unicorn/no-unsafe-dom-html': 'off', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/no-unreadable-new-expression` from `eslint-plugin-unicorn@v74.0.0`.

The rule reports direct member access from a `new` expression and complex constructor expressions.

- Preserve ESTree behavior for parenthesized expressions and JavaScript JSDoc casts.
- Keep authored TypeScript assertions and optional chains visible when determining whether a constructor is complex.
- Handle property, computed, optional, and private member access.
- Register the rule in the native Unicorn catalog.
- Keep the rule disabled in the Unicorn recommended preset, matching upstream.
- Migrate the complete upstream v74.0.0 test suite.
- Add coverage for tsgo AST differences, nested expressions, TypeScript syntax, diagnostic ranges, and real-world upstream examples.
- Add an end-to-end RuleTester suite.

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/1309
- Documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-unreadable-new-expression.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-unreadable-new-expression.js
- Upstream tests: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/no-unreadable-new-expression.js

## Validation

- `go test -count=1 ./internal/plugins/unicorn ./internal/plugins/unicorn/rules/no_unreadable_new_expression`
- `pnpm build`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 no-unreadable-new-expression presets`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint v2.12.2`: 0 issues
- Differential checks against the upstream ESLint rule for JavaScript and TypeScript edge cases

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
