### PR TITLE
feat: port rule unicorn/prefer-string-trim-start-end

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -37,6 +37,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_set_has"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_string_trim_start_end"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_ternary"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_then_catch"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_array_join_separator"
@@ -83,6 +84,7 @@ func GetAllRules() []rule.Rule {
 		prefer_node_protocol.PreferNodeProtocolRule,
 		prefer_number_properties.PreferNumberPropertiesRule,
 		prefer_set_has.PreferSetHasRule,
+		prefer_string_trim_start_end.PreferStringTrimStartEndRule,
 		prefer_then_catch.PreferThenCatchRule,
 		prefer_ternary.PreferTernaryRule,
 		require_array_join_separator.RequireArrayJoinSeparatorRule,

--- a/internal/plugins/unicorn/rules/no_unsafe_string_replacement/no_unsafe_string_replacement.go
+++ b/internal/plugins/unicorn/rules/no_unsafe_string_replacement/no_unsafe_string_replacement.go
@@ -2,7 +2,6 @@ package no_unsafe_string_replacement
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -53,7 +52,7 @@ func checkCall(ctx rule.RuleContext, node *ast.Node) {
 	replacement := node.Arguments()[1]
 	if isAllowedReplacement(ctx, replacement) ||
 		isPlainObjectReplacement(ctx, replacement) ||
-		isKnownNonStringReceiver(ctx, call.Object) {
+		unicornutil.IsKnownNonStringType(ctx, call.Object) {
 		return
 	}
 
@@ -157,25 +156,4 @@ func isPlainObjectProperty(property *ast.Node) bool {
 		staticName, ok = utils.NormalizeBigIntLiteral(name.AsBigIntLiteral().Text), true
 	}
 	return ok && !objectCoercionPropertyNames[staticName]
-}
-
-// isKnownNonStringReceiver mirrors the type-information half of Unicorn's
-// createTypeCheckers. Unlike upstream there is no syntax-level fallback: the
-// rule declares RequiresTypeInfo, so a TypeChecker is always present.
-//
-// The rule reports unless the receiver is known not to be a string, so an
-// undecided type is a report. Every type the classifier cannot decide is
-// therefore a potential false positive, and types that are provably not
-// strings — numeric and bigint literals, tuples — must reach TypeNonTarget
-// even where Unicorn leaves them unknown and lets its syntax classifier
-// answer instead.
-func isKnownNonStringReceiver(ctx rule.RuleContext, node *ast.Node) bool {
-	t := ctx.TypeChecker.GetTypeAtLocation(node)
-	return unicornutil.ClassifyType(ctx, t, unicornutil.TypeClassifierOptions{
-		HeritageSymbolFlags:          ast.SymbolFlagsClass | ast.SymbolFlagsInterface,
-		NonTargetSymbolLessTypeFlags: checker.TypeFlagsObject,
-		IsTargetType: func(t *checker.Type) bool {
-			return utils.IsTypeFlagSet(t, checker.TypeFlagsStringLike)
-		},
-	}) == unicornutil.TypeNonTarget
 }

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end.go
@@ -1,0 +1,65 @@
+// Package prefer_string_trim_start_end ports eslint-plugin-unicorn's
+// `prefer-string-trim-start-end` rule.
+package prefer_string_trim_start_end
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const messageID = "prefer-string-trim-start-end"
+
+var trimMethods = []string{"trimLeft", "trimRight"}
+
+func preferTrimStartEndMessage(method, replacement string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageID,
+		Description: fmt.Sprintf("Prefer `String#%s()` over `String#%s()`.", replacement, method),
+		Data: map[string]string{
+			"method":      method,
+			"replacement": replacement,
+		},
+	}
+}
+
+// PreferStringTrimStartEndRule prefers the direction-independent names
+// String#trimStart and String#trimEnd over their legacy aliases.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-string-trim-start-end.js
+var PreferStringTrimStartEndRule = rule.Rule{
+	Name:   "unicorn/prefer-string-trim-start-end",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		zeroArguments := 0
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Methods:             trimMethods,
+					ArgumentsLength:     &zeroArguments,
+					RejectSpreadElement: true,
+					AllowOptionalMember: true,
+				})
+				if !ok || unicornutil.IsKnownNonString(ctx, call.Object) {
+					return
+				}
+
+				method := call.Property.AsIdentifier().Text
+				replacement := "trimStart"
+				if method == "trimRight" {
+					replacement = "trimEnd"
+				}
+
+				ctx.ReportNodeWithDeferredFixes(
+					call.Property,
+					preferTrimStartEndMessage(method, replacement),
+					func() []rule.RuleFix {
+						return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, call.Property, replacement)}
+					},
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end.md
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end.md
@@ -1,0 +1,34 @@
+# prefer-string-trim-start-end
+
+## Rule Details
+
+Prefer `String#trimStart()` and `String#trimEnd()` over the legacy
+`String#trimLeft()` and `String#trimRight()` aliases. The preferred names are
+direction-independent and therefore clearer for both left-to-right and
+right-to-left text.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const leading = value.trimLeft();
+const trailing = value.trimRight();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const leading = value.trimStart();
+const trailing = value.trimEnd();
+```
+
+Optional access is checked, while an optional call is left unchanged:
+
+```javascript
+value?.trimLeft(); // Reported and fixed to value?.trimStart()
+value.trimLeft?.(); // Allowed
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: prefer-string-trim-start-end](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-string-trim-start-end.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-string-trim-start-end.js)

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
@@ -233,6 +233,21 @@ func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: "direct class expression heritage remains unknown",
+			code: `class Collection extends class {} {} function f(foo: Collection) { foo.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "using binding is not a const alias",
+			code: `using Alias = class {}; class Collection extends Alias {} function f(foo: Collection) { foo.trimRight(); }`,
+			want: 1,
+		},
+		{
+			name: "await using binding is not a const alias",
+			code: `await using Alias = class {}; class Collection extends Alias {} function f(foo: Collection) { foo.trimLeft(); }`,
+			want: 1,
+		},
+		{
 			name: "constrained type parameter",
 			code: `function f<T extends number[]>(foo: T) { foo.trimRight(); }`,
 			want: 0,

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
@@ -1,0 +1,355 @@
+// TestPreferStringTrimStartEndExtras locks in branches and tsgo edge shapes
+// that the upstream test suite does not exercise.
+package prefer_string_trim_start_end_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_string_trim_start_end"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestPreferStringTrimStartEndExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_string_trim_start_end.PreferStringTrimStartEndRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Real-user: upstream PR #1768 optional-call direction ----
+			// Optional calls are deliberately allowed.
+			{Code: `foo.trimRight?.()`, FileName: "file.js"},
+
+			// ---- Dimension 4: receiver and callee wrappers ----
+			{Code: `(foo.trimLeft)?.()`, FileName: "file.js"},
+
+			// ---- Dimension 4: access/key forms ----
+			// Only non-computed identifier properties are matched.
+			{Code: "foo[`trimLeft`]()", FileName: "file.js"},
+			{Code: `foo[0]()`, FileName: "file.js"},
+			{Code: `foo[Symbol.iterator]()`, FileName: "file.js"},
+			{Code: `class C { #trimLeft() {} method() { this.#trimLeft(); } }`, FileName: "file.js"},
+
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `const object: Record<string, unknown> = {}; const { ...rest } = object; rest.trimRight()`, FileName: "file.ts"},
+
+			// Locks in the known-non-string union branch.
+			{Code: `function f(foo: number[] | Set<number>) { foo.trimRight(); }`, FileName: "file.ts"},
+			// Locks in the authored TypeScript assertion path.
+			{Code: `(foo as number[]).trimLeft()`, FileName: "file.ts"},
+
+			// N/A Dimension 4 declaration/container forms: the rule targets call
+			// expressions, not function or class declarations.
+			// N/A Dimension 4 body-absent forms: overloads, abstract members, and
+			// declarations cannot themselves be trim method calls.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: receiver and expression wrappers ----
+			// Parenthesized callees are transparent in ESTree and must remain so in tsgo.
+			trimInvalid(`(foo.trimLeft)()`, "file.js", "trimLeft", "trimStart", 0),
+			trimInvalid(`((foo)).trimRight()`, "file.js", "trimRight", "trimEnd", 0),
+			trimInvalid(`foo!.trimLeft()`, "file.ts", "trimLeft", "trimStart", 0),
+			// A known string assertion stays a target; satisfies classifies its expression.
+			trimInvalid(`(foo as string).trimLeft()`, "file.ts", "trimLeft", "trimStart", 0),
+			trimInvalid(`(foo satisfies string).trimRight()`, "file.ts", "trimRight", "trimEnd", 0),
+			// Mixed target/non-target unions are unknown, so the rule reports.
+			trimInvalid(`function f(foo: string | number) { foo.trimRight(); }`, "file.ts", "trimRight", "trimEnd", 0),
+
+			// ---- Dimension 4: nesting/traversal boundary ----
+			// Locks in upstream isMethodCall() argument-count arm: the outer call
+			// is ignored while the nested zero-argument call is still reported.
+			trimInvalid(`foo.trimLeft(foo.trimRight())`, "file.js", "trimRight", "trimEnd", 0),
+
+			// ---- Dimension 4: graceful degradation ----
+			// An object spread is not statically classified in a source-only file,
+			// but it must remain safe to inspect and fix.
+			trimInvalid(`({ ...foo }).trimLeft()`, "file.js", "trimLeft", "trimStart", 0),
+
+			// ---- Real-user: upstream PR #1768 optional-member direction ----
+			// Optional access reports even though optional calls do not.
+			trimInvalid(`foo?.trimRight()`, "file.js", "trimRight", "trimEnd", 0),
+
+			// ---- Dimension 3: autofix comment boundary ----
+			trimInvalid(`foo./* before */trimLeft/* after */()`, "file.js", "trimLeft", "trimStart", 0),
+		},
+	)
+}
+
+func TestPreferStringTrimStartEndEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const source = `foo.trimLeft()`
+	const fixedSource = `foo.trimStart()`
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.js",
+		Path:     "/edit-demand.js",
+	}, source, core.ScriptKindJS)
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		comments := rule.NewCommentStore(sourceFile)
+		diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(
+			prefer_string_trim_start_end.PreferStringTrimStartEndRule.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		)
+
+		listeners := prefer_string_trim_start_end.PreferStringTrimStartEndRule.Run(ctx, nil)
+		var visit ast.Visitor
+		visit = func(node *ast.Node) bool {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+			return node.ForEachChild(visit)
+		}
+		sourceFile.AsNode().ForEachChild(visit)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnostics := map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+		rule.EditDemandAll:        run(rule.EditDemandAll),
+	}
+	base := diagnostics[rule.EditDemandNone]
+	for demand, diagnostic := range diagnostics {
+		withoutEdits := diagnostic
+		withoutEdits.FixesPtr = nil
+		withoutEdits.Suggestions = nil
+		want := base
+		want.FixesPtr = nil
+		want.Suggestions = nil
+		if !reflect.DeepEqual(withoutEdits, want) {
+			t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, withoutEdits, want)
+		}
+		if diagnostic.Suggestions != nil {
+			t.Errorf("demand %d unexpectedly materialized suggestions", demand)
+		}
+	}
+
+	if diagnostics[rule.EditDemandNone].FixesPtr != nil {
+		t.Errorf("none demand unexpectedly materialized fixes")
+	}
+	if diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+		t.Errorf("suggestion-only demand unexpectedly materialized fixes")
+	}
+	autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+	allFixes := diagnostics[rule.EditDemandAll].FixesPtr
+	if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
+		t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+	}
+	output, unapplied, fixed := linter.ApplyRuleFixes(source, []rule.RuleDiagnostic{diagnostics[rule.EditDemandAll]})
+	if !fixed || len(unapplied) != 0 || output != fixedSource {
+		t.Fatalf("autofix result = %q, unapplied = %d, fixed = %v; want %q", output, len(unapplied), fixed, fixedSource)
+	}
+}
+
+func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+		want int
+	}{
+		{
+			name: "parameter array annotation",
+			code: `function f(foo: number[]) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "authored non-string assertion",
+			code: `(foo as number[]).trimRight();`,
+			want: 0,
+		},
+		{
+			name: "local type alias",
+			code: `type Numbers = number[]; function f(foo: Numbers) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "local interface",
+			code: `interface Collection {} function f(foo: Collection) { foo.trimRight(); }`,
+			want: 0,
+		},
+		{
+			name: "local interface heritage",
+			code: `interface Base {} interface Collection extends Base {} function f(foo: Collection) { foo.trimRight(); }`,
+			want: 0,
+		},
+		{
+			name: "local class",
+			code: `class Collection {} function f(foo: Collection) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "local class heritage",
+			code: `class Base {} class Collection extends Base {} function f(foo: Collection) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "constrained type parameter",
+			code: `function f<T extends number[]>(foo: T) { foo.trimRight(); }`,
+			want: 0,
+		},
+		{
+			name: "readonly annotation",
+			code: `function f(foo: readonly (number | boolean)[]) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "parenthesized annotation",
+			code: `function f(foo: (number[])) { foo.trimRight(); }`,
+			want: 0,
+		},
+		{
+			name: "non-string literal annotation",
+			code: `function f(foo: 1) { foo.trimRight(); }`,
+			want: 0,
+		},
+		{
+			name: "all non-string union",
+			code: `function f(foo: number | boolean) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "all non-string intersection",
+			code: `function f(foo: number[] & {brand: true}) { foo.trimRight(); }`,
+			want: 0,
+		},
+		{
+			name: "const initializer assertion",
+			code: `const foo = value as number[]; foo.trimLeft();`,
+			want: 0,
+		},
+		{
+			name: "string annotation remains target",
+			code: `function f(foo: string) { foo.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "string literal annotation remains target",
+			code: `function f(foo: "value") { foo.trimRight(); }`,
+			want: 1,
+		},
+		{
+			name: "mixed union remains unknown",
+			code: `function f(foo: string | number) { foo.trimRight(); }`,
+			want: 1,
+		},
+		{
+			name: "unresolved type reference remains unknown",
+			code: `function f(foo: ExternalCollection) { foo.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "unresolved interface heritage remains unknown",
+			code: `interface Collection extends ExternalCollection {} function f(foo: Collection) { foo.trimRight(); }`,
+			want: 1,
+		},
+		{
+			name: "unresolved class heritage remains unknown",
+			code: `class Collection extends ExternalCollection {} function f(foo: Collection) { foo.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "any assertion falls through",
+			code: `(foo as any).trimLeft();`,
+			want: 1,
+		},
+		{
+			name: "satisfies annotation is ignored",
+			code: `(foo satisfies number[]).trimRight();`,
+			want: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostics := lintPreferStringTrimStartEndSourceOnly(t, test.code)
+			if len(diagnostics) != test.want {
+				t.Fatalf("diagnostics = %d, want %d: %+v", len(diagnostics), test.want, diagnostics)
+			}
+		})
+	}
+}
+
+func lintPreferStringTrimStartEndSourceOnly(t *testing.T, code string) []rule.RuleDiagnostic {
+	t.Helper()
+
+	dir := tspath.NormalizePath(t.TempDir())
+	fileName := tspath.NormalizePath(filepath.Join(dir, "file.ts"))
+	fs := utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), map[string]string{fileName: code})
+	sourceProgram, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
+		RootFileNames:   []string{fileName},
+		Host:            utils.CreateCompilerHost(dir, fs),
+		CompilerOptions: &core.CompilerOptions{Target: core.ScriptTargetESNext},
+		SingleThreaded:  true,
+	})
+	if err != nil {
+		t.Fatalf("create source-only program: %v", err)
+	}
+
+	diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+	lintPlan, err := linter.PrepareLintPlan(linter.PrepareLintPlanOptions{
+		Programs:         []*lintprogram.Program{sourceProgram},
+		TargetsByProgram: [][]string{{fileName}},
+		SingleThreaded:   true,
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{
+				Name:     prefer_string_trim_start_end.PreferStringTrimStartEndRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					if ctx.TypeChecker != nil {
+						t.Fatal("source-only fixture unexpectedly received a TypeChecker")
+					}
+					return prefer_string_trim_start_end.PreferStringTrimStartEndRule.Run(ctx, nil)
+				},
+			}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare source-only lint plan: %v", err)
+	}
+	_, err = linter.RunLinter(linter.RunLinterOptions{
+		SingleThreaded: true,
+		LintPlan:       lintPlan,
+		Consumer: rule.DiagnosticConsumer{Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		}},
+	})
+	if err != nil {
+		t.Fatalf("lint source-only program: %v", err)
+	}
+	return diagnostics
+}

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
@@ -84,6 +84,13 @@ func TestPreferStringTrimStartEndExtras(t *testing.T) {
 
 			// ---- Dimension 3: autofix comment boundary ----
 			trimInvalid(`foo./* before */trimLeft/* after */()`, "file.js", "trimLeft", "trimStart", 0),
+
+			// ---- Regression: symbol-less checker types remain unknown ----
+			// Unicorn reports literal primitives and symbol-less object types
+			// because the checker cannot prove a named non-string type for them.
+			trimInvalid(`(1).trimLeft()`, "file.ts", "trimLeft", "trimStart", 0),
+			trimInvalid(`const value = 1; value.trimRight()`, "file.ts", "trimRight", "trimEnd", 0),
+			trimInvalid(`([1, 2] as const).trimLeft()`, "file.ts", "trimLeft", "trimStart", 0),
 		},
 	)
 }
@@ -213,6 +220,16 @@ func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
 		{
 			name: "local class heritage",
 			code: `class Base {} class Collection extends Base {} function f(foo: Collection) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "const alias in class heritage",
+			code: `class Base {} const Alias = Base; class Collection extends Alias {} function f(foo: Collection) { foo.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "const class expression in heritage",
+			code: `const Alias = class {}; class Collection extends Alias {} function f(foo: Collection) { foo.trimRight(); }`,
 			want: 0,
 		},
 		{

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
@@ -51,6 +51,11 @@ func TestPreferStringTrimStartEndExtras(t *testing.T) {
 			// Locks in the authored TypeScript assertion path.
 			{Code: `(foo as number[]).trimLeft()`, FileName: "file.ts"},
 
+			// ---- Regression: checker boolean literals are known non-strings ----
+			{Code: `const value = true; value.trimLeft()`, FileName: "file.ts"},
+			{Code: `({flag: true} as const).flag.trimRight()`, FileName: "file.ts"},
+			{Code: `type Box = {flag: true}; declare const value: Box["flag"]; value.trimLeft()`, FileName: "file.ts"},
+
 			// N/A Dimension 4 declaration/container forms: the rule targets call
 			// expressions, not function or class declarations.
 			// N/A Dimension 4 body-absent forms: overloads, abstract members, and
@@ -91,6 +96,11 @@ func TestPreferStringTrimStartEndExtras(t *testing.T) {
 			trimInvalid(`(1).trimLeft()`, "file.ts", "trimLeft", "trimStart", 0),
 			trimInvalid(`const value = 1; value.trimRight()`, "file.ts", "trimRight", "trimEnd", 0),
 			trimInvalid(`([1, 2] as const).trimLeft()`, "file.ts", "trimLeft", "trimStart", 0),
+
+			// ---- Regression: syntax string targets precede checker results ----
+			trimInvalid(`function f() { function String(): number { return 1 } String().trimLeft() }`, "file.ts", "trimLeft", "trimStart", 0),
+			trimInvalid(`function f() { const String = {fromCharCode() { return 1 }}; String.fromCharCode().trimRight() }`, "file.ts", "trimRight", "trimEnd", 0),
+			trimInvalid(`function f() { const String = {fromCodePoint() { return {} }}; String.fromCodePoint().trimLeft() }`, "file.ts", "trimLeft", "trimStart", 0),
 		},
 	)
 }
@@ -183,9 +193,10 @@ func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		code string
-		want int
+		name     string
+		fileName string
+		code     string
+		want     int
 	}{
 		{
 			name: "parameter array annotation",
@@ -322,13 +333,29 @@ func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
 			code: `(foo satisfies number[]).trimRight();`,
 			want: 1,
 		},
+		{
+			name:     "JSDoc declaration annotation is ignored",
+			fileName: "file.js",
+			code:     `/** @type {number} */ let value; value.trimLeft();`,
+			want:     1,
+		},
+		{
+			name:     "JSDoc cast annotation is ignored",
+			fileName: "file.js",
+			code:     `(/** @type {number} */ (value)).trimRight();`,
+			want:     1,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			diagnostics := lintPreferStringTrimStartEndSourceOnly(t, test.code)
+			fileName := test.fileName
+			if fileName == "" {
+				fileName = "file.ts"
+			}
+			diagnostics := lintPreferStringTrimStartEndSourceOnly(t, fileName, test.code)
 			if len(diagnostics) != test.want {
 				t.Fatalf("diagnostics = %d, want %d: %+v", len(diagnostics), test.want, diagnostics)
 			}
@@ -336,11 +363,11 @@ func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
 	}
 }
 
-func lintPreferStringTrimStartEndSourceOnly(t *testing.T, code string) []rule.RuleDiagnostic {
+func lintPreferStringTrimStartEndSourceOnly(t *testing.T, baseName, code string) []rule.RuleDiagnostic {
 	t.Helper()
 
 	dir := tspath.NormalizePath(t.TempDir())
-	fileName := tspath.NormalizePath(filepath.Join(dir, "file.ts"))
+	fileName := tspath.NormalizePath(filepath.Join(dir, baseName))
 	fs := utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), map[string]string{fileName: code})
 	sourceProgram, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
 		RootFileNames:   []string{fileName},

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_upstream_test.go
@@ -1,0 +1,90 @@
+// TestPreferStringTrimStartEndUpstream migrates the complete v74.0.0
+// upstream test/prefer-string-trim-start-end.js suite. rslint-specific edge
+// shapes and branch lock-ins live in the sibling extras test file.
+package prefer_string_trim_start_end_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_string_trim_start_end"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const messageID = "prefer-string-trim-start-end"
+
+func expectedMessage(method, replacement string) string {
+	return "Prefer `String#" + replacement + "()` over `String#" + method + "()`."
+}
+
+func trimInvalid(code, fileName, method, replacement string, occurrence int) rule_tester.InvalidTestCase {
+	offset := -1
+	searchFrom := 0
+	for range occurrence + 1 {
+		relative := strings.Index(code[searchFrom:], method)
+		if relative < 0 {
+			panic("method not found in prefer-string-trim-start-end test: " + method)
+		}
+		offset = searchFrom + relative
+		searchFrom = offset + len(method)
+	}
+
+	prefix := code[:offset]
+	line := strings.Count(prefix, "\n") + 1
+	lastNewline := strings.LastIndex(prefix, "\n")
+	column := offset + 1
+	if lastNewline >= 0 {
+		column = offset - lastNewline
+	}
+
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: fileName,
+		Output:   []string{code[:offset] + replacement + code[offset+len(method):]},
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: messageID,
+			Message:   expectedMessage(method, replacement),
+			Line:      line,
+			Column:    column,
+			EndLine:   line,
+			EndColumn: column + len(method),
+		}},
+	}
+}
+
+func TestPreferStringTrimStartEndUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_string_trim_start_end.PreferStringTrimStartEndRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `function f(foo: number[]) { foo.trimLeft(); }`, FileName: "file.ts"},
+			{Code: `foo.trimStart()`, FileName: "file.js"},
+			{Code: `foo.trimStart?.()`, FileName: "file.js"},
+			{Code: `foo.trimEnd()`, FileName: "file.js"},
+			{Code: `new foo.trimLeft();`, FileName: "file.js"},
+			{Code: `trimLeft();`, FileName: "file.js"},
+			{Code: `foo['trimLeft']();`, FileName: "file.js"},
+			{Code: `foo[trimLeft]();`, FileName: "file.js"},
+			{Code: `foo.bar();`, FileName: "file.js"},
+			{Code: `foo.trimLeft(extra);`, FileName: "file.js"},
+			{Code: `foo.trimLeft(...argumentsArray)`, FileName: "file.js"},
+			{Code: `foo.bar(trimLeft)`, FileName: "file.js"},
+			{Code: `foo.bar(foo.trimLeft)`, FileName: "file.js"},
+			{Code: `trimLeft.foo()`, FileName: "file.js"},
+			{Code: `foo.trimLeft.bar()`, FileName: "file.js"},
+		},
+		[]rule_tester.InvalidTestCase{
+			trimInvalid(`function f(foo: string) { foo.trimLeft(); }`, "file.ts", "trimLeft", "trimStart", 0),
+			trimInvalid(`foo.trimLeft()`, "file.js", "trimLeft", "trimStart", 0),
+			trimInvalid(`foo.trimRight()`, "file.js", "trimRight", "trimEnd", 0),
+			trimInvalid(`trimLeft.trimRight()`, "file.js", "trimRight", "trimEnd", 0),
+			trimInvalid(`foo.trimLeft.trimRight()`, "file.js", "trimRight", "trimEnd", 0),
+			trimInvalid(`"foo".trimLeft()`, "file.js", "trimLeft", "trimStart", 0),
+			trimInvalid("foo\n\t// comment\n\t.trimRight/* comment */(\n\t\t/* comment */\n\t)", "file.js", "trimRight", "trimEnd", 0),
+			trimInvalid(`foo?.trimLeft()`, "file.js", "trimLeft", "trimStart", 0),
+		},
+	)
+}

--- a/internal/plugins/unicorn/unicornutil/string_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/string_receiver.go
@@ -1,0 +1,344 @@
+package unicornutil
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// IsKnownNonString reports whether node's type is definitely not string-like.
+// It follows local TypeScript annotations and const initializers before using
+// the checker, matching Unicorn's source-only behavior for files that are not
+// part of a configured project. Unknown receivers return false so syntactic
+// string rules can still report them.
+func IsKnownNonString(ctx rule.RuleContext, node *ast.Node) bool {
+	return classifyStringReceiver(ctx, node, &stringReceiverWalkState{
+		visiting: map[*ast.Symbol]bool{},
+		memo:     map[*ast.Symbol]TypeClass{},
+	}) == TypeNonTarget
+}
+
+// IsKnownNonStringType reports whether the checker alone proves that node is
+// not string-like. Rules that require type information and intentionally do
+// not follow Unicorn's syntax classifier use this narrower helper.
+func IsKnownNonStringType(ctx rule.RuleContext, node *ast.Node) bool {
+	if ctx.TypeChecker == nil || node == nil {
+		return false
+	}
+
+	return classifyStringType(ctx, node) == TypeNonTarget
+}
+
+type stringReceiverWalkState struct {
+	visiting map[*ast.Symbol]bool
+	memo     map[*ast.Symbol]TypeClass
+	depth    int
+	steps    int
+}
+
+const (
+	maxStringReceiverDepth = 1024
+	maxStringReceiverSteps = 4096
+)
+
+func classifyStringReceiver(ctx rule.RuleContext, node *ast.Node, state *stringReceiverWalkState) TypeClass {
+	if node == nil || state.depth >= maxStringReceiverDepth || state.steps >= maxStringReceiverSteps {
+		return TypeUnknown
+	}
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return TypeUnknown
+	}
+
+	state.depth++
+	state.steps++
+	defer func() { state.depth-- }()
+
+	// Unicorn ignores a satisfies annotation and classifies the expression.
+	if node.Kind == ast.KindSatisfiesExpression {
+		return classifyStringReceiver(ctx, node.Expression(), state)
+	}
+	// An informative assertion wins. `any` and `unknown` fall through to the
+	// wrapped expression, matching upstream's getTypeFromExpression.
+	if node.Kind == ast.KindAsExpression || node.Kind == ast.KindTypeAssertionExpression {
+		if class := classifyStringTypeNode(ctx, node.Type(), map[*ast.Symbol]bool{}); class != TypeUnknown {
+			return class
+		}
+		return classifyStringReceiver(ctx, node.Expression(), state)
+	}
+	if node.Kind == ast.KindNonNullExpression {
+		return classifyStringReceiver(ctx, node.Expression(), state)
+	}
+
+	if ast.IsIdentifier(node) {
+		if class := classifyStringIdentifier(ctx, node, state); class != TypeUnknown {
+			return class
+		}
+	}
+	if node.Kind == ast.KindConditionalExpression {
+		conditional := node.AsConditionalExpression()
+		class := combineStringUnion([]TypeClass{
+			classifyStringReceiver(ctx, conditional.WhenTrue, state),
+			classifyStringReceiver(ctx, conditional.WhenFalse, state),
+		})
+		if class != TypeUnknown {
+			return class
+		}
+	}
+	if ast.IsBinaryExpression(node) &&
+		node.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken {
+		if class := classifyStringReceiver(ctx, node.AsBinaryExpression().Right, state); class != TypeUnknown {
+			return class
+		}
+	}
+
+	if ctx.TypeChecker != nil {
+		return classifyStringType(ctx, node)
+	}
+	return TypeUnknown
+}
+
+func classifyStringIdentifier(ctx rule.RuleContext, node *ast.Node, state *stringReceiverWalkState) TypeClass {
+	if ctx.Refs == nil {
+		return TypeUnknown
+	}
+	symbol := ctx.Refs.ResolveInFile(node)
+	if symbol == nil || len(symbol.Declarations) != 1 {
+		return TypeUnknown
+	}
+	if class, ok := state.memo[symbol]; ok {
+		return class
+	}
+	if state.visiting[symbol] {
+		return TypeUnknown
+	}
+	state.visiting[symbol] = true
+	defer delete(state.visiting, symbol)
+
+	declaration := symbol.Declarations[0]
+	if declaration == nil {
+		return TypeUnknown
+	}
+	if class := classifyStringTypeNode(ctx, stringBindingTypeAnnotation(declaration), map[*ast.Symbol]bool{}); class != TypeUnknown {
+		state.memo[symbol] = class
+		return class
+	}
+	if !ast.IsVariableDeclaration(declaration) {
+		return TypeUnknown
+	}
+
+	declarationList := declaration.Parent
+	variable := declaration.AsVariableDeclaration()
+	if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) ||
+		ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList) ||
+		declarationList.Flags&ast.NodeFlagsConst == 0 || variable.Name() == nil ||
+		!ast.IsIdentifier(variable.Name()) || variable.Initializer == nil {
+		return TypeUnknown
+	}
+	class := classifyStringReceiver(ctx, variable.Initializer, state)
+	state.memo[symbol] = class
+	return class
+}
+
+func stringBindingTypeAnnotation(declaration *ast.Node) *ast.Node {
+	if declaration == nil {
+		return nil
+	}
+	switch declaration.Kind {
+	case ast.KindVariableDeclaration, ast.KindParameter:
+		return declaration.Type()
+	default:
+		return nil
+	}
+}
+
+func classifyStringTypeNode(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	visitedSymbols map[*ast.Symbol]bool,
+) TypeClass {
+	if node == nil {
+		return TypeUnknown
+	}
+	for node.Kind == ast.KindParenthesizedType {
+		node = node.AsParenthesizedTypeNode().Type
+		if node == nil {
+			return TypeUnknown
+		}
+	}
+	if node.Kind == ast.KindTypeOperator {
+		operator := node.AsTypeOperatorNode()
+		if operator.Operator != ast.KindReadonlyKeyword {
+			return TypeUnknown
+		}
+		return classifyStringTypeNode(ctx, operator.Type, visitedSymbols)
+	}
+
+	switch node.Kind {
+	case ast.KindStringKeyword:
+		return TypeTarget
+	case ast.KindLiteralType:
+		literal := node.AsLiteralTypeNode().Literal
+		if literal != nil && literal.Kind == ast.KindStringLiteral {
+			return TypeTarget
+		}
+		return TypeNonTarget
+	case ast.KindNullKeyword, ast.KindUndefinedKeyword,
+		ast.KindBigIntKeyword, ast.KindBooleanKeyword, ast.KindNeverKeyword,
+		ast.KindNumberKeyword, ast.KindSymbolKeyword, ast.KindVoidKeyword,
+		ast.KindArrayType, ast.KindTupleType, ast.KindTypeLiteral,
+		ast.KindFunctionType, ast.KindConstructorType:
+		return TypeNonTarget
+	case ast.KindUnionType:
+		types := node.AsUnionTypeNode().Types.Nodes
+		classes := make([]TypeClass, 0, len(types))
+		for _, part := range types {
+			classes = append(classes, classifyStringTypeNode(ctx, part, visitedSymbols))
+		}
+		return combineStringUnion(classes)
+	case ast.KindIntersectionType:
+		types := node.AsIntersectionTypeNode().Types.Nodes
+		classes := make([]TypeClass, 0, len(types))
+		for _, part := range types {
+			classes = append(classes, classifyStringTypeNode(ctx, part, visitedSymbols))
+		}
+		return combineStringIntersection(classes)
+	case ast.KindTypeReference:
+		return classifyStringTypeReference(ctx, node.AsTypeReferenceNode().TypeName, visitedSymbols)
+	default:
+		return TypeUnknown
+	}
+}
+
+func classifyStringTypeReference(
+	ctx rule.RuleContext,
+	typeName *ast.Node,
+	visitedSymbols map[*ast.Symbol]bool,
+) TypeClass {
+	if typeName == nil || !ast.IsIdentifier(typeName) || ctx.Refs == nil {
+		return TypeUnknown
+	}
+	symbol := ctx.Refs.ResolveInFileWithMeaning(
+		typeName, ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+	)
+	if symbol == nil || visitedSymbols[symbol] {
+		return TypeUnknown
+	}
+	visitedSymbols[symbol] = true
+	defer delete(visitedSymbols, symbol)
+
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil {
+			continue
+		}
+		switch declaration.Kind {
+		case ast.KindTypeAliasDeclaration:
+			return classifyStringTypeNode(ctx, declaration.AsTypeAliasDeclaration().Type, visitedSymbols)
+		case ast.KindTypeParameter:
+			return classifyStringTypeNode(ctx, declaration.AsTypeParameterDeclaration().Constraint, visitedSymbols)
+		case ast.KindInterfaceDeclaration:
+			return classifyStringInterface(ctx, declaration, visitedSymbols)
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			return classifyStringClass(ctx, declaration, visitedSymbols)
+		}
+	}
+	return TypeUnknown
+}
+
+func classifyStringInterface(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	visitedSymbols map[*ast.Symbol]bool,
+) TypeClass {
+	declaration := node.AsInterfaceDeclaration()
+	if declaration.HeritageClauses == nil || len(declaration.HeritageClauses.Nodes) == 0 {
+		return TypeNonTarget
+	}
+	classes := make([]TypeClass, 0, len(declaration.HeritageClauses.Nodes))
+	for _, clauseNode := range declaration.HeritageClauses.Nodes {
+		clause := clauseNode.AsHeritageClause()
+		if clause == nil || clause.Token != ast.KindExtendsKeyword || clause.Types == nil {
+			continue
+		}
+		for _, heritageNode := range clause.Types.Nodes {
+			heritage := heritageNode.AsExpressionWithTypeArguments()
+			if heritage == nil {
+				classes = append(classes, TypeUnknown)
+				continue
+			}
+			classes = append(classes, classifyStringTypeReference(ctx, heritage.Expression, visitedSymbols))
+		}
+	}
+	if len(classes) == 0 {
+		return TypeNonTarget
+	}
+	return combineStringIntersection(classes)
+}
+
+func classifyStringClass(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	visitedSymbols map[*ast.Symbol]bool,
+) TypeClass {
+	heritageClauses := utils.GetHeritageClauses(node)
+	if heritageClauses == nil {
+		return TypeNonTarget
+	}
+	for _, clauseNode := range heritageClauses.Nodes {
+		clause := clauseNode.AsHeritageClause()
+		if clause == nil || clause.Token != ast.KindExtendsKeyword || clause.Types == nil || len(clause.Types.Nodes) == 0 {
+			continue
+		}
+		heritage := clause.Types.Nodes[0].AsExpressionWithTypeArguments()
+		if heritage == nil {
+			return TypeUnknown
+		}
+		return classifyStringTypeReference(ctx, heritage.Expression, visitedSymbols)
+	}
+	return TypeNonTarget
+}
+
+func combineStringUnion(classes []TypeClass) TypeClass {
+	if len(classes) == 0 {
+		return TypeNonTarget
+	}
+	allTarget := true
+	allNonTarget := true
+	for _, class := range classes {
+		allTarget = allTarget && class == TypeTarget
+		allNonTarget = allNonTarget && class == TypeNonTarget
+	}
+	if allTarget {
+		return TypeTarget
+	}
+	if allNonTarget {
+		return TypeNonTarget
+	}
+	return TypeUnknown
+}
+
+func combineStringIntersection(classes []TypeClass) TypeClass {
+	allNonTarget := true
+	for _, class := range classes {
+		if class == TypeTarget {
+			return TypeTarget
+		}
+		allNonTarget = allNonTarget && class == TypeNonTarget
+	}
+	if allNonTarget {
+		return TypeNonTarget
+	}
+	return TypeUnknown
+}
+
+func classifyStringType(ctx rule.RuleContext, node *ast.Node) TypeClass {
+	t := ctx.TypeChecker.GetTypeAtLocation(node)
+	return ClassifyType(ctx, t, TypeClassifierOptions{
+		HeritageSymbolFlags:          ast.SymbolFlagsClass | ast.SymbolFlagsInterface,
+		NonTargetSymbolLessTypeFlags: checker.TypeFlagsObject,
+		IsTargetType: func(t *checker.Type) bool {
+			return utils.IsTypeFlagSet(t, checker.TypeFlagsStringLike)
+		},
+	})
+}

--- a/internal/plugins/unicorn/unicornutil/string_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/string_receiver.go
@@ -27,7 +27,7 @@ func IsKnownNonStringType(ctx rule.RuleContext, node *ast.Node) bool {
 		return false
 	}
 
-	return classifyStringType(ctx, node) == TypeNonTarget
+	return classifyRequiredStringType(ctx, node) == TypeNonTarget
 }
 
 type stringReceiverWalkState struct {
@@ -294,9 +294,55 @@ func classifyStringClass(
 		if heritage == nil {
 			return TypeUnknown
 		}
-		return classifyStringTypeReference(ctx, heritage.Expression, visitedSymbols)
+		return classifyStringClassReference(ctx, heritage.Expression, visitedSymbols)
 	}
 	return TypeNonTarget
+}
+
+func classifyStringClassReference(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	visitedSymbols map[*ast.Symbol]bool,
+) TypeClass {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return TypeUnknown
+	}
+	if node.Kind == ast.KindClassDeclaration || node.Kind == ast.KindClassExpression {
+		return classifyStringClass(ctx, node, visitedSymbols)
+	}
+	if !ast.IsIdentifier(node) || ctx.Refs == nil {
+		return TypeUnknown
+	}
+
+	symbol := ctx.Refs.ResolveInFileWithMeaning(
+		node, ast.SymbolFlagsValue|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+	)
+	if symbol == nil || visitedSymbols[symbol] {
+		return TypeUnknown
+	}
+	visitedSymbols[symbol] = true
+	defer delete(visitedSymbols, symbol)
+
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil {
+			continue
+		}
+		switch declaration.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			return classifyStringClass(ctx, declaration, visitedSymbols)
+		case ast.KindVariableDeclaration:
+			declarationList := declaration.Parent
+			variable := declaration.AsVariableDeclaration()
+			if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) ||
+				declarationList.Flags&ast.NodeFlagsConst == 0 || variable.Name() == nil ||
+				!ast.IsIdentifier(variable.Name()) || variable.Initializer == nil {
+				return TypeUnknown
+			}
+			return classifyStringClassReference(ctx, variable.Initializer, visitedSymbols)
+		}
+	}
+	return TypeUnknown
 }
 
 func combineStringUnion(classes []TypeClass) TypeClass {
@@ -333,6 +379,81 @@ func combineStringIntersection(classes []TypeClass) TypeClass {
 }
 
 func classifyStringType(ctx rule.RuleContext, node *ast.Node) TypeClass {
+	t := ctx.TypeChecker.GetTypeAtLocation(node)
+	return classifyStringCheckerType(ctx, t)
+}
+
+func classifyStringCheckerType(ctx rule.RuleContext, t *checker.Type) TypeClass {
+	if t == nil || utils.IsTypeAnyType(t) || utils.IsTypeUnknownType(t) || utils.IsIntrinsicErrorType(t) {
+		return TypeUnknown
+	}
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+		return TypeNonTarget
+	}
+	if utils.IsTypeParameter(t) {
+		constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t)
+		if constraint == nil {
+			return TypeUnknown
+		}
+		return classifyStringCheckerType(ctx, constraint)
+	}
+	if utils.IsUnionType(t) {
+		parts := utils.UnionTypeParts(t)
+		classes := make([]TypeClass, 0, len(parts))
+		for _, part := range parts {
+			classes = append(classes, classifyStringCheckerType(ctx, part))
+		}
+		return combineStringUnion(classes)
+	}
+	if utils.IsIntersectionType(t) {
+		parts := utils.IntersectionTypeParts(t)
+		classes := make([]TypeClass, 0, len(parts))
+		for _, part := range parts {
+			classes = append(classes, classifyStringCheckerType(ctx, part))
+		}
+		return combineStringIntersection(classes)
+	}
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsStringLiteral) ||
+		(utils.IsIntrinsicType(t) && t.AsIntrinsicType().IntrinsicName() == "string") {
+		return TypeTarget
+	}
+
+	constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t)
+	if constraint != nil && constraint != t {
+		return classifyStringCheckerType(ctx, constraint)
+	}
+	if stringTypeHasTargetBase(ctx, t) {
+		return TypeTarget
+	}
+	if utils.IsIntrinsicType(t) {
+		return TypeNonTarget
+	}
+	if _, ok := TypeSymbolName(t); !ok {
+		return TypeUnknown
+	}
+	// is-string.js configures createTypeCheckers with no target type names, so
+	// every named non-intrinsic type is a known non-string at this point.
+	return TypeNonTarget
+}
+
+func stringTypeHasTargetBase(ctx rule.RuleContext, t *checker.Type) bool {
+	symbol := checker.Type_symbol(t)
+	if symbol == nil || symbol.Flags&(ast.SymbolFlagsClass|ast.SymbolFlagsInterface) == 0 {
+		return false
+	}
+	declared := checker.Checker_getDeclaredTypeOfSymbol(ctx.TypeChecker, symbol)
+	if declared == nil {
+		return false
+	}
+	for _, base := range checker.Checker_getBaseTypes(ctx.TypeChecker, declared) {
+		if classifyStringCheckerType(ctx, base) == TypeTarget {
+			return true
+		}
+	}
+	return false
+}
+
+func classifyRequiredStringType(ctx rule.RuleContext, node *ast.Node) TypeClass {
 	t := ctx.TypeChecker.GetTypeAtLocation(node)
 	return ClassifyType(ctx, t, TypeClassifierOptions{
 		HeritageSymbolFlags:          ast.SymbolFlagsClass | ast.SymbolFlagsInterface,

--- a/internal/plugins/unicorn/unicornutil/string_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/string_receiver.go
@@ -92,6 +92,9 @@ func classifyStringReceiver(ctx rule.RuleContext, node *ast.Node, state *stringR
 			return class
 		}
 	}
+	if isSyntacticStringCall(node) {
+		return TypeTarget
+	}
 
 	if ctx.TypeChecker != nil {
 		return classifyStringType(ctx, node)
@@ -158,7 +161,7 @@ func classifyStringTypeNode(
 	node *ast.Node,
 	visitedSymbols map[*ast.Symbol]bool,
 ) TypeClass {
-	if node == nil {
+	if node == nil || utils.IsJSDocSyntaxNode(node) {
 		return TypeUnknown
 	}
 	for node.Kind == ast.KindParenthesizedType {
@@ -386,6 +389,31 @@ func combineStringIntersection(classes []TypeClass) TypeClass {
 	return TypeUnknown
 }
 
+func isSyntacticStringCall(node *ast.Node) bool {
+	if node == nil || !ast.IsCallExpression(node) || ast.IsOptionalChainRoot(node) {
+		return false
+	}
+	callee := utils.ESTreeCallCallee(node.AsCallExpression().Expression)
+	if callee == nil {
+		return false
+	}
+	if ast.IsIdentifier(callee) {
+		return callee.AsIdentifier().Text == "String"
+	}
+	if !ast.IsPropertyAccessExpression(callee) || ast.IsOptionalChainRoot(callee) {
+		return false
+	}
+	access := callee.AsPropertyAccessExpression()
+	object := utils.ESTreeRuntimeExpression(access.Expression)
+	property := access.Name()
+	if object == nil || !ast.IsIdentifier(object) || object.AsIdentifier().Text != "String" ||
+		property == nil || !ast.IsIdentifier(property) {
+		return false
+	}
+	method := property.AsIdentifier().Text
+	return method == "fromCharCode" || method == "fromCodePoint"
+}
+
 func classifyStringType(ctx rule.RuleContext, node *ast.Node) TypeClass {
 	t := ctx.TypeChecker.GetTypeAtLocation(node)
 	return classifyStringCheckerType(ctx, t)
@@ -424,6 +452,11 @@ func classifyStringCheckerType(ctx rule.RuleContext, t *checker.Type) TypeClass 
 	if utils.IsTypeFlagSet(t, checker.TypeFlagsStringLiteral) ||
 		(utils.IsIntrinsicType(t) && t.AsIntrinsicType().IntrinsicName() == "string") {
 		return TypeTarget
+	}
+	// TypeScript's public API exposes true/false as intrinsic types, but tsgo
+	// carries them under TypeFlagsBooleanLiteral without TypeFlagsIntrinsic.
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsBooleanLiteral) {
+		return TypeNonTarget
 	}
 
 	constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t)

--- a/internal/plugins/unicorn/unicornutil/string_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/string_receiver.go
@@ -294,7 +294,14 @@ func classifyStringClass(
 		if heritage == nil {
 			return TypeUnknown
 		}
-		return classifyStringClassReference(ctx, heritage.Expression, visitedSymbols)
+		// Upstream only enters class-reference resolution when the direct
+		// superclass is an identifier. Class expressions are handled only when
+		// reached through a const alias initializer.
+		superClass := ast.SkipParentheses(heritage.Expression)
+		if superClass == nil || !ast.IsIdentifier(superClass) {
+			return TypeUnknown
+		}
+		return classifyStringClassReference(ctx, superClass, visitedSymbols)
 	}
 	return TypeNonTarget
 }
@@ -335,6 +342,7 @@ func classifyStringClassReference(
 			declarationList := declaration.Parent
 			variable := declaration.AsVariableDeclaration()
 			if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) ||
+				ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList) ||
 				declarationList.Flags&ast.NodeFlagsConst == 0 || variable.Name() == nil ||
 				!ast.IsIdentifier(variable.Name()) || variable.Initializer == nil {
 				return TypeUnknown

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -709,6 +709,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-string-trim-start-end.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-then-catch.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-ternary.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-array-join-separator.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-string-trim-start-end.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-string-trim-start-end.test.ts
@@ -1,0 +1,74 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string, filename = 'file.js') => ({ code, filename });
+const invalid = (
+  code: string,
+  output: string,
+  method: 'trimLeft' | 'trimRight',
+  replacement: 'trimStart' | 'trimEnd',
+  filename = 'file.js',
+) => ({
+  code,
+  filename,
+  output,
+  errors: [
+    {
+      messageId: 'prefer-string-trim-start-end',
+      message: `Prefer \`String#${replacement}()\` over \`String#${method}()\`.`,
+      data: { method, replacement },
+    },
+  ],
+});
+
+ruleTester.run('prefer-string-trim-start-end', null as never, {
+  valid: [
+    valid('function f(foo: number[]) { foo.trimLeft(); }', 'file.ts'),
+    valid('foo.trimStart()'),
+    valid('foo.trimStart?.()'),
+    valid('foo.trimEnd()'),
+    valid('new foo.trimLeft();'),
+    valid('trimLeft();'),
+    valid("foo['trimLeft']();"),
+    valid('foo[trimLeft]();'),
+    valid('foo.bar();'),
+    valid('foo.trimLeft(extra);'),
+    valid('foo.trimLeft(...argumentsArray)'),
+    valid('foo.bar(trimLeft)'),
+    valid('foo.bar(foo.trimLeft)'),
+    valid('trimLeft.foo()'),
+    valid('foo.trimLeft.bar()'),
+  ],
+  invalid: [
+    invalid(
+      'function f(foo: string) { foo.trimLeft(); }',
+      'function f(foo: string) { foo.trimStart(); }',
+      'trimLeft',
+      'trimStart',
+      'file.ts',
+    ),
+    invalid('foo.trimLeft()', 'foo.trimStart()', 'trimLeft', 'trimStart'),
+    invalid('foo.trimRight()', 'foo.trimEnd()', 'trimRight', 'trimEnd'),
+    invalid(
+      'trimLeft.trimRight()',
+      'trimLeft.trimEnd()',
+      'trimRight',
+      'trimEnd',
+    ),
+    invalid(
+      'foo.trimLeft.trimRight()',
+      'foo.trimLeft.trimEnd()',
+      'trimRight',
+      'trimEnd',
+    ),
+    invalid('"foo".trimLeft()', '"foo".trimStart()', 'trimLeft', 'trimStart'),
+    invalid(
+      'foo\n\t// comment\n\t.trimRight/* comment */(\n\t\t/* comment */\n\t)',
+      'foo\n\t// comment\n\t.trimEnd/* comment */(\n\t\t/* comment */\n\t)',
+      'trimRight',
+      'trimEnd',
+    ),
+    invalid('foo?.trimLeft()', 'foo?.trimStart()', 'trimLeft', 'trimStart'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -318,7 +318,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-string-replace-all': 'error', // not implemented
     // 'unicorn/prefer-string-slice': 'error', // not implemented
     // 'unicorn/prefer-string-starts-ends-with': 'error', // not implemented
-    // 'unicorn/prefer-string-trim-start-end': 'error', // not implemented
+    'unicorn/prefer-string-trim-start-end': 'error',
     // 'unicorn/prefer-structured-clone': 'error', // not implemented
     // 'unicorn/prefer-switch': 'error', // not implemented
     // 'unicorn/prefer-temporal': 'off', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/prefer-string-trim-start-end` from eslint-plugin-unicorn v74.0.0.

The rule reports zero-argument `trimLeft()` and `trimRight()` calls and safely autofixes them to `trimStart()` and `trimEnd()`.

This change also:

- Preserves upstream optional chaining behavior: optional member access is reported, while optional calls are allowed.
- Skips receivers known not to be strings.
- Supports TypeScript annotations, assertions, aliases, interfaces, classes, and constrained type parameters even when no TypeChecker is available.
- Extracts the shared string receiver classification used by `no-unsafe-string-replacement` while preserving that rule's existing behavior.
- Registers the rule in the Unicorn catalog and recommended preset.
- Adds the complete upstream test suite, source-only regressions, AST edge cases, autofix boundary coverage, and JS integration tests.

## Related Links

- Tracking issue: #1309
- [Rule documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-string-trim-start-end.md)
- [Upstream source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-string-trim-start-end.js)

## Verification

- `go test -count=1 ./internal/plugins/unicorn/rules/prefer_string_trim_start_end ./internal/plugins/unicorn/rules/no_unsafe_string_replacement ./internal/plugins/unicorn/unicornutil`
- `pnpm --dir packages/rslint run build:bin`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 prefer-string-trim-start-end`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint v2.12.2`: 0 issues

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
