### PR TITLE
fix: align react/hook-use-state with upstream

### DIFF
--- a/internal/plugins/react/rules/hook_use_state/hook_use_state.go
+++ b/internal/plugins/react/rules/hook_use_state/hook_use_state.go
@@ -2,6 +2,7 @@ package hook_use_state
 
 import (
 	_ "embed"
+	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -38,7 +39,6 @@ func suggestMemoMessage() rule.RuleMessage {
 // hook-use-state uses for its suggestions and call recognition.
 type importInfo struct {
 	defaultName       string
-	defaultSpecifier  *ast.Node
 	useStateSpecifier *ast.Node
 	useMemoSpecifier  *ast.Node
 	useMemoName       string
@@ -84,7 +84,6 @@ func reactImportInfo(node *ast.Node) importInfo {
 	clause := decl.ImportClause.AsImportClause()
 	if clause.Name() != nil && clause.Name().Kind == ast.KindIdentifier {
 		info.defaultName = clause.Name().AsIdentifier().Text
-		info.defaultSpecifier = clause.Name()
 	}
 	if clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamedImports {
 		return info
@@ -131,12 +130,7 @@ func resolvesToNamedUseState(referenceScopes map[*ast.Node]*scope.Scope, imports
 	if ident == nil || ident.Kind != ast.KindIdentifier {
 		return false
 	}
-	// Components#isReactHookCall requires the local hook spelling to match
-	// /^use[A-Z]/, even when it is imported under another name.
 	name := ident.AsIdentifier().Text
-	if len(name) < 4 || name[:3] != "use" || name[3] < 'A' || name[3] > 'Z' {
-		return false
-	}
 	reference := firstReactHookReference(referenceScopes, imports, ident)
 	if reference == nil {
 		return false
@@ -146,9 +140,19 @@ func resolvesToNamedUseState(referenceScopes map[*ast.Node]*scope.Scope, imports
 			return false
 		}
 	}
-	// Components#isReactHookCall falls back to the local spelling when the
-	// first hook-shaped reference is not mapped to a different imported name.
-	return imports.namedHookNames[name] == "" || imports.namedHookNames[name] == "useState"
+	return true
+}
+
+// Components applies the same local-to-imported mapping to bare callees and
+// member properties. Its prefix excludes digits, unlike reactutil.IsHookName.
+func isUseStateHookName(imports importInfo, name string) bool {
+	if len(name) < 4 || name[:3] != "use" || name[3] < 'A' || name[3] > 'Z' {
+		return false
+	}
+	if imported := imports.namedHookNames[name]; imported != "" {
+		name = imported
+	}
+	return name == "useState"
 }
 
 func firstReference(referenceScopes map[*ast.Node]*scope.Scope, ident *ast.Node, name string) *scope.Reference {
@@ -168,59 +172,57 @@ func firstReference(referenceScopes map[*ast.Node]*scope.Scope, ident *ast.Node,
 }
 
 func resolvesToDefaultReactImport(referenceScopes map[*ast.Node]*scope.Scope, imports importInfo, ident *ast.Node) bool {
-	if imports.defaultName == "" || imports.defaultSpecifier == nil {
+	if imports.defaultName == "" {
 		return false
 	}
 	reference := firstReference(referenceScopes, ident, imports.defaultName)
-	if reference == nil {
+	if reference == nil || len(reference.Declarations) == 0 {
 		return false
 	}
-	matchedImport := false
+	// Components checks the definition kind, even when a nested import
+	// binds the same spelling to a different module.
 	for _, declaration := range reference.Declarations {
 		if declaration == nil || declaration.Kind != scope.DefImport {
 			return false
 		}
-		if declaration.ID == imports.defaultSpecifier {
-			matchedImport = true
-		}
 	}
-	return matchedImport
+	return true
 }
 
 // isReactUseStateCall ports Components#isReactHookCall(node, ["useState"]).
-// Parentheses are transparent because ESTree drops them; TS assertion wrappers
-// deliberately are not, matching the upstream parser's explicit TS nodes.
-func isReactUseStateCall(referenceScopes map[*ast.Node]*scope.Scope, imports importInfo, node *ast.Node) bool {
+// Source parentheses and JSDoc casts are transparent; authored TypeScript
+// assertions remain explicit nodes in the upstream parser.
+func isReactUseStateCall(getReferenceScopes func() map[*ast.Node]*scope.Scope, imports importInfo, node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return false
 	}
-	rawCallee := node.AsCallExpression().Expression
-	callee := ast.SkipParentheses(rawCallee)
+	callee := utils.ESTreeCallCallee(node.AsCallExpression().Expression)
 	if callee == nil {
 		return false
 	}
-	// A direct optional member call is still a MemberExpression to ESTree,
-	// while parentheses around the optional member make the callee a
-	// ChainExpression and prevent the upstream hook matcher from recognizing it.
-	if ast.IsOptionalChain(callee) && rawCallee != callee {
-		return false
-	}
 	if callee.Kind == ast.KindIdentifier {
-		return resolvesToNamedUseState(referenceScopes, imports, callee)
+		return len(imports.namedHookNames) > 0 && isUseStateHookName(imports, callee.Text()) &&
+			resolvesToNamedUseState(getReferenceScopes(), imports, callee)
 	}
-	if callee.Kind != ast.KindPropertyAccessExpression {
+	if !ast.IsAccessExpression(callee) {
 		return false
 	}
-	access := callee.AsPropertyAccessExpression()
-	name := access.Name()
-	if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "useState" {
+	var name *ast.Node
+	if ast.IsPropertyAccessExpression(callee) {
+		name = callee.Name()
+	} else {
+		// ESTree also accepts a computed Identifier property, but not a
+		// literal or a TS assertion around that identifier.
+		name = utils.ESTreeRuntimeExpression(callee.AsElementAccessExpression().ArgumentExpression)
+	}
+	if name == nil || name.Kind != ast.KindIdentifier || !isUseStateHookName(imports, name.Text()) {
 		return false
 	}
-	receiver := ast.SkipParentheses(access.Expression)
+	receiver := utils.ESTreeRuntimeExpression(utils.AccessExpressionObject(callee))
 	if receiver == nil || receiver.Kind != ast.KindIdentifier || receiver.AsIdentifier().Text != imports.defaultName {
 		return false
 	}
-	return resolvesToDefaultReactImport(referenceScopes, imports, receiver)
+	return resolvesToDefaultReactImport(getReferenceScopes(), imports, receiver)
 }
 
 func isDestructuringBinding(node *ast.Node) bool {
@@ -271,15 +273,6 @@ func expectedSetterNames(value string) []string {
 	return []string{"set" + upperFirst + suffix, "set" + upperAll + suffix}
 }
 
-func contains(values []string, value string) bool {
-	for _, candidate := range values {
-		if candidate == value {
-			return true
-		}
-	}
-	return false
-}
-
 // HookUseStateRule ensures that a React useState call is destructured into a
 // symmetric [value, setValue] pair.
 var HookUseStateRule = rule.Rule{
@@ -294,27 +287,39 @@ var HookUseStateRule = rule.Rule{
 		}
 
 		imports := importInfo{}
-		namedHookNames := make(map[string]struct{})
-		if ctx.SourceFile != nil && ctx.SourceFile.Statements != nil {
-			for _, statement := range ctx.SourceFile.Statements.Nodes {
-				info := reactImportInfo(statement)
-				if info.defaultName != "" {
-					namedHookNames[info.defaultName] = struct{}{}
-				}
-				for local := range info.namedHookNames {
-					namedHookNames[local] = struct{}{}
-				}
-			}
-		}
 		// The upstream hook matcher can fall back to a bare `useState` spelling
 		// after finding another hook-shaped React reference in the scope. Keep
 		// that otherwise-unimported reference available to the first-reference
 		// lookup without collecting every identifier in the file.
-		namedHookNames["useState"] = struct{}{}
-		manager := scope.Build(ctx.SourceFile, scope.Options{CollectReferences: true, ReferenceNames: namedHookNames})
-		referenceScopes := make(map[*ast.Node]*scope.Scope, len(manager.References))
-		for _, reference := range manager.References {
-			referenceScopes[reference.Identifier] = reference.From
+		var referenceScopes map[*ast.Node]*scope.Scope
+		getReferenceScopes := func() map[*ast.Node]*scope.Scope {
+			if referenceScopes == nil {
+				referenceNames := map[string]struct{}{"useState": {}}
+				// Collect every import once, including nested and later imports,
+				// without making it visible to the hook matcher before its visit.
+				// This keeps interleaved imports/calls from rebuilding the analysis.
+				if ctx.SourceFile != nil {
+					utils.VisitDescendants(ctx.SourceFile.AsNode(), func(node *ast.Node) bool {
+						if node.Kind != ast.KindImportDeclaration {
+							return true
+						}
+						info := reactImportInfo(node)
+						if info.defaultName != "" {
+							referenceNames[info.defaultName] = struct{}{}
+						}
+						for local := range info.namedHookNames {
+							referenceNames[local] = struct{}{}
+						}
+						return false
+					})
+				}
+				manager := scope.Build(ctx.SourceFile, scope.Options{CollectReferences: true, ReferenceNames: referenceNames})
+				referenceScopes = make(map[*ast.Node]*scope.Scope, len(manager.References))
+				for _, reference := range manager.References {
+					referenceScopes[reference.Identifier] = reference.From
+				}
+			}
+			return referenceScopes
 		}
 		return rule.RuleListeners{
 			ast.KindImportDeclaration: func(node *ast.Node) {
@@ -327,7 +332,6 @@ var HookUseStateRule = rule.Rule{
 				}
 				if imports.defaultName == "" && info.defaultName != "" {
 					imports.defaultName = info.defaultName
-					imports.defaultSpecifier = info.defaultSpecifier
 				}
 				if imports.useStateSpecifier == nil && info.useStateSpecifier != nil {
 					imports.useStateSpecifier = info.useStateSpecifier
@@ -338,20 +342,17 @@ var HookUseStateRule = rule.Rule{
 				}
 			},
 			ast.KindCallExpression: func(node *ast.Node) {
-				if !isReactUseStateCall(referenceScopes, imports, node) {
+				if !isReactUseStateCall(getReferenceScopes, imports, node) {
 					return
 				}
 				// ESTree wraps an optional call in ChainExpression, so it is not
 				// directly initialized by the variable declarator upstream.
-				callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+				callee := utils.ESTreeCallCallee(node.AsCallExpression().Expression)
 				if ast.IsOptionalChain(node) || ast.IsOptionalChain(callee) {
 					ctx.ReportNode(node, useStateErrorMessage())
 					return
 				}
-				parent := node.Parent
-				for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-					parent = parent.Parent
-				}
+				parent := utils.ESTreeParent(node)
 				if parent != nil && parent.Kind == ast.KindReturnStatement {
 					return
 				}
@@ -380,15 +381,21 @@ var HookUseStateRule = rule.Rule{
 				valueName := identifierBindingName(value)
 				setterName := identifierBindingName(setter)
 				expected := expectedSetterNames(valueName)
-				if value != nil && setter != nil && len(elements) == 2 && contains(expected, setterName) {
+				if value != nil && setter != nil && len(elements) == 2 && slices.Contains(expected, setterName) {
 					return
 				}
+				// TSESTree includes the declaration's type annotation in the
+				// ArrayPattern range used by both reports and suggestions.
+				patternRange := utils.TrimNodeTextRange(ctx.SourceFile, pattern)
+				if annotation := utils.ESTreeType(parent); annotation != nil {
+					patternRange = patternRange.WithEnd(annotation.End())
+				}
 				if onlyDestructuredValue {
-					ctx.ReportNode(pattern, destructuredStateErrorMessage())
+					ctx.ReportRange(patternRange, destructuredStateErrorMessage())
 					return
 				}
 
-				ctx.ReportNodeWithDeferredSuggestions(pattern, useStateErrorMessage(), func() []rule.RuleSuggestion {
+				ctx.ReportRangeWithDeferredSuggestions(patternRange, useStateErrorMessage(), func() []rule.RuleSuggestion {
 					suggestions := make([]rule.RuleSuggestion, 0, 2)
 					if isPresentBinding(value) && len(elements) == 1 && node.AsCallExpression().Arguments != nil && len(node.AsCallExpression().Arguments.Nodes) == 1 {
 						argument := node.AsCallExpression().Arguments.Nodes[0]
@@ -417,8 +424,8 @@ var HookUseStateRule = rule.Rule{
 							fixes = append(fixes, *importFix)
 						}
 						fixes = append(fixes,
-							rule.RuleFixReplace(ctx.SourceFile, pattern, memoValueName),
-							rule.RuleFixReplace(ctx.SourceFile, node, memoName+"(() => "+utils.TrimmedNodeText(ctx.SourceFile, ast.SkipParentheses(argument))+
+							rule.RuleFixReplaceRange(patternRange, memoValueName),
+							rule.RuleFixReplace(ctx.SourceFile, node, memoName+"(() => "+utils.TrimmedNodeText(ctx.SourceFile, utils.ESTreeRuntimeExpression(argument))+
 								", [])"),
 						)
 						suggestions = append(suggestions, rule.RuleSuggestion{Message: suggestMemoMessage(), FixesArr: fixes})
@@ -426,7 +433,7 @@ var HookUseStateRule = rule.Rule{
 					if len(expected) > 0 {
 						suggestions = append(suggestions, rule.RuleSuggestion{
 							Message:  suggestPairMessage(),
-							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, pattern, "["+valueName+", "+expected[0]+"]")},
+							FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(patternRange, "["+valueName+", "+expected[0]+"]")},
 						})
 					}
 					return suggestions

--- a/internal/plugins/react/rules/hook_use_state/hook_use_state.md
+++ b/internal/plugins/react/rules/hook_use_state/hook_use_state.md
@@ -9,6 +9,12 @@ This rule ensures that a React `useState` call uses a symmetric
 `[value, setValue]` destructure. Returning a `useState` result directly is
 allowed.
 
+Suggestions that replace a TypeScript destructuring pattern also remove its
+type annotation. The annotation describes the original pattern and is not
+carried over to the replacement.
+
+JavaScript JSDoc casts are transparent to this rule.
+
 Examples of **incorrect** code for this rule:
 
 ```javascript

--- a/internal/plugins/react/rules/hook_use_state/hook_use_state_extras_test.go
+++ b/internal/plugins/react/rules/hook_use_state/hook_use_state_extras_test.go
@@ -5,9 +5,63 @@ package hook_use_state
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+func TestHookUseStateEditDemand(t *testing.T) {
+	const code = `import {useState} from 'react'; const [value]: [number] = useState(initial);`
+	file := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.tsx", Path: "/test.tsx",
+	}, code, core.ScriptKindTSX)
+	for _, testCase := range []struct {
+		name   string
+		demand rule.EditDemand
+		count  int
+	}{
+		{"diagnostics", 0, 0},
+		{"autofix", rule.EditDemandAutofix, 0},
+		{"suggestions", rule.EditDemandSuggestion, 2},
+		{"all", rule.EditDemandAll, 2},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var diagnostics []rule.RuleDiagnostic
+			ctx := (rule.RuleContext{SourceFile: file}).WithDiagnosticConsumer(HookUseStateRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+				Demand: testCase.demand,
+				Report: func(diagnostic rule.RuleDiagnostic) { diagnostics = append(diagnostics, diagnostic) },
+			})
+			listeners := HookUseStateRule.Run(ctx, nil)
+			utils.VisitDescendants(file.AsNode(), func(node *ast.Node) bool {
+				if listener := listeners[node.Kind]; listener != nil {
+					listener(node)
+				}
+				return true
+			})
+			if len(diagnostics) != 1 {
+				t.Fatalf("got %d diagnostics, want 1", len(diagnostics))
+			}
+			diagnostic := diagnostics[0]
+			if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != "[value]: [number]" {
+				t.Errorf("diagnostic covers %q, want the typed pattern", got)
+			}
+			if diagnostic.FixesPtr != nil {
+				t.Error("suggestions must not become automatic fixes")
+			}
+			count := 0
+			if diagnostic.Suggestions != nil {
+				count = len(*diagnostic.Suggestions)
+			}
+			if count != testCase.count {
+				t.Errorf("got %d suggestions, want %d", count, testCase.count)
+			}
+		})
+	}
+}
 
 func TestHookUseStateExtras(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &HookUseStateRule, []rule_tester.ValidTestCase{
@@ -208,4 +262,314 @@ func hookUseStateError(code, message string, line, column int) rule_tester.Inval
 			Column:    column,
 		}},
 	}
+}
+
+// Verified against eslint-plugin-react 7.37.5 and master c99d3b27 with
+// @typescript-eslint/parser 8.69.0, including complete suggestion output.
+func TestHookUseStateCompatibility(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &HookUseStateRule, []rule_tester.ValidTestCase{
+		{Code: "import useOther, { useState } from 'react'; useState; const result=useOther();", Tsx: true},
+		{Code: "import React, { useMemo as useState } from 'react'; const result = React.useState();", Tsx: true},
+		{Code: "import {useState as use9} from 'react';const result=use9();", Tsx: true},
+		{Code: "import {use9 as useState} from 'react';const result=useState();", Tsx: true},
+		{Code: "import {useEffect} from 'react'; type T<A>=typeof useEffect; const result=useState();", Tsx: true},
+		{Code: "import {useEffect} from 'react'; interface T<A> {x:typeof useEffect}; const result=useState();", Tsx: true},
+		{Code: "import {useEffect} from 'react'; type T = { [K in keyof typeof useEffect]: K }; const result=useState();", Tsx: true},
+		{Code: "import {useEffect} from 'react'; type T = () => typeof useEffect; const result=useState();", Tsx: true},
+		{Code: "import {useEffect} from 'react'; type T = typeof useEffect extends any ? 1 : 2; const result=useState();", Tsx: true},
+		{Code: "import {useEffect} from 'react'; type T = any extends any ? typeof useEffect : 2; const result=useState();", Tsx: true},
+		{Code: "import {useEffect} from 'react'; type T<X> = typeof useEffect extends X ? 1 : 2; const result=useState();", Tsx: true},
+		{Code: "import React from 'react'; const [x,setX]=React[useState]();", Tsx: true},
+		{Code: "import React from 'react'; function f() {return React[useState]();}", Tsx: true},
+		{Code: "import React, { useState, useEffect } from 'react';\nconst result=(React?.useState)();", Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: "import React from 'react'; const result = React[useState]();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 43, EndLine: 1, EndColumn: 60,
+				},
+			},
+		},
+		{
+			Code: "import React, { useState as useStore } from 'react'; const result = React.useStore();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 69, EndLine: 1, EndColumn: 85,
+				},
+			},
+		},
+		{
+			Code: "import React from 'react'; const result=React[(useState)]();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 41, EndLine: 1, EndColumn: 60,
+				},
+			},
+		},
+		{
+			Code: "import React from 'react'; const [x]=React[useState](initial);", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 34, EndLine: 1, EndColumn: 37,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import React from 'react'; const x=React.useMemo(() => initial, []);"},
+						{MessageId: "suggestPair", Output: "import React from 'react'; const [x, setX]=React[useState](initial);"},
+					},
+				},
+			},
+		},
+		{
+			Code: "import React from 'react'; const [x,setX]=React?.[useState]();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 43, EndLine: 1, EndColumn: 62,
+				},
+			},
+		},
+		{
+			Code: "import { useState } from 'react'; const [x]: [number] = useState(initial);", Tsx: true,
+			Options: map[string]any{"allowDestructuredState": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 41, EndLine: 1, EndColumn: 54,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import { useState, useMemo } from 'react'; const x = useMemo(() => initial, []);"},
+						{MessageId: "suggestPair", Output: "import { useState } from 'react'; const [x, setX] = useState(initial);"},
+					},
+				},
+			},
+		},
+		{
+			Code: "import {useState} from 'react'; const [x,wrong] /*note*/ : [number,any] = useState(initial);", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 39, EndLine: 1, EndColumn: 72,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestPair", Output: "import {useState} from 'react'; const [x, setX] = useState(initial);"},
+					},
+				},
+			},
+		},
+		{
+			Code: "import {useState} from 'react'; const [{x},setX]:[any,any]=useState(initial);", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessageOrAddOption", Message: destructuredStateErrorText,
+					Line: 1, Column: 39, EndLine: 1, EndColumn: 59,
+				},
+			},
+		},
+		{
+			Code: "import {useEffect} from 'react'; type T=typeof useEffect; const result=useState();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 72, EndLine: 1, EndColumn: 82,
+				},
+			},
+		},
+		{
+			Code: "import {useEffect} from 'react'; interface T {x:typeof useEffect}; const result=useState();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 81, EndLine: 1, EndColumn: 91,
+				},
+			},
+		},
+		{
+			Code: "import {useEffect} from 'react'; function f() { type T=typeof useEffect; const result=useState(); }", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 87, EndLine: 1, EndColumn: 97,
+				},
+			},
+		},
+		{
+			Code: "declare module 'custom' { import React from 'react'; const result=React.useState(); }", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 67, EndLine: 1, EndColumn: 83,
+				},
+			},
+		},
+		{
+			Code: "declare module 'custom' { import {useState as useStore} from 'react'; const result=useStore(); }", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 84, EndLine: 1, EndColumn: 94,
+				},
+			},
+		},
+		{
+			Code: "import React from 'react'; declare module 'custom' { import React from 'other'; const result=React.useState(); }", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 94, EndLine: 1, EndColumn: 110,
+				},
+			},
+		},
+		{
+			Code: "import {useState} from 'react'; useState(); declare module 'custom' { import {useState as useStore} from 'react'; const result=useStore(); }", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 33, EndLine: 1, EndColumn: 43,
+				},
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 128, EndLine: 1, EndColumn: 138,
+				},
+			},
+		},
+		{
+			Code: "import {useState} from 'react'; useState(); import {useState as useStore} from 'react'; const result=useStore();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 33, EndLine: 1, EndColumn: 43,
+				},
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 102, EndLine: 1, EndColumn: 112,
+				},
+			},
+		},
+		{
+			Code: "import React from 'react'; React.useState(); declare module 'custom' { import {useState} from 'react'; const result=useState(); }", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 28, EndLine: 1, EndColumn: 44,
+				},
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 117, EndLine: 1, EndColumn: 127,
+				},
+			},
+		},
+		{
+			Code: "import {useState} from 'react'; const result=useState(); import React from 'react'; const result2=React.useState();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 46, EndLine: 1, EndColumn: 56,
+				},
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 99, EndLine: 1, EndColumn: 115,
+				},
+			},
+		},
+		{
+			Code: "import {useState as useStore} from 'react'; useStore(); declare module 'custom' { import {useEffect as useStore} from 'react'; const result=useStore(); }", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 45, EndLine: 1, EndColumn: 55,
+				},
+			},
+		},
+		{
+			Code: "import {useEffect} from 'react'; type T = any extends any ? 1 : typeof useEffect; const result=useState();", Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 96, EndLine: 1, EndColumn: 106,
+				},
+			},
+		},
+	})
+}
+
+// JSDoc wrappers must be exercised as JavaScript so tsgo reparses them.
+func TestHookUseStateJSDoc(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.allow-js.json", t, &HookUseStateRule, []rule_tester.ValidTestCase{
+		{Code: "import React, {useState, useEffect} from 'react'; const [x,setX] = /** @type {any} */ (useState(initial));", FileName: "audit.js"},
+		{Code: "import React, {useState, useEffect} from 'react'; function f() { return /** @satisfies {any} */ (useState(initial)); }", FileName: "audit.js"},
+		{Code: "import React, {useState, useEffect} from 'react'; const result = (/** @type {any} */ (React?.useState))(initial);", FileName: "audit.js"},
+		{Code: "import React, {useState, useEffect} from 'react'; const result = (/** @satisfies {any} */ (React?.useState))(initial);", FileName: "audit.js"},
+		{Code: "import {useEffect} from 'react'; /** @type {typeof useEffect} */ const value = initial; const result = useState();", FileName: "audit.js"},
+		{Code: "import {useEffect} from 'react'; /** @param {typeof useEffect} value */ function f(value) { const result = useState(); }", FileName: "audit.js"},
+	}, []rule_tester.InvalidTestCase{
+		{Code: "import React, {useState, useEffect} from 'react'; const [x] = (/** @type {any} */ (useState))(initial);", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 57, EndLine: 1, EndColumn: 60,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import React, {useState, useMemo, useEffect} from 'react'; const x = React.useMemo(() => initial, []);"},
+						{MessageId: "suggestPair", Output: "import React, {useState, useEffect} from 'react'; const [x, setX] = (/** @type {any} */ (useState))(initial);"},
+					},
+				},
+			}},
+		{Code: "import React, {useState, useEffect} from 'react'; const result = (/** @satisfies {any} */ (useState))(initial);", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 66, EndLine: 1, EndColumn: 111,
+				},
+			}},
+		{Code: "import React, {useState, useEffect} from 'react'; const [x] = (/** @type {any} */ (React.useState))(initial);", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 57, EndLine: 1, EndColumn: 60,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import React, {useState, useMemo, useEffect} from 'react'; const x = React.useMemo(() => initial, []);"},
+						{MessageId: "suggestPair", Output: "import React, {useState, useEffect} from 'react'; const [x, setX] = (/** @type {any} */ (React.useState))(initial);"},
+					},
+				},
+			}},
+		{Code: "import React, {useState, useEffect} from 'react'; const result = (/** @type {any} */ (React).useState)(initial);", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 66, EndLine: 1, EndColumn: 112,
+				},
+			}},
+		{Code: "import React, {useState, useEffect} from 'react'; const [x] = (React[/** @type {any} */ (useState)])(initial);", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 57, EndLine: 1, EndColumn: 60,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import React, {useState, useMemo, useEffect} from 'react'; const x = React.useMemo(() => initial, []);"},
+						{MessageId: "suggestPair", Output: "import React, {useState, useEffect} from 'react'; const [x, setX] = (React[/** @type {any} */ (useState)])(initial);"},
+					},
+				},
+			}},
+		{Code: "import React, {useState, useEffect} from 'react'; const [x] = /** @type {any} */ (useState(initial));", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 57, EndLine: 1, EndColumn: 60,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import React, {useState, useMemo, useEffect} from 'react'; const x = /** @type {any} */ (React.useMemo(() => initial, []));"},
+						{MessageId: "suggestPair", Output: "import React, {useState, useEffect} from 'react'; const [x, setX] = /** @type {any} */ (useState(initial));"},
+					},
+				},
+			}},
+		{Code: "import React, {useState, useEffect} from 'react'; const [x] = /** @satisfies {any} */ (React.useState(initial));", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 57, EndLine: 1, EndColumn: 60,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import React, {useState, useMemo, useEffect} from 'react'; const x = /** @satisfies {any} */ (React.useMemo(() => initial, []));"},
+						{MessageId: "suggestPair", Output: "import React, {useState, useEffect} from 'react'; const [x, setX] = /** @satisfies {any} */ (React.useState(initial));"},
+					},
+				},
+			}},
+		{Code: "import React, {useState, useEffect} from 'react'; const [x] = useState(/** @type {any} */ (initial));", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 57, EndLine: 1, EndColumn: 60,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import React, {useState, useMemo, useEffect} from 'react'; const x = React.useMemo(() => initial, []);"},
+						{MessageId: "suggestPair", Output: "import React, {useState, useEffect} from 'react'; const [x, setX] = useState(/** @type {any} */ (initial));"},
+					},
+				},
+			}},
+		{Code: "import {useState} from 'react'; /** @type {[number]} */ const [x] = useState(initial);", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 63, EndLine: 1, EndColumn: 66,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestMemo", Output: "import {useState, useMemo} from 'react'; /** @type {[number]} */ const x = useMemo(() => initial, []);"},
+						{MessageId: "suggestPair", Output: "import {useState} from 'react'; /** @type {[number]} */ const [x, setX] = useState(initial);"},
+					},
+				},
+			}},
+		{Code: "import {useState} from 'react'; /** @type {[number, any]} */ const [x,wrong] = useState(initial);", FileName: "audit.js",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useStateErrorMessage", Message: useStateErrorText,
+					Line: 1, Column: 68, EndLine: 1, EndColumn: 77,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestPair", Output: "import {useState} from 'react'; /** @type {[number, any]} */ const [x, setX] = useState(initial);"},
+					},
+				},
+			}},
+	})
 }

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -644,7 +644,7 @@ func (b *builder) visitConditionalType(node *ast.Node, outer *Scope) {
 	condScope := b.push(KindType, node, outer)
 	collectInferTypes(cond.ExtendsType, condScope)
 	if cond.CheckType != nil {
-		b.visitExpression(cond.CheckType, outer)
+		b.visitExpression(cond.CheckType, condScope)
 	}
 	if cond.ExtendsType != nil {
 		b.visitExpression(cond.ExtendsType, condScope)
@@ -945,8 +945,13 @@ func (b *builder) visitClass(node *ast.Node, outer *Scope, isExpression bool) {
 }
 
 func (b *builder) visitTypeDecl(node *ast.Node, outer *Scope) {
-	typeScope := b.push(KindType, node, outer)
-	b.addTypeParameters(node, typeScope)
+	// typescript-eslint only introduces a type scope for generic declarations.
+	// Without type parameters, references in the type belong to the outer scope.
+	typeScope := outer
+	if len(node.TypeParameters()) > 0 {
+		typeScope = b.push(KindType, node, outer)
+		b.addTypeParameters(node, typeScope)
+	}
 	// Recurse into type body / heritage / members to discover FunctionType
 	// and similar type-level scopes.
 	node.ForEachChild(func(child *ast.Node) bool {

--- a/internal/utils/scope/scope_test.go
+++ b/internal/utils/scope/scope_test.go
@@ -468,6 +468,39 @@ func findReference(t *testing.T, m *Manager, name string) *Reference {
 	return nil
 }
 
+func TestBuildTypeDeclarationReferences(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		declaration string
+		kinds       []Kind
+		owner       int
+	}{
+		{"alias", `type T = typeof value;`, []Kind{KindGlobal}, 0},
+		{"interface", `interface T { value: typeof value }`, []Kind{KindGlobal}, 0},
+		{"generic alias", `type T<U> = typeof value;`, []Kind{KindGlobal, KindType}, 1},
+		{"generic interface", `interface T<U> { value: typeof value }`, []Kind{KindGlobal, KindType}, 1},
+		{"function type", `type T = () => typeof value;`, []Kind{KindGlobal, KindFunctionType}, 1},
+		{"mapped type", `type T = { [K in keyof typeof value]: K };`, []Kind{KindGlobal, KindType}, 1},
+		{"conditional check", `type T = typeof value extends unknown ? 1 : 2;`, []Kind{KindGlobal, KindType}, 1},
+		{"conditional extends", `type T = unknown extends typeof value ? 1 : 2;`, []Kind{KindGlobal, KindType}, 1},
+		{"conditional true", `type T = unknown extends unknown ? typeof value : 2;`, []Kind{KindGlobal, KindType}, 1},
+		{"conditional false", `type T = unknown extends unknown ? 1 : typeof value;`, []Kind{KindGlobal, KindType}, 0},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := buildWithReferences(t, `declare const value: unknown; `+testCase.declaration)
+			assertKinds(t, m, testCase.kinds)
+			assertDeclares(t, m.Global, "T", DefType)
+			reference := findReference(t, m, "value")
+			if reference.From != m.Scopes[testCase.owner] {
+				t.Errorf("value reference belongs to kind %d, want kind %d", reference.From.Kind, m.Scopes[testCase.owner].Kind)
+			}
+			if reference.Resolved() != m.Global.Declarations("value")[0] {
+				t.Error("value reference should resolve to the outer declaration")
+			}
+		})
+	}
+}
+
 func TestBuildKeepsTheFirstFunctionOverloadAsTheBindingAnchor(t *testing.T) {
 	m := buildWithReferences(t, `function f(x: string): void; f(); function f(x: any) {}`)
 	declarations := m.Global.Declarations("f")


### PR DESCRIPTION
## Summary

Align `react/hook-use-state` diagnostics and suggestions with `eslint-plugin-react` 7.37.5 and upstream master `c99d3b27`.

- Recognize computed identifier properties, member aliases, and nested imports using upstream's import and reference semantics. For example, `React[useState]()` is checked, and `React.useStore()` follows a `useState as useStore` import.
- Include TypeScript destructuring annotations in diagnostic and suggestion ranges. A memo suggestion for `const [value]: [number] = useState(initial)` now produces `const value = useMemo(() => initial, [])`.
- Reuse existing ESTree helpers for JavaScript JSDoc casts, preserving valid destructuring and direct returns while retaining authored TypeScript assertion and optional-chain boundaries.
- Correct reference ownership in non-generic declarations and conditional types. Build reference information lazily, once per file, including later and nested imports.

Validation:

- Differential execution of 3,982 cases: 2,162 TypeScript and 1,820 JavaScript cases, including all 47 upstream cases, compared with both the published plugin and current master. Diagnostic messages, ranges, suggestion descriptions, and complete replacement output match.
- Additional ESLint 10.10.0 execution matches all 2,110 cases that return normally; the upstream rule itself throws for 52 default/rest-binding suggestion cases. The supported ESLint 8.57.1 run completes all TypeScript cases. TypeScript parser: 8.69.0.
- Added 50 rule compatibility cases, edit-demand checks, and 10 reference-ownership cases. Targeted tests passed across 18 affected or consuming Go packages, including consumers added by the latest main.
- `check-spell`, `format:check`, `git diff --check`, and `golangci-lint run --new-from-merge-base=origin/main` on the two changed Go packages passed.

Temporary Go benchmarks against main `a48368cb` used six alternating runs of 1,000 iterations, 32 calls per fixture, and excluded parsing. Allocated bytes per operation fell from 23,688 to 608 without React imports, from 14,944 to 1,280 with unrelated hooks, and from 76,640 to 66,432 when producing suggestions (880 to 818 allocations). Other matching paths add 32 bytes and two allocations for lazy initialization. Interleaved 16/64-import fixtures also verify diagnostic counts. Timing was noisy under concurrent machine load. Benchmark code is not included.

## Related Links

- [Upstream rule implementation](https://github.com/jsx-eslint/eslint-plugin-react/blob/c99d3b274efbc593e46563358e7b77cad8d01957/lib/rules/hook-use-state.js)
- [Upstream hook detection](https://github.com/jsx-eslint/eslint-plugin-react/blob/c99d3b274efbc593e46563358e7b77cad8d01957/lib/util/Components.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
