### PR TITLE
feat: port rule unicorn/no-await-expression-member

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_fill_with_reference_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_from_fill"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_array_front_mutation"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_expression_member"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_in_promise_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_document_cookie"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_exports_in_scripts"
@@ -59,6 +60,7 @@ func GetAllRules() []rule.Rule {
 		no_array_fill_with_reference_type.NoArrayFillWithReferenceTypeRule,
 		no_array_from_fill.NoArrayFromFillRule,
 		no_array_front_mutation.NoArrayFrontMutationRule,
+		no_await_expression_member.NoAwaitExpressionMemberRule,
 		no_await_in_promise_methods.NoAwaitInPromiseMethodsRule,
 		no_document_cookie.NoDocumentCookieRule,
 		no_exports_in_scripts.NoExportsInScriptsRule,

--- a/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member.go
+++ b/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member.go
@@ -1,0 +1,112 @@
+package no_await_expression_member
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var message = rule.RuleMessage{
+	Id:          "noAwaitExpressionMember",
+	Description: "Do not access a member directly from an await expression.",
+}
+
+// NoAwaitExpressionMemberRule disallows member access directly from await.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-await-expression-member.js
+var NoAwaitExpressionMemberRule = rule.Rule{
+	Name:   "unicorn/no-await-expression-member",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			object := node.Expression()
+			await := utils.ESTreeRuntimeExpression(object)
+			if await == nil || await.Kind != ast.KindAwaitExpression {
+				return
+			}
+
+			property := node.Name()
+			if node.Kind == ast.KindElementAccessExpression {
+				property = utils.ESTreeRuntimeExpression(node.AsElementAccessExpression().ArgumentExpression)
+			}
+			if property == nil {
+				return
+			}
+
+			ctx.ReportNodeWithDeferredFixes(property, message, func() []rule.RuleFix {
+				return destructuringFix(ctx, node, object, property)
+			})
+		}
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: check,
+			ast.KindElementAccessExpression:  check,
+		}
+	},
+}
+
+func destructuringFix(ctx rule.RuleContext, member, object, property *ast.Node) []rule.RuleFix {
+	parent := utils.ESTreeParent(member)
+	if ast.IsOptionalChain(member) || parent == nil || parent.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	// NOTE: Unlike eslint-plugin-unicorn v74.0.0, do not fix using or await
+	// using declarations: resource declarations cannot use binding patterns.
+	declarationList := parent.Parent
+	if declarationList != nil && declarationList.Kind == ast.KindVariableDeclarationList &&
+		(ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList)) {
+		return nil
+	}
+	declaration := parent.AsVariableDeclaration()
+	variable := declaration.Name()
+	if utils.ESTreeRuntimeExpression(declaration.Initializer) != member ||
+		variable == nil || variable.Kind != ast.KindIdentifier || declaration.Type != nil {
+		return nil
+	}
+
+	var opening, closing string
+	if member.Kind == ast.KindElementAccessExpression {
+		if property.Kind != ast.KindNumericLiteral {
+			return nil
+		}
+		switch utils.NormalizeNumericLiteral(property.AsNumericLiteral().Text) {
+		case "0":
+			opening, closing = "[", "]"
+		case "1":
+			opening, closing = "[, ", "]"
+		default:
+			return nil
+		}
+	} else {
+		if property.Kind != ast.KindIdentifier || variable.Text() != property.Text() {
+			return nil
+		}
+		opening, closing = "{", "}"
+	}
+
+	fixes := []rule.RuleFix{
+		rule.RuleFixInsertBefore(ctx.SourceFile, variable, opening),
+		rule.RuleFixInsertAfter(variable, closing),
+		rule.RuleFixRemoveRange(core.NewTextRange(object.End(), member.End())),
+	}
+	// Remove only the parentheses around await, preserving their comments and
+	// whitespace. Parentheses around the complete member expression stay intact.
+	// JSDoc casts are transparent to ESTree; authored TS assertions are not.
+	for current := object; current != nil; {
+		if current.Kind == ast.KindParenthesizedExpression {
+			span := utils.TrimNodeTextRange(ctx.SourceFile, current)
+			fixes = append(fixes,
+				rule.RuleFixRemoveRange(core.NewTextRange(span.Pos(), span.Pos()+1)),
+				rule.RuleFixRemoveRange(core.NewTextRange(span.End()-1, span.End())),
+			)
+			current = current.AsParenthesizedExpression().Expression
+			continue
+		}
+		if expression := utils.JSDocTypeCastExpression(current); expression != nil {
+			current = expression
+			continue
+		}
+		break
+	}
+	return fixes
+}

--- a/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member.md
+++ b/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member.md
@@ -1,0 +1,39 @@
+# no-await-expression-member
+
+## Rule Details
+
+Disallow accessing a property or element directly from an `await` expression.
+Use destructuring or store the awaited result in a variable before accessing
+its members.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const property = (await getObject()).property;
+const secondElement = (await getArray())[1];
+const data = await (await fetch('/foo')).json();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const { property } = await getObject();
+const [, secondElement] = await getArray();
+const response = await fetch('/foo');
+const data = await response.json();
+```
+
+The rule has no options. It automatically fixes variable declarations that
+access element `0` or `1`, or a named property matching the variable name.
+Optional member access and declarations with a type annotation are reported
+without an automatic fix.
+
+## Differences from ESLint
+
+Unlike eslint-plugin-unicorn v74.0.0, rslint reports `using` and `await using`
+declarations without automatic fixes, because these declarations cannot use destructuring.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-await-expression-member](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-await-expression-member.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-await-expression-member.js)

--- a/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member_extras_test.go
@@ -1,0 +1,199 @@
+// TestNoAwaitExpressionMemberExtras locks in upstream branches, AST edge
+// shapes, and real-user examples. The complete upstream migration lives in
+// no_await_expression_member_upstream_test.go.
+package no_await_expression_member_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_expression_member"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAwaitExpressionMemberExtras(t *testing.T) {
+	jsdoc := memberInvalid(`const value = /** @type {any} */ (await promise).value`, "value",
+		`const {value} = /** @type {any} */ await promise`)
+	jsdoc.FileName = "file.mjs"
+	jsdocInitializer := memberInvalid(`const value = /** @type {any} */ ((await promise).value)`, "value",
+		`const {value} = /** @type {any} */ (await promise)`)
+	jsdocInitializer.FileName = "file.mjs"
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&no_await_expression_member.NoAwaitExpressionMemberRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream create() early return: the object must be await.
+			{Code: `const value = (promise).value`},
+			{Code: `const value = await promise.value`},
+			{Code: `const value = object[await key]`},
+			// ---- Dimension 4: authored TS wrappers are not transparent. ----
+			{Code: `const value = ((await promise) as any).value`},
+			{Code: `const value = ((await promise) satisfies any).value`},
+			{Code: `const value = (<any>(await promise)).value`},
+			{Code: `const value = (await promise)!.value`},
+			// A sequence, unlike source parentheses, also changes the object.
+			{Code: `const value = (0, await promise).value`},
+			// ---- Dimension 4 N/A: missing function/class bodies do not affect
+			// this member-expression rule. No options or name/key matching across
+			// separate members is performed. ----
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: source parentheses are transparent on both the
+			// receiver and initializer; only receiver parentheses are removed. ----
+			// Locks in upstream array-fix arms for values 0 and 1, including
+			// alternate numeric spellings and parenthesized computed keys.
+			memberInvalid(`const x = (((await promise)))[((0))]`, "0", `const [x] = await promise`),
+			memberInvalid(`const x = (((await promise)[1]))`, "1", `const [, x] = ((await promise))`),
+			memberInvalid(`const x = (await promise)[0x1]`, "0x1", `const [, x] = await promise`),
+			memberInvalid(`const x = (await promise)[0b0]`, "0b0", `const [x] = await promise`),
+			memberInvalid(`const x = (await promise)[1.0]`, "1.0", `const [, x] = await promise`),
+			memberInvalid(`const x = (await promise)[1e0]`, "1e0", `const [, x] = await promise`),
+			// Locks in upstream object-fix arm: names match after decoding.
+			memberInvalid(`const value = (((await promise))).value`, "value", `const {value} = await promise`),
+			memberInvalid(`const v\u0061lue = (await promise).value`, "value", `const {v\u0061lue} = await promise`),
+			memberInvalid(`const value = (await promise).v\u0061lue`, `v\u0061lue`, `const {value} = await promise`),
+			jsdoc,
+			jsdocInitializer,
+
+			// ---- Dimension 4: computed/private keys all report, but cannot use
+			// the identifier-property fix or numeric 0/1 fix. ----
+			// Locks in upstream numeric-literal and property-Identifier gates.
+			memberInvalid(`const x = (await promise)["0"]`, `"0"`),
+			memberInvalid("const x = (await promise)[`x`]", "`x`"),
+			memberInvalid(`const x = (await promise)[Symbol.iterator]`, "Symbol.iterator"),
+			memberInvalid(`const x = (await promise)[0n]`, "0n"),
+			memberInvalid(`const x = (await promise)[-0]`, "-0"),
+			memberInvalid(`const x = (await promise)[+1]`, "+1"),
+			memberInvalid(`const x = (await promise)[2]`, "2"),
+			memberInvalid(`const x = (await promise)[1 as number]`, "1 as number"),
+			memberInvalid(`const x = (await promise)[1 satisfies number]`, "1 satisfies number"),
+			memberInvalid(`const x = (await promise)[1!]`, "1!"),
+			memberInvalid(`class C { #value; async f() { const value = (await promise).#value; } }`, "#value"),
+
+			// ---- Dimension 4: optional members report without a fix, whereas
+			// an optional operation inside the awaited operand can be fixed. ----
+			// Locks in upstream !memberExpression.optional in both fix branches.
+			memberInvalid(`const x = (await promise)?.x`, "x"),
+			memberInvalid(`const x = (await promise)?.[1]`, "1"),
+			memberInvalid(`const x = (await promise?.()) .x`, "x", `const {x} = await promise?.()`),
+			memberInvalid(`const x = (await promise.x)?.y?.()`, "y"),
+
+			// Locks in upstream variable-declarator, identifier-binding,
+			// initializer-identity, matching-name, and type-annotation gates.
+			memberInvalid(`x = (await promise)[1]`, "1"),
+			memberInvalid(`const renamed = (await promise).x`, "x"),
+			memberInvalid(`const x: number = (await promise)[1]`, "1"),
+			memberInvalid(`const x: number = (await promise).x`, "x"),
+			memberInvalid(`const x = ((await promise).x) as number`, "x"),
+			memberInvalid(`const x = ((await promise)[0])!`, "0"),
+			memberInvalid(`for (const x of (await promise).x) {}`, "x"),
+			// ---- Regression: unlike upstream v74.0.0, resource declarations
+			// report without fixes because using cannot bind a pattern. ----
+			memberInvalid(`using x = (await promise).x;`, "x"),
+			memberInvalid(`using x = (await promise)[0];`, "0"),
+			memberInvalid(`using x = (await promise)[1];`, "1"),
+			memberInvalid(`await using x = (await promise).x;`, "x"),
+			memberInvalid(`await using x = (await promise)[0];`, "0"),
+			memberInvalid(`await using x = (await promise)[1];`, "1"),
+			memberInvalid(`async function f() { using x = (((await promise).x)); }`, "x"),
+			memberInvalid(`async function f() { await using x = (((await promise)[1])); }`, "1"),
+			// ---- Dimension 4: empty/rest bindings and spread containers. ----
+			memberInvalid(`const {} = (await promise).x`, "x"),
+			memberInvalid(`const [...rest] = (await promise)[0]`, "0"),
+			memberInvalid(`const x = {...(await promise).x}`, "x"),
+
+			// ---- Dimension 4: comments, whitespace, and multiline ranges. ----
+			memberInvalid(`const /* before */ x /* after */ = (/* inner */ await promise /* end */).x`, "x",
+				`const /* before */ {x} /* after */ = /* inner */ await promise /* end */`),
+			// Upstream removes comments in the deleted member suffix, too.
+			memberInvalid(`const x = (await promise) /* member */ [/* key */ 0]`, "0", `const [x] = await promise`),
+			memberInvalid("const x = (\n  await promise\n).x;", "x", "const {x} = \n  await promise\n;"),
+			memberInvalid("const x = (await promise)[\n  1\n];", "1", "const [, x] = await promise;"),
+
+			// ---- Dimension 4: nested members report independently, not once
+			// per chain. The outer fix can leave another diagnostic behind. ----
+			{
+				Code: `const x = (await (await promise).y).x`, FileName: "file.mts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					memberError(`const x = (await (await promise).y).x`, "x"),
+					memberError(`const x = (await (await promise).y).x`, "y"),
+				},
+				Output: []string{`const {x} = await (await promise).y`},
+			},
+			// ---- Real-user: upstream #2557, dynamic import in a condition. ----
+			memberInvalid(`if ((await import("electron-squirrel-startup")).default) { app.exit(); }`, "default"),
+			// ---- Real-user: upstream #1458, filtering Promise.all results. ----
+			memberInvalid(`const filtered = (await Promise.all(promises)).filter(Boolean);`, "filter"),
+		},
+	)
+}
+
+func TestNoAwaitExpressionMemberEditDemand(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct{ code, output string }{
+		{`const value = (await promise).value`, `const {value} = await promise`},
+		{`const value = (await promise)[1]`, `const [, value] = await promise`},
+		{`const value = (await promise)?.value`, ""},
+		{`using value = (await promise).value`, ""},
+		{`await using value = (await promise)[1]`, ""},
+	} {
+		t.Run(test.code, func(t *testing.T) {
+			t.Parallel()
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/edit-demand.mts", Path: "/edit-demand.mts",
+			}, test.code, core.ScriptKindTS)
+			var baseline rule.RuleDiagnostic
+			for _, demand := range []rule.EditDemand{
+				rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll,
+			} {
+				var diagnostics []rule.RuleDiagnostic
+				comments := rule.NewCommentStore(sourceFile)
+				ctx := rule.RuleContext{
+					SourceFile: sourceFile, Comments: comments,
+					DisableManager: rule.NewDisableManager(sourceFile, comments),
+				}.WithDiagnosticConsumer(no_await_expression_member.NoAwaitExpressionMemberRule.Name,
+					rule.SeverityError, rule.DiagnosticConsumer{
+						Demand: demand,
+						Report: func(diagnostic rule.RuleDiagnostic) { diagnostics = append(diagnostics, diagnostic) },
+					})
+				listeners := no_await_expression_member.NoAwaitExpressionMemberRule.Run(ctx, nil)
+				var visit ast.Visitor
+				visit = func(node *ast.Node) bool {
+					if listener := listeners[node.Kind]; listener != nil {
+						listener(node)
+					}
+					return node.ForEachChild(visit)
+				}
+				visit(sourceFile.AsNode())
+				if len(diagnostics) != 1 {
+					t.Fatalf("demand %d: got %d diagnostics, want 1", demand, len(diagnostics))
+				}
+				diagnostic := diagnostics[0]
+				if demand == rule.EditDemandNone {
+					baseline = diagnostic
+				}
+				withoutFixes := diagnostic
+				withoutFixes.FixesPtr = nil
+				if !reflect.DeepEqual(withoutFixes, baseline) {
+					t.Errorf("demand %d changed diagnostic identity", demand)
+				}
+				wantFix := demand&rule.EditDemandAutofix != 0 && test.output != ""
+				if (diagnostic.FixesPtr != nil) != wantFix {
+					t.Fatalf("demand %d: unexpected fixes: %+v", demand, diagnostic.FixesPtr)
+				}
+				if wantFix {
+					output, _, fixed := linter.ApplyRuleFixes(test.code, diagnostics)
+					if !fixed || output != test.output {
+						t.Errorf("demand %d: fixed = %v, output = %q, want %q", demand, fixed, output, test.output)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member_upstream_test.go
@@ -1,0 +1,101 @@
+// TestNoAwaitExpressionMemberUpstream migrates every valid/invalid case from
+// Unicorn v74.0.0 test/no-await-expression-member.js and its documentation.
+// Every diagnostic has position and message assertions. Additional edge shapes
+// and branch lock-ins live in no_await_expression_member_extras_test.go.
+package no_await_expression_member_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_await_expression_member"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAwaitExpressionMemberUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&no_await_expression_member.NoAwaitExpressionMemberRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `const foo = await promise`},
+			{Code: `const {foo: bar} = await promise`},
+			{Code: `const foo = !await promise`},
+			{Code: `const foo = typeof await promise`},
+			{Code: `const foo = await notPromise.method()`},
+			{Code: `const foo = foo[await promise]`},
+			// These await expressions need parentheses, but are rarely used.
+			{Code: `new (await promiseReturnsAClass)`},
+			{Code: `(await promiseReturnsAFunction)()`},
+			// ---- TypeScript ----
+			{Code: `function foo () {return (await promise) as string;}`},
+			{Code: `(await promise)!.property`},
+			// ---- Documentation ----
+			{Code: `const {default: foo} = await import('./foo.js');`},
+			{Code: `const [, secondElement] = await getArray();`},
+			{Code: `const {property} = await getObject();`},
+			{Code: `const response = await fetch('/foo'); const data = await response.json();`},
+		},
+		[]rule_tester.InvalidTestCase{
+			memberInvalid(`(await promise)[0]`, "0"),
+			memberInvalid(`(await promise).property`, "property"),
+			memberInvalid(`const foo = (await promise).bar()`, "bar"),
+			memberInvalid(`const foo = (await promise).bar?.()`, "bar"),
+			memberInvalid(`const foo = (await promise)?.bar()`, "bar"),
+
+			memberInvalid(`const firstElement = (await getArray())[0]`, "0", `const [firstElement] = await getArray()`),
+			memberInvalid(`const secondElement = (await getArray())[1]`, "1", `const [, secondElement] = await getArray()`),
+			memberInvalid(`const thirdElement = (await getArray())[2]`, "2"),
+			memberInvalid(`const optionalFirstElement = (await getArray())?.[0]`, "0"),
+			memberInvalid(`const {propertyOfFirstElement} = (await getArray())[0]`, "0"),
+			memberInvalid(`const [firstElementOfFirstElement] = (await getArray())[0]`, "0"),
+			memberInvalid(`let foo, firstElement = (await getArray())[0]`, "0", `let foo, [firstElement] = await getArray()`),
+			memberInvalid(`var firstElement = (await getArray())[0], bar`, "0", `var [firstElement] = await getArray(), bar`),
+
+			memberInvalid(`const property = (await getObject()).property`, "property", `const {property} = await getObject()`),
+			memberInvalid(`let property = (await getObject()).property`, "property", `let {property} = await getObject()`),
+			memberInvalid(`const renamed = (await getObject()).property`, "property"),
+			// Only the member directly off await is flagged, not the chained .bar.
+			memberInvalid(`(await promise).foo.bar`, "foo"),
+			memberInvalid(`const property = (await getObject())[property]`, "property"),
+			memberInvalid(`const property = (await getObject())?.property`, "property"),
+			memberInvalid(`const {propertyOfProperty} = (await getObject()).property`, "property"),
+			memberInvalid(`const {propertyOfProperty} = (await getObject()).propertyOfProperty`, "propertyOfProperty"),
+			memberInvalid(`const [firstElementOfProperty] = (await getObject()).property`, "property"),
+			memberInvalid(`const [firstElementOfProperty] = (await getObject()).firstElementOfProperty`, "firstElementOfProperty"),
+
+			memberInvalid(`firstElement = (await getArray())[0]`, "0"),
+			memberInvalid(`property = (await getArray()).property`, "property"),
+			// ---- TypeScript ----
+			memberInvalid(`const foo: Type = (await promise)[0]`, "0"),
+			memberInvalid(`const foo: Type | A = (await promise).foo`, "foo"),
+			// ---- Documentation (the other two examples are covered above) ----
+			memberInvalid(`const foo = (await import('./foo.js')).default;`, "default"),
+			memberInvalid(`const data = await (await fetch('/foo')).json();`, "json"),
+		},
+	)
+}
+
+func memberInvalid(code, property string, output ...string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.mts",
+		Output:   output,
+		Errors:   []rule_tester.InvalidTestCaseError{memberError(code, property)},
+	}
+}
+
+func memberError(code, property string) rule_tester.InvalidTestCaseError {
+	start := strings.LastIndex(code, property)
+	if property == "" || start < 0 {
+		panic("missing property in test input: " + property)
+	}
+	end := start + len(property)
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "noAwaitExpressionMember",
+		Message:   "Do not access a member directly from an await expression.",
+		Line:      strings.Count(code[:start], "\n") + 1,
+		Column:    start - strings.LastIndex(code[:start], "\n"),
+		EndLine:   strings.Count(code[:end], "\n") + 1,
+		EndColumn: end - strings.LastIndex(code[:end], "\n"),
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -686,6 +686,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/no-array-fill-with-reference-type.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-from-fill.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-array-front-mutation.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-await-expression-member.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-await-in-promise-methods.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-document-cookie.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-exports-in-scripts.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -179,5 +179,6 @@ describe('defineConfig and config presets', () => {
       'error',
     );
     expect(rec.rules?.['unicorn/no-exports-in-scripts']).toBe('error');
+    expect(rec.rules?.['unicorn/no-await-expression-member']).toBe('error');
   });
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-await-expression-member.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-await-expression-member.test.ts
@@ -1,0 +1,63 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors Unicorn v74.0.0. Additional edge shapes are tested in Go only.
+ruleTester.run('no-await-expression-member', null as never, {
+  valid: [
+    'const foo = await promise',
+    'const {foo: bar} = await promise',
+    'const foo = !await promise',
+    'const foo = typeof await promise',
+    'const foo = await notPromise.method()',
+    'const foo = foo[await promise]',
+    'new (await promiseReturnsAClass)',
+    '(await promiseReturnsAFunction)()',
+    'function foo () {return (await promise) as string;}',
+    '(await promise)!.property',
+    "const {default: foo} = await import('./foo.js');",
+    'const [, secondElement] = await getArray();',
+    'const {property} = await getObject();',
+    "const response = await fetch('/foo'); const data = await response.json();",
+  ].map((code) => ({ code, filename: 'src/virtual.mts' })),
+  invalid: [
+    '(await promise)[0]',
+    '(await promise).property',
+    'const foo = (await promise).bar()',
+    'const foo = (await promise).bar?.()',
+    'const foo = (await promise)?.bar()',
+    'const firstElement = (await getArray())[0]',
+    'const secondElement = (await getArray())[1]',
+    'const thirdElement = (await getArray())[2]',
+    'const optionalFirstElement = (await getArray())?.[0]',
+    'const {propertyOfFirstElement} = (await getArray())[0]',
+    'const [firstElementOfFirstElement] = (await getArray())[0]',
+    'let foo, firstElement = (await getArray())[0]',
+    'var firstElement = (await getArray())[0], bar',
+    'const property = (await getObject()).property',
+    'let property = (await getObject()).property',
+    'const renamed = (await getObject()).property',
+    '(await promise).foo.bar',
+    'const property = (await getObject())[property]',
+    'const property = (await getObject())?.property',
+    'const {propertyOfProperty} = (await getObject()).property',
+    'const {propertyOfProperty} = (await getObject()).propertyOfProperty',
+    'const [firstElementOfProperty] = (await getObject()).property',
+    'const [firstElementOfProperty] = (await getObject()).firstElementOfProperty',
+    'firstElement = (await getArray())[0]',
+    'property = (await getArray()).property',
+    'const foo: Type = (await promise)[0]',
+    'const foo: Type | A = (await promise).foo',
+    "const foo = (await import('./foo.js')).default;",
+    "const data = await (await fetch('/foo')).json();",
+  ].map((code) => ({
+    code,
+    filename: 'src/virtual.mts',
+    errors: [
+      {
+        messageId: 'noAwaitExpressionMember',
+        message: 'Do not access a member directly from an await expression.',
+      },
+    ],
+  })),
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -72,7 +72,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-array-splice': 'error', // not implemented
     // 'unicorn/no-asterisk-prefix-in-documentation-comments': 'off', // not implemented
     // 'unicorn/no-async-promise-finally': 'error', // not implemented
-    // 'unicorn/no-await-expression-member': 'error', // not implemented
+    'unicorn/no-await-expression-member': 'error',
     'unicorn/no-await-in-promise-methods': 'error',
     // 'unicorn/no-barrel-files': 'off', // not implemented
     // 'unicorn/no-blob-to-file': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/no-await-expression-member` from eslint-plugin-unicorn v74.0.0.

- Report property and element access directly from an `await` expression, including optional member access.
- Autofix simple variable declarations using array or object destructuring.
- Register the rule and enable it in the Unicorn recommended preset.
- Add documentation, upstream test coverage, edge-case regressions, and JS integration tests.

## Safety difference from upstream

Unlike upstream v74.0.0, `using` and `await using` declarations are reported without autofixes. Resource declarations cannot use destructuring, so applying the upstream fix would produce invalid code.

This difference is documented and covered by regression tests.

## Validation

- Go upstream, edge-case, edit-demand, and rule catalog tests.
- JS rule integration and preset tests.
- Go lint, TypeScript type checking, formatting, and spell checking.
- Differential checks against v74.0.0: 673 inputs, including 76 real source files, plus 838 additional edge-shape inputs. Only the documented resource-declaration autofix differences remain.
- Verified that `fix: true` leaves resource declarations unchanged while still fixing ordinary declarations.

## Related Links

- Tracking issue: #1309
- [Upstream documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/no-await-expression-member.md)
- [Upstream implementation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/no-await-expression-member.js)

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
