### PR TITLE
feat(jest,rstest): add shared padding engine

### DIFF
--- a/internal/utils/test_framework/padding/cache_test.go
+++ b/internal/utils/test_framework/padding/cache_test.go
@@ -1,0 +1,32 @@
+package padding
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func TestEngineIsSharedAcrossRules(t *testing.T) {
+	const code = "setup();\nbeforeAll(connect);\ntest('works', run);"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/padding.ts",
+		Path:     "/padding.ts",
+	}, code, core.ScriptKindTS)
+	cache := rule.NewFileCache()
+	ctx := rule.RuleContext{SourceFile: sourceFile}.WithFileCache(cache)
+
+	first := rule.CachedByFile(ctx, paddingFileCacheKey{}, func() *engine {
+		return &engine{sourceFile: sourceFile}
+	})
+	second := rule.CachedByFile(ctx, paddingFileCacheKey{}, func() *engine {
+		t.Fatal("second padding rule replaced the shared engine")
+		return nil
+	})
+
+	if first != second {
+		t.Fatalf("cached engine was not reused: first=%p second=%p", first, second)
+	}
+}

--- a/internal/utils/test_framework/padding/padding.go
+++ b/internal/utils/test_framework/padding/padding.go
@@ -1,0 +1,368 @@
+// Package padding provides the framework-neutral engine used by test-framework
+// rules that require blank lines around selected statement kinds.
+package padding
+
+import (
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// StatementType classifies a statement for padding configuration. Framework
+// wrappers supply the source names that map to each non-wildcard type.
+type StatementType uint8
+
+const (
+	statementUnknown StatementType = iota
+	StatementAny
+	StatementAfterAll
+	StatementAfterEach
+	StatementBeforeAll
+	StatementBeforeEach
+	StatementDescribe
+	StatementExpect
+	StatementTest
+)
+
+// PaddingType controls the required spacing for one adjacent statement pair.
+type PaddingType uint8
+
+const (
+	// PaddingAny accepts the pair without inspecting its spacing. Put a more
+	// specific PaddingAny config after a broad PaddingAlways config to exempt
+	// pairs such as consecutive expect statements.
+	PaddingAny PaddingType = iota
+	// PaddingAlways requires at least one blank line between the statements.
+	PaddingAlways
+)
+
+// StatementTypes is a set of statement classifications matched by a Config.
+type StatementTypes []StatementType
+
+// Types constructs a statement-type set for a Config.
+func Types(types ...StatementType) StatementTypes {
+	return types
+}
+
+// Config describes the padding requirement for one adjacent statement pair.
+// Configs are matched from last to first, following ESLint's
+// padding-line-between-statements precedence.
+type Config struct {
+	Padding  PaddingType
+	Previous StatementTypes
+	Next     StatementTypes
+}
+
+// StatementNames maps the first identifier token of an expression statement
+// to its framework-specific classification. The engine intentionally follows
+// the syntax-only contract of the upstream Jest/Vitest padding rules; it does
+// not resolve bindings or imports.
+type StatementNames map[string]StatementType
+
+var missingPaddingMessage = rule.RuleMessage{
+	Id:          "missingPadding",
+	Description: "Expected blank line before this statement.",
+}
+
+// Definition describes one framework-specific padding rule.
+type Definition struct {
+	Name string
+	// Family groups rules that must not report the same statement boundary
+	// twice. The lowest-priority matching rule owns the boundary.
+	Family string
+	// Priority orders rules within a family. Atomic rules should keep the zero
+	// value; aggregate rules should use a larger value so a specific enabled
+	// rule owns an overlapping diagnostic.
+	Priority int
+	Message  rule.RuleMessage
+	Names    StatementNames
+	Configs  []Config
+}
+
+// NewRule creates a no-options padding rule. It copies names and configs so
+// package-level tables owned by framework wrappers cannot mutate a live rule.
+func NewRule(definition Definition) rule.Rule {
+	definition.Names = cloneNames(definition.Names)
+	definition.Configs = cloneConfigs(definition.Configs)
+
+	return rule.Rule{
+		Name:   definition.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+			if definition.Family == "" || len(definition.Names) == 0 || len(definition.Configs) == 0 {
+				return nil
+			}
+			state := rule.CachedByFile(ctx, paddingFileCacheKey{}, func() *engine {
+				return &engine{sourceFile: ctx.SourceFile}
+			})
+			state.requests = append(state.requests, ruleRequest{
+				ctx:      ctx,
+				name:     definition.Name,
+				family:   definition.Family,
+				priority: definition.Priority,
+				message:  definition.Message,
+				names:    definition.Names,
+				configs:  definition.Configs,
+			})
+			if state.listenerRegistered {
+				return nil
+			}
+			state.listenerRegistered = true
+			return rule.RuleListeners{
+				ast.KindBlock: func(node *ast.Node) {
+					if node.Parent != nil && node.Parent.Kind == ast.KindClassStaticBlockDeclaration {
+						return
+					}
+					state.addStatementList(node.Statements())
+				},
+				ast.KindCaseClause: func(node *ast.Node) {
+					state.addStatementList(node.Statements())
+				},
+				ast.KindDefaultClause: func(node *ast.Node) {
+					state.addStatementList(node.Statements())
+				},
+				rule.ListenerOnExit(ast.KindEndOfFile): func(*ast.Node) {
+					if state.sourceFile != nil && state.sourceFile.Statements != nil {
+						state.addStatementList(state.sourceFile.Statements.Nodes)
+					}
+					state.run()
+				},
+			}
+		},
+	}
+}
+
+func cloneNames(names StatementNames) StatementNames {
+	cloned := make(StatementNames, len(names))
+	for name, statementType := range names {
+		cloned[name] = statementType
+	}
+	return cloned
+}
+
+func cloneConfigs(configs []Config) []Config {
+	cloned := make([]Config, len(configs))
+	for i, config := range configs {
+		cloned[i] = Config{
+			Padding:  config.Padding,
+			Previous: slices.Clone(config.Previous),
+			Next:     slices.Clone(config.Next),
+		}
+	}
+	return cloned
+}
+
+type paddingFileCacheKey struct{}
+
+type ruleRequest struct {
+	ctx      rule.RuleContext
+	name     string
+	family   string
+	priority int
+	message  rule.RuleMessage
+	names    StatementNames
+	configs  []Config
+}
+
+type engine struct {
+	sourceFile         *ast.SourceFile
+	requests           []ruleRequest
+	pairs              []statementPair
+	listenerRegistered bool
+}
+
+type statementInfo struct {
+	node      *ast.Node
+	firstName string
+}
+
+type statementPair struct {
+	previous statementInfo
+	next     statementInfo
+}
+
+func (state *engine) run() {
+	if state.sourceFile == nil {
+		return
+	}
+
+	sort.SliceStable(state.pairs, func(i, j int) bool {
+		return utils.TrimNodeTextRange(state.sourceFile, state.pairs[i].next.node).Pos() <
+			utils.TrimNodeTextRange(state.sourceFile, state.pairs[j].next.node).Pos()
+	})
+	sort.SliceStable(state.requests, func(i, j int) bool {
+		left, right := state.requests[i], state.requests[j]
+		if left.family != right.family {
+			return strings.Compare(left.family, right.family) < 0
+		}
+		if left.priority != right.priority {
+			return left.priority < right.priority
+		}
+		return strings.Compare(left.name, right.name) < 0
+	})
+	for _, pair := range state.pairs {
+		reportedFamilies := make(map[string]struct{})
+		for _, request := range state.requests {
+			if _, reported := reportedFamilies[request.family]; reported {
+				continue
+			}
+			previousType := request.names[pair.previous.firstName]
+			nextType := request.names[pair.next.firstName]
+			paddingType, matched := matchConfig(previousType, nextType, request.configs)
+			if !matched || paddingType == PaddingAny ||
+				hasPaddingLine(request.ctx, pair.previous.node, pair.next.node) {
+				continue
+			}
+			nextStart := utils.TrimNodeTextRange(state.sourceFile, pair.next.node).Pos()
+			if request.ctx.DisableManager != nil &&
+				request.ctx.DisableManager.IsRuleDisabled(request.name, nextStart) {
+				continue
+			}
+			message := request.message
+			if message.Id == "" {
+				message = missingPaddingMessage
+			}
+			request.ctx.ReportNodeWithDeferredFixes(pair.next.node, message, func() []rule.RuleFix {
+				position, text := paddingInsertion(request.ctx, pair.previous.node, pair.next.node)
+				return []rule.RuleFix{rule.RuleFixReplaceRange(core.NewTextRange(position, position), text)}
+			})
+			reportedFamilies[request.family] = struct{}{}
+		}
+	}
+}
+
+func (state *engine) addStatementList(statements []*ast.Node) {
+	for i := 1; i < len(statements); i++ {
+		state.pairs = append(state.pairs, statementPair{
+			previous: statementInfo{
+				node:      statements[i-1],
+				firstName: firstTokenName(state.sourceFile, statements[i-1]),
+			},
+			next: statementInfo{
+				node:      statements[i],
+				firstName: firstTokenName(state.sourceFile, statements[i]),
+			},
+		})
+	}
+}
+
+func matchConfig(previous, next StatementType, configs []Config) (PaddingType, bool) {
+	for i := len(configs) - 1; i >= 0; i-- {
+		config := configs[i]
+		if matches(previous, config.Previous) && matches(next, config.Next) {
+			return config.Padding, true
+		}
+	}
+	return PaddingAny, false
+}
+
+func matches(statementType StatementType, candidates StatementTypes) bool {
+	return slices.Contains(candidates, StatementAny) || slices.Contains(candidates, statementType)
+}
+
+func firstTokenName(sourceFile *ast.SourceFile, statement *ast.Node) string {
+	statement = unwrapLabels(statement)
+	if statement == nil || statement.Kind != ast.KindExpressionStatement {
+		return ""
+	}
+	expression := statement.AsExpressionStatement().Expression
+	expression = utils.ESTreeRuntimeExpression(expression)
+	if expression != nil && expression.Kind == ast.KindAwaitExpression {
+		expression = utils.ESTreeRuntimeExpression(expression.AsAwaitExpression().Expression)
+	}
+	if expression == nil {
+		return ""
+	}
+	token, ok := utils.TokenAtOrAfter(sourceFile, utils.TrimNodeTextRange(sourceFile, expression).Pos())
+	if !ok || token.Kind != ast.KindIdentifier {
+		return ""
+	}
+	lexicalScanner := scanner.NewScanner()
+	lexicalScanner.SetText(token.Text)
+	if lexicalScanner.Scan() != ast.KindIdentifier {
+		return ""
+	}
+	return lexicalScanner.TokenValue()
+}
+
+func unwrapLabels(statement *ast.Node) *ast.Node {
+	for statement != nil && statement.Kind == ast.KindLabeledStatement {
+		statement = statement.AsLabeledStatement().Statement
+	}
+	return statement
+}
+
+func hasPaddingLine(ctx rule.RuleContext, previous, next *ast.Node) bool {
+	previousToken, ok := actualLastToken(ctx.SourceFile, previous)
+	if !ok {
+		return false
+	}
+	nextStart := utils.TrimNodeTextRange(ctx.SourceFile, next).Pos()
+	previousEnd := previousToken.End
+	for _, comment := range commentsBetween(ctx, previousEnd, nextStart) {
+		if linesApart(ctx.SourceFile, previousEnd, comment.Pos()) >= 2 {
+			return true
+		}
+		previousEnd = comment.End()
+	}
+	return linesApart(ctx.SourceFile, previousEnd, nextStart) >= 2
+}
+
+func paddingInsertion(ctx rule.RuleContext, previous, next *ast.Node) (int, string) {
+	previousToken, ok := actualLastToken(ctx.SourceFile, previous)
+	if !ok {
+		position := utils.TrimNodeTextRange(ctx.SourceFile, previous).End()
+		return position, "\n"
+	}
+
+	nextStart := utils.TrimNodeTextRange(ctx.SourceFile, next).Pos()
+	insertAfter := previousToken.End
+	nextEntityStart := nextStart
+	for _, comment := range commentsBetween(ctx, previousToken.End, nextStart) {
+		if linesApart(ctx.SourceFile, insertAfter, comment.Pos()) != 0 {
+			nextEntityStart = comment.Pos()
+			break
+		}
+		insertAfter = comment.End()
+	}
+
+	if linesApart(ctx.SourceFile, insertAfter, nextEntityStart) == 0 {
+		return insertAfter, "\n\n"
+	}
+	return insertAfter, "\n"
+}
+
+func commentsBetween(ctx rule.RuleContext, start, end int) []*ast.CommentRange {
+	if ctx.Comments == nil {
+		return nil
+	}
+	return utils.CommentsInSpan(ctx.Comments.All(), start, end)
+}
+
+func linesApart(sourceFile *ast.SourceFile, left, right int) int {
+	lineMap := sourceFile.ECMALineMap()
+	return scanner.ComputeLineOfPosition(lineMap, right) - scanner.ComputeLineOfPosition(lineMap, left)
+}
+
+func actualLastToken(sourceFile *ast.SourceFile, statement *ast.Node) (utils.SourceToken, bool) {
+	statementRange := utils.TrimNodeTextRange(sourceFile, statement)
+	last, ok := utils.TokenBeforePosition(sourceFile, statementRange.End())
+	if !ok || last.Kind != ast.KindSemicolonToken {
+		return last, ok
+	}
+
+	previous, hasPrevious := utils.TokenBeforePosition(sourceFile, last.Start)
+	next, hasNext := utils.TokenAtOrAfter(sourceFile, last.End)
+	if hasPrevious && hasNext && previous.Start >= statementRange.Pos() &&
+		linesApart(sourceFile, previous.End, last.Start) != 0 &&
+		linesApart(sourceFile, last.End, next.Start) == 0 {
+		return previous, true
+	}
+	return last, true
+}

--- a/internal/utils/test_framework/padding/padding_test.go
+++ b/internal/utils/test_framework/padding/padding_test.go
@@ -1,0 +1,615 @@
+package padding_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/test_framework/padding"
+)
+
+var names = padding.StatementNames{
+	"beforeAll": padding.StatementBeforeAll,
+	"describe":  padding.StatementDescribe,
+	"expect":    padding.StatementExpect,
+	"test":      padding.StatementTest,
+}
+
+func around(statementType padding.StatementType) []padding.Config {
+	return []padding.Config{
+		{Padding: padding.PaddingAlways, Previous: padding.Types(padding.StatementAny), Next: padding.Types(statementType)},
+		{Padding: padding.PaddingAlways, Previous: padding.Types(statementType), Next: padding.Types(padding.StatementAny)},
+	}
+}
+
+func expectGroups() []padding.Config {
+	return append(around(padding.StatementExpect), padding.Config{
+		Padding:  padding.PaddingAny,
+		Previous: padding.Types(padding.StatementExpect),
+		Next:     padding.Types(padding.StatementExpect),
+	})
+}
+
+func runRule(
+	t *testing.T,
+	code string,
+	statementNames padding.StatementNames,
+	configs []padding.Config,
+	demand rule.EditDemand,
+) ([]rule.RuleDiagnostic, string) {
+	t.Helper()
+	return runRules(t, code, statementNames, [][]padding.Config{configs}, demand)
+}
+
+func runRules(
+	t *testing.T,
+	code string,
+	statementNames padding.StatementNames,
+	configSets [][]padding.Config,
+	demand rule.EditDemand,
+) ([]rule.RuleDiagnostic, string) {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/padding.ts",
+		Path:     "/padding.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer("test/padding", rule.SeverityError, rule.DiagnosticConsumer{
+		Demand: demand,
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	cache := rule.NewFileCache()
+	var eofListeners []func(*ast.Node)
+	var listenersForTraversal []rule.RuleListeners
+	for _, configs := range configSets {
+		testRule := padding.NewRule(padding.Definition{
+			Name: "test/padding", Family: "test", Names: statementNames, Configs: configs,
+		})
+		listeners := testRule.Run(ctx.WithFileCache(cache), nil)
+		listenersForTraversal = append(listenersForTraversal, listeners)
+		if listener := listeners[rule.ListenerOnExit(ast.KindEndOfFile)]; listener != nil {
+			eofListeners = append(eofListeners, listener)
+		}
+	}
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		for _, listeners := range listenersForTraversal {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	for _, listener := range eofListeners {
+		listener(nil)
+	}
+	output, _, _ := linter.ApplyRuleFixes(code, diagnostics)
+	return diagnostics, output
+}
+
+func runNamedRules(
+	t *testing.T,
+	code string,
+	rules []struct {
+		name    string
+		configs []padding.Config
+	},
+) []rule.RuleDiagnostic {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/padding.ts",
+		Path:     "/padding.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	disableManager := rule.NewDisableManager(sourceFile, comments)
+	cache := rule.NewFileCache()
+	var diagnostics []rule.RuleDiagnostic
+	var eof func(*ast.Node)
+	var listenersForTraversal []rule.RuleListeners
+	for _, configured := range rules {
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: disableManager,
+		}.WithFileCache(cache).WithDiagnosticConsumer(
+			configured.name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		)
+		listeners := padding.NewRule(padding.Definition{
+			Name: configured.name, Family: "test", Names: names, Configs: configured.configs,
+		}).Run(ctx, nil)
+		listenersForTraversal = append(listenersForTraversal, listeners)
+		if listener := listeners[rule.ListenerOnExit(ast.KindEndOfFile)]; listener != nil {
+			eof = listener
+		}
+	}
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		for _, listeners := range listenersForTraversal {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	if eof != nil {
+		eof(nil)
+	}
+	return diagnostics
+}
+
+func TestPaddingAroundStatement(t *testing.T) {
+	code := "const database = createDatabase();\nbeforeAll(connect);\ntest('loads', run);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "const database = createDatabase();\n\nbeforeAll(connect);\n\ntest('loads', run);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingExistingBlankLines(t *testing.T) {
+	code := "setup();\n\nbeforeAll(connect);\n\ntest('loads', run);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 0 || output != code {
+		t.Fatalf("diagnostics = %d, output = %q", len(diagnostics), output)
+	}
+}
+
+func TestPaddingExpectGroupsUseLastMatchingConfig(t *testing.T) {
+	code := "const user = getUser();\nexpect(user.name).toBe('Ada');\nexpect(user.active).toBe(true);\nconst account = getAccount();"
+	diagnostics, output := runRule(t, code, names, expectGroups(), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "const user = getUser();\n\nexpect(user.name).toBe('Ada');\nexpect(user.active).toBe(true);\n\nconst account = getAccount();"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingStatementListsAreIndependent(t *testing.T) {
+	code := "setup();\nfunction run() {\n  prepare();\n  beforeAll(connect);\n  cleanup();\n}\ntest('loads', run);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "setup();\nfunction run() {\n  prepare();\n\n  beforeAll(connect);\n\n  cleanup();\n}\ntest('loads', run);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingIgnoresTypeScriptModuleBlocks(t *testing.T) {
+	code := "namespace Feature {\n  setup();\n  beforeAll(connect);\n  cleanup();\n}"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 0 || output != code {
+		t.Fatalf("diagnostics = %d, output = %q", len(diagnostics), output)
+	}
+}
+
+func TestPaddingIgnoresClassStaticBlocks(t *testing.T) {
+	code := "class Feature {\n  static {\n    setup();\n    beforeAll(connect);\n    cleanup();\n  }\n}"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 0 || output != code {
+		t.Fatalf("diagnostics = %d, output = %q", len(diagnostics), output)
+	}
+}
+
+func TestPaddingSwitchClauseStatementList(t *testing.T) {
+	code := "switch (kind) {\ncase 'a':\n  setup();\n  beforeAll(connect);\n  break;\ndefault:\n  cleanup();\n}"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "switch (kind) {\ncase 'a':\n  setup();\n\n  beforeAll(connect);\n\n  break;\ndefault:\n  cleanup();\n}"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingLabelsAndAwait(t *testing.T) {
+	code := "async function run() {\n  setup();\n  label: beforeAll(connect);\n  await expect(load()).resolves.toBe(true);\n  cleanup();\n}"
+	configs := append(around(padding.StatementBeforeAll), around(padding.StatementExpect)...)
+	diagnostics, output := runRule(t, code, names, configs, rule.EditDemandAutofix)
+	if len(diagnostics) != 3 {
+		t.Fatalf("diagnostics = %d, want 3", len(diagnostics))
+	}
+	want := "async function run() {\n  setup();\n\n  label: beforeAll(connect);\n\n  await expect(load()).resolves.toBe(true);\n\n  cleanup();\n}"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingAwaitParenthesizedSubject(t *testing.T) {
+	code := "async function run() {\n  setup();\n  await (expect(load()).resolves.toBe(true));\n  cleanup();\n}"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementExpect), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "async function run() {\n  setup();\n\n  await (expect(load()).resolves.toBe(true));\n\n  cleanup();\n}"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingUnwrapsSourceParentheses(t *testing.T) {
+	code := "setup();\n(expect(value).toBe(true));\ncleanup();"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementExpect), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "setup();\n\n(expect(value).toBe(true));\n\ncleanup();"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingComments(t *testing.T) {
+	code := "setup(); // setup\n// hook docs\nbeforeAll(connect);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	want := "setup(); // setup\n\n// hook docs\nbeforeAll(connect);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingBlockCommentOnSameLine(t *testing.T) {
+	code := "setup(); /* setup */ beforeAll(connect);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	want := "setup(); /* setup */\n\n beforeAll(connect);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingExistingBlankLineBeforeComment(t *testing.T) {
+	code := "setup();\n\n// hook docs\nbeforeAll(connect);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 0 || output != code {
+		t.Fatalf("diagnostics = %d, output = %q", len(diagnostics), output)
+	}
+}
+
+func TestPaddingMatchesUpstreamLFInsertionsInCRLFSource(t *testing.T) {
+	code := "setup();\r\nbeforeAll(connect);\r\ncleanup();"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "setup();\n\r\nbeforeAll(connect);\n\r\ncleanup();"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingSameLineStatements(t *testing.T) {
+	code := "setup(); beforeAll(connect);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	want := "setup();\n\n beforeAll(connect);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingSemicolonStatement(t *testing.T) {
+	code := "setup()\n;beforeAll(connect);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	want := "setup()\n\n;beforeAll(connect);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingReportsInSourceOrder(t *testing.T) {
+	code := "function run() {\n  setup();\n  beforeAll(connect);\n}\nsetup();\nbeforeAll(connect);"
+	diagnostics, _ := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandNone)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	if diagnostics[0].Range.Pos() >= diagnostics[1].Range.Pos() {
+		t.Fatalf("diagnostics are not in source order: %v then %v", diagnostics[0].Range, diagnostics[1].Range)
+	}
+}
+
+func TestPaddingFrameworkNamesStaySeparate(t *testing.T) {
+	code := "setup();\nfit('focused', run);\nbeforeAll(connect);"
+	diagnostics, output := runRules(t, code, names, [][]padding.Config{
+		around(padding.StatementTest),
+		around(padding.StatementBeforeAll),
+	}, rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	want := "setup();\nfit('focused', run);\n\nbeforeAll(connect);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingRulesDeduplicateMatchingPairs(t *testing.T) {
+	code := "setup();\nbeforeAll(connect);"
+	diagnostics, output := runRules(t, code, names, [][]padding.Config{
+		around(padding.StatementBeforeAll),
+		around(padding.StatementBeforeAll),
+	}, rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	want := "setup();\n\nbeforeAll(connect);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingAtomicRuleWinsOverAggregateRegardlessOfRegistrationOrder(t *testing.T) {
+	const code = "setup();\nbeforeAll(connect);"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/padding.ts",
+		Path:     "/padding.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	cache := rule.NewFileCache()
+	var diagnostics []rule.RuleDiagnostic
+	definitions := []padding.Definition{
+		{Name: "test/padding-around-all", Family: "test", Priority: 100, Names: names, Configs: around(padding.StatementBeforeAll)},
+		{Name: "test/padding-around-before-all", Family: "test", Names: names, Configs: around(padding.StatementBeforeAll)},
+	}
+	var listenersForTraversal []rule.RuleListeners
+	var eof func(*ast.Node)
+	for _, definition := range definitions {
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithFileCache(cache).WithDiagnosticConsumer(
+			definition.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		)
+		listeners := padding.NewRule(definition).Run(ctx, nil)
+		listenersForTraversal = append(listenersForTraversal, listeners)
+		if listener := listeners[rule.ListenerOnExit(ast.KindEndOfFile)]; listener != nil {
+			eof = listener
+		}
+	}
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		for _, listeners := range listenersForTraversal {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	eof(nil)
+	if len(diagnostics) != 1 || diagnostics[0].RuleName != "test/padding-around-before-all" {
+		t.Fatalf("diagnostics = %#v", diagnostics)
+	}
+}
+
+func TestPaddingFamiliesReportIndependently(t *testing.T) {
+	const code = "setup();\nbeforeAll(connect);"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/padding.ts",
+		Path:     "/padding.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	cache := rule.NewFileCache()
+	var diagnostics []rule.RuleDiagnostic
+	var listenersForTraversal []rule.RuleListeners
+	var eof func(*ast.Node)
+	for _, definition := range []padding.Definition{
+		{Name: "jest/padding", Family: "jest", Names: names, Configs: around(padding.StatementBeforeAll)},
+		{Name: "rstest/padding", Family: "rstest", Names: names, Configs: around(padding.StatementBeforeAll)},
+	} {
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithFileCache(cache).WithDiagnosticConsumer(
+			definition.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		)
+		listeners := padding.NewRule(definition).Run(ctx, nil)
+		listenersForTraversal = append(listenersForTraversal, listeners)
+		if listener := listeners[rule.ListenerOnExit(ast.KindEndOfFile)]; listener != nil {
+			eof = listener
+		}
+	}
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		for _, listeners := range listenersForTraversal {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	eof(nil)
+	if len(diagnostics) != 2 || diagnostics[0].RuleName != "jest/padding" ||
+		diagnostics[1].RuleName != "rstest/padding" {
+		t.Fatalf("diagnostics = %#v", diagnostics)
+	}
+}
+
+func TestPaddingDisabledRuleFallsThroughToNextMatchingRule(t *testing.T) {
+	code := "setup();\n// rslint-disable-next-line first/padding\nbeforeAll(connect);\ncleanup();"
+	diagnostics := runNamedRules(t, code, []struct {
+		name    string
+		configs []padding.Config
+	}{
+		{name: "first/padding", configs: around(padding.StatementBeforeAll)},
+		{name: "second/padding", configs: around(padding.StatementBeforeAll)},
+	})
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	if diagnostics[0].RuleName != "second/padding" || diagnostics[1].RuleName != "first/padding" {
+		t.Fatalf("rule names = %q, %q", diagnostics[0].RuleName, diagnostics[1].RuleName)
+	}
+}
+
+func TestPaddingUsesSyntaxNamesWithoutBindingResolution(t *testing.T) {
+	code := "function beforeAll(callback) { callback(); }\nsetup();\nbeforeAll(connect);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandAutofix)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	want := "function beforeAll(callback) { callback(); }\nsetup();\n\nbeforeAll(connect);"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingDecodesEscapedIdentifierToken(t *testing.T) {
+	code := "setup();\nt\\u0065st('works', run);\ncleanup();"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementTest), rule.EditDemandAutofix)
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %d, want 2", len(diagnostics))
+	}
+	want := "setup();\n\nt\\u0065st('works', run);\n\ncleanup();"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestPaddingEmptyConfigurationDoesNotRegisterListener(t *testing.T) {
+	testRule := padding.NewRule(padding.Definition{Name: "test/padding", Family: "test", Names: names})
+	if listeners := testRule.Run(rule.RuleContext{}, nil); listeners != nil {
+		t.Fatalf("listeners = %#v, want nil", listeners)
+	}
+}
+
+func TestPaddingDiagnosticIdentityAndRange(t *testing.T) {
+	code := "setup();\nbeforeAll(connect);"
+	diagnostics, _ := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandNone)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Message.Id != "missingPadding" || diagnostic.Message.Description != "Expected blank line before this statement." {
+		t.Fatalf("message = %#v", diagnostic.Message)
+	}
+	if got := code[diagnostic.Range.Pos():diagnostic.Range.End()]; got != "beforeAll(connect);" {
+		t.Fatalf("reported text = %q", got)
+	}
+}
+
+func TestPaddingUsesDefinitionMessage(t *testing.T) {
+	const code = "setup();\nbeforeAll(connect);"
+	customMessage := rule.RuleMessage{Id: "custom", Description: "Custom padding message."}
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/padding.ts",
+		Path:     "/padding.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithFileCache(rule.NewFileCache()).WithDiagnosticConsumer(
+		"test/padding",
+		rule.SeverityError,
+		rule.DiagnosticConsumer{Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		}},
+	)
+	listeners := padding.NewRule(padding.Definition{
+		Name: "test/padding", Family: "test", Message: customMessage, Names: names,
+		Configs: around(padding.StatementBeforeAll),
+	}).Run(ctx, nil)
+	listeners[rule.ListenerOnExit(ast.KindEndOfFile)](nil)
+	if len(diagnostics) != 1 || diagnostics[0].Message.Id != customMessage.Id ||
+		diagnostics[0].Message.Description != customMessage.Description {
+		t.Fatalf("diagnostics = %#v, want message %#v", diagnostics, customMessage)
+	}
+}
+
+func TestPaddingAutofixIsDeferred(t *testing.T) {
+	code := "setup();\nbeforeAll(connect);"
+	diagnostics, output := runRule(t, code, names, around(padding.StatementBeforeAll), rule.EditDemandNone)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	if diagnostics[0].FixesPtr != nil || output != code {
+		t.Fatalf("unexpected deferred fix: fixes = %#v, output = %q", diagnostics[0].FixesPtr, output)
+	}
+}
+
+func TestPaddingCopiesInputs(t *testing.T) {
+	mutableNames := padding.StatementNames{"beforeAll": padding.StatementBeforeAll}
+	mutableConfigs := around(padding.StatementBeforeAll)
+	testRule := padding.NewRule(padding.Definition{
+		Name: "test/padding", Family: "test", Names: mutableNames, Configs: mutableConfigs,
+	})
+	mutableNames["beforeAll"] = padding.StatementTest
+	mutableConfigs[0].Next[0] = padding.StatementTest
+
+	code := "setup();\nbeforeAll(connect);"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/padding.ts",
+		Path:     "/padding.ts",
+	}, code, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer("test/padding", rule.SeverityError, rule.DiagnosticConsumer{
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	listeners := testRule.Run(ctx, nil)
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	listeners[rule.ListenerOnExit(ast.KindEndOfFile)](nil)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics after mutating inputs = %d, want 1", len(diagnostics))
+	}
+}


### PR DESCRIPTION
## Summary

Add a shared per-file padding engine for Jest and Rstest rules.
Use one `CachedByFile` coordinator to collect statement boundaries once while preserving padding, comment, and autofix behavior.

## Related Links

Related #476.
Related #935.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).