### PR TITLE
feat: port rule unicorn/no-array-front-mutation

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_concat_in_loop"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_fill_with_reference_type"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_front_mutation"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_exports_in_scripts"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
@@ -49,6 +50,7 @@ func GetAllRules() []rule.Rule {
 		new_for_builtins.NewForBuiltinsRule,
 		no_array_concat_in_loop.NoArrayConcatInLoopRule,
 		no_array_fill_with_reference_type.NoArrayFillWithReferenceTypeRule,
+		no_array_front_mutation.NoArrayFrontMutationRule,
 		no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
 		no_exports_in_scripts.NoExportsInScriptsRule,
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,

--- a/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation.go
+++ b/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation.go
@@ -1,0 +1,69 @@
+package no_array_front_mutation
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const messageID = "no-array-front-mutation"
+
+var ignoredUnshiftCallees = []string{
+	"stream.unshift",
+	"this.unshift",
+	"this.stream.unshift",
+	"process.stdin.unshift",
+	"process.stdout.unshift",
+	"process.stderr.unshift",
+}
+
+func mutationMessage(method string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageID,
+		Description: "Avoid front-of-array mutation with `Array#" + method + "()`.",
+		Data: map[string]string{
+			"method": method,
+		},
+	}
+}
+
+// NoArrayFrontMutationRule disallows Array#shift() and Array#unshift(), whose
+// front-of-array mutation can be unexpectedly expensive for large arrays.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-array-front-mutation.js
+var NoArrayFrontMutationRule = rule.Rule{
+	Name:   "unicorn/no-array-front-mutation",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Methods:             []string{"shift", "unshift"},
+					AllowOptionalMember: true,
+				})
+				if !ok {
+					return
+				}
+
+				method := call.Property.AsIdentifier().Text
+				if method == "unshift" && isIgnoredUnshiftCallee(call.Callee) {
+					return
+				}
+				if unicornutil.ShouldSkipKnownNonArrayReceiver(ctx, call.Object) {
+					return
+				}
+
+				ctx.ReportNode(call.Property, mutationMessage(method))
+			},
+		}
+	},
+}
+
+func isIgnoredUnshiftCallee(callee *ast.Node) bool {
+	for _, path := range ignoredUnshiftCallees {
+		if unicornutil.NodeMatchesPath(callee, path) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation.md
+++ b/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation.md
@@ -1,0 +1,37 @@
+# no-array-front-mutation
+
+## Rule Details
+
+Disallow mutating the front of an array with `Array#shift()` or
+`Array#unshift()`. Re-indexing the remaining elements can make these methods
+unexpectedly expensive for large arrays.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const first = items.shift();
+items.unshift(newItem);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+for (const item of items) {
+  consume(item);
+}
+
+queue.enqueue(newItem);
+```
+
+The rule allows `unshift()` on common Node.js stream objects, where it has
+stream-specific semantics rather than array semantics:
+
+```javascript
+stream.unshift(chunk);
+process.stdin.unshift(chunk);
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-array-front-mutation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-array-front-mutation.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-array-front-mutation.js)

--- a/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation_extras_test.go
@@ -1,0 +1,93 @@
+// TestNoArrayFrontMutationExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case identifies the upstream
+// branch, Dimension 4 row, or real-user scenario it covers.
+package no_array_front_mutation_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_front_mutation"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoArrayFrontMutationExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_array_front_mutation.NoArrayFrontMutationRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream create() arm 1: only CallExpression nodes match.
+			valid(`array.shift`, "file.mjs"),
+			valid(`array.unshift`, "file.mjs"),
+
+			// Locks in upstream isMethodCall() method-name rejection branch.
+			valid(`array.pop()`, "file.mjs"),
+			valid(`array.push(value)`, "file.mjs"),
+
+			// ---- Dimension 4: element-access key forms are excluded ----
+			valid(`array['shift']()`, "file.mjs"),
+			valid("array[`unshift`](value)", "file.mjs"),
+			valid(`array[0]()`, "file.mjs"),
+			valid(`array[Symbol.iterator]()`, "file.mjs"),
+
+			// ---- Dimension 4: optional calls are excluded ----
+			valid(`(array.shift)?.()`, "file.mjs"),
+			valid(`array.unshift?.(value)`, "file.mjs"),
+
+			// ---- Dimension 4: authored TypeScript callee wrappers stay visible ----
+			valid(`(array.shift as () => void)()`, "file.ts"),
+			valid(`(array.unshift satisfies (value: unknown) => number)(value)`, "file.ts"),
+
+			// Locks in upstream ignoredUnshiftCallees branch for stream APIs.
+			valid(`stream.unshift(chunk)`, "file.mjs"),
+			valid(`process.stdin.unshift(chunk)`, "file.mjs"),
+
+			// Locks in upstream shouldSkipKnownNonArrayReceiver() branch.
+			valid(`function consume(queue: Set<number>) { queue.shift(); }`, "file.ts"),
+			valid(`function consume(queue: Map<string, number>) { queue.unshift(1); }`, "file.ts"),
+
+			// N/A: declaration/container and property-key forms; the rule only inspects calls.
+			// N/A: ancestor walks and body-absent declarations; the rule performs no ancestor traversal.
+			// N/A: object spread and binding rest; neither can be a matched dot-method callee.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver wrappers are transparent ----
+			invalid(`(array).shift()`, "file.mjs", "shift"),
+			invalid(`((array)).unshift(value)`, "file.mjs", "unshift"),
+
+			// ---- Dimension 4: TypeScript receiver wrappers are transparent ----
+			invalid(`items!.shift()`, "file.ts", "shift"),
+			invalid(`(items as unknown[]).unshift(value)`, "file.ts", "unshift"),
+			invalid(`(items satisfies unknown[]).shift()`, "file.ts", "shift"),
+
+			// ---- Dimension 4: optional member access remains reportable ----
+			invalid(`items?.shift()`, "file.mjs", "shift"),
+			invalid(`items?.unshift(value)`, "file.mjs", "unshift"),
+
+			// ---- Dimension 4: same-kind nesting reports both calls ----
+			invalid(`items.unshift(other.shift())`, "file.mjs", "unshift", "shift"),
+
+			// Locks in upstream ignored-callee condition's method guard: shift is not exempt.
+			invalid(`process.stdin.shift()`, "file.mjs", "shift"),
+			// Locks in the ignored-path rejection branch: other unshift receivers still report.
+			invalid(`socket.unshift(chunk)`, "file.mjs", "unshift"),
+
+			// ---- Real-user: issue #1282 proposal uses whitespace before call parens ----
+			invalid(
+				"const items = [];\nitems.shift ();\nitems.unshift ();",
+				"file.mjs",
+				"shift",
+				"unshift",
+			),
+
+			// ---- Real-user: issue #1282 highlights repeated front mutation in hot loops ----
+			invalid(
+				"for (let index = 0; index < 10_000; index++) {\n\titems.unshift(value);\n}",
+				"file.mjs",
+				"unshift",
+			),
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_array_front_mutation/no_array_front_mutation_upstream_test.go
@@ -1,0 +1,116 @@
+// TestNoArrayFrontMutationUpstream migrates the full valid/invalid suite from
+// upstream test/no-array-front-mutation.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// no_array_front_mutation_extras_test.go.
+package no_array_front_mutation_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_front_mutation"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const messageID = "no-array-front-mutation"
+
+func expectedMessage(method string) string {
+	return "Avoid front-of-array mutation with `Array#" + method + "()`."
+}
+
+func methodError(code, method string, occurrence int) rule_tester.InvalidTestCaseError {
+	needle := "." + method
+	offset := -1
+	searchFrom := 0
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], needle)
+		if relative < 0 {
+			panic("method not found in no-array-front-mutation test: " + method)
+		}
+		offset = searchFrom + relative + 1
+		searchFrom = offset + len(method)
+	}
+
+	prefix := code[:offset]
+	line := strings.Count(prefix, "\n") + 1
+	lastNewline := strings.LastIndex(prefix, "\n")
+	column := offset + 1
+	if lastNewline >= 0 {
+		column = offset - lastNewline
+	}
+
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   expectedMessage(method),
+		Line:      line,
+		Column:    column,
+		EndLine:   line,
+		EndColumn: column + len(method),
+	}
+}
+
+func valid(code, fileName string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: fileName}
+}
+
+func invalid(code, fileName string, methods ...string) rule_tester.InvalidTestCase {
+	seen := map[string]int{}
+	errors := make([]rule_tester.InvalidTestCaseError, 0, len(methods))
+	for _, method := range methods {
+		errors = append(errors, methodError(code, method, seen[method]))
+		seen[method]++
+	}
+	return rule_tester.InvalidTestCase{Code: code, FileName: fileName, Errors: errors}
+}
+
+func TestNoArrayFrontMutationUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_array_front_mutation.NoArrayFrontMutationRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Known non-array receiver (type information) ----
+			valid(`function f(foo: Set<number>) { foo.shift(); }`, "file.ts"),
+			valid(`function f(foo: Set<number>) { foo.unshift(value); }`, "file.ts"),
+
+			valid(`array.shift`, "file.mjs"),
+			valid(`array.unshift`, "file.mjs"),
+			valid(`array.shift?.()`, "file.mjs"),
+			valid(`array.unshift?.(value)`, "file.mjs"),
+			valid(`array?.shift?.()`, "file.mjs"),
+			valid(`array?.unshift?.(value)`, "file.mjs"),
+			valid(`array["shift"]()`, "file.mjs"),
+			valid(`array["unshift"](value)`, "file.mjs"),
+			valid(`shift(array)`, "file.mjs"),
+			valid(`unshift(array, value)`, "file.mjs"),
+			valid(`Array.prototype.shift.call(array)`, "file.mjs"),
+			valid(`Array.prototype.unshift.call(array, value)`, "file.mjs"),
+			valid(`stream.unshift(chunk)`, "file.mjs"),
+			valid(`this.unshift(chunk)`, "file.mjs"),
+			valid(`this.stream.unshift(chunk)`, "file.mjs"),
+			valid(`process.stdin.unshift(chunk)`, "file.mjs"),
+			valid(`process.stdout.unshift(chunk)`, "file.mjs"),
+			valid(`process.stderr.unshift(chunk)`, "file.mjs"),
+		},
+		[]rule_tester.InvalidTestCase{
+			invalid(`array.shift()`, "file.mjs", "shift"),
+			invalid(`array.shift(extraArgument)`, "file.mjs", "shift"),
+			invalid(`array?.shift()`, "file.mjs", "shift"),
+			invalid(`array.unshift()`, "file.mjs", "unshift"),
+			invalid(`array.unshift(value)`, "file.mjs", "unshift"),
+			invalid(`array.unshift(...values)`, "file.mjs", "unshift"),
+			invalid(`array?.unshift(value)`, "file.mjs", "unshift"),
+			invalid(`stream.shift()`, "file.mjs", "shift"),
+			invalid(`const item = array.shift()`, "file.mjs", "shift"),
+			invalid(`const length = array.unshift(value)`, "file.mjs", "unshift"),
+			invalid(`function getItem() { return array.shift(); }`, "file.mjs", "shift"),
+			invalid(`while (array.shift()) {}`, "file.mjs", "shift"),
+			invalid(`if (array.unshift(value)) {}`, "file.mjs", "unshift"),
+			invalid(`for (; array.shift(); ) {}`, "file.mjs", "shift"),
+			invalid(`(array as string[]).shift()`, "file.ts", "shift"),
+			invalid(`array!.unshift(value)`, "file.ts", "unshift"),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -672,6 +672,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-concat-in-loop.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-fill-with-reference-type.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-array-front-mutation.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-exports-in-scripts.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-array-front-mutation.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-array-front-mutation.test.ts
@@ -1,0 +1,63 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string, filename = 'file.mjs') => ({ code, filename });
+const invalid = (
+  code: string,
+  method: 'shift' | 'unshift',
+  filename = 'file.mjs',
+) => ({
+  code,
+  filename,
+  errors: [
+    {
+      messageId: 'no-array-front-mutation',
+      message: `Avoid front-of-array mutation with \`Array#${method}()\`.`,
+      data: { method },
+    },
+  ],
+});
+
+ruleTester.run('no-array-front-mutation', null as never, {
+  valid: [
+    valid('function f(foo: Set<number>) { foo.shift(); }', 'file.ts'),
+    valid('function f(foo: Set<number>) { foo.unshift(value); }', 'file.ts'),
+    valid('array.shift'),
+    valid('array.unshift'),
+    valid('array.shift?.()'),
+    valid('array.unshift?.(value)'),
+    valid('array?.shift?.()'),
+    valid('array?.unshift?.(value)'),
+    valid('array["shift"]()'),
+    valid('array["unshift"](value)'),
+    valid('shift(array)'),
+    valid('unshift(array, value)'),
+    valid('Array.prototype.shift.call(array)'),
+    valid('Array.prototype.unshift.call(array, value)'),
+    valid('stream.unshift(chunk)'),
+    valid('this.unshift(chunk)'),
+    valid('this.stream.unshift(chunk)'),
+    valid('process.stdin.unshift(chunk)'),
+    valid('process.stdout.unshift(chunk)'),
+    valid('process.stderr.unshift(chunk)'),
+  ],
+  invalid: [
+    invalid('array.shift()', 'shift'),
+    invalid('array.shift(extraArgument)', 'shift'),
+    invalid('array?.shift()', 'shift'),
+    invalid('array.unshift()', 'unshift'),
+    invalid('array.unshift(value)', 'unshift'),
+    invalid('array.unshift(...values)', 'unshift'),
+    invalid('array?.unshift(value)', 'unshift'),
+    invalid('stream.shift()', 'shift'),
+    invalid('const item = array.shift()', 'shift'),
+    invalid('const length = array.unshift(value)', 'unshift'),
+    invalid('function getItem() { return array.shift(); }', 'shift'),
+    invalid('while (array.shift()) {}', 'shift'),
+    invalid('if (array.unshift(value)) {}', 'unshift'),
+    invalid('for (; array.shift(); ) {}', 'shift'),
+    invalid('(array as string[]).shift()', 'shift', 'file.ts'),
+    invalid('array!.unshift(value)', 'unshift', 'file.ts'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -63,7 +63,7 @@ const recommended: RslintConfigEntry = {
     'unicorn/no-array-concat-in-loop': 'error',
     'unicorn/no-array-fill-with-reference-type': 'error',
     // 'unicorn/no-array-from-fill': 'error', // not implemented
-    // 'unicorn/no-array-front-mutation': 'off', // not implemented
+    'unicorn/no-array-front-mutation': 'off',
     // 'unicorn/no-array-method-this-argument': 'error', // not implemented
     // 'unicorn/no-array-reduce': 'error', // not implemented
     // 'unicorn/no-array-reverse': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/no-array-front-mutation` from `eslint-plugin-unicorn@v74.0.0`.

The rule reports calls to `Array#shift()` and `Array#unshift()`, which can cause unexpectedly expensive front-of-array mutations.

- Preserve the upstream exceptions for Node.js stream `unshift()` calls.
- Skip receivers that are statically known not to be arrays.
- Support optional member access while excluding optional calls and computed method access.
- Register the rule in the native Unicorn catalog.
- Keep the rule disabled in the Unicorn recommended preset, matching upstream.
- Migrate the complete upstream v74.0.0 test suite.
- Add coverage for TypeScript wrappers, optional chains, nested calls, diagnostic ranges, and real-world examples from the upstream proposal.
- Add an end-to-end RuleTester suite.

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/1309
- Upstream proposal: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1282
- Documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-array-front-mutation.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-array-front-mutation.js
- Upstream tests: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/no-array-front-mutation.js

## Validation

- `go test -count=1 ./internal/plugins/unicorn/rules/no_array_front_mutation`
- `pnpm --dir packages/rslint run build:bin`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 no-array-front-mutation`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint v2.12.2`: 0 issues

## Checklist

- [x] Tests updated.
- [x] Documentation updated.