### PR TITLE
fix(test): isolate rule tester files and fix no-var UMD autofix

### DIFF
--- a/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
@@ -18,7 +18,7 @@ func TestNoCycleExtras(t *testing.T) {
 		"tsconfig.json",
 		t,
 		&no_cycle.NoCycleRule,
-		[]rule_tester.ValidTestCase{
+		withDefaultNoCycleValidFileName([]rule_tester.ValidTestCase{
 			// ---- JSDoc import types are comments, not module-graph edges ----
 			// @typescript-eslint/parser exposes these through comments / parser
 			// services rather than ESTree import nodes, so import/no-cycle ignores
@@ -85,8 +85,8 @@ func TestNoCycleExtras(t *testing.T) {
 
 			// A json.Number maxDepth is schema-valid and must limit traversal like a plain number.
 			{Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"maxDepth": json.Number("2")}}},
-		},
-		[]rule_tester.InvalidTestCase{
+		}),
+		withDefaultNoCycleInvalidFileName([]rule_tester.InvalidTestCase{
 			// Control for the JSDoc cases above: with the same JavaScript filename,
 			// tsconfig, and target, an authored import is a graph edge and closes
 			// the cycle through no-cycle/depth-one.ts.
@@ -268,6 +268,6 @@ export const realValue = realBarrel.run || run;`,
 					cycleError(messageDetected),
 				},
 			},
-		},
+		}),
 	)
 }

--- a/internal/plugins/import/rules/no_cycle/no_cycle_upstream_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_upstream_test.go
@@ -26,8 +26,8 @@ func TestNoCycleUpstream(t *testing.T) {
 		"tsconfig.json",
 		t,
 		&no_cycle.NoCycleRule,
-		withDisableSccValid(noCycleUpstreamValidCases()),
-		withDisableSccInvalid(noCycleUpstreamInvalidCases()),
+		withDefaultNoCycleValidFileName(withDisableSccValid(noCycleUpstreamValidCases())),
+		withDefaultNoCycleInvalidFileName(withDisableSccInvalid(noCycleUpstreamInvalidCases())),
 	)
 }
 
@@ -346,4 +346,22 @@ func cycleError(message string) rule_tester.InvalidTestCaseError {
 		Line:      1,
 		Column:    1,
 	}
+}
+
+func withDefaultNoCycleValidFileName(cases []rule_tester.ValidTestCase) []rule_tester.ValidTestCase {
+	for i := range cases {
+		if cases[i].FileName == "" {
+			cases[i].FileName = "file.ts"
+		}
+	}
+	return cases
+}
+
+func withDefaultNoCycleInvalidFileName(cases []rule_tester.InvalidTestCase) []rule_tester.InvalidTestCase {
+	for i := range cases {
+		if cases[i].FileName == "" {
+			cases[i].FileName = "file.ts"
+		}
+	}
+	return cases
 }

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises_test.go
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises_test.go
@@ -661,7 +661,8 @@ myTag` + "`" + `abc` + "`" + `;
 
         it('...', () => {});
       `,
-			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"it"}, "path": "file.ts"}}},
+			FileName: "file.ts",
+			Options:  map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"it"}, "path": "file.ts"}}},
 		},
 		{
 			Code: `

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -130,6 +131,20 @@ type ESLintSuggestion struct {
 type ESLintTestSuite struct {
 	Valid   []ESLintTestCase        `json:"valid"`
 	Invalid []ESLintInvalidTestCase `json:"invalid"`
+}
+
+var defaultTestFileID atomic.Uint64
+
+func resolveTestCaseFileName(fileName string, tsx bool) string {
+	if fileName != "" {
+		return fileName
+	}
+
+	extension := ".ts"
+	if tsx {
+		extension = ".tsx"
+	}
+	return "filename-" + strconv.FormatUint(defaultTestFileID.Add(1), 10) + extension
 }
 
 // ResolveTestCaseOptions puts a test case's options through the same step a
@@ -264,13 +279,7 @@ func RunRuleTester(root Root, tsconfigPath string, t *testing.T, r *rule.Rule, v
 				t.SkipNow()
 			}
 
-			fileName := "file.ts"
-			if testCase.Tsx {
-				fileName = "react.tsx"
-			}
-			if testCase.FileName != "" {
-				fileName = testCase.FileName
-			}
+			fileName := resolveTestCaseFileName(testCase.FileName, testCase.Tsx)
 
 			diagnostics := runLinter(t, testCase.Code, testCase.Options, testCase.Settings, testCase.LanguageOptions, testCase.Globals, testCase.TSConfig, fileName)
 			if len(diagnostics) != 0 {
@@ -296,13 +305,7 @@ func RunRuleTester(root Root, tsconfigPath string, t *testing.T, r *rule.Rule, v
 			outputs := make([]string, 0, 1)
 			code := testCase.Code
 
-			fileName := "file.ts"
-			if testCase.Tsx {
-				fileName = "react.tsx"
-			}
-			if testCase.FileName != "" {
-				fileName = testCase.FileName
-			}
+			fileName := resolveTestCaseFileName(testCase.FileName, testCase.Tsx)
 
 			for i := range 10 {
 				diagnostics := runLinter(t, code, testCase.Options, testCase.Settings, testCase.LanguageOptions, testCase.Globals, testCase.TSConfig, fileName)
@@ -425,7 +428,7 @@ func ConvertESLintTestCase(tc ESLintTestCase) ValidTestCase {
 		}
 	}
 
-	fileName := "file.ts"
+	fileName := ""
 	tsx := false
 	if tc.Filename != "" {
 		fileName = tc.Filename
@@ -456,7 +459,7 @@ func ConvertESLintInvalidTestCase(tc ESLintInvalidTestCase) InvalidTestCase {
 		}
 	}
 
-	fileName := "file.ts"
+	fileName := ""
 	tsx := false
 	if tc.Filename != "" {
 		fileName = tc.Filename

--- a/internal/rule_tester/rule_tester_test.go
+++ b/internal/rule_tester/rule_tester_test.go
@@ -1,6 +1,7 @@
 package rule_tester
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,6 +9,27 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+func TestResolveTestCaseFileName(t *testing.T) {
+	t.Parallel()
+
+	first := resolveTestCaseFileName("", false)
+	second := resolveTestCaseFileName("", false)
+	tsx := resolveTestCaseFileName("", true)
+
+	if first == second {
+		t.Fatalf("default test filenames must be unique, got %q twice", first)
+	}
+	if !strings.HasPrefix(first, "filename-") || !strings.HasSuffix(first, ".ts") {
+		t.Fatalf("default TypeScript filename = %q, want filename-<id>.ts", first)
+	}
+	if !strings.HasPrefix(tsx, "filename-") || !strings.HasSuffix(tsx, ".tsx") {
+		t.Fatalf("default TSX filename = %q, want filename-<id>.tsx", tsx)
+	}
+	if explicit := resolveTestCaseFileName("explicit.jsx", false); explicit != "explicit.jsx" {
+		t.Fatalf("explicit filename = %q, want explicit.jsx", explicit)
+	}
+}
 
 func TestRunRuleTesterPropagatesLanguageOptions(t *testing.T) {
 	probe := rule.Rule{

--- a/internal/rules/no_var/no_var.go
+++ b/internal/rules/no_var/no_var.go
@@ -1,6 +1,8 @@
 package no_var
 
 import (
+	"slices"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 
@@ -171,7 +173,8 @@ func canFix(node *ast.Node, ctx *rule.RuleContext) bool {
 		// Collect references only after the cheap blockers above. A reference
 		// can only resolve to this symbol from within its variable scope, so the
 		// file-wide list is identical to a bounded scope walk.
-		refs := filterSafeAmbientNamespaceReferences(v.nameNode, ctx.Refs.References(v.sym))
+		refs := filterSafeNamespaceExportReferences(ctx.Refs.References(v.sym))
+		refs = filterSafeAmbientNamespaceReferences(v.nameNode, refs)
 
 		// Condition 2: self-reference in TDZ
 		if hasTDZIssue(v.nameNode, refs) {
@@ -352,6 +355,15 @@ func bindingContainsName(binding *ast.Node, target string) bool {
 		}
 	})
 	return found
+}
+
+// filterSafeNamespaceExportReferences removes `export as namespace Name`.
+// It names the UMD module in the global namespace but does not read the local
+// value at runtime, so it cannot make a var-to-let replacement unsafe.
+func filterSafeNamespaceExportReferences(refs []*ast.Node) []*ast.Node {
+	return slices.DeleteFunc(slices.Clone(refs), func(ref *ast.Node) bool {
+		return ref != nil && ref.Parent != nil && ref.Parent.Kind == ast.KindNamespaceExportDeclaration
+	})
 }
 
 // filterSafeAmbientNamespaceReferences removes type-only reads contributed by


### PR DESCRIPTION
## Summary

- give RuleTester cases unique default filenames to prevent parallel programs from sharing source files
- preserve the explicit `file.ts` entry for no-cycle fixtures and ignore UMD namespace exports in no-var autofix safety

## Testing

- `GOMAXPROCS=16 go test -count=10 ./internal/rules/no_var ./internal/plugins/import/rules/no_cycle ./internal/rule_tester`
- `golangci-lint run ./internal/rule_tester/... ./internal/rules/no_var/... ./internal/plugins/import/rules/no_cycle/...`