### PR TITLE
feat: port rule react/function-component-definition

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -12,6 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_foreign_prop_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_prop_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forward_ref_uses_ref"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/function_component_definition"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/hook_use_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_bracket_location"
@@ -99,6 +100,7 @@ func GetAllRules() []rule.Rule {
 		forbid_foreign_prop_types.ForbidForeignPropTypesRule,
 		forbid_prop_types.ForbidPropTypesRule,
 		forward_ref_uses_ref.ForwardRefUsesRefRule,
+		function_component_definition.FunctionComponentDefinitionRule,
 		hook_use_state.HookUseStateRule,
 		jsx_boolean_value.JsxBooleanValueRule,
 		jsx_closing_bracket_location.JsxClosingBracketLocationRule,

--- a/internal/plugins/react/reactutil/component_class.go
+++ b/internal/plugins/react/reactutil/component_class.go
@@ -216,6 +216,20 @@ func EnclosingClass(node *ast.Node) *ast.Node {
 // Pass `sourceFile.Text()` as `text` so trailing trivia after the
 // modifier list is properly skipped.
 func ClassKeywordStart(text string, node *ast.Node) int {
+	return DeclarationKeywordStart(text, node)
+}
+
+// DeclarationKeywordStart returns the offset of a declaration's own leading
+// keyword (`class`, `function`, `var`, ...), skipping the `export` and
+// `default` modifiers that tsgo keeps on the declaration node but ESTree
+// lifts into a separate ExportNamedDeclaration / ExportDefaultDeclaration
+// wrapper. Any other modifier (decorators, `abstract`, `declare`,
+// accessibility, `async`) is PART of the declaration's range in ESTree too,
+// so trimming stops at the first one.
+//
+// Pass `sourceFile.Text()` as `text` so trivia after the modifier list is
+// skipped as well.
+func DeclarationKeywordStart(text string, node *ast.Node) int {
 	mods := node.Modifiers()
 	pos := node.Pos()
 	if mods != nil {

--- a/internal/plugins/react/reactutil/component_detect.go
+++ b/internal/plugins/react/reactutil/component_detect.go
@@ -210,7 +210,8 @@ func GetEnclosingReactComponent(node *ast.Node, pragma, createClass string) *ast
 // Only a restricted subset of upstream's heuristics is implemented — the
 // patterns covering production React code: named FunctionDeclaration,
 // FunctionExpression / ArrowFunction assigned to a capital-cased
-// VariableDeclarator, PropertyAssignment, or ExportAssignment (default export),
+// VariableDeclarator, PropertyAssignment, or ExportAssignment (`export
+// default` only — `export =` is not a component upstream),
 // plus function expression in a CallExpression (e.g. React.memo wrapper —
 // approximate match). This is intentionally conservative: missed detection
 // causes a rule miss, over-detection would cause false-positive reports in
@@ -427,7 +428,7 @@ func isStatelessReactComponentCore(fn *ast.Node, pragma string, tc *checker.Chec
 	}
 
 	// Branch 1 — ExportDefault (strict isReturningJSX).
-	if parent.Kind == ast.KindExportAssignment {
+	if isExportDefaultAssignment(parent) {
 		return functionReturnsJSXInternal(fn, false, pragma, tc)
 	}
 
@@ -719,6 +720,19 @@ func functionReturnsOnlyNull(fn *ast.Node) bool {
 	return sawReturn && allNull
 }
 
+// isExportDefaultAssignment reports whether `node` is ESTree's
+// `ExportDefaultDeclaration`. tsgo represents both `export default <expr>`
+// and TypeScript's `export = <expr>` with a KindExportAssignment node and
+// tells them apart through `IsExportEquals`, while typescript-eslint keeps
+// them as distinct node types — `ExportDefaultDeclaration` versus
+// `TSExportAssignment`. eslint-plugin-react's component detection only ever
+// matches `ExportDefaultDeclaration`, so `export = function Hello() { ... }`
+// is not a component upstream and must not be classified as one here.
+func isExportDefaultAssignment(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindExportAssignment &&
+		!node.AsExportAssignment().IsExportEquals
+}
+
 // isInAllowedPositionForComponent mirrors eslint-plugin-react's
 // `utils.isInAllowedPositionForComponent`: only parent node kinds in the
 // allow-list may host a stateless functional component. Sequence expressions
@@ -735,9 +749,10 @@ func isInAllowedPositionForComponent(fn *ast.Node) bool {
 	case ast.KindVariableDeclaration,
 		ast.KindPropertyAssignment,
 		ast.KindReturnStatement,
-		ast.KindExportAssignment,
 		ast.KindArrowFunction:
 		return true
+	case ast.KindExportAssignment:
+		return isExportDefaultAssignment(parent)
 	case ast.KindBinaryExpression:
 		bin := parent.AsBinaryExpression()
 		if bin.OperatorToken == nil {

--- a/internal/plugins/react/reactutil/component_detect_shared.go
+++ b/internal/plugins/react/reactutil/component_detect_shared.go
@@ -1,0 +1,96 @@
+package reactutil
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+)
+
+// IsAsyncGeneratorFunction reports whether `node` is a function expression /
+// declaration / object-literal shorthand method that is BOTH `async` AND a
+// generator (`async function*` or `async *Foo() {}`).
+//
+// Mirrors upstream's `node.async && node.generator` gate inside the
+// `Components.detect` FunctionExpression / FunctionDeclaration listeners —
+// the only path that registers a node with `confidence 0`, which permanently
+// bans it from `components.get()` and `components.list()`. Arrow functions
+// cannot be generators (syntax), so this never fires on KindArrowFunction.
+//
+// MethodDeclaration is included because ESTree's
+// `Property { method: true, value: FunctionExpression }` shape funnels
+// object-literal shorthand methods through the same FunctionExpression
+// listener upstream, so `{ async *Foo() {...} }` is banned there as an
+// async-generator function expression. tsgo collapses that form into a
+// MethodDeclaration whose AsteriskToken and `async` modifier carry the same
+// signal.
+func IsAsyncGeneratorFunction(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	mods := node.Modifiers()
+	hasAsync := false
+	if mods != nil {
+		for _, m := range mods.Nodes {
+			if m.Kind == ast.KindAsyncKeyword {
+				hasAsync = true
+				break
+			}
+		}
+	}
+	if !hasAsync {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().AsteriskToken != nil
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().AsteriskToken != nil
+	case ast.KindMethodDeclaration:
+		return node.AsMethodDeclaration().AsteriskToken != nil
+	}
+	return false
+}
+
+// OutermostComponentWrapperCall walks up through nested pragma-wrapper calls
+// (paren / TS-wrapper transparent) and returns the OUTER-MOST CallExpression
+// that wraps `fn` and matches `wrappers`. Returns nil when the immediate
+// effective parent is not a matching wrapper.
+//
+// Mirrors upstream's `getPragmaComponentWrapper`, which loops while
+// `isPragmaComponentWrapper(currentNode.parent)` keeps yielding truthy and
+// remembers the last truthy ancestor. Why the ascent matters: for
+// `React.memo(React.forwardRef(arrow))`, the inner arrow's
+// `getStatelessComponent` returns the OUTER-MOST wrapper (the memo call),
+// not the inner forwardRef call — so the component is registered against the
+// memo call's range, which on multi-line source changes the report's line
+// number compared to picking the inner wrapper.
+func OutermostComponentWrapperCall(fn *ast.Node, pragma string, wrappers []ComponentWrapperEntry, tc *checker.Checker) *ast.Node {
+	return OutermostComponentWrapperCallFunc(fn, func(call, arg *ast.Node) bool {
+		return MatchesAnyComponentWrapperWithChecker(call, arg, wrappers, pragma, tc)
+	})
+}
+
+// OutermostComponentWrapperCallFunc is OutermostComponentWrapperCall with a
+// caller-supplied wrapper matcher. Callers that memoize the match decision
+// per CallExpression (rules that visit the same wrapper call many times) pass
+// their cached predicate here instead of paying for a fresh
+// MatchesAnyComponentWrapperWithChecker resolution on every ascent.
+//
+// `matches(call, arg)` must answer "is `call` a component-wrapper call whose
+// first argument is `arg`".
+func OutermostComponentWrapperCallFunc(fn *ast.Node, matches func(call, arg *ast.Node) bool) *ast.Node {
+	cur := SkipExpressionWrappersUp(fn)
+	if cur == nil || cur.Kind != ast.KindCallExpression || !matches(cur, fn) {
+		return nil
+	}
+	for {
+		// Try ascending one more level: the parent of the current wrapper
+		// call (paren / TS-wrapper transparent) must itself be a
+		// CallExpression matching the wrapper list, with `cur` as its FIRST
+		// argument.
+		next := SkipExpressionWrappersUp(cur)
+		if next == nil || next.Kind != ast.KindCallExpression || !matches(next, cur) {
+			return cur
+		}
+		cur = next
+	}
+}

--- a/internal/plugins/react/reactutil/jsx_returns.go
+++ b/internal/plugins/react/reactutil/jsx_returns.go
@@ -106,8 +106,8 @@ func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool, pragma string, tc
 
 // isJSXExpression reports whether `expr` may evaluate to JSX (or to `null`
 // when `acceptNull` is true) on at least one control-flow path. Walks through
-// ParenthesizedExpression, TS expression wrappers (`as` / `satisfies` / `<T>x`
-// / `x!`), ConditionalExpression and LogicalExpression (NON-strict semantics:
+// ParenthesizedExpression, ConditionalExpression and LogicalExpression
+// (NON-strict semantics:
 // either side qualifying is enough), comma-sequence right-most operands, and
 // optional chains. A `<pragma>.createElement(...)` CallExpression also
 // qualifies — upstream's jsxUtil.isReturningJSX treats `createElement` calls
@@ -137,8 +137,18 @@ func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool, pragma string, tc
 // recurse. No depth bookkeeping needed because the function does not
 // recurse on Identifier; the only recursion sites (Conditional / comma /
 // `&&` / `||` / `??`) walk strictly smaller AST subtrees.
+//
+// TS expression wrappers (`as` / `satisfies` / `<T>x` / `x!`) are deliberately
+// NOT peeled back here. ESTree has no node for parentheses, so upstream's
+// `isJSXValue` sees straight through them, but TSESTree DOES keep
+// TSAsExpression / TSSatisfiesExpression / TSTypeAssertion /
+// TSNonNullExpression as real nodes, and `isJSXValue` falls through to its
+// `default: return false` for every one of them. So
+// `function Hello() { return <div /> as ReactNode; }` is not a component
+// upstream, and peeling the wrapper here would report components ESLint never
+// reports.
 func isJSXExpression(expr *ast.Node, acceptNull bool, pragma string, tc *checker.Checker) bool {
-	expr = SkipExpressionWrappers(expr)
+	expr = ast.SkipParentheses(expr)
 	if expr == nil {
 		return false
 	}
@@ -161,7 +171,7 @@ func isJSXExpression(expr *ast.Node, acceptNull bool, pragma string, tc *checker
 		if init == nil {
 			return false
 		}
-		init = SkipExpressionWrappers(init)
+		init = ast.SkipParentheses(init)
 		switch init.Kind {
 		case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
 			return true

--- a/internal/plugins/react/rules/display_name/display_name.go
+++ b/internal/plugins/react/rules/display_name/display_name.go
@@ -415,28 +415,12 @@ func hasTranspilerNameForClass(node *ast.Node) bool {
 	return false
 }
 
-// outermostWrapperCall walks up through nested pragma-wrapper calls and
-// returns the outer-most CallExpression that matches `wrappers`. Mirrors
-// upstream's `getPragmaComponentWrapper` loop. Used for the
-// `Components.detect` redirect from inner FunctionLike to its outer wrapper
-// call, so that the report node's range tracks upstream's
-// `getStatelessComponent` output.
+// outermostWrapperCall returns the outer-most component-wrapper
+// CallExpression around `fn`, using this walker's memoized wrapper matcher.
+// See reactutil.OutermostComponentWrapperCallFunc for the upstream
+// `getPragmaComponentWrapper` semantics it mirrors.
 func (w *nodeWalker) outermostWrapperCall(fn *ast.Node) *ast.Node {
-	cur := reactutil.SkipExpressionWrappersUp(fn)
-	if cur == nil || cur.Kind != ast.KindCallExpression ||
-		!w.matchesComponentWrapper(cur, fn) {
-		return nil
-	}
-	for {
-		next := reactutil.SkipExpressionWrappersUp(cur)
-		if next == nil || next.Kind != ast.KindCallExpression {
-			return cur
-		}
-		if !w.matchesComponentWrapper(next, cur) {
-			return cur
-		}
-		cur = next
-	}
+	return reactutil.OutermostComponentWrapperCallFunc(fn, w.matchesComponentWrapper)
 }
 
 func (w *nodeWalker) matchesComponentWrapper(call, fn *ast.Node) bool {
@@ -867,44 +851,6 @@ func (w *nodeWalker) resolveDeepRelatedComponent(member *ast.Node) *ast.Node {
 	return reactutil.SkipExpressionWrappers(node)
 }
 
-// isAsyncGenerator reports whether `node` is a function expression /
-// declaration / shorthand method that is BOTH `async` AND a generator.
-// Mirrors upstream's `Components.detect` listener gate
-// `node.async && node.generator → components.add(node, 0)` — confidence 0
-// nodes are PERMANENTLY banned from `components.list()`. Arrow functions
-// cannot be generators (syntax) so this never fires on KindArrowFunction.
-//
-// In tsgo, the syntactic generator marker is `AsteriskToken` on the
-// FunctionDeclaration / FunctionExpression / MethodDeclaration; the
-// `async` modifier is in the modifiers list.
-func isAsyncGenerator(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	mods := node.Modifiers()
-	hasAsync := false
-	if mods != nil {
-		for _, m := range mods.Nodes {
-			if m.Kind == ast.KindAsyncKeyword {
-				hasAsync = true
-				break
-			}
-		}
-	}
-	if !hasAsync {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindFunctionDeclaration:
-		return node.AsFunctionDeclaration().AsteriskToken != nil
-	case ast.KindFunctionExpression:
-		return node.AsFunctionExpression().AsteriskToken != nil
-	case ast.KindMethodDeclaration:
-		return node.AsMethodDeclaration().AsteriskToken != nil
-	}
-	return false
-}
-
 // classifyAndRegisterFunctionLike runs the upstream FunctionLike component
 // classification (Branch 11 of `getStatelessComponent` plus the pragma
 // wrapper redirect) and registers the node. `componentNode` is the node
@@ -918,7 +864,7 @@ func (w *nodeWalker) classifyAndRegisterFunctionLike(n *ast.Node) {
 	// silently classify here as a component and report. Arrow functions
 	// can't be generators by syntax, so the gate is naturally a no-op for
 	// KindArrowFunction.
-	if isAsyncGenerator(n) {
+	if reactutil.IsAsyncGeneratorFunction(n) {
 		return
 	}
 	directParent := reactutil.SkipExpressionWrappersUp(n)

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition.go
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition.go
@@ -75,25 +75,25 @@ func parseOptions(opts []any) options {
 		return parsed
 	}
 	optsMap, _ := opts[0].(map[string]any)
-	if list := readStringOrList(optsMap["namedComponents"]); len(list) > 0 {
+	if list, ok := readStringOrList(optsMap["namedComponents"]); ok {
 		parsed.named = list
 	}
-	if list := readStringOrList(optsMap["unnamedComponents"]); len(list) > 0 {
+	if list, ok := readStringOrList(optsMap["unnamedComponents"]); ok {
 		parsed.unnamed = list
 	}
 	return parsed
 }
 
 // readStringOrList mirrors JS's `[].concat(value)` coercion for the
-// `string | string[]` option shape. An empty array stays empty, which lets
-// the caller fall back to the default exactly like upstream's `|| default`
-// does for `undefined` — note that upstream keeps an explicitly configured
-// empty array as-is, so we only substitute the default when the key is
-// absent or not a recognized shape.
-func readStringOrList(raw any) []string {
+// `string | string[]` option shape. The bool result says whether the key was
+// present in a recognized shape at all: upstream's `configuration.x || default`
+// substitutes the default only for `undefined`, and an explicitly configured
+// `[]` is truthy in JS and therefore kept as an empty list. So an empty array
+// returns `(nil, true)` and must NOT fall back to the default.
+func readStringOrList(raw any) ([]string, bool) {
 	switch v := raw.(type) {
 	case string:
-		return []string{v}
+		return []string{v}, true
 	case []any:
 		out := make([]string, 0, len(v))
 		for _, item := range v {
@@ -101,9 +101,9 @@ func readStringOrList(raw any) []string {
 				out = append(out, s)
 			}
 		}
-		return out
+		return out, true
 	}
-	return nil
+	return nil, false
 }
 
 var FunctionComponentDefinitionRule = rule.Rule{
@@ -241,11 +241,17 @@ func (w *walker) validate(node *ast.Node, functionType string) {
 	}
 
 	named := hasName(node)
-	if named && !contains(w.cfg.named, functionType) {
+	// An explicitly configured empty list allows nothing, so upstream reaches
+	// `report({ messageId: config[0] })` with `config[0] === undefined` and
+	// ESLint aborts the whole lint run with "Missing `message` property in
+	// report() call". rslint has no equivalent of that crash; staying silent is
+	// the closest safe behavior and, unlike falling back to the default list,
+	// it never invents a diagnostic upstream would not have produced.
+	if named && len(w.cfg.named) > 0 && !contains(w.cfg.named, functionType) {
 		target := w.cfg.named[0]
 		w.report(node, target, namedFunctionTemplates[target], w.namedFixRange(node))
 	}
-	if !named && !contains(w.cfg.unnamed, functionType) {
+	if !named && len(w.cfg.unnamed) > 0 && !contains(w.cfg.unnamed, functionType) {
 		target := w.cfg.unnamed[0]
 		w.report(node, target, unnamedFunctionTemplates[target], utils.TrimNodeTextRange(w.ctx.SourceFile, node))
 	}
@@ -470,10 +476,19 @@ func (w *walker) paramsText(node *ast.Node) string {
 
 // bodyText mirrors upstream's `getBody`: a block body is copied verbatim,
 // while an arrow's expression body is wrapped into an explicit block.
+//
+// Upstream slices `node.body.range`, and ESTree has no node for parentheses,
+// so `const Hello = (props) => (cond ? <A /> : null);` yields the body text
+// WITHOUT the source parentheses. tsgo keeps a ParenthesizedExpression node,
+// so the outer parens have to be peeled back explicitly to produce the same
+// fix.
 func (w *walker) bodyText(node *ast.Node) (string, bool) {
 	body := reactutil.FunctionBody(node)
 	if body == nil {
 		return "", false
+	}
+	if body.Kind != ast.KindBlock {
+		body = ast.SkipParentheses(body)
 	}
 	bodyRange := utils.TrimNodeTextRange(w.ctx.SourceFile, body)
 	if body.Kind != ast.KindBlock {

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition.go
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition.go
@@ -1,0 +1,530 @@
+package function_component_definition
+
+import (
+	_ "embed"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed function_component_definition.schema.json
+var schemaJSON []byte
+
+// The three function forms the rule can enforce. These double as messageIds,
+// matching upstream's `messages` map keys.
+const (
+	typeFunctionDeclaration = "function-declaration"
+	typeFunctionExpression  = "function-expression"
+	typeArrowFunction       = "arrow-function"
+)
+
+// namedFunctionTemplates / unnamedFunctionTemplates mirror upstream's
+// NAMED_FUNCTION_TEMPLATES / UNNAMED_FUNCTION_TEMPLATES.
+var namedFunctionTemplates = map[string]string{
+	typeFunctionDeclaration: "function {name}{typeParams}({params}){returnType} {body}",
+	typeArrowFunction:       "{varType} {name}{typeAnnotation} = {typeParams}({params}){returnType} => {body}",
+	typeFunctionExpression:  "{varType} {name}{typeAnnotation} = function{typeParams}({params}){returnType} {body}",
+}
+
+var unnamedFunctionTemplates = map[string]string{
+	typeFunctionExpression: "function{typeParams}({params}){returnType} {body}",
+	typeArrowFunction:      "{typeParams}({params}){returnType} => {body}",
+}
+
+var messages = map[string]string{
+	typeFunctionDeclaration: "Function component is not a function declaration",
+	typeFunctionExpression:  "Function component is not a function expression",
+	typeArrowFunction:       "Function component is not an arrow function",
+}
+
+// templatePartOrder is the key order upstream's `buildFunction` iterates
+// (`Object.keys(parts)` over the object literal built in `getFixer`). Each
+// key replaces only its FIRST occurrence in the template, so the order
+// matters whenever an earlier-substituted value happens to contain the
+// literal text of a later placeholder (a component body containing `{name}`,
+// for instance). Keeping the order identical to upstream keeps the produced
+// fix identical too.
+var templatePartOrder = []string{"typeAnnotation", "typeParams", "params", "returnType", "body", "name", "varType"}
+
+// buildFunction mirrors upstream's `buildFunction(template, parts)`.
+func buildFunction(template string, parts map[string]string) string {
+	out := template
+	for _, key := range templatePartOrder {
+		out = strings.Replace(out, "{"+key+"}", parts[key], 1)
+	}
+	return out
+}
+
+type options struct {
+	named   []string
+	unnamed []string
+}
+
+func parseOptions(opts []any) options {
+	// Upstream: `[].concat(configuration.namedComponents || 'function-declaration')`.
+	parsed := options{
+		named:   []string{typeFunctionDeclaration},
+		unnamed: []string{typeFunctionExpression},
+	}
+	if len(opts) == 0 {
+		return parsed
+	}
+	optsMap, _ := opts[0].(map[string]any)
+	if list := readStringOrList(optsMap["namedComponents"]); len(list) > 0 {
+		parsed.named = list
+	}
+	if list := readStringOrList(optsMap["unnamedComponents"]); len(list) > 0 {
+		parsed.unnamed = list
+	}
+	return parsed
+}
+
+// readStringOrList mirrors JS's `[].concat(value)` coercion for the
+// `string | string[]` option shape. An empty array stays empty, which lets
+// the caller fall back to the default exactly like upstream's `|| default`
+// does for `undefined` — note that upstream keeps an explicitly configured
+// empty array as-is, so we only substitute the default when the key is
+// absent or not a recognized shape.
+func readStringOrList(raw any) []string {
+	switch v := raw.(type) {
+	case string:
+		return []string{v}
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+var FunctionComponentDefinitionRule = rule.Rule{
+	Name:   "react/function-component-definition",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, opts []any) rule.RuleListeners {
+		cfg := parseOptions(opts)
+		pragma := reactutil.GetReactPragmaFromContext(ctx)
+		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
+
+		w := &walker{
+			ctx:      ctx,
+			text:     ctx.SourceFile.Text(),
+			pragma:   pragma,
+			wrappers: wrappers,
+			cfg:      cfg,
+		}
+		w.run()
+		return rule.RuleListeners{}
+	},
+}
+
+type functionPair struct {
+	node         *ast.Node
+	functionType string
+}
+
+type walker struct {
+	ctx      rule.RuleContext
+	text     string
+	pragma   string
+	wrappers []reactutil.ComponentWrapperEntry
+	cfg      options
+
+	pairs []functionPair
+	// hasES6OrJsx mirrors upstream's file-level flag: any ES module syntax or
+	// any JSX element, plus any `const` / `let` declaration, means the file is
+	// modern enough that a synthesized variable should use `const` instead of
+	// `var`.
+	hasES6OrJsx bool
+}
+
+func (w *walker) run() {
+	w.collect(w.ctx.SourceFile.AsNode())
+	// Upstream defers every report to `Program:exit` so that `fileVarType` is
+	// final before any fix text is built.
+	for _, pair := range w.pairs {
+		w.validate(pair.node, pair.functionType)
+	}
+}
+
+// collect walks the file once, mirroring upstream's listener set: the three
+// function listeners push `[node, functionType]` pairs, and the ES-module /
+// JSX / `const`-`let` listeners raise `hasES6OrJsx`.
+func (w *walker) collect(root *ast.Node) {
+	var visit ast.Visitor
+	visit = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n.Kind {
+		case ast.KindFunctionDeclaration:
+			w.pairs = append(w.pairs, functionPair{n, typeFunctionDeclaration})
+		case ast.KindFunctionExpression:
+			w.pairs = append(w.pairs, functionPair{n, typeFunctionExpression})
+		case ast.KindArrowFunction:
+			w.pairs = append(w.pairs, functionPair{n, typeArrowFunction})
+		case ast.KindVariableDeclarationList:
+			// ESTree `VariableDeclaration.kind`; tsgo keeps the kind on the
+			// declaration list's node flags.
+			switch utils.GetVarDeclListKind(n) {
+			case "const", "let":
+				w.hasES6OrJsx = true
+			}
+		case ast.KindImportDeclaration,
+			ast.KindExportDeclaration,
+			ast.KindExportAssignment,
+			ast.KindExportSpecifier,
+			ast.KindImportEqualsDeclaration,
+			ast.KindJsxElement,
+			ast.KindJsxSelfClosingElement:
+			// tsgo splits ESTree's single JSXElement into JsxElement (with
+			// children) and JsxSelfClosingElement; both are JSXElement
+			// upstream. JsxFragment is deliberately absent — ESTree models it
+			// as JSXFragment, which upstream's selector does not list.
+			//
+			// ExportDeclaration covers both `export {x}` and `export * from`;
+			// ExportAssignment covers `export default <expr>` and `export =`.
+			w.hasES6OrJsx = true
+		}
+		// ESTree hoists `export`/`export default` into wrapper nodes
+		// (ExportNamedDeclaration / ExportDefaultDeclaration) that upstream's
+		// selector matches; tsgo keeps `export` as a modifier on the declaration
+		// itself, so the flag has to be read off the modifier list.
+		if hasExportModifier(n) {
+			w.hasES6OrJsx = true
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	root.ForEachChild(visit)
+}
+
+func hasExportModifier(n *ast.Node) bool {
+	mods := n.Modifiers()
+	if mods == nil {
+		return false
+	}
+	for _, m := range mods.Nodes {
+		if m.Kind == ast.KindExportKeyword {
+			return true
+		}
+	}
+	return false
+}
+
+// fileVarType mirrors upstream's `fileVarType`, resolved at `Program:exit`.
+func (w *walker) fileVarType() string {
+	if w.hasES6OrJsx {
+		return "const"
+	}
+	return "var"
+}
+
+func (w *walker) validate(node *ast.Node, functionType string) {
+	if !w.isDetectedComponentNode(node) {
+		return
+	}
+	// Upstream `if (node.parent && node.parent.type === 'Property') return;`.
+	// Object-literal shorthand methods reach the same early return upstream
+	// through the FunctionExpression listener; in tsgo they are
+	// MethodDeclaration nodes, which `collect` never records at all.
+	if node.Parent != nil && node.Parent.Kind == ast.KindPropertyAssignment {
+		return
+	}
+
+	named := hasName(node)
+	if named && !contains(w.cfg.named, functionType) {
+		target := w.cfg.named[0]
+		w.report(node, target, namedFunctionTemplates[target], w.namedFixRange(node))
+	}
+	if !named && !contains(w.cfg.unnamed, functionType) {
+		target := w.cfg.unnamed[0]
+		w.report(node, target, unnamedFunctionTemplates[target], utils.TrimNodeTextRange(w.ctx.SourceFile, node))
+	}
+}
+
+func (w *walker) report(node *ast.Node, target, template string, fixRange core.TextRange) {
+	w.ctx.ReportRangeWithDeferredFixes(w.reportRange(node), rule.RuleMessage{
+		Id:          target,
+		Description: messages[target],
+	}, func() []rule.RuleFix {
+		replacement, ok := w.buildFix(node, target, template)
+		if !ok {
+			return nil
+		}
+		return []rule.RuleFix{rule.RuleFixReplaceRange(fixRange, replacement)}
+	})
+}
+
+// reportRange is the ESTree range of the reported function node. tsgo folds
+// `export` / `export default` into the declaration's modifier list, whereas
+// ESTree lifts them into a wrapper node that is not what upstream reports, so
+// those two modifiers are skipped to keep the reported column aligned with
+// ESLint's.
+func (w *walker) reportRange(node *ast.Node) core.TextRange {
+	if node.Kind == ast.KindFunctionDeclaration {
+		return core.NewTextRange(reactutil.DeclarationKeywordStart(w.text, node), node.End())
+	}
+	return utils.TrimNodeTextRange(w.ctx.SourceFile, node)
+}
+
+// namedFixRange mirrors upstream's
+// `node.type === 'FunctionDeclaration' ? node.range : node.parent.parent.range`.
+//
+// For the variable form, ESTree's `node.parent.parent` is the
+// VariableDeclaration — the `var`/`let`/`const` keyword through the trailing
+// semicolon, with any `export` kept on the enclosing wrapper node. tsgo splits
+// that into VariableDeclarationList (keyword + declarators, no semicolon)
+// inside a VariableStatement (which owns both the modifiers and the
+// semicolon), so the equivalent range runs from the list's start to the
+// statement's end.
+func (w *walker) namedFixRange(node *ast.Node) core.TextRange {
+	if node.Kind == ast.KindFunctionDeclaration {
+		return core.NewTextRange(reactutil.DeclarationKeywordStart(w.text, node), node.End())
+	}
+	decl := declaratorParent(node)
+	list := decl.Parent
+	end := list.End()
+	if list.Parent != nil && list.Parent.Kind == ast.KindVariableStatement {
+		end = list.Parent.End()
+	}
+	return core.NewTextRange(utils.TrimNodeTextRange(w.ctx.SourceFile, list).Pos(), end)
+}
+
+// buildFix mirrors upstream's `getFixer`. The bool result is upstream's
+// "returned undefined" — the diagnostic stands but carries no autofix.
+func (w *walker) buildFix(node *ast.Node, target, template string) (string, bool) {
+	typeAnnotation := w.typeAnnotationText(node)
+
+	if target == typeFunctionDeclaration && typeAnnotation != "" {
+		return "", false
+	}
+	if target == typeArrowFunction && hasOneUnconstrainedTypeParam(node) {
+		return "", false
+	}
+	if isUnfixableBecauseOfExport(node) {
+		return "", false
+	}
+	if isFunctionExpressionWithName(node) {
+		return "", false
+	}
+
+	varType := w.fileVarType()
+	if node.Kind == ast.KindFunctionExpression || node.Kind == ast.KindArrowFunction {
+		if decl := declaratorParent(node); decl != nil && decl.Kind == ast.KindVariableDeclaration {
+			if kind := utils.GetVarDeclListKind(decl.Parent); kind != "" {
+				varType = kind
+			}
+		}
+	}
+
+	body, ok := w.bodyText(node)
+	if !ok {
+		return "", false
+	}
+
+	return buildFunction(template, map[string]string{
+		"typeAnnotation": typeAnnotation,
+		"typeParams":     w.typeParamsText(node),
+		"params":         w.paramsText(node),
+		"returnType":     w.typeNodeTextWithColon(node.Type()),
+		"body":           body,
+		"name":           getName(node),
+		"varType":        varType,
+	}), true
+}
+
+// hasName mirrors upstream's `hasName`: a function declaration always has a
+// name, and a function expression / arrow gets one from the variable
+// declarator it initializes.
+func hasName(node *ast.Node) bool {
+	if node.Kind == ast.KindFunctionDeclaration {
+		return true
+	}
+	decl := declaratorParent(node)
+	return decl != nil && decl.Kind == ast.KindVariableDeclaration
+}
+
+// declaratorParent returns the node's parent as ESTree would see it, looking
+// through parentheses only. ESTree has no ParenthesizedExpression, so
+// `var Hello = ((props) => ...)` reaches the declarator directly upstream; TS
+// wrappers (`as`, `satisfies`, `!`, `<T>x`) DO exist in TSESTree and are
+// deliberately not skipped, because upstream treats a function behind one of
+// them as unnamed.
+func declaratorParent(node *ast.Node) *ast.Node {
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	return parent
+}
+
+func getName(node *ast.Node) string {
+	if node.Kind == ast.KindFunctionDeclaration {
+		return identifierText(node.Name())
+	}
+	if !hasName(node) {
+		return ""
+	}
+	return identifierText(declaratorParent(node).Name())
+}
+
+func identifierText(name *ast.Node) string {
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+// typeAnnotationText mirrors upstream's `getTypeAnnotation`: only the variable
+// declarator's own annotation, and never for a function declaration.
+func (w *walker) typeAnnotationText(node *ast.Node) string {
+	if !hasName(node) || node.Kind == ast.KindFunctionDeclaration {
+		return ""
+	}
+	return w.typeNodeTextWithColon(declaratorParent(node).Type())
+}
+
+// typeNodeTextWithColon returns the source text of a type annotation
+// INCLUDING its leading colon, matching the range of ESTree's TSTypeAnnotation
+// wrapper (which tsgo has no node for — it stores the bare type). tsgo sets a
+// node's Pos to the end of the preceding token, so the colon always sits at
+// `Type.Pos() - 1`.
+func (w *walker) typeNodeTextWithColon(typeNode *ast.Node) string {
+	if typeNode == nil {
+		return ""
+	}
+	start := typeNode.Pos() - 1
+	if start < 0 || start >= len(w.text) || w.text[start] != ':' {
+		return ""
+	}
+	return w.text[start:typeNode.End()]
+}
+
+// typeParamsText returns `<...>` including both angle brackets, matching the
+// range of ESTree's TSTypeParameterDeclaration. tsgo's type-parameter NodeList
+// spans only the parameters between the brackets.
+func (w *walker) typeParamsText(node *ast.Node) string {
+	list := typeParameterList(node)
+	if list == nil || len(list.Nodes) == 0 {
+		return ""
+	}
+	open := list.Pos() - 1
+	if open < 0 || open >= len(w.text) || w.text[open] != '<' {
+		return ""
+	}
+	// The closing `>` follows the last type parameter, possibly after a
+	// trailing comma and/or trivia.
+	closeIdx := list.End()
+	for closeIdx < len(w.text) {
+		closeIdx = scanner.SkipTrivia(w.text, closeIdx)
+		if closeIdx >= len(w.text) {
+			return ""
+		}
+		if w.text[closeIdx] == '>' {
+			return w.text[open : closeIdx+1]
+		}
+		closeIdx++
+	}
+	return ""
+}
+
+func typeParameterList(node *ast.Node) *ast.NodeList {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction:
+		return node.TypeParameterList()
+	}
+	return nil
+}
+
+// hasOneUnconstrainedTypeParam mirrors upstream's helper of the same name: one
+// type parameter with no `extends` constraint, the shape whose arrow-function
+// form (`<T>(props) => …`) is ambiguous with JSX and therefore unfixable.
+func hasOneUnconstrainedTypeParam(node *ast.Node) bool {
+	list := typeParameterList(node)
+	if list == nil || len(list.Nodes) != 1 {
+		return false
+	}
+	return list.Nodes[0].AsTypeParameterDeclaration().Constraint == nil
+}
+
+// paramsText mirrors upstream's `getParams`: the source span from the first
+// parameter's start to the last parameter's end, excluding the parentheses and
+// any trailing comma.
+func (w *walker) paramsText(node *ast.Node) string {
+	params := node.Parameters()
+	if len(params) == 0 {
+		return ""
+	}
+	start := utils.TrimNodeTextRange(w.ctx.SourceFile, params[0]).Pos()
+	return w.text[start:params[len(params)-1].End()]
+}
+
+// bodyText mirrors upstream's `getBody`: a block body is copied verbatim,
+// while an arrow's expression body is wrapped into an explicit block.
+func (w *walker) bodyText(node *ast.Node) (string, bool) {
+	body := reactutil.FunctionBody(node)
+	if body == nil {
+		return "", false
+	}
+	bodyRange := utils.TrimNodeTextRange(w.ctx.SourceFile, body)
+	if body.Kind != ast.KindBlock {
+		return "{\n  return " + w.text[bodyRange.Pos():bodyRange.End()] + "\n}", true
+	}
+	return w.text[bodyRange.Pos():bodyRange.End()], true
+}
+
+// isUnfixableBecauseOfExport mirrors upstream's helper: a default-exported
+// function declaration has no variable form to be rewritten into. tsgo keeps
+// `export default` as modifiers on the declaration rather than as an
+// ExportDefaultDeclaration parent.
+func isUnfixableBecauseOfExport(node *ast.Node) bool {
+	if node.Kind != ast.KindFunctionDeclaration {
+		return false
+	}
+	return ast.GetCombinedModifierFlags(node)&ast.ModifierFlagsDefault != 0
+}
+
+func isFunctionExpressionWithName(node *ast.Node) bool {
+	return node.Kind == ast.KindFunctionExpression && identifierText(node.Name()) != ""
+}
+
+// isDetectedComponentNode answers upstream's `components.get(node)` for the
+// function node the rule is about to validate — that is, whether the
+// `Components.detect` pipeline registered THIS node (rather than nothing, or a
+// wrapper call around it) with a non-zero confidence.
+func (w *walker) isDetectedComponentNode(node *ast.Node) bool {
+	// Confidence 0: `Components.detect`'s FunctionExpression /
+	// FunctionDeclaration listeners permanently ban an async generator.
+	if node.Kind != ast.KindArrowFunction && reactutil.IsAsyncGeneratorFunction(node) {
+		return false
+	}
+	wrapper := reactutil.OutermostComponentWrapperCall(node, w.pragma, w.wrappers, w.ctx.TypeChecker)
+	if wrapper != nil && reactutil.WrapperWrapsKnownSiblingComponent(wrapper, node) {
+		return false
+	}
+	if !reactutil.IsStatelessReactComponentWithWrappers(node, w.pragma, w.ctx.TypeChecker, w.wrappers) {
+		return false
+	}
+	// `getStatelessComponent` redirects a wrapped function to its outer-most
+	// wrapper call, so the function node itself never enters the components
+	// list — `components.get(node)` is null and the rule stays silent.
+	return wrapper == nil
+}
+
+func contains(list []string, value string) bool {
+	for _, item := range list {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition.md
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition.md
@@ -137,6 +137,10 @@ The autofix rewrites the function's head, so an `async` component loses its
   later `Hello.propTypes = {}` / `Hello.defaultProps = {}` assignment marks it as
   one. ESLint reports `var Hello = function(props) { return 1; }` in that file;
   rslint does not.
+- `namedComponents: []` / `unnamedComponents: []` allows no function form at all.
+  The schema accepts an empty array, but ESLint then has no message to report and
+  aborts the whole lint run with "Missing `message` property in report() call".
+  rslint reports nothing for that category instead of failing the run.
 
 ## Original Documentation
 

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition.md
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition.md
@@ -1,0 +1,144 @@
+# react/function-component-definition
+
+## Rule Details
+
+This rule enforces a consistent function type for React function components. By
+default it prefers function declarations for named components and function
+expressions for unnamed ones.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+const Component = function (props) {
+  return <div>{props.content}</div>;
+};
+
+const Component = (props) => {
+  return <div>{props.content}</div>;
+};
+
+function getComponent() {
+  return (props) => {
+    return <div>{props.content}</div>;
+  };
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+function Component(props) {
+  return <div>{props.content}</div>;
+}
+
+function getComponent() {
+  return function (props) {
+    return <div>{props.content}</div>;
+  };
+}
+```
+
+## Rule Options
+
+```json
+{
+  "react/function-component-definition": [
+    "error",
+    { "namedComponents": "function-declaration", "unnamedComponents": "function-expression" }
+  ]
+}
+```
+
+- `namedComponents` — `"function-declaration"` (default), `"function-expression"`,
+  `"arrow-function"`, or an array of any of those.
+- `unnamedComponents` — `"function-expression"` (default), `"arrow-function"`, or an
+  array of either.
+
+When an array is given, any listed form is accepted and the first entry is the
+one the autofix rewrites to.
+
+Examples of **incorrect** code with `{ "namedComponents": "arrow-function" }`:
+
+```json
+{ "react/function-component-definition": ["error", { "namedComponents": "arrow-function" }] }
+```
+
+```jsx
+function Component(props) {
+  return <div />;
+}
+
+const Component = function (props) {
+  return <div />;
+};
+```
+
+Examples of **correct** code with `{ "namedComponents": "arrow-function" }`:
+
+```json
+{ "react/function-component-definition": ["error", { "namedComponents": "arrow-function" }] }
+```
+
+```jsx
+const Component = (props) => {
+  return <div />;
+};
+```
+
+Examples of **incorrect** code with `{ "unnamedComponents": "arrow-function" }`:
+
+```json
+{ "react/function-component-definition": ["error", { "unnamedComponents": "arrow-function" }] }
+```
+
+```jsx
+function getComponent() {
+  return function (props) {
+    return <div />;
+  };
+}
+```
+
+Examples of **correct** code with `{ "unnamedComponents": "arrow-function" }`:
+
+```json
+{ "react/function-component-definition": ["error", { "unnamedComponents": "arrow-function" }] }
+```
+
+```jsx
+function getComponent() {
+  return (props) => {
+    return <div />;
+  };
+}
+```
+
+## Unfixable patterns
+
+Some reports intentionally come without an autofix, because no equivalent
+rewrite exists:
+
+- A default-exported function declaration, since `export default var Component = …`
+  is not valid syntax.
+- A named function expression, since the rewrite would drop its own binding.
+- A variable with a type annotation being rewritten to a function declaration,
+  since a function declaration has nowhere to put the annotation.
+- A function with exactly one unconstrained type parameter being rewritten to an
+  arrow function, since `<T>(props) => …` is ambiguous with JSX. Two type
+  parameters, or one constrained type parameter, are fixable.
+
+The autofix rewrites the function's head, so an `async` component loses its
+`async` keyword: `async function Component(props) { … }` becomes
+`const Component = (props) => { … }`. Review such a fix before accepting it.
+
+## Differences from ESLint
+
+- A function that returns no JSX is not treated as a component here, even when a
+  later `Hello.propTypes = {}` / `Hello.defaultProps = {}` assignment marks it as
+  one. ESLint reports `var Hello = function(props) { return 1; }` in that file;
+  rslint does not.
+
+## Original Documentation
+
+- [eslint-plugin-react: function-component-definition](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/function-component-definition.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/function-component-definition.js)

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition.schema.json
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition.schema.json
@@ -1,0 +1,46 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "namedComponents": {
+          "anyOf": [
+            {
+              "enum": [
+                "function-declaration",
+                "arrow-function",
+                "function-expression"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "function-declaration",
+                  "arrow-function",
+                  "function-expression"
+                ]
+              }
+            }
+          ]
+        },
+        "unnamedComponents": {
+          "anyOf": [
+            { "enum": ["arrow-function", "function-expression"] },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["arrow-function", "function-expression"]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition_extras_test.go
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition_extras_test.go
@@ -126,6 +126,54 @@ func TestFunctionComponentDefinitionExtras(t *testing.T) {
 			Tsx:     true,
 			Options: []interface{}{map[string]interface{}{}},
 		},
+
+		// ---- Dimension 4: TS type-expression wrapper on the RETURNED value ----
+		// TSESTree keeps `as` / `satisfies` / `!` / `<T>x` as real nodes and
+		// upstream's `isJSXValue` falls through to `default: return false` for
+		// every one of them, so a function whose only `return` is TS-wrapped
+		// does not return JSX upstream and is not a component at all.
+		{
+			Code:    `function Hello() { return <div/> as ReactNode; }`,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		{
+			Code:    `function Hello() { return <div/> as ReactNode; }`,
+			Tsx:     true,
+			Options: named("function-expression"),
+		},
+		// `satisfies` binds inside the arrow body here, so the arrow's own
+		// parent is still the declarator — the component would be reported as
+		// a NAMED one if the wrapper were peeled back.
+		{
+			Code: `const Hello = (props) => <div/> satisfies ReactNode;`,
+			Tsx:  true,
+		},
+
+		// ---- Explicitly configured empty option arrays ----
+		// `[]` is truthy in JS, so upstream's
+		// `[].concat(configuration.namedComponents || 'function-declaration')`
+		// keeps it empty; nothing then matches and upstream reports with
+		// `messageId: undefined`, which makes ESLint abort the run with
+		// "Missing `message` property in report() call". rslint cannot
+		// reproduce that crash, so it stays silent — the point is that it must
+		// NOT quietly fall back to the default list and report a component the
+		// configuration never asked about.
+		{
+			Code:    `function Hello() { return <div/>; }`,
+			Tsx:     true,
+			Options: named([]interface{}{}),
+		},
+		{
+			Code:    `const Hello = (props) => { return <div/>; };`,
+			Tsx:     true,
+			Options: named([]interface{}{}),
+		},
+		{
+			Code:    `function wrap() { return function() { return <div/>; }; }`,
+			Tsx:     true,
+			Options: unnamed([]interface{}{}),
+		},
 	}, []rule_tester.InvalidTestCase{
 		// Schema defaults: omitting the options entirely and passing an empty
 		// object must produce byte-identical output.
@@ -186,6 +234,25 @@ func TestFunctionComponentDefinitionExtras(t *testing.T) {
 			Options: named("function-expression"),
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 1, Column: 13, EndLine: 1, EndColumn: 30}},
 		},
+		// ---- Dimension 4: parenthesized arrow expression body ----
+		// Upstream slices `node.body.range`, and ESTree has no node for the
+		// parentheses, so the synthesized block body carries the inner
+		// expression only. tsgo keeps a ParenthesizedExpression node, so the
+		// parentheses have to be peeled back to produce the same fix.
+		{
+			Code:   `const Hello = (props) => (condition ? <A/> : null);`,
+			Tsx:    true,
+			Output: []string{"function Hello(props) {\n  return condition ? <A/> : null\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 1, Column: 15, EndLine: 1, EndColumn: 51}},
+		},
+		{
+			Code:    `const Hello = (props) => (condition ? <A/> : null);`,
+			Tsx:     true,
+			Output:  []string{"const Hello = function(props) {\n  return condition ? <A/> : null\n}"},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 1, Column: 15, EndLine: 1, EndColumn: 51}},
+		},
+
 		// ---- Dimension 4: parameter with a leading comment ----
 		// ESTree parameter ranges exclude leading comments, and so does the
 		// trimmed tsgo range, so the comment is dropped from the rewritten

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition_extras_test.go
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition_extras_test.go
@@ -1,0 +1,420 @@
+package function_component_definition
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestFunctionComponentDefinitionExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+func TestFunctionComponentDefinitionExtras(t *testing.T) {
+	named := func(value interface{}) []interface{} {
+		return []interface{}{map[string]interface{}{"namedComponents": value}}
+	}
+	unnamed := func(value interface{}) []interface{} {
+		return []interface{}{map[string]interface{}{"unnamedComponents": value}}
+	}
+
+	// Dimension 4 rows that do not apply to this rule:
+	// N/A: optional chain / member-access receivers — the rule inspects
+	// function nodes and their declarators, never a property access.
+	// N/A: literal kinds — no literal value is ever compared.
+	// N/A: computed member keys as an equivalence class — an object property of
+	// any key shape hits the same `Property` early return.
+	// N/A: class bodies — methods and accessors are MethodDeclaration /
+	// GetAccessor / SetAccessor in tsgo and are never collected, matching
+	// upstream's `Property` early return for the object-literal forms.
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &FunctionComponentDefinitionRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: TS type-expression wrapper on the initializer ----
+		// TSESTree keeps `as` / `satisfies` / `!` as real nodes, so the function
+		// is not in one of the positions component detection accepts and is not
+		// a component at all.
+		{
+			Code:    `var Hello = ((props) => { return <div/>; }) as React.FC;`,
+			Tsx:     true,
+			Options: named("function-expression"),
+		},
+
+		// A function that returns no JSX is only a component upstream because a
+		// later `Hello.propTypes = …` assignment registers it; rslint has no
+		// equivalent of that late registration, so nothing is reported. See the
+		// rule doc's "Differences from ESLint".
+		{
+			Code:    "var Hello = function(props) { return 1; }\nHello.propTypes = {};",
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+
+		// ---- Dimension 4: body-absent function forms ----
+		// An overload signature and an ambient declaration have no body, so
+		// they can never return JSX and are never components.
+		{
+			Code:    "declare function Hello(props: Test): JSX.Element;",
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		// ---- Dimension 4: empty function body ----
+		{
+			Code:    `function Hello(props) {}`,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+
+		// Locks in upstream Components.detect FunctionDeclaration listener arm 1:
+		// `node.async && node.generator` registers confidence 0, which bans the
+		// node from `components.get` no matter what it returns.
+		{
+			Code:    `async function* Hello(props) { return <div/>; }`,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		{
+			Code:    `var Hello = async function*(props) { return <div/>; };`,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+
+		// Locks in upstream getStatelessComponent's pragma-wrapper arm: the
+		// component is registered against the WRAPPER call, so
+		// `components.get(fn)` is null and the inner function is never checked.
+		{
+			Code:    `const Foo = React.memo((props) => { return <div/>; });`,
+			Tsx:     true,
+			Options: unnamed("function-expression"),
+		},
+		{
+			Code:    `const Foo = React.forwardRef(function(props, ref) { return <div/>; });`,
+			Tsx:     true,
+			Options: unnamed("arrow-function"),
+		},
+		// Nested wrappers redirect to the OUTER-MOST call, so neither the inner
+		// function nor an intermediate wrapper is validated.
+		{
+			Code:    `const Foo = React.memo(React.forwardRef((props, ref) => { return <div/>; }));`,
+			Tsx:     true,
+			Options: unnamed("function-expression"),
+		},
+
+		// ---- Dimension 4: computed property key ----
+		// Upstream's `node.parent.type === 'Property'` early return covers
+		// computed keys too.
+		{
+			Code:    `const key = 'a'; const obj = { [key]: (props) => { return <div/>; } };`,
+			Tsx:     true,
+			Options: named("function-declaration"),
+		},
+
+		// Locks in the default options: named components default to
+		// `function-declaration` and unnamed ones to `function-expression`.
+		{
+			Code: `function Hello(props) { return <div/>; }`,
+			Tsx:  true,
+		},
+		{
+			Code:    `function wrap() { return function(props) { return <div/>; }; }`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// Schema defaults: omitting the options entirely and passing an empty
+		// object must produce byte-identical output.
+		{
+			Code:   `var Hello = (props) => { return <div/>; };`,
+			Tsx:    true,
+			Output: []string{`function Hello(props) { return <div/>; }`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 1, Column: 13, EndLine: 1, EndColumn: 42}},
+		},
+		{
+			Code:    `var Hello = (props) => { return <div/>; };`,
+			Tsx:     true,
+			Output:  []string{`function Hello(props) { return <div/>; }`},
+			Options: []interface{}{map[string]interface{}{}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 1, Column: 13, EndLine: 1, EndColumn: 42}},
+		},
+
+		// ---- Dimension 4: parenthesized initializer ----
+		// ESTree has no ParenthesizedExpression, so upstream sees the variable
+		// declarator as the arrow's direct parent and treats the component as
+		// named. The parentheses are inside the replaced declaration, so the
+		// fix drops them.
+		{
+			Code:    `var Hello = ((props) => { return <div/>; });`,
+			Tsx:     true,
+			Output:  []string{`var Hello = function(props) { return <div/>; }`},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 1, Column: 14, EndLine: 1, EndColumn: 43}},
+		},
+
+		// The same shape returning JSX is a component on its own merit, so the
+		// `propTypes` assignment makes no difference here.
+		{
+			Code:    "function Hello(props) { return <div/>; }\nHello.propTypes = {};",
+			Tsx:     true,
+			Output:  []string{"const Hello = (props) => { return <div/>; }\nHello.propTypes = {};"},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 1, EndColumn: 41}},
+		},
+
+		// ---- Dimension 4: empty parameter list ----
+		// Locks in upstream getParams()'s `params.length === 0 → null` arm,
+		// which `buildFunction` turns into the empty string.
+		{
+			Code:    `function Hello() { return <div/>; }`,
+			Tsx:     true,
+			Output:  []string{`const Hello = () => { return <div/>; }`},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 1, EndColumn: 36}},
+		},
+		// ---- Dimension 4: arrow with an expression body ----
+		// Locks in upstream getBody()'s non-BlockStatement arm, which wraps the
+		// expression in a synthesized block with fixed two-space indentation.
+		{
+			Code:    `var Hello = (props) => <div/>;`,
+			Tsx:     true,
+			Output:  []string{"var Hello = function(props) {\n  return <div/>\n}"},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 1, Column: 13, EndLine: 1, EndColumn: 30}},
+		},
+		// ---- Dimension 4: parameter with a leading comment ----
+		// ESTree parameter ranges exclude leading comments, and so does the
+		// trimmed tsgo range, so the comment is dropped from the rewritten
+		// parameter list either way.
+		{
+			Code:    `function Hello(/* props */ props) { return <div/>; }`,
+			Tsx:     true,
+			Output:  []string{`const Hello = (props) => { return <div/>; }`},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 1, EndColumn: 53}},
+		},
+		// ---- Dimension 4: trailing comma in the parameter list ----
+		// The copied span ends at the last parameter, so the trailing comma is
+		// dropped.
+		{
+			Code:    `function Hello(props,) { return <div/>; }`,
+			Tsx:     true,
+			Output:  []string{`const Hello = (props) => { return <div/>; }`},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 1, EndColumn: 42}},
+		},
+		// ---- Dimension 4: default and rest parameters ----
+		{
+			Code:    `function Hello(props = {}, ...rest) { return <div/>; }`,
+			Tsx:     true,
+			Output:  []string{`const Hello = (props = {}, ...rest) => { return <div/>; }`},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 1, EndColumn: 55}},
+		},
+
+		// ---- Dimension 4: async function component ----
+		// The rewrite templates have no slot for `async`, so upstream's fix
+		// drops the keyword. Mirrored verbatim rather than diverging.
+		{
+			Code:    `async function Hello(props) { return <div/>; }`,
+			Tsx:     true,
+			Output:  []string{`const Hello = (props) => { return <div/>; }`},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 1, EndColumn: 47}},
+		},
+
+		// ---- Dimension 4: JSX fragment return ----
+		// A fragment makes the function a component, but ESTree models it as
+		// JSXFragment, which upstream's `hasES6OrJsx` selector does not list —
+		// so the synthesized variable is still `var`, not `const`.
+		{
+			Code:    `function Hello() { return <></>; }`,
+			Tsx:     true,
+			Output:  []string{`var Hello = function() { return <></>; }`},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 1, Column: 1, EndLine: 1, EndColumn: 35}},
+		},
+
+		// Locks in upstream's `varType = node.parent.parent.kind` override:
+		// the declarator's own keyword wins over the file-level default.
+		{
+			Code:    `const Hello = (props) => { return <div/>; };`,
+			Tsx:     true,
+			Output:  []string{`const Hello = function(props) { return <div/>; }`},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 1, Column: 15, EndLine: 1, EndColumn: 44}},
+		},
+
+		// Locks in each `hasES6OrJsx` arm that raises fileVarType to `const`
+		// without any JSX or `const`/`let` declaration in the file.
+		{
+			// `export * from` — ESTree ExportAllDeclaration.
+			Code:    "export * from './x';\nfunction Hello(props) { return React.createElement('div'); }",
+			Tsx:     true,
+			Output:  []string{"export * from './x';\nconst Hello = function(props) { return React.createElement('div'); }"},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 1, EndLine: 2, EndColumn: 61}},
+		},
+		{
+			// `export { x }` — ESTree ExportNamedDeclaration / ExportSpecifier.
+			Code:    "var x = 1;\nexport { x };\nfunction Hello(props) { return React.createElement('div'); }",
+			Tsx:     true,
+			Output:  []string{"var x = 1;\nexport { x };\nconst Hello = function(props) { return React.createElement('div'); }"},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 3, Column: 1, EndLine: 3, EndColumn: 61}},
+		},
+		{
+			// `import x = require(...)` — ESTree TSImportEqualsDeclaration.
+			Code:    "import x = require('./x');\nfunction Hello(props) { return React.createElement('div'); }",
+			Tsx:     true,
+			Output:  []string{"import x = require('./x');\nconst Hello = function(props) { return React.createElement('div'); }"},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 1, EndLine: 2, EndColumn: 61}},
+		},
+
+		// ---- Real-user: #3207, "do not break on dollar signs" ----
+		// Every `$`-prefixed replacement pattern JavaScript's String#replace
+		// understands must survive the template substitution untouched.
+		{
+			Code:    "function Hello(props) {\n  return <div>{'$&' + \"$`\" + '$1' + \"$$\"}</div>;\n}",
+			Tsx:     true,
+			Output:  []string{"const Hello = (props) => {\n  return <div>{'$&' + \"$`\" + '$1' + \"$$\"}</div>;\n}"},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 3, EndColumn: 2}},
+		},
+		// ---- Real-user: #3248, "replace var by const in certain situations" ----
+		// A `let` anywhere in the file is enough to make the synthesized
+		// declaration `const`, even when the component itself returns no JSX.
+		{
+			Code:    "let counter = 0;\nfunction Hello(props) { return React.createElement('div'); }",
+			Tsx:     true,
+			Output:  []string{"let counter = 0;\nconst Hello = function(props) { return React.createElement('div'); }"},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 1, EndLine: 2, EndColumn: 61}},
+		},
+
+		// Locks in upstream hasOneUnconstrainedTypeParam()'s `length === 1` arm:
+		// two type parameters are unambiguous, so the arrow fix is offered.
+		{
+			Code:    `function Hello<T1, T2>(props: Props<T1, T2>) { return <div/>; }`,
+			Tsx:     true,
+			Output:  []string{`const Hello = <T1, T2>(props: Props<T1, T2>) => { return <div/>; }`},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 1, Column: 1, EndLine: 1, EndColumn: 64}},
+		},
+
+		// ---- Dimension 4: multi-declarator variable statement ----
+		// Upstream replaces `node.parent.parent.range` — the WHOLE declaration,
+		// including sibling declarators. Mirrored verbatim.
+		{
+			Code:    `var a = 1, Hello = (props) => { return <div/>; };`,
+			Tsx:     true,
+			Output:  []string{`var Hello = function(props) { return <div/>; }`},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 1, Column: 20, EndLine: 1, EndColumn: 49}},
+		},
+
+		// Locks in the report order for a file with both a named and an unnamed
+		// offender: reports follow source order, matching upstream's single
+		// `Program:exit` pass over the collected pairs.
+		{
+			Code:    "var Hello = (props) => { return <div/>; };\nfunction wrap() { return function(props) { return <span/>; }; }",
+			Tsx:     true,
+			Output:  []string{"var Hello = function(props) { return <div/>; }\nfunction wrap() { return (props) => { return <span/>; }; }"},
+			Options: []interface{}{map[string]interface{}{"namedComponents": "function-expression", "unnamedComponents": "arrow-function"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "function-expression", Line: 1, Column: 13, EndLine: 1, EndColumn: 42},
+				{MessageId: "arrow-function", Line: 2, Column: 26, EndLine: 2, EndColumn: 61},
+			},
+		},
+	})
+}
+
+// TestFunctionComponentDefinitionEditDemand exercises Dimension 3 (autofix
+// boundaries): diagnostic count, message, and range must stay identical across
+// every edit demand, and the replacement text must materialize only when an
+// autofix is actually requested.
+func TestFunctionComponentDefinitionEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"var Hello = (props) => { return <div/>; };\nvar World = (props) => { return <span/>; };",
+		"edit-demand.tsx",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name:     FunctionComponentDefinitionRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return FunctionComponentDefinitionRule.Run(ctx, []any{
+							map[string]any{"namedComponents": "function-expression"},
+						})
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got, want := withoutEdits(diagnostics[index]), withoutEdits(allEdits[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if fixes := *allEdits[index].FixesPtr; len(fixes) == 0 {
+			t.Fatalf("diagnostic %d: all-edits demand produced no fixes", index)
+		}
+		if diagnostic := allEdits[index]; diagnostic.Suggestions != nil {
+			t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+		}
+	}
+}

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition_extras_test.go
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition_extras_test.go
@@ -56,6 +56,22 @@ func TestFunctionComponentDefinitionExtras(t *testing.T) {
 			Options: named("arrow-function"),
 		},
 
+		// ---- TS `export =` is not an `export default` ----
+		// tsgo gives `export default <expr>` and `export = <expr>` the same
+		// KindExportAssignment node, but typescript-eslint models the latter as
+		// TSExportAssignment, which eslint-plugin-react's component detection
+		// never matches — so neither of these is a component upstream.
+		{
+			Code:    `export = function Hello() { return <div/>; };`,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		{
+			Code:    `export = () => <div/>;`,
+			Tsx:     true,
+			Options: unnamed("function-expression"),
+		},
+
 		// ---- Dimension 4: body-absent function forms ----
 		// An overload signature and an ambient declaration have no body, so
 		// they can never return JSX and are never components.

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition_upstream_test.go
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition_upstream_test.go
@@ -1,0 +1,1069 @@
+package function_component_definition
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestFunctionComponentDefinitionUpstream migrates the full valid/invalid
+// suite from upstream tests/lib/rules/function-component-definition.js 1:1.
+// Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in the
+// function_component_definition_extras_test.go file.
+func TestFunctionComponentDefinitionUpstream(t *testing.T) {
+	named := func(value interface{}) []interface{} {
+		return []interface{}{map[string]interface{}{"namedComponents": value}}
+	}
+	unnamed := func(value interface{}) []interface{} {
+		return []interface{}{map[string]interface{}{"unnamedComponents": value}}
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &FunctionComponentDefinitionRule, []rule_tester.ValidTestCase{
+		// ---- class components are never reported ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() { return <div>Hello {this.props.name}</div> }
+        }
+      `,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() { return <div>Hello {this.props.name}</div> }
+        }
+      `,
+			Tsx:     true,
+			Options: named("function-declaration"),
+		},
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() { return <div>Hello {this.props.name}</div> }
+        }
+      `,
+			Tsx:     true,
+			Options: named("function-expression"),
+		},
+
+		// ---- named components matching the configured form ----
+		{Code: `var Hello = (props) => { return <div/> }`, Tsx: true, Options: named("arrow-function")},
+		{Code: `const Hello = (props) => { return <div/> }`, Tsx: true, Options: named("arrow-function")},
+		{Code: `function Hello(props) { return <div/> }`, Tsx: true, Options: named("function-declaration")},
+		{Code: `var Hello = function(props) { return <div/> }`, Tsx: true, Options: named("function-expression")},
+		{Code: `const Hello = function(props) { return <div/> }`, Tsx: true, Options: named("function-expression")},
+
+		// ---- unnamed components matching the configured form ----
+		{Code: `function Hello() { return function() { return <div/> } }`, Tsx: true, Options: unnamed("function-expression")},
+		{Code: `function Hello() { return () => { return <div/> }}`, Tsx: true, Options: unnamed("arrow-function")},
+
+		// ---- pragma-wrapped components are registered on the wrapper call ----
+		{Code: `var Foo = React.memo(function Foo() { return <p/> })`, Tsx: true, Options: named("function-declaration")},
+		{Code: `const Foo = React.memo(function Foo() { return <p/> })`, Tsx: true, Options: named("function-declaration")},
+
+		// ---- functions starting with a lowercase letter are not components ----
+		{
+			Code: `
+        const selectAvatarByUserId = (state, id) => {
+          const user = selectUserById(state, id)
+          return null
+        }
+      `,
+			Tsx:     true,
+			Options: named("function-declaration"),
+		},
+		{
+			Code: `
+        function ensureValidSourceType(sourceType: string) {
+          switch (sourceType) {
+            case 'ALBUM':
+            case 'PLAYLIST':
+              return sourceType;
+            default:
+              return null;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+
+		// ---- TypeScript-annotated components matching the configured form ----
+		{Code: `function Hello(props: Test) { return <p/> }`, Tsx: true, Options: named("function-declaration")},
+		{Code: `var Hello = function(props: Test) { return <p/> }`, Tsx: true, Options: named("function-expression")},
+		{Code: `var Hello = (props: Test) => { return <p/> }`, Tsx: true, Options: named("arrow-function")},
+		{Code: `var Hello: React.FC<Test> = function(props) { return <p/> }`, Tsx: true, Options: named("function-expression")},
+		{Code: `var Hello: React.FC<Test> = (props) => { return <p/> }`, Tsx: true, Options: named("arrow-function")},
+		{Code: `function Hello<Test>(props: Props<Test>) { return <p/> }`, Tsx: true, Options: named("function-declaration")},
+		{Code: `function Hello<Test extends {}>(props: Props<Test>) { return <p/> }`, Tsx: true, Options: named("function-declaration")},
+		{Code: `var Hello = function<Test>(props: Props<Test>) { return <p/> }`, Tsx: true, Options: named("function-expression")},
+		{Code: `var Hello = function<Test extends {}>(props: Props<Test>) { return <p/> }`, Tsx: true, Options: named("function-expression")},
+		{Code: `var Hello = <Test extends {}>(props: Props<Test>) => { return <p/> }`, Tsx: true, Options: named("arrow-function")},
+		{Code: `function wrapper() { return function<Test>(props: Props<Test>) { return <p/> } } `, Tsx: true, Options: unnamed("function-expression")},
+		{Code: `function wrapper() { return function<Test extends {}>(props: Props<Test>) { return <p/> } } `, Tsx: true, Options: unnamed("function-expression")},
+		{Code: `function wrapper() { return<Test extends {}>(props: Props<Test>) => { return <p/> } } `, Tsx: true, Options: unnamed("arrow-function")},
+		{Code: `var Hello = function(props): ReactNode { return <p/> }`, Tsx: true, Options: named("function-expression")},
+		{Code: `var Hello = (props): ReactNode => { return <p/> }`, Tsx: true, Options: named("arrow-function")},
+		{Code: `function wrapper() { return function(props): ReactNode { return <p/> } }`, Tsx: true, Options: unnamed("function-expression")},
+		{Code: `function wrapper() { return (props): ReactNode => { return <p/> } }`, Tsx: true, Options: unnamed("arrow-function")},
+		{Code: `function Hello(props): ReactNode { return <p/> }`, Tsx: true, Options: named("function-declaration")},
+
+		// ---- object properties are never reported (issue #2765) ----
+		{
+			Code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: named("function-declaration"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: named("function-expression"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: named("function-declaration"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: named("function-expression"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: named("function-declaration"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: named("arrow-function"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: named("function-expression"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: unnamed("arrow-function"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: unnamed("function-expression"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: unnamed("arrow-function"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: unnamed("function-expression"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: unnamed("arrow-function"),
+		},
+		{
+			Code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: unnamed("function-expression"),
+		},
+
+		// ---- array-valued options accept any listed form ----
+		{Code: `function Hello(props) { return <div/> }`, Tsx: true, Options: named([]interface{}{"function-declaration", "function-expression"})},
+		{Code: `var Hello = function(props) { return <div/> }`, Tsx: true, Options: named([]interface{}{"function-declaration", "function-expression"})},
+		{Code: `var Foo = React.memo(function Foo() { return <p/> })`, Tsx: true, Options: named([]interface{}{"function-declaration", "function-expression"})},
+		{Code: `function Hello(props: Test) { return <p/> }`, Tsx: true, Options: named([]interface{}{"function-declaration", "function-expression"})},
+		{Code: `var Hello = function(props: Test) { return <p/> }`, Tsx: true, Options: named([]interface{}{"function-expression", "function-expression"})},
+		{Code: `var Hello = (props: Test) => { return <p/> }`, Tsx: true, Options: named([]interface{}{"arrow-function", "function-expression"})},
+		{
+			Code: `
+        function wrap(Component) {
+          return function(props) {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+			Tsx:     true,
+			Options: unnamed([]interface{}{"arrow-function", "function-expression"}),
+		},
+		{
+			Code: `
+        function wrap(Component) {
+          return (props) => {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+			Tsx:     true,
+			Options: unnamed([]interface{}{"arrow-function", "function-expression"}),
+		},
+
+		// ---- non-JSX functions are not components ----
+		{
+			Code: `
+        export default (key, subTree = {}) => {
+          return (state) => {
+            const dataInStore = getFromDataModel(key)(state);
+            const fullPaths = dataInStore.map((item, index) => {
+              return [key, index];
+            });
+
+            return {
+              key,
+              paths: fullPaths.map((p) => [p[1]]),
+              fullPaths,
+              subTree: Object.keys(subTree).length ? subTree : null,
+            }
+          };
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        function mapStateToProps() {
+          const internItems = makeInternArray();
+          const internClassList = makeInternArray();
+
+          return (state, props) => {
+            const { store, bucket, singleCharacter } = props;
+
+            return {
+              store: null,
+              destinyVersion: store.destinyVersion,
+              storeId: store.id,
+            }
+          }
+        }
+      `,
+			Tsx: true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- named components: JavaScript forms ----
+		{
+			Code: `
+        function Hello(props) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = (props) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Message: "Function component is not an arrow function", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = function(props) {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = (props) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        function Hello(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Message: "Function component is not a function declaration", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = function(props) {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        function Hello(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = function(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Message: "Function component is not a function expression", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        let Hello = (props) => {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        let Hello = function(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        let Hello;
+        Hello = (props) => {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        let Hello;
+        Hello = function(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 3, Column: 17, EndLine: 5, EndColumn: 10}},
+		},
+		{
+			Code: `
+        let Hello = (props) => {
+          return <div/>;
+        }
+        Hello = function(props) {
+          return <span/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        let Hello = function(props) {
+          return <div/>;
+        }
+        Hello = function(props) {
+          return <span/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        function Hello(props) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = function(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+
+		// ---- unnamed components ----
+		{
+			Code: `
+        function wrap(Component) {
+          return function(props) {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        function wrap(Component) {
+          return (props) => {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `},
+			Options: unnamed("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 3, Column: 18, EndLine: 5, EndColumn: 12}},
+		},
+		{
+			Code: `
+        function wrap(Component) {
+          return (props) => {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        function wrap(Component) {
+          return function(props) {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `},
+			Options: unnamed("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 3, Column: 18, EndLine: 5, EndColumn: 12}},
+		},
+
+		// ---- TypeScript parameter annotations ----
+		{
+			Code: `
+        var Hello = (props: Test) => {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        function Hello(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = function(props: Test) {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        function Hello(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        function Hello(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = (props: Test) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = function(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = (props: Test) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        function Hello(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = function(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+
+		// ---- fileVarType: `var` unless the file uses ES module syntax or JSX ----
+		{
+			Code: `
+        function Hello(props: Test) {
+          return React.createElement('div');
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = function(props: Test) {
+          return React.createElement('div');
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        import * as React from 'react';
+        function Hello(props: Test) {
+          return React.createElement('div');
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        import * as React from 'react';
+        const Hello = function(props: Test) {
+          return React.createElement('div');
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 3, Column: 9, EndLine: 5, EndColumn: 10}},
+		},
+		{
+			Code: `
+        export function Hello(props: Test) {
+          return React.createElement('div');
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        export const Hello = function(props: Test) {
+          return React.createElement('div');
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 16, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        function Hello(props) {
+          return React.createElement('div');
+        }
+        export default Hello;
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = function(props) {
+          return React.createElement('div');
+        }
+        export default Hello;
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = (props: Test) => {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = function(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+
+		// ---- variable type annotations ----
+		{
+			Code: `
+        var Hello: React.FC<Test> = (props) => {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello: React.FC<Test> = function(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 37, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello: React.FC<Test> = function(props) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello: React.FC<Test> = (props) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 37, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			// A type-annotated variable has no function-declaration form to move
+			// the annotation to, so the diagnostic carries no fix.
+			Code: `
+        var Hello: React.FC<Test> = function(props) {
+          return <div/>;
+        }
+      `,
+			Tsx:     true,
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 37, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello: React.FC<Test> = (props) => {
+          return <div/>;
+        };
+      `,
+			Tsx:     true,
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 37, EndLine: 4, EndColumn: 10}},
+		},
+
+		// ---- type parameters ----
+		{
+			Code: `
+        function Hello<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = <Test extends {}>(props: Test) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			// One unconstrained type parameter would produce `<Test>(props) =>`,
+			// which is ambiguous with JSX, so no fix is offered.
+			Code: `
+        function Hello<Test>(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx:     true,
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        function Hello<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        function Hello<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = <Test extends {}>(props: Test) => {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = <Test extends {}>(props: Test) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        function Hello<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        function wrap(Component) {
+          return function<Test extends {}>(props) {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        function wrap(Component) {
+          return <Test extends {}>(props) => {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `},
+			Options: unnamed("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 3, Column: 18, EndLine: 5, EndColumn: 12}},
+		},
+		{
+			Code: `
+        function wrap(Component) {
+          return function<Test>(props) {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: unnamed("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 3, Column: 18, EndLine: 5, EndColumn: 12}},
+		},
+		{
+			Code: `
+        function wrap(Component) {
+          return <Test extends {}>(props) => {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        function wrap(Component) {
+          return function<Test extends {}>(props) {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `},
+			Options: unnamed("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 3, Column: 18, EndLine: 5, EndColumn: 12}},
+		},
+
+		// ---- return type annotations ----
+		{
+			Code: `
+        function wrap(Component) {
+          return function(props): ReactNode {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        function wrap(Component) {
+          return (props): ReactNode => {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `},
+			Options: unnamed("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 3, Column: 18, EndLine: 5, EndColumn: 12}},
+		},
+		{
+			Code: `
+        function wrap(Component) {
+          return (props): ReactNode => {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        function wrap(Component) {
+          return function(props): ReactNode {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `},
+			Options: unnamed("function-expression"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 3, Column: 18, EndLine: 5, EndColumn: 12}},
+		},
+
+		// ---- exported components ----
+		{
+			Code: `
+        export function Hello(props) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        export const Hello = (props) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 16, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        export var Hello = function(props) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        export var Hello = (props) => {
+          return <div/>;
+        }
+      `},
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 28, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        export var Hello = (props) => {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        export function Hello(props) {
+          return <div/>;
+        }
+      `},
+			Options: named("function-declaration"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 28, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			// `export default var Hello = …` is not valid syntax, so this shape
+			// has to be fixed by hand.
+			Code: `
+        export default function Hello(props) {
+          return <div/>;
+        }
+      `,
+			Tsx:     true,
+			Options: named("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 24, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			// A named function expression keeps its own binding, so rewriting it
+			// into an arrow would drop the name.
+			Code: `
+        module.exports = function Hello(props) {
+          return <div/>;
+        }
+      `,
+			Tsx:     true,
+			Options: unnamed("arrow-function"),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 26, EndLine: 4, EndColumn: 10}},
+		},
+
+		// ---- array-valued options report the first listed form ----
+		{
+			Code: `
+        function Hello(props) {
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Hello = (props) => {
+          return <div/>;
+        }
+      `},
+			Options: named([]interface{}{"arrow-function", "function-expression"}),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrow-function", Line: 2, Column: 9, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        function Hello(props) {
+          return <div/>;
+        }
+      `},
+			Options: named([]interface{}{"function-declaration", "function-expression"}),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        var Hello = function(props) {
+          return <div/>;
+        }
+      `},
+			Options: named([]interface{}{"function-expression", "function-declaration"}),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-expression", Line: 2, Column: 21, EndLine: 4, EndColumn: 10}},
+		},
+		{
+			Code:    "\n        const genX = (symbol) => `the symbol is ${symbol}`;\n\n        const IndexPage = () => {\n          return (\n            <div>\n              Hello World.{genX('$')}\n            </div>\n          )\n        }\n\n        export default IndexPage;\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        const genX = (symbol) => `the symbol is ${symbol}`;\n\n        function IndexPage() {\n          return (\n            <div>\n              Hello World.{genX('$')}\n            </div>\n          )\n        }\n\n        export default IndexPage;\n      "},
+			Options: named([]interface{}{"function-declaration"}),
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "function-declaration", Line: 4, Column: 27, EndLine: 10, EndColumn: 10}},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp.go
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp.go
@@ -47,82 +47,6 @@ type componentEntry struct {
 	pos  int
 }
 
-// isAsyncGenerator reports whether `node` is a function expression /
-// declaration / object-literal shorthand method that is BOTH `async` AND a
-// generator (`function*` or `async *Foo() {}`). Mirrors upstream's
-// `node.async && node.generator` gate inside the `Components.detect` FE / FD
-// listeners — the only path that adds a node with `confidence 0` and excludes
-// it from `components.list()`. Arrow functions cannot be generators, so this
-// never fires on KindArrowFunction.
-//
-// MethodDeclaration is included because ESTree's
-// `Property { method: true, value: FunctionExpression }` shape funnels object-
-// literal shorthand methods through the same FE listener upstream — so a
-// `{ async *Foo() {...} }` declaration is banned upstream as an async-generator
-// FE. tsgo collapses this into a MethodDeclaration whose AsteriskToken / async
-// modifier carry the same signal; we honor it here.
-func isAsyncGenerator(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	mods := node.Modifiers()
-	hasAsync := false
-	if mods != nil {
-		for _, m := range mods.Nodes {
-			if m.Kind == ast.KindAsyncKeyword {
-				hasAsync = true
-				break
-			}
-		}
-	}
-	if !hasAsync {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindFunctionDeclaration:
-		return node.AsFunctionDeclaration().AsteriskToken != nil
-	case ast.KindFunctionExpression:
-		return node.AsFunctionExpression().AsteriskToken != nil
-	case ast.KindMethodDeclaration:
-		return node.AsMethodDeclaration().AsteriskToken != nil
-	}
-	return false
-}
-
-// outermostWrapperCall walks up through nested pragma-wrapper calls (paren /
-// TS-wrapper transparent) and returns the outer-most CallExpression that
-// matches `wrappers`. Mirrors upstream's `getPragmaComponentWrapper` which
-// loops while `isPragmaComponentWrapper(currentNode.parent)` keeps yielding
-// truthy and tracks the last truthy ancestor. Returns nil when the immediate
-// effective parent is not a matching wrapper.
-//
-// Why upstream walks up: for `React.memo(React.forwardRef(arrow))`, the inner
-// arrow's getStatelessComponent returns `pragmaComponentWrapper` — the
-// OUTER-MOST wrapper, not the inner forwardRef call. The component is then
-// registered against the memo call's range, which on multi-line source
-// changes the report's line number compared to picking the inner wrapper.
-func outermostWrapperCall(fn *ast.Node, pragma string, wrappers []reactutil.ComponentWrapperEntry, tc *checker.Checker) *ast.Node {
-	cur := reactutil.SkipExpressionWrappersUp(fn)
-	if cur == nil || cur.Kind != ast.KindCallExpression ||
-		!reactutil.MatchesAnyComponentWrapperWithChecker(cur, fn, wrappers, pragma, tc) {
-		return nil
-	}
-	for {
-		// Try ascending one more level: the parent of the current
-		// wrapper call (paren/TS-wrapper transparent) must itself be a
-		// CallExpression matching the wrappers list, with `cur` as its
-		// FIRST argument.
-		next := reactutil.SkipExpressionWrappersUp(cur)
-		if next == nil || next.Kind != ast.KindCallExpression {
-			return cur
-		}
-		if !reactutil.MatchesAnyComponentWrapperWithChecker(next, cur, wrappers, pragma, tc) {
-			return cur
-		}
-		cur = next
-	}
-}
-
 // collectComponents walks the source file once and returns every node the
 // upstream `Components.detect` pipeline would register at confidence ≥ 2,
 // deduplicated by node pointer and sorted by source position. Mirrors
@@ -188,8 +112,8 @@ func collectComponents(sf *ast.SourceFile, pragma, createClass string, wrappers 
 			// MethodDeclaration form does not slip past
 			// IsStatelessReactComponentWithWrappers (which lacks this
 			// gate). Getters / setters cannot be generators by syntax,
-			// so `isAsyncGenerator` always returns false on them.
-			if isAsyncGenerator(n) {
+			// so `IsAsyncGeneratorFunction` always returns false on them.
+			if reactutil.IsAsyncGeneratorFunction(n) {
 				break
 			}
 			if reactutil.IsStatelessReactComponentWithWrappers(n, pragma, tc, wrappers) {
@@ -203,7 +127,7 @@ func collectComponents(sf *ast.SourceFile, pragma, createClass string, wrappers 
 			// adds the node with confidence 0, which never surfaces in
 			// `components.list()`. Arrow functions can't be generators
 			// (syntax) so this gate only fires on FE/FD.
-			if n.Kind != ast.KindArrowFunction && isAsyncGenerator(n) {
+			if n.Kind != ast.KindArrowFunction && reactutil.IsAsyncGeneratorFunction(n) {
 				break
 			}
 			directParent := reactutil.SkipExpressionWrappersUp(n)
@@ -234,7 +158,7 @@ func collectComponents(sf *ast.SourceFile, pragma, createClass string, wrappers 
 				// must mirror that ascent to keep the report node's
 				// line number aligned with upstream when wrappers span
 				// multiple lines.
-				if outer := outermostWrapperCall(n, pragma, wrappers, tc); outer != nil {
+				if outer := reactutil.OutermostComponentWrapperCall(n, pragma, wrappers, tc); outer != nil {
 					add(outer)
 				} else {
 					add(n)
@@ -246,7 +170,7 @@ func collectComponents(sf *ast.SourceFile, pragma, createClass string, wrappers 
 				// only honors wrappers in its Branch 11; user wrappers
 				// applied to a FunctionLike that doesn't satisfy a
 				// branch's structural gates need this explicit check.
-				if outer := outermostWrapperCall(n, pragma, wrappers, tc); outer != nil {
+				if outer := reactutil.OutermostComponentWrapperCall(n, pragma, wrappers, tc); outer != nil {
 					add(outer)
 				}
 			}

--- a/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components_test.go
+++ b/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components_test.go
@@ -760,6 +760,29 @@ func TestNoUnstableNestedComponentsRule(t *testing.T) {
           return <Wrap />;
         }
       `, Tsx: true},
+
+		// ---- TS expression wrappers on the returned value ----
+		// TSESTree keeps `satisfies` / `as` / `!` / `<T>x` as real nodes and
+		// upstream's `isJSXValue` falls through to `default: return false` for
+		// all of them, so a function whose only `return` is TS-wrapped is not a
+		// component upstream and nothing is reported. Verified against
+		// eslint-plugin-react v7.37.5 with @typescript-eslint/parser.
+		{Code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return <div /> satisfies React.ReactNode;
+          }
+          return <UnstableNestedComponent />;
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return React.createElement("div", null)!;
+          }
+          return <UnstableNestedComponent />;
+        }
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: function declaration nested in function component ----
 		{
@@ -1521,38 +1544,6 @@ func TestNoUnstableNestedComponentsRule(t *testing.T) {
 		// ============================================================
 		// tsgo-specific edge cases beyond the upstream test suite
 		// ============================================================
-
-		// ---- TS wrapper: `<div/> satisfies JSX.Element` return ----
-		{
-			Code: `
-        function ParentComponent() {
-          function UnstableNestedComponent() {
-            return <div /> satisfies React.ReactNode;
-          }
-          return <UnstableNestedComponent />;
-        }
-      `,
-			Tsx: true,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{Message: errorMessage, Line: 3, Column: 11},
-			},
-		},
-
-		// ---- TS wrapper: non-null `!` on createElement call ----
-		{
-			Code: `
-        function ParentComponent() {
-          function UnstableNestedComponent() {
-            return React.createElement("div", null)!;
-          }
-          return <UnstableNestedComponent />;
-        }
-      `,
-			Tsx: true,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{Message: errorMessage, Line: 3, Column: 11},
-			},
-		},
 
 		// ---- ParenthesizedExpression around React.memo argument ----
 		{

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -190,6 +190,7 @@ define.test({
     './tests/eslint-plugin-react/rules/forbid-prop-types.test.ts',
     './tests/eslint-plugin-react/rules/prop-types.test.ts',
     './tests/eslint-plugin-react/rules/forward-ref-uses-ref.test.ts',
+    './tests/eslint-plugin-react/rules/function-component-definition.test.ts',
     './tests/eslint-plugin-react/rules/hook-use-state.test.ts',
     './tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts',
     './tests/eslint-plugin-react/rules/self-closing-comp.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/function-component-definition.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/function-component-definition.test.ts
@@ -1,0 +1,877 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('function-component-definition', {} as never, {
+  valid: [
+    {
+      code: `
+        class Hello extends React.Component {
+          render() { return <div>Hello {this.props.name}</div> }
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() { return <div>Hello {this.props.name}</div> }
+        }
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() { return <div>Hello {this.props.name}</div> }
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'var Hello = (props) => { return <div/> }',
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'const Hello = (props) => { return <div/> }',
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'function Hello(props) { return <div/> }',
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: 'var Hello = function(props) { return <div/> }',
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'const Hello = function(props) { return <div/> }',
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'function Hello() { return function() { return <div/> } }',
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: 'function Hello() { return () => { return <div/> }}',
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'var Foo = React.memo(function Foo() { return <p/> })',
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: 'const Foo = React.memo(function Foo() { return <p/> })',
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      // shouldn't trigger this rule since functions stating with a lowercase
+      // letter are not considered components
+      code: `
+        const selectAvatarByUserId = (state, id) => {
+          const user = selectUserById(state, id)
+          return null
+        }
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      // shouldn't trigger this rule since functions stating with a lowercase
+      // letter are not considered components
+      code: `
+        function ensureValidSourceType(sourceType: string) {
+          switch (sourceType) {
+            case 'ALBUM':
+            case 'PLAYLIST':
+              return sourceType;
+            default:
+              return null;
+          }
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'function Hello(props: Test) { return <p/> }',
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: 'var Hello = function(props: Test) { return <p/> }',
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'var Hello = (props: Test) => { return <p/> }',
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'var Hello: React.FC<Test> = function(props) { return <p/> }',
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'var Hello: React.FC<Test> = (props) => { return <p/> }',
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'function Hello<Test>(props: Props<Test>) { return <p/> }',
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: 'function Hello<Test extends {}>(props: Props<Test>) { return <p/> }',
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: 'var Hello = function<Test>(props: Props<Test>) { return <p/> }',
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'var Hello = function<Test extends {}>(props: Props<Test>) { return <p/> }',
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'var Hello = <Test extends {}>(props: Props<Test>) => { return <p/> }',
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'function wrapper() { return function<Test>(props: Props<Test>) { return <p/> } } ',
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: 'function wrapper() { return function<Test extends {}>(props: Props<Test>) { return <p/> } } ',
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: 'function wrapper() { return<Test extends {}>(props: Props<Test>) => { return <p/> } } ',
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'var Hello = function(props): ReactNode { return <p/> }',
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: 'var Hello = (props): ReactNode => { return <p/> }',
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'function wrapper() { return function(props): ReactNode { return <p/> } }',
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: 'function wrapper() { return (props): ReactNode => { return <p/> } }',
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: 'function Hello(props): ReactNode { return <p/> }',
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    // https://github.com/jsx-eslint/eslint-plugin-react/issues/2765
+    {
+      code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        }
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize(el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: (el) => {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        const obj = {
+          serialize: function (el) {
+            return <p/>
+          }
+        };
+      `,
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+
+    {
+      code: 'function Hello(props) { return <div/> }',
+      options: [
+        { namedComponents: ['function-declaration', 'function-expression'] },
+      ],
+    },
+    {
+      code: 'var Hello = function(props) { return <div/> }',
+      options: [
+        { namedComponents: ['function-declaration', 'function-expression'] },
+      ],
+    },
+    {
+      code: 'var Foo = React.memo(function Foo() { return <p/> })',
+      options: [
+        { namedComponents: ['function-declaration', 'function-expression'] },
+      ],
+    },
+    {
+      code: 'function Hello(props: Test) { return <p/> }',
+      options: [
+        { namedComponents: ['function-declaration', 'function-expression'] },
+      ],
+    },
+    {
+      code: 'var Hello = function(props: Test) { return <p/> }',
+      options: [
+        { namedComponents: ['function-expression', 'function-expression'] },
+      ],
+    },
+    {
+      code: 'var Hello = (props: Test) => { return <p/> }',
+      options: [{ namedComponents: ['arrow-function', 'function-expression'] }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return function(props) {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+      options: [
+        { unnamedComponents: ['arrow-function', 'function-expression'] },
+      ],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return (props) => {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+      options: [
+        { unnamedComponents: ['arrow-function', 'function-expression'] },
+      ],
+    },
+    {
+      // should not report non-jsx components
+      code: `
+        export default (key, subTree = {}) => {
+          return (state) => {
+            const dataInStore = getFromDataModel(key)(state);
+            const fullPaths = dataInStore.map((item, index) => {
+              return [key, index];
+            });
+
+            return {
+              key,
+              paths: fullPaths.map((p) => [p[1]]),
+              fullPaths,
+              subTree: Object.keys(subTree).length ? subTree : null,
+            }
+          };
+        }
+      `,
+    },
+    {
+      // should not report non-jsx components
+      code: `
+        function mapStateToProps() {
+          const internItems = makeInternArray();
+          const internClassList = makeInternArray();
+
+          return (state, props) => {
+            const { store, bucket, singleCharacter } = props;
+
+            return {
+              store: null,
+              destinyVersion: store.destinyVersion,
+              storeId: store.id,
+            }
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Hello(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        var Hello = function(props) {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        var Hello = function(props) {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        let Hello = (props) => {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        let Hello;
+        Hello = (props) => {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        let Hello = (props) => {
+          return <div/>;
+        }
+        Hello = function(props) {
+          return <span/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        function Hello(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return function(props) {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+      errors: [{ messageId: 'arrow-function' }],
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return (props) => {
+            return <div><Component {...props}/></div>;
+          };
+        }
+      `,
+      errors: [{ messageId: 'function-expression' }],
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        var Hello = (props: Test) => {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        var Hello = function(props: Test) {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        function Hello(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        var Hello = function(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        function Hello(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        function Hello(props: Test) {
+          return React.createElement('div');
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        import * as React from 'react';
+        function Hello(props: Test) {
+          return React.createElement('div');
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        export function Hello(props: Test) {
+          return React.createElement('div');
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        function Hello(props) {
+          return React.createElement('div');
+        }
+        export default Hello;
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        var Hello = (props: Test) => {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        var Hello: React.FC<Test> = (props) => {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        var Hello: React.FC<Test> = function(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        var Hello: React.FC<Test> = function(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        var Hello: React.FC<Test> = (props) => {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        function Hello<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        function Hello<Test>(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        function Hello<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        var Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        };
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        var Hello = <Test extends {}>(props: Test) => {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-expression' }],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        var Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        var Hello = function<Test extends {}>(props: Test) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return function<Test extends {}>(props) {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'arrow-function' }],
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return function<Test>(props) {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'arrow-function' }],
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return <Test extends {}>(props) => {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'function-expression' }],
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return function(props): ReactNode {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'arrow-function' }],
+      options: [{ unnamedComponents: 'arrow-function' }],
+    },
+    {
+      code: `
+        function wrap(Component) {
+          return (props): ReactNode => {
+            return <div><Component {...props}/></div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'function-expression' }],
+      options: [{ unnamedComponents: 'function-expression' }],
+    },
+    {
+      code: `
+        export function Hello(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        export var Hello = function(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        export var Hello = (props) => {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'function-declaration' }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        export default function Hello(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        module.exports = function Hello(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ unnamedComponents: 'arrow-function' }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        function Hello(props) {
+          return <div/>;
+        }
+      `,
+      options: [{ namedComponents: ['arrow-function', 'function-expression'] }],
+      errors: [{ messageId: 'arrow-function' }],
+    },
+    {
+      code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+      options: [
+        { namedComponents: ['function-declaration', 'function-expression'] },
+      ],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+    {
+      code: `
+        var Hello = (props) => {
+          return <div/>;
+        };
+      `,
+      options: [
+        { namedComponents: ['function-expression', 'function-declaration'] },
+      ],
+      errors: [{ messageId: 'function-expression' }],
+    },
+    {
+      code: `
+        const genX = (symbol) => \`the symbol is \${symbol}\`;
+
+        const IndexPage = () => {
+          return (
+            <div>
+              Hello World.{genX('$')}
+            </div>
+          )
+        }
+
+        export default IndexPage;
+      `,
+      output: `
+        const genX = (symbol) => \`the symbol is \${symbol}\`;
+
+        function IndexPage() {
+          return (
+            <div>
+              Hello World.{genX('$')}
+            </div>
+          )
+        }
+
+        export default IndexPage;
+      `,
+      options: [{ namedComponents: ['function-declaration'] }],
+      errors: [{ messageId: 'function-declaration' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/function-component-definition` rule from ESLint to rslint.

The rule enforces a consistent function type for React function components — function declaration, function expression, or arrow function — separately for named and unnamed components, with an autofix that rewrites the function's head.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/function-component-definition.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/function-component-definition.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).