### PR TITLE
perf: warm plugin workers during CLI preparation

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -850,6 +850,8 @@ The transport and target phase differ by surface:
   failures join the pending activation before returning. Initialization errors
   remain fatal and can now appear through the ordinary aborted-run output
   after the interactive start line, before any diagnostics or fixes execute.
+  The start line uses stdout; initialization and other aborted-run errors use
+  stderr in every format.
   Native-only configurations return fully verified metadata without a worker
   or a second request. `--singleThreaded` still uses one JS worker and serial
   Go work groups; that worker's initialization can overlap Go preparation.

--- a/architecture.md
+++ b/architecture.md
@@ -851,7 +851,14 @@ The transport and target phase differ by surface:
   remain fatal and can now appear through the ordinary aborted-run output
   after the interactive start line, before any diagnostics or fixes execute.
   The start line uses stdout; initialization and other aborted-run errors use
-  stderr in every format.
+  stderr in every format. If Go preparation and worker initialization both
+  fail, both errors are reported. Explicit `--cpuprof` and `--trace` outputs
+  record the Go preparation and execution reached by this invocation, including
+  failure paths. Recording starts before the activation barrier and replaces
+  the selected output file; an initialization failure still finalizes that
+  recording. Cancellation retains the engine's existing termination fallback:
+  a Go child blocked in I/O may require forced termination and report its
+  corresponding signal exit code while the engine drains owned workers.
   Native-only configurations return fully verified metadata without a worker
   or a second request. `--singleThreaded` still uses one JS worker and serial
   Go work groups; that worker's initialization can overlap Go preparation.

--- a/architecture.md
+++ b/architecture.md
@@ -851,7 +851,8 @@ The transport and target phase differ by surface:
   remain fatal and can now appear through the ordinary aborted-run output
   after the interactive start line, before any diagnostics or fixes execute.
   Native-only configurations return fully verified metadata without a worker
-  or a second request; `--singleThreaded` retains synchronous activation.
+  or a second request. `--singleThreaded` still uses one JS worker and serial
+  Go work groups; that worker's initialization can overlap Go preparation.
   The engine owns one activation per invocation: identical requests share its
   completion, conflicting selections fail, and shutdown prevents late host
   publication while draining owned builds with the existing initialization
@@ -1395,7 +1396,9 @@ Other invariants:
 | Program source identity index | Canonical source paths are resolved serially through `core.NewWorkGroup(true)`.                               |
 
 These workload stages run serially with `--singleThreaded`; infrastructure
-goroutines remain outside that guarantee.
+goroutines remain outside that guarantee. CLI plugin initialization uses one
+JS worker and can overlap the serial Go target planning and Program loading;
+lint and fix execution still await full config activation.
 
 ## 10. Performance & Memory Considerations
 

--- a/architecture.md
+++ b/architecture.md
@@ -838,8 +838,25 @@ Automatic discovery uses these rules:
 
 The transport and target phase differ by surface:
 
-- CLI sends `loadConfigs` / `activateConfigs` as reverse framed-IPC requests
-  during initialization. The resulting catalog and the later Go lint-target
+- CLI sends `loadConfigs` and the CLI-only `prepareConfigs` as reverse
+  framed-IPC requests during initialization. After final effective-ID selection
+  and the first fingerprint check, Node starts the existing plugin-host build
+  and returns provisional plugin metadata. Go may use that metadata for
+  read-only target planning and Program construction. Before `RunPipeline`,
+  `activateConfigs` joins the same activation, including its second fingerprint
+  check and host publication. The CLI adapter validates that the completed
+  metadata matches the prepared metadata. This barrier also runs with zero
+  targets, disabled plugin rules, or `--type-check-only`; earlier command
+  failures join the pending activation before returning. Initialization errors
+  remain fatal and can now appear through the ordinary aborted-run output
+  after the interactive start line, before any diagnostics or fixes execute.
+  Native-only configurations return fully verified metadata without a worker
+  or a second request; `--singleThreaded` retains synchronous activation.
+  The engine owns one activation per invocation: identical requests share its
+  completion, conflicting selections fail, and shutdown prevents late host
+  publication while draining owned builds with the existing initialization
+  timeout. API and LSP activation/commit behavior is unchanged.
+  The resulting catalog and the later Go lint-target
   walker are separate traversals, but the staged catalog already freezes the
   Git sources observed on its reachable frontier. There is no second per-owner
   directory sweep. Automatic literal scopes and explicit file-only invocations

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1844,7 +1844,7 @@ func TestPlainLintSkipsProjectResolutionWhenAllTargetsAreIgnored(t *testing.T) {
 		SingleThreaded: true,
 		TypeCheck:      true,
 	})
-	if code == 0 || !strings.Contains(stdout, "missing.json") {
+	if code != 1 || !strings.Contains(stderr, "missing.json") || strings.Contains(stdout, "missing.json") {
 		t.Fatalf("type-check must resolve every configured project: code=%d stdout=%s stderr=%s", code, stdout, stderr)
 	}
 }

--- a/cmd/rslint/config_activation_test.go
+++ b/cmd/rslint/config_activation_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/microsoft/typescript-go/shim/bundled"
-	"github.com/microsoft/typescript-go/shim/tspath"
-	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/microsoft/TypeScript/tsc/shim/bundled"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/microsoft/TypeScript/tsc/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/config/discovery"
 	"github.com/web-infra-dev/rslint/internal/ipc"

--- a/cmd/rslint/config_activation_test.go
+++ b/cmd/rslint/config_activation_test.go
@@ -141,16 +141,14 @@ func TestCLIConfigActivationBeforeExecution(t *testing.T) {
 func TestCLIConfigPreparationProtocol(t *testing.T) {
 	for _, test := range []struct {
 		name     string
-		warmup   bool
 		plugins  bool
 		mismatch bool
 		fail     bool
 	}{
-		{name: "plugins warm up", warmup: true, plugins: true},
-		{name: "native only", warmup: true},
-		{name: "single threaded", plugins: true},
-		{name: "changed metadata", warmup: true, plugins: true, mismatch: true},
-		{name: "worker failure", warmup: true, plugins: true, fail: true},
+		{name: "plugins warm up", plugins: true},
+		{name: "native only"},
+		{name: "changed metadata", plugins: true, mismatch: true},
+		{name: "worker failure", plugins: true, fail: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cli, peer := newCLIChannelPair(t)
@@ -177,7 +175,7 @@ func TestCLIConfigPreparationProtocol(t *testing.T) {
 			})
 			cli.Start()
 			peer.Start()
-			loader := &ipcConfigModuleLoader{channel: cli, warmup: test.warmup}
+			loader := &ipcConfigModuleLoader{channel: cli}
 			_, err := loader.ActivateConfigs(context.Background(), discovery.ConfigActivationRequest{
 				ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
 				TransactionID:   "selected", EffectiveConfigIDs: []string{"root"},
@@ -185,11 +183,8 @@ func TestCLIConfigPreparationProtocol(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			wantKinds := []ipc.MessageKind{kindActivateConfigs}
-			if test.warmup {
-				wantKinds[0] = kindPrepareConfigs
-			}
-			if test.warmup && test.plugins {
+			wantKinds := []ipc.MessageKind{kindPrepareConfigs}
+			if test.plugins {
 				if loader.completeActivation == nil {
 					t.Fatal("plugin preparation has no completion barrier")
 				}
@@ -204,5 +199,65 @@ func TestCLIConfigPreparationProtocol(t *testing.T) {
 				t.Fatalf("requests = %v, want %v", kinds, wantKinds)
 			}
 		})
+	}
+}
+
+func TestDiscoverCLISingleThreadedConfigPreparesPlugins(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configPath := filepath.Join(dir, "rslint.config.mjs")
+	if err := os.WriteFile(configPath, []byte("export default [];\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cli, peer := newCLIChannelPair(t)
+	var kinds []ipc.MessageKind
+	peer.SetInboundHandler(func(_ context.Context, msg *ipc.Message) (any, error) {
+		kinds = append(kinds, msg.Kind)
+		if msg.Kind == kindLoadConfigs {
+			var request discovery.ConfigLoadBatchRequest
+			if err := msg.Decode(&request); err != nil {
+				return nil, err
+			}
+			if !request.SingleThreaded || len(request.Candidates) != 1 {
+				return nil, errors.New("expected one config with single-threaded module evaluation")
+			}
+			return discovery.ConfigLoadBatchResponse{
+				TransactionID: request.TransactionID,
+				Results: []discovery.ConfigLoadResult{{
+					ID: request.Candidates[0].ID, Status: "loaded",
+					Entries: config.RslintConfig{{
+						Plugins: []string{"external"},
+						Rules:   config.Rules{"external/check": "error"},
+					}},
+				}},
+			}, nil
+		}
+		var request discovery.ConfigActivationRequest
+		if err := msg.Decode(&request); err != nil {
+			return nil, err
+		}
+		return discovery.ConfigActivationResponse{
+			TransactionID:       request.TransactionID,
+			EslintPluginEntries: []config.EslintPluginEntry{{Prefix: "external", RuleNames: []string{"check"}}},
+		}, nil
+	})
+	cli.Start()
+	peer.Start()
+	args := lintArgs{FS: osvfs.FS(), SingleThreaded: true}
+	payload := initPayload{ConfigDiscovery: &configDiscoveryPayload{ExplicitConfigPath: configPath}}
+	if err := discoverCLIConfigCatalog(context.Background(), &args, &payload, cli); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(kinds, []ipc.MessageKind{kindLoadConfigs, kindPrepareConfigs}) {
+		t.Fatalf("discovery requests = %v, want load then prepare", kinds)
+	}
+	if args.CompleteConfigActivation == nil {
+		t.Fatal("single-threaded preparation has no completion barrier")
+	}
+	if err := args.CompleteConfigActivation(); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(kinds, []ipc.MessageKind{kindLoadConfigs, kindPrepareConfigs, kindActivateConfigs}) {
+		t.Fatalf("completed requests = %v, want load then prepare then activate", kinds)
 	}
 }

--- a/cmd/rslint/config_activation_test.go
+++ b/cmd/rslint/config_activation_test.go
@@ -1,0 +1,208 @@
+//go:build !js
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/config/discovery"
+	"github.com/web-infra-dev/rslint/internal/ipc"
+	"github.com/web-infra-dev/rslint/internal/linter"
+)
+
+func TestCLIConfigActivationBeforeExecution(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		ignore        bool
+		disabled      bool
+		typeCheckOnly bool
+		badOptions    bool
+		badProject    bool
+		fix           bool
+		succeed       bool
+		defaultFormat bool
+	}{
+		{name: "lint failure"},
+		{name: "no targets", ignore: true},
+		{name: "disabled plugin", disabled: true},
+		{name: "type check only", typeCheckOnly: true},
+		{name: "preflight failure", badOptions: true},
+		{name: "Program failure", badProject: true},
+		{name: "fix failure", fix: true},
+		{name: "successful activation", succeed: true},
+		{name: "default format abort", defaultFormat: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			targetPath := tspath.NormalizePath(filepath.Join(dir, "index.ts"))
+			const content = "const value = true; if (!!value) { debugger; }\n"
+			if err := os.WriteFile(targetPath, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{"files":["index.ts"]}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			project := "./tsconfig.json"
+			if test.badProject {
+				project = "./missing.json"
+			}
+			entries := config.RslintConfig{{
+				Files:   []string{"**/*.ts"},
+				Plugins: []string{"external"},
+				Rules: config.Rules{
+					"no-debugger":           "error",
+					"no-extra-boolean-cast": "error",
+					"external/check":        "error",
+				},
+				LanguageOptions: &config.LanguageOptions{ParserOptions: &config.ParserOptions{Project: config.ProjectPaths{project}}},
+			}}
+			if test.disabled {
+				entries[0].Rules["external/check"] = "off"
+			}
+			if test.badOptions {
+				entries[0].Rules["no-debugger"] = []any{"error", "invalid-option"}
+			}
+			if test.ignore {
+				entries = append(config.RslintConfig{{Ignores: []string{"**/*.ts"}}}, entries...)
+			}
+			catalog := explicitConfigCatalogForTest(dir, entries)
+			catalog.EslintPlugins = []config.EslintPluginEntry{{Prefix: "external", RuleNames: []string{"check"}}}
+			fsys := &commandReadCountingFS{FS: bundled.WrapFS(osvfs.FS()), reads: make(map[string]int)}
+			calls, dispatches := 0, 0
+			activationError := errors.New("worker preparation rejected")
+			format := "jsonline"
+			if test.defaultFormat {
+				format = "default"
+			}
+			code, stdout, stderr := runLintCommandWithDispatcherForTest(t, dir, lintArgs{
+				ConfigCatalog:  catalog,
+				FS:             fsys,
+				AllowFiles:     []string{targetPath},
+				Format:         format,
+				SingleThreaded: true,
+				TypeCheck:      test.typeCheckOnly,
+				TypeCheckOnly:  test.typeCheckOnly,
+				Fix:            test.fix,
+				CompleteConfigActivation: func() error {
+					calls++
+					if !test.ignore && !test.badOptions && !test.badProject && fsys.readCount(targetPath) == 0 {
+						t.Error("activation joined before Program read the target")
+					}
+					if dispatches != 0 {
+						t.Error("plugin execution preceded activation")
+					}
+					if test.succeed {
+						return nil
+					}
+					return activationError
+				},
+			}, func(_ context.Context, req linter.EslintPluginLintRequest) (*linter.EslintPluginLintResult, error) {
+				dispatches++
+				if calls != 1 {
+					t.Error("plugin dispatch did not await activation")
+				}
+				results := make([]linter.EslintPluginFileResult, len(req.Files))
+				for index, file := range req.Files {
+					results[index].FilePath = file.Path
+				}
+				return &linter.EslintPluginLintResult{Results: results}, nil
+			})
+			if calls != 1 {
+				t.Fatalf("activation joins = %d, want 1", calls)
+			}
+			if test.succeed {
+				if dispatches != 1 || !strings.Contains(stdout, "no-debugger") || stderr != "" {
+					t.Fatalf("execution after activation: dispatches=%d stdout=%q stderr=%q", dispatches, stdout, stderr)
+				}
+			} else if test.defaultFormat {
+				if code != 1 || dispatches != 0 || !strings.Contains(stdout, activationError.Error()) || strings.Contains(stdout, "no-debugger") || stderr != "" {
+					t.Fatalf("default activation failure: code=%d dispatches=%d stdout=%q stderr=%q", code, dispatches, stdout, stderr)
+				}
+			} else if code != 1 || dispatches != 0 || stdout != "" || strings.Count(stderr, activationError.Error()) != 1 {
+				t.Fatalf("activation failure: code=%d dispatches=%d stdout=%q stderr=%q", code, dispatches, stdout, stderr)
+			}
+			if got, err := os.ReadFile(targetPath); err != nil || string(got) != content {
+				t.Fatalf("source changed before activation: content=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestCLIConfigPreparationProtocol(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		warmup   bool
+		plugins  bool
+		mismatch bool
+		fail     bool
+	}{
+		{name: "plugins warm up", warmup: true, plugins: true},
+		{name: "native only", warmup: true},
+		{name: "single threaded", plugins: true},
+		{name: "changed metadata", warmup: true, plugins: true, mismatch: true},
+		{name: "worker failure", warmup: true, plugins: true, fail: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cli, peer := newCLIChannelPair(t)
+			var kinds []ipc.MessageKind
+			peer.SetInboundHandler(func(_ context.Context, msg *ipc.Message) (any, error) {
+				kinds = append(kinds, msg.Kind)
+				var request discovery.ConfigActivationRequest
+				if err := msg.Decode(&request); err != nil {
+					return nil, err
+				}
+				response := discovery.ConfigActivationResponse{TransactionID: request.TransactionID}
+				if test.plugins {
+					response.EslintPluginEntries = []config.EslintPluginEntry{{Prefix: "external", RuleNames: []string{"check"}}}
+				}
+				if msg.Kind == kindActivateConfigs {
+					if test.fail {
+						return nil, errors.New("worker preparation rejected")
+					}
+					if test.mismatch {
+						response.EslintPluginEntries[0].RuleNames = []string{"different"}
+					}
+				}
+				return response, nil
+			})
+			cli.Start()
+			peer.Start()
+			loader := &ipcConfigModuleLoader{channel: cli, warmup: test.warmup}
+			_, err := loader.ActivateConfigs(context.Background(), discovery.ConfigActivationRequest{
+				ProtocolVersion: discovery.ConfigDiscoveryProtocolVersion,
+				TransactionID:   "selected", EffectiveConfigIDs: []string{"root"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantKinds := []ipc.MessageKind{kindActivateConfigs}
+			if test.warmup {
+				wantKinds[0] = kindPrepareConfigs
+			}
+			if test.warmup && test.plugins {
+				if loader.completeActivation == nil {
+					t.Fatal("plugin preparation has no completion barrier")
+				}
+				if err := loader.completeActivation(); (err != nil) != (test.fail || test.mismatch) {
+					t.Fatalf("complete activation: %v", err)
+				}
+				wantKinds = append(wantKinds, kindActivateConfigs)
+			} else if loader.completeActivation != nil {
+				t.Fatal("already activated config has a redundant barrier")
+			}
+			if !slices.Equal(kinds, wantKinds) {
+				t.Fatalf("requests = %v, want %v", kinds, wantKinds)
+			}
+		})
+	}
+}

--- a/cmd/rslint/config_activation_test.go
+++ b/cmd/rslint/config_activation_test.go
@@ -90,6 +90,7 @@ func TestCLIConfigActivationBeforeExecution(t *testing.T) {
 				FS:             fsys,
 				AllowFiles:     []string{targetPath},
 				Format:         format,
+				NoColor:        true,
 				SingleThreaded: true,
 				TypeCheck:      test.typeCheckOnly,
 				TypeCheckOnly:  test.typeCheckOnly,

--- a/cmd/rslint/config_activation_test.go
+++ b/cmd/rslint/config_activation_test.go
@@ -41,6 +41,7 @@ func TestCLIConfigActivationBeforeExecution(t *testing.T) {
 		{name: "fix failure", fix: true},
 		{name: "successful activation", succeed: true},
 		{name: "default format abort", defaultFormat: true},
+		{name: "default format Program failure", defaultFormat: true, badProject: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -125,8 +126,12 @@ func TestCLIConfigActivationBeforeExecution(t *testing.T) {
 					t.Fatalf("execution after activation: dispatches=%d stdout=%q stderr=%q", dispatches, stdout, stderr)
 				}
 			} else if test.defaultFormat {
-				if code != 1 || dispatches != 0 || !strings.Contains(stdout, activationError.Error()) || strings.Contains(stdout, "no-debugger") || stderr != "" {
+				if code != 1 || dispatches != 0 || stdout != "start   Linting...\n" ||
+					!strings.HasPrefix(stderr, "error   Linting failed in ") || strings.Count(stderr, activationError.Error()) != 1 {
 					t.Fatalf("default activation failure: code=%d dispatches=%d stdout=%q stderr=%q", code, dispatches, stdout, stderr)
+				}
+				if test.badProject && !strings.Contains(stderr, "missing.json") {
+					t.Fatalf("Program failure missing from stderr: %q", stderr)
 				}
 			} else if code != 1 || dispatches != 0 || stdout != "" || strings.Count(stderr, activationError.Error()) != 1 {
 				t.Fatalf("activation failure: code=%d dispatches=%d stdout=%q stderr=%q", code, dispatches, stdout, stderr)

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -95,7 +95,6 @@ type configDiscoveryPayload struct {
 
 type ipcConfigModuleLoader struct {
 	channel            *ipc.Channel
-	warmup             bool
 	completeActivation func() error
 }
 
@@ -112,15 +111,11 @@ func (loader *ipcConfigModuleLoader) LoadConfigs(ctx context.Context, request di
 }
 
 func (loader *ipcConfigModuleLoader) ActivateConfigs(ctx context.Context, request discovery.ConfigActivationRequest) (discovery.ConfigActivationResponse, error) {
-	kind := kindActivateConfigs
-	if loader.warmup {
-		kind = kindPrepareConfigs
-	}
-	response, err := loader.requestActivation(ctx, kind, request)
+	response, err := loader.requestActivation(ctx, kindPrepareConfigs, request)
 	if err != nil {
 		return discovery.ConfigActivationResponse{}, err
 	}
-	if loader.warmup && len(response.EslintPluginEntries) > 0 {
+	if len(response.EslintPluginEntries) > 0 {
 		loader.completeActivation = func() error {
 			activated, err := loader.requestActivation(ctx, kindActivateConfigs, request)
 			if err != nil {
@@ -551,7 +546,7 @@ func discoverCLIConfigCatalog(
 			Explicit: true,
 		})
 	}
-	loader := &ipcConfigModuleLoader{channel: channel, warmup: !args.SingleThreaded}
+	loader := &ipcConfigModuleLoader{channel: channel}
 	var catalog *discovery.ConfigCatalog
 	if payload.ConfigDiscovery.ExplicitConfigPath != "" {
 		targetFiles := append([]discovery.DiscoveryFile(nil), request.Files...)

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -39,6 +39,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -52,6 +53,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/ipc"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/output"
+	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 // Application-level IPC message kinds for the CLI ⇆ Node engine protocol.
@@ -64,6 +66,7 @@ const (
 	kindPluginLint      ipc.MessageKind = "pluginLint"      // Go → Node: run ESLint-plugin rules in a worker
 	kindLoadConfigs     ipc.MessageKind = "loadConfigs"     // Go → Node: evaluate one config frontier
 	kindActivateConfigs ipc.MessageKind = "activateConfigs" // Go → Node: prepare the effective config/plugin set
+	kindPrepareConfigs  ipc.MessageKind = "prepareConfigs"  // Go → Node: start activation, return planning metadata
 )
 
 // initPayload mirrors the IPC `init` message sent by engine.ts. Field shape
@@ -91,7 +94,9 @@ type configDiscoveryPayload struct {
 }
 
 type ipcConfigModuleLoader struct {
-	channel *ipc.Channel
+	channel            *ipc.Channel
+	warmup             bool
+	completeActivation func() error
 }
 
 func (loader *ipcConfigModuleLoader) LoadConfigs(ctx context.Context, request discovery.ConfigLoadBatchRequest) (discovery.ConfigLoadBatchResponse, error) {
@@ -107,13 +112,42 @@ func (loader *ipcConfigModuleLoader) LoadConfigs(ctx context.Context, request di
 }
 
 func (loader *ipcConfigModuleLoader) ActivateConfigs(ctx context.Context, request discovery.ConfigActivationRequest) (discovery.ConfigActivationResponse, error) {
-	msg, err := loader.channel.SendRequest(ctx, kindActivateConfigs, request)
+	kind := kindActivateConfigs
+	if loader.warmup {
+		kind = kindPrepareConfigs
+	}
+	response, err := loader.requestActivation(ctx, kind, request)
+	if err != nil {
+		return discovery.ConfigActivationResponse{}, err
+	}
+	if loader.warmup && len(response.EslintPluginEntries) > 0 {
+		loader.completeActivation = func() error {
+			activated, err := loader.requestActivation(ctx, kindActivateConfigs, request)
+			if err != nil {
+				return err
+			}
+			if activated.TransactionID != response.TransactionID || !slices.EqualFunc(
+				activated.EslintPluginEntries, response.EslintPluginEntries,
+				func(a, b rule.ESLintPluginMetadata) bool {
+					return a.Prefix == b.Prefix && slices.Equal(a.RuleNames, b.RuleNames)
+				},
+			) {
+				return errors.New("config activation does not match prepared metadata")
+			}
+			return nil
+		}
+	}
+	return response, nil
+}
+
+func (loader *ipcConfigModuleLoader) requestActivation(ctx context.Context, kind ipc.MessageKind, request discovery.ConfigActivationRequest) (discovery.ConfigActivationResponse, error) {
+	msg, err := loader.channel.SendRequest(ctx, kind, request)
 	if err != nil {
 		return discovery.ConfigActivationResponse{}, err
 	}
 	var response discovery.ConfigActivationResponse
 	if err := msg.Decode(&response); err != nil {
-		return discovery.ConfigActivationResponse{}, fmt.Errorf("decode activateConfigs response: %w", err)
+		return discovery.ConfigActivationResponse{}, fmt.Errorf("decode %s response: %w", kind, err)
 	}
 	return response, nil
 }
@@ -517,7 +551,7 @@ func discoverCLIConfigCatalog(
 			Explicit: true,
 		})
 	}
-	loader := &ipcConfigModuleLoader{channel: channel}
+	loader := &ipcConfigModuleLoader{channel: channel, warmup: !args.SingleThreaded}
 	var catalog *discovery.ConfigCatalog
 	if payload.ConfigDiscovery.ExplicitConfigPath != "" {
 		targetFiles := append([]discovery.DiscoveryFile(nil), request.Files...)
@@ -553,6 +587,7 @@ func discoverCLIConfigCatalog(
 		return errors.New("no rslint config found; run `rslint --init` to create one")
 	}
 	args.ConfigCatalog = catalog
+	args.CompleteConfigActivation = loader.completeActivation
 	return nil
 }
 

--- a/cmd/rslint/ipc_cli_test.go
+++ b/cmd/rslint/ipc_cli_test.go
@@ -115,7 +115,7 @@ func TestDiscoverCLIExplicitConfigProjectsMixedTargetsOnly(t *testing.T) {
 					Status: "loaded",
 				}},
 			}, nil
-		case kindActivateConfigs:
+		case kindPrepareConfigs:
 			var request discovery.ConfigActivationRequest
 			if err := msg.Decode(&request); err != nil {
 				return nil, err

--- a/cmd/rslint/ipc_cli_test.go
+++ b/cmd/rslint/ipc_cli_test.go
@@ -714,7 +714,7 @@ func serveCLITestPeer(
 				recordError(fmt.Errorf("write loadConfigs response: %w", err))
 			}
 
-		case msg.ID > 0 && msg.Kind == kindActivateConfigs:
+		case msg.ID > 0 && (msg.Kind == kindActivateConfigs || msg.Kind == kindPrepareConfigs):
 			var request discovery.ConfigActivationRequest
 			if err := msg.Decode(&request); err != nil {
 				recordError(fmt.Errorf("decode activateConfigs request: %w", err))

--- a/cmd/rslint/lint_command.go
+++ b/cmd/rslint/lint_command.go
@@ -64,7 +64,20 @@ func resolveStartTime(startTimeMs int64) time.Time {
 // handleLintCommand handles one CLI invocation: it prepares command-owned
 // config/targets/Programs, delegates lint execution to linter.RunPipeline, and
 // projects the result to the selected output format.
-func handleLintCommand(args lintArgs, ctx context.Context, dispatch linter.EslintPluginDispatcher) int {
+func handleLintCommand(args lintArgs, ctx context.Context, dispatch linter.EslintPluginDispatcher) (exitCode int) {
+	completeActivation := args.CompleteConfigActivation
+	// Even a preflight/Program error must observe preparation failure and join
+	// the pending transaction. Cancellation is still owned by the IPC adapter.
+	defer func() {
+		if completeActivation != nil {
+			if err := completeActivation(); err != nil {
+				if ctx.Err() == nil {
+					fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				}
+				exitCode = 1
+			}
+		}
+	}()
 	// Unpack into locals so the command body below stays focused — only the
 	// flag-parse front matter lives in parseLintFlags.
 	init := args.Init
@@ -379,6 +392,17 @@ func handleLintCommand(args lintArgs, ctx context.Context, dispatch linter.Eslin
 			return abortRun(err.Error(), fmt.Sprintf("error: %v", err))
 		}
 		programs = loadedPrograms.Programs
+	}
+
+	// Metadata was sufficient for planning, but execution requires the exact
+	// host validated by Node's post-prepare fingerprint check. Join even when
+	// there are no targets, no enabled plugin rules, or only type checking.
+	if completeActivation != nil {
+		complete := completeActivation
+		completeActivation = nil
+		if err := complete(); err != nil {
+			return abortRun(err.Error(), fmt.Sprintf("error: %v", err))
+		}
 	}
 
 	// Only the default formatter consumes the completed-run summary. Freeze

--- a/cmd/rslint/lint_command.go
+++ b/cmd/rslint/lint_command.go
@@ -297,7 +297,7 @@ func handleLintCommand(args lintArgs, ctx context.Context, dispatch linter.Eslin
 			return 1
 		}
 		if format == output.FormatDefault {
-			if err := output.RenderAbort(os.Stdout, mode, timeBefore, reason, outputOptions); err != nil {
+			if err := output.RenderAbort(os.Stderr, mode, timeBefore, reason, outputOptions); err != nil {
 				fmt.Fprintf(os.Stderr, "error writing lint report: %v\n", err)
 			}
 		} else {

--- a/cmd/rslint/lint_command.go
+++ b/cmd/rslint/lint_command.go
@@ -137,6 +137,9 @@ func handleLintCommand(args lintArgs, ctx context.Context, dispatch linter.Eslin
 	enableVirtualTerminalProcessing()
 	timeBefore := resolveStartTime(startTimeMs)
 
+	// Explicit profiles cover this Go invocation's preparation as well as linting.
+	// Start before joining plugin activation and finalize on failure too; the
+	// requested output replaces any previous recording at the same path.
 	if traceOut != "" {
 		f, err := os.Create(traceOut)
 		if err != nil {

--- a/cmd/rslint/lint_options.go
+++ b/cmd/rslint/lint_options.go
@@ -60,6 +60,10 @@ type lintArgs struct {
 	// Every lint invocation requires a non-empty automatic catalog or one
 	// explicit config entry.
 	ConfigCatalog *discovery.ConfigCatalog
+	// CompleteConfigActivation validates the CLI's provisional plugin metadata
+	// after read-only target/Program preparation and before any lint or fixes.
+	// The command also joins it on early failure. Nil means already activated.
+	CompleteConfigActivation func() error
 }
 
 // repeatedFlag collects multiple values for the same flag (e.g. --rule used multiple times).

--- a/internal/ipc/channel.go
+++ b/internal/ipc/channel.go
@@ -232,7 +232,10 @@ func (c *Channel) SendRequest(ctx context.Context, kind MessageKind, payload any
 		if resp.Kind == KindError {
 			var e ErrorResponseData
 			_ = resp.Decode(&e)
-			return nil, fmt.Errorf("ipc: peer error: %s", e.Message)
+			if e.Message == "" {
+				e.Message = "request failed"
+			}
+			return nil, errors.New(e.Message)
 		}
 		return resp, nil
 	case <-ctx.Done():

--- a/internal/ipc/channel_test.go
+++ b/internal/ipc/channel_test.go
@@ -74,22 +74,34 @@ func TestChannel_RequestResponse(t *testing.T) {
 }
 
 func TestChannel_InboundError(t *testing.T) {
-	a, b := newChannelPair(t)
-	b.SetInboundHandler(func(_ context.Context, _ *Message) (any, error) {
-		return nil, io.ErrUnexpectedEOF // arbitrary handler failure
-	})
-	a.Start()
-	b.Start()
+	for _, test := range []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{name: "message", message: "invalid config: boom", want: "invalid config: boom"},
+		{name: "empty", want: "request failed"},
+		{name: "user prefix", message: "ipc: peer error: from config", want: "ipc: peer error: from config"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a, b := newChannelPair(t)
+			b.SetInboundHandler(func(_ context.Context, _ *Message) (any, error) {
+				return nil, errors.New(test.message)
+			})
+			a.Start()
+			b.Start()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	_, err := a.SendRequest(ctx, "boom", nil)
-	if err == nil {
-		t.Fatal("expected error from peer handler")
-		return
-	}
-	if got := err.Error(); got == "" || !strings.Contains(got, "peer error") {
-		t.Fatalf("expected peer error, got %q", got)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, err := a.SendRequest(ctx, "boom", nil)
+			if err == nil {
+				t.Fatal("expected error from peer handler")
+				return
+			}
+			if got := err.Error(); got != test.want {
+				t.Fatalf("handler error = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 
@@ -721,8 +733,8 @@ func TestChannel_HandlerPanicRecovered(t *testing.T) {
 		t.Fatal("expected error from panicking handler")
 		return
 	}
-	if !strings.Contains(err.Error(), "peer error") {
-		t.Fatalf("expected peer error frame, got %v", err)
+	if got, want := err.Error(), "inbound handler panicked: handler boom"; got != want {
+		t.Fatalf("handler error = %q, want %q", got, want)
 	}
 }
 

--- a/packages/rslint/src/cli/engine.ts
+++ b/packages/rslint/src/cli/engine.ts
@@ -437,10 +437,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
           selected,
           configAbort.signal,
           async (activation) => {
-            if (
-              activation.pluginConfigs.length > 0 &&
-              !opts.runtime?.singleThreaded
-            ) {
+            if (activation.pluginConfigs.length > 0) {
               // This response permits read-only Go planning, never execution.
               // The original activation still owns preparation and its second
               // fingerprint check; activateConfigs below awaits that result.
@@ -461,7 +458,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
       }
     })();
     // Observe failure immediately, even before Go reaches its final barrier.
-    // Native-only and single-threaded runs receive fully validated metadata.
+    // Native-only runs receive fully validated metadata.
     void ready.then(resolveMetadata, rejectMetadata);
     configActivation = { request: selected, metadata, ready };
     return configActivation;

--- a/packages/rslint/src/cli/engine.ts
+++ b/packages/rslint/src/cli/engine.ts
@@ -18,6 +18,7 @@ import {
   CONFIG_DISCOVERY_PROTOCOL_VERSION,
   ConfigModuleHost,
   type ActivateConfigsRequest,
+  type ActivateConfigsResponse,
   type LoadConfigsRequest,
 } from '../config/config-loader.js';
 
@@ -322,6 +323,14 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
   const configModuleHost = opts.configModuleHost ?? new ConfigModuleHost();
   const configTransactions = new Set<string>();
   let shuttingDown = false;
+  const configAbort = new AbortController();
+  let configActivation:
+    | {
+        request: ActivateConfigsRequest;
+        metadata: Promise<ActivateConfigsResponse>;
+        ready: Promise<ActivateConfigsResponse>;
+      }
+    | undefined;
   const pendingPluginHostBuilds = new Set<Promise<PluginLintHost | null>>();
   const stagedPluginHosts = new Set<PluginLintHost>();
   const pluginHostShutdowns = new WeakMap<PluginLintHost, Promise<void>>();
@@ -369,6 +378,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
         }
         createPluginLintHost = mod.createPluginLintHost;
       }
+      if (shuttingDown) return null;
       const host = await createPluginLintHost(
         pluginConfigs,
         (rec) => stderr.write(`[rslint:plugin] ${rec.text}\n`),
@@ -390,6 +400,73 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
     return host;
   };
 
+  const activateConfigs = (request: ActivateConfigsRequest) => {
+    if (shuttingDown)
+      throw new Error('engine: config activation after shutdown');
+    if (configActivation) {
+      const previous = configActivation.request;
+      if (
+        previous.transactionId !== request.transactionId ||
+        previous.effectiveConfigIds.length !==
+          request.effectiveConfigIds.length ||
+        previous.effectiveConfigIds.some(
+          (id, index) => id !== request.effectiveConfigIds[index],
+        )
+      ) {
+        throw new Error('engine: conflicting config activation');
+      }
+      return configActivation;
+    }
+    // One CLI invocation owns one selection. Snapshot it so both fingerprint
+    // checks and every waiter refer to the same effective sources.
+    const selected = {
+      ...request,
+      effectiveConfigIds: [...request.effectiveConfigIds],
+    };
+    let resolveMetadata!: (response: ActivateConfigsResponse) => void;
+    let rejectMetadata!: (error: unknown) => void;
+    const metadata = new Promise<ActivateConfigsResponse>((resolve, reject) => {
+      resolveMetadata = resolve;
+      rejectMetadata = reject;
+    });
+    void metadata.catch(() => undefined);
+    let stagedPluginHost: PluginLintHost | null = null;
+    const ready = (async () => {
+      try {
+        const response = await configModuleHost.activateConfigs(
+          selected,
+          configAbort.signal,
+          async (activation) => {
+            if (
+              activation.pluginConfigs.length > 0 &&
+              !opts.runtime?.singleThreaded
+            ) {
+              // This response permits read-only Go planning, never execution.
+              // The original activation still owns preparation and its second
+              // fingerprint check; activateConfigs below awaits that result.
+              resolveMetadata({
+                transactionId: activation.transactionId,
+                eslintPluginEntries: activation.eslintPluginEntries,
+              });
+            }
+            stagedPluginHost = await buildPluginHost(activation.pluginConfigs);
+          },
+        );
+        await publishPluginHost(stagedPluginHost);
+        stagedPluginHost = null;
+        return response;
+      } catch (error) {
+        await shutdownPluginHost(stagedPluginHost).catch(() => undefined);
+        throw error;
+      }
+    })();
+    // Observe failure immediately, even before Go reaches its final barrier.
+    // Native-only and single-threaded runs receive fully validated metadata.
+    void ready.then(resolveMetadata, rejectMetadata);
+    configActivation = { request: selected, metadata, ready };
+    return configActivation;
+  };
+
   // Without our own SIGINT handler Node's default action _exit(130)s
   // immediately, leaving the Go child to discover the disconnect via stdin EOF
   // — which a wedged child can't. Intercept and force it down first.
@@ -398,6 +475,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
     // expected path, not an error — forward the kill to the Go child and tear
     // the worker pool down so its threads don't outlive us.
     shuttingDown = true;
+    configAbort.abort();
     safeKillGo(child);
     void Promise.allSettled([
       shutdownPluginHost(pluginHost),
@@ -427,46 +505,29 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
     ipc.setInboundHandler(async (msg) => {
       switch (msg.kind) {
         case 'loadConfigs': {
+          if (shuttingDown || configActivation) {
+            throw new Error('engine: config load after activation or shutdown');
+          }
           if (!isLoadConfigsRequest(msg.data)) {
             throw new Error('engine: invalid loadConfigs request');
           }
           const request = msg.data;
-          const response = await configModuleHost.loadConfigs(request);
           configTransactions.add(request.transactionId);
+          const response = await configModuleHost.loadConfigs(
+            request,
+            configAbort.signal,
+          );
           return response;
         }
+        case 'prepareConfigs':
         case 'activateConfigs': {
           if (!isActivateConfigsRequest(msg.data)) {
             throw new Error('engine: invalid activateConfigs request');
           }
-          const request = msg.data;
-          let stagedPluginHost: PluginLintHost | null = null;
-          try {
-            const response = await configModuleHost.activateConfigs(
-              request,
-              undefined,
-              async (activation) => {
-                if (pluginHost) return;
-                const createdHost = await buildPluginHost(
-                  activation.pluginConfigs,
-                );
-                if (shuttingDown) {
-                  await shutdownPluginHost(createdHost).catch(() => undefined);
-                  return;
-                }
-                stagedPluginHost = createdHost;
-              },
-            );
-            // Do not expose a worker that re-imported the config until the
-            // post-prepare fingerprint check has accepted the activation.
-            const preparedHost = stagedPluginHost;
-            await publishPluginHost(preparedHost);
-            stagedPluginHost = null;
-            return response;
-          } catch (error) {
-            await shutdownPluginHost(stagedPluginHost).catch(() => undefined);
-            throw error;
-          }
+          const activation = activateConfigs(msg.data);
+          return msg.kind === 'prepareConfigs'
+            ? activation.metadata
+            : activation.ready;
         }
         case 'output': {
           if (!isOutputRequest(msg.data)) {
@@ -485,6 +546,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
           return { ok: true };
         }
         case 'pluginLint':
+          if (configActivation) await configActivation.ready;
           // Go dispatched a plugin-lint batch in parallel with native linting.
           // Go only dispatches after activation returned plugin metadata, so a
           // missing published host is a protocol/lifecycle failure. Surface it
@@ -567,6 +629,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
     // even on the normal path and after the signal handler already fired.
     removeSignalHandlers();
     shuttingDown = true;
+    configAbort.abort();
     await Promise.allSettled([...pendingPluginHostBuilds]);
     await Promise.allSettled([
       shutdownPluginHost(pluginHost),

--- a/packages/rslint/src/eslint-plugin/worker-pool.ts
+++ b/packages/rslint/src/eslint-plugin/worker-pool.ts
@@ -830,7 +830,7 @@ export class WorkerPool {
         void terminateWorker(worker);
         reject(
           new Error(
-            `worker ${id} init timed out after ${this.opts.workerInitTimeoutMs}ms`,
+            `worker init timed out after ${this.opts.workerInitTimeoutMs}ms`,
           ),
         );
       }, this.opts.workerInitTimeoutMs);
@@ -848,7 +848,7 @@ export class WorkerPool {
         clearTimeout(initTimer);
         reject(
           new Error(
-            `worker ${id} exited during init (code=${code}) before sending ready`,
+            `worker exited during init (code=${code}) before sending ready`,
           ),
         );
       };
@@ -893,7 +893,7 @@ export class WorkerPool {
           worker.once('exit', () => {
             clearTimeout(graceTimer);
           });
-          reject(new Error(`worker ${id} init failed: ${String(msg.message)}`));
+          reject(new Error(`worker init failed: ${String(msg.message)}`));
         } else {
           // Unexpected pre-ready message — ignore.
         }
@@ -901,7 +901,7 @@ export class WorkerPool {
       const onError = (err: Error) => {
         clearTimeout(initTimer);
         worker.off('exit', onExit);
-        reject(new Error(`worker ${id} error during init: ${err.message}`));
+        reject(new Error(`worker error during init: ${err.message}`));
       };
       worker.on('message', onMessage);
       worker.once('error', onError);
@@ -946,7 +946,7 @@ export class WorkerPool {
       this.opts.onLog?.({
         level: 'error',
         source: 'runner',
-        text: `worker ${slot.id} error: ${err instanceof Error ? err.message : String(err)}`,
+        text: `worker error: ${err instanceof Error ? err.message : String(err)}`,
       });
     });
 
@@ -955,7 +955,7 @@ export class WorkerPool {
       for (const [, p] of slot.inflight) {
         clearTimeout(p.timer);
         this.cancelPool.release(p.cancelSlot);
-        p.reject(new Error(`worker ${slot.id} exited with code ${code}`));
+        p.reject(new Error(`worker exited with code ${code}`));
       }
       slot.inflight.clear();
       slot.ready = false;
@@ -968,7 +968,7 @@ export class WorkerPool {
         this.opts.onLog?.({
           level: 'warn',
           source: 'runner',
-          text: `worker ${slot.id} exited unexpectedly (code=${code}); respawning (try ${slot.crashCount}/${this.opts.retryCap})`,
+          text: `worker exited unexpectedly (code=${code}); respawning (try ${slot.crashCount}/${this.opts.retryCap})`,
         });
         // Replace this slot with a fresh worker. We re-use init's logic.
         //
@@ -1026,7 +1026,7 @@ export class WorkerPool {
             this.opts.onLog?.({
               level: 'error',
               source: 'runner',
-              text: `worker ${slot.id} respawn failed: ${(err as Error).message}`,
+              text: `worker respawn failed: ${(err as Error).message}`,
             });
             // Respawn rejected: slot stays `ready=false` from the exit
             // handler above and there is no further event that could
@@ -1049,7 +1049,7 @@ export class WorkerPool {
         this.opts.onLog?.({
           level: 'error',
           source: 'runner',
-          text: `worker ${slot.id} respawn cap reached (${this.opts.retryCap}); pool degraded`,
+          text: `worker respawn cap reached (${this.opts.retryCap}); pool degraded`,
         });
         // If THIS exit was the last one keeping the pool servicing
         // tasks, drain `pendingQueue` so the caller's
@@ -1153,7 +1153,7 @@ export class WorkerPool {
       this.opts.onLog?.({
         level: 'warn',
         source: 'runner',
-        text: `task ${taskId} on worker ${slot.id} timed out after ${this.opts.taskTimeoutMs}ms; terminating worker`,
+        text: `worker task timed out after ${this.opts.taskTimeoutMs}ms; terminating worker`,
       });
       // Reject this task with a "plugin-lint-failed"-shaped result.
       resolveOk({

--- a/packages/rslint/src/ipc/client.ts
+++ b/packages/rslint/src/ipc/client.ts
@@ -508,7 +508,14 @@ export class IpcClient {
     this.pending.delete(msg.id);
     if (msg.kind === ERROR_KIND) {
       const data = msg.data as ErrorResponseData | undefined;
-      p.reject(new Error(`peer error: ${data?.message ?? '(no message)'}`));
+      const message = data?.message;
+      p.reject(
+        new Error(
+          typeof message === 'string' && message.length > 0
+            ? message
+            : 'request failed',
+        ),
+      );
       return;
     }
     p.resolve(msg);

--- a/packages/rslint/src/ipc/protocol.ts
+++ b/packages/rslint/src/ipc/protocol.ts
@@ -36,6 +36,9 @@ export type MessageKind =
   // logical payload is used by the API and LSP adapters.
   | 'loadConfigs'
   | 'activateConfigs'
+  // CLI-only: start the same activation, returning provisional metadata for
+  // planning. activateConfigs must complete before lint/fix execution.
+  | 'prepareConfigs'
   // Go → Node reverse request: run JS ESLint-plugin rules for a batch of
   // files in the worker pool and return the diagnostics.
   | 'pluginLint';

--- a/packages/rslint/tests/engine-warmup.test.ts
+++ b/packages/rslint/tests/engine-warmup.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, test } from 'rstack/test';
+import { ChildProcess } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough, Writable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { runEngine, type EngineRunOptions } from '../src/cli/engine.js';
+import { ConfigModuleHost } from '../src/config/config-loader.js';
+
+const FAKE_BIN = fileURLToPath(
+  new URL('./fixtures/fake-worker-warmup.cjs', import.meta.url),
+);
+const PLUGIN_CONFIG = [{ plugins: { local: { rules: { example: {} } } } }];
+
+function gate<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+interface WireResult {
+  kind: string;
+  data: Record<string, unknown>;
+}
+
+interface FixtureEvent {
+  event: string;
+  preparation?: WireResult;
+  duplicates?: WireResult[];
+  conflicts?: WireResult[];
+  loadAfterActivation?: WireResult;
+  settled?: boolean | boolean[];
+  results?: WireResult[];
+  activation?: WireResult;
+  plugin?: WireResult;
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rslint-worker-warmup-'));
+  const configPath = path.join(root, 'rslint.config.mjs');
+  fs.writeFileSync(configPath, '// original config bytes\n');
+  const events = new Map<string, ReturnType<typeof gate<FixtureEvent>>>();
+  const eventGate = (name: string) => {
+    let deferred = events.get(name);
+    if (!deferred) {
+      deferred = gate<FixtureEvent>();
+      events.set(name, deferred);
+    }
+    return deferred;
+  };
+  let beforeAcknowledge = async (_event: FixtureEvent): Promise<void> => {};
+  const stdout = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      const event: FixtureEvent = JSON.parse(chunk.toString());
+      eventGate(event.event).resolve(event);
+      void beforeAcknowledge(event).then(
+        () => callback(),
+        (error: Error) => callback(error),
+      );
+    },
+  });
+  return {
+    configPath,
+    setAcknowledge(callback: typeof beforeAcknowledge) {
+      beforeAcknowledge = callback;
+    },
+    async event(name: string): Promise<FixtureEvent> {
+      // This is only a deadlock cleanup sentinel. Success and ordering are
+      // established by the peer's acknowledged IPC gates, never elapsed time.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          eventGate(name).promise,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error(`warmup peer did not report ${name}`)),
+              30_000,
+            );
+          }),
+        ]);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    run(mode: string, options: Partial<EngineRunOptions> = {}) {
+      return runEngine({
+        binPath: process.execPath,
+        goArgs: [FAKE_BIN, configPath, mode],
+        stdout,
+        stderr: new PassThrough(),
+        configModuleHost: new ConfigModuleHost({
+          loadCached: async () => PLUGIN_CONFIG,
+        }),
+        ...options,
+      });
+    },
+    dispose() {
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('CLI worker warmup', () => {
+  test('returns planning metadata once and joins concurrent activation and plugin requests', async () => {
+    const peer = fixture();
+    const build = gate();
+    const buildStarted = gate();
+    let createCalls = 0;
+    let shutdownCalls = 0;
+    const lintRequests: unknown[] = [];
+    peer.setAcknowledge(async ({ event }) => {
+      if (event === 'waiters-started') await buildStarted.promise;
+    });
+    const run = peer.run('concurrent', {
+      createPluginLintHost: async () => {
+        createCalls++;
+        buildStarted.resolve();
+        await build.promise;
+        return {
+          async lint(request) {
+            lintRequests.push(request);
+            return { results: [] };
+          },
+          async shutdown() {
+            shutdownCalls++;
+          },
+        };
+      },
+    });
+    try {
+      const prepared = await peer.event('prepared');
+      expect(prepared.preparation).toMatchObject({
+        kind: 'response',
+        data: {
+          transactionId: 'cli-worker-warmup',
+          eslintPluginEntries: [{ prefix: 'local', ruleNames: ['example'] }],
+        },
+      });
+      const repeated = await peer.event('repeated');
+      expect(repeated.duplicates).toHaveLength(2);
+      for (const duplicate of repeated.duplicates ?? []) {
+        expect(duplicate.data).toEqual(prepared.preparation?.data);
+        expect(duplicate.kind).toBe('response');
+      }
+      expect(repeated.conflicts).toHaveLength(2);
+      for (const conflict of repeated.conflicts ?? []) {
+        expect(conflict).toMatchObject({
+          kind: 'error',
+          data: { message: 'engine: conflicting config activation' },
+        });
+      }
+      expect(repeated.loadAfterActivation).toMatchObject({ kind: 'error' });
+      expect((await peer.event('waiters-pending')).settled).toEqual([
+        false,
+        false,
+        false,
+      ]);
+      expect(createCalls).toBe(1);
+      expect(lintRequests).toEqual([]);
+      build.resolve();
+      const completed = await peer.event('completed');
+      expect(completed.results?.map(({ kind }) => kind)).toEqual([
+        'response',
+        'response',
+        'response',
+      ]);
+      expect(completed.results?.[0].data).toEqual(prepared.preparation?.data);
+      expect(lintRequests).toEqual([
+        { request: 'first' },
+        { request: 'second' },
+      ]);
+      expect(await run).toBe(0);
+      expect(shutdownCalls).toBe(1);
+    } finally {
+      build.resolve();
+      await run;
+      peer.dispose();
+    }
+  });
+
+  test.each([
+    ['before preparation', 'changed while it was being loaded', 0],
+    ['during preparation', 'plugin host was being prepared', 1],
+    ['factory failure', 'mocked worker import failed', 0],
+    ['without tasks', 'mocked worker import failed', 0],
+  ] as const)(
+    'propagates failure %s to the activation barrier',
+    async (phase, message, expectedShutdowns) => {
+      const peer = fixture();
+      const build = gate();
+      let reads = 0;
+      let createCalls = 0;
+      let lintCalls = 0;
+      let shutdownCalls = 0;
+      const run = peer.run(
+        phase === 'without tasks' ? 'failure-without-tasks' : 'failure',
+        {
+          configModuleHost: new ConfigModuleHost({
+            loadCached: async () => PLUGIN_CONFIG,
+            readSource: async (sourcePath) => {
+              reads++;
+              if (phase === 'before preparation' && reads === 3) {
+                fs.writeFileSync(sourcePath, '// changed before preparation\n');
+              }
+              return fs.promises.readFile(sourcePath);
+            },
+          }),
+          createPluginLintHost: async () => {
+            createCalls++;
+            await build.promise;
+            if (phase !== 'during preparation') {
+              throw new Error('mocked worker import failed');
+            }
+            fs.writeFileSync(
+              peer.configPath,
+              '// changed during preparation\n',
+            );
+            return {
+              async lint() {
+                lintCalls++;
+                return { results: [] };
+              },
+              async shutdown() {
+                shutdownCalls++;
+              },
+            };
+          },
+        },
+      );
+      try {
+        const prepared = await peer.event('prepared');
+        expect(prepared.preparation?.kind).toBe(
+          phase === 'before preparation' ? 'error' : 'response',
+        );
+        build.resolve();
+        const completed = await peer.event('completed');
+        expect(completed.activation?.kind).toBe('error');
+        expect(completed.activation?.data.message).toContain(message);
+        if (phase !== 'without tasks') {
+          expect(completed.plugin?.kind).toBe('error');
+          expect(completed.plugin?.data.message).toContain(message);
+        } else {
+          expect(completed.plugin).toBeUndefined();
+        }
+        expect(await run).toBe(0);
+        expect(createCalls).toBe(phase === 'before preparation' ? 0 : 1);
+        expect(lintCalls).toBe(0);
+        expect(shutdownCalls).toBe(expectedShutdowns);
+      } finally {
+        build.resolve();
+        await run;
+        peer.dispose();
+      }
+    },
+  );
+
+  test.each(['native-only', 'single-threaded'] as const)(
+    'keeps %s preparation synchronous',
+    async (mode) => {
+      const peer = fixture();
+      const preparation = gate();
+      const preparationStarted = gate();
+      let reads = 0;
+      let createCalls = 0;
+      let shutdownCalls = 0;
+      peer.setAcknowledge(async ({ event }) => {
+        if (event === 'waiters-started') await preparationStarted.promise;
+      });
+      const run = peer.run('blocked-prepare', {
+        runtime: { singleThreaded: mode === 'single-threaded' },
+        configModuleHost: new ConfigModuleHost({
+          loadCached: async () => (mode === 'native-only' ? [] : PLUGIN_CONFIG),
+          readSource: async (sourcePath) => {
+            reads++;
+            if (mode === 'native-only' && reads === 4) {
+              preparationStarted.resolve();
+              await preparation.promise;
+            }
+            return fs.promises.readFile(sourcePath);
+          },
+        }),
+        createPluginLintHost: async (_configs, _onLog, singleThreaded) => {
+          createCalls++;
+          expect(singleThreaded).toBe(true);
+          preparationStarted.resolve();
+          await preparation.promise;
+          return {
+            async lint() {
+              return { results: [] };
+            },
+            async shutdown() {
+              shutdownCalls++;
+            },
+          };
+        },
+      });
+      try {
+        expect((await peer.event('waiters-pending')).settled).toBe(false);
+        preparation.resolve();
+        expect((await peer.event('completed')).preparation?.kind).toBe(
+          'response',
+        );
+        expect(await run).toBe(0);
+        expect(createCalls).toBe(mode === 'native-only' ? 0 : 1);
+        expect(shutdownCalls).toBe(createCalls);
+      } finally {
+        preparation.resolve();
+        preparationStarted.resolve();
+        await run;
+        peer.dispose();
+      }
+    },
+  );
+
+  test('joins shutdown for a warmed host that finishes after child exit', async () => {
+    const peer = fixture();
+    const childExited = gate();
+    const shutdownStarted = gate();
+    const shutdown = gate();
+    let shutdownCalls = 0;
+    let lintCalls = 0;
+    const originalOnce = ChildProcess.prototype.once;
+    let wrappedExit = false;
+    ChildProcess.prototype.once = function (event, listener) {
+      if (event !== 'exit' || wrappedExit) {
+        return originalOnce.call(this, event, listener);
+      }
+      wrappedExit = true;
+      return originalOnce.call(this, event, function (...args: unknown[]) {
+        Reflect.apply(listener, this, args);
+        childExited.resolve();
+      });
+    } as typeof ChildProcess.prototype.once;
+    let run: Promise<number>;
+    try {
+      run = peer.run('exit', {
+        createPluginLintHost: async () => {
+          await childExited.promise;
+          return {
+            async lint() {
+              lintCalls++;
+              return { results: [] };
+            },
+            async shutdown() {
+              shutdownCalls++;
+              shutdownStarted.resolve();
+              await shutdown.promise;
+            },
+          };
+        },
+      });
+    } finally {
+      ChildProcess.prototype.once = originalOnce;
+    }
+    let settled = false;
+    void run.then(() => {
+      settled = true;
+    });
+    try {
+      expect((await peer.event('prepared')).preparation?.kind).toBe('response');
+      await shutdownStarted.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      expect(wrappedExit).toBe(true);
+      expect(shutdownCalls).toBe(1);
+      expect(lintCalls).toBe(0);
+      shutdown.resolve();
+      expect(await run).toBe(0);
+      expect(shutdownCalls).toBe(1);
+    } finally {
+      childExited.resolve();
+      shutdown.resolve();
+      await run;
+      peer.dispose();
+    }
+  });
+});

--- a/packages/rslint/tests/engine-warmup.test.ts
+++ b/packages/rslint/tests/engine-warmup.test.ts
@@ -38,7 +38,7 @@ interface FixtureEvent {
   plugin?: WireResult;
 }
 
-function fixture() {
+function fixture(singleThreaded: boolean) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rslint-worker-warmup-'));
   const configPath = path.join(root, 'rslint.config.mjs');
   fs.writeFileSync(configPath, '// original config bytes\n');
@@ -51,7 +51,8 @@ function fixture() {
     }
     return deferred;
   };
-  let beforeAcknowledge = async (_event: FixtureEvent): Promise<void> => {};
+  let beforeAcknowledge = (_event: FixtureEvent): Promise<void> =>
+    Promise.resolve();
   const stdout = new Writable({
     write(chunk: Buffer, _encoding, callback) {
       const event: FixtureEvent = JSON.parse(chunk.toString());
@@ -91,6 +92,7 @@ function fixture() {
         goArgs: [FAKE_BIN, configPath, mode],
         stdout,
         stderr: new PassThrough(),
+        runtime: { singleThreaded },
         configModuleHost: new ConfigModuleHost({
           loadCached: async () => PLUGIN_CONFIG,
         }),
@@ -103,164 +105,172 @@ function fixture() {
   };
 }
 
-describe('CLI worker warmup', () => {
-  test('returns planning metadata once and joins concurrent activation and plugin requests', async () => {
-    const peer = fixture();
-    const build = gate();
-    const buildStarted = gate();
-    let createCalls = 0;
-    let shutdownCalls = 0;
-    const lintRequests: unknown[] = [];
-    peer.setAcknowledge(async ({ event }) => {
-      if (event === 'waiters-started') await buildStarted.promise;
-    });
-    const run = peer.run('concurrent', {
-      createPluginLintHost: async () => {
-        createCalls++;
-        buildStarted.resolve();
-        await build.promise;
-        return {
-          async lint(request) {
-            lintRequests.push(request);
-            return { results: [] };
-          },
-          async shutdown() {
-            shutdownCalls++;
-          },
-        };
-      },
-    });
-    try {
-      const prepared = await peer.event('prepared');
-      expect(prepared.preparation).toMatchObject({
-        kind: 'response',
-        data: {
-          transactionId: 'cli-worker-warmup',
-          eslintPluginEntries: [{ prefix: 'local', ruleNames: ['example'] }],
+describe.each([false, true])(
+  'CLI worker warmup (singleThreaded=%s)',
+  (singleThreaded) => {
+    test('returns planning metadata once and joins concurrent activation and plugin requests', async () => {
+      const peer = fixture(singleThreaded);
+      const build = gate();
+      const buildStarted = gate();
+      let createCalls = 0;
+      let shutdownCalls = 0;
+      const lintRequests: unknown[] = [];
+      peer.setAcknowledge(async ({ event }) => {
+        if (event === 'waiters-started') await buildStarted.promise;
+      });
+      const run = peer.run('concurrent', {
+        createPluginLintHost: async (
+          _configs,
+          _onLog,
+          workerSingleThreaded,
+        ) => {
+          expect(workerSingleThreaded).toBe(singleThreaded);
+          createCalls++;
+          buildStarted.resolve();
+          await build.promise;
+          return {
+            async lint(request) {
+              lintRequests.push(request);
+              return { results: [] };
+            },
+            async shutdown() {
+              shutdownCalls++;
+            },
+          };
         },
       });
-      const repeated = await peer.event('repeated');
-      expect(repeated.duplicates).toHaveLength(2);
-      for (const duplicate of repeated.duplicates ?? []) {
-        expect(duplicate.data).toEqual(prepared.preparation?.data);
-        expect(duplicate.kind).toBe('response');
-      }
-      expect(repeated.conflicts).toHaveLength(2);
-      for (const conflict of repeated.conflicts ?? []) {
-        expect(conflict).toMatchObject({
-          kind: 'error',
-          data: { message: 'engine: conflicting config activation' },
-        });
-      }
-      expect(repeated.loadAfterActivation).toMatchObject({ kind: 'error' });
-      expect((await peer.event('waiters-pending')).settled).toEqual([
-        false,
-        false,
-        false,
-      ]);
-      expect(createCalls).toBe(1);
-      expect(lintRequests).toEqual([]);
-      build.resolve();
-      const completed = await peer.event('completed');
-      expect(completed.results?.map(({ kind }) => kind)).toEqual([
-        'response',
-        'response',
-        'response',
-      ]);
-      expect(completed.results?.[0].data).toEqual(prepared.preparation?.data);
-      expect(lintRequests).toEqual([
-        { request: 'first' },
-        { request: 'second' },
-      ]);
-      expect(await run).toBe(0);
-      expect(shutdownCalls).toBe(1);
-    } finally {
-      build.resolve();
-      await run;
-      peer.dispose();
-    }
-  });
-
-  test.each([
-    ['before preparation', 'changed while it was being loaded', 0],
-    ['during preparation', 'plugin host was being prepared', 1],
-    ['factory failure', 'mocked worker import failed', 0],
-    ['without tasks', 'mocked worker import failed', 0],
-  ] as const)(
-    'propagates failure %s to the activation barrier',
-    async (phase, message, expectedShutdowns) => {
-      const peer = fixture();
-      const build = gate();
-      let reads = 0;
-      let createCalls = 0;
-      let lintCalls = 0;
-      let shutdownCalls = 0;
-      const run = peer.run(
-        phase === 'without tasks' ? 'failure-without-tasks' : 'failure',
-        {
-          configModuleHost: new ConfigModuleHost({
-            loadCached: async () => PLUGIN_CONFIG,
-            readSource: async (sourcePath) => {
-              reads++;
-              if (phase === 'before preparation' && reads === 3) {
-                fs.writeFileSync(sourcePath, '// changed before preparation\n');
-              }
-              return fs.promises.readFile(sourcePath);
-            },
-          }),
-          createPluginLintHost: async () => {
-            createCalls++;
-            await build.promise;
-            if (phase !== 'during preparation') {
-              throw new Error('mocked worker import failed');
-            }
-            fs.writeFileSync(
-              peer.configPath,
-              '// changed during preparation\n',
-            );
-            return {
-              async lint() {
-                lintCalls++;
-                return { results: [] };
-              },
-              async shutdown() {
-                shutdownCalls++;
-              },
-            };
-          },
-        },
-      );
       try {
         const prepared = await peer.event('prepared');
-        expect(prepared.preparation?.kind).toBe(
-          phase === 'before preparation' ? 'error' : 'response',
-        );
+        expect(prepared.preparation).toMatchObject({
+          kind: 'response',
+          data: {
+            transactionId: 'cli-worker-warmup',
+            eslintPluginEntries: [{ prefix: 'local', ruleNames: ['example'] }],
+          },
+        });
+        const repeated = await peer.event('repeated');
+        expect(repeated.duplicates).toHaveLength(2);
+        for (const duplicate of repeated.duplicates ?? []) {
+          expect(duplicate.data).toEqual(prepared.preparation?.data);
+          expect(duplicate.kind).toBe('response');
+        }
+        expect(repeated.conflicts).toHaveLength(2);
+        for (const conflict of repeated.conflicts ?? []) {
+          expect(conflict).toMatchObject({
+            kind: 'error',
+            data: { message: 'engine: conflicting config activation' },
+          });
+        }
+        expect(repeated.loadAfterActivation).toMatchObject({ kind: 'error' });
+        expect((await peer.event('waiters-pending')).settled).toEqual([
+          false,
+          false,
+          false,
+        ]);
+        expect(createCalls).toBe(1);
+        expect(lintRequests).toEqual([]);
         build.resolve();
         const completed = await peer.event('completed');
-        expect(completed.activation?.kind).toBe('error');
-        expect(completed.activation?.data.message).toContain(message);
-        if (phase !== 'without tasks') {
-          expect(completed.plugin?.kind).toBe('error');
-          expect(completed.plugin?.data.message).toContain(message);
-        } else {
-          expect(completed.plugin).toBeUndefined();
-        }
+        expect(completed.results?.map(({ kind }) => kind)).toEqual([
+          'response',
+          'response',
+          'response',
+        ]);
+        expect(completed.results?.[0].data).toEqual(prepared.preparation?.data);
+        expect(lintRequests).toEqual([
+          { request: 'first' },
+          { request: 'second' },
+        ]);
         expect(await run).toBe(0);
-        expect(createCalls).toBe(phase === 'before preparation' ? 0 : 1);
-        expect(lintCalls).toBe(0);
-        expect(shutdownCalls).toBe(expectedShutdowns);
+        expect(shutdownCalls).toBe(1);
       } finally {
         build.resolve();
         await run;
         peer.dispose();
       }
-    },
-  );
+    });
 
-  test.each(['native-only', 'single-threaded'] as const)(
-    'keeps %s preparation synchronous',
-    async (mode) => {
-      const peer = fixture();
+    test.each([
+      ['before preparation', 'changed while it was being loaded', 0],
+      ['during preparation', 'plugin host was being prepared', 1],
+      ['factory failure', 'mocked worker import failed', 0],
+      ['without tasks', 'mocked worker import failed', 0],
+    ] as const)(
+      'propagates failure %s to the activation barrier',
+      async (phase, message, expectedShutdowns) => {
+        const peer = fixture(singleThreaded);
+        const build = gate();
+        let reads = 0;
+        let createCalls = 0;
+        let lintCalls = 0;
+        let shutdownCalls = 0;
+        const run = peer.run(
+          phase === 'without tasks' ? 'failure-without-tasks' : 'failure',
+          {
+            configModuleHost: new ConfigModuleHost({
+              loadCached: async () => PLUGIN_CONFIG,
+              readSource: async (sourcePath) => {
+                reads++;
+                if (phase === 'before preparation' && reads === 3) {
+                  fs.writeFileSync(
+                    sourcePath,
+                    '// changed before preparation\n',
+                  );
+                }
+                return fs.promises.readFile(sourcePath);
+              },
+            }),
+            createPluginLintHost: async () => {
+              createCalls++;
+              await build.promise;
+              if (phase !== 'during preparation') {
+                throw new Error('mocked worker import failed');
+              }
+              fs.writeFileSync(
+                peer.configPath,
+                '// changed during preparation\n',
+              );
+              return {
+                async lint() {
+                  lintCalls++;
+                  return { results: [] };
+                },
+                async shutdown() {
+                  shutdownCalls++;
+                },
+              };
+            },
+          },
+        );
+        try {
+          const prepared = await peer.event('prepared');
+          expect(prepared.preparation?.kind).toBe(
+            phase === 'before preparation' ? 'error' : 'response',
+          );
+          build.resolve();
+          const completed = await peer.event('completed');
+          expect(completed.activation?.kind).toBe('error');
+          expect(completed.activation?.data.message).toContain(message);
+          if (phase !== 'without tasks') {
+            expect(completed.plugin?.kind).toBe('error');
+            expect(completed.plugin?.data.message).toContain(message);
+          } else {
+            expect(completed.plugin).toBeUndefined();
+          }
+          expect(await run).toBe(0);
+          expect(createCalls).toBe(phase === 'before preparation' ? 0 : 1);
+          expect(lintCalls).toBe(0);
+          expect(shutdownCalls).toBe(expectedShutdowns);
+        } finally {
+          build.resolve();
+          await run;
+          peer.dispose();
+        }
+      },
+    );
+
+    test('keeps native-only preparation synchronous', async () => {
+      const peer = fixture(singleThreaded);
       const preparation = gate();
       const preparationStarted = gate();
       let reads = 0;
@@ -270,23 +280,19 @@ describe('CLI worker warmup', () => {
         if (event === 'waiters-started') await preparationStarted.promise;
       });
       const run = peer.run('blocked-prepare', {
-        runtime: { singleThreaded: mode === 'single-threaded' },
         configModuleHost: new ConfigModuleHost({
-          loadCached: async () => (mode === 'native-only' ? [] : PLUGIN_CONFIG),
+          loadCached: async () => [],
           readSource: async (sourcePath) => {
             reads++;
-            if (mode === 'native-only' && reads === 4) {
+            if (reads === 4) {
               preparationStarted.resolve();
               await preparation.promise;
             }
             return fs.promises.readFile(sourcePath);
           },
         }),
-        createPluginLintHost: async (_configs, _onLog, singleThreaded) => {
+        createPluginLintHost: async () => {
           createCalls++;
-          expect(singleThreaded).toBe(true);
-          preparationStarted.resolve();
-          await preparation.promise;
           return {
             async lint() {
               return { results: [] };
@@ -304,7 +310,7 @@ describe('CLI worker warmup', () => {
           'response',
         );
         expect(await run).toBe(0);
-        expect(createCalls).toBe(mode === 'native-only' ? 0 : 1);
+        expect(createCalls).toBe(0);
         expect(shutdownCalls).toBe(createCalls);
       } finally {
         preparation.resolve();
@@ -312,69 +318,71 @@ describe('CLI worker warmup', () => {
         await run;
         peer.dispose();
       }
-    },
-  );
-
-  test('joins shutdown for a warmed host that finishes after child exit', async () => {
-    const peer = fixture();
-    const childExited = gate();
-    const shutdownStarted = gate();
-    const shutdown = gate();
-    let shutdownCalls = 0;
-    let lintCalls = 0;
-    const originalOnce = ChildProcess.prototype.once;
-    let wrappedExit = false;
-    ChildProcess.prototype.once = function (event, listener) {
-      if (event !== 'exit' || wrappedExit) {
-        return originalOnce.call(this, event, listener);
-      }
-      wrappedExit = true;
-      return originalOnce.call(this, event, function (...args: unknown[]) {
-        Reflect.apply(listener, this, args);
-        childExited.resolve();
-      });
-    } as typeof ChildProcess.prototype.once;
-    let run: Promise<number>;
-    try {
-      run = peer.run('exit', {
-        createPluginLintHost: async () => {
-          await childExited.promise;
-          return {
-            async lint() {
-              lintCalls++;
-              return { results: [] };
-            },
-            async shutdown() {
-              shutdownCalls++;
-              shutdownStarted.resolve();
-              await shutdown.promise;
-            },
-          };
-        },
-      });
-    } finally {
-      ChildProcess.prototype.once = originalOnce;
-    }
-    let settled = false;
-    void run.then(() => {
-      settled = true;
     });
-    try {
-      expect((await peer.event('prepared')).preparation?.kind).toBe('response');
-      await shutdownStarted.promise;
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      expect(settled).toBe(false);
-      expect(wrappedExit).toBe(true);
-      expect(shutdownCalls).toBe(1);
-      expect(lintCalls).toBe(0);
-      shutdown.resolve();
-      expect(await run).toBe(0);
-      expect(shutdownCalls).toBe(1);
-    } finally {
-      childExited.resolve();
-      shutdown.resolve();
-      await run;
-      peer.dispose();
-    }
-  });
-});
+
+    test('joins shutdown for a warmed host that finishes after child exit', async () => {
+      const peer = fixture(singleThreaded);
+      const childExited = gate();
+      const shutdownStarted = gate();
+      const shutdown = gate();
+      let shutdownCalls = 0;
+      let lintCalls = 0;
+      const originalOnce = ChildProcess.prototype.once;
+      let wrappedExit = false;
+      ChildProcess.prototype.once = function (event, listener) {
+        if (event !== 'exit' || wrappedExit) {
+          return originalOnce.call(this, event, listener);
+        }
+        wrappedExit = true;
+        return originalOnce.call(this, event, function (...args: unknown[]) {
+          Reflect.apply(listener, this, args);
+          childExited.resolve();
+        });
+      } as typeof ChildProcess.prototype.once;
+      let run: Promise<number>;
+      try {
+        run = peer.run('exit', {
+          createPluginLintHost: async () => {
+            await childExited.promise;
+            return {
+              async lint() {
+                lintCalls++;
+                return { results: [] };
+              },
+              async shutdown() {
+                shutdownCalls++;
+                shutdownStarted.resolve();
+                await shutdown.promise;
+              },
+            };
+          },
+        });
+      } finally {
+        ChildProcess.prototype.once = originalOnce;
+      }
+      let settled = false;
+      void run.then(() => {
+        settled = true;
+      });
+      try {
+        expect((await peer.event('prepared')).preparation?.kind).toBe(
+          'response',
+        );
+        await shutdownStarted.promise;
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(settled).toBe(false);
+        expect(wrappedExit).toBe(true);
+        expect(shutdownCalls).toBe(1);
+        expect(lintCalls).toBe(0);
+        shutdown.resolve();
+        expect(await run).toBe(0);
+        expect(shutdownCalls).toBe(1);
+      } finally {
+        childExited.resolve();
+        shutdown.resolve();
+        await run;
+        peer.dispose();
+      }
+    });
+  },
+);

--- a/packages/rslint/tests/engine.test.ts
+++ b/packages/rslint/tests/engine.test.ts
@@ -279,9 +279,7 @@ describe('runEngine config activation', () => {
 
       expect(exitCode).toBe(0);
       expect(captured).toContain('plugin host was being prepared');
-      expect(captured).toContain(
-        'pluginLint requested without an activated plugin host',
-      );
+      expect(captured.match(/plugin host was being prepared/g)).toHaveLength(2);
       expect(lintCalls).toBe(0);
       expect(shutdownCalls).toBe(1);
     } finally {

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-init-errors.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-init-errors.test.ts
@@ -36,7 +36,7 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
       // missing specifier appears in the message so users get a
       // pointer to the broken config entry.
       await expect(pool.init()).rejects.toThrow(
-        /eslint-plugin-this-does-not-exist/,
+        /^worker init failed: failed to import config file .*eslint-plugin-this-does-not-exist/,
       );
     });
 

--- a/packages/rslint/tests/fixtures/fake-worker-warmup.cjs
+++ b/packages/rslint/tests/fixtures/fake-worker-warmup.cjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+// Exercise the CLI's two config responses over the real framed IPC transport.
+// Output requests are acknowledged gates, so tests can hold worker preparation
+// while this peer proves which independent requests have already completed.
+const path = require('node:path');
+
+const configPath = path.resolve(process.argv[2]);
+const mode = process.argv[3];
+const transactionId = 'cli-worker-warmup';
+const selection = {
+  protocolVersion: 3,
+  transactionId,
+  effectiveConfigIds: ['root'],
+};
+const load = {
+  protocolVersion: 3,
+  transactionId,
+  loadMode: 'cached',
+  candidates: [
+    { id: 'root', configPath, configDirectory: path.dirname(configPath) },
+  ],
+};
+const pending = new Map();
+let nextId = 200;
+let buffer = Buffer.alloc(0);
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8');
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  process.stdout.write(Buffer.concat([header, body]));
+}
+
+function request(kind, data) {
+  const id = nextId++;
+  return new Promise((resolve) => {
+    pending.set(id, resolve);
+    send({ kind, id, data });
+  });
+}
+
+function report(event, data = {}) {
+  return request('output', {
+    stream: 'stdout',
+    text: `${JSON.stringify({ event, ...data })}\n`,
+  });
+}
+
+async function run() {
+  const loaded = await request('loadConfigs', load);
+  if (loaded.kind !== 'response') throw new Error('config load failed');
+
+  if (mode === 'blocked-prepare') {
+    let settled = false;
+    const preparation = request('prepareConfigs', selection).then((result) => {
+      settled = true;
+      return result;
+    });
+    await report('waiters-started');
+    await new Promise((resolve) => setImmediate(resolve));
+    await report('waiters-pending', { settled });
+    await report('completed', { preparation: await preparation });
+  } else {
+    const preparation = await request('prepareConfigs', selection);
+    await report('prepared', { preparation });
+
+    if (mode === 'exit') {
+      process.exit(0);
+    }
+    if (mode === 'concurrent') {
+      const duplicates = await Promise.all([
+        request('prepareConfigs', selection),
+        request('prepareConfigs', selection),
+      ]);
+      const conflicts = await Promise.all([
+        request('prepareConfigs', {
+          ...selection,
+          effectiveConfigIds: ['other'],
+        }),
+        request('activateConfigs', {
+          ...selection,
+          transactionId: 'different-transaction',
+        }),
+      ]);
+      const loadAfterActivation = await request('loadConfigs', load);
+      await report('repeated', { duplicates, conflicts, loadAfterActivation });
+
+      const settled = [false, false, false];
+      const waiters = [
+        request('activateConfigs', selection),
+        request('pluginLint', { request: 'first' }),
+        request('pluginLint', { request: 'second' }),
+      ].map((promise, index) =>
+        promise.then((result) => {
+          settled[index] = true;
+          return result;
+        }),
+      );
+      await report('waiters-started');
+      await new Promise((resolve) => setImmediate(resolve));
+      await report('waiters-pending', { settled });
+      await report('completed', { results: await Promise.all(waiters) });
+    } else {
+      const activation = await request('activateConfigs', selection);
+      const plugin =
+        mode === 'failure-without-tasks'
+          ? undefined
+          : await request('pluginLint', {});
+      await report('completed', { activation, plugin });
+    }
+  }
+  await request('shutdown', {});
+  process.exit(0);
+}
+
+function onMessage(message) {
+  if (message.kind === 'init') {
+    send({ kind: 'response', id: message.id, data: { ok: true } });
+    void run().catch((error) => {
+      process.stderr.write(`${error.stack}\n`);
+      process.exit(2);
+    });
+    return;
+  }
+  const resolve = pending.get(message.id);
+  if (resolve) {
+    pending.delete(message.id);
+    resolve(message);
+  }
+}
+
+process.stdin.on('data', (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  while (buffer.length >= 4) {
+    const length = buffer.readUInt32LE(0);
+    if (buffer.length < 4 + length) break;
+    const body = buffer.subarray(4, 4 + length).toString('utf8');
+    buffer = buffer.subarray(4 + length);
+    onMessage(JSON.parse(body));
+  }
+});
+process.stdin.once('end', () => process.exit(2));

--- a/packages/rslint/tests/ipc-client.test.ts
+++ b/packages/rslint/tests/ipc-client.test.ts
@@ -443,15 +443,21 @@ describe('IpcClient request/response', () => {
     }
   });
 
-  test('handler thrown error → peer receives error reply', async () => {
+  test.each([
+    ['boom', 'boom'],
+    ['', 'request failed'],
+    ['peer error: from config', 'peer error: from config'],
+  ])('handler error %j → peer receives %j', async (message, expected) => {
     const { a, b, cleanup } = pairClients();
     try {
       b.setInboundHandler(() => {
-        throw new Error('boom');
+        throw new Error(message);
       });
       a.start();
       b.start();
-      await expect(a.sendRequest('lint', {})).rejects.toThrow(/boom/);
+      await expect(a.sendRequest('lint', {})).rejects.toMatchObject({
+        message: expected,
+      });
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary

CLI configuration activation currently waits for JavaScript plugin workers before Go can plan targets and construct Programs. Start worker preparation after the first existing configuration fingerprint check, return provisional metadata for Go preparation, and join the same activation before linting or fixing. The original activation still owns worker initialization, the second fingerprint check and host publication. The CLI validates completed metadata against the prepared selection.

Repeated activation requests share one result; conflicting selections fail. Cancellation and shutdown prevent late host publication and drain owned workers. Zero targets, disabled plugin rules and type-check-only still join activation. Native-only runs create no plugin workers. `--singleThreaded` uses one JS worker and serial Go preparation, with the worker startup allowed to overlap preparation. API/LSP activation retains its existing protocol.

User-visible behavior:

- Initialization failure remains fatal before lint/fix. The default formatter prints its start line on stdout, then the abort error on stderr. Aborted-run errors use stderr in every format; normal diagnostics and completed reports retain their existing output path. When Go preparation and worker initialization both fail, both causes are reported.
- Explicit `--cpuprof` and `--trace` record the Go preparation/execution reached by this invocation. They replace the selected output file and finalize the recording even when worker initialization subsequently fails.
- Cancellation retains the existing forced-termination fallback and signal-code mapping. In the controlled blocked-config-read case, main exits 130 and the candidate exits 137; both exit in approximately eight seconds with no owned processes left. This accepted case does not require rewriting 137 to 130.
- Remote IPC errors preserve the supplied message without adding `ipc: peer error:` or `peer error:`; empty messages use `request failed`. Worker messages omit worker/task indexes while retaining useful timeout, exit-code and retry information.

### Validation

Plugin-benchmark baseline: main `8ea63fc7e7e22f1a479134e86b5bf122583a8876`. Candidate runtime source: `f520d7b48b14ba97e8fb50d30b1d1379ca3bd2ad`; `bf5a843a` adds only an explicit no-color setting in the activation-output test. Both use TypeScript submodule `1f70213d4922b434345f639b441681e470c7cfc1`.

- Independent adversarial review and primary review accept the complete implementation, 2:0. The sampling scripts also passed adversarial review of output validation, diagnostic equality and monitor coverage checks.
- `go test -p 4 ./cmd/rslint ./internal/ipc ./internal/output` passed; 172 Node tests passed across 12 affected engine/config/IPC/worker files.
- 30 real package-bin probes cover normal diagnostic parity, worker initialization failures, Go/worker double failures, zero targets, disabled rules, type-check-only, failed fixes, successful native + JS fixes, profiling output and cancellation. Failed runs preserve source bytes; successful fixes match in both concurrency modes. Go tools successfully parse the CPU profile and trace produced by the failed candidate invocation.
- `pnpm run check-spell`, `pnpm run format:check`, gofmt and `git diff --check` passed. Go lint reported 0 issues with only changed packages/new lines: `GOMAXPROCS=4 pnpm exec golangci-lint run ./cmd/rslint ./internal/ipc --new-from-merge-base=origin/main`.

### Fresh benchmark against main

Measured in `bench-linter` at `fc3def6774c76082adf699d366f31a557ce5573f` with its pre-existing local benchmark configurations and input changes preserved. Apple M5 Max, 18 logical CPUs, 64 GiB RAM, macOS 26.5.1, Node v22.18.0, go version go1.26.5 darwin/arm64. Both variants use the same default worker/thread counts, with no runtime CPU-limit overrides.

Standalone baseline and candidate package-bin installations contain 111 files each. Only the engine bundle, worker-pool host bundle and native Go CLI differ; the Worker runtime, Oxc native module and runtime dependencies are byte-identical. Both were freshly rebuilt against the same compiler and dependency versions. The baseline comes from an archive of the exact main commit; the candidate was built from the recorded rebased source plus documentation/comment edits before commit. The recorded source-diff SHA-256 is `eed9011ce0404ed9ae2757cdd4e7a4c09ae2b9b4cf76273d92886cacefe310cf`. No clean VCS build-stamp equivalence is claimed.

The simple mixed configuration (`rslint.js-plugin-simple-native.config.mjs`) checks 10,501 files and 2 effective rules; complex (`rslint.js-plugins-native.config.mjs`) checks 10,500 files and 67 rules. Each series uses one warmup per variant/scenario followed by six serial alternating A/B and B/A pairs. Each command requires three CPU-idle observations of at least 85% and a post-run observation of at least 85%. A one-second process monitor vetoes captured external Go activity and incomplete monitoring intervals. Busy attempts are discarded; output/exit validation occurs before contamination filtering. All 48 accepted timed invocations have identical complete JSON diagnostics for their scenario and exit 0. All 16,225 benchmark input entries and both installations remain unchanged.

A/B command from the benchmark checkout:

```sh
/usr/bin/time -lp "$INSTALL/node_modules/@rslint/core/bin/rslint.js" --config "$CONFIG" --format jsonline .
```

| Scenario | Main → candidate wall median | Change | CPU median | Max RSS median |
| --- | --- | --- | --- | --- |
| simple | 7.604 → 7.292 s | -4.11% | 43.285 → 42.910 s | 3249.9 → 3261.3 MiB |
| complex | 10.385 → 10.172 s | -2.05% | 76.510 → 76.700 s | 4246.9 → 4023.6 MiB |

CPU is the median of user + system time. RSS is BSD time's maximum-resident-set measurement, not the sum of memory across concurrently running processes. Six-sample medians describe this machine and workload.

Independent replication uses hyperfine 1.20.0: six accepted single-run exports per variant/scenario, plus separate warmups, with idle gates outside the timed command. Raw stdout/stderr and exit codes are checked for every attempt, and diagnostic content is compared with the A/B baseline after normalization.

| Scenario | Main mean ± SD | Candidate mean ± SD | Change |
| --- | --- | --- | --- |
| simple | 7.586 ± 0.084 s | 7.335 ± 0.048 s | -3.30% |
| complex | 10.313 ± 0.406 s | 9.801 ± 0.225 s | -4.97% |

The complex Hyperfine series has greater variability, as shown by its standard deviations. The A/B and Hyperfine tables are separate fresh series on main `8ea63fc7`. These results describe startup overlap; they do not establish a general memory improvement or a guaranteed saving for every repository.

### Fresh real-repository comparison

Compare candidate `bf5a843a` (unchanged runtime), latest fetched main `cd637f5e`, and independently installed npm `@rslint/core@0.9.1` with its matching native package. The main baseline is newly built. The npm binary uses Go 1.26.0; both local products use Go 1.26.5. The machine and Node version match the plugin benchmark above.

In rsbuild and rspack, four modes with two paired rounds provide 16 matching candidate/main comparisons: diagnostics, exit codes, files and rules. Another 18 matching scenarios cover JSON/GitHub/GitLab output, single-threaded operation, quiet/max-warnings and real PTY rendering. The same checks also agree with npm 0.9.1. Isolated fixes leave both repositories unchanged across all three products. Original repository files, modes, configs and HEADs are preserved.

| Repository | Plain files | npm → main/candidate rules | npm → main/candidate errors | Warnings |
| --- | ---: | ---: | ---: | ---: |
| rsbuild | 2,204 | 85 → 85 | 0 → 0 | 0 |
| rspack | 480 | 74 → 74 | 0 → 0 | 0 |

Type checking reports 1,089 errors in rsbuild and 81 in rspack on all three products. These existing repository diagnostics are identical across versions; each run completes normally and exits 1.

Timing uses the corresponding package bin with config data evaluated beforehand through that product's API. It includes process startup, lint/type-check and output, but excludes original Rstack config evaluation and the `rs` wrapper. Three versions run serially in alternating forward/reverse orders: one warmup per version/mode and 10 accepted triples per mode/repository, totaling 180 accepted timed runs. Three pre-run CPU idle observations and one post-run observation must be at least 85%; captured external Go activity or incomplete monitoring rejects the complete triple and retries its original order. Raw output and outcome validation occurs before rejection. All variants keep stable per-version workloads.

| Repository | Mode | npm 0.9.1 (s) | main (s) | Candidate (s) | vs main | vs npm 0.9.1 |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| rsbuild | lint | 0.421 | 0.428 | 0.419 | -2.22% | -0.57% |
| rsbuild | lint + type-check | 0.629 | 0.572 | 0.584 | +2.17% | -7.11% |
| rsbuild | type-check-only | 0.510 | 0.440 | 0.436 | -0.95% | -14.59% |
| rspack | lint | 0.237 | 0.219 | 0.218 | -0.47% | -8.13% |
| rspack | lint + type-check | 0.313 | 0.310 | 0.310 | -0.10% | -1.03% |
| rspack | type-check-only | 0.283 | 0.266 | 0.266 | +0.11% | -5.85% |

Values are wall-time medians; negative percentages mean the candidate is faster. These configurations use native Go rules and do not start external JS plugin workers, so this table measures whole-version performance, not a worker warmup gain. Per-sample output hashes, complete triple membership, actual pair numbers and recorded timings are independently bound and audited before calculating medians and paired ratios.

Candidate/main percentage changes in wall-time medians range from -2.22% to +2.17%, with overlapping interquartile ranges in every group; this is not proof of statistical equivalence. All six wall-time medians are lower than npm 0.9.1, but this does not imply consistent per-run improvement. For rsbuild lint, the median paired change is +0.62% and only 4/10 pairs are faster, despite a -0.57% change in medians.

<details>
<summary>CLI-reported internal time from the same timed runs</summary>

| Repository | Mode | npm 0.9.1 (ms) | main (ms) | Candidate (ms) | vs main | vs npm 0.9.1 |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| rsbuild | lint | 390.5 | 390.5 | 377.5 | -3.33% | -3.33% |
| rsbuild | lint + type-check | 589.5 | 526.0 | 545.5 | +3.71% | -7.46% |
| rsbuild | type-check-only | 471.5 | 398.0 | 398.5 | +0.13% | -15.48% |
| rspack | lint | 201.0 | 186.5 | 189.5 | +1.61% | -5.72% |
| rspack | lint + type-check | 280.5 | 273.5 | 277.5 | +1.46% | -1.07% |
| rspack | type-check-only | 246.0 | 231.0 | 233.0 | +0.87% | -5.28% |

Values are medians of the CLI's completed-run time in milliseconds. Compared with main, rsbuild type-check-only and rspack lint / lint + type-check have slightly higher internal medians despite slightly lower wall medians. These timers cover different intervals; process startup/exit overhead and sampling variation affect small deltas. This run does not independently decompose that overhead or establish a rule-execution gain.

</details>

The follow-up activation test now explicitly requests plain output. The GitHub Actions color environment reproduced the previous Linux/Windows assertion failure; the complete CLI Go test package passes after the one-line test fix. Spell, format and incremental Go lint checks pass again. Runtime behavior is unchanged.

## Related Links

- Real-repository main baseline: https://github.com/web-infra-dev/rslint/commit/cd637f5e9db4638d855dcc20a680052aaf7ead90
- Baseline: https://github.com/web-infra-dev/rslint/commit/8ea63fc7e7e22f1a479134e86b5bf122583a8876

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
