### PR TITLE
chore: bump tsgo packages to 0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-client"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bitflags",
  "cbor4ii",

--- a/crates/tsgo-client/Cargo.toml
+++ b/crates/tsgo-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsgo-client"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 description = "TypeScript Go client library"
 license = "MIT"

--- a/npm/tsgo/darwin-arm64/package.json
+++ b/npm/tsgo/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-darwin-arm64",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "tsgo server binary for darwin arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/darwin-x64/package.json
+++ b/npm/tsgo/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-darwin-x64",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "tsgo server binary for darwin x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-arm64/package.json
+++ b/npm/tsgo/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-linux-arm64",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "tsgo server binary for linux arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-x64/package.json
+++ b/npm/tsgo/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-linux-x64",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "tsgo server binary for linux x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-arm64/package.json
+++ b/npm/tsgo/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-win32-arm64",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "tsgo server binary for windows arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-x64/package.json
+++ b/npm/tsgo/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-win32-x64",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "tsgo server binary for windows x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/packages/tsgo/package.json
+++ b/packages/tsgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "TypeScript Go semantic server",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump `tsgo-client`, `@rslint/tsgo-server`, and all six platform packages from `0.0.10` to `0.0.11`, keeping `Cargo.lock` in sync. This prepares the next release following the shorthand binding property symbol support added in #2055.

## Related Links

- https://github.com/web-infra-dev/rslint/pull/2055

## Validation

- Validated package versions, platform metadata, and workspace dependencies using `readTsgoReleaseState` / `validateTsgoReleaseState`: `0.0.11`.
- `pnpm run format:check` passed.
- `git diff --check` passed.
- `pnpm run check-spell` on all nine changed files passed with a temporary supplemental dictionary for existing dependency names (`thiserror`, `cbor`, `bitflags`, `insta`); the repository spelling configuration is unchanged. The default check reports those four existing names.
- Language tests were not run because this change only updates version metadata.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).