### PR TITLE
feat(rstest): add prefer-called-with rule

### DIFF
--- a/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.go
+++ b/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.go
@@ -1,55 +1,30 @@
 package prefer_called_with
 
 import (
-	"slices"
-
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_called_with"
 )
 
-var preferCalledWithMatcherNames = map[string]bool{
-	"toBeCalled":       true,
-	"toHaveBeenCalled": true,
-}
-
-// Message builder
-
-func buildPreferCalledWithMessage(matcherName string) rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "preferCalledWith",
-		Description: "Prefer " + matcherName + "With(/* expected args */)",
-		Data: map[string]string{
-			"matcherName": matcherName,
-		},
-	}
-}
-
-var PreferCalledWithRule = rule.Rule{
-	Name:   "jest/prefer-called-with",
-	Schema: rule.EmptyArraySchema,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				jestFnCall := jestUtils.ParseJestFnCall(node, ctx)
-				if jestFnCall == nil ||
-					jestFnCall.Kind != jestUtils.JestFnTypeExpect ||
-					slices.Contains(jestFnCall.Modifiers, "not") {
-					return
-				}
-
-				matcherName := jestFnCall.Matcher
-				if !preferCalledWithMatcherNames[matcherName] {
-					return
-				}
-
-				reportNode := node
-				if jestFnCall.MatcherEntry != nil && jestFnCall.MatcherEntry.Node != nil {
-					reportNode = jestFnCall.MatcherEntry.Node
-				}
-
-				ctx.ReportNode(reportNode, buildPreferCalledWithMessage(matcherName))
-			},
-		}
+var PreferCalledWithRule = shared.NewRule(shared.Config{
+	Name: "jest/prefer-called-with",
+	Replacements: map[string]string{
+		"toBeCalled":       "toBeCalledWith",
+		"toHaveBeenCalled": "toHaveBeenCalledWith",
 	},
-}
+	Autofix: false,
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		return shared.Runtime{Parse: func(node *ast.Node) *shared.ExpectCall {
+			parsed := jestUtils.ParseJestFnCall(node, ctx)
+			if parsed == nil || parsed.Kind != jestUtils.JestFnTypeExpect {
+				return nil
+			}
+			call := &shared.ExpectCall{Matcher: parsed.Matcher, Modifiers: parsed.Modifiers}
+			if parsed.MatcherEntry != nil {
+				call.MatcherEntry = *parsed.MatcherEntry
+			}
+			return call
+		}}
+	},
+})

--- a/internal/plugins/jest/rules/prefer_called_with/prefer_called_with_extras_test.go
+++ b/internal/plugins/jest/rules/prefer_called_with/prefer_called_with_extras_test.go
@@ -1,0 +1,28 @@
+// Supplements the unchanged upstream cases in prefer_called_with_test.go.
+package prefer_called_with_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_called_with"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferCalledWithJestContract(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_called_with.PreferCalledWithRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect(fn).toHaveBeenCalledOnce();`},
+			{Code: `expect(fn).not.toHaveBeenCalled();`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `expect(fn).toBeCalled();`, Output: []string{},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toBeCalledWith(/* expected args */)", Line: 1, Column: 12, EndLine: 1, EndColumn: 22}},
+			},
+			{
+				Code: `expect(fn)['toHaveBeenCalled']();`, Output: []string{},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toHaveBeenCalledWith(/* expected args */)", Line: 1, Column: 12, EndLine: 1, EndColumn: 30}},
+			},
+		})
+}

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -25,6 +25,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_exactly_once_with"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_once"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_times"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_with"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_each"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_expect_type_of"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_hooks_in_order"
@@ -72,6 +73,7 @@ func GetAllRules() []rule.Rule {
 		prefer_called_exactly_once_with.PreferCalledExactlyOnceWithRule,
 		prefer_called_once.PreferCalledOnceRule,
 		prefer_called_times.PreferCalledTimesRule,
+		prefer_called_with.PreferCalledWithRule,
 		prefer_each.PreferEachRule,
 		prefer_expect_type_of.PreferExpectTypeOfRule,
 		prefer_hooks_in_order.PreferHooksInOrderRule,

--- a/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with.go
+++ b/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with.go
@@ -1,0 +1,33 @@
+package prefer_called_with
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_called_with"
+)
+
+var PreferCalledWithRule = shared.NewRule(shared.Config{
+	Name: "rstest/prefer-called-with",
+	Replacements: map[string]string{
+		"toBeCalled":           "toBeCalledWith",
+		"toHaveBeenCalled":     "toHaveBeenCalledWith",
+		"toHaveBeenCalledOnce": "toHaveBeenCalledExactlyOnceWith",
+	},
+	Autofix: true,
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return shared.Runtime{Parse: func(node *ast.Node) *shared.ExpectCall {
+			parsed := analysis.ParseExpectCall(node)
+			if parsed == nil || parsed.Head == nil || len(parsed.Matchers) == 0 ||
+				parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall {
+				return nil
+			}
+			return &shared.ExpectCall{
+				Matcher:      parsed.Matcher,
+				MatcherEntry: parsed.Matchers[0].Entry,
+				Modifiers:    parsed.Modifiers,
+			}
+		}}
+	},
+})

--- a/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with.md
+++ b/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with.md
@@ -1,0 +1,43 @@
+# rstest/prefer-called-with
+
+## Rule Details
+
+Prefer checking the arguments passed to a mock instead of only checking whether it was called. This rule reports `toBeCalled()`, `toHaveBeenCalled()`, and `toHaveBeenCalledOnce()`, recommending `toBeCalledWith()`, `toHaveBeenCalledWith()`, and `toHaveBeenCalledExactlyOnceWith()` respectively. Assertions negated with `.not` are exempt.
+
+The rule recognizes global Rstest `expect`, imports and aliases from `@rstest/core`, namespace imports, `const` namespace receivers from `require` or `import.meta.rstest`, destructured imports, and Test Context `expect`. Namespace receivers declared with `let` or `var` are ignored. It also checks assertion factories such as `expect.soft` and `expect.poll`. It does not require type information, though import aliases and local shadowing are resolved when a TypeScript project is available.
+
+Only the first matcher in an assertion chain is checked, and it must be called. Chai language chains before that matcher are allowed; Chai property assertions such as `.called` and `.calledOnce`, later matchers, and static `expect` APIs are ignored. Computed matcher names must be string or template literals without substitutions. The rule does not validate which matchers a factory allows; in particular, it does not make mock matchers available on `expect.element`.
+
+## Incorrect
+
+```ts
+import { expect, rs, test } from '@rstest/core';
+
+test('notifies the customer', () => {
+  const notify = rs.fn();
+  notify('order-confirmed');
+
+  expect(notify).toHaveBeenCalled();
+  expect(notify).toHaveBeenCalledOnce();
+});
+```
+
+## Correct
+
+```ts
+import { expect, rs, test } from '@rstest/core';
+
+test('notifies the customer', () => {
+  const notify = rs.fn();
+  notify('order-confirmed');
+
+  expect(notify).toHaveBeenCalledWith('order-confirmed');
+  expect(notify).toHaveBeenCalledExactlyOnceWith('order-confirmed');
+});
+```
+
+## Autofix
+
+The fix replaces only the matcher name, preserving the factory, modifiers, optional calls, arguments, comments, and the quote style of computed accessors. If the matcher accessor cannot be safely located, the rule reports without a fix.
+
+The fix does not infer or insert expected arguments. Add them yourself after applying it: an empty `toHaveBeenCalledWith()` checks for a call with no arguments, and an empty `toHaveBeenCalledExactlyOnceWith()` checks for exactly one call with no arguments.

--- a/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with_extras_test.go
@@ -1,0 +1,190 @@
+// Rstest parser and edit boundaries supplement prefer_called_with_upstream_test.go.
+package prefer_called_with
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferCalledWithExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		{Code: `expect(fn).not.toHaveBeenCalledOnce();`},
+		{Code: `expect.soft(fn).rejects.not.toHaveBeenCalledOnce();`},
+		{Code: `expect(fn)['not'].toHaveBeenCalled();`},
+		{Code: `expect(fn).toHaveBeenCalled;`},
+		{Code: `expect(fn).resolves.rejects.toHaveBeenCalled();`},
+		{Code: `expect(fn).not.not.toHaveBeenCalled();`},
+		{Code: `expect(fn).unknown.toHaveBeenCalled();`},
+		{Code: `expect.toHaveBeenCalled();`},
+		{Code: `expect.toHaveBeenCalledOnce();`},
+		{Code: `expect.assertions(1); expect.extend({}); expect.anything();`},
+		{Code: `expect(fn).to.have.been.called;`},
+		{Code: `expect(fn).calledOnce;`},
+		// Only the first matcher is considered, even if a later matcher is call-style.
+		{Code: `expect(fn).called.and.toHaveBeenCalled();`},
+		{Code: `expect(fn).toBeTypeOf('function').and.toHaveBeenCalled();`},
+		{Code: `expect(fn).toHaveBeenCalledWith(1).and.toHaveBeenCalledOnce();`},
+		{Code: `expect(fn).not.toHaveBeenCalled().and.toHaveBeenCalledOnce();`},
+		{Code: `expect(fn).toBeCalledOnce();`},
+		{Code: `other(fn).toHaveBeenCalled();`},
+		{Code: `custom.expect(fn).toHaveBeenCalled();`},
+		{Code: `import { expect } from 'vitest'; expect(fn).toHaveBeenCalled();`},
+		{Code: `import { expect } from '@jest/globals'; expect(fn).toHaveBeenCalled();`},
+		{Code: `const expect = makeExpect(); expect(fn).toHaveBeenCalled();`},
+		{Code: `import { expect } from '@rstest/core'; function check(expect: any) { expect(fn).toHaveBeenCalled(); }`},
+		{Code: `import { expect as check } from '@rstest/core'; function run(check: any) { check(fn).toHaveBeenCalled(); }`},
+		{Code: `import * as core from '@rstest/core'; function run(core: any) { core.expect(fn).toHaveBeenCalled(); }`},
+		{Code: `function test(name: string, callback: any) {} test('local', ({ expect }) => expect(fn).toHaveBeenCalled());`},
+		// Dynamic keys cannot identify a matcher, regardless of the identifier's spelling.
+		{Code: `expect(fn)[toHaveBeenCalled]();`},
+		{Code: `expect(fn)[('toHaveBeen' + 'Called')]();`},
+		{Code: "expect(fn)[`toHaveBeen${suffix}`]();"},
+		{Code: `expect(fn)[42]();`},
+		// Mutable namespace receivers are not candidates in the existing shared analysis.
+		{Code: `let core = require('@rstest/core'); core = replacement; core.expect(fn).toHaveBeenCalled();`},
+		{Code: `let core = import.meta.rstest; core = replacement; core.expect(fn).toHaveBeenCalled();`},
+		// each supplies row values only; for supplies TestContext as its second argument.
+		{Code: `test.each([1])('sends request %s', (value, { expect }) => expect(fn).toHaveBeenCalled());`},
+		// Type wrappers on the receiver are boundaries of the existing expect parser.
+		{Code: `expect(fn)!.toHaveBeenCalled();`},
+		{Code: `(expect(fn) as any).toHaveBeenCalled();`},
+		{Code: `(expect(fn) satisfies Assertion).toHaveBeenCalled();`},
+	}
+	var invalid []rule_tester.InvalidTestCase
+	for _, code := range []string{
+		`expect(fn).rejects.toHaveBeenCalled();`,
+		`expect.soft(fn).toHaveBeenCalled();`,
+		`expect(fn, 'request sent').toHaveBeenCalled();`,
+		`import { expect } from '@rstest/core'; expect(fn).toHaveBeenCalled();`,
+		`import { expect as check } from '@rstest/core'; check(fn).toHaveBeenCalled();`,
+		`const { expect: check } = require('@rstest/core'); check(fn).toHaveBeenCalled();`,
+		`const core = require('@rstest/core'); core.expect(fn).toHaveBeenCalled();`,
+		`import * as core from '@rstest/core'; core.expect(fn).toHaveBeenCalled();`,
+		`import.meta.rstest.expect(fn).toHaveBeenCalled();`,
+		`const { expect: check } = import.meta.rstest; check(fn).toHaveBeenCalled();`,
+		`const core = import.meta.rstest; core.expect(fn).toHaveBeenCalled();`,
+		`test('sends request', ({ expect }) => { expect(fn).toHaveBeenCalled(); });`,
+		`test('sends request', ({ expect: check }) => { check(fn).toHaveBeenCalled(); });`,
+		`import { test as check } from '@rstest/core'; check('sends request', ctx => { ctx.expect(fn).toHaveBeenCalled(); });`,
+		`test.for([1])('sends request %s', (value, { expect }) => expect(fn).toHaveBeenCalled());`,
+		// No Entry gate: poll permits mock matchers; element's narrower types remain the user's constraint.
+		`expect.poll(() => fn).toHaveBeenCalled();`,
+		`expect.element(locator).toHaveBeenCalled();`,
+		// Dimension 4: parentheses, optional chains, generic calls and literal accessor forms.
+		`((expect(fn))).toHaveBeenCalled();`,
+		`((expect(fn).toHaveBeenCalled))();`,
+		`expect?.(fn)?.toHaveBeenCalled?.();`,
+		`(expect(fn)?.toHaveBeenCalled)?.();`,
+		`expect(fn).toHaveBeenCalled<string>(value);`,
+		`expect(fn)['toHaveBeenCalled']();`,
+		`expect(fn)["toHaveBeenCalled"]();`,
+		"expect(fn)[`toHaveBeenCalled`]();",
+		`expect(fn)[(('toHaveBeenCalled'))]();`,
+		`expect(fn)?.[ /* key */ 'toHaveBeenCalled' /* end */ ]?.(/* args */);`,
+		`expect(fn).toHaveBeenCalled(sideEffect(), ...args);`,
+		// Rstest parses the outermost chain once; Vitest reports this matcher twice.
+		`expect(fn).toHaveBeenCalled()();`,
+		`expect(fn).toHaveBeenCalled().and.not.toBeNull();`,
+		`expect(fn).toHaveBeenCalled().and.toHaveBeenCalledOnce();`,
+		`expect(fn).to.have.been.toHaveBeenCalled();`,
+		`expect(fn).toHaveBeenCalled()[key]();`,
+		`expect(fn). /* matcher */ toHaveBeenCalled /* call */ (/* argument */);`,
+	} {
+		invalid = append(invalid, rule_tester.InvalidTestCase{
+			Code: code, Output: []string{strings.Replace(code, "toHaveBeenCalled", "toHaveBeenCalledWith", 1)},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toHaveBeenCalledWith(/* expected args */)"}},
+		})
+	}
+	invalid = append(invalid,
+		// Vitest issues #910 and #917: once needs the real ExactlyOnceWith matcher, not OnceWith.
+		rule_tester.InvalidTestCase{
+			Code: `expect(fn).toHaveBeenCalledOnce()`, Output: []string{`expect(fn).toHaveBeenCalledExactlyOnceWith()`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toHaveBeenCalledExactlyOnceWith(/* expected args */)"}},
+		},
+		rule_tester.InvalidTestCase{
+			Code: `expect(something).toHaveBeenCalledOnce();`, Output: []string{`expect(something).toHaveBeenCalledExactlyOnceWith();`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toHaveBeenCalledExactlyOnceWith(/* expected args */)"}},
+		},
+		rule_tester.InvalidTestCase{
+			Code: "expect(fn).\n  toHaveBeenCalled();", Output: []string{"expect(fn).\n  toHaveBeenCalledWith();"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Line: 2, Column: 3, EndLine: 2, EndColumn: 19}},
+		},
+		rule_tester.InvalidTestCase{
+			Code: `expect(fn)["toHaveBeenCalled"]();`, Output: []string{`expect(fn)["toHaveBeenCalledWith"]();`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Line: 1, Column: 12, EndLine: 1, EndColumn: 30}},
+		},
+		rule_tester.InvalidTestCase{
+			Code: "expect(fn)[\n  'toHaveBeenCalled'\n]();", Output: []string{"expect(fn)[\n  'toHaveBeenCalledWith'\n]();"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Line: 2, Column: 3, EndLine: 2, EndColumn: 21}},
+		},
+		rule_tester.InvalidTestCase{
+			Code: `expect(fn)['\x74oHaveBeenCalled']();`, Output: []string{`expect(fn)['toHaveBeenCalledWith']();`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith"}},
+		},
+		rule_tester.InvalidTestCase{
+			Code: `expect(fn).\u0074oHaveBeenCalled();`, Output: []string{`expect(fn).toHaveBeenCalledWith();`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith"}},
+		},
+		rule_tester.InvalidTestCase{
+			Code: `expect(expect(fn).toBeCalled()).toHaveBeenCalledOnce();`, Output: []string{`expect(expect(fn).toBeCalledWith()).toHaveBeenCalledExactlyOnceWith();`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith"}, {MessageId: "preferCalledWith"}},
+		},
+	)
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferCalledWithRule, valid, invalid)
+}
+
+func TestPreferCalledWithEditDemand(t *testing.T) {
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"expect(fn).toBeCalled();\nexpect.soft(fn)['toHaveBeenCalledOnce']();",
+		"edit-demand.ts", "tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var baseline []rule.RuleDiagnostic
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program: lintprogram.NewFromCompiler(program), File: sourceFile.FileName(), HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{Name: PreferCalledWithRule.Name, Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners { return PreferCalledWithRule.Run(ctx, nil) },
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: got %d diagnostics, want 2", demand, len(diagnostics))
+		}
+		for index := range diagnostics {
+			diagnostic := &diagnostics[index]
+			if demand&rule.EditDemandAutofix == 0 {
+				if diagnostic.FixesPtr != nil {
+					t.Fatalf("demand %d materialized fixes", demand)
+				}
+			} else if diagnostic.FixesPtr == nil || len(*diagnostic.FixesPtr) != 1 {
+				t.Fatalf("demand %d: expected one accessor fix", demand)
+			}
+			if diagnostic.Suggestions != nil {
+				t.Fatal("unexpected suggestions")
+			}
+			diagnostic.FixesPtr = nil
+		}
+		if baseline == nil {
+			baseline = diagnostics
+		} else if !reflect.DeepEqual(diagnostics, baseline) {
+			t.Fatalf("demand %d changed diagnostics", demand)
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with_upstream_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with_upstream_test.go
@@ -1,0 +1,47 @@
+// Mirrors @vitest/eslint-plugin@1.6.27; Rstest-specific coverage is in prefer_called_with_extras_test.go.
+package prefer_called_with
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferCalledWithUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferCalledWithRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect(fn).toBeCalledWith();`},
+			{Code: `expect(fn).toHaveBeenCalledWith();`},
+			{Code: `expect(fn).toBeCalledWith(expect.anything());`},
+			{Code: `expect(fn).toHaveBeenCalledWith(expect.anything());`},
+			{Code: `expect(fn).not.toBeCalled();`},
+			{Code: `expect(fn).rejects.not.toBeCalled();`},
+			{Code: `expect(fn).not.toHaveBeenCalled();`},
+			{Code: `expect(fn).not.toBeCalledWith();`},
+			{Code: `expect(fn).not.toHaveBeenCalledWith();`},
+			{Code: `expect(fn).resolves.not.toHaveBeenCalledWith();`},
+			{Code: `expect(fn).toBeCalledTimes(0);`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(0);`},
+			{Code: `expect(fn);`},
+			{Code: `expect(fn).toHaveBeenCalledExactlyOnceWith()`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `expect(fn).toBeCalled();`, Output: []string{`expect(fn).toBeCalledWith();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toBeCalledWith(/* expected args */)", Line: 1, Column: 12, EndLine: 1, EndColumn: 22}},
+			},
+			{
+				Code: `expect(fn).resolves.toBeCalled();`, Output: []string{`expect(fn).resolves.toBeCalledWith();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toBeCalledWith(/* expected args */)", Line: 1, Column: 21, EndLine: 1, EndColumn: 31}},
+			},
+			{
+				Code: `expect(fn).toHaveBeenCalled();`, Output: []string{`expect(fn).toHaveBeenCalledWith();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toHaveBeenCalledWith(/* expected args */)", Line: 1, Column: 12, EndLine: 1, EndColumn: 28}},
+			},
+			{
+				Code: `it("some test", () => {expect(mockApi).toHaveBeenCalledOnce();});`, Output: []string{`it("some test", () => {expect(mockApi).toHaveBeenCalledExactlyOnceWith();});`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCalledWith", Message: "Prefer toHaveBeenCalledExactlyOnceWith(/* expected args */)", Line: 1, Column: 40, EndLine: 1, EndColumn: 60}},
+			},
+		})
+}

--- a/internal/utils/test_framework/rules/prefer_called_with/prefer_called_with.go
+++ b/internal/utils/test_framework/rules/prefer_called_with/prefer_called_with.go
@@ -1,0 +1,74 @@
+package prefer_called_with
+
+import (
+	"slices"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type ExpectCall struct {
+	Matcher      string
+	MatcherEntry testFramework.MemberEntry
+	Modifiers    []string
+}
+
+type Runtime struct {
+	Parse func(*ast.Node) *ExpectCall
+}
+
+type Config struct {
+	Name         string
+	Prepare      func(rule.RuleContext) Runtime
+	Replacements map[string]string
+	Autofix      bool
+}
+
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+			runtime := config.Prepare(ctx)
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					parsed := runtime.Parse(node)
+					if parsed == nil || slices.Contains(parsed.Modifiers, "not") {
+						return
+					}
+					preferred, ok := config.Replacements[parsed.Matcher]
+					if !ok {
+						return
+					}
+
+					matcherName := preferred
+					if !config.Autofix {
+						// Jest's message data names the source matcher, not the replacement.
+						matcherName = parsed.Matcher
+					}
+					message := rule.RuleMessage{
+						Id:          "preferCalledWith",
+						Description: "Prefer " + preferred + "(/* expected args */)",
+						Data:        map[string]string{"matcherName": matcherName},
+					}
+					reportNode := parsed.MatcherEntry.Node
+					if reportNode == nil {
+						reportNode = node
+					}
+					if !config.Autofix {
+						ctx.ReportNode(reportNode, message)
+						return
+					}
+					ctx.ReportNodeWithDeferredFixes(reportNode, message, func() []rule.RuleFix {
+						fixRange, fixText, ok := testFramework.AccessorReplacement(ctx.SourceFile, parsed.MatcherEntry.Node, preferred)
+						if !ok {
+							return nil
+						}
+						return []rule.RuleFix{rule.RuleFixReplaceRange(fixRange, fixText)}
+					})
+				},
+			}
+		},
+	}
+}

--- a/internal/utils/test_framework/rules/prefer_called_with/prefer_called_with_test.go
+++ b/internal/utils/test_framework/rules/prefer_called_with/prefer_called_with_test.go
@@ -1,0 +1,84 @@
+package prefer_called_with
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+func TestPreferCalledWithMessageDataAndEditDemand(t *testing.T) {
+	source := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/test.ts", Path: "/test.ts"}, `expect(fn).toBeCalled();`, core.ScriptKindTS)
+	node := source.Statements.Nodes[0].AsExpressionStatement().Expression
+	accessor := node.AsCallExpression().Expression.AsPropertyAccessExpression().Name()
+	for _, autofix := range []bool{false, true} {
+		testRule := NewRule(Config{
+			Name: "test/prefer-called-with", Autofix: autofix,
+			Replacements: map[string]string{"toBeCalled": "toBeCalledWith"},
+			Prepare: func(rule.RuleContext) Runtime {
+				return Runtime{Parse: func(*ast.Node) *ExpectCall {
+					return &ExpectCall{Matcher: "toBeCalled", MatcherEntry: testFramework.MemberEntry{Node: accessor}}
+				}}
+			},
+		})
+		if err := testRule.Schema.Validate(nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := testRule.Schema.Validate([]any{map[string]any{}}); err == nil {
+			t.Fatal("the rule must reject options")
+		}
+		for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+			var diagnostics []rule.RuleDiagnostic
+			ctx := (rule.RuleContext{SourceFile: source}).WithDiagnosticConsumer(testRule.Name, rule.SeverityWarning, rule.DiagnosticConsumer{
+				Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) { diagnostics = append(diagnostics, diagnostic) },
+			})
+			testRule.Run(ctx, nil)[ast.KindCallExpression](node)
+			if len(diagnostics) != 1 {
+				t.Fatalf("got %d diagnostics, want 1", len(diagnostics))
+			}
+			diagnostic := diagnostics[0]
+			wantData := "toBeCalled"
+			if autofix {
+				wantData = "toBeCalledWith"
+			}
+			if diagnostic.Message.Data["matcherName"] != wantData || diagnostic.Message.Description != "Prefer toBeCalledWith(/* expected args */)" {
+				t.Fatalf("unexpected message: %#v", diagnostic.Message)
+			}
+			wantFix := autofix && demand&rule.EditDemandAutofix != 0
+			if (diagnostic.FixesPtr != nil) != wantFix {
+				t.Fatalf("autofix %t, demand %d: unexpected fixes", autofix, demand)
+			}
+		}
+	}
+}
+
+func TestPreferCalledWithReportWithoutFix(t *testing.T) {
+	source := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/test.ts", Path: "/test.ts"}, `expect(fn)[key]();`, core.ScriptKindTS)
+	node := source.Statements.Nodes[0].AsExpressionStatement().Expression
+	key := node.AsCallExpression().Expression.AsElementAccessExpression().ArgumentExpression
+	for _, accessor := range []*ast.Node{nil, key, node} {
+		testRule := NewRule(Config{
+			Name: "test/prefer-called-with", Autofix: true,
+			Replacements: map[string]string{"toBeCalled": "toBeCalledWith"},
+			Prepare: func(rule.RuleContext) Runtime {
+				return Runtime{Parse: func(*ast.Node) *ExpectCall {
+					return &ExpectCall{Matcher: "toBeCalled", MatcherEntry: testFramework.MemberEntry{Node: accessor}}
+				}}
+			},
+		})
+		var diagnostics []rule.RuleDiagnostic
+		ctx := (rule.RuleContext{SourceFile: source}).WithReporter(testRule.Name, rule.SeverityError, func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		})
+		testRule.Run(ctx, nil)[ast.KindCallExpression](node)
+		if len(diagnostics) != 1 {
+			t.Fatalf("got %d diagnostics, want 1", len(diagnostics))
+		}
+		if fixes := diagnostics[0].FixesPtr; fixes != nil && len(*fixes) != 0 {
+			t.Fatal("unsafe accessor received a fix")
+		}
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -646,6 +646,7 @@ define.test({
     './tests/rstest/rules/prefer-called-exactly-once-with.test.ts',
     './tests/rstest/rules/prefer-called-once.test.ts',
     './tests/rstest/rules/prefer-called-times.test.ts',
+    './tests/rstest/rules/prefer-called-with.test.ts',
     './tests/rstest/rules/prefer-each.test.ts',
     './tests/rstest/rules/prefer-expect-type-of.test.ts',
     './tests/rstest/rules/prefer-hooks-in-order.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/prefer-called-with.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/prefer-called-with.test.ts
@@ -1,0 +1,86 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-called-with', {} as never, {
+  valid: [
+    { code: 'expect(fn).toBeCalledWith();' },
+    { code: 'expect(fn).toHaveBeenCalledWith();' },
+    { code: 'expect(fn).toBeCalledWith(expect.anything());' },
+    { code: 'expect(fn).toHaveBeenCalledWith(expect.anything());' },
+    { code: 'expect(fn).not.toBeCalled();' },
+    { code: 'expect(fn).rejects.not.toBeCalled();' },
+    { code: 'expect(fn).not.toHaveBeenCalled();' },
+    { code: 'expect(fn).not.toBeCalledWith();' },
+    { code: 'expect(fn).not.toHaveBeenCalledWith();' },
+    { code: 'expect(fn).resolves.not.toHaveBeenCalledWith();' },
+    { code: 'expect(fn).toBeCalledTimes(0);' },
+    { code: 'expect(fn).toHaveBeenCalledTimes(0);' },
+    { code: 'expect(fn);' },
+    { code: 'expect(fn).toHaveBeenCalledExactlyOnceWith()' },
+  ],
+  invalid: [
+    {
+      code: 'expect(fn).toBeCalled();',
+      output: 'expect(fn).toBeCalledWith();',
+      errors: [
+        {
+          messageId: 'preferCalledWith',
+          message: 'Prefer toBeCalledWith(/* expected args */)',
+          data: { matcherName: 'toBeCalledWith' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 22,
+        },
+      ],
+    },
+    {
+      code: 'expect(fn).resolves.toBeCalled();',
+      output: 'expect(fn).resolves.toBeCalledWith();',
+      errors: [
+        {
+          messageId: 'preferCalledWith',
+          message: 'Prefer toBeCalledWith(/* expected args */)',
+          data: { matcherName: 'toBeCalledWith' },
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 31,
+        },
+      ],
+    },
+    {
+      code: 'expect(fn).toHaveBeenCalled();',
+      output: 'expect(fn).toHaveBeenCalledWith();',
+      errors: [
+        {
+          messageId: 'preferCalledWith',
+          message: 'Prefer toHaveBeenCalledWith(/* expected args */)',
+          data: { matcherName: 'toHaveBeenCalledWith' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 28,
+        },
+      ],
+    },
+    {
+      code: 'it("some test", () => {expect(mockApi).toHaveBeenCalledOnce();});',
+      output:
+        'it("some test", () => {expect(mockApi).toHaveBeenCalledExactlyOnceWith();});',
+      errors: [
+        {
+          messageId: 'preferCalledWith',
+          message:
+            'Prefer toHaveBeenCalledExactlyOnceWith(/* expected args */)',
+          data: { matcherName: 'toHaveBeenCalledExactlyOnceWith' },
+          line: 1,
+          column: 40,
+          endLine: 1,
+          endColumn: 60,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Add `rstest/prefer-called-with` to prefer mock assertions that name the expected arguments over checks that only say a mock was called. It reports `toBeCalled()`, `toHaveBeenCalled()`, and `toHaveBeenCalledOnce()`, and autofixes them to `toBeCalledWith()`, `toHaveBeenCalledWith()`, and `toHaveBeenCalledExactlyOnceWith()` respectively. Negated assertions are left alone. The rule is registered in the Rstest plugin but stays out of the `recommended` preset, matching upstream.

Assertions resolve through the shared Rstest call analysis, covering globals, named and renamed imports, namespace and whole-module `require`, `import.meta.rstest`, assertion factories, and the `expect` supplied by a test callback's context while excluding foreign or shadowed bindings. Only the first called matcher is considered, so Chai property assertions and later assertions in the same chain are not rewritten.

The framework-neutral matcher check now lives under `internal/utils/test_framework/rules/prefer_called_with`. The existing Jest rule uses the same core while retaining its v29.16.0 contract: it recognizes only the two Jest matcher names, reports without an autofix, and keeps the source matcher in message data. Rstest follows `@vitest/eslint-plugin` and constructs its accessor replacement only when autofixes are requested.

## Credits

Port from [`@vitest/eslint-plugin`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `prefer-called-with`.

## Intentional differences from upstream

- **Accessor spelling is preserved by the autofix.** Dot, quoted element, and template-literal accessors keep their authored form instead of every computed accessor being normalized to a single-quoted string. Comments and optional-call syntax outside the matcher name are preserved as well.

- **Only one parsed assertion is reported for a redundantly invoked chain.** Rstest's parser treats `expect(fn).toHaveBeenCalled()()` as one outer assertion and rewrites its matcher once, while upstream's listener reports the same matcher twice through the nested call expressions.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
