### PR TITLE
test: preserve ESLint JSON test case fields

### DIFF
--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -93,6 +93,8 @@ type TestSuite struct {
 type ESLintTestCase struct {
 	Code     string                 `json:"code"`
 	Filename string                 `json:"filename,omitempty"`
+	Tsx      bool                   `json:"tsx,omitempty"`
+	Globals  map[string]interface{} `json:"globals,omitempty"`
 	Options  []interface{}          `json:"options,omitempty"`
 	Settings map[string]interface{} `json:"settings,omitempty"`
 	Only     bool                   `json:"only,omitempty"`
@@ -428,7 +430,7 @@ func ConvertESLintTestCase(tc ESLintTestCase) ValidTestCase {
 	}
 
 	fileName := ""
-	tsx := false
+	tsx := tc.Tsx
 	if tc.Filename != "" {
 		fileName = tc.Filename
 		if filepath.Ext(fileName) == ".tsx" || filepath.Ext(fileName) == ".jsx" {
@@ -443,6 +445,7 @@ func ConvertESLintTestCase(tc ESLintTestCase) ValidTestCase {
 		Skip:     tc.Skip,
 		Options:  options,
 		Settings: tc.Settings,
+		Globals:  tc.Globals,
 		Tsx:      tsx,
 	}
 }
@@ -459,7 +462,7 @@ func ConvertESLintInvalidTestCase(tc ESLintInvalidTestCase) InvalidTestCase {
 	}
 
 	fileName := ""
-	tsx := false
+	tsx := tc.Tsx
 	if tc.Filename != "" {
 		fileName = tc.Filename
 		if filepath.Ext(fileName) == ".tsx" || filepath.Ext(fileName) == ".jsx" {
@@ -503,6 +506,7 @@ func ConvertESLintInvalidTestCase(tc ESLintInvalidTestCase) InvalidTestCase {
 		Errors:   errors,
 		Options:  options,
 		Settings: tc.Settings,
+		Globals:  tc.Globals,
 		Tsx:      tsx,
 	}
 }

--- a/internal/rule_tester/rule_tester_test.go
+++ b/internal/rule_tester/rule_tester_test.go
@@ -1,6 +1,7 @@
 package rule_tester
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -72,4 +73,48 @@ func TestRunRuleTesterPropagatesLanguageOptions(t *testing.T) {
 			}},
 		}},
 	)
+}
+
+func TestConvertESLintTestCasesPreservesFilenameGlobalsAndTSX(t *testing.T) {
+	var suite ESLintTestSuite
+	err := json.Unmarshal([]byte(`{
+		"valid": [{
+			"code": "<div />;",
+			"filename": "example.tsx",
+			"globals": {"console": "readonly"},
+			"tsx": true
+		}],
+		"invalid": [{
+			"code": "<div />;",
+			"filename": "example.tsx",
+			"globals": {"window": "writable"},
+			"tsx": true,
+			"errors": []
+		}]
+	}`), &suite)
+	if err != nil {
+		t.Fatalf("unmarshal ESLint test suite: %v", err)
+	}
+
+	valid := ConvertESLintTestCase(suite.Valid[0])
+	if valid.FileName != "example.tsx" {
+		t.Fatalf("valid filename = %q, want example.tsx", valid.FileName)
+	}
+	if !valid.Tsx {
+		t.Fatal("valid tsx = false, want true")
+	}
+	if valid.Globals["console"] != "readonly" {
+		t.Fatalf("valid globals = %+v, want console readonly", valid.Globals)
+	}
+
+	invalid := ConvertESLintInvalidTestCase(suite.Invalid[0])
+	if invalid.FileName != "example.tsx" {
+		t.Fatalf("invalid filename = %q, want example.tsx", invalid.FileName)
+	}
+	if !invalid.Tsx {
+		t.Fatal("invalid tsx = false, want true")
+	}
+	if invalid.Globals["window"] != "writable" {
+		t.Fatalf("invalid globals = %+v, want window writable", invalid.Globals)
+	}
 }


### PR DESCRIPTION
## Summary

Extend the ESLint-format JSON RuleTester bridge to preserve test-case metadata:

- support the `tsx` field for TSX parsing
- preserve `filename` for source-file setup
- preserve `globals` for rule context construction
- add regression coverage for both valid and invalid test cases

## Related Links

N/A

## Validation

- `go test ./internal/rule_tester`

## Checklist

- [x] Tests updated.
- [x] Documentation updated (or not required).