### PR TITLE
feat: port rule unicorn/no-array-from-fill

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_concat_in_loop"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_fill_with_reference_type"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_from_fill"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_front_mutation"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_document_cookie"
@@ -54,6 +55,7 @@ func GetAllRules() []rule.Rule {
 		new_for_builtins.NewForBuiltinsRule,
 		no_array_concat_in_loop.NoArrayConcatInLoopRule,
 		no_array_fill_with_reference_type.NoArrayFillWithReferenceTypeRule,
+		no_array_from_fill.NoArrayFromFillRule,
 		no_array_front_mutation.NoArrayFrontMutationRule,
 		no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
 		no_document_cookie.NoDocumentCookieRule,

--- a/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill.go
+++ b/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill.go
@@ -1,0 +1,84 @@
+package no_array_from_fill
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "no-array-from-fill"
+
+var noArrayFromFillMessage = rule.RuleMessage{
+	Id:          messageID,
+	Description: "Use the `Array.from(…, mapFunction)` argument instead of chaining `.fill()`.",
+}
+
+// NoArrayFromFillRule disallows calling .fill() directly on an array created
+// by Array.from({length: ...}).
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-array-from-fill.js
+var NoArrayFromFillRule = rule.Rule{
+	Name:   "unicorn/no-array-from-fill",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		oneArgument := 1
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				fillCall, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Method:              "fill",
+					MaximumArguments:    &oneArgument,
+					RejectSpreadElement: true,
+				})
+				if !ok || !isArrayFromLengthCall(ctx, fillCall.Object, &oneArgument) {
+					return
+				}
+
+				ctx.ReportNode(fillCall.Property, noArrayFromFillMessage)
+			},
+		}
+	},
+}
+
+func isArrayFromLengthCall(ctx rule.RuleContext, node *ast.Node, oneArgument *int) bool {
+	node = utils.ESTreeRuntimeExpression(node)
+	fromCall, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+		Method:              "from",
+		ArgumentsLength:     oneArgument,
+		RejectSpreadElement: true,
+	})
+	if !ok {
+		return false
+	}
+
+	arrayIdentifier := utils.ESTreeRuntimeExpression(fromCall.Object)
+	if arrayIdentifier == nil || !ast.IsIdentifier(arrayIdentifier) ||
+		arrayIdentifier.AsIdentifier().Text != "Array" ||
+		!ctx.Globals.Access("Array").IsDeclared() ||
+		!unicornutil.IsGlobalReference(ctx, arrayIdentifier) {
+		return false
+	}
+
+	argument := utils.ESTreeRuntimeExpression(fromCall.Call.Arguments()[0])
+	if argument == nil || !ast.IsObjectLiteralExpression(argument) {
+		return false
+	}
+
+	properties := argument.AsObjectLiteralExpression().Properties
+	return properties != nil && len(properties.Nodes) == 1 && isLengthProperty(properties.Nodes[0])
+}
+
+func isLengthProperty(property *ast.Node) bool {
+	name, _, ok := unicornutil.ObjectDataProperty(property)
+	if !ok {
+		return false
+	}
+	switch name.Kind {
+	case ast.KindIdentifier:
+		return name.AsIdentifier().Text == "length"
+	case ast.KindStringLiteral:
+		return name.AsStringLiteral().Text == "length"
+	default:
+		return false
+	}
+}

--- a/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill.md
+++ b/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill.md
@@ -1,0 +1,29 @@
+# no-array-from-fill
+
+## Rule Details
+
+Disallow calling `.fill()` after `Array.from({ length: … })`. Prefer the
+mapping function argument of `Array.from()` when creating a fixed-length array
+with generated values.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Array.from({ length: 3 }).fill().map((_, index) => index);
+Array.from({ length: 3 }).fill({});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Array.from({ length: 3 }, (_, index) => index);
+Array.from({ length: 3 }, () => ({}));
+```
+
+Using a mapping function also avoids unintentionally sharing one mutable value
+between every array element.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-array-from-fill](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-array-from-fill.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-array-from-fill.js)

--- a/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill_extras_test.go
@@ -1,0 +1,110 @@
+// TestNoArrayFromFillExtras covers tsgo edge shapes, every rule branch, and
+// real-user examples absent from the upstream suite. The exact upstream
+// migration lives in no_array_from_fill_upstream_test.go.
+package no_array_from_fill_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_from_fill"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoArrayFromFillExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_array_from_fill.NoArrayFromFillRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream isArrayFromFillCall() arm 2: only a direct
+			// Array.from(...) receiver reaches isArrayFromLengthCall().
+			extraValid(`Array.from({length: 3}).slice().fill(0)`, "file.js"),
+
+			// ---- Dimension 4: authored TypeScript wrappers remain visible ----
+			extraValid(`(Array.from({length: 3}) as unknown[]).fill(0)`, "file.ts"),
+			extraValid(`Array!.from({length: 3}).fill(0)`, "file.ts"),
+			extraValid(`(Array satisfies typeof Array).from({length: 3}).fill(0)`, "file.ts"),
+
+			// ---- Dimension 4: optional member access does not match ----
+			extraValid(`Array?.from({length: 3}).fill(0)`, "file.js"),
+
+			// Locks in upstream isMethodCall() computed:false and
+			// allowSpreadElement:false branches for both calls.
+			extraValid(`Array["from"]({length: 3}).fill(0)`, "file.js"),
+			extraValid("Array[`from`]({length: 3}).fill(0)", "file.js"),
+			extraValid(`Array[0]({length: 3}).fill(0)`, "file.js"),
+			extraValid(`Array[Symbol.from]({length: 3}).fill(0)`, "file.js"),
+			extraValid(`Array.from({length: 3})["fill"](0)`, "file.js"),
+			extraValid(`Array.from(...[{length: 3}]).fill(0)`, "file.js"),
+			extraValid(`Array.from({length: 3}).fill(...[])`, "file.js"),
+
+			// ---- Dimension 4: computed and numeric length-key forms are rejected ----
+			extraValid(`Array.from({["length"]: 3}).fill(0)`, "file.js"),
+			extraValid(`Array.from({0: 3}).fill(0)`, "file.js"),
+
+			// Locks in upstream isLengthProperty() method/kind branches: methods
+			// and accessors are not ordinary init data properties.
+			extraValid(`Array.from({length() { return 3; }}).fill(0)`, "file.js"),
+			extraValid(`Array.from({get length() { return 3; }}).fill(0)`, "file.js"),
+
+			// Locks in upstream isArrayFromLengthCall() global-reference guard:
+			// only the direct environment Array binding is accepted.
+			extraValid(`globalThis.Array.from({length: 3}).fill(0)`, "file.js"),
+			{
+				Code:     `Array.from({length: 3}).fill(0)`,
+				FileName: "file.js",
+				Globals:  map[string]any{"Array": "off"},
+			},
+
+			// ---- Dimension 4: SpreadAssignment degrades without masking shape checks ----
+			extraValid(`Array.from({...source}).fill(0)`, "file.js"),
+
+			// N/A: PrivateIdentifier keys cannot appear in object literals.
+			// N/A: declaration/container forms; the rule targets call expressions.
+			// N/A: rest binding patterns; the rule does not inspect bindings.
+			// N/A: empty/abstract/declare bodies; the rule does not inspect bodies.
+			// N/A: rule-specific ancestor walks; the rule performs none.
+			// N/A: autofix boundaries; the rule has no fix or suggestion.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: single/multi-level receiver and argument parentheses ----
+			extraInvalid(`(Array).from(({length: 3})).fill(0)`, "file.js"),
+			extraInvalid(`((Array.from({length: 3}))).fill()`, "file.js"),
+
+			// ---- Dimension 4: TypeScript type arguments do not wrap the callee ----
+			extraInvalid(`Array.from<number>({length: 3}).fill(0)`, "file.ts"),
+
+			// Locks in upstream isLengthPropertyKey() arm 1: identifier key.
+			extraInvalid(`Array.from({length}).fill(undefined)`, "file.js"),
+			// Locks in upstream isLengthPropertyKey() arm 2: string-literal key.
+			extraInvalid(`Array.from({'length': 3}).fill(0)`, "file.js"),
+
+			// ---- Dimension 4: same-kind call nesting reports only the inner fill ----
+			extraInvalid(`consume(Array.from({length: 3}).fill(0))`, "file.js"),
+
+			// ---- Real-user: issue #2943 multiline fill().map() chain ----
+			extraInvalid(
+				"Array.from({ length: 5 })\n\t.fill(null)\n\t.map((_, index) => `Item number: ${index}`);",
+				"file.js",
+			),
+			// ---- Real-user: issue #2943 shared object fill value ----
+			extraInvalid(`Array.from({ length: 5 }).fill({ something: "special" })`, "file.js"),
+		},
+	)
+}
+
+func extraValid(code, fileName string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: fileName}
+}
+
+func extraInvalid(code, fileName string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: fileName,
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, "fill", 0),
+		},
+	}
+}

--- a/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_array_from_fill/no_array_from_fill_upstream_test.go
@@ -1,0 +1,117 @@
+// TestNoArrayFromFillUpstream migrates the complete valid/invalid suite from
+// upstream test/no-array-from-fill.js at v74.0.0. Position assertions cover
+// every invalid case. rslint-specific cases live in
+// no_array_from_fill_extras_test.go.
+package no_array_from_fill_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_from_fill"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID   = "no-array-from-fill"
+	messageText = "Use the `Array.from(…, mapFunction)` argument instead of chaining `.fill()`."
+)
+
+func TestNoArrayFromFillUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_array_from_fill.NoArrayFromFillRule,
+		[]rule_tester.ValidTestCase{
+			upstreamValid(`Array.from({length: 3})`),
+			upstreamValid(`Array.from({length: 3}, (_, index) => index)`),
+			upstreamValid(`Array.from({length: 3}).map((_, index) => index)`),
+			upstreamValid(`Array.from(items).fill(0)`),
+			upstreamValid(`Array.from({length: 3, 0: "value"}).fill(0)`),
+			upstreamValid(`Array.from({...length}).fill(0)`),
+			upstreamValid(`Array.from({["length"]: 3}).fill(0)`),
+			upstreamValid(`Array.from({length: 3}).fill(0, 1)`),
+			upstreamValid(`Array.from({length: 3}).fill(0, 1, 2)`),
+			upstreamValid(`Array.from({length: 3}).fill(...value)`),
+			upstreamValid(`Array.from?.({length: 3}).fill(0)`),
+			upstreamValid(`Array.from({length: 3})?.fill(0)`),
+			upstreamValid(`Array.from({length: 3}).fill?.(0)`),
+			upstreamValid(`NotArray.from({length: 3}).fill(0)`),
+			upstreamValid(`Array.notFrom({length: 3}).fill(0)`),
+			upstreamValid(`Array.from({length: 3}).slice().fill(0)`),
+			upstreamValid(`const Array = {from() { return {fill() { return {map() {}}; }}; }}; Array.from({length: 3}).fill().map((_, index) => index)`),
+			upstreamValid(`function unicorn(Array) { return Array.from({length: 3}).fill(0); }`),
+		},
+		[]rule_tester.InvalidTestCase{
+			upstreamInvalid(`Array.from({length: 3}).fill(0)`),
+			upstreamInvalid(`Array.from({length: 3}).fill()`),
+			upstreamInvalid(`Array.from({length}).fill(null)`),
+			upstreamInvalid(`Array.from({"length": 3}).fill(0)`),
+			upstreamInvalid(`Array.from({length: 3}).fill({})`),
+			upstreamInvalid(`Array.from({length: 3}).fill(0).map((_, index) => index)`),
+			upstreamInvalid(`Array.from({length: 3}).fill().map((value, index) => index)`),
+			upstreamInvalid(`Array.from({length: 3}).fill(0).flatMap((_, index) => [index])`),
+			upstreamInvalid(`Array.from({length: 3}).fill().flatMap(value => [value])`),
+			upstreamInvalid(`Array.from({length: 3}).fill(0).filter(Boolean)`),
+			upstreamInvalid("Array.from({length: 3})\n\t.fill(0)\n\t.map((_, index) => index);"),
+			upstreamInvalid("Array.from(\n\t{length: 3}\n)\n\t.fill(0)\n\t.map((_, index) => index);"),
+		},
+	)
+}
+
+func upstreamValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+func upstreamInvalid(code string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, "fill", 0),
+		},
+	}
+}
+
+func expectedError(code, target string, occurrence int) rule_tester.InvalidTestCaseError {
+	offset := -1
+	searchFrom := 0
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], target)
+		if relative < 0 {
+			panic("target not found in no-array-from-fill test: " + target)
+		}
+		offset = searchFrom + relative
+		searchFrom = offset + len(target)
+	}
+
+	line, column := lineColumn(code, offset)
+	endLine, endColumn := lineColumn(code, offset+len(target))
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   messageText,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func lineColumn(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for index, character := range code {
+		if index >= offset {
+			break
+		}
+		if character == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return line, column
+}

--- a/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.go
+++ b/internal/plugins/unicorn/rules/no_document_cookie/no_document_cookie.go
@@ -2,6 +2,7 @@ package no_document_cookie
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -111,18 +112,11 @@ func (tracker *documentReferenceTracker) trackGlobalRoot(name string, value trac
 func (tracker *documentReferenceTracker) globalReferences(name string) []*ast.Node {
 	var references []*ast.Node
 	for _, identifier := range tracker.identifiersByName[name] {
-		if tracker.isGlobalReference(identifier, name) {
+		if unicornutil.IsGlobalReference(tracker.ctx, identifier) {
 			references = append(references, identifier)
 		}
 	}
 	return references
-}
-
-func (tracker *documentReferenceTracker) isGlobalReference(identifier *ast.Node, name string) bool {
-	if tracker.ctx.Refs != nil {
-		return tracker.ctx.Refs.IsGlobalReference(identifier)
-	}
-	return !utils.IsShadowed(identifier, name)
 }
 
 func (tracker *documentReferenceTracker) trackExpression(node *ast.Node, value tracedValue) {
@@ -266,7 +260,7 @@ func (tracker *documentReferenceTracker) trackIdentifier(identifier *ast.Node, v
 		return
 	}
 	name := identifier.AsIdentifier().Text
-	if tracker.ctx.Globals.Access(name).IsDeclared() && tracker.isGlobalReference(identifier, name) {
+	if tracker.ctx.Globals.Access(name).IsDeclared() && unicornutil.IsGlobalReference(tracker.ctx, identifier) {
 		tracker.trackGlobalVariable(name, value)
 	}
 }
@@ -310,7 +304,7 @@ func (tracker *documentReferenceTracker) trackGlobalVariable(name string, value 
 	defer delete(tracker.globalStack, name)
 
 	for _, reference := range tracker.identifiersByName[name] {
-		if !ast.IsWriteOnlyAccess(reference) && tracker.isGlobalReference(reference, name) {
+		if !ast.IsWriteOnlyAccess(reference) && unicornutil.IsGlobalReference(tracker.ctx, reference) {
 			tracker.trackExpression(reference, value)
 		}
 	}

--- a/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
@@ -43,6 +43,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -167,23 +168,8 @@ func getObjectLength(ctx rule.RuleContext, node *ast.Node) (int, bool) {
 // whose `value` is the key Identifier, so upstream resolves it through scope;
 // tsgo gives shorthand its own kind, so handle it explicitly.
 func lengthPropertyValue(property *ast.Node) (*ast.Node, bool) {
-	if property == nil {
-		return nil, false
-	}
-
-	var name *ast.Node
-	var value *ast.Node
-	switch property.Kind {
-	case ast.KindPropertyAssignment:
-		name = property.AsPropertyAssignment().Name()
-		value = property.AsPropertyAssignment().Initializer
-	case ast.KindShorthandPropertyAssignment:
-		name = property.AsShorthandPropertyAssignment().Name()
-		value = name
-	default:
-		return nil, false
-	}
-	if name == nil || value == nil {
+	name, value, ok := unicornutil.ObjectDataProperty(property)
+	if !ok {
 		return nil, false
 	}
 

--- a/internal/plugins/unicorn/unicornutil/identifier.go
+++ b/internal/plugins/unicorn/unicornutil/identifier.go
@@ -1,6 +1,10 @@
 package unicornutil
 
-import "github.com/microsoft/typescript-go/shim/ast"
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
 
 // PlainParameterIdentifier returns the identifier declared by a parameter
 // whose ESTree shape is a plain Identifier. Type annotations are allowed;
@@ -30,4 +34,16 @@ func IsSameIdentifier(left *ast.Node, right *ast.Node) bool {
 	return left != nil && right != nil &&
 		ast.IsIdentifier(left) && ast.IsIdentifier(right) &&
 		left.AsIdentifier().Text == right.AsIdentifier().Text
+}
+
+// IsGlobalReference reports whether an identifier refers to an environment
+// global rather than an authored declaration in the current file.
+func IsGlobalReference(ctx rule.RuleContext, identifier *ast.Node) bool {
+	if identifier == nil || !ast.IsIdentifier(identifier) {
+		return false
+	}
+	if ctx.Refs != nil {
+		return ctx.Refs.IsGlobalReference(identifier)
+	}
+	return !utils.IsShadowed(identifier, identifier.AsIdentifier().Text)
 }

--- a/internal/plugins/unicorn/unicornutil/object_property.go
+++ b/internal/plugins/unicorn/unicornutil/object_property.go
@@ -1,0 +1,31 @@
+package unicornutil
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// ObjectDataProperty returns the name and value of an object-literal data
+// property. ESTree represents both `key: value` and shorthand `key` entries as
+// Property nodes with kind "init"; tsgo gives them distinct node kinds.
+// Methods, accessors, and spreads are not data properties.
+func ObjectDataProperty(property *ast.Node) (name *ast.Node, value *ast.Node, ok bool) {
+	if property == nil {
+		return nil, nil, false
+	}
+
+	switch property.Kind {
+	case ast.KindPropertyAssignment:
+		assignment := property.AsPropertyAssignment()
+		name = assignment.Name()
+		value = assignment.Initializer
+	case ast.KindShorthandPropertyAssignment:
+		shorthand := property.AsShorthandPropertyAssignment()
+		name = shorthand.Name()
+		value = name
+	default:
+		return nil, nil, false
+	}
+
+	if name == nil || value == nil {
+		return nil, nil, false
+	}
+	return name, value, true
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -676,6 +676,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-concat-in-loop.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-fill-with-reference-type.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-array-from-fill.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-front-mutation.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-document-cookie.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-array-from-fill.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-array-from-fill.test.ts
@@ -1,0 +1,60 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code });
+const invalid = (code: string) => ({
+  code,
+  errors: [
+    {
+      messageId: 'no-array-from-fill',
+      message:
+        'Use the `Array.from(…, mapFunction)` argument instead of chaining `.fill()`.',
+    },
+  ],
+});
+
+ruleTester.run('no-array-from-fill', null as never, {
+  valid: [
+    valid('Array.from({length: 3})'),
+    valid('Array.from({length: 3}, (_, index) => index)'),
+    valid('Array.from({length: 3}).map((_, index) => index)'),
+    valid('Array.from(items).fill(0)'),
+    valid('Array.from({length: 3, 0: "value"}).fill(0)'),
+    valid('Array.from({...length}).fill(0)'),
+    valid('Array.from({["length"]: 3}).fill(0)'),
+    valid('Array.from({length: 3}).fill(0, 1)'),
+    valid('Array.from({length: 3}).fill(0, 1, 2)'),
+    valid('Array.from({length: 3}).fill(...value)'),
+    valid('Array.from?.({length: 3}).fill(0)'),
+    valid('Array.from({length: 3})?.fill(0)'),
+    valid('Array.from({length: 3}).fill?.(0)'),
+    valid('NotArray.from({length: 3}).fill(0)'),
+    valid('Array.notFrom({length: 3}).fill(0)'),
+    valid('Array.from({length: 3}).slice().fill(0)'),
+    valid(
+      'const Array = {from() { return {fill() { return {map() {}}; }}; }}; Array.from({length: 3}).fill().map((_, index) => index)',
+    ),
+    valid(
+      'function unicorn(Array) { return Array.from({length: 3}).fill(0); }',
+    ),
+  ],
+  invalid: [
+    invalid('Array.from({length: 3}).fill(0)'),
+    invalid('Array.from({length: 3}).fill()'),
+    invalid('Array.from({length}).fill(null)'),
+    invalid('Array.from({"length": 3}).fill(0)'),
+    invalid('Array.from({length: 3}).fill({})'),
+    invalid('Array.from({length: 3}).fill(0).map((_, index) => index)'),
+    invalid('Array.from({length: 3}).fill().map((value, index) => index)'),
+    invalid('Array.from({length: 3}).fill(0).flatMap((_, index) => [index])'),
+    invalid('Array.from({length: 3}).fill().flatMap(value => [value])'),
+    invalid('Array.from({length: 3}).fill(0).filter(Boolean)'),
+    invalid(
+      'Array.from({length: 3})\n\t.fill(0)\n\t.map((_, index) => index);',
+    ),
+    invalid(
+      'Array.from(\n\t{length: 3}\n)\n\t.fill(0)\n\t.map((_, index) => index);',
+    ),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -62,7 +62,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-array-callback-reference': 'error', // not implemented
     'unicorn/no-array-concat-in-loop': 'error',
     'unicorn/no-array-fill-with-reference-type': 'error',
-    // 'unicorn/no-array-from-fill': 'error', // not implemented
+    'unicorn/no-array-from-fill': 'error',
     'unicorn/no-array-front-mutation': 'off',
     // 'unicorn/no-array-method-this-argument': 'error', // not implemented
     // 'unicorn/no-array-reduce': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/no-array-from-fill` from eslint-plugin-unicorn v74.0.0.

The rule reports `.fill()` calls directly chained from `Array.from({ length: … })`, while respecting optional calls, spread arguments, computed properties, and shadowed `Array` bindings.

This change also:

- Registers the rule in the Unicorn catalog and recommended preset.
- Adds the complete upstream test suite, additional edge cases, and real-world scenarios.
- Extracts shared helpers for global-reference checks and object data properties, with regression coverage for existing consumers.

## Related Links

- Tracking issue: #1309
- [Rule documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-array-from-fill.md)
- [Upstream source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-array-from-fill.js)
- [Upstream rule proposal](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2943)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
