### PR TITLE
fix: correct no-restricted-syntax selector matching

### DIFF
--- a/internal/rules/no_restricted_syntax/fields.go
+++ b/internal/rules/no_restricted_syntax/fields.go
@@ -220,6 +220,9 @@ func nodesAtField(parent *ast.Node, field string) []*ast.Node {
 			}
 		}
 	case "params":
+		if !isFunctionLikeForParams(parent) {
+			return nil
+		}
 		params := utils.ESTreeParameters(parent)
 		if params == nil {
 			return nil
@@ -279,6 +282,8 @@ func listChildrenOf(parent *ast.Node) [][]*ast.Node {
 		add(statements(parent.AsSourceFile().Statements))
 	case ast.KindBlock:
 		add(statements(parent.AsBlock().Statements))
+	case ast.KindClassStaticBlockDeclaration:
+		add(statements(parent.AsClassStaticBlockDeclaration().Body.AsBlock().Statements))
 	case ast.KindArrayLiteralExpression:
 		add(statements(parent.AsArrayLiteralExpression().Elements))
 	case ast.KindObjectLiteralExpression:
@@ -303,6 +308,15 @@ func listChildrenOf(parent *ast.Node) [][]*ast.Node {
 		add(statements(parent.AsCaseBlock().Clauses))
 	case ast.KindVariableDeclarationList:
 		add(statements(parent.AsVariableDeclarationList().Declarations))
+	case ast.KindJsxElement:
+		add(statements(parent.AsJsxElement().Children))
+	case ast.KindJsxFragment:
+		add(statements(parent.AsJsxFragment().Children))
+	case ast.KindJsxOpeningElement:
+		add(statements(parent.AsJsxOpeningElement().Attributes.AsJsxAttributes().Properties))
+	case ast.KindJsxSelfClosingElement:
+		add(statements(parent.AsJsxSelfClosingElement().Attributes.AsJsxAttributes().Properties))
+
 	case ast.KindImportDeclaration:
 		if attributes := parent.AsImportDeclaration().Attributes; attributes != nil {
 			add(statements(attributes.AsImportAttributes().Attributes))
@@ -311,6 +325,15 @@ func listChildrenOf(parent *ast.Node) [][]*ast.Node {
 		if attributes := parent.AsExportDeclaration().Attributes; attributes != nil {
 			add(statements(attributes.AsImportAttributes().Attributes))
 		}
+	}
+	if modifiers := parent.Modifiers(); modifiers != nil {
+		var decorators []*ast.Node
+		for _, modifier := range modifiers.Nodes {
+			if modifier.Kind == ast.KindDecorator {
+				decorators = append(decorators, modifier)
+			}
+		}
+		add(decorators)
 	}
 	if isFunctionLikeForParams(parent) {
 		if params := utils.ESTreeParameters(parent); len(params) > 0 {

--- a/internal/rules/no_restricted_syntax/mapping.go
+++ b/internal/rules/no_restricted_syntax/mapping.go
@@ -48,14 +48,16 @@ var estreeKindMap = map[string][]ast.Kind{
 	// ESTree's VariableDeclaration is the statement-level node (`var a = 1;`).
 	// tsgo represents that with VariableStatement; the inner declarators
 	// become VariableDeclaration nodes (mapped as VariableDeclarator below).
-	"VariableDeclaration":     {ast.KindVariableStatement, ast.KindVariableDeclarationList},
-	"VariableDeclarator":      {ast.KindVariableDeclaration},
-	"FunctionDeclaration":     {ast.KindFunctionDeclaration},
-	"FunctionExpression":      {ast.KindFunctionExpression, ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor},
-	"ArrowFunctionExpression": {ast.KindArrowFunction},
-	"TSEnumDeclaration":       {ast.KindEnumDeclaration},
-	"TSEnumBody":              {ast.KindEnumDeclaration},
-	"TSEnumMember":            {ast.KindEnumMember},
+	"VariableDeclaration":           {ast.KindVariableStatement, ast.KindVariableDeclarationList},
+	"VariableDeclarator":            {ast.KindVariableDeclaration},
+	"FunctionDeclaration":           {ast.KindFunctionDeclaration},
+	"FunctionExpression":            {ast.KindFunctionExpression, ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor},
+	"TSEmptyBodyFunctionExpression": {ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor},
+	"TSAbstractMethodDefinition":    {ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor},
+	"ArrowFunctionExpression":       {ast.KindArrowFunction},
+	"TSEnumDeclaration":             {ast.KindEnumDeclaration},
+	"TSEnumBody":                    {ast.KindEnumDeclaration},
+	"TSEnumMember":                  {ast.KindEnumMember},
 
 	// Classes
 	"ClassDeclaration": {ast.KindClassDeclaration},
@@ -96,6 +98,7 @@ var estreeKindMap = map[string][]ast.Kind{
 
 	// Literals
 	"Literal": {
+		ast.KindConstructor,
 		ast.KindStringLiteral,
 		ast.KindNumericLiteral,
 		ast.KindBigIntLiteral,
@@ -107,7 +110,7 @@ var estreeKindMap = map[string][]ast.Kind{
 	"RegExpLiteral": {ast.KindRegularExpressionLiteral},
 
 	// Identifiers
-	"Identifier":        {ast.KindIdentifier},
+	"Identifier":        {ast.KindIdentifier, ast.KindConstructor},
 	"PrivateIdentifier": {ast.KindPrivateIdentifier},
 
 	// Object literal members

--- a/internal/rules/no_restricted_syntax/matcher.go
+++ b/internal/rules/no_restricted_syntax/matcher.go
@@ -2,10 +2,10 @@ package no_restricted_syntax
 
 import (
 	"math"
+	"math/big"
+	"slices"
 	"strconv"
 	"strings"
-	"unicode/utf16"
-	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -116,15 +116,14 @@ func matches(sel selector, node *ast.Node, mc *matchContext) bool {
 	return matchesInScope(sel, node, mc, nil)
 }
 
-func matchesInScope(sel selector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node) bool {
-	return matchesInScopeTarget(sel, node, mc, scopeRoot, "")
+func matchesInScope(sel selector, node *ast.Node, mc *matchContext, scopeRoot *virtualNodeFacade) bool {
+	return matchesInScopeTarget(sel, node, mc, scopeRoot, "physical")
 }
 
 // matchesInScopeTarget evaluates the selector against either the physical
-// tsgo node (target == "physical") or one of the ESTree wrapper nodes that
-// tsgo folds into that node. An empty target retains the historical behavior
-// used when walking ancestors and children.
-func matchesInScopeTarget(sel selector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node, target string) bool {
+// tsgo node (target == "physical") or an ESTree facade on that same node.
+// Structural matching carries both the node and its identity through each edge.
+func matchesInScopeTarget(sel selector, node *ast.Node, mc *matchContext, scopeRoot *virtualNodeFacade, target string) bool {
 	switch v := sel.(type) {
 	case subjectSelector:
 		return matchesInScopeTarget(v.Inner, node, mc, scopeRoot, target)
@@ -143,7 +142,7 @@ func matchesInScopeTarget(sel selector, node *ast.Node, mc *matchContext, scopeR
 		if !matchesInScopeTarget(v.Inner, node, mc, scopeRoot, target) {
 			return false
 		}
-		return matchesClassTarget(node, v.Path, scopeRoot, target)
+		return matchesClassTarget(node, v.Path, mc, scopeRoot, target)
 	case attrSelector:
 		if !matchesInScopeTarget(v.Inner, node, mc, scopeRoot, target) {
 			return false
@@ -153,7 +152,7 @@ func matchesInScopeTarget(sel selector, node *ast.Node, mc *matchContext, scopeR
 		}
 		return matchesAttr(node, v.Path, v.Op, v.Value, mc)
 	case combinatorSelector:
-		if !matchesInScopeTarget(v.Right, node, mc, scopeRoot, target) {
+		if v.Kind != combAdjacent && v.Kind != combSibling && !matchesInScopeTarget(v.Right, node, mc, scopeRoot, target) {
 			return false
 		}
 		return matchesCombinatorTarget(v, node, mc, scopeRoot, target)
@@ -210,7 +209,7 @@ func matchesIdentifier(sel identifierSelector, node *ast.Node) bool {
 func refineEstreeMatch(name string, node *ast.Node) bool {
 	switch name {
 	case "Identifier":
-		return !isJSXIdentifier(node)
+		return node.Kind != ast.KindConstructor && !isJSXIdentifier(node)
 	case "JSXIdentifier":
 		return isJSXIdentifier(node)
 	case "MemberExpression":
@@ -222,13 +221,15 @@ func refineEstreeMatch(name string, node *ast.Node) bool {
 	case "JSXEmptyExpression":
 		return node.Kind == ast.KindJsxExpression && node.AsJsxExpression().DotDotDotToken == nil && node.AsJsxExpression().Expression == nil
 	case "JSXElement":
-		return node.Kind == ast.KindJsxElement
+		return node.Kind == ast.KindJsxElement || node.Kind == ast.KindJsxSelfClosingElement
 	case "JSXOpeningElement":
 		return node.Kind == ast.KindJsxOpeningElement
+	case "Literal":
+		return node.Kind != ast.KindConstructor
 	case "FunctionExpression":
 		// Methods expose a synthetic FunctionExpression through ESTree's
 		// MethodDefinition.value / Property.value fields.
-		return !isFunctionValueNode(node)
+		return node.Kind == ast.KindFunctionExpression
 	case "TSEnumBody":
 		return false
 	case "JSXSpreadChild":
@@ -253,14 +254,7 @@ func refineEstreeMatch(name string, node *ast.Node) bool {
 	case "SequenceExpression":
 		return node.Kind == ast.KindBinaryExpression && isCommaOperator(node)
 	case "ChainExpression":
-		// ESTree wraps the entire optional chain in a single
-		// ChainExpression node. tsgo has no analogue, so we match the
-		// outermost link in the chain — the highest node that is itself
-		// part of the chain but whose parent is not.
-		// `ast.IsOutermostOptionalChain` is too permissive for this
-		// purpose (it's true for the link directly under any `?.`-token
-		// wrapper, which still emits an inner Match in `a?.b?.()`).
-		return ast.IsOptionalChain(node) && (node.Parent == nil || !ast.IsOptionalChain(node.Parent))
+		return isChainRoot(node)
 	case "UnaryExpression":
 		// ESTree's UnaryExpression wraps `+`, `-`, `!`, `~`, `typeof`, `void`,
 		// `delete`. ESTree's UpdateExpression wraps `++`/`--`. tsgo splits
@@ -304,6 +298,8 @@ func refineEstreeMatch(name string, node *ast.Node) bool {
 			return node.Parent != nil && node.Parent.Kind == ast.KindObjectLiteralExpression
 		}
 		return true
+	case "TSAbstractMethodDefinition":
+		return isClassLikeNode(node.Parent) && ast.HasSyntacticModifier(node, ast.ModifierFlagsAbstract)
 	case "MethodDefinition":
 		// Mirror of "Property": MethodDefinition only fires for methods
 		// / accessors inside a class body. KindConstructor is class-only
@@ -314,7 +310,7 @@ func refineEstreeMatch(name string, node *ast.Node) bool {
 				return false
 			}
 			pk := node.Parent.Kind
-			return pk == ast.KindClassDeclaration || pk == ast.KindClassExpression
+			return (pk == ast.KindClassDeclaration || pk == ast.KindClassExpression) && !ast.HasSyntacticModifier(node, ast.ModifierFlagsAbstract)
 		case ast.KindConstructor:
 			return true
 		}
@@ -430,48 +426,25 @@ func isAssignmentOperatorKind(k ast.Kind) bool {
 
 // matchesClassTarget evaluates `Foo.bar` — Foo already matched by the inner
 // selector, here we check that the node sits at the named field of its parent.
-func matchesClassTarget(node *ast.Node, path []string, scopeRoot *ast.Node, target string) bool {
+func matchesClassTarget(node *ast.Node, path []string, mc *matchContext, scopeRoot *virtualNodeFacade, target string) bool {
 	if len(path) == 0 {
 		return false
 	}
-	if target != "" && target != "physical" {
-		if matchesVirtualField(node, target, path) {
-			return true
-		}
-	}
-	// esquery selects exactly the Nth ESTree ancestor for an N-segment field
-	// path. Walk logical parents so tsgo-only wrappers do not shift that index.
-	ancestor := node
+	ancestor, ancestorTarget := node, target
 	for range path {
-		ancestor = matchingParent(ancestor, scopeRoot)
-		if ancestor == nil {
+		var ok bool
+		ancestor, ancestorTarget, ok = logicalParentTarget(ancestor, ancestorTarget, scopeRoot)
+		if !ok {
 			return false
 		}
 	}
-	return nodeIsAtFieldPath(node, ancestor, path)
+	return nodeIsAtFieldPath(node, target, targetValue(ancestor, ancestorTarget), path, mc)
 }
 
 func isVirtualOnlyIdentity(name string) bool {
 	switch name {
-	case "ClassBody", "TSEnumBody", "JSXEmptyExpression":
+	case "ClassBody", "TSEnumBody", "JSXEmptyExpression", "TSEmptyBodyFunctionExpression", "ChainExpression":
 		return true
-	}
-	return false
-}
-
-func matchesVirtualField(node *ast.Node, target string, path []string) bool {
-	if len(path) != 1 {
-		return false
-	}
-	switch target {
-	case "ClassBody", "TSEnumBody":
-		return path[0] == "body"
-	case "FunctionExpression":
-		return path[0] == "value"
-	case "JSXElement":
-		return path[0] == "body" || path[0] == "children"
-	case "JSXOpeningElement":
-		return path[0] == "openingElement"
 	}
 	return false
 }
@@ -562,6 +535,7 @@ func lookupStringAttrPath(node *ast.Node, path []string, mc *matchContext) (text
 
 		switch value := current.(type) {
 		case *ast.Node:
+			value = unwrapEstreeNode(value)
 			if value == nil {
 				// A present ESTree property whose value is null remains null when
 				// a deeper path is requested; use the generic resolver to retain
@@ -574,7 +548,7 @@ func lookupStringAttrPath(node *ast.Node, path []string, mc *matchContext) (text
 				case ast.KindIdentifier:
 					return value.AsIdentifier().Text, true, true
 				case ast.KindPrivateIdentifier:
-					return value.AsPrivateIdentifier().Text, true, true
+					return strings.TrimPrefix(value.AsPrivateIdentifier().Text, "#"), true, true
 				}
 				// JSX name attributes resolve to nodes rather than strings, so
 				// let the generic resolver preserve that facade's semantics.
@@ -600,122 +574,56 @@ func lookupStringAttrPath(node *ast.Node, path []string, mc *matchContext) (text
 	return "", false, false
 }
 
-// matchesCombinator handles `>` (parent), descendant, `+` (prev sibling),
-// `~` (any prior sibling). The right-hand side has already been verified
-// against the current node before this function is called.
-func matchesCombinatorTarget(c combinatorSelector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node, target string) bool {
-	if target != "" && target != "physical" {
-		parent, parentTarget, ok := virtualParent(node, target)
-		if !ok {
-			return false
-		}
-		if c.Kind == combChild {
-			return matchesInScopeTarget(c.Left, parent, mc, scopeRoot, parentTarget)
-		}
-		if c.Kind == combDescendant {
-			if matchesInScopeTarget(c.Left, parent, mc, scopeRoot, parentTarget) {
-				return true
-			}
-			for current, currentTarget, ok := logicalParent(parent, scopeRoot); ok; current, currentTarget, ok = logicalParent(current, scopeRoot) {
-				if matchesInScopeTarget(c.Left, current, mc, scopeRoot, currentTarget) {
-					return true
-				}
-			}
-			return false
-		}
-	}
+// matchesCombinatorTarget handles parents, ancestors, and array siblings.
+// Sibling subjects also permit esquery's reverse matching direction.
+func matchesCombinatorTarget(c combinatorSelector, node *ast.Node, mc *matchContext, scopeRoot *virtualNodeFacade, target string) bool {
 	switch c.Kind {
-	case combChild:
-		parent, parentTarget, ok := logicalParent(node, scopeRoot)
+	case combChild, combDescendant:
+		parent, parentTarget, ok := logicalParentTarget(node, target, scopeRoot)
 		if !ok {
 			return false
 		}
-		// ESTree wraps `export default <decl>` in an
-		// ExportDefaultDeclaration node. tsgo flattens this — a default-
-		// exported FunctionDeclaration / ClassDeclaration sits directly
-		// under SourceFile with `export default` modifiers. To honour
-		// `ExportDefaultDeclaration > FunctionDeclaration`-style
-		// selectors, treat such a declaration as if it had a virtual
-		// ExportDefaultDeclaration parent.
-		if isDefaultExportedDeclaration(node) {
-			if selectorMatchesVirtualExportDefault(c.Left) {
-				return true
-			}
-		}
-		return matchesInScopeTarget(c.Left, parent, mc, scopeRoot, parentTarget)
-	case combDescendant:
-		current, currentTarget, ok := logicalParent(node, scopeRoot)
-		if !ok {
-			return false
-		}
-		if isDefaultExportedDeclaration(node) && selectorMatchesVirtualExportDefault(c.Left) {
+		if target == "physical" && isDefaultExportedDeclaration(node) && selectorMatchesVirtualExportDefault(c.Left) {
 			return true
 		}
 		for ok {
-			if matchesInScopeTarget(c.Left, current, mc, scopeRoot, currentTarget) {
+			if matchesInScopeTarget(c.Left, parent, mc, scopeRoot, parentTarget) {
 				return true
 			}
-			current, currentTarget, ok = logicalParent(current, scopeRoot)
+			if c.Kind == combChild {
+				break
+			}
+			parent, parentTarget, ok = logicalParentTarget(parent, parentTarget, scopeRoot)
 		}
-		return false
 	case combAdjacent, combSibling:
-		parent, _, ok := logicalParent(node, scopeRoot)
-		if !ok {
+		siblings, idx := siblingsOf(node, target, scopeRoot)
+		if idx < 0 {
 			return false
 		}
-		// esquery's sibling combinators only consider list-position
-		// siblings — nodes sharing the same NodeList field on the
-		// parent. Two scalar children of the same parent (e.g.
-		// VariableDeclaration's `id` and `init`) are NOT siblings.
-		var siblings []*ast.Node
-		for _, list := range listChildrenOf(parent) {
-			for _, child := range list {
-				if unwrapEstreeNode(child) == node {
-					siblings = list
-					break
-				}
-			}
-			if siblings != nil {
-				break
-			}
-		}
-		if siblings == nil {
-			return false
-		}
-		idx := -1
-		for i, sib := range siblings {
-			if unwrapEstreeNode(sib) == node {
-				idx = i
-				break
-			}
-		}
-		if idx > 0 {
-			if c.Kind == combAdjacent && matchesNodeVariants(c.Left, unwrapEstreeNode(siblings[idx-1]), mc, scopeRoot) {
+		if idx > 0 && matchesInScopeTarget(c.Right, node, mc, scopeRoot, target) {
+			if c.Kind == combAdjacent && matchesInScopeTarget(c.Left, unwrapEstreeNode(siblings[idx-1]), mc, scopeRoot, childTarget(siblings[idx-1])) {
 				return true
 			}
 			if c.Kind == combSibling {
 				for i := idx - 1; i >= 0; i-- {
-					if matchesNodeVariants(c.Left, unwrapEstreeNode(siblings[i]), mc, scopeRoot) {
+					if matchesInScopeTarget(c.Left, unwrapEstreeNode(siblings[i]), mc, scopeRoot, childTarget(siblings[i])) {
 						return true
 					}
 				}
 			}
 		}
-
-		// These reverse-direction branches intentionally mirror esquery 1.7.0:
-		// sibling looks at a subject on the left, while adjacent looks at a
-		// subject on the right.
-		if c.Kind == combSibling && isSubjectSelector(c.Left) && matchesInScope(c.Left, node, mc, scopeRoot) {
+		// These reverse-direction branches mirror esquery 1.7.0's subject
+		// handling. Only nodes in the same ESTree array can be siblings.
+		if c.Kind == combSibling && isSubjectSelector(c.Left) && matchesInScopeTarget(c.Left, node, mc, scopeRoot, target) {
 			for i := idx + 1; i < len(siblings); i++ {
-				if matchesInScope(c.Right, unwrapEstreeNode(siblings[i]), mc, scopeRoot) {
+				if matchesInScopeTarget(c.Right, unwrapEstreeNode(siblings[i]), mc, scopeRoot, childTarget(siblings[i])) {
 					return true
 				}
 			}
 		}
-		if c.Kind == combAdjacent && isSubjectSelector(c.Right) && matchesInScope(c.Left, node, mc, scopeRoot) && idx+1 < len(siblings) {
-			return matchesInScope(c.Right, unwrapEstreeNode(siblings[idx+1]), mc, scopeRoot)
+		if c.Kind == combAdjacent && isSubjectSelector(c.Right) && matchesInScopeTarget(c.Left, node, mc, scopeRoot, target) && idx+1 < len(siblings) {
+			return matchesInScopeTarget(c.Right, unwrapEstreeNode(siblings[idx+1]), mc, scopeRoot, childTarget(siblings[idx+1]))
 		}
-		return false
 	}
 	return false
 }
@@ -735,7 +643,7 @@ func isFunctionValueNode(node *ast.Node) bool {
 	}
 	switch node.Kind {
 	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
-		return true
+		return node.Parent != nil && (isClassLikeNode(node.Parent) || node.Parent.Kind == ast.KindObjectLiteralExpression)
 	}
 	return false
 }
@@ -744,39 +652,57 @@ func isEnumDeclarationNode(node *ast.Node) bool {
 	return node != nil && node.Kind == ast.KindEnumDeclaration
 }
 
-func virtualTargets(node *ast.Node) []string {
-	if node == nil {
-		return nil
-	}
-	var targets []string
-	if isClassLikeNode(node) {
-		targets = append(targets, "ClassBody")
-	}
-	if isEnumDeclarationNode(node) {
-		targets = append(targets, "TSEnumBody")
-	}
-	if node.Kind == ast.KindJsxSelfClosingElement {
-		targets = append(targets, "JSXElement", "JSXOpeningElement")
-	}
-	if isEmptyJSXExpression(node) {
-		targets = append(targets, "JSXEmptyExpression")
-	}
-	if isFunctionValueNode(node) {
-		targets = append(targets, "FunctionExpression")
-	}
-	return targets
+func isChainRoot(node *ast.Node) bool {
+	// Only the receiver continues a chain. An optional chain in an argument
+	// or a computed key belongs to its own ChainExpression.
+	return node != nil && ast.IsOptionalChain(node) &&
+		(node.Parent == nil || !ast.IsOptionalChain(node.Parent) || node.Parent.Expression() != node)
 }
 
-func matchesNodeVariants(sel selector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node) bool {
-	if matchesInScope(sel, node, mc, scopeRoot) {
-		return true
+func childTarget(node *ast.Node) string {
+	if isChainRoot(unwrapEstreeNode(node)) {
+		return "ChainExpression"
 	}
-	for _, target := range virtualTargets(node) {
-		if matchesInScopeTarget(sel, node, mc, scopeRoot, target) {
-			return true
+	return "physical"
+}
+
+func estreeChildValue(node *ast.Node) interface{} {
+	if isChainRoot(node) {
+		return virtualNodeFacade{node, "ChainExpression"}
+	}
+	return node
+}
+
+func constructorKey(node *ast.Node, mc *matchContext) virtualNodeFacade {
+	if mc != nil && mc.sf != nil {
+		if token, ok := utils.TokenBeforePosition(mc.sf, node.ParameterList().Pos()-1); ok && token.Kind == ast.KindStringLiteral {
+			return virtualNodeFacade{node, "Literal"}
 		}
 	}
-	return false
+	return virtualNodeFacade{node, "Identifier"}
+}
+
+// virtualTarget identifies a folded wrapper. Constructor keys are separate
+// scalar facades; self-closing JSX uses the physical node for JSXElement.
+func virtualTarget(node *ast.Node) string {
+	switch {
+	case isChainRoot(node):
+		return "ChainExpression"
+	case isClassLikeNode(node):
+		return "ClassBody"
+	case isEnumDeclarationNode(node):
+		return "TSEnumBody"
+	case node.Kind == ast.KindJsxSelfClosingElement:
+		return "JSXOpeningElement"
+	case isEmptyJSXExpression(node):
+		return "JSXEmptyExpression"
+	case isFunctionValueNode(node):
+		if node.Body() == nil {
+			return "TSEmptyBodyFunctionExpression"
+		}
+		return "FunctionExpression"
+	}
+	return ""
 }
 
 // virtualParent returns the physical node and wrapper identity that is the
@@ -785,6 +711,12 @@ func matchesNodeVariants(sel selector, node *ast.Node, mc *matchContext, scopeRo
 // allocating synthetic AST nodes.
 func virtualParent(node *ast.Node, target string) (*ast.Node, string, bool) {
 	switch target {
+	case "ChainExpression":
+		return structuralParent(node)
+	case "Identifier", "Literal":
+		if node.Kind == ast.KindConstructor {
+			return node, "physical", true
+		}
 	case "ClassBody":
 		if isClassLikeNode(node) {
 			return node, "physical", true
@@ -797,17 +729,13 @@ func virtualParent(node *ast.Node, target string) (*ast.Node, string, bool) {
 		if isEmptyJSXExpression(node) {
 			return node, "physical", true
 		}
-	case "FunctionExpression":
+	case "FunctionExpression", "TSEmptyBodyFunctionExpression":
 		if isFunctionValueNode(node) {
 			return node, "physical", true
 		}
-	case "JSXElement":
-		if node.Kind == ast.KindJsxSelfClosingElement {
-			return estreeParent(node), "physical", true
-		}
 	case "JSXOpeningElement":
 		if node.Kind == ast.KindJsxSelfClosingElement {
-			return node, "JSXElement", true
+			return node, "physical", true
 		}
 	}
 	return nil, "", false
@@ -816,10 +744,20 @@ func virtualParent(node *ast.Node, target string) (*ast.Node, string, bool) {
 // logicalParent returns the parent edge in the ESTree graph. Most tsgo nodes
 // have a direct physical equivalent, but class members, enum members, and
 // method bodies pass through ESTree wrapper nodes that tsgo folds away.
-func logicalParent(node *ast.Node, scopeRoot *ast.Node) (*ast.Node, string, bool) {
-	if node == nil || node == scopeRoot {
+func logicalParentTarget(node *ast.Node, target string, scopeRoot *virtualNodeFacade) (*ast.Node, string, bool) {
+	if node == nil || scopeRoot != nil && node == scopeRoot.node && target == scopeRoot.typeName {
 		return nil, "", false
 	}
+	if target != "physical" && target != "" {
+		return virtualParent(node, target)
+	}
+	if isChainRoot(node) {
+		return node, "ChainExpression", true
+	}
+	return structuralParent(node)
+}
+
+func structuralParent(node *ast.Node) (*ast.Node, string, bool) {
 	parent := estreeParent(node)
 	if parent == nil {
 		return nil, "", false
@@ -831,7 +769,7 @@ func logicalParent(node *ast.Node, scopeRoot *ast.Node) (*ast.Node, string, bool
 		return parent, "TSEnumBody", true
 	}
 	if isFunctionValueNode(parent) && isFunctionValueChild(node, parent) {
-		return parent, "FunctionExpression", true
+		return parent, virtualTarget(parent), true
 	}
 	if parent.Kind == ast.KindJsxSelfClosingElement {
 		return parent, "JSXOpeningElement", true
@@ -846,11 +784,11 @@ func classMembers(node *ast.Node) []*ast.Node {
 	switch node.Kind {
 	case ast.KindClassDeclaration:
 		if members := node.AsClassDeclaration().Members; members != nil {
-			return members.Nodes
+			return utils.ESTreeMembers(members.Nodes)
 		}
 	case ast.KindClassExpression:
 		if members := node.AsClassExpression().Members; members != nil {
-			return members.Nodes
+			return utils.ESTreeMembers(members.Nodes)
 		}
 	}
 	return nil
@@ -879,11 +817,14 @@ func isFunctionValueChild(node, parent *ast.Node) bool {
 	if node == nil || parent == nil {
 		return false
 	}
+	if node == utils.ESTreeType(parent) || nodeInList(node, statements(parent.TypeParameterList())) {
+		return true
+	}
 	if body := parent.Body(); body != nil && node == body {
 		return true
 	}
-	for _, param := range utils.ESTreeParameters(parent) {
-		if unwrapEstreeNode(param) == node {
+	for _, param := range parent.Parameters() {
+		if param == node || unwrapEstreeNode(param) == node || isPlainParameter(param) && node == utils.ESTreeType(param) {
 			return true
 		}
 	}
@@ -971,7 +912,7 @@ func isEmptyJSXExpression(node *ast.Node) bool {
 	return node != nil && node.Kind == ast.KindJsxExpression && node.AsJsxExpression().DotDotDotToken == nil && node.AsJsxExpression().Expression == nil
 }
 
-func matchesPseudoTarget(p pseudoSelector, node *ast.Node, mc *matchContext, scopeRoot *ast.Node, target string) bool {
+func matchesPseudoTarget(p pseudoSelector, node *ast.Node, mc *matchContext, scopeRoot *virtualNodeFacade, target string) bool {
 	switch p.Name {
 	case "is", "matches":
 		for _, a := range p.Args {
@@ -1009,7 +950,7 @@ func matchesPseudoTarget(p pseudoSelector, node *ast.Node, mc *matchContext, sco
 	return false
 }
 
-func matchesNodeClassTarget(node *ast.Node, class string, scopeRoot *ast.Node, target string) bool {
+func matchesNodeClassTarget(node *ast.Node, class string, scopeRoot *virtualNodeFacade, target string) bool {
 	nodeType := estreeNameForKind(node)
 	if target != "" && target != "physical" {
 		nodeType = target
@@ -1022,7 +963,7 @@ func matchesNodeClassTarget(node *ast.Node, class string, scopeRoot *ast.Node, t
 	case "function":
 		return nodeType == "FunctionDeclaration" || nodeType == "FunctionExpression" || nodeType == "ArrowFunctionExpression"
 	case "expression", "pattern":
-		parent := matchingParent(node, scopeRoot)
+		parent, _, _ := logicalParentTarget(node, target, scopeRoot)
 		isExpression := strings.HasSuffix(nodeType, "Expression") ||
 			strings.HasSuffix(nodeType, "Literal") ||
 			nodeType == "MetaProperty" ||
@@ -1043,6 +984,7 @@ func hasMatching(node *ast.Node, sel selector, mc *matchContext, target string) 
 		matched := false
 		var visitDirect func(child *ast.Node, childTarget string) bool
 		visitDirect = func(child *ast.Node, childTarget string) bool {
+			child = unwrapEstreeNode(child)
 			if expression := utils.JSDocTypeCastExpression(child); expression != nil {
 				return visitDirect(expression, childTarget)
 			}
@@ -1050,16 +992,16 @@ func hasMatching(node *ast.Node, sel selector, mc *matchContext, target string) 
 				return false
 			}
 			if isTransparentEstreeContainer(child) {
-				forEachLogicalChild(child, childTarget, visitDirect)
+				forEachLogicalChild(child, childTarget, mc, visitDirect)
 				return matched
 			}
-			if matchesInScopeTarget(relative.Inner, child, mc, node, childTarget) {
+			if matchesInScopeTarget(relative.Inner, child, mc, &virtualNodeFacade{node, target}, childTarget) {
 				matched = true
 				return true
 			}
 			return false
 		}
-		forEachLogicalChild(node, target, visitDirect)
+		forEachLogicalChild(node, target, mc, visitDirect)
 		return matched
 	}
 	return hasDescendantMatching(node, sel, mc, target)
@@ -1069,6 +1011,7 @@ func hasDescendantMatching(node *ast.Node, sel selector, mc *matchContext, targe
 	found := false
 	var visit func(n *ast.Node, currentTarget string) bool
 	visit = func(n *ast.Node, currentTarget string) bool {
+		n = unwrapEstreeNode(n)
 		if found {
 			return true
 		}
@@ -1079,28 +1022,33 @@ func hasDescendantMatching(node *ast.Node, sel selector, mc *matchContext, targe
 			return false
 		}
 		if !isTransparentEstreeContainer(n) {
-			if matchesInScopeTarget(sel, n, mc, node, currentTarget) {
+			if matchesInScopeTarget(sel, n, mc, &virtualNodeFacade{node, target}, currentTarget) {
 				found = true
 				return true
 			}
 		}
-		forEachLogicalChild(n, currentTarget, visit)
+		forEachLogicalChild(n, currentTarget, mc, visit)
 		return found
 	}
 	visit(node, target)
 	return found
 }
 
-func forEachLogicalChild(node *ast.Node, target string, visit func(*ast.Node, string) bool) {
+func forEachLogicalChild(node *ast.Node, target string, mc *matchContext, visit func(*ast.Node, string) bool) {
 	if node == nil {
 		return
 	}
-	visitPhysicalChildren := func(skip func(*ast.Node) bool) {
-		node.ForEachChild(func(child *ast.Node) bool {
+	visitPhysicalChildren := func(skip func(*ast.Node) bool) bool {
+		return node.ForEachChild(func(child *ast.Node) bool {
+			// ForEachChild includes operator/modifier tokens and EOF. Only
+			// token kinds already exposed by the rule have an ESTree identity.
+			if ast.IsToken(child) && !slices.Contains(allInterestingKinds, child.Kind) {
+				return false
+			}
 			if skip != nil && skip(child) {
 				return false
 			}
-			return visit(child, "physical")
+			return visit(child, childTarget(child))
 		})
 	}
 	switch target {
@@ -1118,7 +1066,15 @@ func forEachLogicalChild(node *ast.Node, target string, visit func(*ast.Node, st
 			}
 		}
 		return
-	case "FunctionExpression":
+	case "FunctionExpression", "TSEmptyBodyFunctionExpression":
+		for _, child := range utils.ESTreeTypeParameters(node) {
+			if visit(child, "physical") {
+				return
+			}
+		}
+		if t := utils.ESTreeType(node); t != nil && visit(t, "physical") {
+			return
+		}
 		for _, child := range utils.ESTreeParameters(node) {
 			if visit(child, "physical") {
 				return
@@ -1128,36 +1084,47 @@ func forEachLogicalChild(node *ast.Node, target string, visit func(*ast.Node, st
 			visit(body, "physical")
 		}
 		return
-	case "JSXElement":
-		if node.Kind == ast.KindJsxSelfClosingElement {
-			visit(node, "JSXOpeningElement")
-			return
-		}
 	case "JSXOpeningElement":
 		if node.Kind == ast.KindJsxSelfClosingElement {
 			visitPhysicalChildren(nil)
 		}
 		return
-	case "JSXEmptyExpression":
+	case "ChainExpression":
+		visit(node, "physical")
+		return
+	case "JSXEmptyExpression", "Identifier", "Literal":
 		return
 	}
 
 	switch {
 	case isClassLikeNode(node):
-		visitPhysicalChildren(func(child *ast.Node) bool {
+		if visitPhysicalChildren(func(child *ast.Node) bool {
 			return nodeInList(child, classMembers(node))
-		})
+		}) {
+			return
+		}
 		visit(node, "ClassBody")
 	case isEnumDeclarationNode(node):
-		visitPhysicalChildren(func(child *ast.Node) bool {
+		if visitPhysicalChildren(func(child *ast.Node) bool {
 			return nodeInList(child, enumMembers(node))
-		})
+		}) {
+			return
+		}
 		visit(node, "TSEnumBody")
 	case isFunctionValueNode(node):
-		visitPhysicalChildren(func(child *ast.Node) bool {
+		if node.Kind == ast.KindConstructor && visit(node, constructorKey(node, mc).typeName) {
+			return
+		}
+		if visitPhysicalChildren(func(child *ast.Node) bool {
 			return isFunctionValueChild(child, node)
-		})
-		visit(node, "FunctionExpression")
+		}) {
+			return
+		}
+		visit(node, virtualTarget(node))
+	case node.Kind == ast.KindIdentifier && isPlainParameter(node.Parent) && node.Parent.Name() == node:
+		if t := utils.ESTreeType(node.Parent); t != nil {
+			visit(t, "physical")
+		}
 	case node.Kind == ast.KindJsxSelfClosingElement:
 		visit(node, "JSXOpeningElement")
 	case isEmptyJSXExpression(node):
@@ -1167,17 +1134,41 @@ func forEachLogicalChild(node *ast.Node, target string, visit func(*ast.Node, st
 	}
 }
 
-func nodeIsAtFieldPath(node, ancestor *ast.Node, path []string) bool {
-	ancestor = unwrapEstreeNode(ancestor)
-	if len(path) == 0 {
-		return unwrapEstreeNode(node) == ancestor
+// targetValue shares the attribute facade with structural field matching.
+func targetValue(node *ast.Node, target string) interface{} {
+	if target == "physical" || target == "" {
+		return node
 	}
-	for _, child := range nodesAtField(ancestor, path[0]) {
-		if nodeIsAtFieldPath(node, unwrapEstreeNode(child), path[1:]) {
-			return true
+	return virtualNodeFacade{node, target}
+}
+
+func nodeIsAtFieldPath(node *ast.Node, target string, current interface{}, path []string, mc *matchContext) bool {
+	if nodes, ok := current.([]*ast.Node); ok {
+		for _, child := range nodes {
+			if nodeIsAtFieldPath(node, target, estreeChildValue(unwrapEstreeNode(child)), path, mc) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(path) == 0 {
+		switch value := current.(type) {
+		case *ast.Node:
+			return target == "physical" && node == unwrapEstreeNode(value)
+		case virtualNodeFacade:
+			return node == value.node && target == value.typeName
+		}
+		return false
+	}
+	next, ok := stepAttrPath(current, path[0], mc)
+	if !ok {
+		if physical, isNode := current.(*ast.Node); isNode && physical != nil {
+			next = nodesAtField(physical, path[0])
+		} else {
+			return false
 		}
 	}
-	return false
+	return nodeIsAtFieldPath(node, target, next, path[1:], mc)
 }
 
 // lookupAttrPath walks `path` against `node` to fetch a comparable value.
@@ -1202,10 +1193,15 @@ func stepAttrPath(current interface{}, segment string, mc *matchContext) (interf
 		return nil, true
 	}
 	if n, ok := current.(*ast.Node); ok {
+		n = unwrapEstreeNode(n)
 		if n == nil {
 			return nil, true
 		}
-		return readNodeAttr(n, segment, mc)
+		value, found := readNodeAttr(n, segment, mc)
+		if child, ok := value.(*ast.Node); ok && child != n && segment != "parent" {
+			return estreeChildValue(child), found
+		}
+		return value, found
 	}
 	if rf, ok := current.(regexFacade); ok {
 		switch segment {
@@ -1232,66 +1228,38 @@ func stepAttrPath(current interface{}, segment string, mc *matchContext) (interf
 		case "type":
 			return vn.typeName, true
 		case "parent":
-			switch vn.typeName {
-			case "ClassBody", "TSEnumBody", "FunctionExpression":
-				return vn.node, true
-			case "JSXEmptyExpression":
-				return virtualNodeFacade{node: vn.node, typeName: "JSXExpressionContainer"}, true
-			case "JSXOpeningElement":
-				return virtualNodeFacade{node: vn.node, typeName: "JSXElement"}, true
-			case "JSXExpressionContainer", "JSXElement", "JSXMemberExpression", "JSXIdentifier":
-				return estreeParentValue(vn.node), true
-			default:
-				return estreeParent(vn.node), true
+			parent, target, ok := logicalParentTarget(vn.node, vn.typeName, nil)
+			if !ok {
+				return nil, true
 			}
-		case "expression":
-			if vn.typeName == "JSXExpressionContainer" {
-				return unwrapExpression(vn.node.AsJsxExpression().Expression), true
-			}
+			return targetValue(parent, target), true
 		}
 		return readVirtualNodeAttr(vn, segment, mc)
-	}
-	if fv, ok := current.(functionValueFacade); ok {
-		switch segment {
-		case "type":
-			return "FunctionExpression", true
-		case "id":
-			return nil, true
-		case "parent":
-			return fv.node, true
-		case "body":
-			return fv.node.Body(), true
-		case "params":
-			return utils.ESTreeParameters(fv.node), true
-		case "async":
-			return ast.IsAsyncFunction(fv.node), true
-		case "generator":
-			return methodValueIsGenerator(fv.node), true
-		case "expression":
-			return false, true
-		}
-		return nil, false
 	}
 	// Primitive interpretations: support `.length` on strings / slices.
 	if segment == "length" {
 		switch v := current.(type) {
 		case string:
-			return float64(len([]rune(v))), true
+			return float64(ecmascript.StringCodeUnitCount(v)), true
 		case []*ast.Node:
 			return float64(len(v)), true
 		}
 	}
 	if nodes, ok := current.([]*ast.Node); ok {
 		index, err := strconv.Atoi(segment)
-		if err != nil || index < 0 || index >= len(nodes) {
+		if err != nil || index < 0 || index >= len(nodes) || strconv.Itoa(index) != segment {
 			return nil, false
 		}
-		return nodes[index], true
+		return estreeChildValue(unwrapEstreeNode(nodes[index])), true
 	}
 	return nil, false
 }
 
 type undefinedAttr struct{}
+
+// Keep BigInt distinct from string for typeof and regexp selectors. Its
+// canonical decimal text is also the value esquery uses for string equality.
+type bigintAttr string
 
 func compareStringAttr(left string, op attrOp, right attrValue) bool {
 	equal := attrStringEquals(left, right)
@@ -1334,19 +1302,42 @@ func compareAttr(left interface{}, op attrOp, right attrValue) bool {
 }
 
 func compareRelationalAttr(left interface{}, right attrValue) (int, bool) {
+	if value, ok := left.(bigintAttr); ok {
+		leftInt, valid := ecmascript.StringToBigInt(string(value))
+		if !valid {
+			return 0, false
+		}
+		if right.Kind == attrValueString || right.Kind == attrValueIdent {
+			text := right.Str
+			if right.Kind == attrValueIdent {
+				text = right.Ident
+			}
+			rightInt, valid := ecmascript.StringToBigInt(text)
+			if !valid {
+				return 0, false
+			}
+			return leftInt.Cmp(rightInt), true
+		}
+		if right.Kind != attrValueNumber || math.IsNaN(right.Num) {
+			return 0, false
+		}
+		// SetInt chooses enough precision to preserve every BigInt bit; the
+		// other operand is already an IEEE 754 number in esquery's AST.
+		return new(big.Float).SetInt(leftInt).Cmp(new(big.Float).SetFloat64(right.Num)), true
+	}
 	leftText, leftIsString, leftNumber, leftOK := leftRelationalPrimitive(left)
 	rightText, rightIsString, rightNumber, rightOK := rightRelationalPrimitive(right)
 	if !leftOK || !rightOK {
 		return 0, false
 	}
 	if leftIsString && rightIsString {
-		return compareJSStrings(leftText, rightText), true
+		return ecmascript.CompareStrings(leftText, rightText), true
 	}
 	if leftIsString {
-		leftNumber, leftOK = jsStringToNumber(leftText)
+		leftNumber, leftOK = ecmascript.StringToNumber(leftText)
 	}
 	if rightIsString {
-		rightNumber, rightOK = jsStringToNumber(rightText)
+		rightNumber, rightOK = ecmascript.StringToNumber(rightText)
 	}
 	if !leftOK || !rightOK || math.IsNaN(leftNumber) || math.IsNaN(rightNumber) {
 		return 0, false
@@ -1383,7 +1374,7 @@ func leftRelationalPrimitive(value interface{}) (text string, isString bool, num
 			return "", false, 0, true
 		}
 		return attrAsString(typed), true, 0, true
-	case []*ast.Node, regexFacade, metaIdentifier, functionValueFacade:
+	case []*ast.Node, regexFacade, metaIdentifier, virtualNodeFacade:
 		return attrAsString(typed), true, 0, true
 	default:
 		return "", false, 0, false
@@ -1401,70 +1392,6 @@ func rightRelationalPrimitive(value attrValue) (text string, isString bool, numb
 	default:
 		return "", false, 0, false
 	}
-}
-
-func jsStringToNumber(value string) (float64, bool) {
-	value = ecmascript.StringTrim(value)
-	if value == "" {
-		return 0, true
-	}
-	switch value {
-	case "Infinity", "+Infinity":
-		return math.Inf(1), true
-	case "-Infinity":
-		return math.Inf(-1), true
-	}
-	if len(value) > 2 && value[0] == '0' {
-		base := 0
-		switch value[1] {
-		case 'x', 'X':
-			base = 16
-		case 'b', 'B':
-			base = 2
-		case 'o', 'O':
-			base = 8
-		}
-		if base != 0 {
-			parsed, err := strconv.ParseUint(value[2:], base, 64)
-			return float64(parsed), err == nil
-		}
-	}
-	parsed, err := strconv.ParseFloat(value, 64)
-	return parsed, err == nil && !math.IsNaN(parsed)
-}
-
-func compareJSStrings(left, right string) int {
-	if isASCII(left) && isASCII(right) {
-		return strings.Compare(left, right)
-	}
-	leftUnits := utf16.Encode([]rune(left))
-	rightUnits := utf16.Encode([]rune(right))
-	limit := min(len(leftUnits), len(rightUnits))
-	for index := range limit {
-		if leftUnits[index] < rightUnits[index] {
-			return -1
-		}
-		if leftUnits[index] > rightUnits[index] {
-			return 1
-		}
-	}
-	switch {
-	case len(leftUnits) < len(rightUnits):
-		return -1
-	case len(leftUnits) > len(rightUnits):
-		return 1
-	default:
-		return 0
-	}
-}
-
-func isASCII(value string) bool {
-	for index := range len(value) {
-		if value[index] >= utf8.RuneSelf {
-			return false
-		}
-	}
-	return true
 }
 
 func attrEquals(left interface{}, right attrValue) bool {
@@ -1510,17 +1437,15 @@ func attrAsString(v interface{}) string {
 	switch x := v.(type) {
 	case string:
 		return x
+	case bigintAttr:
+		return string(x)
 	case bool:
 		if x {
 			return "true"
 		}
 		return "false"
 	case float64:
-		// Match JavaScript's "1" not "1.0" formatting.
-		if x == float64(int64(x)) {
-			return strconv.FormatInt(int64(x), 10)
-		}
-		return strconv.FormatFloat(x, 'g', -1, 64)
+		return ecmascript.NumberToString(x)
 	case int:
 		return strconv.Itoa(x)
 	case nil:
@@ -1547,7 +1472,7 @@ func attrAsString(v interface{}) string {
 			}
 		}
 		return text.String()
-	case regexFacade, metaIdentifier, functionValueFacade:
+	case regexFacade, metaIdentifier, virtualNodeFacade:
 		return "[object Object]"
 	}
 	return ""
@@ -1557,6 +1482,8 @@ func attrTypeOf(v interface{}) string {
 	switch v.(type) {
 	case undefinedAttr:
 		return "undefined"
+	case bigintAttr:
+		return "bigint"
 	case string:
 		return "string"
 	case bool:
@@ -1568,31 +1495,39 @@ func attrTypeOf(v interface{}) string {
 	}
 }
 
-func nodeIndexInListFieldTarget(node *ast.Node, scopeRoot *ast.Node, target string) (int, int) {
-	parent, parentTarget, ok := logicalParent(node, scopeRoot)
-	if target != "" && target != "physical" {
-		parent, parentTarget, ok = virtualParent(node, target)
+func nodeIndexInListFieldTarget(node *ast.Node, scopeRoot *virtualNodeFacade, target string) (int, int) {
+	siblings, index := siblingsOf(node, target, scopeRoot)
+	return index, len(siblings)
+}
+
+func siblingsOf(node *ast.Node, target string, scopeRoot *virtualNodeFacade) ([]*ast.Node, int) {
+	// All folded children occupy scalar fields, never a sibling array.
+	if target != "physical" && target != "ChainExpression" || target == "physical" && isChainRoot(node) {
+		return nil, -1
 	}
-	if !ok || parent == nil {
-		return -1, 0
+	parent, parentTarget, ok := logicalParentTarget(node, target, scopeRoot)
+	if !ok {
+		return nil, -1
 	}
-	if parentTarget == "ClassBody" {
-		return indexInNodeList(node, classMembers(parent))
+	var lists [][]*ast.Node
+	switch parentTarget {
+	case "ClassBody":
+		lists = [][]*ast.Node{classMembers(parent)}
+	case "TSEnumBody":
+		lists = [][]*ast.Node{enumMembers(parent)}
+	case "FunctionExpression", "TSEmptyBodyFunctionExpression":
+		lists = [][]*ast.Node{utils.ESTreeParameters(parent)}
+	case "JSXOpeningElement":
+		lists = listChildrenOf(parent)
+	case "physical":
+		lists = listChildrenOf(parent)
 	}
-	if parentTarget == "TSEnumBody" {
-		return indexInNodeList(node, enumMembers(parent))
-	}
-	if parentTarget != "physical" {
-		return -1, 0
-	}
-	for _, list := range listChildrenOf(parent) {
-		for i, child := range list {
-			if unwrapEstreeNode(child) == node {
-				return i, len(list)
-			}
+	for _, list := range lists {
+		if index, _ := indexInNodeList(node, list); index >= 0 {
+			return list, index
 		}
 	}
-	return -1, 0
+	return nil, -1
 }
 
 func indexInNodeList(node *ast.Node, list []*ast.Node) (int, int) {
@@ -1664,42 +1599,33 @@ func selectorMatchesVirtualExportDefault(sel selector) bool {
 // like `MemberExpression[object.name='console']` would silently miss
 // `(console).log`, `(console as any).log`, `console!.log`.
 func unwrapExpression(node *ast.Node) *ast.Node {
-	if node == nil {
-		return nil
-	}
-	for {
-		switch node.Kind {
-		case ast.KindParenthesizedExpression:
-			node = node.AsParenthesizedExpression().Expression
-		case ast.KindAsExpression:
-			node = node.AsAsExpression().Expression
-		case ast.KindSatisfiesExpression:
-			node = node.AsSatisfiesExpression().Expression
-		case ast.KindNonNullExpression:
-			node = node.AsNonNullExpression().Expression
-		case ast.KindTypeAssertionExpression:
-			node = node.AsTypeAssertion().Expression
-		default:
-			return node
-		}
-		if node == nil {
-			return nil
-		}
-	}
+	return utils.SkipAssertionsAndParens(node)
 }
 
 func unwrapEstreeNode(node *ast.Node) *ast.Node {
 	for node != nil {
-		if expression := utils.JSDocTypeCastExpression(node); expression != nil {
-			node = expression
+		node = utils.ESTreeRuntimeExpression(node)
+		if node == nil {
+			return nil
+		}
+		if isPlainParameter(node) {
+			node = node.Name()
 			continue
 		}
-		if node.Kind != ast.KindParenthesizedExpression {
-			break
+		if node.Kind == ast.KindComputedPropertyName {
+			node = node.AsComputedPropertyName().Expression
+			continue
 		}
-		node = node.AsParenthesizedExpression().Expression
+		return node
 	}
-	return node
+	return nil
+}
+
+func isPlainParameter(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindParameter &&
+		node.AsParameterDeclaration().Initializer == nil &&
+		node.AsParameterDeclaration().DotDotDotToken == nil &&
+		!ast.HasSyntacticModifier(node, ast.ModifierFlagsParameterPropertyModifier)
 }
 
 func isTransparentEstreeContainer(node *ast.Node) bool {
@@ -1707,8 +1633,11 @@ func isTransparentEstreeContainer(node *ast.Node) bool {
 		return false
 	}
 	switch node.Kind {
-	case ast.KindParenthesizedExpression, ast.KindImportAttributes:
+	case ast.KindParenthesizedExpression, ast.KindComputedPropertyName, ast.KindSemicolonClassElement,
+		ast.KindImportAttributes, ast.KindJsxAttributes, ast.KindHeritageClause, ast.KindExpressionWithTypeArguments:
 		return true
+	case ast.KindBlock:
+		return node.Parent != nil && node.Parent.Kind == ast.KindClassStaticBlockDeclaration
 	case ast.KindVariableDeclarationList:
 		return node.Parent != nil && node.Parent.Kind == ast.KindVariableStatement
 	}
@@ -1716,63 +1645,19 @@ func isTransparentEstreeContainer(node *ast.Node) bool {
 }
 
 func estreeParent(node *ast.Node) *ast.Node {
-	if node == nil {
-		return nil
-	}
-	parent := node.Parent
-	for parent != nil {
-		if utils.IsJSDocTypeCastWrapper(parent) {
-			parent = parent.Parent
-			continue
-		}
-		switch parent.Kind {
-		case ast.KindParenthesizedExpression, ast.KindImportAttributes:
-			// These are tsgo parser nodes without corresponding ESTree nodes.
-			parent = parent.Parent
-		case ast.KindVariableDeclarationList:
-			// A list under VariableStatement is a tsgo-only container. In a
-			// for-loop initializer, the list itself is ESTree's
-			// VariableDeclaration and must remain in the ancestry.
-			if parent.Parent != nil && parent.Parent.Kind == ast.KindVariableStatement {
-				parent = parent.Parent
-				continue
-			}
-			return parent
-		default:
-			return parent
-		}
+	parent := utils.ESTreeParent(node)
+	for parent != nil && (isTransparentEstreeContainer(parent) || isPlainParameter(parent)) {
+		parent = utils.ESTreeParent(parent)
 	}
 	return parent
 }
 
 func estreeParentValue(node *ast.Node) interface{} {
-	parent := estreeParent(node)
-	if parent == nil {
+	parent, target, ok := logicalParentTarget(node, "physical", nil)
+	if !ok {
 		return nil
 	}
-	if isClassLikeNode(parent) && nodeInList(node, classMembers(parent)) {
-		return virtualNodeFacade{node: parent, typeName: "ClassBody"}
-	}
-	if isEnumDeclarationNode(parent) && nodeInList(node, enumMembers(parent)) {
-		return virtualNodeFacade{node: parent, typeName: "TSEnumBody"}
-	}
-	if isFunctionValueNode(parent) && isFunctionValueChild(node, parent) {
-		return functionValueFacade{node: parent}
-	}
-	if parent.Kind == ast.KindJsxSelfClosingElement {
-		return virtualNodeFacade{node: parent, typeName: "JSXOpeningElement"}
-	}
-	if isJSXMemberExpression(parent) {
-		return jsxFacade(parent)
-	}
-	return parent
-}
-
-func matchingParent(node *ast.Node, scopeRoot *ast.Node) *ast.Node {
-	if node == nil || scopeRoot == node {
-		return nil
-	}
-	return estreeParent(node)
+	return targetValue(parent, target)
 }
 
 // readNodeAttr extracts the named ESTree-style attribute from a tsgo node.
@@ -1852,7 +1737,7 @@ func readNodeAttr(node *ast.Node, name string, mc *matchContext) (interface{}, b
 	case "id":
 		return readIdAttr(node)
 	case "key":
-		return readKeyAttr(node)
+		return readKeyAttr(node, mc)
 	case "left":
 		return readLeftAttr(node)
 	case "right":
@@ -1879,6 +1764,11 @@ func readNodeAttr(node *ast.Node, name string, mc *matchContext) (interface{}, b
 		return readGeneratorAttr(node)
 	case "specifiers":
 		return readSpecifiersAttr(node)
+	case "selfClosing":
+		if node.Kind == ast.KindJsxOpeningElement {
+			return false, true
+		}
+		return nil, false
 	case "openingElement":
 		return readOpeningElementAttr(node)
 	case "closingElement":
@@ -1908,6 +1798,9 @@ func readNodeAttr(node *ast.Node, name string, mc *matchContext) (interface{}, b
 }
 
 func readOpeningElementAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindJsxSelfClosingElement {
+		return virtualNodeFacade{node, "JSXOpeningElement"}, true
+	}
 	if node.Kind == ast.KindJsxElement {
 		return node.AsJsxElement().OpeningElement, true
 	}
@@ -1915,6 +1808,9 @@ func readOpeningElementAttr(node *ast.Node) (interface{}, bool) {
 }
 
 func readClosingElementAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindJsxSelfClosingElement {
+		return nil, true
+	}
 	if node.Kind == ast.KindJsxElement {
 		return node.AsJsxElement().ClosingElement, true
 	}
@@ -1924,9 +1820,7 @@ func readClosingElementAttr(node *ast.Node) (interface{}, bool) {
 func readAttributesAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
 	case ast.KindJsxOpeningElement:
-		return node.AsJsxOpeningElement().Attributes, true
-	case ast.KindJsxSelfClosingElement:
-		return node.AsJsxSelfClosingElement().Attributes, true
+		return statements(node.AsJsxOpeningElement().Attributes.AsJsxAttributes().Properties), true
 	case ast.KindImportDeclaration:
 		return importAttributes(node.AsImportDeclaration().Attributes), true
 	case ast.KindExportDeclaration:
@@ -1943,6 +1837,9 @@ func importAttributes(node *ast.Node) []*ast.Node {
 }
 
 func readChildrenAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindJsxSelfClosingElement {
+		return []*ast.Node{}, true
+	}
 	if node.Kind == ast.KindJsxElement {
 		c := node.AsJsxElement().Children
 		if c == nil {
@@ -1953,9 +1850,7 @@ func readChildrenAttr(node *ast.Node) (interface{}, bool) {
 	return nil, false
 }
 
-// readTagNameAttr returns the JSX tag-name node — esquery exposes this as
-// `name` on JSXOpeningElement / JSXSelfClosingElement, but ESLint also
-// understands `tagName` for direct compatibility with TSGo-style ASTs.
+// readTagNameAttr retains rslint's tsgo-style alias for JSX tag names.
 func readTagNameAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
 	case ast.KindJsxOpeningElement:
@@ -2066,6 +1961,12 @@ func readQuasiAttr(node *ast.Node) (interface{}, bool) {
 // can be unambiguously chosen. If multiple ESTree names map to the same
 // kind, the canonical one is returned.
 func estreeNameForKind(node *ast.Node) string {
+	if isJSXIdentifier(node) {
+		return "JSXIdentifier"
+	}
+	if isJSXMemberExpression(node) {
+		return "JSXMemberExpression"
+	}
 	switch node.Kind {
 	case ast.KindIdentifier:
 		return "Identifier"
@@ -2139,12 +2040,15 @@ func estreeNameForKind(node *ast.Node) string {
 		if node.Parent != nil {
 			switch node.Parent.Kind {
 			case ast.KindClassDeclaration, ast.KindClassExpression:
+				if ast.HasSyntacticModifier(node, ast.ModifierFlagsAbstract) {
+					return "TSAbstractMethodDefinition"
+				}
 				return "MethodDefinition"
 			case ast.KindObjectLiteralExpression:
 				return "Property"
 			}
 		}
-		return "Property"
+		return "TSMethodSignature"
 	case ast.KindImportDeclaration:
 		return "ImportDeclaration"
 	case ast.KindClassDeclaration:
@@ -2173,8 +2077,16 @@ func estreeNameForKind(node *ast.Node) string {
 		// ESTree drops parens, so a node walking via `type` ought to see
 		// the inner expression's type instead.
 		return estreeNameForKind(unwrapExpression(node))
-	case ast.KindAsExpression, ast.KindSatisfiesExpression, ast.KindNonNullExpression, ast.KindTypeAssertionExpression:
-		return estreeNameForKind(unwrapExpression(node))
+	case ast.KindAsExpression:
+		return "TSAsExpression"
+	case ast.KindSatisfiesExpression:
+		return "TSSatisfiesExpression"
+	case ast.KindNonNullExpression:
+		return "TSNonNullExpression"
+	case ast.KindTypeAssertionExpression:
+		return "TSTypeAssertion"
+	case ast.KindDecorator:
+		return "Decorator"
 	case ast.KindThisKeyword:
 		return "ThisExpression"
 	case ast.KindSuperKeyword:
@@ -2224,6 +2136,9 @@ func estreeNameForKind(node *ast.Node) string {
 	case ast.KindJsxClosingElement:
 		return "JSXClosingElement"
 	case ast.KindJsxExpression:
+		if node.AsJsxExpression().DotDotDotToken != nil {
+			return "JSXSpreadChild"
+		}
 		return "JSXExpressionContainer"
 	case ast.KindMetaProperty:
 		return "MetaProperty"
@@ -2252,13 +2167,11 @@ func readNameAttr(node *ast.Node) (interface{}, bool) {
 	case ast.KindIdentifier:
 		return node.AsIdentifier().Text, true
 	case ast.KindPrivateIdentifier:
-		return node.AsPrivateIdentifier().Text, true
+		return strings.TrimPrefix(node.AsPrivateIdentifier().Text, "#"), true
 	// JSX: ESTree calls the tag identifier `name`; tsgo stores it as
 	// TagName. Also expose it through this attribute path.
 	case ast.KindJsxOpeningElement:
 		return node.AsJsxOpeningElement().TagName, true
-	case ast.KindJsxSelfClosingElement:
-		return node.AsJsxSelfClosingElement().TagName, true
 	case ast.KindJsxClosingElement:
 		return node.AsJsxClosingElement().TagName, true
 	case ast.KindJsxAttribute:
@@ -2281,7 +2194,7 @@ func readValueAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
 		}
 		return text, true
 	case ast.KindBigIntLiteral:
-		return utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text), true
+		return bigintAttr(utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text)), true
 	case ast.KindNoSubstitutionTemplateLiteral:
 		return node.AsNoSubstitutionTemplateLiteral().Text, true
 	case ast.KindTrueKeyword:
@@ -2301,7 +2214,12 @@ func readValueAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
 	// ESTree stores a class method's function fields under
 	// MethodDefinition.value, while tsgo puts them directly on the method.
 	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
-		return functionValueFacade{node: node}, true
+		if !isFunctionValueNode(node) {
+			return nil, false
+		}
+		return virtualNodeFacade{node: node, typeName: virtualTarget(node)}, true
+	case ast.KindJsxAttribute:
+		return node.AsJsxAttribute().Initializer, true
 	case ast.KindImportAttribute:
 		return unwrapExpression(node.AsImportAttribute().Value), true
 	}
@@ -2799,7 +2717,7 @@ func regexLiteralText(node *ast.Node, mc *matchContext) string {
 }
 
 func readParamsAttr(node *ast.Node) (interface{}, bool) {
-	if !isFunctionLikeForParams(node) {
+	if !isFunctionLikeForParams(node) || isFunctionValueNode(node) {
 		return nil, false
 	}
 	params := utils.ESTreeParameters(node)
@@ -2868,25 +2786,26 @@ func readArgumentsAttr(node *ast.Node) (interface{}, bool) {
 func readExpressionAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
 	case ast.KindDecorator:
-		return unwrapExpression(node.AsDecorator().Expression), true
+		return unwrapEstreeNode(node.AsDecorator().Expression), true
 	case ast.KindExpressionStatement:
-		return unwrapExpression(node.AsExpressionStatement().Expression), true
-	case ast.KindParenthesizedExpression:
-		return unwrapExpression(node.AsParenthesizedExpression().Expression), true
-	case ast.KindAwaitExpression:
-		return unwrapExpression(node.AsAwaitExpression().Expression), true
-	case ast.KindYieldExpression:
-		return unwrapExpression(node.AsYieldExpression().Expression), true
-	case ast.KindReturnStatement:
-		return unwrapExpression(node.AsReturnStatement().Expression), true
-	case ast.KindThrowStatement:
-		return unwrapExpression(node.AsThrowStatement().Expression), true
-	case ast.KindCallExpression:
-		return unwrapExpression(node.AsCallExpression().Expression), true
-	case ast.KindNewExpression:
-		return unwrapExpression(node.AsNewExpression().Expression), true
+		return unwrapEstreeNode(node.AsExpressionStatement().Expression), true
+	case ast.KindAsExpression:
+		return unwrapEstreeNode(node.AsAsExpression().Expression), true
+	case ast.KindSatisfiesExpression:
+		return unwrapEstreeNode(node.AsSatisfiesExpression().Expression), true
+	case ast.KindNonNullExpression:
+		return unwrapEstreeNode(node.AsNonNullExpression().Expression), true
+	case ast.KindTypeAssertionExpression:
+		return unwrapEstreeNode(node.AsTypeAssertion().Expression), true
+	case ast.KindArrowFunction:
+		return node.Body() != nil && node.Body().Kind != ast.KindBlock, true
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression:
+		return false, true
 	case ast.KindJsxExpression:
-		return unwrapExpression(node.AsJsxExpression().Expression), true
+		if isEmptyJSXExpression(node) {
+			return virtualNodeFacade{node, "JSXEmptyExpression"}, true
+		}
+		return unwrapEstreeNode(node.AsJsxExpression().Expression), true
 	}
 	return nil, false
 }
@@ -2899,28 +2818,32 @@ type virtualNodeFacade struct {
 	typeName string
 }
 
-func jsxFacade(node *ast.Node) interface{} {
-	if node == nil {
-		return nil
-	}
-	if isJSXMemberExpression(node) {
-		return virtualNodeFacade{node: node, typeName: "JSXMemberExpression"}
-	}
-	if isJSXIdentifier(node) {
-		return virtualNodeFacade{node: node, typeName: "JSXIdentifier"}
-	}
-	return node
-}
-
 func readVirtualNodeAttr(facade virtualNodeFacade, name string, mc *matchContext) (interface{}, bool) {
 	node := facade.node
 	if node == nil {
 		return nil, false
 	}
 	switch facade.typeName {
+	case "ChainExpression":
+		if name == "expression" {
+			return node, true
+		}
+	case "Literal":
+		if node.Kind == ast.KindConstructor && name == "value" {
+			return "constructor", true
+		}
+		if node.Kind == ast.KindConstructor && name == "raw" && mc != nil && mc.sf != nil {
+			if token, ok := utils.TokenBeforePosition(mc.sf, node.ParameterList().Pos()-1); ok {
+				return token.Text, true
+			}
+		}
+	case "Identifier":
+		if node.Kind == ast.KindConstructor && name == "name" {
+			return "constructor", true
+		}
 	case "ClassBody":
 		if name == "body" {
-			return readBodyAttr(node)
+			return classMembers(node), true
 		}
 		if name == "type" || name == "parent" {
 			return nil, false
@@ -2940,43 +2863,12 @@ func readVirtualNodeAttr(facade virtualNodeFacade, name string, mc *matchContext
 		if name == "type" || name == "parent" {
 			return nil, false
 		}
-	case "JSXExpressionContainer":
-		if name == "expression" {
-			return unwrapExpression(node.AsJsxExpression().Expression), true
-		}
-		if name == "type" || name == "parent" {
-			return nil, false
-		}
-	case "JSXMemberExpression":
-		if name == "object" {
-			return readObjectAttr(node)
-		}
-		if name == "property" {
-			return readPropertyAttr(node)
-		}
-		if name == "type" || name == "parent" {
-			return nil, false
-		}
-	case "JSXIdentifier":
-		if name == "name" {
-			return readNameAttr(node)
-		}
-		if name == "type" || name == "parent" {
-			return nil, false
-		}
-	case "JSXElement":
-		if name == "openingElement" {
-			return virtualNodeFacade{node: node, typeName: "JSXOpeningElement"}, true
-		}
-		if name == "children" {
-			return []*ast.Node{}, true
-		}
-		if name == "closingElement" || name == "type" || name == "parent" {
-			return nil, true
-		}
 	case "JSXOpeningElement":
+		if name == "selfClosing" {
+			return true, true
+		}
 		if name == "name" || name == "tagName" {
-			return jsxFacade(node.AsJsxSelfClosingElement().TagName), true
+			return node.AsJsxSelfClosingElement().TagName, true
 		}
 		if name == "attributes" {
 			attributes := node.AsJsxSelfClosingElement().Attributes
@@ -2992,7 +2884,7 @@ func readVirtualNodeAttr(facade virtualNodeFacade, name string, mc *matchContext
 		if name == "type" || name == "parent" {
 			return nil, false
 		}
-	case "FunctionExpression":
+	case "FunctionExpression", "TSEmptyBodyFunctionExpression":
 		switch name {
 		case "body":
 			return node.Body(), true
@@ -3011,13 +2903,6 @@ func readVirtualNodeAttr(facade virtualNodeFacade, name string, mc *matchContext
 		}
 	}
 	return nil, false
-}
-
-// functionValueFacade models the synthetic FunctionExpression stored at
-// ESTree MethodDefinition.value. tsgo stores the same function fields directly
-// on the class member node, so attribute paths need this intermediate object.
-type functionValueFacade struct {
-	node *ast.Node
 }
 
 func methodValueIsGenerator(node *ast.Node) bool {
@@ -3058,8 +2943,10 @@ func readIdAttr(node *ast.Node) (interface{}, bool) {
 	return nil, false
 }
 
-func readKeyAttr(node *ast.Node) (interface{}, bool) {
+func readKeyAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
 	switch node.Kind {
+	case ast.KindConstructor:
+		return constructorKey(node, mc), true
 	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
 		return node.Name(), true
 	case ast.KindImportAttribute:
@@ -3093,7 +2980,7 @@ func readObjectAttr(node *ast.Node) (interface{}, bool) {
 	case ast.KindPropertyAccessExpression:
 		object := unwrapExpression(node.AsPropertyAccessExpression().Expression)
 		if isJSXMemberExpression(node) {
-			return jsxFacade(object), true
+			return object, true
 		}
 		return object, true
 	case ast.KindElementAccessExpression:
@@ -3107,7 +2994,7 @@ func readPropertyAttr(node *ast.Node) (interface{}, bool) {
 	case ast.KindPropertyAccessExpression:
 		property := node.AsPropertyAccessExpression().Name()
 		if isJSXMemberExpression(node) {
-			return jsxFacade(property), true
+			return property, true
 		}
 		return property, true
 	case ast.KindElementAccessExpression:
@@ -3174,14 +3061,14 @@ func readAlternateAttr(node *ast.Node) (interface{}, bool) {
 
 func readBodyAttr(node *ast.Node) (interface{}, bool) {
 	switch node.Kind {
+	case ast.KindClassStaticBlockDeclaration:
+		return statements(node.AsClassStaticBlockDeclaration().Body.AsBlock().Statements), true
 	case ast.KindFunctionDeclaration:
 		return node.AsFunctionDeclaration().Body, true
 	case ast.KindFunctionExpression:
 		return node.AsFunctionExpression().Body, true
 	case ast.KindArrowFunction:
 		return node.AsArrowFunction().Body, true
-	case ast.KindMethodDeclaration:
-		return node.AsMethodDeclaration().Body, true
 	case ast.KindIfStatement:
 		return node.AsIfStatement().ThenStatement, true
 	case ast.KindWhileStatement:
@@ -3202,18 +3089,8 @@ func readBodyAttr(node *ast.Node) (interface{}, bool) {
 			return []*ast.Node{}, true
 		}
 		return stmts.Nodes, true
-	case ast.KindClassDeclaration:
-		members := node.AsClassDeclaration().Members
-		if members == nil {
-			return []*ast.Node{}, true
-		}
-		return members.Nodes, true
-	case ast.KindClassExpression:
-		members := node.AsClassExpression().Members
-		if members == nil {
-			return []*ast.Node{}, true
-		}
-		return members.Nodes, true
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return virtualNodeFacade{node, "ClassBody"}, true
 	case ast.KindEnumDeclaration:
 		return virtualNodeFacade{node: node, typeName: "TSEnumBody"}, true
 	}

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 //go:embed no_restricted_syntax.schema.json
@@ -76,30 +77,50 @@ var NoRestrictedSyntaxRule = rule.Rule{
 				}
 			}
 
-			if node.Kind == ast.KindJsxSelfClosingElement {
-				// tsgo folds JSXElement and JSXOpeningElement into one physical node.
-				// Visit the two ESTree identities in their logical order so reports
-				// from selectors on the physical JSXElement remain ahead of the
-				// synthetic opening element.
-				for _, target := range []string{"JSXElement", "JSXOpeningElement"} {
-					visitCandidates(func(index int, indexed bool) {
-						bucket.matchAndReportSelfClosing(index, node, mc, &ctx, indexed, target)
-					})
+			// A dispatch key read from the physical node cannot prune its
+			// folded ESTree child: type, parent and fields can all differ.
+			target := virtualTarget(node)
+			visitVirtual := func() {
+				if !bucket.hasVirtual {
+					return
 				}
-				return
+				if node.Kind == ast.KindConstructor {
+					keyTarget := constructorKey(node, mc).typeName
+					for index := range bucket.entries {
+						bucket.matchVirtual(index, node, keyTarget, mc, &ctx)
+					}
+				}
+				if target != "" {
+					for index := range bucket.entries {
+						bucket.matchVirtual(index, node, target, mc, &ctx)
+					}
+				}
+			}
+			// ChainExpression surrounds the physical node; the other facades
+			// are its children. Exit events reverse that order.
+			virtualBeforePhysical := bucket.entries[0].exit != (target == "ChainExpression")
+			if virtualBeforePhysical {
+				visitVirtual()
 			}
 			visitCandidates(func(index int, indexed bool) {
 				bucket.matchPhysical(index, node, mc, &ctx, indexed)
 			})
-			visitCandidates(func(index int, indexed bool) {
-				bucket.matchVirtual(index, node, mc, &ctx)
-			})
+			if !virtualBeforePhysical {
+				visitVirtual()
+			}
 		}
 
 		listeners := make(rule.RuleListeners, len(plan.buckets))
 		for k, bucket := range plan.buckets {
-			listeners[k] = func(node *ast.Node) {
-				visit(node, bucket)
+			switch k {
+			case ast.KindSourceFile:
+				// The engine starts at SourceFile's children. Program enter runs
+				// eagerly, and EOF provides the matching Program exit event.
+				visit(ctx.SourceFile.AsNode(), bucket)
+			case rule.ListenerOnExit(ast.KindSourceFile):
+				listeners[rule.ListenerOnExit(ast.KindEndOfFile)] = func(*ast.Node) { visit(ctx.SourceFile.AsNode(), bucket) }
+			default:
+				listeners[k] = func(node *ast.Node) { visit(node, bucket) }
 			}
 		}
 		return listeners
@@ -218,8 +239,9 @@ func buildRulePlan(options []any) *rulePlan {
 }
 
 type ruleBucket struct {
-	entries  []ruleEntry
-	dispatch *stringAttrDispatch
+	entries    []ruleEntry
+	dispatch   *stringAttrDispatch
+	hasVirtual bool
 }
 
 type stringAttrDispatch struct {
@@ -246,6 +268,7 @@ func buildRuleBucket(entries []ruleEntry) ruleBucket {
 
 	stats := make(map[string]*dispatchStat)
 	for _, entry := range entries {
+		bucket.hasVirtual = bucket.hasVirtual || !isBareWildcardSelector(entry.compiled)
 		attrs := collectDispatchAttrs(entry.compiled, nil)
 		for index, attr := range attrs {
 			duplicate := false
@@ -428,74 +451,45 @@ func (bucket *ruleBucket) matchPhysical(index int, node *ast.Node, mc *matchCont
 	if indexed && bucket.dispatch != nil && bucket.dispatch.matched[index] != nil {
 		compiled = bucket.dispatch.matched[index]
 	}
+	if node.Kind == ast.KindSourceFile && isBareWildcardSelector(entry.compiled) {
+		return
+	}
+	if isPlainParameter(node) && !isBareWildcardSelector(entry.compiled) {
+		return
+	}
 	if matchesInScopeTarget(compiled, node, mc, nil, "physical") {
-		ctx.ReportNode(node, rule.RuleMessage{
+		ctx.ReportRange(utils.GetESTreeBindingIdentifierRange(mc.sf, node), rule.RuleMessage{
 			Id:          "restrictedSyntax",
 			Description: entry.formatMessage(),
 		})
 	}
 }
 
-func (bucket *ruleBucket) matchVirtual(index int, node *ast.Node, mc *matchContext, ctx *rule.RuleContext) {
+func (bucket *ruleBucket) matchVirtual(index int, node *ast.Node, target string, mc *matchContext, ctx *rule.RuleContext) {
 	entry := &bucket.entries[index]
-	message := rule.RuleMessage{
-		Id:          "restrictedSyntax",
-		Description: entry.formatMessage(),
-	}
-	for _, target := range virtualTargets(node) {
-		// A bare universe selector intentionally walks only the physical tsgo
-		// tree. Other broad selectors, including regex attributes and negative
-		// pseudos, still need to be evaluated against virtual ESTree targets.
-		if isBareWildcardSelector(entry.compiled) {
-			continue
-		}
-		// Dispatch predicates are stripped only for the physical path.
-		// Virtual ESTree identities must be checked against the original
-		// selector, otherwise the stripped wildcard reports them again.
-		if !matchesInScopeTarget(entry.compiled, node, mc, nil, target) {
-			continue
-		}
-		switch target {
-		case "ClassBody":
-			ctx.ReportRange(classBodyTextRange(mc.sf, node), message)
-		case "TSEnumBody":
-			ctx.ReportRange(enumBodyTextRange(mc.sf, node), message)
-		case "JSXEmptyExpression":
-			nodeRange := utils.TrimNodeTextRange(mc.sf, node)
-			ctx.ReportRange(core.NewTextRange(nodeRange.Pos()+1, max(nodeRange.Pos()+1, nodeRange.End()-1)), message)
-		case "FunctionExpression":
-			ctx.ReportRange(functionValueTextRange(mc.sf, node), message)
-		default:
-			ctx.ReportNode(node, message)
-		}
-	}
-}
-
-func (bucket *ruleBucket) matchAndReportSelfClosing(index int, node *ast.Node, mc *matchContext, ctx *rule.RuleContext, indexed bool, target string) {
-	entry := &bucket.entries[index]
-	compiled := entry.compiled
-	if indexed && bucket.dispatch != nil && bucket.dispatch.matched[index] != nil {
-		compiled = bucket.dispatch.matched[index]
-	}
-
-	physicalMatch := matchesInScopeTarget(compiled, node, mc, nil, "physical")
-	if target == "JSXElement" && physicalMatch {
-		ctx.ReportNode(node, rule.RuleMessage{
-			Id:          "restrictedSyntax",
-			Description: entry.formatMessage(),
-		})
+	// Preserve the documented bare-wildcard traversal. Other broad selectors
+	// must see the folded child, including regex and negative selectors.
+	if isBareWildcardSelector(entry.compiled) || !matchesInScopeTarget(entry.compiled, node, mc, nil, target) {
 		return
 	}
-	if !selectorTargetsEstreeType(entry.compiled, target) {
-		return
+	message := rule.RuleMessage{Id: "restrictedSyntax", Description: entry.formatMessage()}
+	switch target {
+	case "Identifier", "Literal":
+		if token, ok := utils.TokenBeforePosition(mc.sf, node.ParameterList().Pos()-1); ok {
+			ctx.ReportRange(core.NewTextRange(token.Start, token.End), message)
+		}
+	case "ClassBody":
+		ctx.ReportRange(classBodyTextRange(mc.sf, node), message)
+	case "TSEnumBody":
+		ctx.ReportRange(enumBodyTextRange(mc.sf, node), message)
+	case "JSXEmptyExpression":
+		nodeRange := utils.TrimNodeTextRange(mc.sf, node)
+		ctx.ReportRange(core.NewTextRange(nodeRange.Pos()+1, max(nodeRange.Pos()+1, nodeRange.End()-1)), message)
+	case "FunctionExpression", "TSEmptyBodyFunctionExpression":
+		ctx.ReportRange(functionValueTextRange(mc.sf, node), message)
+	default:
+		ctx.ReportNode(node, message)
 	}
-	if !matchesInScopeTarget(entry.compiled, node, mc, nil, target) {
-		return
-	}
-	ctx.ReportNode(node, rule.RuleMessage{
-		Id:          "restrictedSyntax",
-		Description: entry.formatMessage(),
-	})
 }
 
 func (e ruleEntry) formatMessage() string {
@@ -503,43 +497,15 @@ func (e ruleEntry) formatMessage() string {
 }
 
 func functionValueTextRange(sf *ast.SourceFile, node *ast.Node) core.TextRange {
-	if sf == nil || node == nil || node.Body() == nil {
-		if node == nil {
-			return core.TextRange{}
-		}
-		return core.NewTextRange(node.Pos(), node.End())
+	// tsgo records the position immediately after '(' (or '<' for generic
+	// methods). Reuse that parser boundary, including for bodyless overloads.
+	if parameters := node.TypeParameterList(); parameters != nil && len(parameters.Nodes) > 0 {
+		return core.NewTextRange(parameters.Pos()-1, node.End())
 	}
-	tokens := utils.TokensOfNode(sf, node)
-	bodyStart := node.Body().Pos()
-	openIndex := -1
-	for index, token := range tokens {
-		if token.Start >= bodyStart {
-			break
-		}
-		if token.Kind == ast.KindOpenParenToken {
-			openIndex = index
-		}
+	if parameters := node.ParameterList(); parameters != nil {
+		return core.NewTextRange(parameters.Pos()-1, node.End())
 	}
-	if openIndex < 0 {
-		return core.NewTextRange(node.Pos(), node.End())
-	}
-	start := tokens[openIndex].Start
-	if openIndex > 0 && tokens[openIndex-1].Kind == ast.KindGreaterThanToken {
-		depth := 0
-		for index := openIndex - 1; index >= 0; index-- {
-			switch tokens[index].Kind {
-			case ast.KindGreaterThanToken:
-				depth++
-			case ast.KindLessThanToken:
-				depth--
-				if depth == 0 {
-					start = tokens[index].Start
-					index = -1
-				}
-			}
-		}
-	}
-	return core.NewTextRange(start, node.Body().End())
+	return utils.TrimNodeTextRange(sf, node)
 }
 
 func classBodyTextRange(sf *ast.SourceFile, node *ast.Node) core.TextRange {
@@ -565,23 +531,10 @@ func enumBodyTextRange(sf *ast.SourceFile, node *ast.Node) core.TextRange {
 }
 
 func listBodyTextRange(sf *ast.SourceFile, node *ast.Node, members *ast.NodeList) core.TextRange {
-	if sf == nil || node == nil || members == nil {
-		return core.NewTextRange(node.Pos(), node.End())
+	if members != nil {
+		return core.NewTextRange(members.Pos()-1, node.End())
 	}
-	open, closeEnd := -1, -1
-	for _, token := range utils.TokensOfNode(sf, node) {
-		if token.Kind == ast.KindOpenBraceToken && token.Start <= members.Pos() {
-			open = token.Start
-		}
-		if open >= 0 && token.Kind == ast.KindCloseBraceToken && token.Start >= members.End() {
-			closeEnd = token.End
-			break
-		}
-	}
-	if open < 0 || closeEnd < 0 {
-		return core.NewTextRange(node.Pos(), node.End())
-	}
-	return core.NewTextRange(open, closeEnd)
+	return utils.TrimNodeTextRange(sf, node)
 }
 
 func deduplicateRuleEntries(entries []ruleEntry) []ruleEntry {
@@ -623,7 +576,7 @@ func sortRuleEntries(entries []ruleEntry) {
 		if a.identifiers != b.identifiers {
 			return a.identifiers < b.identifiers
 		}
-		return compareJSStrings(entries[left].selector, entries[right].selector) < 0
+		return ecmascript.CompareStrings(entries[left].selector, entries[right].selector) < 0
 	})
 }
 

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.md
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.md
@@ -66,7 +66,7 @@ The rule accepts an array of restriction entries. Each entry is either:
 ### Supported selector forms
 
 The implementation follows the esquery 1.7 selector forms used by ESLint
-10.9.1, including the complete upstream `no-restricted-syntax` test suite.
+10.10.0, including the complete upstream `no-restricted-syntax` test suite.
 Malformed selectors are a deliberate compatibility divergence: rslint drops
 the malformed entry so one bad selector does not disable the rest of the
 configuration, while ESLint rejects the whole rule configuration:
@@ -74,8 +74,9 @@ configuration, while ESLint rejects the whole rule configuration:
 - ESTree node names (e.g. `Identifier`, `FunctionDeclaration`,
   `BinaryExpression`) and supported TS-ESTree names such as
   `TSEnumDeclaration`. ESTree-only wrapper shapes such as `ClassBody`,
-  `JSXEmptyExpression`, and `MethodDefinition.value` are exposed as virtual
-  facades over the tsgo AST.
+  `JSXEmptyExpression`, `ChainExpression`, and `MethodDefinition.value` are
+  exposed as virtual facades over the tsgo AST. Bodyless class methods expose
+  `TSEmptyBodyFunctionExpression` as their value.
 - Wildcard `*`.
 - Field selectors, including nested fields (e.g. `Literal.key` and
   `.body.declarations.init`).
@@ -83,9 +84,10 @@ configuration, while ESLint rejects the whole rule configuration:
   (`[name="x"]`, `[kind='using']`), inequality (`!=`), numeric comparisons
   (`[params.length>2]`), numeric path segments (`[arguments.0.type='Literal']`),
   `type(...)`, and regex matching (`[regex.flags=/i/]`). Attribute paths may
-  inspect ESLint's `parent` link. BigInt metadata and class-method function
-  fields are available through selectors such as `Literal[bigint]` and
-  `MethodDefinition[value.body.body.length=0]`.
+  inspect ESLint's `parent` link. BigInt values retain their JavaScript type:
+  `Literal[value=type(bigint)]` selects them, while a string regex equality
+  selector does not. Class-method function fields are available through
+  selectors such as `MethodDefinition[value.body.body.length=0]`.
 - Combinators `>` (direct child), descendant whitespace, `+`
   (adjacent sibling), `~` (general sibling), including decorator selectors
   such as `Decorator > CallExpression[callee.name='sealed']`.
@@ -100,13 +102,21 @@ configuration, while ESLint rejects the whole rule configuration:
 
 tsgo does not allocate separate nodes for every ESTree wrapper. Direct
 selectors and structural relationships for those wrappers are modeled, with
-ESLint-compatible ranges. A universe selector such as `*`, however, walks the
-physical tsgo tree and therefore does not emit an additional diagnostic for
-each virtual wrapper around the same physical node.
+ESLint-compatible ranges. The bare `*` selector retains the engine's physical
+tsgo traversal, which starts at the program's children and does not emit
+additional diagnostics for virtual wrappers. Other broad selectors evaluate
+each supported ESTree identity separately. `Program` and `Program:exit` can
+select the program itself.
+
+TS-ESTree coverage is limited to the supported node mappings; the rule does
+not materialize every TypeScript type annotation or type-parameter wrapper.
+Broad selectors on type-only syntax can therefore differ from the TypeScript
+ESLint parser. Runtime receiver attribute paths retain their existing behavior
+of looking through TypeScript assertions, such as `(console as any).log()`.
 
 ## Original Documentation
 
 - [ESLint: no-restricted-syntax](https://eslint.org/docs/latest/rules/no-restricted-syntax)
-- [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-restricted-syntax.js)
+- [Source code](https://github.com/eslint/eslint/blob/v10.10.0/lib/rules/no-restricted-syntax.js)
 
 [esquery]: https://github.com/estools/esquery

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax_extras_structure_test.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax_extras_structure_test.go
@@ -1,0 +1,1109 @@
+package no_restricted_syntax
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Regression expectations were checked against ESLint 10.10.0, esquery 1.7.0,
+// and @typescript-eslint/parser 8.69.0. These cases exercise the tsgo facade.
+func TestNoRestrictedSyntaxStructureRegressions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRestrictedSyntaxRule,
+		[]rule_tester.ValidTestCase{
+			{
+				// virtual sibling function
+				Code:    "class C { a() {} b() {} }",
+				Options: []any{"FunctionExpression + MethodDefinition"},
+			},
+			{
+				// virtual sibling class body
+				Code:    "class A {} class B {}",
+				Options: []any{"ClassBody + ClassDeclaration"},
+			},
+			{
+				// fields do not panic
+				Code:    "class C { m(a,b) {} } const x = <Foo a b={c} />;",
+				Options: []any{".body.params"},
+				Tsx:     true,
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"ClassBody:has(ClassDeclaration)"},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"ClassBody:has(ClassDeclaration > ClassBody)"},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"MethodDefinition[body]"},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"MethodDefinition[params]"},
+			},
+			{
+				// quoted constructor
+				Code:    "class C { \"constructor\"(){} }",
+				Options: []any{"Identifier.key"},
+			},
+			{
+				// quoted constructor
+				Code:    "class C { \"constructor\"(){} }",
+				Options: []any{"MethodDefinition[key.name=\"constructor\"]"},
+			},
+			{
+				// static block
+				Code:    "class C { static { f(); } }",
+				Options: []any{"BlockStatement"},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"CallExpression + CallExpression"},
+			},
+			{
+				// attributes
+				Code:    "f(); new F(); returnValue; function f(){ return x; }",
+				Options: []any{"CallExpression[expression]"},
+			},
+			{
+				// attributes
+				Code:    "f(); new F(); returnValue; function f(){ return x; }",
+				Options: []any{"ReturnStatement[expression]"},
+			},
+			{
+				// array index
+				Code:    "f(a,b);",
+				Options: []any{"CallExpression[arguments.01.name=\"b\"]"},
+			},
+			{
+				// jsx identity fields
+				Code:    "const x=<Foo a />;",
+				Options: []any{"JSXElement[name]"},
+				Tsx:     true,
+			},
+			{
+				// jsx identity fields
+				Code:    "const x=<Foo a />;",
+				Options: []any{"JSXElement[attributes]"},
+				Tsx:     true,
+			},
+			{
+				// parser token children
+				Code:    "class C {; async m(){} }",
+				Options: []any{"ClassDeclaration:has(> :not(Identifier,ClassBody))"},
+			},
+			{
+				// parser token children
+				Code:    "class C {; async m(){} }",
+				Options: []any{"MethodDefinition:has(> :not(Identifier,FunctionExpression))"},
+			},
+			{
+				// operator children
+				Code:    "a + 1;",
+				Options: []any{"BinaryExpression:has(> :not(Identifier,Literal))"},
+			},
+			{
+				// operator children
+				Code:    "a + 1;",
+				Options: []any{"Program:has(> :not(ExpressionStatement))"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				// desc class method
+				Code:    "class C { m() {} }",
+				Options: []any{"ClassDeclaration MethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				// desc method body
+				Code:    "class C { m() {} }",
+				Options: []any{"MethodDefinition BlockStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				// desc class call
+				Code:    "class C { m() { foo(); } }",
+				Options: []any{"ClassDeclaration CallExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 17, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				// desc jsx name
+				Code:    "const x = <Foo />;",
+				Options: []any{"JSXElement JSXIdentifier"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				// child chain control
+				Code:    "class C { m() {} }",
+				Options: []any{"ClassDeclaration > ClassBody > MethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				// dispatch virtual parent
+				Code:    "class C { m() {} }",
+				Options: []any{"[parent.type='MethodDefinition']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 17},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				// dispatch virtual parent explicit
+				Code:    "class C { m() {} }",
+				Options: []any{"FunctionExpression[parent.type='MethodDefinition']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				// dispatch virtual parent class
+				Code:    "class C {}",
+				Options: []any{"[parent.type='ClassDeclaration']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 9, EndLine: 1, EndColumn: 11},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				// jsx regex union
+				Code:    "const x = <Foo a b={c} />;",
+				Options: []any{"[type=/^(JSXElement|JSXOpeningElement)$/]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 26},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				// jsx regex child
+				Code:    "const x = <Foo />;",
+				Options: []any{"JSXElement > [type=/^JSXOpeningElement$/]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// jsx not
+				Code:    "const x = <Foo />;",
+				Options: []any{":not(Program,VariableDeclaration,VariableDeclarator,Identifier,JSXElement,JSXIdentifier)"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// method range call
+				Code:    "class C { m(x = foo()) {} }",
+				Options: []any{"FunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				// method range type
+				Code:    "class C { m(x: () => void) {} }",
+				Options: []any{"FunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				// method range return type
+				Code:    "class C { m(): () => void {} }",
+				Options: []any{"FunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				// param position
+				Code:    "class C { m(x, y) {} }",
+				Options: []any{"FunctionExpression > Identifier:nth-child(2)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				// jsx opening attrs
+				Code:    "const x = <Foo a b />;",
+				Options: []any{"JSXOpeningElement[attributes.length=2]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				// jsx opening self
+				Code:    "const x = <Foo />;",
+				Options: []any{"JSXOpeningElement[selfClosing=true]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// jsx expression empty
+				Code:    "const x = <Foo>{/* c */}</Foo>;",
+				Options: []any{"JSXExpressionContainer[expression.type='JSXEmptyExpression']"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// enum members field
+				Code:    "enum E { A, B }",
+				Options: []any{"TSEnumMember.members"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				// decorator expression field
+				Code:    "@sealed() class C {}",
+				Options: []any{"Decorator > CallExpression.expression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 2, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				// param position direct
+				Code:    "class C { m(x, y) {} }",
+				Options: []any{"Identifier:nth-child(2)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				// param position control
+				Code:    "function m(x, y) {}",
+				Options: []any{"Identifier:nth-child(2)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				// dispatch virtual parent class explicit
+				Code:    "class C {}",
+				Options: []any{"ClassBody[parent.type='ClassDeclaration']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 9, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				// jsx regex paired
+				Code:    "const x = <Foo a b={c}></Foo>;",
+				Options: []any{"[type=/^(JSXElement|JSXOpeningElement)$/]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 30},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// fields do not panic
+				Code:    "class C { m(a,b) {} } const x = <Foo a b={c} />;",
+				Options: []any{".params"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				// fields do not panic
+				Code:    "class C { m(a,b) {} } const x = <Foo a b={c} />;",
+				Options: []any{":has(> .params)"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				// fields do not panic
+				Code:    "class C { m(a,b) {} } const x = <Foo a b={c} />;",
+				Options: []any{"[params.length=2]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				// program
+				Code:    "if(a) f(); while(b) g();",
+				Options: []any{"Program"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// program
+				Code:    "if(a) f(); while(b) g();",
+				Options: []any{"Program:exit"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// program
+				Code:    "if(a) f(); while(b) g();",
+				Options: []any{":has(!IfStatement ~ WhileStatement)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// program
+				Code:    "if(a) f(); while(b) g();",
+				Options: []any{":has(IfStatement + !WhileStatement)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// program
+				Code:    "if(a) f(); while(b) g();",
+				Options: []any{"Program:has(Program > IfStatement)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// program
+				Code:    "if(a) f(); while(b) g();",
+				Options: []any{"[parent.type=\"Program\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 11},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// program empty
+				Code:    "/* empty */",
+				Options: []any{"Program"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				// program empty
+				Code:    "/* empty */",
+				Options: []any{"Program:exit"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				// params
+				Code:    "function f(a,b=1,...rest){} const g={m(a,b){}};",
+				Options: []any{"FunctionExpression:has(> Identifier)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 39, EndLine: 1, EndColumn: 46},
+				},
+			},
+			{
+				// params
+				Code:    "function f(a,b=1,...rest){} const g={m(a,b){}};",
+				Options: []any{"Identifier.params"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 40, EndLine: 1, EndColumn: 41},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 42, EndLine: 1, EndColumn: 43},
+				},
+			},
+			{
+				// params
+				Code:    "function f(a,b=1,...rest){} const g={m(a,b){}};",
+				Options: []any{"Identifier:nth-child(2)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 42, EndLine: 1, EndColumn: 43},
+				},
+			},
+			{
+				// params
+				Code:    "function f(a,b=1,...rest){} const g={m(a,b){}};",
+				Options: []any{"AssignmentPattern:nth-child(2)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 14, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				// params
+				Code:    "function f(a,b=1,...rest){} const g={m(a,b){}};",
+				Options: []any{"RestElement:last-child"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 18, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				// params
+				Code:    "function f(a,b=1,...rest){} const g={m(a,b){}};",
+				Options: []any{"[parent.type=\"FunctionExpression\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 40, EndLine: 1, EndColumn: 41},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 42, EndLine: 1, EndColumn: 43},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 44, EndLine: 1, EndColumn: 46},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"ClassDeclaration > Identifier"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"MethodDefinition:first-child"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"MethodDefinition:last-child"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 29, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"MethodDefinition + MethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 29, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"ClassBody[body.length=2]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 19, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"ClassDeclaration:has(ClassDeclaration > ClassBody)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"ClassDeclaration[body.type=\"ClassBody\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"ClassBody.body"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 19, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"MethodDefinition.body.body"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 27},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 29, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				// class boundaries
+				Code:    "class C extends B {; m(){}; n(){}; }",
+				Options: []any{"FunctionExpression.body.body.value"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 23, EndLine: 1, EndColumn: 27},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 30, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				// constructor
+				Code:    "class C { constructor(x){} }",
+				Options: []any{"Identifier"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 22},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// constructor
+				Code:    "class C { constructor(x){} }",
+				Options: []any{"MethodDefinition > Identifier"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				// constructor
+				Code:    "class C { constructor(x){} }",
+				Options: []any{"Identifier.key"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				// constructor
+				Code:    "class C { constructor(x){} }",
+				Options: []any{"MethodDefinition[key.name=\"constructor\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				// constructor
+				Code:    "class C { constructor(x){} }",
+				Options: []any{"FunctionExpression:has(> Identifier)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				// quoted constructor
+				Code:    "class C { \"constructor\"(){} }",
+				Options: []any{"Literal.key"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// quoted constructor
+				Code:    "class C { \"constructor\"(){} }",
+				Options: []any{"Literal[value=\"constructor\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// quoted constructor
+				Code:    "class C { \"constructor\"(){} }",
+				Options: []any{"MethodDefinition[key.type=\"Literal\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				// generic method
+				Code:    "class C { m<T extends { x: () => void }>(x:T): (() => void) {} }",
+				Options: []any{"FunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 63},
+				},
+			},
+			{
+				// generic method
+				Code:    "class C { m<T extends { x: () => void }>(x:T): (() => void) {} }",
+				Options: []any{"FunctionExpression > Identifier"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 42, EndLine: 1, EndColumn: 45},
+				},
+			},
+			{
+				// generic method
+				Code:    "class C { m<T extends { x: () => void }>(x:T): (() => void) {} }",
+				Options: []any{"FunctionExpression Identifier"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 42, EndLine: 1, EndColumn: 45},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 44, EndLine: 1, EndColumn: 45},
+				},
+			},
+			{
+				// generic method
+				Code:    "class C { m<T extends { x: () => void }>(x:T): (() => void) {} }",
+				Options: []any{"Identifier:has(> *)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 42, EndLine: 1, EndColumn: 45},
+				},
+			},
+			{
+				// bodyless
+				Code:    "abstract class C { abstract m(x:string):void; m2(x:number):void; m2(x:any){} } interface I { get value():number; }",
+				Options: []any{"FunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 68, EndLine: 1, EndColumn: 77},
+				},
+			},
+			{
+				// bodyless
+				Code:    "abstract class C { abstract m(x:string):void; m2(x:number):void; m2(x:any){} } interface I { get value():number; }",
+				Options: []any{"TSEmptyBodyFunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 30, EndLine: 1, EndColumn: 46},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 49, EndLine: 1, EndColumn: 65},
+				},
+			},
+			{
+				// bodyless
+				Code:    "abstract class C { abstract m(x:string):void; m2(x:number):void; m2(x:any){} } interface I { get value():number; }",
+				Options: []any{"TSEmptyBodyFunctionExpression:has(> Identifier)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 30, EndLine: 1, EndColumn: 46},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 49, EndLine: 1, EndColumn: 65},
+				},
+			},
+			{
+				// bodyless
+				Code:    "abstract class C { abstract m(x:string):void; m2(x:number):void; m2(x:any){} } interface I { get value():number; }",
+				Options: []any{"TSAbstractMethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 20, EndLine: 1, EndColumn: 46},
+				},
+			},
+			{
+				// bodyless
+				Code:    "abstract class C { abstract m(x:string):void; m2(x:number):void; m2(x:any){} } interface I { get value():number; }",
+				Options: []any{"MethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 47, EndLine: 1, EndColumn: 65},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 66, EndLine: 1, EndColumn: 77},
+				},
+			},
+			{
+				// bodyless
+				Code:    "abstract class C { abstract m(x:string):void; m2(x:number):void; m2(x:any){} } interface I { get value():number; }",
+				Options: []any{"FunctionExpression:exit"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 68, EndLine: 1, EndColumn: 77},
+				},
+			},
+			{
+				// static block
+				Code:    "class C { static { f(); } }",
+				Options: []any{"StaticBlock > ExpressionStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 20, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// static block
+				Code:    "class C { static { f(); } }",
+				Options: []any{"StaticBlock:has(> ExpressionStatement)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXExpressionContainer.value"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 24, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"[value.type=\"JSXExpressionContainer\"]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXExpressionContainer:first-child"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 28, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXSpreadChild:nth-child(2)"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 44},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXElement:nth-child(3)"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 44, EndLine: 1, EndColumn: 51},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXOpeningElement[attributes.length=2]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXOpeningElement[selfClosing=false]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXSpreadChild[expression.type=\"Identifier\"]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 44},
+				},
+			},
+			{
+				// jsx edges
+				Code:    "const x = <Foo.Bar a b={c}>{/*x*/}{...rest}<Bar />text</Foo.Bar>;",
+				Options: []any{"JSXEmptyExpression.expression"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 29, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				// jsx fragment
+				Code:    "const x = <><Foo />{a}<span /></>;",
+				Options: []any{"JSXElement + JSXExpressionContainer"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 20, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				// jsx fragment
+				Code:    "const x = <><Foo />{a}<span /></>;",
+				Options: []any{"JSXElement ~ JSXElement"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 23, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				// jsx fragment
+				Code:    "const x = <><Foo />{a}<span /></>;",
+				Options: []any{"JSXElement:first-child"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 13, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				// jsx fragment
+				Code:    "const x = <><Foo />{a}<span /></>;",
+				Options: []any{"JSXElement:last-child"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 23, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 9},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 28},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"ChainExpression > CallExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 9},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 28},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"[expression.type=\"CallExpression\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 9},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 28},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"[parent.type=\"ChainExpression\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 9},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 28},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"ChainExpression:first-child"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"ChainExpression:last-child"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"ChainExpression + CallExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 30, EndLine: 1, EndColumn: 33},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"CallExpression ~ ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"ChainExpression.elements"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 22, EndLine: 1, EndColumn: 28},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 35, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				// chain
+				Code:    "a?.b?.(); const x = [a?.b(), f(), g?.()];",
+				Options: []any{"CallExpression.elements"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 30, EndLine: 1, EndColumn: 33},
+				},
+			},
+			{
+				// attributes
+				Code:    "f(); new F(); returnValue; function f(){ return x; }",
+				Options: []any{"[expression.type=\"Identifier\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				// attributes
+				Code:    "f(); new F(); returnValue; function f(){ return x; }",
+				Options: []any{"[body.type=\"BlockStatement\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 28, EndLine: 1, EndColumn: 53},
+				},
+			},
+			{
+				// parent roundtrip
+				Code:    "const x = <Foo>{/*x*/}<Bar /></Foo>;",
+				Options: []any{"JSXEmptyExpression[parent.expression.type=\"JSXEmptyExpression\"]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 17, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				// parent roundtrip
+				Code:    "const x = <Foo>{/*x*/}<Bar /></Foo>;",
+				Options: []any{"JSXOpeningElement[parent.openingElement.type=\"JSXOpeningElement\"]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 16},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				// parent roundtrip
+				Code:    "const x = <Foo>{/*x*/}<Bar /></Foo>;",
+				Options: []any{"JSXIdentifier[parent.type=\"JSXOpeningElement\"]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 15},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 24, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				// array index
+				Code:    "f(a,b);",
+				Options: []any{"CallExpression[arguments.1.name=\"b\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				// jsx identity fields
+				Code:    "const x=<Foo a />;",
+				Options: []any{"JSXOpeningElement[name]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 9, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// jsx identity fields
+				Code:    "const x=<Foo a />;",
+				Options: []any{"JSXOpeningElement[attributes.length=1]"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 9, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// static fields
+				Code:    "class C { static { f(); g(); } }",
+				Options: []any{"StaticBlock[body.length=2]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				// static fields
+				Code:    "class C { static { f(); g(); } }",
+				Options: []any{"ExpressionStatement.body"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 20, EndLine: 1, EndColumn: 24},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 25, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				// static fields
+				Code:    "class C { static { f(); g(); } }",
+				Options: []any{"ExpressionStatement:nth-child(2)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 25, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				// quoted raw
+				Code:    "class C { \"constructor\"(){} }",
+				Options: []any{"Literal[raw=/constructor/]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// nested chains
+				Code:    "f?.(a?.b); obj?.[key?.x];",
+				Options: []any{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 5, EndLine: 1, EndColumn: 9},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 25},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 18, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// nested chains
+				Code:    "f?.(a?.b); obj?.[key?.x];",
+				Options: []any{"ChainExpression > CallExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				// nested chains
+				Code:    "f?.(a?.b); obj?.[key?.x];",
+				Options: []any{"CallExpression > ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 5, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				// nested chains
+				Code:    "f?.(a?.b); obj?.[key?.x];",
+				Options: []any{"MemberExpression > ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 18, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				// computed key
+				Code:    "class C { [name()](){} }",
+				Options: []any{"MethodDefinition > CallExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// computed key
+				Code:    "class C { [name()](){} }",
+				Options: []any{"CallExpression.key"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				// computed key
+				Code:    "class C { [name()](){} }",
+				Options: []any{"MethodDefinition[key.type=\"CallExpression\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				// chain subjects
+				Code:    "const x=[a?.b(), f()];",
+				Options: []any{":matches(:not(*), !ChainExpression ~ CallExpression)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 10, EndLine: 1, EndColumn: 16},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 18, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				// chain subjects
+				Code:    "const x=[a?.b(), f()];",
+				Options: []any{":matches(:not(*), ChainExpression + !CallExpression)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 10, EndLine: 1, EndColumn: 16},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 18, EndLine: 1, EndColumn: 21},
+				},
+			},
+		})
+}

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax_extras_values_test.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax_extras_values_test.go
@@ -1,0 +1,215 @@
+package no_restricted_syntax
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Regression expectations were checked against ESLint 10.10.0, esquery 1.7.0,
+// and @typescript-eslint/parser 8.69.0. These cases exercise the tsgo facade.
+func TestNoRestrictedSyntaxValuesRegressions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRestrictedSyntaxRule,
+		[]rule_tester.ValidTestCase{
+			{
+				// bigint regex
+				Code:    "const n = 1n;",
+				Options: []any{"Literal[value=/^1$/]"},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value=type(string)]"},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value=/^1$/]"},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value>\"1.5\"]"},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value<\"Infinity\"]"},
+			},
+			{
+				// private name
+				Code:    "class C { #x = 1; m(){ return this.#x; } }",
+				Options: []any{"PrivateIdentifier[name=\"#x\"]"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				// bigint type
+				Code:    "const n = 1n;",
+				Options: []any{"Literal[value=type(bigint)]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				// number coercion
+				Code:    "const x = [1e21, 1e-7, 1e-6, 1e20, 1e999];",
+				Options: []any{"Literal[value=\"1e+21\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				// number coercion
+				Code:    "const x = [1e21, 1e-7, 1e-6, 1e20, 1e999];",
+				Options: []any{"Literal[value=\"1e-7\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 18, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				// number coercion
+				Code:    "const x = [1e21, 1e-7, 1e-6, 1e20, 1e999];",
+				Options: []any{"Literal[value=\"0.000001\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 24, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				// number coercion
+				Code:    "const x = [1e21, 1e-7, 1e-6, 1e20, 1e999];",
+				Options: []any{"Literal[value=\"100000000000000000000\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 30, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				// number coercion
+				Code:    "const x = [1e21, 1e-7, 1e-6, 1e20, 1e999];",
+				Options: []any{"Literal[value=\"Infinity\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 36, EndLine: 1, EndColumn: 41},
+				},
+			},
+			{
+				// string coercion
+				Code:    "const x = [\"0x100000000000000000000\", \"NaN\", \"\u0085\", \"😀\", \"\\uD800\", \"Infinity\", \"inf\"];",
+				Options: []any{"Literal[value>0]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 37},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 67, EndLine: 1, EndColumn: 77},
+				},
+			},
+			{
+				// string coercion
+				Code:    "const x = [\"0x100000000000000000000\", \"NaN\", \"\u0085\", \"😀\", \"\\uD800\", \"Infinity\", \"inf\"];",
+				Options: []any{"Literal[value.length=2]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 51, EndLine: 1, EndColumn: 55},
+				},
+			},
+			{
+				// string coercion
+				Code:    "const x = [\"0x100000000000000000000\", \"NaN\", \"\u0085\", \"😀\", \"\\uD800\", \"Infinity\", \"inf\"];",
+				Options: []any{"Literal[value.length=1]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 46, EndLine: 1, EndColumn: 49},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 57, EndLine: 1, EndColumn: 65},
+				},
+			},
+			{
+				// string coercion
+				Code:    "const x = [\"0x100000000000000000000\", \"NaN\", \"\u0085\", \"😀\", \"\\uD800\", \"Infinity\", \"inf\"];",
+				Options: []any{"Literal[value<\"�\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 37},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 39, EndLine: 1, EndColumn: 44},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 46, EndLine: 1, EndColumn: 49},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 51, EndLine: 1, EndColumn: 55},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 57, EndLine: 1, EndColumn: 65},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 67, EndLine: 1, EndColumn: 77},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 79, EndLine: 1, EndColumn: 84},
+				},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value=type(bigint)]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 14},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 32},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 33, EndLine: 1, EndColumn: 38},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 40, EndLine: 1, EndColumn: 82},
+				},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value!=/^1$/]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 32},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 33, EndLine: 1, EndColumn: 38},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 40, EndLine: 1, EndColumn: 82},
+				},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value>9007199254740992]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 32},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 40, EndLine: 1, EndColumn: 82},
+				},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value<\"9007199254740994\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 14},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 32},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 33, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value<9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 12, EndLine: 1, EndColumn: 14},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 32},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 33, EndLine: 1, EndColumn: 38},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 40, EndLine: 1, EndColumn: 82},
+				},
+			},
+			{
+				// bigint
+				Code:    "const x = [1n,9007199254740993n,0xFFn, 10000000000000000000000000000000000000000n];",
+				Options: []any{"Literal[value>\"0xFE\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 15, EndLine: 1, EndColumn: 32},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 33, EndLine: 1, EndColumn: 38},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 40, EndLine: 1, EndColumn: 82},
+				},
+			},
+			{
+				// private name
+				Code:    "class C { #x = 1; m(){ return this.#x; } }",
+				Options: []any{"PrivateIdentifier[name=\"x\"]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 13},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 36, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				// private name
+				Code:    "class C { #x = 1; m(){ return this.#x; } }",
+				Options: []any{"PrivateIdentifier[name=/^x$/]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Line: 1, Column: 11, EndLine: 1, EndColumn: 13},
+					{MessageId: "restrictedSyntax", Line: 1, Column: 36, EndLine: 1, EndColumn: 38},
+				},
+			},
+		})
+}

--- a/internal/rules/no_restricted_syntax/parser.go
+++ b/internal/rules/no_restricted_syntax/parser.go
@@ -527,9 +527,9 @@ func (p *parser) parseNumber() (float64, error) {
 			return 0, fmt.Errorf("expected digit at position %d", p.pos)
 		}
 	}
-	val, err := strconv.ParseFloat(p.src[start:p.pos], 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid number at position %d: %w", start, err)
+	val, ok := ecmascript.StringToNumber(p.src[start:p.pos])
+	if !ok {
+		return 0, fmt.Errorf("invalid number at position %d", start)
 	}
 	return val, nil
 }

--- a/internal/rules/no_restricted_syntax/probe_test.go
+++ b/internal/rules/no_restricted_syntax/probe_test.go
@@ -127,13 +127,14 @@ func TestNoRestrictedSyntax_ProbeDeepEdges(t *testing.T) {
 				},
 			},
 			// Probe: `[type!='Identifier']` — matches every non-Identifier
-			// node. For `var x = 1;` that is: VariableStatement,
+			// node. For `var x = 1;` that is: Program, VariableStatement,
 			// VariableDeclaration (the declarator), NumericLiteral.
 			// Identifier `x` is excluded.
 			{
 				Code:    `var x = 1;`,
 				Options: []interface{}{`[type!='Identifier']`},
 				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using '[type!='Identifier']' is not allowed."},
 					{MessageId: "restrictedSyntax", Message: "Using '[type!='Identifier']' is not allowed."},
 					{MessageId: "restrictedSyntax", Message: "Using '[type!='Identifier']' is not allowed."},
 					{MessageId: "restrictedSyntax", Message: "Using '[type!='Identifier']' is not allowed."},


### PR DESCRIPTION
## Summary

Fix `no-restricted-syntax` false negatives, false positives, incorrect ranges, and a panic on legal field selectors such as `.body.params`.

- Share ESTree identity and parent/child relationships across attributes, fields, combinators, sibling positions, and `:has()`. Cover folded method values, class/enum bodies, optional chains, constructors, and JSX; prevent physical-node dispatch from dropping virtual-node matches.
- Handle `Program` enter/exit, parser-only children, computed keys, and typed binding ranges. Reuse rslint's ESTree helpers and tsgo's parser boundaries instead of rescanning source.
- Use the existing ECMAScript helpers for numeric coercion, BigInt, and UTF-16 string behavior. Preserve the documented bare-wildcard and TypeScript receiver behavior, and document unsupported type-only node mappings.
- Add 159 focused regression cases checked against ESLint 10.10.0, esquery 1.7.0, and `@typescript-eslint/parser` 8.69.0. Also run the complete 34-case upstream suite, 20 real ESLint source files, and 13,442 adversarial selector/source combinations. Remaining matrix differences are unsupported TypeScript type-only nodes.

Validation passed: rule Go tests, Go race tests, JS integration tests, `check-spell`, `format:check`, changed-code Go lint, and JS lint. The additional repository-wide `typecheck` still fails in eight unchanged test adapters missing `describe`/`test`/`assert`; these errors also exist on main. JS lint has 461 existing warnings.

Temporary Go benchmarks over 100 classes, measured against the branch base:

| Scenario | Before B/op | After B/op |
| --- | ---: | ---: |
| Indexed selectors | 18,840 | 18,841 |
| Structural selectors | 1,326,168 | 137,766 |
| Wrapper ranges | 2,207,404 | 3,032 |

Structural and range workloads also ran faster. The indexed control's interleaved median was about 8% slower (49.7 to 53.8 µs/op); timing is indicative on the shared host. Benchmark and differential harness code are not included in the commit.

## Related Links

- [ESLint rule documentation](https://eslint.org/docs/latest/rules/no-restricted-syntax)
- [ESLint 10.10.0 upstream tests](https://github.com/eslint/eslint/blob/v10.10.0/tests/lib/rules/no-restricted-syntax.js)
- [esquery](https://github.com/estools/esquery)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
