### PR TITLE
feat(tsgo): expose shorthand binding property symbols

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -162,6 +162,8 @@ type Semantic struct {
 	// ShorthandSymbols maps node reference to the value symbol for shorthand property assignments
 	// (node -> value_symbol_id)
 	ShorthandSymbols map[NodeReference]ast.SymbolId `json:"shorthand_symbols"`
+	// ShorthandBindingSymbols maps local shorthand object binding symbols to the property symbols they read.
+	ShorthandBindingSymbols map[ast.SymbolId]ast.SymbolId `json:"shorthand_binding_symbols"`
 	// ParameterPropertySymbols maps a parameter property name node to the other symbol declared at that location.
 	// The primary symbol remains recorded in Node2sym.
 	ParameterPropertySymbols map[NodeReference]ast.SymbolId `json:"parameter_property_symbols"`
@@ -179,6 +181,7 @@ func NewSemantic() Semantic {
 		Node2type:                make(map[NodeReference]checker.TypeId),
 		NodeFlags:                make(map[NodeReference]uint32),
 		ShorthandSymbols:         make(map[NodeReference]ast.SymbolId),
+		ShorthandBindingSymbols:  make(map[ast.SymbolId]ast.SymbolId),
 		ParameterPropertySymbols: make(map[NodeReference]ast.SymbolId),
 		ExternalSymbols:          []ExternalSymbol{},
 		Primtypes:                PrimTypes{},
@@ -378,6 +381,26 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 				value_sym_id := ast.GetSymbolId(valueSymbol)
 				semantic.ShorthandSymbols[key] = value_sym_id
 				recordSymbol(valueSymbol)
+			}
+
+			// In an object binding shorthand such as `const { y } = x`, the identifier's
+			// primary symbol is the new local binding. Record the source property symbol
+			// separately, matching the symbol returned for `y` in `x.y`.
+			if ast.IsIdentifier(node) && node.Parent != nil && ast.IsBindingElement(node.Parent) {
+				binding := node.Parent.AsBindingElement()
+				pattern := node.Parent.Parent
+				if binding.PropertyName == nil && binding.DotDotDotToken == nil &&
+					node.Parent.Name() == node && ast.IsObjectBindingPattern(pattern) {
+					if patternType := tc.GetTypeAtLocation(pattern); patternType != nil {
+						if propertySymbol := tc.GetPropertyOfType(patternType, node.Text()); propertySymbol != nil {
+							propertySymbolID := ast.GetSymbolId(propertySymbol)
+							if localSymbolID, ok := semantic.Node2sym[key]; ok {
+								semantic.ShorthandBindingSymbols[localSymbolID] = propertySymbolID
+							}
+							recordSymbol(propertySymbol)
+						}
+					}
+				}
 			}
 
 			if ast.IsParameterPropertyDeclaration(node, node.Parent) {

--- a/crates/tsgo-client/src/proto.rs
+++ b/crates/tsgo-client/src/proto.rs
@@ -55,6 +55,9 @@ pub struct Semantic {
     // Shorthand property assignment value symbols (node -> value_symbol_id)
     #[serde(default, deserialize_with = "vecmap_or_empty")]
     pub shorthand_symbols: Vec<(NodeReference, u32)>,
+    // Shorthand object binding symbols (local_symbol_id -> property_symbol_id).
+    #[serde(default, deserialize_with = "vecmap_or_empty")]
+    pub shorthand_binding_symbols: Vec<(u32, u32)>,
     // Parameter property declarations create another symbol at the same name node; node2sym keeps the primary symbol.
     #[serde(default, deserialize_with = "vecmap_or_empty")]
     pub parameter_property_symbols: Vec<(NodeReference, u32)>,
@@ -255,6 +258,17 @@ impl Semantic {
                     && node_ref.start == location.start
                     && node_ref.end == location.end
             })
+            .map(|(_, sym_id)| *sym_id)
+    }
+
+    /// Returns the source property symbol of a shorthand object binding name.
+    ///
+    /// In `const { x } = value`, this maps the newly declared local `x` symbol
+    /// to the property symbol equivalent to `x` in `value.x`.
+    pub fn get_shorthand_binding_property_symbol(&self, local_symbol: u32) -> Option<u32> {
+        self.shorthand_binding_symbols
+            .iter()
+            .find(|(symbol, _)| *symbol == local_symbol)
             .map(|(_, sym_id)| *sym_id)
     }
 

--- a/crates/tsgo-client/tests/fixtures/simple-project/src/shorthand.ts
+++ b/crates/tsgo-client/tests/fixtures/simple-project/src/shorthand.ts
@@ -25,3 +25,14 @@ export function mixedProperties(id: number) {
     timestamp: Date.now(), // regular property
   };
 }
+
+interface DestructuringSource {
+  destructured: string;
+  defaulted?: number;
+  restOnly: boolean;
+}
+
+export function readDestructured(source: DestructuringSource) {
+  const { destructured, defaulted = 1, ...rest } = source;
+  return [destructured, defaulted, rest];
+}

--- a/crates/tsgo-client/tests/integration_test.rs
+++ b/crates/tsgo-client/tests/integration_test.rs
@@ -358,6 +358,105 @@ fn test_get_shorthand_assignment_value_symbol() {
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+struct ShorthandBindingSymbolMapping {
+    local_decl_span: String,
+    local_symbol_name: String,
+    property_symbol_name: String,
+    property_decl_span: String,
+}
+
+#[test]
+fn test_get_shorthand_binding_property_symbol() {
+    let tsgo_path = get_tsgo_path().expect(
+        "Could not find tsgo executable. \
+         Please build tsgo first or ensure it's in your PATH.",
+    );
+
+    let fixture_dir = get_fixtures_dir().join("simple-project");
+    let config_file = fixture_dir.join("tsconfig.json");
+    let options = Options {
+        cwd: Some(fixture_dir.clone()),
+        log_file: None,
+        config_file: config_file.to_string_lossy().to_string(),
+    };
+    let client = Client::builder(OsStr::new(&tsgo_path), options)
+        .build()
+        .expect("Failed to build client");
+    let api = Api::with_uninitialized_client(client).expect("Failed to initialize API");
+    let mut buffer = Vec::new();
+    let project = api
+        .load_project(&mut buffer)
+        .expect("Failed to load project");
+    let semantic = &project.semantic;
+    let mut mappings = Vec::new();
+
+    for (local_symbol_id, property_symbol_id) in &semantic.shorthand_binding_symbols {
+        let Some(property_symbol_id_from_lookup) =
+            semantic.get_shorthand_binding_property_symbol(*local_symbol_id)
+        else {
+            panic!("shorthand binding property lookup should find the local symbol");
+        };
+        assert_eq!(*property_symbol_id, property_symbol_id_from_lookup);
+
+        let Some((_, property_symbol_data)) = semantic
+            .symtab
+            .iter()
+            .find(|(id, _)| id == property_symbol_id)
+        else {
+            panic!("property symbol should be present in symtab");
+        };
+        let property_symbol_name = String::from_utf8_lossy(&property_symbol_data.name).to_string();
+        if !["destructured", "defaulted"].contains(&property_symbol_name.as_str()) {
+            continue;
+        }
+
+        assert_ne!(
+            local_symbol_id, property_symbol_id,
+            "property symbol should differ from the local binding symbol"
+        );
+
+        let Some((_, local_symbol_data)) =
+            semantic.symtab.iter().find(|(id, _)| id == local_symbol_id)
+        else {
+            panic!("local binding symbol should be present in symtab");
+        };
+        let local_symbol_name = String::from_utf8_lossy(&local_symbol_data.name).to_string();
+        assert_eq!(local_symbol_name, property_symbol_name);
+
+        let property_flags = SymbolFlags::from_bits_truncate(property_symbol_data.flags);
+        assert!(
+            property_flags.contains(SymbolFlags::PROPERTY),
+            "shorthand binding target should be a property, got: {property_flags:?}"
+        );
+
+        let local_decl_span = if let Some(decl) = &local_symbol_data.decl {
+            format!("{}:{}..{}", decl.sourcefile_id, decl.start, decl.end)
+        } else {
+            "unknown".to_string()
+        };
+        let property_decl_span = if let Some(decl) = &property_symbol_data.decl {
+            format!("{}:{}..{}", decl.sourcefile_id, decl.start, decl.end)
+        } else {
+            "unknown".to_string()
+        };
+        mappings.push(ShorthandBindingSymbolMapping {
+            local_decl_span,
+            local_symbol_name,
+            property_symbol_name,
+            property_decl_span,
+        });
+    }
+
+    mappings.sort();
+    assert_eq!(
+        mappings.len(),
+        2,
+        "expected mappings for the plain and defaulted shorthand bindings"
+    );
+    insta::assert_json_snapshot!(mappings);
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 struct ParameterPropertySymbolMapping {
     source_node_span: String,
     primary_symbol_name: String,

--- a/crates/tsgo-client/tests/snapshots/integration_test__get_shorthand_binding_property_symbol.snap
+++ b/crates/tsgo-client/tests/snapshots/integration_test__get_shorthand_binding_property_symbol.snap
@@ -1,0 +1,18 @@
+---
+source: crates/tsgo-client/tests/integration_test.rs
+expression: mappings
+---
+[
+  {
+    "local_decl_span": "52:867..880",
+    "local_symbol_name": "destructured",
+    "property_symbol_name": "destructured",
+    "property_decl_span": "52:723..747"
+  },
+  {
+    "local_decl_span": "52:881..895",
+    "local_symbol_name": "defaulted",
+    "property_symbol_name": "defaulted",
+    "property_decl_span": "52:747..769"
+  }
+]


### PR DESCRIPTION
## Summary

- record source property symbols for shorthand object bindings in tsgo semantic output
- expose a Rust client lookup from local binding symbols to their source property symbols
- add fixture coverage and an integration snapshot for plain and defaulted destructuring bindings

## Testing

- `go test ./cmd/tsgo`
- `cargo test -p tsgo-client`
- `cargo fmt --all -- --check`