### PR TITLE
fix: correct no-var autofixes for deferred initializer calls

### DIFF
--- a/internal/rules/no_var/no_var.go
+++ b/internal/rules/no_var/no_var.go
@@ -361,9 +361,13 @@ func bindingContainsName(binding *ast.Node, target string) bool {
 // It names the UMD module in the global namespace but does not read the local
 // value at runtime, so it cannot make a var-to-let replacement unsafe.
 func filterSafeNamespaceExportReferences(refs []*ast.Node) []*ast.Node {
-	return slices.DeleteFunc(slices.Clone(refs), func(ref *ast.Node) bool {
+	isNamespaceExport := func(ref *ast.Node) bool {
 		return ref != nil && ref.Parent != nil && ref.Parent.Kind == ast.KindNamespaceExportDeclaration
-	})
+	}
+	if !slices.ContainsFunc(refs, isNamespaceExport) {
+		return refs
+	}
+	return slices.DeleteFunc(slices.Clone(refs), isNamespaceExport)
 }
 
 // filterSafeAmbientNamespaceReferences removes type-only reads contributed by
@@ -454,18 +458,21 @@ func hasUnsafeHoistedFunctionReference(nameNode *ast.Node, refs []*ast.Node, ctx
 	}
 	declarationScope := findEnclosingExecutionScope(nameNode)
 	declarationStart := nameNode.Pos()
+	var checkedFunction *ast.Node
 	for _, ref := range refs {
 		if ref.Pos() < declarationStart || isTypeOnlyReferenceLocation(ref) {
 			continue
 		}
 		for currentScope := findEnclosingExecutionScope(ref); currentScope != nil && currentScope != declarationScope; currentScope = findEnclosingExecutionScope(currentScope) {
-			if currentScope.Kind != ast.KindFunctionDeclaration || currentScope.Name() == nil {
+			if currentScope.Kind != ast.KindFunctionDeclaration || currentScope.Name() == nil || currentScope == checkedFunction {
 				continue
 			}
+			// Consecutive reads in one function have the same invocation sites.
+			checkedFunction = currentScope
 			functionSymbol := utils.BindingNameSymbol(currentScope.Name())
 			for _, functionRef := range ctx.Refs.References(functionSymbol) {
-				if isImmediateInvocation(functionRef) &&
-					(functionRef.Pos() < declarationStart || isInvocationInOwnInitializer(nameNode, functionRef)) {
+				if (functionRef.Pos() < declarationStart || isInvocationInOwnInitializer(nameNode, functionRef, ctx)) &&
+					isImmediateInvocation(functionRef) {
 					return true
 				}
 			}
@@ -475,21 +482,104 @@ func hasUnsafeHoistedFunctionReference(nameNode *ast.Node, refs []*ast.Node, ctx
 }
 
 // isInvocationInOwnInitializer catches calls such as
-// `var value = readValue(); function readValue() { return value; }`. The call
-// is textually after the binding name but still runs before let initializes
-// it. A function/arrow used directly as the initializer stays deferred.
-func isInvocationInOwnInitializer(nameNode *ast.Node, invocation *ast.Node) bool {
+// `var value = readValue(); function readValue() { return value; }`. A call
+// inside a stored callback or method runs later, even when its source range
+// is inside the initializer. Immediately invoked functions still run in TDZ.
+func isInvocationInOwnInitializer(nameNode *ast.Node, invocation *ast.Node, ctx *rule.RuleContext) bool {
 	if !scope.IsInsideOwnInitializer(nameNode, invocation.End()) {
 		return false
 	}
-	root := ast.GetRootDeclaration(nameNode.Parent)
-	return root == nil || !isInDirectFunctionInitializer(root.AsVariableDeclaration(), invocation)
+	return isExecutedInInitializer(nameNode, invocation, ctx, nil)
+}
+
+func isExecutedInInitializer(nameNode, reference *ast.Node, ctx *rule.RuleContext, active map[*ast.Node]bool) bool {
+	boundary := findEnclosingExecutionScope(nameNode)
+	for current := findEnclosingExecutionScope(reference); current != nil && current != boundary; current = findEnclosingExecutionScope(current) {
+		if isImmediateInvocation(current) {
+			continue
+		}
+		expression := invocationResultExpression(current)
+		if expression.Parent != nil && (expression.Parent.Kind == ast.KindCallExpression ||
+			expression.Parent.Kind == ast.KindNewExpression) {
+			// A callback passed to a call may be invoked synchronously.
+			continue
+		}
+
+		// Named local functions, including arrows stored in a local variable,
+		// may be called by another part of the initializer. Follow their calls
+		// without recursing forever on mutually recursive functions.
+		var binding *ast.Node
+		if current.Kind == ast.KindFunctionDeclaration {
+			binding = current.Name()
+		} else if expression.Parent != nil &&
+			expression.Parent.Kind == ast.KindVariableDeclaration && expression.Parent.Initializer() == expression {
+			binding = expression.Parent.Name()
+		}
+		if binding != nil && binding.Kind == ast.KindIdentifier {
+			return hasInitializerCall(nameNode, current, binding, false, ctx, active)
+		}
+
+		// Accessing a freshly created object can invoke its getter/method;
+		// constructing a class can execute its constructor and instance fields.
+		// Ordinary stored objects and classes leave those bodies deferred.
+		owner := expression.Parent
+		if owner != nil && owner.Kind == ast.KindPropertyAssignment {
+			owner = owner.Parent
+		}
+		if owner != nil && (owner.Kind == ast.KindObjectLiteralExpression || ast.IsClassLike(owner)) {
+			if ast.IsClassLike(owner) && owner.Name() != nil &&
+				hasInitializerCall(nameNode, current, owner.Name(), true, ctx, active) {
+				return true
+			}
+			value := invocationResultExpression(owner)
+			if value.Parent != nil && value.Parent.Kind == ast.KindVariableDeclaration &&
+				value.Parent.Name() != nil && value.Parent.Name().Kind == ast.KindIdentifier {
+				return hasInitializerCall(nameNode, current, value.Parent.Name(), true, ctx, active)
+			}
+			if isImmediateInvocation(value) || (value.Parent != nil && ast.IsAccessExpression(value.Parent) &&
+				utils.AccessExpressionObject(value.Parent) == value) ||
+				(value.Parent != nil && value.Parent.Kind == ast.KindSpreadAssignment) {
+				current = owner
+				continue
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func hasInitializerCall(nameNode, functionNode, binding *ast.Node, memberAccess bool, ctx *rule.RuleContext, active map[*ast.Node]bool) bool {
+	if active[functionNode] {
+		return false
+	}
+	if active == nil {
+		active = make(map[*ast.Node]bool)
+	}
+	active[functionNode] = true
+	defer delete(active, functionNode)
+	for _, reference := range ctx.Refs.References(utils.BindingNameSymbol(binding)) {
+		if !scope.IsInsideOwnInitializer(nameNode, reference.End()) {
+			continue
+		}
+		expression := invocationResultExpression(reference)
+		canInvoke := isImmediateInvocation(reference) ||
+			(expression.Parent != nil && (expression.Parent.Kind == ast.KindCallExpression || expression.Parent.Kind == ast.KindNewExpression)) ||
+			(memberAccess && expression.Parent != nil && ast.IsAccessExpression(expression.Parent) && utils.AccessExpressionObject(expression.Parent) == expression)
+		if canInvoke && isExecutedInInitializer(nameNode, reference, ctx, active) {
+			return true
+		}
+	}
+	return false
 }
 
 func isImmediateInvocation(reference *ast.Node) bool {
+	return immediateInvocationResult(reference) != nil
+}
+
+func immediateInvocationResult(reference *ast.Node) *ast.Node {
 	current := invocationResultExpression(reference)
 	if utils.IsCallee(current) || isTaggedTemplateTag(current) {
-		return true
+		return current.Parent
 	}
 
 	// Function.prototype.call/apply invoke their receiver immediately. Reuse
@@ -498,10 +588,19 @@ func isImmediateInvocation(reference *ast.Node) bool {
 	parent := current.Parent
 	if parent == nil || !ast.IsAccessExpression(parent) ||
 		utils.AccessExpressionObject(parent) != current {
-		return false
+		return nil
 	}
 	name, ok := utils.AccessExpressionStaticName(parent)
-	return ok && (name == "call" || name == "apply") && utils.IsCallee(parent)
+	if !ok || !utils.IsCallee(parent) {
+		return nil
+	}
+	if name == "call" || name == "apply" {
+		return parent.Parent
+	}
+	if name == "bind" {
+		return immediateInvocationResult(parent.Parent)
+	}
+	return nil
 }
 
 // invocationResultExpression walks only expressions whose result can be the
@@ -530,6 +629,21 @@ func invocationResultExpression(reference *ast.Node) *ast.Node {
 			if conditional != nil && (conditional.WhenTrue == current || conditional.WhenFalse == current) {
 				current = parent
 				continue
+			}
+		}
+		// An immediately invoked function can return a callable that is used
+		// again in the same initializer, as in (() => () => read())()().
+		if parent.Kind == ast.KindReturnStatement ||
+			(parent.Kind == ast.KindArrowFunction && parent.AsArrowFunction().Body == current) {
+			owner := parent
+			if parent.Kind == ast.KindReturnStatement {
+				owner = findEnclosingExecutionScope(parent)
+			}
+			if owner != nil {
+				if result := immediateInvocationResult(owner); result != nil {
+					current = result
+					continue
+				}
 			}
 		}
 		break

--- a/internal/rules/no_var/no_var.md
+++ b/internal/rules/no_var/no_var.md
@@ -22,3 +22,20 @@ const CONFIG = {};
 
 - [ESLint: no-var](https://eslint.org/docs/latest/rules/no-var)
 - [Source code](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-var.js)
+
+## Differences from ESLint
+
+Rslint leaves some declarations unfixed when replacing `var` with `let` would
+introduce a temporal dead zone, even if ESLint offers a fix. This includes a
+function called during the variable's initialization that reads that variable:
+
+```javascript
+var value = read();
+function read() {
+  return value;
+}
+```
+
+The same protection applies to immediately invoked callbacks, constructors,
+getters and loop binding defaults that read an uninitialized variable. Stored
+callbacks and methods that run after initialization can still be fixed.

--- a/internal/rules/no_var/no_var_extras_test.go
+++ b/internal/rules/no_var/no_var_extras_test.go
@@ -1,16 +1,23 @@
+package no_var
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/binder"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
 // TestNoVarComputedAssignmentKey locks in rule behavior inside an evaluated
 // computed property name of a destructuring assignment target. The shared
 // traversal contract is covered by internal/linter; this test protects the
 // rule's listener-to-diagnostic integration.
-package no_var
-
-import (
-	"testing"
-
-	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
-	"github.com/web-infra-dev/rslint/internal/rule_tester"
-)
-
 func TestNoVarComputedAssignmentKey(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),
@@ -29,4 +36,141 @@ func TestNoVarComputedAssignmentKey(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoVarDeferredInitializerCalls(t *testing.T) {
+	initializers := []struct {
+		code string
+		fix  bool
+	}{
+		// Stored bodies, including callbacks returned by an IIFE, do not run
+		// while value is initialized. These fixes match ESLint 10.9.1.
+		{`({ method() { return read(); } })`, true},
+		{`({ method: function() { return read(); } })`, true},
+		{`({ get value() { return read(); } })`, true},
+		{`({ later: (arg = read()) => arg })`, true},
+		{`(() => ({ method: function() { return read(); } }))()`, true},
+		{`(() => { function later() { return read(); } return later; })()`, true},
+		{`(() => { const later = () => read(); return later; })()`, true},
+		{`class { method() { return read(); } }`, true},
+		{`class { field = read(); }`, true},
+		// Reduced from the ReadableStream constructor in streams-lib.js.
+		{`function() { function Value() {} Value.prototype.tee = function() { return read(); }; return Value; }()`, true},
+
+		// These calls actually read value before initialization completes.
+		// Retain the existing safety protection even where upstream offers a fix.
+		{`read()`, false},
+		{`(() => read())()`, false},
+		{`(function() { return read(); }).call(null)`, false},
+		{`(function() { return read(); }).apply(null)`, false},
+		{`(function() { return read(); }).bind(null)()`, false},
+		{`(0, () => read())()`, false},
+		{`(() => () => read())()()`, false},
+		{`(function() { return function() { return read(); }; })()()`, false},
+		{`(() => { function now() { return read(); } return now(); })()`, false},
+		{`(() => { const now = () => read(); return now(); })()`, false},
+		{`(() => { function first() { second(); } function second() { read(); first(); } first(); })()`, false},
+		{`((callback) => callback())(() => read())`, false},
+		{`[0].map(() => read())`, false},
+		{`class { static field = read(); }`, false},
+		{`class { static { read(); } }`, false},
+		{`class { [read()]() {} }`, false},
+		{`({ [read()]() {} })`, false},
+		{`new class { field = read(); }`, false},
+		{`new class { constructor() { read(); } }`, false},
+		{`(() => { class C { field = read(); } return new C(); })()`, false},
+		{`({ method() { return read(); } }).method()`, false},
+		{`({ get value() { return read(); } }).value`, false},
+		{`({...{get key() { return read(); }}})`, false},
+		{`(() => { const object = { method() { return read(); } }; return object.method(); })()`, false},
+	}
+	var cases []rule_tester.InvalidTestCase
+	for _, sourceType := range []string{"module", "script", "commonjs"} {
+		for _, initializer := range initializers {
+			declaration := "var value = " + initializer.code + ";"
+			code := "function wrap() { " + declaration + " function read() { return value; } }"
+			c := rule_tester.InvalidTestCase{
+				Code:            code,
+				FileName:        "deferred.js",
+				TSConfig:        "tsconfig.allow-js.json",
+				LanguageOptions: rule.LanguageOptions{SourceType: sourceType},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpectedVar",
+					Message:   "Unexpected var, use let or const instead.",
+					Line:      1, Column: 19, EndLine: 1, EndColumn: 19 + len(declaration),
+				}},
+			}
+			if initializer.fix {
+				c.Output = []string{strings.Replace(code, "var value", "let value", 1)}
+			}
+			cases = append(cases, c)
+		}
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoVarRule, nil, cases)
+}
+
+func TestNoVarDeferredInitializerTypeScript(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoVarRule, nil, []rule_tester.InvalidTestCase{
+		{
+			Code:   `var value = { method: (() => read()) as () => unknown }; function read() { return value; }`,
+			Output: []string{`let value = { method: (() => read()) as () => unknown }; function read() { return value; }`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedVar"}},
+		},
+		{
+			Code:   `var value = class { method() { return (read satisfies Function)(); } }; function read() { return value; }`,
+			Output: []string{`let value = class { method() { return (read satisfies Function)(); } }; function read() { return value; }`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedVar"}},
+		},
+		{
+			Code:   `var value = ((() => (read as Function)()) as Function)(); function read() { return value; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedVar"}},
+		},
+		{
+			Code:   `var value = ({ method: (() => read()) as Function }).method(); function read() { return value; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedVar"}},
+		},
+	})
+}
+
+func TestNoVarDeferredInitializerEditDemand(t *testing.T) {
+	const body = "var value = { method() { return read(); } }; function read() { return value; }"
+	for _, prefix := range []string{"/* comment */\n", "// eslint-disable-next-line no-var\n", "/* rslint-disable no-var */\n"} {
+		for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+			sf := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/demand.js", Path: tspath.Path("/demand.js")}, prefix+body, core.ScriptKindJS)
+			binder.BindSourceFile(sf)
+			_, init, language := rule.ResolveLanguageDefaults(sf.FileName(), rule.LanguageOptions{})
+			var diagnostics []rule.RuleDiagnostic
+			ctx := rule.RuleContext{
+				SourceFile: sf, LanguageOptions: language,
+				Refs:           rule.NewRefStore(sf, &core.CompilerOptions{}, nil, init),
+				DisableManager: rule.NewDisableManager(sf, rule.NewCommentStore(sf)),
+			}.WithDiagnosticConsumer("no-var", rule.SeverityError, rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) },
+			})
+			declaration := sf.Statements.Nodes[0].AsVariableStatement().DeclarationList
+			NoVarRule.Run(ctx, nil)[ast.KindVariableDeclarationList](declaration)
+			if strings.Contains(prefix, "disable") {
+				if len(diagnostics) != 0 {
+					t.Fatalf("suppressed diagnostic with demand %d: %v", demand, diagnostics)
+				}
+				continue
+			}
+			if len(diagnostics) != 1 {
+				t.Fatalf("demand %d: got %d diagnostics", demand, len(diagnostics))
+			}
+			d := diagnostics[0]
+			if d.Message.Id != "unexpectedVar" || d.Range.Pos() != len(prefix) || d.Range.End() != len(prefix)+44 || d.Suggestions != nil {
+				t.Fatalf("demand %d: unexpected diagnostic: %v", demand, d)
+			}
+			if demand&rule.EditDemandAutofix != 0 {
+				fixes := d.Fixes()
+				if len(fixes) != 1 || fixes[0].Text != "let" || fixes[0].Range.Pos() != len(prefix) || fixes[0].Range.End() != len(prefix)+3 {
+					t.Fatalf("demand %d: unexpected fixes: %v", demand, fixes)
+				}
+			} else if d.FixesPtr != nil {
+				t.Fatalf("demand %d: unwanted fix artifact", demand)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

`no-var` withheld safe autofixes when an initializer created methods or callbacks that called a hoisted function reading the variable. ESLint offered `var` → `let`, while rslint reported the same diagnostic without an edit.

Distinguish deferred execution from calls that run during initialization. Cover stored object methods, getters, class members and returned callbacks, while retaining temporal-dead-zone protections for immediate calls, synchronous callbacks, constructors, spreads and recursive local functions. Document the existing safety differences from ESLint. Avoid copying reference slices unless filtering is necessary, and reuse checks for consecutive reads in the same function.

Validation was limited to this rule and its direct integration:

- `go test ./internal/rules/no_var -count=3`
- `golangci-lint run --new-from-merge-base=origin/main ./internal/rules/no_var`
- `CI=true pnpm --dir packages/rslint-test-tools exec rs test run tests/eslint/rules/no-var.test.ts`
- Spell check on the three changed files, Go formatting, staged formatting and `git diff --check`.
- Differential audit of 188 inputs, including all 76 upstream cases. All upstream cases match ESLint 10.9.1; additional cases retain safety guards where an upstream fix would introduce a TDZ. Runtime adversarial checks cover newly fixable inputs.

### Go benchmark

Go 1.26.5, darwin/arm64, Apple M5 Max. Medians of six samples, 200 ms per sample, `-cpu=1`, with CPU idle above 70% before each run. Baseline: `3d84aec5`.

The benchmark invoked only the `no-var` declaration listener and consumed diagnostics/fixes. Parsing and binding were outside the timed region; each operation used a fresh reference store. Synthetic cases contain 64 independent examples; `RepresentativeSource` measures a larger JavaScript input.

```sh
go test ./internal/rules/no_var -run '^$' -bench '^BenchmarkNoVar$' -benchmem -benchtime=200ms -count=6 -cpu=1
```

| Case | ns/op before → after | Change | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: | ---: |
| NoMatch/Diagnostics | 419.5 → 449.6 | +7.2% | 1,424 → 1,424 | 6 → 6 |
| NoMatch/Autofix | 429.2 → 426.7 | -0.6% | 1,424 → 1,424 | 6 → 6 |
| Simple/Diagnostics | 4,722.0 → 4,542.0 | -3.8% | 11,664 → 11,664 | 70 → 70 |
| Simple/Autofix | 40,947.5 → 35,426.0 | -13.5% | 49,064 → 48,552 | 545 → 481 |
| HoistedSafe/Diagnostics | 5,039.0 → 5,180.5 | +2.8% | 11,664 → 11,664 | 70 → 70 |
| HoistedSafe/Autofix | 81,221.5 → 75,973.0 | -6.5% | 66,632 → 65,096 | 741 → 677 |
| HoistedUnsafe/Diagnostics | 4,901.0 → 4,626.5 | -5.6% | 11,664 → 11,664 | 70 → 70 |
| HoistedUnsafe/Autofix | 43,027.0 → 40,182.5 | -6.6% | 35,528 → 35,016 | 355 → 291 |
| LoopClosure/Diagnostics | 4,931.0 → 4,552.5 | -7.7% | 11,664 → 11,664 | 70 → 70 |
| LoopClosure/Autofix | 35,564.5 → 32,835.0 | -7.7% | 26,528 → 26,016 | 296 → 232 |
| RepresentativeSource/Diagnostics | 25,232.0 → 24,686.5 | -2.2% | 46,384 → 46,384 | 287 → 287 |
| RepresentativeSource/Autofix | 836,783.0 → 777,122.0 | -7.1% | 380,000 → 371,968 | 4,763 → 4,420 |

The representative-source autofix path takes 7.1% less time and uses 343 fewer allocations per operation. Diagnostic/control timings fluctuate with unchanged allocation counts; these measurements do not establish an end-to-end CLI speedup.

## Related Links

- [ESLint 10.9.1 no-var source](https://github.com/eslint/eslint/blob/v10.9.1/lib/rules/no-var.js) (identical in 10.10.0).
- [ESLint 10.9.1 no-var tests](https://github.com/eslint/eslint/blob/v10.9.1/tests/lib/rules/no-var.js).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
