### PR TITLE
feat(rstest): add no-restricted-rstest-methods rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -19,6 +19,7 @@ import (
 	no_import_node "github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_import_node_test"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_interpolation_in_snapshots"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_restricted_rstest_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_standalone_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_exactly_once_with"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_once"
@@ -62,6 +63,7 @@ func GetAllRules() []rule.Rule {
 		no_import_node.NoImportNodeTestRule,
 		no_interpolation_in_snapshots.NoInterpolationInSnapshotsRule,
 		no_mocks_import.NoMocksImportRule,
+		no_restricted_rstest_methods.NoRestrictedRstestMethodsRule,
 		no_standalone_expect.NoStandaloneExpectRule,
 		prefer_called_exactly_once_with.PreferCalledExactlyOnceWithRule,
 		prefer_called_once.PreferCalledOnceRule,

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.go
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.go
@@ -1,0 +1,171 @@
+package no_restricted_rstest_methods
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed no_restricted_rstest_methods.schema.json
+var schemaJSON []byte
+
+// restriction is one entry of the option object: the member is disallowed, and
+// the author may have written a message saying what to reach for instead.
+type restriction struct {
+	Message    string
+	HasMessage bool
+}
+
+func parseOptions(rawOptions []any) map[string]restriction {
+	if len(rawOptions) == 0 {
+		return nil
+	}
+	raw, ok := rawOptions[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	restricted := make(map[string]restriction, len(raw))
+	for member, rawMessage := range raw {
+		if rawMessage == nil {
+			restricted[member] = restriction{}
+			continue
+		}
+		message, ok := rawMessage.(string)
+		if !ok {
+			continue
+		}
+		if message == "" {
+			restricted[member] = restriction{}
+			continue
+		}
+		restricted[member] = restriction{Message: message, HasMessage: true}
+	}
+	return restricted
+}
+
+func restrictedMethodMessage(member string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "restrictedRstestMethod",
+		Description: "Use of `" + member + "` is disallowed",
+		Data:        map[string]string{"restriction": member},
+	}
+}
+
+func restrictedMethodWithMessage(member string, message string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "restrictedRstestMethodWithMessage",
+		Description: message,
+		Data: map[string]string{
+			"message":     message,
+			"restriction": member,
+		},
+	}
+}
+
+var NoRestrictedRstestMethodsRule = rule.Rule{
+	Name:   "rstest/no-restricted-rstest-methods",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		restricted := parseOptions(options)
+		if len(restricted) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		report := func(memberNode *ast.Node, member string) {
+			entry := restricted[member]
+			if entry.HasMessage {
+				ctx.ReportNode(memberNode, restrictedMethodWithMessage(member, entry.Message))
+				return
+			}
+			ctx.ReportNode(memberNode, restrictedMethodMessage(member))
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				// The two kinds of member on the utilities object are reached
+				// in opposite ways, and which kind a name is cannot be known
+				// until the option object is read, so both are tried here.
+				if managed := rstestUtils.ParseRstestPluginManagedCall(node); managed != nil {
+					if _, ok := restricted[managed.Member]; !ok {
+						return
+					}
+					// The build hands the two members that resolve their
+					// receiver back to a local declaration, so a call on the
+					// file's own object is that object's, not Rstest's.
+					if managed.API.ResolvesReceiver &&
+						rstestUtils.ReceiverIsLocallyDeclared(ctx, managed.NamespaceNode) {
+						return
+					}
+					report(managed.MemberNode, managed.Member)
+					return
+				}
+
+				memberNode, member, receiver := calledMember(node)
+				if memberNode == nil {
+					return
+				}
+				// A plugin-managed member that did not parse above is written
+				// in a shape the build does not rewrite, so the call reaches
+				// the stub that throws rather than the API being restricted.
+				if rstestUtils.IsPluginManagedAPI(member) {
+					return
+				}
+				if _, ok := restricted[member]; !ok {
+					return
+				}
+				if !rstestUtils.IsUtilitiesObject(ctx, receiver) {
+					return
+				}
+				report(memberNode, member)
+			},
+		}
+	},
+}
+
+// calledMember returns the member a call reaches its callee through, the name
+// it is written as, and the expression it is read off.
+//
+// Every shape counts here, because the members matched this way are ordinary
+// functions on an ordinary object: `rs['fn']()`, `rs.fn?.()` and `rs?.fn()`
+// all really call `fn`. That is the opposite of the plugin-managed members,
+// where the shape decides whether anything runs at all.
+func calledMember(node *ast.Node) (*ast.Node, string, *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil {
+		return nil, "", nil
+	}
+	callee := internalUtils.SkipAssertionsAndParens(call.Expression)
+	if callee == nil {
+		return nil, "", nil
+	}
+
+	switch callee.Kind {
+	case ast.KindPropertyAccessExpression:
+		access := callee.AsPropertyAccessExpression()
+		if access == nil {
+			return nil, "", nil
+		}
+		name := access.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return nil, "", nil
+		}
+		return name, name.AsIdentifier().Text, access.Expression
+	case ast.KindElementAccessExpression:
+		access := callee.AsElementAccessExpression()
+		if access == nil {
+			return nil, "", nil
+		}
+		key := internalUtils.SkipAssertionsAndParens(access.ArgumentExpression)
+		name, ok := internalUtils.GetStaticStringLiteralValue(key)
+		if !ok || name == "" {
+			return nil, "", nil
+		}
+		return key, name, access.Expression
+	default:
+		return nil, "", nil
+	}
+}

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.md
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.md
@@ -46,7 +46,7 @@ test('charges the card after the retry window', async () => {
 }
 ```
 
-The option object maps a member name to the message reported in its place, or to `null` for the default message. A name that is not a member of the utilities object never matches anything.
+The option object maps a member name to the message reported in its place, or to `null` for the default message. The name is matched wherever it is written on the utilities object, so a name the object does not carry matches nothing a test would really write.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.md
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.md
@@ -1,0 +1,53 @@
+# no-restricted-rstest-methods
+
+## Rule Details
+
+Disallow members of the Rstest utilities object that a team has decided not to use, each with an optional message naming what to reach for instead. Nothing is disallowed until the option object says so.
+
+The utilities object is reached as `rs` or `rstest`, and its members come in two kinds that this rule matches differently, because Rstest reaches them differently. `fn`, `spyOn`, `mocked`, the timer helpers and the stub helpers are ordinary functions, so the rule follows the binding: a rename such as `import { rs as mocker }`, a namespace as in `core.rs.fn()`, `import.meta.rstest.rs.fn()`, a `require` and the [globals](https://rstest.rs/config/test/globals) are all reported, a receiver the file declares itself is a different object and is left alone, and every call shape counts, so `rs['fn']()`, `rs.fn?.()` and `rs?.fn()` are reported alongside `rs.fn()`.
+
+The module mock APIs — `mock`, `doMock`, `unmock`, `hoisted`, `importActual`, `requireMock` and the rest — are rewritten by Rstest's build rather than called, so the rule reads the receiver as written instead of following the binding. A renamed binding is not reported, because Rstest does not rewrite it either and the call throws where it stands; a receiver the file declares itself is reported, because the build rewrites the call regardless of that declaration. Only the shapes the build actually rewrites are reported: `rs.mock('./payments')` is, while `rs['mock']('./payments')`, `rs.mock?.('./payments')` and `rs?.mock('./payments')` are not, since none of them runs. `importActual` and `requireActual` are the two the build also reads through a bracketed string and an optional call, so `rs['importActual']('./payments')` is reported.
+
+The rule reports where a disallowed member is used. Where the call stands and what it is passed are not its concern.
+
+## Incorrect
+
+```ts
+"rstest/no-restricted-rstest-methods": ["error", { "useFakeTimers": "Use the clock fixture instead." }]
+```
+
+```ts
+test('charges the card after the retry window', async () => {
+  rs.useFakeTimers();
+  await retryCharge(card);
+});
+```
+
+## Correct
+
+```ts
+test('charges the card after the retry window', async () => {
+  const clock = installClock();
+  await retryCharge(card);
+});
+```
+
+## Options
+
+```json
+{
+  "rstest/no-restricted-rstest-methods": [
+    "error",
+    {
+      "useFakeTimers": "Use the clock fixture instead.",
+      "stubGlobal": null
+    }
+  ]
+}
+```
+
+The option object maps a member name to the message reported in its place, or to `null` for the default message. A name that is not a member of the utilities object never matches anything.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| _(member name)_ | `string \| null` | `{}` | Message to report where this member is used, or `null` for the default message. |

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.schema.json
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods.schema.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "null"]
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
@@ -35,6 +35,7 @@ func TestNoRestrictedRstestMethods(t *testing.T) {
 	noMock := []any{map[string]any{"mock": nil}}
 	noImportActual := []any{map[string]any{"importActual": nil}}
 	noImportMock := []any{map[string]any{"importMock": nil}}
+	noUnknownMember := []any{map[string]any{"notAnRstestMember": nil}}
 	empty := []any{map[string]any{}}
 
 	rule_tester.RunRuleTester(
@@ -49,6 +50,10 @@ func TestNoRestrictedRstestMethods(t *testing.T) {
 			{Code: `helpers.fn();`, Options: noFn},
 			{Code: `helpers.mock('./m');`, Options: noMock},
 			{Code: `fn();`, Options: noFn},
+			{Code: `helpers.notAnRstestMember();`, Options: noUnknownMember},
+			// A whole-module require binds the module namespace, not the
+			// utilities object, which is the `rs` on it.
+			{Code: `const rs = require('@rstest/core'); rs.fn();`, Options: noFn},
 
 			// ---- The ordinary members follow the binding ----
 			// A receiver the file declares itself is a different object.
@@ -109,6 +114,32 @@ func TestNoRestrictedRstestMethods(t *testing.T) {
 				Code:    `import.meta.rstest.rs.fn();`,
 				Options: noFn,
 				Errors:  disallowed("fn", 1, 23, 25),
+			},
+			// A require reaches the same bindings as an import: the utilities
+			// object destructured off the module, under either name, and the
+			// module namespace it is a member of.
+			{
+				Code:    `const { rs } = require('@rstest/core'); rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 44, 46),
+			},
+			{
+				Code:    `const { rs: mocker } = require('@rstest/core'); mocker.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 56, 58),
+			},
+			{
+				Code:    `const core = require('@rstest/core'); core.rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 47, 49),
+			},
+			// The option object is taken as written: a name that is not a
+			// member of the utilities object matches nothing real, but it is
+			// still matched where it is written on the object.
+			{
+				Code:    `rs.notAnRstestMember();`,
+				Options: noUnknownMember,
+				Errors:  disallowed("notAnRstestMember", 1, 4, 21),
 			},
 
 			// ---- The plugin-managed members are read as written ----

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
@@ -54,6 +54,22 @@ func TestNoRestrictedRstestMethods(t *testing.T) {
 			// A whole-module require binds the module namespace, not the
 			// utilities object, which is the `rs` on it.
 			{Code: `const rs = require('@rstest/core'); rs.fn();`, Options: noFn},
+			// A type-only import is erased before runtime, so a namespace it
+			// binds reaches nothing: `core` stands for no value at all.
+			{
+				Code:    `import type core = require('@rstest/core'); core.rs.fn();`,
+				Options: noFn,
+			},
+			{
+				Code:    `import type * as core from '@rstest/core'; core.rs.fn();`,
+				Options: noFn,
+			},
+			// Erased under a further name, the call reaches neither the import
+			// nor a global: nothing named `mocker` is Rstest's.
+			{
+				Code:    `import type { rs as mocker } from '@rstest/core'; mocker.fn();`,
+				Options: noFn,
+			},
 
 			// ---- The ordinary members follow the binding ----
 			// A receiver the file declares itself is a different object.
@@ -146,6 +162,30 @@ func TestNoRestrictedRstestMethods(t *testing.T) {
 				Code:    `import core = require('@rstest/core'); core.rs.fn();`,
 				Options: noFn,
 				Errors:  disallowed("fn", 1, 48, 50),
+			},
+			// A type-only import of the utilities object binds no value, so
+			// the call is the global `rs` under `globals: true` rather than
+			// the erased binding — the same reading the registrations get.
+			{
+				Code:    `import type { rs } from '@rstest/core'; rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 44, 46),
+			},
+			{
+				Code:    `import { type rs } from '@rstest/core'; rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 44, 46),
+			},
+			{
+				Code:    `import type rs = require('@rstest/core'); rs.importActual('./m');`,
+				Options: noImportActual,
+				Errors:  disallowed("importActual", 1, 46, 58),
+			},
+			// An assertion on the specifier is erased too.
+			{
+				Code:    `const core = require('@rstest/core' as any); core.rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 54, 56),
 			},
 			// The option object is taken as written: a name that is not a
 			// member of the utilities object matches nothing real, but it is

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
@@ -133,6 +133,20 @@ func TestNoRestrictedRstestMethods(t *testing.T) {
 				Options: noFn,
 				Errors:  disallowed("fn", 1, 47, 49),
 			},
+			// An assertion on the require call is erased before runtime, so
+			// the binding is still the module namespace.
+			{
+				Code:    `const core = require('@rstest/core') as any; core.rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 54, 56),
+			},
+			// `import x = require(...)` binds the module namespace the same
+			// way a namespace import does.
+			{
+				Code:    `import core = require('@rstest/core'); core.rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 48, 50),
+			},
 			// The option object is taken as written: a name that is not a
 			// member of the utilities object matches nothing real, but it is
 			// still matched where it is written on the object.

--- a/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
+++ b/internal/plugins/rstest/rules/no_restricted_rstest_methods/no_restricted_rstest_methods_test.go
@@ -1,0 +1,138 @@
+package no_restricted_rstest_methods
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func disallowed(member string, line, column, endColumn int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{{
+		MessageId: "restrictedRstestMethod",
+		Message:   "Use of `" + member + "` is disallowed",
+		Line:      line,
+		Column:    column,
+		EndLine:   line,
+		EndColumn: endColumn,
+	}}
+}
+
+func withMessage(message string, line, column, endColumn int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{{
+		MessageId: "restrictedRstestMethodWithMessage",
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   line,
+		EndColumn: endColumn,
+	}}
+}
+
+func TestNoRestrictedRstestMethods(t *testing.T) {
+	noFn := []any{map[string]any{"fn": nil}}
+	fnWithMessage := []any{map[string]any{"fn": "Use the shared factory instead."}}
+	noMock := []any{map[string]any{"mock": nil}}
+	noImportActual := []any{map[string]any{"importActual": nil}}
+	noImportMock := []any{map[string]any{"importMock": nil}}
+	empty := []any{map[string]any{}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &NoRestrictedRstestMethodsRule,
+		[]rule_tester.ValidTestCase{
+			// Nothing is disallowed until the option object says so.
+			{Code: `rs.fn();`},
+			{Code: `rs.fn();`, Options: empty},
+			{Code: `rs.spyOn(target, 'method');`, Options: noFn},
+			// A member of something else is not a member of the utilities
+			// object, whichever kind of member it is named after.
+			{Code: `helpers.fn();`, Options: noFn},
+			{Code: `helpers.mock('./m');`, Options: noMock},
+			{Code: `fn();`, Options: noFn},
+
+			// ---- The ordinary members follow the binding ----
+			// A receiver the file declares itself is a different object.
+			{Code: `const rs = { fn: () => {} }; rs.fn();`, Options: noFn},
+			{Code: `function make(rs) { return rs.fn(); }`, Options: noFn},
+			{Code: `import { rs } from './helpers'; rs.fn();`, Options: noFn},
+
+			// ---- The plugin-managed members are read as written ----
+			// A renamed binding is never rewritten: the call throws where it
+			// stands rather than mocking anything.
+			{Code: `import { rs as mocker } from '@rstest/core'; mocker.mock('./m');`, Options: noMock},
+			{Code: `import * as core from '@rstest/core'; core.rs.mock('./m');`, Options: noMock},
+			// Shapes the build does not rewrite reach the stub that throws.
+			{Code: `rs['mock']('./m');`, Options: noMock},
+			{Code: `rs.mock?.('./m');`, Options: noMock},
+			{Code: `rs?.mock('./m');`, Options: noMock},
+			{Code: "rs[`importActual`]('./m');", Options: noImportActual},
+			{Code: `rs?.importActual('./m');`, Options: noImportActual},
+			{Code: `rs['importMock']('./m');`, Options: noImportMock},
+			// These two are handed back to a local declaration of the
+			// receiver, so the call runs that object's method.
+			{Code: `const rs = { importActual: async (p) => ({}) }; rs.importActual('./m');`, Options: noImportActual},
+			{Code: `function load(rs) { return rs.requireActual('./m'); }`, Options: []any{map[string]any{"requireActual": nil}}},
+			// `import.meta.rstest` carries the module namespace, and the
+			// plugin-managed members are not rewritten through it.
+			{Code: `import.meta.rstest.rs.mock('./m');`, Options: noMock},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: `rs.fn();`, Options: noFn, Errors: disallowed("fn", 1, 4, 6)},
+			{Code: `rstest.fn();`, Options: noFn, Errors: disallowed("fn", 1, 8, 10)},
+			{
+				Code:    `rs.fn();`,
+				Options: fnWithMessage,
+				Errors:  withMessage("Use the shared factory instead.", 1, 4, 6),
+			},
+
+			// ---- The ordinary members are real functions in every shape ----
+			{Code: `rs['fn']();`, Options: noFn, Errors: disallowed("fn", 1, 4, 8)},
+			{Code: `rs.fn?.();`, Options: noFn, Errors: disallowed("fn", 1, 4, 6)},
+			{Code: `rs?.fn();`, Options: noFn, Errors: disallowed("fn", 1, 5, 7)},
+			// However the binding was made, it names the same function.
+			{
+				Code:    `import { rs as mocker } from '@rstest/core'; mocker.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 53, 55),
+			},
+			{
+				Code:    `import { rstest as testing } from 'rstack/test'; testing.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 58, 60),
+			},
+			{
+				Code:    `import * as core from '@rstest/core'; core.rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 47, 49),
+			},
+			{
+				Code:    `import.meta.rstest.rs.fn();`,
+				Options: noFn,
+				Errors:  disallowed("fn", 1, 23, 25),
+			},
+
+			// ---- The plugin-managed members are read as written ----
+			{Code: `rs.mock('./m');`, Options: noMock, Errors: disallowed("mock", 1, 4, 8)},
+			{Code: `rstest.mock('./m');`, Options: noMock, Errors: disallowed("mock", 1, 8, 12)},
+			// A local declaration of the receiver is bypassed rather than
+			// honored, so the call is still Rstest's.
+			{
+				Code:    `const rs = { mock() {} }; rs.mock('./m');`,
+				Options: noMock,
+				Errors:  disallowed("mock", 1, 30, 34),
+			},
+			{
+				Code:    `const rs = { importMock: async (p) => ({}) }; rs.importMock('./m');`,
+				Options: noImportMock,
+				Errors:  disallowed("importMock", 1, 50, 60),
+			},
+			// The two members whose rewrite reads a wider set of shapes.
+			{Code: `rs['importActual']('./m');`, Options: noImportActual, Errors: disallowed("importActual", 1, 4, 18)},
+			{Code: `rs.importActual?.('./m');`, Options: noImportActual, Errors: disallowed("importActual", 1, 4, 16)},
+			// Parentheses and TypeScript's type-only syntax are transparent on
+			// both sides of the callee.
+			{Code: `(rs as any).mock('./m');`, Options: noMock, Errors: disallowed("mock", 1, 13, 17)},
+			{Code: `(rs.fn)();`, Options: noFn, Errors: disallowed("fn", 1, 5, 7)},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/require_mock_type_parameters/require_mock_type_parameters_extras_test.go
+++ b/internal/plugins/rstest/rules/require_mock_type_parameters/require_mock_type_parameters_extras_test.go
@@ -95,11 +95,7 @@ func TestRequireMockTypeParametersExtras(t *testing.T) {
 			// takes the implementation to infer from, and a tag is handed a
 			// `TemplateStringsArray` that no `FunctionLike` accepts.
 			{Code: "import { rs } from '@rstest/core'; rs.fn`service`;"},
-			// `import = require` binds the module namespace, but the shared
-			// resolver in internal/utils/test_framework recognizes only a
-			// namespace import and a `require` initializer as one.
-			{Code: `import core = require('@rstest/core'); core.rs.fn();`},
-			// The same resolver has no branch for a dynamic import, so a
+			// The shared resolver has no branch for a dynamic import, so a
 			// destructure of one — renamed or not — is not resolved either.
 			{Code: `async function setup() { const { rs } = await import('@rstest/core'); rs.fn(); }`},
 			{Code: `async function setup() { const { rs: mocker } = await import('@rstest/core'); mocker.fn(); }`},
@@ -163,6 +159,9 @@ func TestRequireMockTypeParametersExtras(t *testing.T) {
 			{Code: `rs!.fn()`, Errors: missing("fn", 1, 5, 7)},
 			{Code: `(rs as any).fn()`, Errors: missing("fn", 1, 13, 15)},
 			{Code: `(rs satisfies object).fn()`, Errors: missing("fn", 1, 23, 25)},
+			// `import = require` binds the module namespace the same way a
+			// namespace import does, so the utilities object is the `rs` on it.
+			{Code: `import core = require('@rstest/core'); core.rs.fn();`, Errors: missing("fn", 1, 48, 50)},
 			{Code: `(rs.fn)()`, Errors: missing("fn", 1, 5, 7)},
 			{Code: `(rs.fn as any)()`, Errors: missing("fn", 1, 5, 7)},
 			// An optional chain still reaches the same function, so the mock it

--- a/internal/plugins/rstest/utils/utilities_object.go
+++ b/internal/plugins/rstest/utils/utilities_object.go
@@ -41,14 +41,24 @@ func IsUtilitiesObject(ctx rule.RuleContext, receiver *ast.Node) bool {
 		return name == "rs" || name == "rstest"
 	}
 
-	// A namespace import or a whole-module require reaches the same object
-	// through one more member: `core.rs.fn()`.
+	// A namespace import, a whole-module require and `import.meta.rstest` all
+	// reach the same object through one more member: `core.rs.fn()`,
+	// `import.meta.rstest.rs.fn()`. The last one is the module namespace
+	// itself (packages/core/importMeta.d.ts types it as
+	// `typeof import('@rstest/core')`), so the utilities object is the `rs` or
+	// `rstest` on it rather than the property itself.
 	member, namespace := CalledPlainMember(receiver)
 	if member == nil || (member.Text() != "rs" && member.Text() != "rstest") {
 		return false
 	}
 	namespace = internalUtils.SkipAssertionsAndParens(namespace)
-	if namespace == nil || namespace.Kind != ast.KindIdentifier {
+	if namespace == nil {
+		return false
+	}
+	if isImportMetaRstest(namespace) {
+		return true
+	}
+	if namespace.Kind != ast.KindIdentifier {
 		return false
 	}
 	return testFramework.IsModuleNamespaceSymbolModules(

--- a/internal/utils/test_framework/module_reference.go
+++ b/internal/utils/test_framework/module_reference.go
@@ -221,9 +221,36 @@ func IsModuleNamespaceSymbolModules(symbol *ast.Symbol, importModules []string) 
 				return true
 			}
 		}
+
+		// `import core = require('m')` binds the module namespace the same way
+		// a namespace import does.
+		if declaration.Kind == ast.KindImportEqualsDeclaration {
+			if isImportEqualsOfModules(declaration, importModules) {
+				return true
+			}
+		}
 	}
 
 	return false
+}
+
+// isImportEqualsOfModules reports whether declaration is
+// `import name = require(module)` for any of importModules.
+func isImportEqualsOfModules(declaration *ast.Node, importModules []string) bool {
+	importEquals := declaration.AsImportEqualsDeclaration()
+	if importEquals == nil || importEquals.ModuleReference == nil ||
+		importEquals.ModuleReference.Kind != ast.KindExternalModuleReference {
+		return false
+	}
+	reference := importEquals.ModuleReference.AsExternalModuleReference()
+	if reference == nil || reference.Expression == nil {
+		return false
+	}
+	specifier := internalUtils.SkipAssertionsAndParens(reference.Expression)
+	if specifier == nil || !ast.IsStringLiteralLike(specifier) {
+		return false
+	}
+	return matchesModule(specifier.Text(), importModules)
 }
 
 func resolveModuleImportSpecifier(declaration *ast.Node, importModules []string) (string, *ast.Node, bool) {
@@ -291,7 +318,9 @@ func IsModuleRequireCallModules(node *ast.Node, importModules []string) bool {
 		return false
 	}
 
-	node = ast.SkipParentheses(node)
+	// TypeScript assertions are erased before runtime, so
+	// `require('m') as any` still binds the module.
+	node = internalUtils.SkipAssertionsAndParens(node)
 	if node == nil || !ast.IsRequireCall(node, true /* requireStringLiteralLikeArgument */) {
 		return false
 	}

--- a/internal/utils/test_framework/module_reference.go
+++ b/internal/utils/test_framework/module_reference.go
@@ -160,6 +160,13 @@ func ResolveFunctionIdentifierReferenceFromSymbolModules(
 			continue
 		}
 
+		// A type-only import is erased before runtime, so it neither binds the
+		// module's export nor shadows anything: the call is the global
+		// registration, whether the `type` sits on the clause or the specifier.
+		if ast.IsTypeOnlyImportDeclaration(declaration) {
+			continue
+		}
+
 		if name, originalNode, ok := resolveModuleImportSpecifier(declaration, importModules); ok {
 			return name, originalNode, ReferenceModeImport
 		}
@@ -203,6 +210,12 @@ func IsModuleNamespaceSymbolModules(symbol *ast.Symbol, importModules []string) 
 
 	for _, declaration := range symbol.Declarations {
 		if declaration == nil {
+			continue
+		}
+
+		// A type-only import is erased before runtime: it binds a name in the
+		// type world only, so nothing reaches the module namespace through it.
+		if ast.IsTypeOnlyImportDeclaration(declaration) {
 			continue
 		}
 
@@ -321,7 +334,9 @@ func IsModuleRequireCallModules(node *ast.Node, importModules []string) bool {
 	// TypeScript assertions are erased before runtime, so
 	// `require('m') as any` still binds the module.
 	node = internalUtils.SkipAssertionsAndParens(node)
-	if node == nil || !ast.IsRequireCall(node, true /* requireStringLiteralLikeArgument */) {
+	// The argument is checked below rather than by IsRequireCall, which would
+	// reject `require('m' as any)` before the assertion is skipped.
+	if node == nil || !ast.IsRequireCall(node, false /* requireStringLiteralLikeArgument */) {
 		return false
 	}
 
@@ -329,7 +344,7 @@ func IsModuleRequireCallModules(node *ast.Node, importModules []string) bool {
 	if len(arguments) == 0 || arguments[0] == nil {
 		return false
 	}
-	specifier := ast.SkipParentheses(arguments[0])
+	specifier := internalUtils.SkipAssertionsAndParens(arguments[0])
 	if specifier == nil {
 		return false
 	}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -626,6 +626,7 @@ define.test({
     './tests/rstest/rules/no-import-node-test.test.ts',
     './tests/rstest/rules/no-interpolation-in-snapshots.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
+    './tests/rstest/rules/no-restricted-rstest-methods.test.ts',
     './tests/rstest/rules/no-standalone-expect.test.ts',
     './tests/rstest/rules/prefer-called-exactly-once-with.test.ts',
     './tests/rstest/rules/prefer-called-once.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/no-restricted-rstest-methods.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-restricted-rstest-methods.test.ts
@@ -1,0 +1,90 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-restricted-rstest-methods', {} as never, {
+  valid: [
+    { code: `rs.fn()` },
+    { code: `rs.fn()`, options: [{}] },
+    { code: `rs.spyOn(target, 'method')`, options: [{ fn: null }] },
+    { code: `helpers.fn()`, options: [{ fn: null }] },
+    { code: `const rs = { fn: () => {} }; rs.fn();`, options: [{ fn: null }] },
+    {
+      code: `import { rs as mocker } from '@rstest/core'; mocker.mock('./m');`,
+      options: [{ mock: null }],
+    },
+    { code: `rs['mock']('./m')`, options: [{ mock: null }] },
+    { code: `rs.mock?.('./m')`, options: [{ mock: null }] },
+    {
+      code: `const rs = { importActual: async (p) => ({}) }; rs.importActual('./m');`,
+      options: [{ importActual: null }],
+    },
+  ],
+  invalid: [
+    {
+      code: `rs.fn()`,
+      options: [{ fn: null }],
+      errors: [
+        {
+          messageId: 'restrictedRstestMethod',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 6,
+        },
+      ],
+    },
+    {
+      code: `rs.fn()`,
+      options: [{ fn: 'Use the shared factory instead.' }],
+      errors: [
+        {
+          messageId: 'restrictedRstestMethodWithMessage',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 6,
+        },
+      ],
+    },
+    {
+      code: `rs['fn']()`,
+      options: [{ fn: null }],
+      errors: [
+        {
+          messageId: 'restrictedRstestMethod',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 8,
+        },
+      ],
+    },
+    {
+      code: `rs.mock('./m')`,
+      options: [{ mock: null }],
+      errors: [
+        {
+          messageId: 'restrictedRstestMethod',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 8,
+        },
+      ],
+    },
+    {
+      code: `const rs = { mock() {} }; rs.mock('./m');`,
+      options: [{ mock: null }],
+      errors: [
+        {
+          messageId: 'restrictedRstestMethod',
+          line: 1,
+          column: 30,
+          endLine: 1,
+          endColumn: 34,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Disallow members of the Rstest utilities object that a team has decided not to use, each with an optional message naming what to reach for instead. Nothing is disallowed by default, and the rule stays out of the recommended preset.

Because the member names come from configuration, the rule cannot know which half of the object it will be handed, so it looks each one up in the shared table and matches it the way Rstest reaches it. The two halves pull in opposite directions. `fn`, `spyOn`, `mocked` and the other ordinary functions follow the binding, so `import { rs as mocker }` is reported and a local `const rs = { … }` is not, and every call shape counts because they all really call the function. The module mock APIs are read as written, so a renamed binding is not reported — it throws where it stands rather than mocking anything — and a local declaration of the receiver is reported, because the build rewrites the call regardless. For the same reason `rs['fn']()` is reported and `rs['mock']()` is not: the first really calls `fn`, the second calls nothing.

`IsUtilitiesObject` also learns one receiver shape here: `import.meta.rstest.rs.fn()`, which reaches the same object through the module namespace.

The rule does not check where the call stands or what it is passed. Those decide whether a call that is already a use of the API is hoisted or valid, which is `hoisted-apis-on-top`'s question, not this one's.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
