### PR TITLE
fix: align React namespace checks with upstream

### DIFF
--- a/internal/plugins/react/reactutil/create_element.go
+++ b/internal/plugins/react/reactutil/create_element.go
@@ -1,8 +1,11 @@
 package reactutil
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -45,16 +48,15 @@ func IsCreateElementCallWithChecker(callee *ast.Node, pragma string, tc *checker
 	return isCreateElementCallCore(callee, pragma, tc)
 }
 
-// IsCreateElementCallWithRefs is the file-scope-aware variant. When refs is
-// provided, it is authoritative for bare imported createElement calls so
-// checker-backed linting cannot resolve a binding from another global script.
-func IsCreateElementCallWithRefs(
-	callee *ast.Node,
-	pragma string,
-	tc *checker.Checker,
-	refs ReferenceResolver,
-) bool {
-	return isPragmaFactoryCallCore(callee, pragma, tc, refs, createElementOnly)
+// NewCreateElementCallMatcher returns a per-file matcher with the definition
+// lookup used by eslint-plugin-react. Bindings are resolved lazily and cached,
+// independently of whether this file has a TypeChecker.
+func NewCreateElementCallMatcher(ctx rule.RuleContext) func(*ast.Node) bool {
+	pragma := GetReactPragmaFromContext(ctx)
+	isImported := newPragmaImportMatcher(ctx, pragma, "createElement")
+	return func(callee *ast.Node) bool {
+		return isPragmaFactoryCallCore(callee, pragma, nil, isImported, createElementOnly)
+	}
 }
 
 func isCreateElementCallCore(callee *ast.Node, pragma string, tc *checker.Checker) bool {
@@ -101,7 +103,7 @@ func isPragmaFactoryCallCore(
 	callee *ast.Node,
 	pragma string,
 	tc *checker.Checker,
-	refs ReferenceResolver,
+	isImported func(*ast.Node) bool,
 	names pragmaFactoryNames,
 ) bool {
 	if callee == nil {
@@ -122,7 +124,10 @@ func isPragmaFactoryCallCore(
 		if !names.matches(callee.AsIdentifier().Text) {
 			return false
 		}
-		return IsDestructuredFromPragmaImportWithRefs(callee, pragma, tc, refs)
+		if isImported != nil {
+			return isImported(callee)
+		}
+		return IsDestructuredFromPragmaImport(callee, pragma, tc)
 	}
 
 	// Member-access callee: `<pragma>.<name>(arg)` or
@@ -153,7 +158,17 @@ func isPragmaFactoryCallCore(
 	if nameNode == nil || pragmaExpr == nil {
 		return false
 	}
-	if nameNode.Kind != ast.KindIdentifier || !names.matches(nameNode.AsIdentifier().Text) {
+	// ESTree exposes .name on both Identifier and PrivateIdentifier keys.
+	var propertyName string
+	switch nameNode.Kind {
+	case ast.KindIdentifier:
+		propertyName = nameNode.Text()
+	case ast.KindPrivateIdentifier:
+		propertyName = strings.TrimPrefix(nameNode.Text(), "#")
+	default:
+		return false
+	}
+	if !names.matches(propertyName) {
 		return false
 	}
 	// JSDoc casts and parentheses are absent from ESTree, while an authored

--- a/internal/plugins/react/reactutil/pragma_binding.go
+++ b/internal/plugins/react/reactutil/pragma_binding.go
@@ -8,15 +8,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
-// ReferenceResolver is the file-local portion of rule.RefStore needed by
-// import-aware helpers. Keeping this small interface here avoids coupling the
-// React utility package to the rule package while allowing source-only callers
-// to retain lexical-scope resolution without a TypeChecker.
-type ReferenceResolver interface {
-	ResolveInFile(node *ast.Node) *ast.Symbol
-	LatestValueDefinitionInFile(node *ast.Node) *ast.Node
-}
-
 // IsDestructuredFromPragmaImport mirrors upstream eslint-plugin-react's
 // `lib/util/isDestructuredFromPragmaImport.js`: reports whether the
 // Identifier `ident` (a bare callee like `memo`) was bound from the
@@ -39,20 +30,6 @@ type ReferenceResolver interface {
 // is available the function uses rslint's shared lexical scope model so every
 // local binding shape is resolved before checking its import origin.
 func IsDestructuredFromPragmaImport(ident *ast.Node, pragma string, tc *checker.Checker) bool {
-	return IsDestructuredFromPragmaImportWithRefs(ident, pragma, tc, nil)
-}
-
-// IsDestructuredFromPragmaImportWithRefs is the RefStore-aware variant. When
-// refs is provided, it resolves bindings through the file's lexical scopes and
-// is authoritative: an absent value definition means the bare identifier is
-// not a React helper in this file. This keeps checker-backed linting from
-// treating a declaration in another global script as a local React binding.
-func IsDestructuredFromPragmaImportWithRefs(
-	ident *ast.Node,
-	pragma string,
-	tc *checker.Checker,
-	refs ReferenceResolver,
-) bool {
 	if ident == nil || ident.Kind != ast.KindIdentifier {
 		return false
 	}
@@ -60,13 +37,6 @@ func IsDestructuredFromPragmaImportWithRefs(
 		pragma = DefaultReactPragma
 	}
 	pragmaLower := ecmascript.StringToLowerCase(pragma)
-
-	if refs != nil {
-		if declaration := refs.LatestValueDefinitionInFile(ident); declaration != nil {
-			return isDestructuredFromPragmaDeclaration(declaration, pragma, pragmaLower)
-		}
-		return false
-	}
 
 	if tc == nil {
 		return sourceOnlyPragmaBinding(ident, pragma, pragmaLower)
@@ -387,7 +357,7 @@ func initializerMatchesPragma(init *ast.Node, pragma, pragmaLower string) bool {
 // Upstream's helper checks `callee.name === 'require'` and
 // `arguments[0].value === pragma.toLocaleLowerCase()`.
 func isRequireCallOfPragma(call *ast.Node, pragmaLower string) bool {
-	if call == nil || call.Kind != ast.KindCallExpression {
+	if call == nil || call.Kind != ast.KindCallExpression || ast.IsOptionalChain(call) {
 		return false
 	}
 	c := call.AsCallExpression()

--- a/internal/plugins/react/reactutil/pragma_import_matcher.go
+++ b/internal/plugins/react/reactutil/pragma_import_matcher.go
@@ -1,0 +1,70 @@
+package reactutil
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
+)
+
+// newPragmaImportMatcher mirrors isDestructuredFromPragmaImport's name lookup.
+// Upstream searches the current scope, its first child, and that child's first
+// child before moving to the parent. It reads the last definition regardless
+// of whether that definition declares a value. Reference resolution alone
+// therefore cannot answer this particular React question.
+func newPragmaImportMatcher(ctx rule.RuleContext, pragma, name string) func(*ast.Node) bool {
+	sourceFile := ctx.SourceFile
+	// Only a script puts configured globals in the same scope as its code.
+	// Modules and CommonJS wrappers search their own children first.
+	hasGlobalBinding := ctx.LanguageOptions.EffectiveSourceType() == "script" && ctx.Globals.Access(name).IsDeclared()
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	var pragmaLower string
+	var manager *scope.Manager
+	var firstChild map[*scope.Scope]*scope.Scope
+	var matches map[*scope.Scope]bool
+	return func(ident *ast.Node) bool {
+		if sourceFile == nil || ident == nil || ident.Kind != ast.KindIdentifier || ident.Text() != name {
+			return false
+		}
+		if manager == nil {
+			pragmaLower = ecmascript.StringToLowerCase(pragma)
+			manager = scope.Build(sourceFile, scope.Options{})
+			firstChild = make(map[*scope.Scope]*scope.Scope)
+			for _, current := range manager.Scopes {
+				if current.Parent != nil && firstChild[current.Parent] == nil {
+					firstChild[current.Parent] = current
+				}
+			}
+			matches = make(map[*scope.Scope]bool)
+		}
+		from := manager.Acquire(ident)
+		if matched, ok := matches[from]; ok {
+			return matched
+		}
+		definition := latestPragmaDefinition(from, name, firstChild, hasGlobalBinding)
+		matched := isDestructuredFromPragmaDeclaration(definition, pragma, pragmaLower)
+		matches[from] = matched
+		return matched
+	}
+}
+
+func latestPragmaDefinition(from *scope.Scope, name string, firstChild map[*scope.Scope]*scope.Scope, hasGlobalBinding bool) *ast.Node {
+	for current := from; current != nil; current = current.Parent {
+		candidate := current
+		for range 3 {
+			if candidate == nil {
+				break
+			}
+			if declarations := candidate.Declarations(name); len(declarations) != 0 {
+				return declarations[len(declarations)-1].DefNode
+			}
+			if candidate.Kind == scope.KindGlobal && hasGlobalBinding {
+				return nil
+			}
+			candidate = firstChild[candidate]
+		}
+	}
+	return nil
+}

--- a/internal/plugins/react/rules/no_namespace/no_namespace.go
+++ b/internal/plugins/react/rules/no_namespace/no_namespace.go
@@ -15,7 +15,7 @@ var NoNamespaceRule = rule.Rule{
 	Name:   "react/no-namespace",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		pragma := reactutil.GetReactPragmaFromContext(ctx)
+		isCreateElement := reactutil.NewCreateElementCallMatcher(ctx)
 
 		reportIfNamespaced := func(node *ast.Node, name string) {
 			if name == "" || strings.IndexByte(name, ':') == -1 {
@@ -38,7 +38,8 @@ var NoNamespaceRule = rule.Rule{
 			ast.KindJsxSelfClosingElement: checkJSX,
 			ast.KindCallExpression: func(node *ast.Node) {
 				call := node.AsCallExpression()
-				if !reactutil.IsCreateElementCallWithRefs(call.Expression, pragma, ctx.TypeChecker, ctx.Refs) {
+				// Unrelated bare calls are common and need no argument inspection.
+				if callee := call.Expression; callee != nil && callee.Kind == ast.KindIdentifier && callee.Text() != "createElement" {
 					return
 				}
 				if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
@@ -51,7 +52,13 @@ var NoNamespaceRule = rule.Rule{
 				if argument == nil || argument.Kind != ast.KindStringLiteral {
 					return
 				}
-				reportIfNamespaced(node, argument.AsStringLiteral().Text)
+				name := argument.AsStringLiteral().Text
+				// Most calls cannot report. Avoid building the binding model for
+				// files that contain no namespace-qualified string argument.
+				if strings.IndexByte(name, ':') == -1 || !isCreateElement(call.Expression) {
+					return
+				}
+				reportIfNamespaced(node, name)
 			},
 		}
 	},

--- a/internal/plugins/react/rules/no_namespace/no_namespace_extras_test.go
+++ b/internal/plugins/react/rules/no_namespace/no_namespace_extras_test.go
@@ -27,6 +27,37 @@ func TestNoNamespaceSourceOnlyRespectsShadowing(t *testing.T) {
 		want int
 	}{
 		{
+			name: "inner type definition wins by name",
+			code: `import { createElement } from "react";
+function f() { type createElement = {}; createElement("ns:Panel"); }`,
+			want: 0,
+		},
+		{
+			name: "parameter default uses the latest body definition",
+			code: `const createElement = React.createElement;
+function f(x = createElement("ns:Panel")) { const createElement = other; }`,
+			want: 0,
+		},
+		{
+			name: "first child definitions follow upstream lookup",
+			code: `function child() { const createElement = React.createElement; }
+createElement("ns:Panel");`,
+			want: 1,
+		},
+		{
+			name: "cached bindings stay separate across functions",
+			code: `import { createElement } from "react";
+createElement("ns:One");
+function f(createElement) { createElement("ns:Ignored"); }
+createElement("ns:Two");`,
+			want: 2,
+		},
+		{
+			name: "optional require is not a React definition",
+			code: `const { createElement } = require?.("react"); createElement("ns:Panel");`,
+			want: 0,
+		},
+		{
 			name: "local createElement shadows imported binding",
 			code: `import { createElement } from "react";
 function f() {
@@ -415,4 +446,154 @@ func TestNoNamespaceDoesNotUseCrossFileCheckerBinding(t *testing.T) {
 	if len(diagnostics) != 0 {
 		t.Fatalf("diagnostic count = %d, want 0: %+v", len(diagnostics), diagnostics)
 	}
+}
+
+// TestNoNamespaceBindingCompatibility is checked against eslint-plugin-react
+// 7.37.5 and its current upstream implementation with ESLint 10 and the TS parser.
+func TestNoNamespaceBindingCompatibility(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// An inner type declaration wins over an outer value import.
+		{Code: `import {createElement} from "react";
+function f(){ type createElement = {}; createElement("ns:Panel") }`,
+			Tsx: true},
+		// Interfaces participate in the same name lookup as runtime declarations.
+		{Code: `import {createElement} from "react";
+function f(){ interface createElement {} createElement("ns:Panel") }`,
+			Tsx: true},
+		// Type parameters shadow the imported name.
+		{Code: `import {createElement} from "react";
+function f<createElement>(){ createElement("ns:Panel") }`,
+			Tsx: true},
+		// Parameter defaults see the function body declarations in the upstream lookup.
+		{Code: `import {createElement} from "react";
+function f(x = createElement("ns:Panel")){ const createElement = other; }`,
+			Tsx: true},
+		// The first child block is searched before the enclosing import.
+		{Code: `import {createElement} from "react";
+function f(){ { const createElement = other; } createElement("ns:Panel") }`,
+			Tsx: true},
+		// A class decorator acquires the class environment, including its type parameters.
+		{Code: `import {createElement} from "react";
+@(createElement("ns:Panel")) class C<createElement> {}`,
+			Tsx: true},
+		// Computed method keys skip the method environment but still search its first child.
+		{Code: `import {createElement} from "react";
+class C { [createElement("ns:Panel")](){ const createElement = other; } }`,
+			Tsx: true},
+		// Parameter decorators acquire the function environment.
+		{Code: `import {createElement} from "react";
+class C { method(@(createElement("ns:Panel")) x, createElement){} }`,
+			Tsx: true},
+		// A non-React body declaration also blocks an otherwise unbound default call.
+		{Code: `function f(x = createElement("ns:Panel")){ const createElement = other; }`,
+			Tsx: true},
+		// The latest definition wins even when it has no initializer.
+		{Code: `var createElement=React.x; var createElement; createElement("ns:Panel");`,
+			Tsx: true},
+		// An optional require call is an ESTree ChainExpression, not a require initializer.
+		{Code: `const {createElement} = require?.("react");createElement("ns:Panel");`,
+			Tsx: true},
+		// Parentheses do not turn an optional require call into a plain CallExpression.
+		{Code: `const createElement = (require?.("react")).x;createElement("ns:Panel");`,
+			Tsx: true},
+		// JSDoc casts must preserve the optional-chain boundary.
+		{Code: `const {createElement} = /** @type {any} */ (require?.("react")); createElement("ns:Panel");`,
+			FileName: "compatibility-16.js",
+			TSConfig: "tsconfig.allow-js.json"},
+		// Configured script globals stop lookup before child declarations.
+		{Code: `function inner(){const createElement=React.x;} createElement("ns:Panel");`,
+			FileName:        "compatibility-17.js",
+			TSConfig:        "tsconfig.allow-js.json",
+			LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			Globals:         map[string]any{"createElement": "readonly"}},
+		// Inline globals have the same effect as configured globals.
+		{Code: `/* global createElement:readonly */function inner(){const createElement=React.x;} createElement("ns:Panel");`,
+			FileName:        "compatibility-19.js",
+			TSConfig:        "tsconfig.allow-js.json",
+			LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+		// A with environment puts this declaration beyond the two-child search limit.
+		{Code: `with(obj){function f(){const createElement=React.x;}} createElement("ns:Panel");`,
+			FileName:        "compatibility-21.js",
+			TSConfig:        "tsconfig.allow-js.json",
+			LanguageOptions: rule.LanguageOptions{SourceType: "script"}},
+		// Loop initializers search the loop body before outer environments.
+		{Code: `function f(){for(let i=createElement("ns:Panel"); i<1; i++){const createElement=other;}}`,
+			Tsx: true},
+		// Switch discriminants acquire the switch environment.
+		{Code: `switch(createElement("ns:Panel")){case 0:const createElement=other;}`,
+			Tsx: true},
+	}
+	invalid := []rule_tester.InvalidTestCase{
+		{
+			Code:   `class C { #createElement; f(React) { React.#createElement("ns:Panel"); } }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNamespace", Line: 1, Column: 38, EndLine: 1, EndColumn: 70}},
+		},
+		{
+			Code: `React.createElement("ns:\ud800");`,
+			Tsx:  true,
+			// Compiler strings preserve a lone surrogate as WTF-8.
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNamespace", Message: "React component ns:\xed\xa0\x80 must not be in a namespace, as React does not support them", Line: 1, Column: 1, EndLine: 1, EndColumn: 33}},
+		},
+		// Only the first child and its first child are searched.
+		{Code: `import {createElement} from "react";
+function f(){ function child(){ function grandchild(){ const createElement = React.x; } } createElement("ns:Panel") }`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 2, Column: 91, EndLine: 2, EndColumn: 116},
+			}},
+		// A third child level is skipped, leaving the outer import visible.
+		{Code: `import {createElement} from "react";
+function f(){ function child(){ function grandchild(){ function ignored(){ const createElement = React.x; } } } createElement("ns:Panel") }`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 2, Column: 113, EndLine: 2, EndColumn: 138},
+			}},
+		// Later sibling environments are skipped, leaving the outer import visible.
+		{Code: `import {createElement} from "react";
+function f(){ function first(){} function second(){ const createElement = React.x; } createElement("ns:Panel") }`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 2, Column: 86, EndLine: 2, EndColumn: 111},
+			}},
+		// An otherwise unbound call can find the first child and grandchild.
+		{Code: `function child(){ {const createElement=React.x;} } createElement("ns:Panel");`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 1, Column: 52, EndLine: 1, EndColumn: 77},
+			}},
+		// Module bindings are searched before configured globals.
+		{Code: `function inner(){const createElement=React.x;} createElement("ns:Panel");`,
+			FileName:        "compatibility-18.js",
+			TSConfig:        "tsconfig.allow-js.json",
+			LanguageOptions: rule.LanguageOptions{SourceType: "module"},
+			Globals:         map[string]any{"createElement": "readonly"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 1, Column: 48, EndLine: 1, EndColumn: 73},
+			}},
+		// A disabled global does not stop child lookup.
+		{Code: `function inner(){const createElement=React.x;} createElement("ns:Panel");`,
+			FileName:        "compatibility-20.js",
+			TSConfig:        "tsconfig.allow-js.json",
+			LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			Globals:         map[string]any{"createElement": "off"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 1, Column: 48, EndLine: 1, EndColumn: 73},
+			}},
+		// A with statement and its body are two separate child environments.
+		{Code: `with(obj){const createElement=React.x;} createElement("ns:Panel");`,
+			FileName:        "compatibility-22.js",
+			TSConfig:        "tsconfig.allow-js.json",
+			LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 1, Column: 41, EndLine: 1, EndColumn: 66},
+			}},
+		// A dotted namespace introduces one environment for all name segments.
+		{Code: `namespace N.M.O {const createElement=React.x;} createElement("ns:Panel");`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noNamespace", Message: `React component ns:Panel must not be in a namespace, as React does not support them`, Line: 1, Column: 48, EndLine: 1, EndColumn: 73},
+			}},
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNamespaceRule, valid, invalid)
 }

--- a/internal/plugins/unicorn/rules/no_array_concat_in_loop/no_array_concat_in_loop.go
+++ b/internal/plugins/unicorn/rules/no_array_concat_in_loop/no_array_concat_in_loop.go
@@ -105,22 +105,11 @@ func (variable scopeVariable) sameBinding(other scopeVariable) bool {
 }
 
 type scopeVariableFinder struct {
-	manager      *scope.Manager
-	scopeByBlock map[*ast.Node]*scope.Scope
+	manager *scope.Manager
 }
 
 func newScopeVariableFinder(sourceFile *ast.SourceFile) *scopeVariableFinder {
-	manager := scope.Build(sourceFile, scope.Options{})
-	scopeByBlock := make(map[*ast.Node]*scope.Scope, len(manager.Scopes))
-	for _, current := range manager.Scopes {
-		if current.Block != nil {
-			// A named function expression owns an outer name scope and an inner
-			// function scope with the same block. Build creates them in that
-			// order, so the later entry is the scope getScope() acquires first.
-			scopeByBlock[current.Block] = current
-		}
-	}
-	return &scopeVariableFinder{manager: manager, scopeByBlock: scopeByBlock}
+	return &scopeVariableFinder{manager: scope.Build(sourceFile, scope.Options{})}
 }
 
 func (finder *scopeVariableFinder) find(identifier *ast.Node) scopeVariable {
@@ -128,7 +117,7 @@ func (finder *scopeVariableFinder) find(identifier *ast.Node) scopeVariable {
 		return scopeVariable{}
 	}
 	name := identifier.Text()
-	for current := finder.acquire(identifier); current != nil; current = current.Parent {
+	for current := finder.manager.Acquire(identifier); current != nil; current = current.Parent {
 		definitions := current.Declarations(name)
 		if hasAuthoredDefinition(definitions) {
 			return scopeVariable{scope: current, name: name, definitions: definitions, found: true}
@@ -142,37 +131,6 @@ func (finder *scopeVariableFinder) find(identifier *ast.Node) scopeVariable {
 		}
 	}
 	return scopeVariable{}
-}
-
-func (finder *scopeVariableFinder) acquire(identifier *ast.Node) *scope.Scope {
-	var child *ast.Node
-	for current := identifier; current != nil; current = current.Parent {
-		if acquired := finder.scopeByBlock[current]; acquired != nil &&
-			!outsideRuntimeMethodScope(current, child) {
-			return acquired
-		}
-		child = current
-	}
-	return finder.manager.Global
-}
-
-// TSESTree represents a runtime method as a MethodDefinition wrapping a
-// FunctionExpression. Its computed key and member-level decorators sit
-// outside that function, while parameters (including their decorators), type
-// parameters, return type, and body sit inside it. ts-go combines both parts
-// into one method node, so acquisition must skip that node only for the two
-// outer positions. TypeScript method signatures are not combined runtime
-// methods and deliberately keep their function-type scope here.
-func outsideRuntimeMethodScope(method *ast.Node, child *ast.Node) bool {
-	if method == nil || child == nil {
-		return false
-	}
-	switch method.Kind {
-	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
-		return child == method.Name() || child.Kind == ast.KindDecorator
-	default:
-		return false
-	}
 }
 
 func hasImplicitArguments(block *ast.Node) bool {

--- a/internal/rule/disable_manager.go
+++ b/internal/rule/disable_manager.go
@@ -4,12 +4,14 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 )
 
-// blockDirective represents a block-level disable or enable event at a specific line
+// blockDirective represents a block-level disable or enable event at a source location
 type blockDirective struct {
 	line      int
+	column    core.UTF16Offset
 	isDisable bool     // true = disable, false = enable
 	rules     []string // nil means all rules (wildcard)
 }
@@ -114,7 +116,7 @@ func (dm *DisableManager) parseDirectives(comments []*ast.CommentRange) {
 			continue
 		}
 
-		lineNum, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(dm.sourceFile, comment.Pos())
+		lineNum, columnNum := scanner.GetECMALineAndUTF16CharacterOfPosition(dm.sourceFile, comment.Pos())
 
 		switch kind {
 		case directiveLine:
@@ -139,12 +141,14 @@ func (dm *DisableManager) parseDirectives(comments []*ast.CommentRange) {
 		case directiveBlock:
 			dm.blockDirectives = append(dm.blockDirectives, blockDirective{
 				line:      lineNum,
+				column:    columnNum,
 				isDisable: true,
 				rules:     rules,
 			})
 		case directiveEnable:
 			dm.blockDirectives = append(dm.blockDirectives, blockDirective{
 				line:      lineNum,
+				column:    columnNum,
 				isDisable: false,
 				rules:     rules,
 			})
@@ -207,10 +211,10 @@ func (dm *DisableManager) IsRuleDisabled(ruleName string, pos int) bool {
 		return false
 	}
 
-	line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(dm.sourceFile, pos)
+	line, column := scanner.GetECMALineAndUTF16CharacterOfPosition(dm.sourceFile, pos)
 
 	// Check block disable/enable directives (range-based)
-	if dm.isBlockDisabled(ruleName, line) {
+	if dm.isBlockDisabled(ruleName, line, column) {
 		return true
 	}
 
@@ -236,14 +240,14 @@ func (dm *DisableManager) IsRuleDisabled(ruleName string, pos int) bool {
 }
 
 // isBlockDisabled replays block directives in source order to determine
-// whether a rule is disabled at the given line.
-func (dm *DisableManager) isBlockDisabled(ruleName string, line int) bool {
+// whether a rule is disabled at the given source location.
+func (dm *DisableManager) isBlockDisabled(ruleName string, line int, column core.UTF16Offset) bool {
 	allDisabled := false
 	ruleDisabled := false
 	hasRuleSpecific := false
 
 	for _, d := range dm.blockDirectives {
-		if d.line > line {
+		if d.line > line || (d.line == line && d.column > column) {
 			break
 		}
 

--- a/internal/rule/disable_manager_test.go
+++ b/internal/rule/disable_manager_test.go
@@ -1,8 +1,51 @@
 package rule
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 )
+
+func TestDisableManagerSameLineBoundaries(t *testing.T) {
+	for _, prefix := range []string{"eslint", "rslint"} {
+		for _, testCase := range []struct {
+			name          string
+			disable       string
+			enable        string
+			otherDisabled bool
+		}{
+			{"specific", " react/no-namespace", " react/no-namespace", false},
+			{"wildcard then specific", "", " react/no-namespace", true},
+			{"specific then wildcard", " react/no-namespace", "", false},
+		} {
+			t.Run(prefix+"/"+testCase.name, func(t *testing.T) {
+				code := "/* 😀 */ before(); /* " + prefix + "-disable" + testCase.disable + " */ inside(); /* " + prefix + "-enable" + testCase.enable + " */ after();"
+				sf := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/directives.js", Path: "/directives.js"}, code, core.ScriptKindJS)
+				dm := NewDisableManager(sf, NewCommentStore(sf))
+				for _, query := range []struct {
+					marker string
+					want   bool
+				}{
+					{"before()", false}, {"inside()", true}, {"after()", false},
+				} {
+					pos := strings.Index(code, query.marker)
+					if pos < 0 {
+						t.Fatalf("missing marker %q", query.marker)
+					}
+					if got := dm.IsRuleDisabled("react/no-namespace", pos); got != query.want {
+						t.Errorf("%s: disabled = %v, want %v", query.marker, got, query.want)
+					}
+				}
+				if got := dm.IsRuleDisabled("no-console", strings.Index(code, "after()")); got != testCase.otherDisabled {
+					t.Errorf("unrelated rule disabled = %v, want %v", got, testCase.otherDisabled)
+				}
+			})
+		}
+	}
+}
 
 // ---------------------------------------------------------------------------
 // parseRuleNames
@@ -457,7 +500,7 @@ func TestIsBlockDisabled(t *testing.T) {
 			want:     false,
 		},
 		{
-			name: "query line 0 with no directives",
+			name:       "query line 0 with no directives",
 			directives: nil,
 			ruleName:   "no-console",
 			line:       0,
@@ -496,7 +539,7 @@ func TestIsBlockDisabled(t *testing.T) {
 				lineDisabledRules:     make(map[int][]string),
 				nextLineDisabledRules: make(map[int][]string),
 			}
-			got := dm.isBlockDisabled(tt.ruleName, tt.line)
+			got := dm.isBlockDisabled(tt.ruleName, tt.line, 0)
 			if got != tt.want {
 				t.Errorf("isBlockDisabled(%q, %d) = %v, want %v", tt.ruleName, tt.line, got, tt.want)
 			}
@@ -601,7 +644,7 @@ func TestDisableManagerBlockAndLineCombined(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := dm.isBlockDisabled(tt.ruleName, tt.line)
+			got := dm.isBlockDisabled(tt.ruleName, tt.line, 0)
 			// For line-level checks we call the helper directly
 			if !got {
 				got = dm.isLineDisabled(tt.ruleName, tt.line)

--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -47,7 +47,6 @@ type RefStore struct {
 	resolver   binder.NameResolver
 	tc         *checker.Checker
 	init       RefStoreInit
-	scope      *scope.Manager
 	walked     bool
 	// candidates maps identifier text to the reference-position identifiers
 	// still awaiting resolution; entries move into refs on first query.
@@ -263,38 +262,6 @@ func (s *RefStore) ResolveInFile(node *ast.Node) *ast.Symbol {
 		return nil
 	}
 	return s.binderReferenceSymbol(node, referenceMeaning(node))
-}
-
-// LatestValueDefinitionInFile returns the last definition of the local binding
-// read by node, in the order ESLint's scope manager exposes it. The returned
-// definition may be type-only: upstream reads variable.defs[defs.length - 1]
-// without filtering by value space. It is deliberately based on the file-local
-// scope model rather than a checker symbol: checker symbols can merge
-// declarations from several global script files, where AST offsets are not
-// comparable.
-func (s *RefStore) LatestValueDefinitionInFile(node *ast.Node) *ast.Node {
-	if s == nil || node == nil || !scope.IsReferenceIdentifier(node) {
-		return nil
-	}
-	if s.scope == nil {
-		s.scope = scope.Build(s.sourceFile, scope.Options{
-			CollectReferences: true,
-			ReferenceNames:    map[string]struct{}{node.Text(): {}},
-		})
-	}
-	for _, reference := range s.scope.References {
-		if reference.Identifier != node {
-			continue
-		}
-		for i := len(reference.Declarations) - 1; i >= 0; i-- {
-			declaration := reference.Declarations[i]
-			if declaration != nil {
-				return declaration.DefNode
-			}
-		}
-		return nil
-	}
-	return nil
 }
 
 // ResolveInFileWithMeaning is ResolveInFile with an explicit declaration-space

--- a/internal/utils/scope/acquire.go
+++ b/internal/utils/scope/acquire.go
@@ -1,0 +1,43 @@
+package scope
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// Acquire returns the innermost scope associated with node's ESTree position.
+// This is a syntactic query like SourceCode.getScope, not reference resolution:
+// it does not skip type-only definitions or function bodies for parameter
+// defaults. The index is built lazily for consumers that need this query.
+func (m *Manager) Acquire(node *ast.Node) *Scope {
+	if m.byBlock == nil {
+		m.byBlock = make(map[*ast.Node]*Scope, len(m.Scopes))
+		for _, current := range m.Scopes {
+			if current.Block != nil {
+				// A named function expression owns both a name scope and a
+				// function scope. The later, inner scope is acquired first.
+				m.byBlock[current.Block] = current
+			}
+		}
+	}
+	var child *ast.Node
+	for current := node; current != nil; current = current.Parent {
+		if acquired := m.byBlock[current]; acquired != nil && !outsideRuntimeMethodScope(current, child) {
+			return acquired
+		}
+		child = current
+	}
+	return m.Global
+}
+
+// ESTree methods wrap a FunctionExpression. Their computed keys and member
+// decorators sit outside that function, while parameters and their decorators
+// sit inside. tsgo combines both parts into one runtime method node.
+func outsideRuntimeMethodScope(method, child *ast.Node) bool {
+	if child == nil {
+		return false
+	}
+	switch method.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		return child == method.Name() || child.Kind == ast.KindDecorator
+	default:
+		return false
+	}
+}

--- a/internal/utils/scope/builder.go
+++ b/internal/utils/scope/builder.go
@@ -466,7 +466,7 @@ func (b *builder) visitStatement(stmt *ast.Node, parent *Scope) {
 		ws := stmt.AsWithStatement()
 		if ws != nil {
 			b.visitExpression(ws.Expression, parent)
-			b.visitStatement(ws.Statement, parent)
+			b.visitStatement(ws.Statement, b.push(KindWith, stmt, parent))
 		}
 	default:
 		// Catch-all — traverse children.
@@ -1009,7 +1009,11 @@ func (b *builder) visitModuleDecl(node *ast.Node, outer *Scope) {
 		}
 		return
 	}
-	moduleScope := b.push(KindModule, node, outer)
+	// TSESTree represents A.B.C as one qualified namespace declaration.
+	moduleScope := outer
+	if node.Parent == nil || node.Parent.Kind != ast.KindModuleDeclaration {
+		moduleScope = b.push(KindModule, node, outer)
+	}
 	// Inherit the global-augmentation flag from the parent chain.
 	if outer != nil && outer.GlobalAugmentation {
 		moduleScope.GlobalAugmentation = true

--- a/internal/utils/scope/scope.go
+++ b/internal/utils/scope/scope.go
@@ -95,6 +95,7 @@ const (
 	KindType                       // TS type alias / interface: type parameters
 	KindClassStaticBlock           // `static { ... }`
 	KindClassFieldInitializer      // the initializer expression of a class field
+	KindWith                       // the body environment of a with statement
 )
 
 // Scope is one node of the scope tree.
@@ -237,6 +238,8 @@ type Manager struct {
 	// References lists every reference in the file, in the order the builder
 	// discovered them. Populated only when [Options.CollectReferences] is set.
 	References []*Reference
+	// byBlock is the lazy index used by Acquire.
+	byBlock map[*ast.Node]*Scope
 }
 
 // Build analyzes `sf` and returns its scope tree.

--- a/internal/utils/scope/scope_test.go
+++ b/internal/utils/scope/scope_test.go
@@ -140,6 +140,69 @@ namespace A.B { export const value = 1; }
 			t.Fatalf("scope %v unexpectedly declares dotted namespace segment B", candidate.Kind)
 		}
 	}
+	assertKinds(t, m, []Kind{KindGlobal, KindModule})
+	assertDeclares(t, m.Scopes[1], "value", DefVariable)
+}
+
+func TestBuildKeepsExplicitNestedNamespaces(t *testing.T) {
+	m := build(t, `namespace A { namespace B { namespace C { const value = 1; } } }`)
+	assertKinds(t, m, []Kind{KindGlobal, KindModule, KindModule, KindModule})
+	assertDeclares(t, m.Scopes[1], "B", DefNamespaceName)
+	assertDeclares(t, m.Scopes[2], "C", DefNamespaceName)
+	assertDeclares(t, m.Scopes[3], "value", DefVariable)
+}
+
+func TestBuildWithBodyHasItsOwnEnvironment(t *testing.T) {
+	m := build(t, `with (object) { function inner() {} }`)
+	assertKinds(t, m, []Kind{KindGlobal, KindWith, KindBlock, KindFunction})
+	assertDeclares(t, m.Scopes[2], "inner", DefFunctionName)
+	if m.Scopes[1].VariableScope() != m.Global {
+		t.Fatal("with must not introduce a var hoisting target")
+	}
+}
+
+func TestAcquireUsesTheESTreePosition(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		code    string
+		kind    Kind
+		binding string
+	}{
+		{"parameter default", `function f(x = probe()) { const local = 1; }`, KindFunction, "local"},
+		{"named function", `const f = function named(local) { probe(); };`, KindFunction, "local"},
+		{"method key", `class C<Local> { [probe()](Local) {} }`, KindClass, "Local"},
+		{"method decorator", `class C<Local> { @probe() method(Local) {} }`, KindClass, "Local"},
+		{"parameter decorator", `class C { method(@probe() x, local) {} }`, KindFunction, "local"},
+		{"class decorator", `@probe() class C<Local> {}`, KindClass, "Local"},
+		{"field initializer", `class C { field = probe(); }`, KindClassFieldInitializer, ""},
+		{"switch discriminant", `switch (probe()) { case 0: const local = 1; }`, KindBlock, "local"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := build(t, testCase.code)
+			var call *ast.Node
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindCallExpression && node.AsCallExpression().Expression.Kind == ast.KindIdentifier && node.AsCallExpression().Expression.Text() == "probe" {
+					call = node
+				}
+				return node.ForEachChild(visit)
+			}
+			m.SourceFile.AsNode().ForEachChild(visit)
+			if call == nil {
+				t.Fatal("missing probe call")
+			}
+			acquired := m.Acquire(call)
+			if acquired.Kind != testCase.kind {
+				t.Fatalf("kind = %v, want %v", acquired.Kind, testCase.kind)
+			}
+			if testCase.binding != "" && len(acquired.Declarations(testCase.binding)) == 0 {
+				t.Fatalf("missing declaration %q", testCase.binding)
+			}
+			if m.Acquire(call) != acquired {
+				t.Fatal("cached acquisition changed")
+			}
+		})
+	}
 }
 
 func TestBuildFunctionExpressionNameGetsItsOwnScope(t *testing.T) {

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-namespace.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-namespace.test.ts
@@ -7,6 +7,12 @@ const message = (name: string) =>
 
 ruleTester.run('no-namespace', {} as never, {
   valid: [
+    {
+      code: 'import { createElement } from "react"; function f() { type createElement = {}; createElement("ns:Panel"); }',
+    },
+    {
+      code: 'const { createElement } = require?.("react"); createElement("ns:Panel");',
+    },
     // ---- Upstream valid: JSX elements ----
     { code: '<testcomponent />' },
     { code: '<testComponent />' },
@@ -39,6 +45,28 @@ ruleTester.run('no-namespace', {} as never, {
     { code: 'React.createElement({})' },
   ],
   invalid: [
+    {
+      code: 'function child() { const createElement = React.createElement; } createElement("ns:Panel");',
+      errors: [{ message: message('ns:Panel') }],
+    },
+    {
+      code: 'namespace A.B.C { const createElement = React.createElement; } createElement("ns:Panel");',
+      errors: [{ message: message('ns:Panel') }],
+    },
+    {
+      code: 'class C { #createElement; f(React) { React.#createElement("ns:Panel"); } }',
+      errors: [{ message: message('ns:Panel') }],
+    },
+    ...[
+      '/* eslint-disable react/no-namespace */ React.createElement("ns:A"); /* eslint-enable react/no-namespace */ React.createElement("ns:B");',
+      '/* eslint-disable */ React.createElement("ns:A"); /* eslint-enable react/no-namespace */ React.createElement("ns:B");',
+      '/* eslint-disable react/no-namespace */ React.createElement("ns:A"); /* eslint-enable */ React.createElement("ns:B");',
+      '/* eslint-disable react/no-namespace */\nReact.createElement("ns:A");\n/* eslint-enable react/no-namespace */\nReact.createElement("ns:B");',
+    ].map((code) => ({ code, errors: [{ message: message('ns:B') }] })),
+    {
+      code: 'React.createElement("ns:A"); /* eslint-disable react/no-namespace */ React.createElement("ns:B");',
+      errors: [{ message: message('ns:A') }],
+    },
     // ---- Upstream invalid: lower-case namespace ----
     ...[
       'ns:testcomponent',


### PR DESCRIPTION
## Summary

`react/no-namespace` could incorrectly report calls shadowed by type declarations and miss calls found through upstream's first-child declaration lookup. Match upstream's file-local name lookup for type declarations, parameter defaults, decorators, globals, and namespace boundaries, and align optional `require` initializers and private factory member names.

Reuse the existing lexical model and extract its syntactic acquisition logic from the Unicorn consumer. Correct `with` and dotted namespace environments in the shared builder. Apply disable/enable comments at their UTF-16 columns so same-line diagnostics are suppressed only within the intended interval.

Skip calls that cannot report and lazily cache declaration matches per file, removing repeated scans of all references.

Validation:

- Executed both the latest published eslint-plugin-react 7.37.5 and upstream master `c99d3b274efbc593e46563358e7b77cad8d01957`, with ESLint 10.10.0, @typescript-eslint/parser 8.69.0, and supported TypeScript 6.0.3. All 3,340 parser-accepted cases match diagnostic counts, messages, IDs, and start/end locations; 117 syntax-rejected inputs were recorded separately. Published upstream and master also agree.
- Adversarial review covered declaration order, child/sibling lookup, type/value shadowing, defaults, decorators, globals, optional chains, private members, Unicode, loop boundaries, namespaces, and directive ordering.
- Go tests passed for all 87 React rule packages, the changed shared packages, and their direct consumers. JS/API and CLI validation passed 46 tests; the namespace tests were rerun after the final fast-path adjustment.
- `pnpm build`, `pnpm run check-spell`, and `pnpm run format:check` passed. Go lint passed for only the five changed packages with `--new-from-merge-base=origin/main`.

Rule microbenchmarks use identical diagnostic-count assertions, a single CPU, 300 ms per case, and five interleaved before/after pairs. Values are medians and exclude parsing/binding. Benchmark and oracle sources are not included in this PR.

| Scenario | Before | After | Time change |
| --- | ---: | ---: | ---: |
| 1,000 plain bare calls | 0.273 ms | 0.032 ms | -88.1% |
| 10,000 plain bare calls | 23.061 ms | 0.321 ms | -98.6% |
| 1,000 namespaced bare calls | 0.393 ms | 0.193 ms | -50.8% |
| 10,000 namespaced bare calls | 24.882 ms | 2.073 ms | -91.7% |
| 1,000 namespaced member calls | 0.165 ms | 0.169 ms | +2.3% |
| 1,000 namespaced JSX elements | 0.163 ms | 0.168 ms | +3.0% |
| 10,000 unrelated calls | 0.312 ms | 0.291 ms | -6.9% |
| 1,000 sibling blocks | 0.486 ms | 0.367 ms | -24.4% |

The member/JSX controls changed by 2–3%. The sibling-block case allocates 6.6% more bytes for the caches, with 42.2% fewer allocations and 24.4% lower runtime.

## Related Links

- [Upstream rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/c99d3b274efbc593e46563358e7b77cad8d01957/lib/rules/no-namespace.js)
- [Upstream declaration lookup](https://github.com/jsx-eslint/eslint-plugin-react/blob/c99d3b274efbc593e46563358e7b77cad8d01957/lib/util/variable.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; the documented rule contract is unchanged).
