### PR TITLE
ci: report binary size change on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,25 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      # `Build` already compiled every package behind ./cmd/rslint, so this
+      # relink is link-only off the warm cache. It measures the stripped
+      # executable users download, not the unstripped one tested above.
+      - name: Measure rslint binary size
+        env:
+          BINARY_SIZE_GO_VERSION: ${{ matrix.go-version }}
+        run: |
+          go build -ldflags="-s -w" -o "${RUNNER_TEMP}/rslint-release" ./cmd/rslint
+          node scripts/binary-size.mjs record "${RUNNER_TEMP}/rslint-release" "${RUNNER_TEMP}/binary-size.json"
+
+      # Uploaded on every run, main included: a pull request's baseline is the
+      # artifact of the main run for its base commit.
+      - name: Upload rslint binary size
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rslint-binary-size
+          path: ${{ runner.temp }}/binary-size.json
+          if-no-files-found: error
+
       - name: Dogfooding
         run: pnpm run lint --format github
 
@@ -200,6 +219,71 @@ jobs:
 
       - name: Test
         run: xvfb-run -a pnpm run test
+
+  binary-size:
+    name: Binary Size
+    needs: test-node
+    # Reports only, deliberately kept out of `done` below: porting a rule
+    # legitimately grows the binary.
+    if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+    runs-on: rspack-ubuntu-22.04-mini
+    permissions:
+      contents: read
+      # Reading the base commit's run and downloading its artifact.
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+
+      # Missing when `test-node` failed before the measurement.
+      - name: Download this run's measurement
+        id: head-size
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: rslint-binary-size
+          path: head-size
+
+      # On failure `run-id` stays empty and the report omits the comparison.
+      - name: Find the base measurement
+        id: base
+        if: steps.head-size.outcome == 'success'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/binary-size.mjs base-run
+
+      - name: Download the base measurement
+        if: steps.base.outputs.run-id != ''
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: rslint-binary-size
+          path: base-size
+          run-id: ${{ steps.base.outputs.run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Write report
+        if: steps.head-size.outcome == 'success'
+        run: |
+          node scripts/binary-size.mjs report head-size/binary-size.json base-size/binary-size.json > binary-size-report.md
+          cat binary-size-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # A fork's token is read-only, so this fails there and the job summary
+      # written above stays the report.
+      - name: Comment on the pull request
+        if: steps.head-size.outcome == 'success'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/binary-size.mjs comment binary-size-report.md
 
   test-node-windows:
     name: Test npm packages (rspack-windows-2022-large)

--- a/scripts/binary-size.mjs
+++ b/scripts/binary-size.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+/**
+ * Binary size monitoring for the `rslint` executable.
+ *
+ *   node scripts/binary-size.mjs record <binary> <out.json>
+ *   node scripts/binary-size.mjs base-run                    # -> $GITHUB_OUTPUT
+ *   node scripts/binary-size.mjs report <head.json> [base.json]
+ *   node scripts/binary-size.mjs comment <report.md>
+ *
+ * The measurement itself is produced inside the existing `Test npm packages`
+ * job, which has already compiled every package behind ./cmd/rslint — so the
+ * release relink it measures is a link-only action off a warm Go build cache
+ * rather than a second build. Each run stores its number as a workflow
+ * artifact; a pull request reads back the artifact of the main run for its
+ * base commit. That keeps the whole system on the built-in GITHUB_TOKEN: no
+ * data branch, no personal access token, no repository writes.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SCHEMA_VERSION = 1;
+
+// Ties an update to the comment this workflow posted last time, instead of
+// opening a new thread on every push.
+const COMMENT_MARKER = '<!-- rslint-binary-size -->';
+
+const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+const repository = process.env.GITHUB_REPOSITORY || '';
+
+async function api(endpoint) {
+  const response = await fetch(`${apiBase}${endpoint}`, {
+    headers: githubHeaders(),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GET ${endpoint} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+function githubHeaders() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN is not set');
+  return {
+    accept: 'application/vnd.github+json',
+    authorization: `Bearer ${token}`,
+    'content-type': 'application/json',
+    'x-github-api-version': '2022-11-28',
+  };
+}
+
+function readEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set');
+  return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
+/**
+ * The commit a reader can actually find in the pull request.
+ *
+ * On a `pull_request` event GITHUB_SHA is the ephemeral merge commit GitHub
+ * built for CI; it appears nowhere in the pull request's commit list. Since
+ * the report is edited in place across pushes, and a build takes minutes, the
+ * comment has to name the head commit it measured so a stale report is
+ * obvious.
+ */
+/**
+ * Subject line of the commit that was checked out.
+ *
+ * Recorded here rather than looked up when the report is rendered, so a
+ * baseline read back from an artifact carries its own description. Best
+ * effort: a shallow or absent checkout just leaves it blank.
+ */
+function commitSubject() {
+  try {
+    return execFileSync('git', ['log', '-1', '--format=%s'], {
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function headCommitSha() {
+  try {
+    return readEvent().pull_request?.head?.sha || process.env.GITHUB_SHA || '';
+  } catch {
+    return process.env.GITHUB_SHA || '';
+  }
+}
+
+/** Measure `binary` and write the record this run will publish as an artifact. */
+function record(binary, out) {
+  const size = fs.statSync(binary).size;
+  const measurement = {
+    schemaVersion: SCHEMA_VERSION,
+    sha: process.env.GITHUB_SHA || '',
+    headSha: headCommitSha(),
+    subject: commitSubject(),
+    ref: process.env.GITHUB_REF_NAME || '',
+    event: process.env.GITHUB_EVENT_NAME || '',
+    runId: process.env.GITHUB_RUN_ID || '',
+    target: 'linux-x64-gnu',
+    goVersion: process.env.BINARY_SIZE_GO_VERSION || '',
+    buildFlags: '-ldflags=-s -w',
+    size,
+    measuredAt: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(path.resolve(out)), { recursive: true });
+  fs.writeFileSync(out, `${JSON.stringify(measurement, null, 2)}\n`);
+  return measurement;
+}
+
+/**
+ * Locate the workflow run that measured the pull request's base commit.
+ *
+ * The base commit is on main, so its own CI run holds the baseline artifact.
+ * A miss is not an error: the base may predate this workflow, its run may
+ * still be going, or its artifact may have expired. The report then just
+ * states the current size.
+ */
+async function findBaseRun() {
+  const baseSha = readEvent().pull_request?.base?.sha;
+  if (!baseSha) return { baseSha: '', runId: '' };
+
+  const runs = await api(
+    `/repos/${repository}/actions/runs?head_sha=${baseSha}&per_page=100`,
+  );
+  const candidates = (runs.workflow_runs || [])
+    .filter((run) => run.path === '.github/workflows/ci.yml')
+    .sort((a, b) => b.run_number - a.run_number);
+
+  for (const run of candidates) {
+    const artifacts = await api(
+      `/repos/${repository}/actions/runs/${run.id}/artifacts?per_page=100`,
+    );
+    const artifact = (artifacts.artifacts || []).find(
+      (item) => item.name === 'rslint-binary-size' && !item.expired,
+    );
+    if (artifact) return { baseSha, runId: String(run.id) };
+  }
+
+  return { baseSha, runId: '' };
+}
+
+function formatBytes(bytes) {
+  const mib = bytes / 1024 / 1024;
+  if (Math.abs(mib) >= 1) return `${mib.toFixed(2)} MiB`;
+  return `${(bytes / 1024).toFixed(2)} KiB`;
+}
+
+function formatDelta(delta) {
+  const sign = delta > 0 ? '+' : delta < 0 ? '-' : '';
+  return `${sign}${formatBytes(Math.abs(delta))}`;
+}
+
+function formatPercent(delta, base) {
+  if (base === 0) return 'n/a';
+  const percent = (delta / base) * 100;
+  const sign = percent > 0 ? '+' : percent < 0 ? '-' : '';
+  return `${sign}${Math.abs(percent).toFixed(2)}%`;
+}
+
+/** Link a commit by its short SHA, so a reader can open exactly what was measured. */
+function commitLink(sha) {
+  if (!sha) return '`unknown`';
+  const short = `\`${sha.slice(0, 7)}\``;
+  const server = process.env.GITHUB_SERVER_URL;
+  if (!server || !repository) return short;
+  return `[${short}](${server}/${repository}/commit/${sha})`;
+}
+
+/**
+ * A commit subject as an inline code span.
+ *
+ * A code span rather than plain text on purpose: it keeps a `#1234` in the
+ * subject from auto-linking, which would post a cross-reference onto whatever
+ * unrelated pull request that number belongs to every time this comment is
+ * edited. Backticks are dropped so the span cannot be broken out of.
+ */
+function formatSubject(subject) {
+  if (!subject) return '';
+  const clean = subject.replaceAll('`', '');
+  const trimmed = clean.length > 72 ? `${clean.slice(0, 71)}…` : clean;
+  return trimmed ? ` — \`${trimmed}\`` : '';
+}
+
+/** "2026-09-07 03:22 UTC" — minute precision is enough to spot a stale report. */
+function formatTimestamp(iso) {
+  if (!iso) return '';
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+}
+
+/** Render the Markdown shared by the job summary and the pull request comment. */
+function report(headPath, basePath) {
+  const head = JSON.parse(fs.readFileSync(headPath, 'utf8'));
+  const base =
+    basePath && fs.existsSync(basePath)
+      ? JSON.parse(fs.readFileSync(basePath, 'utf8'))
+      : undefined;
+
+  const lines = [COMMENT_MARKER, '', '## 🦀📦 Binary size', ''];
+
+  if (base) {
+    const delta = head.size - base.size;
+    lines.push(
+      `Commit ${commitLink(head.headSha)} merged into base ${commitLink(base.headSha || base.sha)}${formatSubject(base.subject)}.`,
+      '',
+      '| Binary | Base | This PR | Change |',
+      '| --- | ---: | ---: | ---: |',
+      `| \`rslint\` (${head.target}) | ${formatBytes(base.size)} | ${formatBytes(head.size)} | ${formatDelta(delta)} (${formatPercent(delta, base.size)}) |`,
+    );
+  } else {
+    lines.push(
+      `Commit ${commitLink(head.headSha)}. No baseline measurement was available for the base commit — it may predate this workflow, still be running, or have expired — so only the current size is reported.`,
+      '',
+      '| Binary | This PR |',
+      '| --- | ---: |',
+      `| \`rslint\` (${head.target}) | ${formatBytes(head.size)} |`,
+    );
+  }
+
+  const goVersion = head.goVersion ? `Go ${head.goVersion}, ` : '';
+  const server = process.env.GITHUB_SERVER_URL;
+  const measured =
+    head.runId && server && repository
+      ? `[Measured](${server}/${repository}/actions/runs/${head.runId})`
+      : 'Measured';
+  lines.push(
+    '',
+    `<sub>Stripped release build: \`go build -ldflags="-s -w" ./cmd/rslint\` (${goVersion}linux/amd64) — the executable alone, not the full npm install. ${measured} ${formatTimestamp(head.measuredAt)}.</sub>`,
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Post or update the report on the pull request.
+ *
+ * Best-effort by design: a pull request from a fork gets a read-only
+ * GITHUB_TOKEN, so this call fails there and the job summary stays the only
+ * channel. That is why the caller runs this step with `continue-on-error`.
+ */
+async function comment(reportPath) {
+  const body = fs.readFileSync(reportPath, 'utf8');
+  const issueNumber = readEvent().pull_request?.number;
+  if (!issueNumber) throw new Error('no pull request number in the event');
+
+  const existing = await api(
+    `/repos/${repository}/issues/${issueNumber}/comments?per_page=100`,
+  );
+  const previous = (existing || []).find((item) =>
+    item.body?.includes(COMMENT_MARKER),
+  );
+
+  const endpoint = previous
+    ? `/repos/${repository}/issues/comments/${previous.id}`
+    : `/repos/${repository}/issues/${issueNumber}/comments`;
+  const response = await fetch(`${apiBase}${endpoint}`, {
+    method: previous ? 'PATCH' : 'POST',
+    headers: githubHeaders(),
+    body: JSON.stringify({ body }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${previous ? 'PATCH' : 'POST'} ${endpoint} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+function appendOutput(key, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  fs.appendFileSync(outputPath, `${key}=${value}\n`);
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+
+  switch (command) {
+    case 'record': {
+      const [binary, out] = args;
+      if (!binary || !out) throw new Error('usage: record <binary> <out.json>');
+      const measurement = record(binary, out);
+      process.stdout.write(
+        `${measurement.target} rslint: ${measurement.size} bytes (${formatBytes(measurement.size)})\n`,
+      );
+      break;
+    }
+    case 'base-run': {
+      const { baseSha, runId } = await findBaseRun();
+      appendOutput('run-id', runId);
+      process.stdout.write(
+        runId
+          ? `baseline run for ${baseSha}: ${runId}\n`
+          : `no baseline measurement found for ${baseSha || 'the base commit'}\n`,
+      );
+      break;
+    }
+    case 'report': {
+      const [headPath, basePath] = args;
+      if (!headPath) throw new Error('usage: report <head.json> [base.json]');
+      process.stdout.write(report(headPath, basePath));
+      break;
+    }
+    case 'comment': {
+      const [reportPath] = args;
+      if (!reportPath) throw new Error('usage: comment <report.md>');
+      await comment(reportPath);
+      break;
+    }
+    default:
+      throw new Error(`unknown command: ${command ?? '(none)'}`);
+  }
+}
+
+await main();

--- a/scripts/binary-size.mjs
+++ b/scripts/binary-size.mjs
@@ -15,7 +15,6 @@
  * base commit. That keeps the whole system on the built-in GITHUB_TOKEN: no
  * data branch, no personal access token, no repository writes.
  */
-import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -24,6 +23,10 @@ const SCHEMA_VERSION = 1;
 // Ties an update to the comment this workflow posted last time, instead of
 // opening a new thread on every push.
 const COMMENT_MARKER = '<!-- rslint-binary-size -->';
+
+// Written by `base-run`, read by `report`, so the base commit can be named
+// whether or not a measurement for it turned up.
+const BASE_COMMIT_FILE = 'base-commit.json';
 
 const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
 const repository = process.env.GITHUB_REPOSITORY || '';
@@ -38,6 +41,37 @@ async function api(endpoint) {
     );
   }
   return response.json();
+}
+
+/** The `rel="next"` target of an API `Link` header, if there is another page. */
+function nextPageUrl(link) {
+  if (!link) return '';
+  for (const part of link.split(',')) {
+    const match = /<([^>]+)>;\s*rel="next"/.exec(part);
+    if (match) return match[1];
+  }
+  return '';
+}
+
+/**
+ * Walk a list endpoint page by page.
+ *
+ * Reading only the first page would miss the marker comment once a pull
+ * request has more than a page of comments, and every later push would then
+ * post a fresh report instead of editing the existing one.
+ */
+async function* apiPages(endpoint) {
+  let url = `${apiBase}${endpoint}`;
+  while (url) {
+    const response = await fetch(url, { headers: githubHeaders() });
+    if (!response.ok) {
+      throw new Error(
+        `GET ${url} failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    yield await response.json();
+    url = nextPageUrl(response.headers.get('link'));
+  }
 }
 
 function githubHeaders() {
@@ -66,23 +100,6 @@ function readEvent() {
  * comment has to name the head commit it measured so a stale report is
  * obvious.
  */
-/**
- * Subject line of the commit that was checked out.
- *
- * Recorded here rather than looked up when the report is rendered, so a
- * baseline read back from an artifact carries its own description. Best
- * effort: a shallow or absent checkout just leaves it blank.
- */
-function commitSubject() {
-  try {
-    return execFileSync('git', ['log', '-1', '--format=%s'], {
-      encoding: 'utf8',
-    }).trim();
-  } catch {
-    return '';
-  }
-}
-
 function headCommitSha() {
   try {
     return readEvent().pull_request?.head?.sha || process.env.GITHUB_SHA || '';
@@ -98,7 +115,6 @@ function record(binary, out) {
     schemaVersion: SCHEMA_VERSION,
     sha: process.env.GITHUB_SHA || '',
     headSha: headCommitSha(),
-    subject: commitSubject(),
     ref: process.env.GITHUB_REF_NAME || '',
     event: process.env.GITHUB_EVENT_NAME || '',
     runId: process.env.GITHUB_RUN_ID || '',
@@ -116,7 +132,7 @@ function record(binary, out) {
 /**
  * Locate the workflow run that measured the pull request's base commit.
  *
- * The base commit is on main, so its own CI run holds the baseline artifact.
+ * The base commit is on main, so its own CI run holds its measurement.
  * A miss is not an error: the base may predate this workflow, its run may
  * still be going, or its artifact may have expired. The report then just
  * states the current size.
@@ -124,6 +140,8 @@ function record(binary, out) {
 async function findBaseRun() {
   const baseSha = readEvent().pull_request?.base?.sha;
   if (!baseSha) return { baseSha: '', runId: '' };
+
+  await writeBaseCommit(baseSha);
 
   const runs = await api(
     `/repos/${repository}/actions/runs?head_sha=${baseSha}&per_page=100`,
@@ -143,6 +161,26 @@ async function findBaseRun() {
   }
 
   return { baseSha, runId: '' };
+}
+
+/**
+ * Record the base commit's identity next to its measurement.
+ *
+ * Looked up rather than read off the base measurement so the report can name
+ * the base commit even when no measurement for it exists.
+ */
+async function writeBaseCommit(sha) {
+  let subject;
+  try {
+    const commit = await api(`/repos/${repository}/commits/${sha}`);
+    subject = (commit.commit?.message || '').split('\n')[0];
+  } catch {
+    subject = '';
+  }
+  fs.writeFileSync(
+    BASE_COMMIT_FILE,
+    `${JSON.stringify({ sha, subject }, null, 2)}\n`,
+  );
 }
 
 function formatBytes(bytes) {
@@ -193,6 +231,15 @@ function formatTimestamp(iso) {
   return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
 }
 
+/** The base commit this pull request is measured against. */
+function baseCommit() {
+  try {
+    return JSON.parse(fs.readFileSync(BASE_COMMIT_FILE, 'utf8'));
+  } catch {
+    return { sha: readEvent().pull_request?.base?.sha || '', subject: '' };
+  }
+}
+
 /** Render the Markdown shared by the job summary and the pull request comment. */
 function report(headPath, basePath) {
   const head = JSON.parse(fs.readFileSync(headPath, 'utf8'));
@@ -200,41 +247,41 @@ function report(headPath, basePath) {
     basePath && fs.existsSync(basePath)
       ? JSON.parse(fs.readFileSync(basePath, 'utf8'))
       : undefined;
+  const baseOn = baseCommit();
 
-  const lines = [COMMENT_MARKER, '', '## 🦀📦 Binary size', ''];
-
-  if (base) {
-    const delta = head.size - base.size;
-    lines.push(
-      `Commit ${commitLink(head.headSha)} merged into base ${commitLink(base.headSha || base.sha)}${formatSubject(base.subject)}.`,
-      '',
-      '| Binary | Base | This PR | Change |',
-      '| --- | ---: | ---: | ---: |',
-      `| \`rslint\` (${head.target}) | ${formatBytes(base.size)} | ${formatBytes(head.size)} | ${formatDelta(delta)} (${formatPercent(delta, base.size)}) |`,
-    );
-  } else {
-    lines.push(
-      `Commit ${commitLink(head.headSha)}. No baseline measurement was available for the base commit — it may predate this workflow, still be running, or have expired — so only the current size is reported.`,
-      '',
-      '| Binary | This PR |',
-      '| --- | ---: |',
-      `| \`rslint\` (${head.target}) | ${formatBytes(head.size)} |`,
-    );
-  }
+  // One table either way: an em dash where a missing measurement would go says
+  // everything a sentence about it would.
+  const delta = base ? head.size - base.size : undefined;
+  const row = [
+    `\`rslint\` (${head.target})`,
+    base ? formatBytes(base.size) : '—',
+    formatBytes(head.size),
+    delta === undefined
+      ? '—'
+      : `${formatDelta(delta)} (${formatPercent(delta, base.size)})`,
+  ];
 
   const goVersion = head.goVersion ? `Go ${head.goVersion}, ` : '';
   const server = process.env.GITHUB_SERVER_URL;
-  const measured =
+  const run =
     head.runId && server && repository
-      ? `[Measured](${server}/${repository}/actions/runs/${head.runId})`
-      : 'Measured';
-  lines.push(
-    '',
-    `<sub>Stripped release build: \`go build -ldflags="-s -w" ./cmd/rslint\` (${goVersion}linux/amd64) — the executable alone, not the full npm install. ${measured} ${formatTimestamp(head.measuredAt)}.</sub>`,
-    '',
-  );
+      ? `[run](${server}/${repository}/actions/runs/${head.runId})`
+      : 'run';
 
-  return lines.join('\n');
+  return [
+    COMMENT_MARKER,
+    '',
+    '## 🦀📦 Binary size',
+    '',
+    `Commit ${commitLink(head.headSha)} merged into base ${commitLink(baseOn.sha)}${formatSubject(baseOn.subject)}.`,
+    '',
+    '| Binary | Base | This PR | Change |',
+    '| --- | ---: | ---: | ---: |',
+    `| ${row.join(' | ')} |`,
+    '',
+    `<sub>Stripped \`go build -ldflags="-s -w" ./cmd/rslint\`, ${goVersion}linux/amd64 · ${run} · ${formatTimestamp(head.measuredAt)}</sub>`,
+    '',
+  ].join('\n');
 }
 
 /**
@@ -249,12 +296,13 @@ async function comment(reportPath) {
   const issueNumber = readEvent().pull_request?.number;
   if (!issueNumber) throw new Error('no pull request number in the event');
 
-  const existing = await api(
+  let previous;
+  for await (const page of apiPages(
     `/repos/${repository}/issues/${issueNumber}/comments?per_page=100`,
-  );
-  const previous = (existing || []).find((item) =>
-    item.body?.includes(COMMENT_MARKER),
-  );
+  )) {
+    previous = page.find((item) => item.body?.includes(COMMENT_MARKER));
+    if (previous) break;
+  }
 
   const endpoint = previous
     ? `/repos/${repository}/issues/comments/${previous.id}`
@@ -295,8 +343,8 @@ async function main() {
       appendOutput('run-id', runId);
       process.stdout.write(
         runId
-          ? `baseline run for ${baseSha}: ${runId}\n`
-          : `no baseline measurement found for ${baseSha || 'the base commit'}\n`,
+          ? `run measuring ${baseSha}: ${runId}\n`
+          : `no measurement found for ${baseSha || 'the base commit'}\n`,
       );
       break;
     }


### PR DESCRIPTION
## Summary

Nothing in CI tells a reviewer how much a pull request grows the binary. This reports it, with no added build and no repository configuration.

### How it works

- **Measure** — `Test npm packages` already compiles everything behind `./cmd/rslint`, so a release relink right after `Build` is link-only off the warm cache: 49s against 5m12s for a full build. It relinks rather than measuring the binary that job already produced, which is 52.20 MiB unstripped where the released one is 37.10 MiB.
- **Store** — every run, `main` included, uploads its measurement as a workflow artifact. No repository writes, no token beyond the built-in `GITHUB_TOKEN`.
- **Compare** — a pull request's baseline is the artifact of the `main` run for its base commit. The new `Binary Size` job reads both, writes the comparison to the job summary, and updates one pull request comment in place.

The job is deliberately absent from `CI Done` — porting a rule legitimately grows the binary, so this informs a review rather than blocking a merge.

### Limits

- A fork's token is read-only, so the comment step fails there by design and the job summary is the report.
- Artifacts expire, so this covers the per-pull-request comparison; the long-term `main` trend still needs somewhere durable to write.

## Related Links

Closes #2059

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

> **Token scope in the `Binary Size` job**
>
> The trigger is `pull_request`, never `pull_request_target`: a fork's token is capped read-only regardless of the `permissions:` block, and a same-repo author already has push access. The `pull-requests: write` token crosses no privilege boundary.
