### PR TITLE
fix: align unicorn/no-await-expression-member with upstream

### DIFF
--- a/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member.go
+++ b/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member.go
@@ -7,8 +7,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+const messageID = "no-await-expression-member"
+
 var message = rule.RuleMessage{
-	Id:          "noAwaitExpressionMember",
+	Id:          messageID,
 	Description: "Do not access a member directly from an await expression.",
 }
 

--- a/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_await_expression_member/no_await_expression_member_upstream_test.go
@@ -91,7 +91,7 @@ func memberError(code, property string) rule_tester.InvalidTestCaseError {
 	}
 	end := start + len(property)
 	return rule_tester.InvalidTestCaseError{
-		MessageId: "noAwaitExpressionMember",
+		MessageId: "no-await-expression-member",
 		Message:   "Do not access a member directly from an await expression.",
 		Line:      strings.Count(code[:start], "\n") + 1,
 		Column:    start - strings.LastIndex(code[:start], "\n"),

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-await-expression-member.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-await-expression-member.test.ts
@@ -55,7 +55,7 @@ ruleTester.run('no-await-expression-member', null as never, {
     filename: 'src/virtual.mts',
     errors: [
       {
-        messageId: 'noAwaitExpressionMember',
+        messageId: 'no-await-expression-member',
         message: 'Do not access a member directly from an await expression.',
       },
     ],


### PR DESCRIPTION
`unicorn/no-await-expression-member` reported its diagnostic under the message ID `noAwaitExpressionMember`, while eslint-plugin-unicorn v74.0.0 uses `no-await-expression-member`; since message IDs are externally visible through the programmatic API, the mismatch broke consumers that identify diagnostics by `messageId`. This switches the rule to the upstream ID and updates the Go and JS expectations accordingly, matching how other ported Unicorn rules such as `no-array-from-fill` preserve their upstream message IDs.

Follow-up to #2063.
