### PR TITLE
fix: ignore intrinsic JSX tags in rstest imports

### DIFF
--- a/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals.go
+++ b/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
@@ -67,17 +68,14 @@ const (
 )
 
 // classifyIdentifier decides what an identifier does with the Rstest global of
-// the same name. IsReadReference carries the shared classification of
-// reference positions, so labels (`test: for (...) { break test; }`), property
-// keys, and type positions are all excluded here rather than re-derived; a
-// shorthand property value stays a reference, and IsWriteReference then tells
-// its read form (`{ expect }`) from its destructuring form (`({ expect } =
-// holder)`).
+// the same name. IsReferenceIdentifier matches the positions Refs.Resolve
+// accepts, including JSX names. IsReadReference excludes type-only uses, and
+// IsWriteReference distinguishes runtime reads from assignments.
 func classifyIdentifier(ctx rule.RuleContext, node *ast.Node) identifierUse {
 	if node == nil || node.Kind != ast.KindIdentifier || !rstestUtils.IsRstestGlobal(node.AsIdentifier().Text) {
 		return useIrrelevant
 	}
-	if !internalUtils.IsReadReference(node) {
+	if !scope.IsReferenceIdentifier(node) || !internalUtils.IsReadReference(node) {
 		return useIrrelevant
 	}
 	for parent := node.Parent; parent != nil; parent = parent.Parent {

--- a/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals.md
+++ b/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals.md
@@ -8,6 +8,8 @@ It recognizes all APIs provided by Rstest's `globals` setting, including `expect
 
 Only a runtime read of the API counts. A type position such as `const value: expect = input` never reaches the value, a write such as `expect = value` assigns to the global rather than reading it, and a label such as `test: for (...) {}` lives in its own namespace. None of them is reported.
 
+Intrinsic JSX tags such as `<test />` do not read a variable and are ignored. Expressions inside JSX and the object of a member tag such as `<test.Component />` still count as runtime reads.
+
 ## Incorrect
 
 ```javascript

--- a/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals_extras_test.go
@@ -9,6 +9,31 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+func TestPreferImportingRstestGlobalsJSX(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_importing_rstest_globals.PreferImportingRstestGlobalsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `const view = <test />;`, Tsx: true},
+			{Code: `const view = <test><expect /></test>;`, Tsx: true},
+			{Code: `const view = <Component test={value} onTestFinished={handler} />;`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Expressions inside JSX still read globals; intrinsic tag names do not.
+			{
+				Code:   `const view = <test>{expect(value)}</test>;`,
+				Tsx:    true,
+				Output: []string{"import { expect } from '@rstest/core';\nconst view = <test>{expect(value)}</test>;"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferImportingRstestGlobals", Message: "Import `expect` from `@rstest/core`."}},
+			},
+			// A member tag reads its object even when the name starts with lowercase.
+			{
+				Code:   `const view = <test.Component />;`,
+				Tsx:    true,
+				Output: []string{"import { test } from '@rstest/core';\nconst view = <test.Component />;"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferImportingRstestGlobals"}},
+			},
+		})
+}
+
 // TestPreferImportingRstestGlobalsExtras locks in identifier shapes and merge
 // branches beyond the baseline suite in the sibling upstream file.
 func TestPreferImportingRstestGlobalsExtras(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix `rstest/prefer-importing-rstest-globals` reporting intrinsic JSX tags such as `<test />` and inserting an unnecessary `test` import. Use the same identifier classification as reference resolution while preserving diagnostics and fixes for expressions inside JSX and member tags.

Add regression coverage for JSX tags, attributes, expressions, and member tags, and clarify the rule documentation.

Validation passed:

- `go test ./internal/plugins/rstest/rules/prefer_importing_rstest_globals`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-merge-base=origin/main ./internal/plugins/rstest/rules/prefer_importing_rstest_globals`

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
