### PR TITLE
feat: port rule unicorn/no-null

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_remove_event_listener"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_magic_array_flat_depth"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_nested_ternary"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_null"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_object_as_default_parameter"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
@@ -57,6 +58,7 @@ func GetAllRules() []rule.Rule {
 		no_invalid_remove_event_listener.NoInvalidRemoveEventListenerRule,
 		no_magic_array_flat_depth.NoMagicArrayFlatDepthRule,
 		no_nested_ternary.NoNestedTernaryRule,
+		no_null.NoNullRule,
 		no_object_as_default_parameter.NoObjectAsDefaultParameterRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,

--- a/internal/plugins/unicorn/rules/no_null/no_null.go
+++ b/internal/plugins/unicorn/rules/no_null/no_null.go
@@ -202,7 +202,7 @@ func reportNull(ctx rule.RuleContext, node *ast.Node, opts options) {
 		declarationList := parent.Parent
 		if declaration != nil && declarationList != nil &&
 			declarationList.Kind == ast.KindVariableDeclarationList &&
-			declarationList.Flags&ast.NodeFlagsConst == 0 &&
+			!ast.IsVarConst(declarationList) &&
 			utils.ESTreeRuntimeExpression(declaration.Initializer) == node {
 			start := variableIDEnd(ctx, declaration)
 			if start > 0 {

--- a/internal/plugins/unicorn/rules/no_null/no_null.go
+++ b/internal/plugins/unicorn/rules/no_null/no_null.go
@@ -65,7 +65,8 @@ func equalityKind(node *ast.Node) ast.Kind {
 
 func directCallOrNewArgumentParent(node *ast.Node) *ast.Node {
 	parent := utils.ESTreeParent(node)
-	if parent == nil || (!ast.IsCallExpression(parent) && !ast.IsNewExpression(parent)) {
+	if parent == nil || ast.IsImportCall(parent) ||
+		(!ast.IsCallExpression(parent) && !ast.IsNewExpression(parent)) {
 		return nil
 	}
 	for _, argument := range parent.Arguments() {

--- a/internal/plugins/unicorn/rules/no_null/no_null.go
+++ b/internal/plugins/unicorn/rules/no_null/no_null.go
@@ -1,0 +1,245 @@
+package no_null
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDError   = "error"
+	messageIDReplace = "replace"
+	messageIDRemove  = "remove"
+)
+
+var (
+	errorMessage = rule.RuleMessage{
+		Id:          messageIDError,
+		Description: "Use `undefined` instead of `null`.",
+	}
+	replaceMessage = rule.RuleMessage{
+		Id:          messageIDReplace,
+		Description: "Replace `null` with `undefined`.",
+	}
+	removeMessage = rule.RuleMessage{
+		Id:          messageIDRemove,
+		Description: "Remove `null`.",
+	}
+)
+
+//go:embed no_null.schema.json
+var schemaJSON []byte
+
+type options struct {
+	checkArguments      bool
+	checkStrictEquality bool
+}
+
+func parseOptions(raw []any) options {
+	result := options{checkArguments: true}
+	if len(raw) == 0 {
+		return result
+	}
+
+	values, _ := raw[0].(map[string]any)
+	if checkArguments, ok := values["checkArguments"].(bool); ok {
+		result.checkArguments = checkArguments
+	}
+	if checkStrictEquality, ok := values["checkStrictEquality"].(bool); ok {
+		result.checkStrictEquality = checkStrictEquality
+	}
+	return result
+}
+
+func equalityKind(node *ast.Node) ast.Kind {
+	parent := utils.ESTreeParent(node)
+	if parent == nil || parent.Kind != ast.KindBinaryExpression {
+		return ast.KindUnknown
+	}
+	return parent.AsBinaryExpression().OperatorToken.Kind
+}
+
+func directCallOrNewArgumentParent(node *ast.Node) *ast.Node {
+	parent := utils.ESTreeParent(node)
+	if parent == nil || (!ast.IsCallExpression(parent) && !ast.IsNewExpression(parent)) {
+		return nil
+	}
+	for _, argument := range parent.Arguments() {
+		if utils.ESTreeRuntimeExpression(argument) == node {
+			return parent
+		}
+	}
+	return nil
+}
+
+func isIdentifierNamed(node *ast.Node, name string) bool {
+	node = utils.ESTreeRuntimeExpression(node)
+	return node != nil && ast.IsIdentifier(node) && node.AsIdentifier().Text == name
+}
+
+func isExemptObjectCreate(call *ast.Node, nullNode *ast.Node) bool {
+	minimumArguments := 1
+	maximumArguments := 2
+	match, ok := unicornutil.MatchDotMethodCall(call, unicornutil.DotMethodCallOptions{
+		Method:              "create",
+		MinimumArguments:    &minimumArguments,
+		MaximumArguments:    &maximumArguments,
+		RejectSpreadElement: true,
+		AllowOptionalCall:   false,
+		AllowOptionalMember: false,
+	})
+	return ok && isIdentifierNamed(match.Object, "Object") &&
+		utils.ESTreeRuntimeExpression(call.Arguments()[0]) == nullNode
+}
+
+func isExemptUseRef(call *ast.Node, nullNode *ast.Node) bool {
+	if !ast.IsCallExpression(call) || len(call.Arguments()) != 1 ||
+		utils.ESTreeRuntimeExpression(call.Arguments()[0]) != nullNode {
+		return false
+	}
+
+	// Upstream's identifier-call check does not consume its optionalCall and
+	// optionalMember fields, so `useRef?.(null)` receives the same exception.
+	if isIdentifierNamed(call.AsCallExpression().Expression, "useRef") {
+		return true
+	}
+
+	argumentsLength := 1
+	match, ok := unicornutil.MatchDotMethodCall(call, unicornutil.DotMethodCallOptions{
+		Method:              "useRef",
+		ArgumentsLength:     &argumentsLength,
+		RejectSpreadElement: true,
+		AllowOptionalCall:   false,
+		AllowOptionalMember: false,
+	})
+	return ok && isIdentifierNamed(match.Object, "React")
+}
+
+func isExemptInsertBefore(call *ast.Node, nullNode *ast.Node) bool {
+	argumentsLength := 2
+	match, ok := unicornutil.MatchDotMethodCall(call, unicornutil.DotMethodCallOptions{
+		Method:              "insertBefore",
+		ArgumentsLength:     &argumentsLength,
+		RejectSpreadElement: true,
+		AllowOptionalCall:   false,
+		AllowOptionalMember: true,
+	})
+	return ok && utils.ESTreeRuntimeExpression(match.Call.Arguments()[1]) == nullNode
+}
+
+func replacementSuggestion(ctx rule.RuleContext, node *ast.Node) rule.RuleSuggestion {
+	return rule.RuleSuggestion{
+		Message:  replaceMessage,
+		FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, "undefined")},
+	}
+}
+
+func variableIDEnd(ctx rule.RuleContext, declaration *ast.VariableDeclaration) int {
+	name := declaration.Name()
+	if name == nil {
+		return 0
+	}
+	if ast.IsIdentifier(name) {
+		return utils.GetESTreeBindingIdentifierRange(ctx.SourceFile, name).End()
+	}
+	if declaration.Type != nil {
+		return declaration.Type.End()
+	}
+	return utils.TrimNodeTextRange(ctx.SourceFile, name).End()
+}
+
+func reportNull(ctx rule.RuleContext, node *ast.Node, opts options) {
+	// TSESTree represents `null` in a type position as TSNullKeyword rather
+	// than the runtime Literal node that this rule listens for upstream.
+	if node.Parent != nil && node.Parent.Kind == ast.KindLiteralType {
+		return
+	}
+
+	operator := equalityKind(node)
+	if !opts.checkStrictEquality &&
+		(operator == ast.KindEqualsEqualsEqualsToken || operator == ast.KindExclamationEqualsEqualsToken) {
+		return
+	}
+
+	argumentParent := directCallOrNewArgumentParent(node)
+	if argumentParent != nil {
+		if !opts.checkArguments ||
+			isExemptObjectCreate(argumentParent, node) ||
+			isExemptUseRef(argumentParent, node) ||
+			isExemptInsertBefore(argumentParent, node) {
+			return
+		}
+	}
+
+	if operator == ast.KindEqualsEqualsToken || operator == ast.KindExclamationEqualsToken {
+		ctx.ReportNodeWithDeferredFixes(node, errorMessage, func() []rule.RuleFix {
+			return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, "undefined")}
+		})
+		return
+	}
+
+	parent := utils.ESTreeParent(node)
+	if parent != nil && parent.Kind == ast.KindReturnStatement &&
+		utils.ESTreeRuntimeExpression(parent.AsReturnStatement().Expression) == node {
+		ctx.ReportNodeWithDeferredSuggestions(node, errorMessage, func() []rule.RuleSuggestion {
+			return []rule.RuleSuggestion{
+				{
+					Message:  removeMessage,
+					FixesArr: []rule.RuleFix{rule.RuleFixRemove(ctx.SourceFile, node)},
+				},
+				replacementSuggestion(ctx, node),
+			}
+		})
+		return
+	}
+
+	if parent != nil && parent.Kind == ast.KindVariableDeclaration {
+		declaration := parent.AsVariableDeclaration()
+		declarationList := parent.Parent
+		if declaration != nil && declarationList != nil &&
+			declarationList.Kind == ast.KindVariableDeclarationList &&
+			declarationList.Flags&ast.NodeFlagsConst == 0 &&
+			utils.ESTreeRuntimeExpression(declaration.Initializer) == node {
+			start := variableIDEnd(ctx, declaration)
+			if start > 0 {
+				ctx.ReportNodeWithDeferredSuggestions(node, errorMessage, func() []rule.RuleSuggestion {
+					return []rule.RuleSuggestion{
+						{
+							Message: removeMessage,
+							FixesArr: []rule.RuleFix{
+								rule.RuleFixRemoveRange(core.NewTextRange(start, node.End())),
+							},
+						},
+						replacementSuggestion(ctx, node),
+					}
+				})
+				return
+			}
+		}
+	}
+
+	ctx.ReportNodeWithDeferredSuggestions(node, errorMessage, func() []rule.RuleSuggestion {
+		return []rule.RuleSuggestion{replacementSuggestion(ctx, node)}
+	})
+}
+
+// NoNullRule disallows the null literal, with narrowly scoped exceptions for
+// APIs that require null and configurable direct-argument/strict-equality checks.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-null.js
+var NoNullRule = rule.Rule{
+	Name:   "unicorn/no-null",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		return rule.RuleListeners{
+			ast.KindNullKeyword: func(node *ast.Node) {
+				reportNull(ctx, node, opts)
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_null/no_null.md
+++ b/internal/plugins/unicorn/rules/no_null/no_null.md
@@ -1,0 +1,49 @@
+# no-null
+
+## Rule Details
+
+Disallow the `null` literal and encourage using `undefined` as the single value
+for missing data.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+let value = null;
+
+if (value == null) {}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+let value;
+
+if (value == undefined) {}
+
+const dictionary = Object.create(null);
+```
+
+Strict equality comparisons are ignored by default:
+
+```javascript
+if (value === null) {}
+```
+
+## Options
+
+This rule accepts an object with two boolean options:
+
+- `checkArguments` (default: `true`) checks `null` when it is a direct function
+  call or constructor argument. Set it to `false` when APIs require `null`
+  arguments.
+- `checkStrictEquality` (default: `false`) checks strict equality and inequality
+  comparisons against `null`.
+
+The rule follows Unicorn's built-in exceptions for `Object.create(null)`,
+`useRef(null)`, `React.useRef(null)`, and `null` as the second argument of a
+two-argument `insertBefore` call.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-null](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-null.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-null.js)

--- a/internal/plugins/unicorn/rules/no_null/no_null.schema.json
+++ b/internal/plugins/unicorn/rules/no_null/no_null.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "checkArguments": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to check null used as a direct function call or constructor argument."
+        },
+        "checkStrictEquality": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to check strict equality comparisons against null."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/unicorn/rules/no_null/no_null_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_null/no_null_extras_test.go
@@ -110,6 +110,14 @@ func TestNoNullExtras(t *testing.T) {
 				`for (let value = null; ; ) {}`,
 				`for (let value; ; ) {}`,
 			),
+			mutableVariableCase(
+				`using value = null;`,
+				`using value;`,
+			),
+			mutableVariableCase(
+				`async function f() { await using value = null; }`,
+				`async function f() { await using value; }`,
+			),
 
 			// ---- Dimension 4: same-kind nesting reports each null independently ----
 			replacementCase(`const first = null, second = null;`, nil, 1, 2),

--- a/internal/plugins/unicorn/rules/no_null/no_null_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_null/no_null_extras_test.go
@@ -95,6 +95,9 @@ func TestNoNullExtras(t *testing.T) {
 			replacementCase(`fn({value: null})`, ignoreArguments, 1),
 			replacementCase(`new Box([null])`, ignoreArguments, 1),
 
+			// ---- Dimension 4: ts-go CallExpression maps to ESTree ImportExpression ----
+			replacementCase(`import(null)`, ignoreArguments, 1),
+
 			// ---- Dimension 4: variable declaration shapes and TSESTree id ranges ----
 			typescriptMutableVariableCase(
 				`let value: string | null = null;`,

--- a/internal/plugins/unicorn/rules/no_null/no_null_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_null/no_null_extras_test.go
@@ -1,0 +1,240 @@
+// TestNoNullExtras covers tsgo/ESTree shape differences, real-user cases, and
+// branch lock-ins that are intentionally separate from no_null_upstream_test.go.
+package no_null_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_null "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_null"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func typescriptReplacementCase(code string, options any, occurrences ...int) rule_tester.InvalidTestCase {
+	testCase := replacementCase(code, options, occurrences...)
+	testCase.FileName = "file.ts"
+	return testCase
+}
+
+func typescriptMutableVariableCase(code, removedOutput string, occurrence int) rule_tester.InvalidTestCase {
+	testCase := mutableVariableCaseAt(code, removedOutput, occurrence)
+	testCase.FileName = "file.ts"
+	return testCase
+}
+
+func TestNoNullExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_null.NoNullRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: null in TypeScript type positions is not a runtime literal ----
+			{Code: `type MaybeString = string | null;`, FileName: "file.ts"},
+			{Code: `interface Value { current: null }`, FileName: "file.ts"},
+
+			// ---- Dimension 4: ESTree drops parentheses around strict-comparison operands ----
+			{Code: `if (value === (((null)))) {}`, FileName: "file.js"},
+			{Code: `if ((((null))) !== value) {}`, FileName: "file.js"},
+			{Code: `if (value === null) {}`, FileName: "file.js", Options: []any{map[string]any{}}},
+
+			// ---- Dimension 4: direct arguments remain direct through parentheses ----
+			{Code: `fn(((null)))`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `new Box(((null)))`, FileName: "file.js", Options: ignoreArguments},
+
+			// ---- Branch lock-ins: every built-in exception accepts ESTree-transparent grouping ----
+			{Code: `((Object)).create(((null)))`, FileName: "file.js"},
+			{Code: `((useRef))(((null)))`, FileName: "file.js"},
+			{Code: `useRef?.(null)`, FileName: "file.js"},
+			{Code: `((React)).useRef(((null)))`, FileName: "file.js"},
+			{Code: `node?.insertBefore(other, ((null)))`, FileName: "file.js"},
+
+			// The exceptions are syntactic, like upstream; local bindings with the
+			// same spelling do not change the result.
+			{Code: `const Object = factory; Object.create(null);`, FileName: "file.js"},
+			{Code: `const useRef = custom; useRef(null);`, FileName: "file.js"},
+
+			// ---- Real-user: #2633 / #1842 — APIs can require null arguments ----
+			{Code: `shape.setMap(null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `markers[index].setMap(null)`, FileName: "file.js", Options: ignoreArguments},
+
+			// ---- Real-user: #888 — React refs are initialized with null ----
+			{Code: `const ref = useRef(null);`, FileName: "file.ts"},
+			{Code: `const ref = React.useRef(null);`, FileName: "file.ts"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parentheses are transparent for reporting and edits ----
+			replacementCase(`const value = (((null)));`, nil, 1),
+			fixedCase(`if (value == (((null)))) {}`),
+			returnCase(`function value() { return (null); }`, nil),
+
+			// ---- Dimension 4: authored TypeScript wrappers remain visible upstream ----
+			typescriptReplacementCase(`fn(null as unknown)`, ignoreArguments, 1),
+			typescriptReplacementCase(`fn(null!)`, ignoreArguments, 1),
+			typescriptReplacementCase(`if (value === (null as unknown)) {}`, nil, 1),
+			typescriptReplacementCase(`if (value == (null as unknown)) {}`, nil, 1),
+
+			// ---- Dimension 4: optional calls/members do not match exceptions that forbid them ----
+			replacementCase(`React.useRef?.(null)`, nil, 1),
+			replacementCase(`React?.useRef(null)`, nil, 1),
+			replacementCase(`Object?.create(null)`, nil, 1),
+			replacementCase(`node.insertBefore?.(other, null)`, nil, 1),
+
+			// ---- Branch lock-ins: exception arity and direct-position gates ----
+			replacementCase(`useRef(null, initialValue)`, nil, 1),
+			replacementCase(`React.useRef(null, initialValue)`, nil, 1),
+			replacementCase(`node.insertBefore(null, other)`, nil, 1),
+			replacementCase(`Object.create(proto, null)`, nil, 1),
+
+			// checkArguments only ignores a direct argument, not a nested null.
+			replacementCase(`fn({value: null})`, ignoreArguments, 1),
+			replacementCase(`new Box([null])`, ignoreArguments, 1),
+
+			// ---- Dimension 4: variable declaration shapes and TSESTree id ranges ----
+			typescriptMutableVariableCase(
+				`let value: string | null = null;`,
+				`let value: string | null;`,
+				2,
+			),
+			typescriptMutableVariableCase(
+				`let {value}: {value: unknown} = null;`,
+				`let {value}: {value: unknown};`,
+				1,
+			),
+			mutableVariableCase(
+				`for (let value = null; ; ) {}`,
+				`for (let value; ; ) {}`,
+			),
+
+			// ---- Dimension 4: same-kind nesting reports each null independently ----
+			replacementCase(`const first = null, second = null;`, nil, 1, 2),
+
+			// An empty option object receives both schema defaults: direct arguments
+			// are checked, while strict equality remains ignored.
+			replacementCase(`fn(null)`, []any{map[string]any{}}, 1),
+
+			// A null used as an optional-chain receiver is still a runtime literal.
+			replacementCase(`const value = null?.property;`, nil, 1),
+
+			// N/A: computed/private property-name equivalence classes do not apply;
+			// the rule reports the null literal itself, not an enclosing property.
+			// N/A: overload/ambient containers do not alter runtime-null handling;
+			// their null occurrences are type nodes covered by the valid cases above.
+		},
+	)
+}
+
+func TestNoNullEditDemand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		source          string
+		expectsAutofix  bool
+		expectsSuggests bool
+	}{
+		{name: "loose equality autofix", source: `if (value == null) {}`, expectsAutofix: true},
+		{name: "replacement suggestion", source: `const value = null;`, expectsSuggests: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+			for _, demand := range []rule.EditDemand{
+				rule.EditDemandNone,
+				rule.EditDemandAutofix,
+				rule.EditDemandSuggestion,
+				rule.EditDemandAll,
+			} {
+				diagnostics[demand] = lintNoNullWithDemand(t, test.source, demand)
+			}
+
+			withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+				diagnostic.FixesPtr = nil
+				diagnostic.Suggestions = nil
+				return diagnostic
+			}
+			base := withoutEdits(diagnostics[rule.EditDemandNone])
+			for demand, diagnostic := range diagnostics {
+				if got := withoutEdits(diagnostic); !reflect.DeepEqual(got, base) {
+					t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, base)
+				}
+			}
+
+			if diagnostics[rule.EditDemandNone].FixesPtr != nil ||
+				diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+				t.Fatal("a non-autofix demand materialized fixes")
+			}
+			if diagnostics[rule.EditDemandNone].Suggestions != nil ||
+				diagnostics[rule.EditDemandAutofix].Suggestions != nil {
+				t.Fatal("a non-suggestion demand materialized suggestions")
+			}
+
+			autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+			allAutofixes := diagnostics[rule.EditDemandAll].FixesPtr
+			if test.expectsAutofix {
+				if autofixOnly == nil || allAutofixes == nil || !reflect.DeepEqual(*autofixOnly, *allAutofixes) {
+					t.Fatal("autofix and all-edits demands produced different fixes")
+				}
+			} else if autofixOnly != nil || allAutofixes != nil {
+				t.Fatal("suggestion-only diagnostic materialized autofixes")
+			}
+
+			suggestionOnly := diagnostics[rule.EditDemandSuggestion].Suggestions
+			allSuggestions := diagnostics[rule.EditDemandAll].Suggestions
+			if test.expectsSuggests {
+				if suggestionOnly == nil || allSuggestions == nil || !reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
+					t.Fatal("suggestion and all-edits demands produced different suggestions")
+				}
+			} else if suggestionOnly != nil || allSuggestions != nil {
+				t.Fatal("autofix-only diagnostic materialized suggestions")
+			}
+		})
+	}
+}
+
+func lintNoNullWithDemand(t testing.TB, source string, demand rule.EditDemand) rule.RuleDiagnostic {
+	t.Helper()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, source, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(
+		no_null.NoNullRule.Name,
+		rule.SeverityError,
+		rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	)
+
+	listeners := no_null.NoNullRule.Run(ctx, nil)
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if len(diagnostics) != 1 {
+		t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+	}
+	return diagnostics[0]
+}

--- a/internal/plugins/unicorn/rules/no_null/no_null_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_null/no_null_upstream_test.go
@@ -1,0 +1,208 @@
+// TestNoNullUpstream migrates the complete valid/invalid suite from Unicorn
+// v74.0.0 test/no-null.js. rslint-specific edge shapes and branch lock-ins live
+// in no_null_extras_test.go.
+package no_null_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	no_null "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_null"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const noNullMessage = "Use `undefined` instead of `null`."
+
+var ignoreArguments = []any{map[string]any{"checkArguments": false}}
+
+func nullOccurrenceRange(code string, occurrence int) (line, column, endLine, endColumn int) {
+	searchFrom := 0
+	offset := -1
+	for index := 1; index <= occurrence; index++ {
+		found := strings.Index(code[searchFrom:], "null")
+		if found < 0 {
+			panic("null occurrence not found in: " + code)
+		}
+		offset = searchFrom + found
+		searchFrom = offset + len("null")
+	}
+
+	before := code[:offset]
+	line = strings.Count(before, "\n") + 1
+	lastNewline := strings.LastIndex(before, "\n")
+	column = offset - lastNewline
+	return line, column, line, column + len("null")
+}
+
+func replaceNullOccurrence(code string, occurrence int, replacement string) string {
+	remaining := code
+	offset := 0
+	for index := 1; index <= occurrence; index++ {
+		found := strings.Index(remaining, "null")
+		if found < 0 {
+			panic("null occurrence not found in: " + code)
+		}
+		offset += found
+		if index == occurrence {
+			return code[:offset] + replacement + code[offset+len("null"):]
+		}
+		offset += len("null")
+		remaining = code[offset:]
+	}
+	panic("unreachable")
+}
+
+func noNullError(code string, occurrence int, suggestions ...rule_tester.InvalidTestCaseSuggestion) rule_tester.InvalidTestCaseError {
+	line, column, endLine, endColumn := nullOccurrenceRange(code, occurrence)
+	return rule_tester.InvalidTestCaseError{
+		MessageId:   "error",
+		Message:     noNullMessage,
+		Line:        line,
+		Column:      column,
+		EndLine:     endLine,
+		EndColumn:   endColumn,
+		Suggestions: suggestions,
+	}
+}
+
+func replacementCase(code string, options any, occurrences ...int) rule_tester.InvalidTestCase {
+	errors := make([]rule_tester.InvalidTestCaseError, 0, len(occurrences))
+	for _, occurrence := range occurrences {
+		errors = append(errors, noNullError(code, occurrence, rule_tester.InvalidTestCaseSuggestion{
+			MessageId: "replace",
+			Output:    replaceNullOccurrence(code, occurrence, "undefined"),
+		}))
+	}
+	return rule_tester.InvalidTestCase{Code: code, FileName: "file.js", Options: options, Errors: errors}
+}
+
+func fixedCase(code string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output:   []string{replaceNullOccurrence(code, 1, "undefined")},
+		Errors:   []rule_tester.InvalidTestCaseError{noNullError(code, 1)},
+	}
+}
+
+func returnCase(code string, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Options:  options,
+		Errors: []rule_tester.InvalidTestCaseError{noNullError(code, 1,
+			rule_tester.InvalidTestCaseSuggestion{
+				MessageId: "remove",
+				Output:    replaceNullOccurrence(code, 1, ""),
+			},
+			rule_tester.InvalidTestCaseSuggestion{
+				MessageId: "replace",
+				Output:    replaceNullOccurrence(code, 1, "undefined"),
+			},
+		)},
+	}
+}
+
+func mutableVariableCase(code, removedOutput string) rule_tester.InvalidTestCase {
+	return mutableVariableCaseAt(code, removedOutput, 1)
+}
+
+func mutableVariableCaseAt(code, removedOutput string, occurrence int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{noNullError(code, occurrence,
+			rule_tester.InvalidTestCaseSuggestion{MessageId: "remove", Output: removedOutput},
+			rule_tester.InvalidTestCaseSuggestion{MessageId: "replace", Output: replaceNullOccurrence(code, occurrence, "undefined")},
+		)},
+	}
+}
+
+func TestNoNullUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_null.NoNullRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `let foo`, FileName: "file.js"},
+			{Code: `Object.create(null)`, FileName: "file.js"},
+			{Code: `Object.create(null, {foo: {value:1}})`, FileName: "file.js"},
+			{Code: `let insertedNode = parentNode.insertBefore(newNode, null)`, FileName: "file.js"},
+			{Code: `let insertedNode = parentNode?.insertBefore(newNode, null)`, FileName: "file.js"},
+			{Code: `const foo = "null";`, FileName: "file.js"},
+			{Code: `Object.create()`, FileName: "file.js"},
+			{Code: `Object.create(bar)`, FileName: "file.js"},
+			{Code: `Object.create("null")`, FileName: "file.js"},
+			{Code: `useRef(null)`, FileName: "file.js"},
+			{Code: `React.useRef(null)`, FileName: "file.js"},
+			{Code: `if (foo === null) {}`, FileName: "file.js"},
+			{Code: `if (null === foo) {}`, FileName: "file.js"},
+			{Code: `if (foo !== null) {}`, FileName: "file.js"},
+			{Code: `if (null !== foo) {}`, FileName: "file.js"},
+			{Code: `if (foo === null) {}`, FileName: "file.js", Options: []any{map[string]any{"checkStrictEquality": false}}},
+			{Code: `if (null === foo) {}`, FileName: "file.js", Options: []any{map[string]any{"checkStrictEquality": false}}},
+			{Code: `if (foo !== null) {}`, FileName: "file.js", Options: []any{map[string]any{"checkStrictEquality": false}}},
+			{Code: `if (null !== foo) {}`, FileName: "file.js", Options: []any{map[string]any{"checkStrictEquality": false}}},
+			{Code: `foo(null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `foo(bar, null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `drawingManager.setMap(null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `markers[index].setMap(null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `object?.method?.(null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `foo?.(null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `new HttpResponse(null)`, FileName: "file.js", Options: ignoreArguments},
+			{Code: `new HttpResponse(body, null)`, FileName: "file.js", Options: ignoreArguments},
+			{
+				Code:            `foo = Object.create(null)`,
+				FileName:        "file.js",
+				LanguageOptions: rule.LanguageOptions{ECMAVersion: 2019},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			replacementCase(`const foo = null`, nil, 1),
+			replacementCase(`foo(null)`, nil, 1),
+			fixedCase(`if (foo == null) {}`),
+			fixedCase(`if (foo != null) {}`),
+			fixedCase(`if (null == foo) {}`),
+			fixedCase(`if (null != foo) {}`),
+			returnCase("function foo() {\n\treturn null;\n}", nil),
+			mutableVariableCase(`let foo = null;`, `let foo;`),
+			mutableVariableCase(`var foo = null;`, `var foo;`),
+			mutableVariableCase(`var foo = 1, bar = null, baz = 2;`, `var foo = 1, bar, baz = 2;`),
+			replacementCase(`const foo = null;`, nil, 1),
+			replacementCase(`const foo = null;`, ignoreArguments, 1),
+			returnCase("function foo() {\n\treturn null;\n}", ignoreArguments),
+			replacementCase(`if (foo === null) {}`, []any{map[string]any{"checkArguments": false, "checkStrictEquality": true}}, 1),
+			replacementCase(`foo([null])`, ignoreArguments, 1),
+			replacementCase(`foo(bar ?? null)`, ignoreArguments, 1),
+			replacementCase(`foo(...[null])`, ignoreArguments, 1),
+			replacementCase(`new HttpResponse([null])`, ignoreArguments, 1),
+			replacementCase(`if (foo === null) {}`, []any{map[string]any{"checkStrictEquality": true}}, 1),
+			replacementCase(`if (null === foo) {}`, []any{map[string]any{"checkStrictEquality": true}}, 1),
+			replacementCase(`if (foo !== null) {}`, []any{map[string]any{"checkStrictEquality": true}}, 1),
+			replacementCase(`if (null !== foo) {}`, []any{map[string]any{"checkStrictEquality": true}}, 1),
+			replacementCase(`new Object.create(null)`, nil, 1),
+			replacementCase(`new foo.insertBefore(bar, null)`, nil, 1),
+			replacementCase(`create(null)`, nil, 1),
+			replacementCase(`insertBefore(bar, null)`, nil, 1),
+			replacementCase(`Object["create"](null)`, nil, 1),
+			replacementCase(`foo["insertBefore"](bar, null)`, nil, 1),
+			replacementCase(`Object[create](null)`, nil, 1),
+			replacementCase(`foo[insertBefore](bar, null)`, nil, 1),
+			replacementCase(`Object[null](null)`, nil, 1, 2),
+			replacementCase(`Object.notCreate(null)`, nil, 1),
+			replacementCase(`foo.notInsertBefore(foo, null)`, nil, 1),
+			replacementCase(`NotObject.create(null)`, nil, 1),
+			replacementCase(`lib.Object.create(null)`, nil, 1),
+			replacementCase(`Object.create(...[null])`, nil, 1),
+			replacementCase(`Object.create(null, bar, extraArgument)`, nil, 1),
+			replacementCase(`foo.insertBefore(null)`, nil, 1),
+			replacementCase(`foo.insertBefore(foo, null, bar)`, nil, 1),
+			replacementCase(`foo.insertBefore(...[foo], null)`, nil, 1),
+			replacementCase(`foo.insertBefore(null, bar)`, nil, 1),
+			replacementCase(`Object.create(bar, null)`, nil, 1),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -682,6 +682,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/no-invalid-remove-event-listener.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-magic-array-flat-depth.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-nested-ternary.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-null.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-object-as-default-parameter.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-null.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-null.test.ts
@@ -1,0 +1,104 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const js = (code: string, options: unknown[] = []) => ({
+  code,
+  filename: 'file.js',
+  options,
+});
+const error = {
+  messageId: 'error',
+  message: 'Use `undefined` instead of `null`.',
+};
+const invalid = (code: string, options: unknown[] = [], errors = [error]) => ({
+  code,
+  filename: 'file.js',
+  options,
+  errors,
+});
+
+const ignoreArguments = [{ checkArguments: false }];
+const checkStrictEquality = [{ checkStrictEquality: true }];
+
+ruleTester.run('no-null', null as never, {
+  valid: [
+    js('let foo'),
+    js('Object.create(null)'),
+    js('Object.create(null, {foo: {value:1}})'),
+    js('let insertedNode = parentNode.insertBefore(newNode, null)'),
+    js('let insertedNode = parentNode?.insertBefore(newNode, null)'),
+    js('const foo = "null";'),
+    js('Object.create()'),
+    js('Object.create(bar)'),
+    js('Object.create("null")'),
+    js('useRef(null)'),
+    js('React.useRef(null)'),
+    js('if (foo === null) {}'),
+    js('if (null === foo) {}'),
+    js('if (foo !== null) {}'),
+    js('if (null !== foo) {}'),
+    js('if (foo === null) {}', [{ checkStrictEquality: false }]),
+    js('if (null === foo) {}', [{ checkStrictEquality: false }]),
+    js('if (foo !== null) {}', [{ checkStrictEquality: false }]),
+    js('if (null !== foo) {}', [{ checkStrictEquality: false }]),
+    js('foo(null)', ignoreArguments),
+    js('foo(bar, null)', ignoreArguments),
+    js('drawingManager.setMap(null)', ignoreArguments),
+    js('markers[index].setMap(null)', ignoreArguments),
+    js('object?.method?.(null)', ignoreArguments),
+    js('foo?.(null)', ignoreArguments),
+    js('new HttpResponse(null)', ignoreArguments),
+    js('new HttpResponse(body, null)', ignoreArguments),
+    {
+      ...js('foo = Object.create(null)'),
+      languageOptions: { ecmaVersion: 2019 },
+    },
+  ],
+  invalid: [
+    invalid('const foo = null'),
+    invalid('foo(null)'),
+    invalid('if (foo == null) {}'),
+    invalid('if (foo != null) {}'),
+    invalid('if (null == foo) {}'),
+    invalid('if (null != foo) {}'),
+    invalid('function foo() {\n\treturn null;\n}'),
+    invalid('let foo = null;'),
+    invalid('var foo = null;'),
+    invalid('var foo = 1, bar = null, baz = 2;'),
+    invalid('const foo = null;'),
+    invalid('const foo = null;', ignoreArguments),
+    invalid('function foo() {\n\treturn null;\n}', ignoreArguments),
+    invalid('if (foo === null) {}', [
+      { checkArguments: false, checkStrictEquality: true },
+    ]),
+    invalid('foo([null])', ignoreArguments),
+    invalid('foo(bar ?? null)', ignoreArguments),
+    invalid('foo(...[null])', ignoreArguments),
+    invalid('new HttpResponse([null])', ignoreArguments),
+    invalid('if (foo === null) {}', checkStrictEquality),
+    invalid('if (null === foo) {}', checkStrictEquality),
+    invalid('if (foo !== null) {}', checkStrictEquality),
+    invalid('if (null !== foo) {}', checkStrictEquality),
+    invalid('new Object.create(null)'),
+    invalid('new foo.insertBefore(bar, null)'),
+    invalid('create(null)'),
+    invalid('insertBefore(bar, null)'),
+    invalid('Object["create"](null)'),
+    invalid('foo["insertBefore"](bar, null)'),
+    invalid('Object[create](null)'),
+    invalid('foo[insertBefore](bar, null)'),
+    invalid('Object[null](null)', [], [error, error]),
+    invalid('Object.notCreate(null)'),
+    invalid('foo.notInsertBefore(foo, null)'),
+    invalid('NotObject.create(null)'),
+    invalid('lib.Object.create(null)'),
+    invalid('Object.create(...[null])'),
+    invalid('Object.create(null, bar, extraArgument)'),
+    invalid('foo.insertBefore(null)'),
+    invalid('foo.insertBefore(foo, null, bar)'),
+    invalid('foo.insertBefore(...[foo], null)'),
+    invalid('foo.insertBefore(null, bar)'),
+    invalid('Object.create(bar, null)'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -131,7 +131,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-new-buffer': 'error', // not implemented
     // 'unicorn/no-non-function-verb-prefix': 'error', // not implemented
     // 'unicorn/no-nonstandard-builtin-properties': 'error', // not implemented
-    // 'unicorn/no-null': 'error', // not implemented
+    'unicorn/no-null': 'error',
     'unicorn/no-object-as-default-parameter': 'error',
     // 'unicorn/no-object-methods-with-collections': 'error', // not implemented
     // 'unicorn/no-optional-chaining-on-undeclared-variable': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/no-null` from `eslint-plugin-unicorn@v74.0.0`.

The rule disallows the `null` literal and encourages using `undefined` as the
single value for missing data.

- Support the `checkArguments` and `checkStrictEquality` options.
- Preserve the upstream exceptions for `Object.create()`, React `useRef()`,
  and `insertBefore()` calls.
- Autofix loose equality comparisons by replacing `null` with `undefined`.
- Provide suggestions for replacing `null`, removing return values, and
  removing mutable variable initializers.
- Ignore `null` in TypeScript type positions.
- Preserve upstream behavior for parentheses, optional calls, TypeScript
  expression wrappers, diagnostic ranges, and suggestion ranges.
- Register the rule in the native Unicorn catalog and enable it in the Unicorn
  recommended preset.
- Migrate the complete upstream v74.0.0 test suite.
- Add coverage for tsgo/ESTree differences, option combinations, edit demand,
  and real-world cases from upstream issues.
- Add an end-to-end RuleTester suite.

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/1309
- Documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-null.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-null.js
- Upstream tests: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/no-null.js

## Validation

- `go test -count=1 ./internal/plugins/unicorn/rules/no_null ./internal/plugins/unicorn ./internal/rules ./internal/config`
- `pnpm --dir packages/rslint run build:bin`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 no-null`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 presets`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint v2.12.2`: 0 issues

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
