### PR TITLE
fix: close TypeScript rule regressions and test coverage gaps

### DIFF
--- a/internal/plugins/import/rules/namespace/namespace.go
+++ b/internal/plugins/import/rules/namespace/namespace.go
@@ -35,6 +35,7 @@ var NamespaceRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindPropertyAccessExpression: checkAccess,
 			ast.KindElementAccessExpression:  checkAccess,
+			ast.KindQualifiedName:            checkAccess,
 			ast.KindVariableDeclaration: func(node *ast.Node) {
 				checkNamespaceDestructuring(ctx, namespaces, node)
 			},
@@ -236,8 +237,12 @@ func checkNamespaceAccess(ctx rule.RuleContext, namespaces map[string]*import_ut
 		return
 	}
 
-	object := ast.SkipParentheses(rslint_utils.AccessExpressionObject(access))
-	if object == nil || object.Kind != ast.KindIdentifier {
+	object, _ := rslint_utils.MemberExpressionParts(access)
+	if object == nil {
+		return
+	}
+	object = ast.SkipParentheses(object)
+	if object.Kind != ast.KindIdentifier {
 		return
 	}
 
@@ -259,7 +264,13 @@ func checkNamespaceAccess(ctx rule.RuleContext, namespaces map[string]*import_ut
 
 func validateNamespaceAccess(ctx rule.RuleContext, opts ruleOptions, access *ast.Node, namespace *import_utils.ExportMap, namePath []string, rootName string) {
 	current := access
-	for namespace != nil && current != nil && ast.IsAccessExpression(current) {
+	for namespace != nil && current != nil {
+		// Only heritage qualified names have ESTree MemberExpression
+		// semantics. Ordinary type names and type queries are excluded.
+		object, property := rslint_utils.MemberExpressionParts(current)
+		if object == nil {
+			return
+		}
 		if current.Kind == ast.KindElementAccessExpression {
 			argument := current.AsElementAccessExpression().ArgumentExpression
 			if !opts.allowComputed && argument != nil {
@@ -268,7 +279,6 @@ func validateNamespaceAccess(ctx rule.RuleContext, opts ruleOptions, access *ast
 			return
 		}
 
-		property := current.AsPropertyAccessExpression().Name()
 		if property == nil {
 			return
 		}
@@ -290,10 +300,8 @@ func validateNamespaceAccess(ctx rule.RuleContext, opts ruleOptions, access *ast
 		if parent != nil && parent.Kind == ast.KindParenthesizedExpression {
 			parent = ast.WalkUpParenthesizedExpressions(parent)
 		}
-		if parent == nil || !ast.IsAccessExpression(parent) {
-			return
-		}
-		if ast.SkipParentheses(rslint_utils.AccessExpressionObject(parent)) != current {
+		parentObject, _ := rslint_utils.MemberExpressionParts(parent)
+		if parentObject == nil || ast.SkipParentheses(parentObject) != current {
 			return
 		}
 		current = parent

--- a/internal/plugins/import/rules/namespace/namespace_extras_test.go
+++ b/internal/plugins/import/rules/namespace/namespace_extras_test.go
@@ -238,3 +238,31 @@ func TestNamespaceExtras(t *testing.T) {
 		},
 	)
 }
+
+func TestNamespaceHeritage(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &namespace.NamespaceRule, []rule_tester.ValidTestCase{
+		{Code: `import * as names from './named-exports'; interface I extends names.a {}`},
+		{Code: `import * as names from './named-exports'; class C implements names.a {}`},
+		{Code: `import * as names from './named-exports'; type T = names.c;`},
+		{Code: `import * as names from './named-exports'; type T = typeof names.c;`},
+		{Code: `import * as names from './named-exports'; interface I extends Base<names.c> {}`},
+		{Code: `import * as names from './named-exports'; function f(names) { class C implements names.c {} return C; }`},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `import * as names from './named-exports'; interface I extends names.c {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notFound", Message: notFoundNamesC, Line: 1, Column: 69, EndLine: 1, EndColumn: 70}},
+		},
+		{
+			Code:   `import * as names from './named-exports'; class C implements names.c {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notFound", Message: notFoundNamesC, Line: 1, Column: 68, EndLine: 1, EndColumn: 69}},
+		},
+		{
+			Code:   `import * as names from './named-exports'; class C extends names.c {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notFound", Message: notFoundNamesC, Line: 1, Column: 65, EndLine: 1, EndColumn: 66}},
+		},
+		{
+			Code:   `import * as names from './named-exports'; interface I extends names.c.d {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "notFound", Message: notFoundNamesC, Line: 1, Column: 69, EndLine: 1, EndColumn: 70}},
+		},
+	})
+}

--- a/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.go
+++ b/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.go
@@ -8,6 +8,7 @@ import (
 	jestutils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	rslintutils "github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 // Message builders
@@ -240,7 +241,8 @@ var NoJasmineGlobalsRule = rule.Rule{
 				reportJasmineAssignedProperty(node, ctx)
 			},
 			ast.KindIdentifier: func(node *ast.Node) {
-				if node.AsIdentifier().Text != "jasmine" || isBindingResolved(node, ctx) {
+				if node.AsIdentifier().Text != "jasmine" || scope.InTypePosition(node) ||
+					ast.IsPartOfTypeQuery(node) || isBindingResolved(node, ctx) {
 					return
 				}
 

--- a/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals_test.go
+++ b/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals_test.go
@@ -347,3 +347,24 @@ func TestNoJasmineGlobalsRule(t *testing.T) {
 		},
 	)
 }
+
+func TestNoJasmineGlobalsTypes(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &no_jasmine_globals.NoJasmineGlobalsRule, []rule_tester.ValidTestCase{
+		{Code: `interface I extends jasmine.SomeType {}`},
+		{Code: `class C implements jasmine.SomeType {}`},
+		{Code: `interface I extends jasmine.nested.SomeType {}`},
+		{Code: `type T = jasmine.SomeType;`},
+		{Code: `type T = typeof jasmine.any;`},
+		{Code: `let value: jasmine;`},
+		{Code: `interface I extends Base<jasmine.SomeType> {}`},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `class C extends jasmine.SomeType {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "illegalJasmine"}},
+		},
+		{
+			Code:   `class C implements Base { value = jasmine; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "illegalJasmine"}},
+		},
+	})
+}

--- a/internal/plugins/react/rules/prefer_read_only_props/prefer_read_only_props.go
+++ b/internal/plugins/react/rules/prefer_read_only_props/prefer_read_only_props.go
@@ -594,6 +594,10 @@ func validateTypeNode(node *ast.Node, aliases map[string][]*ast.Node, genericImp
 					continue
 				}
 				for _, item := range heritage.Types.Nodes {
+					if item.Kind != ast.KindTypeReference {
+						// Recovery trees can retain an expression-shaped target.
+						continue
+					}
 					extends := item.AsTypeReferenceNode()
 					if extends == nil || extends.TypeName == nil {
 						continue

--- a/internal/plugins/react/rules/prefer_read_only_props/prefer_read_only_props_extras_test.go
+++ b/internal/plugins/react/rules/prefer_read_only_props/prefer_read_only_props_extras_test.go
@@ -503,3 +503,20 @@ func runSourceOnlyPreferReadOnlyProps(t *testing.T, code string) []rule.RuleDiag
 	}
 	return diagnostics
 }
+
+func TestPreferReadOnlyPropsRecoveryHeritage(t *testing.T) {
+	// Invalid type heritage remains ExpressionWithTypeArguments in the
+	// compiler's recovery tree. Keep checking the interface's own properties.
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferReadOnlyPropsRule, []rule_tester.ValidTestCase{
+		{Code: `interface Props extends Base() { readonly value: string } function Component(props: Props) { return <div>{props.value}</div>; }`, Tsx: true},
+		{Code: `interface Props extends (Base) { readonly value: string } function Component(props: Props) { return <div>{props.value}</div>; }`, Tsx: true},
+		{Code: `interface Props extends Base['Type'] { readonly value: string } function Component(props: Props) { return <div>{props.value}</div>; }`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `interface Props extends Base() { value: string } function Component(props: Props) { return <div>{props.value}</div>; }`,
+			Tsx:    true,
+			Output: []string{`interface Props extends Base() { readonly value: string } function Component(props: Props) { return <div>{props.value}</div>; }`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "readOnlyProp"}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/array_type/array_type.go
+++ b/internal/plugins/typescript/rules/array_type/array_type.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -345,6 +346,11 @@ var ArrayTypeRule = rule.CreateRule(rule.Rule{
 			},
 
 			ast.KindTypeReference: func(node *ast.Node) {
+				// Heritage targets must remain entity names. Their type arguments
+				// are visited separately and can still use array syntax.
+				if typescriptutil.IsClassImplementsOrInterfaceExtends(node) {
+					return
+				}
 				typeRef := node.AsTypeReferenceNode()
 				if typeRef == nil {
 					return

--- a/internal/plugins/typescript/rules/array_type/array_type_test.go
+++ b/internal/plugins/typescript/rules/array_type/array_type_test.go
@@ -1,6 +1,7 @@
 package array_type
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -603,4 +604,32 @@ type ReadonlySimple = readonly Value[];`,
 			}
 		})
 	}
+}
+
+func TestArrayTypeHeritage(t *testing.T) {
+	var valid []rule_tester.ValidTestCase
+	for _, declaration := range []string{"interface I extends", "class C implements", "class C extends"} {
+		for _, target := range []string{"Array<string>", "ReadonlyArray<string>", "Readonly<string[]>"} {
+			for _, options := range []any{nil, map[string]any{"default": "array-simple"}, map[string]any{"default": "generic", "readonly": "array"}} {
+				// Under generic style the nested string[] still needs a fix.
+				if target == "Readonly<string[]>" && options != nil {
+					if options.(map[string]any)["default"] == "generic" {
+						continue
+					}
+				}
+				valid = append(valid, rule_tester.ValidTestCase{Code: fmt.Sprintf("%s %s {}", declaration, target), Options: options})
+			}
+		}
+	}
+	var invalid []rule_tester.InvalidTestCase
+	for _, declaration := range []string{"interface I extends", "class C implements", "class C extends"} {
+		for _, target := range []string{"Base", "Array"} {
+			invalid = append(invalid, rule_tester.InvalidTestCase{
+				Code:   fmt.Sprintf("%s %s<Array<string>> {}", declaration, target),
+				Output: []string{fmt.Sprintf("%s %s<string[]> {}", declaration, target)},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "errorStringArray"}},
+			})
+		}
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ArrayTypeRule, valid, invalid)
 }

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
@@ -7,6 +7,7 @@ import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -58,6 +59,11 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	if parseOptions(options).Style == "index-signature" {
 		return rule.RuleListeners{
 			ast.KindTypeReference: func(node *ast.Node) {
+				// An object type literal cannot replace an extends/implements
+				// target. Nested type arguments remain ordinary type references.
+				if typescriptutil.IsClassImplementsOrInterfaceExtends(node) {
+					return
+				}
 				reportRecordAsIndexSignature(&ctx, node)
 			},
 		}

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style_test.go
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style_test.go
@@ -1,6 +1,7 @@
 package consistent_indexed_object_style
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -537,3 +538,23 @@ const (
 	expectSuggestion
 	expectNoEdit
 )
+
+func TestConsistentIndexedObjectStyleHeritage(t *testing.T) {
+	var valid []rule_tester.ValidTestCase
+	var invalid []rule_tester.InvalidTestCase
+	for _, declaration := range []string{"interface I extends", "class C implements", "class C extends"} {
+		for _, target := range []string{"Record<string, number>", "Record<'a' | 'b', number>", "Record<string, Array<number>>"} {
+			valid = append(valid, rule_tester.ValidTestCase{
+				Code:    fmt.Sprintf("%s %s {}", declaration, target),
+				Options: []any{"index-signature"},
+			})
+		}
+		invalid = append(invalid, rule_tester.InvalidTestCase{
+			Code:    declaration + " Base<Record<string, number>> {}",
+			Options: []any{"index-signature"},
+			Output:  []string{declaration + " Base<{ [key: string]: number }> {}"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferIndexSignature"}},
+		})
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ConsistentIndexedObjectStyleRule, valid, invalid)
+}

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents_test.go
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents_test.go
@@ -150,7 +150,6 @@ type T = Record<string, A | B>;
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
-			Only:   true,
 			Code:   "type T = 1 | 1;",
 			Output: []string{"type T = 1  ;"},
 			Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/TypeScript/tsc/shim/checker"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -1732,9 +1733,9 @@ func isDirectGenericTypeArgumentUsage(identNode *ast.Node) bool {
 		return false
 	}
 	// The Array<T>/ReadonlyArray<T> exclusion only makes sense for an actual
-	// type reference (e.g. `Foo<T>`), not for a type argument attached to a
-	// call/new/tagged-template/JSX expression (e.g. `foo<T>()`).
-	if grandparent.Kind == ast.KindTypeReference {
+	// type reference (e.g. `Foo<T>`). Heritage targets, like call/new/tagged
+	// template/JSX expressions, have their own ESTree node kinds.
+	if grandparent.Kind == ast.KindTypeReference && !typescriptutil.IsClassImplementsOrInterfaceExtends(grandparent) {
 		outerName := grandparent.AsTypeReferenceNode().TypeName
 		if outerName != nil && outerName.Kind == ast.KindIdentifier {
 			switch outerName.AsIdentifier().Text {

--- a/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters_extras_test.go
@@ -1763,3 +1763,15 @@ func TestNoUnnecessaryTypeParametersEditDemand(t *testing.T) {
 		t.Errorf("suggestions attached without suggestion demand")
 	}
 }
+
+func TestNoUnnecessaryTypeParametersHeritage(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryTypeParametersRule, []rule_tester.ValidTestCase{
+		{Code: `class C<T> implements Array<T> {}`},
+		{Code: `class C<T> implements ReadonlyArray<T> {}`},
+		{Code: `class C<T> implements Array<T> { value: T; }`},
+		{Code: `class C<T> implements ReadonlyArray<T> { value: T; }`},
+		{Code: `class C<T> implements Array<(T)> {}`},
+		{Code: `class C<T> extends Array<T> {}`},
+		{Code: `class C<T> extends ReadonlyArray<T> {}`},
+	}, nil)
+}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	esregexp "github.com/web-infra-dev/rslint/internal/utils/ecmascript/regexp"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
 
 //go:embed no_unused_vars.schema.json
@@ -58,6 +59,7 @@ type analysisContext struct {
 	parameterBoundary  parameterBoundary
 	fallbackInfos      map[*ast.Symbol]referenceInfo
 	fallbackCandidates map[string][]*ast.Node
+	heritageReferences map[*ast.Symbol][]*ast.Node
 	jsxScanned         bool
 	globalSourceFile   bool
 	declarationFile    bool
@@ -1859,6 +1861,53 @@ func classifyReferenceNodes(refs []*ast.Node) referenceInfo {
 	return info
 }
 
+// withHeritageReferences applies ESLint's type-capable binding lookup to the
+// root of interface extends/class implements member names. The compiler's
+// QualifiedName lookup requires a namespace there, so it can miss a class or
+// interface and can even resolve a different, outer namespace. Keep RefStore's
+// checker semantics intact for its other consumers and replace only these
+// references in this rule. Plain value bindings must still be skipped.
+func withHeritageReferences(ctx rule.RuleContext, info referenceInfo, sym *ast.Symbol, ac *analysisContext) referenceInfo {
+	if ctx.Refs == nil || sym == nil || sym.Flags&scope.ReferenceType.DeclarationMeaning() == 0 {
+		return info
+	}
+	if ac.heritageReferences == nil {
+		ac.heritageReferences = make(map[*ast.Symbol][]*ast.Node)
+		var walk func(*ast.Node) bool
+		walk = func(node *ast.Node) bool {
+			if node.Kind == ast.KindIdentifier && utils.IsHeritageQualifiedName(node.Parent) &&
+				node.Parent.AsQualifiedName().Left == node {
+				if target := ctx.Refs.ResolveInFileWithMeaning(node, scope.ReferenceType.DeclarationMeaning()); target != nil {
+					target = ctx.TypeChecker.GetMergedSymbol(target)
+					ac.heritageReferences[target] = append(ac.heritageReferences[target], node)
+				}
+			}
+			return node.ForEachChild(walk)
+		}
+		ctx.SourceFile.AsNode().ForEachChild(walk)
+	}
+	refs := ac.heritageReferences[ctx.TypeChecker.GetMergedSymbol(sym)]
+	var filtered []*ast.Node
+	for i, ref := range info.usages {
+		if utils.IsHeritageQualifiedName(ref.Parent) {
+			if filtered == nil {
+				filtered = make([]*ast.Node, 0, len(info.usages)+len(refs))
+				filtered = append(filtered, info.usages[:i]...)
+			}
+		} else if filtered != nil {
+			filtered = append(filtered, ref)
+		}
+	}
+	if filtered == nil && len(refs) == 0 {
+		return info
+	}
+	if filtered == nil {
+		filtered = append(make([]*ast.Node, 0, len(info.usages)+len(refs)), info.usages...)
+	}
+	info.usages = append(filtered, refs...)
+	return info
+}
+
 // collectCheckerReferenceInfo handles the narrow cases ctx.Refs cannot model:
 // parameter-property names, empty namespaces, and declarations without a
 // binder symbol. Its syntactic candidate index is built at most once per file;
@@ -2115,6 +2164,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	}
 
 	info := getReferenceInfo(ctx, nameNode, name, definition, rawSym, sym, ac)
+	info = withHeritageReferences(ctx, info, sym, ac)
 	varInfo.References = info.usages
 
 	// For declaration merging (e.g., multiple interfaces with same name),

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_typescript_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_typescript_test.go
@@ -562,3 +562,42 @@ export {};`,
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)
 }
+
+func TestNoUnusedVarsHeritage(t *testing.T) {
+	// These member references are syntactically valid even when the checker
+	// rejects the inherited type. ESLint still resolves a type-capable root.
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, []rule_tester.ValidTestCase{
+		{Code: `class Cls { static method() {} } export interface I extends Cls.method {}`},
+		{Code: `class Cls { static method() {} } export class C implements Cls.method {}`},
+		{Code: `interface Obj { method(): void } export interface I extends Obj.method {}`},
+		{Code: `type Obj = { method(): void }; export class C implements Obj.method {}`},
+		{Code: `class Cls {} export interface I extends Cls.nested.member {}`},
+		{Code: `namespace NS { export interface Base {} } export interface I extends NS.Base {}`},
+		{Code: `class Cls {} namespace Cls { export interface Base {} } export interface I extends Cls.Base {}`},
+		{Code: `interface Base<T> { value: T } class Cls {} export interface I extends Base<Cls> {}`},
+		{Code: `declare const obj: { Base: new () => object }; export class C extends obj.Base {}`},
+		{Code: `import type * as NS from 'missing'; export interface I extends NS.Base {}`},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `declare const obj: { m(): void }; export interface I extends obj.m {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Message: "'obj' is defined but never used."}},
+		},
+		{
+			Code:   `namespace NS { export interface Base {} } export function f() { let NS = 0; class C implements NS.Base {} return C; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Message: "'NS' is assigned a value but never used."}},
+		},
+		{
+			Code:   `namespace NS { export interface Base {} } export function f() { class NS {} class C implements NS.Base {} return C; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Message: "'NS' is defined but never used.", Line: 1, Column: 11, EndLine: 1, EndColumn: 13}},
+		},
+		{
+			Code:   `const obj = { m() {} }; export type T = typeof obj.m;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "usedOnlyAsType", Message: "'obj' is assigned a value but only used as a type."}},
+		},
+		{
+			Code:    `interface _Cls {} export interface I extends _Cls.member {}`,
+			Options: map[string]any{"varsIgnorePattern": "^_", "reportUsedIgnorePattern": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "usedIgnoredVar"}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
@@ -263,7 +263,7 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		if len(extends) != 1 {
 			return true
 		}
-		expr := extends[0].AsTypeReferenceNode().TypeName
+		expr := ast.GetHeritageClauseElementName(extends[0])
 		if expr == nil || expr.Kind != ast.KindIdentifier || expr.AsIdentifier().Text != "Function" {
 			return true
 		}

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
@@ -1333,3 +1333,13 @@ interface ThisCallable { (): this; }`,
 		}
 	}
 }
+
+func TestPreferFunctionTypeRecoveryHeritage(t *testing.T) {
+	// The compiler retains expression-shaped heritage for invalid type syntax.
+	// Such input can reach the linter while editing and must not panic.
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferFunctionTypeRule, []rule_tester.ValidTestCase{
+		{Code: `interface I extends Base() { (): void; }`},
+		{Code: `interface I extends (Base) { (): void; }`},
+		{Code: `interface I extends Base['Type'] { (): void; }`},
+	}, nil)
+}

--- a/internal/plugins/typescript/typescriptutil/typescriptutil.go
+++ b/internal/plugins/typescript/typescriptutil/typescriptutil.go
@@ -128,18 +128,17 @@ func hasTypeOrInterfaceInStatements(statements []*ast.Node, name string) bool {
 	return false
 }
 
-// IsClassImplementsOrInterfaceExtends reports whether the given
-// `ExpressionWithTypeArguments` sits in a heritage position the
-// typescript-eslint rules listen to as `TSClassImplements` or
+// IsClassImplementsOrInterfaceExtends reports whether the given node sits in a
+// heritage position typescript-eslint rules listen to as `TSClassImplements` or
 // `TSInterfaceHeritage`:
 //
 //   - `class X implements ...`
 //   - `interface X extends ...`
 //
 // `class X extends ...` is intentionally excluded: upstream does not register
-// a listener for it. Non-heritage uses of `ExpressionWithTypeArguments` (e.g.
-// JSDoc-style type contexts) are also rejected because upstream's listener
-// set never matches them.
+// a listener for it. The compiler represents a valid type heritage target as
+// TypeReference; malformed targets may remain ExpressionWithTypeArguments.
+// Ordinary type references, including heritage type arguments, are excluded.
 func IsClassImplementsOrInterfaceExtends(node *ast.Node) bool {
 	parent := node.Parent
 	if parent == nil || !ast.IsHeritageClause(parent) {

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -209,6 +209,12 @@ func RunRuleTester(root Root, tsconfigPath string, t *testing.T, r *rule.Rule, v
 
 	onlyMode := slices.ContainsFunc(validTestCases, func(c ValidTestCase) bool { return c.Only }) ||
 		slices.ContainsFunc(invalidTestCases, func(c InvalidTestCase) bool { return c.Only })
+	if onlyMode {
+		t.Fatal("focused rule test cases (Only) are not allowed; use go test -run to select tests")
+	}
+	if len(validTestCases)+len(invalidTestCases) == 0 {
+		t.Fatal("rule test suite must not be empty")
+	}
 
 	runLinter := func(t *testing.T, code string, rawOptions any, settings map[string]interface{}, languageOptions rule.LanguageOptions, rawGlobals map[string]any, tsconfigPathOverride string, fileName string) []rule.RuleDiagnostic {
 		options := ResolveTestCaseOptions(t, r, rawOptions)
@@ -277,7 +283,7 @@ func RunRuleTester(root Root, tsconfigPath string, t *testing.T, r *rule.Rule, v
 	for i, testCase := range validTestCases {
 		t.Run("valid-"+strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
-			if (onlyMode && !testCase.Only) || testCase.Skip {
+			if testCase.Skip {
 				t.SkipNow()
 			}
 
@@ -299,7 +305,7 @@ func RunRuleTester(root Root, tsconfigPath string, t *testing.T, r *rule.Rule, v
 		t.Run("invalid-"+strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			if (onlyMode && !testCase.Only) || testCase.Skip {
+			if testCase.Skip {
 				t.SkipNow()
 			}
 

--- a/internal/rule_tester/rule_tester_selection_test.go
+++ b/internal/rule_tester/rule_tester_selection_test.go
@@ -1,0 +1,65 @@
+package rule_tester
+
+// cspell:ignore tparallel
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// Check the test binary's exit status: a focused suite must fail the command,
+// even when the selected case would otherwise be skipped or pass.
+func TestRunRuleTesterRejectsIncompleteSuites(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []string{"valid", "invalid", "json", "empty"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			cmd := exec.Command(os.Args[0], "-test.run=^TestRunRuleTesterIncompleteSuiteSubprocess$")
+			cmd.Env = append(os.Environ(), "RSLINT_TEST_SUITE_SELECTION="+mode)
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("incomplete suite returned success:\n%s", output)
+			}
+			want := "focused rule test cases (Only) are not allowed"
+			if mode == "empty" {
+				want = "rule test suite must not be empty"
+			}
+			if !strings.Contains(string(output), want) {
+				t.Fatalf("test command failed without the selection guard %q:\n%s", want, output)
+			}
+		})
+	}
+}
+
+//nolint:tparallel // RunRuleTester calls t.Parallel; another call here would panic before the guard.
+func TestRunRuleTesterIncompleteSuiteSubprocess(t *testing.T) {
+	mode := os.Getenv("RSLINT_TEST_SUITE_SELECTION")
+	if mode == "" {
+		t.Skip("only runs in the selection guard subprocess")
+	}
+	var valid []ValidTestCase
+	var invalid []InvalidTestCase
+	switch mode {
+	case "valid":
+		valid = []ValidTestCase{{Only: true, Skip: true}}
+	case "invalid":
+		invalid = []InvalidTestCase{{Only: true, Skip: true}}
+	case "json":
+		var suite ESLintTestSuite
+		if err := json.Unmarshal([]byte(`{"valid":[{"code":"","only":true,"skip":true}]}`), &suite); err != nil {
+			t.Fatal(err)
+		}
+		converted := ConvertESLintTestSuite(&suite)
+		valid, invalid = converted.Valid, converted.Invalid
+	case "empty":
+	default:
+		t.Fatalf("unexpected selection mode %q", mode)
+	}
+	RunRuleTester(Root{}, "", t, &rule.Rule{}, valid, invalid)
+}

--- a/internal/rules/compiler_compatibility_test.go
+++ b/internal/rules/compiler_compatibility_test.go
@@ -1,0 +1,110 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/rules"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Exercise every catalog rule, including deferred edits, on compiler recovery
+// trees and recently introduced syntax. Rule-specific tests assert diagnostic
+// and fix semantics; this test guards against panics and silently skipped input.
+func TestAllRulesCompilerCompatibility(t *testing.T) {
+	const code = `
+export {};
+interface Base<T> { value: T }
+interface Normal extends Base<Array<string>> {}
+class Implemented implements Base<string> { value = ''; }
+interface Called extends Base() { (): void; }
+interface Parenthesized extends (Base) { (): void; }
+interface Indexed extends Base['Type'] { (): void; }
+interface Props extends Base() { readonly value: string }
+function Component(props: Props) { return <div>{props.value}</div>; }
+class Private { #value = 1; method(value: typeof this.#value) { return value; } }
+function unreachableFor() { for ((() => { throw 1; })();;) { console.log('unreachable'); } }
+function unreachableForOf() { for (const value of (() => { throw 1; })()) { console.log(value); } }
+`
+	root := fixtures.GetRootDir()
+	fileName := tspath.ResolvePath(root.Dir, "compiler-compatibility.tsx")
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: code})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	compilerProgram, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := compilerProgram.GetSourceFile(fileName)
+	if file == nil {
+		t.Fatal("compiler compatibility fixture was not included")
+	}
+	if len(file.Diagnostics()) != 0 {
+		t.Fatal("fixture has parse diagnostics and would bypass rule execution")
+	}
+	heritageKinds := map[ast.Kind]int{}
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Parent != nil && node.Parent.Kind == ast.KindHeritageClause {
+			heritageKinds[node.Kind]++
+		}
+		return node.ForEachChild(visit)
+	}
+	file.AsNode().ForEachChild(visit)
+	if heritageKinds[ast.KindTypeReference] != 2 || heritageKinds[ast.KindExpressionWithTypeArguments] != 4 {
+		t.Fatalf("fixture must exercise normal and recovery heritage nodes: %v", heritageKinds)
+	}
+
+	catalog := rules.All().AllRules()
+	if len(catalog) == 0 {
+		t.Fatal("rule catalog must not be empty")
+	}
+	configured := make([]rule.ConfiguredRule, 0, len(catalog))
+	initialized := make(map[string]int, len(catalog))
+	for name, impl := range catalog {
+		options := rule_tester.ResolveTestCaseOptions(t, &impl, nil)
+		configured = append(configured, rule.ConfiguredRule{
+			Name:        name,
+			Environment: &rule.RuleEnvironment{},
+			Severity:    rule.SeverityError,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				initialized[name]++
+				return impl.Run(ctx, options)
+			},
+		})
+	}
+	plan, err := linter.PrepareLintPlan(linter.PrepareLintPlanOptions{
+		Programs:         []*program.Program{program.NewFromCompiler(compilerProgram)},
+		TargetsByProgram: [][]string{{fileName}},
+		SingleThreaded:   true,
+		GetRulesForFile:  func(*ast.SourceFile) []rule.ConfiguredRule { return configured },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	diagnostics := 0
+	result, err := linter.RunLinter(linter.RunLinterOptions{
+		SingleThreaded: true,
+		LintPlan:       plan,
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandAll,
+			Report: func(rule.RuleDiagnostic) { diagnostics++ },
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.LintedFileCount != 1 || len(result.ExecutedRules) != len(catalog) || diagnostics == 0 {
+		t.Fatalf("incomplete rule execution: files=%d, rules=%d/%d, diagnostics=%d", result.LintedFileCount, len(result.ExecutedRules), len(catalog), diagnostics)
+	}
+	for name := range catalog {
+		if initialized[name] != 1 {
+			t.Errorf("rule %q initialized %d times, want once", name, initialized[name])
+		}
+	}
+}


### PR DESCRIPTION
Compiler heritage nodes introduced by #2065 exposed invalid automatic fixes, missing namespace diagnostics, incorrect unused-reference reports, and two rule panics. For example, `interface I extends Array<string> {}` could be rewritten to invalid `extends string[]` syntax, and `interface I extends Base() { (): void; }` could crash linting.

This fixes eight rules: `array-type`, `consistent-indexed-object-style`, TypeScript `no-unused-vars`, `no-unnecessary-type-parameters`, `prefer-function-type`, `import/namespace`, `jest/no-jasmine-globals`, and `react/prefer-read-only-props`. Preserve the distinction between inheritance targets, their nested type arguments, ordinary qualified types, and runtime class inheritance. Keep ESLint-specific heritage reference resolution inside `no-unused-vars` so other reference-store consumers retain compiler semantics.

The audit also found an existing `Only: true` in `no-duplicate-type-constituents` that silently skipped 79 active cases. Restore those cases and make focused or empty RuleTester suites fail the test command. Subprocess tests verify that the old harness incorrectly returned success and the new guard fails reliably, including JSON-imported cases.

Validation and coverage:

- 90 new rule regression cases, including false positives, false negatives, exact fixes, shadowing, and recovery trees; all pass without skips.
- Complete Go package suite, affected JavaScript consumers, package build, Go lint, spelling, and formatting checks.
- Catalog-wide stability test exercises all 620 rules and deferred edits, with assertions against empty or skipped execution.
- 563 migration probes with all 620 rules enabled, disputed cases checked against upstream ESLint, and paired CLI/core/native validation on rsbuild and rspack.

The audit covers compiler migration contracts; shared probes do not establish exhaustive semantic coverage of every rule and option.

The compiler remains pinned at `1f70213d4922b434345f639b441681e470c7cfc1`.
