### PR TITLE
feat: port rule unicorn/no-this-outside-of-class

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -23,6 +23,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_this_assignment"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_this_outside_of_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unnecessary_array_flat_depth"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unreadable_new_expression"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unsafe_string_replacement"
@@ -68,6 +69,7 @@ func GetAllRules() []rule.Rule {
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,
 		no_this_assignment.NoThisAssignmentRule,
+		no_this_outside_of_class.NoThisOutsideOfClassRule,
 		no_unnecessary_array_flat_depth.NoUnnecessaryArrayFlatDepthRule,
 		no_unreadable_new_expression.NoUnreadableNewExpressionRule,
 		no_unsafe_string_replacement.NoUnsafeStringReplacementRule,

--- a/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class.go
+++ b/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class.go
@@ -1,0 +1,140 @@
+package no_this_outside_of_class
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "no-this-outside-of-class"
+
+var defaultMessage = rule.RuleMessage{
+	Id:          messageID,
+	Description: "Do not use `this` outside of classes.",
+}
+
+// NoThisOutsideOfClassRule disallows using `this` outside of classes.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/rules/no-this-outside-of-class.js
+var NoThisOutsideOfClassRule = rule.Rule{
+	Name:   "unicorn/no-this-outside-of-class",
+	Schema: rule.EmptyArraySchema,
+	Run:    run,
+}
+
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	checkThis := func(node *ast.Node) {
+		if utils.IsInJsxTagName(node) {
+			return
+		}
+		if node.Parent != nil && ast.IsThisParameter(node.Parent) && node.Parent.Name() == node {
+			return
+		}
+		if !isAllowedThisBinding(node) {
+			ctx.ReportNode(node, defaultMessage)
+		}
+	}
+
+	return rule.RuleListeners{
+		ast.KindThisKeyword: checkThis,
+		ast.KindThisType: func(node *ast.Node) {
+			if isTypeQueryRoot(node) {
+				checkThis(node)
+			}
+		},
+		ast.KindIdentifier: func(node *ast.Node) {
+			if node.AsIdentifier().Text == "this" && isTypeQueryRoot(node) {
+				checkThis(node)
+			}
+		},
+	}
+}
+
+func isAllowedThisBinding(node *ast.Node) bool {
+	child := node
+	parent := node.Parent
+
+	for parent != nil {
+		if parent.Kind == ast.KindArrowFunction {
+			child = parent
+			parent = parent.Parent
+			continue
+		}
+
+		if parent.Kind == ast.KindFunctionDeclaration || parent.Kind == ast.KindFunctionExpression {
+			return hasThisParameter(parent)
+		}
+
+		if isMethodLike(parent) {
+			if isInsideMethodFunction(parent, child) {
+				return (parent.Parent != nil && ast.IsClassLike(parent.Parent)) || hasThisParameter(parent)
+			}
+			child = parent
+			parent = parent.Parent
+			continue
+		}
+
+		if parent.Kind == ast.KindClassStaticBlockDeclaration {
+			return true
+		}
+
+		if parent.Kind == ast.KindPropertyDeclaration {
+			prop := parent.AsPropertyDeclaration()
+			if prop != nil && prop.Initializer == child && parent.Parent != nil && ast.IsClassLike(parent.Parent) {
+				return true
+			}
+			child = parent
+			parent = parent.Parent
+			continue
+		}
+
+		child = parent
+		parent = parent.Parent
+	}
+
+	return false
+}
+
+func isMethodLike(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindMethodDeclaration,
+		ast.KindConstructor,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		return true
+	default:
+		return false
+	}
+}
+
+func isInsideMethodFunction(method *ast.Node, child *ast.Node) bool {
+	if child == nil {
+		return false
+	}
+	if child.Kind == ast.KindParameter {
+		return true
+	}
+	body := method.Body()
+	return body != nil && child == body
+}
+
+func hasThisParameter(node *ast.Node) bool {
+	for _, p := range node.Parameters() {
+		if ast.IsThisParameter(p) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTypeQueryRoot(node *ast.Node) bool {
+	current := node
+	for current != nil && current.Parent != nil && current.Parent.Kind == ast.KindQualifiedName {
+		qualified := current.Parent.AsQualifiedName()
+		if qualified == nil || qualified.Left != current {
+			return false
+		}
+		current = current.Parent
+	}
+	return current != nil && current.Parent != nil && current.Parent.Kind == ast.KindTypeQuery
+}

--- a/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class.go
+++ b/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class.go
@@ -62,11 +62,23 @@ func isAllowedThisBinding(node *ast.Node) bool {
 		}
 
 		if parent.Kind == ast.KindFunctionDeclaration || parent.Kind == ast.KindFunctionExpression {
+			// In TypeScript, an overload signature without a body has no ESTree
+			// FunctionExpression representation (TSDeclareFunction) and does not
+			// bind `this`; it passes through to the enclosing scope.
+			if parent.Body() == nil {
+				child = parent
+				parent = parent.Parent
+				continue
+			}
 			return hasThisParameter(parent)
 		}
 
 		if isMethodLike(parent) {
-			if isInsideMethodFunction(parent, child) {
+			// In ESTree, a class method's FunctionExpression wraps parameters,
+			// type parameters, return type, and body — but only when implemented.
+			// Body-less signatures (overloads, abstract methods) do not bind `this`
+			// and continue upward to the enclosing scope.
+			if isInsideImplementedMethodFunction(parent, child) {
 				return (parent.Parent != nil && ast.IsClassLike(parent.Parent)) || hasThisParameter(parent)
 			}
 			child = parent
@@ -107,15 +119,16 @@ func isMethodLike(node *ast.Node) bool {
 	}
 }
 
-func isInsideMethodFunction(method *ast.Node, child *ast.Node) bool {
-	if child == nil {
+func isInsideImplementedMethodFunction(method *ast.Node, child *ast.Node) bool {
+	if child == nil || method.Body() == nil {
 		return false
 	}
-	if child.Kind == ast.KindParameter {
-		return true
+	// Name (computed property name) is the method's key in ESTree terms,
+	// and modifiers (decorators) attach to the MethodDefinition, outside the FunctionExpression.
+	if child == method.Name() || child.Kind == ast.KindDecorator {
+		return false
 	}
-	body := method.Body()
-	return body != nil && child == body
+	return true
 }
 
 func hasThisParameter(node *ast.Node) bool {

--- a/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class.md
+++ b/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class.md
@@ -1,0 +1,66 @@
+# no-this-outside-of-class
+
+## Rule Details
+
+Disallow `this` outside of classes. `this` should only be used when JavaScript
+class syntax or an explicit TypeScript `this` parameter defines the receiver.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function Foo(value) {
+  this.value = value;
+}
+
+const foo = {
+  method() {
+    return this.value;
+  },
+};
+
+Foo.prototype.method = function () {
+  this.value();
+};
+
+class Foo {
+  method() {
+    function getValue() {
+      return this.value;
+    }
+
+    return getValue();
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class Foo {
+  constructor(value) {
+    this.value = value;
+  }
+
+  method() {
+    return this.value;
+  }
+}
+
+class Foo {
+  method() {
+    const getValue = () => this.value;
+    return getValue();
+  }
+}
+
+const foo = {
+  validator(this: TrackedModel) {
+    return this.value;
+  },
+};
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-this-outside-of-class](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/docs/rules/no-this-outside-of-class.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/rules/no-this-outside-of-class.js)

--- a/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_extras_test.go
@@ -245,6 +245,11 @@ function validator(this: TrackedModel) {
 			invalidCase("abstract class C { abstract method(): typeof this.foo; }"),
 			invalidCase("abstract class C { abstract method(x: typeof this.foo): void; }"),
 			invalidCase("class C { constructor(x: typeof this.foo); constructor(x: any) {} }"),
+			// Occurrence 1 is 'this: C' (parameter name, ignored); occurrence 2 is 'typeof this.foo' (reported).
+			invalidCase("declare function f(this: C): typeof this.foo;", 2),
+			invalidCase("declare class C { method(this: C): typeof this.foo; }", 2),
+			invalidCase("interface I { method(this: C): typeof this.foo; }", 2),
+			invalidCase("type T = { method(this: C): typeof this.foo; };", 2),
 		},
 	)
 }

--- a/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_extras_test.go
@@ -145,6 +145,16 @@ class Foo {
 }
 `,
 			},
+			// ---- Lock-in: Implemented class method return type and type parameter constraints ----
+			{
+				Code: "class C { method(): typeof this.foo { return null as any; } }",
+			},
+			{
+				Code: "class C { method<T extends typeof this.foo>(): void {} }",
+			},
+			{
+				Code: "class C { method() { function foo(x: typeof this.bar): void; function foo(x: any) {} } }",
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 1: Async and generator functions outside class ----
@@ -230,6 +240,11 @@ function validator(this: TrackedModel) {
 // Occurrence 1 is 'this: TrackedModel' (parameter name, ignored).
 // Occurrence 2 is 'this.subValue' (expression inside helper, reported).
 `, 2),
+			// ---- Lock-in: Body-less method/constructor signatures and abstract methods report ----
+			invalidCase("class C { method(value: typeof this.foo): void; method(value: unknown) {} }"),
+			invalidCase("abstract class C { abstract method(): typeof this.foo; }"),
+			invalidCase("abstract class C { abstract method(x: typeof this.foo): void; }"),
+			invalidCase("class C { constructor(x: typeof this.foo); constructor(x: any) {} }"),
 		},
 	)
 }

--- a/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_extras_test.go
@@ -1,0 +1,235 @@
+// TestNoThisOutsideOfClassExtras tests edge-shape augmentation (Dimension 1-4),
+// real-user code shapes from upstream issues, and branch lock-ins.
+package no_this_outside_of_class_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_this_outside_of_class"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoThisOutsideOfClassExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_this_outside_of_class.NoThisOutsideOfClassRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 1: Async, generator, and async generator class methods ----
+			{
+				Code: `
+class Foo {
+	async asyncMethod() {
+		return this.value;
+	}
+	*genMethod() {
+		yield this.value;
+	}
+	async *asyncGenMethod() {
+		yield this.value;
+	}
+}
+`,
+			},
+			// ---- Dimension 4: Parenthesized receiver and expression wrappers ----
+			{
+				Code: `
+class Foo {
+	method() {
+		return (this).value;
+	}
+	nestedParens() {
+		return ((this)).value;
+	}
+	wrappedField = ((this.defaultValue));
+	parenArrowField = (() => (this.defaultValue));
+}
+`,
+			},
+			// ---- Dimension 4: TypeScript private identifiers and parameter properties ----
+			{
+				Code: `
+class Foo {
+	#privateField = this.value;
+	#privateMethod() {
+		return this.value;
+	}
+	get #privateGetter() {
+		return this.value;
+	}
+	set #privateSetter(val) {
+		this.value = val;
+	}
+	constructor(public x = this.value, readonly y = this.value) {}
+}
+`,
+			},
+			// ---- Dimension 4: Deeply nested arrow functions inside class method ----
+			{
+				Code: `
+class Foo {
+	deepArrows() {
+		return () => () => () => this.value;
+	}
+}
+`,
+			},
+			// ---- Dimension 4: Object literal properties inside class method ----
+			{
+				Code: `
+class Foo {
+	method() {
+		const obj = {
+			[this.key]: 1,
+			val: this.value,
+			arrow: () => this.value,
+		};
+		return obj;
+	}
+}
+`,
+			},
+			// ---- Dimension 4: JSX inside class method ----
+			{
+				Tsx: true,
+				Code: `
+class Foo {
+	render() {
+		return <div title={this.title}>{this.content}</div>;
+	}
+}
+`,
+			},
+			// ---- Dimension 4: JSX with <this /> tag name (ignored like ESTree) ----
+			{
+				Tsx:  true,
+				Code: "<this />;",
+			},
+			// ---- Real-user: Issue #3593 - TypeScript this parameter in validator callback ----
+			{
+				Code: `
+const config = {
+	validate: {
+		validator(this: TrackedModel, value: Date | null) {
+			const requiresSpecificDate = this.notificationFrequency === 'once';
+			const hasSpecificDate = value !== null;
+			return requiresSpecificDate === hasSpecificDate;
+		},
+	},
+};
+`,
+			},
+			// ---- Real-user: Nested class inside function with this parameter ----
+			{
+				Code: `
+function outer(this: OuterType) {
+	class Inner {
+		[this.key] = 1;
+		[this.method]() {}
+	}
+	return Inner;
+}
+`,
+			},
+			// ---- Lock-in: Method overload signatures with this in implementation ----
+			{
+				Code: `
+class Foo {
+	method(x: number): void;
+	method(x: string): void;
+	method(x: any): void {
+		this.value = x;
+	}
+}
+`,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 1: Async and generator functions outside class ----
+			invalidCase(`
+async function foo() {
+	return this.value;
+}
+`),
+			invalidCase(`
+function* foo() {
+	yield this.value;
+}
+`),
+			// ---- Dimension 4: Parenthesized this at top level ----
+			invalidCase("(this).value;"),
+			invalidCase("((this)).value;"),
+			invalidCase("(((this)));"),
+			// ---- Dimension 4: Deeply nested arrow functions at top level ----
+			invalidCase("const f = () => () => () => this.value;"),
+			// ---- Dimension 4: Object literal method inside class method (binds its own this) ----
+			invalidCase(`
+class Foo {
+	method() {
+		const obj = {
+			inner() {
+				return this.value;
+			},
+		};
+	}
+}
+`),
+			// ---- Dimension 4: JSX inside non-class function ----
+			func() rule_tester.InvalidTestCase {
+				tc := invalidCase(`
+function Comp() {
+	return <div title={this.title} />;
+}
+`)
+				tc.Tsx = true
+				return tc
+			}(),
+			// ---- Dimension 4: Type query (typeof this) at top level ----
+			invalidCase("type T = typeof this;"),
+			// ---- Dimension 4: Type query (typeof this) in class field type annotation ----
+			invalidCase(`
+class Foo {
+	x: typeof this;
+}
+`),
+			// ---- Real-user: Issue #2450 - UMD wrapper with self : this fallback ----
+			invalidCase("(typeof self !== 'undefined' ? self : this);"),
+			// ---- Real-user: Issue #2450 - Vue options API with this in method ----
+			invalidCase(`
+const component = {
+	methods: {
+		foo() {
+			this.name = 'xxx';
+		},
+	},
+};
+`),
+			// ---- Real-user: Issue #2450 - Vue options API with multiple methods using this ----
+			invalidCase(`
+const component = {
+	methods: {
+		greet() {
+			return this.message;
+		},
+		update() {
+			this.count++;
+		},
+	},
+};
+`, 1, 2),
+			// ---- Real-user: Issue #3593 - Function inside validator with this parameter ----
+			invalidCase(`
+function validator(this: TrackedModel) {
+	const helper = function () {
+		return this.subValue;
+	};
+	return helper();
+}
+// Occurrence 1 is 'this: TrackedModel' (parameter name, ignored).
+// Occurrence 2 is 'this.subValue' (expression inside helper, reported).
+`, 2),
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_this_outside_of_class/no_this_outside_of_class_upstream_test.go
@@ -1,0 +1,367 @@
+// TestNoThisOutsideOfClassUpstream migrates the complete valid/invalid suite from
+// upstream test/no-this-outside-of-class.js at v72.0.0 (plus PR #3596 TypeScript
+// this-parameter tests). Position assertions cover every invalid case.
+// rslint-specific edge shapes, real-user cases, and branch lock-ins live in
+// no_this_outside_of_class_extras_test.go.
+package no_this_outside_of_class_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_this_outside_of_class"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID   = "no-this-outside-of-class"
+	messageText = "Do not use `this` outside of classes."
+)
+
+func thisOccurrenceRange(code string, occurrence int) (line, column, endLine, endColumn int) {
+	searchFrom := 0
+	offset := -1
+	for index := 1; index <= occurrence; index++ {
+		found := strings.Index(code[searchFrom:], "this")
+		if found < 0 {
+			panic("this occurrence not found in: " + code)
+		}
+		offset = searchFrom + found
+		searchFrom = offset + len("this")
+	}
+
+	before := code[:offset]
+	line = strings.Count(before, "\n") + 1
+	lastNewline := strings.LastIndex(before, "\n")
+	column = offset - lastNewline
+	return line, column, line, column + len("this")
+}
+
+func invalidCase(code string, occurrences ...int) rule_tester.InvalidTestCase {
+	if len(occurrences) == 0 {
+		occurrences = []int{1}
+	}
+	errors := make([]rule_tester.InvalidTestCaseError, len(occurrences))
+	for i, occ := range occurrences {
+		line, col, endLine, endCol := thisOccurrenceRange(code, occ)
+		errors[i] = rule_tester.InvalidTestCaseError{
+			MessageId: messageID,
+			Message:   messageText,
+			Line:      line,
+			Column:    col,
+			EndLine:   endLine,
+			EndColumn: endCol,
+		}
+	}
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Errors: errors,
+	}
+}
+
+func TestNoThisOutsideOfClassUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_this_outside_of_class.NoThisOutsideOfClassRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `
+class Foo {
+	constructor() {
+		this.value = 1;
+	}
+
+	method() {
+		return this.value;
+	}
+
+	methodWithDefault(value = this.value) {
+		return value;
+	}
+
+	static method() {
+		return this.value;
+	}
+
+	get value() {
+		return this._value;
+	}
+
+	set value(value) {
+		this._value = value;
+	}
+
+	#method() {
+		return this.value;
+	}
+}
+`,
+			},
+			{
+				Code: `
+const Foo = class {
+	value = this.defaultValue;
+	static value = this.defaultValue;
+};
+`,
+			},
+			{
+				Code: `
+class Foo {
+	static {
+		this.value = 1;
+	}
+}
+`,
+			},
+			{
+				Code: `
+class Foo {
+	method() {
+		const getValue = () => this.value;
+		return getValue();
+	}
+}
+`,
+			},
+			{
+				Code: `
+class Foo {
+	value = () => this.defaultValue;
+
+	static {
+		const update = () => this.value = 1;
+		update();
+	}
+}
+`,
+			},
+			{
+				Code: `
+class Foo {
+	method() {
+		class Bar {
+			method() {
+				return this.value;
+			}
+		}
+
+		return Bar;
+	}
+}
+`,
+			},
+			{
+				Code: `
+class Foo {
+	method() {
+		class Bar extends this.Base {
+			[this.key]() {}
+		}
+
+		return Bar;
+	}
+}
+`,
+			},
+			{
+				Code: `
+class Foo {
+	method() {
+		class Bar {
+			[this.key] = 1;
+		}
+
+		return Bar;
+	}
+}
+`,
+			},
+			// TypeScript: accessor property
+			{
+				Code: `
+class Foo {
+	accessor value = this.defaultValue;
+}
+`,
+			},
+			// TypeScript: non-arrow function with explicit this parameter
+			{
+				Code: `
+const foo = {
+	validator(this: TrackedModel, value: Date | null) {
+		const getValue = () => this.value;
+		return getValue() === value;
+	},
+};
+`,
+			},
+			{
+				Code: `
+function validator(this: TrackedModel) {
+	return this.value;
+}
+`,
+			},
+			{
+				Code: `
+const validator = function (this: TrackedModel) {
+	return this.value;
+};
+`,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			invalidCase("this.value;"),
+			invalidCase("const getValue = () => this.value;"),
+			invalidCase(`
+function foo() {
+	return this.value;
+}
+`),
+			invalidCase(`
+function Foo(value) {
+	this.value = value;
+}
+`),
+			invalidCase(`
+const foo = function () {
+	return this.value;
+};
+`),
+			invalidCase(`
+(function () {
+	this.value = 1;
+})();
+`),
+			invalidCase(`
+function foo() {
+	const getValue = () => this.value;
+	return getValue();
+}
+`),
+			invalidCase(`
+class Foo {
+	method() {
+		function getValue() {
+			return this.value;
+		}
+
+		return getValue();
+	}
+}
+`),
+			invalidCase(`
+class Foo {
+	value = function () {
+		return this.value;
+	};
+}
+`),
+			invalidCase(`
+class Foo {
+	static {
+		function update() {
+			this.value = 1;
+		}
+
+		update();
+	}
+}
+`),
+			invalidCase(`
+const foo = {
+	method() {
+		return this.value;
+	}
+};
+`),
+			invalidCase(`
+const foo = {
+	get value() {
+		return this._value;
+	},
+	set value(value) {
+		this._value = value;
+	}
+};
+`, 1, 2),
+			invalidCase(`
+const foo = {
+	method: function () {
+		return this.value;
+	}
+};
+`),
+			invalidCase(`
+Foo.prototype.method = function () {
+	this.value();
+};
+`),
+			invalidCase(`
+new SDK({
+	onReady: function () {
+		this.value;
+	}
+});
+`),
+			invalidCase(`
+export default {
+	methods: {
+		refresh() {
+			this.list = getList();
+		}
+	}
+};
+`),
+			invalidCase(`
+class Foo {
+	[this.key]() {}
+}
+`),
+			invalidCase(`
+class Foo {
+	[this.key] = 1;
+}
+`),
+			invalidCase("class Foo extends this.Base {}"),
+			// TypeScript: accessor property with computed key
+			invalidCase(`
+class Foo {
+	accessor [this.key] = 1;
+}
+`),
+			// TypeScript: function without this parameter inside function with this parameter
+			invalidCase(`
+const foo = {
+	validator(this: TrackedModel) {
+		function getValue() {
+			return this.value;
+		}
+
+		return getValue();
+	},
+};
+`, 2),
+			// TypeScript: method without this parameter
+			invalidCase(`
+const foo = {
+	method() {
+		return this.value;
+	},
+};
+`),
+			// TypeScript: arrow function with (pseudo-)this parameter
+			invalidCase("const validator = (this: TrackedModel) => this.value;", 2),
+			// TypeScript: function with non-this parameter
+			invalidCase(`
+function validator(value: TrackedModel) {
+	return this.value;
+}
+`),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -689,6 +689,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-this-assignment.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-this-outside-of-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-unnecessary-array-flat-depth.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-unreadable-new-expression.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-unsafe-string-replacement.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-this-outside-of-class.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-this-outside-of-class.test.ts
@@ -1,0 +1,294 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const invalid = (code: string, errorCount = 1) => ({
+  code,
+  errors: Array.from({ length: errorCount }, () => ({
+    messageId: 'no-this-outside-of-class',
+    message: 'Do not use `this` outside of classes.',
+  })),
+});
+
+ruleTester.run('no-this-outside-of-class', null as never, {
+  valid: [
+    {
+      code: `
+class Foo {
+  constructor() {
+    this.value = 1;
+  }
+  method() {
+    return this.value;
+  }
+  methodWithDefault(value = this.value) {
+    return value;
+  }
+  static method() {
+    return this.value;
+  }
+  get value() {
+    return this._value;
+  }
+  set value(value) {
+    this._value = value;
+  }
+  #method() {
+    return this.value;
+  }
+}
+`,
+    },
+    {
+      code: `
+const Foo = class {
+  value = this.defaultValue;
+  static value = this.defaultValue;
+};
+`,
+    },
+    {
+      code: `
+class Foo {
+  static {
+    this.value = 1;
+  }
+}
+`,
+    },
+    {
+      code: `
+class Foo {
+  method() {
+    const getValue = () => this.value;
+    return getValue();
+  }
+}
+`,
+    },
+    {
+      code: `
+class Foo {
+  value = () => this.defaultValue;
+  static {
+    const update = () => this.value = 1;
+    update();
+  }
+}
+`,
+    },
+    {
+      code: `
+class Foo {
+  method() {
+    class Bar {
+      method() {
+        return this.value;
+      }
+    }
+    return Bar;
+  }
+}
+`,
+    },
+    {
+      code: `
+class Foo {
+  method() {
+    class Bar extends this.Base {
+      [this.key]() {}
+    }
+    return Bar;
+  }
+}
+`,
+    },
+    {
+      code: `
+class Foo {
+  method() {
+    class Bar {
+      [this.key] = 1;
+    }
+    return Bar;
+  }
+}
+`,
+    },
+    {
+      code: `
+class Foo {
+  accessor value = this.defaultValue;
+}
+`,
+    },
+    {
+      code: `
+const foo = {
+  validator(this: TrackedModel, value: Date | null) {
+    const getValue = () => this.value;
+    return getValue() === value;
+  },
+};
+`,
+    },
+    {
+      code: `
+function validator(this: TrackedModel) {
+  return this.value;
+}
+`,
+    },
+    {
+      code: `
+const validator = function (this: TrackedModel) {
+  return this.value;
+};
+`,
+    },
+  ],
+  invalid: [
+    invalid('this.value;'),
+    invalid('const getValue = () => this.value;'),
+    invalid(`
+function foo() {
+  return this.value;
+}
+`),
+    invalid(`
+function Foo(value) {
+  this.value = value;
+}
+`),
+    invalid(`
+const foo = function () {
+  return this.value;
+};
+`),
+    invalid(`
+(function () {
+  this.value = 1;
+})();
+`),
+    invalid(`
+function foo() {
+  const getValue = () => this.value;
+  return getValue();
+}
+`),
+    invalid(`
+class Foo {
+  method() {
+    function getValue() {
+      return this.value;
+    }
+    return getValue();
+  }
+}
+`),
+    invalid(`
+class Foo {
+  value = function () {
+    return this.value;
+  };
+}
+`),
+    invalid(`
+class Foo {
+  static {
+    function update() {
+      this.value = 1;
+    }
+    update();
+  }
+}
+`),
+    invalid(`
+const foo = {
+  method() {
+    return this.value;
+  }
+};
+`),
+    invalid(
+      `
+const foo = {
+  get value() {
+    return this._value;
+  },
+  set value(value) {
+    this._value = value;
+  }
+};
+`,
+      2,
+    ),
+    invalid(`
+const foo = {
+  method: function () {
+    return this.value;
+  }
+};
+`),
+    invalid(`
+Foo.prototype.method = function () {
+  this.value();
+};
+`),
+    invalid(`
+new SDK({
+  onReady: function () {
+    this.value;
+  }
+});
+`),
+    invalid(`
+export default {
+  methods: {
+    refresh() {
+      this.list = getList();
+    }
+  }
+};
+`),
+    invalid(`
+class Foo {
+  [this.key]() {}
+}
+`),
+    invalid(`
+class Foo {
+  [this.key] = 1;
+}
+`),
+    invalid('class Foo extends this.Base {}'),
+    invalid(`
+class Foo {
+  accessor [this.key] = 1;
+}
+`),
+    invalid(`
+const foo = {
+  validator(this: TrackedModel) {
+    function getValue() {
+      return this.value;
+    }
+    return getValue();
+  },
+};
+`),
+    invalid(`
+const foo = {
+  method() {
+    return this.value;
+  },
+};
+`),
+    invalid('const validator = (this: TrackedModel) => this.value;'),
+    invalid(`
+function validator(value: TrackedModel) {
+  return this.value;
+}
+`),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -145,7 +145,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-subtraction-comparison': 'error', // not implemented
     'unicorn/no-thenable': 'error',
     'unicorn/no-this-assignment': 'error',
-    // 'unicorn/no-this-outside-of-class': 'error', // not implemented
+    'unicorn/no-this-outside-of-class': 'error',
     // 'unicorn/no-top-level-assignment-in-function': 'error', // not implemented
     // 'unicorn/no-top-level-side-effects': 'error', // not implemented
     // 'unicorn/no-transition-all': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `unicorn/no-this-outside-of-class` rule from ESLint to rslint.

Disallow `this` outside of classes. `this` should only be used when JavaScript class syntax or an explicit TypeScript `this` parameter defines the receiver.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-this-outside-of-class.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-this-outside-of-class.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

