### PR TITLE
fix: align JSX expression line handling with upstream

### DIFF
--- a/internal/plugins/react/rules/jsx_one_expression_per_line/jsx_one_expression_per_line.go
+++ b/internal/plugins/react/rules/jsx_one_expression_per_line/jsx_one_expression_per_line.go
@@ -17,6 +17,7 @@ import (
 var schemaJSON []byte
 
 const (
+	ruleName         = "react/jsx-one-expression-per-line"
 	allowNone        = "none"
 	allowLiteral     = "literal"
 	allowSingleChild = "single-child"
@@ -56,8 +57,7 @@ func fixSource(source string) string {
 }
 
 func hasTrailingTextSpace(source string) bool {
-	trimmed := strings.TrimRight(source, " ")
-	return len(trimmed) < len(source) && !strings.HasSuffix(trimmed, "\n") && !strings.HasSuffix(trimmed, "\r")
+	return strings.HasSuffix(source, " ") && !hasTrailingNewline(source)
 }
 
 func isJSXText(node *ast.Node) bool {
@@ -68,42 +68,17 @@ func isWhitespaceOnly(source string) bool {
 	return ecmascript.IsBlank(source)
 }
 
-// hasLeadingNewline mirrors the upstream `/^\s*\n/` test. The match count in
-// the original rule is the length of a non-global match, so this deliberately
-// returns a boolean rather than counting every line terminator.
+// hasLeadingNewline mirrors the upstream `/^\s*\n/g` test. Its anchored
+// match contributes one entry even when it spans several line terminators.
 func hasLeadingNewline(source string) bool {
-	foundLineFeed := false
-	for _, r := range source {
-		if !ecmascript.IsWhiteSpaceOrLineTerminator(r) {
-			return foundLineFeed
-		}
-		if r == '\n' {
-			foundLineFeed = true
-		}
-	}
-	return foundLineFeed
+	end := ecmascript.SkipLeadingWhitespace(source, 0, len(source))
+	return strings.Contains(source[:end], "\n")
 }
 
 // hasTrailingNewline mirrors the upstream `/\n\s*$/` test.
 func hasTrailingNewline(source string) bool {
-	foundLineFeed := false
-	for _, r := range reverseRunes(source) {
-		if !ecmascript.IsWhiteSpaceOrLineTerminator(r) {
-			return foundLineFeed
-		}
-		if r == '\n' {
-			foundLineFeed = true
-		}
-	}
-	return foundLineFeed
-}
-
-func reverseRunes(source string) []rune {
-	runes := []rune(source)
-	for left, right := 0, len(runes)-1; left < right; left, right = left+1, right-1 {
-		runes[left], runes[right] = runes[right], runes[left]
-	}
-	return runes
+	start := ecmascript.SkipTrailingWhitespace(source, 0, len(source))
+	return strings.Contains(source[start:], "\n")
 }
 
 func childDescriptor(source string, child *ast.Node) string {
@@ -278,13 +253,13 @@ func handleJSX(ctx rule.RuleContext, node *ast.Node, options ruleOptions) {
 	}
 	lineMap := ctx.SourceFile.ECMALineMap()
 	source := ctx.SourceFile.Text()
-	openingStartLine := scanner.ComputeLineOfPosition(lineMap, opening.Pos())
 	openingEndLine := scanner.ComputeLineOfPosition(lineMap, opening.End())
 	closingStartLine := scanner.ComputeLineOfPosition(lineMap, closing.Pos())
-	closingEndLine := scanner.ComputeLineOfPosition(lineMap, closing.End())
 
-	if len(children) == 1 {
+	if len(children) == 1 && (options.allow == allowSingleChild || options.allow == allowLiteral) {
 		child := children[0]
+		openingStartLine := scanner.ComputeLineOfPosition(lineMap, scanner.SkipTrivia(source, opening.Pos()))
+		closingEndLine := scanner.ComputeLineOfPosition(lineMap, closing.End())
 		childStartLine := scanner.ComputeLineOfPosition(lineMap, child.Pos())
 		childEndLine := scanner.ComputeLineOfPosition(lineMap, child.End())
 		if openingStartLine == openingEndLine &&
@@ -377,13 +352,20 @@ func handleJSX(ctx rule.RuleContext, node *ast.Node, options ruleOptions) {
 	}
 
 	detailsList := make([]*fixDetails, 0, len(detailsByChild))
-	for _, details := range detailsByChild {
+	// Children are already in source order. Only reports that survive disable
+	// directives can participate in ESLint's adjacent-fix selection.
+	for _, child := range children {
+		details := detailsByChild[child]
+		if details == nil {
+			continue
+		}
+		if ctx.DisableManager.IsRuleDisabled(ruleName, child.Pos()) {
+			delete(detailsByChild, child)
+			continue
+		}
 		detailsList = append(detailsList, details)
 	}
-	sort.Slice(detailsList, func(i, j int) bool {
-		return detailsList[i].child.Pos() < detailsList[j].child.Pos()
-	})
-	accepted := acceptedFixes(detailsList)
+	var accepted map[*ast.Node]bool
 	for _, details := range detailsList {
 		if details == nil || details.child == nil {
 			continue
@@ -396,10 +378,14 @@ func handleJSX(ctx rule.RuleContext, node *ast.Node, options ruleOptions) {
 		}
 		child := currentDetails.child
 		ctx.ReportRangeWithDeferredFixes(core.NewTextRange(child.Pos(), child.End()), message, func() []rule.RuleFix {
+			if accepted == nil {
+				accepted = acceptedFixes(detailsList)
+			}
 			rawSource := nodeSource(source, child)
 			fixedSource := fixSource(rawSource)
 			if isJSXText(child) && hasTrailingTextSpace(rawSource) && shouldKeepTrailingTextSpace(&currentDetails, accepted) {
-				fixedSource += " "
+				// Preserve the whole trailing run when a following fix protects it.
+				fixedSource = strings.TrimLeft(rawSource, " ")
 			}
 			leadingSpace := ""
 			if currentDetails.leadingSpace && shouldKeepLeadingSpace(&currentDetails, detailsByChild, accepted) {
@@ -426,7 +412,7 @@ func handleJSX(ctx rule.RuleContext, node *ast.Node, options ruleOptions) {
 }
 
 var JsxOneExpressionPerLineRule = rule.Rule{
-	Name:   "react/jsx-one-expression-per-line",
+	Name:   ruleName,
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)

--- a/internal/plugins/react/rules/jsx_one_expression_per_line/jsx_one_expression_per_line.md
+++ b/internal/plugins/react/rules/jsx_one_expression_per_line/jsx_one_expression_per_line.md
@@ -55,10 +55,17 @@ Defaults to `"none"`.
 - `"single-child"`: Allow any single child on the same line.
 - `"non-jsx"`: Allow children when there is no direct JSX element or fragment child.
 
+The `"literal"` and `"single-child"` checks apply to the lines occupied by the JSX
+itself. Line breaks and comments before its opening tag do not affect the exception.
+
 Examples of **correct** code with `"literal"`:
 
 ```jsx
 <App>Hello</App>
+
+const render = () => (
+  <App>Hello</App>
+);
 ```
 
 Examples of **correct** code with `"single-child"`:

--- a/internal/plugins/react/rules/jsx_one_expression_per_line/jsx_one_expression_per_line_extras_test.go
+++ b/internal/plugins/react/rules/jsx_one_expression_per_line/jsx_one_expression_per_line_extras_test.go
@@ -6,8 +6,13 @@ package jsx_one_expression_per_line
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"gotest.tools/v3/assert"
 )
 
 func TestJsxOneExpressionPerLineExtras(t *testing.T) {
@@ -158,4 +163,89 @@ func TestJsxOneExpressionPerLineExtras(t *testing.T) {
 			{MessageId: "moveToNewLine"},
 		}},
 	})
+}
+
+func TestJsxOneExpressionPerLineTriviaAndSpacing(t *testing.T) {
+	var valid []rule_tester.ValidTestCase
+	for _, prefix := range []string{"\n", "\r\n", "\r", "\u2028", "\u2029", "/* comment\n */", "// comment\n"} {
+		for _, allow := range []string{"literal", "single-child"} {
+			for _, jsx := range []string{"<A>text</A>", "<>text</>"} {
+				valid = append(valid, rule_tester.ValidTestCase{
+					Code: "const view = () => (" + prefix + jsx + ");", Tsx: true,
+					Options: map[string]any{"allow": allow},
+				})
+			}
+		}
+	}
+	valid = append(valid,
+		rule_tester.ValidTestCase{Code: "const view = () => (\n<A>{value as string}</A>\n);", Tsx: true, Options: map[string]any{"allow": "single-child"}},
+		rule_tester.ValidTestCase{Code: "const view = () => (\n<><A /></>\n);", Tsx: true, Options: map[string]any{"allow": "single-child"}},
+	)
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxOneExpressionPerLineRule, valid, []rule_tester.InvalidTestCase{
+		{Code: "const view = () => (\n<A>{value}</A>\n);", Tsx: true, Options: map[string]any{"allow": "literal"},
+			Output: []string{"const view = () => (\n<A>\n{value}\n</A>\n);"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine", Line: 2, Column: 4, EndLine: 2, EndColumn: 11}},
+		},
+		{Code: "<A\n>text</A>", Tsx: true, Options: map[string]any{"allow": "literal"},
+			Output: []string{"<A\n>\ntext\n</A>"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}},
+		},
+		{Code: "<A>text</\nA>", Tsx: true, Options: map[string]any{"allow": "single-child"},
+			Output: []string{"<A>\ntext\n</\nA>"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}},
+		},
+		{Code: "<A>text\ntext</A>", Tsx: true, Options: map[string]any{"allow": "single-child"},
+			Output: []string{"<A>\ntext\ntext\n</A>"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}},
+		},
+		{Code: "<A>{x}text  {y}</A>", Tsx: true,
+			Output: []string{"<A>\n{x}\ntext  \n{' '}\n{y}\n</A>"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}},
+		},
+		{Code: "<A><B />text  {y}</A>", Tsx: true, Options: map[string]any{"allow": "non-jsx"},
+			Output: []string{"<A>\n<B />\ntext  \n{' '}\n{y}\n</A>"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}},
+		},
+		{Code: "<A>{x}text\n more\n \t </A>", Tsx: true,
+			Output: []string{"<A>\n{x}\ntext\n more\n \t</A>"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}},
+		},
+		// Upstream's boundary adjustment recognizes LF, not a bare CR.
+		{Code: "<A>{x}text\r  {y}</A>", Tsx: true,
+			Output: []string{"<A>\n{x}\ntext\r  \n{' '}\n{y}\n</A>"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}},
+		},
+		// A suppressed report must not change which following text fixes land.
+		{Code: "<A>\n{/* eslint-disable-next-line react/jsx-one-expression-per-line */}\n{x}{(\nx\n)} text  {y}\n</A>", Tsx: true,
+			Output: []string{"<A>\n{/* eslint-disable-next-line react/jsx-one-expression-per-line */}\n{x}{(\nx\n)}\n{' '}\ntext\n{y}\n</A>"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine", Line: 5, Column: 3, EndLine: 5, EndColumn: 10}, {MessageId: "moveToNewLine", Line: 5, Column: 10, EndLine: 5, EndColumn: 13}},
+		},
+		{Code: "<A>{/* eslint-disable react/jsx-one-expression-per-line */}<B>{x}\n</B> text {y}{/* eslint-enable react/jsx-one-expression-per-line */} text {y}</A>", Tsx: true,
+			Output: []string{"<A>\n{/* eslint-disable react/jsx-one-expression-per-line */}<B>{x}\n</B> text {y}{/* eslint-enable react/jsx-one-expression-per-line */}\n{' '}\ntext\n{y}\n</A>"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}, {MessageId: "moveToNewLine"}},
+		},
+	})
+}
+
+func TestJsxOneExpressionPerLineEditDemand(t *testing.T) {
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/demand.tsx", Path: "/demand.tsx",
+		}, "<A>{x}text  {y}</A>", core.ScriptKindTSX)
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{SourceFile: sourceFile, Comments: comments, DisableManager: rule.NewDisableManager(sourceFile, comments)}.WithDiagnosticConsumer(ruleName, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand, Report: func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) },
+		})
+		listeners := JsxOneExpressionPerLineRule.Run(ctx, nil)
+		listeners[ast.KindJsxElement](sourceFile.Statements.Nodes[0].AsExpressionStatement().Expression)
+		assert.Equal(t, len(diagnostics), 3)
+		for i, expected := range []struct {
+			text       string
+			start, end int
+		}{{"{x}", 3, 6}, {"text  ", 6, 12}, {"{y}", 12, 15}} {
+			d := diagnostics[i]
+			assert.Equal(t, d.Message.Description, "`"+expected.text+"` must be placed on a new line")
+			assert.Equal(t, d.Range, core.NewTextRange(expected.start, expected.end))
+			assert.Equal(t, len(d.Fixes()) > 0, demand&rule.EditDemandAutofix != 0)
+			assert.Assert(t, d.Suggestions == nil)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Fix `react/jsx-one-expression-per-line` so `literal` and `single-child` allowances work when JSX follows a line break or comment. For example, this remains valid with `allow: "literal"`:

```jsx
const view = () => (
  <A>text</A>
);
```

Preserve complete trailing ASCII-space runs, distinguish LF from bare CR when fixing multiline text, and exclude disabled reports from adjacent-fix selection. Reuse tsgo's trivia scanner and rslint's ECMAScript whitespace helpers; avoid reversing entire text nodes, sorting children already in source order, and computing fix selection for diagnostics-only requests.

Validation:

- Compared 10,097 upstream and generated cases against the latest published `eslint-plugin-react@7.37.5` using ESLint 8.57.1 and 10.10.0: zero differences in diagnostic messages, positions, counts, or final multipass output. The ESLint 10 driver delegates its removed `SourceCode.isSpaceBetweenTokens` method to the unchanged ESLint 8 implementation; unused-disable reporting is disabled to isolate this rule.
- `go test ./internal/plugins/react/rules/jsx_one_expression_per_line -count=3` passed, including regression cases and edit-demand checks.
- The corresponding JavaScript rule suite and eight real CLI autofix cases passed, including BOM preservation, CR, and disable directives.
- `pnpm run check-spell`, `pnpm run format:check`, and `pnpm exec golangci-lint run --new-from-merge-base=origin/main ./internal/plugins/react/rules/jsx_one_expression_per_line/...` passed. Go lint was limited to this package and introduced code.

Go benchmark medians from five 500 ms samples on Apple M5 Max, Go 1.26.5, with `-benchmem -cpu=1`. Parsing and JSX-node collection were outside the timed loop; the benchmark exercised rule setup and listeners with different edit demands. The temporary benchmark source was removed.

| Case | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| NoJSX | 175.8 → 174.3 | 512 → 512 | 5 → 5 |
| Formatted | 10,586 → 10,176 | 11,104 → 11,080 | 112 → 111 |
| Diagnostics | 37,782 → 30,686 | 75,232 → 70,272 | 574 → 569 |
| Autofix | 46,124 → 40,422 | 82,400 → 82,392 | 958 → 957 |
| LongText | 73,795 → 292.4 | 156,192 → 520 | 8 → 6 |
| NonJSXAllowed | 338.9 → 345.9 | 512 → 512 | 5 → 5 |
| SingleChildAllowed | 191.4 → 198 | 512 → 512 | 5 → 5 |

Diagnostics and autofix improved by 18.8% and 12.4% respectively. The long-text case avoids a full-text allocation and scan; lightweight control cases varied by less than 4%, so no end-to-end performance claim is made.

## Related Links

- [Upstream rule documentation](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-one-expression-per-line.md)
- [Upstream implementation](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-one-expression-per-line.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
