### PR TITLE
fix: align react static property placement with upstream

### DIFF
--- a/internal/plugins/react/reactutil/component_class.go
+++ b/internal/plugins/react/reactutil/component_class.go
@@ -1,8 +1,15 @@
 package reactutil
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 )
 
 // IsCreateClassCall reports whether the given CallExpression's callee is
@@ -100,58 +107,150 @@ func ExtendsReactComponent(classNode *ast.Node, pragma string) bool {
 	return false
 }
 
-// IsExplicitReactComponent reports whether a class has a JSDoc @extends or
-// @augments tag naming React.Component or React.PureComponent. This is kept
-// separate from ExtendsReactComponent because eslint-plugin-react treats the
-// JSDoc marker as an additional detection path, while other callers may need
-// to preserve the distinction between an actual extends clause and a JSDoc
-// annotation.
-func IsExplicitReactComponent(classNode *ast.Node) bool {
-	if classNode == nil {
+// IsExplicitReactComponent recognizes the JSDoc component marker accepted by
+// eslint-plugin-react. The host follows SourceCode.getJSDocComment, including
+// declarations that own the comment for a class or function expression.
+func IsExplicitReactComponent(node *ast.Node) bool {
+	if node == nil {
 		return false
 	}
-	for _, doc := range classNode.JSDoc(nil) {
-		jsDoc := doc.AsJSDoc()
-		if jsDoc == nil || jsDoc.Tags == nil {
+	sourceFile := ast.GetSourceFileOfNode(node)
+	if sourceFile == nil {
+		return false
+	}
+	host, pos := componentJSDocHost(node, sourceFile)
+	if host == nil {
+		return false
+	}
+	doc, sourceFile := componentJSDoc(host, pos, sourceFile)
+	if doc == nil || doc.AsJSDoc().Tags == nil {
+		return false
+	}
+	text := sourceFile.Text()
+	for _, tag := range doc.AsJSDoc().Tags.Nodes {
+		if !ast.IsJSDocAugmentsTag(tag) {
 			continue
 		}
-		for _, tag := range jsDoc.Tags.Nodes {
-			if !ast.IsJSDocAugmentsTag(tag) {
-				continue
-			}
-			augments := tag.AsJSDocAugmentsTag()
-			if augments == nil || augments.ClassName == nil {
-				continue
-			}
-			if sourceFile := ast.GetSourceFileOfNode(classNode); sourceFile != nil {
-				text := sourceFile.Text()
-				start, end := tag.Pos(), augments.ClassName.Pos()
-				if start < 0 || end < start || end > len(text) || containsJSDocTypeBraces(text[start:end]) {
-					continue
-				}
-			}
-			name := ast.SkipParentheses(augments.ClassName.AsExpressionWithTypeArguments().Expression)
-			if name == nil || name.Kind != ast.KindPropertyAccessExpression {
-				continue
-			}
-			access := name.AsPropertyAccessExpression()
-			object := ast.SkipParentheses(access.Expression)
-			property := access.Name()
-			if object != nil && object.Kind == ast.KindIdentifier && object.AsIdentifier().Text == "React" && property != nil && property.Kind == ast.KindIdentifier && isComponentName(property.AsIdentifier().Text) {
-				return true
-			}
+		augments := tag.AsJSDocAugmentsTag()
+		if augments.ClassName == nil || augments.TagName == nil {
+			continue
+		}
+		// tsgo accepts type braces and generic arguments too. Doctrine's name
+		// must be bare; the gap may contain multiline JSDoc decoration.
+		if strings.ContainsRune(text[augments.TagName.End():augments.ClassName.Pos()], '{') {
+			continue
+		}
+		// Doctrine stops reading tags at an invalid extends description.
+		if augments.Comment != nil {
+			return false
+		}
+		name := utils.TrimmedNodeText(sourceFile, augments.ClassName)
+		if name == "React.Component" || name == "React.PureComponent" {
+			return true
 		}
 	}
 	return false
 }
 
-func containsJSDocTypeBraces(text string) bool {
-	for index := range len(text) {
-		if text[index] == '{' || text[index] == '}' {
-			return true
+func componentJSDoc(host *ast.Node, pos int, sourceFile *ast.SourceFile) (*ast.Node, *ast.SourceFile) {
+	text := sourceFile.Text()
+	start := scanner.SkipTrivia(text, pos)
+	if !strings.Contains(text[pos:start], "/**") {
+		return nil, sourceFile
+	}
+	// Prefer tsgo's cached parse. An intervening comment or blank line breaks
+	// ESLint's attachment, even when TypeScript still attaches the JSDoc.
+	for _, doc := range slices.Backward(host.JSDoc(sourceFile)) {
+		if doc.Pos() >= pos && doc.End() <= start && ecmascript.IsBlank(text[doc.End():start]) &&
+			scanner.ComputeLineOfPosition(sourceFile.ECMALineMap(), start)-scanner.ComputeLineOfPosition(sourceFile.ECMALineMap(), doc.End()) <= 1 {
+			return doc, sourceFile
 		}
 	}
-	return false
+	// tsgo omits some same-line comments (e.g. an object property after `{`).
+	// Use its comment scanner and parser for that case too, without changing
+	// the source AST or implementing a second JSDoc parser.
+	var last ast.CommentRange
+	for comment := range utils.GetCommentsInRange(sourceFile, core.NewTextRange(pos, start)) {
+		if comment.End() > last.End() {
+			last = comment
+		}
+	}
+	if last.End() == 0 || !strings.HasPrefix(text[last.Pos():last.End()], "/**") ||
+		scanner.ComputeLineOfPosition(sourceFile.ECMALineMap(), start)-scanner.ComputeLineOfPosition(sourceFile.ECMALineMap(), last.End()) > 1 {
+		return nil, sourceFile
+	}
+	fragment := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/component.ts", Path: "/component.ts"}, text[last.Pos():last.End()]+"\nconst component = 0;", core.ScriptKindTS)
+	docs := fragment.Statements.Nodes[0].JSDoc(fragment)
+	if len(docs) == 0 {
+		return nil, sourceFile
+	}
+	return docs[0], fragment
+}
+
+func componentJSDocHost(node *ast.Node, sourceFile *ast.SourceFile) (*ast.Node, int) {
+	parentOf := func(node *ast.Node) *ast.Node {
+		parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+		// ESTree has no VariableDeclarationList wrapper.
+		if parent != nil && parent.Kind == ast.KindVariableDeclarationList {
+			parent = parent.Parent
+		}
+		return parent
+	}
+	parent := parentOf(node)
+	host := node
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindFunctionDeclaration:
+		// Export wrappers are part of this node in tsgo.
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		// ESTree gives an object method a FunctionExpression value whose
+		// JSDoc host is the containing Property.
+		if parent == nil || parent.Kind != ast.KindObjectLiteralExpression {
+			return nil, 0
+		}
+	case ast.KindClassExpression:
+		if parent == nil || parent.Kind == ast.KindPropertyDeclaration {
+			// The latter's ESTree grandparent is ClassBody, not the outer class.
+			return nil, 0
+		}
+		if parent.Kind == ast.KindExportAssignment {
+			// `export default (class {})` is a ClassDeclaration in ESTree.
+			host = parent
+		} else {
+			host = parentOf(parent)
+		}
+		if host != nil && host.Kind == ast.KindVariableStatement && host.Modifiers() != nil {
+			// A class expression asks for the inner VariableDeclaration; a
+			// comment before `export` belongs to ExportNamedDeclaration.
+			return host, host.Modifiers().Nodes[len(host.Modifiers().Nodes)-1].End()
+		}
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		if parent == nil || parent.Kind == ast.KindCallExpression || parent.Kind == ast.KindNewExpression {
+			break
+		}
+		for parent != nil {
+			pos := parent.Pos()
+			if parent.Kind == ast.KindVariableStatement && parent.Modifiers() != nil {
+				inner := parent.Modifiers().Nodes[len(parent.Modifiers().Nodes)-1].End()
+				if utils.HasCommentsInRange(sourceFile, core.NewTextRange(inner, scanner.SkipTrivia(sourceFile.Text(), inner))) {
+					return parent, inner
+				}
+			}
+			if ast.IsFunctionLike(parent) || parent.Kind == ast.KindPropertyAssignment ||
+				utils.HasCommentsInRange(sourceFile, core.NewTextRange(pos, scanner.SkipTrivia(sourceFile.Text(), pos))) {
+				break
+			}
+			parent = parentOf(parent)
+		}
+		if parent != nil && parent.Kind != ast.KindFunctionDeclaration && parent.Kind != ast.KindSourceFile {
+			host = parent
+		}
+	default:
+		return nil, 0
+	}
+	if host == nil {
+		return nil, 0
+	}
+	return host, host.Pos()
 }
 
 func isComponentName(name string) bool {

--- a/internal/plugins/react/reactutil/component_class_test.go
+++ b/internal/plugins/react/reactutil/component_class_test.go
@@ -1,0 +1,88 @@
+package reactutil
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+// Expectations were checked with eslint-plugin-react 7.37.5 and ESLint 9.39.5.
+func TestIsExplicitReactComponent(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, code string
+		want       []bool
+	}{
+		{name: "class declaration", code: `/** @extends React.Component */ class C {}`, want: []bool{true}},
+		{name: "class expression", code: `/** @extends React.Component */ const C = class {};`, want: []bool{true}},
+		{name: "parenthesized class expression", code: `/** @extends React.Component */ const C = (class {});`, want: []bool{true}},
+		{name: "exported class", code: `/** @extends React.Component */ export class C {}`, want: []bool{true}},
+		{name: "exported class expression", code: `/** @extends React.Component */ export const C = class {};`, want: []bool{false}},
+		{name: "comment inside export", code: `export /** @extends React.Component */ const C = class {};`, want: []bool{true}},
+		{name: "default export", code: `/** @extends React.Component */ export default (class {});`, want: []bool{true}},
+		{name: "nested class", code: `/** @extends React.Component */ class Outer { C = class {}; }`, want: []bool{true, false}},
+		{name: "function declaration", code: `/** @extends React.Component */ function C() {}`, want: []bool{true}},
+		{name: "function expression", code: `/** @extends React.Component */ const C = function() {};`, want: []bool{true}},
+		{name: "arrow function", code: `/** @extends React.Component */ const C = () => null;`, want: []bool{true}},
+		{name: "intervening ordinary comment", code: `/** @extends React.Component */ const /* ordinary */ C = function() {};`, want: []bool{false}},
+		{name: "intervening export comment", code: `/** @extends React.Component */ export /* ordinary */ const C = () => null;`, want: []bool{false}},
+		{name: "object property function", code: `const Box = { /** @extends React.Component */ C: function() {} };`, want: []bool{true}},
+		{name: "object method", code: `const Box = { /** @extends React.Component */ C() {} };`, want: []bool{true}},
+		{name: "object getter", code: `const Box = { /** @extends React.Component */ get C() {} };`, want: []bool{true}},
+		{name: "object setter", code: `const Box = { /** @extends React.Component */ set C(value) {} };`, want: []bool{true}},
+		{name: "object literal comment", code: `const Box = /** @extends React.Component */ { C: class {} };`, want: []bool{true}},
+		{name: "assignment comment", code: `const Box = {}; /** @extends React.Component */ Box.C = class {};`, want: []bool{true}},
+		{name: "same-line local declaration", code: `function outer() { /** @extends React.Component */ const C = () => null; }`, want: []bool{false, true}},
+		{name: "braced name", code: `/** @extends {React.Component} */ class C {}`, want: []bool{false}},
+		{name: "generic name", code: `/** @extends React.Component<Props> */ class C {}`, want: []bool{false}},
+		{name: "description", code: `/** @extends React.Component description */ class C {}`, want: []bool{false}},
+		{name: "description before valid tag", code: `/** @extends Other nonsense
+ * @augments React.Component */ class C {}`, want: []bool{false}},
+		{name: "braces before valid tag", code: `/** @extends {Other}
+ * @augments React.Component */ class C {}`, want: []bool{true}},
+		{name: "multiline tag", code: `/** @extends
+ * React.Component */ class C {}`, want: []bool{true}},
+		{name: "augments pure component", code: `/** @augments React.PureComponent */ class C {}`, want: []bool{true}},
+		{name: "multiple comments", code: `/** @extends React.Component */
+/** ordinary */ class C {}`, want: []bool{false}},
+		{name: "line comment", code: `/** @extends React.Component */
+// ordinary
+class C {}`, want: []bool{false}},
+		{name: "blank line", code: `/** @extends React.Component */
+
+class C {}`, want: []bool{false}},
+		{name: "adjacent line", code: `/** @extends React.Component */
+class C {}`, want: []bool{true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, script := range []struct {
+				name string
+				kind core.ScriptKind
+			}{
+				{"typescript", core.ScriptKindTSX}, {"javascript", core.ScriptKindJSX},
+			} {
+				t.Run(script.name, func(t *testing.T) {
+					sf := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/component.tsx", Path: "/component.tsx"}, tc.code, script.kind)
+					var got []bool
+					var visit func(*ast.Node) bool
+					visit = func(node *ast.Node) bool {
+						switch node.Kind {
+						case ast.KindClassDeclaration, ast.KindClassExpression, ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+							got = append(got, IsExplicitReactComponent(node))
+						}
+						node.ForEachChild(visit)
+						return false
+					}
+					visit(sf.AsNode())
+					if !slices.Equal(got, tc.want) {
+						t.Fatalf("IsExplicitReactComponent() = %v, want %v", got, tc.want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/plugins/react/rules/sort_comp/sort_comp_extras_test.go
+++ b/internal/plugins/react/rules/sort_comp/sort_comp_extras_test.go
@@ -43,6 +43,8 @@ func TestSortCompExtras(t *testing.T) {
 		{Code: `class Foo extends React.Component { static #private = 1; render() {} }`, Tsx: true},
 		// ---- Compatibility: @jsx changes the component pragma. ----
 		{Code: `/** @jsx Preact */ class Foo extends React.Component { render() {} componentDidMount() {} }`, Tsx: true},
+		{Code: "/** @extends React.Component */\n/** ordinary */ class Foo { render() {} componentDidMount() {} }", Tsx: true},
+		{Code: `/** @extends React.Component */ class Outer { Helper = class { render() {} componentDidMount() {} }; }`, Tsx: true},
 		// ---- Compatibility: non-plain class members are not variable/method groups. ----
 		{Code: `abstract class Foo extends React.Component { render() {} abstract props: string; }`, Tsx: true, Options: sortCompOrder("instance-variables", "render")},
 		{Code: `abstract class Foo extends React.Component { render() {} static abstract method(): void; }`, Tsx: true, Options: sortCompOrder("static-methods", "render")},
@@ -104,6 +106,7 @@ func TestSortCompExtras(t *testing.T) {
 		// ---- Compatibility: JSDoc-only React component declarations. ----
 		{Code: `/** @extends React.Component */ class Foo { render() {} componentDidMount() {} }`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{sortCompError("render", "after", "componentDidMount")}},
 		{Code: `/** @augments React.PureComponent */ class Foo { render() {} componentDidMount() {} }`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{sortCompError("render", "after", "componentDidMount")}},
+		{Code: `/** @extends React.Component */ const Foo = class { render() {} componentDidMount() {} };`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{sortCompError("render", "after", "componentDidMount")}},
 		// ---- Compatibility: computed React component inheritance. ----
 		{Code: `class Foo extends React[Component] { render() {} componentDidMount() {} }`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{sortCompError("render", "after", "componentDidMount")}},
 		// ---- Compatibility: error deduplication uses the original entry snapshot. ----

--- a/internal/plugins/react/rules/static_property_placement/static_property_placement.go
+++ b/internal/plugins/react/rules/static_property_placement/static_property_placement.go
@@ -3,10 +3,14 @@ package static_property_placement
 import (
 	_ "embed"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 //go:embed static_property_placement.schema.json
@@ -35,7 +39,6 @@ type options struct {
 func parseOptions(raw []any) options {
 	o := options{
 		defaultPosition: staticPublicField,
-		overrides:       map[string]string{},
 	}
 	if len(raw) > 0 {
 		if position, ok := raw[0].(string); ok && position != "" {
@@ -44,6 +47,7 @@ func parseOptions(raw []any) options {
 	}
 	if len(raw) > 1 {
 		if m, ok := raw[1].(map[string]interface{}); ok {
+			o.overrides = make(map[string]string, len(m))
 			for name := range propertyNames {
 				if position, ok := m[name].(string); ok && position != "" {
 					o.overrides[name] = position
@@ -152,379 +156,238 @@ func classMemberName(node *ast.Node) string {
 	}
 }
 
-func reportClassMember(name, expected string, node *ast.Node, isStatic bool, ctx rule.RuleContext) {
-	if expected == propertyAssignment {
-		ctx.ReportNode(node, rule.RuleMessage{
-			Id:          "declareOutsideClass",
-			Description: fmt.Sprintf("'%s' should be declared outside the class body.", name),
-			Data:        map[string]string{"name": name},
-		})
-		return
-	}
-
-	if expected == staticPublicField && node.Kind == ast.KindPropertyDeclaration && isStatic {
-		return
-	}
-	if expected == staticGetter && node.Kind == ast.KindGetAccessor && isStatic {
-		return
-	}
-
-	messageID := "notStaticClassProp"
-	description := fmt.Sprintf("'%s' should be declared as a static class property.", name)
-	if expected == staticGetter {
-		messageID = "notGetterClassFunc"
-		description = fmt.Sprintf("'%s' should be declared as a static getter class function.", name)
-	}
-	ctx.ReportNode(node, rule.RuleMessage{
-		Id:          messageID,
-		Description: description,
-		Data:        map[string]string{"name": name},
-	})
-}
-
-func reportAssignment(name, expected string, node *ast.Node, ctx rule.RuleContext) {
-	if expected == propertyAssignment {
-		return
-	}
-	messageID := "notStaticClassProp"
-	description := fmt.Sprintf("'%s' should be declared as a static class property.", name)
-	if expected == staticGetter {
-		messageID = "notGetterClassFunc"
-		description = fmt.Sprintf("'%s' should be declared as a static getter class function.", name)
-	}
-	ctx.ReportNode(node, rule.RuleMessage{
-		Id:          messageID,
-		Description: description,
-		Data:        map[string]string{"name": name},
-	})
-}
-
-func isReactClass(node *ast.Node, pragma string) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindClassDeclaration, ast.KindClassExpression:
-		return reactutil.ExtendsReactComponent(node, pragma) || isExplicitReactClass(node)
-	}
-	return false
-}
-
-func isExplicitReactClass(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	for _, doc := range node.JSDoc(nil) {
-		jsDoc := doc.AsJSDoc()
-		if jsDoc == nil || jsDoc.Tags == nil {
-			continue
-		}
-		for _, tag := range jsDoc.Tags.Nodes {
-			if !ast.IsJSDocAugmentsTag(tag) {
-				continue
+// Messages are immutable; every diagnostic can reuse their formatted text and
+// data instead of allocating the same property names for each source member.
+var placementMessages = func() map[string]map[string]rule.RuleMessage {
+	messages := make(map[string]map[string]rule.RuleMessage, 3)
+	for _, position := range []string{staticPublicField, staticGetter, propertyAssignment} {
+		messages[position] = make(map[string]rule.RuleMessage, len(propertyNames))
+		for name := range propertyNames {
+			id, description := "notStaticClassProp", "'%s' should be declared as a static class property."
+			switch position {
+			case staticGetter:
+				id, description = "notGetterClassFunc", "'%s' should be declared as a static getter class function."
+			case propertyAssignment:
+				id, description = "declareOutsideClass", "'%s' should be declared outside the class body."
 			}
-			augments := tag.AsJSDocAugmentsTag()
-			if augments != nil && isExplicitReactType(augments.ClassName) {
-				return true
+			messages[position][name] = rule.RuleMessage{Id: id, Description: fmt.Sprintf(description, name), Data: map[string]string{"name": name}}
+		}
+	}
+	return messages
+}()
+
+type componentResolver struct {
+	ctx        rule.RuleContext
+	pragma     string
+	classes    map[*ast.Node]bool
+	scopes     *scope.Manager
+	firstChild map[*scope.Scope]*scope.Scope
+}
+
+func (r *componentResolver) isReactComponent(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if result, ok := r.classes[node]; ok {
+		return result
+	}
+	result := ((node.Kind == ast.KindClassDeclaration || node.Kind == ast.KindClassExpression) && reactutil.ExtendsReactComponent(node, r.pragma)) || reactutil.IsExplicitReactComponent(node)
+	if r.classes == nil {
+		r.classes = make(map[*ast.Node]bool)
+	}
+	r.classes[node] = result
+	return result
+}
+
+func (r *componentResolver) variable(node *ast.Node, name string) []*scope.Variable {
+	// A direct top-level assignment to a singly declared top-level binding
+	// cannot reach the child-scope fallback. Reuse the binder's declaration
+	// here; nested scopes and merged declarations use the complete model below.
+	if parent := ast.WalkUpParenthesizedExpressions(node.Parent); parent != nil {
+		statement := ast.WalkUpParenthesizedExpressions(parent.Parent)
+		if statement != nil && statement.Kind == ast.KindExpressionStatement && statement.Parent == r.ctx.SourceFile.AsNode() {
+			if symbol := r.ctx.SourceFile.Locals[name]; symbol != nil && len(symbol.Declarations) == 1 {
+				declaration := symbol.Declarations[0]
+				kind, topLevel := scope.DefVariable, false
+				switch declaration.Kind {
+				case ast.KindVariableDeclaration:
+					topLevel = declaration.Parent.Kind == ast.KindVariableDeclarationList && declaration.Parent.Parent.Kind == ast.KindVariableStatement && declaration.Parent.Parent.Parent == r.ctx.SourceFile.AsNode()
+				case ast.KindClassDeclaration:
+					kind, topLevel = scope.DefClassName, declaration.Parent == r.ctx.SourceFile.AsNode()
+				case ast.KindFunctionDeclaration:
+					kind, topLevel = scope.DefFunctionName, declaration.Parent == r.ctx.SourceFile.AsNode()
+				}
+				if topLevel && declaration.Name() != nil && declaration.Name().Kind == ast.KindIdentifier && declaration.Name().Text() == name {
+					return []*scope.Variable{{ID: declaration.Name(), DefNode: declaration, Kind: kind}}
+				}
 			}
 		}
 	}
-	return false
-}
-
-func isExplicitReactType(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	node = ast.SkipParentheses(node)
-	if node.Kind == ast.KindExpressionWithTypeArguments {
-		return isExplicitReactType(node.AsExpressionWithTypeArguments().Expression)
-	}
-	if node.Kind != ast.KindPropertyAccessExpression {
-		return false
-	}
-	property := node.AsPropertyAccessExpression()
-	object := ast.SkipParentheses(property.Expression)
-	name := property.Name()
-	return object != nil && object.Kind == ast.KindIdentifier && object.AsIdentifier().Text == "React" &&
-		name != nil && name.Kind == ast.KindIdentifier &&
-		(name.AsIdentifier().Text == "Component" || name.AsIdentifier().Text == "PureComponent")
-}
-
-// parentReactClass mirrors componentUtil.getParentES6Component: walk out to the
-// nearest enclosing class and treat it as the component only when that class is
-// itself a React class. The lookup is deliberately ES6-class-only, so a helper
-// class nested inside a createReactClass component is not attributed to that
-// surrounding ES5 component.
-func parentReactClass(node *ast.Node, pragma string) *ast.Node {
-	for parent := node.Parent; parent != nil; parent = parent.Parent {
-		if parent.Kind != ast.KindClassDeclaration && parent.Kind != ast.KindClassExpression {
-			continue
+	if r.scopes == nil {
+		r.scopes = scope.Build(r.ctx.SourceFile, scope.Options{})
+		r.firstChild = make(map[*scope.Scope]*scope.Scope)
+		for _, s := range r.scopes.Scopes {
+			if s.Parent != nil && r.firstChild[s.Parent] == nil {
+				r.firstChild[s.Parent] = s
+			}
 		}
-		if isReactClass(parent, pragma) {
-			return parent
+	}
+	// React's variable helper also checks the first two child scopes before
+	// walking outward. The shared scope model preserves those boundaries.
+	for s := r.scopes.Acquire(node); s != nil; s = s.Parent {
+		child := s
+		for range 3 {
+			if child == nil {
+				break
+			}
+			if declarations := child.Declarations(name); len(declarations) != 0 {
+				return declarations
+			}
+			child = r.firstChild[child]
 		}
-		return nil
 	}
 	return nil
 }
 
-func relatedReactClass(ctx rule.RuleContext, receiver *ast.Node, pragma string) bool {
-	receiver = ast.SkipParentheses(receiver)
-	if ast.IsOptionalChain(receiver) {
-		return false
-	}
-	root, path, ok := componentPath(receiver)
-	if !ok || ctx.Refs == nil {
-		return false
-	}
-	symbol := ctx.Refs.Resolve(root)
-	if symbol != nil && symbol.ValueDeclaration != nil {
-		declaration := symbol.ValueDeclaration
-		if isReactClass(resolveComponentPath(declaration, path), pragma) {
-			return true
+func (r *componentResolver) related(node *ast.Node) bool {
+	// Build the complete ESTree member path. Literal/private keys are omitted,
+	// including a trailing ["displayName"], before separating the binding name.
+	var buffer [8]string
+	path := buffer[:0]
+	for current := node; current != nil; {
+		var object, property *ast.Node
+		switch current.Kind {
+		case ast.KindPropertyAccessExpression:
+			access := current.AsPropertyAccessExpression()
+			object, property = access.Expression, access.Name()
+		case ast.KindElementAccessExpression:
+			access := current.AsElementAccessExpression()
+			object, property = access.Expression, ast.SkipParentheses(access.ArgumentExpression)
+		default:
+			current = nil
+			continue
 		}
-		if relatedReactClassAssignment(ctx, symbol, path, receiver, pragma) {
-			return true
+		if property != nil && property.Kind == ast.KindIdentifier {
+			path = append(path, property.Text())
 		}
-		// A successfully resolved local binding is authoritative. Falling
-		// back to a same-name class elsewhere in the file would cross a
-		// shadowing boundary and report a non-component binding.
-		return false
-	}
-	// The checker/ref store can leave a declaration unresolved in a JS/TSX
-	// file without a usable project symbol. Keep the same-file fallback
-	// conservative and name-based, matching the plugin's related-component
-	// lookup for ordinary class declarations.
-	source := ast.GetSourceFileOfNode(receiver)
-	if source == nil {
-		return false
-	}
-	if len(path) != 0 {
-		return false
-	}
-	want := root.AsIdentifier().Text
-	found := false
-	var visit func(*ast.Node)
-	visit = func(node *ast.Node) {
-		if found || node == nil {
-			return
+		object = ast.SkipParentheses(object)
+		if object != nil && object.Kind == ast.KindIdentifier {
+			path = append(path, object.Text())
 		}
-		if node.Kind == ast.KindClassDeclaration {
-			name := node.Name()
-			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == want && isReactClass(node, pragma) {
-				found = true
-				return
+		current = object
+	}
+	if len(path) == 0 {
+		return false
+	}
+	slices.Reverse(path)
+	declarations := r.variable(node, path[0])
+	if len(declarations) == 0 {
+		return false
+	}
+	componentName := strings.Join(path[:len(path)-1], ".")
+	// Initializer writes are ESLint references, but RefStore deliberately
+	// excludes declaration names. Compare the earliest matching initializer
+	// with its source-ordered index without copying or sorting that index.
+	var first *ast.Node
+	for _, declaration := range declarations {
+		if declaration.Kind == scope.DefVariable && declaration.DefNode.Kind == ast.KindVariableDeclaration && declaration.DefNode.AsVariableDeclaration().Initializer != nil {
+			id := declaration.ID
+			if utils.TrimmedNodeText(r.ctx.SourceFile, id) == componentName && (first == nil || id.Pos() < first.Pos()) {
+				first = id
 			}
 		}
-		node.ForEachChild(func(child *ast.Node) bool { visit(child); return found })
 	}
-	visit(source.AsNode())
-	return found
-}
-
-func relatedReactClassAssignment(ctx rule.RuleContext, symbol *ast.Symbol, path []string, currentReceiver *ast.Node, pragma string) bool {
-	if ctx.Refs == nil || symbol == nil {
-		return false
+	if componentName != "" {
+		for _, reference := range r.ctx.Refs.References(declarations[0].DefNode.Symbol()) {
+			if first != nil && reference.Pos() > first.Pos() {
+				break
+			}
+			ref := reference
+			if parent := ast.WalkUpParenthesizedExpressions(ref.Parent); parent != nil && (parent.Kind == ast.KindPropertyAccessExpression || parent.Kind == ast.KindElementAccessExpression) {
+				ref = parent
+			}
+			if utils.TrimmedNodeText(r.ctx.SourceFile, ref) == componentName {
+				first = ref
+				break
+			}
+		}
 	}
-	for _, reference := range ctx.Refs.References(symbol) {
-		if reference == nil || reference.Parent == nil {
-			continue
+	if first != nil {
+		var component *ast.Node
+		parent := ast.WalkUpParenthesizedExpressions(first.Parent)
+		if first.Kind == ast.KindPropertyAccessExpression || first.Kind == ast.KindElementAccessExpression {
+			component = binaryRight(parent)
+		} else if parent != nil && parent.Kind == ast.KindVariableDeclaration && parent.AsVariableDeclaration().Initializer != nil {
+			init := ast.SkipParentheses(parent.AsVariableDeclaration().Initializer)
+			if init != nil && init.Kind != ast.KindIdentifier {
+				component = init
+			}
 		}
-		// getRelatedComponent stops at the current reference, so assignments
-		// after the property write cannot define the component for that write.
-		if currentReceiver != nil && reference.Pos() >= currentReceiver.Pos() {
-			continue
+		if component != nil {
+			return r.isReactComponent(ast.SkipParentheses(component))
 		}
-		memberRoot, memberPath, ok := componentPath(reference.Parent)
-		if !ok || memberRoot != reference || !samePath(memberPath, path) {
-			continue
+		// The first textual match is authoritative even when it has no right
+		// side: then upstream falls back to the declaration, not a later write.
+	}
+	for _, declaration := range declarations {
+		switch declaration.Kind {
+		case scope.DefVariable, scope.DefClassName, scope.DefClassInnerName, scope.DefFunctionName, scope.DefFnExprName:
+			node := declaration.DefNode
+			if node.Kind == ast.KindBindingElement {
+				node = ast.FindAncestorKind(node, ast.KindVariableDeclaration)
+			}
+			if node != nil && node.Kind == ast.KindVariableDeclaration && node.AsVariableDeclaration().Initializer != nil {
+				node = node.AsVariableDeclaration().Initializer
+			}
+			return r.isReactComponent(resolveComponentPath(node, path[1:]))
 		}
-		parent := reference.Parent.Parent
-		for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-			parent = parent.Parent
-		}
-		if parent == nil || parent.Kind != ast.KindBinaryExpression {
-			return false
-		}
-		binary := parent.AsBinaryExpression()
-		if binary.OperatorToken == nil || binary.OperatorToken.Kind == ast.KindCommaToken || binary.Right == nil {
-			return false
-		}
-		if isReactClass(reactutil.SkipExpressionWrappers(binary.Right), pragma) {
-			return true
-		}
-		return false
 	}
 	return false
 }
 
-func samePath(left, right []string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for i := range left {
-		if left[i] != right[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func componentPath(node *ast.Node) (*ast.Node, []string, bool) {
-	if node == nil {
-		return nil, nil, false
-	}
-	switch node.Kind {
-	case ast.KindIdentifier:
-		return node, nil, true
-	case ast.KindPropertyAccessExpression:
-		property := node.AsPropertyAccessExpression()
-		root, path, ok := componentPath(property.Expression)
-		if !ok {
-			return nil, nil, false
-		}
-		// getRelatedComponent adds only ordinary ESTree Identifier
-		// properties to its path. Private and other non-Identifier names
-		// are skipped while the object prefix remains usable.
-		if name := property.Name(); name != nil && name.Kind == ast.KindIdentifier {
-			return root, append(path, name.AsIdentifier().Text), true
-		}
-		return root, path, true
-	case ast.KindElementAccessExpression:
-		property := node.AsElementAccessExpression()
-		root, path, ok := componentPath(property.Expression)
-		if !ok {
-			return nil, nil, false
-		}
-		// getRelatedComponent includes an ESTree computed identifier in the
-		// component path, but omits literal and other computed keys. Keep the
-		// resolved prefix for the latter so `Box.C["helper"].propTypes`
-		// still resolves through `Box.C` like upstream.
-		argument := ast.SkipParentheses(property.ArgumentExpression)
-		if argument != nil && argument.Kind == ast.KindIdentifier {
-			path = append(path, argument.AsIdentifier().Text)
-		}
-		return root, path, true
-	default:
-		return nil, nil, false
-	}
-}
-
 func resolveComponentPath(node *ast.Node, path []string) *ast.Node {
-	node = reactutil.SkipExpressionWrappers(node)
 	if node == nil {
 		return nil
 	}
-	if node.Kind == ast.KindVariableDeclaration {
-		node = reactutil.SkipExpressionWrappers(node.AsVariableDeclaration().Initializer)
-	}
+	node = ast.SkipParentheses(node)
 	for _, name := range path {
 		if node == nil {
 			return nil
 		}
-		// eslint-plugin-react keeps the component node when a later path
-		// segment is accessed on a class, because class nodes do not have
-		// object-literal `properties`. Preserve that behavior so paths such
-		// as `Box.C.foo.propTypes` still resolve to the component class.
+		// Only object literals have ESTree properties; class and TS wrapper nodes
+		// retain their identity when a later path segment is inspected.
 		if node.Kind != ast.KindObjectLiteralExpression {
 			continue
 		}
 		var next *ast.Node
 		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
-			if property == nil || property.Name() == nil || propertyIdentifierName(property.Name()) != name {
+			key := property.Name()
+			if key != nil && key.Kind == ast.KindComputedPropertyName {
+				key = ast.SkipParentheses(key.AsComputedPropertyName().Expression)
+			}
+			if key == nil || key.Kind != ast.KindIdentifier || key.Text() != name {
 				continue
 			}
 			if property.Kind == ast.KindPropertyAssignment {
 				next = property.AsPropertyAssignment().Initializer
+			} else if ast.IsFunctionLike(property) {
+				next = property
 			}
 			break
 		}
 		if next == nil {
 			return nil
 		}
-		node = reactutil.SkipExpressionWrappers(next)
+		node = ast.SkipParentheses(next)
 	}
 	return node
 }
 
-func propertyIdentifierName(node *ast.Node) string {
-	if node == nil {
-		return ""
+func binaryRight(node *ast.Node) *ast.Node {
+	if node == nil || node.Kind != ast.KindBinaryExpression || utils.IsCommaOperator(node) {
+		return nil
 	}
-	if node.Kind == ast.KindIdentifier {
-		return node.AsIdentifier().Text
-	}
-	if node.Kind == ast.KindComputedPropertyName {
-		expr := ast.SkipParentheses(node.AsComputedPropertyName().Expression)
-		if expr != nil && expr.Kind == ast.KindIdentifier {
-			return expr.AsIdentifier().Text
-		}
-	}
-	return ""
-}
-
-func isInsideClass(node *ast.Node) bool {
-	for parent := node.Parent; parent != nil; parent = parent.Parent {
-		if parent.Kind == ast.KindClassDeclaration {
-			return true
-		}
-	}
-	return false
-}
-
-func assignmentMember(node *ast.Node) (*ast.Node, *ast.Node, bool) {
-	if node == nil {
-		return nil, nil, false
-	}
-	if ast.IsOptionalChain(node) {
-		return nil, nil, false
-	}
-	var nameNode *ast.Node
-	var receiver *ast.Node
-	switch node.Kind {
-	case ast.KindPropertyAccessExpression:
-		property := node.AsPropertyAccessExpression()
-		nameNode, receiver = property.Name(), property.Expression
-	case ast.KindElementAccessExpression:
-		property := node.AsElementAccessExpression()
-		nameNode, receiver = property.ArgumentExpression, property.Expression
-	default:
-		return nil, nil, false
-	}
-	name := propertyName(nameNode)
-	if name == "" {
-		return nil, nil, false
-	}
-	// eslint-plugin-react's getRelatedComponent builds the component path from
-	// the complete MemberExpression. A computed string property is omitted
-	// from that path, so a nested form such as `Box.C["displayName"]` does not
-	// resolve as a related component there. Keep the direct `C["displayName"]`
-	// form below, which upstream does recognize.
-	if node.Kind == ast.KindElementAccessExpression && isNestedComputedDisplayName(nameNode, receiver) {
-		return nil, nil, false
-	}
-	current := node
-	parent := current.Parent
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		current, parent = parent, parent.Parent
-	}
-	if parent == nil || parent.Kind != ast.KindBinaryExpression {
-		return nil, nil, false
-	}
-	binary := parent.AsBinaryExpression()
-	if binary.OperatorToken == nil || binary.OperatorToken.Kind == ast.KindCommaToken || binary.Right == nil {
-		return nil, nil, false
-	}
-	return node, receiver, true
-}
-
-func isNestedComputedDisplayName(nameNode, receiver *ast.Node) bool {
-	nameNode = ast.SkipParentheses(nameNode)
-	receiver = ast.SkipParentheses(receiver)
-	return nameNode != nil && nameNode.Kind == ast.KindStringLiteral &&
-		nameNode.AsStringLiteral().Text == "displayName" &&
-		receiver != nil && receiver.Kind == ast.KindPropertyAccessExpression
+	return node.AsBinaryExpression().Right
 }
 
 var StaticPropertyPlacementRule = rule.Rule{
@@ -532,75 +395,53 @@ var StaticPropertyPlacementRule = rule.Rule{
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		o := parseOptions(rawOptions)
-		pragma := reactutil.GetReactPragma(ctx.Settings)
-		checkClassMember := func(node *ast.Node, isStatic bool) {
-			// @typescript-eslint/parser represents abstract fields as
-			// TSAbstractPropertyDefinition, which is not matched by the upstream
-			// rule's ClassProperty/PropertyDefinition selector. tsgo exposes the
-			// same field as PropertyDeclaration, so filter abstract members here.
-			if hasModifier(node, ast.KindAbstractKeyword) {
+		resolver := componentResolver{ctx: ctx, pragma: reactutil.GetReactPragmaFromContext(ctx)}
+		checkClassMember := func(node *ast.Node) {
+			if !utils.IsPlainClassMember(node) {
 				return
 			}
-			if parentReactClass(node, pragma) == nil {
+			isStatic := ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic)
+			if node.Kind == ast.KindGetAccessor && !isStatic {
 				return
 			}
 			name := classMemberName(node)
 			if name == "" {
 				return
 			}
-			// MethodDefinition's upstream listener only handles static getters;
-			// ordinary methods and instance accessors are not class properties.
-			if node.Kind == ast.KindGetAccessor && !isStatic {
+			expected := o.position(name)
+			if isStatic && ((node.Kind == ast.KindPropertyDeclaration && expected == staticPublicField) || (node.Kind == ast.KindGetAccessor && expected == staticGetter)) {
 				return
 			}
-			reportClassMember(name, o.position(name), node, isStatic, ctx)
+			if resolver.isReactComponent(reactutil.EnclosingClass(node)) {
+				ctx.ReportNode(node, placementMessages[expected][name])
+			}
 		}
-
+		checkAssignment := func(node *ast.Node) {
+			if ast.IsOptionalChain(node) || binaryRight(ast.WalkUpParenthesizedExpressions(node.Parent)) == nil {
+				return
+			}
+			var name string
+			if node.Kind == ast.KindPropertyAccessExpression {
+				name = propertyName(node.AsPropertyAccessExpression().Name())
+			} else {
+				name = propertyName(node.AsElementAccessExpression().ArgumentExpression)
+			}
+			if name == "" {
+				return
+			}
+			expected := o.position(name)
+			if expected == propertyAssignment || ast.FindAncestorKind(node.Parent, ast.KindClassDeclaration) != nil {
+				return
+			}
+			if resolver.related(node) {
+				ctx.ReportNode(node, placementMessages[expected][name])
+			}
+		}
 		return rule.RuleListeners{
-			ast.KindPropertyDeclaration: func(node *ast.Node) {
-				// TypeScript represents auto-accessors as PropertyDeclaration,
-				// while typescript-eslint exposes AccessorProperty, which is not
-				// included in the upstream rule's listener selector.
-				if hasModifier(node, ast.KindAccessorKeyword) {
-					return
-				}
-				checkClassMember(node, node.Modifiers() != nil && node.Modifiers().Nodes != nil && hasStaticModifier(node))
-			},
-			ast.KindGetAccessor: func(node *ast.Node) {
-				checkClassMember(node, hasStaticModifier(node))
-			},
-			ast.KindPropertyAccessExpression: func(node *ast.Node) {
-				member, receiver, ok := assignmentMember(node)
-				if !ok || isInsideClass(node) || !relatedReactClass(ctx, receiver, pragma) {
-					return
-				}
-				name := propertyName(member.AsPropertyAccessExpression().Name())
-				reportAssignment(name, o.position(name), member, ctx)
-			},
-			ast.KindElementAccessExpression: func(node *ast.Node) {
-				member, receiver, ok := assignmentMember(node)
-				if !ok || isInsideClass(node) || !relatedReactClass(ctx, receiver, pragma) {
-					return
-				}
-				name := propertyName(member.AsElementAccessExpression().ArgumentExpression)
-				reportAssignment(name, o.position(name), member, ctx)
-			},
+			ast.KindPropertyDeclaration:      checkClassMember,
+			ast.KindGetAccessor:              checkClassMember,
+			ast.KindPropertyAccessExpression: checkAssignment,
+			ast.KindElementAccessExpression:  checkAssignment,
 		}
 	},
-}
-
-func hasStaticModifier(node *ast.Node) bool {
-	return hasModifier(node, ast.KindStaticKeyword)
-}
-
-func hasModifier(node *ast.Node, kind ast.Kind) bool {
-	if node == nil || node.Modifiers() == nil {
-		return false
-	}
-	for _, modifier := range node.Modifiers().Nodes {
-		if modifier.Kind == kind {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/plugins/react/rules/static_property_placement/static_property_placement.md
+++ b/internal/plugins/react/rules/static_property_placement/static_property_placement.md
@@ -6,6 +6,18 @@ The rule checks `childContextTypes`, `contextTypes`, `contextType`,
 `defaultProps` (including legacy `getDefaultProps`), `displayName`, and
 `propTypes`. The default placement is `static public field`.
 
+Component detection follows `eslint-plugin-react`, including `settings.react.pragma`,
+file-level `@jsx` comments, and adjacent JSDoc `@extends React.Component` or
+`@augments React.PureComponent` markers. For class expressions assigned to a
+variable, put the JSDoc before the variable declaration:
+
+```tsx
+/** @extends React.Component */
+const Component = class {
+  static propTypes = {};
+};
+```
+
 ## Options
 
 The first option selects the default placement:

--- a/internal/plugins/react/rules/static_property_placement/static_property_placement_regressions_test.go
+++ b/internal/plugins/react/rules/static_property_placement/static_property_placement_regressions_test.go
@@ -60,3 +60,57 @@ func TestStaticPropertyPlacementRegressions(t *testing.T) {
 		},
 	)
 }
+
+// These cases were checked against eslint-plugin-react 7.37.5 using ESLint
+// 9.39.5 and @typescript-eslint/parser 8.69.0, including diagnostic ranges.
+func TestStaticPropertyPlacementComponentLookup(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &StaticPropertyPlacementRule,
+		[]rule_tester.ValidTestCase{
+			// An earlier write overrides the initializer.
+			{Code: `const Box = { C: class extends React.Component {} }; Box.C = {}; Box.C.propTypes = {};`, Tsx: true},
+			// Only an exact source reference matches.
+			{Code: `let Box = {}; Box . C = class extends React.Component {}; Box.C.propTypes = {};`, Tsx: true},
+			// Parentheses inside an earlier reference remain significant.
+			{Code: `let Box = {}; (Box).C = class extends React.Component {}; Box.C.propTypes = {};`, Tsx: true},
+			// Preserve TypeScript assertion wrappers.
+			{Code: `const Box = { C: class extends React.Component {} } as const; Box.C.propTypes = {};`, Tsx: true},
+			// Preserve satisfies wrappers.
+			{Code: `const Box = { C: class extends React.Component {} } satisfies Record<string,unknown>; Box.C.propTypes = {};`, Tsx: true},
+			// The first matching initializer is authoritative.
+			{Code: `var C = {}; var C = class extends React.Component {}; C.propTypes = {};`, Tsx: true},
+			// Do not search an unrelated second child scope.
+			{Code: `function f() {} function g() { class C extends React.Component {} } C.propTypes = {};`, Tsx: true},
+			// Parameters shadow outer components.
+			{Code: `class C extends React.Component {} function f(C) { C.propTypes = {}; }`, Tsx: true},
+			// Braced names are not explicit component markers.
+			{Code: `/** @extends {React.Component} */ class C { propTypes = {}; }`, Tsx: true},
+			// An outer class marker does not mark a nested class.
+			{Code: `/** @extends React.Component */ class Outer { C = class { propTypes = {}; }; }`, Tsx: true},
+			// The file pragma changes the recognized superclass.
+			{Code: `/* @jsx R.h */ class C extends React.Component { propTypes = {}; } C.defaultProps = {};`, Tsx: true},
+		}, []rule_tester.InvalidTestCase{
+			// A computed reference must not hide the declaration.
+			{Code: `const Box = { C: class extends React.Component {} }; Box[C] = {}; Box.C.propTypes = {};`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notStaticClassProp", Message: "'propTypes' should be declared as a static class property.", Line: 1, Column: 67, EndLine: 1, EndColumn: 82}}},
+			// Skip ordinary receiver parentheses.
+			{Code: `const Box = { C: class extends React.Component {} }; (Box).C.propTypes = {};`, Tsx: true, Options: []any{staticGetter}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notGetterClassFunc", Message: "'propTypes' should be declared as a static getter class function.", Line: 1, Column: 54, EndLine: 1, EndColumn: 71}}},
+			// Keep the full nested path for a literal property.
+			{Code: `const Box = { nested: { C: class extends React.Component {} } }; Box.nested.C["displayName"] = {};`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notStaticClassProp", Message: "'displayName' should be declared as a static class property.", Line: 1, Column: 66, EndLine: 1, EndColumn: 93}}},
+			// An initializer on a repeated declaration is a reference.
+			{Code: `var C; var C = class extends React.Component {}; C.propTypes = {};`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notStaticClassProp", Message: "'propTypes' should be declared as a static class property.", Line: 1, Column: 50, EndLine: 1, EndColumn: 61}}},
+			// Search the first child scope.
+			{Code: `function f() { class C extends React.Component {} } C.propTypes = {};`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notStaticClassProp", Message: "'propTypes' should be declared as a static class property.", Line: 1, Column: 53, EndLine: 1, EndColumn: 64}}},
+			// Search the first grandchild scope.
+			{Code: `function f() { function g() { class C extends React.Component {} } } C.propTypes = {};`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notStaticClassProp", Message: "'propTypes' should be declared as a static class property.", Line: 1, Column: 70, EndLine: 1, EndColumn: 81}}},
+			// Class expression comments belong to their declaration.
+			{Code: `/** @extends React.Component */ const C = class { propTypes = {}; };`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notStaticClassProp", Message: "'propTypes' should be declared as a static class property.", Line: 1, Column: 51, EndLine: 1, EndColumn: 66}}},
+			// Same-line markers on object methods are supported.
+			{Code: `const Box = { /** @extends React.Component */ C() {} }; Box.C.propTypes = {};`, Tsx: true, Options: []any{staticGetter}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notGetterClassFunc", Message: "'propTypes' should be declared as a static getter class function.", Line: 1, Column: 57, EndLine: 1, EndColumn: 72}}},
+			// Same-line markers on assignments are supported.
+			{Code: `const Box = {}; /** @extends React.Component */ Box.C = class { propTypes = {}; }; Box.C.defaultProps = {};`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notStaticClassProp", Message: "'propTypes' should be declared as a static class property.", Line: 1, Column: 65, EndLine: 1, EndColumn: 80}, {MessageId: "notStaticClassProp", Message: "'defaultProps' should be declared as a static class property.", Line: 1, Column: 84, EndLine: 1, EndColumn: 102}}},
+			// Follow the file pragma.
+			{Code: `/* @jsx R */ class C extends R.Component { propTypes = {}; } C.defaultProps = {};`, Tsx: true, Options: []any{staticGetter}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notGetterClassFunc", Message: "'propTypes' should be declared as a static getter class function.", Line: 1, Column: 44, EndLine: 1, EndColumn: 59}, {MessageId: "notGetterClassFunc", Message: "'defaultProps' should be declared as a static getter class function.", Line: 1, Column: 62, EndLine: 1, EndColumn: 76}}},
+			// Decorated fields retain the diagnostic range.
+			{Code: `class C extends React.Component { @decorator propTypes = {}; }`, Tsx: true, Options: []any{propertyAssignment}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "declareOutsideClass", Message: "'propTypes' should be declared outside the class body.", Line: 1, Column: 35, EndLine: 1, EndColumn: 61}}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/static-property-placement.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/static-property-placement.test.ts
@@ -28,6 +28,27 @@ ruleTester.run('static-property-placement', {} as never, {
         MyComponent.defaultProps = {};`,
       options: ['property assignment'],
     },
+    {
+      code: `const Box = { C: class extends React.Component {} };
+        Box.C = {};
+        Box.C.propTypes = {};`,
+    },
+    {
+      code: `const Box = { C: class extends React.Component {} } as const;
+        Box.C.propTypes = {};`,
+    },
+    {
+      code: `/** @extends {React.Component} */
+        class C { propTypes = {}; }`,
+      filename: 'files/static-property-placement.jsx',
+    },
+    {
+      code: `/** @extends React.Component */
+        const C = class {
+          // eslint-disable-next-line react/static-property-placement
+          propTypes = {};
+        };`,
+    },
   ],
   invalid: [
     {
@@ -46,7 +67,12 @@ ruleTester.run('static-property-placement', {} as never, {
     {
       code: `class MyComponent extends React.Component {}
         MyComponent.propTypes = {};`,
-      errors: [{ messageId: 'declareOutsideClass' }],
+      errors: [
+        {
+          messageId: 'notStaticClassProp',
+          message: "'propTypes' should be declared as a static class property.",
+        },
+      ],
     },
     {
       code: `class MyComponent extends React.Component {
@@ -58,6 +84,39 @@ ruleTester.run('static-property-placement', {} as never, {
       errors: [
         { messageId: 'declareOutsideClass' },
         { messageId: 'declareOutsideClass' },
+      ],
+    },
+    {
+      code: `/** @extends React.Component */
+        const C = class { propTypes = {}; };`,
+      filename: 'files/static-property-placement.jsx',
+      errors: [
+        {
+          messageId: 'notStaticClassProp',
+          message: "'propTypes' should be declared as a static class property.",
+        },
+      ],
+    },
+    {
+      code: `const Box = { C: class extends React.Component {} };
+        (Box).C.propTypes = {};`,
+      options: ['static getter'],
+      errors: [
+        {
+          messageId: 'notGetterClassFunc',
+          message:
+            "'propTypes' should be declared as a static getter class function.",
+        },
+      ],
+    },
+    {
+      code: `/* @jsx Preact.h */
+        class C extends Preact.Component { propTypes = {}; }`,
+      errors: [
+        {
+          messageId: 'notStaticClassProp',
+          message: "'propTypes' should be declared as a static class property.",
+        },
       ],
     },
   ],


### PR DESCRIPTION
## Summary

Fix `react/static-property-placement` component detection to match ESLint. For example, `Box.C = {}` must take precedence over an earlier React class initializer when checking `Box.C.propTypes`. Component lookup now preserves upstream reference order, exact source spelling, nested property paths, repeated declarations, and TypeScript wrapper boundaries.

Reuse rslint's reference index, binding model, class-member helpers, and React pragma utility. Refine the existing JSDoc component helper with tsgo's comment scanner and parser so declaration ownership, adjacent comments, exported expressions, object methods, and tag syntax match upstream. Add regressions for the rule and its shared helper's `sort-comp` consumer, plus JavaScript/JSX integration and disable-comment coverage.

Validation:

- Executed `eslint-plugin-react` **7.37.5** with ESLint **9.39.5** and `@typescript-eslint/parser` **8.69.0**. All **2,824** differential cases agree, including the upstream release's source cases expanded across placement settings, message IDs, message text, and diagnostic ranges.
- Added 22 rule regressions and 31 shared-helper examples checked in both JavaScript and TypeScript parser modes.
- Targeted Go tests and race checks passed for `reactutil`, `static_property_placement`, and `sort_comp`.
- Built `@rslint/core` and passed the two affected JS integration suites.
- `pnpm run check-spell` and `pnpm run format:check` passed.
- Go lint passed with `--new-from-merge-base=origin/main`, restricted to the three affected Go packages.

Local Go benchmark results (median of five 300 ms runs, 100 components per input, parsing/binding excluded):

| Scenario | Before | After | Time change |
| --- | ---: | ---: | ---: |
| No watched members | 16.83 µs | 13.53 µs | -19.6% |
| Invalid class fields | 76.34 µs | 38.44 µs | -49.6% |
| Invalid external assignments (`Box.C`) | 85.14 µs | 131.93 µs | +54.9% |
| Allowed class fields | 17.94 µs | 13.27 µs | -26.0% |
| Allowed external assignments | 48.06 µs | 21.82 µs | -54.6% |

The external-assignment case includes building an uncached reference index and validating the first matching reference, which the previous declaration-first return skipped. Retain that work for correctness. Cached diagnostics and early placement checks reduce allocations elsewhere; invalid class fields drop from 1,514 to 322 allocations per input. Benchmark and profiling source files are not included.

## Related Links

- [Upstream rule documentation](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/static-property-placement.md)
- [Upstream component lookup](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/util/Components.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
