### PR TITLE
chore: release npm 0.9.2

### DIFF
--- a/npm/rslint/darwin-arm64/package.json
+++ b/npm/rslint/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-arm64",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for darwin-arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/darwin-x64/package.json
+++ b/npm/rslint/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-x64",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for darwin-x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-gnu/package.json
+++ b/npm/rslint/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-gnu",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-musl/package.json
+++ b/npm/rslint/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-musl",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-gnu/package.json
+++ b/npm/rslint/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-gnu",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-musl/package.json
+++ b/npm/rslint/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-musl",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-arm64-msvc/package.json
+++ b/npm/rslint/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-arm64-msvc",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for win32-arm64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-x64-msvc/package.json
+++ b/npm/rslint/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-x64-msvc",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "description": "rslint native binaries for win32-x64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rslint-monorepo",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "description": "Rslint Monorepo",
   "homepage": "https://github.com/web-infra-dev/rslint#readme",

--- a/packages/rslint-api/package.json
+++ b/packages/rslint-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/api",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Rslint AST library",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/test-tools",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "src/index.ts",
   "private": true,

--- a/packages/rslint-wasm/package.json
+++ b/packages/rslint-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/wasm",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "rslint wasm package",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/core",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "exports": {
     ".": {
       "@typescript/source": "./src/index.ts",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/rule-tester",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/utils",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "main": "index.ts",
   "private": true,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "rslint",
   "displayName": "Rslint",
   "description": "Language support for Rslint",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "icon": "images/icon.png",
   "private": true,
   "publisher": "rstack",

--- a/website/rule-releases.json
+++ b/website/rule-releases.json
@@ -809,5 +809,41 @@
       "rstest:require-awaited-expect-poll",
       "rstest:require-mock-type-parameters"
     ]
+  },
+  {
+    "version": "0.9.2",
+    "rules": [
+      "eslint-plugin-jest:padding-around-after-all-blocks",
+      "eslint-plugin-jest:padding-around-after-each-blocks",
+      "eslint-plugin-jest:padding-around-all",
+      "eslint-plugin-jest:padding-around-before-all-blocks",
+      "eslint-plugin-jest:padding-around-before-each-blocks",
+      "eslint-plugin-jest:padding-around-describe-blocks",
+      "eslint-plugin-jest:padding-around-expect-groups",
+      "eslint-plugin-jest:padding-around-test-blocks",
+      "eslint-plugin-react:function-component-definition",
+      "eslint-plugin-react:jsx-one-expression-per-line",
+      "eslint-plugin-react:no-arrow-function-lifecycle",
+      "eslint-plugin-react:no-namespace",
+      "eslint-plugin-react:prefer-read-only-props",
+      "eslint-plugin-react:sort-comp",
+      "eslint-plugin-react:static-property-placement",
+      "eslint-plugin-unicorn:no-array-from-fill",
+      "eslint-plugin-unicorn:no-await-expression-member",
+      "eslint-plugin-unicorn:no-this-outside-of-class",
+      "eslint-plugin-unicorn:prefer-string-trim-start-end",
+      "rstest:no-importing-rstest-globals",
+      "rstest:no-restricted-rstest-methods",
+      "rstest:padding-around-after-all-blocks",
+      "rstest:padding-around-after-each-blocks",
+      "rstest:padding-around-all",
+      "rstest:padding-around-before-all-blocks",
+      "rstest:padding-around-before-each-blocks",
+      "rstest:padding-around-describe-blocks",
+      "rstest:padding-around-expect-groups",
+      "rstest:padding-around-test-blocks",
+      "rstest:prefer-importing-rstest-globals",
+      "rstest:prefer-rs-mocked"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- Bump 16 unified rslint package manifests from `0.9.1` to `0.9.2` with `pnpm run version patch`.
- Add release metadata for 31 new Jest, React, Unicorn, and Rstest rules with `pnpm run sync:rule-releases`.
- Remove the generated `eslint:testdata` entry, which refers to a test fixture directory.

## Testing

- `pnpm run check-spell` with all 17 changed JSON files: passed.
- `pnpm run format:check`: passed.
- `git diff --check origin/main`: passed.
- Verified the package changes only update versions, all 31 rules are registered and absent from `v0.9.1`, and historical release metadata is preserved.
- Language test suites were not run for this version and metadata-only change.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

