### PR TITLE
feat: port rule unicorn/no-document-cookie

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_fill_with_reference_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_front_mutation"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_document_cookie"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_exports_in_scripts"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_invalid_fetch_options"
@@ -54,6 +55,7 @@ func GetAllRules() []rule.Rule {
 		no_array_fill_with_reference_type.NoArrayFillWithReferenceTypeRule,
 		no_array_front_mutation.NoArrayFrontMutationRule,
 		no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
+		no_document_cookie.NoDocumentCookieRule,
 		no_exports_in_scripts.NoExportsInScriptsRule,
 		no_instanceof_builtins.NoInstanceofBuiltinsRule,
 		no_invalid_fetch_options.NoInvalidFetchOptionsRule,

--- a/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.go
+++ b/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.go
@@ -17,16 +17,6 @@ const (
 	tracedGlobalObject
 )
 
-type tracedVariable struct {
-	symbol *ast.Symbol
-	value  tracedValue
-}
-
-type tracedGlobal struct {
-	name  string
-	value tracedValue
-}
-
 // documentReferenceTracker follows the global document object through the
 // flow-insensitive aliases supported by @eslint-community/eslint-utils'
 // ReferenceTracker. The active stacks prevent cycles without suppressing the
@@ -35,8 +25,8 @@ type documentReferenceTracker struct {
 	ctx               rule.RuleContext
 	identifiersByName map[string][]*ast.Node
 	propertyEvaluator *utils.StaticStringEvaluator
-	variableStack     map[tracedVariable]bool
-	globalStack       map[tracedGlobal]bool
+	variableStack     map[*ast.Symbol]bool
+	globalStack       map[string]bool
 	problems          []*ast.Node
 }
 
@@ -282,29 +272,25 @@ func (tracker *documentReferenceTracker) trackIdentifier(identifier *ast.Node, v
 }
 
 func documentBindingSymbol(identifier *ast.Node) *ast.Symbol {
-	if identifier == nil || identifier.Kind != ast.KindIdentifier || identifier.Parent == nil {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier ||
+		!utils.IsDeclarationIdentifier(identifier) {
 		return nil
 	}
-	declaration := identifier.Parent
-	if declaration.Name() != identifier {
-		return nil
-	}
-	return declaration.Symbol()
+	return identifier.Parent.Symbol()
 }
 
 func (tracker *documentReferenceTracker) trackVariable(symbol *ast.Symbol, value tracedValue) {
 	if tracker.ctx.Refs == nil || symbol == nil {
 		return
 	}
-	key := tracedVariable{symbol: symbol, value: value}
-	if tracker.variableStack != nil && tracker.variableStack[key] {
+	if tracker.variableStack != nil && tracker.variableStack[symbol] {
 		return
 	}
 	if tracker.variableStack == nil {
-		tracker.variableStack = make(map[tracedVariable]bool)
+		tracker.variableStack = make(map[*ast.Symbol]bool)
 	}
-	tracker.variableStack[key] = true
-	defer delete(tracker.variableStack, key)
+	tracker.variableStack[symbol] = true
+	defer delete(tracker.variableStack, symbol)
 
 	for _, reference := range tracker.ctx.Refs.References(symbol) {
 		if !ast.IsWriteOnlyAccess(reference) {
@@ -314,15 +300,14 @@ func (tracker *documentReferenceTracker) trackVariable(symbol *ast.Symbol, value
 }
 
 func (tracker *documentReferenceTracker) trackGlobalVariable(name string, value tracedValue) {
-	key := tracedGlobal{name: name, value: value}
-	if tracker.globalStack != nil && tracker.globalStack[key] {
+	if tracker.globalStack != nil && tracker.globalStack[name] {
 		return
 	}
 	if tracker.globalStack == nil {
-		tracker.globalStack = make(map[tracedGlobal]bool)
+		tracker.globalStack = make(map[string]bool)
 	}
-	tracker.globalStack[key] = true
-	defer delete(tracker.globalStack, key)
+	tracker.globalStack[name] = true
+	defer delete(tracker.globalStack, name)
 
 	for _, reference := range tracker.identifiersByName[name] {
 		if !ast.IsWriteOnlyAccess(reference) && tracker.isGlobalReference(reference, name) {
@@ -337,7 +322,7 @@ func (tracker *documentReferenceTracker) accessExpressionStaticName(node *ast.No
 		if tracker.propertyEvaluator == nil {
 			tracker.propertyEvaluator = utils.NewStaticStringEvaluatorWithoutScope()
 		}
-		return tracker.propertyEvaluator.Eval(argument)
+		return tracker.propertyEvaluator.EvalToString(argument)
 	}
 	return utils.AccessExpressionStaticName(node)
 }
@@ -347,7 +332,7 @@ func (tracker *documentReferenceTracker) staticPropertyName(node *ast.Node) (str
 		if tracker.propertyEvaluator == nil {
 			tracker.propertyEvaluator = utils.NewStaticStringEvaluatorWithoutScope()
 		}
-		return tracker.propertyEvaluator.Eval(node.AsComputedPropertyName().Expression)
+		return tracker.propertyEvaluator.EvalToString(node.AsComputedPropertyName().Expression)
 	}
 	return utils.GetStaticPropertyName(node)
 }

--- a/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.go
+++ b/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.go
@@ -1,0 +1,392 @@
+package no_document_cookie
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "no-document-cookie"
+
+var globalObjectNames = [...]string{"globalThis", "window", "self", "global"}
+
+type tracedValue uint8
+
+const (
+	tracedDocument tracedValue = iota
+	tracedGlobalObject
+)
+
+type tracedVariable struct {
+	symbol *ast.Symbol
+	value  tracedValue
+}
+
+type tracedGlobal struct {
+	name  string
+	value tracedValue
+}
+
+// documentReferenceTracker follows the global document object through the
+// flow-insensitive aliases supported by @eslint-community/eslint-utils'
+// ReferenceTracker. The active stacks prevent cycles without suppressing the
+// duplicate diagnostics that upstream emits when two roots reach one alias.
+type documentReferenceTracker struct {
+	ctx               rule.RuleContext
+	identifiersByName map[string][]*ast.Node
+	propertyEvaluator *utils.StaticStringEvaluator
+	variableStack     map[tracedVariable]bool
+	globalStack       map[tracedGlobal]bool
+	problems          []*ast.Node
+}
+
+// NoDocumentCookieRule disallows assigning to document.cookie directly.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-document-cookie.js
+var NoDocumentCookieRule = rule.Rule{
+	Name:   "unicorn/no-document-cookie",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		if !sourceMayReferenceDocument(ctx.SourceFile) {
+			return nil
+		}
+
+		tracker := &documentReferenceTracker{
+			ctx:               ctx,
+			identifiersByName: make(map[string][]*ast.Node),
+		}
+
+		return rule.RuleListeners{
+			ast.KindIdentifier: tracker.collectIdentifier,
+			rule.ListenerOnExit(ast.KindEndOfFile): func(*ast.Node) {
+				tracker.finish()
+			},
+		}
+	},
+}
+
+func sourceMayReferenceDocument(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	if _, ok := sourceFile.Identifiers["document"]; ok {
+		return true
+	}
+	for _, name := range globalObjectNames {
+		if _, ok := sourceFile.Identifiers[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (tracker *documentReferenceTracker) collectIdentifier(node *ast.Node) {
+	if utils.IsNonReferenceIdentifier(node) {
+		return
+	}
+	name := node.AsIdentifier().Text
+	tracker.identifiersByName[name] = append(tracker.identifiersByName[name], node)
+}
+
+func (tracker *documentReferenceTracker) finish() {
+	tracker.trackGlobalRoot("document", tracedDocument)
+	for _, name := range globalObjectNames {
+		tracker.trackGlobalRoot(name, tracedGlobalObject)
+	}
+
+	message := rule.RuleMessage{
+		Id:          messageID,
+		Description: "Do not use `document.cookie` directly.",
+	}
+	for _, node := range tracker.problems {
+		tracker.ctx.ReportNode(node, message)
+	}
+}
+
+func (tracker *documentReferenceTracker) trackGlobalRoot(name string, value tracedValue) {
+	if !tracker.ctx.Globals.Access(name).IsDeclared() {
+		return
+	}
+	references := tracker.globalReferences(name)
+	for _, reference := range references {
+		if utils.IsWriteReference(reference) {
+			return
+		}
+	}
+	for _, reference := range references {
+		tracker.trackExpression(reference, value)
+	}
+}
+
+func (tracker *documentReferenceTracker) globalReferences(name string) []*ast.Node {
+	var references []*ast.Node
+	for _, identifier := range tracker.identifiersByName[name] {
+		if tracker.isGlobalReference(identifier, name) {
+			references = append(references, identifier)
+		}
+	}
+	return references
+}
+
+func (tracker *documentReferenceTracker) isGlobalReference(identifier *ast.Node, name string) bool {
+	if tracker.ctx.Refs != nil {
+		return tracker.ctx.Refs.IsGlobalReference(identifier)
+	}
+	return !utils.IsShadowed(identifier, name)
+}
+
+func (tracker *documentReferenceTracker) trackExpression(node *ast.Node, value tracedValue) {
+	if node == nil {
+		return
+	}
+	for node.Parent != nil && documentValuePassesThrough(node, node.Parent) {
+		node = node.Parent
+	}
+
+	parent := node.Parent
+	if parent == nil {
+		return
+	}
+	if ast.IsAccessExpression(parent) && utils.AccessExpressionObject(parent) == node {
+		name, ok := tracker.accessExpressionStaticName(parent)
+		if !ok {
+			return
+		}
+		switch value {
+		case tracedGlobalObject:
+			if name == "document" {
+				tracker.trackExpression(parent, tracedDocument)
+			}
+		case tracedDocument:
+			if name == "cookie" && isDirectAssignmentTarget(parent) {
+				tracker.problems = append(tracker.problems, parent)
+			}
+		}
+		return
+	}
+
+	switch parent.Kind {
+	case ast.KindBinaryExpression:
+		binary := parent.AsBinaryExpression()
+		if binary != nil && binary.Right == node && binary.OperatorToken != nil &&
+			ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
+			tracker.trackAssignmentTarget(binary.Left, value)
+			tracker.trackExpression(parent, value)
+		}
+	case ast.KindVariableDeclaration:
+		declaration := parent.AsVariableDeclaration()
+		if declaration != nil && declaration.Initializer == node {
+			tracker.trackAssignmentTarget(declaration.Name(), value)
+		}
+	case ast.KindParameter:
+		parameter := parent.AsParameterDeclaration()
+		if parameter != nil && parameter.Initializer == node {
+			tracker.trackAssignmentTarget(parameter.Name(), value)
+		}
+	case ast.KindBindingElement:
+		element := parent.AsBindingElement()
+		if element != nil && element.Initializer == node {
+			tracker.trackAssignmentTarget(element.Name(), value)
+		}
+	case ast.KindShorthandPropertyAssignment:
+		property := parent.AsShorthandPropertyAssignment()
+		if property != nil && property.ObjectAssignmentInitializer == node {
+			tracker.trackAssignmentTarget(property.Name(), value)
+		}
+	}
+}
+
+func (tracker *documentReferenceTracker) trackAssignmentTarget(node *ast.Node, value tracedValue) {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		tracker.trackIdentifier(node, value)
+	case ast.KindObjectBindingPattern:
+		tracker.trackObjectBindingPattern(node, value)
+	case ast.KindObjectLiteralExpression:
+		tracker.trackObjectAssignmentPattern(node, value)
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
+			tracker.trackAssignmentTarget(binary.Left, value)
+		}
+	}
+}
+
+func (tracker *documentReferenceTracker) trackObjectBindingPattern(node *ast.Node, value tracedValue) {
+	if value != tracedGlobalObject {
+		return
+	}
+	pattern := node.AsBindingPattern()
+	if pattern == nil || pattern.Elements == nil {
+		return
+	}
+	for _, elementNode := range pattern.Elements.Nodes {
+		element := elementNode.AsBindingElement()
+		if element == nil || element.DotDotDotToken != nil || element.Name() == nil {
+			continue
+		}
+		propertyName := element.PropertyName
+		if propertyName == nil {
+			propertyName = element.Name()
+		}
+		if name, ok := tracker.staticPropertyName(propertyName); ok && name == "document" {
+			tracker.trackAssignmentTarget(element.Name(), tracedDocument)
+		}
+	}
+}
+
+func (tracker *documentReferenceTracker) trackObjectAssignmentPattern(node *ast.Node, value tracedValue) {
+	if value != tracedGlobalObject {
+		return
+	}
+	object := node.AsObjectLiteralExpression()
+	if object == nil || object.Properties == nil {
+		return
+	}
+	for _, propertyNode := range object.Properties.Nodes {
+		switch propertyNode.Kind {
+		case ast.KindPropertyAssignment:
+			property := propertyNode.AsPropertyAssignment()
+			if name, ok := tracker.staticPropertyName(property.Name()); ok && name == "document" {
+				tracker.trackAssignmentTarget(property.Initializer, tracedDocument)
+			}
+		case ast.KindShorthandPropertyAssignment:
+			property := propertyNode.AsShorthandPropertyAssignment()
+			if name, ok := tracker.staticPropertyName(property.Name()); ok && name == "document" {
+				tracker.trackAssignmentTarget(property.Name(), tracedDocument)
+			}
+		}
+	}
+}
+
+func (tracker *documentReferenceTracker) trackIdentifier(identifier *ast.Node, value tracedValue) {
+	if tracker.ctx.Refs != nil {
+		if symbol := tracker.ctx.Refs.Resolve(identifier); utils.IsValueSymbolDeclaredInFile(symbol, tracker.ctx.SourceFile) {
+			tracker.trackVariable(symbol, value)
+			return
+		}
+	}
+	if symbol := documentBindingSymbol(identifier); symbol != nil {
+		tracker.trackVariable(symbol, value)
+		return
+	}
+	name := identifier.AsIdentifier().Text
+	if tracker.ctx.Globals.Access(name).IsDeclared() && tracker.isGlobalReference(identifier, name) {
+		tracker.trackGlobalVariable(name, value)
+	}
+}
+
+func documentBindingSymbol(identifier *ast.Node) *ast.Symbol {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier || identifier.Parent == nil {
+		return nil
+	}
+	declaration := identifier.Parent
+	if declaration.Name() != identifier {
+		return nil
+	}
+	return declaration.Symbol()
+}
+
+func (tracker *documentReferenceTracker) trackVariable(symbol *ast.Symbol, value tracedValue) {
+	if tracker.ctx.Refs == nil || symbol == nil {
+		return
+	}
+	key := tracedVariable{symbol: symbol, value: value}
+	if tracker.variableStack != nil && tracker.variableStack[key] {
+		return
+	}
+	if tracker.variableStack == nil {
+		tracker.variableStack = make(map[tracedVariable]bool)
+	}
+	tracker.variableStack[key] = true
+	defer delete(tracker.variableStack, key)
+
+	for _, reference := range tracker.ctx.Refs.References(symbol) {
+		if !ast.IsWriteOnlyAccess(reference) {
+			tracker.trackExpression(reference, value)
+		}
+	}
+}
+
+func (tracker *documentReferenceTracker) trackGlobalVariable(name string, value tracedValue) {
+	key := tracedGlobal{name: name, value: value}
+	if tracker.globalStack != nil && tracker.globalStack[key] {
+		return
+	}
+	if tracker.globalStack == nil {
+		tracker.globalStack = make(map[tracedGlobal]bool)
+	}
+	tracker.globalStack[key] = true
+	defer delete(tracker.globalStack, key)
+
+	for _, reference := range tracker.identifiersByName[name] {
+		if !ast.IsWriteOnlyAccess(reference) && tracker.isGlobalReference(reference, name) {
+			tracker.trackExpression(reference, value)
+		}
+	}
+}
+
+func (tracker *documentReferenceTracker) accessExpressionStaticName(node *ast.Node) (string, bool) {
+	if node.Kind == ast.KindElementAccessExpression {
+		argument := node.AsElementAccessExpression().ArgumentExpression
+		if tracker.propertyEvaluator == nil {
+			tracker.propertyEvaluator = utils.NewStaticStringEvaluatorWithoutScope()
+		}
+		return tracker.propertyEvaluator.Eval(argument)
+	}
+	return utils.AccessExpressionStaticName(node)
+}
+
+func (tracker *documentReferenceTracker) staticPropertyName(node *ast.Node) (string, bool) {
+	if node != nil && node.Kind == ast.KindComputedPropertyName {
+		if tracker.propertyEvaluator == nil {
+			tracker.propertyEvaluator = utils.NewStaticStringEvaluatorWithoutScope()
+		}
+		return tracker.propertyEvaluator.Eval(node.AsComputedPropertyName().Expression)
+	}
+	return utils.GetStaticPropertyName(node)
+}
+
+func documentValuePassesThrough(node *ast.Node, parent *ast.Node) bool {
+	if ast.IsOuterExpression(parent, ast.OEKParentheses|ast.OEKAssertions|ast.OEKExpressionsWithTypeArguments) {
+		return parent.Expression() == node
+	}
+	if parent.Kind == ast.KindConditionalExpression {
+		conditional := parent.AsConditionalExpression()
+		return conditional.WhenTrue == node || conditional.WhenFalse == node
+	}
+	if parent.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	binary := parent.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		return false
+	}
+	switch binary.OperatorToken.Kind {
+	case ast.KindBarBarToken, ast.KindAmpersandAmpersandToken, ast.KindQuestionQuestionToken:
+		return binary.Left == node || binary.Right == node
+	case ast.KindCommaToken:
+		return binary.Right == node
+	default:
+		return false
+	}
+}
+
+func isDirectAssignmentTarget(node *ast.Node) bool {
+	current := node
+	for current.Parent != nil && current.Parent.Kind == ast.KindParenthesizedExpression {
+		current = current.Parent
+	}
+	parent := current.Parent
+	if parent == nil || parent.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	binary := parent.AsBinaryExpression()
+	return binary != nil && binary.Left == current && binary.OperatorToken != nil &&
+		ast.IsAssignmentOperator(binary.OperatorToken.Kind)
+}

--- a/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.md
+++ b/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.md
@@ -1,0 +1,40 @@
+# no-document-cookie
+
+## Rule Details
+
+Disallow assigning to `document.cookie` directly. Constructing cookie strings
+by hand is error-prone; prefer the Cookie Store API or a cookie library.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+document.cookie = 'name=value; Path=/; Secure';
+document.cookie += '; SameSite=Lax';
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+await cookieStore.set({
+  name: 'name',
+  value: 'value',
+  path: '/',
+});
+
+const cookies = document.cookie.split('; ');
+```
+
+The rule follows aliases of the global `document` object and its standard
+global-object forms, so these assignments are also reported:
+
+```javascript
+const doc = globalThis.document;
+doc.cookie = 'name=value';
+
+window.document.cookie = 'name=value';
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-document-cookie](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-document-cookie.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-document-cookie.js)

--- a/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie_extras_test.go
@@ -1,0 +1,154 @@
+// TestNoDocumentCookieExtras covers ReferenceTracker branches, tsgo edge
+// shapes, and real-user scenarios absent from the upstream suite. The exact
+// upstream migration lives in no_document_cookie_upstream_test.go.
+package no_document_cookie_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_document_cookie"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDocumentCookieExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_document_cookie.NoDocumentCookieRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream filter(): reads and deletes are not assignments.
+			extraValid(`console.log(document.cookie)`),
+			extraValid(`delete document.cookie`),
+
+			// Locks in ReferenceTracker's dynamic-key rejection branch.
+			extraValid(`const key = "cookie"; document[key] = "foo=bar"`),
+			extraValid(`document[0] = "foo=bar"`),
+			extraValid(`document[Symbol.cookie] = "foo=bar"`),
+
+			// Locks in ReferenceTracker's modified-global root guard.
+			extraValid(`document = replacement; document.cookie = "foo=bar"`),
+			extraValid(`document.cookie = "foo=bar"; document = replacement`),
+			extraValid(`window = replacement; window.document.cookie = "foo=bar"`),
+
+			// Locks in global-reference checks for local shadowing and disabled globals.
+			extraValid(`function set(document) { document.cookie = "foo=bar" }`),
+			{
+				Code:     `document.cookie = "foo=bar"`,
+				FileName: "file.mjs",
+				Globals:  map[string]any{"document": "off"},
+			},
+
+			// Locks in SequenceExpression's non-final branch.
+			extraValid(`const doc = (document, replacement); doc.cookie = "foo=bar"`),
+
+			// ---- Dimension 4: optional access is a read and cannot be an assignment target ----
+			extraValid(`const value = document?.cookie`),
+
+			// ---- Dimension 4: full-expression TS wrappers fail upstream's direct-parent filter ----
+			extraValid(`(document.cookie as string) = "foo=bar"`),
+			extraValid(`(document.cookie)! = "foo=bar"`),
+
+			// ---- Dimension 4: empty/rest binding patterns degrade gracefully ----
+			extraValid(`const {} = globalThis`),
+			extraValid(`const {...rest} = globalThis; rest.cookie = "foo=bar"`),
+
+			// ---- Real-user: issue #1542 reads document.cookie in logging code ----
+			extraValid(`console.log("cookie", document.cookie)`),
+
+			// N/A: private keys; private identifiers cannot be used on document.
+			// N/A: function/class container variants; the rule targets assignment expressions.
+			// N/A: body-absent declarations; no declaration body is inspected.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver and full-expression wrappers ----
+			extraInvalid(`(document).cookie = "foo=bar"`, `(document).cookie`),
+			extraInvalid(`((document)).cookie = "foo=bar"`, `((document)).cookie`),
+			extraInvalid(`(document.cookie) = "foo=bar"`, `document.cookie`),
+
+			// ---- Dimension 4: TypeScript receiver wrappers are transparent ----
+			extraInvalid(`document!.cookie = "foo=bar"`, `document!.cookie`),
+			extraInvalid(`(document as Document).cookie = "foo=bar"`, `(document as Document).cookie`),
+			extraInvalid(`(document satisfies Document).cookie = "foo=bar"`, `(document satisfies Document).cookie`),
+
+			// ---- Dimension 4: static element-access key forms are tracked ----
+			extraInvalid(`document["cookie"] = "foo=bar"`, `document["cookie"]`),
+			extraInvalid("document[`cookie`] = \"foo=bar\"", "document[`cookie`]"),
+
+			// Locks in ReferenceTracker's assignment-alias branch.
+			extraInvalid(`let doc; doc = document; doc.cookie = "foo=bar"`, `doc.cookie`),
+
+			// Locks in ReferenceTracker's object-pattern alias branch.
+			extraInvalid(`const {document: doc} = globalThis; doc.cookie = "foo=bar"`, `doc.cookie`),
+			extraInvalid(`let doc; ({document: doc} = globalThis); doc.cookie = "foo=bar"`, `doc.cookie`),
+
+			// Locks in ReferenceTracker's parameter/default AssignmentPattern branch.
+			extraInvalid(`function set(doc = document) { doc.cookie = "foo=bar" }`, `doc.cookie`),
+
+			// Locks in ReferenceTracker's conditional/logical/pass-through branches.
+			extraInvalid(`const doc = flag ? document : replacement; doc.cookie = "foo=bar"`, `doc.cookie`),
+			extraInvalid(`const doc = document || replacement; doc.cookie = "foo=bar"`, `doc.cookie`),
+			extraInvalid(`const doc = (0, document); doc.cookie = "foo=bar"`, `doc.cookie`),
+
+			// Locks in chained local aliases and all supported global-object roots.
+			extraInvalid(`const first = document; const second = first; second.cookie = "foo=bar"`, `second.cookie`),
+			extraInvalid(`self.document.cookie = "foo=bar"`, `self.document.cookie`),
+			extraInvalid(`global.document.cookie = "foo=bar"`, `global.document.cookie`),
+
+			// Locks in ReferenceTracker's per-root traversal: converging roots report twice.
+			extraInvalidCount(
+				`const doc = flag ? document : window.document; doc.cookie = "foo=bar"`,
+				`doc.cookie`,
+				2,
+			),
+
+			// ---- Dimension 4: same-kind nesting keeps each alias scope independent ----
+			extraInvalid(
+				"const doc = document;\nfunction set() {\n\tconst nested = doc;\n\tnested.cookie = \"foo=bar\";\n}",
+				`nested.cookie`,
+			),
+
+			// ---- Real-user: issue #2301 library-generated cookie strings still assign directly ----
+			extraInvalid(`document.cookie = setCookie(MyCookie, {foo: "baz"})`, `document.cookie`),
+
+			// ---- Real-user: PR #1833 added window.document tracking ----
+			extraInvalid(`window["document"]["cookie"] = "foo=bar"`, `window["document"]["cookie"]`),
+		},
+	)
+}
+
+func extraValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{
+		Code:     code,
+		FileName: extraFileName(code),
+		Globals:  noDocumentCookieGlobals(),
+	}
+}
+
+func extraInvalid(code, target string) rule_tester.InvalidTestCase {
+	return extraInvalidCount(code, target, 1)
+}
+
+func extraInvalidCount(code, target string, count int) rule_tester.InvalidTestCase {
+	errors := make([]rule_tester.InvalidTestCaseError, count)
+	for index := range count {
+		errors[index] = expectedError(code, target, 0)
+	}
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: extraFileName(code),
+		Globals:  noDocumentCookieGlobals(),
+		Errors:   errors,
+	}
+}
+
+func extraFileName(code string) string {
+	for _, marker := range []string{" as ", " satisfies ", "!.", ")!"} {
+		if strings.Contains(code, marker) {
+			return "file.ts"
+		}
+	}
+	return "file.mjs"
+}

--- a/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie_extras_test.go
@@ -33,6 +33,9 @@ func TestNoDocumentCookieExtras(t *testing.T) {
 			extraValid(`document.cookie = "foo=bar"; document = replacement`),
 			extraValid(`window = replacement; window.document.cookie = "foo=bar"`),
 
+			// Locks in ReferenceTracker's variable-identity cycle guard.
+			extraValid(`let a = globalThis; let b = a.document; a = b; a.cookie = "foo=bar"`),
+
 			// Locks in global-reference checks for local shadowing and disabled globals.
 			extraValid(`function set(document) { document.cookie = "foo=bar" }`),
 			{
@@ -76,13 +79,16 @@ func TestNoDocumentCookieExtras(t *testing.T) {
 			// ---- Dimension 4: static element-access key forms are tracked ----
 			extraInvalid(`document["cookie"] = "foo=bar"`, `document["cookie"]`),
 			extraInvalid("document[`cookie`] = \"foo=bar\"", "document[`cookie`]"),
+			extraInvalid(`document[["cookie"]] = "foo=bar"`, `document[["cookie"]]`),
 
 			// Locks in ReferenceTracker's assignment-alias branch.
 			extraInvalid(`let doc; doc = document; doc.cookie = "foo=bar"`, `doc.cookie`),
 
 			// Locks in ReferenceTracker's object-pattern alias branch.
 			extraInvalid(`const {document: doc} = globalThis; doc.cookie = "foo=bar"`, `doc.cookie`),
+			extraInvalid(`const {[["document"]]: doc} = globalThis; doc.cookie = "foo=bar"`, `doc.cookie`),
 			extraInvalid(`let doc; ({document: doc} = globalThis); doc.cookie = "foo=bar"`, `doc.cookie`),
+			extraInvalid(`({document} = globalThis); document.cookie = "foo=bar"`, `document.cookie`),
 
 			// Locks in ReferenceTracker's parameter/default AssignmentPattern branch.
 			extraInvalid(`function set(doc = document) { doc.cookie = "foo=bar" }`, `doc.cookie`),

--- a/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie_upstream_test.go
@@ -1,0 +1,122 @@
+// TestNoDocumentCookieUpstream migrates the complete valid/invalid suite from
+// upstream test/no-document-cookie.js at v74.0.0. Position assertions cover
+// every invalid case. rslint-specific cases live in
+// no_document_cookie_extras_test.go.
+package no_document_cookie_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_document_cookie"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID   = "no-document-cookie"
+	messageText = "Do not use `document.cookie` directly."
+)
+
+func TestNoDocumentCookieUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_document_cookie.NoDocumentCookieRule,
+		[]rule_tester.ValidTestCase{
+			upstreamValid(`document.cookie`),
+			upstreamValid(`const foo = document.cookie`),
+			upstreamValid(`foo = document.cookie`),
+			upstreamValid(`foo = document?.cookie`),
+			upstreamValid(`foo = document.cookie + ";foo=bar"`),
+			upstreamValid(`delete document.cookie`),
+			upstreamValid(`if (document.cookie.includes("foo")){}`),
+			upstreamValid(`Object.assign(document, {cookie: "foo=bar"})`),
+			upstreamValid(`document[CONSTANTS_COOKIE] = "foo=bar"`),
+			upstreamValid(`document[cookie] = "foo=bar"`),
+			upstreamValid("const CONSTANTS_COOKIE = \"cookie\";\ndocument[CONSTANTS_COOKIE] = \"foo=bar\";"),
+		},
+		[]rule_tester.InvalidTestCase{
+			upstreamInvalid(`document.cookie = "foo=bar"`, `document.cookie`),
+			upstreamInvalid(`document.cookie += ";foo=bar"`, `document.cookie`),
+			upstreamInvalid(`document.cookie = document.cookie + ";foo=bar"`, `document.cookie`),
+			upstreamInvalid(`document.cookie &&= true`, `document.cookie`),
+			upstreamInvalid(`document["coo" + "kie"] = "foo=bar"`, `document["coo" + "kie"]`),
+			upstreamInvalid(`foo = document.cookie = "foo=bar"`, `document.cookie`),
+			upstreamInvalid(`var doc = document; doc.cookie = "foo=bar"`, `doc.cookie`),
+			upstreamInvalid(`let doc = document; doc.cookie = "foo=bar"`, `doc.cookie`),
+			upstreamInvalid(`const doc = globalThis.document; doc.cookie = "foo=bar"`, `doc.cookie`),
+			upstreamInvalid(`window.document.cookie = "foo=bar"`, `window.document.cookie`),
+		},
+	)
+}
+
+func upstreamValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{
+		Code:     code,
+		FileName: "file.mjs",
+		Globals:  noDocumentCookieGlobals(),
+	}
+}
+
+func upstreamInvalid(code, target string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mjs",
+		Globals:  noDocumentCookieGlobals(),
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, 0),
+		},
+	}
+}
+
+func noDocumentCookieGlobals() map[string]any {
+	return map[string]any{
+		"document": "readonly",
+		"global":   "readonly",
+		"self":     "readonly",
+		"window":   "readonly",
+	}
+}
+
+func expectedError(code, target string, occurrence int) rule_tester.InvalidTestCaseError {
+	offset := -1
+	searchFrom := 0
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], target)
+		if relative < 0 {
+			panic("target not found in no-document-cookie test: " + target)
+		}
+		offset = searchFrom + relative
+		searchFrom = offset + len(target)
+	}
+
+	line, column := lineColumn(code, offset)
+	endLine, endColumn := lineColumn(code, offset+len(target))
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   messageText,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func lineColumn(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for index, character := range code {
+		if index >= offset {
+			break
+		}
+		if character == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return line, column
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -677,6 +677,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/no-array-fill-with-reference-type.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-front-mutation.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-document-cookie.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-exports-in-scripts.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-invalid-fetch-options.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-document-cookie.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-document-cookie.test.ts
@@ -1,0 +1,56 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const withBrowserGlobals = (code: string) => ({
+  code,
+  filename: 'file.mjs',
+  languageOptions: {
+    // The upstream test harness enables browser and Node globals by default.
+    globals: {
+      document: 'readonly',
+      global: 'readonly',
+      self: 'readonly',
+      window: 'readonly',
+    } as const,
+  },
+});
+const invalid = (code: string) => ({
+  ...withBrowserGlobals(code),
+  errors: [
+    {
+      messageId: 'no-document-cookie',
+      message: 'Do not use `document.cookie` directly.',
+    },
+  ],
+});
+
+ruleTester.run('no-document-cookie', null as never, {
+  valid: [
+    withBrowserGlobals('document.cookie'),
+    withBrowserGlobals('const foo = document.cookie'),
+    withBrowserGlobals('foo = document.cookie'),
+    withBrowserGlobals('foo = document?.cookie'),
+    withBrowserGlobals('foo = document.cookie + ";foo=bar"'),
+    withBrowserGlobals('delete document.cookie'),
+    withBrowserGlobals('if (document.cookie.includes("foo")){}'),
+    withBrowserGlobals('Object.assign(document, {cookie: "foo=bar"})'),
+    withBrowserGlobals('document[CONSTANTS_COOKIE] = "foo=bar"'),
+    withBrowserGlobals('document[cookie] = "foo=bar"'),
+    withBrowserGlobals(
+      'const CONSTANTS_COOKIE = "cookie";\ndocument[CONSTANTS_COOKIE] = "foo=bar";',
+    ),
+  ],
+  invalid: [
+    invalid('document.cookie = "foo=bar"'),
+    invalid('document.cookie += ";foo=bar"'),
+    invalid('document.cookie = document.cookie + ";foo=bar"'),
+    invalid('document.cookie &&= true'),
+    invalid('document["coo" + "kie"] = "foo=bar"'),
+    invalid('foo = document.cookie = "foo=bar"'),
+    invalid('var doc = document; doc.cookie = "foo=bar"'),
+    invalid('let doc = document; doc.cookie = "foo=bar"'),
+    invalid('const doc = globalThis.document; doc.cookie = "foo=bar"'),
+    invalid('window.document.cookie = "foo=bar"'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -87,7 +87,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-console-spaces': 'error', // not implemented
     // 'unicorn/no-constant-zero-expression': 'error', // not implemented
     // 'unicorn/no-declarations-before-early-exit': 'error', // not implemented
-    // 'unicorn/no-document-cookie': 'error', // not implemented
+    'unicorn/no-document-cookie': 'error',
     // 'unicorn/no-double-comparison': 'error', // not implemented
     // 'unicorn/no-duplicate-if-branches': 'error', // not implemented
     // 'unicorn/no-duplicate-logical-operands': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/no-document-cookie` from `eslint-plugin-unicorn@v74.0.0`.

The rule disallows assigning to `document.cookie` directly while allowing
cookie reads.

- Follow aliases of the global `document` object.
- Support `globalThis.document`, `window.document`, `self.document`, and
  `global.document`.
- Support statically computed properties such as
  `document["coo" + "kie"]`.
- Preserve upstream behavior for shadowed and modified globals, conditional
  and logical expressions, TypeScript wrappers, converging aliases, and
  diagnostic ranges.
- Register the rule in the native Unicorn catalog and enable it in the Unicorn
  recommended preset.
- Migrate the complete upstream v74.0.0 test suite.
- Add coverage for tsgo/ESTree differences, destructuring, nested aliases,
  static and dynamic properties, and real-world upstream cases.
- Add an end-to-end RuleTester suite.

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/1309
- Documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-document-cookie.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-document-cookie.js
- Upstream tests: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/no-document-cookie.js

## Validation

- `go test -count=1 ./internal/plugins/unicorn/rules/no_document_cookie`
- `pnpm --dir packages/rslint run build:bin`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 no-document-cookie`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 presets`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint v2.13.2`: 0 issues
- Differential checks against the upstream ESLint rule for JavaScript and
  TypeScript edge cases

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
