### PR TITLE
ci: cap Rstest worker concurrency

### DIFF
--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -3,6 +3,8 @@ import { define } from 'rstack';
 define.test({
   testEnvironment: 'node',
   globals: true,
+  // CI pods expose the shared host's CPU count, so cap worker-process churn.
+  pool: { maxWorkers: 16 },
   // Normal completion is event-driven. This is only the final in-process
   // deadlock sentinel, deliberately later than the 30-minute child watchdogs.
   testTimeout: 35 * 60_000,


### PR DESCRIPTION
## Summary

- cap the Rstest worker pool at 16 for `@rslint/test-tools`
- avoid over-provisioning when CI pods expose the shared host CPU count
- reduce worker-process churn that can hit Rstest’s 10-second fixture cleanup deadline

Related flaky job: https://github.com/web-infra-dev/rslint/actions/runs/33846072785/job/100938138873?pr=2051

## Verification

- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm --filter @rslint/test-tools test` (644 files, 4,599 passed, 30 skipped)