### PR TITLE
fix: align string trim class heritage with Unicorn

### DIFF
--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end.go
@@ -12,7 +12,11 @@ import (
 
 const messageID = "prefer-string-trim-start-end"
 
-var trimMethods = []string{"trimLeft", "trimRight"}
+var (
+	trimMethods      = []string{"trimLeft", "trimRight"}
+	trimStartMessage = preferTrimStartEndMessage("trimLeft", "trimStart")
+	trimEndMessage   = preferTrimStartEndMessage("trimRight", "trimEnd")
+)
 
 func preferTrimStartEndMessage(method, replacement string) rule.RuleMessage {
 	return rule.RuleMessage{
@@ -48,13 +52,15 @@ var PreferStringTrimStartEndRule = rule.Rule{
 
 				method := call.Property.AsIdentifier().Text
 				replacement := "trimStart"
+				message := trimStartMessage
 				if method == "trimRight" {
 					replacement = "trimEnd"
+					message = trimEndMessage
 				}
 
 				ctx.ReportNodeWithDeferredFixes(
 					call.Property,
-					preferTrimStartEndMessage(method, replacement),
+					message,
 					func() []rule.RuleFix {
 						return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, call.Property, replacement)}
 					},

--- a/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_string_trim_start_end/prefer_string_trim_start_end_extras_test.go
@@ -29,6 +29,12 @@ func TestPreferStringTrimStartEndExtras(t *testing.T) {
 		t,
 		&prefer_string_trim_start_end.PreferStringTrimStartEndRule,
 		[]rule_tester.ValidTestCase{
+			// With a checker, both direct and recursive class expressions are
+			// known non-strings, including merged type/value declarations.
+			{Code: `class Base extends class { trimLeft() {} } {} function f(value: Base) { value.trimLeft(); }`, FileName: "file.ts"},
+			{Code: `class Base extends class { trimLeft() {} } {} class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`, FileName: "file.ts"},
+			{Code: `type Base = string; const Base = class { trimRight() {} }; class Derived extends Base {} function f(value: Derived) { value.trimRight(); }`, FileName: "file.ts"},
+
 			// ---- Real-user: upstream PR #1768 optional-call direction ----
 			// Optional calls are deliberately allowed.
 			{Code: `foo.trimRight?.()`, FileName: "file.js"},
@@ -189,6 +195,32 @@ func TestPreferStringTrimStartEndEditDemand(t *testing.T) {
 	}
 }
 
+func TestPreferStringTrimStartEndMessages(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := lintPreferStringTrimStartEndSourceOnly(t, "file.js", `value.trimLeft(); value.trimRight();`)
+	want := []rule.RuleMessage{
+		{
+			Id:          messageID,
+			Description: expectedMessage("trimLeft", "trimStart"),
+			Data:        map[string]string{"method": "trimLeft", "replacement": "trimStart"},
+		},
+		{
+			Id:          messageID,
+			Description: expectedMessage("trimRight", "trimEnd"),
+			Data:        map[string]string{"method": "trimRight", "replacement": "trimEnd"},
+		},
+	}
+	if len(diagnostics) != len(want) {
+		t.Fatalf("diagnostics = %d, want %d", len(diagnostics), len(want))
+	}
+	for i, message := range want {
+		if !reflect.DeepEqual(diagnostics[i].Message, message) {
+			t.Errorf("diagnostic %d: message = %+v, want %+v", i, diagnostics[i].Message, message)
+		}
+	}
+}
+
 func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
 	t.Parallel()
 
@@ -247,6 +279,66 @@ func TestPreferStringTrimStartEndSourceOnly(t *testing.T) {
 			name: "direct class expression heritage remains unknown",
 			code: `class Collection extends class {} {} function f(foo: Collection) { foo.trimLeft(); }`,
 			want: 1,
+		},
+		{
+			name: "recursive class expression heritage",
+			code: `class Base extends class { trimLeft() {} } {} class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "nested class expressions through const aliases",
+			code: `const Origin = class extends class extends class { trimRight() {} } {} {}; const Base = Origin; class Derived extends Base {} function f(value: Derived) { value.trimRight(); }`,
+			want: 0,
+		},
+		{
+			name: "recursive heritage through a constrained type parameter",
+			code: `class Base extends class { trimLeft() {} } {} class Derived extends Base {} function f<T extends Derived>(value: T) { value?.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "recursive heritage with a string union remains unknown",
+			code: `class Base extends class { trimRight() {} } {} class Derived extends Base {} function f(value: Derived | string) { value.trimRight(); }`,
+			want: 1,
+		},
+		{
+			name: "recursive factory superclass remains unknown",
+			code: `function factory() { return class { trimLeft() {} }; } class Base extends factory() {} class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "recursive asserted alias remains unknown",
+			code: `const Base = (class { trimLeft() {} }) as any; class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "cyclic class aliases remain unknown",
+			code: `const Base = Alias; const Alias = Base; class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "cyclic class heritage remains unknown",
+			code: `class Base extends Derived {} class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "type declaration before const remains unknown",
+			code: `type Base = string; const Base = class { trimLeft() {} }; class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`,
+			want: 1,
+		},
+		{
+			name: "const declaration before type is resolved",
+			code: `const Base = class { trimLeft() {} }; type Base = string; class Derived extends Base {} function f(value: Derived) { value.trimLeft(); }`,
+			want: 0,
+		},
+		{
+			name: "interface declaration before class remains unknown",
+			code: `interface Base {} class Base { trimRight() {} } class Derived extends Base {} function f(value: Derived) { value.trimRight(); }`,
+			want: 1,
+		},
+		{
+			name: "class declaration before interface is resolved",
+			code: `class Base { trimRight() {} } interface Base {} class Derived extends Base {} function f(value: Derived) { value.trimRight(); }`,
+			want: 0,
 		},
 		{
 			name: "using binding is not a const alias",

--- a/internal/plugins/unicorn/unicornutil/string_receiver.go
+++ b/internal/plugins/unicorn/unicornutil/string_receiver.go
@@ -243,7 +243,7 @@ func classifyStringTypeReference(
 		case ast.KindInterfaceDeclaration:
 			return classifyStringInterface(ctx, declaration, visitedSymbols)
 		case ast.KindClassDeclaration, ast.KindClassExpression:
-			return classifyStringClass(ctx, declaration, visitedSymbols)
+			return classifyStringClass(ctx, declaration, visitedSymbols, true)
 		}
 	}
 	return TypeUnknown
@@ -283,30 +283,20 @@ func classifyStringClass(
 	ctx rule.RuleContext,
 	node *ast.Node,
 	visitedSymbols map[*ast.Symbol]bool,
+	fromTypeReference bool,
 ) TypeClass {
-	heritageClauses := utils.GetHeritageClauses(node)
-	if heritageClauses == nil {
+	heritage := ast.GetClassExtendsHeritageElement(node)
+	if heritage == nil {
 		return TypeNonTarget
 	}
-	for _, clauseNode := range heritageClauses.Nodes {
-		clause := clauseNode.AsHeritageClause()
-		if clause == nil || clause.Token != ast.KindExtendsKeyword || clause.Types == nil || len(clause.Types.Nodes) == 0 {
-			continue
-		}
-		heritage := clause.Types.Nodes[0].AsExpressionWithTypeArguments()
-		if heritage == nil {
-			return TypeUnknown
-		}
-		// Upstream only enters class-reference resolution when the direct
-		// superclass is an identifier. Class expressions are handled only when
-		// reached through a const alias initializer.
-		superClass := ast.SkipParentheses(heritage.Expression)
-		if superClass == nil || !ast.IsIdentifier(superClass) {
-			return TypeUnknown
-		}
-		return classifyStringClassReference(ctx, superClass, visitedSymbols)
+	superClass := ast.SkipParentheses(heritage.AsExpressionWithTypeArguments().Expression)
+	// Unicorn's getClassHeritageType requires an identifier only when entering
+	// from a type reference. Its recursive getClassType also follows inline
+	// class expressions reached through a superclass or const initializer.
+	if superClass == nil || (fromTypeReference && !ast.IsIdentifier(superClass)) {
+		return TypeUnknown
 	}
-	return TypeNonTarget
+	return classifyStringClassReference(ctx, superClass, visitedSymbols)
 }
 
 func classifyStringClassReference(
@@ -319,7 +309,7 @@ func classifyStringClassReference(
 		return TypeUnknown
 	}
 	if node.Kind == ast.KindClassDeclaration || node.Kind == ast.KindClassExpression {
-		return classifyStringClass(ctx, node, visitedSymbols)
+		return classifyStringClass(ctx, node, visitedSymbols, false)
 	}
 	if !ast.IsIdentifier(node) || ctx.Refs == nil {
 		return TypeUnknown
@@ -328,30 +318,31 @@ func classifyStringClassReference(
 	symbol := ctx.Refs.ResolveInFileWithMeaning(
 		node, ast.SymbolFlagsValue|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
 	)
-	if symbol == nil || visitedSymbols[symbol] {
+	if symbol == nil || len(symbol.Declarations) == 0 || visitedSymbols[symbol] {
 		return TypeUnknown
 	}
 	visitedSymbols[symbol] = true
 	defer delete(visitedSymbols, symbol)
 
-	for _, declaration := range symbol.Declarations {
-		if declaration == nil {
-			continue
+	// Match Unicorn's first definition, including merged type/value
+	// declarations. Skipping an earlier type declaration changes its answer.
+	declaration := symbol.Declarations[0]
+	if declaration == nil {
+		return TypeUnknown
+	}
+	switch declaration.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return classifyStringClass(ctx, declaration, visitedSymbols, false)
+	case ast.KindVariableDeclaration:
+		declarationList := declaration.Parent
+		variable := declaration.AsVariableDeclaration()
+		if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) ||
+			ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList) ||
+			declarationList.Flags&ast.NodeFlagsConst == 0 || variable.Name() == nil ||
+			!ast.IsIdentifier(variable.Name()) || variable.Initializer == nil {
+			return TypeUnknown
 		}
-		switch declaration.Kind {
-		case ast.KindClassDeclaration, ast.KindClassExpression:
-			return classifyStringClass(ctx, declaration, visitedSymbols)
-		case ast.KindVariableDeclaration:
-			declarationList := declaration.Parent
-			variable := declaration.AsVariableDeclaration()
-			if declarationList == nil || !ast.IsVariableDeclarationList(declarationList) ||
-				ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList) ||
-				declarationList.Flags&ast.NodeFlagsConst == 0 || variable.Name() == nil ||
-				!ast.IsIdentifier(variable.Name()) || variable.Initializer == nil {
-				return TypeUnknown
-			}
-			return classifyStringClassReference(ctx, variable.Initializer, visitedSymbols)
-		}
+		return classifyStringClassReference(ctx, variable.Initializer, visitedSymbols)
 	}
 	return TypeUnknown
 }


### PR DESCRIPTION
## Summary

Fix `unicorn/prefer-string-trim-start-end` incorrectly renaming inherited custom trim methods in TypeScript files without a TypeChecker. For example, `value.trimLeft()` must stay unchanged here:

```ts
class Base extends class { trimLeft() {} } {}
class Derived extends Base {}
function trim(value: Derived) { value.trimLeft(); }
```

Reuse tsgo's `GetClassExtendsHeritageElement` and distinguish the initial type-reference check from recursive superclass resolution. Also preserve Unicorn's first-declaration behavior for merged type/value bindings, and reuse the two fixed diagnostic messages to reduce allocation overhead.

Validation:

- Compared diagnostic counts and autofix output with the latest released `eslint-plugin-unicorn` (74.0.0): 275 cases in both source-only and typed modes, with all 550 comparisons matching.
- Added regression tests for recursive class expressions, const aliases, declaration ordering, string unions, cycles, checker fallback, and diagnostic metadata.
- Passed the three affected Go package tests, `pnpm run check-spell`, `pnpm run format:check`, and Go lint limited to the two changed packages with `--new-from-merge-base=origin/main`.
- Temporary Go benchmarks reduced the report-only path from 592 B / 6 allocations to 160 B / 1 allocation per operation. Benchmark code is excluded from this change.

## Related Links

- [Unicorn type helpers](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/utils/type-helpers.js)
- [Rule documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-string-trim-start-end.md)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
