### PR TITLE
chore: release npm 0.9.1

### DIFF
--- a/npm/rslint/darwin-arm64/package.json
+++ b/npm/rslint/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-arm64",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for darwin-arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/darwin-x64/package.json
+++ b/npm/rslint/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-x64",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for darwin-x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-gnu/package.json
+++ b/npm/rslint/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-gnu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-musl/package.json
+++ b/npm/rslint/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-musl",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-gnu/package.json
+++ b/npm/rslint/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-gnu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-musl/package.json
+++ b/npm/rslint/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-musl",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-arm64-msvc/package.json
+++ b/npm/rslint/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-arm64-msvc",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for win32-arm64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-x64-msvc/package.json
+++ b/npm/rslint/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-x64-msvc",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "rslint native binaries for win32-x64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rslint-monorepo",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Rslint Monorepo",
   "homepage": "https://github.com/web-infra-dev/rslint#readme",

--- a/packages/rslint-api/package.json
+++ b/packages/rslint-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/api",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Rslint AST library",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/test-tools",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "src/index.ts",
   "private": true,

--- a/packages/rslint-wasm/package.json
+++ b/packages/rslint-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/wasm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "rslint wasm package",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "exports": {
     ".": {
       "@typescript/source": "./src/index.ts",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/rule-tester",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/utils",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "",
   "main": "index.ts",
   "private": true,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "rslint",
   "displayName": "Rslint",
   "description": "Language support for Rslint",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "icon": "images/icon.png",
   "private": true,
   "publisher": "rstack",

--- a/website/rule-releases.json
+++ b/website/rule-releases.json
@@ -772,5 +772,42 @@
       "rstest:require-test-timeout",
       "rstest:warn-todo"
     ]
+  },
+  {
+    "version": "0.9.1",
+    "rules": [
+      "eslint-plugin-react:hook-use-state",
+      "eslint-plugin-react:jsx-props-no-spreading",
+      "eslint-plugin-react:jsx-sort-props",
+      "eslint-plugin-react:no-adjacent-inline-elements",
+      "eslint-plugin-react:no-invalid-html-attribute",
+      "eslint-plugin-react:prop-types",
+      "eslint-plugin-react:sort-prop-types",
+      "eslint-plugin-unicorn:consistent-date-clone",
+      "eslint-plugin-unicorn:consistent-tuple-labels",
+      "eslint-plugin-unicorn:no-array-front-mutation",
+      "eslint-plugin-unicorn:no-document-cookie",
+      "eslint-plugin-unicorn:no-null",
+      "eslint-plugin-unicorn:no-object-as-default-parameter",
+      "eslint-plugin-unicorn:no-unnecessary-array-flat-depth",
+      "eslint-plugin-unicorn:no-unreadable-new-expression",
+      "eslint-plugin-unicorn:prefer-add-event-listener-options",
+      "eslint-plugin-unicorn:prefer-blob-reading-methods",
+      "eslint-plugin-unicorn:prefer-then-catch",
+      "eslint:camelcase",
+      "eslint:func-style",
+      "eslint:no-implicit-globals",
+      "eslint:prefer-named-capture-group",
+      "eslint:require-unicode-regexp",
+      "rstest:consistent-each-for",
+      "rstest:consistent-rstest-namespace",
+      "rstest:consistent-test-filename",
+      "rstest:no-conditional-tests",
+      "rstest:prefer-strict-boolean-matchers",
+      "rstest:prefer-to-be-falsy",
+      "rstest:prefer-to-be-truthy",
+      "rstest:require-awaited-expect-poll",
+      "rstest:require-mock-type-parameters"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- npm packages: `0.9.0` → `0.9.1`
- add rule release metadata for 32 newly added rules
- keep the independently released tsgo packages unchanged

## Testing

- `pnpm run format:check`
- full test validation is left to CI for this version-only change

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).