### PR TITLE
perf: reduce comment traversal allocations

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -361,6 +361,9 @@ for the first consumer; later consumers share that list. A source without `//`
 or `/*` takes a cheap byte-scan fast path. Inline-global parsing first checks
 for an exact raw-text directive candidate, so ordinary files do not force
 comment collection.
+Comment traversal uses parser-owned token ranges and scans the gaps between
+AST children with a scanner local to the walk. It does not populate the
+SourceFile token cache; token APIs still return canonical cached nodes.
 The linter also creates one shared `RefStore` handle per file. Its candidate
 identifier walk is deferred until the first reference query, and binder name
 resolution is then performed once per queried symbol name. Rules query it with

--- a/internal/utils/comment_traversal_bench_test.go
+++ b/internal/utils/comment_traversal_bench_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+)
+
+func BenchmarkForEachComment(b *testing.B) {
+	for _, fixture := range []struct {
+		name, source string
+		comments     int
+	}{
+		{"statements", strings.Repeat("let value = 1 /* comment */;\n", 512), 512},
+		{"wide", "const values = [" + strings.Repeat("0 /* comment */,", 4096) + "];", 4096},
+		{"nested", "const value = " + strings.Repeat("(", 512) + "1 /* comment */" + strings.Repeat(")", 512) + ";", 1},
+	} {
+		b.Run(fixture.name, func(b *testing.B) {
+			parse := func() *ast.SourceFile {
+				return parser.ParseSourceFile(ast.SourceFileParseOptions{
+					FileName: "/comments.ts", Path: "/comments.ts",
+				}, fixture.source, core.ScriptKindTS)
+			}
+			for _, warm := range []bool{false, true} {
+				name := "cold"
+				if warm {
+					name = "warm"
+				}
+				b.Run(name, func(b *testing.B) {
+					sourceFile := parse()
+					if warm {
+						ForEachToken(sourceFile.AsNode(), func(*ast.Node) {}, sourceFile)
+					}
+					b.ReportAllocs()
+					for b.Loop() {
+						if !warm {
+							// Measure first collection without including parsing, and do
+							// not let a previous iteration populate this file's cache.
+							b.StopTimer()
+							sourceFile = parse()
+							b.StartTimer()
+						}
+						comments := 0
+						ForEachComment(sourceFile.AsNode(), func(*ast.CommentRange) { comments++ }, sourceFile)
+						if comments != fixture.comments {
+							b.Fatalf("comments = %d, want %d", comments, fixture.comments)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/utils/comment_traversal_test.go
+++ b/internal/utils/comment_traversal_test.go
@@ -1,0 +1,279 @@
+package utils
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+)
+
+type traversalCommentExpectation struct {
+	text    string
+	kind    ast.Kind
+	newline bool
+}
+
+func parseCommentTraversalSource(source string, kind core.ScriptKind) *ast.SourceFile {
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/comments.tsx",
+		Path:     "/comments.tsx",
+	}, source, kind)
+}
+
+func assertTraversalComments(t *testing.T, sourceFile *ast.SourceFile, node *ast.Node, expected []traversalCommentExpectation) {
+	t.Helper()
+	var want []ast.CommentRange
+	for _, comment := range expected {
+		pos := strings.Index(sourceFile.Text(), comment.text)
+		if pos < 0 || comment.text == "" {
+			t.Fatalf("expected comment %q is missing from the fixture", comment.text)
+		}
+		want = append(want, ast.CommentRange{
+			TextRange:          core.NewTextRange(pos, pos+len(comment.text)),
+			Kind:               comment.kind,
+			HasTrailingNewLine: comment.newline,
+		})
+	}
+	var got []ast.CommentRange
+	ForEachComment(node, func(comment *ast.CommentRange) {
+		got = append(got, *comment)
+	}, sourceFile)
+	// Compare raw callbacks, without sorting or deduplicating them.
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("raw comments = %#v, want %#v", got, want)
+	}
+}
+
+func TestCommentTraversalTriviaAndSyntax(t *testing.T) {
+	const (
+		block = ast.KindMultiLineCommentTrivia
+		line  = ast.KindSingleLineCommentTrivia
+	)
+	tests := []struct {
+		name      string
+		source    string
+		want      []traversalCommentExpectation
+		malformed bool
+	}{
+		{name: "empty"},
+		{name: "whitespace only", source: " \t\v\f\r\n\u00a0\ufeff"},
+		{name: "shebang only", source: "#!/usr/bin/env node"},
+		{
+			name:   "comments after shebang",
+			source: "#!/usr/bin/env node\r\n/* first */\r\n// last",
+			want:   []traversalCommentExpectation{{"/* first */", block, true}, {"// last", line, false}},
+		},
+		{
+			name:   "comment only source",
+			source: "/* first */\n// second",
+			want:   []traversalCommentExpectation{{"/* first */", block, true}, {"// second", line, false}},
+		},
+		{
+			name:      "unterminated comment",
+			source:    "/* incomplete",
+			want:      []traversalCommentExpectation{{"/* incomplete", block, false}},
+			malformed: true,
+		},
+		{
+			name:   "BOM and trailing CRLF",
+			source: "\ufeff/* first */\nconst value = 1; // last\r\n",
+			want:   []traversalCommentExpectation{{"/* first */", block, true}, {"// last", line, true}},
+		},
+		{
+			name:   "Unicode line breaks",
+			source: "// first\u2028/* second */\u2029const value = 1;",
+			want:   []traversalCommentExpectation{{"// first", line, true}, {"/* second */", block, true}},
+		},
+		{
+			name:   "trailing and leading ownership",
+			source: "let first = 1; /* same line */\r\n/* next line */\r\nlet second = 2;",
+			want:   []traversalCommentExpectation{{"/* same line */", block, false}, {"/* next line */", block, true}},
+		},
+		{
+			name:   "string and regex markers",
+			source: `const a = '/* string */'; const b = /[/*]/; const c = /https?:\/\//; /* real */`,
+			want:   []traversalCommentExpectation{{"/* real */", block, false}},
+		},
+		{
+			name:   "template expression and raw text",
+			source: "const value = `/* raw */ ${1 /* expression */ + 2} // raw`; // end\n",
+			want:   []traversalCommentExpectation{{"/* expression */", block, false}, {"// end", line, true}},
+		},
+		{
+			name:      "missing initializer",
+			source:    "const value = ; // recovered\n",
+			want:      []traversalCommentExpectation{{"// recovered", line, true}},
+			malformed: true,
+		},
+		{
+			name:      "unterminated string",
+			source:    "const value = 'unfinished\n/* recovered */ const next = 1;",
+			want:      []traversalCommentExpectation{{"/* recovered */", block, false}},
+			malformed: true,
+		},
+		{
+			name:      "unterminated template expression",
+			source:    "const value = `/* raw */ ${1 /* real */",
+			want:      []traversalCommentExpectation{{"/* real */", block, false}},
+			malformed: true,
+		},
+		{
+			name:      "invalid UTF-8 before comment",
+			source:    "const first = 1;\xff/* recovered */const next = 2;",
+			malformed: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parseCommentTraversalSource(test.source, core.ScriptKindTS)
+			if test.malformed && len(sourceFile.Diagnostics()) == 0 {
+				t.Fatal("fixture must exercise parser recovery")
+			}
+			assertTraversalComments(t, sourceFile, sourceFile.AsNode(), test.want)
+		})
+	}
+}
+
+func TestCommentTraversalJSXTriviaOwners(t *testing.T) {
+	const block = ast.KindMultiLineCommentTrivia
+	tests := []struct {
+		name   string
+		source string
+		want   []traversalCommentExpectation
+	}{
+		{
+			name:   "closing element keeps existing trailing behavior",
+			source: "const value = <><A></A>/* text */</>; /* real */",
+			// The existing closing-element case permits this trailing scan,
+			// even though a closing fragment at the same depth does not.
+			want: []traversalCommentExpectation{{"/* text */", block, false}, {"/* real */", block, false}},
+		},
+		{
+			name:   "nested closing fragment excludes text",
+			source: "const value = <><></>/* text */</>; /* real */",
+			want:   []traversalCommentExpectation{{"/* real */", block, false}},
+		},
+		{
+			name:   "self closing element and expression exclude text",
+			source: "const value = <><A />/* first text */{1 /* expression */}/* second text */</>; /* real */",
+			want:   []traversalCommentExpectation{{"/* expression */", block, false}, {"/* real */", block, false}},
+		},
+		{
+			name:   "type arguments and attributes own trivia",
+			source: "const value = <A<T /* type */> prop={1 /* attribute */}>/* text */</A>; /* real */",
+			want:   []traversalCommentExpectation{{"/* type */", block, false}, {"/* attribute */", block, false}, {"/* real */", block, false}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parseCommentTraversalSource(test.source, core.ScriptKindTSX)
+			if len(sourceFile.Diagnostics()) != 0 {
+				t.Fatal("JSX fixture must parse without errors")
+			}
+			assertTraversalComments(t, sourceFile, sourceFile.AsNode(), test.want)
+		})
+	}
+}
+
+func TestCommentTraversalLongTrivia(t *testing.T) {
+	for _, length := range []int{7, 8, 9, 64} {
+		t.Run(strconv.Itoa(length), func(t *testing.T) {
+			padding := strings.Repeat(" ", length)
+			source := padding + "/* leading */\r\nconst value = 1;" + padding + "/* same line */\r\n" + padding + "// next line\n"
+			sourceFile := parseCommentTraversalSource(source, core.ScriptKindTS)
+			assertTraversalComments(t, sourceFile, sourceFile.AsNode(), []traversalCommentExpectation{
+				{"/* leading */", ast.KindMultiLineCommentTrivia, true},
+				{"/* same line */", ast.KindMultiLineCommentTrivia, false},
+				{"// next line", ast.KindSingleLineCommentTrivia, true},
+			})
+		})
+	}
+}
+
+func TestCommentTraversalSkipsReparsedJSDoc(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		code string
+	}{
+		{"type", "/** @type {number[]} */", "const values = [1, 2];"},
+		{"parameter", "/** @param {number[]} values */", "function use(values) { return values; }"},
+		{"template", "/** @template T\n * @param {T} value\n */", "function identity(value) { return value; }"},
+		{"overload", "/** @overload\n * @param {string} value\n * @returns {string}\n */", "function identity(value) { return value; }"},
+		{"import", "/** @import { Widget } from 'pkg' */", "const value = 1;"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parseCommentTraversalSource(test.doc+"\n"+test.code+" // after\n", core.ScriptKindJS)
+			reparsed := 0
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Flags&ast.NodeFlagsReparsed != 0 {
+					reparsed++
+				}
+				node.ForEachChild(visit)
+				return false
+			}
+			visit(sourceFile.AsNode())
+			if reparsed == 0 {
+				t.Fatal("JS fixture must contain reparsed JSDoc nodes")
+			}
+			assertTraversalComments(t, sourceFile, sourceFile.AsNode(), []traversalCommentExpectation{
+				{test.doc, ast.KindMultiLineCommentTrivia, true},
+				{"// after", ast.KindSingleLineCommentTrivia, true},
+			})
+		})
+	}
+}
+
+func TestCommentTraversalColdSubtrees(t *testing.T) {
+	const source = "/* before first */\nfunction first() { /* inside first */ }\n" +
+		"// before second\nfunction second() { /* inside second */ }\n/* after second */"
+	for _, bodyOnly := range []bool{false, true} {
+		name := "function"
+		if bodyOnly {
+			name = "body"
+		}
+		t.Run(name, func(t *testing.T) {
+			// Parse separately for each subtree so no prior walk can populate
+			// its token cache or accidentally supply file-wide comments.
+			sourceFile := parseCommentTraversalSource(source, core.ScriptKindTS)
+			if len(sourceFile.Statements.Nodes) != 2 {
+				t.Fatal("fixture must contain two functions")
+			}
+			node := sourceFile.Statements.Nodes[1]
+			want := []traversalCommentExpectation{{"// before second", ast.KindSingleLineCommentTrivia, true}}
+			if bodyOnly {
+				node = node.Body()
+				want = nil
+			}
+			if node == nil {
+				t.Fatal("subtree is missing")
+			}
+			want = append(want, traversalCommentExpectation{"/* inside second */", ast.KindMultiLineCommentTrivia, false})
+			assertTraversalComments(t, sourceFile, node, want)
+		})
+	}
+}
+
+func TestCommentTraversalMissingTokenHasNoFileFallback(t *testing.T) {
+	sourceFile := parseCommentTraversalSource("const value = ; /* outside */", core.ScriptKindTS)
+	var missing *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if ast.IsIdentifier(node) && node.Pos() == node.End() {
+			missing = node
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	if missing == nil {
+		t.Fatal("fixture must contain a zero-width missing identifier")
+	}
+	assertTraversalComments(t, sourceFile, missing, nil)
+}

--- a/internal/utils/token_traversal_test.go
+++ b/internal/utils/token_traversal_test.go
@@ -1,0 +1,285 @@
+package utils
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+)
+
+const tokenTraversalSource = `/* leading */
+const n = 0x1_f; // number
+const text = '\u0061';
+const big = 0x10n;
+const pattern = /\/\* fake \*\//g;
+` + "const template = `\\u0061${n /* expression */ + 1} tail`;\n" + `
+const view = <Box<number> label="/* attribute */">{n}{/* child */}<span>text</span></Box>;
+/* trailing */`
+
+type tokenTraversalSnapshot struct {
+	node, parent *ast.Node
+	kind         ast.Kind
+	pos, end     int
+	flags        ast.NodeFlags
+	literalFlags ast.TokenFlags
+}
+
+func snapshotTraversalToken(node *ast.Node) tokenTraversalSnapshot {
+	var literalFlags ast.TokenFlags
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		literalFlags = node.AsStringLiteral().TokenFlags
+	case ast.KindNumericLiteral:
+		literalFlags = node.AsNumericLiteral().TokenFlags
+	case ast.KindBigIntLiteral:
+		literalFlags = node.AsBigIntLiteral().TokenFlags
+	case ast.KindRegularExpressionLiteral:
+		literalFlags = node.AsRegularExpressionLiteral().TokenFlags
+	case ast.KindNoSubstitutionTemplateLiteral:
+		literalFlags = node.AsNoSubstitutionTemplateLiteral().TemplateFlags
+	case ast.KindTemplateHead:
+		literalFlags = node.AsTemplateHead().TemplateFlags
+	case ast.KindTemplateMiddle:
+		literalFlags = node.AsTemplateMiddle().TemplateFlags
+	case ast.KindTemplateTail:
+		literalFlags = node.AsTemplateTail().TemplateFlags
+	}
+	return tokenTraversalSnapshot{node, node.Parent, node.Kind, node.Pos(), node.End(), node.Flags, literalFlags}
+}
+
+func parseTokenTraversalSource(source string) *ast.SourceFile {
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/traversal.tsx",
+		Path:     "/traversal.tsx",
+	}, source, core.ScriptKindTSX)
+}
+
+func collectTraversalTokens(sourceFile *ast.SourceFile) []tokenTraversalSnapshot {
+	var tokens []tokenTraversalSnapshot
+	ForEachToken(sourceFile.AsNode(), func(node *ast.Node) {
+		tokens = append(tokens, snapshotTraversalToken(node))
+	}, sourceFile)
+	return tokens
+}
+
+func collectTraversalComments(sourceFile *ast.SourceFile) []ast.CommentRange {
+	var comments []ast.CommentRange
+	ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
+		comments = append(comments, *comment)
+	}, sourceFile)
+	return comments
+}
+
+func assertTraversalTokens(t *testing.T, got, want []tokenTraversalSnapshot) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("token count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		// Comparing structs directly checks pointer identity as well as fields;
+		// deep equality alone could accept a different node with the same fields.
+		if got[i] != want[i] {
+			t.Fatalf("token %d changed: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestTokenTraversalPreservesCanonicalNodesWithComments(t *testing.T) {
+	for _, warmTokens := range []bool{false, true} {
+		t.Run(fmt.Sprintf("warm_tokens_%t", warmTokens), func(t *testing.T) {
+			sourceFile := parseTokenTraversalSource(tokenTraversalSource)
+			var want []tokenTraversalSnapshot
+			if warmTokens {
+				want = collectTraversalTokens(sourceFile)
+			}
+			callbacks := 0
+			ForEachComment(sourceFile.AsNode(), func(_ *ast.CommentRange) {
+				callbacks++
+				got := collectTraversalTokens(sourceFile)
+				if want == nil {
+					want = got
+				}
+				assertTraversalTokens(t, got, want)
+				// Exercise GetChildren directly on nodes whose keywords and
+				// punctuation are materialized from scanner-filled gaps.
+				for _, child := range GetChildren(sourceFile.AsNode(), sourceFile) {
+					if ast.IsTokenKind(child.Kind) {
+						continue
+					}
+					left := GetChildren(child, sourceFile)
+					right := GetChildren(child, sourceFile)
+					if !slices.Equal(left, right) {
+						t.Fatal("GetChildren did not reuse canonical nodes")
+					}
+				}
+			}, sourceFile)
+			if callbacks == 0 || len(want) == 0 {
+				t.Fatal("fixture must exercise both comments and tokens")
+			}
+			assertTraversalTokens(t, collectTraversalTokens(sourceFile), want)
+			assertTraversalTokens(t, collectTraversalTokens(sourceFile), want)
+			if !slices.ContainsFunc(want, func(token tokenTraversalSnapshot) bool {
+				return token.literalFlags != ast.TokenFlagsNone
+			}) {
+				t.Fatal("fixture must contain literals with nonzero token flags")
+			}
+		})
+	}
+}
+
+func TestTokenTraversalNestedCallbacks(t *testing.T) {
+	sourceFile := parseTokenTraversalSource(tokenTraversalSource)
+	otherFile := parseTokenTraversalSource("/* other */ const x = 1; // end\n")
+	want := collectTraversalComments(parseTokenTraversalSource(tokenTraversalSource))
+	wantOther := collectTraversalComments(parseTokenTraversalSource(otherFile.Text()))
+	if len(want) < 2 || len(wantOther) == 0 {
+		t.Fatal("fixtures must contain comments")
+	}
+	var retained []*ast.CommentRange
+	var values []ast.CommentRange
+	ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
+		retained = append(retained, comment)
+		values = append(values, *comment)
+		if len(retained) != 1 {
+			return
+		}
+		// Nest comment walks inside a token callback, itself called inside a
+		// comment callback. Every invocation must own its scanner and stack.
+		nested := false
+		ForEachToken(sourceFile.AsNode(), func(_ *ast.Node) {
+			if nested {
+				return
+			}
+			nested = true
+			if got := collectTraversalComments(sourceFile); !slices.Equal(got, want) {
+				t.Fatalf("nested same-file comments = %v, want %v", got, want)
+			}
+			if got := collectTraversalComments(otherFile); !slices.Equal(got, wantOther) {
+				t.Fatalf("nested other-file comments = %v, want %v", got, wantOther)
+			}
+			if len(collectTraversalTokens(otherFile)) == 0 {
+				t.Fatal("other-file token walk was empty")
+			}
+		}, sourceFile)
+		if !nested {
+			t.Fatal("nested callback was not exercised")
+		}
+	}, sourceFile)
+	if !slices.Equal(values, want) {
+		t.Fatalf("outer comments = %v, want %v", values, want)
+	}
+	seen := make(map[*ast.CommentRange]bool)
+	for i, comment := range retained {
+		if seen[comment] {
+			t.Fatalf("comment %d reused a callback pointer", i)
+		}
+		seen[comment] = true
+		if *comment != values[i] {
+			t.Fatalf("retained comment %d changed after its callback", i)
+		}
+	}
+}
+
+func TestTokenTraversalStopsAtEveryToken(t *testing.T) {
+	sourceFile := parseTokenTraversalSource(tokenTraversalSource)
+	want := collectTraversalTokens(sourceFile)
+	wantComments := collectTraversalComments(sourceFile)
+	if len(want) == 0 || len(wantComments) == 0 {
+		t.Fatal("fixture must contain tokens and comments")
+	}
+	for stop := range len(want) + 1 {
+		t.Run(fmt.Sprintf("stop_%d", stop), func(t *testing.T) {
+			var got []tokenTraversalSnapshot
+			stopped := forEachToken(sourceFile.AsNode(), func(node *ast.Node) bool {
+				got = append(got, snapshotTraversalToken(node))
+				if len(got)-1 != stop {
+					return false
+				}
+				// Nested walks at the stopping callback must not resume or
+				// extend the outer traversal after it returns true.
+				if gotComments := collectTraversalComments(sourceFile); !slices.Equal(gotComments, wantComments) {
+					t.Fatal("comments changed in stopping callback")
+				}
+				assertTraversalTokens(t, collectTraversalTokens(sourceFile), want)
+				return true
+			}, sourceFile)
+			if stopped != (stop < len(want)) {
+				t.Fatalf("stopped = %t for index %d", stopped, stop)
+			}
+			assertTraversalTokens(t, got, want[:min(stop+1, len(want))])
+		})
+	}
+}
+
+func TestTokenTraversalConcurrentReadOnlySource(t *testing.T) {
+	sourceFile := parseTokenTraversalSource(tokenTraversalSource)
+	wantComments := collectTraversalComments(parseTokenTraversalSource(tokenTraversalSource))
+	if len(wantComments) == 0 {
+		t.Fatal("fixture must contain comments")
+	}
+	const workers = 8
+	start := make(chan struct{})
+	results := make(chan []tokenTraversalSnapshot, workers)
+	for range workers {
+		go func() {
+			<-start
+			var first []tokenTraversalSnapshot
+			for range 4 {
+				if got := collectTraversalComments(sourceFile); !slices.Equal(got, wantComments) {
+					t.Errorf("concurrent comments = %v, want %v", got, wantComments)
+				}
+				got := collectTraversalTokens(sourceFile)
+				if first == nil {
+					first = got
+				} else if !slices.Equal(got, first) {
+					t.Error("concurrent token walk changed canonical nodes")
+				}
+			}
+			results <- first
+		}()
+	}
+	close(start)
+	var got [][]tokenTraversalSnapshot
+	for range workers {
+		got = append(got, <-results)
+	}
+	wantTokens := collectTraversalTokens(sourceFile)
+	if len(wantTokens) == 0 {
+		t.Fatal("fixture must contain tokens")
+	}
+	for _, tokens := range got {
+		assertTraversalTokens(t, tokens, wantTokens)
+	}
+}
+
+func TestTokenTraversalDeepAndWide(t *testing.T) {
+	const depth, width = 512, 1024
+	tests := []struct {
+		name, source string
+		tokens       int
+	}{
+		{"deep", "const value = " + strings.Repeat("(", depth) + "0" + strings.Repeat(")", depth) + ";", 2*depth + 6},
+		{"wide", "const values = [" + strings.Repeat("0,", width) + "];", 2*width + 7},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parseTokenTraversalSource("/* first */ " + test.source + " /* last */")
+			var comments []string
+			ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
+				comments = append(comments, sourceFile.Text()[comment.Pos():comment.End()])
+			}, sourceFile)
+			if !slices.Equal(comments, []string{"/* first */", "/* last */"}) {
+				t.Fatalf("comments = %v", comments)
+			}
+			tokens := collectTraversalTokens(sourceFile)
+			if len(tokens) != test.tokens {
+				t.Fatalf("token count = %d, want %d", len(tokens), test.tokens)
+			}
+			assertTraversalTokens(t, collectTraversalTokens(sourceFile), tokens)
+		})
+	}
+}

--- a/internal/utils/ts_api_utils.go
+++ b/internal/utils/ts_api_utils.go
@@ -228,6 +228,27 @@ func GetWellKnownSymbolPropertyOfType(t *checker.Type, name string, typeChecker 
 
 // getChildrenFromNonJSDocNode from github.com/microsoft/TypeScript/tsc/internal/ls/utilities.go
 func GetChildren(node *ast.Node, sourceFile *ast.SourceFile) []*ast.Node {
+	var tokens *scanner.Scanner
+	return getChildrenWithScanner(node, sourceFile, &tokens)
+}
+
+// Reset each gap to the same defaults as GetScannerForSourceFile. The scanner
+// belongs to one walk; only its storage is reused, never lexical state.
+func resetTokenScanner(tokens **scanner.Scanner, sourceFile *ast.SourceFile, pos int) *scanner.Scanner {
+	if *tokens == nil {
+		*tokens = scanner.NewScanner()
+	} else {
+		(*tokens).Reset()
+	}
+	s := *tokens
+	s.SetText(sourceFile.Text())
+	s.SetLanguageVariant(sourceFile.LanguageVariant)
+	s.ResetPos(pos)
+	s.Scan()
+	return s
+}
+
+func getChildrenWithScanner(node *ast.Node, sourceFile *ast.SourceFile, tokens **scanner.Scanner) []*ast.Node {
 	var childNodes []*ast.Node
 	node.ForEachChild(func(child *ast.Node) bool {
 		// Skip reparsed nodes (synthesized from JSDoc) as they have positions
@@ -242,8 +263,23 @@ func GetChildren(node *ast.Node, sourceFile *ast.SourceFile) []*ast.Node {
 	var children []*ast.Node
 	pos := node.Pos()
 	for _, child := range childNodes {
-		scanner := scanner.GetScannerForSourceFile(sourceFile, pos)
-		for pos < child.Pos() {
+		if pos < child.Pos() {
+			scanner := resetTokenScanner(tokens, sourceFile, pos)
+			for pos < child.Pos() {
+				token := scanner.Token()
+				tokenFullStart := scanner.TokenFullStart()
+				tokenEnd := scanner.TokenEnd()
+				children = append(children, sourceFile.GetOrCreateToken(token, tokenFullStart, tokenEnd, node, ast.TokenFlagsNone))
+				pos = tokenEnd
+				scanner.Scan()
+			}
+		}
+		children = append(children, child)
+		pos = child.End()
+	}
+	if pos < node.End() {
+		scanner := resetTokenScanner(tokens, sourceFile, pos)
+		for pos < node.End() {
 			token := scanner.Token()
 			tokenFullStart := scanner.TokenFullStart()
 			tokenEnd := scanner.TokenEnd()
@@ -251,17 +287,6 @@ func GetChildren(node *ast.Node, sourceFile *ast.SourceFile) []*ast.Node {
 			pos = tokenEnd
 			scanner.Scan()
 		}
-		children = append(children, child)
-		pos = child.End()
-	}
-	scanner := scanner.GetScannerForSourceFile(sourceFile, pos)
-	for pos < node.End() {
-		token := scanner.Token()
-		tokenFullStart := scanner.TokenFullStart()
-		tokenEnd := scanner.TokenEnd()
-		children = append(children, sourceFile.GetOrCreateToken(token, tokenFullStart, tokenEnd, node, ast.TokenFlagsNone))
-		pos = tokenEnd
-		scanner.Scan()
 	}
 	return children
 }
@@ -331,6 +356,7 @@ func ForEachToken(node *ast.Node, callback func(token *ast.Node), sourceFile *as
 // first matching token. Returning true from callback stops the traversal.
 func forEachToken(node *ast.Node, callback func(token *ast.Node) bool, sourceFile *ast.SourceFile) bool {
 	queue := make([]*ast.Node, 0)
+	var tokens *scanner.Scanner
 
 	for {
 		if ast.IsTokenKind(node.Kind) {
@@ -338,7 +364,7 @@ func forEachToken(node *ast.Node, callback func(token *ast.Node) bool, sourceFil
 				return true
 			}
 		} else {
-			children := GetChildren(node, sourceFile)
+			children := getChildrenWithScanner(node, sourceFile, &tokens)
 			for i := len(children) - 1; i >= 0; i-- {
 				queue = append(queue, children[i])
 			}
@@ -369,41 +395,38 @@ func forEachToken(node *ast.Node, callback func(token *ast.Node) bool, sourceFil
 func ForEachComment(node *ast.Node, callback func(comment *ast.CommentRange), sourceFile *ast.SourceFile) {
 	fullText := sourceFile.Text()
 	notJsx := sourceFile.LanguageVariant != core.LanguageVariantJSX
-	// One factory reused across every token of this file instead of
-	// allocating two per token. scanner.GetLeading/TrailingCommentRanges
-	// only ever calls factory.NewCommentRange, which constructs a value
-	// and never reads or mutates the factory (see ast.NodeFactory.
-	// NewCommentRange) — so reuse changes nothing about the comments
-	// produced. The factory is goroutine-local: ForEachToken walks tokens
-	// serially within this single ForEachComment call, so the parallel
-	// per-file lint workers each get their own, never sharing one.
+	// The scanner only uses NewCommentRange, which creates a value without
+	// mutating the factory. Both the factory and visitor are local to this call.
 	commentFactory := &ast.NodeFactory{}
+	yieldComment := func(comment ast.CommentRange) bool {
+		callback(&comment)
+		return true
+	}
 	sawToken := false
 
-	ForEachToken(
+	forEachCommentTokenRange(
 		node,
-		func(token *ast.Node) {
-			if token.Pos() == token.End() {
+		func(kind ast.Kind, pos, end int, parent *ast.Node) {
+			if pos == end {
 				return
 			}
 			sawToken = true
 
-			if token.Kind != ast.KindJsxText {
-				pos := token.Pos()
-				if pos == 0 {
-					pos = len(scanner.GetShebang(fullText))
+			if kind != ast.KindJsxText {
+				commentPos := pos
+				if commentPos == 0 {
+					commentPos = len(scanner.GetShebang(fullText))
 				}
 
-				for comment := range scanner.GetLeadingCommentRanges(commentFactory, fullText, pos) {
-					callback(&comment)
+				if mayStartCommentTrivia(fullText, commentPos, false) {
+					scanner.GetLeadingCommentRanges(commentFactory, fullText, commentPos)(yieldComment)
 				}
 			}
 
-			if notJsx || canHaveTrailingTrivia(token) {
-				for comment := range scanner.GetTrailingCommentRanges(commentFactory, fullText, token.End()) {
-					callback(&comment)
+			if notJsx || canHaveTrailingTriviaRange(kind, end, parent) {
+				if mayStartCommentTrivia(fullText, end, true) {
+					scanner.GetTrailingCommentRanges(commentFactory, fullText, end)(yieldComment)
 				}
-				return
 			}
 		},
 		sourceFile,
@@ -425,26 +448,26 @@ func ForEachComment(node *ast.Node, callback func(comment *ast.CommentRange), so
 //
 // Exclude trailing positions that would lead to scanning for trivia inside `JsxText`.
 // @internal
-func canHaveTrailingTrivia(token *ast.Node) bool {
-	switch token.Kind {
+func canHaveTrailingTriviaRange(kind ast.Kind, end int, parent *ast.Node) bool {
+	switch kind {
 	case ast.KindCloseBraceToken:
 		// after a JsxExpression inside a JsxElement's body can only be other JsxChild, but no trivia
-		return token.Parent.Kind != ast.KindJsxExpression || !isJsxElementOrFragment(token.Parent.Parent)
+		return parent.Kind != ast.KindJsxExpression || !isJsxElementOrFragment(parent.Parent)
 	case ast.KindGreaterThanToken:
-		switch token.Parent.Kind {
+		switch parent.Kind {
 		case ast.KindJsxClosingElement:
 		case ast.KindJsxClosingFragment:
 			// there's only trailing trivia if it's the end of the top element
-			return !isJsxElementOrFragment(token.Parent.Parent.Parent)
+			return !isJsxElementOrFragment(parent.Parent.Parent)
 		case ast.KindJsxOpeningElement:
 			// if end is not equal, this is part of the type arguments list. in all other cases it would be inside the element body
-			return token.End() != token.Parent.End()
+			return end != parent.End()
 		case ast.KindJsxOpeningFragment:
 			return false // would be inside the fragment
 		case ast.KindJsxSelfClosingElement:
 			// if end is not equal, this is part of the type arguments list
 			// there's only trailing trivia if it's the end of the top element
-			return token.End() != token.Parent.End() || !isJsxElementOrFragment(token.Parent.Parent)
+			return end != parent.End() || !isJsxElementOrFragment(parent.Parent)
 		}
 	}
 
@@ -584,4 +607,83 @@ func isConstituentPossiblyTruthy(t *checker.Type) bool {
 		return Every(t.Types(), isConstituentPossiblyTruthy)
 	}
 	return true
+}
+
+// This is a conservative rejection filter, not a comment lexer. Unknown
+// non-ASCII trivia goes to the TypeScript scanner unchanged.
+func mayStartCommentTrivia(text string, pos int, trailing bool) bool {
+	// Bound the lookahead so long trivia is scanned only by TypeScript.
+	// Exhausting this budget delegates to the scanner; it never rejects trivia.
+	const maxTriviaLookahead = 8
+	for inspected := 0; inspected < maxTriviaLookahead && pos >= 0 && pos < len(text); inspected++ {
+		switch text[pos] {
+		case ' ', '\t', '\v', '\f':
+			pos++
+		case '\r', '\n':
+			if trailing {
+				return false
+			}
+			pos++
+		case '/':
+			return pos+1 < len(text) && (text[pos+1] == '/' || text[pos+1] == '*')
+		default:
+			return text[pos] >= 0x80
+		}
+	}
+	return pos >= 0 && pos < len(text)
+}
+
+// A comment visitor needs token ranges and their AST owners, not token nodes.
+// Gap scans reset lexical state. The explicit stack preserves deep-tree safety.
+func forEachCommentTokenRange(root *ast.Node, callback func(ast.Kind, int, int, *ast.Node), sourceFile *ast.SourceFile) {
+	type item struct {
+		node, parent *ast.Node
+		kind         ast.Kind
+		pos, end     int
+	}
+	queue := []item{{node: root}}
+	var tokens *scanner.Scanner
+	var parent *ast.Node
+	var pos int
+	scanGap := func(end int) {
+		if pos >= end {
+			return
+		}
+		resetTokenScanner(&tokens, sourceFile, pos)
+		for pos < end {
+			queue = append(queue, item{parent: parent, kind: tokens.Token(), pos: tokens.TokenFullStart(), end: tokens.TokenEnd()})
+			pos = tokens.TokenEnd()
+			tokens.Scan()
+		}
+	}
+	appendChild := func(child *ast.Node) bool {
+		if child.Flags&ast.NodeFlagsReparsed != 0 {
+			return false
+		}
+		scanGap(child.Pos())
+		queue = append(queue, item{node: child})
+		pos = child.End()
+		return false
+	}
+	for len(queue) > 0 {
+		next := queue[len(queue)-1]
+		queue[len(queue)-1] = item{}
+		queue = queue[:len(queue)-1]
+		if next.node == nil {
+			callback(next.kind, next.pos, next.end, next.parent)
+			continue
+		}
+		node := next.node
+		if ast.IsTokenKind(node.Kind) {
+			callback(node.Kind, node.Pos(), node.End(), node.Parent)
+			continue
+		}
+		parent, pos = node, node.Pos()
+		start := len(queue)
+		node.ForEachChild(appendChild)
+		scanGap(node.End())
+		for left, right := start, len(queue)-1; left < right; left, right = left+1, right-1 {
+			queue[left], queue[right] = queue[right], queue[left]
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Comment collection currently creates and caches punctuation tokens while walking the AST. Visit parser-owned token ranges and scanner-filled gaps directly, so comment queries no longer populate the SourceFile token cache. Public token APIs retain canonical node identity and reuse one scanner per walk, fully reset before each gap.

Keep the existing comment ranges, raw callback order, newline flags, JSX ownership, parser recovery and comment-only fallback. The ASCII trivia filter delegates unknown input to the TypeScript scanner and bounds speculative whitespace scanning to avoid scanning long trivia twice.

### Measurements

Repeated on 2026-09-06 with baseline 72cd2b1f and candidate f696fdba, both using compiler revision 1f70213d. Sources, configurations, binary hashes, the frozen JS CLI host and sample counts match the preceding run. The previous results remain separately below; cohorts are not pooled.

Apple M5 Max, Go 1.26.5, Node 22.18.0; default Go runtime settings. Each public workload used 15 alternating A/B pairs and three A/A pairs before and after the comparison. A/A uses identical baseline binaries. The CPU idle gate was raised from 70% to 85%, with a continuous 30-second quiet window before preflight. Every recorded invocation has an untimed warmup of the same installed native executable; its inode, timestamps, size and hash are checked to prevent replacement between warmup and timing. Both variants use the same native path.

Public source revisions: [rsbuild 93ff4e72](https://github.com/web-infra-dev/rsbuild/commit/93ff4e72bdbc627bcb6a13f5248a17c0b4d12ae3); [rspack 1861a2bc](https://github.com/web-infra-dev/rspack/commit/1861a2bc2695c27a76261f75223eb1e4bbecfe34). Complete JSON diagnostic objects match between variants and with the preceding run: 2,455 warnings for rsbuild (exit 0), 372 errors for rspack (exit 1).

| Repository | Pairs | Baseline CLI median | Candidate CLI median | Change | Paired median delta | 95% bootstrap interval | Faster pairs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| rsbuild | 15 | 495.2 ms | 495.4 ms | +0.03% | -2.1 ms | [-10.3, +2.8] ms | 10/15 |
| rspack | 15 | 295.9 ms | 291.5 ms | -1.5% | -5.7 ms | [-15.1, +4.2] ms | 9/15 |

Wall time includes JS configuration hosting, native execution and piped output. The percentage change compares the two CLI medians; the paired delta is the median of candidate-minus-baseline differences within pairs. Its interval need not be centered on the difference between the two CLI medians. A/A drift is reported separately and is not subtracted from A/B results. The paired-median percentile-bootstrap intervals for these 15-pair public workloads are computed exactly from the empirical distribution.

CPU is cumulative child user plus system time for the CLI and descendants. Memory uses separate instrumented builds and three pairs per repository; instrumented timings are excluded from formal wall/CPU statistics. TotalAlloc is cumulative Go heap allocation, not live memory. RSS is the native Go process only and excludes the JS host.

| Repository | Cumulative CPU, baseline → candidate | Go TotalAlloc, baseline → candidate | Native lint allocations, baseline → candidate | Go peak RSS, baseline → candidate |
| --- | ---: | ---: | ---: | ---: |
| rsbuild | 1.947 → 1.941 s | 570.3 → 568.7 MiB | 155.9 → 150.8 MiB | 483.2 → 473.6 MiB |
| rspack | 1.065 → 1.045 s | 284.5 → 274.9 MiB | 69.3 → 59.4 MiB | 273.8 → 266.2 MiB |

| Repository | A/A before, paired median delta | A/A after, paired median delta | Diagnostics / exit |
| --- | ---: | ---: | --- |
| rsbuild | +2.4 ms | +6.4 ms | 2,455 identical records / 0 |
| rspack | -3.4 ms | -0.5 ms | 372 identical records / 1 |

Native lint allocations fell in all six public pairs, with median reductions of 3.2% for rsbuild and 14.4% for rspack. TotalAlloc also fell in all six pairs, with median reductions of 0.3% and 3.4%.

Native peak RSS medians were 2.0% and 2.8% lower, but only five of six public pairs had lower RSS; one rsbuild pair increased. These are three-pair memory observations.

Both paired wall-time intervals cross zero. The rsbuild CLI median is essentially unchanged (+0.03%); rspack's median is 1.5% lower. The A/A controls still show variability, so these results do not establish a stable end-to-end speedup on the public workloads. Observed CPU medians were 0.3% and 1.9% lower.

No public pair attempt was rejected. All raw logs are retained, and no observation was excluded based on elapsed time. Configuration and host content/metadata were checked around every invocation; full source snapshots and binary hashes were checked across the complete run. Independent verification found no overlap with observed external native/compiler work in any public warmup or timed interval. The same external observer ran for both variants and remained alive throughout measurement, outside the cumulative child CPU delta.

<details>
<summary>All current public A/B and A/A timings</summary>

Milliseconds; pair order alternates A/B and B/A. A/A uses two identical baseline binaries.

| Cohort / pair | rsbuild baseline | rsbuild comparison | rspack baseline | rspack comparison |
| --- | ---: | ---: | ---: | ---: |
| aa-before / 1 | 511.634 | 498.919 | 286.535 | 300.994 |
| aa-before / 2 | 497.226 | 499.589 | 310.155 | 295.135 |
| aa-before / 3 | 502.877 | 507.203 | 296.265 | 292.857 |
| formal / 1 | 484.321 | 500.460 | 292.262 | 298.185 |
| formal / 2 | 502.365 | 493.889 | 290.697 | 294.350 |
| formal / 3 | 514.193 | 513.984 | 295.904 | 290.177 |
| formal / 4 | 508.137 | 506.084 | 301.044 | 290.660 |
| formal / 5 | 503.187 | 492.406 | 296.775 | 289.449 |
| formal / 6 | 483.809 | 516.452 | 288.051 | 292.885 |
| formal / 7 | 495.196 | 497.970 | 301.359 | 336.466 |
| formal / 8 | 485.208 | 483.698 | 292.173 | 277.441 |
| formal / 9 | 489.800 | 481.817 | 306.327 | 291.181 |
| formal / 10 | 506.592 | 495.362 | 296.527 | 276.090 |
| formal / 11 | 495.512 | 475.862 | 293.580 | 297.802 |
| formal / 12 | 494.779 | 484.479 | 305.642 | 288.168 |
| formal / 13 | 484.452 | 496.199 | 290.022 | 291.477 |
| formal / 14 | 509.300 | 507.159 | 295.279 | 294.451 |
| formal / 15 | 481.027 | 481.152 | 311.303 | 294.974 |
| aa-after / 1 | 489.640 | 495.495 | 277.316 | 298.985 |
| aa-after / 2 | 501.772 | 508.131 | 302.547 | 287.551 |
| aa-after / 3 | 495.919 | 520.026 | 295.927 | 295.476 |

</details>

<details>
<summary>All current public memory pairs</summary>

MiB; baseline → candidate.

| Repository / pair | TotalAlloc | Native lint allocations | Go peak RSS |
| --- | ---: | ---: | ---: |
| rsbuild / 1 | 569.715 → 568.686 | 155.918 → 150.648 | 490.344 → 477.125 |
| rsbuild / 2 | 570.299 → 566.290 | 155.565 → 150.902 | 467.531 → 473.641 |
| rsbuild / 3 | 576.630 → 572.422 | 155.857 → 150.832 | 483.219 → 472.875 |
| rspack / 1 | 284.511 → 274.941 | 69.331 → 59.374 | 273.812 → 265.562 |
| rspack / 2 | 283.361 → 274.512 | 69.476 → 59.314 | 269.906 → 266.578 |
| rspack / 3 | 286.801 → 275.755 | 69.227 → 59.771 | 278.891 → 266.203 |

</details>

<details>
<summary>Previous run with a 70% idle threshold, retained for comparison</summary>

Same measured revisions, sources, configurations and binaries. Each public workload had 15 A/B pairs, three A/A pairs before and after, and three memory pairs. Nine public pair attempts were rejected for observed external native work; raw logs were retained and entire pairs repeated. No timing-based exclusions were used. This earlier run is kept separate from the new 85% threshold cohort.

| Repository | Pairs | Baseline CLI median | Candidate CLI median | Change | Paired median delta | 95% bootstrap interval | Faster pairs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| rsbuild | 15 | 523.9 ms | 514.0 ms | -1.9% | -1.4 ms | [-31.5, +17.9] ms | 9/15 |
| rspack | 15 | 300.5 ms | 290.7 ms | -3.3% | -7.2 ms | [-13.2, +7.6] ms | 11/15 |

| Repository | Cumulative CPU, baseline → candidate | Go TotalAlloc, baseline → candidate | Native lint allocations, baseline → candidate | Go peak RSS, baseline → candidate |
| --- | ---: | ---: | ---: | ---: |
| rsbuild | 2.006 → 2.032 s | 573.2 → 571.7 MiB | 155.6 → 151.1 MiB | 486.1 → 477.3 MiB |
| rspack | 1.065 → 1.074 s | 284.5 → 276.2 MiB | 69.3 → 59.7 MiB | 272.4 → 262.9 MiB |

| Repository | A/A before, paired median delta | A/A after, paired median delta | Diagnostics / exit |
| --- | ---: | ---: | --- |
| rsbuild | -9.3 ms | +34.4 ms | 2,455 identical records / 0 |
| rspack | +3.4 ms | -7.0 ms | 372 identical records / 1 |

</details>

### Validation

- Rebased onto `72cd2b1f` with compiler revision `1f70213d`. Migrated nine imports in the three added test files to `github.com/microsoft/TypeScript/tsc`; the optimization logic is unchanged. Revalidated the scoped Go packages, differential and race checks, CLI diagnostic/fix comparison, and both CLI entrypoint builds against this compiler revision.
- The original design and implementation passed independent adversarial reviews. Long-trivia attacks exposed duplicate scanning; bounded lookahead removed that regression before the final measurements.
- Differential comparison against the previous implementation covers independently cold subtrees, repeated walks, 492 generated syntax/trivia attacks and 1,080 lookahead-boundary cases. Compared raw comment ranges/order/newline flags and token fields, including literal/template flags.
- Portable tests cover actual reparsed JSDoc nodes, JSX ownership, canonical token pointers, every early-stop position, nested callbacks, concurrent read-only traversal and deep/wide ASTs.
- All 72 scoped Go packages checked (71 passed, one has no tests); scoped race checks passed.
- Isolated CLI comparison across JS/TS/TSX fixtures: complete diagnostics and every file byte match before/after fixes; three source files actually changed, and a second fix run is idempotent.
- `pnpm run check-spell`, `pnpm run format:check`, and Go lint restricted to new changes passed. After the rebase, Go lint used `pnpm run lint:go --new-from-merge-base=origin/main --concurrency=2` with an isolated Go build cache.

## Related Links

- [Measured baseline commit](https://github.com/web-infra-dev/rslint/commit/72cd2b1f0e3a5673b5a97b08cfb0a079b669a61f)
- [Measured candidate commit](https://github.com/web-infra-dev/rslint/commit/f696fdba22fe857d48034c02de3c698702bbc3ed)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
