### PR TITLE
feat(import): consider query strings in recommended preset

### DIFF
--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.md
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.md
@@ -38,9 +38,11 @@ import { y } from './bar';
 
 ### `considerQueryString`
 
-- **Default:** `true`
+- **Default:**
+  - `false` by default
+  - `true` if using the `importPlugin.configs.recommended` preset
 
-When set to `false`, query strings are ignored when checking for duplicate imports.
+When set to `true`, imports with different query strings are treated as different modules.
 
 ```json
 {
@@ -56,6 +58,8 @@ import iconSource from './icon.svg?raw';
 ```
 
 ### `prefer-inline`
+
+- **Default:** `false`
 
 When set to `true`, supports TypeScript inline type imports, allowing `import type { X }` to be merged into `import { type X }`.
 

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.md
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.md
@@ -38,12 +38,21 @@ import { y } from './bar';
 
 ### `considerQueryString`
 
-When set to `true`, imports with different query strings are treated as different modules.
+- **Default:** `true`
+
+When set to `false`, query strings are ignored when checking for duplicate imports.
 
 ```json
 {
-  "import/no-duplicates": ["error", { "considerQueryString": true }]
+  "import/no-duplicates": ["error", { "considerQueryString": false }]
 }
+```
+
+For example, these imports are reported as duplicates when `considerQueryString` is `false`, but are allowed when it is `true`:
+
+```javascript
+import iconUrl from './icon.svg?url';
+import iconSource from './icon.svg?raw';
 ```
 
 ### `prefer-inline`

--- a/packages/rslint/src/config/presets/import.ts
+++ b/packages/rslint/src/config/presets/import.ts
@@ -1,6 +1,6 @@
 import type { RslintConfigEntry } from '../define-config.js';
 
-// Aligned with official eslint-plugin-import recommended.
+// Based on official eslint-plugin-import recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
 const recommended: RslintConfigEntry = {
   plugins: ['eslint-plugin-import'],
@@ -14,7 +14,7 @@ const recommended: RslintConfigEntry = {
     // warnings
     // 'import/no-named-as-default': 'warn', // not implemented
     // 'import/no-named-as-default-member': 'warn', // not implemented
-    'import/no-duplicates': 'warn',
+    'import/no-duplicates': ['warn', { considerQueryString: true }],
   },
 };
 


### PR DESCRIPTION
## Summary

Imports such as `./icon.svg?url` and `./icon.svg?raw` represent different resources but are reported as duplicates by the recommended preset.

Enable `considerQueryString` in `importPlugin.configs.recommended` and document how to disable it. The standalone rule default remains unchanged, and imports with identical queries are still checked for duplicates.

## Related Links

Closes #2082

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).